### PR TITLE
Route utility session close through lifecycle action

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,8 +33,12 @@ import {
 import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
 import { estimateTerminalDimensions } from './lib/utils.js';
 import { createSessionWithoutActivation } from './lib/session-utils.js';
-import { resolveSessionByKey, scopedSessionKey } from './lib/session-keys.js';
-import { killSession } from './lib/api.js';
+import {
+  resolveSessionByKey,
+  resolveSessionCloseTarget,
+  scopedSessionKey,
+} from './lib/session-keys.js';
+import { executeSessionKillAction } from './lib/actions/session-lifecycle.js';
 import {
   getMainWorkspaceSessions,
   getUtilityTerminalSessions,
@@ -401,11 +405,15 @@ function useUtilityTerminalHandlers({
         .getUtilityRailState(utilityRailStateKey);
       removeUtilityTerminal(utilityRailStateKey, sessionId);
       try {
-        const session = resolveSessionByKey(
+        const { sessionId: localSessionId, nodeId } = resolveSessionCloseTarget(
           useSessionsStore.getState().sessions,
           sessionId
         );
-        await killSession(session?.id ?? sessionId, session?.nodeId);
+        const result = await executeSessionKillAction({
+          id: localSessionId,
+          nodeId,
+        });
+        if (!result.ok) throw new Error(result.error.message);
         await useSessionsStore.getState().refreshAll();
       } catch (error) {
         useUiStore.setState({


### PR DESCRIPTION
## Summary
- route the utility-terminal close path through the shared `sessions.kill` action executor instead of calling the private API helper directly
- preserve local/routed node session resolution via `resolveSessionCloseTarget`
- keep rollback/refresh/toast behavior intact for utility terminal close failures

Closes #869

## Verification
- `npm test -- test/session-lifecycle-action.test.ts test/session-lifecycle-registry.test.ts`
- `npm test -- test/action-coverage.test.ts test/cli-gateway-contract.test.ts test/utility-terminals.test.ts`
- `npm run check` (passes with existing lint warnings)
- `npm run build`

## Notes
- Browser/manual UI verification not run: this is a non-visual handler routing change; downstream QA owns the live browser gate.
- Simplify pass: high-risk session/destructive lifecycle tier; 3 focused reviewers reported no actionable cleanup findings.