### PR TITLE
feat(frontend): add flag-gated topic sidebar shell

### DIFF
--- a/frontend/dev-server.ts
+++ b/frontend/dev-server.ts
@@ -15,6 +15,8 @@ export const backendProxyPaths = [
   '/branches',
   '/worktrees',
   '/workspaces',
+  '/workspace-surfaces',
+  '/workspace-topics',
   '/workspace-groups',
   '/git',
   '/gh',

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
 import WorkspaceGroup from './WorkspaceGroup.js';
 import RepoItem from './RepoItem.js';
 import { SessionHistoryPanel } from './SessionHistoryPanel.js';
+import { TopicSidebarShell } from './TopicSidebarShell.js';
 import { ViewSpineTree } from './ViewSpineTree.js';
 import type { BenchCreatePayload } from '../lib/state/view-tree.js';
 import { TuiButton } from './TuiButton.js';
@@ -490,6 +491,7 @@ export function Sidebar({
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const analyticsView = useUiStore((s) => s.analyticsView);
   const viewSpineEnabled = useUiStore((s) => s.viewSpineEnabled);
+  const topicShellEnabled = useUiStore((s) => s.topicShellEnabled);
   const closeSidebar = useUiStore((s) => s.closeSidebar);
   const toggleSidebarCollapsed = useUiStore((s) => s.toggleSidebarCollapsed);
   const repos = useSessionsStore((s) => s.repos);
@@ -628,6 +630,12 @@ export function Sidebar({
               repoName={historyRepo.name}
               onBack={handleCloseHistory}
             />
+          ) : topicShellEnabled ? (
+            // #1023: flag-gated thin-line WorkspaceTopic shell. Default OFF so
+            // the legacy sidebar and #732 view-spine rollout remain untouched.
+            <div className="sidebar-workspace-list">
+              <TopicSidebarShell onSelectSession={onSelectSession} />
+            </div>
           ) : viewSpineEnabled ? (
             // #732/#729: flag-gated, read-only, client-derived view-spine tree.
             // OFF path below is byte-identical to today.

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -630,20 +630,20 @@ export function Sidebar({
               repoName={historyRepo.name}
               onBack={handleCloseHistory}
             />
-          ) : topicShellEnabled ? (
-            // #1023: flag-gated thin-line WorkspaceTopic shell. Default OFF so
-            // the legacy sidebar and #732 view-spine rollout remain untouched.
-            <div className="sidebar-workspace-list">
-              <TopicSidebarShell onSelectSession={onSelectSession} />
-            </div>
           ) : viewSpineEnabled ? (
             // #732/#729: flag-gated, read-only, client-derived view-spine tree.
-            // OFF path below is byte-identical to today.
+            // Keep this rollout reachable even when the topic shell experiment is on.
             <div className="sidebar-workspace-list">
               <ViewSpineTree
                 onCreateTab={onViewSpineCreateTab}
                 onSelectTab={onSelectSession}
               />
+            </div>
+          ) : topicShellEnabled ? (
+            // #1023: flag-gated thin-line WorkspaceTopic shell. Default OFF so
+            // the legacy sidebar remains untouched until topic parity lands.
+            <div className="sidebar-workspace-list">
+              <TopicSidebarShell onSelectSession={onSelectSession} />
             </div>
           ) : (
             <div className="sidebar-workspace-list">

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1,0 +1,302 @@
+.topic-shell {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  font-family: var(--font-mono);
+}
+
+.topic-shell__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 32px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.topic-shell__derived {
+  color: var(--status-info);
+}
+
+.topic-tree,
+.topic-child-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.topic-node {
+  margin: 0;
+  padding: 0;
+}
+
+.topic-row {
+  display: grid;
+  grid-template-columns: 14px 22px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 32px;
+  padding: 4px 8px;
+  border: 0;
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  text-align: left;
+  cursor: pointer;
+}
+
+.topic-row:hover,
+.topic-row:focus-visible,
+.topic-row.selected {
+  background: var(--surface-hover);
+  color: var(--text);
+  outline: none;
+}
+
+.topic-row.selected {
+  border-left-color: var(--accent);
+}
+
+.topic-row--active:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-success) 60%, transparent);
+}
+
+.topic-row--attention:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-warning) 70%, transparent);
+}
+
+.topic-row--error:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-error) 70%, transparent);
+}
+
+.topic-row.muted {
+  opacity: 0.65;
+}
+
+.topic-row__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.topic-row__chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.topic-row__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 20px;
+  border-radius: 2px;
+  color: #000;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.topic-row__title {
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.topic-row__trail {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  min-width: 0;
+  max-width: 112px;
+}
+
+.topic-status {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border: 1px solid var(--text-muted);
+  border-radius: 50%;
+}
+
+.topic-status--active {
+  border-color: var(--status-success);
+  background: var(--status-success);
+}
+
+.topic-status--attention {
+  border-color: var(--status-warning);
+  background: var(--status-warning);
+}
+
+.topic-status--error {
+  border-color: var(--status-error);
+  background: var(--status-error);
+}
+
+.topic-status--idle {
+  border-color: var(--status-info);
+}
+
+.topic-status--empty {
+  opacity: 0.5;
+}
+
+.topic-chip,
+.topic-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  max-width: 42px;
+  height: 18px;
+  padding: 0 4px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.58rem;
+  line-height: 1;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-action:not(:disabled) {
+  cursor: pointer;
+}
+
+.topic-action:not(:disabled):hover,
+.topic-action:not(:disabled):focus-visible {
+  border-color: var(--accent);
+  color: var(--text);
+  outline: none;
+}
+
+.topic-action--reachable,
+.topic-action--configured {
+  border-color: color-mix(in srgb, var(--status-success) 45%, transparent);
+}
+
+.topic-action--unreachable {
+  border-color: color-mix(in srgb, var(--status-error) 55%, transparent);
+  color: var(--status-error);
+}
+
+.topic-detail {
+  margin: 0 8px 4px 44px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+}
+
+.topic-detail__title {
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.topic-detail__description {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+}
+
+.topic-detail__description.muted {
+  opacity: 0.65;
+}
+
+.topic-detail__meta,
+.topic-detail__surfaces {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.topic-detail__meta > span {
+  border: 1px solid var(--border);
+  padding: 2px 4px;
+}
+
+.topic-child-row__button {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 30px;
+  padding: 3px 8px 3px 52px;
+  border: 0;
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  text-align: left;
+  cursor: pointer;
+}
+
+.topic-child-row__button:hover,
+.topic-child-row__button:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text);
+  outline: none;
+}
+
+.topic-child-row--active .topic-child-row__button {
+  border-left-color: color-mix(in srgb, var(--status-success) 55%, transparent);
+}
+
+.topic-child-row--attention .topic-child-row__button {
+  border-left-color: color-mix(in srgb, var(--status-warning) 65%, transparent);
+}
+
+.topic-child-row--error .topic-child-row__button {
+  border-left-color: color-mix(in srgb, var(--status-error) 65%, transparent);
+}
+
+.topic-child-row__label {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.topic-child-row__meta {
+  max-width: 72px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-shell-state {
+  padding: 16px 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-align: center;
+}
+
+.topic-shell-state.error {
+  color: var(--status-error);
+}

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1,4 +1,11 @@
 .topic-shell {
+  --topic-row-indent: calc(8px + (var(--topic-depth, 0) * 18px));
+  --topic-badge-size: 22px;
+  --topic-badge-center: calc(
+    var(--topic-row-indent) + (var(--topic-badge-size) / 2)
+  );
+  --topic-child-pad: calc(var(--topic-row-indent) + 36px);
+  --topic-connector: color-mix(in srgb, var(--text-muted) 55%, transparent);
   display: flex;
   min-height: 0;
   flex-direction: column;
@@ -10,7 +17,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  min-height: 32px;
+  min-height: 30px;
   padding: 5px 10px;
   border-bottom: 1px solid var(--border);
   color: var(--text-muted);
@@ -30,25 +37,25 @@
 }
 
 .topic-node {
+  position: relative;
   margin: 0;
   padding: 0;
 }
 
 .topic-row {
   display: grid;
-  grid-template-columns: 14px 22px minmax(0, 1fr) auto;
+  grid-template-columns: var(--topic-badge-size) minmax(0, 1fr) auto 18px;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   width: 100%;
-  min-height: 32px;
-  padding: 4px 8px;
+  min-height: 30px;
+  padding: 3px 8px 3px var(--topic-row-indent);
   border: 0;
-  border-left: 2px solid transparent;
   border-radius: 0;
   background: transparent;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: var(--font-size-xs);
+  font-size: 0.72rem;
   text-align: left;
   cursor: pointer;
 }
@@ -61,97 +68,133 @@
   outline: none;
 }
 
-.topic-row.selected {
-  border-left-color: var(--accent);
+.topic-row.selected,
+.topic-row--idle:not(.selected) {
+  background: color-mix(in srgb, var(--surface-hover) 62%, transparent);
 }
 
-.topic-row--active:not(.selected) {
-  border-left-color: color-mix(in srgb, var(--status-success) 60%, transparent);
-}
-
-.topic-row--attention:not(.selected) {
-  border-left-color: color-mix(in srgb, var(--status-warning) 70%, transparent);
-}
-
+.topic-row--attention:not(.selected),
 .topic-row--error:not(.selected) {
-  border-left-color: color-mix(in srgb, var(--status-error) 70%, transparent);
+  color: var(--text);
 }
 
 .topic-row.muted {
-  opacity: 0.65;
-}
-
-.topic-row__chevron {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  font-size: 0.7rem;
-  line-height: 1;
-}
-
-.topic-row__chevron.collapsed {
-  transform: rotate(-90deg);
+  opacity: 0.68;
 }
 
 .topic-row__badge {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 20px;
+  justify-content: flex-end;
+  width: var(--topic-badge-size);
+  height: var(--topic-badge-size);
+  padding-right: 2px;
   border-radius: 2px;
-  color: #000;
-  font-size: 0.62rem;
-  font-weight: 700;
+  color: #050505;
   line-height: 1;
+  opacity: 0.9;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.22);
+}
+
+.topic-row__badge svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  stroke-width: 1.8;
 }
 
 .topic-row__title {
   min-width: 0;
   overflow: hidden;
   color: inherit;
+  font-weight: 560;
   white-space: nowrap;
+}
+
+.topic-row.selected .topic-row__title,
+.topic-row--attention .topic-row__title,
+.topic-row--error .topic-row__title {
+  font-weight: 700;
 }
 
 .topic-row__trail {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 4px;
+  gap: 6px;
   min-width: 0;
-  max-width: 112px;
+}
+
+.topic-row__hover-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.08s ease;
+}
+
+.topic-row:hover .topic-row__hover-actions,
+.topic-row:focus-visible .topic-row__hover-actions,
+.topic-row:focus-within .topic-row__hover-actions {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .topic-status {
-  width: 7px;
-  height: 7px;
-  flex: 0 0 auto;
-  border: 1px solid var(--text-muted);
-  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  color: transparent;
 }
 
 .topic-status--active {
-  border-color: var(--status-success);
-  background: var(--status-success);
+  color: color-mix(in srgb, var(--text-muted) 82%, var(--text));
 }
 
 .topic-status--attention {
-  border-color: var(--status-warning);
-  background: var(--status-warning);
+  color: var(--status-warning);
 }
 
 .topic-status--error {
-  border-color: var(--status-error);
-  background: var(--status-error);
+  color: var(--status-error);
 }
 
-.topic-status--idle {
-  border-color: var(--status-info);
-}
-
+.topic-status--idle,
 .topic-status--empty {
-  opacity: 0.5;
+  color: transparent;
+}
+
+.topic-status svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  stroke-width: 1.8;
+}
+
+.topic-status__spinner {
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid color-mix(in srgb, var(--text-muted) 42%, transparent);
+  border-top-color: color-mix(in srgb, var(--text-muted) 88%, var(--text));
+  border-radius: 50%;
+  animation: topic-status-spin 0.85s linear infinite;
+}
+
+@keyframes topic-status-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .topic-chip,
@@ -187,18 +230,13 @@
   outline: none;
 }
 
