### PR TITLE
Gate Command Center write execution

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -35,7 +35,10 @@ import {
   decideOpenUiAction,
   type CommandCenterAssistantResult,
 } from '../lib/command-center-assistant.js';
-import type { CommandCenterExecutionResult } from '../../../shared/command-center-execution.js';
+import type {
+  CommandCenterExecutionConfirmationInput,
+  CommandCenterExecutionResult,
+} from '../../../shared/command-center-execution.js';
 import './CommandPalette.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -181,7 +184,10 @@ export interface CommandPaletteProps {
   ) => Promise<CommandCenterAssistantResult>;
   executeAssistantCommand?: (
     commandId: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    options?: {
+      confirmation?: CommandCenterExecutionConfirmationInput;
+    }
   ) => Promise<CommandCenterExecutionResult>;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -92,7 +92,10 @@ import type {
   ControlActor,
   InterventionRecord,
 } from '../../../shared/control-state.js';
-import type { CommandCenterExecutionResult } from '../../../shared/command-center-execution.js';
+import type {
+  CommandCenterExecutionConfirmationInput,
+  CommandCenterExecutionResult,
+} from '../../../shared/command-center-execution.js';
 import type { CommandCenterAssistantResult } from './command-center-assistant.js';
 import { registerConfirmationRetry } from './confirmation-retries.js';
 
@@ -295,13 +298,16 @@ export async function resolveCommandCenterAssistantIntent(
 
 export async function executeCommandCenterAssistantCommand(
   commandId: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  options: {
+    confirmation?: CommandCenterExecutionConfirmationInput;
+  } = {}
 ): Promise<CommandCenterExecutionResult> {
   return json<CommandCenterExecutionResult>(
     await fetch('/api/command-center/execute', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ commandId, args }),
+      body: JSON.stringify({ commandId, args, ...options }),
     })
   );
 }

--- a/frontend/src/lib/command-center-assistant.ts
+++ b/frontend/src/lib/command-center-assistant.ts
@@ -115,9 +115,10 @@ export function commandCenterExecutionCopy(
     };
   }
   if (result.kind === 'confirmation_required') {
+    const preview = result.preview;
     return {
       title: 'confirmation required',
-      detail: result.message,
+      detail: `${result.message} command ${preview.commandId} (${preview.label}) targets ${preview.scopedTarget}; side effect ${preview.sideEffectClass}; args sha256 ${preview.args.argsSha256}; result ${preview.expectedResultShape.title ?? preview.expectedResultShape.kind}.`,
       tone: 'warning',
     };
   }

