### PR TITLE
feat: execute read-only command center intents

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -24,13 +24,18 @@ import type { ActionContext, Action } from '../lib/actions/types.js';
 import { isMobileDevice, isMac } from '../lib/utils.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
 import { buildSessionPaletteResults } from '../lib/command-palette-session-results.js';
-import { resolveCommandCenterAssistantIntent } from '../lib/api.js';
+import {
+  executeCommandCenterAssistantCommand,
+  resolveCommandCenterAssistantIntent,
+} from '../lib/api.js';
 import {
   commandCenterAssistantCopy,
+  commandCenterExecutionCopy,
   commandCenterSuggestionLabels,
   decideOpenUiAction,
   type CommandCenterAssistantResult,
 } from '../lib/command-center-assistant.js';
+import type { CommandCenterExecutionResult } from '../../../shared/command-center-execution.js';
 import './CommandPalette.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -174,7 +179,17 @@ export interface CommandPaletteProps {
   resolveAssistantIntent?: (
     query: string
   ) => Promise<CommandCenterAssistantResult>;
+  executeAssistantCommand?: (
+    commandId: string,
+    args: Record<string, unknown>
+  ) => Promise<CommandCenterExecutionResult>;
 }
+
+type AssistantExecutionState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'done'; result: CommandCenterExecutionResult }
+  | { status: 'error'; message: string };
 
 type AssistantState =
   | { status: 'idle' }
