### PR TITLE
fix(runtime): keep runtime SQLite artifacts out of repo checkouts (#961)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Issue workflow: `backlog` (rough) → `refined` (scoped) → `todo` (planned) �
 - Strip `CLAUDECODE` from PTY env so Claude sessions nest.
 - New interactive agent and terminal sessions default to `relay-pty`; tmux is the explicit `tmux-compat` import/fallback backend. xterm.js remains the browser renderer.
 - 256KB scrollback cap per session; oldest trimmed FIFO.
-- Config: `~/.config/relay-ide/config.json` (global) or `./config.json` (local dev).
+- Config + all runtime SQLite live in the config dir: `~/.config/relay-ide/` (global), `~/.config/relay-ide/dev/<slug>-<hash>/` (`npm run dev`), never the repo checkout by default (#961). See `docs/SELF_HOSTING.md` § Runtime state directory and cleanup.
 - PIN reset: `relay-ide pin reset` on the host (interactive TTY).
 - Node.js ≥ 24.0.0 — `nvm use` from `.nvmrc`.
 - Relative imports end in `.js`; builtins use `node:` prefix.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -34,7 +34,7 @@ The `dev` command starts the real Express/WebSocket backend under a supervisor a
 | Mode                 | Command                         | Backend                   | Frontend                  | Config                                                             | Tmux prefix   | Use when                                          |
 | -------------------- | ------------------------------- | ------------------------- | ------------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------------------------- |
 | Production/global    | `relay-ide` or `relay-ide --bg` | `0.0.0.0:3456` by default | compiled `dist/frontend/` | `~/.config/relay-ide/config.json`                                  | `relay-ide-`  | Daily hosted Relay instance                       |
-| Ordinary source dev  | `npm run dev`                   | `127.0.0.1:3457`          | `127.0.0.1:5173`          | `./config.dev.json`                                                | `relay-dev-`  | Local source development outside production Relay |
+| Ordinary source dev  | `npm run dev`                   | `127.0.0.1:3457`          | `127.0.0.1:5173`          | `~/.config/relay-ide/dev/<slug>-<hash>/config.dev.json`            | `relay-dev-`  | Local source development outside production Relay |
 | Self-host source dev | `npm run dev:self`              | allocator-chosen          | allocator-chosen          | `~/.config/relay-ide/self-host/<worktree-slug>-<hash>/config.json` | `relay-self-` | Building Relay from inside Relay                  |
 
 Both dev modes set `RELAY_IDE_DEV_INSTANCE=1` and a mode-specific `RELAY_IDE_TMUX_PREFIX` for process isolation. They do not disable auth; use the normal first-run PIN setup or browser-session login. Self-host mode can also be selected by running the CLI entrypoint directly with `relay-ide dev --self-host` from a source checkout, or by setting `RELAY_IDE_SELF_HOST=1` for the dev command.
@@ -87,11 +87,69 @@ Supported dev override variables:
 | `RELAY_IDE_DEV_BACKEND_HOST`  | `127.0.0.1`                       | Backend bind host                                                                                                                        |
 | `RELAY_IDE_DEV_FRONTEND_HOST` | `127.0.0.1`                       | Vite bind host                                                                                                                           |
 | `RELAY_IDE_DEV_BACKEND_URL`   | `http://127.0.0.1:<backend-port>` | Vite proxy target                                                                                                                        |
-| `RELAY_IDE_CONFIG`            | `./config.dev.json`               | Ignored to avoid inherited production config; pass `--config <path>` for an explicit self-host config override                           |
+| `RELAY_IDE_CONFIG`            | `~/.config/relay-ide/dev/<slug>-<hash>/config.dev.json` | Ignored to avoid inherited production config; pass `--config <path>` for an explicit self-host config override         |
 | `RELAY_IDE_DEV_INSTANCE`      | `1`                               | Marks a dev server for non-security behavior such as restart reason and cleanup isolation; does not bypass auth                           |
 | `RELAY_IDE_TMUX_PREFIX`       | mode-specific                     | Overrides the tmux prefix after normalization                                                                                            |
 
 Invalid self-host port overrides are treated as unset, so the allocator remains the fallback instead of fixed ordinary-dev ports. If you override ports, the effective backend/frontend ports are still written to the worktree `.env` managed block. Generic parent-process `RELAY_IDE_CONFIG` and `RELAY_IDE_PORT` values are intentionally ignored in self-host mode; this prevents a child Relay launched from production Relay from reusing the production config or port by accident.
+
+## Runtime state directory and cleanup
+
+Relay keeps **all** runtime state — the config file plus every SQLite store
+beside it — in the *config directory*, i.e. `dirname(<the config path above>)`.
+The stores include `work-contexts.db`, `context-packets.db`, `workflow-runs.db`,
+`work-context-artifacts.db`, `work-context-messages.db`, `automation-runs.db`,
+`agent-presence.db`, `analytics.db`, `relay-state.db`, `ia.db`,
+`interventions.db`, `security-audit.db`, and their `*-wal` / `*-shm` siblings,
+plus `logs/`, `telemetry/`, and `worktree-meta/`.
+
+Because the config directory drives where these land, **no launch mode writes
+runtime DBs into a repo checkout by default** (#961):
+
+| Launch mode                              | Runtime-state directory                          |
+| ---------------------------------------- | ------------------------------------------------ |
+| `relay-ide` / `relay-ide hub` (prod)     | `~/.config/relay-ide/`                            |
+| `npm run dev`                            | `~/.config/relay-ide/dev/<slug>-<hash>/`         |
+| `npm run dev:backend` (split dev)        | `~/.config/relay-ide/dev/<slug>-<hash>/` (shares `npm run dev`) |
+| `npm run dev:self`                       | `~/.config/relay-ide/self-host/<slug>-<hash>/`   |
+| `npm start` / `node dist/server/index.js` (raw) | `~/.config/relay-ide/source/<slug>-<hash>/` |
+| explicit `RELAY_IDE_CONFIG` / `--config` | `dirname(<that path>)`                            |
+
+`<slug>-<hash>` is derived from the absolute checkout path, so each
+worktree gets its own isolated state and two same-named worktrees never collide.
+(`$XDG_CONFIG_HOME` replaces `~/.config` when set.)
+
+### Inspect
+
+```bash
+# Where is this dev instance's runtime state?
+ls -la "$(dirname "${RELAY_IDE_CONFIG:-$HOME/.config/relay-ide/dev/}"/*/config.dev.json 2>/dev/null | head -1)" 2>/dev/null
+# Or just list everything Relay has created under app-data:
+ls -la ~/.config/relay-ide ~/.config/relay-ide/dev/* ~/.config/relay-ide/self-host/* 2>/dev/null
+```
+
+### Cleanup / migration
+
+To reclaim space or reset a dev instance, stop the instance first, then delete
+its directory — this is **per-checkout**, so it never touches production state:
+
+```bash
+rm -rf ~/.config/relay-ide/dev/<slug>-<hash>      # or .../self-host/<slug>-<hash>
+```
+
+If you have a legacy `config.dev.json` (and stray `*.db` files) in a repo root
+from before #961, `npm run dev` logs a one-time warning and ignores the old
+file. Migrate it without losing data by **moving** it into the new directory:
+
+```bash
+DEST=~/.config/relay-ide/dev/<slug>-<hash>
+mkdir -p "$DEST"
+mv config.dev.json *.db *.db-wal *.db-shm "$DEST"/   # from the repo root
+```
+
+Or discard it if the dogfood state is disposable (`rm` the same files). Never
+blanket-`rm` runtime DBs you have not first confirmed are stale — they hold real
+WorkContext / context-packet / workflow-run history.
 
 ## Running inside production Relay
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:frontend": "vite build --config frontend/vite.config.ts",
     "dev": "npm run build:server && node dist/scripts/dev.js",
     "dev:self": "npm run build:server && node dist/bin/relay-ide.js dev --self-host",
-    "dev:backend": "npm run build:server && RELAY_IDE_CONFIG=./config.dev.json RELAY_IDE_DEV_INSTANCE=1 RELAY_IDE_TMUX_PREFIX=${RELAY_IDE_TMUX_PREFIX:-relay-dev-} RELAY_IDE_HOST=${RELAY_IDE_DEV_BACKEND_HOST:-127.0.0.1} RELAY_IDE_PORT=${RELAY_IDE_DEV_BACKEND_PORT:-3457} node dist/server/index.js",
+    "dev:backend": "npm run build:server && RELAY_IDE_CONFIG=\"$(node dist/scripts/dev-backend-config-path.js)\" RELAY_IDE_DEV_INSTANCE=1 RELAY_IDE_TMUX_PREFIX=${RELAY_IDE_TMUX_PREFIX:-relay-dev-} RELAY_IDE_HOST=${RELAY_IDE_DEV_BACKEND_HOST:-127.0.0.1} RELAY_IDE_PORT=${RELAY_IDE_DEV_BACKEND_PORT:-3457} node dist/server/index.js",
     "dev:vite": "vite --config frontend/vite.config.ts --host ${RELAY_IDE_DEV_FRONTEND_HOST:-127.0.0.1} --port ${RELAY_IDE_DEV_FRONTEND_PORT:-5173}",
     "dev:node": "npm run build:server && node dist/bin/relay-ide.js node link",
     "start": "npm run build && node dist/server/index.js",

--- a/scripts/dev-backend-config-path.ts
+++ b/scripts/dev-backend-config-path.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Prints the per-checkout app-data config path that `npm run dev` (the
+// supervised dev runner, scripts/dev.ts) uses for ordinary source dev. The
+// split-dev `dev:backend` npm script consumes this so it shares the exact same
+// runtime-state directory as `npm run dev` instead of pinning a repo-relative
+// `./config.dev.json` (which spilled config + every SQLite store into the
+// checkout root — #961). Keep the fileName/namespace in sync with the
+// non-self-host branch of scripts/dev-mode.ts.
+import path from 'node:path';
+
+import { resolveSourceLaunchConfigPath } from '../server/runtime-state-paths.js';
+
+const packageRoot = path.resolve(import.meta.dirname, '..', '..');
+process.stdout.write(
+  resolveSourceLaunchConfigPath(packageRoot, {
+    fileName: 'config.dev.json',
+    namespace: 'dev',
+  }).configPath
+);

--- a/scripts/dev-mode.ts
+++ b/scripts/dev-mode.ts
@@ -1,12 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import crypto from 'node:crypto';
 import os from 'node:os';
 
 import {
   PortAllocator,
   upsertPortsInEnvFile,
 } from '../server/port-allocator.js';
+import {
+  pathHash,
+  relayAppDataDir,
+  resolveSourceLaunchConfigPath,
+  safePathSlug,
+} from '../server/runtime-state-paths.js';
 
 const DEV_BACKEND_PORT = 3457;
 const DEV_FRONTEND_PORT = 5173;
@@ -39,6 +44,13 @@ export interface DevModeOptions {
   frontendHost: string;
   backendTarget: string;
   configPath: string;
+  /**
+   * Legacy in-repo config (`config.dev.json`) that still exists on disk but is
+   * no longer the default (#961). Non-null only when ordinary `npm run dev`
+   * relocated the default to app-data yet found an old in-repo file; callers
+   * surface this so the user can migrate it. `null` otherwise.
+   */
+  legacyConfigPath: string | null;
   tmuxPrefix: string;
   portMapping: Record<string, number> | null;
 }
@@ -75,33 +87,6 @@ function normalizeTmuxPrefix(prefix: string | undefined): string | null {
   return sanitized.endsWith('-') ? sanitized : `${sanitized}-`;
 }
 
-function userConfigDir(
-  env: Record<string, string | undefined>,
-  homedir: string
-): string {
-  const xdgConfigHome = env.XDG_CONFIG_HOME?.trim();
-  return path.join(xdgConfigHome || path.join(homedir, '.config'), 'relay-ide');
-}
-
-function safePathSlug(inputPath: string): string {
-  return (
-    path
-      .basename(path.resolve(inputPath))
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 40) || 'workspace'
-  );
-}
-
-function pathHash(inputPath: string): string {
-  return crypto
-    .createHash('sha256')
-    .update(path.resolve(inputPath))
-    .digest('hex')
-    .slice(0, 12);
-}
-
 export function resolveSelfHostConfigPath(
   packageRoot: string,
   options: ResolveSelfHostConfigPathOptions = {}
@@ -109,7 +94,7 @@ export function resolveSelfHostConfigPath(
   const env = options.env ?? process.env;
   const home = options.homedir ?? os.homedir();
   const stateDir = path.join(
-    userConfigDir(env, home),
+    relayAppDataDir(env, home),
     'self-host',
     `${safePathSlug(packageRoot)}-${pathHash(packageRoot)}`
   );
@@ -145,16 +130,32 @@ export async function resolveDevModeOptions(
   const packageRoot = path.resolve(params.packageRoot);
   const selfHost = isSelfHostRequested(argv, env);
   const explicitConfigPath = getArgValue(argv, '--config');
-  const configPath = path.resolve(
-    explicitConfigPath ??
-      (selfHost ? undefined : env.RELAY_IDE_CONFIG) ??
-      (selfHost
-        ? resolveSelfHostConfigPath(packageRoot, {
-            env,
-            homedir: params.homedir,
-          })
-        : path.join(packageRoot, 'config.dev.json'))
-  );
+
+  // Precedence: explicit `--config` > `RELAY_IDE_CONFIG` (non-self-host) >
+  // mode default. The ordinary-dev default now lives under app-data instead of
+  // `<repo>/config.dev.json` so runtime SQLite never spills into the checkout
+  // (#961). An existing in-repo `config.dev.json` is surfaced (not silently
+  // honored) via `legacyConfigPath` so the user can migrate or pin it.
+  let configPath: string;
+  let legacyConfigPath: string | null = null;
+  if (explicitConfigPath) {
+    configPath = path.resolve(explicitConfigPath);
+  } else if (!selfHost && env.RELAY_IDE_CONFIG) {
+    configPath = path.resolve(env.RELAY_IDE_CONFIG);
+  } else if (selfHost) {
+    configPath = path.resolve(
+      resolveSelfHostConfigPath(packageRoot, { env, homedir: params.homedir })
+    );
+  } else {
+    const resolved = resolveSourceLaunchConfigPath(packageRoot, {
+      fileName: 'config.dev.json',
+      namespace: 'dev',
+      env,
+      homedir: params.homedir,
+    });
+    configPath = resolved.configPath;
+    legacyConfigPath = resolved.legacyConfigPath;
+  }
 
   let portMapping: Record<string, number> | null = null;
   if (selfHost) {
@@ -209,6 +210,7 @@ export async function resolveDevModeOptions(
     frontendHost,
     backendTarget,
     configPath,
+    legacyConfigPath,
     tmuxPrefix:
       normalizeTmuxPrefix(env.RELAY_IDE_TMUX_PREFIX) ??
       (selfHost ? SELF_HOST_TMUX_PREFIX : DEV_TMUX_PREFIX),

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -32,8 +32,21 @@ const {
   frontendHost,
   backendTarget,
   configPath,
+  legacyConfigPath,
   tmuxPrefix,
 } = mode;
+
+// #961: runtime state (config + SQLite) now lives under app-data, not the repo
+// checkout. If a legacy in-repo config.dev.json is still present, surface it so
+// the user can migrate or pin it — we never read or delete it automatically.
+if (legacyConfigPath) {
+  console.warn(
+    `relay dev: ignoring legacy in-repo config ${legacyConfigPath}.\n` +
+      `  Runtime state now lives at ${path.dirname(configPath)} (see docs/SELF_HOSTING.md).\n` +
+      `  To keep old settings: move ${path.basename(legacyConfigPath)} (and any *.db files) there,\n` +
+      `  or run with RELAY_IDE_CONFIG=${legacyConfigPath} to pin the old location.`
+  );
+}
 
 const children = new Set<ChildProcess>();
 let shuttingDown = false;

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import {
   normalizeTerminalBackend,
   resolveSessionSettings,
 } from './config.js';
+import { resolveSourceLaunchConfigPath } from './runtime-state-paths.js';
 import * as auth from './auth.js';
 import * as sessions from './sessions.js';
 import {
@@ -300,11 +301,24 @@ const cliGatewayActorRegistry = createCliGatewayActorRegistry();
 const cliGatewayHandshakeGrantRegistry =
   createCliGatewayHandshakeGrantRegistry();
 
-// When run via CLI bin, config lives in ~/.config/relay-ide/
-// When run directly (development), fall back to local config.json
+// When run via the CLI bin or the dev runner, RELAY_IDE_CONFIG is set
+// explicitly. When run directly from source (e.g. `node dist/server/index.js`),
+// default the config — and therefore every runtime SQLite store beside it — to
+// a per-checkout app-data directory instead of the repo root, so runtime state
+// never spills into the checkout (#961). See server/runtime-state-paths.ts.
+const sourceLaunchConfig = resolveSourceLaunchConfigPath(
+  path.join(__dirname, '..', '..'),
+  { fileName: 'config.json', namespace: 'source' }
+);
 const CONFIG_PATH =
-  process.env.RELAY_IDE_CONFIG ||
-  path.join(__dirname, '..', '..', 'config.json');
+  process.env.RELAY_IDE_CONFIG || sourceLaunchConfig.configPath;
+if (!process.env.RELAY_IDE_CONFIG && sourceLaunchConfig.legacyConfigPath) {
+  logger.warn(
+    'Ignoring legacy repo-root config %s; runtime state now lives at %s. Move the old file there or set RELAY_IDE_CONFIG to keep using it (#961).',
+    sourceLaunchConfig.legacyConfigPath,
+    CONFIG_PATH
+  );
+}
 
 const DEFAULT_GITHUB_CLIENT_ID = 'Ov23lilheF3LelYSo0bu';
 

--- a/server/runtime-state-paths.ts
+++ b/server/runtime-state-paths.ts
@@ -1,0 +1,114 @@
+// Runtime-state path resolution (#961).
+//
+// All Relay runtime SQLite stores (`work-contexts.db`, `context-packets.db`,
+// `workflow-runs.db`, `analytics.db`, ...) live in the *config directory* —
+// `path.dirname(CONFIG_PATH)`. So wherever the config file lands, the runtime
+// DBs land beside it.
+//
+// The published CLI bin and `dev:self` already point the config at app-data
+// (`~/.config/relay-ide/...`), but two from-source launch paths historically
+// defaulted the config into the repo checkout root:
+//   - `npm run dev`          → `<repo>/config.dev.json`
+//   - `node dist/server/index.js` (raw) → `<repo>/config.json`
+// Both spilled the runtime DBs into the checkout. This module relocates those
+// defaults to a stable per-checkout directory under app-data so source dev
+// never pollutes the working tree, while still letting explicit
+// `RELAY_IDE_CONFIG` / `--config` win.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+/**
+ * Relay's app-data root for from-source launches: `$XDG_CONFIG_HOME/relay-ide`
+ * when that var is an absolute path, else `~/.config/relay-ide`.
+ *
+ * `~/.config/relay-ide` matches the production root the CLI bin uses
+ * (`server/service.ts`), except service.ts hardcodes `~/.config` and does NOT
+ * honor `$XDG_CONFIG_HOME` — so when XDG is set, prod and from-source roots
+ * intentionally differ rather than spilling source state into prod.
+ *
+ * A *relative* `XDG_CONFIG_HOME` is ignored per the XDG Base Directory spec:
+ * honoring it would make the config path (and the runtime DBs beside it)
+ * resolve against `process.cwd()` — i.e. back into the checkout — defeating the
+ * point of #961. Mirrors the guard in `server/session-attachment.ts`
+ * (security review #472).
+ */
+export function relayAppDataDir(
+  env: Record<string, string | undefined> = process.env,
+  homedir: string = os.homedir()
+): string {
+  const xdgConfigHome = env.XDG_CONFIG_HOME?.trim();
+  const base =
+    xdgConfigHome && path.isAbsolute(xdgConfigHome)
+      ? xdgConfigHome
+      : path.join(homedir, '.config');
+  return path.join(base, 'relay-ide');
+}
+
+/** Filesystem-safe, human-readable slug for a checkout path's basename. */
+export function safePathSlug(inputPath: string): string {
+  return (
+    path
+      .basename(path.resolve(inputPath))
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'workspace'
+  );
+}
+
+/** Short stable hash of the absolute checkout path (disambiguates same-named worktrees). */
+export function pathHash(inputPath: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(path.resolve(inputPath))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+export interface SourceLaunchConfigOptions {
+  /** Config file name to use, e.g. `config.dev.json` or `config.json`. */
+  fileName: string;
+  /** App-data sub-namespace that isolates this launch mode, e.g. `dev` or `source`. */
+  namespace: string;
+  env?: Record<string, string | undefined> | undefined;
+  homedir?: string | undefined;
+}
+
+export interface SourceLaunchConfigResolution {
+  /** Resolved config path under app-data, keyed per checkout. */
+  configPath: string;
+  /**
+   * The legacy in-checkout config path **if it still exists on disk**, else
+   * `null`. Callers should warn (not silently honor) so users can migrate the
+   * old file or pin it via `RELAY_IDE_CONFIG`. We never auto-read or delete it.
+   */
+  legacyConfigPath: string | null;
+}
+
+/**
+ * Resolve the default config path for a from-source launch to a stable
+ * per-checkout directory under app-data: `<app-data>/<namespace>/<slug>-<hash>/<fileName>`.
+ *
+ * This is only the *default*; callers must still let an explicit
+ * `RELAY_IDE_CONFIG` / `--config` take precedence before calling this.
+ */
+export function resolveSourceLaunchConfigPath(
+  checkoutRoot: string,
+  options: SourceLaunchConfigOptions
+): SourceLaunchConfigResolution {
+  const env = options.env ?? process.env;
+  const home = options.homedir ?? os.homedir();
+  const resolvedCheckout = path.resolve(checkoutRoot);
+  const legacyConfigPath = path.join(resolvedCheckout, options.fileName);
+  const stateDir = path.join(
+    relayAppDataDir(env, home),
+    options.namespace,
+    `${safePathSlug(resolvedCheckout)}-${pathHash(resolvedCheckout)}`
+  );
+  return {
+    configPath: path.join(stateDir, options.fileName),
+    legacyConfigPath: fs.existsSync(legacyConfigPath) ? legacyConfigPath : null,
+  };
+}

--- a/test/dev-mode.test.ts
+++ b/test/dev-mode.test.ts
@@ -33,22 +33,93 @@ afterEach(() => {
 });
 
 describe('dev mode option resolution', () => {
-  it('keeps ordinary dev mode on fixed dev defaults with repo-local dev config', async () => {
-    const packageRoot = makeTmpDir();
+  it('keeps ordinary dev mode on fixed dev defaults but relocates config out of the checkout (#961)', async () => {
+    const home = makeTmpDir();
+    const xdgConfigHome = path.join(home, '.config');
+    const packageRoot = path.join(home, 'src', 'relay-ide');
+    fs.mkdirSync(packageRoot, { recursive: true });
 
     const options = await resolveDevModeOptions({
       argv: ['dev'],
-      env: {},
+      env: { XDG_CONFIG_HOME: xdgConfigHome },
       packageRoot,
-      homedir: packageRoot,
+      homedir: home,
     });
 
     expect(options.selfHost).toBe(false);
     expect(options.backendPort).toBe('3457');
     expect(options.frontendPort).toBe('5173');
-    expect(options.configPath).toBe(path.join(packageRoot, 'config.dev.json'));
     expect(options.tmuxPrefix).toBe('relay-dev-');
     expect(options.portMapping).toBeNull();
+    // Runtime state (config + the SQLite stores beside it) must not land in the
+    // checkout — the whole point of #961.
+    expect(options.configPath.startsWith(packageRoot)).toBe(false);
+    expect(
+      options.configPath.startsWith(path.join(xdgConfigHome, 'relay-ide', 'dev'))
+    ).toBe(true);
+    expect(options.configPath.endsWith('config.dev.json')).toBe(true);
+    expect(options.legacyConfigPath).toBeNull();
+  });
+
+  it('ordinary dev mode surfaces (but does not honor) a legacy in-repo config.dev.json (#961)', async () => {
+    const home = makeTmpDir();
+    const xdgConfigHome = path.join(home, '.config');
+    const packageRoot = path.join(home, 'src', 'relay-ide');
+    fs.mkdirSync(packageRoot, { recursive: true });
+    const legacy = path.join(packageRoot, 'config.dev.json');
+    fs.writeFileSync(legacy, '{}', 'utf8');
+
+    const options = await resolveDevModeOptions({
+      argv: ['dev'],
+      env: { XDG_CONFIG_HOME: xdgConfigHome },
+      packageRoot,
+      homedir: home,
+    });
+
+    // Default still moves out of the checkout; the old file is reported so the
+    // runner can warn, but it is never read or deleted.
+    expect(options.configPath.startsWith(packageRoot)).toBe(false);
+    expect(options.legacyConfigPath).toBe(legacy);
+    expect(fs.existsSync(legacy)).toBe(true);
+  });
+
+  it('ordinary dev mode honors an explicit RELAY_IDE_CONFIG', async () => {
+    const home = makeTmpDir();
+    const packageRoot = path.join(home, 'src', 'relay-ide');
+    const explicit = path.join(home, 'custom', 'config.dev.json');
+    fs.mkdirSync(packageRoot, { recursive: true });
+
+    const options = await resolveDevModeOptions({
+      argv: ['dev'],
+      env: {
+        XDG_CONFIG_HOME: path.join(home, '.config'),
+        RELAY_IDE_CONFIG: explicit,
+      },
+      packageRoot,
+      homedir: home,
+    });
+
+    expect(options.configPath).toBe(explicit);
+    expect(options.legacyConfigPath).toBeNull();
+  });
+
+  it('ordinary dev mode honors an explicit --config flag over RELAY_IDE_CONFIG', async () => {
+    const home = makeTmpDir();
+    const packageRoot = path.join(home, 'src', 'relay-ide');
+    const flagConfig = path.join(home, 'flag', 'config.dev.json');
+    fs.mkdirSync(packageRoot, { recursive: true });
+
+    const options = await resolveDevModeOptions({
+      argv: ['dev', '--config', flagConfig],
+      env: {
+        XDG_CONFIG_HOME: path.join(home, '.config'),
+        RELAY_IDE_CONFIG: path.join(home, 'env', 'config.dev.json'),
+      },
+      packageRoot,
+      homedir: home,
+    });
+
+    expect(options.configPath).toBe(flagConfig);
   });
 
   it('resolves self-host config outside the repo and gives each worktree a stable identity', () => {

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -34,8 +34,26 @@ test('server index.ts uses correct path depth to reach dist/frontend/', async ()
     indexSource.includes("path.join(__dirname, '..', 'frontend')")
   ).toBeTruthy();
 
-  // Config fallback must also go up two levels
+  // #961: the from-source config fallback must NOT default into the repo root.
+  // It now resolves to a per-checkout app-data dir via resolveSourceLaunchConfigPath.
   expect(
     indexSource.includes("path.join(__dirname, '..', '..', 'config.json')")
-  ).toBeTruthy();
+  ).toBe(false);
+  expect(indexSource.includes('resolveSourceLaunchConfigPath')).toBe(true);
+});
+
+test('no package.json script pins RELAY_IDE_CONFIG to a repo-relative path (#961)', () => {
+  // A repo-relative RELAY_IDE_CONFIG (e.g. ./config.dev.json) anchors the config
+  // dir — and every SQLite store beside it — to npm's cwd = the checkout root,
+  // spilling runtime state into the repo. Scripts must either omit the var (use
+  // the app-data default) or compute an absolute path.
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')
+  ) as { scripts: Record<string, string> };
+
+  const offenders = Object.entries(pkg.scripts).filter(([, cmd]) =>
+    /RELAY_IDE_CONFIG=(\.|[^"'\s]*\$\{?PWD)/.test(cmd)
+  );
+
+  expect(offenders).toEqual([]);
 });

--- a/test/runtime-state-paths.test.ts
+++ b/test/runtime-state-paths.test.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  pathHash,
+  relayAppDataDir,
+  resolveSourceLaunchConfigPath,
+  safePathSlug,
+} from '../server/runtime-state-paths.js';
+
+let tmpDir: string | null = null;
+
+function makeTmpDir(): string {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-runtime-state-test-'));
+  return tmpDir;
+}
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = null;
+});
+
+describe('relayAppDataDir', () => {
+  it('prefers XDG_CONFIG_HOME when set', () => {
+    expect(
+      relayAppDataDir({ XDG_CONFIG_HOME: '/xdg/cfg' }, '/home/user')
+    ).toBe(path.join('/xdg/cfg', 'relay-ide'));
+  });
+
+  it('falls back to ~/.config when XDG is unset or blank', () => {
+    expect(relayAppDataDir({}, '/home/user')).toBe(
+      path.join('/home/user', '.config', 'relay-ide')
+    );
+    expect(relayAppDataDir({ XDG_CONFIG_HOME: '   ' }, '/home/user')).toBe(
+      path.join('/home/user', '.config', 'relay-ide')
+    );
+  });
+
+  it('ignores a relative XDG_CONFIG_HOME (XDG spec; would resolve into cwd) and stays absolute', () => {
+    // A relative value must not anchor runtime DBs to process.cwd() (= the
+    // checkout for a from-source launch). Mirrors session-attachment.ts (#472).
+    const dir = relayAppDataDir({ XDG_CONFIG_HOME: 'relaydata' }, '/home/user');
+    expect(dir).toBe(path.join('/home/user', '.config', 'relay-ide'));
+    expect(path.isAbsolute(dir)).toBe(true);
+    expect(
+      relayAppDataDir({ XDG_CONFIG_HOME: '.config' }, '/home/user')
+    ).toBe(path.join('/home/user', '.config', 'relay-ide'));
+  });
+});
+
+describe('safePathSlug / pathHash', () => {
+  it('produces a filesystem-safe slug from the basename', () => {
+    expect(safePathSlug('/repo/.worktrees/Feat Branch!')).toBe('feat-branch');
+    expect(safePathSlug('/')).toBe('workspace');
+  });
+
+  it('hashes the absolute path stably to 12 hex chars', () => {
+    const a = pathHash('/repo/.worktrees/feature-a');
+    expect(a).toMatch(/^[a-f0-9]{12}$/);
+    expect(pathHash('/repo/.worktrees/feature-a')).toBe(a);
+    expect(pathHash('/repo/.worktrees/feature-b')).not.toBe(a);
+  });
+});
+
+describe('resolveSourceLaunchConfigPath', () => {
+  it('places the config under app-data, never inside the checkout', () => {
+    const home = makeTmpDir();
+    const xdg = path.join(home, '.config');
+    const checkout = path.join(home, 'src', 'relay-ide');
+    fs.mkdirSync(checkout, { recursive: true });
+
+    const { configPath, legacyConfigPath } = resolveSourceLaunchConfigPath(
+      checkout,
+      { fileName: 'config.dev.json', namespace: 'dev', env: { XDG_CONFIG_HOME: xdg }, homedir: home }
+    );
+
+    expect(configPath.startsWith(path.join(xdg, 'relay-ide', 'dev'))).toBe(true);
+    expect(configPath.endsWith('config.dev.json')).toBe(true);
+    expect(configPath.startsWith(checkout)).toBe(false);
+    // No legacy file present → nothing to migrate.
+    expect(legacyConfigPath).toBeNull();
+  });
+
+  it('gives each checkout a stable, distinct app-data directory', () => {
+    const home = makeTmpDir();
+    const env = { XDG_CONFIG_HOME: path.join(home, '.config') };
+    const wtA = path.join(home, 'repo', '.worktrees', 'feature-a');
+    const wtB = path.join(home, 'repo', '.worktrees', 'feature-b');
+
+    const a1 = resolveSourceLaunchConfigPath(wtA, { fileName: 'config.dev.json', namespace: 'dev', env, homedir: home });
+    const a2 = resolveSourceLaunchConfigPath(wtA, { fileName: 'config.dev.json', namespace: 'dev', env, homedir: home });
+    const b = resolveSourceLaunchConfigPath(wtB, { fileName: 'config.dev.json', namespace: 'dev', env, homedir: home });
+
+    expect(a1.configPath).toBe(a2.configPath); // stable per checkout
+    expect(a1.configPath).not.toBe(b.configPath); // distinct per checkout
+  });
+
+  it('surfaces an existing in-repo config as legacy without honoring it', () => {
+    const home = makeTmpDir();
+    const xdg = path.join(home, '.config');
+    const checkout = path.join(home, 'src', 'relay-ide');
+    fs.mkdirSync(checkout, { recursive: true });
+    const legacy = path.join(checkout, 'config.dev.json');
+    fs.writeFileSync(legacy, '{}', 'utf8');
+
+    const { configPath, legacyConfigPath } = resolveSourceLaunchConfigPath(
+      checkout,
+      { fileName: 'config.dev.json', namespace: 'dev', env: { XDG_CONFIG_HOME: xdg }, homedir: home }
+    );
+
+    // Default still moves out of the checkout; legacy file is reported, not used.
+    expect(configPath.startsWith(checkout)).toBe(false);
+    expect(legacyConfigPath).toBe(legacy);
+  });
+
+  it('namespaces launch modes (dev vs source) into separate subtrees', () => {
+    const home = makeTmpDir();
+    const env = { XDG_CONFIG_HOME: path.join(home, '.config') };
+    const checkout = path.join(home, 'src', 'relay-ide');
+
+    const dev = resolveSourceLaunchConfigPath(checkout, { fileName: 'config.dev.json', namespace: 'dev', env, homedir: home });
+    const source = resolveSourceLaunchConfigPath(checkout, { fileName: 'config.json', namespace: 'source', env, homedir: home });
+
+    expect(dev.configPath).toContain(path.join('relay-ide', 'dev'));
+    expect(source.configPath).toContain(path.join('relay-ide', 'source'));
+    expect(dev.configPath).not.toBe(source.configPath);
+  });
+});


### PR DESCRIPTION
## Summary

Relay's runtime SQLite stores all live in the **config directory** (`dirname(CONFIG_PATH)`). Two from-source launch paths defaulted that config into the **repo checkout root**, so dogfood runs spilled `work-contexts.db`, `context-packets.db`, `workflow-runs.db`, `work-context-artifacts.db`, `automation-runs.db`, etc. into the working tree.

This relocates those defaults to a stable **per-checkout app-data directory** (mirroring the existing `dev:self` pattern), so no launch mode pollutes the checkout by default. Explicit `RELAY_IDE_CONFIG` / `--config` still win; an existing in-repo `config.dev.json` is surfaced with a warning, never silently honored or deleted.

Closes #961.

## Root cause

`CONFIG_PATH` → `getConfigDir()` (`path.dirname`) → every store opens at `path.join(configDir, '<name>.db')`. Three defaults anchored `configDir` to the repo:

| Launch | Before | Now |
| --- | --- | --- |
| `npm run dev` | `<repo>/config.dev.json` (`scripts/dev-mode.ts`) | `~/.config/relay-ide/dev/<slug>-<hash>/` |
| `npm run dev:backend` | `RELAY_IDE_CONFIG=./config.dev.json` (`package.json`) | same app-data path as `npm run dev` |
| `npm start` / raw `node dist/server/index.js` | `path.join(__dirname,'..','..','config.json')` (`server/index.ts`) | `~/.config/relay-ide/source/<slug>-<hash>/` |

The published CLI bin (`relay-ide hub`) and the dev runner already set `RELAY_IDE_CONFIG` explicitly, so production was never affected and stays unchanged. `dev:self` already used app-data.

## Files changed

- **`server/runtime-state-paths.ts`** (new) — shared resolver: `relayAppDataDir` (honors an **absolute** `$XDG_CONFIG_HOME`, ignores a relative one per XDG spec — matches the `session-attachment.ts` #472 guard), `safePathSlug`, `pathHash`, `resolveSourceLaunchConfigPath` (per-checkout path + legacy-spill detection).
- **`scripts/dev-mode.ts`** — ordinary-dev default → app-data `dev` namespace; dedupes slug/hash/app-data helpers into the shared module; surfaces `legacyConfigPath`.
- **`scripts/dev.ts`** — warns (does not honor/delete) a legacy in-repo `config.dev.json`.
- **`server/index.ts`** — raw-launch fallback → app-data `source` namespace; warns on legacy repo-root config.
- **`scripts/dev-backend-config-path.ts`** (new) + **`package.json`** — `dev:backend` no longer pins a repo-relative path; resolves the same app-data path as `npm run dev`.
- **`docs/SELF_HOSTING.md`** — new "Runtime state directory and cleanup" section (inspect + cleanup/migration) and per-mode table; **`AGENTS.md`** config line updated.
- **Tests** — `test/runtime-state-paths.test.ts` (new, incl. relative-XDG guard, per-checkout stability, legacy detection); `test/dev-mode.test.ts` (relocation + legacy/env/`--config` precedence); `test/paths.test.ts` (asserts no repo-root config fallback and no npm script pins a repo-relative `RELAY_IDE_CONFIG`).

## Tests run (exact outputs)

`PATH=… npm run check`
```
✖ 175 problems (0 errors, 175 warnings)
```
(0 errors; the 175 warnings are pre-existing repo-wide `sonarjs/no-duplicate-string`, none in changed files.)

`PATH=… npm run build` → `✓ built in 3.85s` (success).

`PATH=… npm test -- test/runtime-state-paths.test.ts test/dev-mode.test.ts test/paths.test.ts`
```
Test Files  3 passed (3)
     Tests  23 passed (23)
```

`PATH=… npm test` (full)
```
Test Files  2 failed | 360 passed (362)
     Tests  4 failed | 4746 passed (4750)
```
The 4 failures are **pre-existing and environmental**, not coupled to #961:
- `test/sandbox.test.ts` (3) — `Sandbox server did not start within 30000ms`. Spawns a full server with its **own** `RELAY_IDE_CONFIG`; zero references to #961 code; a startup timeout on this loaded devbox.
- `test/relay-session-env.test.ts` (1) — "shim dir is not on PATH in shells spawned outside Relay". Fails because the suite runs **inside** a Relay session: `os.tmpdir()` = `~/.cache/relay-tmp` and the per-session shim `…/relay-ide/<id>/bin` is on PATH — the exact condition the test asserts against. Unrelated to config-path code.

### Manual end-to-end verification (built `dist/server/index.js`)
- `RELAY_IDE_CONFIG` **set** → `/health` 200; all `*.db` open in the config dir, **none** in cwd.
- `RELAY_IDE_CONFIG` **unset** (true fallback) → `configDir=…/relay-ide/source/961-runtime-sqlite-artifacts-<hash>` (fresh dir auto-created); `*.db` land there, **none** in cwd.

`git diff --check` → clean.

## Devbox cleanup: **deferred** (documented)

The pre-existing repo-root spill lives in the **top-level checkout** (`/…/personal/relay-ide/*.db` + `config.dev.json`), not this worktree. Verified safe to remove (no process holds them — every `node` proc's `/proc/<pid>/fd` checked; the live hub on `:3456` uses `~/.config/relay-ide`, not the spill). But they hold real overnight dogfood data and sit outside this PR's tree, so per "do not delete user data silently" I did **not** delete them. Exact manual cleanup/migration is documented in `docs/SELF_HOSTING.md` § Runtime state directory and cleanup.

## Remaining risks / notes

- Switching `npm run dev` away from `<repo>/config.dev.json` means an existing in-repo dev config is no longer the default. It is **not** deleted — a one-time warning points to the new location, and `RELAY_IDE_CONFIG=<old>` pins it. Migration is documented.
- `.gitignore` was intentionally **not** expanded — relocation is the fix, not blanket ignoring (per issue non-goals). Existing entries are left as-is.
- Prod config (`server/service.ts`) still ignores `$XDG_CONFIG_HOME` by design (unchanged, to avoid moving existing users' config); the module doc notes this divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)