### PR TITLE
Show branch identity in PR rows

### DIFF
--- a/frontend/src/components/PrRow.css
+++ b/frontend/src/components/PrRow.css
@@ -91,6 +91,28 @@
   white-space: nowrap;
 }
 
+.pr-row__branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: min(100%, 28rem);
+  min-width: 0;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.pr-row__branch-ref {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pr-row__branch-arrow {
+  flex: none;
+  color: var(--border);
+}
+
 .pr-row__sep {
   opacity: 0.4;
 }
@@ -215,6 +237,10 @@
   .pr-row__ci,
   .pr-row__age {
     display: none;
+  }
+
+  .pr-row__branch {
+    max-width: 100%;
   }
 
   .pr-row__actions {

--- a/frontend/src/components/PrRow.css
+++ b/frontend/src/components/PrRow.css
@@ -3,6 +3,7 @@
   align-items: center;
   border-bottom: 1px solid var(--border);
   cursor: pointer;
+  min-width: 0;
   transition: background 0.1s;
 }
 
@@ -78,6 +79,9 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
   font-size: var(--font-size-xs);
   font-family: var(--font-mono);
   color: var(--text-muted);
@@ -102,6 +106,7 @@
 }
 
 .pr-row__branch-ref {
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/PrRow.tsx
+++ b/frontend/src/components/PrRow.tsx
@@ -75,6 +75,13 @@ function ChevronIcon() {
   );
 }
 
