### PR TITLE
feat: add dedicated nodes section

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import {
   getUtilityTerminalSessions,
 } from './lib/utility-terminals.js';
 import { deriveUtilityRailContext } from './lib/utility-rail-context.js';
+import { resolveAppViewMode } from './lib/state/app-view-mode.js';
 import { initAnalytics, destroyAnalytics, track } from './lib/analytics.js';
 import { startShikiGc } from './lib/stores/shiki-gc.js';
 import type { ActionContext } from './lib/actions/types.js';
@@ -185,6 +186,7 @@ function resolveTerminalFilePath(
 function useTerminalDerivedState() {
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const analyticsView = useUiStore((s) => s.analyticsView);
+  const isNodesTab = useUiStore((s) => s.orgDashboardTab === 'nodes');
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
@@ -249,15 +251,17 @@ function useTerminalDerivedState() {
     [activeRepoPath, activeSession]
   );
 
-  const viewMode = useMemo<
-    'empty' | 'org' | 'dashboard' | 'session' | 'analytics'
-  >(() => {
-    if (analyticsView !== null) return 'analytics';
-    if (hasActiveSession) return 'session';
-    if (!repos.length) return 'empty';
-    if (!activeRepoPath) return 'org';
-    return 'dashboard';
-  }, [analyticsView, repos.length, activeRepoPath, hasActiveSession]);
+  const viewMode = useMemo(
+    () =>
+      resolveAppViewMode({
+        analyticsView,
+        hasActiveSession,
+        reposLength: repos.length,
+        activeRepoPath,
+        isNodesTab,
+      }),
+    [analyticsView, hasActiveSession, repos.length, activeRepoPath, isNodesTab]
+  );
 
   return {
     activeRepoPath,

--- a/frontend/src/components/HubNodeDashboard.css
+++ b/frontend/src/components/HubNodeDashboard.css
@@ -275,10 +275,68 @@
   white-space: nowrap;
 }
 
-.hub-node-locality-worktrees,
+.hub-node-locality-worktrees {
+  grid-column: 1 / -1;
+  min-width: 0;
+}
+
+.hub-node-locality-worktrees-label {
+  color: var(--text-muted);
+  margin-bottom: 2px;
+  text-transform: lowercase;
+}
+
+.hub-node-locality-worktree-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.hub-node-locality-worktree {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1px 8px;
+  min-width: 0;
+  padding-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.hub-node-locality-worktree-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-locality-worktree-branch {
+  max-width: 18ch;
+  overflow: hidden;
+  color: var(--accent);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-locality-worktree-path {
+  grid-column: 1 / -1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-locality-worktree-more,
 .hub-node-locality-more {
   grid-column: 1 / -1;
   color: var(--text-muted);
+}
+
+.hub-node-locality-worktree-more {
+  padding-left: 8px;
 }
 
 .hub-node-capabilities {

--- a/frontend/src/components/HubNodeDashboard.css
+++ b/frontend/src/components/HubNodeDashboard.css
@@ -33,6 +33,35 @@
   gap: 6px;
 }
 
+.hub-node-panel-state {
+  border: 1px solid var(--border);
+  padding: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.hub-node-panel-state--error {
+  color: var(--status-warning);
+}
+
+.hub-node-panel-state button {
+  margin-left: 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+
+.hub-node-panel-state button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .hub-node-card {
   border: 1px solid var(--border);
   border-radius: 0;
@@ -156,7 +185,8 @@
 }
 
 .hub-node-readiness,
-.hub-node-warning {
+.hub-node-warning,
+.hub-node-locality {
   margin-top: 6px;
   padding-left: var(--icon-slot-width);
   font-size: var(--font-size-xs);
@@ -177,6 +207,78 @@
 
 .hub-node-warning {
   color: var(--status-warning);
+}
+
+.hub-node-locality {
+  color: var(--text-muted);
+}
+
+.hub-node-locality-banner {
+  margin-bottom: 8px;
+  border: 1px solid color-mix(in srgb, var(--status-warning) 45%, var(--border));
+  padding: 8px;
+  color: var(--status-warning);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+}
+
+.hub-node-locality--empty {
+  color: var(--text-muted);
+}
+
+.hub-node-locality--unavailable {
+  color: var(--status-warning);
+}
+
+.hub-node-locality-summary {
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.hub-node-locality-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.hub-node-locality-repo {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2px 8px;
+  min-width: 0;
+  padding: 4px 0;
+  border-top: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+}
+
+.hub-node-locality-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-locality-branch {
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.hub-node-locality-path {
+  grid-column: 1 / -1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-locality-worktrees,
+.hub-node-locality-more {
+  grid-column: 1 / -1;
+  color: var(--text-muted);
 }
 
 .hub-node-capabilities {

--- a/frontend/src/components/HubNodeDashboard.tsx
+++ b/frontend/src/components/HubNodeDashboard.tsx
@@ -3,11 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
 import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../../../shared/relay-node-protocol.js';
 import type { NodeManifestDegradedReason } from '../../../shared/node-manifest.js';
-import { fetchHubNodes } from '../lib/api.js';
+import { fetchHubNodes, fetchRepoInventory, HttpError } from '../lib/api.js';
 import {
   deriveHubNodeDashboardRows,
+  deriveNodeRepoLocality,
   hubNodeDashboardSummary,
+  repoLocalitySummary,
   type HubNodeDashboardRow,
+  type NodeRepoLocality,
 } from '../lib/state/node-dashboard.js';
 import './HubNodeDashboard.css';
 
@@ -82,6 +85,71 @@ function DegradedReasonsExpander({
 // NodeHelperMeta — helper version + file-rpc status line
 // ---------------------------------------------------------------------------
 
+interface NodeLocalityProps {
+  locality: NodeRepoLocality | undefined;
+}
+
+function NodeLocality({ locality }: NodeLocalityProps) {
+  if (!locality || locality.repoCount === 0) {
+    return (
+      <div className="hub-node-locality hub-node-locality--empty">
+        no repo locality reported yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="hub-node-locality" aria-label="repo locality">
+      <div className="hub-node-locality-summary">
+        repo locality: {repoLocalitySummary(locality)}
+      </div>
+      <ul className="hub-node-locality-list" role="list">
+        {locality.repos.slice(0, 3).map((repo) => {
+          const branch =
+            repo.currentBranch ?? repo.defaultBranch ?? 'unknown branch';
+          return (
+            <li key={repo.repoInstanceId} className="hub-node-locality-repo">
+              <span className="hub-node-locality-name">{repo.name}</span>
+              <span className="hub-node-locality-branch">{branch}</span>
+              <span className="hub-node-locality-path" title={repo.localPath}>
+                {repo.localPath}
+              </span>
+              {repo.worktrees.length > 0 && (
+                <span className="hub-node-locality-worktrees">
+                  {repo.worktrees.length === 1
+                    ? '1 worktree'
+                    : `${repo.worktrees.length} worktrees`}
+                </span>
+              )}
+            </li>
+          );
+        })}
+        {locality.repoCount > 3 && (
+          <li className="hub-node-locality-more">
+            +{locality.repoCount - 3} more repos on this node
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof HttpError && error.status === 401) {
+    return error.message || 'authorization required';
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return 'request failed';
+}
+
+function nodesErrorMessage(error: unknown): string {
+  if (error instanceof HttpError && error.status === 401) {
+    return error.message || 'authorization required';
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return 'could not load hub nodes';
+}
+
 interface NodeHelperMetaProps {
   row: HubNodeDashboardRow;
 }
@@ -115,12 +183,16 @@ export interface HubNodeDashboardProps {
   nodes: HubNodeSummary[];
   now?: Date;
   expectedProtocolVersion?: string;
+  localityByNode?: Map<string, NodeRepoLocality>;
+  inventoryError?: string;
 }
 
 export function HubNodeDashboard({
   nodes,
   now,
   expectedProtocolVersion = RELAY_NODE_LINK_PROTOCOL_VERSION,
+  localityByNode,
+  inventoryError,
 }: HubNodeDashboardProps) {
   const deriveOptions = useMemo(
     () => ({ ...(now ? { now } : {}), expectedProtocolVersion }),
@@ -145,6 +217,11 @@ export function HubNodeDashboard({
           <div className="hub-node-dashboard-summary">{summary}</div>
         </div>
       </div>
+      {inventoryError && (
+        <div className="hub-node-locality-banner">
+          repo locality unavailable: {inventoryError}
+        </div>
+      )}
       <div className="hub-node-dashboard-list">
         {rows.map((row) => (
           <article
@@ -184,6 +261,7 @@ export function HubNodeDashboard({
             <div className="hub-node-readiness">
               {row.disabledReason ?? row.workReadiness}
             </div>
+            <NodeLocality locality={localityByNode?.get(row.nodeId)} />
             {row.versionWarning && (
               <div className="hub-node-warning">{row.versionWarning}</div>
             )}
@@ -244,16 +322,58 @@ export function HubNodeDashboard({
 }
 
 export function HubNodeDashboardPanel() {
-  const { data: nodes } = useQuery({
+  const {
+    data: nodes,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ['hub-nodes'],
     queryFn: fetchHubNodes,
     staleTime: Infinity,
     refetchOnWindowFocus: 'always',
     retry: false,
   });
+  const inventoryQuery = useQuery({
+    queryKey: ['repo-inventory'],
+    queryFn: fetchRepoInventory,
+    staleTime: 60_000,
+    retry: false,
+    enabled: Boolean(nodes?.length) && !isError,
+  });
 
-  if (!nodes || nodes.length === 0) return null;
-  return <HubNodeDashboard nodes={nodes} />;
+  const localityByNode = useMemo(
+    () => deriveNodeRepoLocality(inventoryQuery.data),
+    [inventoryQuery.data]
+  );
+
+  if (isLoading) {
+    return <div className="hub-node-panel-state">loading nodes...</div>;
+  }
+  if (isError) {
+    return (
+      <div className="hub-node-panel-state hub-node-panel-state--error">
+        nodes unavailable: {nodesErrorMessage(error)}
+        <button type="button" onClick={() => void refetch()}>
+          retry
+        </button>
+      </div>
+    );
+  }
+  if (!nodes || nodes.length === 0) {
+    return <div className="hub-node-panel-state">no paired nodes yet</div>;
+  }
+
+  return (
+    <HubNodeDashboard
+      nodes={nodes}
+      localityByNode={localityByNode}
+      {...(inventoryQuery.isError
+        ? { inventoryError: errorMessage(inventoryQuery.error) }
+        : {})}
+    />
+  );
 }
 
 export default HubNodeDashboard;

--- a/frontend/src/components/HubNodeDashboard.tsx
+++ b/frontend/src/components/HubNodeDashboard.tsx
@@ -85,6 +85,9 @@ function DegradedReasonsExpander({
 // NodeHelperMeta — helper version + file-rpc status line
 // ---------------------------------------------------------------------------
 
+const MAX_LOCALITY_REPOS = 3;
+const MAX_LOCALITY_WORKTREES_PER_REPO = 3;
+
 interface NodeLocalityProps {
   locality: NodeRepoLocality | undefined;
 }
@@ -104,9 +107,15 @@ function NodeLocality({ locality }: NodeLocalityProps) {
         repo locality: {repoLocalitySummary(locality)}
       </div>
       <ul className="hub-node-locality-list" role="list">
-        {locality.repos.slice(0, 3).map((repo) => {
+        {locality.repos.slice(0, MAX_LOCALITY_REPOS).map((repo) => {
           const branch =
             repo.currentBranch ?? repo.defaultBranch ?? 'unknown branch';
+          const visibleWorktrees = repo.worktrees.slice(
+            0,
+            MAX_LOCALITY_WORKTREES_PER_REPO
+          );
+          const hiddenWorktreeCount =
+            repo.worktrees.length - visibleWorktrees.length;
           return (
             <li key={repo.repoInstanceId} className="hub-node-locality-repo">
               <span className="hub-node-locality-name">{repo.name}</span>
@@ -114,19 +123,56 @@ function NodeLocality({ locality }: NodeLocalityProps) {
               <span className="hub-node-locality-path" title={repo.localPath}>
                 {repo.localPath}
               </span>
-              {repo.worktrees.length > 0 && (
-                <span className="hub-node-locality-worktrees">
-                  {repo.worktrees.length === 1
-                    ? '1 worktree'
-                    : `${repo.worktrees.length} worktrees`}
-                </span>
+              {visibleWorktrees.length > 0 && (
+                <div
+                  className="hub-node-locality-worktrees"
+                  aria-label={`${repo.name} worktrees`}
+                >
+                  <div className="hub-node-locality-worktrees-label">
+                    worktrees
+                  </div>
+                  <ul className="hub-node-locality-worktree-list" role="list">
+                    {visibleWorktrees.map((worktree) => {
+                      const worktreeBranch =
+                        worktree.branchName ?? 'unknown branch';
+                      return (
+                        <li
+                          key={worktree.worktreeInstanceId}
+                          className="hub-node-locality-worktree"
+                        >
+                          <span className="hub-node-locality-worktree-name">
+                            {worktree.displayName}
+                          </span>
+                          <span
+                            className="hub-node-locality-worktree-branch"
+                            title={worktreeBranch}
+                          >
+                            {worktreeBranch}
+                          </span>
+                          <span
+                            className="hub-node-locality-worktree-path"
+                            title={worktree.localPath}
+                          >
+                            {worktree.localPath}
+                          </span>
+                        </li>
+                      );
+                    })}
+                    {hiddenWorktreeCount > 0 && (
+                      <li className="hub-node-locality-worktree-more">
+                        +{hiddenWorktreeCount} more{' '}
+                        {hiddenWorktreeCount === 1 ? 'worktree' : 'worktrees'}
+                      </li>
+                    )}
+                  </ul>
+                </div>
               )}
             </li>
           );
         })}
-        {locality.repoCount > 3 && (
+        {locality.repoCount > MAX_LOCALITY_REPOS && (
           <li className="hub-node-locality-more">
-            +{locality.repoCount - 3} more repos on this node
+            +{locality.repoCount - MAX_LOCALITY_REPOS} more repos on this node
           </li>
         )}
       </ul>

--- a/frontend/src/components/OrgDashboard.css
+++ b/frontend/src/components/OrgDashboard.css
@@ -127,6 +127,50 @@
   color: var(--text);
 }
 
+.nodes-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.nodes-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.nodes-section-title {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+.nodes-section-subtitle {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.nodes-section .hub-node-dashboard {
+  border: 1px solid var(--border);
+  padding: 12px;
+}
+
+.nodes-section .hub-node-dashboard-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 10px;
+}
+
 @media (max-width: 600px) {
   .org-dashboard {
     padding: 16px;

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -7,6 +7,7 @@ import {
   savePreset,
   deletePreset,
 } from '../lib/api.js';
+import { useUiStore, type OrgDashboardTab } from '../lib/stores/ui.js';
 import { sortPrs } from '../lib/pr-utils.js';
 import type {
   PullRequest,
@@ -16,6 +17,7 @@ import type {
 } from '../lib/types.js';
 import TicketsPanel from './TicketsPanel.js';
 import ActiveWorkSurface from './ActiveWorkSurface.js';
+import { HubNodeDashboardPanel } from './HubNodeDashboard.js';
 import SecurityAuditPanel from './SecurityAuditPanel.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import { TuiButton } from './TuiButton.js';
@@ -28,8 +30,6 @@ export interface OrgDashboardProps {
   onOpenPrSession: (pr: PullRequest) => void;
   onPrAction: (pr: PullRequest) => void;
 }
-
-type ActiveTab = 'active-work' | 'prs' | 'tickets' | 'audit';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -392,13 +392,42 @@ function PrsTab({ onOpenPrSession, onPrAction }: PrsTabProps) {
   );
 }
 
+function tabButtonClass(
+  activeTab: OrgDashboardTab,
+  target: OrgDashboardTab
+): string {
+  return ['tab-btn', activeTab === target ? 'tab-btn--active' : '']
+    .filter(Boolean)
+    .join(' ');
+}
+
+// ── NodesTab sub-component ────────────────────────────────────────────────────
+
+function NodesTab() {
+  return (
+    <section className="nodes-section" aria-label="nodes management">
+      <div className="nodes-section-header">
+        <div>
+          <div className="nodes-section-title">nodes</div>
+          <div className="nodes-section-subtitle">
+            hub registry, readiness, and repo/worktree locality reported by each
+            node
+          </div>
+        </div>
+      </div>
+      <HubNodeDashboardPanel />
+    </section>
+  );
+}
+
 // ── Main Component ────────────────────────────────────────────────────────────
 
 export function OrgDashboard({
   onOpenPrSession,
   onPrAction,
 }: OrgDashboardProps) {
-  const [activeTab, setActiveTab] = useState<ActiveTab>('active-work');
+  const activeTab = useUiStore((s) => s.orgDashboardTab);
+  const setActiveTab = useUiStore((s) => s.setOrgDashboardTab);
 
   return (
     <div className="org-dashboard">
@@ -408,48 +437,38 @@ export function OrgDashboard({
       {/* tab-strip uses raw buttons intentionally — underline-indicator navigation, not TuiButton actions */}
       <div className="tab-strip">
         <button
-          className={[
-            'tab-btn',
-            activeTab === 'active-work' ? 'tab-btn--active' : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
+          className={tabButtonClass(activeTab, 'active-work')}
           onClick={() => setActiveTab('active-work')}
         >
           active work
         </button>
         <button
-          className={['tab-btn', activeTab === 'prs' ? 'tab-btn--active' : '']
-            .filter(Boolean)
-            .join(' ')}
+          className={tabButtonClass(activeTab, 'nodes')}
+          onClick={() => setActiveTab('nodes')}
+        >
+          nodes
+        </button>
+        <button
+          className={tabButtonClass(activeTab, 'prs')}
           onClick={() => setActiveTab('prs')}
         >
           prs
         </button>
         <button
-          className={[
-            'tab-btn',
-            activeTab === 'tickets' ? 'tab-btn--active' : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
+          className={tabButtonClass(activeTab, 'tickets')}
           onClick={() => setActiveTab('tickets')}
         >
           tickets
         </button>
         <button
-          className={[
-            'tab-btn',
-            activeTab === 'audit' ? 'tab-btn--active' : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
+          className={tabButtonClass(activeTab, 'audit')}
           onClick={() => setActiveTab('audit')}
         >
           audit
         </button>
       </div>
       {activeTab === 'active-work' && <ActiveWorkSurface />}
+      {activeTab === 'nodes' && <NodesTab />}
       {activeTab === 'prs' && (
         <PrsTab onOpenPrSession={onOpenPrSession} onPrAction={onPrAction} />
       )}

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -105,6 +105,70 @@
   overflow-x: hidden;
 }
 
+.sidebar-nodes-summary {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  text-align: left;
+  cursor: pointer;
+}
+
+.sidebar-nodes-summary:hover,
+.sidebar-nodes-summary:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text);
+  outline: none;
+}
+
+.sidebar-nodes-summary-main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.sidebar-nodes-summary-title {
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: lowercase;
+}
+
+.sidebar-nodes-summary-title::before {
+  content: '●';
+  display: inline-block;
+  width: var(--icon-slot-width);
+  color: var(--accent);
+  font-size: 9px;
+}
+
+.sidebar-nodes-summary-status {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-nodes-summary-meta {
+  padding-left: var(--icon-slot-width);
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sidebar-empty-state {
   padding: 16px 12px;
   font-size: var(--font-size-xs);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   useUiStore,
   MIN_SIDEBAR_WIDTH,
@@ -9,9 +9,18 @@ import {
 } from '../lib/stores/ui.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import type { Repo, WorktreeInfo, PullRequest } from '../lib/types.js';
-import { fetchOrgPrs } from '../lib/api.js';
+import {
+  fetchHubNodes,
+  fetchOrgPrs,
+  fetchRepoInventory,
+  HttpError,
+} from '../lib/api.js';
+import {
+  deriveHubNodeDashboardRows,
+  deriveNodeRepoLocality,
+  repoLocalityMapSummary,
+} from '../lib/state/node-dashboard.js';
 import WorkspaceGroup from './WorkspaceGroup.js';
-import { HubNodeDashboardPanel } from './HubNodeDashboard.js';
 import RepoItem from './RepoItem.js';
 import { SessionHistoryPanel } from './SessionHistoryPanel.js';
 import { ViewSpineTree } from './ViewSpineTree.js';
@@ -74,6 +83,69 @@ function useSidebarResize() {
   }, []);
 
   return { startResize, resetWidth };
+}
+
+function nodeQueryErrorLabel(error: unknown): string {
+  if (error instanceof HttpError && error.status === 401)
+    return 'auth required';
+  if (error instanceof Error && error.message) return error.message;
+  return 'unavailable';
+}
+
+interface NodesSidebarSummaryProps {
+  onOpenNodes: () => void;
+}
+
+function NodesSidebarSummary({ onOpenNodes }: NodesSidebarSummaryProps) {
+  const queryClient = useQueryClient();
+  const nodesQuery = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    staleTime: Infinity,
+    refetchOnWindowFocus: 'always',
+    retry: false,
+  });
+  const inventoryQuery = useQuery({
+    queryKey: ['repo-inventory'],
+    queryFn: fetchRepoInventory,
+    staleTime: 60_000,
+    retry: false,
+    enabled: false,
+    initialData: () => queryClient.getQueryData(['repo-inventory']),
+  });
+  const nodes = useMemo(() => nodesQuery.data ?? [], [nodesQuery.data]);
+  const rows = useMemo(() => deriveHubNodeDashboardRows(nodes), [nodes]);
+  const localityByNode = useMemo(
+    () => deriveNodeRepoLocality(inventoryQuery.data),
+    [inventoryQuery.data]
+  );
+  const readyCount = rows.filter((row) => row.attachable).length;
+  const attentionCount = rows.filter((row) => !row.attachable).length;
+  const locality = inventoryQuery.isError
+    ? 'repo locality unavailable'
+    : repoLocalityMapSummary(localityByNode);
+  const summary = nodesQuery.isLoading
+    ? 'loading node registry...'
+    : nodesQuery.isError
+      ? nodeQueryErrorLabel(nodesQuery.error)
+      : nodes.length === 0
+        ? 'no paired nodes yet'
+        : `${readyCount}/${nodes.length} ready${attentionCount > 0 ? ` · ${attentionCount} need attention` : ''}`;
+
+  return (
+    <button
+      type="button"
+      className="sidebar-nodes-summary"
+      onClick={onOpenNodes}
+      aria-label="open nodes section"
+    >
+      <span className="sidebar-nodes-summary-main">
+        <span className="sidebar-nodes-summary-title">nodes</span>
+        <span className="sidebar-nodes-summary-status">{summary}</span>
+      </span>
+      <span className="sidebar-nodes-summary-meta">{locality}</span>
+    </button>
+  );
 }
 
 // ── Sortable repo wrapper for DnD ──
@@ -457,6 +529,14 @@ export function Sidebar({
   const handleHomeBrand = useCallback(() => {
     useUiStore.getState().setActiveRepoPath(null);
     useUiStore.getState().setAnalyticsView(null);
+    useUiStore.getState().setOrgDashboardTab('active-work');
+    useSessionsStore.getState().setActiveSessionId(null);
+    closeSidebar();
+  }, [closeSidebar]);
+  const handleOpenNodes = useCallback(() => {
+    useUiStore.getState().setActiveRepoPath(null);
+    useUiStore.getState().setAnalyticsView(null);
+    useUiStore.getState().setOrgDashboardTab('nodes');
     useSessionsStore.getState().setActiveSessionId(null);
     closeSidebar();
   }, [closeSidebar]);
@@ -559,7 +639,7 @@ export function Sidebar({
             </div>
           ) : (
             <div className="sidebar-workspace-list">
-              <HubNodeDashboardPanel />
+              <NodesSidebarSummary onOpenNodes={handleOpenNodes} />
               <WorkspaceGroupsList
                 sortedGroups={sortedGroups}
                 reposByPath={reposByPath}
@@ -626,7 +706,10 @@ export function Sidebar({
               + add project
             </TuiButton>
             <button
-              className={['sidebar-settings-icon-btn', analyticsView !== null && 'active']
+              className={[
+                'sidebar-settings-icon-btn',
+                analyticsView !== null && 'active',
+              ]
                 .filter(Boolean)
                 .join(' ')}
               data-track="sidebar.analytics"

--- a/frontend/src/lib/state/app-view-mode.ts
+++ b/frontend/src/lib/state/app-view-mode.ts
@@ -1,0 +1,27 @@
+import type { AnalyticsView } from '../stores/ui.js';
+
+export type AppViewMode = 'empty' | 'org' | 'dashboard' | 'session' | 'analytics';
+
+export interface ResolveAppViewModeInput {
+  analyticsView: AnalyticsView;
+  hasActiveSession: boolean;
+  reposLength: number;
+  activeRepoPath: string | null;
+  isNodesTab: boolean;
+}
+
+export function resolveAppViewMode({
+  analyticsView,
+  hasActiveSession,
+  reposLength,
+  activeRepoPath,
+  isNodesTab,
+}: ResolveAppViewModeInput): AppViewMode {
+  if (analyticsView !== null) return 'analytics';
+  if (hasActiveSession) return 'session';
+  if (!reposLength) {
+    return !activeRepoPath && isNodesTab ? 'org' : 'empty';
+  }
+  if (!activeRepoPath) return 'org';
+  return 'dashboard';
+}

--- a/frontend/src/lib/state/node-dashboard.ts
+++ b/frontend/src/lib/state/node-dashboard.ts
@@ -117,6 +117,11 @@ function serviceManagerStatus(kind: string): NodeCapabilityStatus {
   return kind ? 'available' : 'unknown';
 }
 
+function fallbackWorktreeDisplayName(localPath: string): string {
+  const normalizedPath = localPath.replace(/[\\/]+$/, '');
+  return normalizedPath.split(/[\\/]/).pop() || localPath;
+}
+
 function localityWorktree(
   worktree: RepoInventoryWorktreeInstance
 ): NodeRepoLocalityWorktree {
@@ -124,10 +129,7 @@ function localityWorktree(
     worktreeInstanceId: worktree.worktreeInstanceId,
     localPath: worktree.localPath,
     branchName: worktree.branchName,
-    displayName:
-      worktree.displayName ??
-      worktree.localPath.split('/').pop() ??
-      worktree.localPath,
+    displayName: worktree.displayName ?? fallbackWorktreeDisplayName(worktree.localPath),
   };
 }
 

--- a/frontend/src/lib/state/node-dashboard.ts
+++ b/frontend/src/lib/state/node-dashboard.ts
@@ -5,6 +5,11 @@ import {
   type NodeCapabilityStatus,
 } from '../../../../shared/relay-node-protocol.js';
 import type { NodeManifestDegradedReason } from '../../../../shared/node-manifest.js';
+import type {
+  AggregatedRepoInventoryResponse,
+  RepoInventoryRepoInstance,
+  RepoInventoryWorktreeInstance,
+} from '../../../../shared/repo-inventory.js';
 import {
   deriveNodeSecurityVisibility,
   type NodeSecurityVisibility,
@@ -43,6 +48,31 @@ export interface HubNodeDashboardRow {
   fileRpcAvailable: boolean | null;
   /** Structured degraded reasons from the manifest. Empty on healthy nodes. */
   degradedReasons: NodeManifestDegradedReason[];
+}
+
+export interface NodeRepoLocalityRepo {
+  repoInstanceId: string;
+  name: string;
+  localPath: string;
+  currentBranch: string | null;
+  defaultBranch: string | null;
+  worktrees: NodeRepoLocalityWorktree[];
+  reportedAt: string;
+}
+
+export interface NodeRepoLocalityWorktree {
+  worktreeInstanceId: string;
+  localPath: string;
+  branchName: string | null;
+  displayName: string;
+}
+
+export interface NodeRepoLocality {
+  nodeId: string;
+  generatedAt: string;
+  repoCount: number;
+  worktreeCount: number;
+  repos: NodeRepoLocalityRepo[];
 }
 
 interface DeriveOptions {
@@ -85,6 +115,83 @@ function serviceManagerStatus(kind: string): NodeCapabilityStatus {
   if (kind === 'unsupported') return 'unavailable';
   if (kind === 'manual' || kind === 'wsl-manual') return 'degraded';
   return kind ? 'available' : 'unknown';
+}
+
+function localityWorktree(
+  worktree: RepoInventoryWorktreeInstance
+): NodeRepoLocalityWorktree {
+  return {
+    worktreeInstanceId: worktree.worktreeInstanceId,
+    localPath: worktree.localPath,
+    branchName: worktree.branchName,
+    displayName:
+      worktree.displayName ??
+      worktree.localPath.split('/').pop() ??
+      worktree.localPath,
+  };
+}
+
+function localityRepo(repo: RepoInventoryRepoInstance): NodeRepoLocalityRepo {
+  return {
+    repoInstanceId: repo.repoInstanceId,
+    name: repo.selectedRemote?.repoName ?? repo.name,
+    localPath: repo.localPath,
+    currentBranch: repo.currentBranch,
+    defaultBranch: repo.defaultBranch,
+    worktrees: repo.worktrees.map(localityWorktree),
+    reportedAt: repo.reportedAt,
+  };
+}
+
+export function deriveNodeRepoLocality(
+  inventory: AggregatedRepoInventoryResponse | undefined
+): Map<string, NodeRepoLocality> {
+  const localityByNode = new Map<string, NodeRepoLocality>();
+  for (const report of inventory?.reports ?? []) {
+    const repos = report.repos.map(localityRepo);
+    localityByNode.set(report.nodeId, {
+      nodeId: report.nodeId,
+      generatedAt: report.generatedAt,
+      repoCount: repos.length,
+      worktreeCount: repos.reduce(
+        (sum, repo) => sum + repo.worktrees.length,
+        0
+      ),
+      repos,
+    });
+  }
+  return localityByNode;
+}
+
+export function repoLocalitySummary(locality: NodeRepoLocality): string {
+  if (locality.repoCount === 0) return 'no repo locality reported yet';
+  const repoLabel =
+    locality.repoCount === 1 ? '1 repo' : `${locality.repoCount} repos`;
+  const worktreeLabel =
+    locality.worktreeCount === 1
+      ? '1 worktree'
+      : `${locality.worktreeCount} worktrees`;
+  return `${repoLabel} · ${worktreeLabel}`;
+}
+
+export function repoLocalityMapSummary(
+  localityByNode: Map<string, NodeRepoLocality>
+): string {
+  const totals = Array.from(localityByNode.values()).reduce(
+    (acc, locality) => ({
+      repoCount: acc.repoCount + locality.repoCount,
+      worktreeCount: acc.worktreeCount + locality.worktreeCount,
+    }),
+    { repoCount: 0, worktreeCount: 0 }
+  );
+  if (totals.repoCount === 0) return 'no repo locality reported yet';
+  const repoLabel =
+    totals.repoCount === 1 ? '1 repo' : `${totals.repoCount} repos`;
+  const worktreeLabel =
+    totals.worktreeCount === 1
+      ? '1 worktree'
+      : `${totals.worktreeCount} worktrees`;
+  return `${repoLabel} · ${worktreeLabel}`;
 }
 
 function blockerLabel(

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -58,6 +58,13 @@ export type UtilityRailTab =
   | 'stats'
   | 'terminal';
 
+export type OrgDashboardTab =
+  | 'active-work'
+  | 'nodes'
+  | 'prs'
+  | 'tickets'
+  | 'audit';
+
 export interface WorkspaceReviewState {
   activeFilePath: string | null;
   diffSource: DiffSource;
@@ -191,7 +198,9 @@ export function loadViewSpinePins(): Set<string> {
     const parsed = JSON.parse(stored) as unknown;
     if (!Array.isArray(parsed)) return new Set();
     return new Set(
-      parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+      parsed.filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      )
     );
   } catch {
     return new Set();
@@ -330,7 +339,10 @@ function normalizeReviewState(
   const next = defaultReviewState();
   if (typeof legacyFilePath === 'string') next.activeFilePath = legacyFilePath;
   if (!value) return next;
-  if (typeof value.activeFilePath === 'string' || value.activeFilePath === null) {
+  if (
+    typeof value.activeFilePath === 'string' ||
+    value.activeFilePath === null
+  ) {
     next.activeFilePath = value.activeFilePath;
   }
   if (
@@ -380,7 +392,8 @@ function normalizePlacements(
   value: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> | undefined
 ): Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> | undefined {
   if (!value) return undefined;
-  const placements: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> = {};
+  const placements: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> =
+    {};
   for (const tab of UTILITY_RAIL_TABS) {
     const placement = value[tab];
     if (isUtilitySurfacePlacement(placement)) placements[tab] = placement;
@@ -412,7 +425,9 @@ function normalizeUtilityRailState(
       : next.selectedRailTab;
   next.width = clampUtilityRailWidth(value.width ?? next.width);
 
-  const anchoredPaneWidths = normalizeAnchoredPaneWidths(value.anchoredPaneWidths);
+  const anchoredPaneWidths = normalizeAnchoredPaneWidths(
+    value.anchoredPaneWidths
+  );
   if (anchoredPaneWidths) next.anchoredPaneWidths = anchoredPaneWidths;
   const placements = normalizePlacements(value.placements);
   if (placements) next.placements = placements;
@@ -428,7 +443,9 @@ function normalizeUtilityRailState(
     next.branchBase = value.branchBase;
   }
 
-  const utilityTerminalIds = normalizeUtilityTerminalIds(value.utilityTerminalIds);
+  const utilityTerminalIds = normalizeUtilityTerminalIds(
+    value.utilityTerminalIds
+  );
   if (utilityTerminalIds) {
     next.utilityTerminalIds = utilityTerminalIds;
     next.selectedUtilityTerminalId = utilityTerminalIds.includes(
@@ -441,16 +458,17 @@ function normalizeUtilityRailState(
   return next;
 }
 
-function syncSelectedUtilityTerminal(
-  state: WorkspaceUtilityRailState
-): void {
+function syncSelectedUtilityTerminal(state: WorkspaceUtilityRailState): void {
   const ids = state.utilityTerminalIds ?? [];
   if (ids.length === 0) {
     delete state.utilityTerminalIds;
     delete state.selectedUtilityTerminalId;
     return;
   }
-  if (!state.selectedUtilityTerminalId || !ids.includes(state.selectedUtilityTerminalId)) {
+  if (
+    !state.selectedUtilityTerminalId ||
+    !ids.includes(state.selectedUtilityTerminalId)
+  ) {
     state.selectedUtilityTerminalId = ids[0]!;
   }
 }
@@ -583,6 +601,7 @@ export interface UiState {
   sendToTargetSessionId: string | null;
   lastChangedFiles: string[];
   analyticsView: AnalyticsView;
+  orgDashboardTab: OrgDashboardTab;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
   /** #732: view-spine MVP flag. Default false; backed by localStorage. */
@@ -620,6 +639,7 @@ export interface UiState {
   setFileDiffDefaultBranch: (branch: string) => void;
   setLastChangedFiles: (files: string[]) => void;
   setAnalyticsView: (v: AnalyticsView) => void;
+  setOrgDashboardTab: (tab: OrgDashboardTab) => void;
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
@@ -662,6 +682,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   activeFileTabKey: null,
   sendToTargetSessionId: null,
   analyticsView: null,
+  orgDashboardTab: 'active-work',
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
@@ -872,7 +893,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
       (state) => {
         state.visible = true;
         if (!options?.preserveSelectedTab) state.selectedRailTab = 'review';
-        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        const current = normalizeReviewState(
+          state.review,
+          state.reviewFilePath
+        );
         const derived = deriveReviewStateFromBase(options?.base, current);
         const activeFilePath = options?.filePath ?? current.activeFilePath;
         const shouldResetHunkIndex =
@@ -883,7 +907,9 @@ export const useUiStore = create<UiState>()((set, get) => ({
           ...current,
           ...derived,
           activeFilePath,
-          currentHunkIndex: shouldResetHunkIndex ? -1 : current.currentHunkIndex,
+          currentHunkIndex: shouldResetHunkIndex
+            ? -1
+            : current.currentHunkIndex,
         };
         if (state.review.activeFilePath) {
           state.reviewFilePath = state.review.activeFilePath;
@@ -905,7 +931,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
       workspacePath,
       get().utilityRailByWorkspace[workspacePath],
       (state) => {
-        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        const current = normalizeReviewState(
+          state.review,
+          state.reviewFilePath
+        );
         state.review = {
           ...current,
           activeFilePath: filePath,
@@ -927,7 +956,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
       workspacePath,
       get().utilityRailByWorkspace[workspacePath],
       (state) => {
-        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        const current = normalizeReviewState(
+          state.review,
+          state.reviewFilePath
+        );
         state.review = { ...current, diffSource: source, currentHunkIndex: -1 };
       }
     );
@@ -943,7 +975,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
       workspacePath,
       get().utilityRailByWorkspace[workspacePath],
       (state) => {
-        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        const current = normalizeReviewState(
+          state.review,
+          state.reviewFilePath
+        );
         state.review = {
           ...current,
           defaultBranch: branch || 'main',
@@ -963,7 +998,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
       workspacePath,
       get().utilityRailByWorkspace[workspacePath],
       (state) => {
-        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        const current = normalizeReviewState(
+          state.review,
+          state.reviewFilePath
+        );
         state.review = {
           ...current,
           currentHunkIndex: Math.max(-1, Math.trunc(index)),
@@ -1051,8 +1089,8 @@ export const useUiStore = create<UiState>()((set, get) => ({
       workspacePath,
       current,
       (state) => {
-        state.utilityTerminalIds = (state.utilityTerminalIds ?? []).filter((id) =>
-          liveTerminalSessionIds.has(id)
+        state.utilityTerminalIds = (state.utilityTerminalIds ?? []).filter(
+          (id) => liveTerminalSessionIds.has(id)
         );
         syncSelectedUtilityTerminal(state);
       }
@@ -1068,6 +1106,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   setFileDiffDefaultBranch: (branch) => set({ fileDiffDefaultBranch: branch }),
   setLastChangedFiles: (files) => set({ lastChangedFiles: files }),
   setAnalyticsView: (v) => set({ analyticsView: v }),
+  setOrgDashboardTab: (tab) => set({ orgDashboardTab: tab }),
   setActiveModal: (v) => set({ activeModal: v }),
 
   saveRightSidebarWidth: () =>

--- a/test/app-view-mode.test.ts
+++ b/test/app-view-mode.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAppViewMode } from '../frontend/src/lib/state/app-view-mode.js';
+
+describe('resolveAppViewMode', () => {
+  it('keeps the no-project home on the add-project empty state by default', () => {
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        reposLength: 0,
+        activeRepoPath: null,
+        isNodesTab: false,
+      })
+    ).toBe('empty');
+  });
+
+  it('routes a no-project Nodes request to the org dashboard instead of EmptyState', () => {
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        reposLength: 0,
+        activeRepoPath: null,
+        isNodesTab: true,
+      })
+    ).toBe('org');
+  });
+
+  it('preserves session, analytics, and repo dashboard priority', () => {
+    expect(
+      resolveAppViewMode({
+        analyticsView: { sessionId: 'session-1' },
+        hasActiveSession: false,
+        reposLength: 0,
+        activeRepoPath: null,
+        isNodesTab: true,
+      })
+    ).toBe('analytics');
+
+    expect(
+      resolveAppViewMode({
+        analyticsView: 'dashboard',
+        hasActiveSession: false,
+        reposLength: 0,
+        activeRepoPath: null,
+        isNodesTab: true,
+      })
+    ).toBe('analytics');
+
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: true,
+        reposLength: 0,
+        activeRepoPath: null,
+        isNodesTab: true,
+      })
+    ).toBe('session');
+
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        reposLength: 1,
+        activeRepoPath: '/repo/relay-ide',
+        isNodesTab: true,
+      })
+    ).toBe('dashboard');
+  });
+});

--- a/test/components/HubNodeDashboard.test.ts
+++ b/test/components/HubNodeDashboard.test.ts
@@ -93,7 +93,12 @@ function inventory(): AggregatedRepoInventoryResponse {
         worktreeInstanceId: 'node-1:/repo/relay-ide/.worktrees/921',
         localPath: '/repo/relay-ide/.worktrees/921',
         branchName: 'frontend/921-nodes-section',
-        displayName: '921',
+        displayName: 'locality primary bench',
+      },
+      {
+        worktreeInstanceId: 'node-1:C:\\repo\\relay-ide\\.worktrees\\win-921',
+        localPath: 'C:\\repo\\relay-ide\\.worktrees\\win-921',
+        branchName: 'fix/windows-locality',
       },
     ],
     reportedAt: '2026-01-02T03:04:00.000Z',
@@ -202,8 +207,23 @@ describe('HubNodeDashboard', () => {
 
     expect(locality).toBeDefined();
     expect(locality ? repoLocalitySummary(locality) : '').toBe(
-      '1 repo · 1 worktree'
+      '1 repo · 2 worktrees'
     );
+
+    expect(locality?.repos[0]?.worktrees).toEqual([
+      {
+        worktreeInstanceId: 'node-1:/repo/relay-ide/.worktrees/921',
+        localPath: '/repo/relay-ide/.worktrees/921',
+        branchName: 'frontend/921-nodes-section',
+        displayName: 'locality primary bench',
+      },
+      {
+        worktreeInstanceId: 'node-1:C:\\repo\\relay-ide\\.worktrees\\win-921',
+        localPath: 'C:\\repo\\relay-ide\\.worktrees\\win-921',
+        branchName: 'fix/windows-locality',
+        displayName: 'win-921',
+      },
+    ]);
 
     const html = renderToStaticMarkup(
       React.createElement(HubNodeDashboard, {
@@ -213,10 +233,16 @@ describe('HubNodeDashboard', () => {
       })
     );
 
-    expect(html).toContain('repo locality: 1 repo · 1 worktree');
+    expect(html).toContain('repo locality: 1 repo · 2 worktrees');
     expect(html).toContain('relay-ide');
-    expect(html).toContain('frontend/921-nodes-section');
     expect(html).toContain('/repo/relay-ide');
+    expect(html).toContain('worktrees');
+    expect(html).toContain('locality primary bench');
+    expect(html).toContain('/repo/relay-ide/.worktrees/921');
+    expect(html).toContain('frontend/921-nodes-section');
+    expect(html).toContain('win-921');
+    expect(html).toContain('C:\\repo\\relay-ide\\.worktrees\\win-921');
+    expect(html).toContain('fix/windows-locality');
   });
 
   it('renders an explicit empty locality state when a node has no report', () => {

--- a/test/components/HubNodeDashboard.test.ts
+++ b/test/components/HubNodeDashboard.test.ts
@@ -2,13 +2,25 @@ import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import type { AggregatedRepoInventoryResponse } from '../../shared/repo-inventory.js';
 import { HubNodeDashboard } from '../../frontend/src/components/HubNodeDashboard.js';
+import {
+  deriveNodeRepoLocality,
+  repoLocalitySummary,
+} from '../../frontend/src/lib/state/node-dashboard.js';
 
 const now = new Date('2026-01-02T03:05:00.000Z');
 
 function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   return {
     nodeId: 'node-1',
+    identity: {
+      nodeId: 'node-1',
+      displayName: 'dev mac',
+      hostname: 'dev-mac.local',
+      createdAt: '2026-01-02T03:00:00.000Z',
+      pairedAt: '2026-01-02T03:00:00.000Z',
+    },
     displayName: 'dev mac',
     hostname: 'dev-mac.local',
     platform: 'darwin',
@@ -17,6 +29,18 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
     protocolVersion: '1.0',
     status: 'online',
     connection: { route: 'reverse-link', status: 'connected' },
+    trust: { state: 'trusted', level: 'standard', tier: 'dev' },
+    credentialState: 'active',
+    credential: {
+      credentialId: 'cred-1',
+      issuedAt: '2026-01-02T03:00:00.000Z',
+      state: 'active',
+    },
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
     capabilities: {
       totals: { available: 11, degraded: 0, unavailable: 0, unknown: 0 },
       core: {
@@ -37,6 +61,69 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
     lastSeenAt: '2026-01-02T03:04:30.000Z',
     credentialId: 'cred-1',
     ...overrides,
+  };
+}
+
+function inventory(): AggregatedRepoInventoryResponse {
+  const repo = {
+    repoInstanceId: 'node-1:/repo/relay-ide',
+    nodeId: 'node-1',
+    localPath: '/repo/relay-ide',
+    name: 'relay-ide',
+    isGitRepo: true,
+    defaultBranch: 'nightly',
+    currentBranch: 'frontend/921-nodes-section',
+    repoIdentity: 'github.com/donovan-yohan/relay-ide',
+    selectedRemote: {
+      name: 'origin',
+      url: 'https://github.com/donovan-yohan/relay-ide.git',
+      identity: 'github.com/donovan-yohan/relay-ide',
+      provider: 'github' as const,
+      host: 'github.com',
+      path: 'donovan-yohan/relay-ide',
+      owner: 'donovan-yohan',
+      repoName: 'relay-ide',
+    },
+    remotes: [],
+    repoIdentityWarnings: [],
+    dirty: null,
+    divergence: null,
+    worktrees: [
+      {
+        worktreeInstanceId: 'node-1:/repo/relay-ide/.worktrees/921',
+        localPath: '/repo/relay-ide/.worktrees/921',
+        branchName: 'frontend/921-nodes-section',
+        displayName: '921',
+      },
+    ],
+    reportedAt: '2026-01-02T03:04:00.000Z',
+  };
+  return {
+    generatedAt: '2026-01-02T03:04:00.000Z',
+    groups: [
+      {
+        groupId: 'github.com/donovan-yohan/relay-ide',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        displayName: 'relay-ide',
+        selectedRemote: repo.selectedRemote,
+        remotes: [],
+        warnings: [],
+        instances: [repo],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          instanceCount: 1,
+          nodeIds: ['node-1'],
+        },
+      },
+    ],
+    reports: [
+      {
+        nodeId: 'node-1',
+        generatedAt: '2026-01-02T03:04:00.000Z',
+        repos: [repo],
+      },
+    ],
   };
 }
 
@@ -107,5 +194,40 @@ describe('HubNodeDashboard', () => {
     expect(html).toContain('ssh');
     expect(html).toContain('tailscale');
     expect(html).toContain('service');
+  });
+
+  it('renders repo/worktree locality from inventory without inventing missing data', () => {
+    const localityByNode = deriveNodeRepoLocality(inventory());
+    const locality = localityByNode.get('node-1');
+
+    expect(locality).toBeDefined();
+    expect(locality ? repoLocalitySummary(locality) : '').toBe(
+      '1 repo · 1 worktree'
+    );
+
+    const html = renderToStaticMarkup(
+      React.createElement(HubNodeDashboard, {
+        now,
+        nodes: [node()],
+        localityByNode,
+      })
+    );
+
+    expect(html).toContain('repo locality: 1 repo · 1 worktree');
+    expect(html).toContain('relay-ide');
+    expect(html).toContain('frontend/921-nodes-section');
+    expect(html).toContain('/repo/relay-ide');
+  });
+
+  it('renders an explicit empty locality state when a node has no report', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(HubNodeDashboard, {
+        now,
+        nodes: [node({ nodeId: 'missing-locality' })],
+        localityByNode: deriveNodeRepoLocality(inventory()),
+      })
+    );
+
+    expect(html).toContain('no repo locality reported yet');
   });
 });


### PR DESCRIPTION
## Summary
- Adds a dedicated `nodes` tab to the org dashboard and wires the sidebar node summary entrypoint to it.
- Extends the node dashboard with real `/nodes` registry data plus `/hub/repo-inventory` repo/worktree locality, including explicit empty and auth/degraded states.
- Keeps the sidebar compact and avoids starting the full repo-inventory fetch from the sidebar unless cached data already exists.

## Test plan
- `npm test -- test/components/HubNodeDashboard.test.ts`
- `npm run check` (passes; existing lint warnings remain)
- `npm run build` (passes; existing large-chunk warning remains)

## Dogfood evidence
- `curl -i http://127.0.0.1:3456/nodes` against global nightly hub returned `401` with `CLI_GATEWAY_OR_BROWSER_AUTH_REQUIRED` and accepted lanes `scoped-actor-credential`, `browser-session`.
- `curl -i http://127.0.0.1:3456/hub/repo-inventory` against global nightly hub returned `401` with `BROWSER_SESSION_REQUIRED` and accepted lane `browser-session`, validating the unauthorized/degraded UI path.
- `relay-ide hub nodes --json` was unavailable in this worker PATH (`command not found`), recorded as dogfood seam evidence.

Closes #921


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Nodes" tab to the org dashboard to view hub nodes with per-node repository locality and “+N more” indicators.
  * Sidebar now shows a compact nodes summary with readiness/attention counts and an “auth required” label when needed.
  * Dashboard shows a banner when repository locality is unavailable.

* **Tests**
  * Added tests covering view-mode routing and repo-locality rendering/empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->