### PR TITLE
Add workflow run projections and event topics

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1493,6 +1493,8 @@ const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'handoff-artifacts.list',
   'handoff-artifacts.show',
   'handoff-artifacts.copy',
+  'workflow-runs.list',
+  'workflow-runs.get',
 ]);
 
 function gatewayActorToken(): string {
@@ -4040,7 +4042,17 @@ async function runGatewayEventsSubscribe(eventsArgs: string[]): Promise<never> {
 
   const token = gatewayRequiredToken('events.subscribe');
   const port = gatewayWsPort();
-  const url = `http://127.0.0.1:${port}/events?topic=${encodeURIComponent(topic)}`;
+  const query = new URLSearchParams({ topic });
+  for (const [flag, key] of [
+    ['--cursor', 'cursor'],
+    ['--work-context-id', 'workContextId'],
+    ['--session-id', 'sessionId'],
+    ['--global-session-id', 'globalSessionId'],
+  ] as const) {
+    const value = gatewayArg(eventsArgs, flag);
+    if (value) query.set(key, value);
+  }
+  const url = `http://127.0.0.1:${port}/events?${query.toString()}`;
 
   // Use fetch with an AbortController; stream the body as NDJSON.
   const controller = new AbortController();
@@ -4052,11 +4064,10 @@ async function runGatewayEventsSubscribe(eventsArgs: string[]): Promise<never> {
 
   let res: Response;
   try {
-    // `audit` topic requires `tab:intervention:read` in addition to
-    // `session:read` (enforced by the hub router). Other topics only need
-    // `session:read`.
-    const capabilities =
-      topic === 'audit' ? 'session:read,tab:intervention:read' : 'session:read';
+    // Topic-specific capabilities are enforced by the hub router. Metadata
+    // WorkContext topics use context:read, inbox uses inbox:read, and legacy
+    // session/node topics use session:read.
+    const capabilities = eventsSubscribeCapabilities(topic);
     res = await fetch(url, {
       method: 'GET',
       headers: {
@@ -4259,6 +4270,81 @@ async function runGatewayEventsSubscribe(eventsArgs: string[]): Promise<never> {
   }
 }
 
+async function runGatewayWorkflowRuns(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const workflowArgs = gatewayArgs.slice(2);
+  if (subcommand === 'publish') {
+    const input = parseGatewayInputObject('workflow-runs.publish', workflowArgs);
+    const result = await gatewayHttpJson({
+      commandName: 'workflow-runs.publish',
+      pathName: '/workflow-runs',
+      method: 'POST',
+      body: input,
+      capabilities: ['context:write'],
+    });
+    printGatewayEnvelope(gatewayOk('workflow-runs.publish', result), 0);
+  }
+  if (subcommand === 'update') {
+    const id = gatewayArg(workflowArgs, '--id') ?? workflowArgs[0];
+    if (!id || id.startsWith('--')) gatewayInvalid('workflow-runs.update', '--id is required');
+    const input = parseGatewayInputObject('workflow-runs.update', workflowArgs);
+    const result = await gatewayHttpJson({
+      commandName: 'workflow-runs.update',
+      pathName: `/workflow-runs/${encodeURIComponent(id)}`,
+      method: 'PATCH',
+      body: input,
+      capabilities: ['context:write'],
+    });
+    printGatewayEnvelope(gatewayOk('workflow-runs.update', result), 0);
+  }
+  if (subcommand === 'list') {
+    const workContextId = gatewayArg(workflowArgs, '--work-context-id');
+    if (!workContextId) gatewayInvalid('workflow-runs.list', '--work-context-id is required');
+    const query = new URLSearchParams({ workContextId });
+    const state = gatewayArg(workflowArgs, '--state');
+    const providerRuntime = gatewayArg(workflowArgs, '--provider-runtime');
+    const limit = gatewayArg(workflowArgs, '--limit');
+    if (state) query.set('state', state);
+    if (providerRuntime) query.set('providerRuntime', providerRuntime);
+    if (limit) query.set('limit', limit);
+    const result = await gatewayHttpJson({
+      commandName: 'workflow-runs.list',
+      pathName: `/workflow-runs?${query.toString()}`,
+      capabilities: ['context:read'],
+    });
+    printGatewayEnvelope(gatewayOk('workflow-runs.list', result), 0);
+  }
+  if (subcommand === 'get') {
+    const id = gatewayArg(workflowArgs, '--id') ?? workflowArgs[0];
+    if (!id || id.startsWith('--')) gatewayInvalid('workflow-runs.get', '--id is required');
+    const result = await gatewayHttpJson({
+      commandName: 'workflow-runs.get',
+      pathName: `/workflow-runs/${encodeURIComponent(id)}`,
+      capabilities: ['context:read'],
+    });
+    printGatewayEnvelope(gatewayOk('workflow-runs.get', result), 0);
+  }
+  gatewayInvalid('workflow-runs.get', 'unknown workflow-runs command', {
+    args: gatewayArgs,
+  });
+}
+
+function eventsSubscribeCapabilities(topic: string): string {
+  switch (topic) {
+    case 'audit':
+      return 'session:read,tab:intervention:read';
+    case 'inbox':
+      return 'inbox:read';
+    case 'context':
+    case 'work-context-artifacts':
+    case 'handoff-artifacts':
+    case 'workflow-runs':
+      return 'context:read';
+    default:
+      return 'session:read';
+  }
+}
+
 async function runGatewayEvents(gatewayArgs: string[]): Promise<never> {
   const subcommand = gatewayArgs[1];
   if (subcommand === 'subscribe')
@@ -4398,6 +4484,7 @@ async function runGatewayV1(): Promise<never> {
   if (top === 'work-context-artifacts')
     return runGatewayWorkContextArtifacts(gatewayArgs);
   if (top === 'handoff-artifacts') return runGatewayHandoffArtifacts(gatewayArgs);
+  if (top === 'workflow-runs') return runGatewayWorkflowRuns(gatewayArgs);
   if (top === 'artifacts') return runGatewayArtifacts(gatewayArgs);
   if (top === 'supervisor') return runGatewaySupervisor(gatewayArgs);
   if (top === 'events') return runGatewayEvents(gatewayArgs);

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -26,6 +26,7 @@ export const CLI_GATEWAY_COMMAND_HEADER = 'x-relay-cli-command' as const;
 export const CLI_GATEWAY_CORRELATION_ID_HEADER = 'x-relay-correlation-id' as const;
 export const CLI_GATEWAY_ACTOR_GRANT_CAPABILITIES = [
   'session:read',
+  'context:read',
   'context:write',
   'inbox:write',
   'artifact:write',
@@ -44,6 +45,8 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'handoff-artifacts.list',
   'handoff-artifacts.show',
   'handoff-artifacts.copy',
+  'workflow-runs.list',
+  'workflow-runs.get',
 ] as const;
 export type CliGatewayActorReadCommand =
   (typeof CLI_GATEWAY_ACTOR_READ_COMMANDS)[number];
@@ -60,6 +63,8 @@ export const CLI_GATEWAY_ACTOR_WRITE_COMMANDS = [
   'work-context-artifacts.pin',
   'work-context-artifacts.unpin',
   'handoff-artifacts.attach',
+  'workflow-runs.publish',
+  'workflow-runs.update',
 ] as const;
 export type CliGatewayActorWriteCommand =
   (typeof CLI_GATEWAY_ACTOR_WRITE_COMMANDS)[number];
@@ -225,7 +230,7 @@ export function isSupportedCliGatewayActorWriteRequest(
   req: Request,
   expectedCommand?: CliGatewayActorWriteCommand
 ): boolean {
-  if (req.method !== 'POST') return false;
+  if (req.method !== 'POST' && req.method !== 'PATCH') return false;
   if (!expectedCommand || !cliGatewayActorWriteCommandSet.has(expectedCommand)) {
     return false;
   }
@@ -255,7 +260,10 @@ export function isSupportedCliGatewayActorRequest(
 export function cliGatewayActorCommandCapabilities(
   command: CliGatewayActorCommand
 ): readonly RelayCapabilityBit[] {
+  if (command === 'workflow-runs.list' || command === 'workflow-runs.get')
+    return ['context:read'];
   if (cliGatewayActorReadCommandSet.has(command)) return ['session:read'];
+  if (command.startsWith('workflow-runs.')) return ['context:write'];
   if (command.startsWith('context.')) return ['context:write'];
   if (command.startsWith('inbox.')) return ['inbox:write'];
   return ['artifact:write'];

--- a/server/cli-gateway-event-bus.ts
+++ b/server/cli-gateway-event-bus.ts
@@ -1,0 +1,144 @@
+export type CliGatewayMetadataTopic =
+  | 'context'
+  | 'inbox'
+  | 'work-context-artifacts'
+  | 'handoff-artifacts'
+  | 'workflow-runs';
+
+export interface CliGatewayEventRedaction {
+  rawPayloadIncluded: false;
+  rawTranscriptIncluded: false;
+  artifactBodyIncluded: false;
+}
+
+export interface CliGatewayMetadataEvent {
+  cursor: string;
+  topic: CliGatewayMetadataTopic;
+  type: string;
+  occurredAt: string;
+  workContextId?: string;
+  sessionId?: string;
+  globalSessionId?: string;
+  nodeId?: string;
+  actor?: { id?: string; kind?: string };
+  payload: Record<string, unknown>;
+  redaction: CliGatewayEventRedaction;
+}
+
+export interface CliGatewayEventFilter {
+  workContextId?: string;
+  sessionId?: string;
+  globalSessionId?: string;
+}
+
+export interface CliGatewayEventReplayResult {
+  events: CliGatewayMetadataEvent[];
+  replayDropped: boolean;
+}
+
+export interface CliGatewayEventBus {
+  publish(
+    input: Omit<CliGatewayMetadataEvent, 'cursor' | 'occurredAt' | 'redaction'> & {
+      occurredAt?: string;
+      redaction?: CliGatewayEventRedaction;
+    }
+  ): CliGatewayMetadataEvent;
+  subscribe(topic: CliGatewayMetadataTopic, cb: (event: CliGatewayMetadataEvent) => void): () => void;
+  replay(topic: CliGatewayMetadataTopic, cursor?: string): CliGatewayEventReplayResult;
+}
+
+const METADATA_PAYLOAD_FORBIDDEN_KEYS = new Set([
+  'rawcontent',
+  'rawpayload',
+  'rawtranscript',
+  'terminaltranscript',
+  'transcript',
+  'prompt',
+  'prompts',
+  'messages',
+  'secret',
+  'secrets',
+  'env',
+  'token',
+  'apikey',
+  'api_key',
+  'providerauth',
+  'providerprivate',
+  'providerprivatestate',
+]);
+
+function cleanMetadataPayload(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => cleanMetadataPayload(item));
+  if (!value || typeof value !== 'object') return value;
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+    const normalized = key.toLowerCase().replace(/[^a-z0-9_]/g, '');
+    if (METADATA_PAYLOAD_FORBIDDEN_KEYS.has(normalized)) continue;
+    cleaned[key] = cleanMetadataPayload(child);
+  }
+  return cleaned;
+}
+
+export function eventMatchesFilter(
+  event: CliGatewayMetadataEvent,
+  filter: CliGatewayEventFilter
+): boolean {
+  if (filter.workContextId && event.workContextId !== filter.workContextId) return false;
+  if (filter.sessionId && event.sessionId !== filter.sessionId) return false;
+  if (filter.globalSessionId && event.globalSessionId !== filter.globalSessionId) return false;
+  return true;
+}
+
+export function createCliGatewayEventBus(input: { maxEventsPerTopic?: number } = {}): CliGatewayEventBus {
+  const maxEvents = input.maxEventsPerTopic ?? 1000;
+  const listeners = new Map<CliGatewayMetadataTopic, Set<(event: CliGatewayMetadataEvent) => void>>();
+  const buffers = new Map<CliGatewayMetadataTopic, CliGatewayMetadataEvent[]>();
+  let sequence = 0;
+
+  function topicBuffer(topic: CliGatewayMetadataTopic): CliGatewayMetadataEvent[] {
+    const existing = buffers.get(topic);
+    if (existing) return existing;
+    const created: CliGatewayMetadataEvent[] = [];
+    buffers.set(topic, created);
+    return created;
+  }
+
+  return {
+    publish(inputEvent) {
+      const cursor = `cg:${Date.now()}:${sequence++}`;
+      const event: CliGatewayMetadataEvent = {
+        ...inputEvent,
+        payload: cleanMetadataPayload(inputEvent.payload) as Record<string, unknown>,
+        cursor,
+        occurredAt: inputEvent.occurredAt ?? new Date().toISOString(),
+        redaction: inputEvent.redaction ?? {
+          rawPayloadIncluded: false,
+          rawTranscriptIncluded: false,
+          artifactBodyIncluded: false,
+        },
+      };
+      const buffer = topicBuffer(event.topic);
+      buffer.push(event);
+      if (buffer.length > maxEvents) buffer.splice(0, buffer.length - maxEvents);
+      for (const listener of listeners.get(event.topic) ?? []) listener(event);
+      return event;
+    },
+    subscribe(topic, cb) {
+      const bucket = listeners.get(topic) ?? new Set<(event: CliGatewayMetadataEvent) => void>();
+      bucket.add(cb);
+      listeners.set(topic, bucket);
+      return () => {
+        bucket.delete(cb);
+        if (bucket.size === 0) listeners.delete(topic);
+      };
+    },
+    replay(topic, cursor) {
+      const buffer = topicBuffer(topic);
+      if (!cursor) return { events: [], replayDropped: false };
+      const index = buffer.findIndex((event) => event.cursor === cursor);
+      if (index >= 0) return { events: buffer.slice(index + 1), replayDropped: false };
+      return { events: [...buffer], replayDropped: buffer.length > 0 };
+    },
+  };
+}

--- a/server/cli-gateway-events.ts
+++ b/server/cli-gateway-events.ts
@@ -6,6 +6,13 @@ import {
 } from '../shared/cli-gateway-contract.js';
 import type { TabControlEvent } from '../shared/control-state.js';
 import type { HubNodeStatusEvent } from './hub-node-registry.js';
+import {
+  eventMatchesFilter,
+  type CliGatewayEventBus,
+  type CliGatewayEventFilter,
+  type CliGatewayMetadataEvent,
+  type CliGatewayMetadataTopic,
+} from './cli-gateway-event-bus.js';
 
 const ALLOWED_TOPICS: readonly EventsSubscribeTopic[] = EVENTS_SUBSCRIBE_TOPICS;
 
@@ -27,6 +34,11 @@ const REQUIRED_TOPIC_CAPABILITIES: Record<EventsSubscribeTopic, readonly string[
   sessions: ['session:read'],
   nodes: ['session:read'],
   audit: ['session:read', 'tab:intervention:read'],
+  context: ['context:read'],
+  inbox: ['inbox:read'],
+  'work-context-artifacts': ['context:read'],
+  'handoff-artifacts': ['context:read'],
+  'workflow-runs': ['context:read'],
 };
 
 export interface CliGatewayEventsHooks {
@@ -46,8 +58,24 @@ export interface CliGatewayEventsHooks {
 export interface CliGatewayEventsRouterOptions {
   cliGatewayAuth: RequestHandler;
   hooks: CliGatewayEventsHooks;
+  eventBus?: CliGatewayEventBus;
   /** Optional now() override for deterministic tests. */
   now?: () => Date;
+}
+
+function isMetadataTopic(topic: EventsSubscribeTopic): topic is CliGatewayMetadataTopic {
+  return (
+    topic === 'context' ||
+    topic === 'inbox' ||
+    topic === 'work-context-artifacts' ||
+    topic === 'handoff-artifacts' ||
+    topic === 'workflow-runs'
+  );
+}
+
+function queryString(req: Request, key: string): string | undefined {
+  const value = req.query[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
 interface SubscriberHandle {
@@ -106,6 +134,27 @@ function nodePayload(event: HubNodeStatusEvent): Record<string, unknown> {
     nodeId: event.nodeId,
     status: event.status,
     lastSeenAt: event.lastSeenAt,
+  };
+}
+
+function metadataEventFrame(
+  topic: CliGatewayMetadataTopic,
+  sequence: number,
+  event: CliGatewayMetadataEvent,
+  replay?: true
+): Record<string, unknown> {
+  return {
+    event: 'event',
+    topic,
+    sequence,
+    occurredAt: event.occurredAt,
+    cursor: event.cursor,
+    ...(replay ? { replay } : {}),
+    payload: {
+      type: event.type,
+      ...event.payload,
+      redaction: event.redaction,
+    },
   };
 }
 
@@ -215,7 +264,47 @@ export function createCliGatewayEventsRouter(
       }
     };
 
-    if (topic === 'sessions') {
+    if (isMetadataTopic(topic)) {
+      if (!options.eventBus) {
+        res.statusCode = 503;
+        writeNdjson(res, {
+          event: 'error',
+          topic,
+          sequence: sequence++,
+          occurredAt: now().toISOString(),
+          payload: { code: 'SERVER_UNAVAILABLE', message: 'metadata event bus is unavailable' },
+        });
+        res.end();
+        return;
+      }
+      const filter: CliGatewayEventFilter = {};
+      const workContextId = queryString(req, 'workContextId');
+      const sessionId = queryString(req, 'sessionId');
+      const globalSessionId = queryString(req, 'globalSessionId');
+      if (workContextId) filter.workContextId = workContextId;
+      if (sessionId) filter.sessionId = sessionId;
+      if (globalSessionId) filter.globalSessionId = globalSessionId;
+      const replay = options.eventBus.replay(topic, queryString(req, 'cursor'));
+      if (replay.replayDropped) {
+        writeNdjson(res, {
+          event: 'open',
+          topic,
+          sequence: sequence++,
+          occurredAt: now().toISOString(),
+          replayDropped: true,
+        });
+      }
+      for (const event of replay.events) {
+        if (!eventMatchesFilter(event, filter)) continue;
+        writeNdjson(res, metadataEventFrame(topic, sequence++, event, true));
+      }
+      subs.push(
+        options.eventBus.subscribe(topic, (event) => {
+          if (!eventMatchesFilter(event, filter)) return;
+          writeNdjson(res, metadataEventFrame(topic, sequence++, event));
+        })
+      );
+    } else if (topic === 'sessions') {
       subs.push(
         options.hooks.onSessionCreate((sessionId, cwd, branchName) => {
           emit(

--- a/server/features/context-inbox-router.ts
+++ b/server/features/context-inbox-router.ts
@@ -49,6 +49,7 @@ import type {
   ScopedActorCredentialValidationFailureReason,
 } from '../../shared/scoped-actor-credentials.js';
 import type { WorkContextStore } from '../work-contexts.js';
+import type { CliGatewayEventBus } from '../cli-gateway-event-bus.js';
 import {
   TERMINAL_INBOX_MESSAGE_STATES,
   type ContextPacket,
@@ -169,6 +170,7 @@ export interface ContextInboxStore {
 export interface ContextInboxRouterDeps {
   store: ContextInboxStore | null;
   workContextStore?: WorkContextStore;
+  events?: Pick<CliGatewayEventBus, 'publish'>;
   requireAuth?: RequestHandler;
   requireWriteActorAuth?: (
     expectedCommand: CliGatewayActorWriteCommand,
@@ -1061,6 +1063,38 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     return contextPackets.length > 0 ? { ...message, contextPackets } : message;
   }
 
+  function emitContextEvent(type: string, packet: ContextPacket, workContextId?: string): void {
+    deps.events?.publish({
+      topic: 'context',
+      type,
+      ...(workContextId ? { workContextId } : {}),
+      payload: {
+        contextPacketId: packet.id,
+        kind: packet.kind,
+        createdBy: packet.createdBy,
+        ...(packet.binding?.nodeId ? { nodeId: packet.binding.nodeId } : {}),
+        ...(packet.binding?.workspaceId ? { workspaceId: packet.binding.workspaceId } : {}),
+      },
+    });
+  }
+
+  function emitInboxEvent(type: string, message: SessionInboxMessage, previousState?: SessionInboxMessageState): void {
+    deps.events?.publish({
+      topic: 'inbox',
+      type,
+      ...(message.targetWorkContextId ? { workContextId: message.targetWorkContextId } : {}),
+      ...(message.targetSessionId ? { globalSessionId: message.targetSessionId } : {}),
+      payload: {
+        messageId: message.id,
+        state: message.state,
+        ...(previousState ? { previousState } : {}),
+        createdBy: message.createdBy,
+        contextPacketCount: message.contextPacketIds.length,
+        contextPacketIds: message.contextPacketIds,
+      },
+    });
+  }
+
   function workContexts(res: Response): WorkContextStore | null {
     if (!deps.workContextStore) {
       sendGatewayError(
@@ -1162,6 +1196,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
           : {}),
         createdBy,
       });
+      emitContextEvent('context.created', contextPacket);
       res.status(201).json({ contextPacket });
     } catch (err) {
       sendGatewayError(
@@ -1220,6 +1255,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
           artifacts: [artifact],
           summary: `Pinned context packet ${packet.id} to WorkContext ${workContextId}`,
         });
+        emitContextEvent('context.pinned', packet, workContextId);
       }
       const pinned = await pinnedContextPacketsFor(s, workContextId);
       res.status(alreadyPinned ? 200 : 201).json({
@@ -1279,6 +1315,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
         })
       : updated;
     const packet = s.getPacket(packetId);
+    if (removed && packet) emitContextEvent('context.unpinned', packet, workContextId);
     res.json({
       workContext,
       ...(packet ? { contextPacket: packet } : {}),
@@ -1376,6 +1413,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
         ...(readString(body['text']) ? { text: body['text'] as string } : {}),
         createdBy,
       });
+      emitInboxEvent('inbox.sent', message);
       res.status(201).json({ message });
     } catch (err) {
       sendGatewayError(
@@ -1503,6 +1541,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
         sendUpdateFailure(res, result);
         return;
       }
+      emitInboxEvent('inbox.state-changed', result.message, message.state);
       res.json({ message: result.message });
     };
   }

--- a/server/features/work-context-artifact-router.ts
+++ b/server/features/work-context-artifact-router.ts
@@ -24,6 +24,7 @@ import {
   type ViewArtifactPackage,
 } from '../../shared/agent-view-artifact.js';
 import type { WorkContextStore } from '../work-contexts.js';
+import type { CliGatewayEventBus } from '../cli-gateway-event-bus.js';
 import {
   WorkContextArtifactStoreError,
   type StoreAgentViewArtifactInput,
@@ -50,6 +51,7 @@ export const DEFAULT_WORK_CONTEXT_ARTIFACT_EXPORT_MAX_BYTES = 512 * 1024;
 export interface WorkContextArtifactRouterDeps {
   store: WorkContextArtifactStore | null;
   workContextStore?: WorkContextStore;
+  events?: Pick<CliGatewayEventBus, 'publish'>;
   requireAuth?: RequestHandler;
   requireReadAuth?: {
     list?: RequestHandler;
@@ -682,6 +684,39 @@ function queryListInput(req: Request): WorkContextArtifactListInput | 'invalid-t
   };
 }
 
+function emitArtifactEvent(
+  events: Pick<CliGatewayEventBus, 'publish'> | undefined,
+  topic: 'work-context-artifacts' | 'handoff-artifacts',
+  type: string,
+  record: WorkContextArtifactRecord,
+  actorId?: string,
+  pinned?: boolean
+): void {
+  const { metadata } = record;
+  events?.publish({
+    topic,
+    type,
+    workContextId: metadata.workContextId,
+    ...(actorId ? { actor: { id: actorId, kind: 'cli-gateway' } } : {}),
+    payload: {
+      artifactId: metadata.id,
+      payloadKind: metadata.payloadKind,
+      kind: metadata.kind,
+      title: metadata.title,
+      visibility: metadata.visibility,
+      taskRef: metadata.taskRef,
+      ...(metadata.stage ? { stage: metadata.stage } : {}),
+      ...(metadata.projectId ? { projectId: metadata.projectId } : {}),
+      ...(metadata.provenanceActorId ? { provenanceActorId: metadata.provenanceActorId } : {}),
+      ...(metadata.prNumber !== undefined ? { prNumber: metadata.prNumber } : {}),
+      ...(metadata.headSha ? { headSha: metadata.headSha } : {}),
+      ...(metadata.supersedesArtifactId ? { supersedesArtifactId: metadata.supersedesArtifactId } : {}),
+      ...(pinned !== undefined ? { pinned } : {}),
+      rawPayloadAvailable: false,
+    },
+  });
+}
+
 function storeViewArtifactPublish(input: {
   res: Response;
   store: WorkContextArtifactStore;
@@ -691,8 +726,9 @@ function storeViewArtifactPublish(input: {
   workContextId: WorkContextId;
   operation: string;
   maxPublishBytes: number;
+  events?: Pick<CliGatewayEventBus, 'publish'>;
 }): void {
-  const { res, store, workContextStore, body, viewArtifact, workContextId, operation, maxPublishBytes } = input;
+  const { res, store, workContextStore, body, viewArtifact, workContextId, operation, maxPublishBytes, events } = input;
   const payloadBytes = persistedViewArtifactPayloadBytes(viewArtifact);
   if (payloadBytes > AGENT_VIEW_MAX_TOTAL_BYTES) {
     sendGatewayError(res, 'INVALID_ARGUMENT', 'viewArtifact payload exceeds agent view size cap', false, {
@@ -749,6 +785,7 @@ function storeViewArtifactPublish(input: {
     const pinned = shouldPin && workContextStore
       ? pinArtifactRef(workContextStore, workContextId, stored.metadata, actorId)
       : undefined;
+    emitArtifactEvent(events, 'work-context-artifacts', 'artifact.published', stored, actorId, Boolean(pinned && !pinned.alreadyPinned));
     res.status(201).json({
       artifact: recordEnvelope(stored),
       ...(pinned ? { pin: pinned } : {}),
@@ -887,6 +924,7 @@ export function createWorkContextArtifactRouter(
         workContextId,
         operation,
         maxPublishBytes,
+        ...(deps.events ? { events: deps.events } : {}),
       });
       return;
     }
@@ -967,6 +1005,14 @@ export function createWorkContextArtifactRouter(
         shouldPin && deps.workContextStore
           ? pinArtifactRef(deps.workContextStore, workContextId, stored.metadata, actorId)
           : undefined;
+      emitArtifactEvent(
+        deps.events,
+        operation === 'attach' ? 'handoff-artifacts' : 'work-context-artifacts',
+        operation === 'attach' ? 'artifact.attached' : 'artifact.published',
+        stored,
+        actorId,
+        Boolean(pinned && !pinned.alreadyPinned)
+      );
       res.status(201).json({
         artifact: recordEnvelope(stored, current),
         ...(pinned ? { pin: pinned } : {}),
@@ -1241,6 +1287,7 @@ export function createWorkContextArtifactRouter(
       return;
     }
     const pinned = pinArtifactRef(deps.workContextStore!, workContextId, record.metadata, readString(body['actorId']));
+    emitArtifactEvent(deps.events, 'work-context-artifacts', 'artifact.pinned', record, readString(body['actorId']), !pinned.alreadyPinned);
     res.status(pinned.alreadyPinned ? 200 : 201).json({
       artifact: recordEnvelope(record),
       artifactRef: pinned.artifactRef,
@@ -1288,6 +1335,7 @@ export function createWorkContextArtifactRouter(
       return;
     }
     const result = unpinArtifactRef(deps.workContextStore!, workContextId, artifactId, readString(body['actorId']));
+    if (record && result.removed) emitArtifactEvent(deps.events, 'work-context-artifacts', 'artifact.unpinned', record, readString(body['actorId']), false);
     res.json({ workContext: result.workContext, removed: result.removed, lifecycle: { artifactDeleted: false } });
   });
 

--- a/server/features/workflow-run-router.ts
+++ b/server/features/workflow-run-router.ts
@@ -1,0 +1,269 @@
+import { Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+
+import type { RelayCliGatewayErrorCode } from '../../shared/cli-gateway-contract.js';
+import {
+  WORKFLOW_RUN_STATES,
+  WorkflowRunValidationError,
+  workflowRunSummaryPayload,
+  type WorkflowRunProjection,
+  type WorkflowRunState,
+} from '../../shared/workflow-run.js';
+import type { WorkContextId } from '../../shared/work-context.js';
+import type { CliGatewayEventBus } from '../cli-gateway-event-bus.js';
+import type { CliGatewayActorWriteCommand } from '../cli-gateway-actor-auth.js';
+import type { WorkContextStore } from '../work-contexts.js';
+import {
+  WorkflowRunStoreError,
+  type WorkflowRunStore,
+} from '../workflow-runs.js';
+
+const CONTEXT_READ = 'context:read';
+const CONTEXT_WRITE = 'context:write';
+
+export interface WorkflowRunRouterDeps {
+  store: WorkflowRunStore | null;
+  workContextStore?: WorkContextStore | null;
+  requireAuth?: RequestHandler;
+  requireReadAuth?: {
+    list?: RequestHandler;
+    get?: RequestHandler;
+  };
+  requireWriteActorAuth?: (
+    expectedCommand: CliGatewayActorWriteCommand,
+    options?: {
+      scopeForRequest?: (req: Request) => { workContextIds?: string[] } | undefined;
+      deferWorkContextScope?: boolean;
+    }
+  ) => RequestHandler;
+  events?: Pick<CliGatewayEventBus, 'publish'>;
+}
+
+function parseCapabilityHeader(value: string | undefined): Set<string> {
+  if (!value) return new Set();
+  return new Set(value.split(/[\s,]+/).map((entry) => entry.trim()).filter(Boolean));
+}
+
+function sendGatewayError(
+  res: Response,
+  code: RelayCliGatewayErrorCode,
+  message: string,
+  retryable = false,
+  details?: Record<string, unknown>
+): void {
+  const status =
+    code === 'NOT_FOUND'
+      ? 404
+      : code === 'FORBIDDEN'
+        ? 403
+        : code === 'SESSION_CONFLICT'
+          ? 409
+          : code === 'SERVER_UNAVAILABLE'
+            ? 503
+            : code === 'INTERNAL'
+              ? 500
+              : 400;
+  res.status(status).json({ error: { code, message, retryable, ...(details ? { details } : {}) } });
+}
+
+function denyMissingCapability(req: Request, res: Response, required: string[]): boolean {
+  const caps = parseCapabilityHeader(req.header('x-relay-capabilities'));
+  const missing = required.filter((cap) => !caps.has(cap));
+  if (missing.length === 0) return false;
+  sendGatewayError(res, 'FORBIDDEN', `missing required capability: ${missing.join(', ')}`, false, {
+    capability: missing[0],
+  });
+  return true;
+}
+
+function bodyRecord(req: Request): Record<string, unknown> {
+  return req.body && typeof req.body === 'object' && !Array.isArray(req.body)
+    ? (req.body as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readLimit(value: unknown): number | undefined {
+  if (typeof value !== 'string') return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, 100) : undefined;
+}
+
+function readState(value: unknown): WorkflowRunState | undefined {
+  return typeof value === 'string' && (WORKFLOW_RUN_STATES as readonly string[]).includes(value)
+    ? (value as WorkflowRunState)
+    : undefined;
+}
+
+function storeOr503(res: Response, store: WorkflowRunStore | null): WorkflowRunStore | null {
+  if (store) return store;
+  sendGatewayError(res, 'SERVER_UNAVAILABLE', 'workflow run store is unavailable', true, {
+    reasonCode: 'WORKFLOW_RUN_STORE_UNAVAILABLE',
+  });
+  return null;
+}
+
+function ensureWorkContext(
+  res: Response,
+  store: WorkContextStore | null | undefined,
+  workContextId: WorkContextId
+): boolean {
+  if (!store) return true;
+  if (store.get(workContextId)) return true;
+  sendGatewayError(res, 'NOT_FOUND', 'WorkContext not found', false, { workContextId });
+  return false;
+}
+
+function mapError(res: Response, error: unknown, operation: string): void {
+  if (error instanceof WorkflowRunValidationError) {
+    sendGatewayError(res, 'INVALID_ARGUMENT', error.message, false, {
+      reasonCode: 'WORKFLOW_RUN_VALIDATION_FAILED',
+      operation,
+      ...error.details,
+    });
+    return;
+  }
+  if (error instanceof WorkflowRunStoreError) {
+    const code: RelayCliGatewayErrorCode =
+      error.status === 404 ? 'NOT_FOUND' : error.status === 409 ? 'SESSION_CONFLICT' : 'INTERNAL';
+    sendGatewayError(res, code, error.message, false, {
+      reasonCode: error.code.toUpperCase(),
+      operation,
+      ...error.details,
+    });
+    return;
+  }
+  sendGatewayError(res, 'INTERNAL', 'workflow run operation failed', true, { operation });
+}
+
+function emitRunEvent(
+  events: Pick<CliGatewayEventBus, 'publish'> | undefined,
+  type: string,
+  run: WorkflowRunProjection,
+  previousState?: WorkflowRunState
+): void {
+  events?.publish({
+    topic: 'workflow-runs',
+    type,
+    workContextId: run.workContextId,
+    ...(run.links?.sessionIds?.[0] ? { sessionId: run.links.sessionIds[0] } : {}),
+    ...(run.links?.globalSessionIds?.[0] ? { globalSessionId: run.links.globalSessionIds[0] } : {}),
+    payload: {
+      ...workflowRunSummaryPayload(run),
+      ...(previousState ? { previousState } : {}),
+    },
+  });
+}
+
+export function createWorkflowRunRouter(deps: WorkflowRunRouterDeps): Router {
+  const router = Router();
+  const auth = deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
+  const readAuth = deps.requireReadAuth ?? {};
+  const writeAuth = (
+    command: CliGatewayActorWriteCommand,
+    scopeForRequest?: (req: Request) => { workContextIds?: string[] } | undefined
+  ): RequestHandler =>
+    deps.requireWriteActorAuth?.(
+      command,
+      scopeForRequest ? { scopeForRequest } : undefined
+    ) ?? auth;
+
+  const publishScope = (req: Request) => {
+    const workContextId = readString(bodyRecord(req)['workContextId']);
+    return workContextId ? { workContextIds: [workContextId] } : undefined;
+  };
+  const runScope = (req: Request) => {
+    const id = req.params['id'] ?? '';
+    const workflowRun = id && deps.store ? deps.store.get(id) : null;
+    return workflowRun ? { workContextIds: [workflowRun.workContextId] } : undefined;
+  };
+
+  router.post('/workflow-runs', writeAuth('workflow-runs.publish', publishScope), (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const s = storeOr503(res, deps.store);
+    if (!s) return;
+    const workContextId = readString(bodyRecord(req)['workContextId']);
+    if (!workContextId) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'workContextId is required', false, {
+        field: 'workContextId',
+      });
+      return;
+    }
+    if (!ensureWorkContext(res, deps.workContextStore, workContextId)) return;
+    try {
+      const workflowRun = s.publish(bodyRecord(req));
+      emitRunEvent(deps.events, 'workflow-run.published', workflowRun);
+      res.status(201).json({ workflowRun });
+    } catch (error) {
+      mapError(res, error, 'publish');
+    }
+  });
+
+  router.patch('/workflow-runs/:id', writeAuth('workflow-runs.update', runScope), (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const s = storeOr503(res, deps.store);
+    if (!s) return;
+    const id = req.params['id'] ?? '';
+    const existing = s.get(id);
+    if (!existing) {
+      sendGatewayError(res, 'NOT_FOUND', 'workflow run not found', false, { workflowRunId: id });
+      return;
+    }
+    if (!ensureWorkContext(res, deps.workContextStore, existing.workContextId)) return;
+    try {
+      const workflowRun = s.update(id, bodyRecord(req));
+      emitRunEvent(deps.events, 'workflow-run.updated', workflowRun, existing.state);
+      if (workflowRun.state !== existing.state) {
+        emitRunEvent(deps.events, 'workflow-run.state-changed', workflowRun, existing.state);
+      }
+      res.json({ workflowRun });
+    } catch (error) {
+      mapError(res, error, 'update');
+    }
+  });
+
+  router.get('/workflow-runs', readAuth.list ?? auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const s = storeOr503(res, deps.store);
+    if (!s) return;
+    const workContextId = readString(req.query['workContextId']);
+    if (!workContextId) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'workContextId is required', false, {
+        field: 'workContextId',
+      });
+      return;
+    }
+    if (!ensureWorkContext(res, deps.workContextStore, workContextId)) return;
+    const state = readState(req.query['state']);
+    const providerRuntime = readString(req.query['providerRuntime']);
+    const limit = readLimit(req.query['limit']);
+    res.json({
+      workflowRuns: s.list({
+        workContextId,
+        ...(state ? { state } : {}),
+        ...(providerRuntime ? { providerRuntime } : {}),
+        ...(limit ? { limit } : {}),
+      }),
+    });
+  });
+
+  router.get('/workflow-runs/:id', readAuth.get ?? auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const s = storeOr503(res, deps.store);
+    if (!s) return;
+    const workflowRun = s.get(req.params['id'] ?? '');
+    if (!workflowRun) {
+      sendGatewayError(res, 'NOT_FOUND', 'workflow run not found', false, {
+        workflowRunId: req.params['id'] ?? '',
+      });
+      return;
+    }
+    if (!ensureWorkContext(res, deps.workContextStore, workflowRun.workContextId)) return;
+    res.json({ workflowRun });
+  });
+
+  return router;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -134,6 +134,7 @@ import {
 } from './credential-rotation-scheduler.js';
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
+import { createCliGatewayEventBus } from './cli-gateway-event-bus.js';
 import { createCliGatewaySettingsRouter } from './cli-gateway-settings.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import {
@@ -162,10 +163,15 @@ import {
   DEFAULT_WORK_CONTEXT_ARTIFACT_PUBLISH_MAX_BYTES,
   readWorkContextArtifactQueryWorkContextId,
 } from './features/work-context-artifact-router.js';
+import { createWorkflowRunRouter } from './features/workflow-run-router.js';
 import {
   initWorkContextArtifactStore,
   type WorkContextArtifactStore,
 } from './work-context-artifacts.js';
+import {
+  initWorkflowRunStore,
+  type WorkflowRunStore,
+} from './workflow-runs.js';
 import {
   createAnchorFileFetcher,
   createAnchorContentFetcher,
@@ -1373,6 +1379,18 @@ function initWorkContextArtifactStoreBestEffort(
   }
 }
 
+function initWorkflowRunStoreBestEffort(configDir: string): WorkflowRunStore | null {
+  try {
+    return initWorkflowRunStore(configDir);
+  } catch (err) {
+    logger.warn(
+      'Workflow run store disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
 async function ensureStartupTerminalBackendAvailable(
   startupConfig: Config
 ): Promise<void> {
@@ -1613,6 +1631,8 @@ async function main(): Promise<void> {
   // WorkContext artifact store (#889/#890). Own SQLite/payload files; routes
   // degrade to typed 503 when initialization fails so hub startup stays useful.
   const workContextArtifactStore = initWorkContextArtifactStoreBestEffort(configDir);
+  const workflowRunStore = initWorkflowRunStoreBestEffort(configDir);
+  const cliGatewayEventBus = createCliGatewayEventBus();
 
   try {
     initInterventionLog(configDir);
@@ -2160,11 +2180,17 @@ async function main(): Promise<void> {
       requireWriteActorAuth: requireCliGatewayAuthForActorCommand,
       store: contextInboxStore,
       workContextStore,
+      events: cliGatewayEventBus,
     })
   );
   const workContextScopeFromQuery = (req: express.Request): { workContextIds?: string[] } | undefined => {
     const workContextId = readWorkContextArtifactQueryWorkContextId(req.query);
     return workContextId ? { workContextIds: [workContextId] } : undefined;
+  };
+  const workflowRunScopeFromParams = (req: express.Request): { workContextIds?: string[] } | undefined => {
+    const workflowRunId = typeof req.params['id'] === 'string' ? req.params['id'] : '';
+    const workflowRun = workflowRunId && workflowRunStore ? workflowRunStore.get(workflowRunId) : null;
+    return workflowRun ? { workContextIds: [workflowRun.workContextId] } : undefined;
   };
   app.use(
     createWorkContextArtifactRouter({
@@ -2194,12 +2220,30 @@ async function main(): Promise<void> {
       requireWriteActorAuth: requireCliGatewayAuthForActorCommand,
       store: workContextArtifactStore,
       workContextStore,
+      events: cliGatewayEventBus,
       diagnostics: {
         dbPath: path.join(configDir, 'work-context-artifacts.db'),
         payloadRoot: path.join(configDir, 'work-context-artifacts', 'payloads'),
         maxPublishBytes: DEFAULT_WORK_CONTEXT_ARTIFACT_PUBLISH_MAX_BYTES,
         maxExportBytes: DEFAULT_WORK_CONTEXT_ARTIFACT_EXPORT_MAX_BYTES,
       },
+    })
+  );
+  app.use(
+    createWorkflowRunRouter({
+      requireAuth: requireCliGatewayAuth,
+      requireReadAuth: {
+        list: requireCliGatewayAuthForActorCommand('workflow-runs.list', {
+          scopeForRequest: workContextScopeFromQuery,
+        }),
+        get: requireCliGatewayAuthForActorCommand('workflow-runs.get', {
+          scopeForRequest: workflowRunScopeFromParams,
+        }),
+      },
+      requireWriteActorAuth: requireCliGatewayAuthForActorCommand,
+      store: workflowRunStore,
+      workContextStore,
+      events: cliGatewayEventBus,
     })
   );
   // #766/#759: production `AnchorFileFetcher` wired to the session-scoped File
@@ -2232,6 +2276,7 @@ async function main(): Promise<void> {
   app.use(
     createCliGatewayEventsRouter(express, {
       cliGatewayAuth: requireCliGatewayAuth,
+      eventBus: cliGatewayEventBus,
       hooks: {
         onSessionCreate: (cb) => sessions.onSessionCreate(cb),
         onSessionEnd: (cb) => sessions.onSessionEnd(cb),
@@ -4471,6 +4516,7 @@ async function main(): Promise<void> {
         iaStore?.close();
         contextPacketStore?.close();
         workContextArtifactStore?.close();
+        workflowRunStore?.close();
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
@@ -4556,6 +4602,7 @@ async function main(): Promise<void> {
     iaStore?.close();
     contextPacketStore?.close();
     workContextArtifactStore?.close();
+    workflowRunStore?.close();
     closeInterventionLog();
     for (const s of localRelayNode.sessions.list()) {
       try {

--- a/server/workflow-runs.ts
+++ b/server/workflow-runs.ts
@@ -1,0 +1,239 @@
+import Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import {
+  WORKFLOW_RUN_SCHEMA_VERSION,
+  parseWorkflowRunPublishInput,
+  parseWorkflowRunUpdateInput,
+  type WorkflowRunProjection,
+  type WorkflowRunState,
+} from '../shared/workflow-run.js';
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS workflow_runs (
+  id                TEXT PRIMARY KEY,
+  run_id            TEXT NOT NULL,
+  provider_runtime  TEXT NOT NULL,
+  work_context_id   TEXT NOT NULL,
+  state             TEXT NOT NULL,
+  definition_hash   TEXT NOT NULL,
+  projection_json   TEXT NOT NULL,
+  created_at        TEXT NOT NULL,
+  updated_at        TEXT NOT NULL,
+  version           INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_context
+  ON workflow_runs(work_context_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_run_id
+  ON workflow_runs(run_id);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_runtime_context
+  ON workflow_runs(provider_runtime, work_context_id);
+CREATE INDEX IF NOT EXISTS idx_workflow_runs_state_context
+  ON workflow_runs(state, work_context_id);
+`;
+
+interface WorkflowRunRow {
+  projection_json: string;
+}
+
+export interface WorkflowRunListInput {
+  workContextId: string;
+  state?: WorkflowRunState;
+  providerRuntime?: string;
+  limit?: number;
+}
+
+export interface WorkflowRunStore {
+  close(): void;
+  publish(input: unknown): WorkflowRunProjection;
+  update(id: string, input: unknown): WorkflowRunProjection;
+  get(id: string): WorkflowRunProjection | null;
+  list(input: WorkflowRunListInput): WorkflowRunProjection[];
+}
+
+export class WorkflowRunStoreError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message = code,
+    public readonly details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'WorkflowRunStoreError';
+  }
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function parseRow(row: WorkflowRunRow | undefined): WorkflowRunProjection | null {
+  if (!row) return null;
+  return JSON.parse(row.projection_json) as WorkflowRunProjection;
+}
+
+function cleanLimit(limit: number | undefined): number {
+  if (!limit || !Number.isInteger(limit) || limit < 1) return 50;
+  return Math.min(limit, 100);
+}
+
+export function createWorkflowRunStore(input: { dbPath: string }): WorkflowRunStore {
+  const db = new Database(input.dbPath);
+  db.pragma('journal_mode = WAL');
+  db.exec(SCHEMA_SQL);
+
+  const insertStmt = db.prepare(`
+    INSERT INTO workflow_runs (
+      id, run_id, provider_runtime, work_context_id, state, definition_hash,
+      projection_json, created_at, updated_at, version
+    ) VALUES (
+      @id, @runId, @providerRuntime, @workContextId, @state, @definitionHash,
+      @projectionJson, @createdAt, @updatedAt, @version
+    )
+  `);
+  const updateStmt = db.prepare(`
+    UPDATE workflow_runs
+       SET state = @state,
+           projection_json = @projectionJson,
+           updated_at = @updatedAt,
+           version = @version
+     WHERE id = @id
+  `);
+  const getStmt = db.prepare('SELECT projection_json FROM workflow_runs WHERE id = ?');
+
+  return {
+    close() {
+      db.close();
+    },
+    publish(rawInput) {
+      const parsed = parseWorkflowRunPublishInput(rawInput);
+      const createdAt = parsed.createdAt ?? nowIso();
+      const updatedAt = parsed.updatedAt ?? createdAt;
+      const id = parsed.id ?? `workflow-run:${randomUUID()}`;
+      const projection: WorkflowRunProjection = {
+        schemaVersion: WORKFLOW_RUN_SCHEMA_VERSION,
+        id,
+        runId: parsed.runId,
+        providerRuntime: parsed.providerRuntime,
+        workContextId: parsed.workContextId,
+        definition: parsed.definition,
+        state: parsed.state ?? 'queued',
+        ...(parsed.progress ? { progress: parsed.progress } : {}),
+        ...(parsed.phases ? { phases: parsed.phases } : {}),
+        ...(parsed.steps ? { steps: parsed.steps } : {}),
+        ...(parsed.resultSummary ? { resultSummary: parsed.resultSummary } : {}),
+        ...(parsed.errorSummary ? { errorSummary: parsed.errorSummary } : {}),
+        ...(parsed.journal ? { journal: parsed.journal } : {}),
+        ...(parsed.links ? { links: parsed.links } : {}),
+        createdAt,
+        updatedAt,
+        version: 1,
+        redaction: parsed.redaction,
+      };
+      try {
+        insertStmt.run({
+          id: projection.id,
+          runId: projection.runId,
+          providerRuntime: projection.providerRuntime,
+          workContextId: projection.workContextId,
+          state: projection.state,
+          definitionHash: projection.definition.hash,
+          projectionJson: JSON.stringify(projection),
+          createdAt: projection.createdAt,
+          updatedAt: projection.updatedAt,
+          version: projection.version,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('UNIQUE')) {
+          throw new WorkflowRunStoreError(409, 'workflow_run_conflict', 'workflow run already exists', {
+            workflowRunId: projection.id,
+          });
+        }
+        throw error;
+      }
+      return projection;
+    },
+    update(id, rawInput) {
+      const existing = parseRow(getStmt.get(id) as WorkflowRunRow | undefined);
+      if (!existing) {
+        throw new WorkflowRunStoreError(404, 'workflow_run_not_found', 'workflow run not found', {
+          workflowRunId: id,
+        });
+      }
+      const parsed = parseWorkflowRunUpdateInput(rawInput);
+      if (parsed.expectedVersion !== undefined && parsed.expectedVersion !== existing.version) {
+        throw new WorkflowRunStoreError(409, 'workflow_run_stale_version', 'workflow run version is stale', {
+          workflowRunId: id,
+          expectedVersion: parsed.expectedVersion,
+          currentVersion: existing.version,
+        });
+      }
+      const updatedAt = parsed.updatedAt ?? nowIso();
+      const next: WorkflowRunProjection = {
+        ...existing,
+        ...(parsed.state ? { state: parsed.state } : {}),
+        ...(parsed.progress ? { progress: parsed.progress } : {}),
+        ...(parsed.phases ? { phases: parsed.phases } : {}),
+        ...(parsed.steps ? { steps: parsed.steps } : {}),
+        ...(parsed.resultSummary ? { resultSummary: parsed.resultSummary } : {}),
+        ...(parsed.errorSummary ? { errorSummary: parsed.errorSummary } : {}),
+        ...(parsed.journal ? { journal: parsed.journal } : {}),
+        ...(parsed.links ? { links: parsed.links } : {}),
+        updatedAt,
+        version: existing.version + 1,
+        redaction: {
+          rawPayloadStored: false,
+          rawTranscriptStored: false,
+          providerPrivateStateStored: false,
+          truncated: existing.redaction.truncated || parsed.redactionPatch.truncated,
+          omittedKeys: [
+            ...existing.redaction.omittedKeys,
+            ...parsed.redactionPatch.omittedKeys.filter(
+              (key) => !existing.redaction.omittedKeys.includes(key)
+            ),
+          ],
+        },
+      };
+      updateStmt.run({
+        id,
+        state: next.state,
+        projectionJson: JSON.stringify(next),
+        updatedAt: next.updatedAt,
+        version: next.version,
+      });
+      return next;
+    },
+    get(id) {
+      return parseRow(getStmt.get(id) as WorkflowRunRow | undefined);
+    },
+    list(input) {
+      const clauses = ['work_context_id = @workContextId'];
+      const params: Record<string, unknown> = { workContextId: input.workContextId };
+      if (input.state) {
+        clauses.push('state = @state');
+        params['state'] = input.state;
+      }
+      if (input.providerRuntime) {
+        clauses.push('provider_runtime = @providerRuntime');
+        params['providerRuntime'] = input.providerRuntime;
+      }
+      params['limit'] = cleanLimit(input.limit);
+      const rows = db
+        .prepare(
+          `SELECT projection_json FROM workflow_runs WHERE ${clauses.join(
+            ' AND '
+          )} ORDER BY updated_at DESC LIMIT @limit`
+        )
+        .all(params) as WorkflowRunRow[];
+      return rows.flatMap((row) => {
+        const parsed = parseRow(row);
+        return parsed ? [parsed] : [];
+      });
+    },
+  };
+}
+
+export function initWorkflowRunStore(configDir: string): WorkflowRunStore {
+  return createWorkflowRunStore({ dbPath: path.join(configDir, 'workflow-runs.db') });
+}

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -58,6 +58,10 @@ export type RelayCliGatewayCommand =
   | 'handoff-artifacts.list'
   | 'handoff-artifacts.show'
   | 'handoff-artifacts.copy'
+  | 'workflow-runs.publish'
+  | 'workflow-runs.update'
+  | 'workflow-runs.list'
+  | 'workflow-runs.get'
   | 'inbox.send'
   | 'inbox.list'
   | 'inbox.get'
@@ -1477,7 +1481,16 @@ export const gatewayErrorSchema: RelayJsonSchema = {
   required: ['ok', 'contract', 'contractVersion', 'command', 'error'],
 };
 
-export const EVENTS_SUBSCRIBE_TOPICS = ['sessions', 'nodes', 'audit'] as const;
+export const EVENTS_SUBSCRIBE_TOPICS = [
+  'sessions',
+  'nodes',
+  'audit',
+  'context',
+  'inbox',
+  'work-context-artifacts',
+  'handoff-artifacts',
+  'workflow-runs',
+] as const;
 export type EventsSubscribeTopic = (typeof EVENTS_SUBSCRIBE_TOPICS)[number];
 
 const eventsSubscribeInputSchema: RelayJsonSchema = {
@@ -1489,8 +1502,12 @@ const eventsSubscribeInputSchema: RelayJsonSchema = {
       type: 'string',
       enum: EVENTS_SUBSCRIBE_TOPICS,
       description:
-        'Non-destructive event topic to subscribe to: sessions lifecycle/control, node link status, or redacted audit envelopes.',
+        'Non-destructive event topic to subscribe to: sessions lifecycle/control, node link status, redacted audit envelopes, or WorkContext workflow metadata.',
     },
+    cursor: stringSchema,
+    workContextId: stringSchema,
+    sessionId: stringSchema,
+    globalSessionId: stringSchema,
     maxEvents: {
       type: 'number',
       minimum: 1,
@@ -2216,12 +2233,92 @@ const eventsSubscribeFrameSchema: RelayJsonSchema = {
     topic: { type: 'string', enum: EVENTS_SUBSCRIBE_TOPICS },
     sequence: { type: 'number', minimum: 0 },
     occurredAt: { type: 'string', format: 'date-time' },
+    cursor: { type: 'string' },
+    replay: { type: 'boolean' },
+    replayDropped: { type: 'boolean' },
     payload: { type: 'object', additionalProperties: true },
     frames: { type: 'number', minimum: 0 },
     closeCode: { type: 'number' },
     reason: { type: 'string' },
   },
   required: ['event', 'topic', 'sequence'],
+};
+
+const workflowRunProjectionSchema: RelayJsonSchema = {
+  title: 'WorkflowRunProjection',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    runId: stringSchema,
+    providerRuntime: stringSchema,
+    workContextId: stringSchema,
+    state: stringSchema,
+    version: { type: 'number', minimum: 1 },
+    redaction: { type: 'object', additionalProperties: true },
+  },
+  required: ['id', 'runId', 'providerRuntime', 'workContextId', 'state', 'version', 'redaction'],
+};
+
+const workflowRunPublishInputSchema: RelayJsonSchema = {
+  title: 'WorkflowRunPublishInput',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    runId: stringSchema,
+    providerRuntime: stringSchema,
+    workContextId: stringSchema,
+    definition: { type: 'object', additionalProperties: true },
+    state: stringSchema,
+  },
+  required: ['runId', 'providerRuntime', 'workContextId', 'definition'],
+};
+
+const workflowRunUpdateInputSchema: RelayJsonSchema = {
+  title: 'WorkflowRunUpdateInput',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    expectedVersion: { type: 'number', minimum: 1 },
+    state: stringSchema,
+  },
+};
+
+const workflowRunListInputSchema: RelayJsonSchema = {
+  title: 'WorkflowRunListInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    workContextId: stringSchema,
+    state: stringSchema,
+    providerRuntime: stringSchema,
+    limit: { type: 'number', minimum: 1, maximum: 100 },
+  },
+  required: ['workContextId'],
+};
+
+const workflowRunGetInputSchema: RelayJsonSchema = {
+  title: 'WorkflowRunGetInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { id: stringSchema },
+  required: ['id'],
+};
+
+const workflowRunOutputDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { workflowRun: workflowRunProjectionSchema },
+  required: ['workflowRun'],
+};
+
+const workflowRunListOutputDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { workflowRuns: { type: 'array', items: workflowRunProjectionSchema } },
+  required: ['workflowRuns'],
 };
 
 const okOutput = (title: string, data: RelayJsonSchema): RelayJsonSchema => ({
@@ -4097,6 +4194,56 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     errorCodes: gatewaySupervisorErrorCodes,
   },
   {
+    name: 'workflow-runs.publish',
+    cli: ['relay-ide', 'v1', 'workflow-runs', 'publish', '--input-json', '<json>', '--json'],
+    summary:
+      'Publish a bounded WorkContext-scoped external workflow run projection without raw transcripts or provider-private state.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:write'],
+    inputSchema: workflowRunPublishInputSchema,
+    outputSchema: okOutput('WorkflowRunPublishOutput', workflowRunOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'FORBIDDEN', 'NOT_FOUND', 'SESSION_CONFLICT', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'workflow-runs.update',
+    cli: ['relay-ide', 'v1', 'workflow-runs', 'update', '--id', '<id>', '--input-json', '<json>', '--json'],
+    summary:
+      'Update a bounded WorkContext-scoped workflow run projection, optionally with an expected version guard.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:write'],
+    inputSchema: workflowRunUpdateInputSchema,
+    outputSchema: okOutput('WorkflowRunUpdateOutput', workflowRunOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'FORBIDDEN', 'NOT_FOUND', 'SESSION_CONFLICT', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'workflow-runs.list',
+    cli: ['relay-ide', 'v1', 'workflow-runs', 'list', '--work-context-id', '<id>', '--json'],
+    summary: 'List bounded workflow run projections by WorkContext.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: workflowRunListInputSchema,
+    outputSchema: okOutput('WorkflowRunListOutput', workflowRunListOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'FORBIDDEN', 'NOT_FOUND', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'workflow-runs.get',
+    cli: ['relay-ide', 'v1', 'workflow-runs', 'get', '--id', '<id>', '--json'],
+    summary: 'Get one bounded workflow run projection by Relay workflowRun id.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: workflowRunGetInputSchema,
+    outputSchema: okOutput('WorkflowRunGetOutput', workflowRunOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'FORBIDDEN', 'NOT_FOUND', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
     name: 'events.subscribe',
     cli: [
       'relay-ide',
@@ -4112,12 +4259,13 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    // Union of capabilities across all topics: `sessions` and `nodes` need
-    // `session:read`; `audit` additionally needs `tab:intervention:read`
-    // (enforced by the hub router on the `audit` topic). Generators that
-    // surface this verb should request the superset so a single tool
-    // definition covers every topic.
-    capabilityHints: ['session:read', 'tab:intervention:read'],
+    // Union of capabilities across all topics: legacy `sessions` and `nodes`
+    // need `session:read`; `audit` additionally needs
+    // `tab:intervention:read`; WorkContext metadata topics need
+    // `context:read`; `inbox` needs `inbox:read`. Generators that surface
+    // this verb should request the superset so a single tool definition covers
+    // every topic.
+    capabilityHints: ['session:read', 'tab:intervention:read', 'context:read', 'inbox:read'],
     inputSchema: eventsSubscribeInputSchema,
     outputSchema: okOutput('EventsSubscribeFrame', eventsSubscribeFrameSchema),
     errorCodes: [

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -127,6 +127,10 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'handoff-artifacts.list': 'list pipeline handoff artifacts',
   'handoff-artifacts.show': 'show pipeline handoff artifact',
   'handoff-artifacts.copy': 'copy pipeline handoff artifact',
+  'workflow-runs.publish': 'publish workflow run projection',
+  'workflow-runs.update': 'update workflow run projection',
+  'workflow-runs.list': 'list workflow run projections',
+  'workflow-runs.get': 'workflow run details',
   'inbox.send': 'send inbox message',
   'inbox.list': 'list inbox messages',
   'inbox.get': 'inbox message details',
@@ -187,6 +191,8 @@ const WRITE_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
   'work-context-artifacts.pin',
   'work-context-artifacts.unpin',
   'handoff-artifacts.attach',
+  'workflow-runs.publish',
+  'workflow-runs.update',
   'repos.add',
   'workspaces.launch',
   'worktrees.create',
@@ -219,6 +225,7 @@ function scopeKindsForGatewayCommand(
   if (name.startsWith('work-contexts.')) return ['work-context'];
   if (name.startsWith('work-context-artifacts.')) return ['work-context'];
   if (name.startsWith('handoff-artifacts.')) return ['work-context'];
+  if (name.startsWith('workflow-runs.')) return ['work-context'];
   if (name.startsWith('context.')) return ['work-context', 'session'];
   if (name.startsWith('inbox.')) return ['session', 'work-context'];
   if (name.startsWith('handoffs.'))

--- a/shared/workflow-run.ts
+++ b/shared/workflow-run.ts
@@ -1,0 +1,444 @@
+import type { GlobalSessionId } from './identity.js';
+import type { TaskRef, TaskRefKind, WorkContextId } from './work-context.js';
+
+export const WORKFLOW_RUN_SCHEMA_VERSION = 1 as const;
+export const WORKFLOW_RUN_STATES = [
+  'queued',
+  'running',
+  'waiting',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'stale',
+  'unknown',
+] as const;
+export type WorkflowRunState = (typeof WORKFLOW_RUN_STATES)[number];
+
+export interface WorkflowRunProgress {
+  total?: number;
+  completed?: number;
+  failed?: number;
+  blocked?: number;
+}
+
+export interface WorkflowRunNodeSummary {
+  id: string;
+  label?: string | undefined;
+  state?: WorkflowRunState | undefined;
+  progress?: WorkflowRunProgress | undefined;
+}
+
+export interface WorkflowRunJournalEntry {
+  id?: string | undefined;
+  type?: string | undefined;
+  summary: string;
+  occurredAt?: string | undefined;
+}
+
+export interface WorkflowRunLinks {
+  sessionIds?: string[] | undefined;
+  globalSessionIds?: GlobalSessionId[] | undefined;
+  artifactIds?: string[] | undefined;
+  inboxMessageIds?: string[] | undefined;
+  handoffArtifactIds?: string[] | undefined;
+  taskRefs?: Pick<TaskRef, 'kind' | 'id' | 'title' | 'url' | 'status'>[] | undefined;
+}
+
+export interface WorkflowRunProjection {
+  schemaVersion: typeof WORKFLOW_RUN_SCHEMA_VERSION;
+  id: string;
+  runId: string;
+  providerRuntime: string;
+  workContextId: WorkContextId;
+  definition: {
+    hash: string;
+    version?: string | undefined;
+    templateId?: string | undefined;
+  };
+  state: WorkflowRunState;
+  progress?: WorkflowRunProgress | undefined;
+  phases?: WorkflowRunNodeSummary[] | undefined;
+  steps?: WorkflowRunNodeSummary[] | undefined;
+  resultSummary?: string | undefined;
+  errorSummary?: string | undefined;
+  journal?: WorkflowRunJournalEntry[] | undefined;
+  links?: WorkflowRunLinks | undefined;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
+  redaction: {
+    rawPayloadStored: false;
+    rawTranscriptStored: false;
+    providerPrivateStateStored: false;
+    truncated: boolean;
+    omittedKeys: string[];
+  };
+}
+
+export interface WorkflowRunPublishInput {
+  id?: string | undefined;
+  runId: string;
+  providerRuntime: string;
+  workContextId: WorkContextId;
+  definition: WorkflowRunProjection['definition'];
+  state?: WorkflowRunState | undefined;
+  progress?: WorkflowRunProgress | undefined;
+  phases?: WorkflowRunNodeSummary[] | undefined;
+  steps?: WorkflowRunNodeSummary[] | undefined;
+  resultSummary?: string | undefined;
+  errorSummary?: string | undefined;
+  journal?: WorkflowRunJournalEntry[] | undefined;
+  links?: WorkflowRunLinks | undefined;
+  createdAt?: string | undefined;
+  updatedAt?: string | undefined;
+}
+
+export interface WorkflowRunUpdateInput {
+  expectedVersion?: number | undefined;
+  state?: WorkflowRunState | undefined;
+  progress?: WorkflowRunProgress | undefined;
+  phases?: WorkflowRunNodeSummary[] | undefined;
+  steps?: WorkflowRunNodeSummary[] | undefined;
+  resultSummary?: string | undefined;
+  errorSummary?: string | undefined;
+  journal?: WorkflowRunJournalEntry[] | undefined;
+  links?: WorkflowRunLinks | undefined;
+  updatedAt?: string | undefined;
+}
+
+export const WORKFLOW_RUN_SUMMARY_MAX_BYTES = 8 * 1024;
+export const WORKFLOW_RUN_JOURNAL_SUMMARY_MAX_BYTES = 2 * 1024;
+export const WORKFLOW_RUN_MAX_JOURNAL_ENTRIES = 100;
+export const WORKFLOW_RUN_MAX_PHASES = 50;
+export const WORKFLOW_RUN_MAX_STEPS = 200;
+
+const SECRETISH_KEYS = new Set<string>([
+  'rawcontent',
+  'rawpayload',
+  'rawtranscript',
+  'terminaltranscript',
+  'transcript',
+  'prompt',
+  'prompts',
+  'messages',
+  'secret',
+  'secrets',
+  'env',
+  'token',
+  'apikey',
+  'api_key',
+  'providerauth',
+  'providerprivate',
+  'providerprivatestate',
+  'hermesprofilestate',
+  'rawhermesprofilestate',
+]);
+const TASK_REF_KINDS = new Set<string>([
+  'github-issue',
+  'github-pr',
+  'kanban-task',
+  'jira-ticket',
+  'linear-issue',
+  'external',
+]);
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export class WorkflowRunValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'WorkflowRunValidationError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function stringField(input: Record<string, unknown>, key: string): string | undefined {
+  return optionalString(input[key]);
+}
+
+function requireString(input: Record<string, unknown>, key: string): string {
+  const value = stringField(input, key);
+  if (!value) throw new WorkflowRunValidationError(`${key} is required`, { field: key });
+  return value;
+}
+
+function optionalInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function parseState(value: unknown): WorkflowRunState | undefined {
+  if (typeof value !== 'string') return undefined;
+  return (WORKFLOW_RUN_STATES as readonly string[]).includes(value)
+    ? (value as WorkflowRunState)
+    : undefined;
+}
+
+function truncateUtf8(value: string, maxBytes: number): { value: string; truncated: boolean } {
+  const encoded = textEncoder.encode(value);
+  if (encoded.length <= maxBytes) return { value, truncated: false };
+  return {
+    value: textDecoder.decode(encoded.slice(0, maxBytes)).replace(/�+$/u, ''),
+    truncated: true,
+  };
+}
+
+function collectForbiddenKeys(value: unknown, path = '$', found: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectForbiddenKeys(item, `${path}[${index}]`, found));
+    return found;
+  }
+  if (!isRecord(value)) return found;
+  for (const [key, child] of Object.entries(value)) {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9_]/g, '');
+    if (SECRETISH_KEYS.has(normalized)) {
+      found.push(`${path}.${key}`);
+      continue;
+    }
+    collectForbiddenKeys(child, `${path}.${key}`, found);
+  }
+  return found;
+}
+
+function parseDefinition(value: unknown): WorkflowRunProjection['definition'] {
+  if (!isRecord(value)) {
+    throw new WorkflowRunValidationError('definition is required', { field: 'definition' });
+  }
+  return {
+    hash: requireString(value, 'hash'),
+    ...(stringField(value, 'version') ? { version: stringField(value, 'version') } : {}),
+    ...(stringField(value, 'templateId') ? { templateId: stringField(value, 'templateId') } : {}),
+  };
+}
+
+function parseProgress(value: unknown): WorkflowRunProgress | undefined {
+  if (!isRecord(value)) return undefined;
+  const progress: WorkflowRunProgress = {};
+  for (const key of ['total', 'completed', 'failed', 'blocked'] as const) {
+    const parsed = optionalInteger(value[key]);
+    if (parsed !== undefined) progress[key] = parsed;
+  }
+  return Object.keys(progress).length ? progress : undefined;
+}
+
+function parseNodeSummaries(
+  value: unknown,
+  limit: number,
+  field: 'phases' | 'steps'
+): { items?: WorkflowRunNodeSummary[]; truncated: boolean } {
+  if (!Array.isArray(value)) return { truncated: false };
+  const truncated = value.length > limit;
+  const items: WorkflowRunNodeSummary[] = [];
+  for (const entry of value.slice(0, limit)) {
+    if (!isRecord(entry)) continue;
+    const id = stringField(entry, 'id');
+    if (!id) {
+      throw new WorkflowRunValidationError(`${field} entries must include string id`, { field });
+    }
+    const progress = parseProgress(entry['progress']);
+    const state = parseState(entry['state']);
+    const item: WorkflowRunNodeSummary = {
+      id,
+      ...(stringField(entry, 'label') ? { label: stringField(entry, 'label') } : {}),
+      ...(state ? { state } : {}),
+      ...(progress ? { progress } : {}),
+    };
+    items.push(item);
+  }
+  return items.length ? { items, truncated } : { truncated };
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  return strings.length ? strings : undefined;
+}
+
+function parseTaskRefs(value: unknown): WorkflowRunLinks['taskRefs'] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const refs: NonNullable<WorkflowRunLinks['taskRefs']> = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const kind = stringField(entry, 'kind');
+    const id = stringField(entry, 'id');
+    if (!kind || !id || !TASK_REF_KINDS.has(kind)) continue;
+    const ref: Pick<TaskRef, 'kind' | 'id' | 'title' | 'url' | 'status'> = {
+      kind: kind as TaskRefKind,
+      id,
+    };
+    const title = stringField(entry, 'title');
+    const url = stringField(entry, 'url');
+    const status = stringField(entry, 'status');
+    if (title) ref.title = title;
+    if (url) ref.url = url;
+    if (status) ref.status = status;
+    refs.push(ref);
+  }
+  return refs.length ? refs : undefined;
+}
+
+function parseLinks(value: unknown): WorkflowRunLinks | undefined {
+  if (!isRecord(value)) return undefined;
+  const links: WorkflowRunLinks = {};
+  const fields = [
+    ['sessionIds', parseStringArray(value['sessionIds'])],
+    ['globalSessionIds', parseStringArray(value['globalSessionIds'])],
+    ['artifactIds', parseStringArray(value['artifactIds'])],
+    ['inboxMessageIds', parseStringArray(value['inboxMessageIds'])],
+    ['handoffArtifactIds', parseStringArray(value['handoffArtifactIds'])],
+  ] as const;
+  for (const [key, values] of fields) {
+    if (values?.length) links[key] = values;
+  }
+  const taskRefs = parseTaskRefs(value['taskRefs']);
+  if (taskRefs?.length) links.taskRefs = taskRefs;
+  return Object.keys(links).length ? links : undefined;
+}
+
+function parseJournal(value: unknown): { journal?: WorkflowRunJournalEntry[]; truncated: boolean } {
+  if (!Array.isArray(value)) return { truncated: false };
+  let truncated = value.length > WORKFLOW_RUN_MAX_JOURNAL_ENTRIES;
+  const journal: WorkflowRunJournalEntry[] = [];
+  for (const entry of value.slice(0, WORKFLOW_RUN_MAX_JOURNAL_ENTRIES)) {
+    if (!isRecord(entry)) continue;
+    const summaryRaw = optionalString(entry['summary']);
+    if (!summaryRaw) {
+      throw new WorkflowRunValidationError('journal entries must include string summary', {
+        field: 'journal',
+      });
+    }
+    const summary = truncateUtf8(summaryRaw, WORKFLOW_RUN_JOURNAL_SUMMARY_MAX_BYTES);
+    truncated = truncated || summary.truncated;
+    journal.push({
+      summary: summary.value,
+      ...(stringField(entry, 'id') ? { id: stringField(entry, 'id') } : {}),
+      ...(stringField(entry, 'type') ? { type: stringField(entry, 'type') } : {}),
+      ...(stringField(entry, 'occurredAt') ? { occurredAt: stringField(entry, 'occurredAt') } : {}),
+    });
+  }
+  return journal.length ? { journal, truncated } : { truncated };
+}
+
+function parseProjectionParts(input: Record<string, unknown>): {
+  partial: Omit<WorkflowRunUpdateInput, 'expectedVersion'>;
+  truncated: boolean;
+  omittedKeys: string[];
+} {
+  const omittedKeys = collectForbiddenKeys(input);
+  if (omittedKeys.length > 0) {
+    throw new WorkflowRunValidationError('workflow run payload contains forbidden raw/private fields', {
+      omittedKeys,
+    });
+  }
+  let truncated = false;
+  const resultSummary = optionalString(input['resultSummary'])
+    ? truncateUtf8(input['resultSummary'] as string, WORKFLOW_RUN_SUMMARY_MAX_BYTES)
+    : undefined;
+  const errorSummary = optionalString(input['errorSummary'])
+    ? truncateUtf8(input['errorSummary'] as string, WORKFLOW_RUN_SUMMARY_MAX_BYTES)
+    : undefined;
+  truncated = truncated || Boolean(resultSummary?.truncated || errorSummary?.truncated);
+  const phases = parseNodeSummaries(input['phases'], WORKFLOW_RUN_MAX_PHASES, 'phases');
+  const steps = parseNodeSummaries(input['steps'], WORKFLOW_RUN_MAX_STEPS, 'steps');
+  const journal = parseJournal(input['journal']);
+  truncated = truncated || phases.truncated || steps.truncated || journal.truncated;
+  const state = parseState(input['state']);
+  if (input['state'] !== undefined && !state) {
+    throw new WorkflowRunValidationError('state must be a known WorkflowRunState', { field: 'state' });
+  }
+  const progress = parseProgress(input['progress']);
+  const links = parseLinks(input['links']);
+  return {
+    partial: {
+      ...(state ? { state } : {}),
+      ...(progress ? { progress } : {}),
+      ...(phases.items ? { phases: phases.items } : {}),
+      ...(steps.items ? { steps: steps.items } : {}),
+      ...(resultSummary ? { resultSummary: resultSummary.value } : {}),
+      ...(errorSummary ? { errorSummary: errorSummary.value } : {}),
+      ...(journal.journal ? { journal: journal.journal } : {}),
+      ...(links ? { links } : {}),
+      ...(stringField(input, 'updatedAt') ? { updatedAt: stringField(input, 'updatedAt') } : {}),
+    },
+    truncated,
+    omittedKeys,
+  };
+}
+
+export function parseWorkflowRunPublishInput(value: unknown): WorkflowRunPublishInput & {
+  redaction: WorkflowRunProjection['redaction'];
+} {
+  if (!isRecord(value)) {
+    throw new WorkflowRunValidationError('workflow run publish payload must be an object');
+  }
+  const parts = parseProjectionParts(value);
+  return {
+    runId: requireString(value, 'runId'),
+    providerRuntime: requireString(value, 'providerRuntime'),
+    workContextId: requireString(value, 'workContextId'),
+    definition: parseDefinition(value['definition']),
+    ...(stringField(value, 'id') ? { id: stringField(value, 'id') } : {}),
+    state: parts.partial.state ?? 'queued',
+    ...(parts.partial.progress ? { progress: parts.partial.progress } : {}),
+    ...(parts.partial.phases ? { phases: parts.partial.phases } : {}),
+    ...(parts.partial.steps ? { steps: parts.partial.steps } : {}),
+    ...(parts.partial.resultSummary ? { resultSummary: parts.partial.resultSummary } : {}),
+    ...(parts.partial.errorSummary ? { errorSummary: parts.partial.errorSummary } : {}),
+    ...(parts.partial.journal ? { journal: parts.partial.journal } : {}),
+    ...(parts.partial.links ? { links: parts.partial.links } : {}),
+    ...(stringField(value, 'createdAt') ? { createdAt: stringField(value, 'createdAt') } : {}),
+    ...(parts.partial.updatedAt ? { updatedAt: parts.partial.updatedAt } : {}),
+    redaction: {
+      rawPayloadStored: false,
+      rawTranscriptStored: false,
+      providerPrivateStateStored: false,
+      truncated: parts.truncated,
+      omittedKeys: parts.omittedKeys,
+    },
+  };
+}
+
+export function parseWorkflowRunUpdateInput(value: unknown): WorkflowRunUpdateInput & {
+  redactionPatch: Pick<WorkflowRunProjection['redaction'], 'truncated' | 'omittedKeys'>;
+} {
+  if (!isRecord(value)) {
+    throw new WorkflowRunValidationError('workflow run update payload must be an object');
+  }
+  const parts = parseProjectionParts(value);
+  const expectedVersion = optionalInteger(value['expectedVersion']);
+  return {
+    ...(expectedVersion !== undefined ? { expectedVersion } : {}),
+    ...parts.partial,
+    redactionPatch: {
+      truncated: parts.truncated,
+      omittedKeys: parts.omittedKeys,
+    },
+  };
+}
+
+export function workflowRunSummaryPayload(run: WorkflowRunProjection): Record<string, unknown> {
+  return {
+    workflowRunId: run.id,
+    runId: run.runId,
+    providerRuntime: run.providerRuntime,
+    workContextId: run.workContextId,
+    state: run.state,
+    version: run.version,
+    updatedAt: run.updatedAt,
+    artifactIds: run.links?.artifactIds ?? [],
+    inboxMessageIds: run.links?.inboxMessageIds ?? [],
+    handoffArtifactIds: run.links?.handoffArtifactIds ?? [],
+    taskRefs: run.links?.taskRefs ?? [],
+  };
+}

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -214,6 +214,8 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'handoff-artifacts.list',
     'handoff-artifacts.show',
     'handoff-artifacts.copy',
+    'workflow-runs.list',
+    'workflow-runs.get',
   ]);
   expect(
     classifyCliGatewayCredentialLane(
@@ -288,6 +290,8 @@ test('classifies explicitly scoped CLI gateway actor write routes into the actor
     'work-context-artifacts.pin',
     'work-context-artifacts.unpin',
     'handoff-artifacts.attach',
+    'workflow-runs.publish',
+    'workflow-runs.update',
   ]);
 
   for (const command of CLI_GATEWAY_ACTOR_WRITE_COMMANDS) {
@@ -360,6 +364,10 @@ test('maps write actor commands to required Relay capability bits', () => {
   expect(cliGatewayActorCommandCapabilities('handoff-artifacts.attach')).toEqual([
     'artifact:write',
   ]);
+  expect(cliGatewayActorCommandCapabilities('workflow-runs.list')).toEqual(['context:read']);
+  expect(cliGatewayActorCommandCapabilities('workflow-runs.get')).toEqual(['context:read']);
+  expect(cliGatewayActorCommandCapabilities('workflow-runs.publish')).toEqual(['context:write']);
+  expect(cliGatewayActorCommandCapabilities('workflow-runs.update')).toEqual(['context:write']);
 });
 
 test('denies spoofed actor command headers on non-MVP route identities', () => {
@@ -401,6 +409,8 @@ test('allows only the MVP actor command and route identity pairs', () => {
     { command: 'handoff-artifacts.list', expected: 'handoff-artifacts.list' },
     { command: 'handoff-artifacts.show', expected: 'handoff-artifacts.show' },
     { command: 'handoff-artifacts.copy', expected: 'handoff-artifacts.copy' },
+    { command: 'workflow-runs.list', expected: 'workflow-runs.list' },
+    { command: 'workflow-runs.get', expected: 'workflow-runs.get' },
   ] as const;
 
   for (const { command, expected } of allowed) {

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -196,6 +196,10 @@ describe('CLI gateway contract', () => {
       'supervisor.sendText',
       'supervisor.sendKey',
       'supervisor.submit',
+      'workflow-runs.publish',
+      'workflow-runs.update',
+      'workflow-runs.list',
+      'workflow-runs.get',
       'events.subscribe',
       'settings.get',
       'settings.update',
@@ -968,6 +972,10 @@ describe('CLI gateway contract', () => {
       'supervisor.sendText',
       'supervisor.sendKey',
       'supervisor.submit',
+      'workflow-runs.publish',
+      'workflow-runs.update',
+      'workflow-runs.list',
+      'workflow-runs.get',
       'events.subscribe',
     ] as const;
 

--- a/test/cli-gateway/events.test.ts
+++ b/test/cli-gateway/events.test.ts
@@ -11,7 +11,16 @@ import {
 } from '../../shared/cli-gateway-contract.js';
 
 const RELAY_BIN = 'dist/bin/relay-ide.js';
-const ALLOWED_TOPICS = ['sessions', 'nodes', 'audit'] as const;
+const ALLOWED_TOPICS = [
+  'sessions',
+  'nodes',
+  'audit',
+  'context',
+  'inbox',
+  'work-context-artifacts',
+  'handoff-artifacts',
+  'workflow-runs',
+] as const;
 
 type CapturedRequest = {
   method: string | undefined;
@@ -269,7 +278,9 @@ describe('CLI gateway events.subscribe contract', () => {
     expect(spec.cli).toContain('subscribe');
     expect(spec.cli).toContain('--topic');
     expect(spec.cli).toContain('--json');
-    expect(spec.capabilityHints).toContain('session:read');
+    expect(spec.capabilityHints).toEqual(
+      expect.arrayContaining(['session:read', 'tab:intervention:read', 'context:read', 'inbox:read'])
+    );
     expect(spec.transport).toBe('hub-http');
 
     // No destructive ops in the verb's argument surface.
@@ -279,7 +290,7 @@ describe('CLI gateway events.subscribe contract', () => {
 
     const inputProps = spec.inputSchema.properties ?? {};
     expect(inputProps['topic']).toBeDefined();
-    expect(inputProps['topic']?.enum).toEqual(expect.arrayContaining(['sessions', 'nodes', 'audit']));
+    expect(inputProps['topic']?.enum).toEqual(expect.arrayContaining([...ALLOWED_TOPICS]));
 
     expect(spec.errorCodes).toEqual(
       expect.arrayContaining(['UNAUTHORIZED', 'INVALID_ARGUMENT', 'FORBIDDEN'])
@@ -297,7 +308,7 @@ describe('CLI gateway events.subscribe contract', () => {
     );
     expect(dataProps['topic']).toBeDefined();
     expect(dataProps['topic']?.enum).toEqual(
-      expect.arrayContaining(['sessions', 'nodes', 'audit'])
+      expect.arrayContaining([...ALLOWED_TOPICS])
     );
     expect(dataProps['sequence']).toBeDefined();
   });
@@ -448,6 +459,56 @@ describe('CLI gateway events.subscribe runtime', () => {
       (e) => e.ok && (e.data as { event: string }).event === 'closed'
     );
     expect(closed).toBeDefined();
+  });
+
+  it('subscribes to workflow-runs metadata with context read capability', async () => {
+    hub = await startFakeHub();
+
+    const runPromise = runCli(
+      ['v1', 'events', 'subscribe', '--topic', 'workflow-runs', '--max-events', '1', '--json'],
+      {
+        RELAY_IDE_PORT: String(hub.port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+      { timeoutMs: 5000 }
+    );
+
+    const streamRes = await hub.whenSubscribed();
+    ndjsonWrite(streamRes, { event: 'open', topic: 'workflow-runs', sequence: 0 });
+    ndjsonWrite(streamRes, {
+      event: 'event',
+      topic: 'workflow-runs',
+      sequence: 1,
+      cursor: 'cg:1:1',
+      occurredAt: '2026-05-19T00:00:00.000Z',
+      payload: {
+        type: 'workflow-run.state-changed',
+        workflowRunId: 'workflow-run:test',
+        workContextId: 'wc:test',
+        state: 'succeeded',
+        redaction: {
+          rawPayloadIncluded: false,
+          rawTranscriptIncluded: false,
+          artifactBodyIncluded: false,
+        },
+      },
+    });
+
+    const result = await runPromise;
+    expect(result.exitCode).toBe(0);
+
+    const captured = hub.captured.find((entry) => entry.url?.startsWith('/events'));
+    expect(captured?.url).toContain('topic=workflow-runs');
+    expect(captured?.capabilities).toContain('context:read');
+
+    const dataFrame = result.envelopes.find(
+      (e) => e.ok && e.command === 'events.subscribe' && (e.data as { event: string }).event === 'event'
+    );
+    if (!dataFrame || !dataFrame.ok) throw new Error('expected workflow-runs event frame');
+    const data = dataFrame.data as { topic: string; payload: { type?: string; workflowRunId?: string } };
+    expect(data.topic).toBe('workflow-runs');
+    expect(data.payload.type).toBe('workflow-run.state-changed');
+    expect(data.payload.workflowRunId).toBe('workflow-run:test');
   });
 
   it('subscribes to the audit topic with the union of required capabilities', async () => {

--- a/test/server-shutdown-contract.test.ts
+++ b/test/server-shutdown-contract.test.ts
@@ -24,7 +24,7 @@ describe('server shutdown store closing contract', () => {
     expect(signalHandlerStart).toBeGreaterThan(gracefulShutdownStart);
     expect(gracefulShutdownSource).toContain('workContextArtifactStore?.close();');
     expect(gracefulShutdownSource).toMatch(
-      /contextPacketStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+closeInterventionLog\(\);/
+      /contextPacketStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+closeInterventionLog\(\);/
     );
   });
 

--- a/test/workflow-run-router.test.ts
+++ b/test/workflow-run-router.test.ts
@@ -1,0 +1,222 @@
+import express from 'express';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createCliGatewayEventBus, type CliGatewayMetadataEvent } from '../server/cli-gateway-event-bus.js';
+import { createWorkflowRunRouter } from '../server/features/workflow-run-router.js';
+import { createWorkflowRunStore, type WorkflowRunStore } from '../server/workflow-runs.js';
+
+let server: http.Server | undefined;
+let baseUrl = '';
+let store: WorkflowRunStore | undefined;
+const tempRoots: string[] = [];
+
+function createStore(): WorkflowRunStore {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-workflow-runs-'));
+  tempRoots.push(root);
+  return createWorkflowRunStore({ dbPath: path.join(root, 'workflow-runs.db') });
+}
+
+async function mount(events = createCliGatewayEventBus()): Promise<{
+  events: ReturnType<typeof createCliGatewayEventBus>;
+  published: CliGatewayMetadataEvent[];
+}> {
+  store = createStore();
+  const published: CliGatewayMetadataEvent[] = [];
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createWorkflowRunRouter({
+      store,
+      events: {
+        publish(input) {
+          const event = events.publish(input);
+          published.push(event);
+          return event;
+        },
+      },
+      requireAuth: (_req, _res, next) => next(),
+    })
+  );
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const addr = server?.address();
+      if (!addr || typeof addr === 'string') throw new Error('missing server address');
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+  return { events, published };
+}
+
+async function req(
+  method: string,
+  route: string,
+  input?: unknown,
+  caps = method === 'GET' ? 'context:read' : 'context:write'
+): Promise<{ status: number; body: any }> {
+  const headers: Record<string, string> = { 'x-relay-capabilities': caps };
+  if (input !== undefined) headers['content-type'] = 'application/json';
+  const res = await fetch(`${baseUrl}${route}`, {
+    method,
+    headers,
+    ...(input !== undefined ? { body: JSON.stringify(input) } : {}),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : {} };
+}
+
+const publishInput = {
+  id: 'workflow-run:test-1',
+  runId: 'dynamic-workflow-run-1',
+  providerRuntime: 'hermes-dynamic-workflows',
+  workContextId: 'wc:test',
+  definition: { hash: 'sha256:abc123', templateId: 'relay/github-exact-head' },
+  state: 'running',
+  progress: { total: 2, completed: 1 },
+  links: { sessionIds: ['session:test'], taskRefs: [{ kind: 'github-issue', id: '944' }] },
+};
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server?.close(() => resolve()));
+  server = undefined;
+  store?.close();
+  store = undefined;
+  for (const root of tempRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('workflow run projection router', () => {
+  it('publishes, lists, updates, and gets redacted WorkContext-scoped workflow runs', async () => {
+    const { published } = await mount();
+
+    const created = await req('POST', '/workflow-runs', publishInput);
+    expect(created.status).toBe(201);
+    expect(created.body.workflowRun).toMatchObject({
+      id: 'workflow-run:test-1',
+      runId: 'dynamic-workflow-run-1',
+      workContextId: 'wc:test',
+      state: 'running',
+      version: 1,
+      redaction: {
+        rawPayloadStored: false,
+        rawTranscriptStored: false,
+        providerPrivateStateStored: false,
+      },
+    });
+
+    const listed = await req('GET', '/workflow-runs?workContextId=wc:test');
+    expect(listed.status).toBe(200);
+    expect(listed.body.workflowRuns).toHaveLength(1);
+
+    const updated = await req('PATCH', '/workflow-runs/workflow-run%3Atest-1', {
+      expectedVersion: 1,
+      state: 'succeeded',
+      resultSummary: 'release gate passed at exact head',
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.body.workflowRun).toMatchObject({
+      id: 'workflow-run:test-1',
+      state: 'succeeded',
+      version: 2,
+      resultSummary: 'release gate passed at exact head',
+    });
+
+    const got = await req('GET', '/workflow-runs/workflow-run%3Atest-1');
+    expect(got.status).toBe(200);
+    expect(got.body.workflowRun.state).toBe('succeeded');
+
+    expect(published.map((event) => event.type)).toEqual([
+      'workflow-run.published',
+      'workflow-run.updated',
+      'workflow-run.state-changed',
+    ]);
+    expect(published[0]).toMatchObject({
+      topic: 'workflow-runs',
+      workContextId: 'wc:test',
+      sessionId: 'session:test',
+      payload: {
+        workflowRunId: 'workflow-run:test-1',
+        runId: 'dynamic-workflow-run-1',
+        state: 'running',
+      },
+      redaction: {
+        rawPayloadIncluded: false,
+        rawTranscriptIncluded: false,
+        artifactBodyIncluded: false,
+      },
+    });
+  });
+
+  it('rejects raw/private workflow state instead of storing transcripts', async () => {
+    await mount();
+
+    const rejected = await req('POST', '/workflow-runs', {
+      ...publishInput,
+      id: 'workflow-run:raw-private',
+      rawTranscript: 'do not store this',
+    });
+
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      details: { reasonCode: 'WORKFLOW_RUN_VALIDATION_FAILED' },
+    });
+  });
+
+  it('rejects publish requests missing workContextId with a typed error', async () => {
+    await mount();
+
+    const rejected = await req('POST', '/workflow-runs', {
+      ...publishInput,
+      id: 'workflow-run:missing-context',
+      workContextId: undefined,
+    });
+
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      details: { field: 'workContextId' },
+    });
+  });
+
+  it('supports cursor replay on the metadata event bus without replaying raw payloads', async () => {
+    const events = createCliGatewayEventBus();
+    const first = events.publish({
+      topic: 'workflow-runs',
+      type: 'workflow-run.published',
+      workContextId: 'wc:test',
+      payload: { workflowRunId: 'workflow-run:old', state: 'running' },
+    });
+    const second = events.publish({
+      topic: 'workflow-runs',
+      type: 'workflow-run.state-changed',
+      workContextId: 'wc:test',
+      payload: JSON.parse(
+        '{"workflowRunId":"workflow-run:new","state":"succeeded","rawTranscript":"SECRET","__proto__":{"polluted":true},"constructor":{"polluted":true},"prototype":{"polluted":true}}'
+      ) as Record<string, unknown>,
+    });
+
+    const replay = events.replay('workflow-runs', first.cursor);
+    expect(replay).toMatchObject({ replayDropped: false });
+    expect(replay.events).toHaveLength(1);
+    expect(replay.events[0]).toMatchObject({
+      cursor: second.cursor,
+      payload: { workflowRunId: 'workflow-run:new', state: 'succeeded' },
+      redaction: {
+        rawPayloadIncluded: false,
+        rawTranscriptIncluded: false,
+        artifactBodyIncluded: false,
+      },
+    });
+    const payload = replay.events[0]?.payload ?? {};
+    expect(payload['rawTranscript']).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(payload, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(payload, 'constructor')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(payload, 'prototype')).toBe(false);
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add WorkContext-scoped WorkflowRun projection model, SQLite store, HTTP router, and CLI gateway commands
- add redacted metadata event bus and subscribe topics for context, inbox, artifacts, handoff artifacts, and workflow runs
- wire actor auth/scope checks, event emissions, shutdown lifecycle, contracts, and tests

Closes #944
Closes #945

## Verification
- npm test -- --reporter=dot (4601 passed)
- npm run check (0 errors, 166 existing warnings)
- npm run build
- git diff --check
- delegated final review: approved true after contract/event-topic fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow runs management: publish, update, list, and retrieve workflow runs.
  * Expanded event subscription with new topics (context, inbox, work-context-artifacts, handoff-artifacts, workflow-runs).
  * Enhanced event filtering with cursor, workContextId, sessionId, and globalSessionId parameters.

* **Chores**
  * Extended actor token permissions for workflow-runs operations.
  * Introduced metadata event bus infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->