### PR TITLE
CLI: add device-code node pairing client

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ Commands:
     status                             Show local node/service status
     logs [--lines <n>] [--follow]      Print or follow local node log files
     doctor [--hub <url>] [--json]      Diagnose local node health and hub reachability; surfaces all degraded reasons
+    pair <hub> [--json]               Request a device code, wait for operator approval, store the credential, and send one heartbeat
     pair --hub <url> --pair-token <token>
-                                       Exchange a pair token with a hub and send one heartbeat (pair-only, no service)
+                                       Legacy automation path: exchange a pair token with a hub and send one heartbeat
     mint-pair-token --hub <url> --operator-grant <handle> [--display-name <name>] [--platform <name>] [--task-ref <ref>] [--json]
                                        Mint a short-lived node pair token through the scoped operator-grant lane
     install --hub <url> [--service auto|manual|launchd|systemd-user|wsl-systemd|wsl-manual]
@@ -174,11 +175,11 @@ Bare `relay-ide` and `relay-ide hub` run the hub web server. A node can pair wit
 ```bash
 relay-ide manifest
 relay-ide node doctor --hub http://hub.example:3456
-relay-ide node pair --hub http://hub.example:3456 --pair-token <token>
+relay-ide node pair http://hub.example:3456
 relay-ide node link --hub http://hub.example:3456
 ```
 
