### PR TITLE
feat(supervisor): typed session submit primitive for agent TUI steering (#958)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -73,6 +73,7 @@ import {
   SUPERVISOR_SEND_KEY_NAMES,
   supervisorActionCommandId,
   supervisorActionRequiredCapabilities,
+  supervisorSubmitRequiredCapabilities,
   type SupervisorActionType,
 } from '../shared/supervisor-actions.js';
 import {
@@ -3536,7 +3537,8 @@ function parseGatewaySupervisorActionBody(
   }
   const text = gatewayArg(supervisorArgs, '--text');
   if (
-    commandName === 'supervisor.sendText' &&
+    (commandName === 'supervisor.sendText' ||
+      commandName === 'supervisor.submit') &&
     text !== undefined &&
     body['text'] === undefined
   ) {
@@ -3549,6 +3551,18 @@ function parseGatewaySupervisorActionBody(
     body['key'] === undefined
   ) {
     body['key'] = key;
+  }
+  // Submit-only boolean flags (#958).
+  if (commandName === 'supervisor.submit') {
+    if (supervisorArgs.includes('--clear-input') && body['clearInput'] === undefined) {
+      body['clearInput'] = true;
+    }
+    if (supervisorArgs.includes('--paste') && body['paste'] === undefined) {
+      body['paste'] = true;
+    }
+    if (supervisorArgs.includes('--dry-run') && body['dryRun'] === undefined) {
+      body['dryRun'] = true;
+    }
   }
   return body;
 }
@@ -3641,12 +3655,20 @@ async function runGatewaySupervisorAction(
   const commandName = supervisorActionCommandId(action);
   const body = parseGatewaySupervisorActionBody(commandName, supervisorArgs);
   validateGatewaySupervisorActionBody(commandName, body);
+  // A submit that carries an inline text body must also present the send-text
+  // capability so the hub accepts the typed content (#958).
+  const capabilities =
+    action === 'submit'
+      ? supervisorSubmitRequiredCapabilities(
+          typeof body['text'] === 'string' && body['text'].length > 0
+        )
+      : supervisorActionRequiredCapabilities(action);
   const result = await gatewayHttpJson({
     commandName,
     pathName: `/supervisor/actions/${action}`,
     method: 'POST',
     body,
-    capabilities: supervisorActionRequiredCapabilities(action),
+    capabilities,
   });
   printGatewayEnvelope(gatewayOk(commandName, result), 0);
 }

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -76,6 +76,7 @@ relay-ide v1 supervisor send-text --target-ids <session-id-1,session-id-2> --tex
 relay-ide v1 supervisor send-key --id <session-id-or-global-id> --key <escape|tab|arrow-up|arrow-down|arrow-left|arrow-right|ctrl-c|ctrl-d|home|end|page-up|page-down> --json
 relay-ide v1 supervisor send-key --target-ids <session-id-1,session-id-2> --key <escape|tab|arrow-up|arrow-down|arrow-left|arrow-right|ctrl-c|ctrl-d|home|end|page-up|page-down> --json
 relay-ide v1 supervisor submit --id <session-id-or-global-id> --json
+relay-ide v1 supervisor submit --id <session-id-or-global-id> --text 'multi-line prompt' [--clear-input] [--paste] [--dry-run] --json
 relay-ide v1 supervisor submit --target-ids <session-id-1,session-id-2> --json
 relay-ide v1 events subscribe --topic <sessions|nodes|audit|context|inbox|work-context-artifacts|handoff-artifacts|workflow-runs> [--work-context-id <id>] [--session-id <id>] [--global-session-id <id>] [--cursor <cursor>] [--max-events <n>] --json
 relay-ide v1 settings get --json
@@ -561,6 +562,8 @@ Exactly one predicate is allowed: `--output-text <text>`, `--idle-ms <ms>`, or `
 
 `sessions.input --wait-for` is a raw PTY-output substring wait. It is not a rendered-screen wait and must not be treated as proof of visible viewport/cursor/title state. A future Boo-style screen wait must be added as a separate stable gateway command/schema before adapters depend on terminal-model semantics.
 
+To steer an interactive agent/TUI — type a prompt and submit it — prefer the typed [`supervisor submit`](#supervisor-typed-actions-and-rmux-mapping-704) primitive over raw `sessions.input` scripts. `supervisor submit --text ...` hides newline/carriage-return weirdness (it appends the submit carriage return itself, so you never send a second `\r`), handles paste-ish/long bodies, optionally clears the current input, and returns structured submission evidence. Raw `sessions.input` is for narrow smoke/debug and emergency fallback.
+
 Example:
 
 ```bash
@@ -589,8 +592,9 @@ Commands:
 | `relay-ide v1 supervisor send-text --target-ids <id-1,id-2> --text <literal-text> --json`       | Sends the same bounded literal text to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:send-text` |
 | `relay-ide v1 supervisor send-key --id <session-id-or-global-id> --key <key-name> --json`       | Sends one canonical closed-enum key as a typed intervention.                             | `session:attach`, `tab:intervention:send-key`  |
 | `relay-ide v1 supervisor send-key --target-ids <id-1,id-2> --key <key-name> --json`             | Sends the same canonical key to multiple sessions and reports per-target results.        | `session:attach`, `tab:intervention:send-key`  |
-| `relay-ide v1 supervisor submit --id <session-id-or-global-id> --json`                          | Sends Enter (`\n`) as a typed intervention.                                              | `session:attach`, `tab:intervention:submit`    |
-| `relay-ide v1 supervisor submit --target-ids <id-1,id-2> --json`                                | Sends Enter to multiple sessions and reports per-target results.                         | `session:attach`, `tab:intervention:submit`    |
+| `relay-ide v1 supervisor submit --id <session-id-or-global-id> --json`                          | Submits Enter (carriage return) as a typed intervention.                                 | `session:attach`, `tab:intervention:submit`    |
+| `relay-ide v1 supervisor submit --id <id> --text <prompt> [--clear-input] [--paste] [--dry-run] --json` | Typed submit primitive: optionally clears the input, types a (multi-line) body, then submits with an owned carriage return; returns structured submission evidence (#958). | `session:attach`, `tab:intervention:submit`, `tab:intervention:send-text` (only when `--text` is present) |
+| `relay-ide v1 supervisor submit --target-ids <id-1,id-2> --json`                                | Submits to multiple sessions and reports per-target results.                             | `session:attach`, `tab:intervention:submit`    |
 
 Inputs:
 
@@ -598,7 +602,12 @@ Inputs:
 - `supervisor.snapshot` requires `id`. Optional `--expected-control-mode <agent-driven|human-driven|co-driven>` and `--latest-seen-intervention-event-id <event-id>` are preflight guards. Stale or mismatched control state returns `CONTROL_STATE_STALE`; an unacknowledged newer intervention returns `INTERVENTION_ACK_REQUIRED`. The snapshot path is read-only: it never writes to the session, accepts prompts, or stores raw prompt/transcript/PTY/provider state.
 - `supervisor.sendText` requires `text` plus exactly one target shape: `id` or `targetIds`. CLI flags are `--id`, positional `<id>`, or comma-separated `--target-ids`; `--input-json` / `--input-file` may provide the same object shape, including optional `actor` metadata. Text must be non-empty literal text, at most 1000 characters, with no CR/LF, ESC, DEL, or control characters except tab. Use `supervisor.submit` for Enter instead of embedding a newline.
 - `supervisor.sendKey` requires `key` plus exactly one target shape: `id` or `targetIds`. CLI flags are `--id`, positional `<id>`, comma-separated `--target-ids`, and `--key`; `--input-json` / `--input-file` may provide the same object shape, including optional `actor` metadata. Keys are a closed enum only: `escape`, `tab`, `arrow-up`, `arrow-down`, `arrow-left`, `arrow-right`, `ctrl-c`, `ctrl-d`, `home`, `end`, `page-up`, and `page-down`. Aliases, function keys, raw escape/control strings, newlines, and arbitrary byte payloads are rejected; Relay maps the canonical name to substrate bytes behind the capability/control/audit boundary.
-- `supervisor.submit` requires `id` or `targetIds`, accepts optional `actor` metadata via JSON input, and writes exactly `\n`. It does not accept a text payload.
+- `supervisor.submit` is the typed submit primitive for agent/TUI steering (#958). It requires `id` or `targetIds` and accepts optional `actor` metadata. It owns the submission: it always ends with a single carriage return (Enter, `\r`) — the carriage return the browser Enter key sends — so callers never need to send a second raw `\r`. (The pre-#958 behavior wrote a bare line feed `\n`, which is exactly what left text sitting unsubmitted in carriage-return-driven TUIs.) Optional fields:
+  - `text` (CLI `--text`, also accepted via `--input-json`): a message body to type before submitting. Unlike `send-text`, it may contain newlines (multi-line prompts) and tabs, up to 100,000 characters; embedded `\r\n` / lone `\r` are normalized to `\n` and trailing newlines are stripped before the owned carriage return is appended. ESC/DEL and other control bytes are still rejected (`TEXT_MUST_BE_LITERAL`) so this stays a typed text primitive, not a raw byte-injection API. Supplying `text` additionally requires the `tab:intervention:send-text` capability.
+  - `clearInput` (CLI `--clear-input`): clears the current input buffer first (best-effort Ctrl-U), so a partially-typed prompt is replaced rather than appended to.
+  - `paste` (CLI `--paste`): wraps the body in DEC 2004 bracketed-paste markers so long/multi-line content is inserted as one paste; recommended for paste-ish bodies.
+  - `dryRun` (CLI `--dry-run`): previews the planned submission — eligibility, ordered `steps`, and `charsAccepted`/`plannedBytes` — without writing to the PTY or emitting an audit intervention.
+  - Each `data.results[]` entry carries submission evidence: `charsAccepted`, `bytesAccepted`, `submitPerformed`, `submitKey` (`enter`), `clearInputPerformed`, `pasteBracketed`, `steps` (`clear-input` → `type-text` → `submit`), `bytesWritten` / `plannedBytes`, and a best-effort `postSubmit` observation (`{ available, agentState, idle }`) derived from the session snapshot when the backend exposes a classified state.
 
 Successful action envelope shape:
 
@@ -667,7 +676,7 @@ Action failure semantics:
 
 This is deliberately distinct from raw PTY input and terminal substrates:
 
-- `sessions input` remains the raw PTY input path for narrow smoke/debug use. It writes bytes through the temporary attach path, can wait for output markers, and is useful for adapter handshake tests, but it is not the blessed typed agent-to-agent command API.
+- `sessions input` (and the underlying `POST /sessions/:id/input`) remains the raw PTY input path for narrow smoke/debug use. It writes bytes through the temporary attach path, can wait for output markers, and is useful for adapter handshake tests, but it is **not** the blessed typed agent-to-agent command API. To steer a running agent/TUI — type a prompt and have it submit — use `supervisor submit --text ...` (#958), which owns the carriage return and returns structured submission evidence; the old raw-input pattern of "POST text with a newline, then POST a second `\r` to make it submit" is an emergency fallback only.
 - Existing browser/human PTY input remains a different event/API path from supervisor automation interventions.
 - rmux/tmux panes may become backing substrates for Relay sessions, but adapters must not call rmux actions, rmux broadcast, tmux send-keys, or shell commands as stable Relay API. Add or extend a Relay-owned `relay-ide v1 supervisor ... --json` command first, then map that typed command to the substrate behind Relay capability, control-state, and hashes-only audit checks.
 

--- a/server/supervisor-actions.ts
+++ b/server/supervisor-actions.ts
@@ -14,12 +14,32 @@ import {
   type SupervisorSendKeyName,
   type SupervisorSessionEligibility,
   type SupervisorSessionsResponse,
+  type SupervisorSubmitObservation,
+  type SupervisorSubmitStep,
 } from '../shared/supervisor-actions.js';
 import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
 import { encodeTerminalInput, type TerminalInputKey } from './terminal-model-backend.js';
 import type { Session, SessionSummary } from './types.js';
 
 const MAX_SUPERVISOR_TEXT_CHARS = 1000;
+// A submit body is the typed primitive's "paste-ish" lane (#958): it may carry
+// multi-line prompts, so its cap is much larger than the single-line sendText
+// limit, but it is still bounded so this never becomes an unbounded write API.
+const MAX_SUPERVISOR_SUBMIT_TEXT_CHARS = 100_000;
+// The submit primitive owns the carriage return so callers never need to send a
+// second `\r`. We reuse the canonical Enter encoding (CR, not LF) — the LF the
+// old submit wrote is exactly what left text sitting unsubmitted in TUIs (#958).
+const SUBMIT_ENTER_SEQUENCE = encodeTerminalInput({
+  type: 'key',
+  key: 'Enter',
+}).sequence;
+// Ctrl-U (unix-line-discard): a best-effort, provider-generic "clear the current
+// input line" before typing. Not provider-specific magic; standard readline/TUI.
+const CLEAR_INPUT_SEQUENCE = '\u0015';
+// DEC 2004 bracketed paste markers. Wrapping a multi-line/long body lets the TUI
+// treat embedded newlines as literal content instead of premature submissions.
+const BRACKETED_PASTE_START = '\u001b[200~';
+const BRACKETED_PASTE_END = '\u001b[201~';
 const SUPERVISOR_SEND_KEY_INPUTS: Record<SupervisorSendKeyName, TerminalInputKey> = {
   escape: 'Escape',
   tab: 'Tab',
@@ -97,7 +117,9 @@ function validateActionPayload(
   if (action === 'sendKey') {
     return validateSendKey(key);
   }
-  return { ok: true, text: '\n' };
+  // `submit` is handled by buildSubmitPlan() (#958), not here. This fallback is
+  // unreachable for submit but kept for exhaustiveness of the action union.
+  return { ok: true, text: SUBMIT_ENTER_SEQUENCE };
 }
 
 function payloadForValidation(
@@ -126,21 +148,23 @@ function countLines(input: string): number {
 
 function redactionForPayload(
   payload: string,
-  action: SupervisorActionType
+  action: SupervisorActionType,
+  classesOverride?: readonly string[]
 ): SupervisorActionRedactionMetadata {
   const classes =
-    action === 'submit'
+    classesOverride ??
+    (action === 'submit'
       ? ['submit']
       : action === 'sendKey'
         ? ['named-key']
-        : ['literal-text'];
+        : ['literal-text']);
   return {
     rawContentAvailable: false,
     hashSha256: sha256(payload),
     byteCount: Buffer.byteLength(payload, 'utf8'),
     charCount: Array.from(payload).length,
     lineCount: countLines(payload),
-    classes,
+    classes: [...classes],
     redacted: true,
   };
 }
@@ -227,6 +251,172 @@ function validateSendKey(
   };
 }
 
+/**
+ * The fully-resolved byte plan + evidence for one `supervisor.submit` (#958).
+ * Computed once per request and reused for every target (the bytes are
+ * identical across targets); per-target evidence is layered on at write time.
+ */
+interface SupervisorSubmitPlan {
+  /** Exact bytes written to the PTY: [clear?] + [body|bracketed-body] + CR. */
+  payload: string;
+  /** The normalized text body (no control framing, trailing newlines stripped). */
+  body: string;
+  charsAccepted: number;
+  bytesAccepted: number;
+  plannedBytes: number;
+  clearInputPerformed: boolean;
+  pasteBracketed: boolean;
+  steps: SupervisorSubmitStep[];
+  classes: string[];
+}
+
+/**
+ * Normalize a submit body: collapse CRLF / lone CR to LF so embedded line breaks
+ * are consistent, then strip trailing newlines. The primitive appends exactly
+ * one owned carriage return, so callers never need to send a second `\r` (#958).
+ */
+function normalizeSubmitBody(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\n+$/u, '');
+}
+
+function validateSubmitText(
+  text: string
+): { ok: true; text: string } | { ok: false; error: SupervisorActionError } {
+  if (Array.from(text).length > MAX_SUPERVISOR_SUBMIT_TEXT_CHARS) {
+    return {
+      ok: false,
+      error: error(
+        'INVALID_ARGUMENT',
+        'TEXT_TOO_LARGE',
+        `supervisor.submit text is limited to ${MAX_SUPERVISOR_SUBMIT_TEXT_CHARS} characters`,
+        false,
+        { maxChars: MAX_SUPERVISOR_SUBMIT_TEXT_CHARS }
+      ),
+    };
+  }
+  // Newlines (\n, \r) and tabs are allowed in a submit body — multi-line prompts
+  // are the whole point. Other C0 control bytes and ESC (0x1b) / DEL (0x7f) are
+  // rejected so this stays a typed text primitive, not a raw byte-injection API.
+  const hasDisallowedControl = Array.from(text).some((char) => {
+    const code = char.charCodeAt(0);
+    return (
+      code === 0x1b ||
+      code === 0x7f ||
+      (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d)
+    );
+  });
+  if (hasDisallowedControl) {
+    return {
+      ok: false,
+      error: error(
+        'INVALID_ARGUMENT',
+        'TEXT_MUST_BE_LITERAL',
+        'supervisor.submit text accepts literal text (newlines and tabs allowed); control/escape sequences are not permitted',
+        false
+      ),
+    };
+  }
+  return { ok: true, text };
+}
+
+/**
+ * Build the submit byte plan. Order: optional clear-input (Ctrl-U), optional
+ * typed body (raw or bracketed-paste-wrapped), then the owned carriage return.
+ */
+function buildSubmitPlan(input: {
+  text?: unknown;
+  clearInput?: boolean | undefined;
+  paste?: boolean | undefined;
+}):
+  | { ok: true; plan: SupervisorSubmitPlan }
+  | { ok: false; error: SupervisorActionError } {
+  let body = '';
+  const hasText = input.text !== undefined && input.text !== null;
+  if (hasText) {
+    if (typeof input.text !== 'string') {
+      return {
+        ok: false,
+        error: error(
+          'INVALID_ARGUMENT',
+          'TEXT_REQUIRED',
+          'supervisor.submit text must be a string when provided',
+          false
+        ),
+      };
+    }
+    const validated = validateSubmitText(input.text);
+    if (!validated.ok) return validated;
+    body = normalizeSubmitBody(validated.text);
+  }
+
+  const clearInputPerformed = input.clearInput === true;
+  const pasteBracketed = input.paste === true && body.length > 0;
+  const steps: SupervisorSubmitStep[] = [];
+  const parts: string[] = [];
+  if (clearInputPerformed) {
+    parts.push(CLEAR_INPUT_SEQUENCE);
+    steps.push('clear-input');
+  }
+  if (body.length > 0) {
+    parts.push(
+      pasteBracketed
+        ? `${BRACKETED_PASTE_START}${body}${BRACKETED_PASTE_END}`
+        : body
+    );
+    steps.push('type-text');
+  }
+  parts.push(SUBMIT_ENTER_SEQUENCE);
+  steps.push('submit');
+
+  const payload = parts.join('');
+  const classes = [
+    'submit',
+    ...(body.length > 0 ? ['literal-text'] : []),
+    ...(pasteBracketed ? ['paste'] : []),
+    ...(clearInputPerformed ? ['clear-input'] : []),
+  ];
+  return {
+    ok: true,
+    plan: {
+      payload,
+      body,
+      charsAccepted: Array.from(body).length,
+      bytesAccepted: Buffer.byteLength(body, 'utf8'),
+      plannedBytes: Buffer.byteLength(payload, 'utf8'),
+      clearInputPerformed,
+      pasteBracketed,
+      steps,
+      classes,
+    },
+  };
+}
+
+/**
+ * Best-effort derived post-submit state (#958). Reads the last-known agent state
+ * from the resolved session snapshot; returns `available: false` when no derived
+ * state exists yet (mock/dry-run/unclassified). Never exposes raw bytes.
+ */
+function observePostSubmit(
+  session: Session,
+  observedAt: string
+): SupervisorSubmitObservation {
+  const agentState = (session as { agentState?: unknown }).agentState;
+  if (typeof agentState === 'string' && agentState.length > 0) {
+    const idle = (session as { idle?: unknown }).idle;
+    return {
+      available: true,
+      agentState,
+      ...(typeof idle === 'boolean' ? { idle } : {}),
+      source: 'session-snapshot',
+      observedAt,
+    };
+  }
+  return { available: false };
+}
+
 function missingSessionError(requestedId: string): SupervisorActionError {
   return error('NOT_FOUND', 'SESSION_NOT_FOUND', 'session was not found or is not locally writable', false, { sessionId: requestedId });
 }
@@ -295,76 +485,207 @@ export function listSupervisorSessions(sessions: readonly SessionSummary[]): Sup
   };
 }
 
+/** Resolved byte plan + redaction for one action, shared across all targets. */
+interface PreparedSupervisorAction {
+  payload: string;
+  canonicalKey?: SupervisorSendKeyName;
+  payloadValidationError?: SupervisorActionError;
+  auditContent?: SupervisorActionRedactionMetadata;
+  submitPlan?: SupervisorSubmitPlan;
+}
+
+interface SupervisorTargetContext {
+  action: SupervisorActionType;
+  actor: ControlActor;
+  dryRun: boolean;
+  boundary: SupervisorActionSessionBoundary;
+  timestamp: string;
+  deniedByCapability?: SupervisorActionError;
+}
+
+/**
+ * Resolve the byte plan + redaction once. Submit composes optional clear-input +
+ * optional typed text + an owned carriage return (#958); sendText/sendKey keep
+ * their existing literal/named-key validation.
+ */
+function prepareSupervisorAction(
+  action: SupervisorActionType,
+  text: unknown,
+  key: unknown,
+  clearInput: boolean | undefined,
+  paste: boolean | undefined
+): PreparedSupervisorAction {
+  if (action === 'submit') {
+    const planResult = buildSubmitPlan({ text, clearInput, paste });
+    if (!planResult.ok) {
+      return { payload: '', payloadValidationError: planResult.error };
+    }
+    return {
+      payload: planResult.plan.payload,
+      submitPlan: planResult.plan,
+      auditContent: redactionForPayload(
+        planResult.plan.body,
+        'submit',
+        planResult.plan.classes
+      ),
+    };
+  }
+  const validation = validateActionPayload(action, text, key);
+  const payload = payloadForValidation(validation);
+  const canonicalKey = keyForValidation(validation);
+  const payloadValidationError = validationError(validation);
+  return {
+    payload,
+    ...(canonicalKey === undefined ? {} : { canonicalKey }),
+    ...(payloadValidationError ? { payloadValidationError } : {}),
+    ...(validation.ok
+      ? { auditContent: redactionForPayload(payload, action) }
+      : {}),
+  };
+}
+
+/** Submit evidence layered onto a successful real (non-dry-run) write (#958). */
+function submitSuccessEvidence(
+  submitPlan: SupervisorSubmitPlan,
+  session: Session,
+  timestamp: string
+): Partial<SupervisorActionTargetResult> {
+  return {
+    charsAccepted: submitPlan.charsAccepted,
+    bytesAccepted: submitPlan.bytesAccepted,
+    submitPerformed: true,
+    submitKey: 'enter',
+    clearInputPerformed: submitPlan.clearInputPerformed,
+    pasteBracketed: submitPlan.pasteBracketed,
+    steps: submitPlan.steps,
+    postSubmit: observePostSubmit(session, timestamp),
+  };
+}
+
+/** Submit dry-run preview: planned evidence with nothing written (#958). */
+function submitDryRunResult(
+  identity: ReturnType<typeof targetIdentity>,
+  submitPlan: SupervisorSubmitPlan
+): SupervisorActionTargetResult {
+  return {
+    ...identity,
+    ok: true,
+    action: 'submit',
+    dryRun: true,
+    plannedBytes: submitPlan.plannedBytes,
+    charsAccepted: submitPlan.charsAccepted,
+    bytesAccepted: submitPlan.bytesAccepted,
+    submitPerformed: false,
+    submitKey: 'enter',
+    clearInputPerformed: submitPlan.clearInputPerformed,
+    pasteBracketed: submitPlan.pasteBracketed,
+    steps: submitPlan.steps,
+    postSubmit: { available: false },
+  };
+}
+
+/** Run one target: guard checks, then dry-run preview or a real write. */
+function runSupervisorTarget(
+  id: string,
+  prepared: PreparedSupervisorAction,
+  ctx: SupervisorTargetContext
+): SupervisorActionTargetResult {
+  const session = id ? ctx.boundary.get(id) : undefined;
+  const identity = targetIdentity(session, id);
+  const fail = (error: SupervisorActionError): SupervisorActionTargetResult => ({
+    ...identity,
+    ok: false,
+    action: ctx.action,
+    error,
+  });
+
+  if (ctx.deniedByCapability) return fail(ctx.deniedByCapability);
+  if (prepared.payloadValidationError) return fail(prepared.payloadValidationError);
+  if (!session) return fail(missingSessionError(id));
+  const preflight = targetPreflight(session);
+  if (preflight) return fail(preflight);
+
+  if (prepared.submitPlan && ctx.dryRun) {
+    return submitDryRunResult(identity, prepared.submitPlan);
+  }
+
+  try {
+    const write = ctx.boundary.supervisorWrite(session.id, {
+      action: ctx.action,
+      actor: ctx.actor,
+      payload: prepared.payload,
+    });
+    return {
+      ...identity,
+      ok: true,
+      action: ctx.action,
+      bytesWritten: Buffer.byteLength(prepared.payload, 'utf8'),
+      ...(prepared.canonicalKey === undefined ? {} : { key: prepared.canonicalKey }),
+      interventionEventId: write.eventId,
+      ...(write.modeBefore === undefined ? {} : { controlModeBefore: write.modeBefore }),
+      ...(write.modeAfter === undefined ? {} : { controlModeAfter: write.modeAfter }),
+      ...(prepared.submitPlan
+        ? submitSuccessEvidence(prepared.submitPlan, session, ctx.timestamp)
+        : {}),
+    };
+  } catch (caught) {
+    const message =
+      caught instanceof Error ? caught.message : 'failed to write supervisor action';
+    return fail(
+      error('UPSTREAM_ERROR', 'UPSTREAM_WRITE_FAILED', message, true, {
+        sessionId: session.id,
+      })
+    );
+  }
+}
+
 export function executeSupervisorAction(input: {
   boundary: SupervisorActionSessionBoundary;
   action: SupervisorActionType;
   targetIds: readonly string[];
   text?: unknown;
   key?: unknown;
+  /** Submit-only (#958): clear the current input buffer before typing. */
+  clearInput?: boolean;
+  /** Submit-only (#958): wrap a multi-line/long body in bracketed-paste markers. */
+  paste?: boolean;
+  /** Submit-only (#958): preview the plan + evidence without writing/auditing. */
+  dryRun?: boolean;
   actor?: ControlActor;
   now?: Date;
   deniedByCapability?: SupervisorActionError;
 }): SupervisorActionResponse {
   const actor = input.actor ?? DEFAULT_SUPERVISOR_ACTOR;
   const timestamp = (input.now ?? new Date()).toISOString();
-  const validation = validateActionPayload(input.action, input.text, input.key);
-  const payload = payloadForValidation(validation);
-  const canonicalKey = keyForValidation(validation);
-  const payloadValidationError = validationError(validation);
-  const results: SupervisorActionTargetResult[] = [];
+  const dryRun = input.action === 'submit' && input.dryRun === true;
+  const prepared = prepareSupervisorAction(
+    input.action,
+    input.text,
+    input.key,
+    input.clearInput,
+    input.paste
+  );
 
-  const uniqueTargetIds = Array.from(new Set(input.targetIds.filter((id) => id.trim().length > 0)));
+  const uniqueTargetIds = Array.from(
+    new Set(input.targetIds.filter((id) => id.trim().length > 0))
+  );
   if (uniqueTargetIds.length === 0) {
     uniqueTargetIds.push('');
   }
 
-  for (const id of uniqueTargetIds) {
-    const session = id ? input.boundary.get(id) : undefined;
-    const identity = targetIdentity(session, id);
-    if (input.deniedByCapability) {
-      results.push({ ...identity, ok: false, action: input.action, error: input.deniedByCapability });
-      continue;
-    }
-    if (payloadValidationError) {
-      results.push({ ...identity, ok: false, action: input.action, error: payloadValidationError });
-      continue;
-    }
-    if (!session) {
-      results.push({ ...identity, ok: false, action: input.action, error: missingSessionError(id) });
-      continue;
-    }
-    const preflight = targetPreflight(session);
-    if (preflight) {
-      results.push({ ...identity, ok: false, action: input.action, error: preflight });
-      continue;
-    }
-    try {
-      const write = input.boundary.supervisorWrite(session.id, {
-        action: input.action,
-        actor,
-        payload,
-      });
-      const targetResult: SupervisorActionTargetResult = {
-        ...identity,
-        ok: true,
-        action: input.action,
-        bytesWritten: Buffer.byteLength(payload, 'utf8'),
-        ...(canonicalKey === undefined ? {} : { key: canonicalKey }),
-        interventionEventId: write.eventId,
-        ...(write.modeBefore === undefined ? {} : { controlModeBefore: write.modeBefore }),
-        ...(write.modeAfter === undefined ? {} : { controlModeAfter: write.modeAfter }),
-      };
-      results.push(targetResult);
-    } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'failed to write supervisor action';
-      results.push({
-        ...identity,
-        ok: false,
-        action: input.action,
-        error: error('UPSTREAM_ERROR', 'UPSTREAM_WRITE_FAILED', message, true, { sessionId: session.id }),
-      });
-    }
-  }
+  const ctx: SupervisorTargetContext = {
+    action: input.action,
+    actor,
+    dryRun,
+    boundary: input.boundary,
+    timestamp,
+    ...(input.deniedByCapability
+      ? { deniedByCapability: input.deniedByCapability }
+      : {}),
+  };
+  const results = uniqueTargetIds.map((id) =>
+    runSupervisorTarget(id, prepared, ctx)
+  );
 
   const counts = tally(results);
   const audit: SupervisorActionAuditSummary = {
@@ -372,12 +693,13 @@ export function executeSupervisorAction(input: {
     actor: actorSummary(actor),
     targetSessionIds: results.map((result) => result.sessionId),
     targetCount: results.length,
-    ...(canonicalKey === undefined ? {} : { key: canonicalKey }),
+    ...(prepared.canonicalKey === undefined ? {} : { key: prepared.canonicalKey }),
     timestamp,
-    ...(validation.ok ? { content: redactionForPayload(payload, input.action) } : {}),
+    ...(prepared.auditContent ? { content: prepared.auditContent } : {}),
     counts,
     rawContentStored: false,
     partialFailure: counts.failed > 0 || counts.denied > 0 || counts.skipped > 0,
+    ...(dryRun ? { dryRun: true } : {}),
   };
   return {
     command: supervisorActionCommandId(input.action),

--- a/server/supervisor-route-handlers.ts
+++ b/server/supervisor-route-handlers.ts
@@ -142,6 +142,22 @@ function validateSupervisorActionTargets(
   return { ok: true, targetIds: targetIds.map((entry) => entry.trim()) };
 }
 
+function validateSubmitBooleanOptions(
+  body: Record<string, unknown>
+): SupervisorActionError | undefined {
+  for (const field of ['clearInput', 'paste', 'dryRun'] as const) {
+    const value = body[field];
+    if (value !== undefined && typeof value !== 'boolean') {
+      return supervisorActionError(
+        'TARGET_SELECTOR_INVALID',
+        `${field} must be a boolean when provided`,
+        { field }
+      );
+    }
+  }
+  return undefined;
+}
+
 function missingCapabilityEvidenceDecision(
   capability: ControlCapabilityDecision['capability']
 ): ControlCapabilityDecision {
@@ -220,6 +236,16 @@ export function handleSupervisorActionRequest(
     action === 'submit' &&
     typeof body['text'] === 'string' &&
     (body['text'] as string).length > 0;
+
+  if (action === 'submit') {
+    const submitOptionsError = validateSubmitBooleanOptions(body);
+    if (submitOptionsError) {
+      res
+        .status(supervisorActionErrorStatus(submitOptionsError))
+        .json({ error: submitOptionsError });
+      return;
+    }
+  }
 
   const decision = supervisorActionCapabilitiesDecision(req, action, hasSubmitText);
   if (decision.decision !== 'allow') {

--- a/server/supervisor-route-handlers.ts
+++ b/server/supervisor-route-handlers.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express';
 import {
   SUPERVISOR_READ_REQUIRED_CAPABILITIES,
   supervisorActionRequiredCapabilities,
+  supervisorSubmitRequiredCapabilities,
   type SupervisorActionError,
   type SupervisorActionType,
 } from '../shared/supervisor-actions.js';
@@ -155,9 +156,15 @@ function missingCapabilityEvidenceDecision(
 
 function supervisorActionCapabilitiesDecision(
   req: Request,
-  action: SupervisorActionType
+  action: SupervisorActionType,
+  hasSubmitText: boolean
 ): ControlCapabilityDecision {
-  const capabilities = supervisorActionRequiredCapabilities(action);
+  // A submit that types an inline text body needs the send-text capability in
+  // addition to the submit capability (#958).
+  const capabilities =
+    action === 'submit'
+      ? supervisorSubmitRequiredCapabilities(hasSubmitText)
+      : supervisorActionRequiredCapabilities(action);
   const header = req.header('x-relay-capabilities') ?? undefined;
   if (header === undefined || header.trim().length === 0) {
     const highRiskCapability =
@@ -209,7 +216,12 @@ export function handleSupervisorActionRequest(
     return;
   }
 
-  const decision = supervisorActionCapabilitiesDecision(req, action);
+  const hasSubmitText =
+    action === 'submit' &&
+    typeof body['text'] === 'string' &&
+    (body['text'] as string).length > 0;
+
+  const decision = supervisorActionCapabilitiesDecision(req, action, hasSubmitText);
   if (decision.decision !== 'allow') {
     const error = capabilityError(decision);
     res.status(sessionControlErrorStatus(error)).json({ error });
@@ -223,6 +235,14 @@ export function handleSupervisorActionRequest(
     targetIds: targets.targetIds,
     text: body['text'],
     key: body['key'],
+    // Submit-only options (#958); ignored for sendText/sendKey.
+    ...(action === 'submit'
+      ? {
+          clearInput: body['clearInput'] === true,
+          paste: body['paste'] === true,
+          dryRun: body['dryRun'] === true,
+        }
+      : {}),
     ...(actor === undefined ? {} : { actor }),
   });
   res.json(result);

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -2095,6 +2095,26 @@ const supervisorSubmitInputSchema: RelayJsonSchema = {
   properties: {
     id: stringSchema,
     targetIds: { type: 'array', items: stringSchema },
+    text: {
+      ...stringSchema,
+      description:
+        'Optional message body to type before submitting. May contain newlines (multi-line prompts) and tabs; control/escape sequences are rejected. The command appends the carriage return itself — callers must not include a trailing Enter. Requires the tab:intervention:send-text capability in addition to tab:intervention:submit.',
+    },
+    clearInput: {
+      ...booleanSchema,
+      description:
+        'Clear the current input buffer (best-effort Ctrl-U) before typing/submitting.',
+    },
+    paste: {
+      ...booleanSchema,
+      description:
+        'Wrap the text body in bracketed-paste markers so multi-line/long content is inserted as one paste instead of submitting line-by-line.',
+    },
+    dryRun: {
+      ...booleanSchema,
+      description:
+        'Preview the planned submission (bytes/chars accepted, steps, eligibility) without writing to the PTY or emitting an audit intervention.',
+    },
     actor: { type: 'object', additionalProperties: true },
   },
   oneOf: [{ required: ['id'] }, { required: ['targetIds'] }],
@@ -4629,10 +4649,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'submit',
       '--id',
       '<session-id>',
+      '[--text',
+      '<text>]',
+      '[--clear-input]',
+      '[--paste]',
+      '[--dry-run]',
       '--json',
     ],
     summary:
-      'Submit Enter to one or more PTY sessions as a typed supervisor intervention.',
+      'Typed submit primitive for agent/TUI steering: optionally type a (multi-line) text body, optionally clear the input first, then submit with an owned carriage return — callers never send a second Enter. Returns structured submission evidence. Inline text additionally requires tab:intervention:send-text.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,

--- a/shared/supervisor-actions.ts
+++ b/shared/supervisor-actions.ts
@@ -30,6 +30,18 @@ export const SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES = [
   'tab:intervention:submit',
 ] as const satisfies readonly RelayCapabilityBit[];
 
+/**
+ * `supervisor.submit` with an inline `text` body composes a typed text
+ * intervention and an Enter submission in one atomic action (#958). Because the
+ * caller types arbitrary content, it must hold the send-text capability in
+ * addition to the submit capability — a plain Enter-only submit does not.
+ */
+export const SUPERVISOR_SUBMIT_WITH_TEXT_REQUIRED_CAPABILITIES = [
+  'session:attach',
+  'tab:intervention:submit',
+  'tab:intervention:send-text',
+] as const satisfies readonly RelayCapabilityBit[];
+
 export const SUPERVISOR_SEND_KEY_NAMES = [
   'escape',
   'tab',
@@ -92,6 +104,29 @@ export interface SupervisorActionRedactionMetadata {
   redacted: boolean;
 }
 
+/**
+ * Ordered steps a `supervisor.submit` action performs against a target (#958).
+ * `clear-input` is emitted only when the caller asks to clear the current
+ * prompt buffer first; `type-text` only when an inline `text` body is supplied;
+ * `submit` is always present (the Enter/carriage-return the primitive owns).
+ */
+export type SupervisorSubmitStep = 'clear-input' | 'type-text' | 'submit';
+
+/**
+ * Best-effort, derived post-submit session state (#958). Populated from the
+ * last-known session snapshot after a real submit; `available: false` when the
+ * backend does not expose a derived agent state (e.g. dry-run, mock, or a
+ * session that has not been classified yet). Never carries raw transcript or
+ * provider-private bytes.
+ */
+export interface SupervisorSubmitObservation {
+  available: boolean;
+  agentState?: string;
+  idle?: boolean;
+  source?: 'session-snapshot';
+  observedAt?: string;
+}
+
 export interface SupervisorActionTargetResult {
   sessionId: string;
   globalSessionId?: string;
@@ -104,6 +139,27 @@ export interface SupervisorActionTargetResult {
   controlModeBefore?: ControlMode;
   controlModeAfter?: ControlMode;
   error?: SupervisorActionError;
+  // --- Typed submit evidence (#958); only set for the `submit` action. ---
+  /** Characters of the inline text body accepted (excludes control framing). */
+  charsAccepted?: number;
+  /** UTF-8 bytes of the inline text body accepted (excludes control framing). */
+  bytesAccepted?: number;
+  /** Total bytes the submit would write, when not actually written (dry-run). */
+  plannedBytes?: number;
+  /** Whether the Enter/carriage-return submission was performed. */
+  submitPerformed?: boolean;
+  /** The named key used to submit; always `enter` for the submit primitive. */
+  submitKey?: 'enter';
+  /** Whether the current input buffer was cleared before typing. */
+  clearInputPerformed?: boolean;
+  /** Whether the body was wrapped in bracketed-paste markers. */
+  pasteBracketed?: boolean;
+  /** Whether this was a dry-run preview (no bytes written, no audit write). */
+  dryRun?: boolean;
+  /** Ordered steps performed (or planned, for a dry-run). */
+  steps?: SupervisorSubmitStep[];
+  /** Derived post-submit session state, when available. */
+  postSubmit?: SupervisorSubmitObservation;
 }
 
 export interface SupervisorActionCounts {
@@ -131,6 +187,8 @@ export interface SupervisorActionAuditSummary {
   counts: SupervisorActionCounts;
   rawContentStored: false;
   partialFailure: boolean;
+  /** True when the action was a dry-run preview; no bytes were written (#958). */
+  dryRun?: boolean;
 }
 
 export interface SupervisorActionResponse {
@@ -175,6 +233,19 @@ export function supervisorActionRequiredCapabilities(
   if (action === 'sendText') return SUPERVISOR_SEND_TEXT_REQUIRED_CAPABILITIES;
   if (action === 'sendKey') return SUPERVISOR_SEND_KEY_REQUIRED_CAPABILITIES;
   return SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES;
+}
+
+/**
+ * Capabilities required for `supervisor.submit` (#958). A plain Enter-only
+ * submit needs just the submit capability; a submit that types an inline text
+ * body additionally needs the send-text capability.
+ */
+export function supervisorSubmitRequiredCapabilities(
+  hasText: boolean
+): readonly RelayCapabilityBit[] {
+  return hasText
+    ? SUPERVISOR_SUBMIT_WITH_TEXT_REQUIRED_CAPABILITIES
+    : SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES;
 }
 
 export function supervisorActionCommandId(

--- a/test/supervisor-actions.test.ts
+++ b/test/supervisor-actions.test.ts
@@ -85,7 +85,7 @@ describe('typed supervisor actions', () => {
       now: new Date('2026-05-16T00:00:01.000Z'),
     });
 
-    expect(writes).toEqual(['sess-1:hello', 'sess-1:\n']);
+    expect(writes).toEqual(['sess-1:hello', 'sess-1:\r']);
     expect(sendText).toMatchObject({
       command: 'supervisor.sendText',
       action: 'sendText',
@@ -271,6 +271,192 @@ describe('typed supervisor actions', () => {
     expect(result.results[0]?.error).toMatchObject({
       code: 'INVALID_ARGUMENT',
       reasonCode: 'TEXT_MUST_BE_LITERAL',
+    });
+  });
+});
+
+describe('#958 typed supervisor submit', () => {
+  it('submits a bare carriage return (Enter), not a line feed', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+    });
+
+    // The classic #958 bug was submitting '\n' (LF), which left content sitting
+    // in CR-submit TUIs. The primitive owns a single '\r'.
+    expect(writes).toEqual(['sess-1:\r']);
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      action: 'submit',
+      submitPerformed: true,
+      submitKey: 'enter',
+      clearInputPerformed: false,
+      pasteBracketed: false,
+      charsAccepted: 0,
+      bytesAccepted: 0,
+      steps: ['submit'],
+    });
+  });
+
+  it('types a newline-containing prompt then submits with one owned carriage return', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'first line\nsecond line\n',
+    });
+
+    // Trailing newline is stripped; embedded newline is preserved as a literal
+    // LF; exactly one CR is appended by the primitive.
+    expect(writes).toEqual(['sess-1:first line\nsecond line\r']);
+    expect(result.counts).toMatchObject({ requested: 1, succeeded: 1, failed: 0 });
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      submitPerformed: true,
+      submitKey: 'enter',
+      charsAccepted: 'first line\nsecond line'.length,
+      bytesAccepted: Buffer.byteLength('first line\nsecond line', 'utf8'),
+      pasteBracketed: false,
+      steps: ['type-text', 'submit'],
+    });
+    expect(result.audit.content).toMatchObject({
+      rawContentAvailable: false,
+      classes: ['submit', 'literal-text'],
+      redacted: true,
+    });
+    expect(JSON.stringify(result)).not.toContain('first line');
+  });
+
+  it('normalizes CRLF/lone-CR line endings in the body to LF', () => {
+    const writes: string[] = [];
+    executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'echo hi\r\nmore\rtail\r\n',
+    });
+
+    expect(writes).toEqual(['sess-1:echo hi\nmore\ntail\r']);
+  });
+
+  it('wraps a long pasted prompt in bracketed-paste markers before the carriage return', () => {
+    const writes: string[] = [];
+    const longBody = 'x'.repeat(5000);
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: longBody,
+      paste: true,
+    });
+
+    expect(writes).toEqual([`sess-1:[200~${longBody}[201~\r`]);
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      pasteBracketed: true,
+      charsAccepted: 5000,
+      submitPerformed: true,
+      steps: ['type-text', 'submit'],
+    });
+  });
+
+  it('clears the current input buffer before typing when asked', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'redo',
+      clearInput: true,
+    });
+
+    expect(writes).toEqual(['sess-1:redo\r']);
+    expect(result.results[0]).toMatchObject({
+      clearInputPerformed: true,
+      steps: ['clear-input', 'type-text', 'submit'],
+    });
+  });
+
+  it('previews a dry-run submission without writing or auditing a write', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'preview me',
+      dryRun: true,
+    });
+
+    expect(writes).toEqual([]);
+    expect(result.counts).toMatchObject({ requested: 1, succeeded: 1, failed: 0 });
+    expect(result.audit).toMatchObject({ dryRun: true, rawContentStored: false });
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      dryRun: true,
+      submitPerformed: false,
+      charsAccepted: 'preview me'.length,
+      plannedBytes: Buffer.byteLength('preview me\r', 'utf8'),
+      steps: ['type-text', 'submit'],
+      postSubmit: { available: false },
+    });
+    expect(result.results[0]?.interventionEventId).toBeUndefined();
+  });
+
+  it('rejects control/escape sequences in the submit body before writing', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'safe[31mred',
+    });
+
+    expect(writes).toEqual([]);
+    expect(result.counts).toMatchObject({ requested: 1, succeeded: 0, failed: 1 });
+    expect(result.results[0]?.error).toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      reasonCode: 'TEXT_MUST_BE_LITERAL',
+    });
+  });
+
+  it('rejects an oversized submit body before writing', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session() }, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'y'.repeat(100_001),
+    });
+
+    expect(writes).toEqual([]);
+    expect(result.results[0]?.error).toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      reasonCode: 'TEXT_TOO_LARGE',
+    });
+  });
+
+  it('reports derived post-submit session state when the session exposes it', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary(
+        { 'sess-1': session({ agentState: 'processing', idle: false }) },
+        writes
+      ),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      text: 'go',
+      now: new Date('2026-06-14T00:00:00.000Z'),
+    });
+
+    expect(result.results[0]?.postSubmit).toEqual({
+      available: true,
+      agentState: 'processing',
+      idle: false,
+      source: 'session-snapshot',
+      observedAt: '2026-06-14T00:00:00.000Z',
     });
   });
 });

--- a/test/supervisor-route-handlers.test.ts
+++ b/test/supervisor-route-handlers.test.ts
@@ -283,6 +283,79 @@ describe('supervisor route handlers', () => {
     );
   });
 
+  it('submits a plain Enter (carriage return) with only the submit capability', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        action: 'submit',
+        body: { id: 'sess-1' },
+        capabilities: 'session:attach,tab:intervention:submit',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ action: 'submit', payload: '\r' })
+    );
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'supervisor.submit', action: 'submit' })
+    );
+  });
+
+  it('requires the send-text capability when a submit carries inline text (#958)', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        action: 'submit',
+        body: { id: 'sess-1', text: 'do the thing' },
+        capabilities: 'session:attach,tab:intervention:submit',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'FORBIDDEN',
+        reasonCode: 'CAPABILITY_REQUIRED',
+        details: expect.objectContaining({
+          capability: 'tab:intervention:send-text',
+        }),
+      }),
+    });
+  });
+
+  it('types and submits inline text with submit + send-text capabilities (#958)', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        action: 'submit',
+        body: { id: 'sess-1', text: 'run it\n' },
+        capabilities:
+          'session:attach,tab:intervention:submit,tab:intervention:send-text',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ action: 'submit', payload: 'run it\r' })
+    );
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it('preserves multi-target partial-failure semantics for valid supervisor action requests', () => {
     const sessions = supervisorBoundary({
       'sess-1': session({ id: 'sess-1' }),

--- a/test/supervisor-route-handlers.test.ts
+++ b/test/supervisor-route-handlers.test.ts
@@ -334,6 +334,31 @@ describe('supervisor route handlers', () => {
     });
   });
 
+  it('rejects non-boolean submit option fields before writing (#958)', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        action: 'submit',
+        body: { id: 'sess-1', dryRun: 'true' },
+        capabilities: 'session:attach,tab:intervention:submit',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'INVALID_ARGUMENT',
+        reasonCode: 'TARGET_SELECTOR_INVALID',
+        details: { field: 'dryRun' },
+      }),
+    });
+  });
+
   it('types and submits inline text with submit + send-text capabilities (#958)', () => {
     const sessions = supervisorBoundary();
     const res = jsonResponse();


### PR DESCRIPTION
## Summary

Implements #958 by extending the existing `supervisor.submit` gateway command into a **typed, Relay-owned submit primitive** for steering interactive agent/TUI sessions. It hides PTY newline/carriage-return weirdness, supports paste-ish/multi-line bodies, optionally clears the current input, and returns structured submission evidence — instead of agents scripting raw `POST /sessions/:id/input` + a second `\r`.

**Why:** during the Relay-driven Claude ultracode run, raw `POST /sessions/:id/input` with newline-containing text *typed* the text but did **not** submit until a separate carriage return was sent. The old `supervisor.submit` wrote a bare line feed (`\n`) — exactly the byte that leaves content sitting unsubmitted in carriage-return-driven TUIs.

This extends the existing command (reusing its capability/audit/control-mode/multi-target machinery) rather than adding a brand-new `sessions.submit` surface — the issue explicitly blesses "a `supervisor.submit` projection."

## What changed

- **Owned carriage return.** Submit now ends with a single `\r` (the canonical Enter encoding the browser Enter key uses), not `\n`. Plain submit = just `\r`. Callers never send a second `\r`.
- **New optional `supervisor.submit` inputs:**
  - `text` (`--text`): message body to type before submitting. May contain newlines (multi-line prompts) and tabs; `\r\n`/lone `\r` normalized to `\n`; trailing newlines stripped; ESC/DEL/other control bytes rejected (`TEXT_MUST_BE_LITERAL`); 100k-char cap.
  - `clearInput` (`--clear-input`): best-effort Ctrl-U to clear the current input buffer first.
  - `paste` (`--paste`): DEC 2004 bracketed-paste framing for long/multi-line bodies.
  - `dryRun` (`--dry-run`): preview the plan (eligibility, steps, byte/char counts) without writing to the PTY or emitting an audit intervention.
- **Structured evidence** per target: `charsAccepted`, `bytesAccepted`, `submitPerformed`, `submitKey` (`enter`), `clearInputPerformed`, `pasteBracketed`, ordered `steps` (`clear-input` → `type-text` → `submit`), `bytesWritten`/`plannedBytes`, and a best-effort derived `postSubmit` (`{ available, agentState, idle }`).
- **Capability composition:** a submit that types inline text additionally requires `tab:intervention:send-text` alongside `tab:intervention:submit`; enforced in both the hub route handler and the CLI. Plain Enter-only submit capability is unchanged.
- **Constraints honored:** not a raw byte-injection API (control/escape bytes in the body are rejected); hashes-only audit/redaction promise preserved (no raw body in response/audit); `/sessions/:id/input` behavior is untouched and documented as an emergency fallback only; provider-generic (tested against the Relay PTY/session abstraction, no Claude-specific magic).

## Files

- `shared/supervisor-actions.ts` — evidence types, `SUPERVISOR_SUBMIT_WITH_TEXT_REQUIRED_CAPABILITIES`, `supervisorSubmitRequiredCapabilities()`.
- `server/supervisor-actions.ts` — submit byte-plan builder (validate/normalize/clear/paste/CR), dry-run, evidence, post-submit observation; `executeSupervisorAction` refactored into helpers.
- `server/supervisor-route-handlers.ts` — dynamic submit capabilities + threads `clearInput`/`paste`/`dryRun`.
- `bin/relay-ide.ts` — `--text`/`--clear-input`/`--paste`/`--dry-run` parsing + capability selection for `supervisor submit`.
- `shared/cli-gateway-contract.ts` — `supervisorSubmitInputSchema` fields + command summary/argv.
- `docs/CLI_GATEWAY.md` — typed-primitive docs + steering away from raw input scripts.
- `test/supervisor-actions.test.ts`, `test/supervisor-route-handlers.test.ts` — regression coverage.

## Tests run (exact commands + results)

- `npx vitest run test/supervisor-actions.test.ts test/supervisor-route-handlers.test.ts test/cli-gateway-contract.test.ts test/control-engine.test.ts` → **66 passed**
- `npx vitest run test/auth.test.ts test/cli-gateway-actor-auth.test.ts test/dev-supervisor.test.ts test/server/supervisor-snapshot.test.ts test/stores/node-dashboard.test.ts` → **71 passed**
- `npm run check` (`tsc` x2 + typecheck:test + eslint) → **EXIT 0** (0 errors; only pre-existing repo-wide `sonarjs/no-duplicate-string` warnings)
- `npm run build` → **EXIT 0**

New regression tests cover: bare-CR (not LF) submit, newline-containing prompt, CRLF/lone-CR normalization, long pasted prompt (bracketed paste), clear-input, dry-run (no write/no audit), control-sequence rejection, oversize rejection, derived post-submit state, and the inline-text send-text capability gate.

## Design decisions

- **Extend `supervisor.submit`, not a new command.** Reuses the existing typed-action capability/audit/control-mode/multi-target path; minimal new surface; matches the issue's blessed option.
- **CR, not LF.** The submit byte is the canonical `Enter` encoding (`\r`). Fixing the bare-`\n` write is the core of the bug; the one existing test asserting `\n` was updated to `\r`.
- **Body newlines stay literal; only the final CR submits.** A `\r` is the only submit byte, so embedded `\n` becomes literal multi-line content. `paste` adds bracketed-paste framing for reliability on long/multi-line content without baking in provider-specific behavior.
- **Inline text ⇒ send-text capability.** Typing arbitrary content is a send-text + submit composite, so it requires both bits.
- **Post-submit state is best-effort** ("when available") — derived from the session snapshot's `agentState`/`idle`; `available:false` when unclassified (e.g. dry-run/mock).

## Risks

- Changing the plain-submit byte from `\n` to `\r` is a deliberate behavior change (the fix). It matches the browser Enter path; the one affected unit test was updated. Low risk; broad supervisor/control/auth suites pass.
- `clearInput` (Ctrl-U) and `paste` (bracketed paste) are best-effort, terminal-generic mechanisms; exact rendering depends on the target app's input mode. Evidence flags (`clearInputPerformed`, `pasteBracketed`) report what was attempted.

## Next recommended slice

- Cross-node routed submit (current execution is local-owned sessions, consistent with the rest of the supervisor surface).
- A first-class rendered-screen post-submit wait (Boo-style) so `postSubmit` can confirm `processing`/`waiting-for-input`/`permission-prompt` transitions rather than reporting the last-known snapshot.

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed text submission for supervisor submit—users can now include content with the `--text` flag
  * Added optional submit modifiers: `--clear-input` to clear previous input, `--paste` for bracketed paste handling, and `--dry-run` to preview submissions without executing

* **Documentation**
  * Updated CLI Gateway documentation with the new typed submit form and available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->