### PR TITLE
Command Center resolver foundation

### DIFF
--- a/server/command-center-intent-resolver.ts
+++ b/server/command-center-intent-resolver.ts
@@ -4,6 +4,7 @@ import {
   summarizeCommandCenterCatalogForResolver,
   validateCommandCenterProviderIntent,
   type CommandCenterFallbackReason,
+  type CommandCenterIntentKind,
   type CommandCenterResolution,
   type CommandCenterResolverCatalog,
 } from '../shared/command-center-resolver.js';
@@ -15,6 +16,8 @@ export interface CommandCenterIntentResolverConfig {
   organization?: string;
   timeoutMs: number;
   minConfidence: number;
+  maxOutputTokens: number;
+  temperature: number;
 }
 
 export interface CommandCenterIntentResolverHealth {
@@ -38,12 +41,15 @@ export interface ResolveCommandCenterIntentOptions {
   provider?: CommandCenterIntentProvider | null;
   catalog?: CommandCenterResolverCatalog;
   minConfidence?: number;
+  /** Opt into provider health preflight. Default avoids hot-path /models calls. */
+  preflightHealthCheck?: boolean;
+  /** @deprecated use preflightHealthCheck; false still opts into preflight for compatibility. */
   skipHealthCheck?: boolean;
   now?: () => number;
 }
 
 export interface CommandCenterIntentAudit {
-  outcome: 'resolved' | 'fallback';
+  outcome: CommandCenterIntentKind;
   reason?: CommandCenterFallbackReason;
   commandId?: string;
   confidence?: number;
@@ -67,18 +73,22 @@ export type CommandCenterFetchLike = (
 
 const DEFAULT_TIMEOUT_MS = 8_000;
 const DEFAULT_MIN_CONFIDENCE = 0.6;
+const DEFAULT_MAX_OUTPUT_TOKENS = 512;
+const DEFAULT_TEMPERATURE = 0;
 const ENV_BASE_URL = 'RELAY_COMMAND_CENTER_RESOLVER_BASE_URL';
 const ENV_MODEL = 'RELAY_COMMAND_CENTER_RESOLVER_MODEL';
 const ENV_API_KEY = 'RELAY_COMMAND_CENTER_RESOLVER_API_KEY';
 const ENV_ORGANIZATION = 'RELAY_COMMAND_CENTER_RESOLVER_ORG';
 const ENV_TIMEOUT_MS = 'RELAY_COMMAND_CENTER_RESOLVER_TIMEOUT_MS';
 const ENV_MIN_CONFIDENCE = 'RELAY_COMMAND_CENTER_RESOLVER_MIN_CONFIDENCE';
+const ENV_MAX_OUTPUT_TOKENS = 'RELAY_COMMAND_CENTER_RESOLVER_MAX_OUTPUT_TOKENS';
+const ENV_TEMPERATURE = 'RELAY_COMMAND_CENTER_RESOLVER_TEMPERATURE';
 
 const SYSTEM_PROMPT =
-  'Map the operator request to exactly one Relay command from the catalog. ' +
-  'Return only JSON: {"commandId":string,"args":object,"confidence":number}. ' +
-  'Use only commandIds from the catalog. If unsure, return low confidence. ' +
-  'Never invent commands, arguments, shell strings, or execution plans.';
+  'Map the operator request to exactly one strict Relay Command Center resolver result. ' +
+  'Return only JSON with kind open_ui, ask_followup, explain, execute_command, or no_match. ' +
+  'For execute_command/open_ui include commandId,args,confidence and use only commandIds from the catalog. ' +
+  'execute_command is read-only only. Never invent commands, arguments, shell strings, execution plans, or provider escalations.';
 
 export function readCommandCenterIntentResolverConfig(
   env: Record<string, string | undefined> = process.env
@@ -96,6 +106,8 @@ export function readCommandCenterIntentResolverConfig(
     ...(organization ? { organization } : {}),
     timeoutMs: parseTimeoutMs(env[ENV_TIMEOUT_MS]),
     minConfidence: parseMinConfidence(env[ENV_MIN_CONFIDENCE]),
+    maxOutputTokens: parseMaxOutputTokens(env[ENV_MAX_OUTPUT_TOKENS]),
+    temperature: parseTemperature(env[ENV_TEMPERATURE]),
   };
 }
 
@@ -109,6 +121,18 @@ function parseMinConfidence(value: string | undefined): number {
   return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
     ? parsed
     : DEFAULT_MIN_CONFIDENCE;
+}
+
+function parseMaxOutputTokens(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_OUTPUT_TOKENS;
+}
+
+function parseTemperature(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_TEMPERATURE;
 }
 
 function headersForConfig(
@@ -189,7 +213,8 @@ export function createOpenAiCompatibleCommandCenterIntentProvider(
           signal,
           body: JSON.stringify({
             model: config.model,
-            temperature: 0,
+            temperature: config.temperature,
+            max_tokens: config.maxOutputTokens,
             response_format: { type: 'json_object' },
             messages: [
               { role: 'system', content: SYSTEM_PROMPT },
@@ -232,7 +257,7 @@ function fallbackResolution(
   detail?: string
 ): CommandCenterResolution {
   return {
-    kind: 'fallback',
+    kind: 'no_match',
     reason,
     ...(detail ? { detail } : {}),
     suggestions: searchCommandCenterCatalog(request.query, catalog),
@@ -243,18 +268,29 @@ function auditFromResolution(
   resolution: CommandCenterResolution,
   durationMs: number | undefined
 ): CommandCenterIntentAudit {
-  if (resolution.kind === 'resolved') {
+  if (resolution.kind === 'execute_command' || resolution.kind === 'open_ui') {
     return {
-      outcome: 'resolved',
+      outcome: resolution.kind,
       commandId: resolution.intent.commandId,
       confidence: Math.round(resolution.intent.confidence * 100) / 100,
       ...(durationMs !== undefined ? { durationMs } : {}),
       suggestionCount: resolution.suggestions.length,
     };
   }
+  if (resolution.kind === 'ask_followup' || resolution.kind === 'explain') {
+    return {
+      outcome: resolution.kind,
+      confidence: Math.round(resolution.confidence * 100) / 100,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      suggestionCount: resolution.suggestions.length,
+    };
+  }
   return {
-    outcome: 'fallback',
+    outcome: 'no_match',
     reason: resolution.reason,
+    ...(resolution.confidence !== undefined
+      ? { confidence: Math.round(resolution.confidence * 100) / 100 }
+      : {}),
     ...(durationMs !== undefined ? { durationMs } : {}),
     suggestionCount: resolution.suggestions.length,
   };
@@ -271,7 +307,9 @@ export async function resolveCommandCenterIntent(
   }
 
   const start = options.now?.();
-  if (!options.skipHealthCheck) {
+  const shouldPreflightHealth =
+    options.preflightHealthCheck === true || options.skipHealthCheck === false;
+  if (shouldPreflightHealth) {
     const health = await safeHealth(options.provider);
     if (health.state !== 'healthy') {
       const resolution = fallbackResolution(

--- a/server/command-center-intent-resolver.ts
+++ b/server/command-center-intent-resolver.ts
@@ -1,0 +1,334 @@
+import {
+  COMMAND_CENTER_RESOLVER_CATALOG,
+  searchCommandCenterCatalog,
+  summarizeCommandCenterCatalogForResolver,
+  validateCommandCenterProviderIntent,
+  type CommandCenterFallbackReason,
+  type CommandCenterResolution,
+  type CommandCenterResolverCatalog,
+} from '../shared/command-center-resolver.js';
+
+export interface CommandCenterIntentResolverConfig {
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+  organization?: string;
+  timeoutMs: number;
+  minConfidence: number;
+}
+
+export interface CommandCenterIntentResolverHealth {
+  state: 'healthy' | 'unconfigured' | 'unreachable' | 'error';
+  model?: string;
+  baseUrl?: string;
+  detail?: string;
+}
+
+export interface CommandCenterIntentRequest {
+  /** Natural language query. Must not be logged or copied into audit metadata. */
+  query: string;
+}
+
+export interface CommandCenterIntentProvider {
+  health(): Promise<CommandCenterIntentResolverHealth>;
+  propose(request: CommandCenterIntentRequest): Promise<unknown>;
+}
+
+export interface ResolveCommandCenterIntentOptions {
+  provider?: CommandCenterIntentProvider | null;
+  catalog?: CommandCenterResolverCatalog;
+  minConfidence?: number;
+  skipHealthCheck?: boolean;
+  now?: () => number;
+}
+
+export interface CommandCenterIntentAudit {
+  outcome: 'resolved' | 'fallback';
+  reason?: CommandCenterFallbackReason;
+  commandId?: string;
+  confidence?: number;
+  durationMs?: number;
+  suggestionCount: number;
+}
+
+export interface ResolveCommandCenterIntentResult {
+  resolution: CommandCenterResolution;
+  audit: CommandCenterIntentAudit;
+}
+
+export type CommandCenterFetchLike = (
+  url: string,
+  init: RequestInit
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_MIN_CONFIDENCE = 0.6;
+const ENV_BASE_URL = 'RELAY_COMMAND_CENTER_RESOLVER_BASE_URL';
+const ENV_MODEL = 'RELAY_COMMAND_CENTER_RESOLVER_MODEL';
+const ENV_API_KEY = 'RELAY_COMMAND_CENTER_RESOLVER_API_KEY';
+const ENV_ORGANIZATION = 'RELAY_COMMAND_CENTER_RESOLVER_ORG';
+const ENV_TIMEOUT_MS = 'RELAY_COMMAND_CENTER_RESOLVER_TIMEOUT_MS';
+const ENV_MIN_CONFIDENCE = 'RELAY_COMMAND_CENTER_RESOLVER_MIN_CONFIDENCE';
+
+const SYSTEM_PROMPT =
+  'Map the operator request to exactly one Relay command from the catalog. ' +
+  'Return only JSON: {"commandId":string,"args":object,"confidence":number}. ' +
+  'Use only commandIds from the catalog. If unsure, return low confidence. ' +
+  'Never invent commands, arguments, shell strings, or execution plans.';
+
+export function readCommandCenterIntentResolverConfig(
+  env: Record<string, string | undefined> = process.env
+): CommandCenterIntentResolverConfig | null {
+  const baseUrl = env[ENV_BASE_URL]?.trim();
+  const model = env[ENV_MODEL]?.trim();
+  if (!baseUrl || !model) return null;
+  const resolverCredential = env[ENV_API_KEY]?.trim();
+  const organization = env[ENV_ORGANIZATION]?.trim();
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+    model,
+    ...(resolverCredential ? { apiKey: resolverCredential } : {}),
+    ...(organization ? { organization } : {}),
+    timeoutMs: parseTimeoutMs(env[ENV_TIMEOUT_MS]),
+    minConfidence: parseMinConfidence(env[ENV_MIN_CONFIDENCE]),
+  };
+}
+
+function parseTimeoutMs(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_MS;
+}
+
+function parseMinConfidence(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
+    ? parsed
+    : DEFAULT_MIN_CONFIDENCE;
+}
+
+function headersForConfig(
+  config: CommandCenterIntentResolverConfig
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (config.apiKey) headers.authorization = `Bearer ${config.apiKey}`;
+  if (config.organization) headers['openai-organization'] = config.organization;
+  return headers;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+async function runWithTimeout<T>(
+  timeoutMs: number,
+  run: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await run(controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function createOpenAiCompatibleCommandCenterIntentProvider(
+  config: CommandCenterIntentResolverConfig,
+  deps: {
+    fetch: CommandCenterFetchLike;
+    catalog?: CommandCenterResolverCatalog;
+  }
+): CommandCenterIntentProvider {
+  const catalog = deps.catalog ?? COMMAND_CENTER_RESOLVER_CATALOG;
+
+  return {
+    async health() {
+      try {
+        const response = await runWithTimeout(config.timeoutMs, (signal) =>
+          deps.fetch(`${config.baseUrl}/models`, {
+            method: 'GET',
+            headers: headersForConfig(config),
+            signal,
+          })
+        );
+        if (!response.ok) {
+          return {
+            state: 'error',
+            model: config.model,
+            baseUrl: config.baseUrl,
+            detail: `status ${response.status}`,
+          };
+        }
+        return {
+          state: 'healthy',
+          model: config.model,
+          baseUrl: config.baseUrl,
+        };
+      } catch (error) {
+        return {
+          state: 'unreachable',
+          model: config.model,
+          baseUrl: config.baseUrl,
+          detail: isAbortError(error) ? 'timeout' : 'network-error',
+        };
+      }
+    },
+
+    async propose(request) {
+      const response = await runWithTimeout(config.timeoutMs, (signal) =>
+        deps.fetch(`${config.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: headersForConfig(config),
+          signal,
+          body: JSON.stringify({
+            model: config.model,
+            temperature: 0,
+            response_format: { type: 'json_object' },
+            messages: [
+              { role: 'system', content: SYSTEM_PROMPT },
+              {
+                role: 'system',
+                content: JSON.stringify(
+                  summarizeCommandCenterCatalogForResolver(catalog)
+                ),
+              },
+              { role: 'user', content: request.query },
+            ],
+          }),
+        })
+      );
+      if (!response.ok) throw new Error(`provider status ${response.status}`);
+      return parseOpenAiCompatibleResolverResponse(await response.json());
+    },
+  };
+}
+
+function parseOpenAiCompatibleResolverResponse(payload: unknown): unknown {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('provider response was not an object');
+  }
+  const choices = (payload as { choices?: unknown }).choices;
+  if (!Array.isArray(choices))
+    throw new Error('provider response missing choices');
+  const content = (
+    choices[0] as { message?: { content?: unknown } } | undefined
+  )?.message?.content;
+  if (typeof content !== 'string')
+    throw new Error('provider response missing content');
+  return JSON.parse(content) as unknown;
+}
+
+function fallbackResolution(
+  reason: CommandCenterFallbackReason,
+  request: CommandCenterIntentRequest,
+  catalog: CommandCenterResolverCatalog,
+  detail?: string
+): CommandCenterResolution {
+  return {
+    kind: 'fallback',
+    reason,
+    ...(detail ? { detail } : {}),
+    suggestions: searchCommandCenterCatalog(request.query, catalog),
+  };
+}
+
+function auditFromResolution(
+  resolution: CommandCenterResolution,
+  durationMs: number | undefined
+): CommandCenterIntentAudit {
+  if (resolution.kind === 'resolved') {
+    return {
+      outcome: 'resolved',
+      commandId: resolution.intent.commandId,
+      confidence: Math.round(resolution.intent.confidence * 100) / 100,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      suggestionCount: resolution.suggestions.length,
+    };
+  }
+  return {
+    outcome: 'fallback',
+    reason: resolution.reason,
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    suggestionCount: resolution.suggestions.length,
+  };
+}
+
+export async function resolveCommandCenterIntent(
+  request: CommandCenterIntentRequest,
+  options: ResolveCommandCenterIntentOptions = {}
+): Promise<ResolveCommandCenterIntentResult> {
+  const catalog = options.catalog ?? COMMAND_CENTER_RESOLVER_CATALOG;
+  if (!options.provider) {
+    const resolution = fallbackResolution('provider-missing', request, catalog);
+    return { resolution, audit: auditFromResolution(resolution, undefined) };
+  }
+
+  const start = options.now?.();
+  if (!options.skipHealthCheck) {
+    const health = await safeHealth(options.provider);
+    if (health.state !== 'healthy') {
+      const resolution = fallbackResolution(
+        'provider-unhealthy',
+        request,
+        catalog,
+        health.state
+      );
+      return {
+        resolution,
+        audit: auditFromResolution(resolution, duration(start, options.now)),
+      };
+    }
+  }
+
+  let raw: unknown;
+  try {
+    raw = await options.provider.propose(request);
+  } catch (error) {
+    const resolution = fallbackResolution(
+      isAbortError(error) ? 'timeout' : 'provider-error',
+      request,
+      catalog,
+      isAbortError(error) ? 'timeout' : 'provider-error'
+    );
+    return {
+      resolution,
+      audit: auditFromResolution(resolution, duration(start, options.now)),
+    };
+  }
+
+  const resolution = validateCommandCenterProviderIntent(raw, {
+    catalog,
+    query: request.query,
+    ...(options.minConfidence !== undefined
+      ? { minConfidence: options.minConfidence }
+      : {}),
+  });
+  return {
+    resolution,
+    audit: auditFromResolution(resolution, duration(start, options.now)),
+  };
+}
+
+async function safeHealth(
+  provider: CommandCenterIntentProvider
+): Promise<CommandCenterIntentResolverHealth> {
+  try {
+    return await provider.health();
+  } catch {
+    return { state: 'unreachable' };
+  }
+}
+
+function duration(
+  start: number | undefined,
+  now: (() => number) | undefined
+): number | undefined {
+  return start !== undefined && now ? now() - start : undefined;
+}

--- a/shared/command-center-resolver.ts
+++ b/shared/command-center-resolver.ts
@@ -1,0 +1,543 @@
+import type {
+  RelayCliGatewayCommand,
+  RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import {
+  relayCommandDefinitionsForSurface,
+  type RelayCommandControlRequirement,
+  type RelayCommandDefinition,
+  type RelayCommandScopeKind,
+  type RelayCommandSideEffect,
+} from './relay-command-manifest.js';
+import {
+  relayActionDescriptorFromCommandDefinition,
+  type RelayActionDescriptor,
+  type RelayActionSurface,
+} from './action-descriptor.js';
+import type { RelayCapabilityBit } from './security-policy.js';
+
+export interface CommandCenterResolverCatalogEntry {
+  commandId: RelayCliGatewayCommand;
+  label: string;
+  summary: string;
+  keywords: readonly string[];
+  sideEffect: RelayCommandSideEffect;
+  requiresConfirmation: boolean;
+  controlRequirements: readonly RelayCommandControlRequirement[];
+  scopeKinds: readonly RelayCommandScopeKind[];
+  capabilityHints: readonly RelayCapabilityBit[];
+  surfaces: readonly RelayActionSurface[];
+  ui?: {
+    actionId?: string;
+    category?: string;
+  };
+  inputSchema: RelayJsonSchema;
+}
+
+export interface CommandCenterResolverCatalog {
+  entries: readonly CommandCenterResolverCatalogEntry[];
+  byCommandId: ReadonlyMap<
+    RelayCliGatewayCommand,
+    CommandCenterResolverCatalogEntry
+  >;
+}
+
+export interface CommandCenterResolverSearchHit {
+  entry: CommandCenterResolverCatalogEntry;
+  score: number;
+}
+
+export interface CommandCenterProviderIntent {
+  commandId: string;
+  args?: unknown;
+  confidence: number;
+  rationale?: string;
+  sideEffect?: string;
+  requiresConfirmation?: boolean;
+  scopeKinds?: readonly string[];
+  capabilityHints?: readonly string[];
+  surfaces?: readonly string[];
+  ui?: {
+    actionId?: string;
+    category?: string;
+  };
+}
+
+export interface CommandCenterResolvedIntent {
+  commandId: RelayCliGatewayCommand;
+  args: Record<string, unknown>;
+  confidence: number;
+  rationale?: string;
+  sideEffect: RelayCommandSideEffect;
+  requiresConfirmation: boolean;
+  controlRequirements: readonly RelayCommandControlRequirement[];
+  scopeKinds: readonly RelayCommandScopeKind[];
+  capabilityHints: readonly RelayCapabilityBit[];
+  surfaces: readonly RelayActionSurface[];
+  ui?: {
+    actionId?: string;
+    category?: string;
+  };
+}
+
+export type CommandCenterFallbackReason =
+  | 'provider-missing'
+  | 'provider-unhealthy'
+  | 'timeout'
+  | 'provider-error'
+  | 'malformed-output'
+  | 'low-confidence'
+  | 'unknown-command'
+  | 'invalid-args'
+  | 'metadata-mismatch';
+
+export type CommandCenterResolution =
+  | {
+      kind: 'resolved';
+      intent: CommandCenterResolvedIntent;
+      entry: CommandCenterResolverCatalogEntry;
+      suggestions: readonly CommandCenterResolverSearchHit[];
+    }
+  | {
+      kind: 'fallback';
+      reason: CommandCenterFallbackReason;
+      detail?: string;
+      suggestions: readonly CommandCenterResolverSearchHit[];
+    };
+
+export interface ValidateProviderIntentOptions {
+  catalog?: CommandCenterResolverCatalog;
+  minConfidence?: number;
+  query?: string;
+  suggestionLimit?: number;
+}
+
+const DEFAULT_MIN_CONFIDENCE = 0.6;
+const WORD_SPLIT = /[^a-z0-9]+/i;
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'of',
+  'for',
+  'to',
+  'and',
+  'or',
+  'with',
+  'command',
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(WORD_SPLIT)
+    .filter((token) => token.length > 0 && !STOPWORDS.has(token));
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function keywordsForDescriptor(descriptor: RelayActionDescriptor): string[] {
+  return uniqueStrings([
+    ...tokenize(descriptor.id),
+    ...tokenize(descriptor.label),
+    ...tokenize(descriptor.title),
+    ...tokenize(descriptor.description ?? ''),
+    ...(descriptor.ui?.aliases?.flatMap(tokenize) ?? []),
+    ...(descriptor.contract?.cli?.flatMap(tokenize) ?? []),
+  ]);
+}
+
+export function catalogEntryFromActionDescriptor(
+  descriptor: RelayActionDescriptor
+): CommandCenterResolverCatalogEntry | null {
+  if (!descriptor.contract) return null;
+  if (descriptor.input.kind !== 'json-schema') return null;
+  if (descriptor.sideEffect === 'ui') return null;
+
+  return {
+    commandId: descriptor.contract.relayCommandName,
+    label: descriptor.label,
+    summary: descriptor.description ?? descriptor.label,
+    keywords: keywordsForDescriptor(descriptor),
+    sideEffect: descriptor.sideEffect,
+    requiresConfirmation: descriptor.confirmation.required,
+    controlRequirements: descriptor.confirmation.controlRequirements,
+    scopeKinds: scopeKindsFromDescriptor(descriptor),
+    capabilityHints:
+      descriptor.availability.capabilityHints ??
+      ([] as readonly RelayCapabilityBit[]),
+    surfaces: descriptor.surfaces,
+    ...(descriptor.ui
+      ? {
+          ui: {
+            ...(descriptor.ui.actionId
+              ? { actionId: descriptor.ui.actionId }
+              : {}),
+            ...(descriptor.ui.category
+              ? { category: descriptor.ui.category }
+              : {}),
+          },
+        }
+      : {}),
+    inputSchema: descriptor.input.schema,
+  };
+}
+
+function scopeKindsFromDescriptor(
+  descriptor: RelayActionDescriptor
+): readonly RelayCommandScopeKind[] {
+  const command = relayCommandDefinitionsForSurface('web').find(
+    (entry) => entry.name === descriptor.contract?.relayCommandName
+  );
+  return command?.scopeKinds ?? [];
+}
+
+export function buildCommandCenterResolverCatalog(
+  descriptors: readonly RelayActionDescriptor[] = relayCommandDefinitionsForSurface(
+    'web'
+  ).map((definition) =>
+    relayActionDescriptorFromCommandDefinition(definition, {
+      surfaces: [...definition.surfaces, 'command-center'],
+    })
+  )
+): CommandCenterResolverCatalog {
+  const entries = descriptors
+    .map(catalogEntryFromActionDescriptor)
+    .filter(
+      (entry): entry is CommandCenterResolverCatalogEntry => entry !== null
+    );
+  const byCommandId = new Map<
+    RelayCliGatewayCommand,
+    CommandCenterResolverCatalogEntry
+  >();
+  entries.forEach((entry) => byCommandId.set(entry.commandId, entry));
+  return { entries, byCommandId };
+}
+
+export function commandCenterDescriptorFromCommandDefinition(
+  definition: RelayCommandDefinition
+): RelayActionDescriptor {
+  return relayActionDescriptorFromCommandDefinition(definition, {
+    surfaces: [...definition.surfaces, 'command-center'],
+  });
+}
+
+export const COMMAND_CENTER_RESOLVER_CATALOG: CommandCenterResolverCatalog =
+  buildCommandCenterResolverCatalog();
+
+export function searchCommandCenterCatalog(
+  query: string,
+  catalog: CommandCenterResolverCatalog = COMMAND_CENTER_RESOLVER_CATALOG,
+  limit = 8
+): CommandCenterResolverSearchHit[] {
+  const terms = tokenize(query);
+  if (terms.length === 0) return [];
+
+  const hits: CommandCenterResolverSearchHit[] = [];
+  for (const entry of catalog.entries) {
+    const score = scoreCatalogEntry(entry, terms);
+    if (score > 0) hits.push({ entry, score });
+  }
+
+  return hits
+    .sort(
+      (a, b) =>
+        b.score - a.score || a.entry.commandId.localeCompare(b.entry.commandId)
+    )
+    .slice(0, limit);
+}
+
+function scoreCatalogEntry(
+  entry: CommandCenterResolverCatalogEntry,
+  terms: readonly string[]
+): number {
+  let score = 0;
+  for (const term of terms) {
+    if (entry.commandId.toLowerCase().includes(term)) score += 4;
+    if (entry.keywords.includes(term)) score += 2;
+    else if (entry.keywords.some((keyword) => keyword.startsWith(term)))
+      score += 1;
+  }
+  return score;
+}
+
+function jsonType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  if (Number.isInteger(value)) return 'integer';
+  return typeof value;
+}
+
+function typeMatches(value: unknown, type: string): boolean {
+  const actual = jsonType(value);
+  if (type === 'number') return actual === 'number' || actual === 'integer';
+  if (type === 'integer') return actual === 'integer';
+  return actual === type;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return jsonType(value) === 'object';
+}
+
+export function validateCommandCenterArgs(
+  value: unknown,
+  schema: RelayJsonSchema,
+  path = '$'
+): string[] {
+  const errors: string[] = [];
+
+  if (schema.const !== undefined && value !== schema.const) {
+    errors.push(`${path}: expected const`);
+  }
+  if (schema.enum && !schema.enum.includes(value as string)) {
+    errors.push(`${path}: not in enum`);
+  }
+  errors.push(...validateSchemaType(value, schema, path));
+  if (errors.length > 0) return errors;
+
+  if (typeof value === 'number') {
+    if (schema.minimum !== undefined && value < schema.minimum) {
+      errors.push(`${path}: below minimum`);
+    }
+    if (schema.maximum !== undefined && value > schema.maximum) {
+      errors.push(`${path}: above maximum`);
+    }
+  }
+
+  errors.push(...validateSchemaObject(value, schema, path));
+  errors.push(...validateSchemaArray(value, schema, path));
+  errors.push(...validateSchemaBranches(value, schema, path));
+
+  return errors;
+}
+
+function validateSchemaType(
+  value: unknown,
+  schema: RelayJsonSchema,
+  path: string
+): string[] {
+  if (schema.type === undefined) return [];
+  const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+  if (types.some((type) => typeMatches(value, type))) return [];
+  return [`${path}: expected ${types.join('|')}, got ${jsonType(value)}`];
+}
+
+function validateSchemaObject(
+  value: unknown,
+  schema: RelayJsonSchema,
+  path: string
+): string[] {
+  if (
+    !schema.properties &&
+    !schema.required &&
+    schema.additionalProperties !== false
+  ) {
+    return [];
+  }
+  if (!isPlainObject(value)) return [`${path}: expected object`];
+
+  const errors: string[] = [];
+  const properties = schema.properties ?? {};
+  for (const requiredKey of schema.required ?? []) {
+    if (!(requiredKey in value))
+      errors.push(`${path}.${requiredKey}: required`);
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childSchema = properties[key];
+    if (childSchema) {
+      errors.push(
+        ...validateCommandCenterArgs(child, childSchema, `${path}.${key}`)
+      );
+    } else if (schema.additionalProperties === false) {
+      errors.push(`${path}.${key}: unknown property`);
+    }
+  }
+  return errors;
+}
+
+function validateSchemaArray(
+  value: unknown,
+  schema: RelayJsonSchema,
+  path: string
+): string[] {
+  if (!schema.items || !Array.isArray(value)) return [];
+  return value.flatMap((item, index) =>
+    validateCommandCenterArgs(
+      item,
+      schema.items as RelayJsonSchema,
+      `${path}[${index}]`
+    )
+  );
+}
+
+function validateSchemaBranches(
+  value: unknown,
+  schema: RelayJsonSchema,
+  path: string
+): string[] {
+  const errors: string[] = [];
+  if (schema.anyOf?.length) {
+    const matched = schema.anyOf.some(
+      (branch) => validateCommandCenterArgs(value, branch, path).length === 0
+    );
+    if (!matched) errors.push(`${path}: did not match anyOf`);
+  }
+  if (schema.oneOf?.length) {
+    const matches = schema.oneOf.filter(
+      (branch) => validateCommandCenterArgs(value, branch, path).length === 0
+    ).length;
+    if (matches !== 1) errors.push(`${path}: did not match exactly one oneOf`);
+  }
+  return errors;
+}
+
+function sameStringSet(
+  declared: readonly string[] | undefined,
+  canonical: readonly string[]
+): boolean {
+  if (declared === undefined) return true;
+  const declaredSet = new Set(declared);
+  const canonicalSet = new Set(canonical);
+  if (declaredSet.size !== canonicalSet.size) return false;
+  for (const value of Array.from(declaredSet)) {
+    if (!canonicalSet.has(value)) return false;
+  }
+  return true;
+}
+
+function uiMetadataMatches(
+  declared: CommandCenterProviderIntent['ui'],
+  entry: CommandCenterResolverCatalogEntry
+): boolean {
+  if (!declared) return true;
+  return (
+    (declared.actionId === undefined ||
+      declared.actionId === entry.ui?.actionId) &&
+    (declared.category === undefined ||
+      declared.category === entry.ui?.category)
+  );
+}
+
+function metadataMatches(
+  claim: CommandCenterProviderIntent,
+  entry: CommandCenterResolverCatalogEntry
+): boolean {
+  return (
+    (claim.sideEffect === undefined || claim.sideEffect === entry.sideEffect) &&
+    (claim.requiresConfirmation === undefined ||
+      claim.requiresConfirmation === entry.requiresConfirmation) &&
+    sameStringSet(claim.scopeKinds, entry.scopeKinds) &&
+    sameStringSet(claim.capabilityHints, entry.capabilityHints) &&
+    sameStringSet(claim.surfaces, entry.surfaces) &&
+    uiMetadataMatches(claim.ui, entry)
+  );
+}
+
+function fallback(
+  reason: CommandCenterFallbackReason,
+  suggestions: readonly CommandCenterResolverSearchHit[],
+  detail?: string
+): CommandCenterResolution {
+  return {
+    kind: 'fallback',
+    reason,
+    ...(detail ? { detail } : {}),
+    suggestions,
+  };
+}
+
+export function validateCommandCenterProviderIntent(
+  raw: unknown,
+  options: ValidateProviderIntentOptions = {}
+): CommandCenterResolution {
+  const catalog = options.catalog ?? COMMAND_CENTER_RESOLVER_CATALOG;
+  const suggestions = options.query
+    ? searchCommandCenterCatalog(
+        options.query,
+        catalog,
+        options.suggestionLimit
+      )
+    : [];
+  const minConfidence = options.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+
+  if (!isPlainObject(raw)) {
+    return fallback(
+      'malformed-output',
+      suggestions,
+      'provider output is not an object'
+    );
+  }
+  const claim = raw as unknown as CommandCenterProviderIntent;
+  if (typeof claim.commandId !== 'string') {
+    return fallback('malformed-output', suggestions, 'missing commandId');
+  }
+  if (
+    typeof claim.confidence !== 'number' ||
+    !Number.isFinite(claim.confidence)
+  ) {
+    return fallback('malformed-output', suggestions, 'missing confidence');
+  }
+
+  const entry = catalog.byCommandId.get(
+    claim.commandId as RelayCliGatewayCommand
+  );
+  if (!entry) return fallback('unknown-command', suggestions);
+  if (claim.confidence < minConfidence)
+    return fallback('low-confidence', suggestions);
+
+  const args = claim.args ?? {};
+  if (!isPlainObject(args)) return fallback('invalid-args', suggestions);
+  const argErrors = validateCommandCenterArgs(args, entry.inputSchema);
+  if (argErrors.length > 0) {
+    return fallback(
+      'invalid-args',
+      suggestions,
+      argErrors.slice(0, 3).join('; ')
+    );
+  }
+  if (!metadataMatches(claim, entry))
+    return fallback('metadata-mismatch', suggestions);
+
+  return {
+    kind: 'resolved',
+    entry,
+    suggestions,
+    intent: {
+      commandId: entry.commandId,
+      args,
+      confidence: claim.confidence,
+      ...(typeof claim.rationale === 'string'
+        ? { rationale: claim.rationale }
+        : {}),
+      sideEffect: entry.sideEffect,
+      requiresConfirmation: entry.requiresConfirmation,
+      controlRequirements: entry.controlRequirements,
+      scopeKinds: entry.scopeKinds,
+      capabilityHints: entry.capabilityHints,
+      surfaces: entry.surfaces,
+      ...(entry.ui ? { ui: entry.ui } : {}),
+    },
+  };
+}
+
+export function summarizeCommandCenterCatalogForResolver(
+  catalog: CommandCenterResolverCatalog = COMMAND_CENTER_RESOLVER_CATALOG
+): Array<{
+  commandId: RelayCliGatewayCommand;
+  label: string;
+  summary: string;
+  sideEffect: RelayCommandSideEffect;
+  requiresConfirmation: boolean;
+  inputSchema: RelayJsonSchema;
+}> {
+  return catalog.entries.map((entry) => ({
+    commandId: entry.commandId,
+    label: entry.label,
+    summary: entry.summary,
+    sideEffect: entry.sideEffect,
+    requiresConfirmation: entry.requiresConfirmation,
+    inputSchema: entry.inputSchema,
+  }));
+}

--- a/shared/command-center-resolver.ts
+++ b/shared/command-center-resolver.ts
@@ -47,11 +47,35 @@ export interface CommandCenterResolverSearchHit {
   score: number;
 }
 
+export type CommandCenterIntentKind =
+  | 'open_ui'
+  | 'ask_followup'
+  | 'explain'
+  | 'execute_command'
+  | 'no_match';
+
+export const COMMAND_CENTER_INTENT_KINDS: readonly CommandCenterIntentKind[] = [
+  'open_ui',
+  'ask_followup',
+  'explain',
+  'execute_command',
+  'no_match',
+];
+
+export interface CommandCenterUiTarget {
+  actionId: string;
+  category?: string;
+}
+
 export interface CommandCenterProviderIntent {
-  commandId: string;
+  kind: CommandCenterIntentKind;
+  commandId?: string;
   args?: unknown;
-  confidence: number;
+  confidence?: number;
   rationale?: string;
+  question?: string;
+  message?: string;
+  reason?: string;
   sideEffect?: string;
   requiresConfirmation?: boolean;
   scopeKinds?: readonly string[];
@@ -74,34 +98,58 @@ export interface CommandCenterResolvedIntent {
   scopeKinds: readonly RelayCommandScopeKind[];
   capabilityHints: readonly RelayCapabilityBit[];
   surfaces: readonly RelayActionSurface[];
-  ui?: {
-    actionId?: string;
-    category?: string;
-  };
+  ui?: CommandCenterUiTarget;
 }
 
-export type CommandCenterFallbackReason =
+export type CommandCenterNoMatchReason =
   | 'provider-missing'
   | 'provider-unhealthy'
+  | 'provider-no-match'
   | 'timeout'
   | 'provider-error'
   | 'malformed-output'
   | 'low-confidence'
   | 'unknown-command'
   | 'invalid-args'
-  | 'metadata-mismatch';
+  | 'metadata-mismatch'
+  | 'unsafe-command';
+
+export type CommandCenterFallbackReason = CommandCenterNoMatchReason;
 
 export type CommandCenterResolution =
   | {
-      kind: 'resolved';
+      kind: 'execute_command';
       intent: CommandCenterResolvedIntent;
       entry: CommandCenterResolverCatalogEntry;
       suggestions: readonly CommandCenterResolverSearchHit[];
     }
   | {
-      kind: 'fallback';
-      reason: CommandCenterFallbackReason;
+      kind: 'open_ui';
+      intent: CommandCenterResolvedIntent;
+      entry: CommandCenterResolverCatalogEntry;
+      ui: CommandCenterUiTarget;
+      suggestions: readonly CommandCenterResolverSearchHit[];
+    }
+  | {
+      kind: 'ask_followup';
+      question: string;
+      confidence: number;
+      rationale?: string;
+      suggestions: readonly CommandCenterResolverSearchHit[];
+    }
+  | {
+      kind: 'explain';
+      message: string;
+      confidence: number;
+      rationale?: string;
+      suggestions: readonly CommandCenterResolverSearchHit[];
+    }
+  | {
+      kind: 'no_match';
+      reason: CommandCenterNoMatchReason;
       detail?: string;
+      confidence?: number;
+      rationale?: string;
       suggestions: readonly CommandCenterResolverSearchHit[];
     };
 
@@ -341,7 +389,7 @@ function validateSchemaObject(
   const errors: string[] = [];
   const properties = schema.properties ?? {};
   for (const requiredKey of schema.required ?? []) {
-    if (!(requiredKey in value))
+    if (!Object.prototype.hasOwnProperty.call(value, requiredKey))
       errors.push(`${path}.${requiredKey}: required`);
   }
   for (const [key, child] of Object.entries(value)) {
@@ -435,16 +483,101 @@ function metadataMatches(
   );
 }
 
-function fallback(
-  reason: CommandCenterFallbackReason,
+function noMatch(
+  reason: CommandCenterNoMatchReason,
   suggestions: readonly CommandCenterResolverSearchHit[],
-  detail?: string
+  detail?: string,
+  claim?: Pick<CommandCenterProviderIntent, 'confidence' | 'rationale'>
 ): CommandCenterResolution {
   return {
-    kind: 'fallback',
+    kind: 'no_match',
     reason,
     ...(detail ? { detail } : {}),
+    ...(typeof claim?.confidence === 'number' &&
+    Number.isFinite(claim.confidence)
+      ? { confidence: claim.confidence }
+      : {}),
+    ...(typeof claim?.rationale === 'string'
+      ? { rationale: claim.rationale }
+      : {}),
     suggestions,
+  };
+}
+
+function isCommandCenterIntentKind(
+  value: unknown
+): value is CommandCenterIntentKind {
+  return (
+    typeof value === 'string' &&
+    (COMMAND_CENTER_INTENT_KINDS as readonly string[]).includes(value)
+  );
+}
+
+function confidenceForClaim(
+  claim: CommandCenterProviderIntent,
+  suggestions: readonly CommandCenterResolverSearchHit[]
+): number | CommandCenterResolution {
+  if (
+    typeof claim.confidence !== 'number' ||
+    !Number.isFinite(claim.confidence)
+  ) {
+    return noMatch('malformed-output', suggestions, 'missing confidence');
+  }
+  return claim.confidence;
+}
+
+function uiTargetForEntry(
+  entry: CommandCenterResolverCatalogEntry,
+  claim: CommandCenterProviderIntent
+): CommandCenterUiTarget | null {
+  if (!entry.ui?.actionId) return null;
+  if (
+    claim.ui?.actionId !== undefined &&
+    claim.ui.actionId !== entry.ui.actionId
+  )
+    return null;
+  if (
+    claim.ui?.category !== undefined &&
+    claim.ui.category !== entry.ui.category
+  )
+    return null;
+  return {
+    actionId: entry.ui.actionId,
+    ...(entry.ui.category ? { category: entry.ui.category } : {}),
+  };
+}
+
+function isReadOnlyResolverTarget(
+  entry: CommandCenterResolverCatalogEntry
+): boolean {
+  return (
+    entry.sideEffect === 'read' &&
+    entry.requiresConfirmation === false &&
+    entry.controlRequirements.length === 0
+  );
+}
+
+function resolvedIntentForEntry(
+  claim: CommandCenterProviderIntent,
+  entry: CommandCenterResolverCatalogEntry,
+  args: Record<string, unknown>,
+  confidence: number
+): CommandCenterResolvedIntent {
+  const uiTarget = uiTargetForEntry(entry, claim);
+  return {
+    commandId: entry.commandId,
+    args,
+    confidence,
+    ...(typeof claim.rationale === 'string'
+      ? { rationale: claim.rationale }
+      : {}),
+    sideEffect: entry.sideEffect,
+    requiresConfirmation: entry.requiresConfirmation,
+    controlRequirements: entry.controlRequirements,
+    scopeKinds: entry.scopeKinds,
+    capabilityHints: entry.capabilityHints,
+    surfaces: entry.surfaces,
+    ...(uiTarget ? { ui: uiTarget } : {}),
   };
 }
 
@@ -463,63 +596,118 @@ export function validateCommandCenterProviderIntent(
   const minConfidence = options.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
 
   if (!isPlainObject(raw)) {
-    return fallback(
+    return noMatch(
       'malformed-output',
       suggestions,
       'provider output is not an object'
     );
   }
   const claim = raw as unknown as CommandCenterProviderIntent;
-  if (typeof claim.commandId !== 'string') {
-    return fallback('malformed-output', suggestions, 'missing commandId');
-  }
-  if (
-    typeof claim.confidence !== 'number' ||
-    !Number.isFinite(claim.confidence)
-  ) {
-    return fallback('malformed-output', suggestions, 'missing confidence');
+  if (!isCommandCenterIntentKind(claim.kind)) {
+    return noMatch('malformed-output', suggestions, 'missing or invalid kind');
   }
 
-  const entry = catalog.byCommandId.get(
-    claim.commandId as RelayCliGatewayCommand
-  );
-  if (!entry) return fallback('unknown-command', suggestions);
-  if (claim.confidence < minConfidence)
-    return fallback('low-confidence', suggestions);
+  const confidence = confidenceForClaim(claim, suggestions);
+  if (typeof confidence !== 'number') return confidence;
 
-  const args = claim.args ?? {};
-  if (!isPlainObject(args)) return fallback('invalid-args', suggestions);
-  const argErrors = validateCommandCenterArgs(args, entry.inputSchema);
-  if (argErrors.length > 0) {
-    return fallback(
-      'invalid-args',
+  if (claim.kind === 'no_match') {
+    return noMatch(
+      'provider-no-match',
       suggestions,
-      argErrors.slice(0, 3).join('; ')
+      typeof claim.reason === 'string' ? claim.reason : undefined,
+      claim
     );
   }
-  if (!metadataMatches(claim, entry))
-    return fallback('metadata-mismatch', suggestions);
 
-  return {
-    kind: 'resolved',
-    entry,
-    suggestions,
-    intent: {
-      commandId: entry.commandId,
-      args,
-      confidence: claim.confidence,
+  if (claim.kind === 'ask_followup') {
+    if (
+      typeof claim.question !== 'string' ||
+      claim.question.trim().length === 0
+    ) {
+      return noMatch(
+        'malformed-output',
+        suggestions,
+        'missing question',
+        claim
+      );
+    }
+    return {
+      kind: 'ask_followup',
+      question: claim.question,
+      confidence,
       ...(typeof claim.rationale === 'string'
         ? { rationale: claim.rationale }
         : {}),
-      sideEffect: entry.sideEffect,
-      requiresConfirmation: entry.requiresConfirmation,
-      controlRequirements: entry.controlRequirements,
-      scopeKinds: entry.scopeKinds,
-      capabilityHints: entry.capabilityHints,
-      surfaces: entry.surfaces,
-      ...(entry.ui ? { ui: entry.ui } : {}),
-    },
-  };
+      suggestions,
+    };
+  }
+
+  if (claim.kind === 'explain') {
+    if (
+      typeof claim.message !== 'string' ||
+      claim.message.trim().length === 0
+    ) {
+      return noMatch('malformed-output', suggestions, 'missing message', claim);
+    }
+    return {
+      kind: 'explain',
+      message: claim.message,
+      confidence,
+      ...(typeof claim.rationale === 'string'
+        ? { rationale: claim.rationale }
+        : {}),
+      suggestions,
+    };
+  }
+
+  if (confidence < minConfidence)
+    return noMatch('low-confidence', suggestions, undefined, claim);
+
+  if (typeof claim.commandId !== 'string') {
+    return noMatch('malformed-output', suggestions, 'missing commandId', claim);
+  }
+  const entry = catalog.byCommandId.get(
+    claim.commandId as RelayCliGatewayCommand
+  );
+  if (!entry) return noMatch('unknown-command', suggestions, undefined, claim);
+
+  const args = claim.args ?? {};
+  if (!isPlainObject(args))
+    return noMatch('invalid-args', suggestions, undefined, claim);
+  const argErrors = validateCommandCenterArgs(args, entry.inputSchema);
+  if (argErrors.length > 0) {
+    return noMatch(
+      'invalid-args',
+      suggestions,
+      argErrors.slice(0, 3).join('; '),
+      claim
+    );
+  }
+  if (!metadataMatches(claim, entry))
+    return noMatch('metadata-mismatch', suggestions, undefined, claim);
+  if (!isReadOnlyResolverTarget(entry)) {
+    return noMatch(
+      'unsafe-command',
+      suggestions,
+      `command ${entry.commandId} is not a read-only resolver target in this resolver slice`,
+      claim
+    );
+  }
+
+  const intent = resolvedIntentForEntry(claim, entry, args, confidence);
+  if (claim.kind === 'open_ui') {
+    const ui = uiTargetForEntry(entry, claim);
+    if (!ui)
+      return noMatch(
+        'metadata-mismatch',
+        suggestions,
+        'missing ui target',
+        claim
+      );
+    return { kind: 'open_ui', entry, suggestions, intent, ui };
+  }
+
+  return { kind: 'execute_command', entry, suggestions, intent };
 }
 
 export function summarizeCommandCenterCatalogForResolver(

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -89,6 +89,7 @@ export {
 } from './safe-defaults.js';
 
 export {
+  COMMAND_CENTER_INTENT_KINDS,
   COMMAND_CENTER_RESOLVER_CATALOG,
   buildCommandCenterResolverCatalog,
   catalogEntryFromActionDescriptor,
@@ -98,12 +99,16 @@ export {
   validateCommandCenterArgs,
   validateCommandCenterProviderIntent,
   type CommandCenterFallbackReason,
+  type CommandCenterIntentKind,
+  type CommandCenterNoMatchReason,
   type CommandCenterProviderIntent,
   type CommandCenterResolution,
   type CommandCenterResolvedIntent,
   type CommandCenterResolverCatalog,
   type CommandCenterResolverCatalogEntry,
   type CommandCenterResolverSearchHit,
+  type CommandCenterUiTarget,
+  type ValidateProviderIntentOptions,
 } from './command-center-resolver.js';
 
 export {

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -89,6 +89,24 @@ export {
 } from './safe-defaults.js';
 
 export {
+  COMMAND_CENTER_RESOLVER_CATALOG,
+  buildCommandCenterResolverCatalog,
+  catalogEntryFromActionDescriptor,
+  commandCenterDescriptorFromCommandDefinition,
+  searchCommandCenterCatalog,
+  summarizeCommandCenterCatalogForResolver,
+  validateCommandCenterArgs,
+  validateCommandCenterProviderIntent,
+  type CommandCenterFallbackReason,
+  type CommandCenterProviderIntent,
+  type CommandCenterResolution,
+  type CommandCenterResolvedIntent,
+  type CommandCenterResolverCatalog,
+  type CommandCenterResolverCatalogEntry,
+  type CommandCenterResolverSearchHit,
+} from './command-center-resolver.js';
+
+export {
   WORKSPACE_EVIDENCE_DEFAULT_LIST_ENTRIES,
   WORKSPACE_EVIDENCE_DEFAULT_PREVIEW_BYTES,
   WORKSPACE_EVIDENCE_HASH_BYTE_LIMIT,

--- a/test/command-center-intent-resolver.test.ts
+++ b/test/command-center-intent-resolver.test.ts
@@ -42,6 +42,12 @@ const descriptor: RelayActionDescriptor = {
 
 const catalog = buildCommandCenterResolverCatalog([descriptor]);
 const request = { query: 'show relay sessions' };
+const providerIntent = {
+  kind: 'execute_command',
+  commandId: 'sessions.list',
+  args: { repoId: 'repo-1' },
+  confidence: 0.95,
+};
 
 function provider(raw: unknown): CommandCenterIntentProvider {
   return {
@@ -55,14 +61,14 @@ describe('Command Center intent resolver wrapper', () => {
     const result = await resolveCommandCenterIntent(request, { catalog });
 
     expect(result.resolution).toMatchObject({
-      kind: 'fallback',
+      kind: 'no_match',
       reason: 'provider-missing',
     });
     expect(result.resolution.suggestions[0]?.entry.commandId).toBe(
       'sessions.list'
     );
     expect(result.audit).toEqual({
-      outcome: 'fallback',
+      outcome: 'no_match',
       reason: 'provider-missing',
       suggestionCount: 1,
     });
@@ -73,42 +79,54 @@ describe('Command Center intent resolver wrapper', () => {
     const result = await resolveCommandCenterIntent(request, {
       catalog,
       provider: provider({
-        commandId: 'sessions.list',
+        ...providerIntent,
         args: { repoId: privateArg },
-        confidence: 0.91,
-        sideEffect: 'read',
-        requiresConfirmation: false,
-        capabilityHints: ['session:read'],
-        scopeKinds: ['session'],
-        surfaces: ['web', 'command-center'],
-        ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
       }),
       now: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(25),
     });
 
-    expect(result.resolution.kind).toBe('resolved');
+    expect(result.resolution.kind).toBe('execute_command');
     expect(JSON.stringify(result.audit)).not.toContain(privateArg);
     expect(JSON.stringify(result.audit)).not.toContain(request.query);
     expect(result.audit).toEqual({
-      outcome: 'resolved',
+      outcome: 'execute_command',
       commandId: 'sessions.list',
-      confidence: 0.91,
+      confidence: 0.95,
       durationMs: 15,
       suggestionCount: 1,
     });
   });
 
-  it('falls back for unhealthy provider, timeout, malformed output, and invalid args', async () => {
-    const unhealthy: CommandCenterIntentProvider = {
-      health: async () => ({ state: 'unreachable', detail: 'network-error' }),
-      propose: async () => ({ commandId: 'sessions.list', confidence: 1 }),
+  it('does not run provider health on the hot path unless preflight is requested', async () => {
+    const health = vi.fn(async () => ({ state: 'unreachable' as const }));
+    const hotPathProvider: CommandCenterIntentProvider = {
+      health,
+      propose: async () => providerIntent,
     };
-    await expect(
-      resolveCommandCenterIntent(request, { catalog, provider: unhealthy })
-    ).resolves.toMatchObject({
-      resolution: { kind: 'fallback', reason: 'provider-unhealthy' },
-    });
 
+    await expect(
+      resolveCommandCenterIntent(request, {
+        catalog,
+        provider: hotPathProvider,
+      })
+    ).resolves.toMatchObject({
+      resolution: { kind: 'execute_command' },
+    });
+    expect(health).not.toHaveBeenCalled();
+
+    await expect(
+      resolveCommandCenterIntent(request, {
+        catalog,
+        provider: hotPathProvider,
+        preflightHealthCheck: true,
+      })
+    ).resolves.toMatchObject({
+      resolution: { kind: 'no_match', reason: 'provider-unhealthy' },
+    });
+    expect(health).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back for timeout, malformed output, and invalid args', async () => {
     const timeout = new Error('provider timed out');
     timeout.name = 'AbortError';
     await expect(
@@ -120,7 +138,7 @@ describe('Command Center intent resolver wrapper', () => {
         },
       })
     ).resolves.toMatchObject({
-      resolution: { kind: 'fallback', reason: 'timeout' },
+      resolution: { kind: 'no_match', reason: 'timeout' },
     });
 
     await expect(
@@ -129,19 +147,18 @@ describe('Command Center intent resolver wrapper', () => {
         provider: provider('nope'),
       })
     ).resolves.toMatchObject({
-      resolution: { kind: 'fallback', reason: 'malformed-output' },
+      resolution: { kind: 'no_match', reason: 'malformed-output' },
     });
     await expect(
       resolveCommandCenterIntent(request, {
         catalog,
         provider: provider({
-          commandId: 'sessions.list',
+          ...providerIntent,
           args: { rawShell: 'relay-ide v1 sessions list' },
-          confidence: 0.9,
         }),
       })
     ).resolves.toMatchObject({
-      resolution: { kind: 'fallback', reason: 'invalid-args' },
+      resolution: { kind: 'no_match', reason: 'invalid-args' },
     });
   });
 });
@@ -155,13 +172,23 @@ describe('OpenAI-compatible Command Center provider', () => {
         RELAY_COMMAND_CENTER_RESOLVER_MODEL: 'resolver-small',
         RELAY_COMMAND_CENTER_RESOLVER_TIMEOUT_MS: '42',
         RELAY_COMMAND_CENTER_RESOLVER_MIN_CONFIDENCE: '0.7',
+        RELAY_COMMAND_CENTER_RESOLVER_MAX_OUTPUT_TOKENS: '123',
+        RELAY_COMMAND_CENTER_RESOLVER_TEMPERATURE: '0.2',
       })
     ).toEqual({
       baseUrl: 'https://resolver.example/v1',
       model: 'resolver-small',
       timeoutMs: 42,
       minConfidence: 0.7,
+      maxOutputTokens: 123,
+      temperature: 0.2,
     });
+    expect(
+      readCommandCenterIntentResolverConfig({
+        RELAY_COMMAND_CENTER_RESOLVER_BASE_URL: 'https://resolver.example/v1/',
+        RELAY_COMMAND_CENTER_RESOLVER_MODEL: 'resolver-small',
+      })
+    ).toMatchObject({ maxOutputTokens: 512, temperature: 0 });
   });
 
   it('health omits prompt payloads and proposal parses chat completions JSON', async () => {
@@ -174,8 +201,12 @@ describe('OpenAI-compatible Command Center provider', () => {
       }
       expect(url).toBe('https://resolver.example/v1/chat/completions');
       const body = JSON.parse(String(init.body)) as {
+        max_tokens: number;
+        temperature: number;
         messages: Array<{ content: string }>;
       };
+      expect(body.max_tokens).toBe(77);
+      expect(body.temperature).toBe(0.1);
       expect(JSON.stringify(body.messages)).toContain('sessions.list');
       expect(JSON.stringify(body.messages)).toContain(request.query);
       return {
@@ -185,11 +216,7 @@ describe('OpenAI-compatible Command Center provider', () => {
           choices: [
             {
               message: {
-                content: JSON.stringify({
-                  commandId: 'sessions.list',
-                  args: { repoId: 'repo-1' },
-                  confidence: 0.95,
-                }),
+                content: JSON.stringify(providerIntent),
               },
             },
           ],
@@ -203,6 +230,8 @@ describe('OpenAI-compatible Command Center provider', () => {
         model: 'resolver-small',
         timeoutMs: 1000,
         minConfidence: 0.6,
+        maxOutputTokens: 77,
+        temperature: 0.1,
       },
       { fetch, catalog }
     );
@@ -212,11 +241,9 @@ describe('OpenAI-compatible Command Center provider', () => {
       model: 'resolver-small',
       baseUrl: 'https://resolver.example/v1',
     });
-    await expect(openAiProvider.propose(request)).resolves.toEqual({
-      commandId: 'sessions.list',
-      args: { repoId: 'repo-1' },
-      confidence: 0.95,
-    });
+    await expect(openAiProvider.propose(request)).resolves.toEqual(
+      providerIntent
+    );
     expect(JSON.stringify(await openAiProvider.health())).not.toContain(
       request.query
     );

--- a/test/command-center-intent-resolver.test.ts
+++ b/test/command-center-intent-resolver.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createOpenAiCompatibleCommandCenterIntentProvider,
+  readCommandCenterIntentResolverConfig,
+  resolveCommandCenterIntent,
+  type CommandCenterIntentProvider,
+} from '../server/command-center-intent-resolver.js';
+import { buildCommandCenterResolverCatalog } from '../shared/command-center-resolver.js';
+import type { RelayActionDescriptor } from '../shared/action-descriptor.js';
+
+const descriptor: RelayActionDescriptor = {
+  id: 'sessions.list',
+  title: 'sessions list',
+  label: 'sessions list',
+  description: 'List Relay sessions',
+  input: {
+    kind: 'json-schema',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { repoId: { type: 'string' } },
+    },
+  },
+  availability: { state: 'available', capabilityHints: ['session:read'] },
+  sideEffect: 'read',
+  confirmation: { required: false, controlRequirements: [] },
+  surfaces: ['web', 'command-center'],
+  result: { kind: 'json-schema', schema: { type: 'object' } },
+  error: { kind: 'json-schema', schema: { type: 'object' } },
+  stable: true,
+  source: 'cli-gateway-v1',
+  contract: {
+    relayCommandName: 'sessions.list',
+    stable: true,
+    source: 'shared/relay-command-manifest.ts',
+    cli: ['relay-ide', 'v1', 'sessions', 'list', '--json'],
+    errorCodes: ['INTERNAL'],
+  },
+  ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+};
+
+const catalog = buildCommandCenterResolverCatalog([descriptor]);
+const request = { query: 'show relay sessions' };
+
+function provider(raw: unknown): CommandCenterIntentProvider {
+  return {
+    health: async () => ({ state: 'healthy' }),
+    propose: async () => raw,
+  };
+}
+
+describe('Command Center intent resolver wrapper', () => {
+  it('falls back with deterministic search when provider is missing', async () => {
+    const result = await resolveCommandCenterIntent(request, { catalog });
+
+    expect(result.resolution).toMatchObject({
+      kind: 'fallback',
+      reason: 'provider-missing',
+    });
+    expect(result.resolution.suggestions[0]?.entry.commandId).toBe(
+      'sessions.list'
+    );
+    expect(result.audit).toEqual({
+      outcome: 'fallback',
+      reason: 'provider-missing',
+      suggestionCount: 1,
+    });
+  });
+
+  it('resolves valid fake provider output and redacts prompt/args from audit', async () => {
+    const privateArg = 'private-repo-name-that-stays-out-of-audit';
+    const result = await resolveCommandCenterIntent(request, {
+      catalog,
+      provider: provider({
+        commandId: 'sessions.list',
+        args: { repoId: privateArg },
+        confidence: 0.91,
+        sideEffect: 'read',
+        requiresConfirmation: false,
+        capabilityHints: ['session:read'],
+        scopeKinds: ['session'],
+        surfaces: ['web', 'command-center'],
+        ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+      }),
+      now: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(25),
+    });
+
+    expect(result.resolution.kind).toBe('resolved');
+    expect(JSON.stringify(result.audit)).not.toContain(privateArg);
+    expect(JSON.stringify(result.audit)).not.toContain(request.query);
+    expect(result.audit).toEqual({
+      outcome: 'resolved',
+      commandId: 'sessions.list',
+      confidence: 0.91,
+      durationMs: 15,
+      suggestionCount: 1,
+    });
+  });
+
+  it('falls back for unhealthy provider, timeout, malformed output, and invalid args', async () => {
+    const unhealthy: CommandCenterIntentProvider = {
+      health: async () => ({ state: 'unreachable', detail: 'network-error' }),
+      propose: async () => ({ commandId: 'sessions.list', confidence: 1 }),
+    };
+    await expect(
+      resolveCommandCenterIntent(request, { catalog, provider: unhealthy })
+    ).resolves.toMatchObject({
+      resolution: { kind: 'fallback', reason: 'provider-unhealthy' },
+    });
+
+    const timeout = new Error('provider timed out');
+    timeout.name = 'AbortError';
+    await expect(
+      resolveCommandCenterIntent(request, {
+        catalog,
+        provider: {
+          health: async () => ({ state: 'healthy' }),
+          propose: async () => Promise.reject(timeout),
+        },
+      })
+    ).resolves.toMatchObject({
+      resolution: { kind: 'fallback', reason: 'timeout' },
+    });
+
+    await expect(
+      resolveCommandCenterIntent(request, {
+        catalog,
+        provider: provider('nope'),
+      })
+    ).resolves.toMatchObject({
+      resolution: { kind: 'fallback', reason: 'malformed-output' },
+    });
+    await expect(
+      resolveCommandCenterIntent(request, {
+        catalog,
+        provider: provider({
+          commandId: 'sessions.list',
+          args: { rawShell: 'relay-ide v1 sessions list' },
+          confidence: 0.9,
+        }),
+      })
+    ).resolves.toMatchObject({
+      resolution: { kind: 'fallback', reason: 'invalid-args' },
+    });
+  });
+});
+
+describe('OpenAI-compatible Command Center provider', () => {
+  it('reads provider-neutral env config without exposing missing config as healthy', () => {
+    expect(readCommandCenterIntentResolverConfig({})).toBeNull();
+    expect(
+      readCommandCenterIntentResolverConfig({
+        RELAY_COMMAND_CENTER_RESOLVER_BASE_URL: 'https://resolver.example/v1/',
+        RELAY_COMMAND_CENTER_RESOLVER_MODEL: 'resolver-small',
+        RELAY_COMMAND_CENTER_RESOLVER_TIMEOUT_MS: '42',
+        RELAY_COMMAND_CENTER_RESOLVER_MIN_CONFIDENCE: '0.7',
+      })
+    ).toEqual({
+      baseUrl: 'https://resolver.example/v1',
+      model: 'resolver-small',
+      timeoutMs: 42,
+      minConfidence: 0.7,
+    });
+  });
+
+  it('health omits prompt payloads and proposal parses chat completions JSON', async () => {
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      if (url.endsWith('/models')) {
+        expect(init.headers).toMatchObject({
+          'content-type': 'application/json',
+        });
+        return { ok: true, status: 200, json: async () => ({ data: [] }) };
+      }
+      expect(url).toBe('https://resolver.example/v1/chat/completions');
+      const body = JSON.parse(String(init.body)) as {
+        messages: Array<{ content: string }>;
+      };
+      expect(JSON.stringify(body.messages)).toContain('sessions.list');
+      expect(JSON.stringify(body.messages)).toContain(request.query);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  commandId: 'sessions.list',
+                  args: { repoId: 'repo-1' },
+                  confidence: 0.95,
+                }),
+              },
+            },
+          ],
+        }),
+      };
+    });
+
+    const openAiProvider = createOpenAiCompatibleCommandCenterIntentProvider(
+      {
+        baseUrl: 'https://resolver.example/v1',
+        model: 'resolver-small',
+        timeoutMs: 1000,
+        minConfidence: 0.6,
+      },
+      { fetch, catalog }
+    );
+
+    await expect(openAiProvider.health()).resolves.toEqual({
+      state: 'healthy',
+      model: 'resolver-small',
+      baseUrl: 'https://resolver.example/v1',
+    });
+    await expect(openAiProvider.propose(request)).resolves.toEqual({
+      commandId: 'sessions.list',
+      args: { repoId: 'repo-1' },
+      confidence: 0.95,
+    });
+    expect(JSON.stringify(await openAiProvider.health())).not.toContain(
+      request.query
+    );
+  });
+});

--- a/test/command-center-resolver.test.ts
+++ b/test/command-center-resolver.test.ts
@@ -9,41 +9,65 @@ import {
   type CommandCenterProviderIntent,
 } from '../shared/command-center-resolver.js';
 import type { RelayActionDescriptor } from '../shared/action-descriptor.js';
+import type { RelayCliGatewayCommand } from '../shared/cli-gateway-contract.js';
+import type { RelayCommandSideEffect } from '../shared/relay-command-manifest.js';
 
-const sessionsListDescriptor: RelayActionDescriptor = {
-  id: 'sessions.list',
-  title: 'sessions list',
-  label: 'sessions list',
-  description: 'List Relay sessions',
-  input: {
-    kind: 'json-schema',
-    schema: {
-      type: 'object',
-      additionalProperties: false,
-      properties: { repoId: { type: 'string' } },
+function descriptorFor(
+  commandId: RelayCliGatewayCommand,
+  sideEffect: RelayCommandSideEffect = 'read',
+  overrides: Partial<RelayActionDescriptor> = {}
+): RelayActionDescriptor {
+  return {
+    id: commandId,
+    title: commandId,
+    label: commandId,
+    description: `Command ${commandId}`,
+    input: {
+      kind: 'json-schema',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { repoId: { type: 'string' } },
+      },
     },
-  },
-  availability: { state: 'available', capabilityHints: ['session:read'] },
-  sideEffect: 'read',
-  confirmation: { required: false, controlRequirements: [] },
-  surfaces: ['web', 'command-center'],
-  result: { kind: 'json-schema', schema: { type: 'object' } },
-  error: { kind: 'json-schema', schema: { type: 'object' } },
-  stable: true,
-  source: 'cli-gateway-v1',
-  contract: {
-    relayCommandName: 'sessions.list',
+    availability: { state: 'available', capabilityHints: ['session:read'] },
+    sideEffect,
+    confirmation: { required: false, controlRequirements: [] },
+    surfaces: ['web', 'command-center'],
+    result: { kind: 'json-schema', schema: { type: 'object' } },
+    error: { kind: 'json-schema', schema: { type: 'object' } },
     stable: true,
-    source: 'shared/relay-command-manifest.ts',
-    cli: ['relay-ide', 'v1', 'sessions', 'list', '--json'],
-    errorCodes: ['INTERNAL'],
+    source: 'cli-gateway-v1',
+    contract: {
+      relayCommandName: commandId,
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+      cli: ['relay-ide', 'v1', commandId, '--json'],
+      errorCodes: ['INTERNAL'],
+    },
+    ui: { actionId: `gateway.${commandId}`, category: 'gateway' },
+    ...overrides,
+  };
+}
+
+const sessionsListDescriptor = descriptorFor('sessions.list');
+const destructiveDescriptor = descriptorFor('sessions.kill', 'destructive', {
+  confirmation: {
+    required: true,
+    controlRequirements: ['confirmation-challenge'],
   },
-  ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
-};
+});
+const streamDescriptor = descriptorFor('sessions.stream', 'stream');
 
 const catalog = buildCommandCenterResolverCatalog([sessionsListDescriptor]);
+const unsafeCatalog = buildCommandCenterResolverCatalog([
+  sessionsListDescriptor,
+  destructiveDescriptor,
+  streamDescriptor,
+]);
 
 const validIntent: CommandCenterProviderIntent = {
+  kind: 'execute_command',
   commandId: 'sessions.list',
   args: { repoId: 'repo-1' },
   confidence: 0.92,
@@ -62,7 +86,7 @@ describe('Command Center resolver catalog', () => {
 
     expect(entry).toMatchObject({
       commandId: 'sessions.list',
-      label: 'sessions list',
+      label: 'sessions.list',
       sideEffect: 'read',
       requiresConfirmation: false,
       scopeKinds: ['session'],
@@ -71,7 +95,7 @@ describe('Command Center resolver catalog', () => {
       ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
     });
     expect(entry?.keywords).toEqual(
-      expect.arrayContaining(['sessions', 'list', 'relay'])
+      expect.arrayContaining(['sessions', 'list'])
     );
   });
 
@@ -79,8 +103,8 @@ describe('Command Center resolver catalog', () => {
     expect(summarizeCommandCenterCatalogForResolver(catalog)).toEqual([
       {
         commandId: 'sessions.list',
-        label: 'sessions list',
-        summary: 'List Relay sessions',
+        label: 'sessions.list',
+        summary: 'Command sessions.list',
         sideEffect: 'read',
         requiresConfirmation: false,
         inputSchema: sessionsListDescriptor.input.schema,
@@ -107,17 +131,35 @@ describe('Command Center args validation', () => {
       validateCommandCenterArgs({ extra: true }, schema).join('\n')
     ).toContain('unknown property');
   });
+
+  it('requires own properties for required schema keys', () => {
+    const inherited = Object.create({ toString: 'not-own' }) as Record<
+      string,
+      unknown
+    >;
+    const schema = {
+      type: 'object' as const,
+      required: ['toString'],
+      properties: { toString: { type: 'string' as const } },
+      additionalProperties: false,
+    };
+
+    expect(validateCommandCenterArgs(inherited, schema).join('\n')).toContain(
+      '$.toString: required'
+    );
+    expect(validateCommandCenterArgs({ toString: 'own' }, schema)).toEqual([]);
+  });
 });
 
 describe('Command Center provider intent validation', () => {
-  it('returns a strict resolved contract for valid provider output', () => {
+  it('returns a strict execute_command contract for valid provider output', () => {
     const resolution = validateCommandCenterProviderIntent(validIntent, {
       catalog,
       query: 'sessions',
     });
 
-    expect(resolution.kind).toBe('resolved');
-    if (resolution.kind !== 'resolved') return;
+    expect(resolution.kind).toBe('execute_command');
+    if (resolution.kind !== 'execute_command') return;
     expect(resolution.intent).toMatchObject({
       commandId: 'sessions.list',
       args: { repoId: 'repo-1' },
@@ -132,25 +174,66 @@ describe('Command Center provider intent validation', () => {
     expect(resolution.suggestions[0]?.entry.commandId).toBe('sessions.list');
   });
 
+  it('validates strict open_ui, ask_followup, explain, and no_match shapes', () => {
+    expect(
+      validateCommandCenterProviderIntent(
+        { ...validIntent, kind: 'open_ui' },
+        { catalog }
+      )
+    ).toMatchObject({
+      kind: 'open_ui',
+      ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+    });
+    expect(
+      validateCommandCenterProviderIntent(
+        { kind: 'ask_followup', question: 'Which session?', confidence: 0.8 },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'ask_followup', question: 'Which session?' });
+    expect(
+      validateCommandCenterProviderIntent(
+        { kind: 'ask_followup', question: 'Which session?', confidence: 0.1 },
+        { catalog, minConfidence: 0.6 }
+      )
+    ).toMatchObject({ kind: 'ask_followup', question: 'Which session?' });
+    expect(
+      validateCommandCenterProviderIntent(
+        { kind: 'explain', message: 'I can list sessions.', confidence: 0.8 },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'explain', message: 'I can list sessions.' });
+    expect(
+      validateCommandCenterProviderIntent(
+        { kind: 'no_match', reason: 'not a Relay command', confidence: 0.2 },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'no_match', reason: 'provider-no-match' });
+  });
+
   it('falls back safely for malformed output, unknown command, and low confidence', () => {
     expect(
       validateCommandCenterProviderIntent(null, { catalog })
     ).toMatchObject({
-      kind: 'fallback',
+      kind: 'no_match',
       reason: 'malformed-output',
     });
     expect(
       validateCommandCenterProviderIntent(
-        { commandId: 'not.real', args: {}, confidence: 0.95 },
+        {
+          kind: 'execute_command',
+          commandId: 'not.real',
+          args: {},
+          confidence: 0.95,
+        },
         { catalog }
       )
-    ).toMatchObject({ kind: 'fallback', reason: 'unknown-command' });
+    ).toMatchObject({ kind: 'no_match', reason: 'unknown-command' });
     expect(
       validateCommandCenterProviderIntent(
         { ...validIntent, confidence: 0.1 },
         { catalog, minConfidence: 0.6 }
       )
-    ).toMatchObject({ kind: 'fallback', reason: 'low-confidence' });
+    ).toMatchObject({ kind: 'no_match', reason: 'low-confidence' });
   });
 
   it('falls back safely for invalid args and metadata/ui target mismatch', () => {
@@ -159,18 +242,58 @@ describe('Command Center provider intent validation', () => {
         { ...validIntent, args: { extra: true } },
         { catalog }
       )
-    ).toMatchObject({ kind: 'fallback', reason: 'invalid-args' });
+    ).toMatchObject({ kind: 'no_match', reason: 'invalid-args' });
     expect(
       validateCommandCenterProviderIntent(
         { ...validIntent, sideEffect: 'destructive' },
         { catalog }
       )
-    ).toMatchObject({ kind: 'fallback', reason: 'metadata-mismatch' });
+    ).toMatchObject({ kind: 'no_match', reason: 'metadata-mismatch' });
     expect(
       validateCommandCenterProviderIntent(
-        { ...validIntent, ui: { actionId: 'gateway.sessions.kill' } },
+        {
+          ...validIntent,
+          kind: 'open_ui',
+          ui: { actionId: 'gateway.sessions.kill' },
+        },
         { catalog }
       )
-    ).toMatchObject({ kind: 'fallback', reason: 'metadata-mismatch' });
+    ).toMatchObject({ kind: 'no_match', reason: 'metadata-mismatch' });
+  });
+
+  it('does not resolve write/destructive/stream commands as first-slice executable or UI intents', () => {
+    expect(
+      validateCommandCenterProviderIntent(
+        {
+          kind: 'execute_command',
+          commandId: 'sessions.kill',
+          args: {},
+          confidence: 0.99,
+        },
+        { catalog: unsafeCatalog }
+      )
+    ).toMatchObject({ kind: 'no_match', reason: 'unsafe-command' });
+    expect(
+      validateCommandCenterProviderIntent(
+        {
+          kind: 'open_ui',
+          commandId: 'sessions.kill',
+          args: {},
+          confidence: 0.99,
+        },
+        { catalog: unsafeCatalog }
+      )
+    ).toMatchObject({ kind: 'no_match', reason: 'unsafe-command' });
+    expect(
+      validateCommandCenterProviderIntent(
+        {
+          kind: 'execute_command',
+          commandId: 'sessions.stream',
+          args: {},
+          confidence: 0.99,
+        },
+        { catalog: unsafeCatalog }
+      )
+    ).toMatchObject({ kind: 'no_match', reason: 'unsafe-command' });
   });
 });

--- a/test/command-center-resolver.test.ts
+++ b/test/command-center-resolver.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCommandCenterResolverCatalog,
+  searchCommandCenterCatalog,
+  summarizeCommandCenterCatalogForResolver,
+  validateCommandCenterArgs,
+  validateCommandCenterProviderIntent,
+  type CommandCenterProviderIntent,
+} from '../shared/command-center-resolver.js';
+import type { RelayActionDescriptor } from '../shared/action-descriptor.js';
+
+const sessionsListDescriptor: RelayActionDescriptor = {
+  id: 'sessions.list',
+  title: 'sessions list',
+  label: 'sessions list',
+  description: 'List Relay sessions',
+  input: {
+    kind: 'json-schema',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { repoId: { type: 'string' } },
+    },
+  },
+  availability: { state: 'available', capabilityHints: ['session:read'] },
+  sideEffect: 'read',
+  confirmation: { required: false, controlRequirements: [] },
+  surfaces: ['web', 'command-center'],
+  result: { kind: 'json-schema', schema: { type: 'object' } },
+  error: { kind: 'json-schema', schema: { type: 'object' } },
+  stable: true,
+  source: 'cli-gateway-v1',
+  contract: {
+    relayCommandName: 'sessions.list',
+    stable: true,
+    source: 'shared/relay-command-manifest.ts',
+    cli: ['relay-ide', 'v1', 'sessions', 'list', '--json'],
+    errorCodes: ['INTERNAL'],
+  },
+  ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+};
+
+const catalog = buildCommandCenterResolverCatalog([sessionsListDescriptor]);
+
+const validIntent: CommandCenterProviderIntent = {
+  commandId: 'sessions.list',
+  args: { repoId: 'repo-1' },
+  confidence: 0.92,
+  sideEffect: 'read',
+  requiresConfirmation: false,
+  scopeKinds: ['session'],
+  capabilityHints: ['session:read'],
+  surfaces: ['web', 'command-center'],
+  ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+};
+
+describe('Command Center resolver catalog', () => {
+  it('projects compact command metadata from shared action descriptors', () => {
+    expect(catalog.entries).toHaveLength(1);
+    const entry = catalog.byCommandId.get('sessions.list');
+
+    expect(entry).toMatchObject({
+      commandId: 'sessions.list',
+      label: 'sessions list',
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      scopeKinds: ['session'],
+      capabilityHints: ['session:read'],
+      surfaces: ['web', 'command-center'],
+      ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+    });
+    expect(entry?.keywords).toEqual(
+      expect.arrayContaining(['sessions', 'list', 'relay'])
+    );
+  });
+
+  it('summarizes the provider catalog without prompts, args, or secret fields', () => {
+    expect(summarizeCommandCenterCatalogForResolver(catalog)).toEqual([
+      {
+        commandId: 'sessions.list',
+        label: 'sessions list',
+        summary: 'List Relay sessions',
+        sideEffect: 'read',
+        requiresConfirmation: false,
+        inputSchema: sessionsListDescriptor.input.schema,
+      },
+    ]);
+  });
+
+  it('keeps deterministic search available without a provider', () => {
+    const hits = searchCommandCenterCatalog('show relay sessions', catalog);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.entry.commandId).toBe('sessions.list');
+    expect(searchCommandCenterCatalog('the and', catalog)).toEqual([]);
+  });
+});
+
+describe('Command Center args validation', () => {
+  it('accepts valid json-schema args and rejects unknown/malformed args', () => {
+    const schema = sessionsListDescriptor.input.schema;
+    expect(validateCommandCenterArgs({ repoId: 'repo-1' }, schema)).toEqual([]);
+    expect(
+      validateCommandCenterArgs({ repoId: 42 }, schema).join('\n')
+    ).toContain('expected string');
+    expect(
+      validateCommandCenterArgs({ extra: true }, schema).join('\n')
+    ).toContain('unknown property');
+  });
+});
+
+describe('Command Center provider intent validation', () => {
+  it('returns a strict resolved contract for valid provider output', () => {
+    const resolution = validateCommandCenterProviderIntent(validIntent, {
+      catalog,
+      query: 'sessions',
+    });
+
+    expect(resolution.kind).toBe('resolved');
+    if (resolution.kind !== 'resolved') return;
+    expect(resolution.intent).toMatchObject({
+      commandId: 'sessions.list',
+      args: { repoId: 'repo-1' },
+      confidence: 0.92,
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      scopeKinds: ['session'],
+      capabilityHints: ['session:read'],
+      surfaces: ['web', 'command-center'],
+      ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+    });
+    expect(resolution.suggestions[0]?.entry.commandId).toBe('sessions.list');
+  });
+
+  it('falls back safely for malformed output, unknown command, and low confidence', () => {
+    expect(
+      validateCommandCenterProviderIntent(null, { catalog })
+    ).toMatchObject({
+      kind: 'fallback',
+      reason: 'malformed-output',
+    });
+    expect(
+      validateCommandCenterProviderIntent(
+        { commandId: 'not.real', args: {}, confidence: 0.95 },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'fallback', reason: 'unknown-command' });
+    expect(
+      validateCommandCenterProviderIntent(
+        { ...validIntent, confidence: 0.1 },
+        { catalog, minConfidence: 0.6 }
+      )
+    ).toMatchObject({ kind: 'fallback', reason: 'low-confidence' });
+  });
+
+  it('falls back safely for invalid args and metadata/ui target mismatch', () => {
+    expect(
+      validateCommandCenterProviderIntent(
+        { ...validIntent, args: { extra: true } },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'fallback', reason: 'invalid-args' });
+    expect(
+      validateCommandCenterProviderIntent(
+        { ...validIntent, sideEffect: 'destructive' },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'fallback', reason: 'metadata-mismatch' });
+    expect(
+      validateCommandCenterProviderIntent(
+        { ...validIntent, ui: { actionId: 'gateway.sessions.kill' } },
+        { catalog }
+      )
+    ).toMatchObject({ kind: 'fallback', reason: 'metadata-mismatch' });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared Command Center resolver catalog projected from Relay command/action descriptors.
- Add strict provider intent validation for command IDs, args, side-effect metadata, confirmation requirements, scope/capability hints, surfaces, and UI targets.
- Add a server-side OpenAI-compatible provider wrapper with provider-neutral env config, health checks, timeout handling, safe fallback behavior, and audit metadata that avoids raw prompt/arg payloads.

## Verification
- `npx vitest run test/command-center-resolver.test.ts test/command-center-intent-resolver.test.ts` — 12 passed
- `npm run check` — passed, existing repo warnings only
- `npm run build` — passed, existing Vite chunk warnings only
- `npm test` — failed on existing `test/branch-watcher.test.ts` watcher flake; reproduced with targeted `npx vitest run test/branch-watcher.test.ts` (2 failures unrelated to this resolver slice)
- push hook reran changed tests — 12 passed

## Safety / scope notes
- No execution path from natural language was added.
- Resolver failures fall back to deterministic catalog search.
- Provider config uses env names only; no committed secrets.
- Audit metadata intentionally excludes raw prompt text and provider args.

Closes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced AI-powered command center that intelligently resolves user intents through external providers
  * Implemented comprehensive command catalog with search, validation, and confirmation workflows
  * Integrated resilient fallback system with intelligent suggestions when services are unavailable
  * Added health checks and timeout protection for improved reliability
  * Enabled flexible provider configuration via environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->