-.topic-action--reachable,
-.topic-action--configured {
-  border-color: color-mix(in srgb, var(--status-success) 45%, transparent);
-}
-
 .topic-action--unreachable {
   border-color: color-mix(in srgb, var(--status-error) 55%, transparent);
   color: var(--status-error);
 }
 
 .topic-detail {
-  margin: 0 8px 4px 44px;
+  margin: 8px;
   padding: 8px;
   border: 1px solid var(--border);
   background: transparent;
@@ -236,21 +274,67 @@
   padding: 2px 4px;
 }
 
+.topic-child-list {
+  position: relative;
+  padding: 2px 0 3px var(--topic-child-pad);
+}
+
+.topic-node.expanded > .topic-child-list::before,
+.topic-node.expanded > :not(.topic-child-list) + .topic-child-list::before {
+  content: '';
+  position: absolute;
+  top: -3px;
+  bottom: 15px;
+  left: var(--topic-badge-center);
+  width: 0;
+  border-left: 2px solid var(--topic-connector);
+  pointer-events: none;
+}
+
+.topic-child-row {
+  position: relative;
+}
+
+.topic-child-row::before,
+.topic-child-list--topics > .topic-node::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  left: calc(var(--topic-badge-center) - var(--topic-child-pad));
+  width: 16px;
+  height: 17px;
+  border-left: 2px solid var(--topic-connector);
+  border-bottom: 2px solid var(--topic-connector);
+  border-bottom-left-radius: 7px;
+  pointer-events: none;
+}
+
+.topic-child-row:last-child::after,
+.topic-child-list--topics > .topic-node:last-child::after {
+  content: '';
+  position: absolute;
+  top: 13px;
+  bottom: -5px;
+  left: calc(var(--topic-badge-center) - var(--topic-child-pad) - 1px);
+  width: 4px;
+  background: var(--bg);
+  pointer-events: none;
+}
+
 .topic-child-row__button {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto auto 18px;
   align-items: center;
   gap: 6px;
   width: 100%;
-  min-height: 30px;
-  padding: 3px 8px 3px 52px;
+  min-height: 28px;
+  padding: 3px 8px 3px 2px;
   border: 0;
-  border-left: 2px solid transparent;
   border-radius: 0;
   background: transparent;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: var(--font-size-xs);
+  font-size: 0.72rem;
   text-align: left;
   cursor: pointer;
 }
@@ -262,16 +346,13 @@
   outline: none;
 }
 
-.topic-child-row--active .topic-child-row__button {
-  border-left-color: color-mix(in srgb, var(--status-success) 55%, transparent);
+.topic-child-row--idle .topic-child-row__button {
+  background: color-mix(in srgb, var(--surface-hover) 44%, transparent);
 }
 
-.topic-child-row--attention .topic-child-row__button {
-  border-left-color: color-mix(in srgb, var(--status-warning) 65%, transparent);
-}
-
+.topic-child-row--attention .topic-child-row__button,
 .topic-child-row--error .topic-child-row__button {
-  border-left-color: color-mix(in srgb, var(--status-error) 65%, transparent);
+  color: var(--text);
 }
 
 .topic-child-row__label {
@@ -280,13 +361,25 @@
   white-space: nowrap;
 }
 
+.topic-child-row--attention .topic-child-row__label,
+.topic-child-row--error .topic-child-row__label {
+  font-weight: 700;
+}
+
 .topic-child-row__meta {
   max-width: 72px;
   overflow: hidden;
   color: var(--text-muted);
   font-size: 0.58rem;
+  opacity: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: opacity 0.08s ease;
+}
+
+.topic-child-row__button:hover .topic-child-row__meta,
+.topic-child-row__button:focus-visible .topic-child-row__meta {
+  opacity: 1;
 }
 
 .topic-shell-state {

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -44,7 +44,7 @@
 
 .topic-row {
   display: grid;
-  grid-template-columns: var(--topic-badge-size) minmax(0, 1fr) auto 18px;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
   align-items: center;
   gap: 7px;
   width: 100%;
@@ -57,14 +57,34 @@
   font-family: inherit;
   font-size: 0.72rem;
   text-align: left;
-  cursor: pointer;
 }
 
 .topic-row:hover,
-.topic-row:focus-visible,
+.topic-row:focus-within,
 .topic-row.selected {
   background: var(--surface-hover);
   color: var(--text);
+  outline: none;
+}
+
+.topic-row__main {
+  display: grid;
+  grid-template-columns: var(--topic-badge-size) minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  height: 100%;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.topic-row__main:focus-visible {
   outline: none;
 }
 
@@ -85,15 +105,14 @@
 .topic-row__badge {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   width: var(--topic-badge-size);
   height: var(--topic-badge-size);
-  padding-right: 2px;
   border-radius: 2px;
-  color: #050505;
+  color: var(--bg);
   line-height: 1;
   opacity: 0.9;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.22);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg) 28%, transparent);
 }
 
 .topic-row__badge svg {
@@ -139,7 +158,6 @@
 }
 
 .topic-row:hover .topic-row__hover-actions,
