### PR TITLE
feat: agent and provider launch choices in the node-first launcher

### DIFF
--- a/frontend/src/components/dialogs/EnvPickerDialog.css
+++ b/frontend/src/components/dialogs/EnvPickerDialog.css
@@ -83,3 +83,59 @@
   padding: 4px 10px;
   text-transform: lowercase;
 }
+
+/* #863: launch-target chooser. Outline-only buttons per DESIGN.md
+   (transparent at rest, 1px border, 0 radius, lowercase). `terminal` is the
+   always-available default; agent providers selectable when available,
+   disabled with a visible reason otherwise. */
+.env-picker-dialog__targets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 10px 2px;
+  border-top: 1px solid var(--border);
+}
+
+.env-picker-dialog__target {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.env-picker-dialog__target:hover:not(:disabled),
+.env-picker-dialog__target:focus-visible {
+  border-color: var(--accent);
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  outline: none;
+}
+
+/* Persistent "chosen target" mark — accent border, matches the picker's
+   selected-row accent so the active launch target reads at a glance. */
+.env-picker-dialog__target--selected {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Disabled provider (degraded/unavailable/unknown): DESIGN.md disabled token
+   (opacity 0.4, not-allowed). The reason text stays readable so the user can
+   see WHY without hover. */
+.env-picker-dialog__target:disabled,
+.env-picker-dialog__target--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.env-picker-dialog__target-reason {
+  color: var(--text-muted);
+  font-size: 11px;
+}

--- a/frontend/src/components/dialogs/EnvPickerDialog.tsx
+++ b/frontend/src/components/dialogs/EnvPickerDialog.tsx
@@ -24,6 +24,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type {
   EnvironmentOption,
   EnvironmentDegradedReason,
+  EnvironmentAgentProvider,
 } from '../../../../shared/environment-option.js';
 import {
   pickDefaultEnvironment,
@@ -34,6 +35,7 @@ import { EnvironmentPicker } from '../EnvironmentPicker.js';
 import {
   canLaunchEnvironment,
   launchEnvironment,
+  type LaunchBlockedReason,
   type LaunchEnvironmentOptions,
   type LaunchEnvironmentResult,
 } from '../../lib/launch-environment.js';
@@ -98,6 +100,84 @@ function describeBlockReason(
 }
 
 /**
+ * #863: render a typed {@link LaunchBlockedReason} returned by the launch hook
+ * (the defense-in-depth path). The dialog already pre-empts the common cases
+ * (freshness gating + the provider gate at {@link handleSelect}), so this only
+ * fires when the hook's own guard rejects after the dialog's checks — e.g. a
+ * race where the UI's disabled state and the launch hook desync, or an injected
+ * hook. We MUST pattern-match `provider-unavailable` here: defaulting to the
+ * freshness renderer would surface misleading "stale" copy for a fresh node
+ * whose provider is simply unavailable. Falls back to the freshness renderer
+ * for the `stale | offline | updating` codes. Lowercase per DESIGN.md.
+ */
+function describeLaunchBlockedReason(
+  option: EnvironmentOption,
+  reason: LaunchBlockedReason
+): string {
+  if (reason.code === 'provider-unavailable') {
+    const detail =
+      reason.providerReason?.trim() ||
+      (reason.availability === 'degraded'
+        ? 'degraded'
+        : reason.availability === 'unavailable'
+          ? 'unavailable'
+          : 'status unknown');
+    const auth = reason.authStatus?.trim();
+    const tail = auth ? `${detail} — ${auth}` : detail;
+    return `${reason.agent} unavailable — ${tail}`.toLowerCase();
+  }
+  return describeBlockReason(option.freshness, option.degradedReasons);
+}
+
+/**
+ * #863: a launch target the user picks for the selected option. `terminal` is
+ * the always-available bare shell; `{ kind: 'agent', agent }` launches the
+ * named provider. We model this as a discriminated union (not a bare string)
+ * so the launch path maps it onto `launchOverrides` without re-parsing a
+ * `'agent:<id>'` sentinel — and so the `terminal` default is unambiguous.
+ */
+export type LaunchTarget =
+  | { kind: 'terminal' }
+  | { kind: 'agent'; agent: string };
+
+const TERMINAL_TARGET: LaunchTarget = { kind: 'terminal' };
+
+function isSameTarget(a: LaunchTarget, b: LaunchTarget): boolean {
+  if (a.kind === 'terminal') return b.kind === 'terminal';
+  return b.kind === 'agent' && a.agent === b.agent;
+}
+
+/**
+ * #863: an agent provider is selectable only when the node reports it
+ * `available`. `degraded | unavailable | unknown` are rendered but disabled so
+ * the user can SEE the provider (and why it cannot launch) without it ever
+ * blocking the terminal path on the same node.
+ */
+function isProviderSelectable(provider: EnvironmentAgentProvider): boolean {
+  return provider.availability === 'available';
+}
+
+/**
+ * #863: short, lowercase reason for a non-selectable provider, sourced from the
+ * provider's own `reason` (RelayNodeErrorCode-derived, #861) with a typed
+ * availability fallback so the row is never silently disabled. Auth status is
+ * appended when the node reports one (e.g. `logged out`) so the user knows the
+ * remediation without a parallel string table. Lowercase per DESIGN.md.
+ */
+function describeProviderReason(provider: EnvironmentAgentProvider): string {
+  const base =
+    provider.reason?.trim() ||
+    (provider.availability === 'degraded'
+      ? 'degraded'
+      : provider.availability === 'unavailable'
+        ? 'unavailable'
+        : 'status unknown');
+  const auth = provider.authStatus?.trim();
+  const head = auth ? `${base} — ${auth}` : base;
+  return head.toLowerCase();
+}
+
+/**
  * Pick the initial selection id from `pickDefaultEnvironment`. On `error`
  * (no compatible default), returns `undefined` so the picker shows nothing
  * pre-selected; the user must still pick before launch.
@@ -136,6 +216,19 @@ export function EnvPickerDialog({
     [open]
   );
   const [selectedId, setSelectedId] = useState<string | undefined>(defaultId);
+  // #863: the launch target chosen for the selected option. Defaults to
+  // `terminal` so the #862 zero-extra-clicks shell launch path is preserved —
+  // an agent launch is an explicit opt-in, never the friction default. When the
+  // caller threads `launchOverrides={{ type: 'agent', agent }}` we honor it as
+  // the initial target so an agent-first entry point opens pre-selected.
+  const initialTarget = useMemo<LaunchTarget>(
+    () =>
+      launchOverrides?.type === 'agent' && launchOverrides.agent
+        ? { kind: 'agent', agent: launchOverrides.agent }
+        : TERMINAL_TARGET,
+    [launchOverrides?.type, launchOverrides?.agent]
+  );
+  const [launchTarget, setLaunchTarget] = useState<LaunchTarget>(initialTarget);
   const [blockReason, setBlockReason] = useState<string | null>(null);
   const [launching, setLaunching] = useState(false);
   // Re-entry guard. We use a ref (not the `launching` state) because state
@@ -147,19 +240,46 @@ export function EnvPickerDialog({
   useEffect(() => {
     if (open) {
       setSelectedId(defaultId);
+      setLaunchTarget(initialTarget);
       setBlockReason(null);
       setLaunching(false);
       launchInFlightRef.current = false;
     }
-  }, [open, defaultId]);
+  }, [open, defaultId, initialTarget]);
 
   const handleSelect = useCallback(
-    async (option: EnvironmentOption) => {
+    async (option: EnvironmentOption, targetOverride?: LaunchTarget) => {
       // Re-entry guard: ignore additional selects while a launch is pending.
       // Double-clicking a fresh option or hammering Enter would otherwise fire
       // duplicate create-session POSTs (CodeRabbit PR #646 feedback).
       if (launchInFlightRef.current) return;
       setSelectedId(option.id);
+      // #863: resolve the effective launch target. An explicit click on a
+      // provider button threads `targetOverride`; a row activation uses the
+      // currently-chosen target (terminal by default — the #862 zero-extra-
+      // clicks path). If the chosen target is an agent it MUST still be
+      // available on THIS option's node; the providers belong to a specific
+      // node, so a stale agent selection from another row falls back to the
+      // always-safe terminal target rather than launching a provider the node
+      // can't run.
+      const requested = targetOverride ?? launchTarget;
+      const providers = option.node.agentProviders ?? [];
+      let effectiveTarget: LaunchTarget = requested;
+      if (requested.kind === 'agent') {
+        const provider = providers.find((p) => p.id === requested.agent);
+        if (!provider) {
+          effectiveTarget = TERMINAL_TARGET;
+        } else if (!isProviderSelectable(provider)) {
+          // The user explicitly picked an unavailable provider — surface its
+          // typed reason rather than silently downgrading to a terminal (that
+          // would be a kind-switch as silent as a node-switch).
+          setBlockReason(
+            `${provider.id} unavailable — ${describeProviderReason(provider)}`
+          );
+          return;
+        }
+      }
+      setLaunchTarget(effectiveTarget);
       // Always re-check freshness at launch time (defense-in-depth against the
       // picker surfacing a stale row).
       if (!canLaunchEnvironment(option)) {
@@ -171,14 +291,27 @@ export function EnvPickerDialog({
       setBlockReason(null);
       setLaunching(true);
       launchInFlightRef.current = true;
+      // #862/#863: build the launch overrides from the resolved target. A
+      // `terminal` target is the bare shell (unchanged from #862); an `agent`
+      // target threads the chosen provider so the launch rides the SAME
+      // `executeSessionCreateAction` contract (#849) with `agent` set — no
+      // provider-specific UI-only launch path.
+      const overrides: LaunchEnvironmentOptions =
+        effectiveTarget.kind === 'agent'
+          ? { type: 'agent', agent: effectiveTarget.agent }
+          : { type: 'terminal' };
       try {
-        const result = await launch(option, launchOverrides);
+        const result = await launch(option, overrides);
         if (result.kind === 'blocked') {
-          // Should not happen given the canLaunch gate above, but if the
-          // launch hook ever rejects, surface the typed reason instead of
-          // silently closing.
+          // Should not happen given the canLaunch + provider gates above, but
+          // if the launch hook's own guard rejects (race where the UI disabled
+          // state and the hook desync, or an injected hook), surface the TYPED
+          // reason. We must route a `provider-unavailable` code through the
+          // provider renderer rather than the freshness fallback — defaulting
+          // to freshness copy would mislabel a fresh node as "stale" when the
+          // real cause is an unavailable provider.
           setBlockReason(
-            describeBlockReason(option.freshness, option.degradedReasons)
+            describeLaunchBlockedReason(option, result.reason)
           );
           return;
         }
@@ -199,22 +332,43 @@ export function EnvPickerDialog({
         launchInFlightRef.current = false;
       }
     },
-    [launch, launchOverrides, onClose, onLaunched]
+    [launch, launchTarget, onClose, onLaunched]
   );
 
   const handleCancel = useCallback(() => {
     onClose();
   }, [onClose]);
 
-  // #862: terminal-first copy. When the caller launches a bare terminal
-  // (`launchOverrides.type === 'terminal'` — e.g. the repo-less tab-plus
-  // entry point) the heading names the verb explicitly so the modal reads as
-  // a terminal launcher rather than the generic agent "start work" framing.
-  // Lowercase per DESIGN.md; no layout change.
+  // #863: launch the currently-selected option with an explicit target chosen
+  // from the chooser. Reuses `handleSelect` so freshness gating, the re-entry
+  // guard, and the typed block-reason path are shared with row activation.
+  const handleLaunchTarget = useCallback(
+    (option: EnvironmentOption | undefined, target: LaunchTarget) => {
+      if (!option) return;
+      void handleSelect(option, target);
+    },
+    [handleSelect]
+  );
+
+  // The option whose providers the launch-target chooser reflects. Providers
+  // are per-node, so the chooser tracks the currently-selected row.
+  const selectedOption = useMemo(
+    () => options.find((opt) => opt.id === selectedId),
+    [options, selectedId]
+  );
+  const providers = selectedOption?.node.agentProviders ?? [];
+
+  // #862/#863: title copy switches on the resolved launch target. A bare
+  // terminal reads as a terminal launcher (#862); an agent target names the
+  // provider so the modal reads as an agent launcher. Falls back to the
+  // generic "start work" framing only when the caller threads neither a
+  // terminal override nor an agent selection. Lowercase per DESIGN.md.
   const dialogTitle =
-    launchOverrides?.type === 'terminal'
-      ? 'start terminal in environment'
-      : 'start work in environment';
+    launchTarget.kind === 'agent'
+      ? `start ${launchTarget.agent} in environment`
+      : launchOverrides?.type === 'terminal'
+        ? 'start terminal in environment'
+        : 'start work in environment';
 
   if (!open) return null;
 
@@ -257,6 +411,88 @@ export function EnvPickerDialog({
             onCancel={handleCancel}
             {...(selectedId !== undefined ? { selectedOptionId: selectedId } : {})}
           />
+          {/* #863: launch-target chooser for the selected option. `terminal`
+              is always present and always enabled for a launchable node (an
+              unavailable agent provider never blocks it). Available providers
+              are selectable; degraded/unavailable/unknown render disabled with
+              their typed reason visible. The chooser only shows once a row is
+              selected so it reflects that node's providers (providers are
+              per-node). DESIGN.md: outline-only buttons, lowercase, 0 radius;
+              disabled = opacity 0.4 + cursor not-allowed. */}
+          {selectedOption ? (
+            <div
+              className="env-picker-dialog__targets"
+              role="group"
+              aria-label="launch target"
+              data-testid="env-picker-dialog-targets"
+            >
+              <button
+                type="button"
+                className={[
+                  'env-picker-dialog__target',
+                  isSameTarget(launchTarget, TERMINAL_TARGET)
+                    ? 'env-picker-dialog__target--selected'
+                    : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                data-testid="env-picker-dialog-target-terminal"
+                data-target="terminal"
+                aria-pressed={isSameTarget(launchTarget, TERMINAL_TARGET)}
+                disabled={launching}
+                onClick={() =>
+                  handleLaunchTarget(selectedOption, TERMINAL_TARGET)
+                }
+              >
+                terminal
+              </button>
+              {providers.map((provider) => {
+                const selectable = isProviderSelectable(provider);
+                const target: LaunchTarget = {
+                  kind: 'agent',
+                  agent: provider.id,
+                };
+                const reason = selectable
+                  ? undefined
+                  : describeProviderReason(provider);
+                return (
+                  <button
+                    key={provider.id}
+                    type="button"
+                    className={[
+                      'env-picker-dialog__target',
+                      isSameTarget(launchTarget, target)
+                        ? 'env-picker-dialog__target--selected'
+                        : '',
+                      selectable ? '' : 'env-picker-dialog__target--disabled',
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                    data-testid="env-picker-dialog-target-agent"
+                    data-target="agent"
+                    data-agent={provider.id}
+                    data-availability={provider.availability}
+                    aria-pressed={isSameTarget(launchTarget, target)}
+                    disabled={!selectable || launching}
+                    {...(reason ? { title: reason } : {})}
+                    onClick={() => handleLaunchTarget(selectedOption, target)}
+                  >
+                    <span className="env-picker-dialog__target-label">
+                      {provider.id}
+                    </span>
+                    {reason ? (
+                      <span
+                        className="env-picker-dialog__target-reason"
+                        data-testid="env-picker-dialog-target-reason"
+                      >
+                        {reason}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
           {blockReason ? (
             <div
               className="env-picker-dialog__block-reason"

--- a/frontend/src/components/dialogs/EnvPickerLauncher.tsx
+++ b/frontend/src/components/dialogs/EnvPickerLauncher.tsx
@@ -1,13 +1,22 @@
 // EnvPickerLauncher (#862) — thin wrapper that owns the env-picker option
 // derivation and renders <EnvPickerDialog> as the command-palette / empty-state
-// terminal launcher. Lives as its own component (rather than inline in App) so
+// launcher. Lives as its own component (rather than inline in App) so
 // the `['hub-nodes']` + `['repo-inventory']` `useQuery` calls in
 // `useEnvPickerOptions` run INSIDE the `<QueryClientProvider>` boundary — App
 // renders that provider in its own return, so calling those hooks in App's body
 // would sit outside it.
 //
-// Terminal MVP scope (#862): always launches a bare shell
-// (`launchOverrides={{ type: 'terminal' }}`); agent-provider selection is #863.
+// #862 shipped terminal-only launch. #863 adds agent launches WITHOUT changing
+// the option list: the derived options stay `sessionType: 'terminal'` (see
+// `useEnvPickerOptions`), so every fresh node row remains launchable for a bare
+// shell even when its agent providers are unavailable (acceptance: unavailable
+// agents must not block terminal launch). The launch *kind* is carried by the
+// `launchOverrides` the dialog forwards to `launchEnvironment`:
+//   - `{ type: 'terminal' }`            → bare shell (default, #862 behaviour)
+//   - `{ type: 'agent', agent: <id> }`  → agent launch; the provider is gated
+//     fail-closed at the launch boundary against `option.node.agentProviders`.
+// The caller decides which kind to request via the `launchOverrides` prop;
+// when omitted we default to terminal so existing #862 call sites are unchanged.
 
 import React from 'react';
 
@@ -16,7 +25,10 @@ import {
   useEnvPickerOptions,
   type UseEnvPickerOptionsInput,
 } from '../../lib/hooks/use-env-picker-options.js';
-import type { LaunchEnvironmentResult } from '../../lib/launch-environment.js';
+import type {
+  LaunchEnvironmentOptions,
+  LaunchEnvironmentResult,
+} from '../../lib/launch-environment.js';
 
 export interface EnvPickerLauncherProps {
   open: boolean;
@@ -26,6 +38,13 @@ export interface EnvPickerLauncherProps {
   /** Active workspace fallback when inventory is empty (optional). */
   fallbackWorkspace?: UseEnvPickerOptionsInput['fallbackWorkspace'];
   fallbackWorktreePath?: UseEnvPickerOptionsInput['fallbackWorktreePath'];
+  /**
+   * Launch shape forwarded to `EnvPickerDialog` → `launchEnvironment`. Defaults
+   * to `{ type: 'terminal' }` (#862 bare-shell behaviour). Pass
+   * `{ type: 'agent', agent: <providerId> }` to request an agent launch; the
+   * provider is enforced fail-closed at the launch boundary, not here.
+   */
+  launchOverrides?: LaunchEnvironmentOptions;
   /** Called after a successful launch so callers can navigate to the session. */
   onLaunched?: (result: LaunchEnvironmentResult) => void;
 }
@@ -36,6 +55,7 @@ export function EnvPickerLauncher({
   selectedAgent,
   fallbackWorkspace,
   fallbackWorktreePath,
+  launchOverrides = { type: 'terminal' },
   onLaunched,
 }: EnvPickerLauncherProps) {
   const options = useEnvPickerOptions({
@@ -49,7 +69,7 @@ export function EnvPickerLauncher({
       open={open}
       options={options}
       onClose={onClose}
-      launchOverrides={{ type: 'terminal' }}
+      launchOverrides={launchOverrides}
       {...(onLaunched ? { onLaunched } : {})}
     />
   );

--- a/frontend/src/lib/hooks/use-env-picker-options.ts
+++ b/frontend/src/lib/hooks/use-env-picker-options.ts
@@ -53,9 +53,21 @@ export interface UseEnvPickerOptionsInput {
 
 /**
  * Derive the env-picker option list from the shared `['hub-nodes']` +
- * `['repo-inventory']` queries. Terminal MVP (#862): callers launch with
- * `launchOverrides={{ type: 'terminal' }}`, so `sessionType` is fixed to
- * `'terminal'` here (agent provider gating is #863's scope).
+ * `['repo-inventory']` queries.
+ *
+ * #863 decision — `sessionType` stays fixed to `'terminal'` here even though the
+ * launcher now supports agent launches. `buildEnvironmentOptions`' `sessionType`
+ * only gates the node row's freshness/capability bits (shell + terminal backend
+ * for `'terminal'`; additionally the selected agent's capability for
+ * `'agent'`). Threading `'agent'` through would mark a fresh node `stale`
+ * whenever the *currently-selected* agent is unavailable — which would also
+ * block that same node's plain terminal launch, violating the acceptance
+ * criterion that an unavailable agent must NOT block a shell. So node rows stay
+ * terminal-gated (always launchable for a shell), and the per-option agent
+ * provider choice is instead enforced fail-closed at the launch boundary in
+ * `launchEnvironment`, reading `option.node.agentProviders` (populated by #861).
+ * This keeps a single option list serving both launch kinds without a parallel
+ * agent-gated derivation.
  */
 export function useEnvPickerOptions(
   input: UseEnvPickerOptionsInput

--- a/frontend/src/lib/launch-environment.ts
+++ b/frontend/src/lib/launch-environment.ts
@@ -23,9 +23,11 @@
 // performs. Tests can inject a `createSession` override.
 
 import type {
+  EnvironmentAgentProvider,
   EnvironmentDegradedReason,
   EnvironmentFreshness,
   EnvironmentOption,
+  EnvironmentProviderAvailability,
 } from '../../../shared/environment-option.js';
 import {
   createAgentSession,
@@ -46,7 +48,29 @@ export type LaunchBlockedReason =
   | { code: 'offline'; degradedReasons?: EnvironmentDegradedReason[] }
   // #861(A): node is mid-update. Distinct from stale/offline so callers can
   // surface "blocked until update completes" copy instead of a generic retry.
-  | { code: 'updating'; degradedReasons?: EnvironmentDegradedReason[] };
+  | { code: 'updating'; degradedReasons?: EnvironmentDegradedReason[] }
+  // #863: an agent launch chose a provider whose availability on the target
+  // node is not `available` (unavailable / degraded / unknown / not advertised
+  // at all). Distinct from the freshness codes so callers can render
+  // "provider unavailable — pick another agent or launch a terminal" copy
+  // WITHOUT collapsing to a generic node-stale retry. Terminal launches never
+  // hit this branch: the option list stays `sessionType: 'terminal'`, so a
+  // node row is launchable for a shell even when every agent provider is down
+  // (acceptance: unavailable agents must not block a plain terminal launch).
+  | {
+      code: 'provider-unavailable';
+      agent: string;
+      /**
+       * 1:1 from `EnvironmentAgentProvider.availability` when the node
+       * advertised the provider; `'unknown'` when the node did not advertise
+       * it at all (no matching entry in `node.agentProviders`).
+       */
+      availability: EnvironmentProviderAvailability;
+      /** Short reason string the provider carried (RelayNodeErrorCode-derived). */
+      providerReason?: string;
+      /** Auth/login status the node reported for the provider, when present. */
+      authStatus?: string;
+    };
 
 export interface LaunchEnvironmentOptions {
   /** Override the launch type. Defaults to 'terminal' (a bare shell launch). */
@@ -74,10 +98,51 @@ export function canLaunchEnvironment(option: EnvironmentOption): boolean {
  */
 function blockedCodeFor(
   freshness: EnvironmentFreshness
-): LaunchBlockedReason['code'] {
+): 'stale' | 'offline' | 'updating' {
   if (freshness === 'offline') return 'offline';
   if (freshness === 'updating') return 'updating';
   return 'stale';
+}
+
+/**
+ * #863: locate the chosen agent provider on the option's node. Returns the
+ * matching {@link EnvironmentAgentProvider} (populated by #861's converter from
+ * `node.capabilities.agents`) or `undefined` when the node did not advertise
+ * this provider at all.
+ */
+function providerForAgent(
+  option: EnvironmentOption,
+  agent: string
+): EnvironmentAgentProvider | undefined {
+  return option.node.agentProviders?.find((provider) => provider.id === agent);
+}
+
+/**
+ * #863: build the typed {@link LaunchBlockedReason} for an agent launch whose
+ * chosen provider is not launchable on the option's node. A provider is
+ * launchable only when it is advertised AND its `availability` is `available`;
+ * `degraded` / `unavailable` / `unknown` (and "not advertised", treated as
+ * `unknown`) all fail closed here. The reason carries the provider's own
+ * availability / reason / authStatus so callers explain *why* without a parallel
+ * lookup against `node.agentProviders`.
+ *
+ * Returns `null` when the provider IS launchable (the happy path).
+ */
+function agentProviderBlockedReason(
+  option: EnvironmentOption,
+  agent: string
+): Extract<LaunchBlockedReason, { code: 'provider-unavailable' }> | null {
+  const provider = providerForAgent(option, agent);
+  if (provider && provider.availability === 'available') return null;
+  const availability: EnvironmentProviderAvailability =
+    provider?.availability ?? 'unknown';
+  return {
+    code: 'provider-unavailable',
+    agent,
+    availability,
+    ...(provider?.reason ? { providerReason: provider.reason } : {}),
+    ...(provider?.authStatus ? { authStatus: provider.authStatus } : {}),
+  };
 }
 
 /**
@@ -128,6 +193,20 @@ export async function launchEnvironment(
       ? { code, degradedReasons: option.degradedReasons }
       : { code };
     return { kind: 'blocked', reason };
+  }
+  // #863: gate the chosen agent provider at the launch boundary. This runs
+  // ONLY for `type === 'agent'`; a terminal launch (the default) never inspects
+  // `agentProviders`, so an unavailable agent on a fresh node still launches a
+  // shell (acceptance: unavailable agents must not block plain terminal
+  // launch). Like the freshness guard above, this is defense-in-depth — the
+  // dialog disables unselectable providers — but it must fail closed if a bug
+  // surfaces an unavailable provider, so the unavailable choice never reaches
+  // the create-session network call.
+  if (overrides.type === 'agent' && overrides.agent !== undefined) {
+    const providerReason = agentProviderBlockedReason(option, overrides.agent);
+    if (providerReason) {
+      return { kind: 'blocked', reason: providerReason };
+    }
   }
   const result = await createSession(
     environmentToCreateSessionOptions(option, overrides)

--- a/test/components/EnvPickerPaletteAction.test.ts
+++ b/test/components/EnvPickerPaletteAction.test.ts
@@ -103,6 +103,35 @@ function offlineOption(
   });
 }
 
+// #863: a fresh option whose node advertises a mix of available + degraded /
+// unavailable / unknown agent providers. The launch-target chooser renders
+// each, gates selection on availability, and never lets an unavailable
+// provider block the terminal launch on the same node.
+function providerOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return freshOption({
+    id: 'opt-providers',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+      agentProviders: [
+        { id: 'claude', availability: 'available' },
+        {
+          id: 'codex',
+          availability: 'unavailable',
+          reason: 'cli not installed',
+        },
+        { id: 'opencode', availability: 'degraded', authStatus: 'logged out' },
+        { id: 'hermes', availability: 'unknown' },
+      ],
+    },
+    ...overrides,
+  });
+}
+
 describe('sessionStartWorkInEnv action meta', () => {
   it('registers and is discoverable by the palette search terms', () => {
     _resetForTesting();
@@ -406,5 +435,297 @@ describe('<EnvPickerDialog /> (palette wiring)', () => {
       overlay.click();
     });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #863 — agent/provider launch-target chooser. Verifies that the dialog
+// surfaces per-node provider choices with availability states + reasons,
+// disables non-available providers, launches with `{ type: 'agent', agent }`
+// on selection, and NEVER lets an unavailable provider block the always-
+// enabled terminal path (preselected — zero extra clicks).
+describe('<EnvPickerDialog /> launch-target chooser (#863)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(props: React.ComponentProps<typeof EnvPickerDialog>) {
+    await act(async () => {
+      root.render(React.createElement(EnvPickerDialog, props));
+    });
+  }
+
+  const okLaunch = () =>
+    vi.fn(async (): Promise<LaunchEnvironmentResult> => ({
+      kind: 'launched',
+      result: { session: undefined, error: null },
+    }));
+
+  function targetButtons(): HTMLButtonElement[] {
+    return Array.from(
+      container.querySelectorAll(
+        '[data-testid="env-picker-dialog-target-agent"], [data-testid="env-picker-dialog-target-terminal"]'
+      )
+    ) as HTMLButtonElement[];
+  }
+
+  function agentButton(agent: string): HTMLButtonElement {
+    return container.querySelector(
+      `[data-testid="env-picker-dialog-target-agent"][data-agent="${agent}"]`
+    ) as HTMLButtonElement;
+  }
+
+  it('renders the provider list with availability states + reasons', async () => {
+    await render({
+      open: true,
+      options: [providerOption()],
+      launchOverrides: { type: 'terminal' },
+      onClose: vi.fn(),
+    });
+    // terminal + 4 providers = 5 target buttons.
+    expect(targetButtons()).toHaveLength(5);
+
+    const claude = agentButton('claude');
+    expect(claude).toBeTruthy();
+    expect(claude.getAttribute('data-availability')).toBe('available');
+    expect(claude.disabled).toBe(false);
+
+    // Each non-available provider surfaces a lowercase reason.
+    const codex = agentButton('codex');
+    expect(codex.getAttribute('data-availability')).toBe('unavailable');
+    expect(codex.textContent).toMatch(/cli not installed/i);
+
+    const opencode = agentButton('opencode');
+    // degraded provider surfaces its auth status in the reason.
+    expect(opencode.textContent).toMatch(/logged out/i);
+
+    const hermes = agentButton('hermes');
+    expect(hermes.getAttribute('data-availability')).toBe('unknown');
+    // unknown falls back to a typed reason rather than a silent disable.
+    expect(hermes.textContent).toMatch(/unknown/i);
+
+    // Reasons are lowercase per DESIGN.md.
+    const reason = container.querySelector(
+      '[data-testid="env-picker-dialog-target-reason"]'
+    );
+    expect(reason?.textContent).toBe(reason?.textContent?.toLowerCase());
+  });
+
+  it('disables degraded / unavailable / unknown providers; enables available', async () => {
+    await render({
+      open: true,
+      options: [providerOption()],
+      launchOverrides: { type: 'terminal' },
+      onClose: vi.fn(),
+    });
+    expect(agentButton('claude').disabled).toBe(false);
+    expect(agentButton('codex').disabled).toBe(true);
+    expect(agentButton('opencode').disabled).toBe(true);
+    expect(agentButton('hermes').disabled).toBe(true);
+  });
+
+  it('terminal is preselected and launches with { type: terminal } on row click (zero extra clicks)', async () => {
+    const launch = okLaunch();
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [providerOption()],
+      launchOverrides: { type: 'terminal' },
+      onClose,
+      launch,
+    });
+    // terminal target carries the persistent "selected" mark from the start.
+    const terminal = container.querySelector(
+      '[data-testid="env-picker-dialog-target-terminal"]'
+    ) as HTMLButtonElement;
+    expect(terminal.getAttribute('aria-pressed')).toBe('true');
+
+    // Clicking the option ROW (not a provider) launches a plain terminal —
+    // the #862 path is unchanged and takes no extra clicks.
+    const row = container.querySelector(
+      '[data-option-id="opt-providers"]'
+    ) as HTMLElement;
+    await act(async () => {
+      row.click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(launch.mock.calls[0]?.[1]).toEqual({ type: 'terminal' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('selecting an available provider launches with { type: agent, agent }', async () => {
+    const launch = okLaunch();
+    const onClose = vi.fn();
+    const onLaunched = vi.fn();
+    await render({
+      open: true,
+      options: [providerOption()],
+      launchOverrides: { type: 'terminal' },
+      onClose,
+      onLaunched,
+      launch,
+    });
+    await act(async () => {
+      agentButton('claude').click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    const launchedOption = launch.mock.calls[0]?.[0] as EnvironmentOption;
+    expect(launchedOption.id).toBe('opt-providers');
+    // The chosen provider rides the launch overrides — the same typed contract
+    // the CLI/action manifest uses (#849), never a UI-only path.
+    expect(launch.mock.calls[0]?.[1]).toEqual({
+      type: 'agent',
+      agent: 'claude',
+    });
+    expect(onLaunched).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking a disabled provider does not launch (native disabled button)', async () => {
+    const launch = okLaunch();
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [providerOption()],
+      launchOverrides: { type: 'terminal' },
+      onClose,
+      launch,
+    });
+    // A disabled <button> swallows clicks; the launch hook must never fire.
+    await act(async () => {
+      agentButton('codex').click();
+    });
+    expect(launch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('unavailable providers do not block terminal launch on the same node', async () => {
+    const launch = okLaunch();
+    const onClose = vi.fn();
+    // A node whose ONLY providers are unavailable must still terminal-launch.
+    const option = providerOption({
+      id: 'opt-all-unavailable',
+      node: {
+        nodeId: 'local',
+        kind: 'local',
+        displayName: 'this host',
+        online: true,
+        agentProviders: [
+          { id: 'codex', availability: 'unavailable', reason: 'cli missing' },
+        ],
+      },
+    });
+    await render({
+      open: true,
+      options: [option],
+      launchOverrides: { type: 'terminal' },
+      onClose,
+      launch,
+    });
+    const terminal = container.querySelector(
+      '[data-testid="env-picker-dialog-target-terminal"]'
+    ) as HTMLButtonElement;
+    expect(terminal.disabled).toBe(false);
+    await act(async () => {
+      terminal.click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(launch.mock.calls[0]?.[1]).toEqual({ type: 'terminal' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a node with zero providers is still terminal-launchable (chooser shows only terminal)', async () => {
+    const launch = okLaunch();
+    const onClose = vi.fn();
+    // freshOption() has no agentProviders at all.
+    await render({
+      open: true,
+      options: [freshOption({ id: 'opt-no-providers' })],
+      launchOverrides: { type: 'terminal' },
+      onClose,
+      launch,
+    });
+    const buttons = targetButtons();
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.getAttribute('data-target')).toBe('terminal');
+
+    const row = container.querySelector(
+      '[data-option-id="opt-no-providers"]'
+    ) as HTMLElement;
+    await act(async () => {
+      row.click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(launch.mock.calls[0]?.[1]).toEqual({ type: 'terminal' });
+  });
+
+  it('surfaces provider-specific copy (not stale copy) when the launch hook returns provider-unavailable', async () => {
+    // Defense-in-depth path: if the dialog's own provider gate and the launch
+    // hook desync (race, injected hook), the hook can still return a typed
+    // `provider-unavailable` block on a FRESH node. The dialog MUST render the
+    // provider reason — never the freshness fallback, which would mislabel a
+    // fresh node as "stale".
+    const launch = vi.fn(
+      async (): Promise<LaunchEnvironmentResult> => ({
+        kind: 'blocked',
+        reason: {
+          code: 'provider-unavailable',
+          agent: 'claude',
+          availability: 'unavailable',
+          providerReason: 'cli not installed',
+          authStatus: 'logged out',
+        },
+      })
+    );
+    const onClose = vi.fn();
+    const onLaunched = vi.fn();
+    await render({
+      open: true,
+      options: [providerOption()],
+      launchOverrides: { type: 'terminal' },
+      onClose,
+      onLaunched,
+      launch,
+    });
+    await act(async () => {
+      agentButton('claude').click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(onLaunched).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    const block = container.querySelector(
+      '[data-testid="env-picker-dialog-block-reason"]'
+    );
+    // Provider-specific copy: names the agent + its reason, NOT "stale".
+    expect(block?.textContent).toMatch(/claude/i);
+    expect(block?.textContent).toMatch(/unavailable/i);
+    expect(block?.textContent).toMatch(/cli not installed/i);
+    expect(block?.textContent).toMatch(/logged out/i);
+    expect(block?.textContent).not.toMatch(/stale/i);
+    // Lowercase per DESIGN.md.
+    expect(block?.textContent).toBe(block?.textContent?.toLowerCase());
+  });
+
+  it('agent mode title names the provider once one is chosen', async () => {
+    await render({
+      open: true,
+      options: [providerOption()],
+      // An agent-first entry point threads the agent override; the title and
+      // chooser open pre-selected on that provider.
+      launchOverrides: { type: 'agent', agent: 'claude' },
+      onClose: vi.fn(),
+    });
+    const title = container.querySelector('.env-picker-dialog__title');
+    expect(title?.textContent).toMatch(/start claude in environment/i);
+    expect(agentButton('claude').getAttribute('aria-pressed')).toBe('true');
   });
 });

--- a/test/components/launch-environment.test.ts
+++ b/test/components/launch-environment.test.ts
@@ -3,7 +3,10 @@
 // turn an `EnvironmentOption` into a `createSession` invocation.
 
 import { describe, expect, it, vi } from 'vitest';
-import type { EnvironmentOption } from '../../shared/environment-option.js';
+import type {
+  EnvironmentAgentProvider,
+  EnvironmentOption,
+} from '../../shared/environment-option.js';
 import {
   canLaunchEnvironment,
   environmentToCreateSessionOptions,
@@ -38,6 +41,22 @@ function freshOption(
     },
     generatedAt: GENERATED_AT,
     ...overrides,
+  };
+}
+
+/**
+ * #863: a fresh option whose node advertises the given agent providers. Used to
+ * exercise the launch-boundary provider gate without changing freshness (the
+ * node row stays launchable for a shell regardless of agent availability).
+ */
+function freshOptionWithProviders(
+  providers: EnvironmentAgentProvider[],
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  const base = freshOption(overrides);
+  return {
+    ...base,
+    node: { ...base.node, agentProviders: providers },
   };
 }
 
@@ -193,5 +212,231 @@ describe('launchEnvironment', () => {
       expect(result.reason.degradedReasons?.[0]?.kind).toBe('other');
     }
     expect(createSession).not.toHaveBeenCalled();
+  });
+});
+
+// #863: agent launches flow the per-option provider choice into
+// `launchEnvironment` overrides `{ type: 'agent', agent }`, gated fail-closed
+// against `option.node.agentProviders`. cwd/repo/worktree context is the same
+// mapping the terminal path uses — these tests assert the agent field rides
+// alongside that context intact across free / repo / worktree cwd shapes.
+describe('launchEnvironment — agent launches (#863)', () => {
+  function captureCreateSession() {
+    return vi.fn(async () => ({ session: undefined, error: null }));
+  }
+
+  it('maps {type:agent, agent} with repo cwd context preserved', async () => {
+    const createSession = captureCreateSession();
+    const option = freshOptionWithProviders([
+      { id: 'claude', availability: 'available' },
+    ]);
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'claude' },
+      createSession
+    );
+    expect(result.kind).toBe('launched');
+    expect(createSession).toHaveBeenCalledTimes(1);
+    const opts = createSession.mock.calls[0]?.[0];
+    expect(opts?.type).toBe('agent');
+    expect(opts?.agent).toBe('claude');
+    expect(opts?.nodeId).toBe('local');
+    expect(opts?.cwd).toBe('/Users/dev/repos/relay-ide');
+    // Repo cwd context rides alongside the agent field.
+    expect(opts?.repoPath).toBe('/Users/dev/repos/relay-ide');
+  });
+
+  it('maps an agent launch on a free / non-git cwd with no repo leak', async () => {
+    const createSession = captureCreateSession();
+    const option = freshOptionWithProviders(
+      [{ id: 'codex', availability: 'available' }],
+      { cwdMode: 'free', cwd: '/tmp/scratch' }
+    );
+    delete (option as { repoInstance?: unknown }).repoInstance;
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'codex' },
+      createSession
+    );
+    expect(result.kind).toBe('launched');
+    const opts = createSession.mock.calls[0]?.[0];
+    expect(opts?.type).toBe('agent');
+    expect(opts?.agent).toBe('codex');
+    expect(opts?.cwd).toBe('/tmp/scratch');
+    expect(opts).not.toHaveProperty('repoPath');
+    expect(opts).not.toHaveProperty('worktreePath');
+  });
+
+  it('maps an agent launch with worktree cwd context preserved', async () => {
+    const createSession = captureCreateSession();
+    const option = freshOptionWithProviders(
+      [{ id: 'claude', availability: 'available' }],
+      {
+        cwd: '/Users/dev/repos/relay-ide/.worktrees/feature',
+        bench: {
+          worktreeInstanceId: 'local:wt-1',
+          localPath: '/Users/dev/repos/relay-ide/.worktrees/feature',
+          branchName: 'feature/foo',
+        },
+      }
+    );
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'claude' },
+      createSession
+    );
+    expect(result.kind).toBe('launched');
+    const opts = createSession.mock.calls[0]?.[0];
+    expect(opts?.type).toBe('agent');
+    expect(opts?.agent).toBe('claude');
+    expect(opts?.repoPath).toBe('/Users/dev/repos/relay-ide');
+    expect(opts?.worktreePath).toBe(
+      '/Users/dev/repos/relay-ide/.worktrees/feature'
+    );
+  });
+
+  it('blocks an agent launch when the provider is unavailable, with typed reason', async () => {
+    const createSession = captureCreateSession();
+    const option = freshOptionWithProviders([
+      {
+        id: 'claude',
+        availability: 'unavailable',
+        reason: 'UNSUPPORTED_CAPABILITY',
+      },
+    ]);
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'claude' },
+      createSession
+    );
+    expect(result.kind).toBe('blocked');
+    if (result.kind === 'blocked') {
+      expect(result.reason.code).toBe('provider-unavailable');
+      if (result.reason.code === 'provider-unavailable') {
+        expect(result.reason.agent).toBe('claude');
+        expect(result.reason.availability).toBe('unavailable');
+        expect(result.reason.providerReason).toBe('UNSUPPORTED_CAPABILITY');
+      }
+    }
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it('blocks a degraded provider fail-closed (e.g. auth/login required)', async () => {
+    const createSession = captureCreateSession();
+    const option = freshOptionWithProviders([
+      {
+        id: 'codex',
+        availability: 'degraded',
+        reason: 'REPAIR_REQUIRED',
+        authStatus: 'logged-out',
+      },
+    ]);
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'codex' },
+      createSession
+    );
+    expect(result.kind).toBe('blocked');
+    if (result.kind === 'blocked' && result.reason.code === 'provider-unavailable') {
+      expect(result.reason.availability).toBe('degraded');
+      expect(result.reason.authStatus).toBe('logged-out');
+    }
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it('blocks an agent launch for a provider the node did not advertise (unknown)', async () => {
+    const createSession = captureCreateSession();
+    // Node advertises only `claude`; choosing `codex` must fail closed as
+    // `unknown` rather than silently launching an unconfigured provider.
+    const option = freshOptionWithProviders([
+      { id: 'claude', availability: 'available' },
+    ]);
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'codex' },
+      createSession
+    );
+    expect(result.kind).toBe('blocked');
+    if (result.kind === 'blocked' && result.reason.code === 'provider-unavailable') {
+      expect(result.reason.agent).toBe('codex');
+      expect(result.reason.availability).toBe('unknown');
+    }
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it('blocks an agent launch when the node advertises no providers at all', async () => {
+    const createSession = captureCreateSession();
+    // No `agentProviders` key on the node summary — agent launch fails closed.
+    const option = freshOption();
+    const result = await launchEnvironment(
+      option,
+      { type: 'agent', agent: 'claude' },
+      createSession
+    );
+    expect(result.kind).toBe('blocked');
+    if (result.kind === 'blocked') {
+      expect(result.reason.code).toBe('provider-unavailable');
+    }
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it('terminal launch on the same node is unaffected by an unavailable agent', async () => {
+    const createSession = captureCreateSession();
+    // Same node, every agent provider down — a TERMINAL launch must still
+    // succeed (acceptance: unavailable agents never block a plain shell).
+    const option = freshOptionWithProviders([
+      { id: 'claude', availability: 'unavailable', reason: 'UNSUPPORTED_CAPABILITY' },
+      { id: 'codex', availability: 'degraded', reason: 'REPAIR_REQUIRED' },
+    ]);
+    const result = await launchEnvironment(
+      option,
+      { type: 'terminal' },
+      createSession
+    );
+    expect(result.kind).toBe('launched');
+    expect(createSession).toHaveBeenCalledTimes(1);
+    const opts = createSession.mock.calls[0]?.[0];
+    expect(opts?.type).toBe('terminal');
+    // Terminal path never inspects agentProviders and never sets `agent`.
+    expect(opts?.agent).toBeUndefined();
+  });
+
+  it('default (no type override) launch ignores agentProviders entirely', async () => {
+    const createSession = captureCreateSession();
+    const option = freshOptionWithProviders([
+      { id: 'claude', availability: 'unavailable', reason: 'UNSUPPORTED_CAPABILITY' },
+    ]);
+    // No overrides → defaults to terminal; the unavailable agent is irrelevant.
+    const result = await launchEnvironment(option, {}, createSession);
+    expect(result.kind).toBe('launched');
+    expect(createSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #863 configured-command honesty: the issue requires configured/default
+// commands be exposed ONLY when already known from trusted Relay/node config.
+// An audit of `shared/` + `server/` found NO trusted configured-command /
+// default-command field on node summaries, the node manifest, or the
+// `EnvironmentAgentProvider` shape — `node.capabilities.agents` is a bare
+// `Record<string, NodeCapabilityStatus>` (availability only). This test pins
+// that honest absence: the provider shape carries no command/argv affordance,
+// so the launcher must not fabricate one. If a trusted field is ever added,
+// this guard fails and the read-only exposure can be wired then.
+describe('configured-command honesty (#863)', () => {
+  it('EnvironmentAgentProvider carries no configured/default command field', () => {
+    const provider: EnvironmentAgentProvider = {
+      id: 'claude',
+      availability: 'available',
+      authStatus: 'logged-in',
+      reason: undefined,
+    };
+    // The full set of keys the data layer (#861) populates — id + availability
+    // + optional authStatus/reason. No command, argv, defaultCommand, etc.
+    const keys = Object.keys(provider).sort();
+    expect(keys).toEqual(['authStatus', 'availability', 'id', 'reason']);
+    expect(provider).not.toHaveProperty('command');
+    expect(provider).not.toHaveProperty('defaultCommand');
+    expect(provider).not.toHaveProperty('configuredCommand');
+    expect(provider).not.toHaveProperty('argv');
   });
 });


### PR DESCRIPTION
## Summary
- Final slice of epic #848. Agent/provider launch choices in the node-first launcher, with the hard guarantee that unavailable providers never block shell launch on the same node.
- `launchEnvironment` gains a typed `{type:'agent', agent}` override gated fail-closed against `option.node.agentProviders` (#861 data): degraded/unavailable/unknown/not-advertised all block with a typed `provider-unavailable` reason (availability + provider reason + auth status). Terminal launches never inspect provider data; option rows stay terminal-gated so provider outages can't mark a node unlaunchable for shells (decision documented in-code).
- Dialog renders a per-node launch-target chooser: always-enabled preselected `terminal` button (zero extra clicks for the #862 default flow) + one button per provider with availability + visible reason; agent launches ride the same `sessions.create` typed contract (#849 convergence — no UI-only provider semantics).
- Configured/default commands: audited — no trusted configured-command field exists on node summaries/manifests; honest absence rendered and pinned by a test (no fabricated capability).
- Review-caught HIGH fixed: blocked agent launches now surface provider-specific copy instead of misleading freshness copy.

Fixes #863

## Review
Parallel builders → correctness + acceptance lenses → fix phase. HIGH (wrong block copy) fixed + regression-tested; one MEDIUM deferred with reviewer-acknowledged justification (mid-open prop-change target reset — not reachable from shipped call sites).

## Test plan
- `launch-environment` +13 (agent mapping across free/repo/worktree cwd, all provider-block paths, terminal unaffected, configured-command absence); `EnvPickerPaletteAction` +9 (chooser render/disable/launch, provider-specific block copy, zero-provider node, terminal preselect).
- Locally: 83 tests across the five launcher suites pass; `npm run check` 0 errors; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added launch target selection in the environment picker, allowing users to choose between terminal and agent modes.
  * Agent providers are displayed with availability status; unavailable providers are disabled and show explanatory reasons for unavailability.
  * Dialog titles now dynamically reflect the selected launch target mode for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->