@@ -211,6 +226,10 @@ function matchesTab(type: PaletteResult['type'], activeTab: Tab): boolean {
   if (activeTab === 'prs') return type === 'pr' || type === 'attention';
   if (activeTab === 'settings') return type === 'setting' || type === 'command';
   return true;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
@@ -637,18 +656,24 @@ interface CommandCenterAssistantPanelProps {
   state: AssistantState;
   copy: ReturnType<typeof commandCenterAssistantCopy> | undefined;
   isOpenUi: boolean;
+  isExecuteCommand: boolean;
   openUiDecision: ReturnType<typeof decideOpenUiAction> | undefined;
+  execution: AssistantExecutionState;
   suggestions: string[];
   onOpenUi: () => void;
+  onExecuteCommand: () => void;
 }
 
 function CommandCenterAssistantPanel({
   state,
   copy,
   isOpenUi,
+  isExecuteCommand,
   openUiDecision,
+  execution,
   suggestions,
   onOpenUi,
+  onExecuteCommand,
 }: CommandCenterAssistantPanelProps) {
   if (state.status === 'idle') return null;
   return (
@@ -691,6 +716,28 @@ function CommandCenterAssistantPanel({
               )}
             </div>
           )}
+          {isExecuteCommand && (
+            <div className="assistant-actions">
+              <button
+                type="button"
+                className="palette-assistant-action"
+                disabled={execution.status === 'loading'}
+                onClick={onExecuteCommand}
+              >
+                {execution.status === 'loading'
+                  ? 'running read-only command...'
+                  : (copy.cta ?? 'run command')}
+              </button>
+            </div>
+          )}
+          {execution.status === 'error' && (
+            <div className="assistant-copy assistant-copy-error">
+              command request failed: {execution.message}
+            </div>
+          )}
+          {execution.status === 'done' && (
+            <CommandCenterExecutionSummary result={execution.result} />
+          )}
           {suggestions.length > 0 && (
             <div className="assistant-suggestions">
               suggestions: {suggestions.join(' · ')}
@@ -699,6 +746,26 @@ function CommandCenterAssistantPanel({
         </>
       )}
     </div>
+  );
+}
+
+function CommandCenterExecutionSummary({
+  result,
+}: {
+  result: CommandCenterExecutionResult;
+}) {
+  const copy = commandCenterExecutionCopy(result);
+  return (
+    <>
+      <div
+        className={['assistant-title', `assistant-title-${copy.tone}`].join(
+          ' '
+        )}
+      >
+        {copy.title}
+      </div>
+      <div className="assistant-copy">{copy.detail}</div>
+    </>
   );
 }
 
@@ -715,14 +782,18 @@ export function CommandPalette({
   onSelectPr,
   onOpenSettings,
   resolveAssistantIntent = resolveCommandCenterAssistantIntent,
+  executeAssistantCommand = executeCommandCenterAssistantCommand,
 }: CommandPaletteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
   const [assistantState, setAssistantState] = useState<AssistantState>({
     status: 'idle',
   });
+  const [assistantExecution, setAssistantExecution] =
+    useState<AssistantExecutionState>({ status: 'idle' });
   const assistantOpenRef = useRef(open);
   const assistantRequestIdRef = useRef(0);
+  const assistantExecutionRequestIdRef = useRef(0);
 
   const {
     query,
@@ -843,6 +914,7 @@ export function CommandPalette({
     if (!assistantQuery || assistantState.status === 'loading') return;
     const requestId = assistantRequestIdRef.current + 1;
     assistantRequestIdRef.current = requestId;
+    setAssistantExecution({ status: 'idle' });
     setAssistantState({ status: 'loading', query: assistantQuery });
     try {
       const result = await resolveAssistantIntent(assistantQuery);
@@ -877,15 +949,52 @@ export function CommandPalette({
     onClose();
   }, [actionContext, assistantState, onClose]);
 
+  const runAssistantCommand = useCallback(async () => {
+    if (assistantState.status !== 'result') return;
+    const resolution = assistantState.result.resolution;
+    if (resolution.kind !== 'execute_command') return;
+    const requestId = assistantRequestIdRef.current;
+    const executionRequestId = assistantExecutionRequestIdRef.current + 1;
+    assistantExecutionRequestIdRef.current = executionRequestId;
+    setAssistantExecution({ status: 'loading' });
+    try {
+      const result = await executeAssistantCommand(
+        resolution.intent.commandId,
+        isPlainRecord(resolution.intent.args) ? resolution.intent.args : {}
+      );
+      if (
+        !assistantOpenRef.current ||
+        assistantRequestIdRef.current !== requestId ||
+        assistantExecutionRequestIdRef.current !== executionRequestId
+      )
+        return;
+      setAssistantExecution({ status: 'done', result });
+    } catch (error) {
+      if (
+        !assistantOpenRef.current ||
+        assistantRequestIdRef.current !== requestId ||
+        assistantExecutionRequestIdRef.current !== executionRequestId
+      )
+        return;
+      setAssistantExecution({
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [assistantState, executeAssistantCommand]);
+
   useEffect(() => {
     assistantOpenRef.current = open;
     if (!open) {
       assistantRequestIdRef.current += 1;
+      assistantExecutionRequestIdRef.current += 1;
       setAssistantState({ status: 'idle' });
+      setAssistantExecution({ status: 'idle' });
     }
     return () => {
       assistantOpenRef.current = false;
       assistantRequestIdRef.current += 1;
+      assistantExecutionRequestIdRef.current += 1;
     };
   }, [open]);
 
@@ -985,9 +1094,12 @@ export function CommandPalette({
           state={assistantState}
           copy={assistantCopy}
           isOpenUi={assistantResolution?.kind === 'open_ui'}
+          isExecuteCommand={assistantResolution?.kind === 'execute_command'}
           openUiDecision={openUiDecision}
+          execution={assistantExecution}
           suggestions={assistantSuggestions}
           onOpenUi={() => void openAssistantUi()}
+          onExecuteCommand={() => void runAssistantCommand()}
         />
         <div className="palette-tabs" role="tablist">
           {TABS.map((tab) => (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -92,6 +92,7 @@ import type {
   ControlActor,
   InterventionRecord,
 } from '../../../shared/control-state.js';
+import type { CommandCenterExecutionResult } from '../../../shared/command-center-execution.js';
 import type { CommandCenterAssistantResult } from './command-center-assistant.js';
 import { registerConfirmationRetry } from './confirmation-retries.js';
 
@@ -288,6 +289,19 @@ export async function resolveCommandCenterAssistantIntent(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query }),
+    })
+  );
+}
+
+export async function executeCommandCenterAssistantCommand(
+  commandId: string,
+  args: Record<string, unknown>
+): Promise<CommandCenterExecutionResult> {
+  return json<CommandCenterExecutionResult>(
+    await fetch('/api/command-center/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ commandId, args }),
     })
   );
 }

--- a/frontend/src/lib/command-center-assistant.ts
+++ b/frontend/src/lib/command-center-assistant.ts
@@ -2,6 +2,7 @@ import type {
   CommandCenterNoMatchReason,
   CommandCenterResolution,
 } from '../../../shared/command-center-resolver.js';
+import type { CommandCenterExecutionResult } from '../../../shared/command-center-execution.js';
 import type { Action, ActionContext } from './actions/types.js';
 
 export interface CommandCenterIntentAuditView {
@@ -23,6 +24,12 @@ export interface CommandCenterAssistantCopy {
   detail: string;
   tone: 'info' | 'success' | 'warning' | 'error';
   cta?: string;
+}
+
+export interface CommandCenterExecutionCopy {
+  title: string;
+  detail: string;
+  tone: 'success' | 'warning' | 'error';
 }
 
 const REASON_COPY: Record<CommandCenterNoMatchReason, string> = {
@@ -67,9 +74,10 @@ export function commandCenterAssistantCopy(
   }
   if (resolution.kind === 'execute_command') {
     return {
-      title: 'preview only',
-      detail: `${resolution.entry.label} is read-only, but natural-language execution is deferred to a later slice. Use the deterministic command entry below instead.`,
+      title: 'ready to run read-only command',
+      detail: `${resolution.entry.label} is read-only and will run through Relay's typed command policy with schema-valid args only.`,
       tone: 'info',
+      cta: 'run read-only command',
     };
   }
 
@@ -86,6 +94,44 @@ export function commandCenterAssistantCopy(
         : resolution.reason === 'unsafe-command'
           ? 'error'
           : 'info',
+  };
+}
+
+export function commandCenterExecutionCopy(
+  result: CommandCenterExecutionResult
+): CommandCenterExecutionCopy {
+  if (result.kind === 'success') {
+    return {
+      title: 'command executed',
+      detail: `${result.commandId} returned read-only data. Audit recorded ${result.audit.sideEffectClass ?? 'read'} result ${result.audit.resultKind} without raw args.`,
+      tone: 'success',
+    };
+  }
+  if (result.kind === 'unavailable') {
+    return {
+      title: `${result.reason.replace(/-/g, ' ')} unavailable`,
+      detail: result.message,
+      tone: 'warning',
+    };
+  }
+  if (result.kind === 'confirmation_required') {
+    return {
+      title: 'confirmation required',
+      detail: result.message,
+      tone: 'warning',
+    };
+  }
+  if (result.kind === 'blocked') {
+    return {
+      title: `blocked: ${result.reason.replace(/-/g, ' ')}`,
+      detail: result.message,
+      tone: 'error',
+    };
+  }
+  return {
+    title: 'command failed',
+    detail: result.message,
+    tone: 'error',
   };
 }
 

--- a/server/cli-gateway-settings.ts
+++ b/server/cli-gateway-settings.ts
@@ -112,7 +112,10 @@ function validateSettingValue(
   switch (key) {
     case 'defaultAgent': {
       if (typeof value !== 'string' || !value.trim()) {
-        return { ok: false, message: 'defaultAgent must be a non-empty string' };
+        return {
+          ok: false,
+          message: 'defaultAgent must be a non-empty string',
+        };
       }
       const trimmed = value.trim();
       if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) {
@@ -132,10 +135,14 @@ function validateSettingValue(
       }
       return { ok: true, value };
     case 'renamerTool':
-      if (typeof value !== 'string' || !RENAMER_TOOLS.includes(value as RenamerTool)) {
+      if (
+        typeof value !== 'string' ||
+        !RENAMER_TOOLS.includes(value as RenamerTool)
+      ) {
         return {
           ok: false,
-          message: 'renamerTool must be one of: claude, codex, none, custom-script',
+          message:
+            'renamerTool must be one of: claude, codex, none, custom-script',
         };
       }
       return { ok: true, value };
@@ -144,7 +151,10 @@ function validateSettingValue(
         typeof value !== 'string' ||
         !UPDATE_CHANNELS.includes(value as 'stable' | 'nightly')
       ) {
-        return { ok: false, message: 'updateChannel must be stable or nightly' };
+        return {
+          ok: false,
+          message: 'updateChannel must be stable or nightly',
+        };
       }
       return { ok: true, value };
   }
@@ -155,7 +165,8 @@ function riskySettingWriteRequiresConfirmation(
   value: string | boolean,
   previousValue: string | boolean
 ): boolean {
-  if (key === 'defaultYolo' && value === true && previousValue !== true) return true;
+  if (key === 'defaultYolo' && value === true && previousValue !== true)
+    return true;
   if (key === 'updateChannel' && value !== previousValue) return true;
   return false;
 }
@@ -184,7 +195,11 @@ export function updateSafeSetting(
 
   const nextValue = validation.value;
   if (
-    riskySettingWriteRequiresConfirmation(input.key, nextValue, previousValue) &&
+    riskySettingWriteRequiresConfirmation(
+      input.key,
+      nextValue,
+      previousValue
+    ) &&
     input.confirmRiskyWrite !== true
   ) {
     return {
@@ -240,11 +255,16 @@ export function updateSafeSetting(
   };
 }
 
-function parseSettingsUpdateInput(body: unknown):
+function parseSettingsUpdateInput(
+  body: unknown
+):
   | { ok: true; input: CliGatewaySettingsUpdateInput }
   | { ok: false; message: string } {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    return { ok: false, message: 'settings.update input JSON must be an object' };
+    return {
+      ok: false,
+      message: 'settings.update input JSON must be an object',
+    };
   }
   const record = body as Record<string, unknown>;
   if (!isSafeSettingKey(record['key'])) {
@@ -273,7 +293,9 @@ function parseSettingsUpdateInput(body: unknown):
   };
 }
 
-function webhookStatusFromConfig(config: Config): CliGatewayWebhookStatusResult {
+export function webhookStatusFromConfig(
+  config: Config
+): CliGatewayWebhookStatusResult {
   const { smeeConnected, lastEventAt } = getSmeeStatus();
   const repoStatuses = Object.entries(config.repoSettings ?? {}).map(
     ([repoPath, settings]) => ({

--- a/server/command-center-executor.ts
+++ b/server/command-center-executor.ts
@@ -1,0 +1,505 @@
+import { createHash } from 'node:crypto';
+
+import {
+  COMMAND_CENTER_RESOLVER_CATALOG,
+  validateCommandCenterArgs,
+  type CommandCenterResolverCatalog,
+  type CommandCenterResolverCatalogEntry,
+} from '../shared/command-center-resolver.js';
+import type { RelayCliGatewayCommand } from '../shared/cli-gateway-contract.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import type {
+  CommandCenterExecutionAudit,
+  CommandCenterExecutionConfirmationOutcome,
+  CommandCenterExecutionPolicyOutcome,
+  CommandCenterExecutionResult,
+  CommandCenterExecutionResultKind,
+} from '../shared/command-center-execution.js';
+
+export interface CommandCenterExecutionRequest {
+  commandId: string;
+  args?: unknown;
+}
+
+export type CommandCenterReadOnlyHandlerResult =
+  | { ok: true; data: unknown }
+  | {
+      ok: false;
+      kind: 'unavailable' | 'error';
+      reason: string;
+      message: string;
+      details?: Record<string, unknown>;
+    };
+
+export type CommandCenterReadOnlyHandler = (
+  args: Record<string, unknown>
+) =>
+  | Promise<CommandCenterReadOnlyHandlerResult>
+  | CommandCenterReadOnlyHandlerResult;
+
+export interface CommandCenterExecutionDeps {
+  catalog?: CommandCenterResolverCatalog;
+  handlers: Partial<
+    Record<RelayCliGatewayCommand, CommandCenterReadOnlyHandler>
+  >;
+  trustedCapabilities?:
+    | {
+        source: 'browser-session' | 'actor-grant';
+        capabilities: readonly RelayCapabilityBit[];
+      }
+    | undefined;
+  now?: () => number;
+  auditSink?: (audit: CommandCenterExecutionAudit) => void;
+}
+
+const EMPTY_ARGS_HASH = sha256(canonicalJson({}));
+const MAX_COMMAND_CENTER_ARG_DEPTH = 12;
+const MAX_COMMAND_CENTER_ARG_KEYS = 100;
+const MAX_COMMAND_CENTER_ARG_CHARS = 16_384;
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function jsonType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  if (Number.isInteger(value)) return 'integer';
+  return typeof value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return jsonType(value) === 'object';
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => [key, canonicalize(child)])
+  );
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function argKeys(args: unknown): string[] {
+  if (!isPlainObject(args)) return [];
+  return Object.keys(args).sort();
+}
+
+function capabilityOutcome(
+  required: readonly RelayCapabilityBit[],
+  trusted: CommandCenterExecutionDeps['trustedCapabilities']
+): CommandCenterExecutionAudit['capabilityOutcome'] {
+  if (required.length === 0) return 'not-required';
+  if (!trusted) return 'blocked';
+  if (trusted.source === 'browser-session') return 'allowed-browser-session';
+  const granted = new Set(trusted.capabilities);
+  return required.every((capability) => granted.has(capability))
+    ? 'allowed-explicit'
+    : 'blocked';
+}
+
+function argsBudgetOk(value: unknown): boolean {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  let keys = 0;
+  let chars = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.depth > MAX_COMMAND_CENTER_ARG_DEPTH) return false;
+    const child = current.value;
+    if (typeof child === 'string') chars += child.length;
+    else if (typeof child === 'number' || typeof child === 'boolean')
+      chars += 8;
+    else if (Array.isArray(child)) {
+      keys += child.length;
+      for (const item of child) {
+        stack.push({ value: item, depth: current.depth + 1 });
+      }
+    } else if (isPlainObject(child)) {
+      const entries = Object.entries(child);
+      keys += entries.length;
+      chars += entries.reduce((total, [key]) => total + key.length, 0);
+      for (const [, item] of entries) {
+        stack.push({ value: item, depth: current.depth + 1 });
+      }
+    }
+    if (
+      keys > MAX_COMMAND_CENTER_ARG_KEYS ||
+      chars > MAX_COMMAND_CENTER_ARG_CHARS
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function auditFor(input: {
+  commandId: string;
+  resultKind: CommandCenterExecutionResultKind;
+  entry?: CommandCenterResolverCatalogEntry;
+  args: unknown;
+  durationMs: number;
+  policyOutcome: CommandCenterExecutionPolicyOutcome;
+  confirmationOutcome: CommandCenterExecutionConfirmationOutcome;
+  capabilityOutcome: CommandCenterExecutionAudit['capabilityOutcome'];
+  reason?: string;
+}): CommandCenterExecutionAudit {
+  const args = isPlainObject(input.args) ? input.args : {};
+  return {
+    commandId: input.commandId,
+    resultKind: input.resultKind,
+    ...(input.entry ? { sideEffectClass: input.entry.sideEffect } : {}),
+    durationMs: input.durationMs,
+    args: {
+      rawArgsReturned: false,
+      argKeys: argKeys(args),
+      argsSha256: isPlainObject(input.args)
+        ? sha256(canonicalJson(args))
+        : EMPTY_ARGS_HASH,
+    },
+    policyOutcome: input.policyOutcome,
+    confirmationOutcome: input.confirmationOutcome,
+    scopeKinds: input.entry?.scopeKinds ?? [],
+    ...(input.entry
+      ? { availabilityState: input.entry.availability.state }
+      : {}),
+    capabilityOutcome: input.capabilityOutcome,
+    ...(input.reason ? { reason: input.reason } : {}),
+  };
+}
+
+function finish(
+  result: CommandCenterExecutionResult,
+  sink: CommandCenterExecutionDeps['auditSink']
+): CommandCenterExecutionResult {
+  sink?.(result.audit);
+  return result;
+}
+
+function duration(start: number, now: () => number): number {
+  return Math.max(0, now() - start);
+}
+
+export async function executeCommandCenterCommand(
+  request: CommandCenterExecutionRequest,
+  deps: CommandCenterExecutionDeps
+): Promise<CommandCenterExecutionResult> {
+  const now = deps.now ?? Date.now;
+  const start = now();
+  const catalog = deps.catalog ?? COMMAND_CENTER_RESOLVER_CATALOG;
+  const rawArgs = request.args ?? {};
+  const baseCommandId =
+    typeof request.commandId === 'string' ? request.commandId : 'unknown';
+
+  if (!argsBudgetOk(rawArgs)) {
+    const audit = auditFor({
+      commandId: baseCommandId,
+      resultKind: 'blocked',
+      args: {},
+      durationMs: duration(start, now),
+      policyOutcome: 'blocked',
+      confirmationOutcome: 'blocked',
+      capabilityOutcome: 'not-required',
+      reason: 'args-over-budget',
+    });
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: baseCommandId,
+        reason: 'invalid-args',
+        message:
+          'Command Center command args exceeded the bounded read-only budget.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  const entry = catalog.byCommandId.get(
+    baseCommandId as RelayCliGatewayCommand
+  );
+  if (!entry) {
+    const audit = auditFor({
+      commandId: baseCommandId,
+      resultKind: 'blocked',
+      args: rawArgs,
+      durationMs: duration(start, now),
+      policyOutcome: 'blocked',
+      confirmationOutcome: 'blocked',
+      capabilityOutcome: 'not-required',
+      reason: 'unknown-command',
+    });
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: baseCommandId,
+        reason: 'unknown-command',
+        message:
+          'Command Center can only execute Relay-owned typed command ids.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  const caps = capabilityOutcome(
+    entry.capabilityHints,
+    deps.trustedCapabilities
+  );
+  const blockedAudit = (
+    resultKind: CommandCenterExecutionResultKind,
+    policyOutcome: CommandCenterExecutionPolicyOutcome,
+    confirmationOutcome: CommandCenterExecutionConfirmationOutcome,
+    reason: string
+  ) =>
+    auditFor({
+      commandId: entry.commandId,
+      resultKind,
+      entry,
+      args: rawArgs,
+      durationMs: duration(start, now),
+      policyOutcome,
+      confirmationOutcome,
+      capabilityOutcome: caps,
+      reason,
+    });
+
+  if (!isPlainObject(rawArgs)) {
+    const audit = blockedAudit('blocked', 'blocked', 'blocked', 'invalid-args');
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: entry.commandId,
+        reason: 'invalid-args',
+        message: 'Command Center command args must be a JSON object.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  const argErrors = validateCommandCenterArgs(rawArgs, entry.inputSchema);
+  if (argErrors.length > 0) {
+    const audit = blockedAudit('blocked', 'blocked', 'blocked', 'invalid-args');
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: entry.commandId,
+        reason: 'invalid-args',
+        message: argErrors.slice(0, 3).join('; '),
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  if (entry.requiresConfirmation) {
+    const audit = blockedAudit(
+      'confirmation_required',
+      'confirmation-required',
+      'required',
+      'confirmation-required'
+    );
+    return finish(
+      {
+        kind: 'confirmation_required',
+        commandId: entry.commandId,
+        reason: 'confirmation-required',
+        message:
+          'Natural-language execution cannot satisfy confirmation-gated commands in this slice.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  if (entry.controlRequirements.length > 0) {
+    const audit = blockedAudit(
+      'confirmation_required',
+      'confirmation-required',
+      'required',
+      'control-requirement'
+    );
+    return finish(
+      {
+        kind: 'confirmation_required',
+        commandId: entry.commandId,
+        reason: 'control-requirement',
+        message:
+          'This command requires fresh control/intervention state and is preview-only in this slice.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  if (entry.sideEffect !== 'read') {
+    const audit = blockedAudit(
+      'blocked',
+      'blocked',
+      'blocked',
+      'unsafe-command'
+    );
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: entry.commandId,
+        reason: 'unsafe-command',
+        message:
+          'Natural-language execution is limited to read-only Relay commands.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  if (entry.availability.state !== 'available') {
+    const audit = blockedAudit(
+      'unavailable',
+      'blocked',
+      'blocked',
+      'command-unavailable'
+    );
+    return finish(
+      {
+        kind: 'unavailable',
+        commandId: entry.commandId,
+        reason: 'command-unavailable',
+        message: entry.availability.reason ?? 'command is unavailable',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  if (caps === 'blocked') {
+    const audit = blockedAudit(
+      'blocked',
+      'blocked',
+      'blocked',
+      'missing-capability'
+    );
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: entry.commandId,
+        reason: 'missing-capability',
+        message: `missing required capability: ${entry.capabilityHints.join(', ')}`,
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  const handler = deps.handlers[entry.commandId];
+  if (!handler) {
+    const audit = blockedAudit(
+      'blocked',
+      'blocked',
+      'blocked',
+      'unsupported-command'
+    );
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: entry.commandId,
+        reason: 'unsupported-command',
+        message:
+          'This read-only command is typed, but Command Center execution is not wired for it yet.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+
+  try {
+    const handlerResult = await handler(rawArgs);
+    if (handlerResult.ok === false) {
+      const resultKind = handlerResult.kind;
+      const audit = auditFor({
+        commandId: entry.commandId,
+        resultKind,
+        entry,
+        args: rawArgs,
+        durationMs: duration(start, now),
+        policyOutcome: 'allowed',
+        confirmationOutcome: 'not-required',
+        capabilityOutcome: caps,
+        reason: handlerResult.reason,
+      });
+      if (handlerResult.kind === 'unavailable') {
+        return finish(
+          {
+            kind: 'unavailable',
+            commandId: entry.commandId,
+            reason: handlerResult.reason as 'not-found',
+            message: handlerResult.message,
+            ...(handlerResult.details
+              ? { details: handlerResult.details }
+              : {}),
+            audit,
+          },
+          deps.auditSink
+        );
+      }
+      return finish(
+        {
+          kind: 'error',
+          commandId: entry.commandId,
+          reason: 'handler-error',
+          message: handlerResult.message,
+          audit,
+        },
+        deps.auditSink
+      );
+    }
+
+    const audit = auditFor({
+      commandId: entry.commandId,
+      resultKind: 'success',
+      entry,
+      args: rawArgs,
+      durationMs: duration(start, now),
+      policyOutcome: 'allowed',
+      confirmationOutcome: 'not-required',
+      capabilityOutcome: caps,
+    });
+    return finish(
+      {
+        kind: 'success',
+        commandId: entry.commandId,
+        data: handlerResult.data,
+        audit,
+      },
+      deps.auditSink
+    );
+  } catch {
+    const audit = auditFor({
+      commandId: entry.commandId,
+      resultKind: 'error',
+      entry,
+      args: rawArgs,
+      durationMs: duration(start, now),
+      policyOutcome: 'allowed',
+      confirmationOutcome: 'not-required',
+      capabilityOutcome: caps,
+      reason: 'internal-error',
+    });
+    return finish(
+      {
+        kind: 'error',
+        commandId: entry.commandId,
+        reason: 'internal-error',
+        message: 'Command Center command handler failed.',
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -138,6 +138,10 @@ import {
   readCommandCenterIntentResolverConfig,
   resolveCommandCenterIntent,
 } from './command-center-intent-resolver.js';
+import {
+  executeCommandCenterCommand,
+  type CommandCenterReadOnlyHandler,
+} from './command-center-executor.js';
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
 import {
@@ -147,7 +151,11 @@ import {
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
 import { createCliGatewayEventBus } from './cli-gateway-event-bus.js';
-import { createCliGatewaySettingsRouter } from './cli-gateway-settings.js';
+import {
+  createCliGatewaySettingsRouter,
+  safeSettingsFromConfig,
+  webhookStatusFromConfig,
+} from './cli-gateway-settings.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import {
   createHandoffRouter,
@@ -231,6 +239,7 @@ import type { SessionLane } from '../shared/session-lane.js';
 import {
   EVENTS_SUBSCRIBE_TOPIC_CAPABILITIES,
   type EventsSubscribeTopic,
+  type RelayCliGatewayCommand,
   type RelayCliGatewayError,
 } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeLocalGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
@@ -300,7 +309,10 @@ import {
   type CliGatewayActorIssueInput,
   type CliGatewayActorReadCommand,
 } from './cli-gateway-actor-auth.js';
-import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import {
+  RELAY_CAPABILITY_BITS,
+  type RelayCapabilityBit,
+} from '../shared/security-policy.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -3261,6 +3273,138 @@ async function main(): Promise<void> {
       res.status(500).json({ error: 'command-center-resolver-failed' });
     }
   });
+
+  // POST /api/command-center/execute — execute one already-resolved typed
+  // read-only Relay command through the same manifest/catalog policy boundary.
+  // This route never accepts shell strings or prompt payloads; audit metadata
+  // logs command/result/latency plus hashed args only.
+  app.post(
+    '/api/command-center/execute',
+    requireCliGatewayAuth,
+    async (req, res) => {
+      const body = isRecord(req.body) ? req.body : {};
+      const commandId =
+        typeof body.commandId === 'string' ? body.commandId : '';
+      const args = Object.prototype.hasOwnProperty.call(body, 'args')
+        ? body.args
+        : {};
+      const actorCredential = authenticatedCliGatewayActorCredential(req);
+      const trustedCapabilities = actorCredential
+        ? {
+            source: 'actor-grant' as const,
+            capabilities: actorCredential.capabilities,
+          }
+        : authenticatedBrowserSession(req)
+          ? {
+              source: 'browser-session' as const,
+              capabilities: RELAY_CAPABILITY_BITS,
+            }
+          : undefined;
+
+      const listSessions = async () => {
+        const [localSessions, remoteSessions] = await Promise.all([
+          Promise.resolve(
+            localRelayNode.sessions
+              .list()
+              .map((session) =>
+                withWorkContextMetadata(workContextStore, session)
+              )
+          ),
+          aggregateRemoteSessions({
+            registry: hubNodeRegistry,
+            nodeLinks: hubNodeLinks,
+            logger,
+            sessionEnvelopes: sessionEnvelopeRegistry,
+            workContextStore,
+            readModelCache: remoteSessionReadModelCache,
+          }),
+        ]);
+        return [...localSessions, ...remoteSessions];
+      };
+
+      const findSession = async (id: string) => {
+        const local = localRelayNode.sessions
+          .list()
+          .map((session) => withWorkContextMetadata(workContextStore, session))
+          .find(
+            (session) => session.id === id || session.globalSessionId === id
+          );
+        if (local) return local;
+        const remoteSessions = await aggregateRemoteSessions({
+          registry: hubNodeRegistry,
+          nodeLinks: hubNodeLinks,
+          logger,
+          sessionEnvelopes: sessionEnvelopeRegistry,
+          workContextStore,
+          readModelCache: remoteSessionReadModelCache,
+        });
+        return remoteSessions.find(
+          (session) => session.id === id || session.globalSessionId === id
+        );
+      };
+
+      const handlers: Partial<
+        Record<RelayCliGatewayCommand, CommandCenterReadOnlyHandler>
+      > = {
+        'nodes.list': () => ({
+          ok: true,
+          data: { nodes: hubNodeRegistry.listNodes() },
+        }),
+        'sessions.list': async () => ({
+          ok: true,
+          data: { sessions: await listSessions() },
+        }),
+        'sessions.get': async (commandArgs) => {
+          const id = commandArgs['id'];
+          if (typeof id !== 'string' || !id.trim()) {
+            return {
+              ok: false,
+              kind: 'unavailable',
+              reason: 'not-found',
+              message: 'session id is required',
+            };
+          }
+          const found = await findSession(id.trim());
+          if (!found) {
+            return {
+              ok: false,
+              kind: 'unavailable',
+              reason: 'not-found',
+              message: 'session was not found',
+              details: { sessionId: id },
+            };
+          }
+          return { ok: true, data: found };
+        },
+        'settings.get': () => ({
+          ok: true,
+          data: {
+            settings: safeSettingsFromConfig(getConfig()),
+            redaction: {
+              rawConfigReturned: false,
+              secretsReturned: false,
+              tokenMaterialReturned: false,
+            },
+          },
+        }),
+        'webhooks.status': () => ({
+          ok: true,
+          data: webhookStatusFromConfig(getConfig()),
+        }),
+      };
+
+      const result = await executeCommandCenterCommand(
+        { commandId, args },
+        {
+          handlers,
+          trustedCapabilities,
+          auditSink: (audit) =>
+            logger.info('Command Center execution audit', audit),
+        }
+      );
+      res.json(result);
+    }
+  );
 
   // Restore sessions from a previous update restart
   const restoredCount = await restoreFromDisk(

--- a/shared/command-center-execution.ts
+++ b/shared/command-center-execution.ts
@@ -1,0 +1,105 @@
+import type { RelayCliGatewayCommand } from './cli-gateway-contract.js';
+import type {
+  RelayCommandScopeKind,
+  RelayCommandSideEffect,
+} from './relay-command-manifest.js';
+
+export type CommandCenterExecutionResultKind =
+  | 'success'
+  | 'blocked'
+  | 'confirmation_required'
+  | 'unavailable'
+  | 'error';
+
+export type CommandCenterExecutionPolicyOutcome =
+  | 'allowed'
+  | 'blocked'
+  | 'confirmation-required';
+
+export type CommandCenterExecutionConfirmationOutcome =
+  | 'not-required'
+  | 'required'
+  | 'blocked';
+
+export interface CommandCenterExecutionArgsRedaction {
+  rawArgsReturned: false;
+  argKeys: readonly string[];
+  argsSha256: string;
+}
+
+export interface CommandCenterExecutionAudit {
+  commandId: string;
+  resultKind: CommandCenterExecutionResultKind;
+  sideEffectClass?: RelayCommandSideEffect;
+  durationMs: number;
+  args: CommandCenterExecutionArgsRedaction;
+  policyOutcome: CommandCenterExecutionPolicyOutcome;
+  confirmationOutcome: CommandCenterExecutionConfirmationOutcome;
+  scopeKinds: readonly RelayCommandScopeKind[];
+  availabilityState?: 'available' | 'unavailable' | 'unknown';
+  capabilityOutcome:
+    | 'not-required'
+    | 'allowed-browser-session'
+    | 'allowed-explicit'
+    | 'blocked';
+  reason?: string;
+}
+
+export interface CommandCenterExecutionSuccess {
+  kind: 'success';
+  commandId: RelayCliGatewayCommand;
+  data: unknown;
+  audit: CommandCenterExecutionAudit;
+}
+
+export interface CommandCenterExecutionBlocked {
+  kind: 'blocked';
+  commandId?: string;
+  reason:
+    | 'unknown-command'
+    | 'invalid-args'
+    | 'unsafe-command'
+    | 'missing-capability'
+    | 'unsupported-command'
+    | 'metadata-mismatch';
+  message: string;
+  audit: CommandCenterExecutionAudit;
+}
+
+export interface CommandCenterExecutionConfirmationRequired {
+  kind: 'confirmation_required';
+  commandId: RelayCliGatewayCommand;
+  reason: 'confirmation-required' | 'control-requirement';
+  message: string;
+  audit: CommandCenterExecutionAudit;
+}
+
+export interface CommandCenterExecutionUnavailable {
+  kind: 'unavailable';
+  commandId: RelayCliGatewayCommand;
+  reason:
+    | 'command-unavailable'
+    | 'node-unavailable'
+    | 'session-unavailable'
+    | 'workspace-unavailable'
+    | 'provider-unavailable'
+    | 'not-found';
+  message: string;
+  details?: Record<string, unknown>;
+  audit: CommandCenterExecutionAudit;
+}
+
+export interface CommandCenterExecutionError {
+  kind: 'error';
+  commandId: RelayCliGatewayCommand;
+  reason: 'handler-error' | 'internal-error';
+  message: string;
+  audit: CommandCenterExecutionAudit;
+}
+
+export type CommandCenterExecutionResult =
+  | CommandCenterExecutionSuccess
+  | CommandCenterExecutionBlocked
+  | CommandCenterExecutionConfirmationRequired
+  | CommandCenterExecutionUnavailable
+  | CommandCenterExecutionError;

--- a/test/command-center-assistant-shell.test.ts
+++ b/test/command-center-assistant-shell.test.ts
@@ -19,6 +19,7 @@ import type {
   Action,
   ActionContext,
 } from '../frontend/src/lib/actions/types.js';
+import type { CommandCenterExecutionResult } from '../shared/command-center-execution.js';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -54,6 +55,7 @@ const sessionsListEntry = {
   scopeKinds: ['session'],
   capabilityHints: ['session:read'],
   surfaces: ['web', 'command-center'],
+  availability: { state: 'available' },
   ui: { actionId: 'session.start-work-in-env', category: 'session' },
   inputSchema: { type: 'object', additionalProperties: false, properties: {} },
 } as const;
@@ -85,6 +87,51 @@ function providerMissingResult(): CommandCenterAssistantResult {
     reason: 'provider-missing',
     suggestions: [{ entry: sessionsListEntry, score: 4 }],
   });
+}
+
+function executeCommandResult(): CommandCenterAssistantResult {
+  return resultFor({
+    kind: 'execute_command',
+    entry: sessionsListEntry,
+    intent: {
+      commandId: 'sessions.list',
+      args: {},
+      confidence: 0.92,
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      controlRequirements: [],
+      scopeKinds: ['session'],
+      capabilityHints: ['session:read'],
+      surfaces: ['web', 'command-center'],
+      ui: { actionId: 'gateway.sessions.list', category: 'gateway' },
+    },
+    suggestions: [],
+  });
+}
+
+function executionSuccess(): CommandCenterExecutionResult {
+  return {
+    kind: 'success',
+    commandId: 'sessions.list',
+    data: { sessions: [] },
+    audit: {
+      commandId: 'sessions.list',
+      resultKind: 'success',
+      sideEffectClass: 'read',
+      durationMs: 4,
+      args: {
+        rawArgsReturned: false,
+        argKeys: [],
+        argsSha256:
+          '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
+      },
+      policyOutcome: 'allowed',
+      confirmationOutcome: 'not-required',
+      scopeKinds: ['session'],
+      availabilityState: 'available',
+      capabilityOutcome: 'allowed-browser-session',
+    },
+  };
 }
 
 function setInputValue(input: HTMLInputElement, value: string): void {
@@ -178,7 +225,13 @@ describe('<CommandPalette /> assistant shell', () => {
     resolveAssistantIntent: (
       query: string
     ) => Promise<CommandCenterAssistantResult>,
-    options: { open?: boolean } = {}
+    options: {
+      open?: boolean;
+      executeAssistantCommand?: (
+        commandId: string,
+        args: Record<string, unknown>
+      ) => Promise<CommandCenterExecutionResult>;
+    } = {}
   ) {
     await act(async () => {
       root.render(
@@ -195,6 +248,7 @@ describe('<CommandPalette /> assistant shell', () => {
             onSelectSession: vi.fn(),
             onSelectPr: vi.fn(),
             resolveAssistantIntent,
+            executeAssistantCommand: options.executeAssistantCommand,
           })
         )
       );
@@ -296,5 +350,38 @@ describe('<CommandPalette /> assistant shell', () => {
     });
 
     expect(handler).toHaveBeenCalledWith(actionContext);
+  });
+
+  it('executes a typed read-only resolver result and renders success state', async () => {
+    const executeAssistantCommand = vi.fn(async () => executionSuccess());
+    await render(async () => executeCommandResult(), {
+      executeAssistantCommand,
+    });
+    const input = container.querySelector(
+      '.palette-search-input'
+    ) as HTMLInputElement;
+    const ask = container.querySelector(
+      '.palette-assistant-button'
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      setInputValue(input, 'show sessions');
+    });
+    await act(async () => {
+      ask.click();
+    });
+
+    expect(container.textContent).toContain('ready to run read-only command');
+    const runButton = container.querySelector(
+      '.palette-assistant-action'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      runButton.click();
+      await Promise.resolve();
+    });
+
+    expect(executeAssistantCommand).toHaveBeenCalledWith('sessions.list', {});
+    expect(container.textContent).toContain('command executed');
+    expect(container.textContent).toContain('without raw args');
   });
 });

--- a/test/command-center-executor.test.ts
+++ b/test/command-center-executor.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  executeCommandCenterCommand,
+  type CommandCenterReadOnlyHandler,
+} from '../server/command-center-executor.js';
+import { buildCommandCenterResolverCatalog } from '../shared/command-center-resolver.js';
+import type { RelayActionDescriptor } from '../shared/action-descriptor.js';
+import type { RelayCliGatewayCommand } from '../shared/cli-gateway-contract.js';
+import type { RelayCommandSideEffect } from '../shared/relay-command-manifest.js';
+
+function descriptorFor(
+  commandId: RelayCliGatewayCommand,
+  sideEffect: RelayCommandSideEffect = 'read',
+  overrides: Partial<RelayActionDescriptor> = {}
+): RelayActionDescriptor {
+  return {
+    id: commandId,
+    title: commandId,
+    label: commandId,
+    description: `Command ${commandId}`,
+    input: {
+      kind: 'json-schema',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { repoId: { type: 'string' } },
+      },
+    },
+    availability: { state: 'available', capabilityHints: ['session:read'] },
+    sideEffect,
+    confirmation: { required: false, controlRequirements: [] },
+    surfaces: ['web', 'command-center'],
+    result: { kind: 'json-schema', schema: { type: 'object' } },
+    error: { kind: 'json-schema', schema: { type: 'object' } },
+    stable: true,
+    source: 'cli-gateway-v1',
+    contract: {
+      relayCommandName: commandId,
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+      cli: ['relay-ide', 'v1', commandId, '--json'],
+      errorCodes: ['INTERNAL'],
+    },
+    ui: { actionId: `gateway.${commandId}`, category: 'gateway' },
+    ...overrides,
+  };
+}
+
+const sessionsListDescriptor = descriptorFor('sessions.list');
+const nodesListDescriptor = descriptorFor('nodes.list', 'read', {
+  availability: { state: 'unavailable', reason: 'node offline' },
+});
+const writeDescriptor = descriptorFor('sessions.rename', 'write');
+const confirmationDescriptor = descriptorFor('sessions.kill', 'destructive', {
+  confirmation: {
+    required: true,
+    controlRequirements: ['confirmation-challenge'],
+  },
+});
+
+const catalog = buildCommandCenterResolverCatalog([
+  sessionsListDescriptor,
+  nodesListDescriptor,
+  writeDescriptor,
+  confirmationDescriptor,
+]);
+
+const handlers: Partial<
+  Record<RelayCliGatewayCommand, CommandCenterReadOnlyHandler>
+> = {
+  'sessions.list': (args) => ({
+    ok: true,
+    data: { sessions: [{ id: 's1', repoId: args['repoId'] }] },
+  }),
+};
+
+describe('Command Center read-only executor', () => {
+  it('executes a schema-valid read-only command and records redacted audit', async () => {
+    const auditSink = vi.fn();
+    const result = await executeCommandCenterCommand(
+      { commandId: 'sessions.list', args: { repoId: 'secret-repo-name' } },
+      {
+        catalog,
+        handlers,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          capabilities: ['session:read'],
+        },
+        now: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(37),
+        auditSink,
+      }
+    );
+
+    expect(result.kind).toBe('success');
+    expect(result).toMatchObject({
+      commandId: 'sessions.list',
+      audit: {
+        commandId: 'sessions.list',
+        resultKind: 'success',
+        sideEffectClass: 'read',
+        durationMs: 27,
+        policyOutcome: 'allowed',
+        confirmationOutcome: 'not-required',
+        capabilityOutcome: 'allowed-explicit',
+        args: {
+          rawArgsReturned: false,
+          argKeys: ['repoId'],
+        },
+      },
+    });
+    expect(JSON.stringify(result.audit)).not.toContain('secret-repo-name');
+    expect(result.audit.args.argsSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(auditSink).toHaveBeenCalledWith(result.audit);
+  });
+
+  it('rejects malformed args before handler execution', async () => {
+    const handler = vi.fn();
+    const result = await executeCommandCenterCommand(
+      { commandId: 'sessions.list', args: { repoId: 42, extra: true } },
+      {
+        catalog,
+        handlers: { 'sessions.list': handler },
+      }
+    );
+
+    expect(result).toMatchObject({
+      kind: 'blocked',
+      reason: 'invalid-args',
+      audit: {
+        policyOutcome: 'blocked',
+        confirmationOutcome: 'blocked',
+        resultKind: 'blocked',
+      },
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('blocks write/destructive command ids instead of executing', async () => {
+    await expect(
+      executeCommandCenterCommand(
+        { commandId: 'sessions.rename', args: { repoId: 'repo-1' } },
+        { catalog, handlers }
+      )
+    ).resolves.toMatchObject({
+      kind: 'blocked',
+      reason: 'unsafe-command',
+      audit: { sideEffectClass: 'write', policyOutcome: 'blocked' },
+    });
+
+    await expect(
+      executeCommandCenterCommand(
+        { commandId: 'sessions.kill', args: { repoId: 'repo-1' } },
+        { catalog, handlers }
+      )
+    ).resolves.toMatchObject({
+      kind: 'confirmation_required',
+      reason: 'confirmation-required',
+      audit: {
+        sideEffectClass: 'destructive',
+        policyOutcome: 'confirmation-required',
+      },
+    });
+  });
+
+  it('returns typed unavailable state before handler execution', async () => {
+    const result = await executeCommandCenterCommand(
+      { commandId: 'nodes.list', args: { repoId: 'repo-1' } },
+      { catalog, handlers }
+    );
+
+    expect(result).toMatchObject({
+      kind: 'unavailable',
+      commandId: 'nodes.list',
+      reason: 'command-unavailable',
+      message: 'node offline',
+      audit: {
+        resultKind: 'unavailable',
+        availabilityState: 'unavailable',
+      },
+    });
+  });
+
+  it('fails closed for unknown ids and missing explicit capabilities', async () => {
+    await expect(
+      executeCommandCenterCommand(
+        { commandId: 'raw.shell', args: { command: 'rm -rf /' } },
+        { catalog, handlers }
+      )
+    ).resolves.toMatchObject({
+      kind: 'blocked',
+      reason: 'unknown-command',
+      audit: { commandId: 'raw.shell', args: { rawArgsReturned: false } },
+    });
+
+    await expect(
+      executeCommandCenterCommand(
+        { commandId: 'sessions.list', args: { repoId: 'repo-1' } },
+        {
+          catalog,
+          handlers,
+          trustedCapabilities: { source: 'actor-grant', capabilities: [] },
+        }
+      )
+    ).resolves.toMatchObject({
+      kind: 'blocked',
+      reason: 'missing-capability',
+      audit: { capabilityOutcome: 'blocked' },
+    });
+    await expect(
+      executeCommandCenterCommand(
+        { commandId: 'sessions.list', args: { repoId: 'repo-1' } },
+        { catalog, handlers }
+      )
+    ).resolves.toMatchObject({
+      kind: 'blocked',
+      reason: 'missing-capability',
+      audit: { capabilityOutcome: 'blocked' },
+    });
+  });
+
+  it('rejects over-budget args before canonical audit hashing', async () => {
+    const handler = vi.fn();
+    const result = await executeCommandCenterCommand(
+      {
+        commandId: 'sessions.list',
+        args: { repoId: 'repo-1', payload: 'x'.repeat(20_000) },
+      },
+      {
+        catalog,
+        handlers: { 'sessions.list': handler },
+        trustedCapabilities: {
+          source: 'actor-grant',
+          capabilities: ['session:read'],
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      kind: 'blocked',
+      reason: 'invalid-args',
+      audit: {
+        policyOutcome: 'blocked',
+        confirmationOutcome: 'blocked',
+        reason: 'args-over-budget',
+      },
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- adds a typed `/api/command-center/execute` path for already-resolved Relay read-only command ids only
- enforces command catalog policy, schema validation, side-effect/confirmation/control blocking, trusted browser/actor capability handling, bounded args, and redacted audit metadata
- wires Command Palette execute-command results into explicit loading/success/blocked/unavailable/error UI states

## Scope boundaries
- no arbitrary shell/raw CLI string execution
- no write/destructive/stream/provider-agent escalation execution
- unsupported or unavailable typed read commands return typed blocked/unavailable states

## Test Plan
- `npm test -- test/command-center-executor.test.ts test/command-center-assistant-shell.test.ts test/command-center-resolver.test.ts test/command-center-intent-resolver.test.ts`
- `npm run check`
- `npm run build`

Closes #1009


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command Center now supports executing read-only commands directly from the assistant panel.
  * Added new executable commands: list nodes, list sessions, get session, get settings, and check webhook status.
  * Assistant panel displays command execution results with success or error feedback.
  * Enhanced messaging clarifies that commands execute as read-only operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->