### PR TITLE
chore: ignore runtime SQLite databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,30 @@ relay-state.db-wal
 ia.db
 ia.db-shm
 ia.db-wal
+context-packets.db
+context-packets.db-shm
+context-packets.db-wal
+interventions.db
+interventions.db-shm
+interventions.db-wal
+security-audit.db
+security-audit.db-shm
+security-audit.db-wal
+work-context-artifacts.db
+work-context-artifacts.db-shm
+work-context-artifacts.db-wal
+work-context-messages.db
+work-context-messages.db-shm
+work-context-messages.db-wal
+work-contexts.db
+work-contexts.db-shm
+work-contexts.db-wal
+workflow-runs.db
+workflow-runs.db-shm
+workflow-runs.db-wal
+agent-presence.db
+agent-presence.db-shm
+agent-presence.db-wal
 
 # Runtime port allocator state
 port-assignments.json


### PR DESCRIPTION
Recent features (work-context messages, workflow runs, agent presence, security audit, interventions) create runtime SQLite files in the repo root that were not covered by the existing gitignore entries. This adds the missing patterns so On branch fix/gitignore-runtime-dbs
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	1

nothing added to commit but untracked files present (use "git add" to track) stays clean during local dev/dogfood.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude additional local database files and their temporary artifacts from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->