### PR TITLE
feat: agent-authored view artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,9 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | WSL2 nodes         | `docs/WSL2_RELAY_NODE_SUPPORT.md`      | Windows/WSL2 node bootstrap, service mode, known limits                                        |
 | Federated dev      | `docs/FEDERATED_DEV.md`                | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew                     |
 | Federated Relay    | `docs/federated-relay.md`              | Hub/node architecture, pairing, routing, ADRs                                                  |
-| CLI gateway        | `docs/CLI_GATEWAY.md`                  | Versioned `relay-ide v1 ... --json` contract for external agent adapters                       |
-| Web chat           | `docs/WEB_CHAT.md`                     | Experimental adapter-shaped web chat surface for agent CLIs (status, scope, limits)            |
+| CLI gateway        | `docs/CLI_GATEWAY.md`              | Versioned `relay-ide v1 ... --json` contract for external agent adapters                       |
+| Agent view artifacts | `docs/AGENT_VIEW_ARTIFACTS.md`   | Agent-authored static HTML/CSS WorkContext artifact contract, viewer package route, security model |
+| Web chat           | `docs/WEB_CHAT.md`                 | Experimental adapter-shaped web chat surface for agent CLIs (status, scope, limits)            |
 | Provider guide     | `docs/provider-guide.md`               | Authoring/configuring agent framework providers (Claude/Codex/OpenCode/Hermes/custom)          |
 | Handoff template   | `docs/pipeline-handoff-artifact-template.md` | PipelineHandoffArtifact authoring template: stages, evidence dispositions, exact-head fields |
 | ADRs               | `docs/adrs/`                           | Accepted ADRs (latest: ADR-017 brain-as-peer, ADR-018 command-mediated handoff, ADR-019 context-packet storage) |

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -3485,11 +3485,10 @@ async function runGatewayWorkContextArtifacts(gatewayArgs: string[]): Promise<ne
     if (typeof input['workContextId'] !== 'string') {
       gatewayInvalid(commandName, '--work-context-id is required', { field: 'workContextId' });
     }
