### PR TITLE
test: cover Active Work node-scoped repo binding

### DIFF
--- a/test/active-work-surface.test.ts
+++ b/test/active-work-surface.test.ts
@@ -230,4 +230,68 @@ describe('active-work-surface anchor rendering', () => {
     );
     expect(activeWorkContextLabel(group)).toBe('unbound session group group-1');
   });
+
+  it('does not bind a remote same-path session to a local configured repo', () => {
+    const session = makeSession({
+      id: 'remote-same-path',
+      nodeId: 'mac-node',
+      cwd: '/home/user/relay-ide',
+      repoPath: '/home/user/relay-ide',
+      repoName: undefined,
+      branchName: undefined,
+    });
+    const repos = [
+      makeRepo('/home/user/relay-ide', 'repo', {
+        name: 'relay-ide',
+        defaultBranch: 'nightly',
+        currentBranch: 'nightly',
+        nodeId: 'local',
+      }),
+    ];
+    const group = makeGroup([session], {
+      node: {
+        nodeId: 'mac-node',
+        status: 'online',
+        displayName: 'mac node',
+        kind: 'remote',
+      },
+    });
+
+    expect(repoKind(session, repos)).toBeNull();
+    expect(repoBindingLabel(session, repos)).toBeNull();
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'remote mac node · /home/user/relay-ide · no repo binding'
+    );
+  });
+
+  it('binds a same-path repo when the session node matches the repo node', () => {
+    const session = makeSession({
+      nodeId: 'mac-node',
+      cwd: '/home/user/relay-ide',
+      repoPath: '/home/user/relay-ide',
+      branchName: 'nightly',
+    });
+    const repos = [
+      makeRepo('/home/user/relay-ide', 'repo', {
+        name: 'relay-ide',
+        defaultBranch: 'nightly',
+        currentBranch: 'nightly',
+        nodeId: 'mac-node',
+      }),
+    ];
+    const group = makeGroup([session], {
+      node: {
+        nodeId: 'mac-node',
+        status: 'online',
+        displayName: 'mac node',
+        kind: 'remote',
+      },
+    });
+
+    expect(repoKind(session, repos)).toBe('repo');
+    expect(repoBindingLabel(session, repos)).toBe('relay-ide · nightly');
+    expect(activeWorkAnchorLabel(group, session, repos)).toBe(
+      'repo relay-ide · nightly'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add exact regression coverage for the #932 Active Work same-path cross-node binding case
- assert remote same-path sessions do not inherit local repo badges/branch labels
- assert matching-node same-path repo sessions still bind normally

## Note
`nightly` moved while this task was in flight and now contains the implementation helper from #940 (`resolveSessionRepoBinding` matching both `repoPath` and normalized `nodeId`). This PR keeps the focused QA repro locked as a regression test on top of that fix.

## Test Plan
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/active-work-surface.test.ts test/active-work-control.test.ts test/app-view-mode.test.ts`
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` (passes with existing lint warnings)
- `/simplify` pass: reviewed the initial helper patch, applied one efficiency cleanup, then resolved the rebase by keeping nightly's equivalent helper and this PR's focused regression coverage.

Refs #932