-`relay-ide node pair` exchanges a pair token and sends one heartbeat (pair-only, no service); `relay-ide node connect` is a back-compat alias for `pair`. `relay-ide node install` installs relay-ide globally and optionally sets up the local service (no pairing). Bootstrap diagnostics exist for pairing and local capability checks; do not assume every planned remote file/log capability is shipped unless the relevant doc and tests say so.
+`relay-ide node pair <hub>` is the interactive device-code flow and sends one heartbeat after approval (pair-only, no service). `relay-ide node pair --hub <url> --pair-token <token>` and `relay-ide node connect` remain legacy/automation paths. `relay-ide node install` installs relay-ide globally and optionally sets up the local service (no pairing). Bootstrap diagnostics exist for pairing and local capability checks; do not assume every planned remote file/log capability is shipped unless the relevant doc and tests say so.
 
 ## Features
 

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -53,6 +53,12 @@ import {
   type NodeLinkProofAudience,
 } from '../shared/node-identity-keys.js';
 import {
+  DEFAULT_NODE_PAIRING_TRUST_PROFILE,
+  isNodePairingTrustProfile,
+  type NodePairingRequestSummary,
+  type NodePairingTrustProfile,
+} from '../shared/node-pairing-requests.js';
+import {
   EVENTS_SUBSCRIBE_TOPICS,
   EVENTS_SUBSCRIBE_TOPIC_CAPABILITIES,
   RELAY_CLI_GATEWAY_CONTRACT,
@@ -158,8 +164,9 @@ Commands:
     status                             Show local node/service status
     logs [--lines <n>] [--follow]      Print or follow local node log files
     doctor [--hub <url>] [--json]      Diagnose local node health and hub reachability; surfaces all degraded reasons
+    pair <hub> [--json]                 Create a device-code pairing request and wait for approval (pair-only)
     pair --hub <url> --pair-token <token>
-                                       Exchange a pair token with a hub and send one heartbeat (pair-only, no service)
+                                       Legacy/automation pair-token exchange; sends one heartbeat (pair-only)
     mint-pair-token --hub <url> --operator-grant <handle> [--display-name <name>] [--platform <name>] [--task-ref <ref>] [--json]
                                        Mint a short-lived node pair token through the scoped operator-grant lane
     install --hub <url> [--service auto|manual|launchd|systemd-user|wsl-systemd|wsl-manual]
@@ -7079,6 +7086,380 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
 
 type NodePairLifecycle = 'connect' | 'install';
 
+type NodeCredentialForPairing = {
+  token: string;
+  nodeId: string;
+  credentialId?: string;
+  publicKeyFingerprint?: string;
+};
+
+type PendingPairingSubmitResponse = {
+  request?: NodePairingRequestSummary;
+  statusToken?: string;
+  error?: { code?: string; message?: string };
+};
+
+type PendingPairingPollResponse = {
+  request?: NodePairingRequestSummary;
+  credential?: NodeCredentialForPairing;
+  node?: { displayName?: string };
+  error?: { code?: string; message?: string; reasonCode?: string };
+};
+
+function nodePairHubUrl(nodeArgs: string[]): string | undefined {
+  const explicit = getNodeArg(nodeArgs, '--hub');
+  if (explicit) return explicit;
+  const pairIndex = nodeArgs.indexOf('pair');
+  const candidate = pairIndex >= 0 ? nodeArgs[pairIndex + 1] : undefined;
+  return candidate && !candidate.startsWith('-') ? candidate : undefined;
+}
+
+function nodePairDisplayName(nodeArgs: string[], manifest: NodeManifest): string {
+  return (
+    getNodeArg(nodeArgs, '--display-name') ??
+    process.env['RELAY_IDE_NODE_DISPLAY_NAME'] ??
+    manifest.hostname ??
+    'relay-node'
+  ).trim();
+}
+
+function nodePairRequestedProfile(nodeArgs: string[]): NodePairingTrustProfile {
+  const raw = getNodeArg(nodeArgs, '--profile') ?? getNodeArg(nodeArgs, '--trust-profile');
+  if (!raw) return DEFAULT_NODE_PAIRING_TRUST_PROFILE;
+  if (isNodePairingTrustProfile(raw)) return raw;
+  logger.error(
+    `Invalid --profile ${raw}. Expected one of: dev-workstation, sandbox-runner, automation-runner, infra-prod-host`
+  );
+  process.exit(1);
+}
+
+function repeatedNodeArg(nodeArgs: string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < nodeArgs.length; i += 1) {
+    if (nodeArgs[i] !== flag) continue;
+    const value = nodeArgs[i + 1];
+    if (value && !value.startsWith('-')) values.push(value);
+  }
+  return values;
+}
+
+function nodePairRequestedRoots(nodeArgs: string[]): string[] | undefined {
+  const raw = [
+    ...repeatedNodeArg(nodeArgs, '--root'),
+    ...repeatedNodeArg(nodeArgs, '--requested-root'),
+  ];
+  const roots = raw
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return roots.length ? roots : undefined;
+}
+
+function nodePairPollIntervalMs(nodeArgs: string[]): number {
+  const raw =
+    getNodeArg(nodeArgs, '--poll-interval-ms') ??
+    process.env['RELAY_IDE_NODE_PAIR_POLL_INTERVAL_MS'];
+  if (!raw) return 2_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 100) return 2_000;
+  return Math.min(parsed, 30_000);
+}
+
+function redactHostHint(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const suffix = trimmed.slice(-16);
+  return suffix.length < trimmed.length ? `…${suffix}` : suffix;
+}
+
+function secondsUntil(iso: string, now = Date.now()): number {
+  const ms = Date.parse(iso) - now;
+  return Number.isFinite(ms) ? Math.max(0, Math.ceil(ms / 1000)) : 0;
+}
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function safeJsonLine(value: unknown): void {
+  console.log(redactNodeDiagnostics(JSON.stringify(value)));
+}
+
+async function readJsonResponse<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  if (!text) return {} as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return { error: { code: 'MALFORMED_RESPONSE', message: text } } as T;
+  }
+}
+
+function validateNodeCredentialForPairing(
+  credential: unknown
+): NodeCredentialForPairing | null {
+  if (typeof credential !== 'object' || credential === null) return null;
+  const record = credential as Record<string, unknown>;
+  if (typeof record['token'] !== 'string' || !record['token']) return null;
+  if (typeof record['nodeId'] !== 'string' || !record['nodeId']) return null;
+  return {
+    token: record['token'],
+    nodeId: record['nodeId'],
+    ...(typeof record['credentialId'] === 'string' && record['credentialId']
+      ? { credentialId: record['credentialId'] }
+      : {}),
+    ...(typeof record['publicKeyFingerprint'] === 'string' &&
+    record['publicKeyFingerprint']
+      ? { publicKeyFingerprint: record['publicKeyFingerprint'] }
+      : {}),
+  };
+}
+
+async function sendInitialNodeHeartbeat(
+  hubUrl: string,
+  credential: NodeCredentialForPairing,
+  manifest: NodeManifest
+): Promise<void> {
+  const bootstrapProof = credential.publicKeyFingerprint
+    ? nodeLinkProofFactory(
+        credential.nodeId,
+        credential.credentialId,
+        'relay:node-heartbeat:v1'
+      )()
+    : undefined;
+  const heartbeatRes = await fetch(nodeEndpoint(hubUrl, '/hub/node-heartbeat'), {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${credential.token}`,
+      ...(bootstrapProof ? { 'x-relay-node-proof': bootstrapProof } : {}),
+    },
+    body: JSON.stringify({
+      nodeId: credential.nodeId,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      manifest,
+    }),
+  });
+  if (!heartbeatRes.ok) {
+    const body = await heartbeatRes.text();
+    throw new Error(`heartbeat rejected: ${body}`);
+  }
+}
+
+function renderNodePairRequest(input: {
+  request: NodePairingRequestSummary;
+  hubUrl: string;
+  manifest: NodeManifest;
+  outputJson: boolean;
+}): void {
+  const { request, hubUrl, manifest, outputJson } = input;
+  const pairUrl = new URL(
+    `/pair/${encodeURIComponent(request.deviceCode)}`,
+    hubUrl
+  ).toString();
+  const expiresSeconds = secondsUntil(request.expiresAt);
+  if (outputJson) {
+    safeJsonLine({
+      ok: true,
+      event: 'pairing-requested',
+      requestId: request.requestId,
+      deviceCode: request.deviceCode,
+      pairUrl,
+      expiresAt: request.expiresAt,
+      requestedProfile: request.requestedProfile,
+      publicKeyFingerprint: request.publicKeyFingerprint,
+    });
+    return;
+  }
+  logger.info('relay node pairing');
+  logger.info('');
+  logger.info(`device: ${request.displayName}`);
+  const hostHint = redactHostHint(manifest.hostname);
+  if (hostHint) logger.info(`host hint: ${hostHint}`);
+  logger.info(`platform: ${manifest.platform} ${manifest.arch}`);
+  logger.info(`relay: ${manifest.relayVersion ?? manifest.helperVersion}`);
+  logger.info('');
+  logger.info('open this URL on a signed-in device:');
+  logger.info(pairUrl);
+  logger.info('');
+  logger.info('or enter code:');
+  logger.info(request.deviceCode);
+  logger.info('');
+  logger.info(`waiting for approval... expires in ${formatCountdown(expiresSeconds)}`);
+}
+
+function exitNodePairError(input: {
+  code: string;
+  message: string;
+  outputJson: boolean;
+  retryable?: boolean;
+}): never {
+  const { code, message, outputJson, retryable } = input;
+  if (outputJson) safeJsonLine({ ok: false, code, message, retryable });
+  else logger.error(redactNodeDiagnostics(`${code}: ${message}`));
+  process.exit(1);
+}
+
+function exitNodePairDenied(hubUrl: string, outputJson: boolean): never {
+  if (outputJson) safeJsonLine({ ok: false, code: 'PAIRING_DENIED' });
+  else {
+    logger.error('pairing denied by operator');
+    logger.error('no credential was issued');
+    logger.error(`run \`relay-ide node pair ${hubUrl}\` again to request a new code`);
+  }
+  process.exit(1);
+}
+
+function exitNodePairExpired(outputJson: boolean): never {
+  if (outputJson) safeJsonLine({ ok: false, code: 'PAIRING_EXPIRED' });
+  else {
+    logger.error('pairing request expired (no approval within 10:00)');
+    logger.error('run `relay-ide node pair <hub>` again to get a fresh code');
+  }
+  process.exit(1);
+}
+
+async function finishApprovedDevicePairing(input: {
+  hubUrl: string;
+  manifest: NodeManifest;
+  poll: PendingPairingPollResponse;
+  outputJson: boolean;
+}): Promise<boolean> {
+  const { hubUrl, manifest, poll, outputJson } = input;
+  const credential = validateNodeCredentialForPairing(poll.credential);
+  if (!credential || !poll.request) return false;
+  writeNodeCredential(credential);
+  await sendInitialNodeHeartbeat(hubUrl, credential, manifest);
+  const approvedName = poll.node?.displayName ?? poll.request.displayName;
+  if (outputJson) {
+    safeJsonLine({
+      ok: true,
+      event: 'paired',
+      nodeId: credential.nodeId,
+      credentialId: credential.credentialId,
+      displayName: approvedName,
+      linkCommand: `relay-ide node link --hub ${hubUrl}`,
+    });
+    return true;
+  }
+  logger.info(`approved as ${approvedName}`);
+  logger.info('credential stored');
+  logger.info('node is paired but the link is not running');
+  logger.info(`start it with: relay-ide node link --hub ${hubUrl}`);
+  return true;
+}
+
+async function runNodeDeviceCodePair(nodeArgs: string[]): Promise<void> {
+  const hubUrl = nodePairHubUrl(nodeArgs);
+  const outputJson = nodeArgs.includes('--json');
+  if (!hubUrl) {
+    logger.error('Usage: relay-ide node pair <hub> [--json]');
+    logger.error(
+      'Legacy automation path: relay-ide node pair --hub <url> --pair-token <token>'
+    );
+    process.exit(1);
+  }
+  try {
+    new URL(hubUrl);
+  } catch {
+    logger.error(`invalid hub url: ${hubUrl}`);
+    process.exit(1);
+  }
+
+  const manifest = await getNodeManifest();
+  const identityKey = loadOrCreateNodeIdentityKey();
+  const displayName = nodePairDisplayName(nodeArgs, manifest);
+  const requestedProfile = nodePairRequestedProfile(nodeArgs);
+  const requestedRoots = nodePairRequestedRoots(nodeArgs);
+  const submitRes = await fetch(nodeEndpoint(hubUrl, '/hub/pairing/requests'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      manifest,
+      publicKey: identityKey.publicKeyPem,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      displayName,
+      requestedProfile,
+      ...(requestedRoots ? { requestedRoots } : {}),
+    }),
+  });
+  const submit = await readJsonResponse<PendingPairingSubmitResponse>(submitRes);
+  if (!submitRes.ok || !submit.request || !submit.statusToken) {
+    exitNodePairError({
+      code: submit.error?.code ?? 'PAIRING_REQUEST_FAILED',
+      message: submit.error?.message ?? 'hub did not accept pairing request',
+      outputJson,
+      retryable: true,
+    });
+  }
+
+  const request = submit.request;
+  renderNodePairRequest({ request, hubUrl, manifest, outputJson });
+
+  let interrupted = false;
+  const markInterrupted = (): void => {
+    interrupted = true;
+  };
+  process.once('SIGINT', markInterrupted);
+  process.once('SIGTERM', markInterrupted);
+  const pollIntervalMs = nodePairPollIntervalMs(nodeArgs);
+  try {
+    while (true) {
+      if (interrupted) {
+        if (outputJson) safeJsonLine({ ok: false, code: 'INTERRUPTED' });
+        else logger.error('pairing interrupted; no credential was issued');
+        process.exit(130);
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      const pollRes = await fetch(
+        nodeEndpoint(hubUrl, `/hub/pairing/requests/${request.requestId}/status`),
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-relay-pairing-status-token': submit.statusToken,
+          },
+          body: JSON.stringify({}),
+        }
+      );
+      const poll = await readJsonResponse<PendingPairingPollResponse>(pollRes);
+      if (!pollRes.ok || !poll.request) {
+        exitNodePairError({
+          code: poll.error?.code ?? 'PAIRING_STATUS_FAILED',
+          message: poll.error?.message ?? 'hub status poll failed',
+          outputJson,
+          retryable: true,
+        });
+      }
+      if (poll.request.state === 'pending') continue;
+      if (poll.request.state === 'denied') exitNodePairDenied(hubUrl, outputJson);
+      if (poll.request.state === 'expired') exitNodePairExpired(outputJson);
+      if (
+        poll.request.state === 'approved' &&
+        (await finishApprovedDevicePairing({
+          hubUrl,
+          manifest,
+          poll,
+          outputJson,
+        }))
+      ) {
+        return;
+      }
+      if (poll.request.state === 'approved') continue;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (outputJson) safeJsonLine({ ok: false, code: 'NODE_PAIR_FAILED', message });
+    else logger.error(redactNodeDiagnostics(`NODE_PAIR_FAILED: ${message}`));
+    process.exit(1);
+  } finally {
+    process.off('SIGINT', markInterrupted);
+    process.off('SIGTERM', markInterrupted);
+  }
+}
+
 async function pairNode(
   nodeArgs: string[],
   lifecycle: NodePairLifecycle = 'connect'
@@ -7273,27 +7654,11 @@ if (command === 'node') {
   }
   if (subCommand === 'pair') {
     const pairToken = getNodeArg(nodeArgs, '--pair-token');
-    const hubUrl = getNodeArg(nodeArgs, '--hub');
-    if (!hubUrl) {
-      logger.error(
-        'Usage: relay-ide node pair --hub <url> --pair-token <token>'
-      );
-      logger.error(
-        'Get a pair token from your hub with an approved operator grant: relay-ide node mint-pair-token --hub <url> --operator-grant <relay-ohg-v1...>'
-      );
-      process.exit(1);
+    if (pairToken) {
+      await pairNode(nodeArgs, 'connect');
+    } else {
+      await runNodeDeviceCodePair(nodeArgs);
     }
-    if (!pairToken) {
-      logger.info(`to get a pair token from your hub, run:`);
-      logger.info(
-        `  relay-ide node mint-pair-token --hub ${hubUrl} --operator-grant <relay-ohg-v1...> --display-name <name> --ttl-seconds 600`
-      );
-      logger.info(
-        `then re-run: relay-ide node pair --hub ${hubUrl} --pair-token <token>`
-      );
-      process.exit(1);
-    }
-    await pairNode(nodeArgs, 'connect');
     process.exit(0);
   }
   // relay-ide node ssh-bootstrap --target <host> --hub <url>

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -6348,6 +6348,83 @@ function nodeEndpoint(hubUrl: string, pathname: string): string {
   return new URL(pathname, hubUrl).toString();
 }
 
+const NODE_PAIR_FETCH_TIMEOUT_MS = 15_000;
+
+const SENSITIVE_URL_QUERY_KEY =
+  /(?:token|secret|credential|password|passwd|auth|authorization|key|code|grant|cookie|session|pin)/i;
+
+function sanitizeHubUrlForDisplay(rawHubUrl: string): string {
+  try {
+    const url = new URL(rawHubUrl);
+    url.username = '';
+    url.password = '';
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (SENSITIVE_URL_QUERY_KEY.test(key)) {
+        url.searchParams.set(key, '…redacted');
+      }
+    }
+    return url.toString();
+  } catch {
+    return '<invalid hub url>';
+  }
+}
+
+function parseNodePairHubUrl(rawHubUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawHubUrl);
+  } catch {
+    logger.error('INVALID_HUB_URL: hub URL must be an absolute http(s) URL');
+    process.exit(1);
+  }
+  if (url.username || url.password) {
+    logger.error(
+      `INVALID_HUB_URL: hub URL must not contain embedded credentials (${sanitizeHubUrlForDisplay(rawHubUrl)})`
+    );
+    process.exit(1);
+  }
+  return url.toString();
+}
+
+function sanitizeNodePairTextForDisplay(text: string): string {
+  return redactNodeDiagnostics(text).replace(/[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi, (url) =>
+    sanitizeHubUrlForDisplay(url)
+  );
+}
+
+function abortError(): Error {
+  return new Error('operation aborted');
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(abortError());
+  return new Promise((resolve, reject) => {
+    const timerRef: { current?: ReturnType<typeof setTimeout> } = {};
+    const cleanup = (): void => signal.removeEventListener('abort', abort);
+    const finish = (): void => {
+      cleanup();
+      resolve();
+    };
+    const abort = (): void => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      cleanup();
+      reject(abortError());
+    };
+    timerRef.current = setTimeout(finish, ms);
+    signal.addEventListener('abort', abort, { once: true });
+  });
+}
+
+async function nodePairFetch(
+  url: string,
+  init: RequestInit,
+  signal: AbortSignal
+): Promise<Response> {
+  const timeout = AbortSignal.timeout(NODE_PAIR_FETCH_TIMEOUT_MS);
+  const combinedSignal = AbortSignal.any([signal, timeout]);
+  return fetch(url, { ...init, signal: combinedSignal });
+}
+
 type RequestedNodeServiceMode =
   | 'auto'
   | 'manual'
