### PR TITLE
Fix Active Work node-scoped repo binding

### DIFF
--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -148,24 +148,49 @@ function latestStatus(group: WorkContextActiveGroup): string {
     : 'session has no work context yet';
 }
 
+type SessionRepoBinding = {
+  repo: Repo;
+  kind: 'repo' | 'directory';
+};
+
 export function repoKind(
   session: WorkContextSessionSummary,
   repos: Repo[]
 ): 'repo' | 'directory' | null {
-  if (!session.repoPath) return null;
-  const match = repos.find((r) => r.path === session.repoPath);
-  if (!match) return null;
-  return match.kind ?? (match.isGitRepo ? 'repo' : 'directory');
+  return resolveSessionRepoBinding(session, repos)?.kind ?? null;
 }
 
-export function repoBindingLabel(
+function repoKindFor(repo: Repo): 'repo' | 'directory' {
+  return repo.kind ?? (repo.isGitRepo ? 'repo' : 'directory');
+}
+
+function normalizedNodeId(nodeId: string | undefined): string {
+  return nodeId ?? DEFAULT_LOCAL_NODE_ID;
+}
+
+function resolveSessionRepoBinding(
   session: WorkContextSessionSummary,
   repos: Repo[]
+): SessionRepoBinding | null {
+  const repoPath = session.repoPath;
+  if (!repoPath) return null;
+  const sessionNodeId = normalizedNodeId(session.nodeId);
+  const repo = repos.find(
+    (candidate) =>
+      candidate.path === repoPath &&
+      normalizedNodeId(candidate.nodeId) === sessionNodeId
+  );
+  if (!repo) return null;
+  return { repo, kind: repoKindFor(repo) };
+}
+
+function formatRepoBindingLabel(
+  session: WorkContextSessionSummary,
+  binding: SessionRepoBinding
 ): string | null {
-  const kind = repoKind(session, repos);
   const repoPath = session.repoPath;
 
-  if (kind === 'directory') {
+  if (binding.kind === 'directory') {
     const nodeLabel =
       session.nodeId && session.nodeId !== DEFAULT_LOCAL_NODE_ID
         ? session.nodeId
@@ -174,12 +199,20 @@ export function repoBindingLabel(
     return `${nodeLabel} · ${cwd} · directory`;
   }
 
-  if (kind !== 'repo' || !repoPath) return null;
+  if (!repoPath) return null;
 
-  const repo = session.repoName ?? repos.find((r) => r.path === repoPath)?.name;
-  if (!repo && !repoPath) return null;
+  const repoName = session.repoName ?? binding.repo.name;
   const branch = session.branchName;
-  return [repo ?? repoPath, branch].filter(Boolean).join(' · ');
+  return [repoName ?? repoPath, branch].filter(Boolean).join(' · ');
+}
+
+export function repoBindingLabel(
+  session: WorkContextSessionSummary,
+  repos: Repo[]
+): string | null {
+  const binding = resolveSessionRepoBinding(session, repos);
+  if (!binding) return null;
+  return formatRepoBindingLabel(session, binding);
 }
 
 export function activeWorkAnchorLabel(
@@ -191,11 +224,13 @@ export function activeWorkAnchorLabel(
   const nodeKind = group.node.kind ?? 'remote';
   const cwd = session?.cwd ?? group.context?.anchors?.session?.cwd ?? 'no cwd reported';
   if (session) {
-    const kind = repoKind(session, repos);
-    if (kind === 'directory') {
+    const binding = resolveSessionRepoBinding(session, repos);
+    if (binding?.kind === 'directory') {
       return `${nodeLabel} · ${cwd} · directory`;
     }
-    const repoLabel = repoBindingLabel(session, repos);
+    const repoLabel = binding
+      ? formatRepoBindingLabel(session, binding)
+      : null;
     if (repoLabel) return `repo ${repoLabel}`;
   }
   const anchorPrefix =
@@ -240,13 +275,13 @@ function sessionMeta(
       ? `control ${session.controlFreshness}`
       : undefined,
   ].filter(Boolean) as string[];
-  const kind = repoKind(session, repos);
-  const binding = repoBindingLabel(session, repos);
-  if (kind === 'directory') {
+  const binding = resolveSessionRepoBinding(session, repos);
+  const bindingLabel = binding ? formatRepoBindingLabel(session, binding) : null;
+  if (binding?.kind === 'directory') {
     // directory-kind: hide git-only meta (branch, PR chips handled at card level)
-    if (binding) meta.push(binding);
-  } else if (binding) {
-    meta.push(`repo ${binding}`);
+    if (bindingLabel) meta.push(bindingLabel);
+  } else if (bindingLabel) {
+    meta.push(`repo ${bindingLabel}`);
   } else {
     meta.push('no repo binding');
   }

--- a/test/active-work-surface.test.ts
+++ b/test/active-work-surface.test.ts
@@ -44,7 +44,11 @@ function makeGroup(
   };
 }
 
-function makeRepo(path: string, kind: 'repo' | 'directory'): Repo {
+function makeRepo(
+  path: string,
+  kind: 'repo' | 'directory',
+  overrides: Partial<Repo> = {}
+): Repo {
   return {
     path,
     name: path.split('/').pop() ?? path,
@@ -52,6 +56,7 @@ function makeRepo(path: string, kind: 'repo' | 'directory'): Repo {
     kind,
     defaultBranch: kind === 'repo' ? 'main' : null,
     currentBranch: kind === 'repo' ? 'main' : null,
+    ...overrides,
   };
 }
 
@@ -112,13 +117,76 @@ describe('active-work-surface anchor rendering', () => {
     );
   });
 
+  it('remote session does not bind to a local repo with the same path', () => {
+    const session = makeSession({
+      nodeId: 'mac-node',
+      cwd: '/Users/user/relay-ide',
+      repoPath: '/Users/user/relay-ide',
+      repoName: 'relay-ide',
+      branchName: 'feature/active-work',
+    });
+    const repos = [makeRepo('/Users/user/relay-ide', 'repo')];
+    const group = makeGroup([session], {
+      node: {
+        nodeId: 'mac-node',
+        status: 'online',
+        displayName: 'mac node',
+        kind: 'remote',
+      },
+    });
+
+    expect(repoKind(session, repos)).toBeNull();
+    expect(repoBindingLabel(session, repos)).toBeNull();
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'remote mac node · /Users/user/relay-ide · no repo binding'
+    );
+    expect(activeWorkAnchorLabel(group, session, repos)).toMatch(
+      /no repo binding$/
+    );
+  });
+
+  it('remote session binds to a repo on the matching remote node', () => {
+    const session = makeSession({
+      nodeId: 'mac-node',
+      cwd: '/Users/user/relay-ide',
+      repoPath: '/Users/user/relay-ide',
+      repoName: undefined,
+      branchName: 'feature/active-work',
+    });
+    const repos = [
+      makeRepo('/Users/user/relay-ide', 'repo', { name: 'local-relay' }),
+      makeRepo('/Users/user/relay-ide', 'repo', {
+        nodeId: 'mac-node',
+        name: 'remote-relay',
+      }),
+    ];
+    const group = makeGroup([session], {
+      node: {
+        nodeId: 'mac-node',
+        status: 'online',
+        displayName: 'mac node',
+        kind: 'remote',
+      },
+    });
+
+    expect(repoKind(session, repos)).toBe('repo');
+    expect(repoBindingLabel(session, repos)).toBe(
+      'remote-relay · feature/active-work'
+    );
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'repo remote-relay · feature/active-work'
+    );
+  });
+
   it('directory-kind shows remote node name in anchor', () => {
     const session = makeSession({
       nodeId: 'remote-server',
       cwd: '/srv/workspace',
       repoPath: '/srv/workspace',
     });
-    const repos = [makeRepo('/srv/workspace', 'directory')];
+    const repos = [
+      makeRepo('/srv/workspace', 'directory', { nodeId: 'remote-server' }),
+    ];
     const group = makeGroup([session], {
       node: {
         nodeId: 'remote-server',


### PR DESCRIPTION
## Summary\n- require Active Work repo binding resolution to match both checkout path and normalized node id\n- keep remote/free sessions with same-path local repos in the no-repo-binding state\n- add focused coverage for same-path local/remote collisions and matching remote-node repos\n\n## Verification\n- PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/active-work-surface.test.ts test/app-view-mode.test.ts\n- PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check\n\nRefs #932\nFollows #936