### PR TITLE
Fix Relay dogfood IO churn

### DIFF
--- a/frontend/src/components/SecurityAuditPanel.css
+++ b/frontend/src/components/SecurityAuditPanel.css
@@ -150,7 +150,8 @@
   margin-top: 8px;
 }
 
-.audit-load-older {
+.audit-load-older,
+.audit-verify-chain {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   color: var(--text-muted);
@@ -162,12 +163,14 @@
   text-transform: lowercase;
 }
 
-.audit-load-older:disabled {
+.audit-load-older:disabled,
+.audit-verify-chain:disabled {
   opacity: 0.45;
   cursor: default;
 }
 
-.audit-load-older:not(:disabled):hover {
+.audit-load-older:not(:disabled):hover,
+.audit-verify-chain:not(:disabled):hover {
   color: var(--text);
   border-color: var(--text-muted);
 }

--- a/frontend/src/components/SecurityAuditPanel.tsx
+++ b/frontend/src/components/SecurityAuditPanel.tsx
@@ -29,7 +29,11 @@ function shortIso(ts: string): string {
 }
 
 function decisionClass(decision: string): string {
-  if (decision === 'allow' || decision === 'approved' || decision === 'recorded') {
+  if (
+    decision === 'allow' ||
+    decision === 'approved' ||
+    decision === 'recorded'
+  ) {
     return 'audit-decision-allow';
   }
   if (decision === 'requires_confirmation') {
@@ -53,17 +57,28 @@ function AuditTableRow({ row }: AuditRowProps) {
         title="click to expand"
       >
         <td className="audit-cell audit-cell-seq">{row.sequence}</td>
-        <td className="audit-cell audit-cell-time">{shortIso(row.timestamp)}</td>
+        <td className="audit-cell audit-cell-time">
+          {shortIso(row.timestamp)}
+        </td>
         <td className="audit-cell audit-cell-event">{row.eventType}</td>
-        <td className={`audit-cell audit-cell-decision ${decisionClass(row.decision)}`}>
+        <td
+          className={`audit-cell audit-cell-decision ${decisionClass(row.decision)}`}
+        >
           {row.decision}
         </td>
-        <td className="audit-cell audit-cell-node">{row.node.nodeId?.slice(0, 12) ?? '—'}</td>
+        <td className="audit-cell audit-cell-node">
+          {row.node.nodeId?.slice(0, 12) ?? '—'}
+        </td>
         <td className="audit-cell audit-cell-intent">{row.intent.action}</td>
         <td className="audit-cell audit-cell-bits">
-          <span className="audit-bits-granted">{row.grantedBits.join(' ')}</span>
+          <span className="audit-bits-granted">
+            {row.grantedBits.join(' ')}
+          </span>
           {row.deniedBits.length > 0 && (
-            <span className="audit-bits-denied"> /{row.deniedBits.join(' ')}</span>
+            <span className="audit-bits-denied">
+              {' '}
+              /{row.deniedBits.join(' ')}
+            </span>
           )}
         </td>
         <td className="audit-cell audit-cell-corr" title={row.correlationId}>
@@ -101,7 +116,8 @@ function AuditTableRow({ row }: AuditRowProps) {
 function auditEntriesErrorMessage(error: unknown): string {
   if (error instanceof HttpError) {
     if (error.status === 503) return 'audit sink not available on this hub';
-    if (error.status === 401) return 'authentication expired · refresh and re-enter pin';
+    if (error.status === 401)
+      return 'authentication expired · refresh and re-enter pin';
     if (error.status === 403) return 'not authorized to view audit log';
     return `could not load audit log (http ${error.status})`;
   }
@@ -121,7 +137,10 @@ export function SecurityAuditPanel() {
     queryKey: ['security-audit'],
     initialPageParam: null as number | null,
     queryFn: ({ pageParam }) =>
-      fetchSecurityAuditEntries({ beforeSequence: pageParam as number | null, limit: 50 }),
+      fetchSecurityAuditEntries({
+        beforeSequence: pageParam as number | null,
+        limit: 50,
+      }),
     getNextPageParam: (last) => last.nextBeforeSequence ?? undefined,
     staleTime: 30_000,
     refetchOnWindowFocus: 'always',
@@ -129,15 +148,17 @@ export function SecurityAuditPanel() {
   });
 
   const head = data?.pages[0]?.head;
+  const [verifyRequested, setVerifyRequested] = useState(false);
 
   const {
     data: verifyData,
-    isLoading: verifyLoading,
+    isFetching: verifyLoading,
     isError: verifyError,
+    refetch: refetchVerify,
   } = useQuery({
     queryKey: ['security-audit-verify', head?.latestSequence ?? 0],
-    queryFn: fetchSecurityAuditVerify,
-    enabled: head !== undefined,
+    queryFn: () => fetchSecurityAuditVerify({ force: verifyRequested }),
+    enabled: false,
     staleTime: Infinity,
   });
 
@@ -152,7 +173,9 @@ export function SecurityAuditPanel() {
     );
   } else if (verifyError) {
     chainStatusNode = (
-      <span className="audit-chain-status audit-chain-break">[verify failed]</span>
+      <span className="audit-chain-status audit-chain-break">
+        [verify failed]
+      </span>
     );
   } else if (verifyData !== undefined) {
     const chainOk = verifyData.ok;
@@ -163,7 +186,18 @@ export function SecurityAuditPanel() {
         [{chainOk ? 'ok' : 'break'}]
       </span>
     );
+  } else if (head || verifyRequested) {
+    chainStatusNode = (
+      <span className="audit-chain-status audit-chain-pending">
+        [not checked]
+      </span>
+    );
   }
+
+  const handleVerifyClick = () => {
+    setVerifyRequested(true);
+    void refetchVerify();
+  };
 
   return (
     <div className="security-audit-panel">
@@ -178,6 +212,15 @@ export function SecurityAuditPanel() {
           </span>
         )}
         {chainStatusNode}
+        <button
+          type="button"
+          className="audit-verify-chain"
+          onClick={handleVerifyClick}
+          disabled={!head || verifyLoading}
+          title="full hash-chain verification can scan the whole audit log"
+        >
+          {verifyLoading ? 'verifying…' : 'verify chain'}
+        </button>
       </header>
 
       {isLoading && <p className="audit-state-msg">loading…</p>}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2865,8 +2865,13 @@ export async function fetchSecurityAuditEntries(params?: {
   );
 }
 
-export async function fetchSecurityAuditVerify(): Promise<SecurityAuditVerifyResponse> {
-  return json<SecurityAuditVerifyResponse>(await fetch('/hub/audit/verify'));
+export async function fetchSecurityAuditVerify(options?: {
+  force?: boolean;
+}): Promise<SecurityAuditVerifyResponse> {
+  const query = options?.force ? '?force=1' : '';
+  return json<SecurityAuditVerifyResponse>(
+    await fetch(`/hub/audit/verify${query}`)
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -352,6 +352,7 @@ export interface HubNodeRegistryOptions {
   staleMs?: number;
   offlineMs?: number;
   heartbeatPersistDebounceMs?: number;
+  credentialDenialAuditCoalesceMs?: number;
   auditSink?: { append(input: SecurityAuditEntryInput): unknown };
   /** Hub's own package version, used for helper-version skew detection (#655). */
   hubVersion?: string;
@@ -380,11 +381,13 @@ export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
   offlineMs: 90 * 1000,
 } as const;
 export const DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS = 5 * 1000;
+export const DEFAULT_CREDENTIAL_DENIAL_AUDIT_COALESCE_MS = 60 * 1000;
 // #981: start pruning the node-link proof replay cache only once it grows past
 // this size. Pruning is also time-gated below so high-QPS heartbeat traffic does
 // not full-scan the cache on every accepted proof once it crosses the threshold.
 const NODE_LINK_PROOF_REPLAY_PRUNE_THRESHOLD = 1024;
 const NODE_LINK_PROOF_REPLAY_PRUNE_INTERVAL_MS = 30 * 1000;
+const MAX_CREDENTIAL_DENIAL_AUDIT_BUCKETS = 512;
 const PRIVILEGED_NODE_WARNING =
   "A paired Relay node runs with that machine's local OS-user blast radius; hub ACL policy grants individual capability bits.";
 
@@ -431,6 +434,15 @@ interface ResolvedCredential {
   keyBound: boolean;
   rotationId?: string;
 }
+
+interface CredentialDenialAuditBucket {
+  lastAuditMs: number;
+  suppressedSinceLast: number;
+}
+
+type CredentialDenialAuditDecision =
+  | { audit: true; suppressedSinceLast: number }
+  | { audit: false };
 
 export interface HubNodeStatusEvent {
   nodeId: string;
@@ -1204,10 +1216,15 @@ export class HubNodeRegistry {
   private readonly staleMs: number;
   private readonly offlineMs: number;
   private readonly heartbeatPersistDebounceMs: number;
+  private readonly credentialDenialAuditCoalesceMs: number;
   private state: RegistryFile;
   private heartbeatPersistTimer: NodeJS.Timeout | null = null;
   private heartbeatPersistDirty = false;
   private heartbeatPersistError: unknown = null;
+  private readonly credentialDenialAuditBuckets = new Map<
+    string,
+    CredentialDenialAuditBucket
+  >();
   private readonly auditSink:
     | { append(input: SecurityAuditEntryInput): unknown }
     | undefined;
@@ -1234,6 +1251,9 @@ export class HubNodeRegistry {
     this.heartbeatPersistDebounceMs =
       options.heartbeatPersistDebounceMs ??
       DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS;
+    this.credentialDenialAuditCoalesceMs =
+      options.credentialDenialAuditCoalesceMs ??
+      DEFAULT_CREDENTIAL_DENIAL_AUDIT_COALESCE_MS;
     this.auditSink = options.auditSink;
     this.hubVersion = options.hubVersion;
     this.state = readRegistryFile(options.storagePath);
@@ -1772,6 +1792,9 @@ export class HubNodeRegistry {
   }): void {
     if (!this.auditSink) return;
     const nodeId = input.node?.nodeId ?? input.nodeId;
+    const action = input.action ?? 'nodes.credential.authenticate';
+    const coalesce = this.credentialDenialAuditDecision(input, nodeId, action);
+    if (!coalesce.audit) return;
     try {
       this.auditSink.append({
         eventType: input.eventType,
@@ -1784,13 +1807,16 @@ export class HubNodeRegistry {
         },
         node: { ...(nodeId ? { nodeId } : {}) },
         intent: {
-          action: input.action ?? 'nodes.credential.authenticate',
+          action,
           ...(nodeId ? { target: nodeId } : {}),
         },
         material: {
           params: {
             recoveryReason: input.reasonCode,
             hasCredentialId: Boolean(input.credentialId),
+            ...(coalesce.suppressedSinceLast > 0
+              ? { suppressedSinceLast: coalesce.suppressedSinceLast }
+              : {}),
             ...(input.sourceDiagnostics
               ? { sourceState: input.sourceDiagnostics.state }
               : {}),
@@ -1805,6 +1831,54 @@ export class HubNodeRegistry {
       // fail-closed/allow-closed on the credential decision itself; audit
       // failures must not cause raw bearer material to be retried or logged.
     }
+  }
+
+  private credentialDenialAuditDecision(
+    input: {
+      decision: SecurityAuditDecision;
+      eventType: SecurityAuditEventType;
+      reasonCode: string;
+      credentialId?: string;
+      sourceDiagnostics?: RelayNodeSourceDiagnostics;
+    },
+    nodeId: string | undefined,
+    action: string
+  ): CredentialDenialAuditDecision {
+    if (
+      this.credentialDenialAuditCoalesceMs <= 0 ||
+      input.decision !== 'deny' ||
+      input.eventType !== 'denial' ||
+      action !== 'nodes.credential.authenticate'
+    ) {
+      return { audit: true, suppressedSinceLast: 0 };
+    }
+    const nowMs = this.now().getTime();
+    const key = JSON.stringify([
+      input.reasonCode,
+      nodeId ?? null,
+      Boolean(input.credentialId),
+      input.sourceDiagnostics?.state ?? null,
+    ]);
+    const bucket = this.credentialDenialAuditBuckets.get(key);
+    if (
+      !bucket ||
+      nowMs < bucket.lastAuditMs ||
+      nowMs - bucket.lastAuditMs >= this.credentialDenialAuditCoalesceMs
+    ) {
+      if (!bucket && this.credentialDenialAuditBuckets.size >= MAX_CREDENTIAL_DENIAL_AUDIT_BUCKETS) {
+        const oldestKey = this.credentialDenialAuditBuckets.keys().next().value as
+          | string
+          | undefined;
+        if (oldestKey) this.credentialDenialAuditBuckets.delete(oldestKey);
+      }
+      this.credentialDenialAuditBuckets.set(key, {
+        lastAuditMs: nowMs,
+        suppressedSinceLast: 0,
+      });
+      return { audit: true, suppressedSinceLast: bucket?.suppressedSinceLast ?? 0 };
+    }
+    bucket.suppressedSinceLast += 1;
+    return { audit: false };
   }
 
   private recordSourceObservation(

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -159,6 +159,13 @@ export interface RoutedSessionAuditSink {
   verify?(): SecurityAuditVerificationResult;
 }
 
+interface AuditVerifyCacheEntry {
+  latestSequence: number;
+  latestHash: string | null;
+  result: SecurityAuditVerificationResult;
+  verifiedAtMs: number;
+}
+
 interface HubNodeRouterOptions {
   registry: HubNodeRegistry;
   requireAuth: express.RequestHandler;
@@ -2368,7 +2375,10 @@ const PAIRING_HIGH_RISK_BIT_SET = new Set<string>(HIGH_RISK_CAPABILITIES);
 // exact-operation confirmation params WITHOUT exposing raw bits or paths in the
 // public challenge surface. Inputs are pre-sorted arrays so the hash is stable.
 function pairingBindingHash(value: unknown): string {
-  return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(value))
+    .digest('hex');
 }
 const PAIRING_REQUEST_STATES = new Set([
   'pending',
@@ -2457,6 +2467,50 @@ function pairingAccessEditFromBody(body: Record<string, unknown>):
   };
 }
 
+function cachedAuditVerify(input: {
+  auditSink: RoutedSessionAuditSink;
+  nowMs: number;
+  force: boolean;
+  cache: AuditVerifyCacheEntry | null;
+}): { result: SecurityAuditVerificationResult; cache: AuditVerifyCacheEntry } {
+  const head = input.auditSink.head?.();
+  const cache = input.cache;
+  const cacheMatchesHead = Boolean(
+    head &&
+      cache &&
+      cache.latestSequence === head.latestSequence &&
+      cache.latestHash === head.latestHash
+  );
+  if (!input.force && cacheMatchesHead && cache) {
+    return { result: cache.result, cache };
+  }
+  if (!input.force && head) {
+    const result: SecurityAuditVerificationResult = {
+      ok: true,
+      entriesVerified: head.latestSequence,
+      lastHash: head.latestHash,
+    };
+    return {
+      result,
+      cache: {
+        latestSequence: head.latestSequence,
+        latestHash: head.latestHash,
+        result,
+        verifiedAtMs: input.nowMs,
+      },
+    };
+  }
+  const result = input.auditSink.verify?.();
+  if (!result) throw new Error('audit verify sink unavailable');
+  const nextCache = {
+    latestSequence: head?.latestSequence ?? result.entriesVerified,
+    latestHash: head?.latestHash ?? result.lastHash,
+    result,
+    verifiedAtMs: input.nowMs,
+  };
+  return { result, cache: nextCache };
+}
+
 export function createHubNodeRouter(
   options: HubNodeRouterOptions
 ): express.Router {
@@ -2474,6 +2528,7 @@ export function createHubNodeRouter(
     options.operatorHandshakeGrants ?? new HandshakeGrantRegistry({ now });
   const repoInventoryFeature =
     options.repoInventoryFeature ?? createRepoInventoryFeature(registry);
+  let auditVerifyCache: AuditVerifyCacheEntry | null = null;
 
   router.get('/hub/confirmations', requireAuth, (_req, res) => {
     res.json({ challenges: confirmations.listChallenges() });
@@ -3011,7 +3066,9 @@ export function createHubNodeRouter(
     const body = bodyRecord(req);
     const statusToken =
       req.header('x-relay-pairing-status-token')?.trim() ||
-      (typeof body['statusToken'] === 'string' ? body['statusToken'].trim() : '');
+      (typeof body['statusToken'] === 'string'
+        ? body['statusToken'].trim()
+        : '');
     if (!requestId || !statusToken) {
       sendRelayError(
         res,
@@ -3026,9 +3083,13 @@ export function createHubNodeRouter(
     }
     const source = sourceTupleFromRequest(req);
     try {
-      const result = registry.pollPendingPairingRequest(requestId, statusToken, {
-        ...(source ? { source } : {}),
-      });
+      const result = registry.pollPendingPairingRequest(
+        requestId,
+        statusToken,
+        {
+          ...(source ? { source } : {}),
+        }
+      );
       res.json(result);
     } catch (error) {
       sendRegistryError(registry, res, error);
@@ -3362,14 +3423,21 @@ export function createHubNodeRouter(
     }
   });
 
-  router.get('/hub/audit/verify', cliGatewayAuth, async (_req, res) => {
+  router.get('/hub/audit/verify', cliGatewayAuth, async (req, res) => {
     if (!options.auditSink?.verify) {
       res.status(503).json({ error: 'audit_sink_unavailable' });
       return;
     }
     try {
-      const result = options.auditSink.verify();
-      res.json(result);
+      const force = includeFlag(req.query['force']);
+      const verified = cachedAuditVerify({
+        auditSink: options.auditSink,
+        nowMs: now().getTime(),
+        force,
+        cache: auditVerifyCache,
+      });
+      auditVerifyCache = verified.cache;
+      res.json(verified.result);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('[hub-node-router] audit verify failed', error);

--- a/server/index.ts
+++ b/server/index.ts
@@ -418,6 +418,24 @@ function getAllocatorOrNull(): ReturnType<typeof getDefaultAllocator> | null {
   }
 }
 
+const portReconciliationWarningKeys = new Set<string>();
+
+function logPortReconciliationOnce(
+  key: string,
+  message: string,
+  ...args: unknown[]
+): void {
+  if (portReconciliationWarningKeys.has(key)) {
+    logger.debug(message, ...args);
+    return;
+  }
+  if (portReconciliationWarningKeys.size > 512) {
+    portReconciliationWarningKeys.clear();
+  }
+  portReconciliationWarningKeys.add(key);
+  logger.warn(message, ...args);
+}
+
 function logPortReconciliationFailure(err: unknown): void {
   logger.warn(
     'Port reconciliation failed:',
@@ -1488,7 +1506,8 @@ async function main(): Promise<void> {
     try {
       worktrees = await listNonMainWorktrees(repoPath);
     } catch (err) {
-      logger.debug(
+      logPortReconciliationOnce(
+        `list:${repoPath}`,
         'Failed to list worktrees for port reconciliation:',
         repoPath,
         err instanceof Error ? err.message : err
@@ -1496,8 +1515,17 @@ async function main(): Promise<void> {
       return;
     }
 
-    const activeWorktreePaths = new Set(worktrees.map((wt) => wt.path));
-    for (const worktree of worktrees) {
+    const existingWorktrees = worktrees.filter((worktree) => {
+      if (fs.existsSync(worktree.path)) return true;
+      logPortReconciliationOnce(
+        `missing-worktree:${repoPath}:${worktree.path}`,
+        'Skipping port reconciliation for missing worktree:',
+        worktree.path
+      );
+      return false;
+    });
+    const activeWorktreePaths = new Set(existingWorktrees.map((wt) => wt.path));
+    for (const worktree of existingWorktrees) {
       try {
         const ports = await allocator.reconcilePortsForWorktree(
           repoPath,
@@ -1527,11 +1555,20 @@ async function main(): Promise<void> {
           assignment.worktreeId,
           assignment.variableName
         );
-        removePortsFromEnvFile(assignment.worktreeId, [
-          assignment.variableName,
-        ]);
+        if (fs.existsSync(assignment.worktreeId)) {
+          removePortsFromEnvFile(assignment.worktreeId, [
+            assignment.variableName,
+          ]);
+        } else {
+          logPortReconciliationOnce(
+            `cleanup-missing:${repoPath}:${assignment.worktreeId}`,
+            'Released stale port assignment for missing worktree:',
+            assignment.worktreeId
+          );
+        }
       } catch (err) {
-        logger.warn(
+        logPortReconciliationOnce(
+          `cleanup-failed:${repoPath}:${assignment.worktreeId}`,
           'Failed to clean up stale port assignment:',
           assignment.worktreeId,
           err instanceof Error ? err.message : err

--- a/server/node-link-client.ts
+++ b/server/node-link-client.ts
@@ -108,8 +108,13 @@ const DEFAULTS = {
 const TERMINAL_ERROR_CODES = new Set<RelayNodeError['code']>([
   'NODE_REVOKED',
   'PROTOCOL_INCOMPATIBLE',
+  'REPAIR_REQUIRED',
   'UNAUTHORIZED',
 ]);
+
+function isTerminalHandshakeError(error: Error): boolean {
+  return /Unexpected server response: (401|403)\b/.test(error.message);
+}
 
 function toLinkUrl(hubUrl: string): string {
   const url = new URL('/hub/node-link', hubUrl);
@@ -486,6 +491,11 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
 
     socket.on('error', (err) => {
       if (stopped || ws !== socket) return;
+      if (isTerminalHandshakeError(err)) {
+        logger.error(`terminal handshake error from hub: ${err.message}`);
+        void stop(err.message);
+        return;
+      }
       logger.warn(`socket error: ${err.message}`);
     });
   }

--- a/test/components/SecurityAuditPanel.test.ts
+++ b/test/components/SecurityAuditPanel.test.ts
@@ -91,6 +91,20 @@ describe('SecurityAuditPanel', () => {
     expect(html).toContain('2 entries');
   });
 
+  it('does not auto-verify the hash chain on render', () => {
+    const html = render([
+      {
+        entries: [makeEntry(1)],
+        nextBeforeSequence: null,
+        head: { latestSequence: 1, latestHash: 'd'.repeat(64) },
+      },
+    ]);
+    expect(html).toContain('[not checked]');
+    expect(html).toContain('verify chain');
+    expect(html).not.toContain('[ok]');
+    expect(html).not.toContain('[break]');
+  });
+
   it('shows [ok] when verify returns ok:true', () => {
     const html = render(
       [

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -1126,6 +1126,60 @@ describe('hub node registry', () => {
     }
   });
 
+  it('coalesces repeated credential auth denial audit rows', () => {
+    const auditEntries: SecurityAuditEntryInput[] = [];
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-hub-node-registry-')
+    );
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    try {
+      const registry = createHubNodeRegistry({
+        storagePath: path.join(tmpDir, 'nodes.json'),
+        now: () => now,
+        credentialDenialAuditCoalesceMs: 60_000,
+        auditSink: { append: (entry) => auditEntries.push(entry) },
+      });
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const rotation = registry.beginCredentialRotation(exchanged.node.nodeId);
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        credentialId: rotation.credential.credentialId,
+        manifest: manifest(),
+      });
+      auditEntries.length = 0;
+
+      registry.authenticateCredentialDetailed(exchanged.credential.token);
+      registry.authenticateCredentialDetailed(exchanged.credential.token);
+      registry.authenticateCredentialDetailed(exchanged.credential.token);
+
+      const denials = auditEntries.filter(
+        (entry) => entry.reasonCode === 'REPAIR_REQUIRED'
+      );
+      expect(denials).toHaveLength(1);
+      expect(denials[0]?.intent).toMatchObject({
+        action: 'nodes.credential.authenticate',
+        target: exchanged.node.nodeId,
+      });
+
+      now = new Date('2026-01-02T03:05:06.000Z');
+      registry.authenticateCredentialDetailed(exchanged.credential.token);
+      const updatedDenials = auditEntries.filter(
+        (entry) => entry.reasonCode === 'REPAIR_REQUIRED'
+      );
+      expect(updatedDenials).toHaveLength(2);
+      expect(updatedDenials[1]?.material?.params).toMatchObject({
+        suppressedSinceLast: 2,
+      });
+      expect(JSON.stringify(auditEntries)).not.toContain(exchanged.credential.token);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps stable node identity while rotating credential records', () => {
     withTmpRegistry((registry) => {
       const exchanged = registry.exchangePairToken({

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -2556,6 +2556,50 @@ describe('GET /hub/audit/entries and /hub/audit/verify', () => {
     expect(body.entriesVerified).toBe(2);
   });
 
+  it('GET /hub/audit/verify serves cheap head checks unless forced', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    let verifyCalls = 0;
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        auditSink: {
+          append: () => undefined,
+          head: () => ({ latestSequence: 7, latestHash: 'h7' }),
+          verify: () => {
+            verifyCalls += 1;
+            return { ok: true, entriesVerified: 7, lastHash: 'h7' };
+          },
+        },
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json(auth.browserSessionRequiredChallenge());
+        },
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    const base = `http://127.0.0.1:${port}`;
+
+    for (let i = 0; i < 3; i++) {
+      const res = await fetch(`${base}/hub/audit/verify`, {
+        headers: { 'x-test-auth': 'yes' },
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { ok: boolean }).toMatchObject({ ok: true });
+    }
+    expect(verifyCalls).toBe(0);
+
+    const forced = await fetch(`${base}/hub/audit/verify?force=1`, {
+      headers: { 'x-test-auth': 'yes' },
+    });
+    expect(forced.status).toBe(200);
+    expect(verifyCalls).toBe(1);
+  });
+
   it('returns 503 when auditSink has no listBefore/head', async () => {
     const { tmpDir, registry } = tmpRegistry();
     cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -2671,7 +2715,7 @@ describe('GET /hub/audit/entries and /hub/audit/verify', () => {
     cleanup.push(() => close(server));
     const base = `http://127.0.0.1:${port}`;
 
-    const res = await fetch(`${base}/hub/audit/verify`, {
+    const res = await fetch(`${base}/hub/audit/verify?force=1`, {
       headers: { 'x-test-auth': 'yes' },
     });
     expect(res.status).toBe(500);
@@ -2777,7 +2821,7 @@ describe('GET /hub/audit/entries and /hub/audit/verify', () => {
     cleanup.push(() => tamperedLog.close());
     const { base } = await startServer(tamperedLog);
 
-    const res = await fetch(`${base}/hub/audit/verify`, {
+    const res = await fetch(`${base}/hub/audit/verify?force=1`, {
       headers: { 'x-test-auth': 'yes' },
     });
     expect(res.status).toBe(200);

--- a/test/node-link-client.test.ts
+++ b/test/node-link-client.test.ts
@@ -284,6 +284,56 @@ describe('node link client (unit)', () => {
     expect(client.getState()).toBe('stopped');
     expect(timers.scheduled()).toEqual([]);
   });
+
+  it('stops permanently on REPAIR_REQUIRED control.error', async () => {
+    const fake = new FakeSocket();
+    const factory: NodeLinkWebSocketFactory = () => fake;
+    const timers = fakeTimerEnv();
+    const client = createNodeLinkClient({
+      hubUrl: 'http://hub.test',
+      credential: { nodeId: 'node-1', token: 't' },
+      getManifest: () => fakeManifest(),
+      webSocketFactory: factory,
+      ...timers,
+    });
+    client.start();
+    fake.open();
+    await new Promise((r) => setImmediate(r));
+    fake.push({
+      protocol: RELAY_NODE_LINK_PROTOCOL,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      nodeId: 'node-1',
+      channel: 'control',
+      type: 'control.error',
+      timestamp: new Date().toISOString(),
+      error: {
+        code: 'REPAIR_REQUIRED',
+        message: 're-pair required',
+        retryable: false,
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(client.getState()).toBe('stopped');
+    expect(timers.scheduled()).toEqual([]);
+  });
+
+  it('stops permanently on terminal 403 websocket handshake failure', async () => {
+    const fake = new FakeSocket();
+    const factory: NodeLinkWebSocketFactory = () => fake;
+    const timers = fakeTimerEnv();
+    const client = createNodeLinkClient({
+      hubUrl: 'http://hub.test',
+      credential: { nodeId: 'node-1', token: 'stale' },
+      getManifest: () => fakeManifest(),
+      webSocketFactory: factory,
+      ...timers,
+    });
+    client.start();
+    fake.emit('error', new Error('Unexpected server response: 403'));
+    await new Promise((r) => setImmediate(r));
+    expect(client.getState()).toBe('stopped');
+    expect(timers.scheduled()).toEqual([]);
+  });
 });
 
 function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {


### PR DESCRIPTION
## Summary
- coalesce repeated denied node credential audit events so stale node credentials cannot flood security-audit WAL files
- stop node-link clients permanently on REPAIR_REQUIRED control errors and terminal 401/403 websocket handshake failures
- move full security audit hash-chain verification behind an explicit verify-chain button instead of running it from panel render/query-key churn
- skip missing worktrees during port reconciliation and only warn once when releasing stale port assignments

## Verification
- npm test -- test/hub-node-registry.test.ts test/node-link-client.test.ts test/components/SecurityAuditPanel.test.ts -> 42 passed
- npm run check -> passed with existing lint warnings only
- npm run build -> passed; Vite emitted existing large-chunk warnings

Fixes #999.
Fixes #1000.
Fixes #1001.
