### PR TITLE
Add Command Center assistant shell

### DIFF
--- a/frontend/src/components/CommandPalette.css
+++ b/frontend/src/components/CommandPalette.css
@@ -55,6 +55,88 @@
   opacity: 0.6;
 }
 
+.palette-assistant-button,
+.palette-assistant-action {
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 4px 8px;
+  text-transform: lowercase;
+}
+
+.palette-assistant-button:hover,
+.palette-assistant-action:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.palette-assistant-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.palette-assistant-panel {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px;
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--surface-hover) 35%, transparent);
+}
+
+.assistant-kicker {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  margin-bottom: 4px;
+  text-transform: lowercase;
+}
+
+.assistant-title {
+  font-size: var(--font-size-sm);
+  margin-bottom: 4px;
+}
+
+.assistant-title-info {
+  color: var(--status-info);
+}
+
+.assistant-title-success {
+  color: var(--status-success);
+}
+
+.assistant-title-warning {
+  color: var(--status-warning);
+}
+
+.assistant-title-error,
+.assistant-copy-error {
+  color: var(--status-error);
+}
+
+.assistant-copy,
+.assistant-blocked,
+.assistant-suggestions {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+}
+
+.assistant-actions {
+  margin-top: 8px;
+}
+
+.assistant-blocked {
+  display: inline-block;
+  border: 1px solid color-mix(in srgb, var(--status-warning) 50%, transparent);
+  color: var(--status-warning);
+  padding: 4px 8px;
+}
+
+.assistant-suggestions {
+  margin-top: 8px;
+}
+
 .palette-tabs {
   display: flex;
   gap: 0;

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -18,12 +18,19 @@ import type {
 } from '../lib/types.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import StatusDot from './StatusDot.js';
-import { getAllActions } from '../lib/actions/registry.js';
+import { getAction, getAllActions } from '../lib/actions/registry.js';
 import { formatShortcut } from '../lib/actions/shortcuts.js';
 import type { ActionContext, Action } from '../lib/actions/types.js';
 import { isMobileDevice, isMac } from '../lib/utils.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
 import { buildSessionPaletteResults } from '../lib/command-palette-session-results.js';
+import { resolveCommandCenterAssistantIntent } from '../lib/api.js';
+import {
+  commandCenterAssistantCopy,
+  commandCenterSuggestionLabels,
+  decideOpenUiAction,
+  type CommandCenterAssistantResult,
+} from '../lib/command-center-assistant.js';
 import './CommandPalette.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -164,7 +171,16 @@ export interface CommandPaletteProps {
   onSelectSession: (id: string) => void;
   onSelectPr: (pr: PullRequest) => void;
   onOpenSettings?: (sectionId: string) => void;
+  resolveAssistantIntent?: (
+    query: string
+  ) => Promise<CommandCenterAssistantResult>;
 }
+
+type AssistantState =
+  | { status: 'idle' }
+  | { status: 'loading'; query: string }
+  | { status: 'result'; query: string; result: CommandCenterAssistantResult }
+  | { status: 'error'; query: string; message: string };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -617,6 +633,75 @@ function usePaletteHandlers(
   };
 }
 