@@ -7297,8 +7374,9 @@ function exitNodePairError(input: {
   retryable?: boolean;
 }): never {
   const { code, message, outputJson, retryable } = input;
-  if (outputJson) safeJsonLine({ ok: false, code, message, retryable });
-  else logger.error(redactNodeDiagnostics(`${code}: ${message}`));
+  const safeMessage = sanitizeNodePairTextForDisplay(message);
+  if (outputJson) safeJsonLine({ ok: false, code, message: safeMessage, retryable });
+  else logger.error(sanitizeNodePairTextForDisplay(`${code}: ${message}`));
   process.exit(1);
 }
 
@@ -7307,7 +7385,9 @@ function exitNodePairDenied(hubUrl: string, outputJson: boolean): never {
   else {
     logger.error('pairing denied by operator');
     logger.error('no credential was issued');
-    logger.error(`run \`relay-ide node pair ${hubUrl}\` again to request a new code`);
+    logger.error(
+      `run \`relay-ide node pair ${sanitizeHubUrlForDisplay(hubUrl)}\` again to request a new code`
+    );
   }
   process.exit(1);
 }
@@ -7323,13 +7403,21 @@ function exitNodePairExpired(outputJson: boolean): never {
 
 async function finishApprovedDevicePairing(input: {
   hubUrl: string;
+  displayHubUrl: string;
   manifest: NodeManifest;
   poll: PendingPairingPollResponse;
   outputJson: boolean;
-}): Promise<boolean> {
-  const { hubUrl, manifest, poll, outputJson } = input;
+}): Promise<void> {
+  const { hubUrl, displayHubUrl, manifest, poll, outputJson } = input;
   const credential = validateNodeCredentialForPairing(poll.credential);
-  if (!credential || !poll.request) return false;
+  if (!credential || !poll.request) {
+    exitNodePairError({
+      code: 'PAIRING_PROTOCOL_ERROR',
+      message: 'hub approved pairing without a valid node credential',
+      outputJson,
+      retryable: false,
+    });
+  }
   writeNodeCredential(credential);
   await sendInitialNodeHeartbeat(hubUrl, credential, manifest);
   const approvedName = poll.node?.displayName ?? poll.request.displayName;
@@ -7340,119 +7428,170 @@ async function finishApprovedDevicePairing(input: {
       nodeId: credential.nodeId,
       credentialId: credential.credentialId,
       displayName: approvedName,
-      linkCommand: `relay-ide node link --hub ${hubUrl}`,
+      linkCommand: `relay-ide node link --hub ${displayHubUrl}`,
     });
-    return true;
+    return;
   }
   logger.info(`approved as ${approvedName}`);
   logger.info('credential stored');
   logger.info('node is paired but the link is not running');
