### PR TITLE
fix: refresh session store after rename action

### DIFF
--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -116,7 +116,9 @@ export function useSessionHandlers({
       });
       if (!result.ok) {
         logger.error('Failed to rename session:', result.error);
+        return;
       }
+      await useSessionsStore.getState().refreshAll();
     }
   }, []);
 

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -275,6 +275,42 @@ describe('session lifecycle handlers', () => {
     });
   });
 
+  it('refreshes session state after a successful active-session rename', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const promptMock = vi.fn(() => 'qa renamed session');
+    vi.stubGlobal('prompt', promptMock);
+    const local = makeSession({
+      id: 'rename-session-1',
+      displayName: 'Terminal 2',
+    });
+    useSessionsStore.setState({
+      sessions: [local],
+      activeSessionId: local.id,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      await handlers!.handleRenameActiveSession();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/sessions/rename-session-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName: 'qa renamed session' }),
+    });
+    expect(refreshAll).toHaveBeenCalledTimes(1);
+  });
+
   it('routes archive cleanup for remote sessions through the owning node', async () => {
     const fetchMock = stubSuccessfulFetch();
     const remote = makeSession({


### PR DESCRIPTION
## Summary
- refresh the sessions store after a successful shared `sessions.rename` action
- add handler coverage for the command-palette/sidebar rename path so PATCH success reconciles visible display names

## Verification
- npx vitest run test/session-lifecycle-handlers.test.ts
- npx vitest run test/session-lifecycle-action.test.ts test/session-lifecycle-registry.test.ts test/action-coverage.test.ts test/session-lifecycle-handlers.test.ts
- npm run check (0 errors; existing lint warnings only)
- npm run build
- browser smoke on production build at http://127.0.0.1:4574: app loaded authenticated workspace/session UI with no console errors; full rename UI flow could not be completed because the local verification session menu only exposed close while the throwaway session remained initializing

Refs #869
Remediates stale UI evidence from #914 QA.