+function branchIdentityLabel(pr: PullRequest): string {
+  const head = pr.headRefName.trim();
+  const base = pr.baseRefName.trim();
+  if (head && base) return `${head} → ${base}`;
+  return head || base;
+}
+
 export function PrRow({
   pr,
   onOpen,
@@ -87,6 +94,7 @@ export function PrRow({
   const repoName = pr.repoName ?? '';
   const chipColor = showRepo ? deriveColor(repoName) : undefined;
   const updatedAgo = formatRelativeTime(pr.updatedAt);
+  const branchLabel = branchIdentityLabel(pr);
 
   const handleRowClick = useCallback(
     (e: React.MouseEvent) => {
@@ -148,6 +156,22 @@ export function PrRow({
             </>
           )}
           <span className="pr-row__sep">&middot;</span>
+          {branchLabel && (
+            <>
+              <span
+                className="pr-row__branch"
+                title={`branch ${branchLabel}`}
+                aria-label={`branch ${branchLabel}`}
+              >
+                <span className="pr-row__branch-ref">{pr.headRefName}</span>
+                {pr.headRefName && pr.baseRefName && (
+                  <span className="pr-row__branch-arrow">→</span>
+                )}
+                <span className="pr-row__branch-ref">{pr.baseRefName}</span>
+              </span>
+              <span className="pr-row__sep">&middot;</span>
+            </>
+          )}
           <span className="pr-row__meta-text">{prRoleLabel(pr)}</span>
           <span className="pr-row__sep">&middot;</span>
           <span className="pr-row__meta-text">{updatedAgo}</span>

--- a/frontend/src/components/PrRow.tsx
+++ b/frontend/src/components/PrRow.tsx
@@ -75,11 +75,15 @@ function ChevronIcon() {
   );
 }
 
-function branchIdentityLabel(pr: PullRequest): string {
+function branchIdentity(pr: PullRequest): {
+  head: string;
+  base: string;
+  label: string;
+} {
   const head = pr.headRefName.trim();
   const base = pr.baseRefName.trim();
-  if (head && base) return `${head} → ${base}`;
-  return head || base;
+  const label = head && base ? `${head} → ${base}` : head || base;
+  return { head, base, label };
 }
 
 export function PrRow({
@@ -94,7 +98,8 @@ export function PrRow({
   const repoName = pr.repoName ?? '';
   const chipColor = showRepo ? deriveColor(repoName) : undefined;
   const updatedAgo = formatRelativeTime(pr.updatedAt);
-  const branchLabel = branchIdentityLabel(pr);
+  const { head: headRef, base: baseRef, label: branchLabel } =
+    branchIdentity(pr);
 
   const handleRowClick = useCallback(
     (e: React.MouseEvent) => {
@@ -163,11 +168,11 @@ export function PrRow({
                 title={`branch ${branchLabel}`}
                 aria-label={`branch ${branchLabel}`}
               >
-                <span className="pr-row__branch-ref">{pr.headRefName}</span>
-                {pr.headRefName && pr.baseRefName && (
+                <span className="pr-row__branch-ref">{headRef}</span>
+                {headRef && baseRef && (
                   <span className="pr-row__branch-arrow">→</span>
                 )}
-                <span className="pr-row__branch-ref">{pr.baseRefName}</span>
+                <span className="pr-row__branch-ref">{baseRef}</span>
               </span>
               <span className="pr-row__sep">&middot;</span>
             </>

--- a/frontend/src/test-pr-row-long.tsx
+++ b/frontend/src/test-pr-row-long.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { PrRow } from './components/PrRow.js';
+import type { PullRequest } from './lib/types.js';
+import './App.css';
+
+const longBranchPr: PullRequest = {
+  number: 995,
+  title: 'Fix mobile branch overflow in PR rows',
+  url: 'https://github.com/donovan-yohan/relay-ide/pull/995',
+  headRefName:
+    'feature/super-long-mobile-branch-name-that-used-to-force-the-pr-row-to-scroll-sideways-on-small-screens',
+  baseRefName:
+    'release/another-extremely-long-base-branch-name-that-must-truncate-inside-the-row',
+  state: 'OPEN',
+  author: 'donovan-yohan',
+  role: 'author',
+  updatedAt: '2026-06-20T22:00:00.000Z',
+  additions: 12,
+  deletions: 3,
+  reviewDecision: null,
+  mergeable: 'MERGEABLE',
+  ciStatus: 'SUCCESS',
+  isDraft: false,
+  repoName: 'relay-ide',
+  repoPath: '/repo/relay-ide',
+};
+
+function Harness() {
+  return (
+    <main
+      className="pr-row-long-fixture"
+      aria-label="long branch PR row fixture"
+      style={{ width: '358px', maxWidth: 'calc(100vw - 32px)', margin: '16px' }}
+    >
+      <PrRow
+        pr={longBranchPr}
+        onOpen={() => undefined}
+        onAction={() => undefined}
+        showRepo
+        showCi
+      />
+    </main>
+  );
+}
+
+createRoot(document.getElementById('app')!).render(<Harness />);

--- a/frontend/test-pr-row-long.html
+++ b/frontend/test-pr-row-long.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>pr row long branch harness</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-pr-row-long.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -44,6 +44,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-env-picker-dialog.html'
   );
+  buildInputs['test-pr-row-long'] = resolve(
+    import.meta.dirname,
+    'test-pr-row-long.html'
+  );
 }
 
 export default defineConfig({

--- a/test/e2e/components/PrRow.spec.ts
+++ b/test/e2e/components/PrRow.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('PrRow long branch mobile layout', () => {
+  test('truncates branch identity without horizontal row overflow at 390px', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 640 });
+    await page.goto('/test-pr-row-long.html');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.locator('.pr-row');
+    await expect(row).toBeVisible();
+    await expect(page.locator('.pr-row__branch')).toHaveAttribute(
+      'title',
+      /feature\/super-long-mobile-branch-name.* → release\/another-extremely-long-base-branch-name/
+    );
+
+    const metrics = await page.evaluate(() => {
+      const fixture = document.querySelector<HTMLElement>('.pr-row-long-fixture');
+      const row = document.querySelector<HTMLElement>('.pr-row');
+      const branch = document.querySelector<HTMLElement>('.pr-row__branch');
+      const title = document.querySelector<HTMLElement>('.pr-row__title');
+      const actions = document.querySelector<HTMLElement>('.pr-row__actions');
+      if (!fixture || !row || !branch || !title || !actions) {
+        throw new Error('missing PrRow fixture elements');
+      }
+      return {
+        fixtureClientWidth: fixture.clientWidth,
+        fixtureScrollWidth: fixture.scrollWidth,
+        rowClientWidth: row.clientWidth,
+        rowScrollWidth: row.scrollWidth,
+        branchClientWidth: branch.clientWidth,
+        branchScrollWidth: branch.scrollWidth,
+        titleClientWidth: title.clientWidth,
+        actionsClientWidth: actions.clientWidth,
+        branchRefOverflow: Array.from(
+          document.querySelectorAll<HTMLElement>('.pr-row__branch-ref')
+        ).map((ref) => ref.scrollWidth > ref.clientWidth),
+      };
+    });
+
+    expect(metrics.fixtureScrollWidth).toBeLessThanOrEqual(metrics.fixtureClientWidth);
+    expect(metrics.rowScrollWidth).toBeLessThanOrEqual(metrics.rowClientWidth);
+    expect(metrics.branchClientWidth).toBeLessThan(metrics.rowClientWidth);
+    expect(metrics.branchRefOverflow).toContain(true);
+    expect(metrics.titleClientWidth).toBeGreaterThan(0);
+    expect(metrics.actionsClientWidth).toBeGreaterThan(0);
+  });
+});

--- a/test/pr-row.test.ts
+++ b/test/pr-row.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from 'node:fs';
 import React, { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
@@ -89,6 +90,35 @@ describe('PrRow', () => {
     ]);
     expect(refs.every((ref) => ref.className === 'pr-row__branch-ref')).toBe(
       true
+    );
+
+    const meta = container!.querySelector<HTMLElement>('.pr-row__meta');
+    expect(meta).toBeTruthy();
+
+    const css = readFileSync(
+      `${process.cwd()}/frontend/src/components/PrRow.css`,
+      'utf8'
+    );
+    expect(css).toMatch(/\.pr-row__meta\s*{[^}]*min-width:\s*0;/s);
+    expect(css).toMatch(/\.pr-row__meta\s*{[^}]*overflow:\s*hidden;/s);
+    expect(css).toMatch(/\.pr-row__branch-ref\s*{[^}]*text-overflow:\s*ellipsis;/s);
+  });
+
+  it('renders trimmed branch refs consistently with the branch title', async () => {
+    await renderPrRow({
+      ...basePr,
+      headRefName: '  feature/trim-head  ',
+      baseRefName: '  release/trim-base  ',
+    });
+
+    const branch = container!.querySelector('.pr-row__branch');
+    expect(branch).toBeTruthy();
+    expect(branch!.textContent).toBe('feature/trim-head→release/trim-base');
+    expect(branch!.getAttribute('title')).toBe(
+      'branch feature/trim-head → release/trim-base'
+    );
+    expect(branch!.getAttribute('aria-label')).toBe(
+      'branch feature/trim-head → release/trim-base'
     );
   });
 });

--- a/test/pr-row.test.ts
+++ b/test/pr-row.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { PrRow } from '../frontend/src/components/PrRow.js';
+import type { PullRequest } from '../frontend/src/lib/types.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+const basePr: PullRequest = {
+  number: 133,
+  title: 'show branch info in pr table',
+  url: 'https://github.com/donovan-yohan/relay-ide/pull/133',
+  headRefName: 'issue-133-pr-table-branch-info',
+  baseRefName: 'nightly',
+  state: 'OPEN',
+  author: 'donovan-yohan',
+  role: 'author',
+  updatedAt: '2026-06-20T22:00:00.000Z',
+  additions: 12,
+  deletions: 3,
+  reviewDecision: null,
+  mergeable: 'MERGEABLE',
+  ciStatus: null,
+  isDraft: false,
+  repoName: 'relay-ide',
+  repoPath: '/repo/relay-ide',
+};
+
+async function renderPrRow(pr: PullRequest = basePr) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root!.render(
+      React.createElement(PrRow, {
+        pr,
+        onOpen: vi.fn(),
+      })
+    );
+  });
+}
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('PrRow', () => {
+  it('renders head and base branch identity in the metadata row', async () => {
+    await renderPrRow();
+
+    const branch = container!.querySelector('.pr-row__branch');
+    expect(branch).toBeTruthy();
+    expect(branch!.textContent).toBe('issue-133-pr-table-branch-info→nightly');
+    expect(branch!.getAttribute('title')).toBe(
+      'branch issue-133-pr-table-branch-info → nightly'
+    );
+    expect(branch!.getAttribute('aria-label')).toBe(
+      'branch issue-133-pr-table-branch-info → nightly'
+    );
+  });
+
+  it('uses truncation-safe branch cells for long branch names', async () => {
+    await renderPrRow({
+      ...basePr,
+      headRefName:
+        'very-long-feature-branch-name-that-should-not-break-pr-table-layout',
+      baseRefName: 'release/2026-06-nightly-candidate',
+    });
+
+    const refs = Array.from(
+      container!.querySelectorAll<HTMLSpanElement>('.pr-row__branch-ref')
+    );
+    expect(refs.map((ref) => ref.textContent)).toEqual([
+      'very-long-feature-branch-name-that-should-not-break-pr-table-layout',
+      'release/2026-06-nightly-candidate',
+    ]);
+    expect(refs.every((ref) => ref.className === 'pr-row__branch-ref')).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Show PR head → base branch identity in `PrRow` metadata using existing `headRefName` / `baseRefName` fields.
- Add truncation-safe branch cells plus title/aria-label text so long branch names remain discoverable on compact/mobile layouts.
- Add focused Vitest coverage for normal and long branch-name rendering.

Closes #133

## Verification
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/pr-row.test.ts` — 2 tests passed
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run check` — passed with existing warnings only
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run build:frontend` — passed; Vite emitted existing large-chunk warning
- Browser smoke via temporary Vite fixture at `http://127.0.0.1:52913/pr-row-verify.html` — desktop row showed `issue-133-pr-table-branch-info → nightly`, fit on one row, and browser console had no JS errors. Mobile Playwright smoke was attempted but local Playwright browser binary is not installed in this environment.

## Notes
- Simplify pass: risk tier 2 (small localized frontend component + CSS + focused test); local quality/reuse review found no worthwhile cleanup beyond the implemented truncation/title shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR rows now display source and destination branch information with a visual arrow separator, providing clearer context at a glance.
  * Branch information is fully responsive, optimizing layout across all screen sizes including mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->