### PR TITLE
Promote Active Work to primary WorkContext cockpit

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,6 @@ import { useTelemetryStore } from './lib/stores/telemetry.js';
 import { sendPtyData } from './lib/ws.js';
 import {
   useOnboardingHints,
-  HINT_NO_REPOS,
   HINT_REPO_ADDED_NO_SESSIONS,
 } from './hooks/useOnboardingHints.js';
 import { useHintsStore } from './lib/stores/hints.js';
@@ -59,7 +58,6 @@ import { getActiveTerminalHandle } from './lib/terminal-refs.js';
 import PrTopBar from './components/PrTopBar.js';
 import RepoDashboard from './components/RepoDashboard.js';
 import OrgDashboard from './components/OrgDashboard.js';
-import EmptyState from './components/EmptyState.js';
 import Toolbar from './components/Toolbar.js';
 import MobileHeader from './components/MobileHeader.js';
 import SessionStatusBar from './components/SessionStatusBar.js';
@@ -122,12 +120,8 @@ initNotifications((sessionId: string, sessionType: string) => {
 // Tracks session/repo count transitions and returns onboarding hint state.
 // Extracted to reduce TerminalAreaContent's cyclomatic complexity.
 
-function useTerminalOnboardingHints(
-  reposLength: number,
-  sessionsLength: number
-) {
+function useTerminalOnboardingHints(sessionsLength: number) {
   const prevSessionsRef = useRef(sessionsLength);
-  const prevReposRef = useRef(reposLength);
   const [sessionJustStarted, setSessionJustStarted] = useState(false);
   const markHintSeen = useHintsStore((s) => s.markSeen);
 
@@ -146,13 +140,6 @@ function useTerminalOnboardingHints(
     }
     prevSessionsRef.current = sessionsLength;
   }, [sessionsLength, markHintSeen]);
-
-  useEffect(() => {
-    if (prevReposRef.current === 0 && reposLength > 0) {
-      markHintSeen(HINT_NO_REPOS);
-    }
-    prevReposRef.current = reposLength;
-  }, [reposLength, markHintSeen]);
 
   return { sessionJustStarted };
 }
@@ -186,7 +173,6 @@ function resolveTerminalFilePath(
 function useTerminalDerivedState() {
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const analyticsView = useUiStore((s) => s.analyticsView);
-  const isNodesTab = useUiStore((s) => s.orgDashboardTab === 'nodes');
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
@@ -256,11 +242,9 @@ function useTerminalDerivedState() {
       resolveAppViewMode({
         analyticsView,
         hasActiveSession,
-        reposLength: repos.length,
         activeRepoPath,
-        isNodesTab,
       }),
-    [analyticsView, hasActiveSession, repos.length, activeRepoPath, isNodesTab]
+    [analyticsView, hasActiveSession, activeRepoPath]
   );
 
   return {
@@ -467,7 +451,6 @@ function useUtilityTerminalHandlers({
 interface TerminalAreaContentProps {
   setSpotlightOpen: React.Dispatch<React.SetStateAction<boolean>>;
   fileTreeSidebarRef: React.RefObject<FileTreeHandle | null>;
-  onAddWorkspace: () => void;
   onImageUpload: (text: string, showInsert: boolean, path?: string) => void;
   onQuickAgent: () => Promise<void>;
   onNewWorktree: (workspace: Repo) => Promise<void>;
@@ -483,7 +466,6 @@ interface TerminalAreaContentProps {
 function TerminalAreaContent({
   setSpotlightOpen,
   fileTreeSidebarRef,
-  onAddWorkspace,
   onImageUpload,
   onQuickAgent,
   onNewWorktree,
@@ -498,8 +480,6 @@ function TerminalAreaContent({
   // Store access (layout / sidebar values not in derived state hook)
   const openSidebar = useUiStore((s) => s.openSidebar);
   const keyboardOpen = useUiStore((s) => s.keyboardOpen);
-  // #862: empty-state secondary action opens the env picker modal.
-  const setActiveModal = useUiStore((s) => s.setActiveModal);
   const hydrateUtilityRailState = useUiStore((s) => s.hydrateUtilityRailState);
   const setUtilityRailWidth = useUiStore((s) => s.setUtilityRailWidth);
   const saveUtilityRailState = useUiStore((s) => s.saveUtilityRailState);
@@ -547,10 +527,7 @@ function TerminalAreaContent({
   );
 
   // ── Onboarding hints ──────────────────────────────────────────────────────
-  const { sessionJustStarted } = useTerminalOnboardingHints(
-    repos.length,
-    sessions.length
-  );
+  const { sessionJustStarted } = useTerminalOnboardingHints(sessions.length);
 
   // ── Copy mode ─────────────────────────────────────────────────────────────
   const [copyModeActive, setCopyModeActive] = useState(false);
@@ -712,25 +689,6 @@ function TerminalAreaContent({
         onRightSidebarClick={handleToggleUtilityRail}
         hidden={keyboardOpen}
       />
-
-      {viewMode === 'empty' && (
-        <EmptyState
-          heading="add a project to get started"
-          description="point to any folder on your machine. git repos get pr tracking and branch management."
-          actionLabel="+ add project"
-          onAction={onAddWorkspace}
-          secondaryActionLabel="start a terminal on a node"
-          onSecondaryAction={() => setActiveModal({ modal: 'env-picker' })}
-          hint={
-            onboardingHints.showNoReposHint ? (
-              <Hint id={HINT_NO_REPOS} variant="inline-text">
-                relay-ide manages agents and terminals across your projects.
-              </Hint>
-            ) : undefined
-          }
-        />
-      )}
-
       {viewMode === 'org' && (
         <OrgDashboard
           onOpenPrSession={onOpenPrSession}
@@ -1319,7 +1277,6 @@ export default function App() {
         <TerminalAreaContent
           setSpotlightOpen={setSpotlightOpen}
           fileTreeSidebarRef={fileTreeSidebarRef}
-          onAddWorkspace={handleAddWorkspace}
           onImageUpload={handleImageUpload}
           onQuickAgent={handleQuickAgent}
           onNewWorktree={handleNewWorktree}

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -59,6 +59,11 @@ function taskLabel(group: WorkContextActiveGroup): string {
   );
 }
 
+export function activeWorkContextLabel(group: WorkContextActiveGroup): string {
+  if (group.context?.id) return `workcontext ${shortId(group.context.id)}`;
+  return `unbound session group ${shortId(group.id)}`;
+}
+
 function taskRefs(
   group: WorkContextActiveGroup
 ): Array<{ id: string; label: string; url?: string }> {
@@ -154,12 +159,11 @@ export function repoKind(
 }
 
 export function repoBindingLabel(
-  group: WorkContextActiveGroup,
   session: WorkContextSessionSummary,
   repos: Repo[]
 ): string | null {
   const kind = repoKind(session, repos);
-  const repoPath = session.repoPath ?? group.context?.anchors?.repo?.localPath;
+  const repoPath = session.repoPath;
 
   if (kind === 'directory') {
     const nodeLabel =
@@ -170,10 +174,56 @@ export function repoBindingLabel(
     return `${nodeLabel} · ${cwd} · directory`;
   }
 
-  const repo = session.repoName ?? group.context?.anchors?.repo?.ownerRepo;
+  if (kind !== 'repo' || !repoPath) return null;
+
+  const repo = session.repoName ?? repos.find((r) => r.path === repoPath)?.name;
   if (!repo && !repoPath) return null;
-  const branch = session.branchName ?? group.context?.anchors?.repo?.branchName;
+  const branch = session.branchName;
   return [repo ?? repoPath, branch].filter(Boolean).join(' · ');
+}
+
+export function activeWorkAnchorLabel(
+  group: WorkContextActiveGroup,
+  session: WorkContextSessionSummary | undefined,
+  repos: Repo[]
+): string {
+  const nodeLabel = group.node.displayName ?? group.node.nodeId;
+  const nodeKind = group.node.kind ?? 'remote';
+  const cwd = session?.cwd ?? group.context?.anchors?.session?.cwd ?? 'no cwd reported';
+  if (session) {
+    const kind = repoKind(session, repos);
+    if (kind === 'directory') {
+      return `${nodeLabel} · ${cwd} · directory`;
+    }
+    const repoLabel = repoBindingLabel(session, repos);
+    if (repoLabel) return `repo ${repoLabel}`;
+  }
+  const anchorPrefix =
+    session?.nodeId && session.nodeId !== DEFAULT_LOCAL_NODE_ID
+      ? `remote ${nodeLabel}`
+      : nodeKind === 'local'
+        ? 'local'
+        : `${nodeKind} ${nodeLabel}`;
+  return `${anchorPrefix} · ${cwd} · no repo binding`;
+}
+
+function controlSummary(
+  controlState: ReturnType<typeof activeWorkMobileControlState>,
+  session?: WorkContextSessionSummary
+): string {
+  const mode = session?.controlMode ?? 'unknown control mode';
+  const freshness = session?.controlFreshness
+    ? `control ${session.controlFreshness}`
+    : 'control freshness unknown';
+  const disabled = [
+    controlState.attachDisabledReason
+      ? `attach disabled: ${controlState.attachDisabledReason}`
+      : 'attach available',
+    controlState.smallInputDisabledReason
+      ? `input disabled: ${controlState.smallInputDisabledReason}`
+      : 'input available',
+  ];
+  return [mode, freshness, ...disabled].join(' · ');
 }
 
 function sessionMeta(
@@ -191,7 +241,7 @@ function sessionMeta(
       : undefined,
   ].filter(Boolean) as string[];
   const kind = repoKind(session, repos);
-  const binding = repoBindingLabel(group, session, repos);
+  const binding = repoBindingLabel(session, repos);
   if (kind === 'directory') {
     // directory-kind: hide git-only meta (branch, PR chips handled at card level)
     if (binding) meta.push(binding);
@@ -325,22 +375,12 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
 
         <div className="active-work-grid">
           <div>
+            <span className="active-work-label">workcontext</span>
+            <span>{activeWorkContextLabel(group)}</span>
+          </div>
+          <div>
             <span className="active-work-label">anchor</span>
-            <span>
-              {(() => {
-                const nodeLabel = group.node.displayName ?? group.node.nodeId;
-                const cwd = primarySession?.cwd ?? 'no cwd';
-                if (primarySession) {
-                  const kind = repoKind(primarySession, repos);
-                  if (kind === 'directory') {
-                    return `${nodeLabel} · ${cwd} · directory`;
-                  }
-                  const repoLabel = repoBindingLabel(group, primarySession, repos);
-                  if (repoLabel) return `repo ${repoLabel}`;
-                }
-                return `${group.node.kind ?? 'remote'} · ${cwd}`;
-              })()}
-            </span>
+            <span>{activeWorkAnchorLabel(group, primarySession, repos)}</span>
           </div>
           <div>
             <span className="active-work-label">freshness</span>
@@ -359,6 +399,18 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
                 ? actors.join(' / ')
                 : (primarySession?.agent ?? 'unknown actor')}
             </span>
+          </div>
+          <div>
+            <span className="active-work-label">session</span>
+            <span>
+              {primarySession
+                ? `${shortId(primarySession.globalSessionId ?? primarySession.id)} · ${primarySession.relationship}`
+                : 'no session selected'}
+            </span>
+          </div>
+          <div>
+            <span className="active-work-label">control</span>
+            <span>{controlSummary(controlState, primarySession)}</span>
           </div>
           <div>
             <span className="active-work-label">latest</span>
@@ -559,11 +611,19 @@ export default function ActiveWorkSurface() {
   ).length;
 
   if (isLoading)
-    return <div className="state-message">loading active work...</div>;
+    return (
+      <div className="state-message">
+        loading active work cockpit — checking workcontexts, node freshness,
+        mailbox refs, and artifacts...
+      </div>
+    );
   if (isError) {
     return (
       <div className="state-message state-message--error">
-        <span>could not load active work.</span>
+        <span>
+          could not load active work cockpit. prs, tickets, nodes, and audit stay
+          available as secondary tabs; retry to refresh workcontext status.
+        </span>
         <TuiButton size="sm" variant="ghost" onClick={() => void refetch()}>
           retry
         </TuiButton>
@@ -579,7 +639,10 @@ export default function ActiveWorkSurface() {
       <div className="active-work-surface__header">
         <div>
           <h2>active work</h2>
-          <p>grouped by workcontext across local and remote nodes</p>
+          <p>
+            primary operator cockpit grouped by workcontext across local, remote,
+            repo-bound, and free sessions
+          </p>
         </div>
         <div className="active-work-surface__summary">
           <span>{groups.length} contexts</span>
@@ -588,10 +651,12 @@ export default function ActiveWorkSurface() {
       </div>
       {groups.length === 0 ? (
         <div className="active-work-empty">
-          <span>no active work yet</span>
+          <span>no active work in the cockpit</span>
           <span>
-            start from assistant, issue, or desktop relay; this surface will
-            group the resulting workcontext here.
+            start from an issue, assistant, or node terminal; workcontexts,
+            mailboxes, artifacts, and stale/offline node state will appear here.
+            prs, tickets, nodes, and audit stay available above as secondary
+            context.
           </span>
         </div>
       ) : (

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -432,7 +432,13 @@ export function OrgDashboard({
   return (
     <div className="org-dashboard">
       <div className="org-header">
-        <span className="org-title">all workspaces</span>
+        <div>
+          <span className="org-title">work cockpit</span>
+          <div className="org-subtitle">
+            active work is primary; prs, tickets, nodes, and audit are verified
+            context
+          </div>
+        </div>
       </div>
       {/* tab-strip uses raw buttons intentionally — underline-indicator navigation, not TuiButton actions */}
       <div className="tab-strip">

--- a/frontend/src/lib/state/app-view-mode.ts
+++ b/frontend/src/lib/state/app-view-mode.ts
@@ -1,27 +1,24 @@
 import type { AnalyticsView } from '../stores/ui.js';
 
-export type AppViewMode = 'empty' | 'org' | 'dashboard' | 'session' | 'analytics';
+export type AppViewMode = 'org' | 'dashboard' | 'session' | 'analytics';
 
 export interface ResolveAppViewModeInput {
   analyticsView: AnalyticsView;
   hasActiveSession: boolean;
-  reposLength: number;
   activeRepoPath: string | null;
-  isNodesTab: boolean;
 }
 
 export function resolveAppViewMode({
   analyticsView,
   hasActiveSession,
-  reposLength,
   activeRepoPath,
-  isNodesTab,
 }: ResolveAppViewModeInput): AppViewMode {
   if (analyticsView !== null) return 'analytics';
   if (hasActiveSession) return 'session';
-  if (!reposLength) {
-    return !activeRepoPath && isNodesTab ? 'org' : 'empty';
-  }
+
+  // The no-session / no-explicit-project landing path is the WorkContext
+  // cockpit, even before a local repo has been added. RepoDashboard remains
+  // reserved for an explicit repo/project selection.
   if (!activeRepoPath) return 'org';
   return 'dashboard';
 }

--- a/test/active-work-surface.test.ts
+++ b/test/active-work-surface.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  activeWorkAnchorLabel,
+  activeWorkContextLabel,
   repoBindingLabel,
   repoKind,
 } from '../frontend/src/components/ActiveWorkSurface.js';
@@ -12,7 +14,7 @@ function makeSession(
   return {
     id: 'sess-1',
     nodeId: 'local',
-    tabKind: 'primary',
+    tabKind: 'terminal',
     type: 'terminal',
     cwd: '/home/user/my-project',
     repoPath: '/home/user/my-project',
@@ -24,7 +26,8 @@ function makeSession(
 }
 
 function makeGroup(
-  sessions: WorkContextSessionSummary[] = []
+  sessions: WorkContextSessionSummary[] = [],
+  overrides: Partial<WorkContextActiveGroup> = {}
 ): WorkContextActiveGroup {
   return {
     id: 'group-1',
@@ -37,6 +40,7 @@ function makeGroup(
     },
     sessions,
     staleReadModel: false,
+    ...overrides,
   };
 }
 
@@ -64,10 +68,13 @@ describe('active-work-surface anchor rendering', () => {
     const kind = repoKind(session, repos);
     expect(kind).toBe('directory');
 
-    const label = repoBindingLabel(group, session, repos);
+    const label = repoBindingLabel(session, repos);
     expect(label).toMatch(/local/);
     expect(label).toMatch(/\/home\/user\/my-project/);
     expect(label).toMatch(/directory/);
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'local · /home/user/my-project · directory'
+    );
   });
 
   it('repo-kind session anchor includes repo name and branch', () => {
@@ -84,18 +91,25 @@ describe('active-work-surface anchor rendering', () => {
     const kind = repoKind(session, repos);
     expect(kind).toBe('repo');
 
-    const label = repoBindingLabel(group, session, repos);
+    const label = repoBindingLabel(session, repos);
     expect(label).toContain('relay-ide');
     expect(label).toContain('nightly');
-    // should NOT contain 'directory'
     expect(label).not.toContain('directory');
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'repo relay-ide · nightly'
+    );
   });
 
-  it('session with no matching repo returns null kind', () => {
+  it('session with no matching repo returns null kind and no repo-binding cockpit copy', () => {
     const session = makeSession({ repoPath: '/some/unknown/path' });
     const repos: Repo[] = [];
+    const group = makeGroup([session]);
 
     expect(repoKind(session, repos)).toBeNull();
+    expect(repoBindingLabel(session, repos)).toBeNull();
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'local · /home/user/my-project · no repo binding'
+    );
   });
 
   it('directory-kind shows remote node name in anchor', () => {
@@ -105,11 +119,47 @@ describe('active-work-surface anchor rendering', () => {
       repoPath: '/srv/workspace',
     });
     const repos = [makeRepo('/srv/workspace', 'directory')];
-    const group = makeGroup([session]);
+    const group = makeGroup([session], {
+      node: {
+        nodeId: 'remote-server',
+        status: 'online',
+        displayName: 'mac node',
+        kind: 'remote',
+      },
+    });
 
-    const label = repoBindingLabel(group, session, repos);
+    const label = repoBindingLabel(session, repos);
     expect(label).toContain('remote-server');
     expect(label).toContain('/srv/workspace');
     expect(label).toContain('directory');
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'mac node · /srv/workspace · directory'
+    );
+  });
+
+  it('repo-less remote/free sessions are honest about node/cwd without repo badges', () => {
+    const session = makeSession({
+      nodeId: 'mac-node',
+      cwd: '/tmp/scratch',
+      repoPath: undefined,
+      repoName: undefined,
+      branchName: undefined,
+      tabKind: 'other',
+    });
+    const group = makeGroup([session], {
+      node: {
+        nodeId: 'mac-node',
+        status: 'offline',
+        displayName: 'mac node',
+        kind: 'remote',
+      },
+      staleReadModel: true,
+    });
+
+    expect(repoBindingLabel(session, [])).toBeNull();
+    expect(activeWorkAnchorLabel(group, session, [])).toBe(
+      'remote mac node · /tmp/scratch · no repo binding'
+    );
+    expect(activeWorkContextLabel(group)).toBe('unbound session group group-1');
   });
 });

--- a/test/app-view-mode.test.ts
+++ b/test/app-view-mode.test.ts
@@ -2,38 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { resolveAppViewMode } from '../frontend/src/lib/state/app-view-mode.js';
 
 describe('resolveAppViewMode', () => {
-  it('keeps the no-project home on the add-project empty state by default', () => {
+  it('routes the no-project/no-session landing path to the WorkContext cockpit', () => {
     expect(
       resolveAppViewMode({
         analyticsView: null,
         hasActiveSession: false,
-        reposLength: 0,
         activeRepoPath: null,
-        isNodesTab: false,
-      })
-    ).toBe('empty');
-  });
-
-  it('routes a no-project Nodes request to the org dashboard instead of EmptyState', () => {
-    expect(
-      resolveAppViewMode({
-        analyticsView: null,
-        hasActiveSession: false,
-        reposLength: 0,
-        activeRepoPath: null,
-        isNodesTab: true,
       })
     ).toBe('org');
   });
 
-  it('preserves session, analytics, and repo dashboard priority', () => {
+  it('preserves session, analytics, and explicit repo dashboard priority', () => {
     expect(
       resolveAppViewMode({
         analyticsView: { sessionId: 'session-1' },
         hasActiveSession: false,
-        reposLength: 0,
         activeRepoPath: null,
-        isNodesTab: true,
       })
     ).toBe('analytics');
 
@@ -41,9 +25,7 @@ describe('resolveAppViewMode', () => {
       resolveAppViewMode({
         analyticsView: 'dashboard',
         hasActiveSession: false,
-        reposLength: 0,
         activeRepoPath: null,
-        isNodesTab: true,
       })
     ).toBe('analytics');
 
@@ -51,9 +33,7 @@ describe('resolveAppViewMode', () => {
       resolveAppViewMode({
         analyticsView: null,
         hasActiveSession: true,
-        reposLength: 0,
         activeRepoPath: null,
-        isNodesTab: true,
       })
     ).toBe('session');
 
@@ -61,9 +41,7 @@ describe('resolveAppViewMode', () => {
       resolveAppViewMode({
         analyticsView: null,
         hasActiveSession: false,
-        reposLength: 1,
         activeRepoPath: '/repo/relay-ide',
-        isNodesTab: true,
       })
     ).toBe('dashboard');
   });


### PR DESCRIPTION
## summary
- Promote the no-session/no-explicit-repo landing path to the Active Work / WorkContext cockpit instead of the old add-project empty state.
- Update cockpit/dashboard copy so Active Work is primary and PRs, tickets, nodes, and audit read as secondary verified context.
- Expose WorkContext, anchor, session, and control details in the Active Work card while keeping repo/worktree labels limited to verified bindings.
- Add focused tests for app view-mode routing and Active Work anchor/context label behavior.

Closes #932
Refs #928

## verification
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/active-work-control.test.ts test/active-work-surface.test.ts test/app-view-mode.test.ts` — 13 tests passed.
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` — passed with existing lint warnings only.
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` — passed; Vite reported existing large chunk warnings.
- Browser smoke on isolated built server `http://127.0.0.1:59333/` with temp config `repos: []`: first-load no-project/no-session path rendered the `work cockpit` shell, `active work` primary tab, secondary `nodes` / `prs` / `tickets` / `audit` tabs, and empty Active Work cockpit copy. Console check after load reported 0 messages / 0 JS errors. Temporary setup PIN was disposable and is not recorded.
- GitHub checks observed green at head `3206a51d3f89447bc83befd9f940a899d061da90`: CI `ci`, CI `e2e`, issue automation `sync-labels`, commit scanner, and CodeRabbit all successful.

## simplify pass
- Ran the `/simplify` review pattern with reuse, quality, and efficiency reviewers.
- Applied worthwhile cleanup from the pass: removed the now-dead empty-state modal plumbing / unused `setActiveModal` selector and aligned Active Work no-repo copy tests with `no repo binding`.
- Skipped broader suggestions to infer repo labels from unverified remote WorkContext/session metadata because this slice intentionally keeps repo/worktree labels as verified bindings only.