--- a/server/command-center-executor.ts
+++ b/server/command-center-executor.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import {
   COMMAND_CENTER_RESOLVER_CATALOG,
@@ -10,7 +10,10 @@ import type { RelayCliGatewayCommand } from '../shared/cli-gateway-contract.js';
 import type { RelayCapabilityBit } from '../shared/security-policy.js';
 import type {
   CommandCenterExecutionAudit,
+  CommandCenterExecutionConfirmationInput,
+  CommandCenterExecutionConfirmationPreview,
   CommandCenterExecutionConfirmationOutcome,
+  CommandCenterExecutionProviderAudit,
   CommandCenterExecutionPolicyOutcome,
   CommandCenterExecutionResult,
   CommandCenterExecutionResultKind,
@@ -19,6 +22,8 @@ import type {
 export interface CommandCenterExecutionRequest {
   commandId: string;
   args?: unknown;
+  confirmation?: CommandCenterExecutionConfirmationInput;
+  providerMetadata?: Record<string, unknown>;
 }
 
 export type CommandCenterReadOnlyHandlerResult =
@@ -37,25 +42,93 @@ export type CommandCenterReadOnlyHandler = (
   | Promise<CommandCenterReadOnlyHandlerResult>
   | CommandCenterReadOnlyHandlerResult;
 
+export type CommandCenterCommandHandler = CommandCenterReadOnlyHandler;
+
+export interface CommandCenterConfirmationChallengeRecord {
+  challengeId: string;
+  commandId: RelayCliGatewayCommand;
+  argsSha256: string;
+  expiresAtMs: number;
+}
+
+export interface CommandCenterConfirmationStore {
+  create(
+    record: Omit<CommandCenterConfirmationChallengeRecord, 'challengeId'>
+  ): CommandCenterConfirmationChallengeRecord;
+  consume(input: {
+    challengeId: string;
+    commandId: RelayCliGatewayCommand;
+    argsSha256: string;
+    nowMs: number;
+  }):
+    | { ok: true; record: CommandCenterConfirmationChallengeRecord }
+    | { ok: false; reason: 'missing' | 'mismatch' | 'expired' };
+}
+
 export interface CommandCenterExecutionDeps {
   catalog?: CommandCenterResolverCatalog;
   handlers: Partial<
-    Record<RelayCliGatewayCommand, CommandCenterReadOnlyHandler>
+    Record<RelayCliGatewayCommand, CommandCenterCommandHandler>
   >;
   trustedCapabilities?:
     | {
         source: 'browser-session' | 'actor-grant';
         capabilities: readonly RelayCapabilityBit[];
+        actorId?: string;
       }
     | undefined;
   now?: () => number;
   auditSink?: (audit: CommandCenterExecutionAudit) => void;
+  confirmationStore?: CommandCenterConfirmationStore;
 }
 
 const EMPTY_ARGS_HASH = sha256(canonicalJson({}));
 const MAX_COMMAND_CENTER_ARG_DEPTH = 12;
 const MAX_COMMAND_CENTER_ARG_KEYS = 100;
 const MAX_COMMAND_CENTER_ARG_CHARS = 16_384;
+const COMMAND_CENTER_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+const MAX_COMMAND_CENTER_CONFIRMATIONS = 512;
+const PROVIDER_AUDIT_FIELDS = ['source', 'model', 'requestId'] as const;
+const MAX_PROVIDER_AUDIT_VALUE_CHARS = 256;
+
+export function createCommandCenterConfirmationStore(): CommandCenterConfirmationStore {
+  const records = new Map<string, CommandCenterConfirmationChallengeRecord>();
+  const sweepExpired = (nowMs: number) => {
+    for (const [challengeId, record] of Array.from(records.entries())) {
+      if (record.expiresAtMs < nowMs) records.delete(challengeId);
+    }
+  };
+  return {
+    create(record) {
+      sweepExpired(Date.now());
+      while (records.size >= MAX_COMMAND_CENTER_CONFIRMATIONS) {
+        const oldestChallengeId = records.keys().next().value;
+        if (typeof oldestChallengeId !== 'string') break;
+        records.delete(oldestChallengeId);
+      }
+      const challenge = { ...record, challengeId: randomUUID() };
+      records.set(challenge.challengeId, challenge);
+      return challenge;
+    },
+    consume(input) {
+      const record = records.get(input.challengeId);
+      if (!record) return { ok: false, reason: 'missing' };
+      records.delete(input.challengeId);
+      sweepExpired(input.nowMs);
+      if (record.expiresAtMs < input.nowMs)
+        return { ok: false, reason: 'expired' };
+      if (
+        record.commandId !== input.commandId ||
+        record.argsSha256 !== input.argsSha256
+      ) {
+        return { ok: false, reason: 'mismatch' };
+      }
+      return { ok: true, record };
+    },
+  };
+}
+
+const DEFAULT_CONFIRMATION_STORE = createCommandCenterConfirmationStore();
 
 function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
@@ -91,6 +164,90 @@ function argKeys(args: unknown): string[] {
   return Object.keys(args).sort();
 }
 
+function argsRedaction(args: unknown) {
+  const safeArgs = isPlainObject(args) ? args : {};
+  return {
+    rawArgsReturned: false as const,
+    argKeys: argKeys(safeArgs),
+    argsSha256: sha256(canonicalJson(safeArgs)),
+  };
+}
+
+function actorAudit(
+  trusted: CommandCenterExecutionDeps['trustedCapabilities']
+): CommandCenterExecutionAudit['actor'] {
+  if (!trusted) return { kind: 'unknown' };
+  return {
+    kind: trusted.source,
+    ...(trusted.actorId ? { id: trusted.actorId } : {}),
+    capabilities: trusted.capabilities,
+  };
+}
+
+function providerAudit(
+  metadata: Record<string, unknown> | undefined
+): CommandCenterExecutionProviderAudit | undefined {
+  if (!metadata) return undefined;
+  const safeMetadata: Partial<
+    Record<(typeof PROVIDER_AUDIT_FIELDS)[number], string>
+  > = {};
+  for (const key of PROVIDER_AUDIT_FIELDS) {
+    const value = metadata[key];
+    if (typeof value !== 'string') continue;
+    safeMetadata[key] = value.slice(0, MAX_PROVIDER_AUDIT_VALUE_CHARS);
+  }
+  const metadataKeys = Object.keys(safeMetadata).sort();
+  return {
+    rawProviderPayloadReturned: false,
+    ...(typeof safeMetadata['source'] === 'string'
+      ? { source: safeMetadata['source'] }
+      : {}),
+    ...(typeof safeMetadata['model'] === 'string'
+      ? { model: safeMetadata['model'] }
+      : {}),
+    ...(typeof safeMetadata['requestId'] === 'string'
+      ? { requestId: safeMetadata['requestId'] }
+      : {}),
+    metadataKeys,
+    ...(metadataKeys.length > 0
+      ? { metadataSha256: sha256(canonicalJson(safeMetadata)) }
+      : {}),
+  };
+}
+
+function expectedResultShape(
+  entry: CommandCenterResolverCatalogEntry
+): CommandCenterExecutionConfirmationPreview['expectedResultShape'] {
+  return {
+    kind: 'json-schema',
+    ...(entry.outputSchema.title ? { title: entry.outputSchema.title } : {}),
+    ...(entry.outputSchema.type ? { schemaType: entry.outputSchema.type } : {}),
+  };
+}
+
+function scopedTarget(
+  entry: CommandCenterResolverCatalogEntry,
+  args: Record<string, unknown>
+): string {
+  for (const key of [
+    'sessionId',
+    'globalSessionId',
+    'nodeId',
+    'repoPath',
+    'worktreePath',
+    'workContextId',
+    'id',
+  ]) {
+    const value = args[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return `${key}:${sha256(value).slice(0, 12)}`;
+    }
+  }
+  return entry.scopeKinds.length > 0
+    ? `${entry.scopeKinds.join('+')}:unspecified`
+    : 'global:unspecified';
+}
+
 function capabilityOutcome(
   required: readonly RelayCapabilityBit[],
   trusted: CommandCenterExecutionDeps['trustedCapabilities']
@@ -102,6 +259,14 @@ function capabilityOutcome(
   return required.every((capability) => granted.has(capability))
     ? 'allowed-explicit'
     : 'blocked';
+}
+
+function unsupportedControlRequirements(
+  entry: CommandCenterResolverCatalogEntry
+): string[] {
+  return entry.controlRequirements.filter(
+    (requirement) => requirement !== 'confirmation-challenge'
+  );
 }
 
 function argsBudgetOk(value: unknown): boolean {
@@ -148,21 +313,20 @@ function auditFor(input: {
   policyOutcome: CommandCenterExecutionPolicyOutcome;
   confirmationOutcome: CommandCenterExecutionConfirmationOutcome;
   capabilityOutcome: CommandCenterExecutionAudit['capabilityOutcome'];
+  actor?: CommandCenterExecutionAudit['actor'];
+  provider?: CommandCenterExecutionProviderAudit;
+  confirmationChallengeId?: string;
   reason?: string;
 }): CommandCenterExecutionAudit {
-  const args = isPlainObject(input.args) ? input.args : {};
+  const redactedArgs = isPlainObject(input.args)
+    ? argsRedaction(input.args)
+    : { ...argsRedaction({}), argsSha256: EMPTY_ARGS_HASH };
   return {
     commandId: input.commandId,
     resultKind: input.resultKind,
     ...(input.entry ? { sideEffectClass: input.entry.sideEffect } : {}),
     durationMs: input.durationMs,
-    args: {
-      rawArgsReturned: false,
-      argKeys: argKeys(args),
-      argsSha256: isPlainObject(input.args)
-        ? sha256(canonicalJson(args))
-        : EMPTY_ARGS_HASH,
-    },
+    args: redactedArgs,
     policyOutcome: input.policyOutcome,
     confirmationOutcome: input.confirmationOutcome,
     scopeKinds: input.entry?.scopeKinds ?? [],
@@ -170,7 +334,38 @@ function auditFor(input: {
       ? { availabilityState: input.entry.availability.state }
       : {}),
     capabilityOutcome: input.capabilityOutcome,
+    actor: input.actor ?? { kind: 'unknown' },
+    ...(input.provider ? { provider: input.provider } : {}),
+    ...(input.confirmationChallengeId
+      ? { confirmationChallengeId: input.confirmationChallengeId }
+      : {}),
     ...(input.reason ? { reason: input.reason } : {}),
+  };
+}
+
+function confirmationPreview(input: {
+  store: CommandCenterConfirmationStore;
+  entry: CommandCenterResolverCatalogEntry;
+  args: Record<string, unknown>;
+  nowMs: number;
+}): CommandCenterExecutionConfirmationPreview {
+  const redaction = argsRedaction(input.args);
+  const challenge = input.store.create({
+    commandId: input.entry.commandId,
+    argsSha256: redaction.argsSha256,
+    expiresAtMs: input.nowMs + COMMAND_CENTER_CONFIRMATION_TTL_MS,
+  });
+  return {
+    challengeId: challenge.challengeId,
+    expiresAtMs: challenge.expiresAtMs,
+    commandId: input.entry.commandId,
+    label: input.entry.label,
+    scopedTarget: scopedTarget(input.entry, input.args),
+    sideEffectClass: input.entry.sideEffect,
+    capabilityHints: input.entry.capabilityHints,
+    controlRequirements: input.entry.controlRequirements,
+    args: redaction,
+    expectedResultShape: expectedResultShape(input.entry),
   };
 }
 
@@ -196,9 +391,21 @@ export async function executeCommandCenterCommand(
   const rawArgs = request.args ?? {};
   const baseCommandId =
     typeof request.commandId === 'string' ? request.commandId : 'unknown';
+  const auditActor = actorAudit(deps.trustedCapabilities);
+  const auditProvider = providerAudit(request.providerMetadata);
+  const confirmationStore =
+    deps.confirmationStore ?? DEFAULT_CONFIRMATION_STORE;
+  const makeAudit = (
+    input: Omit<Parameters<typeof auditFor>[0], 'actor' | 'provider'>
+  ) =>
+    auditFor({
+      ...input,
+      actor: auditActor,
+      ...(auditProvider ? { provider: auditProvider } : {}),
+    });
 
   if (!argsBudgetOk(rawArgs)) {
-    const audit = auditFor({
+    const audit = makeAudit({
       commandId: baseCommandId,
       resultKind: 'blocked',
       args: {},
@@ -225,7 +432,7 @@ export async function executeCommandCenterCommand(
     baseCommandId as RelayCliGatewayCommand
   );
   if (!entry) {
-    const audit = auditFor({
+    const audit = makeAudit({
       commandId: baseCommandId,
       resultKind: 'blocked',
       args: rawArgs,
@@ -256,9 +463,10 @@ export async function executeCommandCenterCommand(
     resultKind: CommandCenterExecutionResultKind,
     policyOutcome: CommandCenterExecutionPolicyOutcome,
     confirmationOutcome: CommandCenterExecutionConfirmationOutcome,
-    reason: string
+    reason: string,
+    confirmationChallengeId?: string
   ) =>
-    auditFor({
+    makeAudit({
       commandId: entry.commandId,
       resultKind,
       entry,
@@ -267,6 +475,7 @@ export async function executeCommandCenterCommand(
       policyOutcome,
       confirmationOutcome,
       capabilityOutcome: caps,
+      ...(confirmationChallengeId ? { confirmationChallengeId } : {}),
       reason,
     });
 
@@ -293,66 +502,6 @@ export async function executeCommandCenterCommand(
         commandId: entry.commandId,
         reason: 'invalid-args',
         message: argErrors.slice(0, 3).join('; '),
-        audit,
-      },
-      deps.auditSink
-    );
-  }
-
-  if (entry.requiresConfirmation) {
-    const audit = blockedAudit(
-      'confirmation_required',
-      'confirmation-required',
-      'required',
-      'confirmation-required'
-    );
-    return finish(
-      {
-        kind: 'confirmation_required',
-        commandId: entry.commandId,
-        reason: 'confirmation-required',
-        message:
-          'Natural-language execution cannot satisfy confirmation-gated commands in this slice.',
-        audit,
-      },
-      deps.auditSink
-    );
-  }
-
-  if (entry.controlRequirements.length > 0) {
-    const audit = blockedAudit(
-      'confirmation_required',
-      'confirmation-required',
-      'required',
-      'control-requirement'
-    );
-    return finish(
-      {
-        kind: 'confirmation_required',
-        commandId: entry.commandId,
-        reason: 'control-requirement',
-        message:
-          'This command requires fresh control/intervention state and is preview-only in this slice.',
-        audit,
-      },
-      deps.auditSink
-    );
-  }
-
-  if (entry.sideEffect !== 'read') {
-    const audit = blockedAudit(
-      'blocked',
-      'blocked',
-      'blocked',
-      'unsafe-command'
-    );
-    return finish(
-      {
-        kind: 'blocked',
-        commandId: entry.commandId,
-        reason: 'unsafe-command',
-        message:
-          'Natural-language execution is limited to read-only Relay commands.',
         audit,
       },
       deps.auditSink
@@ -397,6 +546,112 @@ export async function executeCommandCenterCommand(
     );
   }
 
+  const unsupportedControls = unsupportedControlRequirements(entry);
+  if (unsupportedControls.length > 0) {
+    const audit = blockedAudit(
+      'blocked',
+      'blocked',
+      'blocked',
+      'control-requirement-unsatisfied'
+    );
+    return finish(
+      {
+        kind: 'blocked',
+        commandId: entry.commandId,
+        reason: 'control-requirement-unsatisfied',
+        message: `Command Center cannot execute ${entry.commandId} until these control requirements are validated: ${unsupportedControls.join(', ')}`,
+        audit,
+      },
+      deps.auditSink
+    );
+  }
+  const confirmationRequired =
+    entry.requiresConfirmation ||
+    entry.controlRequirements.includes('confirmation-challenge') ||
+    entry.sideEffect !== 'read';
+  let executionConfirmationOutcome: CommandCenterExecutionConfirmationOutcome =
+    'not-required';
+
+  if (confirmationRequired) {
+    const reason =
+      entry.controlRequirements.length > 0
+        ? 'control-requirement'
+        : 'confirmation-required';
+    if (!request.confirmation) {
+      const preview = confirmationPreview({
+        store: confirmationStore,
+        entry,
+        args: rawArgs,
+        nowMs: now(),
+      });
+      const audit = blockedAudit(
+        'confirmation_required',
+        'confirmation-required',
+        'required',
+        reason,
+        preview.challengeId
+      );
+      return finish(
+        {
+          kind: 'confirmation_required',
+          commandId: entry.commandId,
+          reason,
+          message: `${entry.label} requires explicit confirmation. Review the redacted preview and confirm or deny before execution.`,
+          preview,
+          audit,
+        },
+        deps.auditSink
+      );
+    }
+
+    const consumed = confirmationStore.consume({
+      challengeId: request.confirmation.challengeId,
+      commandId: entry.commandId,
+      argsSha256: argsRedaction(rawArgs).argsSha256,
+      nowMs: now(),
+    });
+    if (consumed.ok === false) {
+      const audit = blockedAudit(
+        'blocked',
+        'blocked',
+        'stale',
+        `confirmation-${consumed.reason}`,
+        request.confirmation.challengeId
+      );
+      return finish(
+        {
+          kind: 'blocked',
+          commandId: entry.commandId,
+          reason: 'confirmation-stale',
+          message:
+            'The Command Center confirmation was stale, missing, or did not match the original redacted args.',
+          audit,
+        },
+        deps.auditSink
+      );
+    }
+    if (request.confirmation.decision === 'deny') {
+      const audit = blockedAudit(
+        'blocked',
+        'blocked',
+        'denied',
+        'confirmation-denied',
+        request.confirmation.challengeId
+      );
+      return finish(
+        {
+          kind: 'blocked',
+          commandId: entry.commandId,
+          reason: 'confirmation-denied',
+          message: 'The operator denied the Command Center confirmation.',
+          audit,
+        },
+        deps.auditSink
+      );
+    }
+    executionConfirmationOutcome = 'confirmed';
+  }
+
   const handler = deps.handlers[entry.commandId];
   if (!handler) {
     const audit = blockedAudit(
@@ -411,7 +666,7 @@ export async function executeCommandCenterCommand(
         commandId: entry.commandId,
         reason: 'unsupported-command',
         message:
-          'This read-only command is typed, but Command Center execution is not wired for it yet.',
+          'This typed command passed policy checks, but Command Center execution is not wired for it yet.',
         audit,
       },
       deps.auditSink
@@ -422,14 +677,14 @@ export async function executeCommandCenterCommand(
     const handlerResult = await handler(rawArgs);
     if (handlerResult.ok === false) {
       const resultKind = handlerResult.kind;
-      const audit = auditFor({
+      const audit = makeAudit({
         commandId: entry.commandId,
         resultKind,
         entry,
         args: rawArgs,
         durationMs: duration(start, now),
         policyOutcome: 'allowed',
-        confirmationOutcome: 'not-required',
+        confirmationOutcome: executionConfirmationOutcome,
         capabilityOutcome: caps,
         reason: handlerResult.reason,
       });
@@ -460,14 +715,14 @@ export async function executeCommandCenterCommand(
       );
     }
 
-    const audit = auditFor({
+    const audit = makeAudit({
       commandId: entry.commandId,
       resultKind: 'success',
       entry,
       args: rawArgs,
       durationMs: duration(start, now),
       policyOutcome: 'allowed',
-      confirmationOutcome: 'not-required',
+      confirmationOutcome: executionConfirmationOutcome,
       capabilityOutcome: caps,
     });
     return finish(
@@ -480,14 +735,14 @@ export async function executeCommandCenterCommand(
       deps.auditSink
     );
   } catch {
-    const audit = auditFor({
+    const audit = makeAudit({
       commandId: entry.commandId,
       resultKind: 'error',
       entry,
       args: rawArgs,
       durationMs: duration(start, now),
       policyOutcome: 'allowed',
-      confirmationOutcome: 'not-required',
+      confirmationOutcome: executionConfirmationOutcome,
       capabilityOutcome: caps,
       reason: 'internal-error',
     });

--- a/server/command-center-executor.ts
+++ b/server/command-center-executor.ts
@@ -18,6 +18,10 @@ import type {
   CommandCenterExecutionResult,
   CommandCenterExecutionResultKind,
 } from '../shared/command-center-execution.js';
+import type {
+  ScopedActorCredentialScope,
+  ScopedActorCredentialValidationFailureReason,
+} from '../shared/scoped-actor-credentials.js';
 
 export interface CommandCenterExecutionRequest {
   commandId: string;
@@ -65,6 +69,22 @@ export interface CommandCenterConfirmationStore {
     | { ok: false; reason: 'missing' | 'mismatch' | 'expired' };
 }
 
+export type CommandCenterActorScopeValidationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: ScopedActorCredentialValidationFailureReason;
+      credentialId?: string;
+      deniedBits?: readonly string[];
+    };
+
+export interface CommandCenterActorScopeValidationInput {
+  entry: CommandCenterResolverCatalogEntry;
+  args: Record<string, unknown>;
+  requiredCapabilities: readonly RelayCapabilityBit[];
+  requestedScope?: ScopedActorCredentialScope;
+}
+
 export interface CommandCenterExecutionDeps {
   catalog?: CommandCenterResolverCatalog;
   handlers: Partial<
@@ -80,6 +100,9 @@ export interface CommandCenterExecutionDeps {
   now?: () => number;
   auditSink?: (audit: CommandCenterExecutionAudit) => void;
   confirmationStore?: CommandCenterConfirmationStore;
+  validateActorScope?: (
+    input: CommandCenterActorScopeValidationInput
+  ) => CommandCenterActorScopeValidationResult;
 }
 
 const EMPTY_ARGS_HASH = sha256(canonicalJson({}));
@@ -246,6 +269,71 @@ function scopedTarget(
   return entry.scopeKinds.length > 0
     ? `${entry.scopeKinds.join('+')}:unspecified`
     : 'global:unspecified';
+}
+
+function stringArg(
+  args: Record<string, unknown>,
+  keys: readonly string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+export function commandCenterActorCredentialScopeFor(
+  entry: CommandCenterResolverCatalogEntry,
+  args: Record<string, unknown>
+): ScopedActorCredentialScope | undefined {
+  const scope: ScopedActorCredentialScope = {};
+  const commandId = entry.commandId;
+
+  if (entry.scopeKinds.includes('node')) {
+    const nodeId = stringArg(args, [
+      'nodeId',
+      ...(commandId.startsWith('nodes.') ? ['id'] : []),
+    ]);
+    if (nodeId) scope.nodeIds = [nodeId];
+  }
+
+  if (entry.scopeKinds.includes('session')) {
+    const sessionId = stringArg(args, ['sessionId', 'id']);
+    const globalSessionId = stringArg(args, ['globalSessionId']);
+    if (sessionId) scope.sessionIds = [sessionId];
+    if (globalSessionId) scope.globalSessionIds = [globalSessionId];
+  }
+
+  if (entry.scopeKinds.includes('work-context')) {
+    const workContextId = stringArg(args, [
+      'workContextId',
+      ...(commandId.startsWith('work-contexts.') ? ['id'] : []),
+    ]);
+    if (workContextId) scope.workContextIds = [workContextId];
+  }
+
+  if (entry.scopeKinds.includes('repo')) {
+    const repoId = stringArg(args, ['repoId']);
+    const repoPath = stringArg(args, ['repoPath']);
+    if (repoId) scope.repoIds = [repoId];
+    if (repoPath) scope.pathPrefixes = [repoPath];
+  }
+
+  if (entry.scopeKinds.includes('worktree')) {
+    const worktreePath = stringArg(args, ['worktreePath']);
+    if (worktreePath) {
+      scope.pathPrefixes = Array.from(
+        new Set([...(scope.pathPrefixes ?? []), worktreePath])
+      );
+    }
+  }
+
+  const taskRef = stringArg(args, ['taskRef']);
+  if (taskRef) scope.taskRefs = [taskRef];
+
+  return Object.keys(scope).length > 0 ? scope : undefined;
 }
 
 function capabilityOutcome(
@@ -544,6 +632,35 @@ export async function executeCommandCenterCommand(
       },
       deps.auditSink
     );
+  }
+
+  if (deps.validateActorScope) {
+    const requestedScope = commandCenterActorCredentialScopeFor(entry, rawArgs);
+    const actorScope = deps.validateActorScope({
+      entry,
+      args: rawArgs,
+      requiredCapabilities: entry.capabilityHints,
+      ...(requestedScope ? { requestedScope } : {}),
+    });
+    if (actorScope.ok === false) {
+      const audit = blockedAudit(
+        'blocked',
+        'blocked',
+        'blocked',
+        `actor-scope-${actorScope.reason}`
+      );
+      return finish(
+        {
+          kind: 'blocked',
+          commandId: entry.commandId,
+          reason: 'actor-scope-denied',
+          message:
+            'The scoped actor credential does not authorize this Command Center target.',
+          audit,
+        },
+        deps.auditSink
+      );
+    }
   }
 
   const unsupportedControls = unsupportedControlRequirements(entry);

--- a/server/command-center-executor.ts
+++ b/server/command-center-executor.ts
@@ -57,7 +57,8 @@ export interface CommandCenterConfirmationChallengeRecord {
 
 export interface CommandCenterConfirmationStore {
   create(
-    record: Omit<CommandCenterConfirmationChallengeRecord, 'challengeId'>
+    record: Omit<CommandCenterConfirmationChallengeRecord, 'challengeId'>,
+    nowMs?: number
   ): CommandCenterConfirmationChallengeRecord;
   consume(input: {
     challengeId: string;
@@ -122,8 +123,8 @@ export function createCommandCenterConfirmationStore(): CommandCenterConfirmatio
     }
   };
   return {
-    create(record) {
-      sweepExpired(Date.now());
+    create(record, nowMs) {
+      sweepExpired(nowMs ?? Date.now());
       while (records.size >= MAX_COMMAND_CENTER_CONFIRMATIONS) {
         const oldestChallengeId = records.keys().next().value;
         if (typeof oldestChallengeId !== 'string') break;
@@ -438,11 +439,14 @@ function confirmationPreview(input: {
   nowMs: number;
 }): CommandCenterExecutionConfirmationPreview {
   const redaction = argsRedaction(input.args);
-  const challenge = input.store.create({
-    commandId: input.entry.commandId,
-    argsSha256: redaction.argsSha256,
-    expiresAtMs: input.nowMs + COMMAND_CENTER_CONFIRMATION_TTL_MS,
-  });
+  const challenge = input.store.create(
+    {
+      commandId: input.entry.commandId,
+      argsSha256: redaction.argsSha256,
+      expiresAtMs: input.nowMs + COMMAND_CENTER_CONFIRMATION_TTL_MS,
+    },
+    input.nowMs
+  );
   return {
     challengeId: challenge.challengeId,
     expiresAtMs: challenge.expiresAtMs,

--- a/server/index.ts
+++ b/server/index.ts
@@ -3305,6 +3305,21 @@ async function main(): Promise<void> {
     );
   };
 
+  const sendCommandCenterInvalidRequest = (
+    res: express.Response,
+    reasonCode: string,
+    message: string
+  ) => {
+    res.status(400).json({
+      error: {
+        code: 'INVALID_ARGUMENT',
+        message,
+        retryable: false,
+        reasonCode,
+      },
+    });
+  };
+
   const validateCommandCenterActorCredentialFor = (
     req: express.Request,
     commandId: string,
@@ -3340,7 +3355,14 @@ async function main(): Promise<void> {
         args,
         correlationId
       );
-      if (!validation) return { actorCredential: undefined, correlationId };
+      if (!validation) {
+        sendCommandCenterInvalidRequest(
+          res,
+          'COMMAND_CENTER_ACTOR_SCOPE_UNRESOLVED',
+          'Command Center actor requests require a known command and valid args before execution.'
+        );
+        return null;
+      }
       if ('reason' in validation) {
         sendCommandCenterActorValidationFailure(res, validation, correlationId);
         return null;
@@ -3397,19 +3419,27 @@ async function main(): Promise<void> {
     const args = Object.prototype.hasOwnProperty.call(body, 'args')
       ? body.args
       : {};
-    const confirmationBody = isRecord(body.confirmation)
-      ? body.confirmation
-      : null;
-    const confirmation: CommandCenterExecutionConfirmationInput | undefined =
-      confirmationBody &&
-      typeof confirmationBody.challengeId === 'string' &&
-      (confirmationBody.decision === 'confirm' ||
-        confirmationBody.decision === 'deny')
-        ? {
-            challengeId: confirmationBody.challengeId,
-            decision: confirmationBody.decision,
-          }
-        : undefined;
+    let confirmation: CommandCenterExecutionConfirmationInput | undefined;
+    if (Object.prototype.hasOwnProperty.call(body, 'confirmation')) {
+      const confirmationBody = body.confirmation;
+      if (
+        !isRecord(confirmationBody) ||
+        typeof confirmationBody['challengeId'] !== 'string' ||
+        (confirmationBody['decision'] !== 'confirm' &&
+          confirmationBody['decision'] !== 'deny')
+      ) {
+        sendCommandCenterInvalidRequest(
+          res,
+          'COMMAND_CENTER_CONFIRMATION_INVALID',
+          'Command Center confirmation must include a challengeId and confirm/deny decision.'
+        );
+        return;
+      }
+      confirmation = {
+        challengeId: confirmationBody['challengeId'],
+        decision: confirmationBody['decision'],
+      };
+    }
 
     const authContext = authenticateCommandCenterExecutionRequest(
       req,

--- a/server/index.ts
+++ b/server/index.ts
@@ -140,8 +140,10 @@ import {
 } from './command-center-intent-resolver.js';
 import {
   executeCommandCenterCommand,
+  type CommandCenterExecutionRequest,
   type CommandCenterReadOnlyHandler,
 } from './command-center-executor.js';
+import type { CommandCenterExecutionConfirmationInput } from '../shared/command-center-execution.js';
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
 import {
@@ -3288,11 +3290,25 @@ async function main(): Promise<void> {
       const args = Object.prototype.hasOwnProperty.call(body, 'args')
         ? body.args
         : {};
+      const confirmationBody = isRecord(body.confirmation)
+        ? body.confirmation
+        : null;
+      const confirmation: CommandCenterExecutionConfirmationInput | undefined =
+        confirmationBody &&
+        typeof confirmationBody.challengeId === 'string' &&
+        (confirmationBody.decision === 'confirm' ||
+          confirmationBody.decision === 'deny')
+          ? {
+              challengeId: confirmationBody.challengeId,
+              decision: confirmationBody.decision,
+            }
+          : undefined;
       const actorCredential = authenticatedCliGatewayActorCredential(req);
       const trustedCapabilities = actorCredential
         ? {
             source: 'actor-grant' as const,
             capabilities: actorCredential.capabilities,
+            actorId: actorCredential.actor.id,
           }
         : authenticatedBrowserSession(req)
           ? {
@@ -3393,15 +3409,18 @@ async function main(): Promise<void> {
         }),
       };
 
-      const result = await executeCommandCenterCommand(
-        { commandId, args },
-        {
-          handlers,
-          trustedCapabilities,
-          auditSink: (audit) =>
-            logger.info('Command Center execution audit', audit),
-        }
-      );
+      const executionRequest: CommandCenterExecutionRequest = {
+        commandId,
+        args,
+        ...(confirmation ? { confirmation } : {}),
+      };
+
+      const result = await executeCommandCenterCommand(executionRequest, {
+        handlers,
+        trustedCapabilities,
+        auditSink: (audit) =>
+          logger.info('Command Center execution audit', audit),
+      });
       res.json(result);
     }
   );

--- a/server/index.ts
+++ b/server/index.ts
@@ -140,9 +140,15 @@ import {
 } from './command-center-intent-resolver.js';
 import {
   executeCommandCenterCommand,
+  commandCenterActorCredentialScopeFor,
+  type CommandCenterActorScopeValidationInput,
   type CommandCenterExecutionRequest,
   type CommandCenterReadOnlyHandler,
 } from './command-center-executor.js';
+import {
+  COMMAND_CENTER_RESOLVER_CATALOG,
+  validateCommandCenterArgs,
+} from '../shared/command-center-resolver.js';
 import type { CommandCenterExecutionConfirmationInput } from '../shared/command-center-execution.js';
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
@@ -3276,154 +3282,269 @@ async function main(): Promise<void> {
     }
   });
 
+  type CommandCenterActorValidationFailure = Extract<
+    ReturnType<typeof validateCliGatewayActorCredential>,
+    { reason: unknown }
+  >;
+
+  const sendCommandCenterActorValidationFailure = (
+    res: express.Response,
+    validation: CommandCenterActorValidationFailure,
+    correlationId: string | undefined
+  ) => {
+    sendCliGatewayActorFailure(
+      res,
+      cliGatewayActorFailure({
+        reason: validation.reason,
+        ...(validation.credentialId
+          ? { credentialId: validation.credentialId }
+          : {}),
+        deniedBits: validation.deniedBits,
+        ...(correlationId ? { correlationId } : {}),
+      })
+    );
+  };
+
+  const validateCommandCenterActorCredentialFor = (
+    req: express.Request,
+    commandId: string,
+    args: unknown,
+    correlationId: string | undefined
+  ) => {
+    const entry = COMMAND_CENTER_RESOLVER_CATALOG.byCommandId.get(
+      commandId as RelayCliGatewayCommand
+    );
+    if (!entry || !isRecord(args)) return undefined;
+    const argErrors = validateCommandCenterArgs(args, entry.inputSchema);
+    if (argErrors.length > 0) return undefined;
+    const requestedScope = commandCenterActorCredentialScopeFor(entry, args);
+    return validateCliGatewayActorCredential(cliGatewayActorRegistry, {
+      token: bearerActorToken(req),
+      capabilities: entry.capabilityHints,
+      ...(requestedScope ? { scope: requestedScope } : {}),
+      ...(correlationId ? { correlationId } : {}),
+    });
+  };
+
+  const authenticateCommandCenterExecutionRequest = (
+    req: express.Request,
+    res: express.Response,
+    commandId: string,
+    args: unknown
+  ) => {
+    const correlationId = cliGatewayCorrelationId(req);
+    if (isCliGatewayActorTokenRequest(req)) {
+      const validation = validateCommandCenterActorCredentialFor(
+        req,
+        commandId,
+        args,
+        correlationId
+      );
+      if (!validation) return { actorCredential: undefined, correlationId };
+      if ('reason' in validation) {
+        sendCommandCenterActorValidationFailure(res, validation, correlationId);
+        return null;
+      }
+      attachAuthenticatedCliGatewayActorCredential(req, validation.credential);
+      return { actorCredential: validation.credential, correlationId };
+    }
+
+    let authorized = false;
+    requireCliGatewayAuth(req, res, () => {
+      authorized = true;
+    });
+    if (!authorized) return null;
+    return {
+      actorCredential: authenticatedCliGatewayActorCredential(req),
+      correlationId,
+    };
+  };
+
+  const createCommandCenterActorScopeValidator =
+    (req: express.Request, correlationId: string | undefined) =>
+    ({
+      requestedScope,
+      requiredCapabilities,
+    }: CommandCenterActorScopeValidationInput) => {
+      const validation = validateCliGatewayActorCredential(
+        cliGatewayActorRegistry,
+        {
+          token: bearerActorToken(req),
+          capabilities: requiredCapabilities,
+          ...(requestedScope ? { scope: requestedScope } : {}),
+          ...(correlationId ? { correlationId } : {}),
+        }
+      );
+      return 'reason' in validation
+        ? {
+            ok: false as const,
+            reason: validation.reason,
+            ...(validation.credentialId
+              ? { credentialId: validation.credentialId }
+              : {}),
+            deniedBits: validation.deniedBits,
+          }
+        : { ok: true as const };
+    };
+
   // POST /api/command-center/execute — execute one already-resolved typed
   // read-only Relay command through the same manifest/catalog policy boundary.
   // This route never accepts shell strings or prompt payloads; audit metadata
   // logs command/result/latency plus hashed args only.
-  app.post(
-    '/api/command-center/execute',
-    requireCliGatewayAuth,
-    async (req, res) => {
-      const body = isRecord(req.body) ? req.body : {};
-      const commandId =
-        typeof body.commandId === 'string' ? body.commandId : '';
-      const args = Object.prototype.hasOwnProperty.call(body, 'args')
-        ? body.args
-        : {};
-      const confirmationBody = isRecord(body.confirmation)
-        ? body.confirmation
-        : null;
-      const confirmation: CommandCenterExecutionConfirmationInput | undefined =
-        confirmationBody &&
-        typeof confirmationBody.challengeId === 'string' &&
-        (confirmationBody.decision === 'confirm' ||
-          confirmationBody.decision === 'deny')
-          ? {
-              challengeId: confirmationBody.challengeId,
-              decision: confirmationBody.decision,
-            }
-          : undefined;
-      const actorCredential = authenticatedCliGatewayActorCredential(req);
-      const trustedCapabilities = actorCredential
+  app.post('/api/command-center/execute', async (req, res) => {
+    const body = isRecord(req.body) ? req.body : {};
+    const commandId = typeof body.commandId === 'string' ? body.commandId : '';
+    const args = Object.prototype.hasOwnProperty.call(body, 'args')
+      ? body.args
+      : {};
+    const confirmationBody = isRecord(body.confirmation)
+      ? body.confirmation
+      : null;
+    const confirmation: CommandCenterExecutionConfirmationInput | undefined =
+      confirmationBody &&
+      typeof confirmationBody.challengeId === 'string' &&
+      (confirmationBody.decision === 'confirm' ||
+        confirmationBody.decision === 'deny')
         ? {
-            source: 'actor-grant' as const,
-            capabilities: actorCredential.capabilities,
-            actorId: actorCredential.actor.id,
+            challengeId: confirmationBody.challengeId,
+            decision: confirmationBody.decision,
           }
-        : authenticatedBrowserSession(req)
-          ? {
-              source: 'browser-session' as const,
-              capabilities: RELAY_CAPABILITY_BITS,
-            }
-          : undefined;
+        : undefined;
 
-      const listSessions = async () => {
-        const [localSessions, remoteSessions] = await Promise.all([
-          Promise.resolve(
-            localRelayNode.sessions
-              .list()
-              .map((session) =>
-                withWorkContextMetadata(workContextStore, session)
-              )
-          ),
-          aggregateRemoteSessions({
-            registry: hubNodeRegistry,
-            nodeLinks: hubNodeLinks,
-            logger,
-            sessionEnvelopes: sessionEnvelopeRegistry,
-            workContextStore,
-            readModelCache: remoteSessionReadModelCache,
-          }),
-        ]);
-        return [...localSessions, ...remoteSessions];
-      };
+    const authContext = authenticateCommandCenterExecutionRequest(
+      req,
+      res,
+      commandId,
+      args
+    );
+    if (!authContext) return;
+    const { actorCredential, correlationId } = authContext;
 
-      const findSession = async (id: string) => {
-        const local = localRelayNode.sessions
-          .list()
-          .map((session) => withWorkContextMetadata(workContextStore, session))
-          .find(
-            (session) => session.id === id || session.globalSessionId === id
-          );
-        if (local) return local;
-        const remoteSessions = await aggregateRemoteSessions({
+    const trustedCapabilities = actorCredential
+      ? {
+          source: 'actor-grant' as const,
+          capabilities: actorCredential.capabilities,
+          actorId: actorCredential.actor.id,
+        }
+      : authenticatedBrowserSession(req)
+        ? {
+            source: 'browser-session' as const,
+            capabilities: RELAY_CAPABILITY_BITS,
+          }
+        : undefined;
+
+    const listSessions = async () => {
+      const [localSessions, remoteSessions] = await Promise.all([
+        Promise.resolve(
+          localRelayNode.sessions
+            .list()
+            .map((session) =>
+              withWorkContextMetadata(workContextStore, session)
+            )
+        ),
+        aggregateRemoteSessions({
           registry: hubNodeRegistry,
           nodeLinks: hubNodeLinks,
           logger,
           sessionEnvelopes: sessionEnvelopeRegistry,
           workContextStore,
           readModelCache: remoteSessionReadModelCache,
-        });
-        return remoteSessions.find(
-          (session) => session.id === id || session.globalSessionId === id
-        );
-      };
+        }),
+      ]);
+      return [...localSessions, ...remoteSessions];
+    };
 
-      const handlers: Partial<
-        Record<RelayCliGatewayCommand, CommandCenterReadOnlyHandler>
-      > = {
-        'nodes.list': () => ({
-          ok: true,
-          data: { nodes: hubNodeRegistry.listNodes() },
-        }),
-        'sessions.list': async () => ({
-          ok: true,
-          data: { sessions: await listSessions() },
-        }),
-        'sessions.get': async (commandArgs) => {
-          const id = commandArgs['id'];
-          if (typeof id !== 'string' || !id.trim()) {
-            return {
-              ok: false,
-              kind: 'unavailable',
-              reason: 'not-found',
-              message: 'session id is required',
-            };
-          }
-          const found = await findSession(id.trim());
-          if (!found) {
-            return {
-              ok: false,
-              kind: 'unavailable',
-              reason: 'not-found',
-              message: 'session was not found',
-              details: { sessionId: id },
-            };
-          }
-          return { ok: true, data: found };
-        },
-        'settings.get': () => ({
-          ok: true,
-          data: {
-            settings: safeSettingsFromConfig(getConfig()),
-            redaction: {
-              rawConfigReturned: false,
-              secretsReturned: false,
-              tokenMaterialReturned: false,
-            },
-          },
-        }),
-        'webhooks.status': () => ({
-          ok: true,
-          data: webhookStatusFromConfig(getConfig()),
-        }),
-      };
-
-      const executionRequest: CommandCenterExecutionRequest = {
-        commandId,
-        args,
-        ...(confirmation ? { confirmation } : {}),
-      };
-
-      const result = await executeCommandCenterCommand(executionRequest, {
-        handlers,
-        trustedCapabilities,
-        auditSink: (audit) =>
-          logger.info('Command Center execution audit', audit),
+    const findSession = async (id: string) => {
+      const local = localRelayNode.sessions
+        .list()
+        .map((session) => withWorkContextMetadata(workContextStore, session))
+        .find((session) => session.id === id || session.globalSessionId === id);
+      if (local) return local;
+      const remoteSessions = await aggregateRemoteSessions({
+        registry: hubNodeRegistry,
+        nodeLinks: hubNodeLinks,
+        logger,
+        sessionEnvelopes: sessionEnvelopeRegistry,
+        workContextStore,
+        readModelCache: remoteSessionReadModelCache,
       });
-      res.json(result);
-    }
-  );
+      return remoteSessions.find(
+        (session) => session.id === id || session.globalSessionId === id
+      );
+    };
+
+    const handlers: Partial<
+      Record<RelayCliGatewayCommand, CommandCenterReadOnlyHandler>
+    > = {
+      'nodes.list': () => ({
+        ok: true,
+        data: { nodes: hubNodeRegistry.listNodes() },
+      }),
+      'sessions.list': async () => ({
+        ok: true,
+        data: { sessions: await listSessions() },
+      }),
+      'sessions.get': async (commandArgs) => {
+        const id = commandArgs['id'];
+        if (typeof id !== 'string' || !id.trim()) {
+          return {
+            ok: false,
+            kind: 'unavailable',
+            reason: 'not-found',
+            message: 'session id is required',
+          };
+        }
+        const found = await findSession(id.trim());
+        if (!found) {
+          return {
+            ok: false,
+            kind: 'unavailable',
+            reason: 'not-found',
+            message: 'session was not found',
+            details: { sessionId: id },
+          };
+        }
+        return { ok: true, data: found };
+      },
+      'settings.get': () => ({
+        ok: true,
+        data: {
+          settings: safeSettingsFromConfig(getConfig()),
+          redaction: {
+            rawConfigReturned: false,
+            secretsReturned: false,
+            tokenMaterialReturned: false,
+          },
+        },
+      }),
+      'webhooks.status': () => ({
+        ok: true,
+        data: webhookStatusFromConfig(getConfig()),
+      }),
+    };
+
+    const executionRequest: CommandCenterExecutionRequest = {
+      commandId,
+      args,
+      ...(confirmation ? { confirmation } : {}),
+    };
+
+    const result = await executeCommandCenterCommand(executionRequest, {
+      handlers,
+      trustedCapabilities,
+      ...(actorCredential
+        ? {
+            validateActorScope: createCommandCenterActorScopeValidator(
+              req,
+              correlationId
+            ),
+          }
+        : {}),
+      auditSink: (audit) =>
+        logger.info('Command Center execution audit', audit),
+    });
+    res.json(result);
+  });
 
   // Restore sessions from a previous update restart
   const restoredCount = await restoreFromDisk(

--- a/shared/command-center-execution.ts
+++ b/shared/command-center-execution.ts
@@ -109,6 +109,7 @@ export interface CommandCenterExecutionBlocked {
     | 'unsafe-command'
     | 'missing-capability'
     | 'unsupported-command'
+    | 'actor-scope-denied'
     | 'control-requirement-unsatisfied'
     | 'confirmation-denied'
     | 'confirmation-stale'

--- a/shared/command-center-execution.ts
+++ b/shared/command-center-execution.ts
@@ -3,6 +3,7 @@ import type {
   RelayCommandScopeKind,
   RelayCommandSideEffect,
 } from './relay-command-manifest.js';
+import type { RelayCapabilityBit } from './security-policy.js';
 
 export type CommandCenterExecutionResultKind =
   | 'success'
@@ -19,12 +20,56 @@ export type CommandCenterExecutionPolicyOutcome =
 export type CommandCenterExecutionConfirmationOutcome =
   | 'not-required'
   | 'required'
+  | 'confirmed'
+  | 'denied'
+  | 'stale'
   | 'blocked';
+
+export type CommandCenterConfirmationDecision = 'confirm' | 'deny';
+
+export interface CommandCenterExecutionConfirmationInput {
+  challengeId: string;
+  decision: CommandCenterConfirmationDecision;
+}
 
 export interface CommandCenterExecutionArgsRedaction {
   rawArgsReturned: false;
   argKeys: readonly string[];
   argsSha256: string;
+}
+
+export interface CommandCenterExecutionActorAudit {
+  kind: 'browser-session' | 'actor-grant' | 'unknown';
+  id?: string;
+  capabilities?: readonly RelayCapabilityBit[];
+}
+
+export interface CommandCenterExecutionProviderAudit {
+  rawProviderPayloadReturned: false;
+  source?: string;
+  model?: string;
+  requestId?: string;
+  metadataKeys: readonly string[];
+  metadataSha256?: string;
+}
+
+export interface CommandCenterExecutionExpectedResultShape {
+  kind: string;
+  title?: string;
+  schemaType?: string | readonly string[];
+}
+
+export interface CommandCenterExecutionConfirmationPreview {
+  challengeId: string;
+  expiresAtMs: number;
+  commandId: RelayCliGatewayCommand;
+  label: string;
+  scopedTarget: string;
+  sideEffectClass: RelayCommandSideEffect;
+  capabilityHints: readonly RelayCapabilityBit[];
+  controlRequirements: readonly string[];
+  args: CommandCenterExecutionArgsRedaction;
+  expectedResultShape: CommandCenterExecutionExpectedResultShape;
 }
 
 export interface CommandCenterExecutionAudit {
@@ -42,6 +87,9 @@ export interface CommandCenterExecutionAudit {
     | 'allowed-browser-session'
     | 'allowed-explicit'
     | 'blocked';
+  actor: CommandCenterExecutionActorAudit;
+  provider?: CommandCenterExecutionProviderAudit;
+  confirmationChallengeId?: string;
   reason?: string;
 }
 
@@ -61,6 +109,9 @@ export interface CommandCenterExecutionBlocked {
     | 'unsafe-command'
     | 'missing-capability'
     | 'unsupported-command'
+    | 'control-requirement-unsatisfied'
+    | 'confirmation-denied'
+    | 'confirmation-stale'
     | 'metadata-mismatch';
   message: string;
   audit: CommandCenterExecutionAudit;
@@ -71,6 +122,7 @@ export interface CommandCenterExecutionConfirmationRequired {
   commandId: RelayCliGatewayCommand;
   reason: 'confirmation-required' | 'control-requirement';
   message: string;
+  preview: CommandCenterExecutionConfirmationPreview;
   audit: CommandCenterExecutionAudit;
 }
 

--- a/shared/command-center-resolver.ts
+++ b/shared/command-center-resolver.ts
@@ -243,9 +243,13 @@ export function catalogEntryFromActionDescriptor(
         : {}),
     },
     outputSchema:
-      descriptor.result.kind === 'json-schema'
+      descriptor.result?.kind === 'json-schema'
         ? descriptor.result.schema
-        : (descriptor.result.schema ?? { title: descriptor.result.type }),
+        : (descriptor.result?.schema ?? {
+            ...(descriptor.result?.type
+              ? { title: descriptor.result.type }
+              : {}),
+          }),
     ...(descriptor.ui
       ? {
           ui: {

--- a/shared/command-center-resolver.ts
+++ b/shared/command-center-resolver.ts
@@ -38,6 +38,7 @@ export interface CommandCenterResolverCatalogEntry {
     state: RelayActionAvailabilityState;
     reason?: string;
   };
+  outputSchema: RelayJsonSchema;
   ui?: {
     actionId?: string;
     category?: string;
@@ -241,6 +242,10 @@ export function catalogEntryFromActionDescriptor(
         ? { reason: descriptor.availability.reason }
         : {}),
     },
+    outputSchema:
+      descriptor.result.kind === 'json-schema'
+        ? descriptor.result.schema
+        : (descriptor.result.schema ?? { title: descriptor.result.type }),
     ...(descriptor.ui
       ? {
           ui: {
@@ -855,9 +860,6 @@ export function validateCommandCenterProviderIntent(
     return validateExplainClaim(claim, catalog, suggestions, confidence);
   }
 
-  if (confidence < minConfidence)
-    return noMatch('low-confidence', suggestions, undefined, claim);
-
   if (typeof claim.commandId !== 'string') {
     return noMatch('malformed-output', suggestions, 'missing commandId', claim);
   }
@@ -880,13 +882,34 @@ export function validateCommandCenterProviderIntent(
   }
   if (!metadataMatches(claim, entry))
     return noMatch('metadata-mismatch', suggestions, undefined, claim);
+
+  if (confidence < minConfidence) {
+    if (!isReadOnlyResolverTarget(entry)) {
+      return {
+        kind: 'ask_followup',
+        commandId: entry.commandId,
+        question: `${entry.label} is ${entry.sideEffect}-class and needs an explicit Command Center confirmation preview before Relay can execute it. Review the suggested action instead of running it from natural language.`,
+        confidence,
+        ...(typeof claim.rationale === 'string'
+          ? { rationale: claim.rationale }
+          : {}),
+        suggestions,
+      };
+    }
+    return noMatch('low-confidence', suggestions, undefined, claim);
+  }
+
   if (!isReadOnlyResolverTarget(entry)) {
-    return noMatch(
-      'unsafe-command',
+    return {
+      kind: 'ask_followup',
+      commandId: entry.commandId,
+      question: `${entry.label} is ${entry.sideEffect}-class and requires an explicit Command Center confirmation preview. Choose the typed action and confirm the redacted preview before execution.`,
+      confidence,
+      ...(typeof claim.rationale === 'string'
+        ? { rationale: claim.rationale }
+        : {}),
       suggestions,
-      `command ${entry.commandId} is not a read-only resolver target in this resolver slice`,
-      claim
-    );
+    };
   }
 
   const intent = resolvedIntentForEntry(claim, entry, args, confidence);
@@ -918,6 +941,7 @@ export function summarizeCommandCenterCatalogForResolver(
   surfaces: readonly RelayActionSurface[];
   availability: CommandCenterResolverCatalogEntry['availability'];
   inputSchema: RelayJsonSchema;
+  outputSchema: RelayJsonSchema;
 }> {
   return catalog.entries.map((entry) => ({
     commandId: entry.commandId,
@@ -930,5 +954,6 @@ export function summarizeCommandCenterCatalogForResolver(
     surfaces: entry.surfaces,
     availability: entry.availability,
     inputSchema: entry.inputSchema,
+    outputSchema: entry.outputSchema,
   }));
 }

--- a/test/command-center-assistant-shell.test.ts
+++ b/test/command-center-assistant-shell.test.ts
@@ -58,6 +58,7 @@ const sessionsListEntry = {
   availability: { state: 'available' },
   ui: { actionId: 'session.start-work-in-env', category: 'session' },
   inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+  outputSchema: { type: 'object' },
 } as const;
 
 function openUiResult(): CommandCenterAssistantResult {
@@ -130,6 +131,7 @@ function executionSuccess(): CommandCenterExecutionResult {
       scopeKinds: ['session'],
       availabilityState: 'available',
       capabilityOutcome: 'allowed-browser-session',
+      actor: { kind: 'browser-session' },
     },
   };
 }

--- a/test/command-center-executor.test.ts
+++ b/test/command-center-executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  commandCenterActorCredentialScopeFor,
   createCommandCenterConfirmationStore,
   executeCommandCenterCommand,
   type CommandCenterReadOnlyHandler,
@@ -25,7 +26,12 @@ function descriptorFor(
       schema: {
         type: 'object',
         additionalProperties: false,
-        properties: { repoId: { type: 'string' } },
+        properties: {
+          repoId: { type: 'string' },
+          id: { type: 'string' },
+          displayName: { type: 'string' },
+          workContextId: { type: 'string' },
+        },
       },
     },
     availability: { state: 'available', capabilityHints: ['session:read'] },
@@ -69,6 +75,9 @@ const controlRequirementDescriptor = descriptorFor(
     },
   }
 );
+const repoScopedDescriptor = descriptorFor('pr-overseer.register', 'write', {
+  availability: { state: 'available', capabilityHints: ['context:write'] },
+});
 
 const catalog = buildCommandCenterResolverCatalog([
   sessionsListDescriptor,
@@ -76,6 +85,7 @@ const catalog = buildCommandCenterResolverCatalog([
   writeDescriptor,
   confirmationDescriptor,
   controlRequirementDescriptor,
+  repoScopedDescriptor,
 ]);
 
 const handlers: Partial<
@@ -154,6 +164,167 @@ describe('Command Center read-only executor', () => {
       },
     });
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('derives actor credential scope from session and repo command args', () => {
+    const sessionEntry = catalog.byCommandId.get('sessions.rename');
+    const repoEntry = catalog.byCommandId.get('pr-overseer.register');
+    if (!sessionEntry || !repoEntry)
+      throw new Error('expected catalog entries');
+
+    expect(
+      commandCenterActorCredentialScopeFor(sessionEntry, {
+        id: 'session-1',
+        globalSessionId: 'global-session-1',
+      })
+    ).toEqual({
+      sessionIds: ['session-1'],
+      globalSessionIds: ['global-session-1'],
+    });
+    expect(
+      commandCenterActorCredentialScopeFor(repoEntry, { repoId: 'repo-1' })
+    ).toEqual({ repoIds: ['repo-1'] });
+  });
+
+  it('validates actor credential scope before minting confirmation previews', async () => {
+    const handler = vi.fn(handlers['sessions.rename']);
+    const store = {
+      create: vi.fn(() => {
+        throw new Error('challenge should not be minted');
+      }),
+      consume: vi.fn(),
+    };
+    const validateActorScope = vi.fn(() => ({
+      ok: false as const,
+      reason: 'wrong_session_scope' as const,
+      credentialId: 'cred-wrong-session',
+    }));
+
+    const result = await executeCommandCenterCommand(
+      {
+        commandId: 'sessions.rename',
+        args: { id: 'session-2', displayName: 'new name' },
+      },
+      {
+        catalog,
+        handlers: { ...handlers, 'sessions.rename': handler },
+        confirmationStore: store,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          actorId: 'actor-1',
+          capabilities: ['session:read'],
+        },
+        validateActorScope,
+      }
+    );
+
+    expect(result).toMatchObject({
+      kind: 'blocked',
+      reason: 'actor-scope-denied',
+      audit: {
+        policyOutcome: 'blocked',
+        confirmationOutcome: 'blocked',
+        reason: 'actor-scope-wrong_session_scope',
+      },
+    });
+    expect(validateActorScope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredCapabilities: ['session:read'],
+        requestedScope: { sessionIds: ['session-2'] },
+      })
+    );
+    expect(store.create).not.toHaveBeenCalled();
+    expect(store.consume).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('validates actor credential scope before redeeming confirmations', async () => {
+    const handler = vi.fn(handlers['sessions.rename']);
+    const store = createCommandCenterConfirmationStore();
+    const first = await executeCommandCenterCommand(
+      {
+        commandId: 'sessions.rename',
+        args: { id: 'session-1', displayName: 'new name' },
+      },
+      {
+        catalog,
+        handlers: { ...handlers, 'sessions.rename': handler },
+        confirmationStore: store,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          actorId: 'actor-1',
+          capabilities: ['session:read'],
+        },
+        validateActorScope: () => ({ ok: true }),
+        now: () => 10,
+      }
+    );
+    if (first.kind !== 'confirmation_required')
+      throw new Error('expected preview');
+
+    const consume = vi.spyOn(store, 'consume');
+    const second = await executeCommandCenterCommand(
+      {
+        commandId: 'sessions.rename',
+        args: { id: 'session-1', displayName: 'new name' },
+        confirmation: {
+          challengeId: first.preview.challengeId,
+          decision: 'confirm',
+        },
+      },
+      {
+        catalog,
+        handlers: { ...handlers, 'sessions.rename': handler },
+        confirmationStore: store,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          actorId: 'actor-2',
+          capabilities: ['session:read'],
+        },
+        validateActorScope: () => ({
+          ok: false,
+          reason: 'wrong_session_scope',
+        }),
+        now: () => 11,
+      }
+    );
+
+    expect(second).toMatchObject({
+      kind: 'blocked',
+      reason: 'actor-scope-denied',
+      audit: { reason: 'actor-scope-wrong_session_scope' },
+    });
+    expect(consume).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('validates repo-style actor credential scope before confirmation minting', async () => {
+    const result = await executeCommandCenterCommand(
+      {
+        commandId: 'pr-overseer.register',
+        args: { repoId: 'repo-denied' },
+      },
+      {
+        catalog,
+        handlers,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          actorId: 'actor-1',
+          capabilities: ['context:write'],
+        },
+        validateActorScope: vi.fn((input) =>
+          input.requestedScope?.repoIds?.includes('repo-allowed')
+            ? ({ ok: true } as const)
+            : ({ ok: false, reason: 'wrong_repo_scope' } as const)
+        ),
+      }
+    );
+
+    expect(result).toMatchObject({
+      kind: 'blocked',
+      reason: 'actor-scope-denied',
+      audit: { reason: 'actor-scope-wrong_repo_scope' },
+    });
   });
 
   it('requires redacted confirmation preview before write/destructive commands', async () => {

--- a/test/command-center-executor.test.ts
+++ b/test/command-center-executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  createCommandCenterConfirmationStore,
   executeCommandCenterCommand,
   type CommandCenterReadOnlyHandler,
 } from '../server/command-center-executor.js';
@@ -58,12 +59,23 @@ const confirmationDescriptor = descriptorFor('sessions.kill', 'destructive', {
     controlRequirements: ['confirmation-challenge'],
   },
 });
+const controlRequirementDescriptor = descriptorFor(
+  'supervisor.sendText',
+  'write',
+  {
+    confirmation: {
+      required: false,
+      controlRequirements: ['fresh-control-state'],
+    },
+  }
+);
 
 const catalog = buildCommandCenterResolverCatalog([
   sessionsListDescriptor,
   nodesListDescriptor,
   writeDescriptor,
   confirmationDescriptor,
+  controlRequirementDescriptor,
 ]);
 
 const handlers: Partial<
@@ -72,6 +84,14 @@ const handlers: Partial<
   'sessions.list': (args) => ({
     ok: true,
     data: { sessions: [{ id: 's1', repoId: args['repoId'] }] },
+  }),
+  'sessions.rename': () => ({
+    ok: true,
+    data: { renamed: true },
+  }),
+  'supervisor.sendText': () => ({
+    ok: true,
+    data: { sent: true },
   }),
 };
 
@@ -136,26 +156,96 @@ describe('Command Center read-only executor', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('blocks write/destructive command ids instead of executing', async () => {
-    await expect(
-      executeCommandCenterCommand(
-        { commandId: 'sessions.rename', args: { repoId: 'repo-1' } },
-        { catalog, handlers }
-      )
-    ).resolves.toMatchObject({
-      kind: 'blocked',
-      reason: 'unsafe-command',
-      audit: { sideEffectClass: 'write', policyOutcome: 'blocked' },
+  it('requires redacted confirmation preview before write/destructive commands', async () => {
+    const store = createCommandCenterConfirmationStore();
+    const handler = vi.fn(handlers['sessions.rename']);
+    const first = await executeCommandCenterCommand(
+      { commandId: 'sessions.rename', args: { repoId: 'secret-repo-name' } },
+      {
+        catalog,
+        handlers: { ...handlers, 'sessions.rename': handler },
+        confirmationStore: store,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          actorId: 'actor-1',
+          capabilities: ['session:read'],
+        },
+        now: () => 100,
+      }
+    );
+    expect(first.kind).toBe('confirmation_required');
+    if (first.kind !== 'confirmation_required')
+      throw new Error('expected preview');
+    expect(first.preview).toMatchObject({
+      commandId: 'sessions.rename',
+      label: 'sessions.rename',
+      scopedTarget: 'session:unspecified',
+      sideEffectClass: 'write',
+      args: { rawArgsReturned: false, argKeys: ['repoId'] },
+      expectedResultShape: { kind: 'json-schema' },
     });
+    expect(JSON.stringify(first)).not.toContain('secret-repo-name');
+    expect(handler).not.toHaveBeenCalled();
+
+    const confirmed = await executeCommandCenterCommand(
+      {
+        commandId: 'sessions.rename',
+        args: { repoId: 'secret-repo-name' },
+        confirmation: {
+          challengeId: first.preview.challengeId,
+          decision: 'confirm',
+        },
+        providerMetadata: {
+          source: 'resolver',
+          model: 'resolver-small',
+          rawPayload: { prompt: 'do not store me' },
+        },
+      },
+      {
+        catalog,
+        handlers: { ...handlers, 'sessions.rename': handler },
+        confirmationStore: store,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          actorId: 'actor-1',
+          capabilities: ['session:read'],
+        },
+        now: () => 101,
+      }
+    );
+    expect(confirmed).toMatchObject({
+      kind: 'success',
+      commandId: 'sessions.rename',
+      audit: {
+        policyOutcome: 'allowed',
+        confirmationOutcome: 'confirmed',
+        actor: { kind: 'actor-grant', id: 'actor-1' },
+        provider: {
+          rawProviderPayloadReturned: false,
+          source: 'resolver',
+          model: 'resolver-small',
+          metadataKeys: ['model', 'source'],
+        },
+      },
+    });
+    expect(JSON.stringify(confirmed)).not.toContain('do not store me');
+    expect(handler).toHaveBeenCalledTimes(1);
 
     await expect(
       executeCommandCenterCommand(
         { commandId: 'sessions.kill', args: { repoId: 'repo-1' } },
-        { catalog, handlers }
+        {
+          catalog,
+          handlers,
+          trustedCapabilities: {
+            source: 'actor-grant',
+            capabilities: ['session:read'],
+          },
+        }
       )
     ).resolves.toMatchObject({
       kind: 'confirmation_required',
-      reason: 'confirmation-required',
+      reason: 'control-requirement',
       audit: {
         sideEffectClass: 'destructive',
         policyOutcome: 'confirmation-required',
@@ -179,6 +269,153 @@ describe('Command Center read-only executor', () => {
         availabilityState: 'unavailable',
       },
     });
+  });
+
+  it('caps retained confirmation challenges and evicts the oldest preview', () => {
+    const store = createCommandCenterConfirmationStore();
+    const nowMs = Date.now();
+    const records = Array.from({ length: 513 }, (_, index) =>
+      store.create({
+        commandId: 'sessions.rename',
+        argsSha256: `args-${index}`,
+        expiresAtMs: nowMs + 60_000,
+      })
+    );
+
+    expect(
+      store.consume({
+        challengeId: records[0]!.challengeId,
+        commandId: 'sessions.rename',
+        argsSha256: 'args-0',
+        nowMs,
+      })
+    ).toEqual({ ok: false, reason: 'missing' });
+    expect(
+      store.consume({
+        challengeId: records[512]!.challengeId,
+        commandId: 'sessions.rename',
+        argsSha256: 'args-512',
+        nowMs,
+      })
+    ).toMatchObject({ ok: true });
+  });
+
+  it('records confirmation deny and stale decisions without executing handlers', async () => {
+    const deniedStore = createCommandCenterConfirmationStore();
+    const deniedHandler = vi.fn(handlers['sessions.rename']);
+    const deniedPreview = await executeCommandCenterCommand(
+      { commandId: 'sessions.rename', args: { repoId: 'repo-1' } },
+      {
+        catalog,
+        handlers: { ...handlers, 'sessions.rename': deniedHandler },
+        confirmationStore: deniedStore,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          capabilities: ['session:read'],
+        },
+        now: () => 1,
+      }
+    );
+    if (deniedPreview.kind !== 'confirmation_required')
+      throw new Error('expected preview');
+    await expect(
+      executeCommandCenterCommand(
+        {
+          commandId: 'sessions.rename',
+          args: { repoId: 'repo-1' },
+          confirmation: {
+            challengeId: deniedPreview.preview.challengeId,
+            decision: 'deny',
+          },
+        },
+        {
+          catalog,
+          handlers: { ...handlers, 'sessions.rename': deniedHandler },
+          confirmationStore: deniedStore,
+          trustedCapabilities: {
+            source: 'actor-grant',
+            capabilities: ['session:read'],
+          },
+          now: () => 2,
+        }
+      )
+    ).resolves.toMatchObject({
+      kind: 'blocked',
+      reason: 'confirmation-denied',
+      audit: { confirmationOutcome: 'denied' },
+    });
+    expect(deniedHandler).not.toHaveBeenCalled();
+
+    const staleStore = createCommandCenterConfirmationStore();
+    const stalePreview = await executeCommandCenterCommand(
+      { commandId: 'sessions.rename', args: { repoId: 'repo-1' } },
+      {
+        catalog,
+        handlers,
+        confirmationStore: staleStore,
+        trustedCapabilities: {
+          source: 'actor-grant',
+          capabilities: ['session:read'],
+        },
+        now: () => 1,
+      }
+    );
+    if (stalePreview.kind !== 'confirmation_required')
+      throw new Error('expected preview');
+    await expect(
+      executeCommandCenterCommand(
+        {
+          commandId: 'sessions.rename',
+          args: { repoId: 'repo-1' },
+          confirmation: {
+            challengeId: stalePreview.preview.challengeId,
+            decision: 'confirm',
+          },
+        },
+        {
+          catalog,
+          handlers,
+          confirmationStore: staleStore,
+          trustedCapabilities: {
+            source: 'actor-grant',
+            capabilities: ['session:read'],
+          },
+          now: () => 120_002,
+        }
+      )
+    ).resolves.toMatchObject({
+      kind: 'blocked',
+      reason: 'confirmation-stale',
+      audit: { confirmationOutcome: 'stale' },
+    });
+  });
+
+  it('blocks non-confirmation control requirements before creating a confirmation challenge', async () => {
+    const handler = vi.fn(handlers['supervisor.sendText']);
+    const result = await executeCommandCenterCommand(
+      { commandId: 'supervisor.sendText', args: { repoId: 'repo-1' } },
+      {
+        catalog,
+        handlers: { ...handlers, 'supervisor.sendText': handler },
+        confirmationStore: createCommandCenterConfirmationStore(),
+        trustedCapabilities: {
+          source: 'actor-grant',
+          capabilities: ['session:read'],
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      kind: 'blocked',
+      reason: 'control-requirement-unsatisfied',
+      message: expect.stringContaining('fresh-control-state'),
+      audit: {
+        policyOutcome: 'blocked',
+        confirmationOutcome: 'blocked',
+        reason: 'control-requirement-unsatisfied',
+      },
+    });
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it('fails closed for unknown ids and missing explicit capabilities', async () => {

--- a/test/command-center-executor.test.ts
+++ b/test/command-center-executor.test.ts
@@ -58,7 +58,12 @@ const sessionsListDescriptor = descriptorFor('sessions.list');
 const nodesListDescriptor = descriptorFor('nodes.list', 'read', {
   availability: { state: 'unavailable', reason: 'node offline' },
 });
-const writeDescriptor = descriptorFor('sessions.rename', 'write');
+const writeDescriptor = descriptorFor('sessions.rename', 'write', {
+  availability: {
+    state: 'available',
+    capabilityHints: ['session:control:rename'],
+  },
+});
 const confirmationDescriptor = descriptorFor('sessions.kill', 'destructive', {
   confirmation: {
     required: true,
@@ -212,7 +217,7 @@ describe('Command Center read-only executor', () => {
         trustedCapabilities: {
           source: 'actor-grant',
           actorId: 'actor-1',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         validateActorScope,
       }
@@ -229,7 +234,7 @@ describe('Command Center read-only executor', () => {
     });
     expect(validateActorScope).toHaveBeenCalledWith(
       expect.objectContaining({
-        requiredCapabilities: ['session:read'],
+        requiredCapabilities: ['session:control:rename'],
         requestedScope: { sessionIds: ['session-2'] },
       })
     );
@@ -253,7 +258,7 @@ describe('Command Center read-only executor', () => {
         trustedCapabilities: {
           source: 'actor-grant',
           actorId: 'actor-1',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         validateActorScope: () => ({ ok: true }),
         now: () => 10,
@@ -279,7 +284,7 @@ describe('Command Center read-only executor', () => {
         trustedCapabilities: {
           source: 'actor-grant',
           actorId: 'actor-2',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         validateActorScope: () => ({
           ok: false,
@@ -339,7 +344,7 @@ describe('Command Center read-only executor', () => {
         trustedCapabilities: {
           source: 'actor-grant',
           actorId: 'actor-1',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         now: () => 100,
       }
@@ -379,7 +384,7 @@ describe('Command Center read-only executor', () => {
         trustedCapabilities: {
           source: 'actor-grant',
           actorId: 'actor-1',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         now: () => 101,
       }
@@ -482,7 +487,7 @@ describe('Command Center read-only executor', () => {
         confirmationStore: deniedStore,
         trustedCapabilities: {
           source: 'actor-grant',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         now: () => 1,
       }
@@ -505,7 +510,7 @@ describe('Command Center read-only executor', () => {
           confirmationStore: deniedStore,
           trustedCapabilities: {
             source: 'actor-grant',
-            capabilities: ['session:read'],
+            capabilities: ['session:control:rename'],
           },
           now: () => 2,
         }
@@ -526,7 +531,7 @@ describe('Command Center read-only executor', () => {
         confirmationStore: staleStore,
         trustedCapabilities: {
           source: 'actor-grant',
-          capabilities: ['session:read'],
+          capabilities: ['session:control:rename'],
         },
         now: () => 1,
       }
@@ -549,7 +554,7 @@ describe('Command Center read-only executor', () => {
           confirmationStore: staleStore,
           trustedCapabilities: {
             source: 'actor-grant',
-            capabilities: ['session:read'],
+            capabilities: ['session:control:rename'],
           },
           now: () => 120_002,
         }

--- a/test/command-center-resolver.test.ts
+++ b/test/command-center-resolver.test.ts
@@ -167,6 +167,7 @@ describe('Command Center resolver catalog', () => {
         surfaces: ['web', 'command-center'],
         availability: { state: 'available' },
         inputSchema: inputSchemaFor(sessionsListDescriptor),
+        outputSchema: { type: 'object' },
       },
     ]);
   });
@@ -343,7 +344,7 @@ describe('Command Center provider intent validation', () => {
         },
         { catalog: unsafeCatalog }
       )
-    ).toMatchObject({ kind: 'no_match', reason: 'unsafe-command' });
+    ).toMatchObject({ kind: 'ask_followup' });
     expect(
       validateCommandCenterProviderIntent(
         {
@@ -354,7 +355,7 @@ describe('Command Center provider intent validation', () => {
         },
         { catalog: unsafeCatalog }
       )
-    ).toMatchObject({ kind: 'no_match', reason: 'unsafe-command' });
+    ).toMatchObject({ kind: 'ask_followup' });
     expect(
       validateCommandCenterProviderIntent(
         {
@@ -365,7 +366,7 @@ describe('Command Center provider intent validation', () => {
         },
         { catalog: unsafeCatalog }
       )
-    ).toMatchObject({ kind: 'no_match', reason: 'unsafe-command' });
+    ).toMatchObject({ kind: 'ask_followup' });
   });
 
   it('rejects explain answers that invent unsupported commands, actions, or citations', () => {

--- a/test/fixtures/command-center-resolver/golden-cases.ts
+++ b/test/fixtures/command-center-resolver/golden-cases.ts
@@ -136,7 +136,11 @@ export const COMMAND_CENTER_RESOLVER_GOLDEN_CASES: readonly CommandCenterResolve
         sideEffect: 'write',
         requiresConfirmation: false,
       },
-      expected: { kind: 'no_match', reason: 'unsafe-command' },
+      expected: {
+        kind: 'ask_followup',
+        commandId: 'sessions.rename',
+        questionIncludes: 'confirmation preview',
+      },
     },
     {
       id: 'policy-blocked-destructive-proposal',
@@ -149,7 +153,11 @@ export const COMMAND_CENTER_RESOLVER_GOLDEN_CASES: readonly CommandCenterResolve
         sideEffect: 'destructive',
         requiresConfirmation: true,
       },
-      expected: { kind: 'no_match', reason: 'unsafe-command' },
+      expected: {
+        kind: 'ask_followup',
+        commandId: 'sessions.kill',
+        questionIncludes: 'confirmation preview',
+      },
     },
     {
       id: 'policy-blocked-provider-escalation',


### PR DESCRIPTION
## Summary
- add bounded confirmation challenges for write/destructive Command Center execution
- return safe redacted previews before side effects and require matching approve/deny decisions
- ignore client-supplied provider audit metadata at the execute route and keep provider audit bounded/redacted
- fail closed on unsupported non-confirmation control requirements before creating confirmation tokens

Closes #1011

## Verification
- `npm test -- test/node-command-center-actions.test.ts test/command-center-executor.test.ts test/command-center-resolver.test.ts test/command-center-intent-resolver.test.ts test/command-center-assistant-shell.test.ts` — 5 files / 50 tests passed
- `npm test -- test/command-center-executor.test.ts test/command-center-resolver.test.ts test/command-center-assistant-shell.test.ts test/cli-gateway-contract.test.ts` — 4 files / 57 tests passed
- `npm run check` — passed; repo has existing lint warnings, 0 errors
- `npm run build` — passed; existing Vite chunk-size/CodeMirror warnings only

## Simplify
- tier 4/high-risk control-gate surface; ran three focused simplify reviewers on the final remediation diff (`deleg_565e3b8a`). No local cleanup applied before PR beyond moving unsupported non-confirmation control blocking before challenge creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a confirmation flow for sensitive command operations, prompting users to confirm decisions before execution.
  * Confirmation previews now include richer impact details (including command and expected-result context).

* **Improvements**
  * Enhanced execution audits with stronger metadata while redacting sensitive argument content.
  * Updated resolver behavior for restricted/unsafe intents to return a follow-up prompting users to review the confirmation preview.

* **Tests**
  * Expanded coverage for confirmation decision outcomes, preview gating, and control requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->