### PR TITLE
Reduce security audit WAL fsync churn

### DIFF
--- a/server/security-audit-log.ts
+++ b/server/security-audit-log.ts
@@ -132,6 +132,9 @@ export class SecurityAuditLog {
       this.closeOnDispose = false;
     }
     this.db.pragma('journal_mode = WAL');
+    // Keep audit writes durable enough for dogfood while avoiding SQLite FULL
+    // synchronous WAL/fsync amplification on every denied node credential event.
+    this.db.pragma('synchronous = NORMAL');
     this.db.pragma('foreign_keys = ON');
     this.db.exec(SCHEMA_SQL);
     ensureSecurityAuditCheckpoint(this.db);
@@ -140,12 +143,17 @@ export class SecurityAuditLog {
   listBefore(
     beforeSequence: number | null,
     limit: number
-  ): { rows: NormalizedSecurityAuditEntry[]; nextBeforeSequence: number | null } {
+  ): {
+    rows: NormalizedSecurityAuditEntry[];
+    nextBeforeSequence: number | null;
+  } {
     const cappedLimit = Math.max(1, Math.min(!limit ? 50 : limit, 200));
     let rawRows: AuditRow[];
     if (beforeSequence === null || beforeSequence === 0) {
       rawRows = this.db
-        .prepare('SELECT * FROM security_audit_log ORDER BY sequence DESC LIMIT ?')
+        .prepare(
+          'SELECT * FROM security_audit_log ORDER BY sequence DESC LIMIT ?'
+        )
         .all(cappedLimit) as AuditRow[];
     } else {
       if (!Number.isFinite(beforeSequence) || beforeSequence < 0) {

--- a/test/security-audit.test.ts
+++ b/test/security-audit.test.ts
@@ -125,6 +125,23 @@ describe('security audit primitives', () => {
     log.close();
   });
 
+  it('opens the audit database with WAL and NORMAL synchronous mode', () => {
+    const dbPath = tmpDbPath();
+    const log = new SecurityAuditLog(dbPath);
+    log.append(sampleEvent({ eventId: 'evt-sync' }));
+    log.close();
+
+    const db = new Database(dbPath);
+    try {
+      const journalMode = db.pragma('journal_mode', { simple: true });
+      const synchronous = db.pragma('synchronous', { simple: true });
+      expect(journalMode).toBe('wal');
+      expect(synchronous).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it('redacts tokens, env values, file bytes, and terminal streams before hashing', () => {
     const payload = {
       authorization: 'Bearer relay-secret-token-1234567890',
@@ -273,7 +290,11 @@ describe('security audit primitives', () => {
     expect(entry.grantedBits).toEqual(['tab:mode:set-agent']);
     expect(entry.deniedBits).toEqual([]);
     expect(entry.requiredBits).not.toEqual(
-      expect.arrayContaining(['rpc:fs:write', 'rpc:git:write', 'pty:exec:arbitrary'])
+      expect.arrayContaining([
+        'rpc:fs:write',
+        'rpc:git:write',
+        'pty:exec:arbitrary',
+      ])
     );
   });
 
@@ -386,9 +407,9 @@ describe('security audit primitives', () => {
     db.close();
 
     const reopened = new SecurityAuditLog(dbPath);
-    expect(() =>
-      reopened.append(sampleEvent({ eventId: 'evt-4' }))
-    ).toThrow(/checkpoint mismatch/);
+    expect(() => reopened.append(sampleEvent({ eventId: 'evt-4' }))).toThrow(
+      /checkpoint mismatch/
+    );
     reopened.close();
 
     expect(verifySecurityAuditLog(dbPath)).toMatchObject({
@@ -426,7 +447,9 @@ describe('security audit primitives', () => {
     it('returns newest N rows first when called with null (from head)', () => {
       const log = new SecurityAuditLog(tmpDbPath());
       for (let i = 1; i <= 5; i++) {
-        log.append(sampleEvent({ eventId: `evt-${i}`, correlationId: `corr-${i}` }));
+        log.append(
+          sampleEvent({ eventId: `evt-${i}`, correlationId: `corr-${i}` })
+        );
       }
       const result = log.listBefore(null, 3);
       expect(result.rows).toHaveLength(3);
@@ -440,7 +463,9 @@ describe('security audit primitives', () => {
     it('paginates correctly: listBefore(3, 100) returns rows 2,1 with nextBeforeSequence:1; listBefore(1,100) returns empty+null', () => {
       const log = new SecurityAuditLog(tmpDbPath());
       for (let i = 1; i <= 5; i++) {
-        log.append(sampleEvent({ eventId: `evt-${i}`, correlationId: `corr-${i}` }));
+        log.append(
+          sampleEvent({ eventId: `evt-${i}`, correlationId: `corr-${i}` })
+        );
       }
       const result = log.listBefore(3, 100);
       expect(result.rows).toHaveLength(2);
@@ -459,7 +484,9 @@ describe('security audit primitives', () => {
     it('caps limit at 200 when limit > 200 is requested', () => {
       const log = new SecurityAuditLog(tmpDbPath());
       for (let i = 1; i <= 5; i++) {
-        log.append(sampleEvent({ eventId: `evt-${i}`, correlationId: `corr-${i}` }));
+        log.append(
+          sampleEvent({ eventId: `evt-${i}`, correlationId: `corr-${i}` })
+        );
       }
       // Should not throw; limit capped at 200 internally
       const result = log.listBefore(null, 9999);
@@ -495,7 +522,9 @@ describe('security audit primitives', () => {
     it('returns the checkpoint values matching verify().lastHash after appends', () => {
       const log = new SecurityAuditLog(tmpDbPath());
       log.append(sampleEvent({ eventId: 'evt-1' }));
-      const second = log.append(sampleEvent({ eventId: 'evt-2', correlationId: 'corr-2' }));
+      const second = log.append(
+        sampleEvent({ eventId: 'evt-2', correlationId: 'corr-2' })
+      );
       const h = log.head();
       const v = log.verify();
       expect(h.latestSequence).toBe(2);


### PR DESCRIPTION
## Summary
- set `SecurityAuditLog` WAL connections to `synchronous = NORMAL`
- cover the security-audit database PRAGMAs in tests
- reduces observed live dogfood write amplification from multi-GB/20s WAL fsync churn while keeping WAL + hash-chain semantics

## Verification
- `rtk npm test -- test/security-audit.test.ts test/hub-node-registry.test.ts test/hub-node-routes.test.ts`
- `rtk npm run check`
- `rtk npm run build`

Follow-up to #1002 / #999 after live dogfood evidence showed the stale credential loop was coalesced but SQLite FULL synchronous was still murdering the disk. because of course it was.
