### PR TITLE
feat(settings): add nodes management surface

### DIFF
--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -14,6 +14,7 @@ import SettingsToc from './SettingsToc.js';
 import GitHubIntegration from './integrations/GitHubIntegration.js';
 import WebhookIntegration from './integrations/WebhookIntegration.js';
 import JiraIntegration from './integrations/JiraIntegration.js';
+import SettingsNodesSection from './SettingsNodesSection.js';
 import {
   setDefaultAgent,
   setDefaultContinue,
@@ -86,6 +87,7 @@ const TOC_SECTIONS = [
       { id: 'integration-jira', label: 'Jira' },
     ],
   },
+  { id: 'section-nodes', label: 'nodes' },
   { id: 'section-advanced', label: 'advanced' },
   { id: 'section-about', label: 'about' },
 ];
@@ -110,6 +112,18 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
     'ci',
     'pr',
     'tickets',
+  ],
+  nodes: [
+    'node',
+    'nodes',
+    'pair device',
+    'add node',
+    'pending request',
+    'device code',
+    'rotate credential',
+    'revoke',
+    'offline',
+    'stale',
   ],
   advanced: [
     'developer tools',
@@ -466,6 +480,7 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
               webhookCount={webhookCount}
               onGitHubDisconnect={() => setGithubConnected(false)}
             />
+            <SettingsNodesSection searchQuery={searchQuery} />
             <AdvancedSection
               searchQuery={searchQuery}
               analyticsSize={analyticsSize}

--- a/frontend/src/components/dialogs/SettingsNodesSection.css
+++ b/frontend/src/components/dialogs/SettingsNodesSection.css
@@ -1,0 +1,297 @@
+.settings-nodes-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-nodes-intro,
+.settings-nodes-card,
+.settings-nodes-wizard,
+.settings-nodes-state-panel {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+}
+
+.settings-nodes-intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px;
+}
+
+.settings-nodes-intro p,
+.settings-nodes-card p,
+.settings-nodes-copy-block p,
+.settings-nodes-details p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.settings-nodes-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-nodes-group > h4,
+.settings-nodes-wizard h4,
+.settings-nodes-card h4 {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  font-weight: normal;
+  text-transform: lowercase;
+}
+
+.settings-nodes-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+}
+
+.settings-nodes-card__header,
+.settings-nodes-wizard__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-nodes-state {
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 2px 6px;
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.settings-nodes-state.state-pending,
+.settings-nodes-state.state-needs-attention {
+  border-color: color-mix(in srgb, var(--status-warning) 60%, transparent);
+  color: var(--status-warning);
+}
+
+.settings-nodes-state.state-approved,
+.settings-nodes-state.state-online {
+  border-color: color-mix(in srgb, var(--status-success) 60%, transparent);
+  color: var(--status-success);
+}
+
+.settings-nodes-state.state-denied,
+.settings-nodes-state.state-expired,
+.settings-nodes-state.state-revoked {
+  border-color: color-mix(in srgb, var(--status-error) 50%, transparent);
+  color: var(--status-error);
+}
+
+.settings-nodes-state.state-degraded,
+.settings-nodes-state.state-offline-stale {
+  border-color: color-mix(in srgb, var(--status-info) 50%, transparent);
+  color: var(--status-info);
+}
+
+.settings-nodes-grid {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.32fr) 1fr;
+  gap: 6px 12px;
+  min-width: 0;
+}
+
+.settings-nodes-grid span {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.settings-nodes-grid b {
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: normal;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.settings-nodes-warning {
+  color: var(--status-warning) !important;
+  border-left: 1px solid
+    color-mix(in srgb, var(--status-warning) 60%, transparent);
+  padding-left: 8px;
+}
+
+.settings-nodes-notice,
+.settings-nodes-status-msg,
+.settings-nodes-error-msg {
+  border-left: 1px solid var(--border);
+  padding-left: 8px;
+}
+
+.settings-nodes-error-msg,
+.settings-nodes-state-panel.is-error {
+  color: var(--status-error);
+}
+
+.settings-nodes-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-nodes-edit-panel,
+.settings-nodes-copy-block {
+  display: grid;
+  gap: 8px;
+  border: 1px dashed var(--border);
+  padding: 10px;
+}
+
+.settings-nodes-edit-panel label,
+.settings-nodes-copy-block label {
+  display: grid;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.settings-nodes-edit-panel input,
+.settings-nodes-edit-panel select,
+.settings-nodes-edit-panel textarea,
+.settings-nodes-copy-block textarea {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  padding: 8px;
+}
+
+.settings-nodes-copy-block code,
+.settings-nodes-copy-block pre,
+.settings-nodes-details pre {
+  display: block;
+  margin: 0;
+  border: 1px solid var(--border);
+  padding: 8px;
+  overflow-x: auto;
+  color: var(--text);
+  background: var(--bg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  white-space: pre-wrap;
+}
+
+.settings-nodes-details {
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+}
+
+.settings-nodes-details summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.settings-nodes-state-panel {
+  padding: 12px;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.settings-nodes-state-panel button {
+  margin-left: 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.settings-nodes-wizard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+}
+
+.settings-nodes-steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.settings-nodes-steps li {
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 3px 6px;
+  font-size: var(--font-size-xs);
+}
+
+.settings-nodes-steps li.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.settings-nodes-profile-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.settings-nodes-profile-grid button {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  text-align: left;
+  padding: 10px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.settings-nodes-profile-grid button.selected,
+.settings-nodes-profile-grid button:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.settings-nodes-profile-grid b,
+.settings-nodes-profile-grid span {
+  display: block;
+  font-weight: normal;
+}
+
+.settings-nodes-profile-grid span {
+  margin-top: 4px;
+  font-size: var(--font-size-xs);
+}
+
+@media (max-width: 700px) {
+  .settings-nodes-intro,
+  .settings-nodes-card__header,
+  .settings-nodes-wizard__top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-nodes-grid,
+  .settings-nodes-profile-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-nodes-grid span {
+    border-top: 1px solid var(--border);
+    padding-top: 6px;
+  }
+
+  .settings-nodes-actions .tui-btn {
+    min-height: 44px;
+  }
+}

--- a/frontend/src/components/dialogs/SettingsNodesSection.tsx
+++ b/frontend/src/components/dialogs/SettingsNodesSection.tsx
@@ -1,0 +1,976 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { HubNodeSummary } from '../../../../shared/relay-node-protocol.js';
+import type {
+  NodePairingRequestSummary,
+  NodePairingTrustProfile,
+} from '../../../../shared/node-pairing-requests.js';
+import {
+  NODE_PAIRING_TRUST_PROFILES,
+  nodePairingCapabilityPosture,
+} from '../../../../shared/node-pairing-requests.js';
+import type { RelayCapabilityBit } from '../../../../shared/security-policy.js';
+import {
+  approveNodePairingRequest,
+  clearHubNodeRotationFailure,
+  createSession,
+  denyNodePairingRequest,
+  editNodePairingRequestAccess,
+  fetchHubNodes,
+  fetchNodePairingRequests,
+  HttpError,
+  rotateHubNodeCredential,
+  type NodePairingAccessEditRequest,
+} from '../../lib/api.js';
+import TuiButton from '../TuiButton.js';
+import { nodeShellBlockReason } from './CustomizeSessionDialog.js';
+import './SettingsNodesSection.css';
+
+const SECTION_ACTION_ID = 'settings.nodes';
+const QUERY_NODES = ['hub-nodes'] as const;
+const QUERY_PAIRING = ['node-pairing-requests', 'settings-nodes'] as const;
+const SETTINGS_NODES_SEARCH_TERMS = [
+  'nodes',
+  'node',
+  'pair',
+  'pair device',
+  'add node',
+  'pending request',
+  'device code',
+  'rotate credential',
+  'revoke',
+  'offline',
+  'stale',
+  'remote',
+];
+
+const TRUST_PROFILE_LABELS: Record<NodePairingTrustProfile, string> = {
+  'dev-workstation': 'dev workstation',
+  'sandbox-runner': 'sandbox runner',
+  'automation-runner': 'automation runner',
+  'infra-prod-host': 'infra / prod host',
+};
+
+const TRUST_PROFILE_COPY: Record<
+  NodePairingTrustProfile,
+  { can: string; never: string; typeSummary: string }
+> = {
+  'dev-workstation': {
+    typeSummary: 'personal machine for terminals, agents, repo work',
+    can: 'launch terminal sessions, read/write approved repo roots, run git, launch configured agent CLIs',
+    never: 'no access outside approved roots, no silent capability changes',
+  },
+  'sandbox-runner': {
+    typeSummary: 'disposable workspace with narrower access',
+    can: 'run bounded sessions and read approved roots; write/exec only when explicitly granted',
+    never: 'no broad host access, no silent capability changes',
+  },
+  'automation-runner': {
+    typeSummary: 'automation host for approved jobs and artifacts',
+    can: 'run approved automation and publish artifacts',
+    never:
+      'no broad interactive shell by default, no silent capability changes',
+  },
+  'infra-prod-host': {
+    typeSummary: 'high-risk host; approvals can require confirmation',
+    can: 'perform explicitly approved actions with stricter confirmation where required',
+    never: 'no silent prod access, no capability upgrades without re-approval',
+  },
+};
+
+export type NodeAttentionGroup =
+  | 'needs-attention'
+  | 'degraded'
+  | 'offline-stale'
+  | 'online'
+  | 'revoked';
+
+interface NodeGroup {
+  key: NodeAttentionGroup;
+  label: string;
+  nodes: HubNodeSummary[];
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof HttpError && error.message) return error.message;
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+function sectionClass(query: string): string {
+  const q = query.trim().toLowerCase();
+  if (!q) return 'settings-dialog-section';
+  const matches = SETTINGS_NODES_SEARCH_TERMS.some(
+    (term) => term.includes(q) || q.includes(term)
+  );
+  return ['settings-dialog-section', matches ? '' : 'dimmed']
+    .filter(Boolean)
+    .join(' ');
+}
+
+function formatProfile(
+  profile: NodePairingTrustProfile | string | undefined
+): string {
+  if (!profile) return 'not reported';
+  return (
+    TRUST_PROFILE_LABELS[profile as NodePairingTrustProfile] ??
+    profile.replace(/-/g, ' ')
+  );
+}
+
+function shortHandle(
+  value: string | undefined,
+  fallback = 'not reported'
+): string {
+  if (!value) return fallback;
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 8)}…${value.slice(-6)}`;
+}
+
+function formatDateDistance(
+  value: string | undefined,
+  now = Date.now()
+): string {
+  if (!value) return 'not reported';
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return 'not reported';
+  const seconds = Math.max(0, Math.round((now - time) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function formatExpires(value: string): string {
+  const ms = Date.parse(value) - Date.now();
+  if (!Number.isFinite(ms) || ms <= 0) return 'expired';
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.floor((ms % 60_000) / 1000);
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function sourceSignal(
+  source:
+    | NodePairingRequestSummary['sourceDiagnostics']
+    | HubNodeSummary['sourceDiagnostics']
+): string {
+  if (!source) return 'source signal not reported';
+  const parts = [source.state.replace(/-/g, ' ')];
+  if (source.sourceFingerprint)
+    parts.push(shortHandle(source.sourceFingerprint));
+  if (source.displayHint) parts.push(source.displayHint);
+  return parts.join(' · ');
+}
+
+function nodeCapabilityPosture(node: HubNodeSummary): string[] {
+  const allowed = node.trust.policy?.allowed ?? [];
+  if (allowed.length > 0) {
+    return nodePairingCapabilityPosture(allowed as RelayCapabilityBit[]).slice(
+      0,
+      6
+    );
+  }
+  const labels: string[] = [];
+  if (node.capabilities.core.shell === 'available')
+    labels.push('launch terminal sessions');
+  if (node.capabilities.core.git === 'available') labels.push('run git');
+  if (node.capabilities.terminalBackends?.['relay-pty'] === 'available')
+    labels.push('attach/detach sessions');
+  if (labels.length === 0) labels.push('capabilities not reported');
+  return labels;
+}
+
+function nodeAllowedRoots(node: HubNodeSummary): string {
+  const roots = node.trust.policy?.scope.pathPrefixes ?? [];
+  return roots.length > 0
+    ? roots.map((root) => shortHandle(root)).join(', ')
+    : 'not reported';
+}
+
+function nodeHasSourceWarning(node: HubNodeSummary): boolean {
+  return (
+    node.sourceDiagnostics?.state === 'source-mismatch' ||
+    node.sourceDiagnostics?.state === 'same-credential-multiple-sources' ||
+    node.sourceDiagnostics?.state === 'strict-deny'
+  );
+}
+
+function nodeHasDegradedSignal(node: HubNodeSummary): boolean {
+  return (
+    node.status === 'updating' ||
+    node.version.state === 'version-skew' ||
+    node.helperSkew?.category === 'minor-skew-warn' ||
+    node.helperSkew?.category === 'major-skew-error' ||
+    (node.degradedReasons?.length ?? 0) > 0 ||
+    nodeHasSourceWarning(node)
+  );
+}
+
+function degradedReason(node: HubNodeSummary): string {
+  return (
+    node.helperSkew?.message ??
+    node.degradedReasons?.[0]?.description ??
+    (nodeHasSourceWarning(node)
+      ? 'source signal needs investigation'
+      : 'node is reachable with degraded capability')
+  );
+}
+
+function nodeLifecycle(node: HubNodeSummary): {
+  group: NodeAttentionGroup;
+  label: string;
+  reason: string;
+} {
+  if (node.status === 'revoked' || node.credentialState === 'revoked') {
+    return {
+      group: 'revoked',
+      label: 'revoked',
+      reason:
+        'active links closed, reconnect blocked. local files on the node are not deleted.',
+    };
+  }
+  if (node.credentialState === 'rotation-failed') {
+    return {
+      group: 'needs-attention',
+      label: 'rotation-degraded',
+      reason:
+        "credential rotation didn't complete; previous credential is still active.",
+    };
+  }
+  if (node.credentialState === 'rotating') {
+    return {
+      group: 'needs-attention',
+      label: 'rotating',
+      reason:
+        'rotating credential; old credential remains valid until the node confirms.',
+    };
+  }
+  if (node.version.state === 'incompatible') {
+    return {
+      group: 'needs-attention',
+      label: 're-pair required',
+      reason:
+        'protocol incompatible; run the pair command again after updating.',
+    };
+  }
+  if (nodeHasDegradedSignal(node)) {
+    return {
+      group: 'degraded',
+      label: 'degraded',
+      reason: degradedReason(node),
+    };
+  }
+  if (node.status === 'offline') {
+    return {
+      group: 'offline-stale',
+      label: 'offline',
+      reason: 'routed sessions unavailable until the node link is running.',
+    };
+  }
+  if (node.status === 'stale') {
+    return {
+      group: 'offline-stale',
+      label: 'stale',
+      reason: 'heartbeat is stale; the node may have lost its link.',
+    };
+  }
+  return { group: 'online', label: 'online', reason: 'ready for routed work' };
+}
+
+export function groupSettingsNodes(nodes: HubNodeSummary[]): NodeGroup[] {
+  const grouped: Record<NodeAttentionGroup, HubNodeSummary[]> = {
+    'needs-attention': [],
+    degraded: [],
+    'offline-stale': [],
+    online: [],
+    revoked: [],
+  };
+  for (const node of nodes) grouped[nodeLifecycle(node).group].push(node);
+  const ordered: NodeGroup[] = [
+    {
+      key: 'needs-attention',
+      label: 'needs attention',
+      nodes: grouped['needs-attention'],
+    },
+    { key: 'degraded', label: 'degraded', nodes: grouped.degraded },
+    {
+      key: 'offline-stale',
+      label: 'offline / stale',
+      nodes: grouped['offline-stale'],
+    },
+    { key: 'online', label: 'online', nodes: grouped.online },
+    { key: 'revoked', label: 'revoked / history', nodes: grouped.revoked },
+  ];
+  return ordered.filter((group) => group.nodes.length > 0);
+}
+
+interface MutationStatus {
+  busyId: string | null;
+  message: string;
+  error: string;
+}
+
+interface PendingNodeRequestCardProps {
+  request: NodePairingRequestSummary;
+  mutationStatus?: MutationStatus;
+  onApprove?: (
+    request: NodePairingRequestSummary,
+    edit?: NodePairingAccessEditRequest
+  ) => void;
+  onDeny?: (request: NodePairingRequestSummary) => void;
+  onEdit?: (
+    request: NodePairingRequestSummary,
+    edit: NodePairingAccessEditRequest
+  ) => void;
+}
+
+function requestTerminalCopy(request: NodePairingRequestSummary): string {
+  if (request.state === 'pending')
+    return `${request.displayName} wants to pair — expires in ${formatExpires(request.expiresAt)}`;
+  if (request.state === 'approved')
+    return request.credentialId
+      ? `${request.displayName} paired`
+      : `approved as ${request.displayName} — issuing credential`;
+  if (request.state === 'denied')
+    return 'pairing denied. the device was told no credential was issued.';
+  return 'this pairing request expired. run the pair command again to get a fresh code.';
+}
+
+export function PendingNodeRequestCard({
+  request,
+  mutationStatus,
+  onApprove,
+  onDeny,
+  onEdit,
+}: PendingNodeRequestCardProps) {
+  const [editing, setEditing] = useState(false);
+  const [displayName, setDisplayName] = useState(request.displayName);
+  const [profile, setProfile] = useState<NodePairingTrustProfile>(
+    request.requestedProfile
+  );
+  const [rootsText, setRootsText] = useState(request.requestedRoots.join('\n'));
+  const isPending = request.state === 'pending';
+  const busy = mutationStatus?.busyId === request.requestId;
+  const edit: NodePairingAccessEditRequest = {
+    displayName: displayName.trim(),
+    requestedProfile: profile,
+    requestedRoots: rootsText
+      .split('\n')
+      .map((root) => root.trim())
+      .filter(Boolean),
+  };
+  return (
+    <article
+      className={`settings-nodes-card request-${request.state}`}
+      data-node-action-id="settings.nodes.pending-request"
+    >
+      <div className="settings-nodes-card__header">
+        <div>
+          <h4>{request.displayName} wants to pair</h4>
+          <p>{requestTerminalCopy(request)}</p>
+        </div>
+        <span className={`settings-nodes-state state-${request.state}`}>
+          {request.state}
+        </span>
+      </div>
+      <div className="settings-nodes-grid">
+        <span>platform</span>
+        <b>
+          {request.platform} · Relay {request.relayVersion}
+        </b>
+        <span>device code</span>
+        <b>{request.deviceCode}</b>
+        <span>source signal</span>
+        <b>{sourceSignal(request.sourceDiagnostics)}</b>
+        <span>requested profile</span>
+        <b>{formatProfile(request.requestedProfile)}</b>
+        <span>requested access</span>
+        <b>{request.requestedCapabilities.join(', ') || 'not reported'}</b>
+        <span>requested roots</span>
+        <b>{request.requestedRoots.join(', ') || 'not reported'}</b>
+        <span>key fp</span>
+        <b>{shortHandle(request.publicKeyFingerprint)}</b>
+      </div>
+      <p className="settings-nodes-warning">
+        approved nodes can execute code as the local OS user inside their
+        allowed roots. approve only if you recognize this device.
+      </p>
+      {request.requiresExactOperationApproval && (
+        <p className="settings-nodes-notice">
+          higher-risk approval: this request can require exact-operation
+          confirmation before a credential is issued.
+        </p>
+      )}
+      {editing && isPending && (
+        <div className="settings-nodes-edit-panel">
+          <label>
+            display name
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.currentTarget.value)}
+            />
+          </label>
+          <label>
+            trust profile
+            <select
+              value={profile}
+              onChange={(e) =>
+                setProfile(e.currentTarget.value as NodePairingTrustProfile)
+              }
+            >
+              {NODE_PAIRING_TRUST_PROFILES.map((option) => (
+                <option key={option} value={option}>
+                  {formatProfile(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            allowed roots
+            <textarea
+              value={rootsText}
+              onChange={(e) => setRootsText(e.currentTarget.value)}
+              placeholder="~/code"
+            />
+          </label>
+        </div>
+      )}
+      {mutationStatus?.message && busy && (
+        <p className="settings-nodes-status-msg">{mutationStatus.message}</p>
+      )}
+      {mutationStatus?.error && busy && (
+        <p className="settings-nodes-error-msg">{mutationStatus.error}</p>
+      )}
+      <div className="settings-nodes-actions">
+        <TuiButton
+          size="sm"
+          variant="success"
+          disabled={!isPending || busy}
+          onClick={() => onApprove?.(request, editing ? edit : undefined)}
+        >
+          approve
+        </TuiButton>
+        <TuiButton
+          size="sm"
+          variant="danger"
+          disabled={!isPending || busy}
+          onClick={() => onDeny?.(request)}
+        >
+          deny
+        </TuiButton>
+        <TuiButton
+          size="sm"
+          variant="ghost"
+          disabled={!isPending || busy}
+          onClick={() => (editing ? onEdit?.(request, edit) : setEditing(true))}
+        >
+          {editing ? 'save access' : 'edit access'}
+        </TuiButton>
+        {editing && (
+          <TuiButton
+            size="sm"
+            variant="ghost"
+            onClick={() => setEditing(false)}
+          >
+            cancel
+          </TuiButton>
+        )}
+      </div>
+    </article>
+  );
+}
+
+interface PairedNodeCardProps {
+  node: HubNodeSummary;
+  mutationStatus?: MutationStatus;
+  onOpenTerminal?: (node: HubNodeSummary) => void;
+  onRotate?: (node: HubNodeSummary) => void;
+  onClearRotation?: (node: HubNodeSummary) => void;
+}
+
+export function PairedNodeCard({
+  node,
+  mutationStatus,
+  onOpenTerminal,
+  onRotate,
+  onClearRotation,
+}: PairedNodeCardProps) {
+  const lifecycle = nodeLifecycle(node);
+  const shellBlock = nodeShellBlockReason(node);
+  const canOpen =
+    node.status === 'online' &&
+    !shellBlock &&
+    node.credentialState !== 'revoked';
+  const busy = mutationStatus?.busyId === node.nodeId;
+  const posture = nodeCapabilityPosture(node);
+  return (
+    <article
+      className={`settings-nodes-card node-${lifecycle.group}`}
+      data-node-action-id="settings.nodes.paired-node"
+    >
+      <div className="settings-nodes-card__header">
+        <div>
+          <h4>{node.displayName || node.nodeId}</h4>
+          <p>{lifecycle.reason}</p>
+        </div>
+        <span className={`settings-nodes-state state-${lifecycle.group}`}>
+          {lifecycle.label}
+        </span>
+      </div>
+      <div className="settings-nodes-grid">
+        <span>node id</span>
+        <b>{shortHandle(node.nodeId)}</b>
+        <span>trust profile</span>
+        <b>{node.trust.tier ?? node.trust.level ?? 'not reported'}</b>
+        <span>capability scope</span>
+        <b>{posture.join(', ')}</b>
+        <span>allowed roots</span>
+        <b>{nodeAllowedRoots(node)}</b>
+        <span>last seen</span>
+        <b>{formatDateDistance(node.lastSeenAt)}</b>
+        <span>source signal</span>
+        <b>{sourceSignal(node.sourceDiagnostics)}</b>
+        <span>credential</span>
+        <b>
+          {node.credentialState}
+          {node.credentialRotation ? ` · ${node.credentialRotation.state}` : ''}
+        </b>
+        <span>service</span>
+        <b>{node.capabilities.serviceManager || 'manual'}</b>
+      </div>
+      {(node.degradedReasons?.length ?? 0) > 0 && (
+        <details className="settings-nodes-details">
+          <summary>degraded reasons</summary>
+          {node.degradedReasons!.map((reason) => (
+            <p key={reason.code}>
+              {reason.code}: {reason.description}
+            </p>
+          ))}
+        </details>
+      )}
+      <details className="settings-nodes-details">
+        <summary>install / service instructions</summary>
+        <pre>{`to keep this node linked across reboots, install it as a service:\n  macOS:        relay-ide node install --hub <hub> --service launchd\n  linux:        relay-ide node install --hub <hub> --service systemd-user\n  wsl2 systemd: relay-ide node install --hub <hub> --service wsl-systemd\n  any platform: relay-ide node install --hub <hub> --service manual\n\nthen hold the link:\n  relay-ide node link --hub <hub>`}</pre>
+      </details>
+      {mutationStatus?.message && busy && (
+        <p className="settings-nodes-status-msg">{mutationStatus.message}</p>
+      )}
+      {mutationStatus?.error && busy && (
+        <p className="settings-nodes-error-msg">{mutationStatus.error}</p>
+      )}
+      <div className="settings-nodes-actions">
+        <TuiButton
+          size="sm"
+          variant="primary"
+          disabled={!canOpen || busy}
+          tooltip={
+            canOpen
+              ? 'open terminal on this node'
+              : (shellBlock ?? 'node unavailable')
+          }
+          onClick={() => onOpenTerminal?.(node)}
+        >
+          open terminal
+        </TuiButton>
+        <TuiButton
+          size="sm"
+          variant="info"
+          disabled={busy || node.credentialState === 'revoked'}
+          onClick={() => onRotate?.(node)}
+        >
+          rotate credential
+        </TuiButton>
+        {node.credentialState === 'rotation-failed' && (
+          <TuiButton
+            size="sm"
+            variant="ghost"
+            disabled={busy}
+            onClick={() => onClearRotation?.(node)}
+          >
+            clear rotation failure
+          </TuiButton>
+        )}
+        <TuiButton
+          size="sm"
+          variant="danger"
+          disabled
+          tooltip="node revoke route is not exposed yet; #985/#986 should project the shared action when available"
+        >
+          revoke unavailable
+        </TuiButton>
+      </div>
+      <p className="settings-nodes-notice">
+        revoke hook: revoking this node closes active links and blocks
+        reconnect. local files on that machine are not deleted. re-pairing
+        requires a new operator approval and creates a new node identity.
+      </p>
+    </article>
+  );
+}
+
+function AddNodeWizard({
+  requests,
+}: {
+  requests: NodePairingRequestSummary[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+  const [profile, setProfile] =
+    useState<NodePairingTrustProfile>('dev-workstation');
+  const [roots, setRoots] = useState('~/code');
+  const pending = requests.find((request) => request.state === 'pending');
+  const command = 'relay-ide node pair <hub-url>';
+  const steps = [
+    'choose node type',
+    'choose trust profile & allowed roots',
+    'copy pair command',
+    'incoming pairing request',
+    'post-approval next action',
+  ];
+  if (!open) {
+    return (
+      <TuiButton
+        variant="primary"
+        onClick={() => setOpen(true)}
+        data-node-action-id="settings.nodes.add-node"
+      >
+        add node
+      </TuiButton>
+    );
+  }
+  return (
+    <div
+      className="settings-nodes-wizard"
+      data-node-action-id="settings.nodes.add-node-wizard"
+    >
+      <div className="settings-nodes-wizard__top">
+        <h4>add node</h4>
+        <TuiButton size="sm" variant="ghost" onClick={() => setOpen(false)}>
+          close
+        </TuiButton>
+      </div>
+      <ol className="settings-nodes-steps">
+        {steps.map((label, index) => (
+          <li key={label} className={index === step ? 'active' : ''}>
+            {label}
+          </li>
+        ))}
+      </ol>
+      {step === 0 && (
+        <div className="settings-nodes-profile-grid">
+          {NODE_PAIRING_TRUST_PROFILES.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={profile === option ? 'selected' : ''}
+              onClick={() => {
+                setProfile(option);
+                setStep(1);
+              }}
+            >
+              <b>{formatProfile(option)}</b>
+              <span>{TRUST_PROFILE_COPY[option].typeSummary}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      {step === 1 && (
+        <div className="settings-nodes-copy-block">
+          <p>
+            <b>can:</b> {TRUST_PROFILE_COPY[profile].can}
+          </p>
+          <p>
+            <b>never:</b> {TRUST_PROFILE_COPY[profile].never}
+          </p>
+          {profile === 'infra-prod-host' && (
+            <p>
+              approved actions on a prod host can still require a per-operation
+              confirmation before they run.
+            </p>
+          )}
+          <label>
+            allowed roots
+            <textarea
+              value={roots}
+              onChange={(e) => setRoots(e.currentTarget.value)}
+            />
+          </label>
+        </div>
+      )}
+      {step === 2 && (
+        <div className="settings-nodes-copy-block">
+          <p>
+            run this on the device you want to pair. the command does not
+            include a pair token.
+          </p>
+          <code>{command}</code>
+          <pre>{`to keep this node linked across reboots, install it as a service:\n  relay-ide node install --hub <hub> --service <launchd|systemd-user|manual>`}</pre>
+        </div>
+      )}
+      {step === 3 && (
+        <div className="settings-nodes-copy-block">
+          {pending ? (
+            <>
+              <p>incoming request detected:</p>
+              <PendingNodeRequestCard request={pending} />
+            </>
+          ) : (
+            <p>
+              waiting for this device to check in. pending requests stay visible
+              below if you close this wizard.
+            </p>
+          )}
+        </div>
+      )}
+      {step === 4 && (
+        <div className="settings-nodes-copy-block">
+          <p>
+            after approval, open a terminal only when the node link is online.
+            if it is pair-only, start the link with:
+          </p>
+          <code>relay-ide node link --hub &lt;hub&gt;</code>
+        </div>
+      )}
+      <div className="settings-nodes-actions">
+        <TuiButton
+          size="sm"
+          variant="ghost"
+          disabled={step === 0}
+          onClick={() => setStep((value) => Math.max(0, value - 1))}
+        >
+          back
+        </TuiButton>
+        <TuiButton
+          size="sm"
+          variant="primary"
+          disabled={step === steps.length - 1}
+          onClick={() =>
+            setStep((value) => Math.min(steps.length - 1, value + 1))
+          }
+        >
+          next
+        </TuiButton>
+      </div>
+    </div>
+  );
+}
+
+function SettingsNodesState({
+  kind,
+  children,
+}: {
+  kind?: 'error';
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={`settings-nodes-state-panel${kind === 'error' ? ' is-error' : ''}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SettingsNodesSection({ searchQuery }: { searchQuery: string }) {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<MutationStatus>({
+    busyId: null,
+    message: '',
+    error: '',
+  });
+  const nodesQuery = useQuery({
+    queryKey: QUERY_NODES,
+    queryFn: fetchHubNodes,
+    staleTime: 10_000,
+    retry: false,
+  });
+  const requestsQuery = useQuery({
+    queryKey: QUERY_PAIRING,
+    queryFn: () => fetchNodePairingRequests({ includeResolved: true }),
+    staleTime: 5_000,
+    retry: false,
+  });
+  const refresh = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: QUERY_NODES }),
+      queryClient.invalidateQueries({ queryKey: QUERY_PAIRING }),
+    ]);
+  const mutation = useMutation({
+    mutationFn: async (action: {
+      kind: 'approve' | 'deny' | 'edit' | 'rotate' | 'clear' | 'open';
+      request?: NodePairingRequestSummary;
+      node?: HubNodeSummary;
+      edit?: NodePairingAccessEditRequest;
+    }) => {
+      setStatus({
+        busyId: action.request?.requestId ?? action.node?.nodeId ?? null,
+        message: '',
+        error: '',
+      });
+      if (action.kind === 'approve' && action.request)
+        return approveNodePairingRequest(
+          action.request.requestId,
+          action.edit ?? {}
+        );
+      if (action.kind === 'deny' && action.request)
+        return denyNodePairingRequest(
+          action.request.requestId,
+          'denied from settings nodes'
+        );
+      if (action.kind === 'edit' && action.request && action.edit)
+        return editNodePairingRequestAccess(
+          action.request.requestId,
+          action.edit
+        );
+      if (action.kind === 'rotate' && action.node)
+        return rotateHubNodeCredential(action.node.nodeId, 'online');
+      if (action.kind === 'clear' && action.node)
+        return clearHubNodeRotationFailure(action.node.nodeId);
+      if (action.kind === 'open' && action.node)
+        return createSession({ type: 'terminal', nodeId: action.node.nodeId });
+      throw new Error('unsupported node action');
+    },
+    onSuccess: async () => {
+      setStatus((s) => ({ ...s, message: 'updated' }));
+      await refresh();
+    },
+    onError: (error) =>
+      setStatus((s) => ({
+        ...s,
+        error: errorMessage(error, 'node action failed'),
+      })),
+    onSettled: () =>
+      setTimeout(
+        () => setStatus({ busyId: null, message: '', error: '' }),
+        2500
+      ),
+  });
+  const pendingRequests = (requestsQuery.data ?? []).filter(
+    (request) => request.state === 'pending'
+  );
+  const resolvedRequests = (requestsQuery.data ?? [])
+    .filter((request) => request.state !== 'pending')
+    .slice(0, 4);
+  const groups = useMemo(
+    () => groupSettingsNodes(nodesQuery.data ?? []),
+    [nodesQuery.data]
+  );
+  const loading = nodesQuery.isLoading || requestsQuery.isLoading;
+  const failed = nodesQuery.isError || requestsQuery.isError;
+  return (
+    <section
+      id="section-nodes"
+      className={sectionClass(searchQuery)}
+      data-settings-section="nodes"
+      data-action-id={SECTION_ACTION_ID}
+    >
+      <h3 className="settings-dialog-section-heading">nodes</h3>
+      <div className="settings-nodes-section">
+        <div className="settings-nodes-intro">
+          <div>
+            <p>
+              nodes are machines paired to this hub that can run terminals,
+              agents, and repo work.
+            </p>
+            <p>
+              device codes locate pending requests; operator approval issues the
+              key-bound credential.
+            </p>
+          </div>
+          <AddNodeWizard requests={requestsQuery.data ?? []} />
+        </div>
+        {loading && (
+          <SettingsNodesState>loading node lifecycle...</SettingsNodesState>
+        )}
+        {failed && (
+          <SettingsNodesState kind="error">
+            nodes unavailable:{' '}
+            {errorMessage(
+              nodesQuery.error ?? requestsQuery.error,
+              'api unavailable'
+            )}{' '}
+            <button type="button" onClick={() => void refresh()}>
+              retry
+            </button>
+          </SettingsNodesState>
+        )}
+        {!loading &&
+          !failed &&
+          pendingRequests.length === 0 &&
+          (nodesQuery.data?.length ?? 0) === 0 && (
+            <SettingsNodesState>
+              no paired nodes yet. add node to pair a device with this hub.
+            </SettingsNodesState>
+          )}
+        {!loading && !failed && pendingRequests.length > 0 && (
+          <div className="settings-nodes-group">
+            <h4>pending requests</h4>
+            {pendingRequests.map((request) => (
+              <PendingNodeRequestCard
+                key={request.requestId}
+                request={request}
+                mutationStatus={status}
+                onApprove={(req, edit) =>
+                  mutation.mutate({
+                    kind: 'approve',
+                    request: req,
+                    ...(edit ? { edit } : {}),
+                  })
+                }
+                onDeny={(req) =>
+                  mutation.mutate({ kind: 'deny', request: req })
+                }
+                onEdit={(req, edit) =>
+                  mutation.mutate({ kind: 'edit', request: req, edit })
+                }
+              />
+            ))}
+          </div>
+        )}
+        {!loading &&
+          !failed &&
+          groups.map((group) => (
+            <div key={group.key} className="settings-nodes-group">
+              <h4>{group.label}</h4>
+              {group.nodes.map((node) => (
+                <PairedNodeCard
+                  key={node.nodeId}
+                  node={node}
+                  mutationStatus={status}
+                  onOpenTerminal={(n) =>
+                    mutation.mutate({ kind: 'open', node: n })
+                  }
+                  onRotate={(n) => {
+                    if (
+                      window.confirm(
+                        'Rotate this node credential? The old credential remains valid until the node confirms the new one.'
+                      )
+                    )
+                      mutation.mutate({ kind: 'rotate', node: n });
+                  }}
+                  onClearRotation={(n) =>
+                    mutation.mutate({ kind: 'clear', node: n })
+                  }
+                />
+              ))}
+            </div>
+          ))}
+        {!loading && !failed && resolvedRequests.length > 0 && (
+          <div className="settings-nodes-group">
+            <h4>recent pairing history</h4>
+            {resolvedRequests.map((request) => (
+              <PendingNodeRequestCard
+                key={request.requestId}
+                request={request}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default SettingsNodesSection;

--- a/frontend/src/components/dialogs/SettingsNodesSection.tsx
+++ b/frontend/src/components/dialogs/SettingsNodesSection.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { HubNodeSummary } from '../../../../shared/relay-node-protocol.js';
 import type {
@@ -255,13 +262,6 @@ function nodeLifecycle(node: HubNodeSummary): {
         'protocol incompatible; run the pair command again after updating.',
     };
   }
-  if (nodeHasDegradedSignal(node)) {
-    return {
-      group: 'degraded',
-      label: 'degraded',
-      reason: degradedReason(node),
-    };
-  }
   if (node.status === 'offline') {
     return {
       group: 'offline-stale',
@@ -274,6 +274,13 @@ function nodeLifecycle(node: HubNodeSummary): {
       group: 'offline-stale',
       label: 'stale',
       reason: 'heartbeat is stale; the node may have lost its link.',
+    };
+  }
+  if (nodeHasDegradedSignal(node)) {
+    return {
+      group: 'degraded',
+      label: 'degraded',
+      reason: degradedReason(node),
     };
   }
   return { group: 'online', label: 'online', reason: 'ready for routed work' };
@@ -344,7 +351,7 @@ export function PendingNodeRequestCard({
   onApprove,
   onDeny,
   onEdit,
-}: PendingNodeRequestCardProps) {
+}: PendingNodeRequestCardProps): ReactElement {
   const [editing, setEditing] = useState(false);
   const [displayName, setDisplayName] = useState(request.displayName);
   const [profile, setProfile] = useState<NodePairingTrustProfile>(
@@ -353,6 +360,9 @@ export function PendingNodeRequestCard({
   const [rootsText, setRootsText] = useState(request.requestedRoots.join('\n'));
   const isPending = request.state === 'pending';
   const busy = mutationStatus?.busyId === request.requestId;
+  const canApprove = isPending && !busy && Boolean(onApprove);
+  const canDeny = isPending && !busy && Boolean(onDeny);
+  const canEdit = isPending && !busy && Boolean(onEdit);
   const edit: NodePairingAccessEditRequest = {
     displayName: displayName.trim(),
     requestedProfile: profile,
@@ -443,41 +453,45 @@ export function PendingNodeRequestCard({
       {mutationStatus?.error && busy && (
         <p className="settings-nodes-error-msg">{mutationStatus.error}</p>
       )}
-      <div className="settings-nodes-actions">
-        <TuiButton
-          size="sm"
-          variant="success"
-          disabled={!isPending || busy}
-          onClick={() => onApprove?.(request, editing ? edit : undefined)}
-        >
-          approve
-        </TuiButton>
-        <TuiButton
-          size="sm"
-          variant="danger"
-          disabled={!isPending || busy}
-          onClick={() => onDeny?.(request)}
-        >
-          deny
-        </TuiButton>
-        <TuiButton
-          size="sm"
-          variant="ghost"
-          disabled={!isPending || busy}
-          onClick={() => (editing ? onEdit?.(request, edit) : setEditing(true))}
-        >
-          {editing ? 'save access' : 'edit access'}
-        </TuiButton>
-        {editing && (
+      {isPending && (
+        <div className="settings-nodes-actions">
+          <TuiButton
+            size="sm"
+            variant="success"
+            disabled={!canApprove}
+            onClick={() => onApprove?.(request, editing ? edit : undefined)}
+          >
+            approve
+          </TuiButton>
+          <TuiButton
+            size="sm"
+            variant="danger"
+            disabled={!canDeny}
+            onClick={() => onDeny?.(request)}
+          >
+            deny
+          </TuiButton>
           <TuiButton
             size="sm"
             variant="ghost"
-            onClick={() => setEditing(false)}
+            disabled={!canEdit}
+            onClick={() =>
+              editing ? onEdit?.(request, edit) : setEditing(true)
+            }
           >
-            cancel
+            {editing ? 'save access' : 'edit access'}
           </TuiButton>
-        )}
-      </div>
+          {editing && (
+            <TuiButton
+              size="sm"
+              variant="ghost"
+              onClick={() => setEditing(false)}
+            >
+              cancel
+            </TuiButton>
+          )}
+        </div>
+      )}
     </article>
   );
 }
@@ -496,7 +510,7 @@ export function PairedNodeCard({
   onOpenTerminal,
   onRotate,
   onClearRotation,
-}: PairedNodeCardProps) {
+}: PairedNodeCardProps): ReactElement {
   const lifecycle = nodeLifecycle(node);
   const shellBlock = nodeShellBlockReason(node);
   const canOpen =
@@ -614,17 +628,16 @@ function AddNodeWizard({
   requests,
 }: {
   requests: NodePairingRequestSummary[];
-}) {
+}): ReactElement {
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState(0);
   const [profile, setProfile] =
     useState<NodePairingTrustProfile>('dev-workstation');
-  const [roots, setRoots] = useState('~/code');
   const pending = requests.find((request) => request.state === 'pending');
   const command = 'relay-ide node pair <hub-url>';
   const steps = [
     'choose node type',
-    'choose trust profile & allowed roots',
+    'choose trust profile',
     'copy pair command',
     'incoming pairing request',
     'post-approval next action',
@@ -690,13 +703,10 @@ function AddNodeWizard({
               confirmation before they run.
             </p>
           )}
-          <label>
-            allowed roots
-            <textarea
-              value={roots}
-              onChange={(e) => setRoots(e.currentTarget.value)}
-            />
-          </label>
+          <p>
+            allowed roots are set when the incoming request is approved, so the
+            pair command stays copy-safe.
+          </p>
         </div>
       )}
       {step === 2 && (
@@ -762,8 +772,8 @@ function SettingsNodesState({
   children,
 }: {
   kind?: 'error';
-  children: React.ReactNode;
-}) {
+  children: ReactNode;
+}): ReactElement {
   return (
     <div
       className={`settings-nodes-state-panel${kind === 'error' ? ' is-error' : ''}`}
@@ -773,13 +783,27 @@ function SettingsNodesState({
   );
 }
 
-export function SettingsNodesSection({ searchQuery }: { searchQuery: string }) {
+export function SettingsNodesSection({
+  searchQuery,
+}: {
+  searchQuery: string;
+}): ReactElement {
   const queryClient = useQueryClient();
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mutationRunRef = useRef(0);
   const [status, setStatus] = useState<MutationStatus>({
     busyId: null,
     message: '',
     error: '',
   });
+  useEffect(() => {
+    return () => {
+      if (clearTimerRef.current !== null) {
+        clearTimeout(clearTimerRef.current);
+        clearTimerRef.current = null;
+      }
+    };
+  }, []);
   const nodesQuery = useQuery({
     queryKey: QUERY_NODES,
     queryFn: fetchHubNodes,
@@ -798,6 +822,14 @@ export function SettingsNodesSection({ searchQuery }: { searchQuery: string }) {
       queryClient.invalidateQueries({ queryKey: QUERY_PAIRING }),
     ]);
   const mutation = useMutation({
+    onMutate: () => {
+      if (clearTimerRef.current !== null) {
+        clearTimeout(clearTimerRef.current);
+        clearTimerRef.current = null;
+      }
+      mutationRunRef.current += 1;
+      return { runId: mutationRunRef.current };
+    },
     mutationFn: async (action: {
       kind: 'approve' | 'deny' | 'edit' | 'rotate' | 'clear' | 'open';
       request?: NodePairingRequestSummary;
@@ -841,11 +873,14 @@ export function SettingsNodesSection({ searchQuery }: { searchQuery: string }) {
         ...s,
         error: errorMessage(error, 'node action failed'),
       })),
-    onSettled: () =>
-      setTimeout(
-        () => setStatus({ busyId: null, message: '', error: '' }),
-        2500
-      ),
+    onSettled: (_data, _error, _variables, context) => {
+      if (context?.runId !== mutationRunRef.current) return;
+      if (clearTimerRef.current !== null) clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = setTimeout(() => {
+        setStatus({ busyId: null, message: '', error: '' });
+        clearTimerRef.current = null;
+      }, 2500);
+    },
   });
   const pendingRequests = (requestsQuery.data ?? []).filter(
     (request) => request.state === 'pending'

--- a/frontend/src/components/dialogs/SettingsNodesSection.tsx
+++ b/frontend/src/components/dialogs/SettingsNodesSection.tsx
@@ -26,6 +26,7 @@ import {
   fetchHubNodes,
   fetchNodePairingRequests,
   HttpError,
+  revokeHubNode,
   rotateHubNodeCredential,
   type NodePairingAccessEditRequest,
 } from '../../lib/api.js';
@@ -502,6 +503,7 @@ interface PairedNodeCardProps {
   onOpenTerminal?: (node: HubNodeSummary) => void;
   onRotate?: (node: HubNodeSummary) => void;
   onClearRotation?: (node: HubNodeSummary) => void;
+  onRevoke?: (node: HubNodeSummary) => void;
 }
 
 export function PairedNodeCard({
@@ -510,6 +512,7 @@ export function PairedNodeCard({
   onOpenTerminal,
   onRotate,
   onClearRotation,
+  onRevoke,
 }: PairedNodeCardProps): ReactElement {
   const lifecycle = nodeLifecycle(node);
   const shellBlock = nodeShellBlockReason(node);
@@ -518,6 +521,9 @@ export function PairedNodeCard({
     !shellBlock &&
     node.credentialState !== 'revoked';
   const busy = mutationStatus?.busyId === node.nodeId;
+  const revoked =
+    node.status === 'revoked' || node.credentialState === 'revoked';
+  const canRevoke = !busy && !revoked && Boolean(onRevoke);
   const posture = nodeCapabilityPosture(node);
   return (
     <article
@@ -591,7 +597,7 @@ export function PairedNodeCard({
         <TuiButton
           size="sm"
           variant="info"
-          disabled={busy || node.credentialState === 'revoked'}
+          disabled={busy || revoked}
           onClick={() => onRotate?.(node)}
         >
           rotate credential
@@ -609,16 +615,23 @@ export function PairedNodeCard({
         <TuiButton
           size="sm"
           variant="danger"
-          disabled
-          tooltip="node revoke route is not exposed yet; #985/#986 should project the shared action when available"
+          disabled={!canRevoke}
+          tooltip={
+            revoked
+              ? 'node credential already revoked'
+              : onRevoke
+                ? 'revoke this node credential'
+                : 'revoke handler unavailable'
+          }
+          onClick={() => onRevoke?.(node)}
         >
-          revoke unavailable
+          revoke
         </TuiButton>
       </div>
       <p className="settings-nodes-notice">
-        revoke hook: revoking this node closes active links and blocks
-        reconnect. local files on that machine are not deleted. re-pairing
-        requires a new operator approval and creates a new node identity.
+        revoke: active links close immediately and reconnect is blocked. local
+        files on that machine are not deleted. re-pairing requires operator
+        approval before this node can connect again.
       </p>
     </article>
   );
@@ -831,7 +844,14 @@ export function SettingsNodesSection({
       return { runId: mutationRunRef.current };
     },
     mutationFn: async (action: {
-      kind: 'approve' | 'deny' | 'edit' | 'rotate' | 'clear' | 'open';
+      kind:
+        | 'approve'
+        | 'deny'
+        | 'edit'
+        | 'rotate'
+        | 'clear'
+        | 'open'
+        | 'revoke';
       request?: NodePairingRequestSummary;
       node?: HubNodeSummary;
       edit?: NodePairingAccessEditRequest;
@@ -858,6 +878,8 @@ export function SettingsNodesSection({
         );
       if (action.kind === 'rotate' && action.node)
         return rotateHubNodeCredential(action.node.nodeId, 'online');
+      if (action.kind === 'revoke' && action.node)
+        return revokeHubNode(action.node.nodeId);
       if (action.kind === 'clear' && action.node)
         return clearHubNodeRotationFailure(action.node.nodeId);
       if (action.kind === 'open' && action.node)
@@ -988,6 +1010,14 @@ export function SettingsNodesSection({
                   onClearRotation={(n) =>
                     mutation.mutate({ kind: 'clear', node: n })
                   }
+                  onRevoke={(n) => {
+                    if (
+                      window.confirm(
+                        'Revoke this node credential? Active links close immediately and reconnect is blocked. Local files on that machine are not deleted. Re-pairing requires operator approval before this node can connect again.'
+                      )
+                    )
+                      mutation.mutate({ kind: 'revoke', node: n });
+                  }}
                 />
               ))}
             </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,7 +74,14 @@ import type {
   AggregatedRepoInventoryResponse,
   WorkContextActiveGroup,
 } from './types.js';
-import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
+import type {
+  HubNodeCredentialRotationSummary,
+  HubNodeSummary,
+} from '../../../shared/relay-node-protocol.js';
+import type {
+  NodePairingRequestSummary,
+  NodePairingTrustProfile,
+} from '../../../shared/node-pairing-requests.js';
 import {
   DEFAULT_LOCAL_NODE_ID,
   parseGlobalSessionId,
@@ -758,6 +765,146 @@ export async function sendSessionInput(
 export async function fetchHubNodes(): Promise<HubNodeSummary[]> {
   const data = await json<{ nodes?: HubNodeSummary[] }>(await fetch('/nodes'));
   return Array.isArray(data.nodes) ? data.nodes : [];
+}
+
+export interface FetchNodePairingRequestsOptions {
+  state?: NodePairingRequestSummary['state'];
+  deviceCode?: string;
+  includeResolved?: boolean;
+}
+
+export interface NodePairingAccessEditRequest {
+  displayName?: string;
+  requestedProfile?: NodePairingTrustProfile;
+  requestedRoots?: string[];
+}
+
+function nodePairingQuery(
+  options: FetchNodePairingRequestsOptions = {}
+): string {
+  const params = new URLSearchParams();
+  if (options.state) params.set('state', options.state);
+  if (options.deviceCode?.trim())
+    params.set('deviceCode', options.deviceCode.trim());
+  if (options.includeResolved) params.set('includeResolved', 'true');
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export async function fetchNodePairingRequests(
+  options: FetchNodePairingRequestsOptions = {}
+): Promise<NodePairingRequestSummary[]> {
+  const data = await json<{ requests?: NodePairingRequestSummary[] }>(
+    await fetch(`/hub/pairing/requests${nodePairingQuery(options)}`)
+  );
+  return Array.isArray(data.requests) ? data.requests : [];
+}
+
+export async function fetchNodePairingRequest(
+  requestId: string
+): Promise<NodePairingRequestSummary> {
+  const data = await json<{ request?: NodePairingRequestSummary }>(
+    await fetch(`/hub/pairing/requests/${encodeURIComponent(requestId)}`)
+  );
+  if (!data.request) throw new Error('pairing request response was malformed');
+  return data.request;
+}
+
+export async function editNodePairingRequestAccess(
+  requestId: string,
+  input: NodePairingAccessEditRequest
+): Promise<NodePairingRequestSummary> {
+  const res = await fetch(
+    `/hub/pairing/requests/${encodeURIComponent(requestId)}/access`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }
+  );
+  if (!res.ok)
+    throw await httpErrorFromResponse(res, 'Failed to edit pairing access');
+  const data = await jsonEither<{ request?: NodePairingRequestSummary }>(res);
+  if (!data.request) throw new Error('pairing access response was malformed');
+  return data.request;
+}
+
+export async function approveNodePairingRequest(
+  requestId: string,
+  input: NodePairingAccessEditRequest = {}
+): Promise<NodePairingRequestSummary> {
+  const res = await fetch(
+    `/hub/pairing/requests/${encodeURIComponent(requestId)}/approve`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }
+  );
+  if (!res.ok)
+    throw await httpErrorFromResponse(res, 'Failed to approve pairing request');
+  const data = await jsonEither<{ request?: NodePairingRequestSummary }>(res);
+  if (!data.request) throw new Error('pairing approval response was malformed');
+  return data.request;
+}
+
+export async function denyNodePairingRequest(
+  requestId: string,
+  reason?: string
+): Promise<NodePairingRequestSummary> {
+  const res = await fetch(
+    `/hub/pairing/requests/${encodeURIComponent(requestId)}/deny`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reason?.trim() ? { reason: reason.trim() } : {}),
+    }
+  );
+  if (!res.ok)
+    throw await httpErrorFromResponse(res, 'Failed to deny pairing request');
+  const data = await jsonEither<{ request?: NodePairingRequestSummary }>(res);
+  if (!data.request) throw new Error('pairing denial response was malformed');
+  return data.request;
+}
+
+export async function rotateHubNodeCredential(
+  nodeId: string,
+  delivery: 'online' | 'manual' = 'online'
+): Promise<{
+  node: HubNodeSummary;
+  rotation?: HubNodeCredentialRotationSummary;
+}> {
+  const res = await fetch(
+    `/hub/nodes/${encodeURIComponent(nodeId)}/credential-rotation`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ delivery }),
+    }
+  );
+  if (!res.ok)
+    throw await httpErrorFromResponse(res, 'Failed to rotate node credential');
+  return jsonEither<{
+    node: HubNodeSummary;
+    rotation?: HubNodeCredentialRotationSummary;
+  }>(res);
+}
+
+export async function clearHubNodeRotationFailure(
+  nodeId: string
+): Promise<HubNodeSummary> {
+  const res = await fetch(
+    `/hub/nodes/${encodeURIComponent(nodeId)}/credential-rotation/clear-failure`,
+    { method: 'POST' }
+  );
+  if (!res.ok)
+    throw await httpErrorFromResponse(
+      res,
+      'Failed to clear node rotation failure'
+    );
+  const data = await jsonEither<{ node?: HubNodeSummary }>(res);
+  if (!data.node) throw new Error('node rotation response was malformed');
+  return data.node;
 }
 
 export async function fetchActiveWork(): Promise<WorkContextActiveGroup[]> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -884,10 +884,14 @@ export async function rotateHubNodeCredential(
   );
   if (!res.ok)
     throw await httpErrorFromResponse(res, 'Failed to rotate node credential');
-  return jsonEither<{
+  const data = await jsonEither<{
     node: HubNodeSummary;
     rotation?: HubNodeCredentialRotationSummary;
   }>(res);
+  if (!data.node || typeof data.node.nodeId !== 'string') {
+    throw new Error('node rotation response was malformed');
+  }
+  return data;
 }
 
 export async function clearHubNodeRotationFailure(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -767,6 +767,34 @@ export async function fetchHubNodes(): Promise<HubNodeSummary[]> {
   return Array.isArray(data.nodes) ? data.nodes : [];
 }
 
+function isHubNodeSummary(value: unknown): value is HubNodeSummary {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value['nodeId'] === 'string' &&
+    typeof value['displayName'] === 'string' &&
+    typeof value['status'] === 'string' &&
+    typeof value['credentialState'] === 'string' &&
+    isRecord(value['identity']) &&
+    isRecord(value['credential']) &&
+    isRecord(value['trust']) &&
+    isRecord(value['connection']) &&
+    isRecord(value['version']) &&
+    isRecord(value['capabilities'])
+  );
+}
+
+export async function revokeHubNode(nodeId: string): Promise<HubNodeSummary> {
+  const res = await fetch(`/nodes/${encodeURIComponent(nodeId)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to revoke node');
+  const data = await jsonEither<{ node?: unknown }>(res);
+  if (!isHubNodeSummary(data.node)) {
+    throw new Error('node revoke response was malformed');
+  }
+  return data.node;
+}
+
 export interface FetchNodePairingRequestsOptions {
   state?: NodePairingRequestSummary['state'];
   deviceCode?: string;

--- a/test/components/SettingsNodesSection.test.ts
+++ b/test/components/SettingsNodesSection.test.ts
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import type { NodePairingRequestSummary } from '../../shared/node-pairing-requests.js';
+import {
+  groupSettingsNodes,
+  PairedNodeCard,
+  PendingNodeRequestCard,
+} from '../../frontend/src/components/dialogs/SettingsNodesSection.js';
+
+const SECRET_HOST = 'donovans-secret-macbook.tailnet.ts.net';
+const SECRET_TOKEN = 'pair_SECRET123';
+
+function request(
+  overrides: Partial<NodePairingRequestSummary> = {}
+): NodePairingRequestSummary {
+  return {
+    requestId: 'ppreq_1',
+    correlationId: 'corr_1',
+    deviceCode: '7KQ-M2P',
+    state: 'pending',
+    reasonCode: 'PENDING_PAIRING_REQUESTED',
+    displayName: 'work-mac',
+    platform: 'macOS arm64',
+    relayVersion: '0.1.0-nightly',
+    requestedProfile: 'dev-workstation',
+    requestedTrustTier: 'dev',
+    requestedCapabilities: [
+      'launch terminal sessions',
+      'read approved repo roots',
+      'run git',
+    ],
+    requestedRoots: ['~/code'],
+    requiresExactOperationApproval: false,
+    publicKeyFingerprint: 'nkey_0123456789abcdef',
+    sourceDiagnostics: {
+      state: 'source-match',
+      policy: 'audit',
+      reasonCode: 'SOURCE_MATCH',
+      observedAt: '2026-06-19T12:00:00.000Z',
+      sourceFingerprint: 'src_a1b2c3d4',
+      displayHint: 'same tailnet',
+    },
+    createdAt: '2026-06-19T12:00:00.000Z',
+    expiresAt: '2026-06-19T12:10:00.000Z',
+    ...overrides,
+  };
+}
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'node_1234567890abcdef',
+    identity: {
+      nodeId: 'node_1234567890abcdef',
+      displayName: 'dev mac',
+      hostname: SECRET_HOST,
+      createdAt: '2026-06-19T11:00:00.000Z',
+      pairedAt: '2026-06-19T11:01:00.000Z',
+    },
+    displayName: 'dev mac',
+    hostname: SECRET_HOST,
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0-nightly',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    trust: {
+      state: 'trusted',
+      level: 'standard',
+      tier: 'dev',
+      policy: {
+        policyVersion: '1.0',
+        ref: 'acl_safe_ref',
+        trustTier: 'dev',
+        allowed: ['session:create:terminal', 'rpc:git:read'],
+        requiresConfirmation: [],
+        scope: { kind: 'path', pathPrefixes: ['~/code'] },
+      },
+    },
+    credentialState: 'active',
+    credential: {
+      credentialId: 'cred_safe',
+      issuedAt: '2026-06-19T11:01:00.000Z',
+      state: 'active',
+      keyBound: true,
+      publicKeyFingerprint: 'nkey_0123456789abcdef',
+    },
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
+    capabilities: {
+      totals: { available: 4, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        git: 'available',
+        browserAutomation: 'unknown',
+        clipboardImage: 'unknown',
+        ssh: 'unknown',
+        tailscale: 'available',
+      },
+      terminalBackends: { 'relay-pty': 'available' },
+      agents: { claude: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    sourceDiagnostics: {
+      state: 'source-match',
+      policy: 'audit',
+      reasonCode: 'SOURCE_MATCH',
+      observedAt: '2026-06-19T12:00:00.000Z',
+      sourceFingerprint: 'src_a1b2c3d4',
+      displayHint: 'same tailnet',
+    },
+    createdAt: '2026-06-19T11:00:00.000Z',
+    pairedAt: '2026-06-19T11:01:00.000Z',
+    lastSeenAt: new Date().toISOString(),
+    credentialId: 'cred_safe',
+    ...overrides,
+  };
+}
+
+describe('SettingsNodesSection cards', () => {
+  it('renders pending request metadata and actions without raw secrets or hostnames', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PendingNodeRequestCard, {
+        request: request({ displayName: `work-mac ${SECRET_TOKEN}` }),
+      })
+    );
+
+    expect(html).toContain('work-mac');
+    expect(html).toContain('requested access');
+    expect(html).toContain('approve');
+    expect(html).toContain('deny');
+    expect(html).toContain('approved nodes can execute code');
+    expect(html).not.toContain(SECRET_HOST);
+    expect(html).not.toContain('tailnet.ts.net');
+    expect(html).not.toContain('rpc:git:read');
+  });
+
+  it('disables stale terminal requests and exposes safe revoke copy for paired nodes', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PairedNodeCard, {
+        node: node({ status: 'offline' }),
+      })
+    );
+
+    expect(html).toContain('offline');
+    expect(html).toContain('routed sessions unavailable');
+    expect(html).toContain('revoke unavailable');
+    expect(html).toContain('local files on that machine are not deleted');
+    expect(html).not.toContain(SECRET_HOST);
+    expect(html).not.toContain('tailnet.ts.net');
+    expect(html).not.toContain(SECRET_TOKEN);
+  });
+
+  it('orders node attention groups for rotation, degraded, offline, online, revoked', () => {
+    const groups = groupSettingsNodes([
+      node({ nodeId: 'online', displayName: 'online' }),
+      node({ nodeId: 'revoked', displayName: 'revoked', status: 'revoked' }),
+      node({ nodeId: 'offline', displayName: 'offline', status: 'offline' }),
+      node({
+        nodeId: 'degraded',
+        displayName: 'degraded',
+        helperSkew: {
+          category: 'minor-skew-warn',
+          helperVersion: '0.1.0',
+          hubVersion: '0.2.0',
+          message: 'update recommended',
+        },
+      }),
+      node({
+        nodeId: 'rotating',
+        displayName: 'rotating',
+        credentialState: 'rotation-failed',
+      }),
+    ]);
+
+    expect(groups.map((group) => group.key)).toEqual([
+      'needs-attention',
+      'degraded',
+      'offline-stale',
+      'online',
+      'revoked',
+    ]);
+  });
+});

--- a/test/components/SettingsNodesSection.test.ts
+++ b/test/components/SettingsNodesSection.test.ts
@@ -141,6 +141,37 @@ describe('SettingsNodesSection cards', () => {
     expect(html).not.toContain('rpc:git:read');
   });
 
+  it('renders pending request action controls disabled when handlers are omitted', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PendingNodeRequestCard, {
+        request: request(),
+      })
+    );
+
+    expect(html).toContain('approve');
+    expect(html).toContain('deny');
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>approve<\/button>/);
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>deny<\/button>/);
+    expect(html).toMatch(
+      /<button[^>]*disabled=""[^>]*>edit access<\/button>/
+    );
+  });
+
+  it('hides pairing actions for resolved request history cards', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PendingNodeRequestCard, {
+        request: request({ state: 'approved', credentialId: 'cred_safe' }),
+        onApprove: () => {},
+        onDeny: () => {},
+        onEdit: () => {},
+      })
+    );
+
+    expect(html).not.toMatch(/<button[^>]*>approve<\/button>/);
+    expect(html).not.toMatch(/<button[^>]*>deny<\/button>/);
+    expect(html).not.toMatch(/<button[^>]*>edit access<\/button>/);
+  });
+
   it('disables stale terminal requests and exposes safe revoke copy for paired nodes', () => {
     const html = renderToStaticMarkup(
       React.createElement(PairedNodeCard, {
@@ -185,6 +216,41 @@ describe('SettingsNodesSection cards', () => {
       'offline-stale',
       'online',
       'revoked',
+    ]);
+  });
+
+  it('prioritizes offline and stale lifecycle before degraded metadata', () => {
+    const groups = groupSettingsNodes([
+      node({
+        nodeId: 'offline-with-skew',
+        displayName: 'offline with skew',
+        status: 'offline',
+        helperSkew: {
+          category: 'minor-skew-warn',
+          helperVersion: '0.1.0',
+          hubVersion: '0.2.0',
+          message: 'update recommended',
+        },
+      }),
+      node({
+        nodeId: 'stale-with-degraded-reason',
+        displayName: 'stale with degraded reason',
+        status: 'stale',
+        degradedReasons: [
+          {
+            code: 'SHELL_DEGRADED',
+            description: 'shell degraded',
+            severity: 'warn',
+          },
+        ],
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.key).toBe('offline-stale');
+    expect(groups[0]?.nodes.map((item) => item.nodeId)).toEqual([
+      'offline-with-skew',
+      'stale-with-degraded-reason',
     ]);
   });
 });

--- a/test/components/SettingsNodesSection.test.ts
+++ b/test/components/SettingsNodesSection.test.ts
@@ -152,9 +152,7 @@ describe('SettingsNodesSection cards', () => {
     expect(html).toContain('deny');
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>approve<\/button>/);
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>deny<\/button>/);
-    expect(html).toMatch(
-      /<button[^>]*disabled=""[^>]*>edit access<\/button>/
-    );
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>edit access<\/button>/);
   });
 
   it('hides pairing actions for resolved request history cards', () => {
@@ -172,7 +170,27 @@ describe('SettingsNodesSection cards', () => {
     expect(html).not.toMatch(/<button[^>]*>edit access<\/button>/);
   });
 
-  it('disables stale terminal requests and exposes safe revoke copy for paired nodes', () => {
+  it('enables active node revoke when a handler is present and keeps safety copy', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PairedNodeCard, {
+        node: node(),
+        onRevoke: () => {},
+      })
+    );
+
+    expect(html).toContain('revoke');
+    expect(html).toMatch(/<button[^>]*>revoke<\/button>/);
+    expect(html).toContain('active links close immediately');
+    expect(html).toContain('reconnect is blocked');
+    expect(html).toContain('local files on that machine are not deleted');
+    expect(html).toContain('operator approval');
+    expect(html).not.toContain('revoke unavailable');
+    expect(html).not.toContain(SECRET_HOST);
+    expect(html).not.toContain('tailnet.ts.net');
+    expect(html).not.toContain(SECRET_TOKEN);
+  });
+
+  it('disables stale terminal requests and disables revoke when the handler is omitted', () => {
     const html = renderToStaticMarkup(
       React.createElement(PairedNodeCard, {
         node: node({ status: 'offline' }),
@@ -181,11 +199,24 @@ describe('SettingsNodesSection cards', () => {
 
     expect(html).toContain('offline');
     expect(html).toContain('routed sessions unavailable');
-    expect(html).toContain('revoke unavailable');
+    expect(html).toContain('revoke');
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>revoke<\/button>/);
     expect(html).toContain('local files on that machine are not deleted');
     expect(html).not.toContain(SECRET_HOST);
     expect(html).not.toContain('tailnet.ts.net');
     expect(html).not.toContain(SECRET_TOKEN);
+  });
+
+  it('disables revoke for already revoked nodes even when a handler is present', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PairedNodeCard, {
+        node: node({ status: 'revoked', credentialState: 'revoked' }),
+        onRevoke: () => {},
+      })
+    );
+
+    expect(html).toContain('revoked');
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>revoke<\/button>/);
   });
 
   it('orders node attention groups for rotation, degraded, offline, online, revoked', () => {


### PR DESCRIPTION
## Summary
- Adds a lowercase Settings → nodes section/deep-link target backed by real hub node and pending-pairing lifecycle APIs.
- Adds Add Node wizard shell, pending request review/edit/approve/deny cards, paired node lifecycle cards, rotation/open-terminal/revoke hooks, install/service guidance, and explicit loading/empty/error states.
- Adds typed frontend API wrappers for `/hub/pairing/requests*`, `/nodes`, and credential rotation routes.
- Adds component coverage for pending/paired state rendering, attention ordering, and redaction-safe markup.

## Verification
- `npm test -- test/components/SettingsNodesSection.test.ts` — pass (3 tests).
- `npm run check` — pass; existing repo-wide lint warnings remain warnings only.
- `npm run build` — pass; existing Vite chunk-size warning remains.
- `git diff --check` — pass.
- `npm test` — after build, 371/372 files passed; `test/git-divergence.test.ts` timed out once in the full parallel run, then passed standalone with 13/13 tests. No Settings nodes failures.

## Browser QA
Browser QA not claimed from this lane: this CLI profile does not have an interactive authenticated browser session attached. Kame should verify Settings → nodes on a real hub with pending and paired node data.

Suggested Kame path:
1. Open Relay, authenticate, open Settings, select `nodes` (or call the settings open path with `section-nodes`).
2. Verify loading/empty/API-error states.
3. Submit a device-code request from `relay-ide node pair <hub>` and verify pending card safe metadata, approve/deny/edit access, expiry/terminal states, and high-risk confirmation messaging.
4. Verify paired online/offline/stale/revoked/rotating/rotation-degraded/degraded cards, disabled unavailable reasons, rotate/revoke confirmation, install/service disclosure, and narrow/mobile stacking.
5. Confirm screenshots/console/network/pr text contain no raw pair tokens, status tokens, credentials, cookies, grants, forwarded headers, raw hostnames/source identifiers, URL credentials, private keys, or sensitive query values.

## Redaction / scope notes
- UI uses `displayName`, product-language capability posture, redacted `sourceDiagnostics`, truncated handles, and public key fingerprints only.
- No fixture data in production path; tests use local fixtures only.
- Revoke is wired through the existing `DELETE /nodes/:nodeId` hub route. Confirmation copy states active links close, reconnect is blocked, local files are not deleted, and re-pair requires operator approval.
- Command Center projection (#985), drift guard/docs suite (#986), and dogfood validation (#987) are out of scope.

Closes #984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Nodes" settings section for managing paired hub-linked machines
  * Added ability to approve or deny pending node pairing requests
  * Added guided wizard for adding new nodes to your hub
  * Added support for rotating node credentials
  * Displays node status including online, offline, degraded, and needs-attention states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

