### PR TITLE
Add next-attention WorkContext command

### DIFF
--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -19,7 +19,9 @@ import { useUiStore } from '../lib/stores/ui.js';
 import {
   activeWorkAttentionPriority,
   activeWorkMobileControlState,
+  activeWorkPrimarySession,
   activeWorkSessionActivationKey,
+  activeWorkSessionActivationRepoPath,
   activeWorkStateLabel,
 } from '../lib/active-work-control.js';
 import SessionMailboxPanel, {
@@ -298,15 +300,7 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
   const [inputStatus, setInputStatus] = useState<string | null>(null);
   const [isSubmittingInput, setIsSubmittingInput] = useState(false);
   const isSubmittingInputRef = useRef(false);
-  const primarySession =
-    group.sessions.find(
-      (session) =>
-        session.live &&
-        (session.agentState === 'permission-prompt' ||
-          session.agentState === 'waiting-for-input')
-    ) ??
-    group.sessions.find((session) => session.live) ??
-    group.sessions[0];
+  const primarySession = activeWorkPrimarySession(group);
   const controlState = activeWorkMobileControlState(group, primarySession);
   const actors = actorLabels(group);
   const refs = taskRefs(group);
@@ -315,9 +309,7 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
   const handleAttach = useCallback(() => {
     if (!primarySession || controlState.attachDisabledReason) return;
     const activationKey = activeWorkSessionActivationKey(primarySession);
-    const nodeId = primarySession.nodeId ?? DEFAULT_LOCAL_NODE_ID;
-    const isLocal = nodeId === DEFAULT_LOCAL_NODE_ID;
-    setActiveRepoPath(isLocal ? (primarySession.repoPath ?? null) : null);
+    setActiveRepoPath(activeWorkSessionActivationRepoPath(primarySession));
     setActiveSessionId(activationKey);
     void refreshAll().then(() => setActiveSessionId(activationKey));
   }, [

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -89,12 +89,14 @@ import {
   navNextTab,
   navSwitchToTab,
   navOpenFile,
+  navNextAttentionWork,
 } from '../lib/actions/definitions/navigation.js';
 import { cliGatewayCommandActions } from '../lib/actions/definitions/cli-gateway.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
-import { ConflictError, setDefaultYolo } from '../lib/api.js';
+import { useToastStore } from '../lib/stores/toasts.js';
+import { ConflictError, fetchActiveWork, setDefaultYolo } from '../lib/api.js';
 import { executeSessionKillAction } from '../lib/actions/session-lifecycle.js';
 import { createLogger } from '../lib/logger.js';
 import type { Action, ActionContext } from '../lib/actions/types.js';
@@ -109,6 +111,7 @@ import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
 import type { CustomizeSessionDialogHandle } from '../components/dialogs/CustomizeSessionDialog.js';
 import type { DeleteWorktreeDialogHandle } from '../components/dialogs/DeleteWorktreeDialog.js';
 import type { WorkspaceSettingsDialogHandle } from '../components/dialogs/WorkspaceSettingsDialog.js';
+import { activeWorkNextAttentionTarget } from '../lib/active-work-control.js';
 
 const logger = createLogger('ActionRegistry');
 
@@ -433,6 +436,40 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       },
 
       // ── Navigation ──────────────────────────────────────────────────────────
+      {
+        ...navNextAttentionWork,
+        handler: async () => {
+          try {
+            const groups = await fetchActiveWork();
+            const target = activeWorkNextAttentionTarget(groups);
+            if (!target) {
+              useToastStore
+                .getState()
+                .showToast('no actionable active work needs attention', 'info');
+              return;
+            }
+
+            const sessions = useSessionsStore.getState();
+            const ui = useUiStore.getState();
+            ui.setAnalyticsView(null);
+            ui.setActiveRepoPath(target.activationRepoPath);
+            sessions.setActiveSessionId(target.activationKey);
+            sessions.handleUserViewed(target.activationKey);
+            ui.closeSidebar();
+            window.setTimeout(() => getActiveTerminalHandle()?.focusTerm(), 0);
+            void sessions.refreshAll().then(() => {
+              useUiStore.getState().setActiveRepoPath(target.activationRepoPath);
+              useSessionsStore.getState().setActiveSessionId(target.activationKey);
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            logger.error('Failed to jump to next active work target', error);
+            useToastStore
+              .getState()
+              .showToast(`could not load active work: ${message}`);
+          }
+        },
+      },
       {
         ...navPreviousTab,
         handler: () => {

--- a/frontend/src/lib/actions/definitions/navigation.ts
+++ b/frontend/src/lib/actions/definitions/navigation.ts
@@ -39,9 +39,25 @@ export const navOpenFile: ActionMeta = {
   when: (ctx) => !!ctx.sessionId,
 };
 
+export const navNextAttentionWork: ActionMeta = {
+  id: 'navigation.next-attention-work',
+  label: 'jump to next attention-needed work',
+  description:
+    'activate the highest-priority actionable WorkContext session from Active Work',
+  aliases: [
+    'next active work',
+    'active work attention',
+    'workcontext attention',
+    'jump to workcontext',
+  ],
+  category: 'navigation',
+  icon: '◆',
+};
+
 export const navigationActions: ActionMeta[] = [
   navPreviousTab,
   navNextTab,
   navSwitchToTab,
   navOpenFile,
+  navNextAttentionWork,
 ];

--- a/frontend/src/lib/active-work-control.ts
+++ b/frontend/src/lib/active-work-control.ts
@@ -46,6 +46,81 @@ export function activeWorkAttentionPriority(
   return 6;
 }
 
+export function activeWorkPrimarySession(
+  group: WorkContextActiveGroup
+): WorkContextSessionSummary | undefined {
+  return (
+    group.sessions.find(
+      (session) =>
+        session.live &&
+        (session.agentState === 'permission-prompt' ||
+          session.agentState === 'waiting-for-input')
+    ) ??
+    group.sessions.find((session) => session.live) ??
+    group.sessions[0]
+  );
+}
+
+export function activeWorkSessionActivationRepoPath(
+  session: WorkContextSessionSummary
+): string | null {
+  const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return nodeId === DEFAULT_LOCAL_NODE_ID ? (session.repoPath ?? null) : null;
+}
+
+export interface ActiveWorkNextAttentionTarget {
+  group: WorkContextActiveGroup;
+  session: WorkContextSessionSummary;
+  activationKey: string;
+  activationRepoPath: string | null;
+  priority: number;
+}
+
+function inverseTimestamp(value: string | undefined): string {
+  const timestamp = Date.parse(value ?? '');
+  const sortable = Number.isFinite(timestamp)
+    ? Number.MAX_SAFE_INTEGER - timestamp
+    : Number.MAX_SAFE_INTEGER;
+  return String(sortable).padStart(16, '0');
+}
+
+function activeWorkTargetSortKey(target: ActiveWorkNextAttentionTarget): string {
+  const lastActivity = target.session.lastActivity ?? target.session.associatedAt;
+  return [
+    target.priority.toString().padStart(2, '0'),
+    // Newer activity wins inside the same Active Work priority bucket.
+    inverseTimestamp(lastActivity),
+    target.group.id,
+    target.activationKey,
+  ].join('\u0000');
+}
+
+export function activeWorkNextAttentionTarget(
+  groups: WorkContextActiveGroup[]
+): ActiveWorkNextAttentionTarget | null {
+  const targets = groups.flatMap((group) => {
+    const session = activeWorkPrimarySession(group);
+    if (!session) return [];
+    const controlState = activeWorkMobileControlState(group, session);
+    if (controlState.attachDisabledReason) return [];
+    return [
+      {
+        group,
+        session,
+        activationKey: activeWorkSessionActivationKey(session),
+        activationRepoPath: activeWorkSessionActivationRepoPath(session),
+        priority: activeWorkAttentionPriority(group),
+      },
+    ];
+  });
+
+  return (
+    [...targets].sort((a, b) =>
+      activeWorkTargetSortKey(a).localeCompare(activeWorkTargetSortKey(b))
+    )[0] ?? null
+  );
+}
+
 export function activeWorkStateLabel(group: WorkContextActiveGroup): string {
   if (
     group.sessions.some((session) => session.agentState === 'permission-prompt')

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -33,8 +33,8 @@ import { workspaceOpenFileBrowser } from '../frontend/src/lib/actions/definition
 import { actionDescriptorFromMeta } from '../frontend/src/lib/actions/descriptors.js';
 import { stableCommandNames } from '../shared/cli-gateway-contract.js';
 
-// Full allowlist: 61 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
-// + workspace.launch from #870)
+// Full allowlist: 62 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
+// + workspace.launch from #870 + next-attention WorkContext jump from #933)
 const ACTION_ALLOWLIST = [
   // Session (10)
   'session.new-agent',
@@ -103,11 +103,12 @@ const ACTION_ALLOWLIST = [
   // Terminal (2)
   'terminal.scroll-top',
   'terminal.scroll-bottom',
-  // Navigation (4)
+  // Navigation (5)
   'navigation.previous-tab',
   'navigation.next-tab',
   'navigation.switch-to-tab',
   'navigation.open-file',
+  'navigation.next-attention-work',
 ] as const;
 
 const ALL_META: ActionMeta[] = [

--- a/test/active-work-control.test.ts
+++ b/test/active-work-control.test.ts
@@ -7,7 +7,10 @@ import type {
 import {
   activeWorkAttentionPriority,
   activeWorkMobileControlState,
+  activeWorkNextAttentionTarget,
+  activeWorkPrimarySession,
   activeWorkSessionActivationKey,
+  activeWorkSessionActivationRepoPath,
   activeWorkStateLabel,
 } from '../frontend/src/lib/active-work-control.js';
 
@@ -176,5 +179,150 @@ describe('active work mobile control helpers', () => {
     expect(
       activeWorkSessionActivationKey(session({ id: 'local-session-2' }))
     ).toBe('local:local-session-2');
+  });
+
+  it('selects the same live primary session the cockpit would attach to', () => {
+    const prompt = session({
+      id: 'needs-input',
+      agentState: 'waiting-for-input',
+      repoPath: '/repo/relay-ide',
+      lastActivity: '2026-05-17T00:02:00.000Z',
+    });
+    const liveProcessing = session({
+      id: 'processing-session',
+      agentState: 'processing',
+      lastActivity: '2026-05-17T00:03:00.000Z',
+    });
+    const work = group({ sessions: [liveProcessing, prompt] });
+
+    expect(activeWorkPrimarySession(work)).toBe(prompt);
+    expect(activeWorkNextAttentionTarget([work])).toMatchObject({
+      group: work,
+      session: prompt,
+      activationKey: 'local:needs-input',
+      activationRepoPath: '/repo/relay-ide',
+      priority: 0,
+    });
+  });
+
+  it('skips stale/offline/last-known groups and chooses the highest-priority actionable target', () => {
+    const offline = group({
+      id: 'offline-work',
+      node: { nodeId: 'remote-a', status: 'offline', kind: 'remote' },
+      sessions: [session({ id: 'offline-session', nodeId: 'remote-a' })],
+    });
+    const stale = group({
+      id: 'stale-work',
+      staleReadModel: true,
+      sessions: [session({ id: 'stale-session' })],
+    });
+    const lastKnown = group({
+      id: 'last-known-work',
+      sessions: [session({ id: 'old-session', live: false })],
+    });
+    const running = group({
+      id: 'running-work',
+      sessions: [
+        session({
+          id: 'running-session',
+          agentState: 'processing',
+          lastActivity: '2026-05-17T00:01:00.000Z',
+        }),
+      ],
+    });
+    const errored = group({
+      id: 'error-work',
+      sessions: [
+        session({
+          id: 'error-session',
+          agentState: 'error',
+          lastActivity: '2026-05-17T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    const target = activeWorkNextAttentionTarget([
+      offline,
+      stale,
+      running,
+      lastKnown,
+      errored,
+    ]);
+
+    expect(target?.group.id).toBe('error-work');
+    expect(target?.activationKey).toBe('local:error-session');
+    expect(target?.priority).toBe(3);
+  });
+
+  it('uses deterministic recency and id tie-breakers inside a priority bucket', () => {
+    const older = group({
+      id: 'b-work',
+      sessions: [
+        session({
+          id: 'older-session',
+          agentState: 'permission-prompt',
+          lastActivity: '2026-05-17T00:01:00.000Z',
+        }),
+      ],
+    });
+    const newer = group({
+      id: 'z-work',
+      sessions: [
+        session({
+          id: 'newer-session',
+          agentState: 'permission-prompt',
+          lastActivity: '2026-05-17T00:02:00.000Z',
+        }),
+      ],
+    });
+    const sameTimeA = group({
+      id: 'a-work',
+      sessions: [
+        session({
+          id: 'same-time-a',
+          agentState: 'permission-prompt',
+          lastActivity: '2026-05-17T00:02:00.000Z',
+        }),
+      ],
+    });
+
+    expect(activeWorkNextAttentionTarget([older, newer])?.session.id).toBe(
+      'newer-session'
+    );
+    expect(activeWorkNextAttentionTarget([newer, sameTimeA])?.group.id).toBe(
+      'a-work'
+    );
+  });
+
+  it('reports no actionable target and avoids stale repo activation for remote/free sessions', () => {
+    const offlineOnly = group({
+      id: 'offline-only',
+      node: { nodeId: 'remote-a', status: 'offline', kind: 'remote' },
+      sessions: [session({ id: 'remote-offline', nodeId: 'remote-a' })],
+    });
+    expect(activeWorkNextAttentionTarget([offlineOnly])).toBeNull();
+
+    const remote = session({
+      id: 'remote-live',
+      nodeId: 'remote-a',
+      repoPath: '/remote/repo/that-must-not-be-activated-locally',
+      globalSessionId: 'remote-a:remote-live',
+    });
+    const freeLocal = session({ id: 'free-local', repoPath: undefined });
+
+    expect(activeWorkSessionActivationRepoPath(remote)).toBeNull();
+    expect(activeWorkSessionActivationRepoPath(freeLocal)).toBeNull();
+    expect(
+      activeWorkNextAttentionTarget([
+        group({
+          id: 'remote-work',
+          node: { nodeId: 'remote-a', status: 'online', kind: 'remote' },
+          sessions: [remote],
+        }),
+      ])
+    ).toMatchObject({
+      activationKey: 'remote-a:remote-live',
+      activationRepoPath: null,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a command-palette navigation action for jumping to the next attention-needed WorkContext/session
- centralize Active Work primary-session and activation repo-path helpers so the cockpit and command share semantics
- add deterministic target selection tests, including stale/offline filtering and remote/free-session no-stale-repo activation

Closes #933
Refs #928

## Verification
- `git diff --check`
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/active-work-control.test.ts test/action-coverage.test.ts test/active-work-surface.test.ts`
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` (passes; repo has existing lint warnings)
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` (passes; existing Vite chunk-size warning)
- Browser smoke: local Relay dev UI at `http://127.0.0.1:10001`, Command Palette opens with `Ctrl+P`, action appears as `jump to next attention-needed work`, no console/page errors after current build

## Notes
- No new global shortcut added; command-palette path avoids stealing established keys.