-  logger.info(`start it with: relay-ide node link --hub ${hubUrl}`);
-  return true;
+  logger.info(`start it with: relay-ide node link --hub ${displayHubUrl}`);
+}
+
+function isRetryableNodePairStatusResponse(response: Response): boolean {
+  return response.status === 408 || response.status === 429 || response.status >= 500;
+}
+
+async function requestNodeDevicePairingStatus(input: {
+  hubUrl: string;
+  requestId: string;
+  statusToken: string;
+  signal: AbortSignal;
+}): Promise<{ response: Response; poll: PendingPairingPollResponse } | null> {
+  const { hubUrl, requestId, statusToken, signal } = input;
+  try {
+    const response = await nodePairFetch(
+      nodeEndpoint(hubUrl, `/hub/pairing/requests/${requestId}/status`),
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-relay-pairing-status-token': statusToken,
+        },
+        body: JSON.stringify({}),
+      },
+      signal
+    );
+    return { response, poll: await readJsonResponse<PendingPairingPollResponse>(response) };
+  } catch (error) {
+    if (signal.aborted) throw error;
+    return null;
+  }
+}
+
+async function handleNodeDevicePairingStatus(input: {
+  hubUrl: string;
+  displayHubUrl: string;
+  manifest: NodeManifest;
+  response: Response;
+  poll: PendingPairingPollResponse;
+  outputJson: boolean;
+}): Promise<'pending' | 'done'> {
+  const { hubUrl, displayHubUrl, manifest, response, poll, outputJson } = input;
+  if (!response.ok) {
+    if (isRetryableNodePairStatusResponse(response)) return 'pending';
+    exitNodePairError({
+      code: poll.error?.code ?? 'PAIRING_STATUS_FAILED',
+      message: poll.error?.message ?? 'hub status poll failed',
+      outputJson,
+      retryable: true,
+    });
+  }
+  if (!poll.request) {
+    exitNodePairError({
+      code: poll.error?.code ?? 'PAIRING_PROTOCOL_ERROR',
+      message: poll.error?.message ?? 'hub returned malformed pairing status',
+      outputJson,
+      retryable: false,
+    });
+  }
+  if (poll.request.state === 'pending') return 'pending';
+  if (poll.request.state === 'denied') exitNodePairDenied(displayHubUrl, outputJson);
+  if (poll.request.state === 'expired') exitNodePairExpired(outputJson);
+  if (poll.request.state === 'approved') {
+    await finishApprovedDevicePairing({ hubUrl, displayHubUrl, manifest, poll, outputJson });
+    return 'done';
+  }
+  exitNodePairError({
+    code: 'PAIRING_PROTOCOL_ERROR',
+    message: 'hub returned unknown pairing status state',
+    outputJson,
+    retryable: false,
+  });
 }
 
 async function runNodeDeviceCodePair(nodeArgs: string[]): Promise<void> {
-  const hubUrl = nodePairHubUrl(nodeArgs);
+  const rawHubUrl = nodePairHubUrl(nodeArgs);
   const outputJson = nodeArgs.includes('--json');
-  if (!hubUrl) {
+  if (!rawHubUrl) {
     logger.error('Usage: relay-ide node pair <hub> [--json]');
     logger.error(
       'Legacy automation path: relay-ide node pair --hub <url> --pair-token <token>'
     );
     process.exit(1);
   }
-  try {
-    new URL(hubUrl);
-  } catch {
-    logger.error(`invalid hub url: ${hubUrl}`);
-    process.exit(1);
-  }
-
-  const manifest = await getNodeManifest();
-  const identityKey = loadOrCreateNodeIdentityKey();
-  const displayName = nodePairDisplayName(nodeArgs, manifest);
-  const requestedProfile = nodePairRequestedProfile(nodeArgs);
-  const requestedRoots = nodePairRequestedRoots(nodeArgs);
-  const submitRes = await fetch(nodeEndpoint(hubUrl, '/hub/pairing/requests'), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      manifest,
-      publicKey: identityKey.publicKeyPem,
-      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
-      displayName,
-      requestedProfile,
-      ...(requestedRoots ? { requestedRoots } : {}),
-    }),
-  });
-  const submit = await readJsonResponse<PendingPairingSubmitResponse>(submitRes);
-  if (!submitRes.ok || !submit.request || !submit.statusToken) {
-    exitNodePairError({
-      code: submit.error?.code ?? 'PAIRING_REQUEST_FAILED',
-      message: submit.error?.message ?? 'hub did not accept pairing request',
-      outputJson,
-      retryable: true,
-    });
-  }
-
-  const request = submit.request;
-  renderNodePairRequest({ request, hubUrl, manifest, outputJson });
-
-  let interrupted = false;
-  const markInterrupted = (): void => {
-    interrupted = true;
-  };
+  const hubUrl = parseNodePairHubUrl(rawHubUrl);
+  const displayHubUrl = sanitizeHubUrlForDisplay(hubUrl);
+  const abortController = new AbortController();
+  const markInterrupted = (): void => abortController.abort();
   process.once('SIGINT', markInterrupted);
   process.once('SIGTERM', markInterrupted);
