### PR TITLE
feat(node): hub pending node pairing request lifecycle API (#982)

### DIFF
--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -176,6 +176,22 @@ When pairing, the node also creates or reuses a local ed25519 identity key at:
 
 Only the **public** key is sent to the hub at pairing (`POST /hub/pairing/exchange`, `publicKey` field); the private key never leaves the node and is reused across re-pairs and rotations. The hub binds the public-key fingerprint (`nkey_…`) to the issued credential. For a key-bound credential, the node must prove private-key possession on `/hub/node-link` and the HTTP heartbeat: it signs a fresh, audience-bound, single-use assertion sent in the `X-Relay-Node-Proof` header on every (re)connect. A captured bearer token alone cannot keep a key-bound node online without its private key. Delete `node-identity-key.json` only if you intend to abandon the node identity; re-pairing then mints a new key and a new node identity. Legacy nodes paired before #981 (no identity key) continue on the bearer-only path.
 
+#### Node-initiated pending pairing requests (#982)
+
+The operator-mints-a-pair-token flow above stays the canonical pre-authorized path. As an alternative, a node can submit a **pending pairing request** that an authenticated operator approves, denies, or edits before any credential exists. The hub API for this lifecycle:
+
+| Lane | Endpoint | Notes |
+| --- | --- | --- |
+| Node (unauthenticated) | `POST /hub/pairing/requests` | Submit `manifest`, optional `publicKey`, `displayName`, `requestedProfile`, `requestedCapabilities`, `requestedRoots`. Returns the redaction-safe request summary, a short **device code**, and a one-time `statusToken`. |
+| Node (status token) | `POST /hub/pairing/requests/:requestId/status` | Poll status with `statusToken`. Returns the current state; on the first poll after approval it returns the issued key-bound credential **exactly once**. |
+| Operator (browser session) | `GET /hub/pairing/requests` | List pending/approved requests. `?deviceCode=<code>` locates one (case-insensitive, dash-tolerant); `?state=` / `?includeResolved=true` filter. |
+| Operator | `GET /hub/pairing/requests/:requestId` | Inspect one request. |
+| Operator | `PATCH /hub/pairing/requests/:requestId/access` | Edit display name / profile / capabilities / roots before approval. Not a re-approval — no credential exists yet. |
+| Operator | `POST /hub/pairing/requests/:requestId/approve` | Approve. Higher-risk (prod profile or elevated capabilities) returns `409 CONFIRMATION_REQUIRED` and must be re-submitted with an exact-operation `confirmationToken`. |
+| Operator | `POST /hub/pairing/requests/:requestId/deny` | Deny. |
+
+Rules: the **device code only locates** a request — it never authorizes a node. `pending` is the only approvable state; `denied` and `expired` are terminal and can never be replayed into an approval or credential. Approval authorizes a key-bound node credential, but the raw credential is minted and delivered only to the waiting node on its authenticated status poll, so it never appears in operator responses, lists, logs, or audit. Requests expire after ten minutes. Public summaries carry only safe handles (`nkey_…` fingerprint, `sourceFingerprint`, lossy `displayHint`, lifecycle state, product-language posture) — never the status token, raw credential, raw hostname, or raw capability bits.
+
 ### 4. Node identity lifecycle
 
 The hub now separates stable node identity from credential records. The stable identity anchor is the `nodeId` and pairing timestamps; operator-facing identity metadata such as `displayName` and `hostname` describes that identity and may be refreshed by later heartbeats. The active credential is replaceable bearer material tied to that identity. `GET /nodes` returns both the identity summary and a redacted credential summary (`credentialId`, `issuedAt`, and state), never the live token or token hash.

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -32,6 +32,7 @@ import {
   type RelayNodeSourceTuple,
 } from './node-source-diagnostics.js';
 import { classifyHelperSkew } from './node-version-skew.js';
+import { redactBootstrapSecrets } from '../shared/bootstrap-diagnostics.js';
 import {
   DEFAULT_NODE_LINK_PROOF_FRESHNESS_MS,
   safeNodePublicKeyFingerprint,
@@ -57,7 +58,6 @@ import {
   NODE_PAIRING_REASON_CODES,
   isHighRiskNodePairingRequest,
   nodePairingCapabilityPosture,
-  nodePairingDeviceHint,
   nodePairingProfileTrustTier,
   normalizeNodePairingDeviceCode,
   type NodePairingRequestState,
@@ -362,6 +362,11 @@ export const DEFAULT_PAIR_TOKEN_TTL_MS = 10 * 60 * 1000;
 // lapses to `expired` (cannot be approved). Matches the pair-token/device-code
 // 10-minute window so the operator countdown and node wait agree.
 export const DEFAULT_PENDING_PAIRING_TTL_MS = 10 * 60 * 1000;
+// Hard upper bound on a request TTL. A non-finite, non-positive, or absurd ttl
+// (NaN/Infinity/huge) is rejected to the default; anything above the max clamps
+// down — so a bad/hostile value can never produce an Invalid Date or a
+// never-expiring request.
+export const MAX_PENDING_PAIRING_TTL_MS = 60 * 60 * 1000;
 // #982: cap concurrent pending requests so the unauthenticated submit lane
 // cannot grow the registry file unbounded. Expired/decided records do not count.
 export const MAX_PENDING_PAIRING_REQUESTS = 256;
@@ -968,6 +973,18 @@ function resolvePendingPairingCapabilityBits(
  * list of folder labels and never becomes a full path inventory. Trims, caps
  * length, de-duplicates, and limits the count.
  */
+/**
+ * #982: a request TTL must be a finite positive number; anything else (NaN,
+ * Infinity, <=0, non-number) falls back to the default, and a too-large value
+ * clamps to the hard maximum. Guarantees `now + ttl` is always a valid Date.
+ */
+function clampPendingPairingTtlMs(ttlMs: unknown): number {
+  if (typeof ttlMs !== 'number' || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    return DEFAULT_PENDING_PAIRING_TTL_MS;
+  }
+  return Math.min(ttlMs, MAX_PENDING_PAIRING_TTL_MS);
+}
+
 function sanitizeRequestedRoots(roots: unknown): string[] {
   if (!Array.isArray(roots)) return [];
   const cleaned: string[] = [];
@@ -1010,6 +1027,19 @@ function createNodeAclForPendingPairing(input: {
 }
 
 /**
+ * #982: a request is "active/claimable" while a node could still turn it into a
+ * credential — `pending`, or `approved` but not yet claimed. The device code of
+ * an active request is never reused, and a code lookup prefers the active match,
+ * so an approved-but-unclaimed request is never silently displaced.
+ */
+function isActiveClaimablePairing(record: StoredPendingPairingRequest): boolean {
+  return (
+    record.state === 'pending' ||
+    (record.state === 'approved' && !record.credentialDeliveredAt)
+  );
+}
+
+/**
  * #982: redaction-safe public summary of a pending pairing request. Emits only
  * safe correlation handles and product-language posture — never the raw
  * hostname, the status token, raw capability bits, or any secret material.
@@ -1017,7 +1047,10 @@ function createNodeAclForPendingPairing(input: {
 function publicPendingPairing(
   record: StoredPendingPairingRequest
 ): NodePairingRequestSummary {
-  const deviceHint = nodePairingDeviceHint(record.hostname);
+  // No hostname-derived hint: even a suffix of a hostname/MagicDNS name leaks
+  // the tailnet domain (`…ts.net`). Recognition is the editable displayName plus
+  // the already-lossy source `displayHint`/`sourceFingerprint`; the raw hostname
+  // is internal-only (stored like StoredNodeRecord.hostname, never surfaced).
   const sourceDiagnostics = publicSourceDiagnostics(
     record.sourceBinding?.diagnostics
   );
@@ -1030,7 +1063,6 @@ function publicPendingPairing(
     displayName: record.displayName,
     platform: record.platform,
     relayVersion: record.relayVersion,
-    ...(deviceHint ? { deviceHint } : {}),
     requestedProfile: record.requestedProfile,
     requestedTrustTier: record.requestedTrustTier,
     requestedCapabilities: nodePairingCapabilityPosture(record.capabilityBits),
@@ -2617,8 +2649,7 @@ export class HubNodeRegistry {
       );
     }
     const timestamp = now.toISOString();
-    const ttlMs =
-      input.ttlMs && input.ttlMs > 0 ? input.ttlMs : DEFAULT_PENDING_PAIRING_TTL_MS;
+    const ttlMs = clampPendingPairingTtlMs(input.ttlMs);
     const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
     const requestedProfile =
       input.requestedProfile ?? DEFAULT_NODE_PAIRING_TRUST_PROFILE;
@@ -2723,15 +2754,15 @@ export class HubNodeRegistry {
     this.expirePendingPairingNow(this.now().getTime());
     const normalized = normalizeNodePairingDeviceCode(deviceCode);
     if (!normalized) return null;
-    // Most-recent pending match wins; a re-run reuses the code namespace only
-    // among non-pending records, so an operator who pastes a fresh code lands
-    // on the live request.
+    // The active (still-claimable) match wins — there is at most one, since
+    // device codes are never reused while a request is active. Only after every
+    // matching request is terminal does the most-recent historical record show.
     const matches = this.state.pendingPairings.filter(
       (record) =>
         normalizeNodePairingDeviceCode(record.deviceCode) === normalized
     );
-    const pending = matches.find((record) => record.state === 'pending');
-    const record = pending ?? matches[matches.length - 1];
+    const active = matches.find((record) => isActiveClaimablePairing(record));
+    const record = active ?? matches[matches.length - 1];
     return record ? publicPendingPairing(record) : null;
   }
 
@@ -2755,6 +2786,26 @@ export class HubNodeRegistry {
       return resolvePendingPairingCapabilityBits(edit.requestedCapabilities);
     }
     return [...record.capabilityBits];
+  }
+
+  /**
+   * #982: the approved repo roots approval WOULD grant given an optional edit.
+   * Used (as a hash) to bind the exact-operation confirmation token to the roots
+   * set, so a token minted for one roots set cannot authorize a widened edit.
+   * Returns null for an unknown request.
+   */
+  pendingPairingEffectiveRoots(
+    requestId: string,
+    edit?: PendingPairingAccessEdit
+  ): string[] | null {
+    const record = this.state.pendingPairings.find(
+      (candidate) => candidate.requestId === requestId
+    );
+    if (!record) return null;
+    if (edit?.requestedRoots) {
+      return sanitizeRequestedRoots(edit.requestedRoots);
+    }
+    return [...record.requestedRoots];
   }
 
   editPendingPairingAccess(
@@ -2808,7 +2859,15 @@ export class HubNodeRegistry {
     record.state = 'denied';
     record.reasonCode = NODE_PAIRING_REASON_CODES.denied;
     record.decidedAt = this.now().toISOString();
-    if (options.reason) record.decisionReason = options.reason.slice(0, 256);
+    // The denial reason is operator free text; scrub secret-shaped material
+    // (pair/node/Bearer/secret_ tokens) and cap length before storing so it can
+    // never leak through the stored record, audit, or any future surface.
+    if (options.reason) {
+      record.decisionReason = redactBootstrapSecrets(options.reason).slice(
+        0,
+        256
+      );
+    }
     this.persist();
     this.auditPendingPairingLifecycle({
       record,
@@ -3083,9 +3142,12 @@ export class HubNodeRegistry {
     for (let attempt = 0; attempt < 64; attempt += 1) {
       const code = randomDeviceCode();
       const normalized = normalizeNodePairingDeviceCode(code);
+      // Never collide with a still-claimable request (pending OR approved but
+      // unclaimed) so an active request's code — and therefore who can locate
+      // and claim it — is never silently reused.
       const collision = this.state.pendingPairings.some(
         (record) =>
-          record.state === 'pending' &&
+          isActiveClaimablePairing(record) &&
           normalizeNodePairingDeviceCode(record.deviceCode) === normalized
       );
       if (!collision) return code;

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -39,6 +39,7 @@ import {
   type NodeLinkProofAudience,
 } from '../shared/node-identity-keys.js';
 import {
+  LEGACY_DEFAULT_ALLOWED_CAPABILITIES,
   RELAY_SECURITY_POLICY_VERSION,
   applyTrustTierOverlay,
   createLegacyDefaultNodeAcl,
@@ -51,6 +52,18 @@ import {
   type RelayNodeAcl,
   type RelayTrustTier,
 } from '../shared/security-policy.js';
+import {
+  DEFAULT_NODE_PAIRING_TRUST_PROFILE,
+  NODE_PAIRING_REASON_CODES,
+  isHighRiskNodePairingRequest,
+  nodePairingCapabilityPosture,
+  nodePairingDeviceHint,
+  nodePairingProfileTrustTier,
+  normalizeNodePairingDeviceCode,
+  type NodePairingRequestState,
+  type NodePairingRequestSummary,
+  type NodePairingTrustProfile,
+} from '../shared/node-pairing-requests.js';
 import type {
   SecurityAuditDecision,
   SecurityAuditEntryInput,
@@ -173,10 +186,60 @@ interface StoredNodeRecord {
   updatingAt?: string;
 }
 
+/**
+ * #982: a node-initiated pending pairing request. Lives here until an operator
+ * approves/denies it or it expires. Stores only the manifest-derived fields the
+ * approval decision and node-record creation need — never the raw manifest, a
+ * repo/path inventory, the node credential, or the node's poll secret (only the
+ * sha256 of the status token is persisted).
+ */
+interface StoredPendingPairingRequest {
+  requestId: string;
+  correlationId: string;
+  deviceCode: string;
+  /** sha256 of the one-time node-held status/poll token. Raw token never stored. */
+  statusTokenHash: string;
+  state: NodePairingRequestState;
+  reasonCode: string;
+  // #981 key binding (public material only). Bound to the issued credential on claim.
+  publicKey?: string;
+  publicKeyFingerprint?: string;
+  // Manifest-derived display/decision metadata (no raw manifest, no path inventory).
+  displayName: string;
+  hostname: string;
+  homeDir?: string;
+  platform: string;
+  arch: string;
+  relayVersion: string;
+  helperVersion?: string;
+  protocolVersion: string;
+  capabilities: NodeCapabilityManifestSummary;
+  fileRpcAvailable?: boolean;
+  degradedReasons?: import('../shared/node-manifest.js').NodeManifestDegradedReason[];
+  // Requested access posture.
+  requestedProfile: NodePairingTrustProfile;
+  requestedTrustTier: RelayTrustTier;
+  /** Resolved allowed capability bits (profile defaults ∪ requested extras). */
+  capabilityBits: RelayCapabilityBit[];
+  requestedRoots: string[];
+  requiresExactOperationApproval: boolean;
+  sourceBinding?: StoredNodeSourceBinding;
+  // Lifecycle.
+  createdAt: string;
+  expiresAt: string;
+  decidedAt?: string;
+  decisionReason?: string;
+  // Outputs once the node has claimed its credential.
+  nodeId?: string;
+  credentialId?: string;
+  credentialDeliveredAt?: string;
+}
+
 interface RegistryFile {
   schemaVersion: 1;
   pairTokens: StoredPairToken[];
   nodes: StoredNodeRecord[];
+  pendingPairings: StoredPendingPairingRequest[];
 }
 
 export interface PairTokenMintIssuer {
@@ -219,6 +282,47 @@ export interface HeartbeatInput {
   repoInventory?: unknown;
 }
 
+/** #982: node-facing submission of a pending pairing request. */
+export interface PendingPairingRequestInput {
+  manifest: NodeManifest;
+  /** #981 SPKI public key (PEM). Public material only; bound on credential issuance. */
+  publicKey?: string;
+  displayName?: string;
+  requestedProfile?: NodePairingTrustProfile;
+  /** Optional extra capability bits beyond the profile defaults. */
+  requestedCapabilities?: RelayCapabilityBit[];
+  requestedRoots?: string[];
+  protocolVersion?: string;
+  correlationId?: string;
+  source?: RelayNodeSourceTuple;
+  ttlMs?: number;
+}
+
+export interface PendingPairingRequestResult {
+  request: NodePairingRequestSummary;
+  /**
+   * One-time poll secret returned to the waiting node. The node presents it to
+   * poll status and claim its issued credential. Hashed at rest; never
+   * re-emitted, logged, or placed in a summary/audit.
+   */
+  statusToken: string;
+}
+
+/** #982: operator edit of requested access before approval (not a re-approval). */
+export interface PendingPairingAccessEdit {
+  displayName?: string;
+  requestedProfile?: NodePairingTrustProfile;
+  requestedCapabilities?: RelayCapabilityBit[];
+  requestedRoots?: string[];
+}
+
+/** #982: result of a node status poll. `credential`/`node` present only on the one-time claim. */
+export interface PendingPairingPollResult {
+  request: NodePairingRequestSummary;
+  credential?: RelayNodeCredential;
+  node?: HubNodeSummary;
+}
+
 export interface CredentialRotationResult {
   node: HubNodeSummary;
   credential: RelayNodeCredential;
@@ -254,6 +358,18 @@ export interface HubNodeRegistryOptions {
 }
 
 export const DEFAULT_PAIR_TOKEN_TTL_MS = 10 * 60 * 1000;
+// #982: a node-initiated pending pairing request lives for this long before it
+// lapses to `expired` (cannot be approved). Matches the pair-token/device-code
+// 10-minute window so the operator countdown and node wait agree.
+export const DEFAULT_PENDING_PAIRING_TTL_MS = 10 * 60 * 1000;
+// #982: cap concurrent pending requests so the unauthenticated submit lane
+// cannot grow the registry file unbounded. Expired/decided records do not count.
+export const MAX_PENDING_PAIRING_REQUESTS = 256;
+// #982: bound retained resolved (denied/expired/claimed) request records so the
+// registry file does not grow without limit across many pair attempts. Recent
+// resolved records are kept briefly for operator visibility, then pruned.
+export const PENDING_PAIRING_RESOLVED_RETENTION_MS = 60 * 60 * 1000;
+export const MAX_RETAINED_RESOLVED_PAIRINGS = 256;
 export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
   staleMs: 45 * 1000,
   offlineMs: 90 * 1000,
@@ -341,7 +457,7 @@ class HubNodeRegistryError extends Error {
 }
 
 function emptyRegistryFile(): RegistryFile {
-  return { schemaVersion: 1, pairTokens: [], nodes: [] };
+  return { schemaVersion: 1, pairTokens: [], nodes: [], pendingPairings: [] };
 }
 
 function sha256(value: string): string {
@@ -350,6 +466,18 @@ function sha256(value: string): string {
 
 function randomToken(prefix: string): string {
   return `${prefix}_${crypto.randomBytes(24).toString('base64url')}`;
+}
+
+// #982: device-code alphabet excludes visually ambiguous characters (0/O, 1/I)
+// so an operator can transcribe a code reliably across devices.
+const DEVICE_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+function randomDeviceCode(): string {
+  let body = '';
+  for (let i = 0; i < 6; i += 1) {
+    body += DEVICE_CODE_ALPHABET[crypto.randomInt(DEVICE_CODE_ALPHABET.length)];
+  }
+  return `${body.slice(0, 3)}-${body.slice(3)}`;
 }
 
 function timingSafeEqualHex(a: string, b: string): boolean {
@@ -517,6 +645,12 @@ function readRegistryFile(storagePath: string): RegistryFile {
       schemaVersion: 1,
       pairTokens: Array.isArray(parsed.pairTokens) ? parsed.pairTokens : [],
       nodes: Array.isArray(parsed.nodes) ? parsed.nodes : [],
+      // #982: default to [] for registry files written before pending pairings
+      // existed. This array-default is the only migration mechanism (schema
+      // stays version 1, mirroring the pairTokens/nodes pattern).
+      pendingPairings: Array.isArray(parsed.pendingPairings)
+        ? parsed.pendingPairings
+        : [],
     };
   } catch (error) {
     const maybeNodeError = error as NodeJS.ErrnoException;
@@ -811,6 +945,107 @@ function createNodeAclForPairToken(input: {
       requiresConfirmation: nodeRequiresConfirmation,
     },
   });
+}
+
+/**
+ * #982: resolve the allowed capability bit set for a pending pairing request —
+ * the legacy default posture plus any node-requested extras, normalized and
+ * de-duplicated. `node:pair-token:create` is never a node ACL bit, so it is
+ * dropped if requested.
+ */
+function resolvePendingPairingCapabilityBits(
+  requestedCapabilities: RelayCapabilityBit[] | undefined
+): RelayCapabilityBit[] {
+  const merged = normalizeCapabilityBits([
+    ...LEGACY_DEFAULT_ALLOWED_CAPABILITIES,
+    ...normalizeCapabilityBits(requestedCapabilities),
+  ]);
+  return merged.filter((capability) => capability !== 'node:pair-token:create');
+}
+
+/**
+ * #982: bound the requested roots so an operator's decision card stays a short
+ * list of folder labels and never becomes a full path inventory. Trims, caps
+ * length, de-duplicates, and limits the count.
+ */
+function sanitizeRequestedRoots(roots: unknown): string[] {
+  if (!Array.isArray(roots)) return [];
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
+  for (const root of roots) {
+    if (typeof root !== 'string') continue;
+    const trimmed = root.trim().slice(0, 256);
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    cleaned.push(trimmed);
+    if (cleaned.length >= 16) break;
+  }
+  return cleaned;
+}
+
+function createNodeAclForPendingPairing(input: {
+  record: StoredPendingPairingRequest;
+  nodeId: string;
+  credentialId: string;
+  displayName: string;
+  createdAt: string;
+}): RelayNodeAcl {
+  const base = createLegacyDefaultNodeAcl({
+    nodeId: input.nodeId,
+    credentialId: input.credentialId,
+    displayName: input.displayName,
+    trustTier: input.record.requestedTrustTier,
+    createdAt: input.createdAt,
+  });
+  // The trust-tier overlay promotes any high-risk allowed bit to
+  // requires-confirmation on the prod tier; dev/sandbox leave them silent-allow
+  // once granted, exactly as documented in SECURITY_POLICY.md.
+  return applyTrustTierOverlay({
+    ...base,
+    grants: {
+      allowed: input.record.capabilityBits,
+      requiresConfirmation: [],
+    },
+  });
+}
+
+/**
+ * #982: redaction-safe public summary of a pending pairing request. Emits only
+ * safe correlation handles and product-language posture — never the raw
+ * hostname, the status token, raw capability bits, or any secret material.
+ */
+function publicPendingPairing(
+  record: StoredPendingPairingRequest
+): NodePairingRequestSummary {
+  const deviceHint = nodePairingDeviceHint(record.hostname);
+  const sourceDiagnostics = publicSourceDiagnostics(
+    record.sourceBinding?.diagnostics
+  );
+  return {
+    requestId: record.requestId,
+    correlationId: record.correlationId,
+    deviceCode: record.deviceCode,
+    state: record.state,
+    reasonCode: record.reasonCode,
+    displayName: record.displayName,
+    platform: record.platform,
+    relayVersion: record.relayVersion,
+    ...(deviceHint ? { deviceHint } : {}),
+    requestedProfile: record.requestedProfile,
+    requestedTrustTier: record.requestedTrustTier,
+    requestedCapabilities: nodePairingCapabilityPosture(record.capabilityBits),
+    requestedRoots: record.requestedRoots,
+    requiresExactOperationApproval: record.requiresExactOperationApproval,
+    ...(record.publicKeyFingerprint
+      ? { publicKeyFingerprint: record.publicKeyFingerprint }
+      : {}),
+    ...(sourceDiagnostics ? { sourceDiagnostics } : {}),
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+    ...(record.decidedAt ? { decidedAt: record.decidedAt } : {}),
+    ...(record.nodeId ? { nodeId: record.nodeId } : {}),
+    ...(record.credentialId ? { credentialId: record.credentialId } : {}),
+  };
 }
 
 function credentialToken(nodeId: string): {
@@ -2350,6 +2585,628 @@ export class HubNodeRegistry {
     );
     this.notifyNodeStatusIfChanged(node, status);
     return publicNode(node, status, this.hubVersion);
+  }
+
+  // ===========================================================================
+  // #982: pending node pairing request lifecycle.
+  //
+  // Node-initiated request -> operator approve/deny/edit -> node claims its
+  // key-bound credential on an authenticated status poll. The device code only
+  // LOCATES a request; only the node's one-time status token (hashed at rest)
+  // authorizes the credential claim, and only `pending` is approvable so a
+  // denied/expired request can never be replayed into an issued credential.
+  // ===========================================================================
+
+  submitPendingPairingRequest(
+    input: PendingPairingRequestInput
+  ): PendingPairingRequestResult {
+    const protocolVersion =
+      input.protocolVersion ?? RELAY_NODE_LINK_PROTOCOL_VERSION;
+    assertCompatibleProtocol(protocolVersion);
+    const now = this.now();
+    this.expirePendingPairingNow(now.getTime());
+    const pendingCount = this.state.pendingPairings.filter(
+      (record) => record.state === 'pending'
+    ).length;
+    if (pendingCount >= MAX_PENDING_PAIRING_REQUESTS) {
+      throw new HubNodeRegistryError(
+        'NODE_BUSY',
+        'too many pending pairing requests; retry after existing requests are resolved or expire',
+        true,
+        { reasonCode: 'PENDING_PAIRING_CAPACITY_EXHAUSTED' }
+      );
+    }
+    const timestamp = now.toISOString();
+    const ttlMs =
+      input.ttlMs && input.ttlMs > 0 ? input.ttlMs : DEFAULT_PENDING_PAIRING_TTL_MS;
+    const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
+    const requestedProfile =
+      input.requestedProfile ?? DEFAULT_NODE_PAIRING_TRUST_PROFILE;
+    const requestedTrustTier = nodePairingProfileTrustTier(requestedProfile);
+    const capabilityBits = resolvePendingPairingCapabilityBits(
+      input.requestedCapabilities
+    );
+    const requestId = randomToken('ppreq');
+    const statusToken = randomToken('pstat');
+    const statusTokenHash = sha256(statusToken);
+    // #981: bind only valid public material. A malformed key fails closed to a
+    // bearer-only request rather than throwing — the boundary is "key-bound
+    // credentials REQUIRE proof", not "pairing without a key is forbidden".
+    const submittedFingerprint = safeNodePublicKeyFingerprint(input.publicKey);
+    const record: StoredPendingPairingRequest = {
+      requestId,
+      correlationId: input.correlationId ?? randomToken('ppcorr'),
+      deviceCode: this.generateUniqueDeviceCode(),
+      statusTokenHash,
+      state: 'pending',
+      reasonCode: NODE_PAIRING_REASON_CODES.requested,
+      ...(submittedFingerprint && input.publicKey
+        ? {
+            publicKey: input.publicKey,
+            publicKeyFingerprint: submittedFingerprint,
+          }
+        : {}),
+      displayName: nodeDisplayName(input.displayName, input.manifest),
+      hostname: input.manifest.hostname,
+      ...(input.manifest.homeDir ? { homeDir: input.manifest.homeDir } : {}),
+      platform: input.manifest.platform,
+      arch: input.manifest.arch,
+      // A validator-passing manifest may carry only the canonical helperVersion
+      // (isNodeManifest accepts either field); mirror the helperVersion fallback
+      // so the stored record's relayVersion is never undefined.
+      relayVersion: input.manifest.relayVersion ?? input.manifest.helperVersion,
+      helperVersion:
+        input.manifest.helperVersion ?? input.manifest.relayVersion,
+      protocolVersion,
+      capabilities: summarizeCapabilities(input.manifest),
+      ...(input.manifest.fileRpc
+        ? { fileRpcAvailable: input.manifest.fileRpc.available }
+        : {}),
+      degradedReasons: input.manifest.degradedReasons ?? [],
+      requestedProfile,
+      requestedTrustTier,
+      capabilityBits,
+      requestedRoots: sanitizeRequestedRoots(input.requestedRoots),
+      requiresExactOperationApproval: isHighRiskNodePairingRequest({
+        profile: requestedProfile,
+        requestedCapabilities: capabilityBits,
+      }),
+      createdAt: timestamp,
+      expiresAt,
+    };
+    const sourceBinding = this.pendingPairingSourceBinding(
+      input.source,
+      input.manifest.hostname,
+      statusTokenHash,
+      timestamp
+    );
+    if (sourceBinding) record.sourceBinding = sourceBinding;
+    this.state.pendingPairings.push(record);
+    this.persist();
+    this.auditPendingPairingLifecycle({
+      record,
+      eventType: 'bridge_event',
+      decision: 'recorded',
+      reasonCode: NODE_PAIRING_REASON_CODES.requested,
+      action: 'nodes.pair.request',
+      grantedBits: capabilityBits,
+    });
+    return { request: publicPendingPairing(record), statusToken };
+  }
+
+  listPendingPairingRequests(
+    options: { state?: NodePairingRequestState; includeResolved?: boolean } = {}
+  ): NodePairingRequestSummary[] {
+    this.expirePendingPairingNow(this.now().getTime());
+    return this.state.pendingPairings
+      .filter((record) => {
+        if (options.state) return record.state === options.state;
+        if (options.includeResolved) return true;
+        return record.state === 'pending' || record.state === 'approved';
+      })
+      .map((record) => publicPendingPairing(record));
+  }
+
+  getPendingPairingRequest(
+    requestId: string
+  ): NodePairingRequestSummary | null {
+    this.expirePendingPairingNow(this.now().getTime());
+    const record = this.state.pendingPairings.find(
+      (candidate) => candidate.requestId === requestId
+    );
+    return record ? publicPendingPairing(record) : null;
+  }
+
+  findPendingPairingRequestByDeviceCode(
+    deviceCode: string
+  ): NodePairingRequestSummary | null {
+    this.expirePendingPairingNow(this.now().getTime());
+    const normalized = normalizeNodePairingDeviceCode(deviceCode);
+    if (!normalized) return null;
+    // Most-recent pending match wins; a re-run reuses the code namespace only
+    // among non-pending records, so an operator who pastes a fresh code lands
+    // on the live request.
+    const matches = this.state.pendingPairings.filter(
+      (record) =>
+        normalizeNodePairingDeviceCode(record.deviceCode) === normalized
+    );
+    const pending = matches.find((record) => record.state === 'pending');
+    const record = pending ?? matches[matches.length - 1];
+    return record ? publicPendingPairing(record) : null;
+  }
+
+  /**
+   * #982: the capability bit set approval WOULD grant given an optional edit —
+   * raw bits, for binding the high-risk exact-operation confirmation challenge.
+   * Read-only and intentionally NOT part of the redaction-safe summary (raw bits
+   * never cross a public surface); the router uses it only to bind the
+   * confirmation token to the exact capabilities being authorized. Returns null
+   * for an unknown request.
+   */
+  pendingPairingEffectiveCapabilityBits(
+    requestId: string,
+    edit?: PendingPairingAccessEdit
+  ): RelayCapabilityBit[] | null {
+    const record = this.state.pendingPairings.find(
+      (candidate) => candidate.requestId === requestId
+    );
+    if (!record) return null;
+    if (edit?.requestedCapabilities) {
+      return resolvePendingPairingCapabilityBits(edit.requestedCapabilities);
+    }
+    return [...record.capabilityBits];
+  }
+
+  editPendingPairingAccess(
+    requestId: string,
+    edit: PendingPairingAccessEdit
+  ): NodePairingRequestSummary {
+    const record = this.requirePendingPairingRecord(requestId);
+    this.assertPendingState(record, 'edit access for');
+    this.applyPendingPairingAccessEdit(record, edit);
+    record.reasonCode = NODE_PAIRING_REASON_CODES.edited;
+    this.persist();
+    this.auditPendingPairingLifecycle({
+      record,
+      eventType: 'bridge_event',
+      decision: 'recorded',
+      reasonCode: NODE_PAIRING_REASON_CODES.edited,
+      action: 'nodes.pair.edit-access',
+      grantedBits: record.capabilityBits,
+    });
+    return publicPendingPairing(record);
+  }
+
+  approvePendingPairingRequest(
+    requestId: string,
+    options: { edit?: PendingPairingAccessEdit } = {}
+  ): NodePairingRequestSummary {
+    const record = this.requirePendingPairingRecord(requestId);
+    this.assertPendingState(record, 'approve');
+    if (options.edit) this.applyPendingPairingAccessEdit(record, options.edit);
+    record.state = 'approved';
+    record.reasonCode = NODE_PAIRING_REASON_CODES.approved;
+    record.decidedAt = this.now().toISOString();
+    this.persist();
+    this.auditPendingPairingLifecycle({
+      record,
+      eventType: 'approval',
+      decision: 'approved',
+      reasonCode: NODE_PAIRING_REASON_CODES.approved,
+      action: 'nodes.pair.approve',
+      grantedBits: record.capabilityBits,
+    });
+    return publicPendingPairing(record);
+  }
+
+  denyPendingPairingRequest(
+    requestId: string,
+    options: { reason?: string } = {}
+  ): NodePairingRequestSummary {
+    const record = this.requirePendingPairingRecord(requestId);
+    this.assertPendingState(record, 'deny');
+    record.state = 'denied';
+    record.reasonCode = NODE_PAIRING_REASON_CODES.denied;
+    record.decidedAt = this.now().toISOString();
+    if (options.reason) record.decisionReason = options.reason.slice(0, 256);
+    this.persist();
+    this.auditPendingPairingLifecycle({
+      record,
+      eventType: 'denial',
+      decision: 'deny',
+      reasonCode: NODE_PAIRING_REASON_CODES.denied,
+      action: 'nodes.pair.deny',
+    });
+    return publicPendingPairing(record);
+  }
+
+  /**
+   * Node-facing status poll + one-time credential claim. The status token
+   * authenticates the waiting node. A `pending`/`denied`/`expired` request
+   * returns status only. Only an `approved`, not-yet-claimed request mints the
+   * key-bound credential, creates the node record, and returns the raw
+   * credential exactly once — it is never stored raw, returned to the operator,
+   * or placed in any list/audit.
+   */
+  pollPendingPairingRequest(
+    requestId: string,
+    statusToken: string,
+    context: CredentialAuthContext = {}
+  ): PendingPairingPollResult {
+    this.expirePendingPairingNow(this.now().getTime());
+    const record = this.requirePendingPairingRecord(requestId);
+    const presentedHash = sha256(statusToken.trim());
+    if (!timingSafeEqualHex(presentedHash, record.statusTokenHash)) {
+      throw new HubNodeRegistryError(
+        'UNAUTHORIZED',
+        'pending pairing status token is invalid',
+        false,
+        { reasonCode: 'PENDING_PAIRING_STATUS_TOKEN_INVALID' }
+      );
+    }
+    if (record.state !== 'approved' || record.credentialDeliveredAt) {
+      return { request: publicPendingPairing(record) };
+    }
+    const now = this.now();
+    const { node, credential, boundFingerprint } =
+      this.buildPairedNodeFromPendingPairing(record, now, context);
+    this.state.nodes.push(node);
+    record.nodeId = node.nodeId;
+    record.credentialId = credential.credentialId;
+    record.credentialDeliveredAt = now.toISOString();
+    record.reasonCode = NODE_PAIRING_REASON_CODES.credentialIssued;
+    this.persist();
+    this.auditPendingPairingLifecycle({
+      record,
+      eventType: 'grant',
+      decision: 'allow',
+      reasonCode: NODE_PAIRING_REASON_CODES.credentialIssued,
+      action: 'nodes.pair.issue-credential',
+      grantedBits: node.acl?.grants.allowed ?? [],
+    });
+    this.notifyNodeStatusIfChanged(node, 'online');
+    return {
+      request: publicPendingPairing(record),
+      credential: {
+        protocol: RELAY_NODE_LINK_PROTOCOL,
+        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+        nodeId: node.nodeId,
+        credentialId: credential.credentialId,
+        token: credential.token,
+        issuedAt: record.credentialDeliveredAt,
+        ...(boundFingerprint ? { publicKeyFingerprint: boundFingerprint } : {}),
+      },
+      node: publicNode(node, 'online', this.hubVersion),
+    };
+  }
+
+  private requirePendingPairingRecord(
+    requestId: string
+  ): StoredPendingPairingRequest {
+    this.expirePendingPairingNow(this.now().getTime());
+    const record = this.state.pendingPairings.find(
+      (candidate) => candidate.requestId === requestId
+    );
+    if (!record) {
+      throw new HubNodeRegistryError(
+        'NOT_FOUND',
+        'pending pairing request was not found',
+        false,
+        { reasonCode: 'PENDING_PAIRING_NOT_FOUND' }
+      );
+    }
+    return record;
+  }
+
+  private assertPendingState(
+    record: StoredPendingPairingRequest,
+    verb: string
+  ): void {
+    if (record.state === 'pending') return;
+    // A denied/expired/already-approved request can never be replayed into a new
+    // approval or edit. `expired` maps to TOKEN_EXPIRED so callers can present
+    // the "request expired, re-run pair" path.
+    if (record.state === 'expired') {
+      throw new HubNodeRegistryError(
+        'TOKEN_EXPIRED',
+        `cannot ${verb} an expired pairing request`,
+        false,
+        { reasonCode: NODE_PAIRING_REASON_CODES.expired, state: record.state }
+      );
+    }
+    throw new HubNodeRegistryError(
+      'INVALID_REQUEST',
+      `cannot ${verb} a ${record.state} pairing request`,
+      false,
+      {
+        reasonCode: NODE_PAIRING_REASON_CODES.replayDenied,
+        state: record.state,
+      }
+    );
+  }
+
+  private applyPendingPairingAccessEdit(
+    record: StoredPendingPairingRequest,
+    edit: PendingPairingAccessEdit
+  ): void {
+    if (typeof edit.displayName === 'string' && edit.displayName.trim()) {
+      record.displayName = edit.displayName.trim();
+    }
+    if (edit.requestedProfile) {
+      record.requestedProfile = edit.requestedProfile;
+      record.requestedTrustTier = nodePairingProfileTrustTier(
+        edit.requestedProfile
+      );
+    }
+    if (edit.requestedCapabilities) {
+      record.capabilityBits = resolvePendingPairingCapabilityBits(
+        edit.requestedCapabilities
+      );
+    }
+    if (edit.requestedRoots) {
+      record.requestedRoots = sanitizeRequestedRoots(edit.requestedRoots);
+    }
+    record.requiresExactOperationApproval = isHighRiskNodePairingRequest({
+      profile: record.requestedProfile,
+      requestedCapabilities: record.capabilityBits,
+    });
+  }
+
+  private buildPairedNodeFromPendingPairing(
+    record: StoredPendingPairingRequest,
+    now: Date,
+    context: CredentialAuthContext
+  ): {
+    node: StoredNodeRecord;
+    credential: ReturnType<typeof credentialToken>;
+    boundFingerprint?: string;
+  } {
+    const timestamp = now.toISOString();
+    const nodeId = randomToken('node');
+    const credential = credentialToken(nodeId);
+    const boundFingerprint = safeNodePublicKeyFingerprint(record.publicKey);
+    const acl = createNodeAclForPendingPairing({
+      record,
+      nodeId,
+      credentialId: credential.credentialId,
+      displayName: record.displayName,
+      createdAt: timestamp,
+    });
+    const sourceBinding = this.pairedSourceBindingForClaim(
+      context.source,
+      record.hostname,
+      credential.hash,
+      timestamp
+    );
+    const node: StoredNodeRecord = {
+      nodeId,
+      identity: {
+        nodeId,
+        displayName: record.displayName,
+        hostname: record.hostname,
+        createdAt: timestamp,
+        pairedAt: timestamp,
+      },
+      activeCredential: {
+        credentialId: credential.credentialId,
+        tokenHash: credential.hash,
+        issuedAt: timestamp,
+        ...(boundFingerprint && record.publicKey
+          ? {
+              publicKey: record.publicKey,
+              publicKeyFingerprint: boundFingerprint,
+              publicKeyAlgorithm: 'ed25519',
+            }
+          : {}),
+      },
+      credentialId: credential.credentialId,
+      credentialHash: credential.hash,
+      credentialIssuedAt: timestamp,
+      displayName: record.displayName,
+      hostname: record.hostname,
+      ...(record.homeDir ? { homeDir: record.homeDir } : {}),
+      platform: record.platform,
+      arch: record.arch,
+      relayVersion: record.relayVersion,
+      ...(record.helperVersion ? { helperVersion: record.helperVersion } : {}),
+      protocolVersion: record.protocolVersion,
+      capabilities: record.capabilities,
+      ...(record.fileRpcAvailable !== undefined
+        ? { fileRpcAvailable: record.fileRpcAvailable }
+        : {}),
+      degradedReasons: record.degradedReasons ?? [],
+      acl,
+      ...(sourceBinding ? { sourceBinding } : {}),
+      createdAt: timestamp,
+      pairedAt: timestamp,
+      lastSeenAt: timestamp,
+    };
+    return {
+      node,
+      credential,
+      ...(boundFingerprint ? { boundFingerprint } : {}),
+    };
+  }
+
+  private pendingPairingSourceBinding(
+    source: RelayNodeSourceTuple | undefined,
+    hostname: string,
+    fingerprintKey: string,
+    now: string
+  ): StoredNodeSourceBinding | undefined {
+    const observed = sourceTupleWithHostname(source, hostname);
+    if (!observed) return undefined;
+    const observedFingerprint = sourceFingerprint(observed, fingerprintKey);
+    const hasSignal = hasTailscaleSourceSignal(observed);
+    return {
+      diagnostics: {
+        state: hasSignal ? 'source-match' : 'signal-unavailable',
+        policy: 'audit',
+        reasonCode: hasSignal
+          ? 'PENDING_PAIRING_SOURCE_RECORDED'
+          : 'PENDING_PAIRING_SOURCE_SIGNAL_UNAVAILABLE',
+        observedAt: now,
+        ...(observedFingerprint ? { sourceFingerprint: observedFingerprint } : {}),
+        displayHint: sourceDisplayHint(observed, observedFingerprint),
+      },
+    };
+  }
+
+  private pairedSourceBindingForClaim(
+    source: RelayNodeSourceTuple | undefined,
+    hostname: string,
+    fingerprintKey: string,
+    now: string
+  ): StoredNodeSourceBinding | undefined {
+    const observed = sourceTupleWithHostname(source, hostname);
+    if (!observed) return undefined;
+    const observedFingerprint = sourceFingerprint(observed, fingerprintKey);
+    const hasSignal = hasTailscaleSourceSignal(observed);
+    return {
+      expected: observed,
+      lastObserved: observed,
+      observedFingerprints: observedFingerprint ? [observedFingerprint] : [],
+      diagnostics: {
+        state: hasSignal ? 'source-match' : 'signal-unavailable',
+        policy: 'audit',
+        reasonCode: hasSignal
+          ? 'NODE_SOURCE_MATCH'
+          : 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+        observedAt: now,
+        ...(observedFingerprint ? { sourceFingerprint: observedFingerprint } : {}),
+        displayHint: sourceDisplayHint(observed, observedFingerprint),
+      },
+    };
+  }
+
+  private generateUniqueDeviceCode(): string {
+    for (let attempt = 0; attempt < 64; attempt += 1) {
+      const code = randomDeviceCode();
+      const normalized = normalizeNodePairingDeviceCode(code);
+      const collision = this.state.pendingPairings.some(
+        (record) =>
+          record.state === 'pending' &&
+          normalizeNodePairingDeviceCode(record.deviceCode) === normalized
+      );
+      if (!collision) return code;
+    }
+    throw new HubNodeRegistryError(
+      'INTERNAL',
+      'could not allocate a unique pairing device code'
+    );
+  }
+
+  private expirePendingPairingNow(nowMs: number): boolean {
+    let changed = false;
+    for (const record of this.state.pendingPairings) {
+      if (record.state !== 'pending') continue;
+      if (Date.parse(record.expiresAt) > nowMs) continue;
+      record.state = 'expired';
+      record.reasonCode = NODE_PAIRING_REASON_CODES.expired;
+      record.decidedAt = new Date(nowMs).toISOString();
+      changed = true;
+      this.auditPendingPairingLifecycle({
+        record,
+        eventType: 'expiry',
+        decision: 'expired',
+        reasonCode: NODE_PAIRING_REASON_CODES.expired,
+        action: 'nodes.pair.expire',
+      });
+    }
+    if (this.prunePendingPairings(nowMs)) changed = true;
+    if (changed) this.persist();
+    return changed;
+  }
+
+  /**
+   * Bound retained resolved records (denied/expired, or approved + already
+   * claimed) so the registry file does not grow without limit across many pair
+   * attempts. Pending and approved-but-unclaimed records are never pruned. Drops
+   * records past the retention window, then caps the most-recent retained set.
+   * Returns true if anything was removed.
+   */
+  private prunePendingPairings(nowMs: number): boolean {
+    const isResolved = (record: StoredPendingPairingRequest): boolean =>
+      record.state === 'denied' ||
+      record.state === 'expired' ||
+      (record.state === 'approved' && Boolean(record.credentialDeliveredAt));
+    const decisionMs = (record: StoredPendingPairingRequest): number =>
+      Date.parse(record.decidedAt ?? record.createdAt);
+    const before = this.state.pendingPairings.length;
+    let kept = this.state.pendingPairings.filter(
+      (record) =>
+        !(
+          isResolved(record) &&
+          decisionMs(record) + PENDING_PAIRING_RESOLVED_RETENTION_MS <= nowMs
+        )
+    );
+    const resolved = kept
+      .filter(isResolved)
+      .sort((a, b) => decisionMs(a) - decisionMs(b));
+    if (resolved.length > MAX_RETAINED_RESOLVED_PAIRINGS) {
+      const drop = new Set(
+        resolved
+          .slice(0, resolved.length - MAX_RETAINED_RESOLVED_PAIRINGS)
+          .map((record) => record.requestId)
+      );
+      kept = kept.filter((record) => !drop.has(record.requestId));
+    }
+    if (kept.length === before) return false;
+    this.state.pendingPairings = kept;
+    return true;
+  }
+
+  private auditPendingPairingLifecycle(input: {
+    record: StoredPendingPairingRequest;
+    decision: SecurityAuditDecision;
+    eventType: SecurityAuditEventType;
+    reasonCode: string;
+    action: string;
+    grantedBits?: RelayCapabilityBit[];
+  }): void {
+    if (!this.auditSink) return;
+    const record = input.record;
+    try {
+      this.auditSink.append({
+        eventType: input.eventType,
+        decision: input.decision,
+        reasonCode: input.reasonCode,
+        peer: {
+          kind: 'node',
+          ...(record.nodeId ? { nodeId: record.nodeId } : {}),
+          // requestId/credentialId are safe correlation handles, never secrets.
+          credentialId: record.credentialId ?? record.requestId,
+        },
+        node: { ...(record.nodeId ? { nodeId: record.nodeId } : {}) },
+        intent: { action: input.action, target: record.requestId },
+        material: {
+          params: {
+            requestId: record.requestId,
+            state: record.state,
+            requestedProfile: record.requestedProfile,
+            requestedTrustTier: record.requestedTrustTier,
+            requiresExactOperationApproval:
+              record.requiresExactOperationApproval,
+            rootCount: record.requestedRoots.length,
+            capabilityBitCount: record.capabilityBits.length,
+            publicKeyFingerprint: record.publicKeyFingerprint ?? null,
+            sourceState: record.sourceBinding?.diagnostics?.state ?? null,
+            ...(record.decisionReason
+              ? { decisionReason: record.decisionReason }
+              : {}),
+          },
+        },
+        grantedBits: input.grantedBits ?? [],
+        refs: { policyVersion: RELAY_SECURITY_POLICY_VERSION },
+        ...(record.sourceBinding?.diagnostics
+          ? { sourceDiagnostics: record.sourceBinding.diagnostics }
+          : {}),
+        correlationId: record.correlationId,
+      });
+    } catch {
+      // Best-effort lifecycle visibility only. Never log/retry raw status
+      // tokens or credential material if the audit sink fails.
+    }
   }
 
   errorBody(error: unknown): { error: RelayNodeError } {

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -570,7 +570,12 @@ function nodeDisplayName(
   manifest: NodeManifest
 ): string {
   const trimmed = displayName?.trim();
-  return trimmed || manifest.hostname;
+  if (trimmed) return trimmed;
+  // #982: pending pairing summaries surface displayName before trust exists.
+  // Never fall back to raw hostname/MagicDNS/IP here; use only coarse manifest
+  // posture so an omitted display name cannot leak private machine identity.
+  const platform = manifest.platform?.trim();
+  return platform ? `${platform} Relay node` : 'Relay node';
 }
 
 function fallbackAclInput(node: StoredNodeRecord): {
@@ -2859,9 +2864,9 @@ export class HubNodeRegistry {
     record.state = 'denied';
     record.reasonCode = NODE_PAIRING_REASON_CODES.denied;
     record.decidedAt = this.now().toISOString();
-    // The denial reason is operator free text; scrub secret-shaped material
-    // (pair/node/Bearer/secret_ tokens) and cap length before storing so it can
-    // never leak through the stored record, audit, or any future surface.
+    // The denial reason is operator free text; scrub secret/privacy-shaped
+    // material and cap length before storing so it can never leak through the
+    // stored record, audit, or any future surface.
     if (options.reason) {
       record.decisionReason = redactBootstrapSecrets(options.reason).slice(
         0,

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import * as express from 'express';
 import { isFileRpcOperation } from '../shared/file-rpc.js';
 import { normalizeHubFileRpcRequest } from './file-rpc.js';
@@ -2362,6 +2363,13 @@ function relayErrorForHandshakeGrantRegistryError(
 }
 
 const PAIRING_HIGH_RISK_BIT_SET = new Set<string>(HIGH_RISK_CAPABILITIES);
+
+// #982: stable sha256 of a value, for binding capability/roots sets into the
+// exact-operation confirmation params WITHOUT exposing raw bits or paths in the
+// public challenge surface. Inputs are pre-sorted arrays so the hash is stable.
+function pairingBindingHash(value: unknown): string {
+  return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
 const PAIRING_REQUEST_STATES = new Set([
   'pending',
   'approved',
@@ -3154,6 +3162,8 @@ export function createHubNodeRouter(
             requestId,
             parsed.edit
           ) ?? [];
+        const effectiveRoots =
+          registry.pendingPairingEffectiveRoots(requestId, parsed.edit) ?? [];
         const requiresApproval =
           summary.requiresExactOperationApproval ||
           isHighRiskNodePairingRequest({
@@ -3187,14 +3197,19 @@ export function createHubNodeRouter(
             req,
             decision,
             // Bind every dimension of the grant into the canonical params so the
-            // approved token cannot be replayed against a divergent capability
-            // set (e.g. one widened by a PATCH /access between mint and redeem).
+            // approved token cannot be replayed against a divergent grant (e.g.
+            // capabilities OR roots widened by a PATCH /access between mint and
+            // redeem). Capabilities and roots are bound as hashes so raw bits /
+            // paths never appear in the public challenge surface.
             params: {
               requestId,
               requestedProfile: effectiveProfile,
               requestedTrustTier: effectiveTrustTier,
               publicKeyFingerprint: summary.publicKeyFingerprint ?? null,
-              capabilityBits: [...effectiveCapabilityBits].sort(),
+              capabilityBitsHash: pairingBindingHash(
+                [...effectiveCapabilityBits].sort()
+              ),
+              rootsHash: pairingBindingHash([...effectiveRoots].sort()),
             },
             now: now(),
           });

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -108,12 +108,20 @@ import {
   type HandshakeGrantValidationScope,
 } from '../shared/operator-handshake-grants.js';
 import {
+  HIGH_RISK_CAPABILITIES,
   isRelayCapabilityBit,
   isRelayTrustTier,
   normalizeCapabilityBits,
   type RelayCapabilityBit,
   type RelayTrustTier,
 } from '../shared/security-policy.js';
+import {
+  isHighRiskNodePairingRequest,
+  isNodePairingTrustProfile,
+  nodePairingProfileTrustTier,
+  type NodePairingTrustProfile,
+} from '../shared/node-pairing-requests.js';
+import type { PendingPairingAccessEdit } from './hub-node-registry.js';
 
 const FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES = 256 * 1024;
 
@@ -2353,6 +2361,94 @@ function relayErrorForHandshakeGrantRegistryError(
   });
 }
 
+const PAIRING_HIGH_RISK_BIT_SET = new Set<string>(HIGH_RISK_CAPABILITIES);
+const PAIRING_REQUEST_STATES = new Set([
+  'pending',
+  'approved',
+  'denied',
+  'expired',
+]);
+
+function pairingStateFromQuery(
+  value: unknown
+): 'pending' | 'approved' | 'denied' | 'expired' | undefined {
+  return typeof value === 'string' && PAIRING_REQUEST_STATES.has(value)
+    ? (value as 'pending' | 'approved' | 'denied' | 'expired')
+    : undefined;
+}
+
+function pairingProfileFromBody(
+  body: Record<string, unknown>
+): { ok: true; profile?: NodePairingTrustProfile } | { ok: false } {
+  const value = body['requestedProfile'] ?? body['profile'];
+  if (value === undefined || value === null) return { ok: true };
+  if (isNodePairingTrustProfile(value)) return { ok: true, profile: value };
+  return { ok: false };
+}
+
+/**
+ * Parse the editable-access fields shared by the request, edit-access, and
+ * approve routes. Capabilities reuse {@link parseCapabilityList} so unknown bits
+ * fail closed; `node:pair-token:create` is dropped (never a node ACL default).
+ */
+function pairingAccessEditFromBody(body: Record<string, unknown>):
+  | {
+      ok: true;
+      edit: PendingPairingAccessEdit;
+      requestedCapabilityBits?: RelayCapabilityBit[];
+    }
+  | { ok: false; error: RelayNodeError } {
+  const profile = pairingProfileFromBody(body);
+  if (!profile.ok) {
+    return {
+      ok: false,
+      error: relayError(
+        'INVALID_REQUEST',
+        'requestedProfile must be a known node pairing trust profile',
+        false,
+        { reasonCode: 'PENDING_PAIRING_PROFILE_INVALID' }
+      ),
+    };
+  }
+  const capabilitiesProvided =
+    body['requestedCapabilities'] !== undefined ||
+    body['capabilities'] !== undefined;
+  const capabilities = parseCapabilityList(
+    body['requestedCapabilities'] ?? body['capabilities']
+  );
+  if (!capabilities.ok) {
+    return {
+      ok: false,
+      error: relayError('INVALID_REQUEST', capabilities.message, false, {
+        reasonCode: capabilities.reasonCode,
+        ...(capabilities.invalidCapability
+          ? { capability: capabilities.invalidCapability }
+          : {}),
+      }),
+    };
+  }
+  const displayName = stringFromBody(body, 'displayName');
+  const rootsValue = body['requestedRoots'] ?? body['roots'];
+  const roots = Array.isArray(rootsValue)
+    ? rootsValue.filter((root): root is string => typeof root === 'string')
+    : undefined;
+  const edit: PendingPairingAccessEdit = {
+    ...(displayName ? { displayName } : {}),
+    ...(profile.profile ? { requestedProfile: profile.profile } : {}),
+    ...(capabilitiesProvided
+      ? { requestedCapabilities: capabilities.capabilities }
+      : {}),
+    ...(roots ? { requestedRoots: roots } : {}),
+  };
+  return {
+    ok: true,
+    edit,
+    ...(capabilitiesProvided
+      ? { requestedCapabilityBits: capabilities.capabilities }
+      : {}),
+  };
+}
+
 export function createHubNodeRouter(
   options: HubNodeRouterOptions
 ): express.Router {
@@ -2839,6 +2935,311 @@ export function createHubNodeRouter(
       sendRegistryError(registry, res, error);
     }
   });
+
+  // ===========================================================================
+  // #982: pending node pairing request lifecycle.
+  //
+  // Node-facing (unauthenticated, like /hub/pairing/exchange):
+  //   POST /hub/pairing/requests             submit a pending request
+  //   POST /hub/pairing/requests/:id/status  poll status / one-time credential claim
+  // Operator (requireAuth):
+  //   GET   /hub/pairing/requests            list (?state=, ?deviceCode=)
+  //   GET   /hub/pairing/requests/:id        inspect
+  //   PATCH /hub/pairing/requests/:id/access edit requested access before approval
+  //   POST  /hub/pairing/requests/:id/approve approve (high-risk → exact-op confirmation)
+  //   POST  /hub/pairing/requests/:id/deny    deny
+  // ===========================================================================
+
+  router.post('/hub/pairing/requests', (req, res) => {
+    const body = bodyRecord(req);
+    let manifest: NodeManifest;
+    try {
+      manifest = manifestFromBody(body, true)!;
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+      return;
+    }
+    const parsed = pairingAccessEditFromBody(body);
+    if (!parsed.ok) {
+      sendRelayError(res, parsed.error);
+      return;
+    }
+    const publicKey =
+      typeof body['publicKey'] === 'string' ? body['publicKey'] : undefined;
+    const protocolVersion =
+      typeof body['protocolVersion'] === 'string'
+        ? body['protocolVersion']
+        : undefined;
+    const correlationId = pairTokenMintCorrelationId(req, body);
+    const source = sourceTupleFromRequest(req);
+    try {
+      const result = registry.submitPendingPairingRequest({
+        manifest,
+        ...(publicKey ? { publicKey } : {}),
+        ...(parsed.edit.displayName
+          ? { displayName: parsed.edit.displayName }
+          : {}),
+        ...(parsed.edit.requestedProfile
+          ? { requestedProfile: parsed.edit.requestedProfile }
+          : {}),
+        ...(parsed.requestedCapabilityBits
+          ? { requestedCapabilities: parsed.requestedCapabilityBits }
+          : {}),
+        ...(parsed.edit.requestedRoots
+          ? { requestedRoots: parsed.edit.requestedRoots }
+          : {}),
+        ...(protocolVersion ? { protocolVersion } : {}),
+        ...(correlationId ? { correlationId } : {}),
+        ...(source ? { source } : {}),
+      });
+      res.status(201).json(result);
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  router.post('/hub/pairing/requests/:requestId/status', (req, res) => {
+    const { requestId } = req.params;
+    const body = bodyRecord(req);
+    const statusToken =
+      req.header('x-relay-pairing-status-token')?.trim() ||
+      (typeof body['statusToken'] === 'string' ? body['statusToken'].trim() : '');
+    if (!requestId || !statusToken) {
+      sendRelayError(
+        res,
+        relayError(
+          'INVALID_REQUEST',
+          'requestId and pairing status token are required',
+          false,
+          { reasonCode: 'PENDING_PAIRING_STATUS_TOKEN_REQUIRED' }
+        )
+      );
+      return;
+    }
+    const source = sourceTupleFromRequest(req);
+    try {
+      const result = registry.pollPendingPairingRequest(requestId, statusToken, {
+        ...(source ? { source } : {}),
+      });
+      res.json(result);
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  router.get('/hub/pairing/requests', requireAuth, (req, res) => {
+    const deviceCode =
+      typeof req.query['deviceCode'] === 'string'
+        ? req.query['deviceCode']
+        : undefined;
+    if (deviceCode) {
+      const match = registry.findPendingPairingRequestByDeviceCode(deviceCode);
+      if (!match) {
+        sendRelayError(
+          res,
+          relayError(
+            'NOT_FOUND',
+            'no pairing request matches that device code',
+            false,
+            { reasonCode: 'PENDING_PAIRING_NOT_FOUND' }
+          )
+        );
+        return;
+      }
+      res.json({ requests: [match], request: match });
+      return;
+    }
+    const state = pairingStateFromQuery(req.query['state']);
+    const includeResolved =
+      req.query['includeResolved'] === 'true' || req.query['all'] === 'true';
+    res.json({
+      requests: registry.listPendingPairingRequests({
+        ...(state ? { state } : {}),
+        ...(includeResolved ? { includeResolved } : {}),
+      }),
+    });
+  });
+
+  router.get('/hub/pairing/requests/:requestId', requireAuth, (req, res) => {
+    const { requestId } = req.params;
+    const request = requestId
+      ? registry.getPendingPairingRequest(requestId)
+      : null;
+    if (!request) {
+      sendRelayError(
+        res,
+        relayError('NOT_FOUND', 'pending pairing request not found', false, {
+          reasonCode: 'PENDING_PAIRING_NOT_FOUND',
+        })
+      );
+      return;
+    }
+    res.json({ request });
+  });
+
+  router.patch(
+    '/hub/pairing/requests/:requestId/access',
+    requireAuth,
+    (req, res) => {
+      const { requestId } = req.params;
+      if (!requestId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'requestId is required', false, {
+            reasonCode: 'PENDING_PAIRING_REQUEST_ID_REQUIRED',
+          })
+        );
+        return;
+      }
+      const parsed = pairingAccessEditFromBody(bodyRecord(req));
+      if (!parsed.ok) {
+        sendRelayError(res, parsed.error);
+        return;
+      }
+      try {
+        const request = registry.editPendingPairingAccess(
+          requestId,
+          parsed.edit
+        );
+        res.json({ request });
+      } catch (error) {
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
+
+  router.post(
+    '/hub/pairing/requests/:requestId/approve',
+    requireAuth,
+    (req, res) => {
+      const { requestId } = req.params;
+      if (!requestId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'requestId is required', false, {
+            reasonCode: 'PENDING_PAIRING_REQUEST_ID_REQUIRED',
+          })
+        );
+        return;
+      }
+      const body = bodyRecord(req);
+      const parsed = pairingAccessEditFromBody(body);
+      if (!parsed.ok) {
+        sendRelayError(res, parsed.error);
+        return;
+      }
+      const summary = registry.getPendingPairingRequest(requestId);
+      if (!summary) {
+        sendRelayError(
+          res,
+          relayError('NOT_FOUND', 'pending pairing request not found', false, {
+            reasonCode: 'PENDING_PAIRING_NOT_FOUND',
+          })
+        );
+        return;
+      }
+      // Higher-risk profile/capability choices route through the existing
+      // exact-operation/high-risk confirmation contract before approval. Only a
+      // still-`pending` request is gated; other states fall through to the
+      // registry's typed state-machine error below.
+      if (summary.state === 'pending') {
+        const effectiveProfile =
+          parsed.edit.requestedProfile ?? summary.requestedProfile;
+        // Derive the capability set approval would actually grant (stored bits,
+        // overlaid with any body edit) — NOT just the bits re-sent on this call.
+        // This makes the challenge name the real high-risk bits and binds the
+        // confirmation token to the exact capability grant.
+        const effectiveCapabilityBits =
+          registry.pendingPairingEffectiveCapabilityBits(
+            requestId,
+            parsed.edit
+          ) ?? [];
+        const requiresApproval =
+          summary.requiresExactOperationApproval ||
+          isHighRiskNodePairingRequest({
+            profile: effectiveProfile,
+            requestedCapabilities: effectiveCapabilityBits,
+          });
+        if (requiresApproval) {
+          const effectiveTrustTier =
+            nodePairingProfileTrustTier(effectiveProfile);
+          const challengeBits = effectiveCapabilityBits.filter((bit) =>
+            PAIRING_HIGH_RISK_BIT_SET.has(bit)
+          );
+          const decision: HubPolicyDecision = {
+            decision: 'challenge',
+            reasonCode: 'POLICY_CHALLENGE_REQUIRED',
+            message: `approving this ${effectiveProfile} pairing request requires exact-operation confirmation`,
+            nodeId: requestId,
+            peer: { kind: 'hub' },
+            intent: { action: 'nodes.pair.approve', target: requestId },
+            scope: { kind: 'node', nodeId: requestId },
+            trustTier: effectiveTrustTier,
+            requiredBits: challengeBits,
+            grantedBits: [],
+            deniedBits: [],
+            challengeBits,
+            unknownBits: [],
+          };
+          const gate = resolveConfirmationForDecision({
+            confirmations,
+            auditSink: options.auditSink,
+            req,
+            decision,
+            // Bind every dimension of the grant into the canonical params so the
+            // approved token cannot be replayed against a divergent capability
+            // set (e.g. one widened by a PATCH /access between mint and redeem).
+            params: {
+              requestId,
+              requestedProfile: effectiveProfile,
+              requestedTrustTier: effectiveTrustTier,
+              publicKeyFingerprint: summary.publicKeyFingerprint ?? null,
+              capabilityBits: [...effectiveCapabilityBits].sort(),
+            },
+            now: now(),
+          });
+          if (!gate.ok) {
+            sendRelayError(res, gate.error);
+            return;
+          }
+        }
+      }
+      try {
+        const request = registry.approvePendingPairingRequest(requestId, {
+          edit: parsed.edit,
+        });
+        res.json({ request });
+      } catch (error) {
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
+
+  router.post(
+    '/hub/pairing/requests/:requestId/deny',
+    requireAuth,
+    (req, res) => {
+      const { requestId } = req.params;
+      if (!requestId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'requestId is required', false, {
+            reasonCode: 'PENDING_PAIRING_REQUEST_ID_REQUIRED',
+          })
+        );
+        return;
+      }
+      const reason = stringFromBody(bodyRecord(req), 'reason');
+      try {
+        const request = registry.denyPendingPairingRequest(requestId, {
+          ...(reason ? { reason } : {}),
+        });
+        res.json({ request });
+      } catch (error) {
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
 
   router.post('/hub/node-heartbeat', (req, res) => {
     const token = bearerToken(req);

--- a/shared/bootstrap-diagnostics.ts
+++ b/shared/bootstrap-diagnostics.ts
@@ -277,7 +277,7 @@ export function redactBootstrapSecrets(value: string): string {
     .replace(/("(?:token|pairToken|operatorGrant|handshakeGrant|grantHandle|actorToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
     .replace(/\b(token|pin|password|secret|cookie)=([^\s&"',}]+)/gi, '$1=…redacted')
     .replace(/\b([A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|COOKIE|KEY)[A-Z0-9_]*)=([^\s&"',}]+)/g, '$1=…redacted')
-    .replace(/\b(?:~|\/Users|\/home|\/var|\/tmp|\/etc)\/[^\s"',;}]+/g, '…path-redacted')
+    .replace(/(^|[\s("'=])(?:~|\/Users|\/home|\/var|\/tmp|\/etc)\/[^\s"',;}]+/g, '$1…path-redacted')
     .replace(/\b[A-Za-z]:\\(?:Users|ProgramData|Windows|Temp)\\[^\s"',;}]+/g, '…path-redacted')
     // URL-embedded credentials, any scheme — keeps bootstrap log lines
     // (which can quote `--hub-url https://user:pass@…` or `wss://…`) in

--- a/shared/bootstrap-diagnostics.ts
+++ b/shared/bootstrap-diagnostics.ts
@@ -268,17 +268,23 @@ export function redactBootstrapSecrets(value: string): string {
     .replace(/\brelay-ohg-v1\.[A-Za-z0-9._~+/=-]+\.[A-Za-z0-9._~+/=-]+\b/g, 'relay-ohg-v1.…redacted')
     .replace(/\brelay-sac-v1\.[A-Za-z0-9._~+/=-]+\.[A-Za-z0-9._~+/=-]+\b/g, 'relay-sac-v1.…redacted')
     .replace(/\bpair_[A-Za-z0-9._~+/=-]+\b/g, 'pair_…redacted')
+    .replace(/\bpstat_[A-Za-z0-9._~+/=-]+\b/g, 'pstat_…redacted')
     .replace(/\bnode_[A-Za-z0-9._~+/=-]+\.secret_[A-Za-z0-9._~+/=-]+\b/g, 'node_…redacted.secret_…redacted')
     .replace(/\bsecret_[A-Za-z0-9._~+/=-]+\b/g, 'secret_…redacted')
+    .replace(/(Cookie:\s*)[^\r\n]+/gi, '$1…redacted')
     .replace(/(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
     .replace(/("(?:token|pairToken|operatorGrant|handshakeGrant|grantHandle|actorToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
     .replace(/\b(token|pin|password|secret|cookie)=([^\s&"',}]+)/gi, '$1=…redacted')
+    .replace(/\b([A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|COOKIE|KEY)[A-Z0-9_]*)=([^\s&"',}]+)/g, '$1=…redacted')
+    .replace(/\b(?:~|\/Users|\/home|\/var|\/tmp|\/etc)\/[^\s"',;}]+/g, '…path-redacted')
+    .replace(/\b[A-Za-z]:\\(?:Users|ProgramData|Windows|Temp)\\[^\s"',;}]+/g, '…path-redacted')
     // URL-embedded credentials, any scheme — keeps bootstrap log lines
     // (which can quote `--hub-url https://user:pass@…` or `wss://…`) in
     // lockstep with the diag-bundle url-credential rule (#604).
     .replace(
       /([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^@\s/]+)@/gi,
       '$1…redacted:…redacted@'
-    );
+    )
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+)@/gi, '$1…redacted@');
 }

--- a/shared/node-pairing-requests.ts
+++ b/shared/node-pairing-requests.ts
@@ -166,18 +166,6 @@ export function isNodePairingDeviceCode(value: unknown): value is string {
 }
 
 /**
- * Lossy, suffix-only hostname hint for operator recognition. Never returns the
- * full hostname/MagicDNS name — only a leading-ellipsis suffix. The editable
- * display name is the primary recognition handle; this is supplementary.
- */
-export function nodePairingDeviceHint(hostname: string): string | undefined {
-  const trimmed = hostname.trim();
-  if (!trimmed) return undefined;
-  if (trimmed.length <= 8) return `…${trimmed.slice(-4)}`;
-  return `…${trimmed.slice(-8)}`;
-}
-
-/**
  * The public, redaction-safe summary of a pending pairing request. Both the
  * authenticated operator surface and the waiting node read this shape; it
  * carries only safe correlation handles and product-language posture.
@@ -193,8 +181,6 @@ export interface NodePairingRequestSummary {
   displayName: string;
   platform: string;
   relayVersion: string;
-  /** Lossy, suffix-only device/hostname hint — never the full hostname. */
-  deviceHint?: string;
   requestedProfile: NodePairingTrustProfile;
   requestedTrustTier: RelayTrustTier;
   /** Product-language posture, never raw capability bits. */

--- a/shared/node-pairing-requests.ts
+++ b/shared/node-pairing-requests.ts
@@ -1,0 +1,231 @@
+/**
+ * #982: shared wire contracts for the hub-side pending node pairing request
+ * lifecycle. A node-initiated pairing request lives on the hub as a `pending`
+ * record until an authenticated operator approves, denies, or it expires. The
+ * device code only LOCATES a pending request in an operator surface; it never
+ * authorizes the node. Approval authorizes a key-bound node credential that is
+ * minted and delivered only to the waiting node on its authenticated status
+ * claim, so raw credential material never appears in operator responses, lists,
+ * or audit. See docs/ADD_NODE_PAIR_DEVICE_UX.md and docs/SECURITY_POLICY.md.
+ *
+ * Everything in this module is PUBLIC and redaction-safe, and is shaped so the
+ * CLI, web UI, and Command Center can later project one `nodes.pair.*` command
+ * family (final stable gateway ids land with #985/#986). These shapes must
+ * NEVER carry raw pair tokens, node credential tokens or hashes, pairing status
+ * tokens, browser cookies, raw forwarded headers, raw hostnames/MagicDNS/tailnet
+ * IPs, env values, terminal bytes, full path inventories, or raw capability-bit
+ * ACL internals in customer-facing copy.
+ */
+import type { RelayNodeSourceDiagnostics } from './relay-node-protocol.js';
+import {
+  HIGH_RISK_CAPABILITIES,
+  LEGACY_DEFAULT_ALLOWED_CAPABILITIES,
+  type RelayCapabilityBit,
+  type RelayTrustTier,
+} from './security-policy.js';
+
+/**
+ * Lifecycle states for a node-initiated pending pairing request. A request is
+ * created `pending`; an operator moves it to `approved` or `denied`, or it
+ * lapses to `expired`. `pending` is the only approvable state: `denied` and
+ * `expired` are terminal and can never be replayed into `approved`.
+ */
+export type NodePairingRequestState =
+  | 'pending'
+  | 'approved'
+  | 'denied'
+  | 'expired';
+
+/**
+ * Product-language trust profile the node asks for at pairing time. Each maps
+ * to an underlying `RelayTrustTier`. `infra-prod-host` is the higher-risk
+ * profile and routes approval through the exact-operation confirmation
+ * contract; the customer-facing copy never surfaces raw capability bits.
+ */
+export type NodePairingTrustProfile =
+  | 'dev-workstation'
+  | 'sandbox-runner'
+  | 'automation-runner'
+  | 'infra-prod-host';
+
+export const NODE_PAIRING_TRUST_PROFILES = [
+  'dev-workstation',
+  'sandbox-runner',
+  'automation-runner',
+  'infra-prod-host',
+] as const satisfies readonly NodePairingTrustProfile[];
+
+export const DEFAULT_NODE_PAIRING_TRUST_PROFILE: NodePairingTrustProfile =
+  'dev-workstation';
+
+export function isNodePairingTrustProfile(
+  value: unknown
+): value is NodePairingTrustProfile {
+  return (
+    typeof value === 'string' &&
+    (NODE_PAIRING_TRUST_PROFILES as readonly string[]).includes(value)
+  );
+}
+
+const PROFILE_TRUST_TIER: Record<NodePairingTrustProfile, RelayTrustTier> = {
+  'dev-workstation': 'dev',
+  'sandbox-runner': 'sandbox',
+  'automation-runner': 'sandbox',
+  'infra-prod-host': 'prod',
+};
+
+export function nodePairingProfileTrustTier(
+  profile: NodePairingTrustProfile
+): RelayTrustTier {
+  return PROFILE_TRUST_TIER[profile];
+}
+
+// The high-risk bits that are NOT already in the legacy default posture. A
+// dev/sandbox node is granted the baseline (which itself contains some
+// high-risk bits like `session:control:kill`) under standard operator
+// approval; only an ELEVATED request — beyond that baseline — escalates the
+// pairing ceremony. This keeps a plain dev-workstation request out of the
+// exact-operation contract while still gating writes/exec/escalation.
+const ELEVATED_HIGH_RISK_CAPABILITY_SET = new Set<string>(
+  HIGH_RISK_CAPABILITIES.filter(
+    (bit) =>
+      !(LEGACY_DEFAULT_ALLOWED_CAPABILITIES as readonly string[]).includes(bit)
+  )
+);
+
+/**
+ * A pairing request is higher-risk when it targets the prod profile OR requests
+ * an elevated high-risk capability beyond the standard baseline. Higher-risk
+ * requests must route through the existing exact-operation/high-risk approval
+ * contract before a credential is authorized.
+ */
+export function isHighRiskNodePairingRequest(input: {
+  profile: NodePairingTrustProfile;
+  requestedCapabilities?: readonly string[];
+}): boolean {
+  if (nodePairingProfileTrustTier(input.profile) === 'prod') return true;
+  return (input.requestedCapabilities ?? []).some((bit) =>
+    ELEVATED_HIGH_RISK_CAPABILITY_SET.has(bit)
+  );
+}
+
+/**
+ * Product-language posture labels for a resolved capability bit set. Raw bits
+ * are NEVER surfaced in customer copy; unmapped bits collapse to a generic
+ * bucket so nothing leaks while the posture stays informative.
+ */
+const CAPABILITY_POSTURE_LABELS: Partial<Record<RelayCapabilityBit, string>> = {
+  'session:read': 'view sessions',
+  'session:create:terminal': 'launch terminal sessions',
+  'session:create:agent': 'launch configured agent CLIs',
+  'session:attach': 'attach/detach sessions',
+  'session:control:kill': 'stop sessions',
+  'session:control:rename': 'rename sessions',
+  'tab:mode:set-agent': 'drive agent tabs',
+  'tab:intervention:read': 'observe agent tabs',
+  'tab:intervention:send-text': 'intervene on agent tabs',
+  'tab:intervention:send-key': 'intervene on agent tabs',
+  'tab:intervention:submit': 'intervene on agent tabs',
+  'rpc:fs:list': 'browse approved repo roots',
+  'rpc:fs:read': 'read approved repo roots',
+  'rpc:fs:tail': 'read approved repo roots',
+  'rpc:fs:write': 'write approved repo roots',
+  'rpc:fs:delete': 'write approved repo roots',
+  'rpc:git:read': 'run git',
+  'rpc:git:write': 'run git',
+  'pty:exec:arbitrary': 'run arbitrary commands',
+  'preview:port-forward': 'forward preview ports',
+  'logs:read': 'read node logs',
+};
+
+const GENERIC_CAPABILITY_LABEL = 'additional approved operations';
+
+export function nodePairingCapabilityPosture(
+  bits: readonly RelayCapabilityBit[]
+): string[] {
+  const labels = new Set<string>();
+  for (const bit of bits) {
+    labels.add(CAPABILITY_POSTURE_LABELS[bit] ?? GENERIC_CAPABILITY_LABEL);
+  }
+  return Array.from(labels).sort();
+}
+
+/**
+ * Device code: a short, human-transcribable locator. Comparison is
+ * case-insensitive and dash/whitespace tolerant — normalize before lookup.
+ */
+export function normalizeNodePairingDeviceCode(input: string): string {
+  return input.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+}
+
+export function isNodePairingDeviceCode(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    normalizeNodePairingDeviceCode(value).length >= 6
+  );
+}
+
+/**
+ * Lossy, suffix-only hostname hint for operator recognition. Never returns the
+ * full hostname/MagicDNS name — only a leading-ellipsis suffix. The editable
+ * display name is the primary recognition handle; this is supplementary.
+ */
+export function nodePairingDeviceHint(hostname: string): string | undefined {
+  const trimmed = hostname.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length <= 8) return `…${trimmed.slice(-4)}`;
+  return `…${trimmed.slice(-8)}`;
+}
+
+/**
+ * The public, redaction-safe summary of a pending pairing request. Both the
+ * authenticated operator surface and the waiting node read this shape; it
+ * carries only safe correlation handles and product-language posture.
+ */
+export interface NodePairingRequestSummary {
+  requestId: string;
+  correlationId: string;
+  /** Locator only; carries no authority. */
+  deviceCode: string;
+  state: NodePairingRequestState;
+  /** Audit-safe lifecycle status code, e.g. `PENDING_PAIRING_REQUESTED`. */
+  reasonCode: string;
+  displayName: string;
+  platform: string;
+  relayVersion: string;
+  /** Lossy, suffix-only device/hostname hint — never the full hostname. */
+  deviceHint?: string;
+  requestedProfile: NodePairingTrustProfile;
+  requestedTrustTier: RelayTrustTier;
+  /** Product-language posture, never raw capability bits. */
+  requestedCapabilities: string[];
+  /** Operator decision metadata (approved repo roots in product language). */
+  requestedRoots: string[];
+  /** True when approval must route through the exact-operation contract. */
+  requiresExactOperationApproval: boolean;
+  /** Stable `nkey_…` public-key fingerprint; absent for bearer-only requests. */
+  publicKeyFingerprint?: string;
+  /** Already-redacted source/provenance diagnostics. */
+  sourceDiagnostics?: RelayNodeSourceDiagnostics;
+  createdAt: string;
+  expiresAt: string;
+  /** Set when an operator approved or denied the request. */
+  decidedAt?: string;
+  /** Present only after approval (stable, safe identity handle). */
+  nodeId?: string;
+  /** Present only after the node has claimed its issued credential. */
+  credentialId?: string;
+}
+
+/** Audit-safe lifecycle reason codes for the pending pairing request flow. */
+export const NODE_PAIRING_REASON_CODES = {
+  requested: 'PENDING_PAIRING_REQUESTED',
+  approved: 'PENDING_PAIRING_APPROVED',
+  denied: 'PENDING_PAIRING_DENIED',
+  expired: 'PENDING_PAIRING_EXPIRED',
+  edited: 'PENDING_PAIRING_ACCESS_EDITED',
+  credentialIssued: 'PENDING_PAIRING_CREDENTIAL_ISSUED',
+  exactOperationApprovalRequired:
+    'PENDING_PAIRING_EXACT_OPERATION_APPROVAL_REQUIRED',
+  replayDenied: 'PENDING_PAIRING_REPLAY_DENIED',
+} as const;

--- a/test/hub-node-pairing-requests.test.ts
+++ b/test/hub-node-pairing-requests.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createHubNodeRegistry,
   DEFAULT_PENDING_PAIRING_TTL_MS,
+  MAX_PENDING_PAIRING_TTL_MS,
 } from '../server/hub-node-registry.js';
 import {
   createNodeLinkProof,
@@ -239,6 +240,24 @@ describe('hub node pending pairing request lifecycle (#982)', () => {
     });
   });
 
+  it('redacts secret-shaped material from a denial reason before storing or auditing', () => {
+    withHarness((h) => {
+      const { request } = submit(h);
+      h.registry.denyPendingPairingRequest(request.requestId, {
+        reason: 'rejected; saw leaked pair_ABC123secret and secret_XYZ789tok',
+      });
+
+      const persisted = fs.readFileSync(h.storagePath, 'utf8');
+      const auditJson = JSON.stringify(h.audit);
+      for (const blob of [persisted, auditJson]) {
+        expect(blob).not.toContain('pair_ABC123secret');
+        expect(blob).not.toContain('secret_XYZ789tok');
+        expect(blob).not.toContain('ABC123');
+        expect(blob).not.toContain('XYZ789');
+      }
+    });
+  });
+
   it('expires a request and refuses approval/issuance after expiry', () => {
     withHarness((h) => {
       const { request, statusToken } = submit(h, { ttlMs: 1000 });
@@ -305,6 +324,52 @@ describe('hub node pending pairing request lifecycle (#982)', () => {
           displayName: 'too late',
         })
       ).toThrow(/INVALID_REQUEST/);
+    });
+  });
+
+  it('clamps or rejects invalid ttlMs values to a valid expiry window', () => {
+    withHarness((h) => {
+      const min = NOW_MS + 1;
+      const maxBound = NOW_MS + MAX_PENDING_PAIRING_TTL_MS;
+      for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1, 0]) {
+        const { request } = submit(h, { ttlMs: bad });
+        // Invalid → default window; expiresAt is always a valid ISO instant.
+        expect(request.expiresAt).toBe(
+          new Date(NOW_MS + DEFAULT_PENDING_PAIRING_TTL_MS).toISOString()
+        );
+        expect(Number.isNaN(Date.parse(request.expiresAt))).toBe(false);
+      }
+      // Absurdly large finite ttl clamps to the hard maximum, never overflows.
+      const huge = submit(h, { ttlMs: 1e15 });
+      const hugeMs = Date.parse(huge.request.expiresAt);
+      expect(Number.isNaN(hugeMs)).toBe(false);
+      expect(hugeMs).toBe(maxBound);
+      expect(hugeMs).toBeGreaterThanOrEqual(min);
+    });
+  });
+
+  it('keeps an approved-but-unclaimed request locatable by its device code and claimable', () => {
+    withHarness((h) => {
+      const keys = generateNodeIdentityKeyPair();
+      const { request, statusToken } = submit(h, {}, keys);
+      h.registry.approvePendingPairingRequest(request.requestId);
+
+      // Approved-but-unclaimed: still the active match for its device code.
+      const located = h.registry.findPendingPairingRequestByDeviceCode(
+        request.deviceCode
+      );
+      expect(located?.requestId).toBe(request.requestId);
+      expect(located?.state).toBe('approved');
+
+      // The original status token still claims the credential — not displaced.
+      const claim = h.registry.pollPendingPairingRequest(
+        request.requestId,
+        statusToken
+      );
+      expect(claim.credential).toBeDefined();
+      expect(claim.credential!.publicKeyFingerprint).toBe(
+        keys.publicKeyFingerprint
+      );
     });
   });
 

--- a/test/hub-node-pairing-requests.test.ts
+++ b/test/hub-node-pairing-requests.test.ts
@@ -113,6 +113,17 @@ describe('hub node pending pairing request lifecycle (#982)', () => {
     });
   });
 
+  it('does not fall back to raw hostname when displayName is omitted', () => {
+    withHarness((h) => {
+      const { request } = submit(h, { displayName: undefined });
+
+      expect(request.displayName).toBe('darwin Relay node');
+      const summaryJson = JSON.stringify(request);
+      expect(summaryJson).not.toContain(SECRET_HOSTNAME);
+      expect(summaryJson).not.toContain('tailnet.ts.net');
+    });
+  });
+
   it('locates a request by device code case-insensitively and dash-tolerantly', () => {
     withHarness((h) => {
       const { request } = submit(h);
@@ -240,19 +251,29 @@ describe('hub node pending pairing request lifecycle (#982)', () => {
     });
   });
 
-  it('redacts secret-shaped material from a denial reason before storing or auditing', () => {
+  it('redacts secret/privacy-shaped material from a denial reason before storing or auditing', () => {
     withHarness((h) => {
       const { request } = submit(h);
       h.registry.denyPendingPairingRequest(request.requestId, {
-        reason: 'rejected; saw leaked pair_ABC123secret and secret_XYZ789tok',
+        reason:
+          'rejected; saw leaked pair_ABC123secret pstat_STATUS123 secret_XYZ789tok ' +
+          'https://token-only-value@hub.example.com Cookie: sid=cookie-secret FAKE_TOKEN_FIELD=token-value ' +
+          '/Users/donovan/private/project /home/donovan/.ssh/id_ed25519',
       });
 
       const persisted = fs.readFileSync(h.storagePath, 'utf8');
       const auditJson = JSON.stringify(h.audit);
       for (const blob of [persisted, auditJson]) {
         expect(blob).not.toContain('pair_ABC123secret');
+        expect(blob).not.toContain('pstat_STATUS123');
         expect(blob).not.toContain('secret_XYZ789tok');
+        expect(blob).not.toContain('token-only-value');
+        expect(blob).not.toContain('cookie-secret');
+        expect(blob).not.toContain('token-value');
+        expect(blob).not.toContain('/Users/donovan/private/project');
+        expect(blob).not.toContain('/home/donovan/.ssh/id_ed25519');
         expect(blob).not.toContain('ABC123');
+        expect(blob).not.toContain('STATUS123');
         expect(blob).not.toContain('XYZ789');
       }
     });

--- a/test/hub-node-pairing-requests.test.ts
+++ b/test/hub-node-pairing-requests.test.ts
@@ -257,8 +257,8 @@ describe('hub node pending pairing request lifecycle (#982)', () => {
       h.registry.denyPendingPairingRequest(request.requestId, {
         reason:
           'rejected; saw leaked pair_ABC123secret pstat_STATUS123 secret_XYZ789tok ' +
-          'https://token-only-value@hub.example.com Cookie: sid=cookie-secret FAKE_TOKEN_FIELD=token-value ' +
-          '/Users/donovan/private/project /home/donovan/.ssh/id_ed25519',
+          'https://token-only-value@hub.example.com FAKE_TOKEN_FIELD=token-value ' +
+          '/Users/donovan/private/project /home/donovan/.ssh/id_ed25519 Cookie: sid=cookie-secret',
       });
 
       const persisted = fs.readFileSync(h.storagePath, 'utf8');

--- a/test/hub-node-pairing-requests.test.ts
+++ b/test/hub-node-pairing-requests.test.ts
@@ -1,0 +1,333 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  createHubNodeRegistry,
+  DEFAULT_PENDING_PAIRING_TTL_MS,
+} from '../server/hub-node-registry.js';
+import {
+  createNodeLinkProof,
+  generateNodeIdentityKeyPair,
+  type NodeIdentityKeyPair,
+} from '../shared/node-identity-keys.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+
+const NOW_MS = Date.parse('2026-06-18T12:00:00.000Z');
+const SECRET_HOSTNAME = 'donovans-secret-macbook.tailnet.ts.net';
+
+interface Harness {
+  registry: ReturnType<typeof createHubNodeRegistry>;
+  storagePath: string;
+  audit: SecurityAuditEntryInput[];
+  now: { ms: number };
+}
+
+function withHarness<T>(fn: (h: Harness) => T): T {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-pending-pairing-'));
+  const storagePath = path.join(tmpDir, 'nodes.json');
+  const audit: SecurityAuditEntryInput[] = [];
+  const now = { ms: NOW_MS };
+  try {
+    const registry = createHubNodeRegistry({
+      storagePath,
+      now: () => new Date(now.ms),
+      auditSink: { append: (entry) => audit.push(entry) },
+    });
+    return fn({ registry, storagePath, audit, now });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
+  return buildManifestWithAgents({
+    agents: [{ id: 'claude' }],
+    overrides: { hostname: SECRET_HOSTNAME, ...overrides },
+  });
+}
+
+function submit(
+  h: Harness,
+  input: Partial<Parameters<Harness['registry']['submitPendingPairingRequest']>[0]> = {},
+  keys?: NodeIdentityKeyPair
+) {
+  return h.registry.submitPendingPairingRequest({
+    manifest: manifest(),
+    displayName: 'work-mac',
+    ...(keys ? { publicKey: keys.publicKeyPem } : {}),
+    ...input,
+  });
+}
+
+describe('hub node pending pairing request lifecycle (#982)', () => {
+  it('creates a pending request with a device code and one-time status token', () => {
+    withHarness((h) => {
+      const keys = generateNodeIdentityKeyPair();
+      const { request, statusToken } = submit(h, {}, keys);
+
+      expect(request.state).toBe('pending');
+      expect(request.reasonCode).toBe('PENDING_PAIRING_REQUESTED');
+      expect(request.displayName).toBe('work-mac');
+      expect(request.requestedProfile).toBe('dev-workstation');
+      expect(request.requestedTrustTier).toBe('dev');
+      expect(request.requiresExactOperationApproval).toBe(false);
+      expect(request.publicKeyFingerprint).toBe(keys.publicKeyFingerprint);
+      expect(request.deviceCode).toMatch(/^[A-Z2-9]{3}-[A-Z2-9]{3}$/);
+      expect(request.expiresAt).toBe(
+        new Date(NOW_MS + DEFAULT_PENDING_PAIRING_TTL_MS).toISOString()
+      );
+      expect(statusToken).toMatch(/^pstat_/);
+      // Posture is product language, never raw capability bits.
+      expect(request.requestedCapabilities).toContain('launch terminal sessions');
+      expect(request.requestedCapabilities).not.toContain('rpc:fs:read');
+    });
+  });
+
+  it('never persists or surfaces the status token, raw hostname, or secrets', () => {
+    withHarness((h) => {
+      const keys = generateNodeIdentityKeyPair();
+      const { request, statusToken } = submit(h, {}, keys);
+
+      const persisted = fs.readFileSync(h.storagePath, 'utf8');
+      expect(persisted).not.toContain(statusToken);
+      // sha256 of the token is what is stored.
+      expect(persisted).toContain('statusTokenHash');
+
+      const summaryJson = JSON.stringify(request);
+      expect(summaryJson).not.toContain(statusToken);
+      expect(summaryJson).not.toContain(SECRET_HOSTNAME);
+      expect(summaryJson).not.toContain('tailnet.ts.net');
+      expect(summaryJson).not.toContain('BEGIN PRIVATE KEY');
+      expect(summaryJson).not.toContain('BEGIN PUBLIC KEY');
+
+      const auditJson = JSON.stringify(h.audit);
+      expect(auditJson).not.toContain(statusToken);
+      expect(auditJson).not.toContain(SECRET_HOSTNAME);
+      expect(auditJson).not.toContain('BEGIN PRIVATE KEY');
+      // The safe public fingerprint is allowed to appear.
+      expect(auditJson).toContain(keys.publicKeyFingerprint);
+    });
+  });
+
+  it('locates a request by device code case-insensitively and dash-tolerantly', () => {
+    withHarness((h) => {
+      const { request } = submit(h);
+      const code = request.deviceCode; // e.g. "7KQ-M2P"
+      const scrambled = code.replace('-', '').toLowerCase();
+      const found = h.registry.findPendingPairingRequestByDeviceCode(scrambled);
+      expect(found?.requestId).toBe(request.requestId);
+      expect(
+        h.registry.findPendingPairingRequestByDeviceCode('zzz-zzz')
+      ).toBeNull();
+    });
+  });
+
+  it('approves a request, then issues a key-bound credential only on the node claim', () => {
+    withHarness((h) => {
+      const keys = generateNodeIdentityKeyPair();
+      const { request, statusToken } = submit(h, {}, keys);
+
+      const approved = h.registry.approvePendingPairingRequest(
+        request.requestId
+      );
+      expect(approved.state).toBe('approved');
+      expect(approved.reasonCode).toBe('PENDING_PAIRING_APPROVED');
+      // No node exists yet — issuance is deferred to the authenticated claim.
+      expect(h.registry.listNodes()).toHaveLength(0);
+
+      const claim = h.registry.pollPendingPairingRequest(
+        request.requestId,
+        statusToken
+      );
+      expect(claim.credential).toBeDefined();
+      expect(claim.node).toBeDefined();
+      expect(claim.credential!.token).toMatch(
+        new RegExp(`^${claim.node!.nodeId}\\.`)
+      );
+      expect(claim.credential!.publicKeyFingerprint).toBe(
+        keys.publicKeyFingerprint
+      );
+      expect(h.registry.listNodes()).toHaveLength(1);
+
+      // The issued credential is key-bound: a fresh proof authenticates.
+      const proof = createNodeLinkProof({
+        privateKeyPem: keys.privateKeyPem,
+        publicKeyFingerprint: keys.publicKeyFingerprint,
+        nodeId: claim.node!.nodeId,
+        credentialId: claim.credential!.credentialId,
+        audience: 'relay:node-link:v1',
+        nowMs: NOW_MS,
+      });
+      const auth = h.registry.authenticateNodeLinkWithProof(
+        claim.credential!.token,
+        { audience: 'relay:node-link:v1', proof }
+      );
+      expect(auth.ok).toBe(true);
+
+      // A bearer-only attempt (no proof) on the key-bound credential fails closed.
+      const noProof = h.registry.authenticateNodeLinkWithProof(
+        claim.credential!.token,
+        { audience: 'relay:node-link:v1' }
+      );
+      expect(noProof.ok).toBe(false);
+      if (!noProof.ok) expect(noProof.error.code).toBe('NODE_PROOF_REQUIRED');
+
+      // Raw credential token never lands in the persisted file.
+      const persisted = fs.readFileSync(h.storagePath, 'utf8');
+      expect(persisted).not.toContain(claim.credential!.token);
+    });
+  });
+
+  it('delivers the issued credential exactly once', () => {
+    withHarness((h) => {
+      const keys = generateNodeIdentityKeyPair();
+      const { request, statusToken } = submit(h, {}, keys);
+      h.registry.approvePendingPairingRequest(request.requestId);
+
+      const first = h.registry.pollPendingPairingRequest(
+        request.requestId,
+        statusToken
+      );
+      expect(first.credential).toBeDefined();
+
+      const second = h.registry.pollPendingPairingRequest(
+        request.requestId,
+        statusToken
+      );
+      expect(second.credential).toBeUndefined();
+      expect(second.node).toBeUndefined();
+      expect(second.request.state).toBe('approved');
+      // No duplicate node record created on re-claim.
+      expect(h.registry.listNodes()).toHaveLength(1);
+    });
+  });
+
+  it('rejects a status poll with an invalid token', () => {
+    withHarness((h) => {
+      const { request } = submit(h);
+      expect(() =>
+        h.registry.pollPendingPairingRequest(request.requestId, 'pstat_wrong')
+      ).toThrow(/UNAUTHORIZED/);
+    });
+  });
+
+  it('denies a request and cannot replay a denial into an approval or credential', () => {
+    withHarness((h) => {
+      const { request, statusToken } = submit(h);
+      const denied = h.registry.denyPendingPairingRequest(request.requestId, {
+        reason: 'unrecognized device',
+      });
+      expect(denied.state).toBe('denied');
+      expect(denied.reasonCode).toBe('PENDING_PAIRING_DENIED');
+
+      // The waiting node sees the denial, never a credential.
+      const poll = h.registry.pollPendingPairingRequest(
+        request.requestId,
+        statusToken
+      );
+      expect(poll.credential).toBeUndefined();
+      expect(poll.request.state).toBe('denied');
+
+      // A denied request cannot be replayed into approval.
+      expect(() =>
+        h.registry.approvePendingPairingRequest(request.requestId)
+      ).toThrow(/INVALID_REQUEST/);
+      expect(h.registry.listNodes()).toHaveLength(0);
+    });
+  });
+
+  it('expires a request and refuses approval/issuance after expiry', () => {
+    withHarness((h) => {
+      const { request, statusToken } = submit(h, { ttlMs: 1000 });
+      h.now.ms = NOW_MS + 2000;
+
+      const listed = h.registry.listPendingPairingRequests({
+        includeResolved: true,
+      });
+      expect(listed[0]?.state).toBe('expired');
+      expect(listed[0]?.reasonCode).toBe('PENDING_PAIRING_EXPIRED');
+
+      // An expired request cannot be replayed into an approval.
+      expect(() =>
+        h.registry.approvePendingPairingRequest(request.requestId)
+      ).toThrow(/TOKEN_EXPIRED/);
+
+      // The node poll surfaces the expiry, never a credential.
+      const poll = h.registry.pollPendingPairingRequest(
+        request.requestId,
+        statusToken
+      );
+      expect(poll.credential).toBeUndefined();
+      expect(poll.request.state).toBe('expired');
+    });
+  });
+
+  it('marks prod-profile and high-risk-capability requests as requiring exact-operation approval', () => {
+    withHarness((h) => {
+      const prod = submit(h, { requestedProfile: 'infra-prod-host' });
+      expect(prod.request.requestedTrustTier).toBe('prod');
+      expect(prod.request.requiresExactOperationApproval).toBe(true);
+
+      const devHighRisk = submit(h, {
+        requestedCapabilities: ['rpc:fs:write'],
+      });
+      expect(devHighRisk.request.requestedTrustTier).toBe('dev');
+      expect(devHighRisk.request.requiresExactOperationApproval).toBe(true);
+      expect(devHighRisk.request.requestedCapabilities).toContain(
+        'write approved repo roots'
+      );
+      // Raw bits never appear in the customer-facing posture.
+      expect(JSON.stringify(devHighRisk.request)).not.toContain('rpc:fs:write');
+    });
+  });
+
+  it('edits requested access before approval but not after a decision', () => {
+    withHarness((h) => {
+      const { request } = submit(h);
+      const edited = h.registry.editPendingPairingAccess(request.requestId, {
+        displayName: 'work-mac (prod)',
+        requestedProfile: 'infra-prod-host',
+        requestedRoots: ['~/code', '~/work'],
+      });
+      expect(edited.displayName).toBe('work-mac (prod)');
+      expect(edited.requestedProfile).toBe('infra-prod-host');
+      expect(edited.requestedTrustTier).toBe('prod');
+      expect(edited.requiresExactOperationApproval).toBe(true);
+      expect(edited.requestedRoots).toEqual(['~/code', '~/work']);
+      expect(edited.reasonCode).toBe('PENDING_PAIRING_ACCESS_EDITED');
+
+      h.registry.approvePendingPairingRequest(request.requestId);
+      expect(() =>
+        h.registry.editPendingPairingAccess(request.requestId, {
+          displayName: 'too late',
+        })
+      ).toThrow(/INVALID_REQUEST/);
+    });
+  });
+
+  it('throws NOT_FOUND for an unknown request id', () => {
+    withHarness((h) => {
+      expect(() =>
+        h.registry.approvePendingPairingRequest('ppreq_missing')
+      ).toThrow(/NOT_FOUND/);
+      expect(h.registry.getPendingPairingRequest('ppreq_missing')).toBeNull();
+    });
+  });
+
+  it('survives a registry reload (durable storage)', () => {
+    withHarness((h) => {
+      const { request } = submit(h);
+      h.registry.approvePendingPairingRequest(request.requestId);
+
+      const reloaded = createHubNodeRegistry({
+        storagePath: h.storagePath,
+        now: () => new Date(h.now.ms),
+      });
+      const found = reloaded.getPendingPairingRequest(request.requestId);
+      expect(found?.state).toBe('approved');
+    });
+  });
+});

--- a/test/hub-node-pairing-routes.test.ts
+++ b/test/hub-node-pairing-routes.test.ts
@@ -1,0 +1,384 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createConfirmationChallengeStore } from '../server/confirmation-challenges.js';
+import * as auth from '../server/auth.js';
+import { generateNodeIdentityKeyPair } from '../shared/node-identity-keys.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+
+const NOW_MS = Date.parse('2026-06-18T12:00:00.000Z');
+const SECRET_HOSTNAME = 'donovans-secret-macbook.tailnet.ts.net';
+
+const cleanup: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  while (cleanup.length > 0) await cleanup.pop()?.();
+});
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('missing server address');
+  }
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function manifest() {
+  return buildManifestWithAgents({
+    agents: [{ id: 'claude' }],
+    overrides: { hostname: SECRET_HOSTNAME, platform: 'darwin' },
+  });
+}
+
+interface Setup {
+  base: string;
+  registry: ReturnType<typeof createHubNodeRegistry>;
+  storagePath: string;
+  clock: { ms: number };
+}
+
+async function setup(): Promise<Setup> {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-pending-pairing-routes-')
+  );
+  const storagePath = path.join(tmpDir, 'nodes.json');
+  const clock = { ms: NOW_MS };
+  const now = () => new Date(clock.ms);
+  const registry = createHubNodeRegistry({ storagePath, now });
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createHubNodeRouter({
+      registry,
+      now,
+      confirmations: createConfirmationChallengeStore({ now }),
+      requireAuth: (req, res, next) => {
+        if (req.header('x-test-auth') === 'yes') next();
+        else res.status(401).json(auth.browserSessionRequiredChallenge());
+      },
+    })
+  );
+  const server = http.createServer(app);
+  const port = await listen(server);
+  cleanup.push(() => close(server));
+  cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  return { base: `http://127.0.0.1:${port}`, registry, storagePath, clock };
+}
+
+function operatorHeaders(session = 'operator-a'): Record<string, string> {
+  return {
+    'content-type': 'application/json',
+    'x-test-auth': 'yes',
+    'x-auth-session': session,
+  };
+}
+
+async function submitRequest(
+  base: string,
+  body: Record<string, unknown> = {}
+): Promise<{ status: number; json: any }> {
+  const keys = generateNodeIdentityKeyPair();
+  const res = await fetch(`${base}/hub/pairing/requests`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      manifest: manifest(),
+      displayName: 'work-mac',
+      publicKey: keys.publicKeyPem,
+      ...body,
+    }),
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+describe('hub node pending pairing routes (#982)', () => {
+  it('submits a request and polls status without operator auth', async () => {
+    const { base } = await setup();
+    const { status, json } = await submitRequest(base);
+    expect(status).toBe(201);
+    expect(json.request.state).toBe('pending');
+    expect(json.statusToken).toMatch(/^pstat_/);
+    expect(json.request.deviceCode).toMatch(/^[A-Z2-9]{3}-[A-Z2-9]{3}$/);
+
+    const poll = await fetch(
+      `${base}/hub/pairing/requests/${json.request.requestId}/status`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ statusToken: json.statusToken }),
+      }
+    );
+    expect(poll.status).toBe(200);
+    const pollJson = await poll.json();
+    expect(pollJson.request.state).toBe('pending');
+    expect(pollJson.credential).toBeUndefined();
+  });
+
+  it('protects the operator list/approve/deny lanes behind auth', async () => {
+    const { base } = await setup();
+    const list = await fetch(`${base}/hub/pairing/requests`);
+    expect(list.status).toBe(401);
+    const { json } = await submitRequest(base);
+    const approve = await fetch(
+      `${base}/hub/pairing/requests/${json.request.requestId}/approve`,
+      { method: 'POST' }
+    );
+    expect(approve.status).toBe(401);
+  });
+
+  it('runs the full dev-profile approve → claim flow and redacts secrets', async () => {
+    const { base, storagePath } = await setup();
+    const submitted = await submitRequest(base);
+    const requestId = submitted.json.request.requestId;
+    const statusToken = submitted.json.statusToken;
+
+    const listRes = await fetch(`${base}/hub/pairing/requests`, {
+      headers: operatorHeaders(),
+    });
+    expect(listRes.status).toBe(200);
+    const listJson = await listRes.json();
+    expect(listJson.requests).toHaveLength(1);
+    const listText = JSON.stringify(listJson);
+    expect(listText).not.toContain(statusToken);
+    expect(listText).not.toContain(SECRET_HOSTNAME);
+
+    const approveRes = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/approve`,
+      { method: 'POST', headers: operatorHeaders() }
+    );
+    expect(approveRes.status).toBe(200);
+    const approveJson = await approveRes.json();
+    expect(approveJson.request.state).toBe('approved');
+    // The operator surface never carries credential material.
+    expect(approveJson.credential).toBeUndefined();
+    expect(JSON.stringify(approveJson)).not.toContain('secret_');
+
+    const claimRes = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/status`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ statusToken }),
+      }
+    );
+    expect(claimRes.status).toBe(200);
+    const claimJson = await claimRes.json();
+    expect(claimJson.credential.token).toMatch(
+      new RegExp(`^${claimJson.node.nodeId}\\.`)
+    );
+    expect(claimJson.credential.publicKeyFingerprint).toMatch(/^nkey_/);
+
+    // Raw credential token never persisted.
+    const persisted = fs.readFileSync(storagePath, 'utf8');
+    expect(persisted).not.toContain(claimJson.credential.token);
+
+    // The node now appears in the node list.
+    const nodesRes = await fetch(`${base}/nodes`, { headers: operatorHeaders() });
+    expect(nodesRes.status).toBe(200);
+    const nodesJson = await nodesRes.json();
+    expect(nodesJson.nodes).toHaveLength(1);
+  });
+
+  it('locates a request by device code via the operator list', async () => {
+    const { base } = await setup();
+    const { json } = await submitRequest(base);
+    const code = json.request.deviceCode;
+    const res = await fetch(
+      `${base}/hub/pairing/requests?deviceCode=${encodeURIComponent(code.toLowerCase())}`,
+      { headers: operatorHeaders() }
+    );
+    expect(res.status).toBe(200);
+    const found = await res.json();
+    expect(found.request.requestId).toBe(json.request.requestId);
+  });
+
+  it('edits requested access before approval', async () => {
+    const { base } = await setup();
+    const { json } = await submitRequest(base);
+    const res = await fetch(
+      `${base}/hub/pairing/requests/${json.request.requestId}/access`,
+      {
+        method: 'PATCH',
+        headers: operatorHeaders(),
+        body: JSON.stringify({
+          displayName: 'renamed',
+          requestedRoots: ['~/code'],
+        }),
+      }
+    );
+    expect(res.status).toBe(200);
+    const edited = await res.json();
+    expect(edited.request.displayName).toBe('renamed');
+    expect(edited.request.requestedRoots).toEqual(['~/code']);
+  });
+
+  it('denies a request; the node poll sees the denial and gets no credential', async () => {
+    const { base } = await setup();
+    const { json } = await submitRequest(base);
+    const denyRes = await fetch(
+      `${base}/hub/pairing/requests/${json.request.requestId}/deny`,
+      {
+        method: 'POST',
+        headers: operatorHeaders(),
+        body: JSON.stringify({ reason: 'unknown device' }),
+      }
+    );
+    expect(denyRes.status).toBe(200);
+    expect((await denyRes.json()).request.state).toBe('denied');
+
+    const poll = await fetch(
+      `${base}/hub/pairing/requests/${json.request.requestId}/status`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ statusToken: json.statusToken }),
+      }
+    );
+    const pollJson = await poll.json();
+    expect(pollJson.request.state).toBe('denied');
+    expect(pollJson.credential).toBeUndefined();
+  });
+
+  it('routes a high-risk (prod) approval through the exact-operation confirmation contract', async () => {
+    const { base } = await setup();
+    const { json } = await submitRequest(base, {
+      requestedProfile: 'infra-prod-host',
+    });
+    const requestId = json.request.requestId;
+    expect(json.request.requiresExactOperationApproval).toBe(true);
+
+    // First approve (no confirmation token) → 409 CONFIRMATION_REQUIRED.
+    const challengeRes = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/approve`,
+      { method: 'POST', headers: operatorHeaders('operator-a') }
+    );
+    expect(challengeRes.status).toBe(409);
+    const challengeJson = await challengeRes.json();
+    expect(challengeJson.error.code).toBe('CONFIRMATION_REQUIRED');
+    const challengeId = challengeJson.error.details.challenge.challengeId;
+
+    // A different operator session approves the challenge (separation of duty).
+    const approveChallengeRes = await fetch(
+      `${base}/hub/confirmations/${challengeId}/approve`,
+      {
+        method: 'POST',
+        headers: operatorHeaders('operator-b'),
+        body: JSON.stringify({ decision: 'approve' }),
+      }
+    );
+    expect(approveChallengeRes.status).toBe(200);
+    const confirmationToken = (await approveChallengeRes.json())
+      .confirmationToken as string;
+    expect(confirmationToken).toBeTruthy();
+
+    // The original requester re-approves with the confirmation token.
+    const approveRes = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/approve`,
+      {
+        method: 'POST',
+        headers: operatorHeaders('operator-a'),
+        body: JSON.stringify({ confirmationToken }),
+      }
+    );
+    expect(approveRes.status).toBe(200);
+    expect((await approveRes.json()).request.state).toBe('approved');
+
+    // Node can now claim its credential.
+    const claim = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/status`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ statusToken: json.statusToken }),
+      }
+    );
+    expect((await claim.json()).credential.token).toBeTruthy();
+  });
+
+  it('names the elevated capability in the confirmation challenge and binds the token to it', async () => {
+    const { base } = await setup();
+    const { json } = await submitRequest(base, {
+      requestedCapabilities: ['rpc:fs:write'],
+    });
+    const requestId = json.request.requestId;
+    expect(json.request.requiresExactOperationApproval).toBe(true);
+
+    const challengeRes = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/approve`,
+      { method: 'POST', headers: operatorHeaders('operator-a') }
+    );
+    expect(challengeRes.status).toBe(409);
+    const challenge = (await challengeRes.json()).error.details.challenge;
+    // The challenge card names the real high-risk bit being authorized.
+    expect(challenge.challengeBits).toContain('rpc:fs:write');
+
+    const confirmToken = await fetch(
+      `${base}/hub/confirmations/${challenge.challengeId}/approve`,
+      {
+        method: 'POST',
+        headers: operatorHeaders('operator-b'),
+        body: JSON.stringify({ decision: 'approve' }),
+      }
+    ).then((r) => r.json());
+
+    // Widening the granted capabilities after the token was minted invalidates
+    // the token — the confirmed set and the granted set must not diverge.
+    await fetch(`${base}/hub/pairing/requests/${requestId}/access`, {
+      method: 'PATCH',
+      headers: operatorHeaders('operator-a'),
+      body: JSON.stringify({
+        requestedCapabilities: ['rpc:fs:write', 'pty:exec:arbitrary'],
+      }),
+    });
+    const replay = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/approve`,
+      {
+        method: 'POST',
+        headers: operatorHeaders('operator-a'),
+        body: JSON.stringify({ confirmationToken: confirmToken.confirmationToken }),
+      }
+    );
+    expect(replay.status).not.toBe(200);
+    const stillPending = await fetch(
+      `${base}/hub/pairing/requests/${requestId}`,
+      { headers: operatorHeaders() }
+    );
+    expect((await stillPending.json()).request.state).toBe('pending');
+  });
+
+  it('refuses to approve an expired request', async () => {
+    const { base, clock } = await setup();
+    // The node does not control its own request TTL; advance past the default
+    // 10-minute pending window to drive expiry.
+    const { json } = await submitRequest(base);
+    clock.ms = NOW_MS + 11 * 60 * 1000;
+    const res = await fetch(
+      `${base}/hub/pairing/requests/${json.request.requestId}/approve`,
+      { method: 'POST', headers: operatorHeaders() }
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('TOKEN_EXPIRED');
+  });
+
+  it('returns NOT_FOUND for an unknown request id', async () => {
+    const { base } = await setup();
+    const res = await fetch(`${base}/hub/pairing/requests/ppreq_missing`, {
+      headers: operatorHeaders(),
+    });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.details.reasonCode).toBe(
+      'PENDING_PAIRING_NOT_FOUND'
+    );
+  });
+});

--- a/test/hub-node-pairing-routes.test.ts
+++ b/test/hub-node-pairing-routes.test.ts
@@ -357,6 +357,55 @@ describe('hub node pending pairing routes (#982)', () => {
     expect((await stillPending.json()).request.state).toBe('pending');
   });
 
+  it('binds the confirmation token to the roots set; a widened roots edit invalidates it', async () => {
+    const { base } = await setup();
+    const { json } = await submitRequest(base, {
+      requestedProfile: 'infra-prod-host',
+      requestedRoots: ['~/code'],
+    });
+    const requestId = json.request.requestId;
+
+    const challenge = (
+      await fetch(`${base}/hub/pairing/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: operatorHeaders('operator-a'),
+      }).then((r) => r.json())
+    ).error.details.challenge;
+
+    const confirmationToken = (
+      await fetch(`${base}/hub/confirmations/${challenge.challengeId}/approve`, {
+        method: 'POST',
+        headers: operatorHeaders('operator-b'),
+        body: JSON.stringify({ decision: 'approve' }),
+      }).then((r) => r.json())
+    ).confirmationToken as string;
+
+    // Widen the approved roots after the token was minted.
+    await fetch(`${base}/hub/pairing/requests/${requestId}/access`, {
+      method: 'PATCH',
+      headers: operatorHeaders('operator-a'),
+      body: JSON.stringify({ requestedRoots: ['~/code', '/'] }),
+    });
+
+    const replay = await fetch(
+      `${base}/hub/pairing/requests/${requestId}/approve`,
+      {
+        method: 'POST',
+        headers: operatorHeaders('operator-a'),
+        body: JSON.stringify({
+          requestedRoots: ['~/code', '/'],
+          confirmationToken,
+        }),
+      }
+    );
+    expect(replay.status).not.toBe(200);
+    const stillPending = await fetch(
+      `${base}/hub/pairing/requests/${requestId}`,
+      { headers: operatorHeaders() }
+    );
+    expect((await stillPending.json()).request.state).toBe('pending');
+  });
+
   it('refuses to approve an expired request', async () => {
     const { base, clock } = await setup();
     // The node does not control its own request TTL; advance past the default

--- a/test/node-bootstrap-cli.test.ts
+++ b/test/node-bootstrap-cli.test.ts
@@ -475,9 +475,9 @@ describe('secret redaction in node bootstrap CLI output', () => {
     const raw = [
       'status pstat_STATUS123',
       'clone https://token-only-value@hub.example.com/repo.git',
-      'Cookie: sid=cookie-secret; prefs=abc',
       'FAKE_TOKEN_FIELD=fake-token-value',
       'path /Users/donovan/private/project /home/donovan/.ssh/id_ed25519',
+      'Cookie: sid=cookie-secret; prefs=abc',
     ].join(' ');
     const redacted = redactBootstrapSecrets(raw);
 

--- a/test/node-bootstrap-cli.test.ts
+++ b/test/node-bootstrap-cli.test.ts
@@ -471,6 +471,24 @@ describe('secret redaction in node bootstrap CLI output', () => {
     expect(redacted).not.toContain('secret_abcdefg');
   });
 
+  it('redacts free-text privacy and credential leak classes', () => {
+    const raw = [
+      'status pstat_STATUS123',
+      'clone https://token-only-value@hub.example.com/repo.git',
+      'Cookie: sid=cookie-secret; prefs=abc',
+      'FAKE_TOKEN_FIELD=fake-token-value',
+      'path /Users/donovan/private/project /home/donovan/.ssh/id_ed25519',
+    ].join(' ');
+    const redacted = redactBootstrapSecrets(raw);
+
+    expect(redacted).not.toContain('pstat_STATUS123');
+    expect(redacted).not.toContain('token-only-value');
+    expect(redacted).not.toContain('cookie-secret');
+    expect(redacted).not.toContain('fake-token-value');
+    expect(redacted).not.toContain('/Users/donovan/private/project');
+    expect(redacted).not.toContain('/home/donovan/.ssh/id_ed25519');
+  });
+
   it('keeps non-sensitive content intact', () => {
     const raw = 'relay-ide node doctor --hub https://hub.example.com';
     const redacted = redactBootstrapSecrets(raw);


### PR DESCRIPTION
## Summary

Implements the hub-side **pending node pairing request lifecycle** for epic #979 (builds on #980 UX spec and #981 key-bound identity, both on nightly). A node-initiated pairing request lives on the hub as a durable `pending` record until an authenticated operator **approves**, **denies**, or **edits access**, or it **expires**. This is the foundation backend/API slice only — no Settings UI and no node CLI device-code client (later issues).

Foundation-first: extends the existing `HubNodeRegistry`/`hub-node-router` patterns rather than inventing a parallel subsystem; the existing operator-mints-a-pair-token flow (`/hub/pair-tokens` → `/hub/pairing/exchange`) is preserved unchanged.

## API / security model

**New shared contracts** — `shared/node-pairing-requests.ts`: `NodePairingRequestState` (`pending|approved|denied|expired`), `NodePairingTrustProfile` → `RelayTrustTier` mapping, high-risk classification, product-language capability posture, device-code normalization, and the redaction-safe `NodePairingRequestSummary`. Shaped to project onto a later stable `nodes.pair.*` gateway/action command family (final ids land with #985/#986).

**Endpoints** (`server/hub-node-router.ts`):

| Lane | Endpoint | Notes |
| --- | --- | --- |
| Node (unauth) | `POST /hub/pairing/requests` | Submit manifest + optional `publicKey`/`displayName`/`requestedProfile`/`requestedCapabilities`/`requestedRoots`. Returns the summary, a device code, and a one-time `statusToken`. |
| Node (status token) | `POST /hub/pairing/requests/:id/status` | Poll status; returns the issued key-bound credential **exactly once** after approval. |
| Operator (`requireAuth`) | `GET /hub/pairing/requests` | List; `?deviceCode=` locates (case-insensitive, dash-tolerant), `?state=`/`?includeResolved=`. |
| Operator | `GET /hub/pairing/requests/:id` | Inspect. |
| Operator | `PATCH /hub/pairing/requests/:id/access` | Edit display name / profile / capabilities / roots before approval (not a re-approval). |
| Operator | `POST /hub/pairing/requests/:id/approve` | Approve; high-risk → `409 CONFIRMATION_REQUIRED`. |
| Operator | `POST /hub/pairing/requests/:id/deny` | Deny. |

**Storage** (`server/hub-node-registry.ts`): a new durable `pendingPairings[]` array on the existing JSON registry file (array-default migration; schema stays v1; atomic `0600` write). Records hold only the manifest-derived fields approval and node-record creation need — never the raw manifest, a repo/path inventory, the node credential, or the node's poll secret (only `sha256(statusToken)` is persisted). Lazy expiry on every read/mutation; concurrent-pending cap + resolved-record retention prune bound file growth.

**Security properties**
- **Device code locates only** — it never authorizes a node; only the hashed, constant-time-compared `statusToken` authorizes the credential claim.
- **No replay** — `pending` is the only approvable state; `denied`/`expired` are terminal and can never become `approved` or yield a credential. The credential is delivered to the waiting node exactly once (`credentialDeliveredAt` guard).
- **Issue-on-claim** — approval authorizes issuance, but the raw key-bound credential is minted and returned only to the waiting node on its authenticated status poll, so it never appears in operator responses, lists, logs, or audit.
- **High-risk gate** — prod-profile or elevated-capability approvals route through the existing exact-operation/high-risk confirmation contract (`ConfirmationChallengeStore` via `resolveConfirmationForDecision`). The confirmation challenge names the real high-risk bits and the token is bound to the effective capability grant (requestId + profile + tier + fingerprint + sorted capability bits), so a grant widened by a `PATCH /access` between mint and redeem cannot reuse the token.
- **Redaction** — summaries/JSON/audit carry only safe handles (`nkey_…` fingerprint, `sourceFingerprint`, lossy `displayHint`, lifecycle state/reason code, product-language posture, display name, timestamps). Never the status token, raw credential, raw hostname/MagicDNS/tailnet IP, PEM, raw capability bits, or path inventory. Asserted by tests.

## Tests run (exact commands)

`PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH` for all:
- `npx vitest run test/hub-node-pairing-requests.test.ts test/hub-node-pairing-routes.test.ts` → 22 pass (lifecycle, key-bound issue-on-claim, deny/expiry replay protection, device-code lookup, edit access, high-risk confirmation flow incl. capability-binding divergence, redaction assertions on persisted file/summaries/audit).
- `npx vitest run test/hub-node-registry.test.ts test/hub-node-routes.test.ts test/node-link-proof.test.ts test/node-bootstrap-docs.test.ts test/cli-gateway-contract.test.ts test/security-policy.test.ts test/security-audit.test.ts test/operator-handshake-grants.test.ts` → all pass (no regressions).
- `npm run check` → 0 errors (tsc server + frontend + test typecheck + eslint; only pre-existing repo-wide `no-duplicate-string` warnings).
- `npm run build:server` → clean.

An adversarial multi-agent security/redaction/correctness review was run; all confirmed findings were fixed (capability-set binding of the confirmation token, challenge-card bit naming, resolved-record retention prune, `relayVersion` fallback).

## Decisions
- **Issue-on-claim, not issue-on-approve.** The only way to deliver the raw credential to the waiting node without exposing it on the operator surface is to mint it during a node-facing call. Approval records the authorized decision; the node's authenticated status poll mints + delivers the key-bound credential once.
- **Node does not control its own request TTL** (default 10 min, matching the pair-token/device-code window); the submit lane ignores body `ttlMs`.
- **High-risk = prod profile OR elevated capability** beyond the standard baseline (the elevated set excludes legacy-default bits like `session:control:kill`, so a plain dev-workstation request stays standard-approval).
- Gateway/action descriptors are intentionally **not** registered here — the API shape is descriptor-compatible, but registering the `nodes.pair.*` command family pulls in the CLI client + Command Center projection, which are later issues.

## Risks / follow-ups
- Settings → Nodes UI and the node CLI device-code client (consume this API) — later #979 children.
- Register the stable `nodes.pair.*` gateway/action/Command-Center command family (#985/#986).
- Pre-existing latent gap (noted, not changed here to preserve behavior): `exchangePairToken` stores `relayVersion` without a `helperVersion` fallback; the new submit path adds the fallback. Worth unifying the two node-creation paths in a follow-up.
- Full Kame QA for #979 is intentionally deferred until #982–#987 ship (per epic plan); not claimed here.

Refs #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added node-initiated pending pairing requests with status-token polling (no pre-existing pairing token required).
  * Introduced operator endpoints to list, look up by device code, edit requested access, and approve/deny pending requests.
  * Implemented higher-risk (prod) approvals with exact-operation confirmation and bound/evolving confirmation checks.

* **Documentation**
  * Documented the node-initiated pending pairing request lifecycle, approval/deny process, redaction rules, and expiry/terminal-state behavior.

* **Tests**
  * Added end-to-end route and lifecycle tests covering approvals, polling, expiry, redaction, confirmation gating, and durability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #982