-    if (
-      (typeof input['artifact'] !== 'object' || input['artifact'] === null) &&
-      (typeof input['viewArtifact'] !== 'object' || input['viewArtifact'] === null)
-    ) {
-      gatewayInvalid(commandName, '--artifact-file, --view-file, input artifact, or input viewArtifact is required', {
+    const hasArtifact = isGatewayRecord(input['artifact']);
+    const hasViewArtifact = isGatewayRecord(input['viewArtifact']);
+    if (hasArtifact === hasViewArtifact) {
+      gatewayInvalid(commandName, 'exactly one of artifact or viewArtifact is required', {
         fields: ['artifact', 'viewArtifact'],
       });
     }

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -145,6 +145,8 @@ Commands:
     list                               Forward to git worktree list
   browser            Open an HTML file in the remote viewer
     <path>             Path to HTML file
+  v1 work-context-artifacts publish --artifact-file <json>|--view-file <json> --work-context-id <id> --json
+                     Publish a handoff artifact or agent-authored static HTML view artifact
   pin                Manage authentication PIN
     reset              Reset the PIN (interactive, requires TTY)
 
@@ -3456,8 +3458,15 @@ function addWorkContextArtifactBodyFlags(
   if (taskRef && body['taskRef'] === undefined) body['taskRef'] = taskRef;
   if (args.includes('--pin')) body['pin'] = true;
   const artifactFile = gatewayArg(args, '--artifact-file');
+  const viewFile = gatewayArg(args, '--view-file');
+  if (artifactFile && viewFile) {
+    gatewayInvalid(commandName, '--artifact-file and --view-file are mutually exclusive');
+  }
   if (artifactFile && body['artifact'] === undefined) {
     body['artifact'] = gatewayReadJsonFile(commandName, artifactFile);
+  }
+  if (viewFile && body['viewArtifact'] === undefined) {
+    body['viewArtifact'] = gatewayReadJsonFile(commandName, viewFile);
   }
   return body;
 }
@@ -3476,8 +3485,13 @@ async function runGatewayWorkContextArtifacts(gatewayArgs: string[]): Promise<ne
     if (typeof input['workContextId'] !== 'string') {
       gatewayInvalid(commandName, '--work-context-id is required', { field: 'workContextId' });
     }
-    if (typeof input['artifact'] !== 'object' || input['artifact'] === null) {
-      gatewayInvalid(commandName, '--artifact-file or input artifact is required', { field: 'artifact' });
+    if (
+      (typeof input['artifact'] !== 'object' || input['artifact'] === null) &&
+      (typeof input['viewArtifact'] !== 'object' || input['viewArtifact'] === null)
+    ) {
+      gatewayInvalid(commandName, '--artifact-file, --view-file, input artifact, or input viewArtifact is required', {
+        fields: ['artifact', 'viewArtifact'],
+      });
     }
     const result = await gatewayHttpJson({
       commandName,

--- a/docs/AGENT_VIEW_ARTIFACTS.md
+++ b/docs/AGENT_VIEW_ARTIFACTS.md
@@ -1,0 +1,128 @@
+# Agent view artifacts
+
+Agent view artifacts are agent-authored, static HTML/CSS packages stored in the WorkContext artifact store. They are for evidence dashboards and summaries that need richer layout than markdown while keeping the render path read-only and isolated.
+
+## Contract
+
+Publish through the WorkContext artifact route with a `viewArtifact` package instead of a pipeline `artifact`:
+
+```http
+POST /work-context-artifacts
+Content-Type: application/json
+x-relay-capabilities: context:write
+
+{
+  "workContextId": "wc:...",
+  "viewArtifact": {
+    "manifest": { "kind": "relay.agentView", "schemaVersion": 1, "...": "..." },
+    "files": { "index.html": "<main>...</main>", "style.css": "main { ... }" }
+  },
+  "pin": true
+}
+```
+
+CLI equivalent:
+
+```bash
+relay-ide v1 work-context-artifacts publish \
+  --work-context-id wc:example \
+  --view-file ./relay-view-package.json \
+  --json
+```
+
+Successful publishes are normal WorkContext artifact rows with `metadata.payloadKind: "agent-view-artifact"`, a SHA-256-addressed JSON payload file, and the manifest revision id as the artifact id. The authenticated viewer package route is:
+
+```http
+GET /work-context-artifacts/:id/view-package
+x-relay-capabilities: context:read
+```
+
+It returns `{ artifact: { metadata, viewArtifact } }` and uses the same auth lane as `GET /work-context-artifacts/:id`.
+
+## Package shape
+
+A package is a JSON object:
+
+```ts
+interface ViewArtifactPackage {
+  manifest: AgentViewManifest;
+  files: Record<string, string>; // relative path -> UTF-8 HTML/CSS text
+}
+```
+
+### Manifest schema
+
+Required manifest fields:
+
+| Field | Required value / meaning |
+| --- | --- |
+| `kind` | Literal `relay.agentView`. |
+| `schemaVersion` | Literal `1`. |
+| `title` | Human-readable title, <= 200 chars. |
+| `description` | Optional summary, <= 2000 chars. |
+| `entry` | Relative `.html` path present in `files`. |
+| `authoring.actorId` | Agent/system actor id that authored the view. |
+| `authoring.harness` | Optional authoring harness name. |
+| `createdAt`, `updatedAt` | Strict ISO timestamps. |
+| `scope.repo` | Optional owner/repo or project scope string. |
+| `scope.taskRefs[]` | Related task refs (`kind`, `id`, optional title/url/status). |
+| `sources[]` | Source evidence with `label`, `url`, optional `capturedAt`, optional `kind`. |
+| `capabilities` | Must be `[]` in the MVP. |
+| `export.policy` | `private` or `public`; private is the default storage visibility unless overridden. |
+| `revision.id` | Artifact id used by storage. |
+| `revision.supersedes` | Optional previous WorkContext artifact id. |
+
+Files must use safe relative paths, no `..`, no absolute paths, no backslashes, no whitespace/control chars, and extensions limited to `.html` and `.css`.
+
+## Size and validation caps
+
+| Cap | Value |
+| --- | ---: |
+| Total view package file bytes | 512 KiB |
+| Per-file bytes | 64 KiB |
+| File count | 16 |
+| Publish payload cap | Also subject to the generic WorkContext artifact publish cap after the view cap. |
+
+Publish-time validation rejects `<script>`, inline `on*=` handlers, `javascript:` URIs, and `<iframe>`, `<object>`, or `<embed>` tags in HTML. This is defense in depth; the render sandbox is the primary security control.
+
+## Security model
+
+Treat every byte as hostile. The only sanctioned browser render path is an iframe using `srcDoc` with an empty sandbox attribute: `sandbox=""`. Do not add `allow-scripts`, `allow-same-origin`, or a fetchable `src=` URL. The assembled document injects a CSP meta tag:
+
+```text
+default-src 'none'; style-src 'unsafe-inline'; img-src data:
+```
+
+The package read route is authenticated and private to Relay. Public export intentionally omits HTML/CSS file bytes; it returns a public summary with sanitized manifest text only. Manifest text is redacted for secret-looking tokens, local absolute paths, and private Kanban task ids. HTML/CSS bytes are not sanitized for public export because they are not included.
+
+## Denied capabilities
+
+The MVP allows no runtime capabilities from the artifact package.
+
+| Requested capability | Status | Reason |
+| --- | --- | --- |
+| `script` / JavaScript execution | Denied | Empty iframe sandbox and validation reject scripts/handlers. |
+| `network` / remote fetch | Denied | CSP uses `default-src 'none'`; no runtime grant exists. |
+| `same-origin` / parent access | Denied | Empty sandbox does not grant same-origin or parent access. |
+| `storage` / cookies / localStorage | Denied | Empty sandbox isolates storage/cookies. |
+| `forms` / navigation / popups | Denied | No sandbox allowances are granted. |
+| Relay API calls | Denied | Artifacts are static bytes, not protocol clients. |
+| File system, shell, git, node RPC | Denied | WorkContext artifacts store evidence only. |
+
+Any non-empty `manifest.capabilities` array fails validation.
+
+## Dogfood steps
+
+1. Create a package JSON with a manifest and `index.html`/`.css` files.
+2. Validate locally with the shared contract tests or by publishing to a dev hub.
+3. Publish:
+   ```bash
+   relay-ide v1 work-context-artifacts publish --work-context-id <wc-id> --view-file ./package.json --json
+   ```
+4. Confirm the response has `metadata.payloadKind: "agent-view-artifact"`, the expected revision id, and a SHA-256.
+5. Read the authenticated package route for viewer integration:
+   ```bash
+   curl -H 'x-relay-capabilities: context:read' \
+     http://127.0.0.1:3456/work-context-artifacts/<artifact-id>/view-package
+   ```
+6. If `export.policy` is `public`, verify `/work-context-artifacts/:id/export` contains the sanitized manifest and does not contain `files` or HTML/CSS bytes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This index separates current source-of-truth docs from historical plans and spik
 | Quality               | `QUALITY.md`                      | Test strategy, isolation rules, known gate behavior                                          |
 | Handoff artifacts     | `pipeline-handoff-artifact-template.md` | Live worker publication pattern and public-safe PipelineHandoffArtifact templates      |
 | CLI gateway           | `CLI_GATEWAY.md`                        | Versioned `relay-ide v1 ... --json` adapter contract, auth lanes, command taxonomy     |
+| Agent view artifacts  | `AGENT_VIEW_ARTIFACTS.md`               | Static HTML/CSS WorkContext view artifact contract, package route, security model       |
 | Security policy       | `SECURITY_POLICY.md`                    | Trust tiers, capability bits, hub ACL defaults, exact-operation approvals, handshake grants |
 | Handshake grants      | `OPERATOR_HANDSHAKE_GRANTS.md`          | One-time operator grant ceremony copy, lane separation, validation, audit/redaction contract |
 | rmux helper protocol  | `RMUX_HELPER_PROTOCOL.md`               | Experimental #707 helper JSON/stdin-stdout boundary and prototype gates                |

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -2,6 +2,8 @@
 
 Relay separates node capability discovery from hub-granted policy. A node manifest says what a node appears able to do right now; the hub ACL says what the hub is willing to route to that node. Manifest data is availability/probe evidence, never a grant.
 
+Agent-authored static HTML/CSS evidence uses the constrained view artifact model in `docs/AGENT_VIEW_ARTIFACTS.md`; its MVP denies all declared runtime capabilities and renders only through an empty-sandbox iframe.
+
 ## Auth lanes and browser-session boundary
 
 Relay auth is split into lanes. The current route inventory is checked into `server/auth.ts` as `AUTH_ROUTE_LANE_INVENTORY`; this section explains the policy boundary behind that source-of-truth table.

--- a/frontend/src/components/AgentViewArtifactViewer.css
+++ b/frontend/src/components/AgentViewArtifactViewer.css
@@ -172,7 +172,7 @@
 .agent-view-artifact-viewer__source-link {
   color: var(--status-info);
   text-decoration: none;
-  border-bottom: 1px solid currentColor;
+  border-bottom: 1px solid currentcolor;
 }
 
 .agent-view-artifact-viewer__source-link:hover,

--- a/frontend/src/components/AgentViewArtifactViewer.css
+++ b/frontend/src/components/AgentViewArtifactViewer.css
@@ -1,0 +1,205 @@
+.agent-view-artifact-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.72);
+  color: var(--text);
+  font-family: var(--font-mono);
+}
+
+.agent-view-artifact-viewer__modal {
+  width: min(1120px, calc(100vw - 32px));
+  height: min(860px, calc(100vh - 32px));
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.agent-view-artifact-viewer__chrome {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.agent-view-artifact-viewer__eyebrow {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+
+.agent-view-artifact-viewer__title {
+  margin: 2px 0 0;
+  color: var(--text);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  text-transform: lowercase;
+}
+
+.agent-view-artifact-viewer__close {
+  margin-left: auto;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.agent-view-artifact-viewer__close:hover,
+.agent-view-artifact-viewer__close:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.agent-view-artifact-viewer__message {
+  padding: 16px;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.agent-view-artifact-viewer__message--error {
+  color: var(--status-error);
+}
+
+.agent-view-artifact-viewer__content {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.agent-view-artifact-viewer__provenance {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  font-size: var(--font-size-xs);
+}
+
+.agent-view-artifact-viewer__provenance-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.agent-view-artifact-viewer__provenance-title {
+  flex: 1;
+  min-width: 0;
+  color: var(--text);
+  font-size: var(--font-size-base);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-view-artifact-viewer__provenance-pill {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  color: var(--accent);
+  padding: 1px 5px;
+}
+
+.agent-view-artifact-viewer__description {
+  margin: 0;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+}
+
+.agent-view-artifact-viewer__meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.agent-view-artifact-viewer__meta div {
+  min-width: 0;
+}
+
+.agent-view-artifact-viewer__meta dt {
+  margin: 0 0 2px;
+  color: var(--text-muted);
+}
+
+.agent-view-artifact-viewer__meta dd {
+  margin: 0;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-view-artifact-viewer__sources {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.agent-view-artifact-viewer__sources-label {
+  flex: 0 0 auto;
+}
+
+.agent-view-artifact-viewer__source-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.agent-view-artifact-viewer__source-list li {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.agent-view-artifact-viewer__source-link {
+  color: var(--status-info);
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+}
+
+.agent-view-artifact-viewer__source-link:hover,
+.agent-view-artifact-viewer__source-link:focus-visible {
+  color: var(--text);
+}
+
+.agent-view-artifact-viewer__source-kind,
+.agent-view-artifact-viewer__empty {
+  color: var(--text-muted);
+}
+
+.agent-view-artifact-viewer__frame {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  border: 0;
+  background: #ffffff;
+}
+
+@media (max-width: 720px) {
+  .agent-view-artifact-viewer__modal {
+    width: 100vw;
+    height: 100vh;
+  }
+
+  .agent-view-artifact-viewer__meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/AgentViewArtifactViewer.tsx
+++ b/frontend/src/components/AgentViewArtifactViewer.tsx
@@ -21,7 +21,7 @@ type LoadState =
 function sourceHref(source: AgentViewSource): string | null {
   try {
     const url = new URL(source.url);
-    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    if (url.protocol !== 'https:') return null;
     return url.toString();
   } catch {
     return null;

--- a/frontend/src/components/AgentViewArtifactViewer.tsx
+++ b/frontend/src/components/AgentViewArtifactViewer.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState, type MouseEvent } from 'react';
+import {
+  assembleInlinedHtml,
+  type AgentViewSource,
+  type ViewArtifactPackage,
+} from '../../../shared/agent-view-artifact.js';
+import { fetchAgentViewArtifactPackage } from '../lib/api.js';
+import './AgentViewArtifactViewer.css';
+
+export interface AgentViewArtifactViewerProps {
+  artifactId: string | null;
+  onClose: () => void;
+}
+
+type LoadState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ready'; pkg: ViewArtifactPackage }
+  | { kind: 'error'; message: string };
+
+function sourceHref(source: AgentViewSource): string | null {
+  try {
+    const url = new URL(source.url);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function authorLabel(pkg: ViewArtifactPackage): string {
+  const { authoring } = pkg.manifest;
+  return authoring.harness
+    ? `${authoring.actorId} · ${authoring.harness}`
+    : authoring.actorId;
+}
+
+export function AgentViewArtifactViewer({
+  artifactId,
+  onClose,
+}: AgentViewArtifactViewerProps) {
+  const [state, setState] = useState<LoadState>({ kind: 'idle' });
+
+  useEffect(() => {
+    if (!artifactId) {
+      setState({ kind: 'idle' });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ kind: 'loading' });
+    fetchAgentViewArtifactPackage(artifactId)
+      .then((pkg) => {
+        if (!cancelled) setState({ kind: 'ready', pkg });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'failed to load view',
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artifactId]);
+
+  const inlinedHtml = useMemo(
+    () => (state.kind === 'ready' ? assembleInlinedHtml(state.pkg) : ''),
+    [state]
+  );
+
+  if (!artifactId) return null;
+
+  const title =
+    state.kind === 'ready'
+      ? state.pkg.manifest.title
+      : state.kind === 'loading'
+        ? 'loading view artifact'
+        : 'view artifact';
+
+  function handleBackdropMouseDown(event: MouseEvent<HTMLDivElement>) {
+    if (event.target === event.currentTarget) onClose();
+  }
+
+  return (
+    <div
+      className="agent-view-artifact-viewer"
+      role="presentation"
+      onMouseDown={handleBackdropMouseDown}
+      data-track="agent-view-artifact.viewer"
+    >
+      <section
+        className="agent-view-artifact-viewer__modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="agent-view-artifact-viewer-title"
+      >
+        <header className="agent-view-artifact-viewer__chrome">
+          <div>
+            <div className="agent-view-artifact-viewer__eyebrow">
+              agent-authored static html
+            </div>
+            <h2
+              className="agent-view-artifact-viewer__title"
+              id="agent-view-artifact-viewer-title"
+            >
+              {title}
+            </h2>
+          </div>
+          <button
+            className="agent-view-artifact-viewer__close"
+            onClick={onClose}
+            type="button"
+            aria-label="close view artifact"
+          >
+            close
+          </button>
+        </header>
+
+        {state.kind === 'loading' && (
+          <div className="agent-view-artifact-viewer__message">loading…</div>
+        )}
+
+        {state.kind === 'error' && (
+          <div className="agent-view-artifact-viewer__message agent-view-artifact-viewer__message--error">
+            {state.message}
+          </div>
+        )}
+
+        {state.kind === 'ready' && (
+          <div className="agent-view-artifact-viewer__content">
+            <section
+              className="agent-view-artifact-viewer__provenance"
+              aria-label="view artifact provenance"
+            >
+              <div className="agent-view-artifact-viewer__provenance-head">
+                <span className="agent-view-artifact-viewer__provenance-title">
+                  {state.pkg.manifest.title}
+                </span>
+                <span className="agent-view-artifact-viewer__provenance-pill">
+                  rev {state.pkg.manifest.revision.id}
+                </span>
+              </div>
+              {state.pkg.manifest.description && (
+                <p className="agent-view-artifact-viewer__description">
+                  {state.pkg.manifest.description}
+                </p>
+              )}
+              <dl className="agent-view-artifact-viewer__meta">
+                <div>
+                  <dt>agent</dt>
+                  <dd>{authorLabel(state.pkg)}</dd>
+                </div>
+                <div>
+                  <dt>created</dt>
+                  <dd>{state.pkg.manifest.createdAt}</dd>
+                </div>
+                <div>
+                  <dt>updated</dt>
+                  <dd>{state.pkg.manifest.updatedAt}</dd>
+                </div>
+              </dl>
+              <div className="agent-view-artifact-viewer__sources">
+                <span className="agent-view-artifact-viewer__sources-label">
+                  sources
+                </span>
+                {state.pkg.manifest.sources.length > 0 ? (
+                  <ul className="agent-view-artifact-viewer__source-list">
+                    {state.pkg.manifest.sources.map((source, index) => {
+                      const href = sourceHref(source);
+                      return (
+                        <li key={`${source.label}-${index}`}>
+                          {href ? (
+                            <a
+                              className="agent-view-artifact-viewer__source-link"
+                              href={href}
+                              target="_blank"
+                              rel="noreferrer noopener"
+                            >
+                              {source.label}
+                            </a>
+                          ) : (
+                            <span>{source.label}</span>
+                          )}
+                          {source.kind && (
+                            <span className="agent-view-artifact-viewer__source-kind">
+                              {source.kind}
+                            </span>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <span className="agent-view-artifact-viewer__empty">
+                    none declared
+                  </span>
+                )}
+              </div>
+            </section>
+
+            {/* SECURITY (#830): this is the ONLY HTML render point for agent view
+                artifacts. Keep sandbox as the hard-coded empty string. Never add
+                allow-scripts, allow-same-origin, a fetchable src, or any sandbox
+                escape hatch here. */}
+            <iframe
+              className="agent-view-artifact-viewer__frame"
+              title={`view artifact preview: ${state.pkg.manifest.title}`}
+              sandbox=""
+              srcDoc={inlinedHtml}
+            />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default AgentViewArtifactViewer;

--- a/frontend/src/components/WorkspaceEvidenceArtifactsSection.css
+++ b/frontend/src/components/WorkspaceEvidenceArtifactsSection.css
@@ -97,6 +97,17 @@
   border-color: var(--accent);
 }
 
+.evidence-artifact__action--view {
+  color: var(--status-info);
+  border-color: var(--status-info);
+}
+
+.evidence-artifact__action--view:hover,
+.evidence-artifact__action--view:focus-visible {
+  background: color-mix(in srgb, var(--status-info) 10%, transparent);
+  border-color: var(--status-info);
+}
+
 .evidence-artifact__action:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/frontend/src/components/WorkspaceEvidenceArtifactsSection.tsx
+++ b/frontend/src/components/WorkspaceEvidenceArtifactsSection.tsx
@@ -13,6 +13,7 @@ import type {
   PublicPipelineHandoffArtifactSummary,
 } from '../lib/pipeline-handoff-timeline.js';
 import type { WorkContextActiveGroup } from '../lib/types.js';
+import AgentViewArtifactViewer from './AgentViewArtifactViewer.js';
 import ArtifactFeedbackPanel from './ArtifactFeedbackPanel.js';
 import './WorkspaceEvidenceArtifactsSection.css';
 
@@ -20,7 +21,9 @@ import './WorkspaceEvidenceArtifactsSection.css';
 // METADATA + the bounded public `summary` text ONLY — never artifact-derived
 // HTML, never an iframe, never raw payload bytes. Copy/export goes through
 // `copyPipelineHandoffArtifact`, which returns the sanitized public-summary
-// form (rawPayloadAvailable: false). Do not add dangerouslySetInnerHTML here.
+// form (rawPayloadAvailable: false). The AgentViewArtifactViewer is the sole
+// sanctioned HTML render path for agent-authored view artifacts. Do not add
+// dangerouslySetInnerHTML here.
 
 export interface WorkspaceEvidenceArtifactsSectionProps {
   repoPath: string;
@@ -46,6 +49,7 @@ function ArtifactCard({
   const meta: PublicPipelineHandoffArtifactSummary = envelope.metadata;
   const sessions = useSessionsStore((s) => s.sessions);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [viewArtifactId, setViewArtifactId] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<
     | { kind: 'idle' }
     | { kind: 'copying' }
@@ -55,6 +59,7 @@ function ArtifactCard({
 
   const headShaShort = shortSha(meta.headSha);
   const payloadShaShort = shortHash(meta.payloadSha256);
+  const isAgentViewArtifact = meta.payloadKind === 'agent-view-artifact';
   const taskSource = meta.taskRef
     ? `${meta.taskRef.kind}:${meta.taskRef.id}`
     : null;
@@ -136,6 +141,15 @@ function ArtifactCard({
         >
           {feedbackOpen ? 'hide feedback' : 'feedback'}
         </button>
+        {isAgentViewArtifact && (
+          <button
+            className="evidence-artifact__action evidence-artifact__action--view"
+            onClick={() => setViewArtifactId(meta.id)}
+            type="button"
+          >
+            open view
+          </button>
+        )}
         {copyState.kind === 'copied' && (
           <span className="evidence-artifact__copy-state">
             copied · {copyState.bytes}b
@@ -161,6 +175,12 @@ function ArtifactCard({
           artifactLabel={`${meta.kind} · ${meta.title}`}
           sessions={sessions}
           preferredTargetSessionId={null}
+        />
+      )}
+      {viewArtifactId && (
+        <AgentViewArtifactViewer
+          artifactId={viewArtifactId}
+          onClose={() => setViewArtifactId(null)}
         />
       )}
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,6 +34,7 @@ import type {
   PipelineHandoffArtifact,
   PipelineHandoffStageName,
 } from '../../../shared/pipeline-handoff-artifact.js';
+import type { ViewArtifactPackage } from '../../../shared/agent-view-artifact.js';
 import type { TaskRef } from '../../../shared/work-context.js';
 import type {
   PipelineHandoffArtifactEnvelope,
@@ -777,6 +778,23 @@ export interface FetchPipelineHandoffArtifactsOptions {
 const HANDOFF_ARTIFACT_HEADERS: HeadersInit = {
   'x-relay-capabilities': 'context:read',
 };
+
+export async function fetchAgentViewArtifactPackage(
+  artifactId: string
+): Promise<ViewArtifactPackage> {
+  const data = await json<{
+    artifact?: { viewArtifact?: ViewArtifactPackage };
+  }>(
+    await fetch(`/work-context-artifacts/${encodeURIComponent(artifactId)}/view-package`, {
+      headers: HANDOFF_ARTIFACT_HEADERS,
+    })
+  );
+  const pkg = data.artifact?.viewArtifact;
+  if (!pkg) {
+    throw new Error('view artifact package response was malformed');
+  }
+  return pkg;
+}
 
 export async function fetchPipelineHandoffArtifacts({
   workContextId,

--- a/frontend/src/lib/pipeline-handoff-timeline.ts
+++ b/frontend/src/lib/pipeline-handoff-timeline.ts
@@ -25,7 +25,7 @@ export interface PublicPipelineHandoffArtifactSummary {
   summary: string;
   visibility: 'private' | 'public';
   capturedAt: string;
-  payloadKind: 'pipeline-handoff-artifact';
+  payloadKind: 'pipeline-handoff-artifact' | 'agent-view-artifact';
   payloadSha256: string;
   payloadBytes: number;
   prNumber?: number;

--- a/server/features/work-context-artifact-router.ts
+++ b/server/features/work-context-artifact-router.ts
@@ -18,9 +18,15 @@ import {
   type PipelineHandoffArtifact,
   type PipelineHandoffStageName,
 } from '../../shared/pipeline-handoff-artifact.js';
+import {
+  AGENT_VIEW_MAX_TOTAL_BYTES,
+  validateAgentViewArtifact,
+  type ViewArtifactPackage,
+} from '../../shared/agent-view-artifact.js';
 import type { WorkContextStore } from '../work-contexts.js';
 import {
   WorkContextArtifactStoreError,
+  type StoreAgentViewArtifactInput,
   type StorePipelineHandoffArtifactInput,
   type WorkContextArtifactListInput,
   type WorkContextArtifactMetadata,
@@ -275,6 +281,10 @@ function persistedArtifactPayloadBytes(artifact: PipelineHandoffArtifact): numbe
   return Buffer.byteLength(JSON.stringify(artifact, null, 2), 'utf8');
 }
 
+function persistedViewArtifactPayloadBytes(viewArtifact: ViewArtifactPackage): number {
+  return Buffer.byteLength(JSON.stringify(viewArtifact, null, 2), 'utf8');
+}
+
 function sameJson(left: unknown, right: unknown): boolean {
   return stableJsonEquals(left, right);
 }
@@ -311,7 +321,7 @@ function ensureAppendOnlySupersedes(
     });
     return false;
   }
-  if (!previous?.payload) {
+  if (!previous?.payload || !isPipelineHandoffArtifact(previous.payload)) {
     sendGatewayError(res, 'NOT_FOUND', 'superseded artifact not found', false, {
       reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_NOT_FOUND',
       operation: input.operation,
@@ -383,7 +393,9 @@ function mapStoreError(
       });
       return;
     case 'invalid_pipeline_handoff_artifact':
+    case 'invalid_agent_view_artifact':
     case 'artifact_id_mismatch':
+    case 'artifact_supersedes_mismatch':
       sendGatewayError(res, 'INVALID_ARGUMENT', err.message, false, {
         reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
         ...details,
@@ -603,6 +615,91 @@ function queryListInput(req: Request): WorkContextArtifactListInput | 'invalid-t
   };
 }
 
+function storeViewArtifactPublish(input: {
+  res: Response;
+  store: WorkContextArtifactStore;
+  workContextStore?: WorkContextStore;
+  body: Record<string, unknown>;
+  viewArtifact: ViewArtifactPackage;
+  workContextId: WorkContextId;
+  operation: string;
+  maxPublishBytes: number;
+}): void {
+  const { res, store, workContextStore, body, viewArtifact, workContextId, operation, maxPublishBytes } = input;
+  const payloadBytes = persistedViewArtifactPayloadBytes(viewArtifact);
+  if (payloadBytes > AGENT_VIEW_MAX_TOTAL_BYTES) {
+    sendGatewayError(res, 'INVALID_ARGUMENT', 'viewArtifact payload exceeds agent view size cap', false, {
+      reasonCode: 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD',
+      operation,
+      workContextId,
+      artifactId: viewArtifact.manifest.revision.id,
+      payloadBytes,
+      maxBytes: AGENT_VIEW_MAX_TOTAL_BYTES,
+    });
+    return;
+  }
+  if (payloadBytes > maxPublishBytes) {
+    sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact payload exceeds publish size cap', false, {
+      reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
+      operation,
+      workContextId,
+      artifactId: viewArtifact.manifest.revision.id,
+      payloadBytes,
+      maxBytes: maxPublishBytes,
+    });
+    return;
+  }
+  const provenanceActorId = readString(body['provenanceActorId']);
+  const id = readString(body['id']);
+  const projectId = readString(body['projectId']);
+  const taskRef = readTaskRef(body['taskRef']);
+  const stage = readStage(body['stage']);
+  const visibility = readVisibility(body['visibility']);
+  const kind = readString(body['kind']) as StoreAgentViewArtifactInput['kind'] | undefined;
+  const title = readString(body['title']);
+  const summary = readString(body['summary']);
+  const capturedAt = readString(body['capturedAt']);
+  const supersedesArtifactId = readString(body['supersedesArtifactId']);
+  const inputRecord: StoreAgentViewArtifactInput = {
+    viewArtifact,
+    workContextId,
+  };
+  if (id) inputRecord.id = id;
+  if (projectId) inputRecord.projectId = projectId;
+  if (taskRef) inputRecord.taskRef = taskRef;
+  if (stage) inputRecord.stage = stage;
+  if (provenanceActorId) inputRecord.provenanceActorId = provenanceActorId;
+  if (visibility) inputRecord.visibility = visibility;
+  if (kind) inputRecord.kind = kind;
+  if (title) inputRecord.title = title;
+  if (summary) inputRecord.summary = summary;
+  if (capturedAt) inputRecord.capturedAt = capturedAt;
+  if (supersedesArtifactId) inputRecord.supersedesArtifactId = supersedesArtifactId;
+  try {
+    const stored = store.storeAgentViewArtifact(inputRecord);
+    const actorId = readString(body['actorId']) ?? provenanceActorId;
+    const shouldPin = readBoolean(body['pin']) ?? false;
+    const pinned = shouldPin && workContextStore
+      ? pinArtifactRef(workContextStore, workContextId, stored.metadata, actorId)
+      : undefined;
+    res.status(201).json({
+      artifact: recordEnvelope(stored),
+      ...(pinned ? { pin: pinned } : {}),
+    });
+  } catch (err) {
+    if (err instanceof WorkContextArtifactStoreError) {
+      mapStoreError(res, err, { operation, workContextId, artifactId: viewArtifact.manifest.revision.id });
+      return;
+    }
+    sendGatewayError(res, 'INTERNAL', 'failed to store WorkContext view artifact', true, {
+      reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+      operation,
+      workContextId,
+      artifactId: viewArtifact.manifest.revision.id,
+    });
+  }
+}
+
 export function createWorkContextArtifactRouter(
   deps: WorkContextArtifactRouterDeps
 ): Router {
@@ -645,6 +742,7 @@ export function createWorkContextArtifactRouter(
     }
   });
 
+  // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- publish validates either handoff artifacts or static view artifacts before shared store/pin handling.
   router.post(['/work-context-artifacts', '/pipeline-handoff-artifacts'], writeAuth, (req, res) => {
     const operation = req.path.startsWith('/pipeline-handoff-artifacts') ? 'attach' : 'publish';
     if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
@@ -661,8 +759,50 @@ export function createWorkContextArtifactRouter(
       return;
     }
     if (!ensureWorkContext(res, deps.workContextStore, workContextId, operation)) return;
+    const viewArtifact = body['viewArtifact'];
     const artifact = body['artifact'];
-    if (!isPipelineHandoffArtifact(artifact)) {
+    if (viewArtifact !== undefined && artifact !== undefined) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'exactly one of artifact or viewArtifact is allowed', false, {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_CONFLICT',
+        operation,
+        workContextId,
+      });
+      return;
+    }
+    if (req.path.startsWith('/pipeline-handoff-artifacts') && viewArtifact !== undefined) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'pipeline-handoff-artifacts only accepts PipelineHandoffArtifact payloads', false, {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_KIND_MISMATCH',
+        operation,
+        workContextId,
+        field: 'viewArtifact',
+      });
+      return;
+    }
+    if (viewArtifact !== undefined) {
+      const validation = validateAgentViewArtifact(viewArtifact);
+      if (!validation.valid) {
+        sendGatewayError(res, 'INVALID_ARGUMENT', 'viewArtifact must be a valid AgentViewArtifact package', false, {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+          operation,
+          workContextId,
+          field: 'viewArtifact',
+          validationErrors: validation.errors,
+        });
+        return;
+      }
+      storeViewArtifactPublish({
+        res,
+        store: s,
+        ...(deps.workContextStore ? { workContextStore: deps.workContextStore } : {}),
+        body,
+        viewArtifact: viewArtifact as ViewArtifactPackage,
+        workContextId,
+        operation,
+        maxPublishBytes,
+      });
+      return;
+    }
+    if (artifact === undefined || !isPipelineHandoffArtifact(artifact)) {
       sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact must be a PipelineHandoffArtifact', false, {
         reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
         operation,
@@ -778,7 +918,40 @@ export function createWorkContextArtifactRouter(
     }
     if (input.workContextId && !ensureWorkContext(res, deps.workContextStore, input.workContextId, 'list')) return;
     const current = currentHeadSha(req);
-    res.json({ artifacts: s.list(input).map((record) => recordEnvelope(record, current)) });
+    const listed = s.list(input);
+    const artifacts = req.path.startsWith('/pipeline-handoff-artifacts')
+      ? listed.filter((record) => record.metadata.payloadKind === 'pipeline-handoff-artifact')
+      : listed;
+    res.json({ artifacts: artifacts.map((record) => recordEnvelope(record, current)) });
+  });
+
+  router.get('/work-context-artifacts/:id/view-package', showAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const s = storeOr503(res, deps.store, 'show-view-package');
+    if (!s) return;
+    const id = req.params['id'] ?? '';
+    try {
+      const record = s.readViewArtifactPackage(id);
+      if (!record) {
+        sendGatewayError(res, 'NOT_FOUND', 'WorkContext view artifact not found', false, {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
+          operation: 'show-view-package',
+          artifactId: id,
+        });
+        return;
+      }
+      res.json({ artifact: { metadata: record.metadata, viewArtifact: record.payload } });
+    } catch (err) {
+      if (err instanceof WorkContextArtifactStoreError) {
+        mapStoreError(res, err, { operation: 'show-view-package', artifactId: id });
+        return;
+      }
+      sendGatewayError(res, 'INTERNAL', 'failed to read WorkContext view artifact package', true, {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+        operation: 'show-view-package',
+        artifactId: id,
+      });
+    }
   });
 
   router.get(['/work-context-artifacts/:id', '/pipeline-handoff-artifacts/:id'], showAuth, (req, res) => {
@@ -803,7 +976,7 @@ export function createWorkContextArtifactRouter(
         return;
       }
       const record = s.read(id);
-      if (!record) {
+      if (!record || (req.path.startsWith('/pipeline-handoff-artifacts') && record.metadata.payloadKind !== 'pipeline-handoff-artifact')) {
         sendGatewayError(res, 'NOT_FOUND', 'WorkContext artifact not found', false, {
           reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
           operation: 'show',

--- a/server/features/work-context-artifact-router.ts
+++ b/server/features/work-context-artifact-router.ts
@@ -663,18 +663,18 @@ function storeViewArtifactPublish(input: {
   const inputRecord: StoreAgentViewArtifactInput = {
     viewArtifact,
     workContextId,
+    ...(id ? { id } : {}),
+    ...(projectId ? { projectId } : {}),
+    ...(taskRef ? { taskRef } : {}),
+    ...(stage ? { stage } : {}),
+    ...(provenanceActorId ? { provenanceActorId } : {}),
+    ...(visibility ? { visibility } : {}),
+    ...(kind ? { kind } : {}),
+    ...(title ? { title } : {}),
+    ...(summary ? { summary } : {}),
+    ...(capturedAt ? { capturedAt } : {}),
+    ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
   };
-  if (id) inputRecord.id = id;
-  if (projectId) inputRecord.projectId = projectId;
-  if (taskRef) inputRecord.taskRef = taskRef;
-  if (stage) inputRecord.stage = stage;
-  if (provenanceActorId) inputRecord.provenanceActorId = provenanceActorId;
-  if (visibility) inputRecord.visibility = visibility;
-  if (kind) inputRecord.kind = kind;
-  if (title) inputRecord.title = title;
-  if (summary) inputRecord.summary = summary;
-  if (capturedAt) inputRecord.capturedAt = capturedAt;
-  if (supersedesArtifactId) inputRecord.supersedesArtifactId = supersedesArtifactId;
   try {
     const stored = store.storeAgentViewArtifact(inputRecord);
     const actorId = readString(body['actorId']) ?? provenanceActorId;
@@ -781,13 +781,24 @@ export function createWorkContextArtifactRouter(
     if (viewArtifact !== undefined) {
       const validation = validateAgentViewArtifact(viewArtifact);
       if (!validation.valid) {
-        sendGatewayError(res, 'INVALID_ARGUMENT', 'viewArtifact must be a valid AgentViewArtifact package', false, {
-          reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
-          operation,
-          workContextId,
-          field: 'viewArtifact',
-          validationErrors: validation.errors,
-        });
+        const oversized = validation.errors.some((error) => error.code === 'view_oversize');
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          oversized
+            ? 'viewArtifact payload exceeds agent view size cap'
+            : 'viewArtifact must be a valid AgentViewArtifact package',
+          false,
+          {
+            reasonCode: oversized
+              ? 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD'
+              : 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+            operation,
+            workContextId,
+            field: 'viewArtifact',
+            validationErrors: validation.errors,
+          }
+        );
         return;
       }
       storeViewArtifactPublish({

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -41,7 +41,7 @@ const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
 const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
 const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
 const STRICT_ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-const AGENT_VIEW_ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const AGENT_VIEW_ISO_TIMESTAMP_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS work_context_artifacts (
@@ -532,14 +532,14 @@ export function createWorkContextArtifactStore(input: {
         storeInput.capturedAt ?? storeInput.viewArtifact.manifest.updatedAt,
         'capturedAt'
       );
-      const payloadJson = JSON.stringify(storeInput.viewArtifact, null, 2);
-      const payloadSha256 = sha256Hex(payloadJson);
-      const payloadPath = writePayloadFile(payloadJson, payloadSha256);
-      const payloadBytes = Buffer.byteLength(payloadJson, 'utf8');
       const visibility = storeInput.viewArtifact.manifest.export.policy;
       if (storeInput.visibility !== undefined && storeInput.visibility !== visibility) {
         throw new WorkContextArtifactStoreError(400, 'artifact_visibility_mismatch');
       }
+      const payloadJson = JSON.stringify(storeInput.viewArtifact, null, 2);
+      const payloadSha256 = sha256Hex(payloadJson);
+      const payloadPath = writePayloadFile(payloadJson, payloadSha256);
+      const payloadBytes = Buffer.byteLength(payloadJson, 'utf8');
       const metadata: WorkContextArtifactMetadata = {
         id: artifactId,
         workContextId: storeInput.workContextId,
@@ -760,9 +760,16 @@ function payloadTaskRefs(row: WorkContextArtifactRow): IndexedTaskRef[] {
     assertPayloadSha256(raw, row);
     const parsed = JSON.parse(raw) as unknown;
     if (!isRecord(parsed)) return [];
-    const scope = parsed.scope;
-    if (!isRecord(scope) || !Array.isArray(scope.taskRefs)) return [];
-    return scope.taskRefs.filter(isIndexableTaskRef);
+    const directScope = parsed.scope;
+    const manifest = parsed.manifest;
+    const manifestScope = isRecord(manifest) ? manifest.scope : undefined;
+    const directRefs = isRecord(directScope) && Array.isArray(directScope.taskRefs)
+      ? directScope.taskRefs
+      : [];
+    const manifestRefs = isRecord(manifestScope) && Array.isArray(manifestScope.taskRefs)
+      ? manifestScope.taskRefs
+      : [];
+    return [...directRefs, ...manifestRefs].filter(isIndexableTaskRef);
   } catch {
     return [];
   }
@@ -876,14 +883,37 @@ function assertIsoTimestamp(value: string, label: string): void {
 }
 
 function normalizeAgentViewIsoTimestamp(value: string, label: string): string {
-  if (!AGENT_VIEW_ISO_TIMESTAMP_RE.test(value)) {
-    throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
-  }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
+  const parsed = parseAgentViewIsoTimestamp(value);
+  if (!parsed) {
     throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
   }
   return parsed.toISOString();
+}
+
+function parseAgentViewIsoTimestamp(value: string): Date | null {
+  const match = AGENT_VIEW_ISO_TIMESTAMP_RE.exec(value);
+  if (!match) return null;
+  const [, rawYear, rawMonth, rawDay, rawHour, rawMinute, rawSecond, rawFraction] = match;
+  const year = Number(rawYear);
+  const month = Number(rawMonth);
+  const day = Number(rawDay);
+  const hour = Number(rawHour);
+  const minute = Number(rawMinute);
+  const second = Number(rawSecond);
+  const milliseconds = rawFraction ? Number(rawFraction.padEnd(3, '0')) : 0;
+  const parsed = new Date(Date.UTC(year, month - 1, day, hour, minute, second, milliseconds));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() + 1 !== month ||
+    parsed.getUTCDate() !== day ||
+    parsed.getUTCHours() !== hour ||
+    parsed.getUTCMinutes() !== minute ||
+    parsed.getUTCSeconds() !== second ||
+    parsed.getUTCMilliseconds() !== milliseconds
+  ) {
+    return null;
+  }
+  return parsed;
 }
 
 function assertNonEmptyString(value: string, label: string): void {

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -14,6 +14,14 @@ import {
   type PipelineHandoffStageName,
 } from '../shared/pipeline-handoff-artifact.js';
 import {
+  isAgentViewArtifact,
+  sanitizeAgentViewManifestForPublic,
+  validateAgentViewArtifact,
+  validatePublicAgentViewManifest,
+  type AgentViewManifest,
+  type ViewArtifactPackage,
+} from '../shared/agent-view-artifact.js';
+import {
   ARTIFACT_KINDS,
   type ArtifactKind,
   type TaskRef,
@@ -33,6 +41,7 @@ const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
 const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
 const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
 const STRICT_ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const AGENT_VIEW_ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS work_context_artifacts (
@@ -88,7 +97,7 @@ CREATE INDEX IF NOT EXISTS idx_work_context_artifact_task_refs_lookup
 `;
 
 export type WorkContextArtifactVisibility = 'private' | 'public';
-export type WorkContextArtifactPayloadKind = 'pipeline-handoff-artifact';
+export type WorkContextArtifactPayloadKind = 'pipeline-handoff-artifact' | 'agent-view-artifact';
 
 export interface WorkContextArtifactIndexInput {
   id?: string;
@@ -107,6 +116,10 @@ export interface WorkContextArtifactIndexInput {
 
 export interface StorePipelineHandoffArtifactInput extends WorkContextArtifactIndexInput {
   artifact: PipelineHandoffArtifact;
+}
+
+export interface StoreAgentViewArtifactInput extends WorkContextArtifactIndexInput {
+  viewArtifact: ViewArtifactPackage;
 }
 
 export interface WorkContextArtifactMetadata {
@@ -140,7 +153,15 @@ export interface WorkContextArtifactRecord {
 }
 
 export interface WorkContextArtifactReadResult extends WorkContextArtifactRecord {
-  payload?: PipelineHandoffArtifact;
+  payload?: PipelineHandoffArtifact | ViewArtifactPackage;
+}
+
+export interface AgentViewArtifactReadResult extends WorkContextArtifactRecord {
+  payload: ViewArtifactPackage;
+}
+
+export interface PublicAgentViewArtifactSummaryPayload {
+  manifest: AgentViewManifest;
 }
 
 export interface PublicWorkContextArtifactSummary {
@@ -166,7 +187,7 @@ export interface PublicWorkContextArtifactSummary {
 
 export interface PublicWorkContextArtifactReadResult {
   metadata: PublicWorkContextArtifactSummary;
-  payload?: PipelineHandoffArtifact;
+  payload?: PipelineHandoffArtifact | PublicAgentViewArtifactSummaryPayload;
 }
 
 export interface WorkContextArtifactListInput {
@@ -181,8 +202,10 @@ export interface WorkContextArtifactListInput {
 export interface WorkContextArtifactStore {
   close(): void;
   storePipelineHandoffArtifact(input: StorePipelineHandoffArtifactInput): WorkContextArtifactRecord;
+  storeAgentViewArtifact(input: StoreAgentViewArtifactInput): WorkContextArtifactRecord;
   get(id: string): WorkContextArtifactRecord | null;
   read(id: string): WorkContextArtifactReadResult | null;
+  readViewArtifactPackage(id: string): AgentViewArtifactReadResult | null;
   list(input?: WorkContextArtifactListInput): WorkContextArtifactRecord[];
   publicSummary(id: string): PublicWorkContextArtifactReadResult | null;
 }
@@ -456,6 +479,129 @@ export function createWorkContextArtifactStore(input: {
       return { metadata, payloadPath };
     },
 
+    storeAgentViewArtifact(storeInput: StoreAgentViewArtifactInput) {
+      assertNonEmptyString(storeInput.workContextId, 'workContextId');
+      if (storeInput.projectId !== undefined)
+        assertNonEmptyString(storeInput.projectId, 'projectId');
+      if (storeInput.stage !== undefined) assertValidStage(storeInput.stage);
+      if (storeInput.provenanceActorId !== undefined)
+        assertNonEmptyString(storeInput.provenanceActorId, 'provenanceActorId');
+      if (storeInput.visibility !== undefined)
+        assertValidVisibility(storeInput.visibility);
+      if (storeInput.kind !== undefined) assertValidArtifactKind(storeInput.kind);
+      if (storeInput.title !== undefined)
+        assertNonEmptyString(storeInput.title, 'title');
+      if (storeInput.summary !== undefined)
+        assertNonEmptyString(storeInput.summary, 'summary');
+      const validation = validateAgentViewArtifact(storeInput.viewArtifact);
+      if (!validation.valid) {
+        throw new WorkContextArtifactStoreError(
+          400,
+          'invalid_agent_view_artifact',
+          validation.errors.map((error) => error.message).join('; ')
+        );
+      }
+      if (storeInput.id !== undefined) {
+        assertNonEmptyString(storeInput.id, 'id');
+        if (storeInput.id !== storeInput.viewArtifact.manifest.revision.id) {
+          throw new WorkContextArtifactStoreError(400, 'artifact_id_mismatch');
+        }
+      }
+      const artifactId = storeInput.id ?? storeInput.viewArtifact.manifest.revision.id;
+      mustNotAlreadyExist(artifactId);
+      const manifestSupersedesArtifactId = storeInput.viewArtifact.manifest.revision.supersedes;
+      const supersedesArtifactId = storeInput.supersedesArtifactId ?? manifestSupersedesArtifactId;
+      mustValidateSupersedes(supersedesArtifactId, storeInput.workContextId);
+      if (
+        storeInput.supersedesArtifactId &&
+        manifestSupersedesArtifactId &&
+        manifestSupersedesArtifactId !== storeInput.supersedesArtifactId
+      ) {
+        throw new WorkContextArtifactStoreError(400, 'artifact_supersedes_mismatch');
+      }
+
+      const taskRef = storeInput.taskRef ?? firstTaskRef(storeInput.viewArtifact);
+      if (!taskRef) {
+        throw new WorkContextArtifactStoreError(400, 'task_ref_required');
+      }
+      assertValidTaskRef(taskRef);
+      const taskRefs = dedupeTaskRefs([taskRef, ...storeInput.viewArtifact.manifest.scope.taskRefs]);
+      for (const indexedTaskRef of taskRefs) assertValidTaskRef(indexedTaskRef);
+      const now = new Date().toISOString();
+      const capturedAt = normalizeAgentViewIsoTimestamp(
+        storeInput.capturedAt ?? storeInput.viewArtifact.manifest.updatedAt,
+        'capturedAt'
+      );
+      const payloadJson = JSON.stringify(storeInput.viewArtifact, null, 2);
+      const payloadSha256 = sha256Hex(payloadJson);
+      const payloadPath = writePayloadFile(payloadJson, payloadSha256);
+      const payloadBytes = Buffer.byteLength(payloadJson, 'utf8');
+      const visibility = storeInput.viewArtifact.manifest.export.policy;
+      if (storeInput.visibility !== undefined && storeInput.visibility !== visibility) {
+        throw new WorkContextArtifactStoreError(400, 'artifact_visibility_mismatch');
+      }
+      const metadata: WorkContextArtifactMetadata = {
+        id: artifactId,
+        workContextId: storeInput.workContextId,
+        ...(storeInput.projectId ? { projectId: storeInput.projectId } : {}),
+        taskRef,
+        ...(storeInput.stage ? { stage: storeInput.stage } : {}),
+        ...(storeInput.provenanceActorId ? { provenanceActorId: storeInput.provenanceActorId } : {}),
+        kind: storeInput.kind ?? 'report',
+        title: storeInput.title ?? storeInput.viewArtifact.manifest.title,
+        summary: storeInput.summary ?? storeInput.viewArtifact.manifest.description ?? storeInput.viewArtifact.manifest.title,
+        visibility,
+        createdAt: now,
+        updatedAt: now,
+        capturedAt,
+        payloadKind: 'agent-view-artifact',
+        payloadMediaType: DEFAULT_PAYLOAD_MEDIA_TYPE,
+        payloadSha256,
+        payloadBytes,
+        ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
+      };
+      db.transaction(() => {
+        insertArtifact.run({
+          id: metadata.id,
+          workContextId: metadata.workContextId,
+          projectId: metadata.projectId ?? null,
+          taskRefKind: metadata.taskRef.kind,
+          taskRefId: metadata.taskRef.id,
+          stage: metadata.stage ?? null,
+          provenanceActorId: metadata.provenanceActorId ?? null,
+          kind: metadata.kind,
+          title: metadata.title,
+          summary: metadata.summary,
+          visibility: metadata.visibility,
+          createdAt: metadata.createdAt,
+          updatedAt: metadata.updatedAt,
+          capturedAt: metadata.capturedAt,
+          payloadKind: metadata.payloadKind,
+          payloadMediaType: metadata.payloadMediaType,
+          payloadPath,
+          payloadSha256: metadata.payloadSha256,
+          payloadBytes: metadata.payloadBytes,
+          prNumber: null,
+          headSha: null,
+          baseName: null,
+          branchName: null,
+          supersedesArtifactId: metadata.supersedesArtifactId ?? null,
+          metadataJson: JSON.stringify({ taskRef: metadata.taskRef } satisfies PersistedMetadataJson),
+        });
+        for (const indexedTaskRef of taskRefs) {
+          insertTaskRef.run({
+            artifactId: metadata.id,
+            taskRefKind: indexedTaskRef.kind,
+            taskRefId: indexedTaskRef.id,
+            taskRefTitle: indexedTaskRef.title ?? null,
+            taskRefUrl: indexedTaskRef.url ?? null,
+            taskRefStatus: indexedTaskRef.status ?? null,
+          });
+        }
+      })();
+      return { metadata, payloadPath };
+    },
+
     get(id: string) {
       const row = getRow(id);
       return row ? rowToRecord(row) : null;
@@ -468,7 +614,32 @@ export function createWorkContextArtifactStore(input: {
       const raw = readFileSync(row.payload_path, 'utf8');
       assertPayloadSha256(raw, row);
       const payload = JSON.parse(raw) as unknown;
-      if (!isPipelineHandoffArtifact(payload)) {
+      if (row.payload_kind === 'pipeline-handoff-artifact') {
+        if (!isPipelineHandoffArtifact(payload)) {
+          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+        }
+        return { ...record, payload };
+      }
+      if (row.payload_kind === 'agent-view-artifact') {
+        if (!isAgentViewArtifact(payload)) {
+          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+        }
+        return { ...record, payload };
+      }
+      throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+    },
+
+    readViewArtifactPackage(id: string) {
+      const row = getRow(id);
+      if (!row) return null;
+      if (row.payload_kind !== 'agent-view-artifact') {
+        throw new WorkContextArtifactStoreError(400, 'artifact_payload_kind_mismatch');
+      }
+      const record = rowToRecord(row);
+      const raw = readFileSync(row.payload_path, 'utf8');
+      assertPayloadSha256(raw, row);
+      const payload = JSON.parse(raw) as unknown;
+      if (!isAgentViewArtifact(payload)) {
         throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
       }
       return { ...record, payload };
@@ -522,19 +693,37 @@ export function createWorkContextArtifactStore(input: {
       const raw = readFileSync(row.payload_path, 'utf8');
       assertPayloadSha256(raw, row);
       const parsed = JSON.parse(raw) as unknown;
-      if (!isPipelineHandoffArtifact(parsed)) {
-        throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+      if (row.payload_kind === 'pipeline-handoff-artifact') {
+        if (!isPipelineHandoffArtifact(parsed)) {
+          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+        }
+        const payload = sanitizePipelineHandoffArtifactForPublic(parsed);
+        const publicValidation = validatePublicPipelineHandoffArtifact(payload);
+        if (!publicValidation.valid) {
+          throw new WorkContextArtifactStoreError(
+            500,
+            'public_artifact_sanitization_failed',
+            publicValidation.errors.join('; ')
+          );
+        }
+        return { metadata, payload };
       }
-      const payload = sanitizePipelineHandoffArtifactForPublic(parsed);
-      const publicValidation = validatePublicPipelineHandoffArtifact(payload);
-      if (!publicValidation.valid) {
-        throw new WorkContextArtifactStoreError(
-          500,
-          'public_artifact_sanitization_failed',
-          publicValidation.errors.join('; ')
-        );
+      if (row.payload_kind === 'agent-view-artifact') {
+        if (!isAgentViewArtifact(parsed)) {
+          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+        }
+        const manifest = sanitizeAgentViewManifestForPublic(parsed.manifest);
+        const publicValidation = validatePublicAgentViewManifest(manifest);
+        if (!publicValidation.valid) {
+          throw new WorkContextArtifactStoreError(
+            500,
+            'public_artifact_sanitization_failed',
+            publicValidation.errors.map((error) => error.message).join('; ')
+          );
+        }
+        return { metadata, payload: { manifest } };
       }
-      return { metadata, payload };
+      throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
     },
   };
 }
@@ -643,11 +832,14 @@ function publicMetadata(
   };
 }
 
-function firstTaskRef(artifact: PipelineHandoffArtifact): TaskRef | undefined {
+function firstTaskRef(artifact: PipelineHandoffArtifact | ViewArtifactPackage): TaskRef | undefined {
+  const taskRefs = isAgentViewArtifact(artifact)
+    ? artifact.manifest.scope.taskRefs
+    : artifact.scope.taskRefs;
   return (
-    artifact.scope.taskRefs.find((taskRef) => taskRef.kind === 'github-issue') ??
-    artifact.scope.taskRefs.find((taskRef) => taskRef.kind === 'github-pr') ??
-    artifact.scope.taskRefs[0]
+    taskRefs.find((taskRef) => taskRef.kind === 'github-issue') ??
+    taskRefs.find((taskRef) => taskRef.kind === 'github-pr') ??
+    taskRefs[0]
   );
 }
 
@@ -681,6 +873,17 @@ function assertIsoTimestamp(value: string, label: string): void {
   if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
     throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
   }
+}
+
+function normalizeAgentViewIsoTimestamp(value: string, label: string): string {
+  if (!AGENT_VIEW_ISO_TIMESTAMP_RE.test(value)) {
+    throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
+  }
+  return parsed.toISOString();
 }
 
 function assertNonEmptyString(value: string, label: string): void {

--- a/shared/agent-view-artifact.ts
+++ b/shared/agent-view-artifact.ts
@@ -122,7 +122,7 @@ export interface AgentViewValidationResult {
 
 // --- shared helpers -------------------------------------------------------
 
-const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const ISO_TIMESTAMP_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
 
 // Secret/credential redaction block — mirrors shared/pipeline-handoff-artifact.ts.
 const SECRET_TEXT_RE =
@@ -134,11 +134,11 @@ const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
 const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
 
 // HTML tripwire patterns — defense in depth, NOT the primary control.
-const HTML_SCRIPT_RE = /<script[\s>]/i;
+const HTML_SCRIPT_RE = /<script\b/i;
 const HTML_SCRIPT_CLOSE_RE = /<\/script\s*>/i;
-const HTML_INLINE_HANDLER_RE = /\son[a-z][a-z0-9-]*\s*=/i;
+const HTML_INLINE_HANDLER_RE = /\bon[a-z][a-z0-9-]*\s*=/i;
 const HTML_JAVASCRIPT_URI_RE = /javascript\s*:/i;
-const HTML_DANGEROUS_TAG_RE = /<(?:iframe|object|embed)[\s>]/i;
+const HTML_DANGEROUS_TAG_RE = /<(?:iframe|object|embed)\b/i;
 const CSS_RAW_HTML_BREAKOUT_RE = /<\/?(?:style|script|iframe|object|embed|html|body|head)\b/i;
 
 // `<link rel="stylesheet">` / `<script>` stripping for assembleInlinedHtml.
@@ -161,8 +161,34 @@ function isOptionalString(value: unknown): boolean {
   return value === undefined || typeof value === 'string';
 }
 
+function parseIsoTimestamp(value: string): Date | null {
+  const match = ISO_TIMESTAMP_RE.exec(value);
+  if (!match) return null;
+  const [, rawYear, rawMonth, rawDay, rawHour, rawMinute, rawSecond, rawFraction] = match;
+  const year = Number(rawYear);
+  const month = Number(rawMonth);
+  const day = Number(rawDay);
+  const hour = Number(rawHour);
+  const minute = Number(rawMinute);
+  const second = Number(rawSecond);
+  const milliseconds = rawFraction ? Number(rawFraction.padEnd(3, '0')) : 0;
+  const parsed = new Date(Date.UTC(year, month - 1, day, hour, minute, second, milliseconds));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() + 1 !== month ||
+    parsed.getUTCDate() !== day ||
+    parsed.getUTCHours() !== hour ||
+    parsed.getUTCMinutes() !== minute ||
+    parsed.getUTCSeconds() !== second ||
+    parsed.getUTCMilliseconds() !== milliseconds
+  ) {
+    return null;
+  }
+  return parsed;
+}
+
 function isIsoTimestamp(value: unknown): value is string {
-  return typeof value === 'string' && ISO_TIMESTAMP_RE.test(value);
+  return typeof value === 'string' && parseIsoTimestamp(value) !== null;
 }
 
 function byteLength(value: string): number {

--- a/shared/agent-view-artifact.ts
+++ b/shared/agent-view-artifact.ts
@@ -1,0 +1,705 @@
+import type { TaskRef } from './work-context.js';
+
+/**
+ * Agent view artifact — a bounded, agent-authored HTML/CSS package rendered as a
+ * read-only, fully isolated artifact in the workspace evidence surface.
+ *
+ * THREAT MODEL (this is agent-authored HTML; treat every byte as hostile):
+ * - The ONLY sanctioned render path is an iframe with `srcDoc` + `sandbox=""`
+ *   (the EMPTY string — no `allow-scripts`, no `allow-same-origin`, never a
+ *   fetchable `src=`). Scripts are inert; there is no same-origin access; the
+ *   document cannot reach the parent, cookies, storage, or network.
+ * - `assembleInlinedHtml` produces a single inlined HTML document that begins
+ *   with a `<meta http-equiv="Content-Security-Policy">` of
+ *   `default-src 'none'; style-src 'unsafe-inline'; img-src data:` —
+ *   belt-and-suspenders even though the empty sandbox already neuters scripts.
+ * - Publish-time validation is defense in depth, NOT the primary control: it
+ *   rejects `<script`, inline `on*=` handlers, `javascript:` URIs, and
+ *   `<iframe`/`<object`/`<embed`; rejects non-`.html`/`.css` files and path
+ *   traversal; rejects any declared capability (MVP denies all); enforces tight
+ *   size/count caps before the generic publish cap.
+ */
+
+export const AGENT_VIEW_SCHEMA_VERSION = 1 as const;
+
+export const AGENT_VIEW_MANIFEST_KIND = 'relay.agentView' as const;
+
+export const AGENT_VIEW_MAX_TOTAL_BYTES = 512 * 1024;
+export const AGENT_VIEW_MAX_FILE_BYTES = 64 * 1024;
+export const AGENT_VIEW_MAX_FILES = 16;
+
+export const AGENT_VIEW_MAX_TITLE_LENGTH = 200;
+export const AGENT_VIEW_MAX_DESCRIPTION_LENGTH = 2000;
+
+export const AGENT_VIEW_EXPORT_POLICIES = ['private', 'public'] as const;
+export type AgentViewExportPolicy = (typeof AGENT_VIEW_EXPORT_POLICIES)[number];
+
+/**
+ * Belt-and-suspenders CSP injected into the assembled document head. The empty
+ * sandbox already disables scripts; this denies network/media/frame loads too.
+ */
+export const AGENT_VIEW_CSP =
+  "default-src 'none'; style-src 'unsafe-inline'; img-src data:";
+
+export interface AgentViewAuthoring {
+  actorId: string;
+  harness?: string;
+}
+
+export interface AgentViewScope {
+  repo?: string;
+  taskRefs: TaskRef[];
+}
+
+export const AGENT_VIEW_SOURCE_KINDS = [
+  'github-issue',
+  'github-pr',
+  'doc',
+  'commit',
+  'url',
+  'other',
+] as const;
+export type AgentViewSourceKind = (typeof AGENT_VIEW_SOURCE_KINDS)[number];
+
+export interface AgentViewSource {
+  label: string;
+  url: string;
+  capturedAt?: string;
+  kind?: AgentViewSourceKind;
+}
+
+export interface AgentViewExport {
+  policy: AgentViewExportPolicy;
+}
+
+export interface AgentViewRevision {
+  id: string;
+  supersedes?: string;
+}
+
+export interface AgentViewManifest {
+  kind: typeof AGENT_VIEW_MANIFEST_KIND;
+  schemaVersion: typeof AGENT_VIEW_SCHEMA_VERSION;
+  title: string;
+  description?: string;
+  /** Relative path of the entry HTML file. Must be present in `files` and end `.html`. */
+  entry: string;
+  authoring: AgentViewAuthoring;
+  createdAt: string;
+  updatedAt: string;
+  scope: AgentViewScope;
+  sources: AgentViewSource[];
+  /** MVP denies all capabilities; this MUST be an empty array. */
+  capabilities: string[];
+  export: AgentViewExport;
+  revision: AgentViewRevision;
+}
+
+export interface ViewArtifactPackage {
+  manifest: AgentViewManifest;
+  /** Map of relative file path -> file content (HTML/CSS only). */
+  files: Record<string, string>;
+}
+
+export interface AgentViewValidationError {
+  code: AgentViewValidationCode;
+  message: string;
+}
+
+export type AgentViewValidationCode =
+  | 'view_invalid_manifest'
+  | 'view_invalid_entry'
+  | 'view_unsafe_path'
+  | 'view_unsupported_file'
+  | 'view_oversize'
+  | 'view_capabilities_denied'
+  | 'view_unsafe_html';
+
+export interface AgentViewValidationResult {
+  valid: boolean;
+  errors: AgentViewValidationError[];
+}
+
+// --- shared helpers -------------------------------------------------------
+
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+// Secret/credential redaction block — mirrors shared/pipeline-handoff-artifact.ts.
+const SECRET_TEXT_RE =
+  /(?:bearer\s+[a-z0-9._~+/-]+=*|sk-[a-z0-9_-]{8,}|relay-(?:sac|ohg|grant|auth|pair)-v1[a-z0-9._-]*|pair_[a-z0-9_-]{8,}|node_[a-z0-9._~+/=-]+\.secret_[a-z0-9._~+/=-]+|secret_[a-z0-9._~+/=-]+)/gi;
+const ABSOLUTE_LOCAL_PATH_RE =
+  /(?:^|[\s:=('"])(?:\/home\/[^\s)'"]+|\/Users\/[^\s)'"]+|\/tmp\/[^\s)'"]+)/g;
+const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
+const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
+const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
+
+// HTML tripwire patterns — defense in depth, NOT the primary control.
+const HTML_SCRIPT_RE = /<script[\s>]/i;
+const HTML_SCRIPT_CLOSE_RE = /<\/script\s*>/i;
+const HTML_INLINE_HANDLER_RE = /\son[a-z][a-z0-9-]*\s*=/i;
+const HTML_JAVASCRIPT_URI_RE = /javascript\s*:/i;
+const HTML_DANGEROUS_TAG_RE = /<(?:iframe|object|embed)[\s>]/i;
+const CSS_RAW_HTML_BREAKOUT_RE = /<\/?(?:style|script|iframe|object|embed|html|body|head)\b/i;
+
+// `<link rel="stylesheet">` / `<script>` stripping for assembleInlinedHtml.
+const LINK_STYLESHEET_TAG_RE =
+  /<link\b[^>]*\brel\s*=\s*(?:["']?)stylesheet(?:["']?)[^>]*>/gi;
+const SCRIPT_BLOCK_RE = /<script\b[^>]*>[\s\S]*?<\/script\s*>/gi;
+const SCRIPT_SELFCLOSE_RE = /<script\b[^>]*\/?>/gi;
+const HEAD_OPEN_RE = /<head\b[^>]*>/i;
+const HTML_OPEN_RE = /<html\b[^>]*>/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === 'string' && ISO_TIMESTAMP_RE.test(value);
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[a-z]:[\\/]/i.test(value) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value);
+}
+
+/** Path safety: reject `..`, leading `/`, drive/UNC, backslash, and NUL. */
+function isSafeFilePath(value: string): boolean {
+  if (value.length === 0) return false;
+  // Reject NUL, control chars, and whitespace outright.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\s]/.test(value)) return false;
+  if (value.includes('\\')) return false;
+  if (value.startsWith('/')) return false;
+  if (isWindowsAbsolutePath(value)) return false;
+  // Treat any `..` segment as traversal.
+  const segments = value.split('/');
+  if (segments.some((segment) => segment === '..')) return false;
+  if (value.includes('..')) return false;
+  return true;
+}
+
+function fileExtension(path: string): string {
+  const dot = path.lastIndexOf('.');
+  if (dot < 0) return '';
+  return path.slice(dot).toLowerCase();
+}
+
+function manifestTextNodes(
+  value: unknown,
+  path: string,
+  out: Array<{ path: string; text: string }>
+): void {
+  if (typeof value === 'string') {
+    out.push({ path, text: value });
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      manifestTextNodes(item, `${path}[${index}]`, out)
+    );
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    manifestTextNodes(nested, `${path}.${key}`, out);
+  }
+}
+
+function containsSecretText(value: string): boolean {
+  SECRET_TEXT_RE.lastIndex = 0;
+  return SECRET_TEXT_RE.test(value);
+}
+
+// --- manifest validation --------------------------------------------------
+
+function validateManifest(
+  manifest: unknown,
+  errors: AgentViewValidationError[]
+): manifest is AgentViewManifest {
+  if (!isRecord(manifest)) {
+    errors.push({
+      code: 'view_invalid_manifest',
+      message: 'manifest must be an object',
+    });
+    return false;
+  }
+  let ok = true;
+  const push = (code: AgentViewValidationCode, message: string): void => {
+    errors.push({ code, message });
+    ok = false;
+  };
+
+  if (manifest.kind !== AGENT_VIEW_MANIFEST_KIND) {
+    push('view_invalid_manifest', `manifest.kind must be ${AGENT_VIEW_MANIFEST_KIND}`);
+  }
+  if (manifest.schemaVersion !== AGENT_VIEW_SCHEMA_VERSION) {
+    push('view_invalid_manifest', 'manifest.schemaVersion is unsupported');
+  }
+  if (!hasString(manifest.title)) {
+    push('view_invalid_manifest', 'manifest.title is required');
+  } else if (manifest.title.length > AGENT_VIEW_MAX_TITLE_LENGTH) {
+    push(
+      'view_invalid_manifest',
+      `manifest.title must be <= ${AGENT_VIEW_MAX_TITLE_LENGTH} chars`
+    );
+  }
+  if (manifest.description !== undefined) {
+    if (typeof manifest.description !== 'string') {
+      push('view_invalid_manifest', 'manifest.description must be a string');
+    } else if (manifest.description.length > AGENT_VIEW_MAX_DESCRIPTION_LENGTH) {
+      push(
+        'view_invalid_manifest',
+        `manifest.description must be <= ${AGENT_VIEW_MAX_DESCRIPTION_LENGTH} chars`
+      );
+    }
+  }
+  if (!hasString(manifest.entry)) {
+    push('view_invalid_entry', 'manifest.entry is required');
+  }
+
+  if (!isRecord(manifest.authoring) || !hasString(manifest.authoring.actorId)) {
+    push('view_invalid_manifest', 'manifest.authoring.actorId is required');
+  } else if (!isOptionalString(manifest.authoring.harness)) {
+    push('view_invalid_manifest', 'manifest.authoring.harness must be a string');
+  }
+
+  if (!isIsoTimestamp(manifest.createdAt)) {
+    push('view_invalid_manifest', 'manifest.createdAt must be a strict ISO timestamp');
+  }
+  if (!isIsoTimestamp(manifest.updatedAt)) {
+    push('view_invalid_manifest', 'manifest.updatedAt must be a strict ISO timestamp');
+  }
+
+  if (!isRecord(manifest.scope)) {
+    push('view_invalid_manifest', 'manifest.scope is required');
+  } else {
+    if (!isOptionalString(manifest.scope.repo)) {
+      push('view_invalid_manifest', 'manifest.scope.repo must be a string');
+    }
+    if (!Array.isArray(manifest.scope.taskRefs)) {
+      push('view_invalid_manifest', 'manifest.scope.taskRefs must be an array');
+    } else {
+      manifest.scope.taskRefs.forEach((taskRef, index) => {
+        if (!isRecord(taskRef) || !hasString(taskRef.kind) || !hasString(taskRef.id)) {
+          push(
+            'view_invalid_manifest',
+            `manifest.scope.taskRefs[${index}] must have kind and id`
+          );
+        }
+      });
+    }
+  }
+
+  if (!Array.isArray(manifest.sources)) {
+    push('view_invalid_manifest', 'manifest.sources must be an array');
+  } else {
+    manifest.sources.forEach((source, index) => {
+      const prefix = `manifest.sources[${index}]`;
+      if (!isRecord(source)) {
+        push('view_invalid_manifest', `${prefix} must be an object`);
+        return;
+      }
+      if (!hasString(source.label)) {
+        push('view_invalid_manifest', `${prefix}.label is required`);
+      }
+      if (!hasString(source.url)) {
+        push('view_invalid_manifest', `${prefix}.url is required`);
+      }
+      if (source.capturedAt !== undefined && !isIsoTimestamp(source.capturedAt)) {
+        push('view_invalid_manifest', `${prefix}.capturedAt must be a strict ISO timestamp`);
+      }
+      if (
+        source.kind !== undefined &&
+        !AGENT_VIEW_SOURCE_KINDS.includes(source.kind as AgentViewSourceKind)
+      ) {
+        push('view_invalid_manifest', `${prefix}.kind is invalid`);
+      }
+    });
+  }
+
+  if (!Array.isArray(manifest.capabilities)) {
+    push('view_capabilities_denied', 'manifest.capabilities must be an array');
+  } else if (manifest.capabilities.length > 0) {
+    push(
+      'view_capabilities_denied',
+      'manifest.capabilities must be empty in MVP (all capabilities denied)'
+    );
+  }
+
+  if (
+    !isRecord(manifest.export) ||
+    !AGENT_VIEW_EXPORT_POLICIES.includes(manifest.export.policy as AgentViewExportPolicy)
+  ) {
+    push('view_invalid_manifest', 'manifest.export.policy must be private or public');
+  }
+
+  if (!isRecord(manifest.revision) || !hasString(manifest.revision.id)) {
+    push('view_invalid_manifest', 'manifest.revision.id is required');
+  } else if (!isOptionalString(manifest.revision.supersedes)) {
+    push('view_invalid_manifest', 'manifest.revision.supersedes must be a string');
+  }
+
+  return ok;
+}
+
+// --- HTML tripwire --------------------------------------------------------
+
+function scanHtmlForUnsafeContent(
+  path: string,
+  content: string,
+  errors: AgentViewValidationError[]
+): void {
+  if (HTML_SCRIPT_RE.test(content) || HTML_SCRIPT_CLOSE_RE.test(content)) {
+    errors.push({
+      code: 'view_unsafe_html',
+      message: `${path} contains a <script> tag`,
+    });
+  }
+  if (HTML_INLINE_HANDLER_RE.test(content)) {
+    errors.push({
+      code: 'view_unsafe_html',
+      message: `${path} contains an inline on*= event handler`,
+    });
+  }
+  if (HTML_JAVASCRIPT_URI_RE.test(content)) {
+    errors.push({
+      code: 'view_unsafe_html',
+      message: `${path} contains a javascript: URI`,
+    });
+  }
+  if (HTML_DANGEROUS_TAG_RE.test(content)) {
+    errors.push({
+      code: 'view_unsafe_html',
+      message: `${path} contains an <iframe>/<object>/<embed> tag`,
+    });
+  }
+}
+
+function scanCssForUnsafeContent(
+  path: string,
+  content: string,
+  errors: AgentViewValidationError[]
+): void {
+  if (CSS_RAW_HTML_BREAKOUT_RE.test(content)) {
+    errors.push({
+      code: 'view_unsafe_html',
+      message: `${path} contains raw HTML that can break out of a <style> block`,
+    });
+  }
+}
+
+function validateEntryReference(
+  manifest: Record<string, unknown> | undefined,
+  files: Record<string, unknown>,
+  errors: AgentViewValidationError[]
+): void {
+  const entry = manifest && typeof manifest.entry === 'string' ? manifest.entry : undefined;
+  if (entry === undefined) return;
+  if (fileExtension(entry) !== '.html') {
+    errors.push({
+      code: 'view_invalid_entry',
+      message: 'manifest.entry must be an .html file',
+    });
+  }
+  if (!Object.prototype.hasOwnProperty.call(files, entry)) {
+    errors.push({
+      code: 'view_invalid_entry',
+      message: `manifest.entry ${JSON.stringify(entry)} must exist in files`,
+    });
+  }
+}
+
+function rejectManifestSecrets(
+  manifest: Record<string, unknown> | undefined,
+  errors: AgentViewValidationError[]
+): void {
+  if (manifest === undefined) return;
+  const nodes: Array<{ path: string; text: string }> = [];
+  manifestTextNodes(manifest, 'manifest', nodes);
+  for (const node of nodes) {
+    if (containsSecretText(node.text)) {
+      errors.push({
+        code: 'view_invalid_manifest',
+        message: `secret-looking text rejected from manifest: ${node.path}`,
+      });
+    }
+  }
+}
+
+// --- package validation ---------------------------------------------------
+
+export function validateAgentViewArtifact(
+  pkg: unknown
+): AgentViewValidationResult {
+  const errors: AgentViewValidationError[] = [];
+  if (!isRecord(pkg)) {
+    return {
+      valid: false,
+      errors: [{ code: 'view_invalid_manifest', message: 'package must be an object' }],
+    };
+  }
+
+  validateManifest(pkg.manifest, errors);
+
+  const files = pkg.files;
+  if (!isRecord(files)) {
+    errors.push({
+      code: 'view_invalid_manifest',
+      message: 'package.files must be an object map of path -> content',
+    });
+    return { valid: errors.length === 0, errors };
+  }
+
+  const filePaths = Object.keys(files);
+  if (filePaths.length === 0) {
+    errors.push({ code: 'view_invalid_entry', message: 'package.files must not be empty' });
+  }
+  if (filePaths.length > AGENT_VIEW_MAX_FILES) {
+    errors.push({
+      code: 'view_oversize',
+      message: `package may contain at most ${AGENT_VIEW_MAX_FILES} files`,
+    });
+  }
+
+  let totalBytes = 0;
+  for (const path of filePaths) {
+    const content = files[path];
+    if (typeof content !== 'string') {
+      errors.push({
+        code: 'view_unsupported_file',
+        message: `file ${path} content must be a string`,
+      });
+      continue;
+    }
+    if (!isSafeFilePath(path)) {
+      errors.push({
+        code: 'view_unsafe_path',
+        message: `file path ${JSON.stringify(path)} is unsafe (traversal/absolute/backslash/NUL)`,
+      });
+      continue;
+    }
+    const ext = fileExtension(path);
+    if (ext !== '.html' && ext !== '.css') {
+      errors.push({
+        code: 'view_unsupported_file',
+        message: `file ${path} must be .html or .css`,
+      });
+      continue;
+    }
+    const size = byteLength(content);
+    totalBytes += size;
+    if (size > AGENT_VIEW_MAX_FILE_BYTES) {
+      errors.push({
+        code: 'view_oversize',
+        message: `file ${path} exceeds per-file cap of ${AGENT_VIEW_MAX_FILE_BYTES} bytes`,
+      });
+    }
+    if (ext === '.html') {
+      scanHtmlForUnsafeContent(path, content, errors);
+    }
+    if (ext === '.css') {
+      scanCssForUnsafeContent(path, content, errors);
+    }
+  }
+
+  if (totalBytes > AGENT_VIEW_MAX_TOTAL_BYTES) {
+    errors.push({
+      code: 'view_oversize',
+      message: `package exceeds total cap of ${AGENT_VIEW_MAX_TOTAL_BYTES} bytes`,
+    });
+  }
+
+  // Entry must be a present `.html` file.
+  const manifest = isRecord(pkg.manifest) ? pkg.manifest : undefined;
+  validateEntryReference(manifest, files, errors);
+
+  // Secret-pattern rejection over all manifest text.
+  rejectManifestSecrets(manifest, errors);
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function isAgentViewArtifact(pkg: unknown): pkg is ViewArtifactPackage {
+  return validateAgentViewArtifact(pkg).valid;
+}
+
+// --- public redaction (manifest text only) --------------------------------
+
+function redactPublicText(value: string): string {
+  SECRET_TEXT_RE.lastIndex = 0;
+  ABSOLUTE_LOCAL_PATH_RE.lastIndex = 0;
+  WINDOWS_ABSOLUTE_PATH_RE.lastIndex = 0;
+  UNC_PATH_RE.lastIndex = 0;
+  KANBAN_TASK_ID_RE.lastIndex = 0;
+  return value
+    .replace(SECRET_TEXT_RE, '[redacted-secret]')
+    .replace(ABSOLUTE_LOCAL_PATH_RE, (match) => {
+      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      return `${prefix}[redacted-local-path]`;
+    })
+    .replace(WINDOWS_ABSOLUTE_PATH_RE, (match) => {
+      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      return `${prefix}[redacted-local-path]`;
+    })
+    .replace(UNC_PATH_RE, (match) => {
+      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      return `${prefix}[redacted-local-path]`;
+    })
+    .replace(KANBAN_TASK_ID_RE, '[redacted-kanban-task]');
+}
+
+function sanitizeTextTree<T>(value: T): T {
+  if (typeof value === 'string') return redactPublicText(value) as T;
+  if (Array.isArray(value)) return value.map((item) => sanitizeTextTree(item)) as T;
+  if (!isRecord(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    out[key] = sanitizeTextTree(nested);
+  }
+  return out as T;
+}
+
+/**
+ * Redact secret-looking values, local paths, and private Kanban ids from
+ * MANIFEST TEXT ONLY. HTML/CSS files are NOT touched — the file bytes are
+ * rendered verbatim inside the sandboxed iframe.
+ */
+export function sanitizeAgentViewManifestForPublic(
+  manifest: AgentViewManifest
+): AgentViewManifest {
+  return sanitizeTextTree(JSON.parse(JSON.stringify(manifest)) as AgentViewManifest);
+}
+
+function collectUnsafePublicText(
+  value: unknown,
+  path: string,
+  errors: AgentViewValidationError[]
+): void {
+  if (typeof value === 'string') {
+    SECRET_TEXT_RE.lastIndex = 0;
+    ABSOLUTE_LOCAL_PATH_RE.lastIndex = 0;
+    WINDOWS_ABSOLUTE_PATH_RE.lastIndex = 0;
+    UNC_PATH_RE.lastIndex = 0;
+    KANBAN_TASK_ID_RE.lastIndex = 0;
+    if (SECRET_TEXT_RE.test(value)) {
+      errors.push({
+        code: 'view_invalid_manifest',
+        message: `secret-looking text rejected from public manifest: ${path}`,
+      });
+    }
+    if (
+      ABSOLUTE_LOCAL_PATH_RE.test(value) ||
+      WINDOWS_ABSOLUTE_PATH_RE.test(value) ||
+      UNC_PATH_RE.test(value)
+    ) {
+      errors.push({
+        code: 'view_invalid_manifest',
+        message: `local absolute path rejected from public manifest: ${path}`,
+      });
+    }
+    if (KANBAN_TASK_ID_RE.test(value)) {
+      errors.push({
+        code: 'view_invalid_manifest',
+        message: `private Kanban task id rejected from public manifest: ${path}`,
+      });
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectUnsafePublicText(item, `${path}[${index}]`, errors)
+    );
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    collectUnsafePublicText(nested, `${path}.${key}`, errors);
+  }
+}
+
+/**
+ * Validate that a manifest (text only) is safe to publish under a `public`
+ * export policy. Does NOT inspect HTML/CSS files.
+ */
+export function validatePublicAgentViewManifest(
+  manifest: AgentViewManifest
+): AgentViewValidationResult {
+  const errors: AgentViewValidationError[] = [];
+  validateManifest(manifest, errors);
+  collectUnsafePublicText(manifest, 'manifest', errors);
+  return { valid: errors.length === 0, errors };
+}
+
+// --- inlined HTML assembly ------------------------------------------------
+
+/**
+ * Build the single inlined HTML document used as the iframe `srcDoc`.
+ *
+ * THREAT MODEL FOR THE OUTPUT:
+ * The returned string becomes the `srcDoc` of an `<iframe sandbox="">`. Because
+ * the sandbox is the empty string, scripts are inert and the document has NO
+ * same-origin access — even if hostile bytes survive, they cannot reach the
+ * parent context, cookies, storage, or network. This function does NOT attempt
+ * to "clean" arbitrary HTML; the validator already rejected scripts/handlers.
+ * Here we only:
+ *   1. inline every `.css` file as a `<style>` block in document order;
+ *   2. defensively strip `<link rel="stylesheet">` and `<script>` from the
+ *      entry HTML so they cannot fetch or execute even outside the validator;
+ *   3. prepend the CSP `<meta>` into `<head>` (wrapping if absent).
+ *
+ * Content that looks like `</iframe>`, stray quotes, or `</script>` inside the
+ * document is harmless: it lives INSIDE the assembled HTML document that the
+ * browser parses as the srcdoc's own document, not in the parent. The caller is
+ * responsible for HTML-attribute-escaping this string when it sets the literal
+ * `srcdoc="..."` attribute (React's `srcDoc` prop does this automatically).
+ */
+export function assembleInlinedHtml(pkg: ViewArtifactPackage): string {
+  const { manifest, files } = pkg;
+  const entryHtmlRaw = files[manifest.entry] ?? '';
+
+  // 1. Strip <link rel=stylesheet> and <script> from the entry document.
+  const entryHtml = entryHtmlRaw
+    .replace(LINK_STYLESHEET_TAG_RE, '')
+    .replace(SCRIPT_BLOCK_RE, '')
+    .replace(SCRIPT_SELFCLOSE_RE, '');
+
+  // 2. Inline every .css file as a <style> block, in document (key) order.
+  const cssBlocks = Object.keys(files)
+    .filter((path) => fileExtension(path) === '.css')
+    .map((path) => `<style data-relay-view-css="${escapeAttribute(path)}">\n${files[path] ?? ''}\n</style>`)
+    .join('\n');
+
+  const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${AGENT_VIEW_CSP}">`;
+  const headInjection = `${cspMeta}${cssBlocks ? `\n${cssBlocks}` : ''}`;
+
+  // 3. Inject CSP meta + styles into <head>, or wrap the document if absent.
+  if (HEAD_OPEN_RE.test(entryHtml)) {
+    return entryHtml.replace(HEAD_OPEN_RE, (match) => `${match}\n${headInjection}`);
+  }
+  if (HTML_OPEN_RE.test(entryHtml)) {
+    return entryHtml.replace(
+      HTML_OPEN_RE,
+      (match) => `${match}\n<head>\n${headInjection}\n</head>`
+    );
+  }
+  return `<!doctype html>\n<html>\n<head>\n${headInjection}\n</head>\n<body>\n${entryHtml}\n</body>\n</html>`;
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/test/agent-view-artifact-viewer.test.tsx
+++ b/test/agent-view-artifact-viewer.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { ViewArtifactPackage } from '../shared/agent-view-artifact.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchAgentViewArtifactPackage: vi.fn(),
+}));
+
+vi.mock('../frontend/src/lib/api.js', () => ({
+  fetchAgentViewArtifactPackage: mocks.fetchAgentViewArtifactPackage,
+}));
+
+const { AgentViewArtifactViewer } = await import(
+  '../frontend/src/components/AgentViewArtifactViewer.js'
+);
+
+const pkg: ViewArtifactPackage = {
+  manifest: {
+    kind: 'relay.agentView',
+    schemaVersion: 1,
+    title: 'qa static dashboard',
+    description: 'agent-authored static evidence view',
+    entry: 'index.html',
+    authoring: { actorId: 'agent-alpha', harness: 'hermes' },
+    createdAt: '2026-06-10T01:02:03Z',
+    updatedAt: '2026-06-10T01:12:13Z',
+    scope: { repo: 'relay-ide', taskRefs: [{ kind: 'github-issue', id: '830' }] },
+    sources: [
+      {
+        label: 'issue 830',
+        url: 'https://github.com/donovan-yohan/relay-ide/issues/830',
+        kind: 'github-issue',
+      },
+      {
+        label: 'design note',
+        url: 'https://example.com/design',
+        kind: 'doc',
+      },
+    ],
+    capabilities: [],
+    export: { policy: 'private' },
+    revision: { id: 'rev-1' },
+  },
+  files: {
+    'index.html': '<!doctype html><html><head><title>x</title></head><body><main>safe view</main></body></html>',
+    'style.css': 'main { color: #111; }',
+  },
+};
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderViewer() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(
+      React.createElement(AgentViewArtifactViewer, {
+        artifactId: 'view-artifact-1',
+        onClose: vi.fn(),
+      })
+    );
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  mocks.fetchAgentViewArtifactPackage.mockResolvedValue(pkg);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  mocks.fetchAgentViewArtifactPackage.mockReset();
+});
+
+describe('AgentViewArtifactViewer', () => {
+  it('renders view html only in a locked-down srcDoc iframe', async () => {
+    await renderViewer();
+
+    expect(mocks.fetchAgentViewArtifactPackage).toHaveBeenCalledWith(
+      'view-artifact-1'
+    );
+    const iframe = container!.querySelector('iframe');
+    expect(iframe).toBeTruthy();
+    expect(iframe!.getAttribute('sandbox')).toBe('');
+    expect(iframe!.getAttribute('src')).toBeNull();
+    expect(iframe!.getAttribute('srcdoc')).toContain('safe view');
+    expect(iframe!.getAttribute('srcdoc')).toContain(
+      "default-src 'none'; style-src 'unsafe-inline'; img-src data:"
+    );
+    expect(container!.innerHTML).not.toContain('allow-scripts');
+    expect(container!.innerHTML).not.toContain('allow-same-origin');
+    expect(iframe!.getAttributeNames()).not.toContain('allow');
+  });
+
+  it('shows provenance title, agent, revision, timestamps, and source links', async () => {
+    await renderViewer();
+
+    const provenance = container!.querySelector(
+      '.agent-view-artifact-viewer__provenance'
+    );
+    expect(provenance).toBeTruthy();
+    const text = provenance!.textContent ?? '';
+    expect(text).toContain('qa static dashboard');
+    expect(text).toContain('agent-alpha · hermes');
+    expect(text).toContain('rev rev-1');
+    expect(text).toContain('2026-06-10T01:02:03Z');
+    expect(text).toContain('2026-06-10T01:12:13Z');
+
+    const links = Array.from(
+      provenance!.querySelectorAll<HTMLAnchorElement>('a')
+    );
+    expect(links.map((link) => link.textContent)).toEqual([
+      'issue 830',
+      'design note',
+    ]);
+    expect(links[0]!.href).toBe(
+      'https://github.com/donovan-yohan/relay-ide/issues/830'
+    );
+    expect(links[1]!.href).toBe('https://example.com/design');
+  });
+});

--- a/test/agent-view-artifact-viewer.test.tsx
+++ b/test/agent-view-artifact-viewer.test.tsx
@@ -134,4 +134,21 @@ describe('AgentViewArtifactViewer', () => {
     );
     expect(links[1]!.href).toBe('https://example.com/design');
   });
+
+  it('renders http source URLs as inert text', async () => {
+    mocks.fetchAgentViewArtifactPackage.mockResolvedValue({
+      ...pkg,
+      manifest: {
+        ...pkg.manifest,
+        sources: [{ label: 'plain http source', url: 'http://example.com/plain', kind: 'doc' }],
+      },
+    });
+    await renderViewer();
+
+    const provenance = container!.querySelector(
+      '.agent-view-artifact-viewer__provenance'
+    );
+    expect(provenance!.textContent).toContain('plain http source');
+    expect(provenance!.querySelector('a')).toBeNull();
+  });
 });

--- a/test/agent-view-artifact.test.ts
+++ b/test/agent-view-artifact.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_VIEW_CSP,
+  AGENT_VIEW_MANIFEST_KIND,
+  AGENT_VIEW_MAX_FILE_BYTES,
+  AGENT_VIEW_MAX_FILES,
+  AGENT_VIEW_MAX_TOTAL_BYTES,
+  AGENT_VIEW_SCHEMA_VERSION,
+  assembleInlinedHtml,
+  isAgentViewArtifact,
+  sanitizeAgentViewManifestForPublic,
+  validateAgentViewArtifact,
+  validatePublicAgentViewManifest,
+  type AgentViewManifest,
+  type AgentViewValidationCode,
+  type ViewArtifactPackage,
+} from '../shared/agent-view-artifact.js';
+
+const now = '2026-06-10T01:02:03Z';
+
+function manifest(overrides: Partial<AgentViewManifest> = {}): AgentViewManifest {
+  return {
+    kind: AGENT_VIEW_MANIFEST_KIND,
+    schemaVersion: AGENT_VIEW_SCHEMA_VERSION,
+    title: 'Repo dependency map',
+    description: 'A read-only summary of module boundaries.',
+    entry: 'index.html',
+    authoring: { actorId: 'agent:kani-backend', harness: 'claude-code' },
+    createdAt: now,
+    updatedAt: now,
+    scope: {
+      repo: 'donovan-yohan/relay-ide',
+      taskRefs: [{ kind: 'github-issue', id: '830' }],
+    },
+    sources: [
+      {
+        label: 'issue #830',
+        url: 'https://github.com/donovan-yohan/relay-ide/issues/830',
+        capturedAt: now,
+        kind: 'github-issue',
+      },
+    ],
+    capabilities: [],
+    export: { policy: 'private' },
+    revision: { id: 'rev-1' },
+    ...overrides,
+  };
+}
+
+function validPackage(overrides: Partial<ViewArtifactPackage> = {}): ViewArtifactPackage {
+  return {
+    manifest: manifest(),
+    files: {
+      'index.html': '<!doctype html><html><head><title>view</title></head><body><h1>hello</h1></body></html>',
+      'styles.css': 'body { color: #0f0; }',
+    },
+    ...overrides,
+  };
+}
+
+function codes(result: { errors: { code: AgentViewValidationCode }[] }): AgentViewValidationCode[] {
+  return result.errors.map((e) => e.code);
+}
+
+describe('validateAgentViewArtifact — valid', () => {
+  it('accepts a minimal valid package', () => {
+    const result = validateAgentViewArtifact(validPackage());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(isAgentViewArtifact(validPackage())).toBe(true);
+  });
+
+  it('accepts a package with no css files', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({
+        files: { 'index.html': '<!doctype html><html><body>ok</body></html>' },
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateAgentViewArtifact — entry rules', () => {
+  it('rejects when entry is not in files', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({
+        manifest: manifest({ entry: 'missing.html' }),
+        files: { 'index.html': '<!doctype html><html><body>ok</body></html>' },
+      })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_entry');
+  });
+
+  it('rejects a non-html entry', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({
+        manifest: manifest({ entry: 'styles.css' }),
+        files: { 'styles.css': 'body{}' },
+      })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_entry');
+  });
+
+  it('rejects a missing entry', () => {
+    const m = manifest();
+    // @ts-expect-error intentionally drop entry
+    delete m.entry;
+    const result = validateAgentViewArtifact({ manifest: m, files: validPackage().files });
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_entry');
+  });
+});
+
+describe('validateAgentViewArtifact — path safety', () => {
+  const unsafePaths = [
+    '../escape.html',
+    'a/../../escape.html',
+    '/abs.html',
+    'C:\\win.html',
+    'dir\\back.html',
+    'has\x00nul.html',
+  ];
+  for (const path of unsafePaths) {
+    it(`rejects unsafe path ${JSON.stringify(path)}`, () => {
+      const result = validateAgentViewArtifact(
+        validPackage({
+          manifest: manifest({ entry: 'index.html' }),
+          files: {
+            'index.html': '<html><body>ok</body></html>',
+            [path]: 'body{}',
+          },
+        })
+      );
+      expect(result.valid).toBe(false);
+      expect(codes(result)).toContain('view_unsafe_path');
+    });
+  }
+});
+
+describe('validateAgentViewArtifact — file allow-list', () => {
+  for (const path of ['app.js', 'icon.svg', 'logo.png']) {
+    it(`rejects unsupported file ${path}`, () => {
+      const result = validateAgentViewArtifact(
+        validPackage({
+          files: {
+            'index.html': '<html><body>ok</body></html>',
+            [path]: 'data',
+          },
+        })
+      );
+      expect(result.valid).toBe(false);
+      expect(codes(result)).toContain('view_unsupported_file');
+    });
+  }
+});
+
+describe('validateAgentViewArtifact — size caps', () => {
+  it('rejects oversize per-file content', () => {
+    const big = 'a'.repeat(AGENT_VIEW_MAX_FILE_BYTES + 1);
+    const result = validateAgentViewArtifact(
+      validPackage({
+        files: {
+          'index.html': '<html><body>ok</body></html>',
+          'big.css': big,
+        },
+      })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_oversize');
+  });
+
+  it('rejects oversize total content', () => {
+    const files: Record<string, string> = {
+      'index.html': '<html><body>ok</body></html>',
+    };
+    // Several near-cap files that exceed the total cap together.
+    const chunk = 'b'.repeat(AGENT_VIEW_MAX_FILE_BYTES);
+    const needed = Math.ceil(AGENT_VIEW_MAX_TOTAL_BYTES / AGENT_VIEW_MAX_FILE_BYTES) + 1;
+    for (let i = 0; i < needed; i += 1) {
+      files[`f${i}.css`] = chunk;
+    }
+    const result = validateAgentViewArtifact(validPackage({ files }));
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_oversize');
+  });
+
+  it('rejects too many files', () => {
+    const files: Record<string, string> = {
+      'index.html': '<html><body>ok</body></html>',
+    };
+    for (let i = 0; i < AGENT_VIEW_MAX_FILES; i += 1) {
+      files[`f${i}.css`] = 'x{}';
+    }
+    const result = validateAgentViewArtifact(validPackage({ files }));
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_oversize');
+  });
+});
+
+describe('validateAgentViewArtifact — manifest schema', () => {
+  it('rejects wrong kind', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({ manifest: manifest({ kind: 'relay.other' as never }) })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_manifest');
+  });
+
+  it('rejects wrong schemaVersion', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({ manifest: manifest({ schemaVersion: 2 as never }) })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_manifest');
+  });
+
+  it('rejects non-strict ISO timestamps', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({ manifest: manifest({ createdAt: '2026-06-10 01:02:03' }) })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_manifest');
+  });
+
+  it('rejects secret-looking text in the manifest', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({
+        manifest: manifest({
+          description: 'token: sk-abcdef0123456789 leaked here',
+        }),
+      })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_manifest');
+  });
+});
+
+describe('validateAgentViewArtifact — capabilities denied', () => {
+  it('rejects non-empty capabilities', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({ manifest: manifest({ capabilities: ['network'] }) })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_capabilities_denied');
+  });
+});
+
+describe('validateAgentViewArtifact — html/css tripwire', () => {
+  const cases: Array<[string, string]> = [
+    ['script tag', '<html><body><script>alert(1)</script></body></html>'],
+    ['onerror handler', '<html><body><img src=x onerror="alert(1)"></body></html>'],
+    ['javascript uri', '<html><body><a href="javascript:alert(1)">x</a></body></html>'],
+    ['nested iframe', '<html><body><iframe src="https://evil"></iframe></body></html>'],
+    ['object tag', '<html><body><object data="x"></object></body></html>'],
+    ['embed tag', '<html><body><embed src="x"></body></html>'],
+  ];
+  for (const [name, html] of cases) {
+    it(`rejects ${name} in entry html`, () => {
+      const result = validateAgentViewArtifact(
+        validPackage({ files: { 'index.html': html } })
+      );
+      expect(result.valid).toBe(false);
+      expect(codes(result)).toContain('view_unsafe_html');
+    });
+  }
+
+  it('rejects CSS that can break out of an inlined style block', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({
+        files: {
+          'index.html': '<html><body>ok</body></html>',
+          'breakout.css': 'body{} </style><iframe src="https://evil"></iframe>',
+        },
+      })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_unsafe_html');
+  });
+});
+
+describe('sanitize + public manifest validation', () => {
+  it('redacts secret-looking text from manifest only', () => {
+    const m = manifest({ description: 'leak sk-abcdef0123456789 here' });
+    const sanitized = sanitizeAgentViewManifestForPublic(m);
+    expect(sanitized.description).not.toContain('sk-abcdef0123456789');
+    expect(sanitized.description).toContain('[redacted-secret]');
+  });
+
+  it('rejects local absolute paths in public manifest', () => {
+    const m = manifest({ description: 'see /home/agent/secret.txt for details' });
+    const result = validatePublicAgentViewManifest(m);
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_manifest');
+  });
+
+  it('accepts a clean public manifest', () => {
+    const result = validatePublicAgentViewManifest(manifest());
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('assembleInlinedHtml', () => {
+  it('inlines css in document order and includes the CSP meta', () => {
+    const html = assembleInlinedHtml(
+      validPackage({
+        files: {
+          'index.html': '<!doctype html><html><head><title>t</title></head><body>x</body></html>',
+          'a.css': '.a{color:red}',
+          'b.css': '.b{color:blue}',
+        },
+      })
+    );
+    expect(html).toContain(`content="${AGENT_VIEW_CSP}"`);
+    expect(html).toContain('.a{color:red}');
+    expect(html).toContain('.b{color:blue}');
+    expect(html.indexOf('.a{color:red}')).toBeLessThan(html.indexOf('.b{color:blue}'));
+  });
+
+  it('strips <link rel=stylesheet> and <script> from the entry html', () => {
+    const html = assembleInlinedHtml(
+      validPackage({
+        files: {
+          'index.html':
+            '<html><head><link rel="stylesheet" href="x.css"></head><body><script>bad()</script>ok</body></html>',
+        },
+      })
+    );
+    expect(html).not.toContain('<link');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('bad()');
+    expect(html).toContain('ok');
+  });
+
+  it('wraps content in a full document when no head/html is present', () => {
+    const html = assembleInlinedHtml(
+      validPackage({
+        files: { 'index.html': '<h1>fragment</h1>' },
+      })
+    );
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('<head>');
+    expect(html).toContain(`content="${AGENT_VIEW_CSP}"`);
+    expect(html).toContain('<h1>fragment</h1>');
+  });
+
+  it('keeps </iframe>, quotes, and </script>-like content inside the document body', () => {
+    const payload = 'breakout </iframe>"\' </script> attempt';
+    const html = assembleInlinedHtml(
+      validPackage({
+        files: {
+          'index.html': `<!doctype html><html><head></head><body>${payload}</body></html>`,
+        },
+      })
+    );
+    // The raw text round-trips inside the assembled document (it is the srcdoc's
+    // OWN document; the parent escapes the attribute when setting srcDoc).
+    expect(html).toContain('breakout </iframe>"\'');
+    // CSP meta is still present ahead of the payload.
+    expect(html.indexOf(AGENT_VIEW_CSP)).toBeLessThan(html.indexOf('breakout'));
+  });
+});

--- a/test/agent-view-artifact.test.ts
+++ b/test/agent-view-artifact.test.ts
@@ -225,6 +225,14 @@ describe('validateAgentViewArtifact — manifest schema', () => {
     expect(codes(result)).toContain('view_invalid_manifest');
   });
 
+  it('rejects impossible calendar timestamps', () => {
+    const result = validateAgentViewArtifact(
+      validPackage({ manifest: manifest({ createdAt: '2026-02-30T01:02:03Z' }) })
+    );
+    expect(result.valid).toBe(false);
+    expect(codes(result)).toContain('view_invalid_manifest');
+  });
+
   it('rejects secret-looking text in the manifest', () => {
     const result = validateAgentViewArtifact(
       validPackage({
@@ -252,6 +260,8 @@ describe('validateAgentViewArtifact — html/css tripwire', () => {
   const cases: Array<[string, string]> = [
     ['script tag', '<html><body><script>alert(1)</script></body></html>'],
     ['onerror handler', '<html><body><img src=x onerror="alert(1)"></body></html>'],
+    ['script slash separator', '<html><body><script/src="https://evil"></script></body></html>'],
+    ['slash-separated onerror handler', '<html><body><img/src=x/onerror="alert(1)"></body></html>'],
     ['javascript uri', '<html><body><a href="javascript:alert(1)">x</a></body></html>'],
     ['nested iframe', '<html><body><iframe src="https://evil"></iframe></body></html>'],
     ['object tag', '<html><body><object data="x"></object></body></html>'],

--- a/test/work-context-artifact-router.test.ts
+++ b/test/work-context-artifact-router.test.ts
@@ -844,6 +844,9 @@ describe('WorkContext artifact router', () => {
       body: JSON.stringify({ workContextId, viewArtifact: oversized }),
     });
     expect(oversizedPublish.status).toBe(400);
+    expect(await json(oversizedPublish)).toMatchObject({
+      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD' } },
+    });
   });
 
   it('exports agent view artifacts as sanitized manifest-only public copies', async () => {

--- a/test/work-context-artifact-router.test.ts
+++ b/test/work-context-artifact-router.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
@@ -23,6 +24,11 @@ import {
   type PipelineHandoffArtifact,
   type PipelineHandoffQaStage,
 } from '../shared/pipeline-handoff-artifact.js';
+import {
+  AGENT_VIEW_MANIFEST_KIND,
+  AGENT_VIEW_SCHEMA_VERSION,
+  type ViewArtifactPackage,
+} from '../shared/agent-view-artifact.js';
 import {
   WORK_CONTEXT_SCHEMA_VERSION,
   createWorkContextPrivacyMetadata,
@@ -113,6 +119,35 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
         migrationOrStateRisk: 'isolated WorkContext artifact store only',
       },
     ],
+    ...input,
+  };
+}
+
+function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPackage {
+  const manifest = {
+    kind: AGENT_VIEW_MANIFEST_KIND,
+    schemaVersion: AGENT_VIEW_SCHEMA_VERSION,
+    title: 'Router static view',
+    description: 'Router view artifact fixture',
+    entry: 'index.html',
+    authoring: { actorId: 'agent:kani-backend', harness: 'router-test' },
+    createdAt: now,
+    updatedAt: now,
+    scope: {
+      repo: 'example-org/example-project',
+      taskRefs: [{ kind: 'github-issue', id: '830', url: 'https://github.com/example-org/example-project/issues/830' }],
+    },
+    sources: [{ label: 'Issue 830', url: 'https://github.com/example-org/example-project/issues/830', kind: 'github-issue' }],
+    capabilities: [],
+    export: { policy: 'private' },
+    revision: { id: 'agent-view:router:aaaaaaaa' },
+  } satisfies ViewArtifactPackage['manifest'];
+  return {
+    manifest,
+    files: {
+      'index.html': '<main><h1>Router static view</h1></main>',
+      'style.css': 'main { color: #123; }',
+    },
     ...input,
   };
 }
@@ -651,6 +686,211 @@ describe('WorkContext artifact router', () => {
     );
     expect(unpin.status).toBe(200);
     expect(await json(unpin)).toMatchObject({ removed: true, lifecycle: { artifactDeleted: false } });
+  });
+
+  it('publishes agent view artifacts and exposes an authenticated package route', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-view';
+    const workContextStore = fakeWorkContextStore(createWorkContext(workContextId));
+    const { baseUrl } = await serve({ root, store, workContextStore });
+    const pkg = viewArtifact();
+
+    const publish = await fetch(`${baseUrl}/work-context-artifacts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write,context:read',
+      },
+      body: JSON.stringify({
+        workContextId,
+        viewArtifact: pkg,
+        pin: true,
+        actorId: 'agent:kani-backend',
+      }),
+    });
+    expect(publish.status).toBe(201);
+    const publishBody = await json(publish);
+    expect(publishBody).toMatchObject({
+      artifact: {
+        metadata: {
+          id: pkg.manifest.revision.id,
+          payloadKind: 'agent-view-artifact',
+          workContextId,
+        },
+      },
+      pin: { alreadyPinned: false },
+    });
+    const payloadJson = JSON.stringify(pkg, null, 2);
+    expect((publishBody.artifact as { metadata: Record<string, unknown> }).metadata.payloadSha256).toBe(
+      createHash('sha256').update(payloadJson).digest('hex')
+    );
+
+    const packageRead = await fetch(
+      `${baseUrl}/work-context-artifacts/${encodeURIComponent(pkg.manifest.revision.id)}/view-package`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(packageRead.status).toBe(200);
+    expect(await json(packageRead)).toMatchObject({
+      artifact: {
+        metadata: { id: pkg.manifest.revision.id, payloadKind: 'agent-view-artifact' },
+        viewArtifact: { manifest: { revision: { id: pkg.manifest.revision.id } }, files: pkg.files },
+      },
+    });
+  });
+
+  it('rejects ambiguous publish payloads and keeps handoff routes handoff-only', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-view-xor';
+    const { baseUrl } = await serve({
+      root,
+      store,
+      workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-relay-capabilities': 'context:write,context:read',
+    };
+
+    const conflict = await fetch(`${baseUrl}/work-context-artifacts`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ workContextId, artifact: artifact(), viewArtifact: viewArtifact() }),
+    });
+    expect(conflict.status).toBe(400);
+    expect(await json(conflict)).toMatchObject({
+      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_CONFLICT' } },
+    });
+
+    const wrongSurface = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ workContextId, viewArtifact: viewArtifact() }),
+    });
+    expect(wrongSurface.status).toBe(400);
+    expect(await json(wrongSurface)).toMatchObject({
+      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_KIND_MISMATCH', operation: 'attach' } },
+    });
+  });
+
+  it('keeps agent view artifacts out of pipeline handoff list/show surfaces', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-handoff-filter';
+    const handoff = store.storePipelineHandoffArtifact({ workContextId, artifact: artifact() });
+    const view = store.storeAgentViewArtifact({ workContextId, viewArtifact: viewArtifact() });
+    const { baseUrl } = await serve({
+      root,
+      store,
+      workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
+    });
+    const readHeaders = { 'x-relay-capabilities': 'context:read' };
+
+    const handoffList = await fetch(`${baseUrl}/pipeline-handoff-artifacts?workContextId=${encodeURIComponent(workContextId)}`, {
+      headers: readHeaders,
+    });
+    expect(handoffList.status).toBe(200);
+    const handoffListBody = await json(handoffList);
+    expect((handoffListBody.artifacts as Array<{ metadata: { id: string } }>).map((entry) => entry.metadata.id)).toEqual([
+      handoff.metadata.id,
+    ]);
+
+    const allList = await fetch(`${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`, {
+      headers: readHeaders,
+    });
+    expect(allList.status).toBe(200);
+    expect((await json(allList)).artifacts as unknown[]).toHaveLength(2);
+
+    const viewViaHandoffRoute = await fetch(`${baseUrl}/pipeline-handoff-artifacts/${encodeURIComponent(view.metadata.id)}`, {
+      headers: readHeaders,
+    });
+    expect(viewViaHandoffRoute.status).toBe(404);
+  });
+
+  it('rejects unsafe or oversized agent view artifact publishes', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-view-guardrails';
+    const { baseUrl } = await serve({
+      root,
+      store,
+      workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-relay-capabilities': 'context:write,context:read',
+    };
+
+    const withCapabilities = viewArtifact({
+      manifest: { ...viewArtifact().manifest, revision: { id: 'agent-view:router:capabilities' }, capabilities: ['network'] },
+    });
+    const denied = await fetch(`${baseUrl}/work-context-artifacts`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ workContextId, viewArtifact: withCapabilities }),
+    });
+    expect(denied.status).toBe(400);
+    expect(await json(denied)).toMatchObject({
+      error: { details: { field: 'viewArtifact', reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED' } },
+    });
+
+    const oversizedFiles = Object.fromEntries(
+      Array.from({ length: 14 }, (_, index) => [`chunk-${index}.css`, 'x'.repeat(40 * 1024)])
+    );
+    const oversized = viewArtifact({
+      manifest: { ...viewArtifact().manifest, revision: { id: 'agent-view:router:oversized' } },
+      files: { 'index.html': '<main>oversized</main>', ...oversizedFiles },
+    });
+    const oversizedPublish = await fetch(`${baseUrl}/work-context-artifacts`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ workContextId, viewArtifact: oversized }),
+    });
+    expect(oversizedPublish.status).toBe(400);
+  });
+
+  it('exports agent view artifacts as sanitized manifest-only public copies', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-view-export';
+    const { baseUrl } = await serve({
+      root,
+      store,
+      workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
+    });
+    const privateStored = store.storeAgentViewArtifact({
+      workContextId,
+      viewArtifact: viewArtifact({ manifest: { ...viewArtifact().manifest, revision: { id: 'agent-view:router:private-export' } } }),
+    });
+    const privateExport = await fetch(
+      `${baseUrl}/work-context-artifacts/${encodeURIComponent(privateStored.metadata.id)}/export`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(privateExport.status).toBe(403);
+
+    const publicPkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        description: 'Public route from /home/operator/relay with t_12345678 scratch id',
+        export: { policy: 'public' },
+        revision: { id: 'agent-view:router:public-export' },
+      },
+      files: { 'index.html': '<main>private raw html /home/operator/relay t_12345678</main>' },
+    });
+    const publicStored = store.storeAgentViewArtifact({ workContextId, viewArtifact: publicPkg });
+    const publicExport = await fetch(
+      `${baseUrl}/work-context-artifacts/${encodeURIComponent(publicStored.metadata.id)}/export`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(publicExport.status).toBe(200);
+    const publicBody = await json(publicExport);
+    expect(publicBody).toMatchObject({
+      artifact: {
+        metadata: { id: publicStored.metadata.id, payloadKind: 'agent-view-artifact' },
+        payload: { manifest: { revision: { id: 'agent-view:router:public-export' } } },
+      },
+      export: { mode: 'public-summary', rawPayloadAvailable: false },
+    });
+    expect(JSON.stringify(publicBody)).toContain('[redacted-local-path]');
+    expect(JSON.stringify(publicBody)).toContain('[redacted-kanban-task]');
+    expect(JSON.stringify(publicBody)).not.toContain('private raw html');
+    expect(JSON.stringify(publicBody)).not.toContain('files');
   });
 
   it('enforces publish and export guardrails with persisted public bytes', async () => {

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -333,6 +333,17 @@ describe('WorkContext artifact store/index', () => {
     expect(stored.metadata.capturedAt).toBe('2026-06-08T12:00:03.000Z');
   });
 
+  it('rejects impossible agent view timestamps without date rollover', () => {
+    const { store } = tmpStore();
+    const pkg = viewArtifact({
+      manifest: { ...viewArtifact().manifest, updatedAt: '2026-02-30T12:00:03Z' },
+    });
+
+    expect(() =>
+      store.storeAgentViewArtifact({ workContextId: 'wc:view-invalid-timestamp', viewArtifact: pkg })
+    ).toThrow(WorkContextArtifactStoreError);
+  });
+
   it('derives agent view supersession from manifest revision when top-level field is omitted', () => {
     const { store } = tmpStore();
     const first = store.storeAgentViewArtifact({
@@ -401,6 +412,36 @@ describe('WorkContext artifact store/index', () => {
       handoff.metadata.id,
       replacement.metadata.id,
     ].sort());
+  });
+
+  it('backfills agent view task refs from manifest scope during migration', () => {
+    const { root, store } = tmpStore();
+    const pkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        scope: {
+          ...viewArtifact().manifest.scope,
+          taskRefs: [
+            { kind: 'github-issue', id: '830' },
+            { kind: 'github-pr', id: '920' },
+          ],
+        },
+      },
+    });
+    const stored = store.storeAgentViewArtifact({ workContextId: 'wc:view-backfill', viewArtifact: pkg });
+    const db = new Database(path.join(root, 'index.db'));
+    cleanup.push(() => db.close());
+    db.prepare('DELETE FROM work_context_artifact_task_refs WHERE artifact_id = ?').run(stored.metadata.id);
+
+    const reopened = createWorkContextArtifactStore({
+      dbPath: path.join(root, 'index.db'),
+      payloadRoot: path.join(root, 'payloads'),
+    });
+    cleanup.push(() => reopened.close());
+
+    expect(reopened.list({ taskRef: { kind: 'github-pr', id: '920' } })[0]?.metadata.id).toBe(
+      stored.metadata.id
+    );
   });
 
   it('indexes every task ref from a handoff artifact payload', () => {

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -16,6 +16,11 @@ import {
   validatePublicPipelineHandoffArtifact,
   type PipelineHandoffArtifact,
 } from '../shared/pipeline-handoff-artifact.js';
+import {
+  AGENT_VIEW_MANIFEST_KIND,
+  AGENT_VIEW_SCHEMA_VERSION,
+  type ViewArtifactPackage,
+} from '../shared/agent-view-artifact.js';
 
 const now = '2026-06-08T12:00:00.000Z';
 const headSha = 'a'.repeat(40);
@@ -113,6 +118,35 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
         migrationOrStateRisk: 'new isolated SQLite index and payload directory only',
       },
     ],
+    ...input,
+  };
+}
+
+function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPackage {
+  const manifest = {
+    kind: AGENT_VIEW_MANIFEST_KIND,
+    schemaVersion: AGENT_VIEW_SCHEMA_VERSION,
+    title: 'Example static dashboard',
+    description: 'A static view for issue 830',
+    entry: 'index.html',
+    authoring: { actorId: 'agent:kani-backend', harness: 'vitest' },
+    createdAt: now,
+    updatedAt: now,
+    scope: {
+      repo: 'example-org/example-project',
+      taskRefs: [{ kind: 'github-issue', id: '830', url: 'https://github.com/example-org/example-project/issues/830' }],
+    },
+    sources: [{ label: 'Issue 830', url: 'https://github.com/example-org/example-project/issues/830', kind: 'github-issue' }],
+    capabilities: [],
+    export: { policy: 'private' },
+    revision: { id: 'agent-view:example:aaaaaaaa' },
+  } satisfies ViewArtifactPackage['manifest'];
+  return {
+    manifest,
+    files: {
+      'index.html': '<main><h1>Issue 830</h1><p>static bytes</p></main>',
+      'style.css': 'main { color: #111; }',
+    },
     ...input,
   };
 }
@@ -256,7 +290,117 @@ describe('WorkContext artifact store/index', () => {
     ]);
 
     const read = store.read(stored.metadata.id);
-    expect(read?.payload?.title).toBe('Example Project implementation handoff');
+    expect((read?.payload as PipelineHandoffArtifact | undefined)?.title).toBe('Example Project implementation handoff');
+  });
+
+  it('stores agent view artifacts with agent-view payload kind and sha-addressed packages', () => {
+    const { root, store } = tmpStore();
+    const pkg = viewArtifact();
+
+    const stored = store.storeAgentViewArtifact({
+      workContextId: 'wc:view',
+      projectId: 'project:example-org/example-project',
+      provenanceActorId: 'agent:kani-backend',
+      viewArtifact: pkg,
+    });
+
+    const payloadJson = JSON.stringify(pkg, null, 2);
+    expect(stored.metadata).toMatchObject({
+      id: 'agent-view:example:aaaaaaaa',
+      workContextId: 'wc:view',
+      projectId: 'project:example-org/example-project',
+      taskRef: { kind: 'github-issue', id: '830' },
+      kind: 'report',
+      visibility: 'private',
+      payloadKind: 'agent-view-artifact',
+      payloadSha256: sha256Hex(payloadJson),
+      payloadBytes: Buffer.byteLength(payloadJson, 'utf8'),
+    });
+    expect(stored.payloadPath.startsWith(path.join(root, 'payloads'))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(stored.payloadPath, 'utf8'))).toEqual(pkg);
+    expect(store.readViewArtifactPackage(stored.metadata.id)?.payload).toEqual(pkg);
+    expect(store.read(stored.metadata.id)?.payload).toEqual(pkg);
+  });
+
+  it('normalizes agent view timestamps accepted by the shared contract', () => {
+    const { store } = tmpStore();
+    const pkg = viewArtifact({
+      manifest: { ...viewArtifact().manifest, updatedAt: '2026-06-08T12:00:03Z' },
+    });
+
+    const stored = store.storeAgentViewArtifact({ workContextId: 'wc:view-timestamp', viewArtifact: pkg });
+
+    expect(stored.metadata.capturedAt).toBe('2026-06-08T12:00:03.000Z');
+  });
+
+  it('derives agent view supersession from manifest revision when top-level field is omitted', () => {
+    const { store } = tmpStore();
+    const first = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-manifest-supersede',
+      viewArtifact: viewArtifact(),
+    });
+    const replacementPkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        updatedAt: '2026-06-08T12:10:00.000Z',
+        revision: { id: 'agent-view:example:manifest-supersedes', supersedes: first.metadata.id },
+      },
+    });
+
+    const replacement = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-manifest-supersede',
+      viewArtifact: replacementPkg,
+    });
+
+    expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
+    expect(store.list({ workContextId: 'wc:view-manifest-supersede' }).map((entry) => entry.metadata.id)).toEqual([
+      replacement.metadata.id,
+    ]);
+  });
+
+  it('rejects top-level visibility that disagrees with an agent view export policy', () => {
+    const { store } = tmpStore();
+
+    expect(() =>
+      store.storeAgentViewArtifact({
+        workContextId: 'wc:view-visibility',
+        viewArtifact: viewArtifact(),
+        visibility: 'public',
+      })
+    ).toThrow(WorkContextArtifactStoreError);
+  });
+
+  it('preserves supersede history for agent view artifacts without changing handoff rows', () => {
+    const { store } = tmpStore();
+    const first = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-supersede',
+      viewArtifact: viewArtifact(),
+    });
+    const handoff = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:view-supersede',
+      artifact: artifact({ id: 'pipeline-handoff:example:view-supersede' }),
+    });
+    const replacementPkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        updatedAt: '2026-06-08T12:10:00.000Z',
+        revision: { id: 'agent-view:example:bbbbbbbb', supersedes: first.metadata.id },
+      },
+    });
+
+    const replacement = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-supersede',
+      viewArtifact: replacementPkg,
+      supersedesArtifactId: first.metadata.id,
+    });
+
+    expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
+    expect(store.get(first.metadata.id)?.metadata.payloadKind).toBe('agent-view-artifact');
+    expect(store.get(handoff.metadata.id)?.metadata.payloadKind).toBe('pipeline-handoff-artifact');
+    expect(store.list({ workContextId: 'wc:view-supersede' }).map((entry) => entry.metadata.id).sort()).toEqual([
+      handoff.metadata.id,
+      replacement.metadata.id,
+    ].sort());
   });
 
   it('indexes every task ref from a handoff artifact payload', () => {
@@ -465,24 +609,56 @@ describe('WorkContext artifact store/index', () => {
     });
 
     const publicCopy = store.publicSummary(stored.metadata.id);
+    const publicPayload = publicCopy?.payload as PipelineHandoffArtifact | undefined;
     expect(publicCopy?.metadata).not.toHaveProperty('payloadPath');
     expect(publicCopy?.metadata.taskRef).toMatchObject({
       kind: 'github-issue',
       id: '42',
     });
-    expect(publicCopy?.payload?.scope.taskRefs).toEqual([
+    expect(publicPayload?.scope.taskRefs).toEqual([
       {
         kind: 'github-issue',
         id: '42',
         url: 'https://github.com/example-org/example-project/issues/42',
       },
     ]);
-    expect(publicCopy?.payload?.stages[0]?.actorId).toBe('agent');
-    expect(publicCopy?.payload?.stages[0]?.summary).toContain('[redacted-local-path]');
+    expect(publicPayload?.stages[0]?.actorId).toBe('agent');
+    expect(publicPayload?.stages[0]?.summary).toContain('[redacted-local-path]');
     expect(
-      publicCopy?.payload?.scope.nonGoals.some((item) => /kanban|dispatcher|worktree/i.test(item))
+      publicPayload?.scope.nonGoals.some((item) => /kanban|dispatcher|worktree/i.test(item))
     ).toBe(false);
-    expect(validatePublicPipelineHandoffArtifact(publicCopy?.payload as PipelineHandoffArtifact).valid).toBe(true);
+    expect(validatePublicPipelineHandoffArtifact(publicPayload as PipelineHandoffArtifact).valid).toBe(true);
+  });
+
+  it('returns public summaries for agent view artifacts with sanitized manifest only', () => {
+    const { store } = tmpStore();
+    const pkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        description: 'Public view from /home/operator/relay with t_12345678 internal scratch id',
+        export: { policy: 'public' },
+        revision: { id: 'agent-view:example:public' },
+      },
+      files: {
+        'index.html': '<main>raw html bytes mention /home/operator/relay and t_12345678</main>',
+      },
+    });
+    const stored = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-public-copy',
+      viewArtifact: pkg,
+    });
+
+    const publicCopy = store.publicSummary(stored.metadata.id);
+    expect(publicCopy?.metadata.payloadKind).toBe('agent-view-artifact');
+    expect(publicCopy?.payload).toMatchObject({
+      manifest: {
+        revision: { id: 'agent-view:example:public' },
+        description: expect.stringContaining('[redacted-local-path]'),
+      },
+    });
+    expect(JSON.stringify(publicCopy)).toContain('[redacted-kanban-task]');
+    expect(JSON.stringify(publicCopy)).not.toContain('raw html bytes mention');
+    expect(JSON.stringify(publicCopy)).not.toContain('files');
   });
 
   it('does not expose private artifacts through publicSummary', () => {

--- a/test/workspace-evidence-dashboard.test.ts
+++ b/test/workspace-evidence-dashboard.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     string,
     { data?: unknown[]; isLoading?: boolean; isError?: boolean }
   >,
+  fetchAgentViewArtifactPackage: vi.fn(),
 }));
 
 vi.mock('@tanstack/react-query', () => ({
@@ -62,7 +63,7 @@ vi.mock('../frontend/src/lib/api.js', () => ({
   fetchActiveWork: vi.fn(),
   fetchPipelineHandoffArtifacts: vi.fn(),
   copyPipelineHandoffArtifact: vi.fn(),
-  fetchAgentViewArtifactPackage: vi.fn(),
+  fetchAgentViewArtifactPackage: mocks.fetchAgentViewArtifactPackage,
 }));
 
 vi.mock('../frontend/src/lib/stores/sessions.js', () => {
@@ -158,6 +159,7 @@ afterEach(async () => {
   mocks.activeWork = [];
   mocks.backendConnectionStatus = 'connected';
   mocks.artifactsByContext = {};
+  mocks.fetchAgentViewArtifactPackage.mockReset();
 });
 
 function activeGroupForRepo(
@@ -191,6 +193,29 @@ function artifactEnvelope(overrides: Record<string, unknown> = {}) {
       headSha: 'deadbeefcafebabe',
       taskRef: { kind: 'github-issue', id: '898' },
       ...overrides,
+    },
+  };
+}
+
+function viewArtifactPackage() {
+  return {
+    manifest: {
+      kind: 'relay.agentView',
+      schemaVersion: 1,
+      title: 'workspace view artifact',
+      description: 'static evidence viewer fixture',
+      entry: 'index.html',
+      authoring: { actorId: 'agent-alpha', harness: 'vitest' },
+      createdAt: '2026-06-10T00:00:00Z',
+      updatedAt: '2026-06-10T00:01:00Z',
+      scope: { repo: 'relay-ide', taskRefs: [{ kind: 'github-issue', id: '830' }] },
+      sources: [],
+      capabilities: [],
+      export: { policy: 'private' },
+      revision: { id: 'art-1' },
+    },
+    files: {
+      'index.html': '<main>workspace static view</main>',
     },
   };
 }
@@ -361,7 +386,7 @@ describe('WorkspaceEvidenceDashboard', () => {
     expect((copyBtn as HTMLButtonElement).title).toBeFalsy();
   });
 
-  it('shows open view for an agent-authored static view artifact', async () => {
+  it('opens the viewer and fetches the package for an agent-authored static view artifact', async () => {
     mocks.roots = [repoRoot()];
     mocks.activeWork = [activeGroupForRepo('g1', 'wc-1', '/repo')];
     mocks.artifactsByContext = {
@@ -369,6 +394,7 @@ describe('WorkspaceEvidenceDashboard', () => {
         data: [artifactEnvelope({ payloadKind: 'agent-view-artifact' })],
       },
     };
+    mocks.fetchAgentViewArtifactPackage.mockResolvedValue(viewArtifactPackage());
     await renderDashboard('/repo');
     const card = container!.querySelector(
       '[data-track="evidence.artifact-card"]'
@@ -378,6 +404,19 @@ describe('WorkspaceEvidenceDashboard', () => {
     );
     expect(openViewBtn).toBeTruthy();
     expect((openViewBtn as HTMLButtonElement).disabled).toBe(false);
+
+    await act(async () => {
+      (openViewBtn as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mocks.fetchAgentViewArtifactPackage).toHaveBeenCalledWith('art-1');
+    expect(
+      container!.querySelector('[data-track="agent-view-artifact.viewer"]')
+    ).toBeTruthy();
+    expect(container!.textContent).toContain('workspace view artifact');
   });
 
   it('does not show open view for pipeline handoff artifacts', async () => {
@@ -392,5 +431,6 @@ describe('WorkspaceEvidenceDashboard', () => {
       b.textContent?.includes('open view')
     );
     expect(openViewBtn).toBeUndefined();
+    expect(mocks.fetchAgentViewArtifactPackage).not.toHaveBeenCalled();
   });
 });

--- a/test/workspace-evidence-dashboard.test.ts
+++ b/test/workspace-evidence-dashboard.test.ts
@@ -62,6 +62,7 @@ vi.mock('../frontend/src/lib/api.js', () => ({
   fetchActiveWork: vi.fn(),
   fetchPipelineHandoffArtifacts: vi.fn(),
   copyPipelineHandoffArtifact: vi.fn(),
+  fetchAgentViewArtifactPackage: vi.fn(),
 }));
 
 vi.mock('../frontend/src/lib/stores/sessions.js', () => {
@@ -358,5 +359,38 @@ describe('WorkspaceEvidenceDashboard', () => {
     expect(copyBtn).toBeTruthy();
     expect((copyBtn as HTMLButtonElement).disabled).toBe(false);
     expect((copyBtn as HTMLButtonElement).title).toBeFalsy();
+  });
+
+  it('shows open view for an agent-authored static view artifact', async () => {
+    mocks.roots = [repoRoot()];
+    mocks.activeWork = [activeGroupForRepo('g1', 'wc-1', '/repo')];
+    mocks.artifactsByContext = {
+      'wc-1': {
+        data: [artifactEnvelope({ payloadKind: 'agent-view-artifact' })],
+      },
+    };
+    await renderDashboard('/repo');
+    const card = container!.querySelector(
+      '[data-track="evidence.artifact-card"]'
+    );
+    const openViewBtn = Array.from(card!.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('open view')
+    );
+    expect(openViewBtn).toBeTruthy();
+    expect((openViewBtn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('does not show open view for pipeline handoff artifacts', async () => {
+    mocks.roots = [repoRoot()];
+    mocks.activeWork = [activeGroupForRepo('g1', 'wc-1', '/repo')];
+    mocks.artifactsByContext = { 'wc-1': { data: [artifactEnvelope()] } };
+    await renderDashboard('/repo');
+    const card = container!.querySelector(
+      '[data-track="evidence.artifact-card"]'
+    );
+    const openViewBtn = Array.from(card!.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('open view')
+    );
+    expect(openViewBtn).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add the Agent View Artifact shared contract, validation, static HTML assembly, docs, and CLI `--view-file` publish support
- store view artifacts as SHA-addressed WorkContext artifact payloads with manifest-only public export
- surface view artifacts in workspace evidence and render them in sandboxed iframes
- harden the cut-off Claude WIP with /simplify fixes: payload XOR checks, handoff-route filtering, CSS raw-text breakout rejection, manifest-derived supersedes, visibility consistency, and timestamp normalization

Closes #830

## Verification
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npx vitest run test/agent-view-artifact.test.ts test/work-context-artifacts.test.ts test/work-context-artifact-router.test.ts test/agent-view-artifact-viewer.test.tsx test/workspace-evidence-dashboard.test.ts --reporter=verbose` → PASS (84) FAIL (0)
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` → passed (vite chunk-size warnings only)
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` → passed, 0 errors / 154 existing warnings
- `git diff --check` → passed

## Notes
- Agent-authored HTML is delivered only through iframe `srcDoc` with an empty sandbox. No scripts, same-origin, fetchable source, external capabilities, or raw package bytes are exposed by public export.
- `/pipeline-handoff-artifacts` stays scoped to handoff payloads so existing handoff timeline consumers do not receive view packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced agent view artifacts—a new artifact type for securely viewing agent-generated HTML/CSS in a sandboxed iframe with comprehensive content validation and security controls.
  * Extended CLI publishing support with `--view-file` parameter for uploading view artifacts.

* **Documentation**
  * Documented agent view artifact contract, security model, package format, and publishing workflow with validation guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review follow-up
- `1a9f230` addresses Gemini/CodeRabbit feedback: slash-separated HTML tripwire bypasses, HTTPS-only manifest links, final CLI payload XOR validation, no orphaned payload writes on visibility mismatch, strict timestamp round-trip validation, agent-view task-ref backfill, and stronger viewer/oversize tests.