+interface CommandCenterAssistantPanelProps {
+  state: AssistantState;
+  copy: ReturnType<typeof commandCenterAssistantCopy> | undefined;
+  isOpenUi: boolean;
+  openUiDecision: ReturnType<typeof decideOpenUiAction> | undefined;
+  suggestions: string[];
+  onOpenUi: () => void;
+}
+
+function CommandCenterAssistantPanel({
+  state,
+  copy,
+  isOpenUi,
+  openUiDecision,
+  suggestions,
+  onOpenUi,
+}: CommandCenterAssistantPanelProps) {
+  if (state.status === 'idle') return null;
+  return (
+    <div className="palette-assistant-panel" role="status">
+      <div className="assistant-kicker">assistant shell</div>
+      {state.status === 'loading' && (
+        <div className="assistant-copy">
+          resolving &quot;{state.query}&quot;...
+        </div>
+      )}
+      {state.status === 'error' && (
+        <div className="assistant-copy assistant-copy-error">
+          resolver request failed: {state.message}
+        </div>
+      )}
+      {copy && (
+        <>
+          <div
+            className={['assistant-title', `assistant-title-${copy.tone}`].join(
+              ' '
+            )}
+          >
+            {copy.title}
+          </div>
+          <div className="assistant-copy">{copy.detail}</div>
+          {isOpenUi && (
+            <div className="assistant-actions">
+              {openUiDecision?.canOpen ? (
+                <button
+                  type="button"
+                  className="palette-assistant-action"
+                  onClick={onOpenUi}
+                >
+                  {copy.cta ?? 'open ui'}
+                </button>
+              ) : (
+                <span className="assistant-blocked">
+                  {openUiDecision?.reason ?? 'ui target unavailable'}
+                </span>
+              )}
+            </div>
+          )}
+          {suggestions.length > 0 && (
+            <div className="assistant-suggestions">
+              suggestions: {suggestions.join(' · ')}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // ── Main Component ────────────────────────────────────────────────────────────
 
 export function CommandPalette({
@@ -629,9 +714,13 @@ export function CommandPalette({
   onSelectSession,
   onSelectPr,
   onOpenSettings,
+  resolveAssistantIntent = resolveCommandCenterAssistantIntent,
 }: CommandPaletteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
+  const [assistantState, setAssistantState] = useState<AssistantState>({
+    status: 'idle',
+  });
 
   const {
     query,
@@ -747,11 +836,62 @@ export function CommandPalette({
     onOpenSettings
   );
 
+  const runAssistant = useCallback(async () => {
+    const assistantQuery = query.trim();
+    if (!assistantQuery || assistantState.status === 'loading') return;
+    setAssistantState({ status: 'loading', query: assistantQuery });
+    try {
+      const result = await resolveAssistantIntent(assistantQuery);
+      setAssistantState({ status: 'result', query: assistantQuery, result });
+    } catch (error) {
+      setAssistantState({
+        status: 'error',
+        query: assistantQuery,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [assistantState.status, query, resolveAssistantIntent]);
+
+  const openAssistantUi = useCallback(async () => {
+    if (assistantState.status !== 'result') return;
+    const resolution = assistantState.result.resolution;
+    if (resolution.kind !== 'open_ui') return;
+    const action = getAction(resolution.ui.actionId as Action['id']);
+    const decision = decideOpenUiAction(action, actionContext);
+    if (!decision.canOpen || !action) return;
+    await action.handler(actionContext);
+    onClose();
+  }, [actionContext, assistantState, onClose]);
+
+  useEffect(() => {
+    if (!open) setAssistantState({ status: 'idle' });
+  }, [open]);
+
   if (!open) return null;
   const paletteStyle =
     isMobileDevice && dragOffset > 0
       ? { transform: `translateY(${dragOffset}px)` }
       : undefined;
+  const assistantResolution =
+    assistantState.status === 'result'
+      ? assistantState.result.resolution
+      : undefined;
+  const assistantCopy = assistantResolution
+    ? commandCenterAssistantCopy(assistantResolution, {
+        mobile: isMobileDevice,
+      })
+    : undefined;
+  const openUiAction =
+    assistantResolution?.kind === 'open_ui'
+      ? getAction(assistantResolution.ui.actionId as Action['id'])
+      : undefined;
+  const openUiDecision =
+    assistantResolution?.kind === 'open_ui'
+      ? decideOpenUiAction(openUiAction, actionContext)
+      : undefined;
+  const assistantSuggestions = assistantResolution
+    ? commandCenterSuggestionLabels(assistantResolution)
+    : [];
 
   return (
     <div
@@ -786,8 +926,19 @@ export function CommandPalette({
             className="palette-search-input"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeydown}
-            placeholder="search commands, workspaces, sessions..."
+            onKeyDown={(e) => {
+              if (
+                e.key === 'Enter' &&
+                query.trim() &&
+                (e.metaKey || e.ctrlKey || e.shiftKey || flatItems.length === 0)
+              ) {
+                e.preventDefault();
+                void runAssistant();
+                return;
+              }
+              handleKeydown(e);
+            }}
+            placeholder="search or ask natural language..."
             autoComplete="off"
             spellCheck={false}
             role="combobox"
@@ -799,7 +950,23 @@ export function CommandPalette({
                 : undefined
             }
           />
+          <button
+            type="button"
+            className="palette-assistant-button"
+            disabled={!query.trim() || assistantState.status === 'loading'}
+            onClick={() => void runAssistant()}
+          >
+            {assistantState.status === 'loading' ? 'asking' : 'ask'}
+          </button>
         </div>
+        <CommandCenterAssistantPanel
+          state={assistantState}
+          copy={assistantCopy}
+          isOpenUi={assistantResolution?.kind === 'open_ui'}
+          openUiDecision={openUiDecision}
+          suggestions={assistantSuggestions}
+          onOpenUi={() => void openAssistantUi()}
+        />
         <div className="palette-tabs" role="tablist">
           {TABS.map((tab) => (
             <button

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -721,6 +721,8 @@ export function CommandPalette({
   const [assistantState, setAssistantState] = useState<AssistantState>({
     status: 'idle',
   });
+  const assistantOpenRef = useRef(open);
+  const assistantRequestIdRef = useRef(0);
 
   const {
     query,
@@ -839,11 +841,23 @@ export function CommandPalette({
   const runAssistant = useCallback(async () => {
     const assistantQuery = query.trim();
     if (!assistantQuery || assistantState.status === 'loading') return;
+    const requestId = assistantRequestIdRef.current + 1;
+    assistantRequestIdRef.current = requestId;
     setAssistantState({ status: 'loading', query: assistantQuery });
     try {
       const result = await resolveAssistantIntent(assistantQuery);
+      if (
+        !assistantOpenRef.current ||
+        assistantRequestIdRef.current !== requestId
+      )
+        return;
       setAssistantState({ status: 'result', query: assistantQuery, result });
     } catch (error) {
+      if (
+        !assistantOpenRef.current ||
+        assistantRequestIdRef.current !== requestId
+      )
+        return;
       setAssistantState({
         status: 'error',
         query: assistantQuery,
@@ -864,7 +878,15 @@ export function CommandPalette({
   }, [actionContext, assistantState, onClose]);
 
   useEffect(() => {
-    if (!open) setAssistantState({ status: 'idle' });
+    assistantOpenRef.current = open;
+    if (!open) {
+      assistantRequestIdRef.current += 1;
+      setAssistantState({ status: 'idle' });
+    }
+    return () => {
+      assistantOpenRef.current = false;
+      assistantRequestIdRef.current += 1;
+    };
   }, [open]);
 
   if (!open) return null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -92,6 +92,7 @@ import type {
   ControlActor,
   InterventionRecord,
 } from '../../../shared/control-state.js';
+import type { CommandCenterAssistantResult } from './command-center-assistant.js';
 import { registerConfirmationRetry } from './confirmation-retries.js';
 
 export class ConflictError extends Error {
@@ -277,6 +278,18 @@ export interface BrowseResponse {
   entries: BrowseEntry[];
   truncated: boolean;
   total: number;
+}
+
+export async function resolveCommandCenterAssistantIntent(
+  query: string
+): Promise<CommandCenterAssistantResult> {
+  return json<CommandCenterAssistantResult>(
+    await fetch('/api/command-center/resolve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+    })
+  );
 }
 
 async function json<T>(res: Response): Promise<T> {

--- a/frontend/src/lib/command-center-assistant.ts
+++ b/frontend/src/lib/command-center-assistant.ts
@@ -1,0 +1,174 @@
+import type {
+  CommandCenterNoMatchReason,
+  CommandCenterResolution,
+} from '../../../shared/command-center-resolver.js';
+import type { Action, ActionContext } from './actions/types.js';
+
+export interface CommandCenterIntentAuditView {
+  outcome: string;
+  reason?: string;
+  commandId?: string;
+  confidence?: number;
+  durationMs?: number;
+  suggestionCount: number;
+}
+
+export interface CommandCenterAssistantResult {
+  resolution: CommandCenterResolution;
+  audit: CommandCenterIntentAuditView;
+}
+
+export interface CommandCenterAssistantCopy {
+  title: string;
+  detail: string;
+  tone: 'info' | 'success' | 'warning' | 'error';
+  cta?: string;
+}
+
+const REASON_COPY: Record<CommandCenterNoMatchReason, string> = {
+  'provider-missing': 'assistant resolver is not configured',
+  'provider-unhealthy': 'assistant resolver is unhealthy',
+  'provider-no-match': 'assistant could not map that to Relay',
+  timeout: 'assistant resolver timed out',
+  'provider-error': 'assistant resolver failed',
+  'malformed-output': 'assistant returned malformed output',
+  'low-confidence': 'assistant confidence was too low',
+  'unknown-command': 'assistant picked an unknown command',
+  'invalid-args': 'assistant needs more fields',
+  'metadata-mismatch': 'assistant metadata did not match the action contract',
+  'unsafe-command': 'policy blocked this action',
+};
+
+export function commandCenterAssistantCopy(
+  resolution: CommandCenterResolution,
+  options: { mobile?: boolean } = {}
+): CommandCenterAssistantCopy {
+  if (resolution.kind === 'open_ui') {
+    return {
+      title: 'guided ui match',
+      detail: `${resolution.entry.label} can open an existing Relay surface. Review before continuing.`,
+      tone: 'success',
+      cta: options.mobile ? 'open guided sheet' : 'open ui',
+    };
+  }
+  if (resolution.kind === 'ask_followup') {
+    return {
+      title: 'needs one more detail',
+      detail: resolution.question,
+      tone: 'warning',
+    };
+  }
+  if (resolution.kind === 'explain') {
+    return {
+      title: 'assistant explanation',
+      detail: resolution.message,
+      tone: 'info',
+    };
+  }
+  if (resolution.kind === 'execute_command') {
+    return {
+      title: 'preview only',
+      detail: `${resolution.entry.label} is read-only, but natural-language execution is deferred to a later slice. Use the deterministic command entry below instead.`,
+      tone: 'info',
+    };
+  }
+
+  return {
+    title: REASON_COPY[resolution.reason],
+    detail:
+      resolution.detail ??
+      noMatchRecoveryCopy(resolution.reason, options.mobile === true),
+    tone:
+      resolution.reason === 'provider-missing' ||
+      resolution.reason === 'provider-unhealthy' ||
+      resolution.reason === 'timeout'
+        ? 'warning'
+        : resolution.reason === 'unsafe-command'
+          ? 'error'
+          : 'info',
+  };
+}
+
+function noMatchRecoveryCopy(
+  reason: CommandCenterNoMatchReason,
+  mobile: boolean
+): string {
+  if (reason === 'provider-missing') {
+    return 'deterministic Command Center search still works below.';
+  }
+  if (reason === 'provider-unhealthy' || reason === 'timeout') {
+    return 'try again, or use deterministic Command Center search below.';
+  }
+  if (reason === 'invalid-args') {
+    return mobile
+      ? 'pick a guided action below so Relay can ask for missing fields.'
+      : 'add the missing field or choose a deterministic action below.';
+  }
+  if (reason === 'unsafe-command') {
+    return 'natural-language write, destructive, stream, and policy-gated execution is blocked in this slice.';
+  }
+  return 'try a more specific request, or choose a deterministic result below.';
+}
+
+export interface OpenUiActionDecision {
+  canOpen: boolean;
+  reason?: string;
+  label?: string;
+}
+
+export function decideOpenUiAction(
+  action: Action | undefined,
+  ctx: ActionContext
+): OpenUiActionDecision {
+  if (!action) return { canOpen: false, reason: 'ui target is not registered' };
+  const disabledReason =
+    action.when && !action.when(ctx)
+      ? (action.disabledReason?.(ctx) ?? 'not available in the current context')
+      : undefined;
+  if (disabledReason) return { canOpen: false, reason: disabledReason };
+  if (action.category === 'gateway') {
+    return {
+      canOpen: false,
+      reason: 'stable CLI gateway commands are preview-only in this shell',
+      label: action.label,
+    };
+  }
+  const descriptor = action.descriptor;
+  if (descriptor?.confirmation.required) {
+    return {
+      canOpen: false,
+      reason: 'confirmation-gated actions require the later execution slice',
+      label: action.label,
+    };
+  }
+  if (
+    descriptor?.sideEffect === 'destructive' ||
+    descriptor?.sideEffect === 'stream'
+  ) {
+    return {
+      canOpen: false,
+      reason: 'policy blocked direct natural-language execution',
+      label: action.label,
+    };
+  }
+  if (
+    descriptor?.sideEffect === 'write' &&
+    action.id !== 'session.start-work-in-env'
+  ) {
+    return {
+      canOpen: false,
+      reason: ctx.isMobile
+        ? 'mobile assistant only opens guided flows for write-shaped actions'
+        : 'write-shaped actions require a guided UI handoff',
+      label: action.label,
+    };
+  }
+  return { canOpen: true, label: action.label };
+}
+
+export function commandCenterSuggestionLabels(
+  resolution: CommandCenterResolution,
+  limit = 3
+): string[] {
+  return resolution.suggestions.slice(0, limit).map((hit) => hit.entry.label);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -3230,31 +3230,36 @@ async function main(): Promise<void> {
   // The response is the shared resolver contract plus redacted audit metadata;
   // raw prompts, provider payloads, and inferred args stay out of durable logs.
   app.post('/api/command-center/resolve', requireAuth, async (req, res) => {
-    const body = isRecord(req.body) ? req.body : {};
-    const query = typeof body.query === 'string' ? body.query.trim() : '';
-    if (query.length === 0) {
-      res.status(400).json({ error: 'query is required' });
-      return;
-    }
-    if (query.length > 2_000) {
-      res.status(400).json({ error: 'query is too long' });
-      return;
-    }
-
-    const config = readCommandCenterIntentResolverConfig();
-    const provider = config
-      ? createOpenAiCompatibleCommandCenterIntentProvider(config, {
-          fetch: globalThis.fetch,
-        })
-      : null;
-    const result = await resolveCommandCenterIntent(
-      { query },
-      {
-        provider,
-        ...(config ? { minConfidence: config.minConfidence } : {}),
+    try {
+      const body = isRecord(req.body) ? req.body : {};
+      const query = typeof body.query === 'string' ? body.query.trim() : '';
+      if (query.length === 0) {
+        res.status(400).json({ error: 'query is required' });
+        return;
       }
-    );
-    res.json(result);
+      if (query.length > 2_000) {
+        res.status(400).json({ error: 'query is too long' });
+        return;
+      }
+
+      const config = readCommandCenterIntentResolverConfig();
+      const provider = config
+        ? createOpenAiCompatibleCommandCenterIntentProvider(config, {
+            fetch: globalThis.fetch,
+          })
+        : null;
+      const result = await resolveCommandCenterIntent(
+        { query },
+        {
+          provider,
+          ...(config ? { minConfidence: config.minConfidence } : {}),
+        }
+      );
+      res.json(result);
+    } catch (error) {
+      logger.error('Command Center resolver failed unexpectedly', error);
+      res.status(500).json({ error: 'command-center-resolver-failed' });
+    }
   });
 
   // Restore sessions from a previous update restart

--- a/server/index.ts
+++ b/server/index.ts
@@ -133,6 +133,11 @@ import {
   getFrameworkClientInfoWithRuntime,
   getFrameworkWebAvailability,
 } from './frameworks.js';
+import {
+  createOpenAiCompatibleCommandCenterIntentProvider,
+  readCommandCenterIntentResolverConfig,
+  resolveCommandCenterIntent,
+} from './command-center-intent-resolver.js';
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
 import {
@@ -3219,6 +3224,37 @@ async function main(): Promise<void> {
   app.get('/api/node/manifest', requireAuth, async (_req, res) => {
     const manifest = await getNodeManifest({ config: getConfig() });
     res.json({ manifest });
+  });
+
+  // POST /api/command-center/resolve — natural-language Command Center resolver.
+  // The response is the shared resolver contract plus redacted audit metadata;
+  // raw prompts, provider payloads, and inferred args stay out of durable logs.
+  app.post('/api/command-center/resolve', requireAuth, async (req, res) => {
+    const body = isRecord(req.body) ? req.body : {};
+    const query = typeof body.query === 'string' ? body.query.trim() : '';
+    if (query.length === 0) {
+      res.status(400).json({ error: 'query is required' });
+      return;
+    }
+    if (query.length > 2_000) {
+      res.status(400).json({ error: 'query is too long' });
+      return;
+    }
+
+    const config = readCommandCenterIntentResolverConfig();
+    const provider = config
+      ? createOpenAiCompatibleCommandCenterIntentProvider(config, {
+          fetch: globalThis.fetch,
+        })
+      : null;
+    const result = await resolveCommandCenterIntent(
+      { query },
+      {
+        provider,
+        ...(config ? { minConfidence: config.minConfidence } : {}),
+      }
+    );
+    res.json(result);
   });
 
   // Restore sessions from a previous update restart

--- a/shared/action-descriptor.ts
+++ b/shared/action-descriptor.ts
@@ -104,6 +104,10 @@ export const relayUnknownErrorSchema: RelayJsonSchema = {
   additionalProperties: true,
 };
 
+function uiActionCategory(actionId: string): string {
+  return actionId.split('.', 1)[0] || 'ui';
+}
+
 export function relayActionDescriptorFromCommandDefinition(
   command: RelayCommandDefinition,
   options: {
@@ -135,6 +139,14 @@ export function relayActionDescriptorFromCommandDefinition(
     },
     stable: command.stable,
     source: 'cli-gateway-v1',
+    ...(command.handler.uiAction
+      ? {
+          ui: {
+            actionId: command.handler.uiAction,
+            category: uiActionCategory(command.handler.uiAction),
+          },
+        }
+      : {}),
     contract: {
       relayCommandName: command.name,
       stable: command.stable,

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -78,6 +78,12 @@ export interface RelayCommandManifest {
 
 const CLI_AGENT_WEB_SURFACES = ['cli', 'agent', 'web'] as const;
 
+const UI_ACTION_BY_GATEWAY_COMMAND: Partial<
+  Record<RelayCliGatewayCommand, string>
+> = {
+  'sessions.list': 'session.start-work-in-env',
+};
+
 const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'contract.list': 'gateway commands list',
   'contract.schema': 'gateway schema',
@@ -265,7 +271,8 @@ function scopeKindsForGatewayCommand(
   if (name.startsWith('worktrees.')) return ['repo', 'worktree'];
   if (name.startsWith('files.')) return ['session'];
   if (name.startsWith('work-contexts.')) return ['work-context'];
-  if (name.startsWith('work-context-messages.templates.')) return ['work-context'];
+  if (name.startsWith('work-context-messages.templates.'))
+    return ['work-context'];
   if (name.startsWith('work-context-messages.')) return ['work-context'];
   if (name.startsWith('work-context-artifacts.')) return ['work-context'];
   if (name.startsWith('handoff-artifacts.')) return ['work-context'];
@@ -368,6 +375,7 @@ function auditRedactionForGatewayCommand(
 export function relayCommandDefinitionFromCliGatewaySpec(
   spec: RelayCliGatewayCommandSpec
 ): RelayCommandDefinition {
+  const uiAction = UI_ACTION_BY_GATEWAY_COMMAND[spec.name];
   return {
     id: spec.name,
     name: spec.name,
@@ -384,7 +392,7 @@ export function relayCommandDefinitionFromCliGatewaySpec(
     auditRedaction: auditRedactionForGatewayCommand(spec),
     errorCodes: spec.errorCodes,
     scopeKinds: scopeKindsForGatewayCommand(spec.name),
-    handler: { cli: spec.cli },
+    handler: { cli: spec.cli, ...(uiAction ? { uiAction } : {}) },
     stable: spec.stable,
     source: 'cli-gateway-v1',
   };

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -81,7 +81,7 @@ const CLI_AGENT_WEB_SURFACES = ['cli', 'agent', 'web'] as const;
 const UI_ACTION_BY_GATEWAY_COMMAND: Partial<
   Record<RelayCliGatewayCommand, string>
 > = {
-  'sessions.list': 'session.start-work-in-env',
+  'settings.get': 'settings.open',
 };
 
 const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {

--- a/test/command-center-assistant-shell.test.ts
+++ b/test/command-center-assistant-shell.test.ts
@@ -177,7 +177,8 @@ describe('<CommandPalette /> assistant shell', () => {
   async function render(
     resolveAssistantIntent: (
       query: string
-    ) => Promise<CommandCenterAssistantResult>
+    ) => Promise<CommandCenterAssistantResult>,
+    options: { open?: boolean } = {}
   ) {
     await act(async () => {
       root.render(
@@ -185,7 +186,7 @@ describe('<CommandPalette /> assistant shell', () => {
           QueryClientProvider,
           { client: queryClient },
           React.createElement(CommandPalette, {
-            open: true,
+            open: options.open ?? true,
             workspaces: [],
             sessions: [],
             actionContext,
@@ -199,6 +200,44 @@ describe('<CommandPalette /> assistant shell', () => {
       );
     });
   }
+
+  it('drops in-flight assistant results when the palette closes', async () => {
+    let resolveRequest:
+      | ((result: CommandCenterAssistantResult) => void)
+      | null = null;
+    const resolveAssistantIntent = vi.fn(
+      () =>
+        new Promise<CommandCenterAssistantResult>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+    await render(resolveAssistantIntent);
+    const input = container.querySelector(
+      '.palette-search-input'
+    ) as HTMLInputElement;
+    const ask = container.querySelector(
+      '.palette-assistant-button'
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      setInputValue(input, 'show sessions');
+    });
+    await act(async () => {
+      ask.click();
+    });
+    await render(resolveAssistantIntent, { open: false });
+    await act(async () => {
+      resolveRequest?.(providerMissingResult());
+      await Promise.resolve();
+    });
+    await render(resolveAssistantIntent);
+
+    expect(resolveAssistantIntent).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain(
+      'assistant resolver is not configured'
+    );
+    expect(container.textContent).not.toContain('sessions list');
+  });
 
   it('keeps deterministic search visible when provider is unconfigured', async () => {
     await render(async () => providerMissingResult());

--- a/test/command-center-assistant-shell.test.ts
+++ b/test/command-center-assistant-shell.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CommandPalette from '../frontend/src/components/CommandPalette.js';
+import {
+  commandCenterAssistantCopy,
+  decideOpenUiAction,
+  type CommandCenterAssistantResult,
+} from '../frontend/src/lib/command-center-assistant.js';
+import {
+  _resetForTesting,
+  registerGlobal,
+} from '../frontend/src/lib/actions/registry.js';
+import type {
+  Action,
+  ActionContext,
+} from '../frontend/src/lib/actions/types.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const actionContext: ActionContext = {
+  view: 'session',
+  workspacePath: '/repo',
+  cwd: '/repo',
+  isMobile: false,
+};
+
+function resultFor(
+  resolution: CommandCenterAssistantResult['resolution']
+): CommandCenterAssistantResult {
+  return {
+    resolution,
+    audit: {
+      outcome: resolution.kind,
+      suggestionCount: resolution.suggestions.length,
+    },
+  };
+}
+
+const sessionsListEntry = {
+  commandId: 'sessions.list',
+  label: 'sessions list',
+  summary: 'List Relay sessions',
+  keywords: ['sessions', 'list'],
+  sideEffect: 'read',
+  requiresConfirmation: false,
+  controlRequirements: [],
+  scopeKinds: ['session'],
+  capabilityHints: ['session:read'],
+  surfaces: ['web', 'command-center'],
+  ui: { actionId: 'session.start-work-in-env', category: 'session' },
+  inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+} as const;
+
+function openUiResult(): CommandCenterAssistantResult {
+  return resultFor({
+    kind: 'open_ui',
+    entry: sessionsListEntry,
+    intent: {
+      commandId: 'sessions.list',
+      args: {},
+      confidence: 0.92,
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      controlRequirements: [],
+      scopeKinds: ['session'],
+      capabilityHints: ['session:read'],
+      surfaces: ['web', 'command-center'],
+      ui: { actionId: 'session.start-work-in-env', category: 'session' },
+    },
+    ui: { actionId: 'session.start-work-in-env', category: 'session' },
+    suggestions: [],
+  });
+}
+
+function providerMissingResult(): CommandCenterAssistantResult {
+  return resultFor({
+    kind: 'no_match',
+    reason: 'provider-missing',
+    suggestions: [{ entry: sessionsListEntry, score: 4 }],
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('Command Center assistant shell helpers', () => {
+  it('renders provider and policy states as recoverable copy', () => {
+    expect(
+      commandCenterAssistantCopy(providerMissingResult().resolution).detail
+    ).toContain('deterministic Command Center search still works');
+    expect(
+      commandCenterAssistantCopy({
+        kind: 'no_match',
+        reason: 'unsafe-command',
+        suggestions: [],
+      }).title
+    ).toBe('policy blocked this action');
+  });
+
+  it('allows the mobile guided env-picker open_ui but blocks raw gateway actions', () => {
+    const guidedAction: Action = {
+      id: 'session.start-work-in-env',
+      label: 'start work in environment…',
+      category: 'session',
+      handler: () => {},
+      descriptor: {
+        id: 'sessions.create',
+        title: 'create session',
+        label: 'create session',
+        input: { kind: 'json-schema', schema: { type: 'object' } },
+        availability: { state: 'available' },
+        sideEffect: 'write',
+        confirmation: { required: false, controlRequirements: [] },
+        surfaces: ['web', 'command-center'],
+        result: { kind: 'json-schema', schema: { type: 'object' } },
+        error: { kind: 'json-schema', schema: { type: 'object' } },
+        stable: true,
+        source: 'cli-gateway-v1',
+        ui: { actionId: 'session.start-work-in-env', category: 'session' },
+      },
+    };
+    const gatewayAction: Action = {
+      ...guidedAction,
+      id: 'gateway.sessions.create',
+      category: 'gateway',
+    };
+
+    expect(
+      decideOpenUiAction(guidedAction, { ...actionContext, isMobile: true })
+        .canOpen
+    ).toBe(true);
+    expect(decideOpenUiAction(gatewayAction, actionContext).canOpen).toBe(
+      false
+    );
+    expect(
+      decideOpenUiAction(
+        { ...guidedAction, id: 'session.new-agent' },
+        actionContext
+      ).canOpen
+    ).toBe(false);
+  });
+});
+
+describe('<CommandPalette /> assistant shell', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    _resetForTesting();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    container.remove();
+    _resetForTesting();
+  });
+
+  async function render(
+    resolveAssistantIntent: (
+      query: string
+    ) => Promise<CommandCenterAssistantResult>
+  ) {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(CommandPalette, {
+            open: true,
+            workspaces: [],
+            sessions: [],
+            actionContext,
+            onClose: vi.fn(),
+            onSelectWorkspace: vi.fn(),
+            onSelectSession: vi.fn(),
+            onSelectPr: vi.fn(),
+            resolveAssistantIntent,
+          })
+        )
+      );
+    });
+  }
+
+  it('keeps deterministic search visible when provider is unconfigured', async () => {
+    await render(async () => providerMissingResult());
+    const input = container.querySelector(
+      '.palette-search-input'
+    ) as HTMLInputElement;
+    const ask = container.querySelector(
+      '.palette-assistant-button'
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      setInputValue(input, 'show sessions');
+    });
+    await act(async () => {
+      ask.click();
+    });
+
+    expect(container.textContent).toContain(
+      'assistant resolver is not configured'
+    );
+    expect(container.textContent).toContain(
+      'deterministic Command Center search'
+    );
+    expect(container.textContent).toContain('sessions list');
+  });
+
+  it('opens a registered guided open_ui action from resolver metadata', async () => {
+    const handler = vi.fn();
+    registerGlobal([
+      {
+        id: 'session.start-work-in-env',
+        label: 'start work in environment…',
+        category: 'session',
+        handler,
+      },
+    ]);
+    await render(async () => openUiResult());
+    const input = container.querySelector(
+      '.palette-search-input'
+    ) as HTMLInputElement;
+    const ask = container.querySelector(
+      '.palette-assistant-button'
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      setInputValue(input, 'start a terminal somewhere');
+    });
+    await act(async () => {
+      ask.click();
+    });
+    const openButton = container.querySelector(
+      '.palette-assistant-action'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      openButton.click();
+    });
+
+    expect(handler).toHaveBeenCalledWith(actionContext);
+  });
+});

--- a/test/command-center-resolver.test.ts
+++ b/test/command-center-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  COMMAND_CENTER_RESOLVER_CATALOG,
   buildCommandCenterResolverCatalog,
   searchCommandCenterCatalog,
   summarizeCommandCenterCatalogForResolver,
@@ -80,6 +81,33 @@ const validIntent: CommandCenterProviderIntent = {
 };
 
 describe('Command Center resolver catalog', () => {
+  it('wires a real shared catalog entry to a guided open_ui action', () => {
+    const uiEntry = COMMAND_CENTER_RESOLVER_CATALOG.entries.find(
+      (entry) => entry.ui?.actionId === 'session.start-work-in-env'
+    );
+
+    expect(uiEntry).toMatchObject({
+      commandId: 'sessions.list',
+      ui: { actionId: 'session.start-work-in-env', category: 'session' },
+    });
+
+    expect(
+      validateCommandCenterProviderIntent(
+        {
+          kind: 'open_ui',
+          commandId: 'sessions.list',
+          args: {},
+          confidence: 0.92,
+          ui: { actionId: 'session.start-work-in-env', category: 'session' },
+        },
+        { catalog: COMMAND_CENTER_RESOLVER_CATALOG }
+      )
+    ).toMatchObject({
+      kind: 'open_ui',
+      ui: { actionId: 'session.start-work-in-env', category: 'session' },
+    });
+  });
+
   it('projects compact command metadata from shared action descriptors', () => {
     expect(catalog.entries).toHaveLength(1);
     const entry = catalog.byCommandId.get('sessions.list');

--- a/test/command-center-resolver.test.ts
+++ b/test/command-center-resolver.test.ts
@@ -83,28 +83,28 @@ const validIntent: CommandCenterProviderIntent = {
 describe('Command Center resolver catalog', () => {
   it('wires a real shared catalog entry to a guided open_ui action', () => {
     const uiEntry = COMMAND_CENTER_RESOLVER_CATALOG.entries.find(
-      (entry) => entry.ui?.actionId === 'session.start-work-in-env'
+      (entry) => entry.ui?.actionId === 'settings.open'
     );
 
     expect(uiEntry).toMatchObject({
-      commandId: 'sessions.list',
-      ui: { actionId: 'session.start-work-in-env', category: 'session' },
+      commandId: 'settings.get',
+      ui: { actionId: 'settings.open', category: 'settings' },
     });
 
     expect(
       validateCommandCenterProviderIntent(
         {
           kind: 'open_ui',
-          commandId: 'sessions.list',
+          commandId: 'settings.get',
           args: {},
           confidence: 0.92,
-          ui: { actionId: 'session.start-work-in-env', category: 'session' },
+          ui: { actionId: 'settings.open', category: 'settings' },
         },
         { catalog: COMMAND_CENTER_RESOLVER_CATALOG }
       )
     ).toMatchObject({
       kind: 'open_ui',
-      ui: { actionId: 'session.start-work-in-env', category: 'session' },
+      ui: { actionId: 'settings.open', category: 'settings' },
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a Command Center assistant shell that resolves natural-language asks through `/api/command-center/resolve`.
- Shows user-facing assistant states for confidence, blocked paths, suggested exact commands, and safe guided UI handoff.
- Adds browser/API tests for the assistant shell, resolver endpoint, mobile-safe gating, keyboard submit, and empty/error states.

## Verification
- `npm test -- test/command-center-assistant-shell.test.ts test/command-center-resolver.test.ts test/command-center-intent-resolver.test.ts` — 20 passed
- `npm run check` — passed, existing lint warnings only
- `npm run build` — passed, existing Vite chunk-size/dynamic-import warnings only
- pre-push changed-test suite — 68 files / 521 tests passed on retry; first run had a flaky unrelated `FileFeedbackPanel` failure that passed isolated and on retry
- browser smoke on `RELAY_IDE_PORT=45678 npm start`: unlocked local UI with fixture PIN, opened Command Center with Ctrl+P, typed `show sessions`, clicked `ask`; assistant shell rendered suggested command state without console errors
- mobile Playwright smoke at 390x844: unlocked UI, opened Command Center via button, typed `show sessions`, clicked `ask`; assistant result text rendered and stayed within the 390px viewport

## Notes
- Significant/multi-file change got a simplify pass. Applied one worthwhile cleanup: tightened write-shaped action gating so only the explicit `session.start-work-in-env` guided flow can auto-open from assistant output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI assistant integration to the command palette, enabling natural-language queries alongside command search.
  * Added "ask" button to trigger assistant with keyboard shortcuts (Enter with modifiers or when no results found).
  * Assistant provides intelligent suggestions, guided workflows, and contextual help with visual feedback (loading/error states).
  * New response tones (info, success, warning, error) for clearer user guidance.

* **Style**
  * Added styling for assistant panel, buttons, and message display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1008
