### PR TITLE
Add typed supervisor send-key gateway command

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -68,6 +68,12 @@ import {
   parseWorktreeInstanceId,
 } from '../shared/identity.js';
 import {
+  SUPERVISOR_SEND_KEY_NAMES,
+  supervisorActionCommandId,
+  supervisorActionRequiredCapabilities,
+  type SupervisorActionType,
+} from '../shared/supervisor-actions.js';
+import {
   isFileRpcOperation,
   FILE_RPC_MAX_WRITE_BYTES,
   type FileRpcOperation,
@@ -3221,7 +3227,7 @@ async function runGatewaySupervisorSessions(): Promise<never> {
 }
 
 function parseGatewaySupervisorActionBody(
-  commandName: 'supervisor.sendText' | 'supervisor.submit',
+  commandName: 'supervisor.sendText' | 'supervisor.sendKey' | 'supervisor.submit',
   supervisorArgs: string[]
 ): Record<string, unknown> {
   const body = parseGatewayInputObject(commandName, supervisorArgs);
@@ -3249,11 +3255,19 @@ function parseGatewaySupervisorActionBody(
   ) {
     body['text'] = text;
   }
+  const key = gatewayArg(supervisorArgs, '--key');
+  if (
+    commandName === 'supervisor.sendKey' &&
+    key !== undefined &&
+    body['key'] === undefined
+  ) {
+    body['key'] = key;
+  }
   return body;
 }
 
 function validateGatewaySupervisorActionBody(
-  commandName: 'supervisor.sendText' | 'supervisor.submit',
+  commandName: 'supervisor.sendText' | 'supervisor.sendKey' | 'supervisor.submit',
   body: Record<string, unknown>
 ): void {
   if (
@@ -3262,6 +3276,24 @@ function validateGatewaySupervisorActionBody(
   ) {
     gatewayInvalid(commandName, '--text is required for supervisor send-text', {
       field: 'text',
+    });
+  }
+  if (
+    commandName === 'supervisor.sendKey' &&
+    (typeof body['key'] !== 'string' || body['key'].length === 0)
+  ) {
+    gatewayInvalid(commandName, '--key is required for supervisor send-key', {
+      field: 'key',
+    });
+  }
+  if (
+    commandName === 'supervisor.sendKey' &&
+    typeof body['key'] === 'string' &&
+    !(SUPERVISOR_SEND_KEY_NAMES as readonly string[]).includes(body['key'])
+  ) {
+    gatewayInvalid(commandName, '--key must be one canonical supervisor key name', {
+      field: 'key',
+      allowedKeys: SUPERVISOR_SEND_KEY_NAMES,
     });
   }
   const id = body['id'];
@@ -3306,19 +3338,21 @@ async function runGatewaySupervisorAction(
   subcommand: string,
   supervisorArgs: string[]
 ): Promise<never> {
-  const commandName =
-    subcommand === 'submit' ? 'supervisor.submit' : 'supervisor.sendText';
+  const action: SupervisorActionType =
+    subcommand === 'submit'
+      ? 'submit'
+      : subcommand === 'send-key' || subcommand === 'sendKey'
+        ? 'sendKey'
+        : 'sendText';
+  const commandName = supervisorActionCommandId(action);
   const body = parseGatewaySupervisorActionBody(commandName, supervisorArgs);
   validateGatewaySupervisorActionBody(commandName, body);
   const result = await gatewayHttpJson({
     commandName,
-    pathName: `/supervisor/actions/${commandName === 'supervisor.submit' ? 'submit' : 'sendText'}`,
+    pathName: `/supervisor/actions/${action}`,
     method: 'POST',
     body,
-    capabilities:
-      commandName === 'supervisor.submit'
-        ? ['session:attach', 'tab:intervention:submit']
-        : ['session:attach', 'tab:intervention:send-text'],
+    capabilities: supervisorActionRequiredCapabilities(action),
   });
   printGatewayEnvelope(gatewayOk(commandName, result), 0);
 }
@@ -3402,6 +3436,8 @@ async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
   if (
     subcommand === 'send-text' ||
     subcommand === 'sendText' ||
+    subcommand === 'send-key' ||
+    subcommand === 'sendKey' ||
     subcommand === 'submit'
   ) {
     return runGatewaySupervisorAction(subcommand, supervisorArgs);

--- a/docs/BOO_PHILOSOPHY.md
+++ b/docs/BOO_PHILOSOPHY.md
@@ -20,7 +20,7 @@ The durable rules are:
 | --- | --- | --- |
 | `new` / detached session | **Partial.** `sessions.create` creates local or routed sessions and returns a descriptor; `sessions.detach` releases the CLI handle without killing the process. There is no explicit `--detached` terminal-multiplexer-style create flag because Relay sessions are already hub-owned handles once created. | `docs/CLI_GATEWAY.md`, `shared/cli-gateway-contract.ts` |
 | `ls --json` | **Implemented.** `sessions.list` / `sessions.get` expose stable JSON descriptors. | `docs/CLI_GATEWAY.md` |
-| `send --text` / `send --key` | **Partial.** Raw `sessions.input` can write bytes; typed `supervisor.sendText` and `supervisor.submit` are auditable. Enter is covered by `supervisor.submit`; missing keys include Escape, Tab, arrows, Ctrl-C, and function keys without raw byte encoding. | `docs/CLI_GATEWAY.md` |
+| `send --text` / `send --key` | **Partial.** Raw `sessions.input` can write bytes; typed `supervisor.sendText`, `supervisor.sendKey`, and `supervisor.submit` are auditable. Enter is covered by `supervisor.submit`; named keys cover Escape, Tab, arrows, Ctrl-C/Ctrl-D, Home/End, and Page Up/Down. Function keys and arbitrary keymaps remain out of scope. | `docs/CLI_GATEWAY.md` |
 | `wait --text` / `wait --idle` | **Partial.** `sessions.input --wait-for` does bounded raw output substring waiting; `sessions.stream --idle-timeout-ms` detaches a stream after quiet. Missing: standalone wait command and rendered-screen/cursor/title/mode predicates. | `docs/CLI_GATEWAY.md` |
 | `peek --json` / rendered screen | **Missing as stable API.** `relay-pty` maintains a libghostty-backed model internally for relay-pty sessions, and internal helpers can read visible text, but no stable gateway command exposes rendered screen JSON/scrollback. | `docs/TERMINAL_BACKENDS.md`, `server/terminal-model-backend.ts` |
 | `attach` / optional UI | **Partial.** Browser attach and CLI descriptor attach exist; `sessions.stream` attaches to the PTY stream. Missing: power-user CLI/TUI cockpit comparable to `boo ui`; current cockpit is web-first. | `docs/CLI_GATEWAY.md`, `docs/WORKBENCH_BOUNDARY.md` |
@@ -33,7 +33,7 @@ The durable rules are:
 - Versioned JSON gateway discovery and schemas: `relay-ide v1 --list --json` and `relay-ide v1 schema --json`.
 - Stable session descriptor/lifecycle commands: `sessions.list`, `sessions.get`, `sessions.create`, `sessions.attach`, `sessions.detach`, `sessions.kill`, `sessions.rename`.
 - Raw PTY stream/input primitives: `sessions.stream --mode ndjson`, `sessions.input --data|--data-base64|--stdin` with `--wait-for`, `--timeout-ms`, and `--max-bytes`.
-- Typed supervisor actions: `supervisor.sessions`, `supervisor.snapshot`, `supervisor.sendText`, and `supervisor.submit` with capability/error metadata.
+- Typed supervisor actions: `supervisor.sessions`, `supervisor.snapshot`, `supervisor.sendText`, `supervisor.sendKey`, and `supervisor.submit` with capability/error metadata.
 - `relay-pty` as the default non-tmux PTY backend, with `tmux-compat` retained for legacy/import/resume cases.
 - Internal libghostty-vt terminal model for relay-pty sessions, used by backend helpers and attention detection.
 - Active Work / workbench/control-plane nouns: `WorkContext`, `Actor`, `Session`, `Node`, `Artifact`, `AuditEvent`, `CapabilityGrant`.
@@ -51,7 +51,7 @@ The durable rules are:
 
 - Stable rendered-screen snapshot API with rows/cols/cursor/title/modes/viewport/scrollback JSON.
 - Stable rendered-screen wait API (`wait --screen-text`, `wait --idle`, `wait --title`, etc.).
-- Stable named-key API for arrows, Escape, Tab, Ctrl-C, and function keys under typed audit/capability semantics.
+- Stable function-key/keymap API beyond the closed `supervisor.sendKey` MVP enum.
 - Durable relay-pty live process reattach across server restart. Browser disconnect is fine; server restart durability is still where `tmux-compat` has the stronger story.
 - A terminal-multiplexer-style power-user CLI/TUI session manager. Relay's richer cockpit is currently web/dashboard oriented.
 - Workbench canvas as the primary integrated cockpit surface.
@@ -62,7 +62,7 @@ Use these rules when updating docs, issues, or UI copy:
 
 - Say **terminal backend** unless the behavior is specifically `tmux-compat`.
 - Say **raw PTY stream/input** for `sessions.stream` and `sessions.input`.
-- Say **typed supervisor action** for `supervisor.sendText` / `supervisor.submit` command IDs, or `relay-ide v1 supervisor send-text` / `relay-ide v1 supervisor submit` CLI argv.
+- Say **typed supervisor action** for `supervisor.sendText` / `supervisor.sendKey` / `supervisor.submit` command IDs, or `relay-ide v1 supervisor send-text` / `relay-ide v1 supervisor send-key` / `relay-ide v1 supervisor submit` CLI argv.
 - Do not call raw stream/input a rendered-screen API.
 - Do not imply `relay-pty` sessions survive server restart as the same live process.
 - Do not tell adapters to use internal REST routes, browser WebSockets, node-link, tmux, or private provider stores as contracts.

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -66,6 +66,8 @@ relay-ide v1 supervisor sessions --json
 relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json
 relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json
 relay-ide v1 supervisor send-text --target-ids <session-id-1,session-id-2> --text <literal-text> --json
+relay-ide v1 supervisor send-key --id <session-id-or-global-id> --key <escape|tab|arrow-up|arrow-down|arrow-left|arrow-right|ctrl-c|ctrl-d|home|end|page-up|page-down> --json
+relay-ide v1 supervisor send-key --target-ids <session-id-1,session-id-2> --key <escape|tab|arrow-up|arrow-down|arrow-left|arrow-right|ctrl-c|ctrl-d|home|end|page-up|page-down> --json
 relay-ide v1 supervisor submit --id <session-id-or-global-id> --json
 relay-ide v1 supervisor submit --target-ids <session-id-1,session-id-2> --json
 relay-ide v1 events subscribe --topic <sessions|nodes|audit> --json
@@ -542,14 +544,17 @@ Commands:
 | `relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json`                        | Reads one redacted supervisor snapshot.                                                  | `session:read`, `tab:intervention:read`        |
 | `relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json` | Sends bounded literal text as a typed intervention.                                      | `session:attach`, `tab:intervention:send-text` |
 | `relay-ide v1 supervisor send-text --target-ids <id-1,id-2> --text <literal-text> --json`       | Sends the same bounded literal text to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:send-text` |
+| `relay-ide v1 supervisor send-key --id <session-id-or-global-id> --key <key-name> --json`        | Sends one canonical closed-enum key as a typed intervention.                             | `session:attach`, `tab:intervention:send-key`  |
+| `relay-ide v1 supervisor send-key --target-ids <id-1,id-2> --key <key-name> --json`              | Sends the same canonical key to multiple sessions and reports per-target results.        | `session:attach`, `tab:intervention:send-key`  |
 | `relay-ide v1 supervisor submit --id <session-id-or-global-id> --json`                          | Sends Enter (`\n`) as a typed intervention.                                              | `session:attach`, `tab:intervention:submit`    |
 | `relay-ide v1 supervisor submit --target-ids <id-1,id-2> --json`                                | Sends Enter to multiple sessions and reports per-target results.                         | `session:attach`, `tab:intervention:submit`    |
 
 Inputs:
 
-- `supervisor.sessions` takes no input and returns `{ command: "supervisor.sessions", sessions, count }`. Each session includes `sessionId`, optional `globalSessionId`/`nodeId`, `mode`, `status`, optional `controlMode`/`controlFreshness`, and `actions.sendText` / `actions.submit` eligibility. Ineligible actions carry a `reasonCode` such as `SESSION_DISCONNECTED`, `SESSION_MODE_UNSUPPORTED`, `CONTROL_STATE_STALE`, or `CONTROL_STATE_UNKNOWN`.
+- `supervisor.sessions` takes no input and returns `{ command: "supervisor.sessions", sessions, count }`. Each session includes `sessionId`, optional `globalSessionId`/`nodeId`, `mode`, `status`, optional `controlMode`/`controlFreshness`, and `actions.sendText` / `actions.sendKey` / `actions.submit` eligibility. Ineligible actions carry a `reasonCode` such as `SESSION_DISCONNECTED`, `SESSION_MODE_UNSUPPORTED`, `CONTROL_STATE_STALE`, or `CONTROL_STATE_UNKNOWN`.
 - `supervisor.snapshot` requires `id`. Optional `--expected-control-mode <agent-driven|human-driven|co-driven>` and `--latest-seen-intervention-event-id <event-id>` are preflight guards. Stale or mismatched control state returns `CONTROL_STATE_STALE`; an unacknowledged newer intervention returns `INTERVENTION_ACK_REQUIRED`. The snapshot path is read-only: it never writes to the session, accepts prompts, or stores raw prompt/transcript/PTY/provider state.
 - `supervisor.sendText` requires `text` plus exactly one target shape: `id` or `targetIds`. CLI flags are `--id`, positional `<id>`, or comma-separated `--target-ids`; `--input-json` / `--input-file` may provide the same object shape, including optional `actor` metadata. Text must be non-empty literal text, at most 1000 characters, with no CR/LF, ESC, DEL, or control characters except tab. Use `supervisor.submit` for Enter instead of embedding a newline.
+- `supervisor.sendKey` requires `key` plus exactly one target shape: `id` or `targetIds`. CLI flags are `--id`, positional `<id>`, comma-separated `--target-ids`, and `--key`; `--input-json` / `--input-file` may provide the same object shape, including optional `actor` metadata. Keys are a closed enum only: `escape`, `tab`, `arrow-up`, `arrow-down`, `arrow-left`, `arrow-right`, `ctrl-c`, `ctrl-d`, `home`, `end`, `page-up`, and `page-down`. Aliases, function keys, raw escape/control strings, newlines, and arbitrary byte payloads are rejected; Relay maps the canonical name to substrate bytes behind the capability/control/audit boundary.
 - `supervisor.submit` requires `id` or `targetIds`, accepts optional `actor` metadata via JSON input, and writes exactly `\n`. It does not accept a text payload.
 
 Successful action envelope shape:
@@ -613,9 +618,9 @@ Action failure semantics:
 
 - CLI parse/auth/connectivity failures return a normal `ok: false` gateway envelope and the CLI exits nonzero. Examples: malformed `--input-json`, missing `RELAY_IDE_BROWSER_TOKEN`, unreachable hub, missing `--id`/`--target-ids`, or missing `--text` for `send-text`.
 - Once the action request reaches the hub, target-level problems are reported in the successful action envelope under `data.results[].error` with aggregate `data.counts` and `data.audit.partialFailure`. This preserves multi-target partial success instead of failing the whole command on the first bad target.
-- Per-target errors use typed `code`, `reasonCode`, `message`, `retryable`, and optional `details`. Current reason codes include `CAPABILITY_REQUIRED`, `SESSION_NOT_FOUND`, `SESSION_DISCONNECTED`, `CONTROL_STATE_STALE`, `CONTROL_STATE_UNKNOWN`, `SESSION_MODE_UNSUPPORTED`, `TEXT_REQUIRED`, `TEXT_TOO_LARGE`, `TEXT_MUST_BE_LITERAL`, and `UPSTREAM_WRITE_FAILED`.
+- Per-target errors use typed `code`, `reasonCode`, `message`, `retryable`, and optional `details`. Current reason codes include `CAPABILITY_REQUIRED`, `SESSION_NOT_FOUND`, `SESSION_DISCONNECTED`, `CONTROL_STATE_STALE`, `CONTROL_STATE_UNKNOWN`, `SESSION_MODE_UNSUPPORTED`, `TEXT_REQUIRED`, `TEXT_TOO_LARGE`, `TEXT_MUST_BE_LITERAL`, `KEY_REQUIRED`, `KEY_INVALID`, and `UPSTREAM_WRITE_FAILED`.
 - `counts.denied` is for capability denials (`FORBIDDEN`). Other per-target errors increment `counts.failed`. `counts.skipped` is reserved for future fan-out decisions.
-- Audit stores actor summary, target session IDs/count, action type, timestamp, hashes/counts/classes for content, and the aggregate partial-failure flag. Raw supervisor text is not returned or stored by default.
+- Audit stores actor summary, target session IDs/count, action type, optional canonical send-key name, timestamp, hashes/counts/classes for content, and the aggregate partial-failure flag. Raw supervisor text or mapped terminal bytes are not returned or stored by default.
 
 This is deliberately distinct from raw PTY input and terminal substrates:
 

--- a/server/control-engine.ts
+++ b/server/control-engine.ts
@@ -25,7 +25,7 @@ import {
 } from './intervention-log.js';
 
 export type ControlModeAction = 'join' | 'take-over' | 'hand-back';
-export type SupervisorInterventionAction = 'sendText' | 'submit';
+export type SupervisorInterventionAction = 'sendText' | 'sendKey' | 'submit';
 
 export interface ControlEngineOptions {
   inputDebounceMs?: number;
@@ -521,7 +521,9 @@ export function recordSupervisorAction(
     kind:
       input.action === 'sendText'
         ? 'supervisor-send-text'
-        : 'supervisor-submit',
+        : input.action === 'sendKey'
+          ? 'supervisor-send-key'
+          : 'supervisor-submit',
     payload: input.payload,
     modeBefore: before.controlMode,
     modeAfter,

--- a/server/supervisor-actions.ts
+++ b/server/supervisor-actions.ts
@@ -2,6 +2,7 @@ import * as crypto from 'node:crypto';
 
 import { normalizeControlStateSummary, type ControlActor, type ControlMode } from '../shared/control-state.js';
 import {
+  SUPERVISOR_SEND_KEY_NAMES,
   supervisorActionCommandId,
   type SupervisorActionAuditSummary,
   type SupervisorActionCounts,
@@ -10,13 +11,30 @@ import {
   type SupervisorActionResponse,
   type SupervisorActionTargetResult,
   type SupervisorActionType,
+  type SupervisorSendKeyName,
   type SupervisorSessionEligibility,
   type SupervisorSessionsResponse,
 } from '../shared/supervisor-actions.js';
 import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
+import { encodeTerminalInput, type TerminalInputKey } from './terminal-model-backend.js';
 import type { Session, SessionSummary } from './types.js';
 
 const MAX_SUPERVISOR_TEXT_CHARS = 1000;
+const SUPERVISOR_SEND_KEY_INPUTS: Record<SupervisorSendKeyName, TerminalInputKey> = {
+  escape: 'Escape',
+  tab: 'Tab',
+  'arrow-up': 'ArrowUp',
+  'arrow-down': 'ArrowDown',
+  'arrow-left': 'ArrowLeft',
+  'arrow-right': 'ArrowRight',
+  'ctrl-c': 'CtrlC',
+  'ctrl-d': 'CtrlD',
+  home: 'Home',
+  end: 'End',
+  'page-up': 'PageUp',
+  'page-down': 'PageDown',
+};
+const SUPERVISOR_SEND_KEY_NAME_SET = new Set<string>(SUPERVISOR_SEND_KEY_NAMES);
 const DEFAULT_SUPERVISOR_ACTOR: ControlActor = {
   kind: 'agent',
   id: 'relay-supervisor',
@@ -57,9 +75,48 @@ function targetIdentity(session: Session | SessionSummary | undefined, requested
 }
 
 function validationError(
-  validation: { ok: true; text: string } | { ok: false; error: SupervisorActionError }
+  validation:
+    | { ok: true; text: string }
+    | { ok: true; key: SupervisorSendKeyName; payload: string }
+    | { ok: false; error: SupervisorActionError }
 ): SupervisorActionError | undefined {
   return 'error' in validation ? validation.error : undefined;
+}
+
+function validateActionPayload(
+  action: SupervisorActionType,
+  text: unknown,
+  key: unknown
+):
+  | { ok: true; text: string }
+  | { ok: true; key: SupervisorSendKeyName; payload: string }
+  | { ok: false; error: SupervisorActionError } {
+  if (action === 'sendText') {
+    return validateLiteralText(text);
+  }
+  if (action === 'sendKey') {
+    return validateSendKey(key);
+  }
+  return { ok: true, text: '\n' };
+}
+
+function payloadForValidation(
+  validation:
+    | { ok: true; text: string }
+    | { ok: true; key: SupervisorSendKeyName; payload: string }
+    | { ok: false; error: SupervisorActionError }
+): string {
+  if (!validation.ok) return '';
+  return 'payload' in validation ? validation.payload : validation.text;
+}
+
+function keyForValidation(
+  validation:
+    | { ok: true; text: string }
+    | { ok: true; key: SupervisorSendKeyName; payload: string }
+    | { ok: false; error: SupervisorActionError }
+): SupervisorSendKeyName | undefined {
+  return validation.ok && 'key' in validation ? validation.key : undefined;
 }
 
 function countLines(input: string): number {
@@ -67,14 +124,23 @@ function countLines(input: string): number {
   return input.split(/\r\n|\r|\n/).length;
 }
 
-function redactionForPayload(payload: string): SupervisorActionRedactionMetadata {
+function redactionForPayload(
+  payload: string,
+  action: SupervisorActionType
+): SupervisorActionRedactionMetadata {
+  const classes =
+    action === 'submit'
+      ? ['submit']
+      : action === 'sendKey'
+        ? ['named-key']
+        : ['literal-text'];
   return {
     rawContentAvailable: false,
     hashSha256: sha256(payload),
     byteCount: Buffer.byteLength(payload, 'utf8'),
     charCount: Array.from(payload).length,
     lineCount: countLines(payload),
-    classes: payload === '\n' ? ['submit'] : ['literal-text'],
+    classes,
     redacted: true,
   };
 }
@@ -119,6 +185,46 @@ function validateLiteralText(text: unknown): { ok: true; text: string } | { ok: 
     };
   }
   return { ok: true, text };
+}
+
+function validateSendKey(
+  key: unknown
+):
+  | { ok: true; key: SupervisorSendKeyName; payload: string }
+  | { ok: false; error: SupervisorActionError } {
+  if (typeof key !== 'string' || key.length === 0) {
+    return {
+      ok: false,
+      error: error(
+        'INVALID_ARGUMENT',
+        'KEY_REQUIRED',
+        'sendKey requires one canonical --key name',
+        false,
+        { allowedKeys: SUPERVISOR_SEND_KEY_NAMES }
+      ),
+    };
+  }
+  if (!SUPERVISOR_SEND_KEY_NAME_SET.has(key)) {
+    return {
+      ok: false,
+      error: error(
+        'INVALID_ARGUMENT',
+        'KEY_INVALID',
+        'sendKey accepts only canonical closed-enum key names',
+        false,
+        { field: 'key', allowedKeys: SUPERVISOR_SEND_KEY_NAMES }
+      ),
+    };
+  }
+  const canonicalKey = key as SupervisorSendKeyName;
+  return {
+    ok: true,
+    key: canonicalKey,
+    payload: encodeTerminalInput({
+      type: 'key',
+      key: SUPERVISOR_SEND_KEY_INPUTS[canonicalKey],
+    }).sequence,
+  };
 }
 
 function missingSessionError(requestedId: string): SupervisorActionError {
@@ -180,6 +286,7 @@ export function listSupervisorSessions(sessions: readonly SessionSummary[]): Sup
         ...(session.controlFreshness === undefined ? {} : { controlFreshness: session.controlFreshness }),
         actions: {
           sendText: { allowed, ...(reason ? { reasonCode: reason } : {}) },
+          sendKey: { allowed, ...(reason ? { reasonCode: reason } : {}) },
           submit: { allowed, ...(reason ? { reasonCode: reason } : {}) },
         },
       };
@@ -193,16 +300,16 @@ export function executeSupervisorAction(input: {
   action: SupervisorActionType;
   targetIds: readonly string[];
   text?: unknown;
+  key?: unknown;
   actor?: ControlActor;
   now?: Date;
   deniedByCapability?: SupervisorActionError;
 }): SupervisorActionResponse {
   const actor = input.actor ?? DEFAULT_SUPERVISOR_ACTOR;
   const timestamp = (input.now ?? new Date()).toISOString();
-  const validation = input.action === 'sendText'
-    ? validateLiteralText(input.text)
-    : { ok: true as const, text: '\n' };
-  const payload = validation.ok ? validation.text : '';
+  const validation = validateActionPayload(input.action, input.text, input.key);
+  const payload = payloadForValidation(validation);
+  const canonicalKey = keyForValidation(validation);
   const payloadValidationError = validationError(validation);
   const results: SupervisorActionTargetResult[] = [];
 
@@ -242,6 +349,7 @@ export function executeSupervisorAction(input: {
         ok: true,
         action: input.action,
         bytesWritten: Buffer.byteLength(payload, 'utf8'),
+        ...(canonicalKey === undefined ? {} : { key: canonicalKey }),
         interventionEventId: write.eventId,
         ...(write.modeBefore === undefined ? {} : { controlModeBefore: write.modeBefore }),
         ...(write.modeAfter === undefined ? {} : { controlModeAfter: write.modeAfter }),
@@ -264,8 +372,9 @@ export function executeSupervisorAction(input: {
     actor: actorSummary(actor),
     targetSessionIds: results.map((result) => result.sessionId),
     targetCount: results.length,
+    ...(canonicalKey === undefined ? {} : { key: canonicalKey }),
     timestamp,
-    ...(validation.ok ? { content: redactionForPayload(payload) } : {}),
+    ...(validation.ok ? { content: redactionForPayload(payload, input.action) } : {}),
     counts,
     rawContentStored: false,
     partialFailure: counts.failed > 0 || counts.denied > 0 || counts.skipped > 0,

--- a/server/supervisor-route-handlers.ts
+++ b/server/supervisor-route-handlers.ts
@@ -54,7 +54,7 @@ function supervisorActionErrorStatus(error: SupervisorActionError): number {
 function actionFromParam(
   actionParam: string | undefined
 ): SupervisorActionType | undefined {
-  return actionParam === 'sendText' || actionParam === 'submit'
+  return actionParam === 'sendText' || actionParam === 'sendKey' || actionParam === 'submit'
     ? actionParam
     : undefined;
 }
@@ -161,9 +161,8 @@ function supervisorActionCapabilitiesDecision(
   const header = req.header('x-relay-capabilities') ?? undefined;
   if (header === undefined || header.trim().length === 0) {
     const highRiskCapability =
-      action === 'submit'
-        ? 'tab:intervention:submit'
-        : 'tab:intervention:send-text';
+      capabilities.find((capability) => capability.startsWith('tab:intervention:')) ??
+      'session:attach';
     return missingCapabilityEvidenceDecision(highRiskCapability);
   }
   return capabilitiesDecisionFromRequest(req, capabilities);
@@ -195,7 +194,7 @@ export function handleSupervisorActionRequest(
   if (!action) {
     const error = supervisorActionError(
       'TARGET_SELECTOR_INVALID',
-      'supervisor action must be sendText or submit',
+      'supervisor action must be sendText, sendKey, or submit',
       { field: 'action' }
     );
     res.status(supervisorActionErrorStatus(error)).json({ error });
@@ -223,6 +222,7 @@ export function handleSupervisorActionRequest(
     action,
     targetIds: targets.targetIds,
     text: body['text'],
+    key: body['key'],
     ...(actor === undefined ? {} : { actor }),
   });
   res.json(result);

--- a/server/terminal-model-backend.ts
+++ b/server/terminal-model-backend.ts
@@ -15,7 +15,12 @@ export type TerminalInputKey =
   | 'ArrowDown'
   | 'ArrowLeft'
   | 'ArrowRight'
-  | 'CtrlC';
+  | 'CtrlC'
+  | 'CtrlD'
+  | 'Home'
+  | 'End'
+  | 'PageUp'
+  | 'PageDown';
 
 export type TerminalInput =
   | { type: 'text'; text: string }
@@ -74,6 +79,11 @@ const KEY_SEQUENCES: Record<TerminalInputKey, string> = {
   ArrowRight: '\x1b[C',
   ArrowLeft: '\x1b[D',
   CtrlC: '\x03',
+  CtrlD: '\x04',
+  Home: '\x1b[H',
+  End: '\x1b[F',
+  PageUp: '\x1b[5~',
+  PageDown: '\x1b[6~',
 };
 
 /**

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -4,6 +4,7 @@ import {
   CONTEXT_PACKET_KINDS,
   SESSION_INBOX_MESSAGE_STATES,
 } from './context-packet.js';
+import { SUPERVISOR_SEND_KEY_NAMES } from './supervisor-actions.js';
 
 export const RELAY_CLI_GATEWAY_MAJOR = 'v1' as const;
 export const RELAY_CLI_GATEWAY_CONTRACT_VERSION = '1.0' as const;
@@ -71,6 +72,7 @@ export type RelayCliGatewayCommand =
   | 'supervisor.snapshot'
   | 'supervisor.sessions'
   | 'supervisor.sendText'
+  | 'supervisor.sendKey'
   | 'supervisor.submit'
   | 'events.subscribe'
   | 'settings.get'
@@ -1725,6 +1727,20 @@ const supervisorSendTextInputSchema: RelayJsonSchema = {
   oneOf: [{ required: ['id'] }, { required: ['targetIds'] }],
 };
 
+const supervisorSendKeyInputSchema: RelayJsonSchema = {
+  title: 'SupervisorSendKeyInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    targetIds: { type: 'array', items: stringSchema },
+    key: { type: 'string', enum: SUPERVISOR_SEND_KEY_NAMES },
+    actor: { type: 'object', additionalProperties: true },
+  },
+  required: ['key'],
+  oneOf: [{ required: ['id'] }, { required: ['targetIds'] }],
+};
+
 const supervisorSubmitInputSchema: RelayJsonSchema = {
   title: 'SupervisorSubmitInput',
   type: 'object',
@@ -1889,9 +1905,14 @@ const supervisorSessionsOutputSchema: RelayJsonSchema = {
 };
 
 const supervisorActionOutputSchema = (
-  command: 'supervisor.sendText' | 'supervisor.submit'
+  command: 'supervisor.sendText' | 'supervisor.sendKey' | 'supervisor.submit'
 ): RelayJsonSchema => {
-  const action = command === 'supervisor.submit' ? 'submit' : 'sendText';
+  const action =
+    command === 'supervisor.submit'
+      ? 'submit'
+      : command === 'supervisor.sendKey'
+        ? 'sendKey'
+        : 'sendText';
   return {
     type: 'object',
     additionalProperties: true,
@@ -3716,6 +3737,32 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     outputSchema: okOutput(
       'SupervisorSendTextOutput',
       supervisorActionOutputSchema('supervisor.sendText')
+    ),
+    errorCodes: gatewaySupervisorErrorCodes,
+  },
+  {
+    name: 'supervisor.sendKey',
+    cli: [
+      'relay-ide',
+      'v1',
+      'supervisor',
+      'send-key',
+      '--id',
+      '<session-id>',
+      '--key',
+      '<key-name>',
+      '--json',
+    ],
+    summary:
+      'Send one canonical closed-enum key to one or more PTY sessions as a typed supervisor intervention.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:attach', 'tab:intervention:send-key'],
+    inputSchema: supervisorSendKeyInputSchema,
+    outputSchema: okOutput(
+      'SupervisorSendKeyOutput',
+      supervisorActionOutputSchema('supervisor.sendKey')
     ),
     errorCodes: gatewaySupervisorErrorCodes,
   },

--- a/shared/control-state.ts
+++ b/shared/control-state.ts
@@ -60,6 +60,7 @@ export type InterventionSource =
 export type InterventionKind =
   | 'human-input'
   | 'supervisor-send-text'
+  | 'supervisor-send-key'
   | 'supervisor-submit'
   | 'join'
   | 'take-over'

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -141,6 +141,7 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'supervisor.snapshot': 'supervisor snapshot',
   'supervisor.sessions': 'supervisor sessions',
   'supervisor.sendText': 'supervisor send text',
+  'supervisor.sendKey': 'supervisor send key',
   'supervisor.submit': 'supervisor submit',
   'events.subscribe': 'subscribe gateway events',
   'settings.get': 'safe settings get',
@@ -172,6 +173,7 @@ const WRITE_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
   'sessions.input',
   'sessions.handBack',
   'supervisor.sendText',
+  'supervisor.sendKey',
   'supervisor.submit',
   'files.write',
   'handoffs.cancel',
@@ -256,6 +258,7 @@ function controlRequirementsForGatewayCommand(
   }
   if (
     spec.name === 'supervisor.sendText' ||
+    spec.name === 'supervisor.sendKey' ||
     spec.name === 'supervisor.submit'
   ) {
     requirements.push('fresh-control-state');
@@ -280,6 +283,7 @@ function auditExpectationForGatewayCommand(
   if (
     spec.name === 'supervisor.snapshot' ||
     spec.name === 'supervisor.sendText' ||
+    spec.name === 'supervisor.sendKey' ||
     spec.name === 'supervisor.submit'
   )
     return 'hashes-only';

--- a/shared/security-audit.ts
+++ b/shared/security-audit.ts
@@ -284,6 +284,9 @@ function controlEventRequiredBits(event: TabControlEvent): RelayCapabilityBit[] 
     if (event.intervention.kind === 'supervisor-send-text') {
       return ['session:attach', 'tab:intervention:send-text'];
     }
+    if (event.intervention.kind === 'supervisor-send-key') {
+      return ['session:attach', 'tab:intervention:send-key'];
+    }
     if (event.intervention.kind === 'supervisor-submit') {
       return ['session:attach', 'tab:intervention:submit'];
     }

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -12,6 +12,7 @@ export const RELAY_CAPABILITY_BITS = [
   'tab:mode:set-agent',
   'tab:intervention:read',
   'tab:intervention:send-text',
+  'tab:intervention:send-key',
   'tab:intervention:submit',
   'rpc:fs:list',
   'rpc:fs:read',
@@ -94,6 +95,7 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
 export const HIGH_RISK_CAPABILITIES = [
   'session:control:kill',
   'tab:intervention:send-text',
+  'tab:intervention:send-key',
   'tab:intervention:submit',
   'rpc:fs:write',
   'rpc:fs:delete',

--- a/shared/supervisor-actions.ts
+++ b/shared/supervisor-actions.ts
@@ -7,6 +7,7 @@ import type { RelayCapabilityBit } from './security-policy.js';
 
 export const SUPERVISOR_SESSIONS_COMMAND_ID = 'supervisor.sessions' as const;
 export const SUPERVISOR_SEND_TEXT_COMMAND_ID = 'supervisor.sendText' as const;
+export const SUPERVISOR_SEND_KEY_COMMAND_ID = 'supervisor.sendKey' as const;
 export const SUPERVISOR_SUBMIT_COMMAND_ID = 'supervisor.submit' as const;
 
 export const SUPERVISOR_READ_REQUIRED_CAPABILITIES = [
@@ -19,12 +20,34 @@ export const SUPERVISOR_SEND_TEXT_REQUIRED_CAPABILITIES = [
   'tab:intervention:send-text',
 ] as const satisfies readonly RelayCapabilityBit[];
 
+export const SUPERVISOR_SEND_KEY_REQUIRED_CAPABILITIES = [
+  'session:attach',
+  'tab:intervention:send-key',
+] as const satisfies readonly RelayCapabilityBit[];
+
 export const SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES = [
   'session:attach',
   'tab:intervention:submit',
 ] as const satisfies readonly RelayCapabilityBit[];
 
-export type SupervisorActionType = 'sendText' | 'submit';
+export const SUPERVISOR_SEND_KEY_NAMES = [
+  'escape',
+  'tab',
+  'arrow-up',
+  'arrow-down',
+  'arrow-left',
+  'arrow-right',
+  'ctrl-c',
+  'ctrl-d',
+  'home',
+  'end',
+  'page-up',
+  'page-down',
+] as const;
+
+export type SupervisorSendKeyName = (typeof SUPERVISOR_SEND_KEY_NAMES)[number];
+
+export type SupervisorActionType = 'sendText' | 'sendKey' | 'submit';
 
 export type SupervisorActionErrorCode =
   | 'FORBIDDEN'
@@ -47,6 +70,8 @@ export type SupervisorActionReasonCode =
   | 'TEXT_REQUIRED'
   | 'TEXT_TOO_LARGE'
   | 'TEXT_MUST_BE_LITERAL'
+  | 'KEY_REQUIRED'
+  | 'KEY_INVALID'
   | 'UPSTREAM_WRITE_FAILED';
 
 export interface SupervisorActionError {
@@ -74,6 +99,7 @@ export interface SupervisorActionTargetResult {
   ok: boolean;
   action: SupervisorActionType;
   bytesWritten?: number;
+  key?: SupervisorSendKeyName;
   interventionEventId?: string;
   controlModeBefore?: ControlMode;
   controlModeAfter?: ControlMode;
@@ -99,6 +125,7 @@ export interface SupervisorActionAuditSummary {
   };
   targetSessionIds: string[];
   targetCount: number;
+  key?: SupervisorSendKeyName;
   timestamp: string;
   content?: SupervisorActionRedactionMetadata;
   counts: SupervisorActionCounts;
@@ -109,6 +136,7 @@ export interface SupervisorActionAuditSummary {
 export interface SupervisorActionResponse {
   command:
     | typeof SUPERVISOR_SEND_TEXT_COMMAND_ID
+    | typeof SUPERVISOR_SEND_KEY_COMMAND_ID
     | typeof SUPERVISOR_SUBMIT_COMMAND_ID;
   action: SupervisorActionType;
   results: SupervisorActionTargetResult[];
@@ -144,17 +172,18 @@ export interface SupervisorSessionsResponse {
 export function supervisorActionRequiredCapabilities(
   action: SupervisorActionType
 ): readonly RelayCapabilityBit[] {
-  return action === 'sendText'
-    ? SUPERVISOR_SEND_TEXT_REQUIRED_CAPABILITIES
-    : SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES;
+  if (action === 'sendText') return SUPERVISOR_SEND_TEXT_REQUIRED_CAPABILITIES;
+  if (action === 'sendKey') return SUPERVISOR_SEND_KEY_REQUIRED_CAPABILITIES;
+  return SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES;
 }
 
 export function supervisorActionCommandId(
   action: SupervisorActionType
 ):
   | typeof SUPERVISOR_SEND_TEXT_COMMAND_ID
+  | typeof SUPERVISOR_SEND_KEY_COMMAND_ID
   | typeof SUPERVISOR_SUBMIT_COMMAND_ID {
-  return action === 'sendText'
-    ? SUPERVISOR_SEND_TEXT_COMMAND_ID
-    : SUPERVISOR_SUBMIT_COMMAND_ID;
+  if (action === 'sendText') return SUPERVISOR_SEND_TEXT_COMMAND_ID;
+  if (action === 'sendKey') return SUPERVISOR_SEND_KEY_COMMAND_ID;
+  return SUPERVISOR_SUBMIT_COMMAND_ID;
 }

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -188,6 +188,7 @@ describe('CLI gateway contract', () => {
       'supervisor.snapshot',
       'supervisor.sessions',
       'supervisor.sendText',
+      'supervisor.sendKey',
       'supervisor.submit',
       'events.subscribe',
       'settings.get',
@@ -448,6 +449,13 @@ describe('CLI gateway contract', () => {
       scopeKinds: ['session'],
     });
     expect(relayCommandDefinition('supervisor.sendText')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      controlRequirements: ['fresh-control-state'],
+      auditRedaction: { expectation: 'hashes-only' },
+      scopeKinds: ['session'],
+    });
+    expect(relayCommandDefinition('supervisor.sendKey')).toMatchObject({
       sideEffect: 'write',
       requiresConfirmation: false,
       controlRequirements: ['fresh-control-state'],
@@ -922,6 +930,7 @@ describe('CLI gateway contract', () => {
       'supervisor.snapshot',
       'supervisor.sessions',
       'supervisor.sendText',
+      'supervisor.sendKey',
       'supervisor.submit',
       'events.subscribe',
     ] as const;

--- a/test/relay-pty-session.test.ts
+++ b/test/relay-pty-session.test.ts
@@ -113,6 +113,11 @@ describe('TerminalModelBackend — libghostty-vt', () => {
     expect(encodeTerminalInput({ type: 'key', key: 'ArrowLeft' }).sequence).toBe('\x1b[D');
     expect(encodeTerminalInput({ type: 'key', key: 'ArrowRight' }).sequence).toBe('\x1b[C');
     expect(encodeTerminalInput({ type: 'key', key: 'CtrlC' }).sequence).toBe('\x03');
+    expect(encodeTerminalInput({ type: 'key', key: 'CtrlD' }).sequence).toBe('\x04');
+    expect(encodeTerminalInput({ type: 'key', key: 'Home' }).sequence).toBe('\x1b[H');
+    expect(encodeTerminalInput({ type: 'key', key: 'End' }).sequence).toBe('\x1b[F');
+    expect(encodeTerminalInput({ type: 'key', key: 'PageUp' }).sequence).toBe('\x1b[5~');
+    expect(encodeTerminalInput({ type: 'key', key: 'PageDown' }).sequence).toBe('\x1b[6~');
   });
 });
 

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -299,6 +299,9 @@ describe('hub node dashboard state', () => {
     // allowed in dev, denied in sandbox + prod.
     // #704 added two typed supervisor action bits; all default node tiers
     // deny them unless a user grants the scoped supervisor capabilities.
+    // #927 added `tab:intervention:send-key` as another high-risk supervisor
+    // capability. These fixtures do not grant or challenge it, so it is
+    // denied in every tier and does not change the prod challenge count.
     // #765 / ADR-019 added four context/inbox bits (context/inbox read+write):
     // dev silent-allows all four (default-allowed grant set), sandbox denies
     // all four (grants nothing), and the prod fixture below denies all four
@@ -320,9 +323,9 @@ describe('hub node dashboard state', () => {
     expect(
       rows.map((row) => [row.security.trustTier, row.security.postureLabel])
     ).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 31'],
-      ['dev', 'allow 18 · challenge 0 · deny 14'],
-      ['prod', 'allow 1 · challenge 2 · deny 29'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 32'],
+      ['dev', 'allow 18 · challenge 0 · deny 15'],
+      ['prod', 'allow 1 · challenge 2 · deny 30'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',

--- a/test/supervisor-actions.test.ts
+++ b/test/supervisor-actions.test.ts
@@ -5,6 +5,7 @@ import {
   type SupervisorActionSessionBoundary,
 } from '../server/supervisor-actions.js';
 import type { Session, SessionSummary } from '../server/types.js';
+import { supervisorActionRequiredCapabilities } from '../shared/supervisor-actions.js';
 
 function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
@@ -56,6 +57,7 @@ describe('typed supervisor actions', () => {
     expect(response).toMatchObject({ command: 'supervisor.sessions', count: 3 });
     expect(response.sessions[0]?.actions).toEqual({
       sendText: { allowed: true },
+      sendKey: { allowed: true },
       submit: { allowed: true },
     });
     expect(response.sessions[1]?.actions.sendText).toMatchObject({
@@ -102,21 +104,77 @@ describe('typed supervisor actions', () => {
     expect(JSON.stringify(sendText)).not.toContain('hello');
   });
 
-  it.each(['sendText', 'submit'] as const)(
+  it('maps canonical sendKey names to terminal bytes while auditing only the key name', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'sendKey',
+      targetIds: ['sess-1'],
+      key: 'arrow-up',
+      now: new Date('2026-05-16T00:00:02.000Z'),
+    });
+
+    expect(writes).toEqual(['sess-1:\u001b[A']);
+    expect(result).toMatchObject({
+      command: 'supervisor.sendKey',
+      action: 'sendKey',
+      counts: { requested: 1, succeeded: 1, denied: 0, failed: 0, skipped: 0 },
+      audit: {
+        action: 'sendKey',
+        key: 'arrow-up',
+        targetSessionIds: ['sess-1'],
+        targetCount: 1,
+        content: {
+          rawContentAvailable: false,
+          byteCount: 3,
+          charCount: 3,
+          lineCount: 1,
+          classes: ['named-key'],
+          redacted: true,
+        },
+      },
+      results: [{ sessionId: 'sess-1', ok: true, key: 'arrow-up' }],
+    });
+    expect(JSON.stringify(result)).not.toContain('\u001b[A');
+  });
+
+  it.each(['ArrowUp', 'up', '\u001b[A', 'ctrl-m', 'arrow-up\n'])(
+    'rejects non-canonical sendKey input %s before writing',
+    (key) => {
+      const writes: string[] = [];
+      const result = executeSupervisorAction({
+        boundary: boundary({ 'sess-1': session() }, writes),
+        action: 'sendKey',
+        targetIds: ['sess-1'],
+        key,
+      });
+
+      expect(writes).toEqual([]);
+      expect(result.counts).toMatchObject({ requested: 1, succeeded: 0, failed: 1 });
+      expect(result.results[0]?.error).toMatchObject({
+        code: 'INVALID_ARGUMENT',
+        reasonCode: 'KEY_INVALID',
+      });
+    }
+  );
+
+  it.each(['sendText', 'sendKey', 'submit'] as const)(
     'reports capability-denied %s without writing to targets',
     (action) => {
       const writes: string[] = [];
+      const deniedCapability = supervisorActionRequiredCapabilities(action)[1];
       const result = executeSupervisorAction({
         boundary: boundary({ 'sess-1': session() }, writes),
         action,
         targetIds: ['sess-1'],
         text: action === 'sendText' ? 'hello' : undefined,
+        key: action === 'sendKey' ? 'escape' : undefined,
         deniedByCapability: {
           code: 'FORBIDDEN',
           reasonCode: 'CAPABILITY_REQUIRED',
-          message: 'missing required capability: tab:intervention:send-text',
+          message: `missing required capability: ${deniedCapability}`,
           retryable: false,
-          details: { capability: 'tab:intervention:send-text' },
+          details: { capability: deniedCapability },
         },
       });
 

--- a/test/supervisor-route-handlers.test.ts
+++ b/test/supervisor-route-handlers.test.ts
@@ -229,6 +229,60 @@ describe('supervisor route handlers', () => {
     });
   });
 
+  it('requires send-key capability evidence for supervisor sendKey actions', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        action: 'sendKey',
+        body: { id: 'sess-1', key: 'escape' },
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'FORBIDDEN',
+        reasonCode: 'CAPABILITY_REQUIRED',
+        details: expect.objectContaining({
+          capability: 'tab:intervention:send-key',
+        }),
+      }),
+    });
+  });
+
+  it('sends canonical sendKey requests through the supervisor boundary', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        action: 'sendKey',
+        body: { id: 'sess-1', key: 'tab' },
+        capabilities: 'session:attach,tab:intervention:send-key',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ action: 'sendKey', payload: '\t' })
+    );
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'supervisor.sendKey',
+        action: 'sendKey',
+        audit: expect.objectContaining({ key: 'tab' }),
+      })
+    );
+  });
+
   it('preserves multi-target partial-failure semantics for valid supervisor action requests', () => {
     const sessions = supervisorBoundary({
       'sess-1': session({ id: 'sess-1' }),


### PR DESCRIPTION
Closes #927

## Summary
- adds stable `supervisor.sendKey` / `relay-ide v1 supervisor send-key` with closed MVP key enum and schema/list/manifest coverage
- wires `tab:intervention:send-key` as a high-risk supervisor capability through route checks, security audit mapping, control intervention state, and per-target partial result/audit metadata
- maps canonical key names to terminal bytes behind Relay using the terminal input encoder, without returning/storing raw terminal bytes
- updates CLI gateway and BOO docs for the typed send-key surface

## Verification
- `npm test -- test/supervisor-actions.test.ts test/supervisor-route-handlers.test.ts test/control-engine.test.ts` (37 passed)
- `npm test -- test/cli-gateway-contract.test.ts` (17 passed)
- `npm test -- test/supervisor-actions.test.ts test/supervisor-route-handlers.test.ts test/control-engine.test.ts test/cli-gateway-contract.test.ts test/relay-pty-session.test.ts` (60 passed)
- `npm run check` (passed; existing lint warnings only)
- `npm run build` (passed; existing Vite chunk-size warning)
- `npm test -- test/cli-gateway-hermes-tools.test.ts test/cli-gateway-codex-tools.test.ts test/cli-gateway-claude-tools.test.ts` (11 passed)
- built CLI smoke: `v1 --list --json` + `v1 schema --json` include `supervisor.sendKey` with 12-key enum and `session:attach`/`tab:intervention:send-key`; invalid `--key f1` exits nonzero with `allowedKeys`

## Simplify pass
- ran parallel reuse/quality/efficiency review
- applied high-value cleanup: reused shared key enum in the gateway schema, reused terminal input encoder for key byte mapping, centralized CLI/route capability lookup, and fixed submit capability test fixture drift
- skipped broader discriminated action-registry refactor as too much surface for this narrow slice