### PR TITLE
fix: show actual settings defaults

### DIFF
--- a/frontend/src/components/dialogs/WorkspaceEditor.tsx
+++ b/frontend/src/components/dialogs/WorkspaceEditor.tsx
@@ -24,6 +24,13 @@ type ChangeHandler = <K extends keyof WorkspaceEditorValues>(
   value: WorkspaceEditorValues[K]
 ) => void;
 
+export const WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS = {
+  remote: 'default: origin',
+  branchPrefix: 'default: none',
+  prompt: 'default: none',
+  portVariable: 'additional var (default: PORT)',
+} as const;
+
 interface Props {
   values: WorkspaceEditorValues;
   onChange: ChangeHandler;
@@ -118,7 +125,7 @@ function GitSettingsSection({ values, branches, onChange }: GitSectionProps) {
           id="ws-remote"
           type="text"
           className="workspace-editor__field-input"
-          placeholder="origin"
+          placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.remote}
           value={values.remote}
           onChange={(e) => onChange('remote', e.currentTarget.value)}
         />
@@ -134,7 +141,7 @@ function GitSettingsSection({ values, branches, onChange }: GitSectionProps) {
           id="ws-branch-prefix"
           type="text"
           className="workspace-editor__field-input"
-          placeholder="e.g. dy/"
+          placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.branchPrefix}
           value={values.branchPrefix}
           onChange={(e) => onChange('branchPrefix', e.currentTarget.value)}
         />
@@ -236,25 +243,25 @@ function PromptsSection({ values, onChange }: PromptsSectionProps) {
       <PromptGroup
         label="Code review preferences"
         value={values.promptCodeReview}
-        placeholder="e.g. focus on security, error handling"
+        placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.prompt}
         onChange={(v) => onChange('promptCodeReview', v)}
       />
       <PromptGroup
         label="Create PR preferences"
         value={values.promptCreatePr}
-        placeholder="e.g. include test plan section"
+        placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.prompt}
         onChange={(v) => onChange('promptCreatePr', v)}
       />
       <PromptGroup
         label="Branch rename preferences"
         value={values.promptBranchRename}
-        placeholder="e.g. prefix with dy/, use conventional commits style"
+        placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.prompt}
         onChange={(v) => onChange('promptBranchRename', v)}
       />
       <PromptGroup
         label="General preferences"
         value={values.promptGeneral}
-        placeholder="e.g. use TypeScript, follow CLAUDE.md"
+        placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.prompt}
         onChange={(v) => onChange('promptGeneral', v)}
       />
     </section>
@@ -385,7 +392,7 @@ function EnvironmentPortsSection({
         <input
           type="text"
           className={`workspace-editor__field-input workspace-editor__add-input${newNameError ? ' workspace-editor__field-input--error' : ''}`}
-          placeholder="e.g. SERVER_PORT"
+          placeholder={WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.portVariable}
           value={newName}
           onChange={(e) => {
             setNewName(e.currentTarget.value);

--- a/test/workspace-editor-validation.test.ts
+++ b/test/workspace-editor-validation.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, test } from 'vitest';
-import {
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import WorkspaceEditor, {
+  WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS,
   validateEnvPortVarName,
   validateEnvPortVarNames,
 } from '../frontend/src/components/dialogs/WorkspaceEditor.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('WorkspaceEditor env var validation', () => {
   test('validateEnvPortVarName accepts valid names', () => {
@@ -24,5 +33,79 @@ describe('WorkspaceEditor env var validation', () => {
       1: 'Invalid format',
       2: 'Duplicate',
     });
+  });
+});
+
+describe('<WorkspaceEditor /> default placeholder copy', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderEditor() {
+    act(() => {
+      root.render(
+        React.createElement(WorkspaceEditor, {
+          values: {
+            defaultBranch: '',
+            remote: '',
+            branchPrefix: '',
+            defaultAgent: 'claude',
+            defaultContinue: true,
+            defaultYolo: false,
+            promptCodeReview: '',
+            promptCreatePr: '',
+            promptBranchRename: '',
+            promptGeneral: '',
+            portVariables: [],
+          },
+          onChange: vi.fn(),
+          branches: [],
+          overriddenKeys: [],
+        })
+      );
+    });
+  }
+
+  function inputPlaceholders(): string[] {
+    return Array.from(container.querySelectorAll('input, textarea')).map(
+      (input) => input.getAttribute('placeholder') ?? ''
+    );
+  }
+
+  test('shows known defaults instead of example-only settings placeholders', () => {
+    renderEditor();
+
+    expect(inputPlaceholders()).toEqual(
+      expect.arrayContaining([
+        WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.remote,
+        WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.branchPrefix,
+        WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.portVariable,
+      ])
+    );
+
+    for (const button of container.querySelectorAll(
+      '.workspace-editor__prompt-toggle'
+    )) {
+      act(() => (button as HTMLButtonElement).click());
+    }
+
+    expect(inputPlaceholders()).toEqual(
+      expect.arrayContaining([
+        WORKSPACE_EDITOR_DEFAULT_PLACEHOLDERS.prompt,
+      ])
+    );
+    expect(inputPlaceholders().some((value) => /e\.g\./i.test(value))).toBe(
+      false
+    );
   });
 });


### PR DESCRIPTION
## Summary
- replace WorkspaceEditor example-only settings placeholders with explicit defaults for remote, branch prefix, prompt preferences, and env port variable fields
- add a happy-dom regression test that renders the settings editor, opens prompt groups, and asserts no affected placeholder falls back to `e.g.` copy

## Verification
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm test -- test/workspace-editor-validation.test.ts` — 4 tests passed
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run check` — passed; existing lint warnings only
- Browser smoke on local dev server `http://127.0.0.1:5179`: opened workspace settings for the issue worktree and confirmed placeholders show `default: origin`, `default: none`, `additional var (default: PORT)`, prompt textareas show `default: none`, no console errors

Closes #145