-  const pollIntervalMs = nodePairPollIntervalMs(nodeArgs);
+
   try {
-    while (true) {
-      if (interrupted) {
-        if (outputJson) safeJsonLine({ ok: false, code: 'INTERRUPTED' });
-        else logger.error('pairing interrupted; no credential was issued');
-        process.exit(130);
-      }
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-      const pollRes = await fetch(
-        nodeEndpoint(hubUrl, `/hub/pairing/requests/${request.requestId}/status`),
-        {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'x-relay-pairing-status-token': submit.statusToken,
-          },
-          body: JSON.stringify({}),
-        }
-      );
-      const poll = await readJsonResponse<PendingPairingPollResponse>(pollRes);
-      if (!pollRes.ok || !poll.request) {
-        exitNodePairError({
-          code: poll.error?.code ?? 'PAIRING_STATUS_FAILED',
-          message: poll.error?.message ?? 'hub status poll failed',
-          outputJson,
-          retryable: true,
-        });
-      }
-      if (poll.request.state === 'pending') continue;
-      if (poll.request.state === 'denied') exitNodePairDenied(hubUrl, outputJson);
-      if (poll.request.state === 'expired') exitNodePairExpired(outputJson);
-      if (
-        poll.request.state === 'approved' &&
-        (await finishApprovedDevicePairing({
-          hubUrl,
+    const manifest = await getNodeManifest();
+    const identityKey = loadOrCreateNodeIdentityKey();
+    const displayName = nodePairDisplayName(nodeArgs, manifest);
+    const requestedProfile = nodePairRequestedProfile(nodeArgs);
+    const requestedRoots = nodePairRequestedRoots(nodeArgs);
+    const submitRes = await nodePairFetch(
+      nodeEndpoint(hubUrl, '/hub/pairing/requests'),
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
           manifest,
-          poll,
-          outputJson,
-        }))
-      ) {
-        return;
-      }
-      if (poll.request.state === 'approved') continue;
+          publicKey: identityKey.publicKeyPem,
+          protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+          displayName,
+          requestedProfile,
+          ...(requestedRoots ? { requestedRoots } : {}),
+        }),
+      },
+      abortController.signal
+    );
+    const submit = await readJsonResponse<PendingPairingSubmitResponse>(submitRes);
+    if (!submitRes.ok || !submit.request || !submit.statusToken) {
+      exitNodePairError({
+        code: submit.error?.code ?? 'PAIRING_REQUEST_FAILED',
+        message: submit.error?.message ?? 'hub did not accept pairing request',
+        outputJson,
+        retryable: true,
+      });
+    }
+
+    const request = submit.request;
+    renderNodePairRequest({ request, hubUrl: displayHubUrl, manifest, outputJson });
+
+    const pollIntervalMs = nodePairPollIntervalMs(nodeArgs);
+    while (true) {
+      await abortableDelay(pollIntervalMs, abortController.signal);
+      const status = await requestNodeDevicePairingStatus({
+        hubUrl,
+        requestId: request.requestId,
+        statusToken: submit.statusToken,
+        signal: abortController.signal,
+      });
+      if (!status) continue;
+      const result = await handleNodeDevicePairingStatus({
+        hubUrl,
+        displayHubUrl,
+        manifest,
+        response: status.response,
+        poll: status.poll,
+        outputJson,
+      });
+      if (result === 'done') return;
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (outputJson) safeJsonLine({ ok: false, code: 'NODE_PAIR_FAILED', message });
-    else logger.error(redactNodeDiagnostics(`NODE_PAIR_FAILED: ${message}`));
+    if (abortController.signal.aborted) {
+      if (outputJson) safeJsonLine({ ok: false, code: 'INTERRUPTED' });
+      else logger.error('pairing interrupted; no credential was issued');
+      process.exit(130);
+    }
+    const safeMessage = sanitizeNodePairTextForDisplay(message);
+    if (outputJson) safeJsonLine({ ok: false, code: 'NODE_PAIR_FAILED', message: safeMessage });
+    else logger.error(sanitizeNodePairTextForDisplay(`NODE_PAIR_FAILED: ${message}`));
     process.exit(1);
   } finally {
     process.off('SIGINT', markInterrupted);
@@ -7464,14 +7603,15 @@ async function pairNode(
   nodeArgs: string[],
   lifecycle: NodePairLifecycle = 'connect'
 ): Promise<void> {
-  const hubUrl = getNodeArg(nodeArgs, '--hub');
+  const rawHubUrl = getNodeArg(nodeArgs, '--hub');
   const pairToken = getNodeArg(nodeArgs, '--pair-token');
-  if (!hubUrl || !pairToken) {
+  if (!rawHubUrl || !pairToken) {
     logger.error(
       'Usage: relay-ide node connect --hub <url> --pair-token <token>'
     );
     process.exit(1);
   }
+  const hubUrl = parseNodePairHubUrl(rawHubUrl);
 
   try {
     const manifest = await getNodeManifest();

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -19,9 +19,9 @@ Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagno
 | Task                             | Command                                                                                                  |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Install relay-ide binary on node | `relay-ide node install --hub <url> [--service <mode>]`                                                  |
-| Pair node with hub (pair-only)   | `relay-ide node pair --hub <url> --pair-token <token>`                                                   |
+| Pair node with hub (pair-only)   | `relay-ide node pair <url>`                                                                              |
 | Mint pair token from grant       | `relay-ide node mint-pair-token --hub <url> --operator-grant <relay-ohg-v1...> --display-name <name>`    |
-| Pair node (back-compat alias)    | `relay-ide node connect --hub <url> --pair-token <token>`                                                |
+| Pair node (automation/legacy)    | `relay-ide node pair --hub <url> --pair-token <token>` or `relay-ide node connect --hub <url> --pair-token <token>` |
 | Generate SSH bootstrap script    | `relay-ide node ssh-bootstrap --target <host> --hub <url>`                                               |
 | Hold reverse node link           | `relay-ide node link --hub <url>`                                                                        |
 | Check node status                | `relay-ide node status`                                                                                  |
@@ -57,7 +57,19 @@ Supported `--service` values:
 | `manual`       | Any                  | Binary only; no background service                                |
 | `auto`         | Any                  | Detects platform and chooses the best supported mode              |
 
-### Step 2: Mint a pair token from the hub
+### Step 2: Pair the node with a device code
+
+For a human/operator pairing flow, run this on the node machine:
+
+```bash
+relay-ide node pair https://hub.example.com
+```
+
+The command creates or reuses the local node identity key, submits a pending pairing request, prints a short device code plus `/pair/<code>` URL, waits for an authenticated operator to approve or deny it, stores the approved credential, sends one bootstrap heartbeat, and exits. It does **not** hold the persistent `/hub/node-link`; start that separately with `relay-ide node link --hub <url>` or a service manager.
+
+The device code is only a locator for the pending request. It is not a credential, not a browser login, and not authorization to issue a node credential.
+
+### Automation alternative: Mint a pair token from the hub
 
 Automation should mint a short-lived, one-time token through a previously approved operator handshake grant. The grant must use audience `relay:node-pair-token:v1`, include capability `node:pair-token:create`, and match the safe scope fields supplied with the mint request (for example `taskRef`, session/work-context binding, device id, or actor id). Browser cookies/PIN state, scoped actor tokens, node credentials, and existing pair tokens are not accepted on this automation lane.
 
@@ -88,16 +100,16 @@ Human fallback: an authenticated browser/PIN session may still create a pair tok
 
 Auth lane boundary: the operator grant only authorizes minting this one pair token. The pair token is accepted only by `POST /hub/pairing/exchange`, and the resulting `node-credential.json` is accepted only by node heartbeat and `/hub/node-link`. A browser PIN/cookie is not a node credential, and a node credential does not log in to browser-only routes. Processes already running as the same OS user may still read local Relay state or run local CLIs, so the PIN should be described as browser/UI auth, not as a same-user process boundary.
 
-### Step 3: Pair the node
+### Automation alternative: Pair with a pair token
 
 On the node machine, exchange the pair token:
 
 ```bash
-# Pair-only: stores credential, sends one heartbeat, then exits
+# Automation/legacy pair-only path: stores credential, sends one heartbeat, then exits
 relay-ide node pair --hub https://hub.example.com --pair-token <token>
 
-# If --pair-token is omitted, the CLI prints instructions for getting one
-relay-ide node pair --hub https://hub.example.com
+# Back-compat alias for the same pair-token exchange
+relay-ide node connect --hub https://hub.example.com --pair-token <token>
 ```
 
 `relay-ide node connect` is a back-compat alias for `pair`. Both sub-commands call the same pairing flow.

--- a/test/node-bootstrap-cli.test.ts
+++ b/test/node-bootstrap-cli.test.ts
@@ -253,25 +253,22 @@ describe('node install argument validation', () => {
 // ---------------------------------------------------------------------------
 
 describe('node pair argument validation', () => {
-  it('requires --hub flag', () => {
-    const args: string[] = ['pair', '--pair-token', 'pair_abc123'];
-    const idx = args.indexOf('--hub');
-    const hubUrl =
-      idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
-    expect(hubUrl).toBeUndefined();
+  it('accepts a positional hub URL for device-code pairing', () => {
+    const args: string[] = ['pair', 'https://hub.example.com'];
+    const pairIndex = args.indexOf('pair');
+    const positional = args[pairIndex + 1];
+    expect(positional).toBe('https://hub.example.com');
   });
 
-  it('requires --pair-token flag (not just --hub)', () => {
+  it('treats --hub without --pair-token as the device-code pairing path', () => {
     const args: string[] = ['pair', '--hub', 'https://hub.example.com'];
+    const hubIdx = args.indexOf('--hub');
     const tokenIdx = args.indexOf('--pair-token');
-    const token =
-      tokenIdx !== -1 && tokenIdx + 1 < args.length
-        ? args[tokenIdx + 1]
-        : undefined;
-    expect(token).toBeUndefined();
+    expect(args[hubIdx + 1]).toBe('https://hub.example.com');
+    expect(tokenIdx).toBe(-1);
   });
 
-  it('accepts both --hub and --pair-token', () => {
+  it('keeps --hub and --pair-token as the legacy automation path', () => {
     const args: string[] = [
       'pair',
       '--hub',

--- a/test/node-device-pair-cli.test.ts
+++ b/test/node-device-pair-cli.test.ts
@@ -1,0 +1,266 @@
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+type CliResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  home: string;
+};
+
+const servers: http.Server[] = [];
+
+function json(res: http.ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+async function fakeHub(handler: Handler): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('fake hub did not bind');
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function runCli(args: string[], env: Record<string, string> = {}): Promise<CliResult> {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-pair-cli-'));
+  return await new Promise<CliResult>((resolve, reject) => {
+    const child = spawn(process.execPath, ['dist/bin/relay-ide.js', ...args], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: home,
+        RELAY_IDE_NODE_PAIR_POLL_INTERVAL_MS: '100',
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`CLI timed out: ${args.join(' ')}`));
+    }, 7_500);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr, home });
+    });
+  });
+}
+
+function baseRequest(state: 'pending' | 'approved' | 'denied' | 'expired' = 'pending') {
+  return {
+    requestId: 'req-1',
+    deviceCode: 'ABCD-EFGH',
+    displayName: 'test-node',
+    requestedProfile: 'dev-workstation',
+    state,
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  };
+}
+
+function expectNoSecrets(output: string): void {
+  expect(output).not.toContain('pstat_SUPER_SECRET');
+  expect(output).not.toContain('pair_SUPER_SECRET');
+  expect(output).not.toContain('node_SECRET_TOKEN');
+  expect(output).not.toContain('user:pass');
+  expect(output).not.toContain('apiToken=shhh');
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+describe('relay-ide node pair CLI device-code pairing', () => {
+  it('waits pending -> approved, heartbeats, stores credential 0600, and does not leak tokens in JSON output', async () => {
+    let polls = 0;
+    let heartbeatAuthorization: string | undefined;
+    const hub = await fakeHub((req, res) => {
+      if (req.method === 'POST' && req.url === '/hub/pairing/requests') {
+        json(res, 200, { request: baseRequest('pending'), statusToken: 'pstat_SUPER_SECRET' });
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/pairing/requests/req-1/status') {
+        polls += 1;
+        json(res, 200, {
+          request: baseRequest(polls === 1 ? 'pending' : 'approved'),
+          ...(polls > 1
+            ? {
+                credential: {
+                  token: 'node_SECRET_TOKEN',
+                  nodeId: 'node-1',
+                  credentialId: 'cred-1',
+                  publicKeyFingerprint: 'fp-1',
+                },
+                node: { displayName: 'approved-node' },
+              }
+            : {}),
+        });
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/node-heartbeat') {
+        heartbeatAuthorization = req.headers.authorization;
+        json(res, 200, { ok: true });
+        return;
+      }
+      json(res, 404, { error: 'not found' });
+    });
+
+    const result = await runCli(['node', 'pair', hub.url, '--json']);
+    expect(result.code).toBe(0);
+    expect(heartbeatAuthorization).toBe('Bearer node_SECRET_TOKEN');
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toContain('"event":"pairing-requested"');
+    expect(output).toContain('"event":"paired"');
+    expectNoSecrets(output);
+    const credentialPath = path.join(result.home, '.config', 'relay-ide', 'node-credential.json');
+    expect(JSON.parse(fs.readFileSync(credentialPath, 'utf8'))).toMatchObject({ nodeId: 'node-1', credentialId: 'cred-1' });
+    expect(fs.statSync(credentialPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('treats denied as a terminal state without leaking the status token', async () => {
+    const hub = await fakeHub((req, res) => {
+      if (req.url === '/hub/pairing/requests') json(res, 200, { request: baseRequest('pending'), statusToken: 'pstat_SUPER_SECRET' });
+      else if (req.url === '/hub/pairing/requests/req-1/status') json(res, 200, { request: baseRequest('denied') });
+      else json(res, 404, {});
+    });
+    const result = await runCli(['node', 'pair', hub.url, '--json']);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('PAIRING_DENIED');
+    expectNoSecrets(`${result.stdout}${result.stderr}`);
+  });
+
+  it('treats expired as a terminal state', async () => {
+    const hub = await fakeHub((req, res) => {
+      if (req.url === '/hub/pairing/requests') json(res, 200, { request: baseRequest('pending'), statusToken: 'pstat_SUPER_SECRET' });
+      else if (req.url === '/hub/pairing/requests/req-1/status') json(res, 200, { request: baseRequest('expired') });
+      else json(res, 404, {});
+    });
+    const result = await runCli(['node', 'pair', hub.url, '--json']);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('PAIRING_EXPIRED');
+    expectNoSecrets(`${result.stdout}${result.stderr}`);
+  });
+
+  it('fails fast on malformed terminal status responses', async () => {
+    const hub = await fakeHub((req, res) => {
+      if (req.url === '/hub/pairing/requests') json(res, 200, { request: baseRequest('pending'), statusToken: 'pstat_SUPER_SECRET' });
+      else if (req.url === '/hub/pairing/requests/req-1/status') {
+        res.statusCode = 200;
+        res.end('not json');
+      } else json(res, 404, {});
+    });
+    const result = await runCli(['node', 'pair', hub.url, '--json']);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('MALFORMED_RESPONSE');
+    expectNoSecrets(`${result.stdout}${result.stderr}`);
+  });
+
+  it('retries a dropped status poll and recovers', async () => {
+    let polls = 0;
+    const hub = await fakeHub((req, res) => {
+      if (req.url === '/hub/pairing/requests') {
+        json(res, 200, { request: baseRequest('pending'), statusToken: 'pstat_SUPER_SECRET' });
+        return;
+      }
+      if (req.url === '/hub/pairing/requests/req-1/status') {
+        polls += 1;
+        if (polls === 1) {
+          req.socket.destroy();
+          return;
+        }
+        json(res, 200, {
+          request: baseRequest('approved'),
+          credential: { token: 'node_SECRET_TOKEN', nodeId: 'node-1', credentialId: 'cred-1' },
+        });
+        return;
+      }
+      if (req.url === '/hub/node-heartbeat') {
+        json(res, 200, { ok: true });
+        return;
+      }
+      json(res, 404, {});
+    });
+    const result = await runCli(['node', 'pair', hub.url, '--json']);
+    expect(result.code).toBe(0);
+    expect(polls).toBeGreaterThanOrEqual(2);
+    expectNoSecrets(`${result.stdout}${result.stderr}`);
+  });
+
+  it('fails fast when approved lacks a valid credential payload', async () => {
+    const hub = await fakeHub((req, res) => {
+      if (req.url === '/hub/pairing/requests') json(res, 200, { request: baseRequest('pending'), statusToken: 'pstat_SUPER_SECRET' });
+      else if (req.url === '/hub/pairing/requests/req-1/status') json(res, 200, { request: baseRequest('approved') });
+      else json(res, 404, {});
+    });
+    const result = await runCli(['node', 'pair', hub.url, '--json']);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('PAIRING_PROTOCOL_ERROR');
+    expect(result.stdout).toContain('approved pairing without a valid node credential');
+    expectNoSecrets(`${result.stdout}${result.stderr}`);
+  });
+
+  it('rejects userinfo hub URLs before request construction and redacts credentials/query secrets', async () => {
+    const result = await runCli(['node', 'pair', 'http://user:pass@127.0.0.1:9/?apiToken=shhh', '--json']);
+    expect(result.code).toBe(1);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toContain('INVALID_HUB_URL');
+    expectNoSecrets(output);
+  });
+
+  it('keeps legacy --pair-token routing on the exchange endpoint without leaking the pair token', async () => {
+    let sawDeviceRequest = false;
+    let sawExchange = false;
+    const hub = await fakeHub((req, res) => {
+      if (req.url === '/hub/pairing/requests') {
+        sawDeviceRequest = true;
+        json(res, 500, {});
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/pairing/exchange') {
+        sawExchange = true;
+        json(res, 200, {
+          credential: { token: 'node_SECRET_TOKEN', nodeId: 'node-legacy', credentialId: 'cred-legacy' },
+          node: { displayName: 'legacy-node' },
+        });
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/node-heartbeat') {
+        json(res, 200, { ok: true });
+        return;
+      }
+      json(res, 404, {});
+    });
+    const result = await runCli(['node', 'pair', '--hub', hub.url, '--pair-token', 'pair_SUPER_SECRET']);
+    expect(result.code).toBe(0);
+    expect(sawExchange).toBe(true);
+    expect(sawDeviceRequest).toBe(false);
+    expectNoSecrets(`${result.stdout}${result.stderr}`);
+    const credentialPath = path.join(result.home, '.config', 'relay-ide', 'node-credential.json');
+    expect(fs.statSync(credentialPath).mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `relay-ide node pair <hub>` device-code pairing client for relay nodes.
- Submit pending pairing request with the local node identity public key, print locator code/URL, poll status, persist approved node credential, and send the bootstrap heartbeat.
- Keep `--pair-token` pair/connect flow as the legacy automation lane.
- Update bootstrap docs and CLI pairing argument tests.

Closes #983

## Verification
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/node-bootstrap-cli.test.ts test/hub-node-pairing-requests.test.ts test/hub-node-pairing-routes.test.ts test/node-identity-keys.test.ts test/node-link-proof.test.ts` — 5 files / 86 tests passed.
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` — passed; eslint reported existing warnings only, 0 errors.
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` — passed; Vite chunk-size warnings only.
- `git diff --check` — passed.
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH node /tmp/relay-983-smoke.mjs` — passed against a local fake hub; verified request, approval, credential write/heartbeat path, and no fake status/credential secrets in CLI output.

## Notes
- Device code/status token handling keeps the device code as a locator only; status token is never printed.
- Settings UI / Command Center projection / dogfood validation remain out of this slice.

## Gates
- Fresh Kame QA and Fugu review gates recommended for PR head `983-device-code-node-pairing-client` before merge because this touches CLI auth/pairing and node credential bootstrap behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a device-code pairing flow for `relay-ide node pair`, enabling secure operator-assisted node registration.

* **Documentation**
  * Updated node bootstrap documentation to clarify the distinction between device-code pairing and legacy pair-token automation workflows.

* **Tests**
  * Updated pairing validation tests to reflect new pairing path behavior with device-code and legacy token options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->