-.topic-row:focus-visible .topic-row__hover-actions,
 .topic-row:focus-within .topic-row__hover-actions {
   opacity: 1;
   pointer-events: auto;
@@ -183,11 +201,6 @@
 }
 
 .topic-status__spinner {
-  width: 10px;
-  height: 10px;
-  border: 1.5px solid color-mix(in srgb, var(--text-muted) 42%, transparent);
-  border-top-color: color-mix(in srgb, var(--text-muted) 88%, var(--text));
-  border-radius: 50%;
   animation: topic-status-spin 0.85s linear infinite;
 }
 

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
+import { fetchWorkspaceSurfaces, fetchWorkspaceTopics } from '../lib/api.js';
+import { deriveColor } from '../lib/colors.js';
+import type { SessionSummary } from '../lib/types.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import {
+  buildTopicNavModel,
+  type TopicNavItem,
+  type TopicNavModel,
+  type TopicNavSessionRef,
+  type TopicNavSurfaceRef,
+} from '../lib/state/topic-nav.js';
+import { MarqueeText } from './MarqueeText.js';
+import './TopicSidebarShell.css';
+
+function StatusGlyph({ tone }: { tone: TopicNavItem['tone'] }) {
+  return <span className={`topic-status topic-status--${tone}`} aria-hidden />;
+}
+
+function TopicBadge({ item }: { item: TopicNavItem }) {
+  return (
+    <span
+      className="topic-row__badge"
+      style={{ background: deriveColor(item.badgeSeed) }}
+      title={`workspace ${item.badgeText}`}
+    >
+      {item.badgeText}
+    </span>
+  );
+}
+
+function SurfaceButton({ surface }: { surface: TopicNavSurfaceRef }) {
+  const canOpen =
+    surface.openMode === 'direct' && surface.target?.startsWith('http');
+  const label = `${surface.kind}: ${surface.label}`;
+  if (canOpen) {
+    return (
+      <a
+        className={`topic-action topic-action--${surface.health}`}
+        href={surface.target ?? undefined}
+        rel="noreferrer"
+        target="_blank"
+        title={`${label} · ${surface.health}`}
+      >
+        {surface.kind}
+      </a>
+    );
+  }
+  return (
+    <button
+      className={`topic-action topic-action--${surface.health}`}
+      type="button"
+      disabled={!surface.target}
+      title={`${label} · ${surface.openMode}`}
+      onClick={() => {
+        if (surface.target) void navigator.clipboard?.writeText(surface.target);
+      }}
+    >
+      {surface.kind}
+    </button>
+  );
+}
+
+function SessionChildRow({
+  session,
+  onSelectSession,
+}: {
+  session: TopicNavSessionRef;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  return (
+    <li className={`topic-child-row topic-child-row--${session.tone}`}>
+      <button
+        type="button"
+        className="topic-child-row__button"
+        onClick={() => onSelectSession?.(session.selectKey)}
+      >
+        <StatusGlyph tone={session.tone} />
+        <span className="topic-child-row__label">
+          <MarqueeText>{session.label}</MarqueeText>
+        </span>
+        {session.branch ? (
+          <span className="topic-child-row__meta">{session.branch}</span>
+        ) : null}
+        {session.nodeId ? (
+          <span className="topic-child-row__meta">{session.nodeId}</span>
+        ) : null}
+      </button>
+    </li>
+  );
+}
+
+function TopicDetail({ item }: { item: TopicNavItem }) {
+  return (
+    <section className="topic-detail" aria-label={`${item.title} details`}>
+      <div className="topic-detail__title">{item.title}</div>
+      {item.description ? (
+        <p className="topic-detail__description">{item.description}</p>
+      ) : (
+        <p className="topic-detail__description muted">no topic brief yet</p>
+      )}
+      <div className="topic-detail__meta">
+        <span>{item.statusLabel}</span>
+        {item.routingLabel ? <span>{item.routingLabel}</span> : null}
+        {item.taskRefs.length > 0 ? (
+          <span>{item.taskRefs.length} task refs</span>
+        ) : null}
+        {item.surfaces.length > 0 ? (
+          <span>{item.surfaces.length} surfaces</span>
+        ) : null}
+      </div>
+      {item.surfaces.length > 0 ? (
+        <div className="topic-detail__surfaces" aria-label="topic surfaces">
+          {item.surfaces.slice(0, 6).map((surface) => (
+            <SurfaceButton key={surface.id} surface={surface} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function TopicRow({
+  item,
+  depth,
+  model,
+  expandedIds,
+  selectedId,
+  onToggle,
+  onSelect,
+  onSelectSession,
+}: {
+  item: TopicNavItem;
+  depth: number;
+  model: TopicNavModel;
+  expandedIds: Set<string>;
+  selectedId: string | null;
+  onToggle: (id: string) => void;
+  onSelect: (id: string) => void;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const hasNested = item.childIds.length > 0 || item.sessions.length > 0;
+  const expanded = expandedIds.has(item.id);
+  const selected = selectedId === item.id;
+  const affordanceCount =
+    item.sessions.length + item.surfaces.length + item.taskRefs.length;
+
+  const activate = () => {
+    onSelect(item.id);
+    if (hasNested) onToggle(item.id);
+  };
+
+  return (
+    <li className="topic-node">
+      <button
+        type="button"
+        className={[
+          'topic-row',
+          `topic-row--${item.tone}`,
+          selected && 'selected',
+          item.muted && 'muted',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        style={{ paddingLeft: `${8 + depth * 18}px` }}
+        aria-expanded={hasNested ? expanded : undefined}
+        aria-current={selected ? 'page' : undefined}
+        onClick={activate}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowRight' && hasNested && !expanded) {
+            event.preventDefault();
+            onToggle(item.id);
+          } else if (event.key === 'ArrowLeft' && hasNested && expanded) {
+            event.preventDefault();
+            onToggle(item.id);
+          }
+        }}
+      >
+        <span
+          className={['topic-row__chevron', !expanded && 'collapsed']
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {hasNested ? '⌄' : '·'}
+        </span>
+        <TopicBadge item={item} />
+        <span className="topic-row__title">
+          <MarqueeText>{item.title}</MarqueeText>
+        </span>
+        <span
+          className="topic-row__trail"
+          aria-label={`${item.statusLabel}, ${affordanceCount} linked items`}
+        >
+          <StatusGlyph tone={item.tone} />
+          {item.sessions.length > 0 ? (
+            <span className="topic-chip">s{item.sessions.length}</span>
+          ) : null}
+          {item.surfaces.slice(0, 2).map((surface) => (
+            <SurfaceButton key={surface.id} surface={surface} />
+          ))}
+          {item.taskRefs.length > 0 ? (
+            <span className="topic-chip">t{item.taskRefs.length}</span>
+          ) : null}
+        </span>
+      </button>
+      {selected ? <TopicDetail item={item} /> : null}
+      {expanded ? (
+        <>
+          {item.sessions.length > 0 ? (
+            <ul className="topic-child-list">
+              {item.sessions.map((session) => (
+                <SessionChildRow
+                  key={session.id}
+                  session={session}
+                  onSelectSession={onSelectSession}
+                />
+              ))}
+            </ul>
+          ) : null}
+          {item.childIds.length > 0 ? (
+            <ul className="topic-child-list topic-child-list--topics">
+              {item.childIds.map((childId) => {
+                const child = model.byId.get(childId);
+                return child ? (
+                  <TopicRow
+                    key={child.id}
+                    item={child}
+                    depth={depth + 1}
+                    model={model}
+                    expandedIds={expandedIds}
+                    selectedId={selectedId}
+                    onToggle={onToggle}
+                    onSelect={onSelect}
+                    onSelectSession={onSelectSession}
+                  />
+                ) : null;
+              })}
+            </ul>
+          ) : null}
+        </>
+      ) : null}
+    </li>
+  );
+}
+
+export function TopicSidebarView({
+  topics,
+  sessions,
+  surfaces,
+  loading = false,
+  error = false,
+  derived = false,
+  onSelectSession,
+}: {
+  topics: WorkspaceTopic[];
+  sessions: SessionSummary[];
+  surfaces: WorkspaceSurface[];
+  loading?: boolean;
+  error?: boolean;
+  derived?: boolean;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const model = useMemo(
+    () => buildTopicNavModel({ topics, sessions, surfaces, derived }),
+    [topics, sessions, surfaces, derived]
+  );
+  const firstId = model.rootIds[0] ?? model.items[0]?.id ?? null;
+  const [selectedId, setSelectedId] = useState<string | null>(firstId);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(
+    () => new Set(model.rootIds)
+  );
+
+  useEffect(() => {
+    setSelectedId((current) =>
+      current && model.byId.has(current) ? current : firstId
+    );
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      for (const id of model.rootIds) next.add(id);
+      return next;
+    });
+  }, [firstId, model.byId, model.rootIds]);
+
+  const toggle = useCallback((id: string) => {
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const select = useCallback((id: string) => setSelectedId(id), []);
+
+  if (loading) {
+    return <div className="topic-shell-state">loading topic shell…</div>;
+  }
+  if (error) {
+    return (
+      <div className="topic-shell-state error">topic shell unavailable</div>
+    );
+  }
+  if (model.items.length === 0) {
+    return <div className="topic-shell-state">no workspace topics yet</div>;
+  }
+
+  return (
+    <div className="topic-shell" data-track="topic-shell">
+      <div className="topic-shell__header">
+        <span>topics</span>
+        {model.derived ? (
+          <span className="topic-shell__derived">derived</span>
+        ) : null}
+      </div>
+      <ul className="topic-tree" aria-label="workspace topics">
+        {model.rootIds.map((id) => {
+          const item = model.byId.get(id);
+          return item ? (
+            <TopicRow
+              key={item.id}
+              item={item}
+              depth={0}
+              model={model}
+              expandedIds={expandedIds}
+              selectedId={selectedId}
+              onToggle={toggle}
+              onSelect={select}
+              onSelectSession={onSelectSession}
+            />
+          ) : null;
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function TopicSidebarShell({
+  onSelectSession,
+}: {
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const sessions = useSessionsStore((s) => s.sessions);
+  const topicsQuery = useQuery({
+    queryKey: ['workspace-topics'],
+    queryFn: () => fetchWorkspaceTopics(),
+    staleTime: 30_000,
+  });
+  const surfacesQuery = useQuery<WorkspaceSurface[]>({
+    queryKey: ['workspace-surfaces', 'topic-shell'],
+    queryFn: () => fetchWorkspaceSurfaces(),
+    staleTime: 30_000,
+  });
+
+  return (
+    <TopicSidebarView
+      topics={topicsQuery.data?.topics ?? []}
+      sessions={sessions}
+      surfaces={surfacesQuery.data ?? []}
+      loading={topicsQuery.isLoading && !topicsQuery.data}
+      error={topicsQuery.isError}
+      derived={topicsQuery.data?.derived ?? false}
+      onSelectSession={onSelectSession}
+    />
+  );
+}
+
+export default TopicSidebarShell;

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
@@ -16,8 +22,63 @@ import {
 import { MarqueeText } from './MarqueeText.js';
 import './TopicSidebarShell.css';
 
+function RepoKindIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden>
+      <path d="M5 3v4M11 3v4M5 7a2 2 0 1 0 0 4M11 7a2 2 0 1 0 0 4M7 9h2" />
+    </svg>
+  );
+}
+
+function FolderKindIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden>
+      <path d="M2 5h5l1 2h6v6H2zM2 5V3h4l1 2" />
+    </svg>
+  );
+}
+
+function ThreadKindIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden>
+      <path d="M3 3h10v8H7l-4 3z" />
+    </svg>
+  );
+}
+
+function WorkspaceKindIcon({ kind }: { kind: TopicNavItem['kind'] }) {
+  if (kind === 'repo') return <RepoKindIcon />;
+  if (kind === 'folder') return <FolderKindIcon />;
+  return <ThreadKindIcon />;
+}
+
+function AttentionIcon({ tone }: { tone: TopicNavItem['tone'] }) {
+  if (tone === 'active')
+    return <span className="topic-status__spinner" aria-hidden />;
+  if (tone === 'attention') {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden>
+        <path d="M8 3v6M8 12v1" />
+      </svg>
+    );
+  }
+  if (tone === 'error') {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden>
+        <path d="M8 2l6 12H2zM8 6v4M8 12v1" />
+      </svg>
+    );
+  }
+  return null;
+}
+
 function StatusGlyph({ tone }: { tone: TopicNavItem['tone'] }) {
-  return <span className={`topic-status topic-status--${tone}`} aria-hidden />;
+  const attention = AttentionIcon({ tone });
+  return (
+    <span className={`topic-status topic-status--${tone}`} aria-hidden>
+      {attention}
+    </span>
+  );
 }
 
 function TopicBadge({ item }: { item: TopicNavItem }) {
@@ -25,9 +86,9 @@ function TopicBadge({ item }: { item: TopicNavItem }) {
     <span
       className="topic-row__badge"
       style={{ background: deriveColor(item.badgeSeed) }}
-      title={`workspace ${item.badgeText}`}
+      title={`${item.kindLabel} workspace`}
     >
-      {item.badgeText}
+      <WorkspaceKindIcon kind={item.kind} />
     </span>
   );
 }
@@ -78,7 +139,6 @@ function SessionChildRow({
         className="topic-child-row__button"
         onClick={() => onSelectSession?.(session.selectKey)}
       >
-        <StatusGlyph tone={session.tone} />
         <span className="topic-child-row__label">
           <MarqueeText>{session.label}</MarqueeText>
         </span>
@@ -88,6 +148,7 @@ function SessionChildRow({
         {session.nodeId ? (
           <span className="topic-child-row__meta">{session.nodeId}</span>
         ) : null}
+        <StatusGlyph tone={session.tone} />
       </button>
     </li>
   );
@@ -153,8 +214,15 @@ function TopicRow({
     if (hasNested) onToggle(item.id);
   };
 
+  const rowStyle = { '--topic-depth': depth } as CSSProperties;
+
   return (
-    <li className="topic-node">
+    <li
+      className={['topic-node', expanded && hasNested && 'expanded']
+        .filter(Boolean)
+        .join(' ')}
+      style={rowStyle}
+    >
       <button
         type="button"
         className={[
@@ -165,7 +233,6 @@ function TopicRow({
         ]
           .filter(Boolean)
           .join(' ')}
-        style={{ paddingLeft: `${8 + depth * 18}px` }}
         aria-expanded={hasNested ? expanded : undefined}
         aria-current={selected ? 'page' : undefined}
         onClick={activate}
@@ -179,13 +246,6 @@ function TopicRow({
           }
         }}
       >
-        <span
-          className={['topic-row__chevron', !expanded && 'collapsed']
-            .filter(Boolean)
-            .join(' ')}
-        >
-          {hasNested ? '⌄' : '·'}
-        </span>
         <TopicBadge item={item} />
         <span className="topic-row__title">
           <MarqueeText>{item.title}</MarqueeText>
@@ -194,19 +254,20 @@ function TopicRow({
           className="topic-row__trail"
           aria-label={`${item.statusLabel}, ${affordanceCount} linked items`}
         >
+          <span className="topic-row__hover-actions" aria-hidden="true">
+            {item.sessions.length > 0 ? (
+              <span className="topic-chip">s{item.sessions.length}</span>
+            ) : null}
+            {item.surfaces.slice(0, 2).map((surface) => (
+              <SurfaceButton key={surface.id} surface={surface} />
+            ))}
+            {item.taskRefs.length > 0 ? (
+              <span className="topic-chip">t{item.taskRefs.length}</span>
+            ) : null}
+          </span>
           <StatusGlyph tone={item.tone} />
-          {item.sessions.length > 0 ? (
-            <span className="topic-chip">s{item.sessions.length}</span>
-          ) : null}
-          {item.surfaces.slice(0, 2).map((surface) => (
-            <SurfaceButton key={surface.id} surface={surface} />
-          ))}
-          {item.taskRefs.length > 0 ? (
-            <span className="topic-chip">t{item.taskRefs.length}</span>
-          ) : null}
         </span>
       </button>
-      {selected ? <TopicDetail item={item} /> : null}
       {expanded ? (
         <>
           {item.sessions.length > 0 ? (
@@ -294,6 +355,7 @@ export function TopicSidebarView({
   }, []);
 
   const select = useCallback((id: string) => setSelectedId(id), []);
+  const selectedItem = selectedId ? model.byId.get(selectedId) : undefined;
 
   if (loading) {
     return <div className="topic-shell-state">loading topic shell…</div>;
@@ -333,6 +395,7 @@ export function TopicSidebarView({
           ) : null;
         })}
       </ul>
+      {selectedItem ? <TopicDetail item={selectedItem} /> : null}
     </div>
   );
 }

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -6,6 +6,14 @@ import {
   type CSSProperties,
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import {
+  CircleAlert,
+  Folder,
+  GitBranch,
+  LoaderCircle,
+  MessageSquare,
+  TriangleAlert,
+} from 'lucide-react';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
 import { fetchWorkspaceSurfaces, fetchWorkspaceTopics } from '../lib/api.js';
@@ -22,53 +30,21 @@ import {
 import { MarqueeText } from './MarqueeText.js';
 import './TopicSidebarShell.css';
 
-function RepoKindIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden>
-      <path d="M5 3v4M11 3v4M5 7a2 2 0 1 0 0 4M11 7a2 2 0 1 0 0 4M7 9h2" />
-    </svg>
-  );
-}
-
-function FolderKindIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden>
-      <path d="M2 5h5l1 2h6v6H2zM2 5V3h4l1 2" />
-    </svg>
-  );
-}
-
-function ThreadKindIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden>
-      <path d="M3 3h10v8H7l-4 3z" />
-    </svg>
-  );
-}
-
 function WorkspaceKindIcon({ kind }: { kind: TopicNavItem['kind'] }) {
-  if (kind === 'repo') return <RepoKindIcon />;
-  if (kind === 'folder') return <FolderKindIcon />;
-  return <ThreadKindIcon />;
+  const props = { 'aria-hidden': true, size: 16, strokeWidth: 1.8 } as const;
+  if (kind === 'repo') return <GitBranch {...props} />;
+  if (kind === 'folder') return <Folder {...props} />;
+  return <MessageSquare {...props} />;
 }
 
 function AttentionIcon({ tone }: { tone: TopicNavItem['tone'] }) {
-  if (tone === 'active')
-    return <span className="topic-status__spinner" aria-hidden />;
-  if (tone === 'attention') {
+  if (tone === 'active') {
     return (
-      <svg viewBox="0 0 16 16" aria-hidden>
-        <path d="M8 3v6M8 12v1" />
-      </svg>
+      <LoaderCircle className="topic-status__spinner" aria-hidden size={13} />
     );
   }
-  if (tone === 'error') {
-    return (
-      <svg viewBox="0 0 16 16" aria-hidden>
-        <path d="M8 2l6 12H2zM8 6v4M8 12v1" />
-      </svg>
-    );
-  }
+  if (tone === 'attention') return <CircleAlert aria-hidden size={13} />;
+  if (tone === 'error') return <TriangleAlert aria-hidden size={13} />;
   return null;
 }
 
@@ -137,7 +113,9 @@ function SessionChildRow({
       <button
         type="button"
         className="topic-child-row__button"
-        onClick={() => onSelectSession?.(session.selectKey)}
+        {...(onSelectSession
+          ? { onClick: () => onSelectSession(session.selectKey) }
+          : {})}
       >
         <span className="topic-child-row__label">
           <MarqueeText>{session.label}</MarqueeText>
@@ -215,6 +193,14 @@ function TopicRow({
   };
 
   const rowStyle = { '--topic-depth': depth } as CSSProperties;
+  const rowClassName = [
+    'topic-row',
+    `topic-row--${item.tone}`,
+    selected && 'selected',
+    item.muted && 'muted',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <li
@@ -223,33 +209,28 @@ function TopicRow({
         .join(' ')}
       style={rowStyle}
     >
-      <button
-        type="button"
-        className={[
-          'topic-row',
-          `topic-row--${item.tone}`,
-          selected && 'selected',
-          item.muted && 'muted',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-        aria-expanded={hasNested ? expanded : undefined}
-        aria-current={selected ? 'page' : undefined}
-        onClick={activate}
-        onKeyDown={(event) => {
-          if (event.key === 'ArrowRight' && hasNested && !expanded) {
-            event.preventDefault();
-            onToggle(item.id);
-          } else if (event.key === 'ArrowLeft' && hasNested && expanded) {
-            event.preventDefault();
-            onToggle(item.id);
-          }
-        }}
-      >
-        <TopicBadge item={item} />
-        <span className="topic-row__title">
-          <MarqueeText>{item.title}</MarqueeText>
-        </span>
+      <div className={rowClassName}>
+        <button
+          type="button"
+          className="topic-row__main"
+          aria-expanded={hasNested ? expanded : undefined}
+          aria-current={selected ? 'page' : undefined}
+          onClick={activate}
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowRight' && hasNested && !expanded) {
+              event.preventDefault();
+              onToggle(item.id);
+            } else if (event.key === 'ArrowLeft' && hasNested && expanded) {
+              event.preventDefault();
+              onToggle(item.id);
+            }
+          }}
+        >
+          <TopicBadge item={item} />
+          <span className="topic-row__title">
+            <MarqueeText>{item.title}</MarqueeText>
+          </span>
+        </button>
         <span
           className="topic-row__trail"
           aria-label={`${item.statusLabel}, ${affordanceCount} linked items`}
@@ -267,7 +248,7 @@ function TopicRow({
           </span>
           <StatusGlyph tone={item.tone} />
         </span>
-      </button>
+      </div>
       {expanded ? (
         <>
           {item.sessions.length > 0 ? (
@@ -422,8 +403,14 @@ export function TopicSidebarShell({
       topics={topicsQuery.data?.topics ?? []}
       sessions={sessions}
       surfaces={surfacesQuery.data ?? []}
-      loading={topicsQuery.isLoading && !topicsQuery.data}
-      error={topicsQuery.isError}
+      loading={
+        (topicsQuery.isLoading && !topicsQuery.data) ||
+        (surfacesQuery.isLoading && !surfacesQuery.data)
+      }
+      error={
+        (topicsQuery.isError && !topicsQuery.data) ||
+        (surfacesQuery.isError && !surfacesQuery.data)
+      }
       derived={topicsQuery.data?.derived ?? false}
       onSelectSession={onSelectSession}
     />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,6 +34,7 @@ import type {
   WorkspaceSurface,
   WorkspaceSurfaceListResponse,
 } from '../../../shared/workspace-surfaces.js';
+import type { WorkspaceTopicListResponse } from '../../../shared/workspace-topics.js';
 import type {
   PipelineHandoffArtifact,
   PipelineHandoffStageName,
@@ -1612,6 +1613,25 @@ export async function fetchWorkspaceSurfaces(
     })
   );
   return Array.isArray(data.surfaces) ? data.surfaces : [];
+}
+
+export async function fetchWorkspaceTopics(
+  args: { workspaceId?: string; includeArchived?: boolean } = {}
+): Promise<WorkspaceTopicListResponse> {
+  const params = new URLSearchParams();
+  if (args.workspaceId) params.set('workspaceId', args.workspaceId);
+  if (args.includeArchived) params.set('includeArchived', '1');
+  const query = params.toString();
+  const data = await json<WorkspaceTopicListResponse>(
+    await fetch(`/workspace-topics${query ? `?${query}` : ''}`, {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  return {
+    topics: Array.isArray(data.topics) ? data.topics : [],
+    truncated: Boolean(data.truncated),
+    derived: Boolean(data.derived),
+  };
 }
 
 export interface NodeFsWriteArgs {

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -1,0 +1,264 @@
+import type { WorkspaceSurface } from '../../../../shared/workspace-surfaces.js';
+import type {
+  WorkspaceTopic,
+  WorkspaceTopicId,
+} from '../../../../shared/workspace-topics.js';
+import type { SessionSummary } from '../types.js';
+import { isAttentionState } from './display-state.js';
+import { highestPriorityState } from './attention.js';
+
+export type TopicNavTone = 'active' | 'attention' | 'idle' | 'empty' | 'error';
+
+export interface TopicNavSessionRef {
+  id: string;
+  selectKey: string;
+  label: string;
+  tone: TopicNavTone;
+  branch: string | null;
+  nodeId: string | null;
+}
+
+export interface TopicNavSurfaceRef {
+  id: string;
+  label: string;
+  kind: WorkspaceSurface['kind'];
+  health: WorkspaceSurface['health'];
+  openMode: WorkspaceSurface['openMode'];
+  target: string | null;
+}
+
+export interface TopicNavItem {
+  id: WorkspaceTopicId;
+  parentId: WorkspaceTopicId | null;
+  title: string;
+  description: string | null;
+  badgeText: string;
+  badgeSeed: string;
+  pinned: boolean;
+  muted: boolean;
+  order: number;
+  tone: TopicNavTone;
+  statusLabel: string;
+  sessions: TopicNavSessionRef[];
+  surfaces: TopicNavSurfaceRef[];
+  taskRefs: NonNullable<WorkspaceTopic['linkedRefs']['taskRefs']>;
+  childIds: WorkspaceTopicId[];
+  routingLabel: string | null;
+}
+
+export interface TopicNavModel {
+  items: TopicNavItem[];
+  rootIds: WorkspaceTopicId[];
+  byId: Map<WorkspaceTopicId, TopicNavItem>;
+  derived: boolean;
+}
+
+function basename(path: string | undefined): string | null {
+  if (!path) return null;
+  const trimmed = path.replace(/[\\/]+$/, '');
+  const segment = trimmed.split(/[\\/]/).pop();
+  return segment && segment.length > 0 ? segment : trimmed || null;
+}
+
+function sessionSelectKey(session: SessionSummary): string {
+  return session.globalSessionId ?? session.id;
+}
+
+function sessionTone(session: SessionSummary): TopicNavTone {
+  if (session.agentState === 'error') return 'error';
+  if (session.agentState === 'permission-prompt') return 'attention';
+  if (
+    session.agentState === 'processing' ||
+    session.agentState === 'initializing'
+  ) {
+    return 'active';
+  }
+  return session.idle ? 'idle' : 'active';
+}
+
+function sessionDisplayState(session: SessionSummary) {
+  if (session.agentState === 'permission-prompt') {
+    return session.permissionType === 'question'
+      ? 'needs-answer'
+      : 'permission';
+  }
+  if (session.agentState === 'error') return 'error';
+  if (session.agentState === 'processing') return 'running';
+  if (session.agentState === 'initializing') return 'initializing';
+  return 'seen-idle';
+}
+
+function sessionMatchesTopic(
+  topic: WorkspaceTopic,
+  session: SessionSummary
+): boolean {
+  const linked = topic.linkedRefs;
+  if (
+    linked.sessionIds?.some(
+      (id) => id === session.id || id === session.globalSessionId
+    )
+  ) {
+    return true;
+  }
+  if (
+    session.workContextId &&
+    linked.workContextIds?.includes(session.workContextId)
+  ) {
+    return true;
+  }
+  const routing = topic.routingDefaults;
+  if (routing.worktreePath && session.worktreePath === routing.worktreePath)
+    return true;
+  if (routing.repoPath && session.repoPath === routing.repoPath) return true;
+  if (routing.cwd && session.cwd === routing.cwd) return true;
+  return false;
+}
+
+function surfaceMatchesTopic(
+  topic: WorkspaceTopic,
+  surface: WorkspaceSurface
+): boolean {
+  if (topic.linkedRefs.workspaceSurfaceIds?.includes(surface.id)) return true;
+  if (surface.workspaceId && surface.workspaceId === topic.workspaceId)
+    return true;
+  if (
+    topic.routingDefaults.repoPath &&
+    surface.repoPath === topic.routingDefaults.repoPath
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function surfaceTarget(surface: WorkspaceSurface): string | null {
+  return surface.url ?? surface.command ?? surface.logRef ?? null;
+}
+
+function routingLabel(topic: WorkspaceTopic): string | null {
+  const routing = topic.routingDefaults;
+  const parts = [
+    routing.providerId,
+    routing.nodeId,
+    basename(routing.worktreePath) ??
+      basename(routing.repoPath) ??
+      basename(routing.cwd),
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+function topicTone(
+  sessions: TopicNavSessionRef[],
+  surfaces: TopicNavSurfaceRef[],
+  topic: WorkspaceTopic
+): { tone: TopicNavTone; label: string } {
+  if (topic.status === 'archived') return { tone: 'empty', label: 'archived' };
+  if (sessions.some((session) => session.tone === 'error')) {
+    return { tone: 'error', label: 'error' };
+  }
+  if (surfaces.some((surface) => surface.health === 'unreachable')) {
+    return { tone: 'error', label: 'surface down' };
+  }
+  if (sessions.some((session) => session.tone === 'attention')) {
+    return { tone: 'attention', label: 'needs input' };
+  }
+  if (sessions.some((session) => session.tone === 'active')) {
+    return { tone: 'active', label: 'active' };
+  }
+  if (sessions.length > 0) return { tone: 'idle', label: 'idle' };
+  if (surfaces.length > 0) return { tone: 'idle', label: 'surfaces' };
+  return { tone: 'empty', label: 'empty' };
+}
+
+function compareItems(a: TopicNavItem, b: TopicNavItem): number {
+  if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+  if (a.order !== b.order) return a.order - b.order;
+  return a.title.localeCompare(b.title);
+}
+
+export function buildTopicNavModel(input: {
+  topics: WorkspaceTopic[];
+  sessions: SessionSummary[];
+  surfaces: WorkspaceSurface[];
+  derived?: boolean;
+}): TopicNavModel {
+  const workspaceNumbers = new Map<string, number>();
+  for (const topic of input.topics) {
+    if (!workspaceNumbers.has(topic.workspaceId)) {
+      workspaceNumbers.set(topic.workspaceId, workspaceNumbers.size + 1);
+    }
+  }
+
+  const items: TopicNavItem[] = input.topics.map((topic) => {
+    const sessions = input.sessions
+      .filter((session) => sessionMatchesTopic(topic, session))
+      .map(
+        (session): TopicNavSessionRef => ({
+          id: session.id,
+          selectKey: sessionSelectKey(session),
+          label: session.displayName || basename(session.cwd) || session.id,
+          tone: sessionTone(session),
+          branch: session.branchName ?? null,
+          nodeId: session.nodeId ?? null,
+        })
+      )
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    const surfaces = input.surfaces
+      .filter((surface) => surfaceMatchesTopic(topic, surface))
+      .map(
+        (surface): TopicNavSurfaceRef => ({
+          id: surface.id,
+          label: surface.label,
+          kind: surface.kind,
+          health: surface.health,
+          openMode: surface.openMode,
+          target: surfaceTarget(surface),
+        })
+      )
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    const tone = topicTone(sessions, surfaces, topic);
+    const number = workspaceNumbers.get(topic.workspaceId) ?? 0;
+    const order = topic.grouping.order ?? Number.MAX_SAFE_INTEGER;
+    return {
+      id: topic.id,
+      parentId: topic.grouping.parentTopicId ?? null,
+      title: topic.display.title,
+      description: topic.display.description ?? null,
+      badgeText: number > 0 ? String(number).padStart(2, '0') : 'ws',
+      badgeSeed: topic.workspaceId || topic.display.title,
+      pinned: topic.state.pinned,
+      muted: topic.state.muted,
+      order,
+      tone: tone.tone,
+      statusLabel: tone.label,
+      sessions,
+      surfaces,
+      taskRefs: topic.linkedRefs.taskRefs ?? [],
+      childIds: [],
+      routingLabel: routingLabel(topic),
+    };
+  });
+
+  const byId = new Map<WorkspaceTopicId, TopicNavItem>();
+  for (const item of items) byId.set(item.id, item);
+  const rootIds: WorkspaceTopicId[] = [];
+  for (const item of items) {
+    if (item.parentId && byId.has(item.parentId)) {
+      byId.get(item.parentId)!.childIds.push(item.id);
+    } else {
+      rootIds.push(item.id);
+    }
+  }
+  for (const item of items)
+    item.childIds.sort((a, b) => compareItems(byId.get(a)!, byId.get(b)!));
+  rootIds.sort((a, b) => compareItems(byId.get(a)!, byId.get(b)!));
+
+  // Touch the same attention priority helper the rest of the sidebar uses, so a
+  // future tone expansion does not drift into a second status model.
+  void highestPriorityState(
+    input.sessions.map(sessionDisplayState).filter(isAttentionState)
+  );
+
+  return { items, rootIds, byId, derived: input.derived ?? false };
+}

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -8,6 +8,7 @@ import { isAttentionState } from './display-state.js';
 import { highestPriorityState } from './attention.js';
 
 export type TopicNavTone = 'active' | 'attention' | 'idle' | 'empty' | 'error';
+export type TopicNavKind = 'repo' | 'folder' | 'thread';
 
 export interface TopicNavSessionRef {
   id: string;
@@ -32,8 +33,9 @@ export interface TopicNavItem {
   parentId: WorkspaceTopicId | null;
   title: string;
   description: string | null;
-  badgeText: string;
   badgeSeed: string;
+  kind: TopicNavKind;
+  kindLabel: string;
   pinned: boolean;
   muted: boolean;
   order: number;
@@ -134,6 +136,20 @@ function surfaceTarget(surface: WorkspaceSurface): string | null {
   return surface.url ?? surface.command ?? surface.logRef ?? null;
 }
 
+function topicKind(topic: WorkspaceTopic): {
+  kind: TopicNavKind;
+  label: string;
+} {
+  const routing = topic.routingDefaults;
+  if (routing.repoPath || routing.worktreePath) {
+    return { kind: 'repo', label: 'git repo' };
+  }
+  if (routing.cwd) {
+    return { kind: 'folder', label: 'folder' };
+  }
+  return { kind: 'thread', label: 'topic' };
+}
+
 function routingLabel(topic: WorkspaceTopic): string | null {
   const routing = topic.routingDefaults;
   const parts = [
@@ -181,13 +197,6 @@ export function buildTopicNavModel(input: {
   surfaces: WorkspaceSurface[];
   derived?: boolean;
 }): TopicNavModel {
-  const workspaceNumbers = new Map<string, number>();
-  for (const topic of input.topics) {
-    if (!workspaceNumbers.has(topic.workspaceId)) {
-      workspaceNumbers.set(topic.workspaceId, workspaceNumbers.size + 1);
-    }
-  }
-
   const items: TopicNavItem[] = input.topics.map((topic) => {
     const sessions = input.sessions
       .filter((session) => sessionMatchesTopic(topic, session))
@@ -218,15 +227,16 @@ export function buildTopicNavModel(input: {
       .sort((a, b) => a.label.localeCompare(b.label));
 
     const tone = topicTone(sessions, surfaces, topic);
-    const number = workspaceNumbers.get(topic.workspaceId) ?? 0;
+    const kind = topicKind(topic);
     const order = topic.grouping.order ?? Number.MAX_SAFE_INTEGER;
     return {
       id: topic.id,
       parentId: topic.grouping.parentTopicId ?? null,
       title: topic.display.title,
       description: topic.display.description ?? null,
-      badgeText: number > 0 ? String(number).padStart(2, '0') : 'ws',
       badgeSeed: topic.workspaceId || topic.display.title,
+      kind: kind.kind,
+      kindLabel: kind.label,
       pinned: topic.state.pinned,
       muted: topic.state.muted,
       order,

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -4,17 +4,29 @@ import type {
   WorkspaceTopicId,
 } from '../../../../shared/workspace-topics.js';
 import type { SessionSummary } from '../types.js';
-import { isAttentionState } from './display-state.js';
+import { isAttentionState, type DisplayState } from './display-state.js';
 import { highestPriorityState } from './attention.js';
 
 export type TopicNavTone = 'active' | 'attention' | 'idle' | 'empty' | 'error';
 export type TopicNavKind = 'repo' | 'folder' | 'thread';
+
+const DISPLAY_PRIORITY: Record<DisplayState, number> = {
+  permission: 1000,
+  'needs-answer': 900,
+  error: 800,
+  'unseen-idle': 500,
+  running: 100,
+  initializing: 50,
+  'seen-idle': 10,
+  inactive: 1,
+};
 
 export interface TopicNavSessionRef {
   id: string;
   selectKey: string;
   label: string;
   tone: TopicNavTone;
+  displayState: DisplayState;
   branch: string | null;
   nodeId: string | null;
 }
@@ -41,6 +53,7 @@ export interface TopicNavItem {
   order: number;
   tone: TopicNavTone;
   statusLabel: string;
+  attentionPriority: number;
   sessions: TopicNavSessionRef[];
   surfaces: TopicNavSurfaceRef[];
   taskRefs: NonNullable<WorkspaceTopic['linkedRefs']['taskRefs']>;
@@ -78,7 +91,7 @@ function sessionTone(session: SessionSummary): TopicNavTone {
   return session.idle ? 'idle' : 'active';
 }
 
-function sessionDisplayState(session: SessionSummary) {
+function sessionDisplayState(session: SessionSummary): DisplayState {
   if (session.agentState === 'permission-prompt') {
     return session.permissionType === 'question'
       ? 'needs-answer'
@@ -166,29 +179,89 @@ function topicTone(
   sessions: TopicNavSessionRef[],
   surfaces: TopicNavSurfaceRef[],
   topic: WorkspaceTopic
-): { tone: TopicNavTone; label: string } {
-  if (topic.status === 'archived') return { tone: 'empty', label: 'archived' };
-  if (sessions.some((session) => session.tone === 'error')) {
-    return { tone: 'error', label: 'error' };
+): { tone: TopicNavTone; label: string; priority: number } {
+  if (topic.status === 'archived') {
+    return { tone: 'empty', label: 'archived', priority: 0 };
   }
+
+  const displayStates = sessions.map((session) => session.displayState);
   if (surfaces.some((surface) => surface.health === 'unreachable')) {
-    return { tone: 'error', label: 'surface down' };
+    displayStates.push('error');
   }
-  if (sessions.some((session) => session.tone === 'attention')) {
-    return { tone: 'attention', label: 'needs input' };
+
+  const attentionState = highestPriorityState(
+    displayStates.filter(isAttentionState)
+  );
+  if (attentionState === 'permission' || attentionState === 'needs-answer') {
+    return {
+      tone: 'attention',
+      label: 'needs input',
+      priority: DISPLAY_PRIORITY[attentionState],
+    };
   }
-  if (sessions.some((session) => session.tone === 'active')) {
-    return { tone: 'active', label: 'active' };
+  if (attentionState === 'error') {
+    return { tone: 'error', label: 'error', priority: DISPLAY_PRIORITY.error };
   }
-  if (sessions.length > 0) return { tone: 'idle', label: 'idle' };
-  if (surfaces.length > 0) return { tone: 'idle', label: 'surfaces' };
-  return { tone: 'empty', label: 'empty' };
+  if (attentionState === 'unseen-idle') {
+    return {
+      tone: 'attention',
+      label: 'unread',
+      priority: DISPLAY_PRIORITY['unseen-idle'],
+    };
+  }
+  if (displayStates.includes('running')) {
+    return {
+      tone: 'active',
+      label: 'active',
+      priority: DISPLAY_PRIORITY.running,
+    };
+  }
+  if (displayStates.includes('initializing')) {
+    return {
+      tone: 'active',
+      label: 'starting',
+      priority: DISPLAY_PRIORITY.initializing,
+    };
+  }
+  if (sessions.length > 0) {
+    return {
+      tone: 'idle',
+      label: 'idle',
+      priority: DISPLAY_PRIORITY['seen-idle'],
+    };
+  }
+  if (surfaces.length > 0) {
+    return {
+      tone: 'idle',
+      label: 'surfaces',
+      priority: DISPLAY_PRIORITY.inactive,
+    };
+  }
+  return { tone: 'empty', label: 'empty', priority: 0 };
 }
 
 function compareItems(a: TopicNavItem, b: TopicNavItem): number {
+  if (a.attentionPriority !== b.attentionPriority) {
+    return b.attentionPriority - a.attentionPriority;
+  }
   if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
   if (a.order !== b.order) return a.order - b.order;
   return a.title.localeCompare(b.title);
+}
+
+function wouldCreateCycle(
+  childId: WorkspaceTopicId,
+  parentId: WorkspaceTopicId,
+  byId: Map<WorkspaceTopicId, TopicNavItem>
+): boolean {
+  const seen = new Set<WorkspaceTopicId>();
+  let currentId: WorkspaceTopicId | null = parentId;
+  while (currentId) {
+    if (currentId === childId || seen.has(currentId)) return true;
+    seen.add(currentId);
+    currentId = byId.get(currentId)?.parentId ?? null;
+  }
+  return false;
 }
 
 export function buildTopicNavModel(input: {
@@ -206,6 +279,7 @@ export function buildTopicNavModel(input: {
           selectKey: sessionSelectKey(session),
           label: session.displayName || basename(session.cwd) || session.id,
           tone: sessionTone(session),
+          displayState: sessionDisplayState(session),
           branch: session.branchName ?? null,
           nodeId: session.nodeId ?? null,
         })
@@ -242,6 +316,7 @@ export function buildTopicNavModel(input: {
       order,
       tone: tone.tone,
       statusLabel: tone.label,
+      attentionPriority: tone.priority,
       sessions,
       surfaces,
       taskRefs: topic.linkedRefs.taskRefs ?? [],
@@ -254,7 +329,12 @@ export function buildTopicNavModel(input: {
   for (const item of items) byId.set(item.id, item);
   const rootIds: WorkspaceTopicId[] = [];
   for (const item of items) {
-    if (item.parentId && byId.has(item.parentId)) {
+    if (
+      item.parentId &&
+      item.parentId !== item.id &&
+      byId.has(item.parentId) &&
+      !wouldCreateCycle(item.id, item.parentId, byId)
+    ) {
       byId.get(item.parentId)!.childIds.push(item.id);
     } else {
       rootIds.push(item.id);
@@ -263,12 +343,6 @@ export function buildTopicNavModel(input: {
   for (const item of items)
     item.childIds.sort((a, b) => compareItems(byId.get(a)!, byId.get(b)!));
   rootIds.sort((a, b) => compareItems(byId.get(a)!, byId.get(b)!));
-
-  // Touch the same attention priority helper the rest of the sidebar uses, so a
-  // future tone expansion does not drift into a second status model.
-  void highestPriorityState(
-    input.sessions.map(sessionDisplayState).filter(isAttentionState)
-  );
 
   return { items, rootIds, byId, derived: input.derived ?? false };
 }

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -21,6 +21,7 @@ const COLLAPSED_WORKSPACES_KEY = 'claude-remote-collapsed-workspaces';
 // is byte-identical to today; ON swaps in the client-derived read-only tree.
 // Dev-only affordance: set `localStorage.relay-view-spine = '1'` and reload.
 const VIEW_SPINE_KEY = 'relay-view-spine';
+const TOPIC_SHELL_KEY = 'relay-topic-shell';
 // #738: persistent View layer (FE-only, localStorage). All three ride the same
 // `ls`/`lsSave`/`lsRemove` helpers + fail-soft pattern as the flag above.
 //   - active lens, restored across reload (the #727 lens was ephemeral).
@@ -172,6 +173,12 @@ function loadDiffViewMode(): DiffViewMode {
 function loadViewSpineEnabled(): boolean {
   // Truthy only for the explicit opt-in value so a stale '0'/'false' reads OFF.
   return ls(VIEW_SPINE_KEY) === '1';
+}
+
+function loadTopicShellEnabled(): boolean {
+  // #1023: desktop topic shell is a separate default-OFF feature flag while the
+  // legacy sidebar and the view-spine remain available during rollout.
+  return ls(TOPIC_SHELL_KEY) === '1';
 }
 
 // ── #738: View-layer persistence (lens / pins / saved Views) ─────────────────
@@ -619,6 +626,8 @@ export interface UiState {
   collapsedWorkspaces: Set<string>;
   /** #732: view-spine MVP flag. Default false; backed by localStorage. */
   viewSpineEnabled: boolean;
+  /** #1023: thin-line WorkspaceTopic sidebar/detail shell flag. Default false. */
+  topicShellEnabled: boolean;
   /** #738: active Views lens, persisted across reload (default `recent`). */
   viewSpineLens: ViewLens;
   /** #738: pinned Project/Bench/Workspace stable ids (pinned-to-top). */
@@ -665,6 +674,8 @@ export interface UiState {
   isWorkspaceCollapsed: (path: string) => boolean;
   setViewSpineEnabled: (enabled: boolean) => void;
   toggleViewSpineEnabled: () => void;
+  setTopicShellEnabled: (enabled: boolean) => void;
+  toggleTopicShellEnabled: () => void;
   /** #738: persist + set the active lens. */
   setViewSpineLens: (lens: ViewLens) => void;
   /** #738: toggle a pin by stable id (Project/Bench/Workspace); persists. */
@@ -709,6 +720,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
   viewSpineEnabled: loadViewSpineEnabled(),
+  topicShellEnabled: loadTopicShellEnabled(),
   viewSpineLens: loadViewSpineLens(),
   viewSpinePins: loadViewSpinePins(),
   viewSpineSavedViews: loadViewSpineSavedViews(),
@@ -1320,10 +1332,16 @@ export const useUiStore = create<UiState>()((set, get) => ({
     else lsRemove(VIEW_SPINE_KEY);
     set({ viewSpineEnabled: enabled });
   },
-
   toggleViewSpineEnabled: () => {
     get().setViewSpineEnabled(!get().viewSpineEnabled);
   },
+  setTopicShellEnabled: (enabled) => {
+    if (enabled) lsSave(TOPIC_SHELL_KEY, '1');
+    else lsRemove(TOPIC_SHELL_KEY);
+    set({ topicShellEnabled: enabled });
+  },
+  toggleTopicShellEnabled: () =>
+    get().setTopicShellEnabled(!get().topicShellEnabled),
 
   setViewSpineLens: (lens) => {
     lsSave(VIEW_SPINE_LENS_KEY, lens);

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "eslint-plugin-sonarjs": "^4.0.2",
         "express": "^4.21.0",
         "get-port": "^7.1.0",
+        "lucide-react": "^1.21.0",
         "node-pty": "^1.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -5530,6 +5531,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-sonarjs": "^4.0.2",
     "express": "^4.21.0",
     "get-port": "^7.1.0",
+    "lucide-react": "^1.21.0",
     "node-pty": "^1.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -123,4 +123,39 @@ describe('buildTopicNavModel', () => {
       { id: 'surface:preview', label: 'Preview server', kind: 'preview' },
     ]);
   });
+
+  it('classifies topic workspace kind from routing defaults', () => {
+    const repo = makeTopic({
+      id: 'topic:repo',
+      routingDefaults: { repoPath: '/repo/relay' },
+    });
+    const folder = makeTopic({
+      id: 'topic:folder',
+      workspaceId: 'workspace:folder',
+      routingDefaults: { cwd: '/tmp/scratch' },
+    });
+    const thread = makeTopic({
+      id: 'topic:thread',
+      workspaceId: 'workspace:thread',
+    });
+
+    const model = buildTopicNavModel({
+      topics: [repo, folder, thread],
+      sessions: [],
+      surfaces: [],
+    });
+
+    expect(model.byId.get('topic:repo')).toMatchObject({
+      kind: 'repo',
+      kindLabel: 'git repo',
+    });
+    expect(model.byId.get('topic:folder')).toMatchObject({
+      kind: 'folder',
+      kindLabel: 'folder',
+    });
+    expect(model.byId.get('topic:thread')).toMatchObject({
+      kind: 'thread',
+      kindLabel: 'topic',
+    });
+  });
 });

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceSurface } from '../shared/workspace-surfaces.js';
+import type { WorkspaceTopic } from '../shared/workspace-topics.js';
+import { buildTopicNavModel } from '../frontend/src/lib/state/topic-nav.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+const NOW = '2026-06-26T00:00:00Z';
+
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:alpha',
+    workspaceId: 'workspace:alpha',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Alpha topic' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: {},
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeSurface(
+  overrides: Partial<WorkspaceSurface> = {}
+): WorkspaceSurface {
+  return {
+    id: 'surface:preview',
+    kind: 'preview',
+    label: 'Preview server',
+    nodeId: 'local',
+    workspaceId: 'workspace:alpha',
+    status: 'published',
+    health: 'reachable',
+    provenance: { source: 'agent-published' },
+    openMode: 'direct',
+    url: 'http://localhost:5173',
+    ...overrides,
+  };
+}
+
+describe('buildTopicNavModel', () => {
+  it('sorts pinned topics first and nests child topics', () => {
+    const parent = makeTopic({
+      id: 'topic:parent',
+      display: { title: 'Parent' },
+      grouping: { order: 2 },
+    });
+    const child = makeTopic({
+      id: 'topic:child',
+      display: { title: 'Child' },
+      grouping: { parentTopicId: 'topic:parent', order: 1 },
+    });
+    const pinned = makeTopic({
+      id: 'topic:pinned',
+      display: { title: 'Pinned' },
+      state: { pinned: true, muted: false },
+      grouping: { order: 99 },
+    });
+
+    const model = buildTopicNavModel({
+      topics: [parent, child, pinned],
+      sessions: [],
+      surfaces: [],
+    });
+
+    expect(model.rootIds).toEqual(['topic:pinned', 'topic:parent']);
+    expect(model.byId.get('topic:parent')?.childIds).toEqual(['topic:child']);
+  });
+
+  it('links sessions by explicit session refs and reports attention state', () => {
+    const topic = makeTopic({
+      linkedRefs: { sessionIds: ['global:agent-1'] },
+    });
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [
+        makeSession({
+          id: 'local-session',
+          globalSessionId: 'global:agent-1',
+          displayName: 'Agent lane',
+          agentState: 'permission-prompt',
+          permissionType: 'question',
+          nodeId: 'devbox',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const item = model.byId.get('topic:alpha');
+    expect(item?.tone).toBe('attention');
+    expect(item?.statusLabel).toBe('needs input');
+    expect(item?.sessions).toMatchObject([
+      { label: 'Agent lane', selectKey: 'global:agent-1', nodeId: 'devbox' },
+    ]);
+  });
+
+  it('links surfaces by workspace id without fabricating sessions', () => {
+    const topic = makeTopic({ workspaceId: 'workspace:alpha' });
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [],
+      surfaces: [makeSurface()],
+      derived: true,
+    });
+
+    const item = model.byId.get('topic:alpha');
+    expect(model.derived).toBe(true);
+    expect(item?.tone).toBe('idle');
+    expect(item?.sessions).toEqual([]);
+    expect(item?.surfaces).toMatchObject([
+      { id: 'surface:preview', label: 'Preview server', kind: 'preview' },
+    ]);
+  });
+});

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -158,4 +158,68 @@ describe('buildTopicNavModel', () => {
       kindLabel: 'topic',
     });
   });
+
+  it('keeps attention topics ahead of idle pinned topics', () => {
+    const pinned = makeTopic({
+      id: 'topic:pinned',
+      display: { title: 'Pinned idle' },
+      linkedRefs: { sessionIds: ['idle-session'] },
+      state: { pinned: true, muted: false },
+      grouping: { order: 1 },
+    });
+    const attention = makeTopic({
+      id: 'topic:attention',
+      display: { title: 'Needs input' },
+      linkedRefs: { sessionIds: ['attention-session'] },
+      grouping: { order: 99 },
+    });
+
+    const model = buildTopicNavModel({
+      topics: [pinned, attention],
+      sessions: [
+        makeSession({ id: 'idle-session', idle: true, agentState: 'idle' }),
+        makeSession({
+          id: 'attention-session',
+          agentState: 'permission-prompt',
+          permissionType: 'approval',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    expect(model.rootIds).toEqual(['topic:attention', 'topic:pinned']);
+    expect(model.byId.get('topic:attention')).toMatchObject({
+      tone: 'attention',
+      statusLabel: 'needs input',
+    });
+  });
+
+  it('breaks cyclic parent links into roots instead of recursive children', () => {
+    const a = makeTopic({
+      id: 'topic:a',
+      display: { title: 'A' },
+      grouping: { parentTopicId: 'topic:b' },
+    });
+    const b = makeTopic({
+      id: 'topic:b',
+      display: { title: 'B' },
+      grouping: { parentTopicId: 'topic:a' },
+    });
+    const self = makeTopic({
+      id: 'topic:self',
+      display: { title: 'Self' },
+      grouping: { parentTopicId: 'topic:self' },
+    });
+
+    const model = buildTopicNavModel({
+      topics: [a, b, self],
+      sessions: [],
+      surfaces: [],
+    });
+
+    expect(model.rootIds.sort()).toEqual(['topic:a', 'topic:b', 'topic:self']);
+    expect(model.byId.get('topic:a')?.childIds).toEqual([]);
+    expect(model.byId.get('topic:b')?.childIds).toEqual([]);
+    expect(model.byId.get('topic:self')?.childIds).toEqual([]);
+  });
 });

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceSurface } from '../shared/workspace-surfaces.js';
+import type { WorkspaceTopic } from '../shared/workspace-topics.js';
+import { TopicSidebarView } from '../frontend/src/components/TopicSidebarShell.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const NOW = '2026-06-26T00:00:00Z';
+
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:alpha',
+    workspaceId: 'workspace:alpha',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Build UI shell', description: 'Thin-line topic detail' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: { nodeId: 'devbox', repoPath: '/repo/relay' },
+    linkedRefs: { sessionIds: ['s1'] },
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeSurface(
+  overrides: Partial<WorkspaceSurface> = {}
+): WorkspaceSurface {
+  return {
+    id: 'surface:preview',
+    kind: 'preview',
+    label: 'Preview server',
+    nodeId: 'devbox',
+    workspaceId: 'workspace:alpha',
+    repoPath: '/repo/relay',
+    status: 'published',
+    health: 'reachable',
+    provenance: { source: 'agent-published' },
+    openMode: 'direct',
+    url: 'http://localhost:5173',
+    ...overrides,
+  };
+}
+
+describe('TopicSidebarView', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onSelectSession = vi.fn();
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function renderView(
+    props: Partial<React.ComponentProps<typeof TopicSidebarView>> = {}
+  ) {
+    await act(async () => {
+      root.render(
+        React.createElement(TopicSidebarView, {
+          topics: [makeTopic()],
+          sessions: [makeSession({ id: 's1', displayName: 'Frontend lane' })],
+          surfaces: [makeSurface()],
+          onSelectSession,
+          ...props,
+        })
+      );
+    });
+  }
+
+  it('renders a topic row, inline detail, linked session, and surface affordance', async () => {
+    await renderView();
+
+    expect(container.querySelector('.topic-shell')).not.toBeNull();
+    expect(container.textContent).toContain('Build UI shell');
+    expect(container.textContent).toContain('Thin-line topic detail');
+    expect(container.textContent).toContain('Frontend lane');
+    expect(container.textContent).toContain('preview');
+  });
+
+  it('selects linked sessions using the existing sidebar callback', async () => {
+    await renderView();
+    const sessionButton = container.querySelector(
+      '.topic-child-row__button'
+    ) as HTMLButtonElement;
+    await act(async () => sessionButton.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+  });
+
+  it('shows detail for a selected topic even when it has no nested sessions', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          linkedRefs: {
+            taskRefs: [
+              { kind: 'github-issue', id: '1023', title: 'thin sidebar' },
+            ],
+          },
+        }),
+      ],
+      sessions: [],
+    });
+
+    expect(container.querySelector('.topic-detail')?.textContent).toContain(
+      'Thin-line topic detail'
+    );
+    expect(container.textContent).toContain('1 task refs');
+  });
+
+  it('reports loading, error, and empty states', async () => {
+    await renderView({ loading: true, topics: [] });
+    expect(container.textContent).toContain('loading topic shell');
+
+    await renderView({ loading: false, error: true, topics: [] });
+    expect(container.textContent).toContain('topic shell unavailable');
+
+    await renderView({ loading: false, error: false, topics: [] });
+    expect(container.textContent).toContain('no workspace topics yet');
+  });
+});

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -118,6 +118,19 @@ describe('TopicSidebarView', () => {
     expect(onSelectSession).toHaveBeenCalledWith('s1');
   });
 
+  it('keeps surface actions outside the clickable row button', async () => {
+    await renderView();
+
+    const rowMain = container.querySelector('.topic-row__main');
+    const surfaceAction = container.querySelector(
+      '.topic-row__trail .topic-action'
+    );
+
+    expect(rowMain).not.toBeNull();
+    expect(surfaceAction).not.toBeNull();
+    expect(rowMain?.contains(surfaceAction)).toBe(false);
+  });
+
   it('shows detail for a selected topic even when it has no nested sessions', async () => {
     await renderView({
       topics: [


### PR DESCRIPTION
## Summary
- Add a default-off `relay-topic-shell` feature flag for a thin-line desktop WorkspaceTopic sidebar shell.
- Build a shared TopicNav view model that maps persisted topics to sessions, WorkspaceSurface affordances, routing labels, status tone, nesting, and task refs.
- Render compact single-line topic rows with square workspace badges, inline status/action chips, expandable session children, selected-topic detail, and loading/empty/error states.
- Proxy `/workspace-topics` and `/workspace-surfaces` in the Vite dev server so the flag-gated shell can be browser-smoked locally.

## Verification
- `npm test -- test/topic-nav.test.ts test/topic-sidebar-shell.test.ts` — 7 passed.
- `npm run check` — passed, existing lint warnings only.
- `npm run build` — passed, existing CodeMirror/chunk-size Vite warnings.
- Pre-push changed-tests hook — 82 files / 660 tests passed.
- Browser smoke at `http://127.0.0.1:5187/` with `localStorage.relay-topic-shell = '1'`: seeded a persisted Browser smoke topic through `/workspace-topics`; verified the left sidebar shows the topic shell, compact row badge/chip, selected detail, no legacy project list, and no `/workspace-topics` fetch errors. Unrelated active-work cockpit/node warning remained visible in main content.

Refs #1021
Closes #1023


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “topic shell” sidebar experience with hierarchical topics, session nesting, surface actions, and a topic detail panel.
  * Added a persistent UI toggle to enable/disable the topic shell sidebar.
  * Expanded dev backend proxy support for workspace topics and surfaces.
* **Bug Fixes**
  * Improved handling and display for loading, error, and empty states in the topic sidebar.
  * Kept topic status/priority visuals consistent with attention vs idle session states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->