### PR TITLE
fix: surface branch session open failures

### DIFF
--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -675,6 +675,9 @@ export function useSessionHandlers({
           return;
         }
         logger.error('Failed to open branch session:', result.error);
+        useToastStore
+          .getState()
+          .showToast(result.error.message || 'failed to open branch session');
         return;
       }
 

--- a/frontend/src/lib/actions/start-work-lifecycle.ts
+++ b/frontend/src/lib/actions/start-work-lifecycle.ts
@@ -772,7 +772,11 @@ async function executeWorkflow(args: {
       return gatewayError(args.command, resolvedPrompt.unsupported);
     }
 
-    const branchName = args.branch?.name;
+    const branchName = args.branch?.name ?? args.pr?.head;
+    const resolvedBranch =
+      branchName !== undefined
+        ? { ...(args.branch ?? {}), name: branchName }
+        : args.branch;
     const resolvedWorktree = await resolveWorktree(
       args.repo.repoPath,
       branchName,
@@ -805,7 +809,7 @@ async function executeWorkflow(args: {
       projectWorkflowOutput({
         session,
         repo: args.repo,
-        branch: args.branch,
+        branch: resolvedBranch,
         pr: args.pr,
         resolvedWorktree,
         worktreePolicy: args.worktree,

--- a/test/start-work-lifecycle-action.test.ts
+++ b/test/start-work-lifecycle-action.test.ts
@@ -302,6 +302,43 @@ describe('tickets.startWork + branches.openSession frontend action contract', ()
       expect(body.worktreePath).toBe('/repo/.worktrees/feat-foo');
     });
 
+    it('derives the branch name from pr.head for PR-only create-if-missing inputs', async () => {
+      const createWorktree: CreateWorktreeDep = vi.fn(async () =>
+        gatewayOk('worktrees.create', {
+          branchName: 'feature/from-pr',
+          mountainName: 'everest',
+          worktreePath: '/repo/.worktrees/feature-from-pr',
+        })
+      );
+      const createSession: CreateSessionDep = vi.fn(async () =>
+        sessionSummary({ branchName: undefined })
+      );
+      const result = await executeBranchOpenSessionAction(
+        {
+          repo: { repoPath: '/repo' },
+          pr: { number: 42, head: 'feature/from-pr', base: 'nightly' },
+          worktree: { mode: 'create-if-missing' },
+        },
+        { createWorktree, createSession }
+      );
+
+      expect(result.ok).toBe(true);
+      expect(createWorktree).toHaveBeenCalledWith({
+        repoPath: '/repo',
+        branch: 'feature/from-pr',
+      });
+      const body = (createSession as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0] as CreateSessionBody;
+      expect(body.branchName).toBe('feature/from-pr');
+      if (!result.ok) throw new Error('expected ok envelope');
+      expect(result.data.branch).toMatchObject({ name: 'feature/from-pr' });
+      expect(result.data.pr).toMatchObject({
+        number: 42,
+        head: 'feature/from-pr',
+        base: 'nightly',
+      });
+    });
+
     it('fails closed when create-if-missing worktree create fails (surfaces the worktree reason)', async () => {
       const createWorktree: CreateWorktreeDep = vi.fn(async () =>
         executeWorktreeCreateFailure()

--- a/test/start-work-lifecycle-registry.test.ts
+++ b/test/start-work-lifecycle-registry.test.ts
@@ -82,6 +82,7 @@ import type { GitHubIssue, PullRequest } from '../frontend/src/lib/types.js';
 import { useSessionHandlers } from '../frontend/src/hooks/useSessionHandlers.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import { useToastStore } from '../frontend/src/lib/stores/toasts.js';
 import { StartWorkModal } from '../frontend/src/components/StartWorkModal.js';
 import {
   prFixConflicts,
@@ -170,6 +171,7 @@ describe('start-work lifecycle action registry wiring (#871/#876)', () => {
       refreshAll: refreshAll as unknown as typeof originalRefreshAll,
     });
     useUiStore.setState({ activeRepoPath: '/repo/relay-ide' });
+    useToastStore.setState({ toasts: [] });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -187,6 +189,7 @@ describe('start-work lifecycle action registry wiring (#871/#876)', () => {
       activeSessionId: null,
       refreshAll: originalRefreshAll,
     });
+    useToastStore.setState({ toasts: [] });
     vi.restoreAllMocks();
   });
 
@@ -289,6 +292,32 @@ describe('start-work lifecycle action registry wiring (#871/#876)', () => {
     // Success path: store refreshed and new session focused.
     expect(refreshAll).toHaveBeenCalledTimes(1);
     expect(useSessionsStore.getState().activeSessionId).toBe('branch-session');
+  });
+
+  it('handleOpenBranchSession surfaces non-conflict executor failures with a toast', async () => {
+    executeBranchOpenSessionAction.mockImplementationOnce(async () =>
+      gatewayError('branches.openSession', {
+        code: 'NODE_OFFLINE',
+        message: 'remote node is offline',
+        retryable: true,
+        details: { nodeId: 'remote-1' },
+      })
+    );
+
+    const handlers = await mountHandlers();
+    await act(async () => {
+      await handlers.handleOpenBranchSession('feature/named', '/repo/relay-ide');
+    });
+    await flushPromises();
+
+    expect(refreshAll).not.toHaveBeenCalled();
+    expect(useSessionsStore.getState().activeSessionId).toBeNull();
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        message: 'remote node is offline',
+        variant: 'error',
+      }),
+    ]);
   });
 
   it('passes existingWorktreePath from the store-state fast path when a worktree already exists', async () => {


### PR DESCRIPTION
## Summary
- show the existing Relay toast error affordance when `handleOpenBranchSession` receives a non-`SESSION_CONFLICT` `branches.openSession` failure
- derive the local branch/session/worktree target from `pr.head` for PR-only `branches.openSession` inputs, and project that resolved branch into the output
- add targeted registry/action coverage for the toast path and PR-only branch derivation

## Test Plan
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- start-work-lifecycle`
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` (passes with existing lint warnings)

Refs #876


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error notifications when branch session operations fail to keep users informed.
  * Improved branch name resolution to ensure proper handling when derived from pull request information instead of explicit branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->