### PR TITLE
Add WorkspaceTopic session launch plumbing

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -412,6 +412,7 @@ function parseGatewayCreateInput(
     ['--initial-prompt', 'initialPrompt'],
     ['--continue-policy', 'continuePolicy'],
     ['--work-context-id', 'workContextId'],
+    ['--workspace-topic-id', 'workspaceTopicId'],
     ['--control-mode', 'controlMode'],
     ['--confirmation-token', 'confirmationToken'],
     ['--expires-at', 'expiresAt'],
@@ -2399,6 +2400,7 @@ async function runGatewaySessionCreate(sessionArgs: string[]): Promise<never> {
       validated.sessionType === 'terminal'
         ? 'session:create:terminal'
         : 'session:create:agent',
+      ...(validated.input['workspaceTopicId'] ? ['context:write'] : []),
       ...(validated.input['controlMode'] === 'agent-driven'
         ? ['tab:mode:set-agent']
         : []),

--- a/server/index.ts
+++ b/server/index.ts
@@ -41,6 +41,11 @@ import {
   parseGlobalSessionId,
 } from '../shared/identity.js';
 import {
+  buildWorkspaceTopicSessionCreateBody,
+  workspaceTopicSessionLinkPatch,
+  type WorkspaceTopic,
+} from '../shared/workspace-topics.js';
+import {
   WorktreeWatcher,
   BranchWatcher,
   RefWatcher,
@@ -1947,6 +1952,88 @@ async function main(): Promise<void> {
       return null;
     }
     return validated.input;
+  }
+
+  function resolveWorkspaceTopicSessionCreate(
+    createBody: Record<string, unknown>,
+    res: express.Response
+  ): { body: Record<string, unknown>; topic?: WorkspaceTopic } | null {
+    if (!Object.prototype.hasOwnProperty.call(createBody, 'workspaceTopicId')) {
+      return { body: createBody };
+    }
+    const workspaceTopicId = createBody['workspaceTopicId'];
+    if (
+      typeof workspaceTopicId !== 'string' ||
+      workspaceTopicId.trim() === ''
+    ) {
+      res.status(400).json({
+        error: 'workspaceTopicId must be a non-empty string',
+      });
+      return null;
+    }
+    if (!workspaceTopicStore) {
+      res.status(503).json({
+        error: {
+          code: 'WORKSPACE_TOPICS_UNAVAILABLE',
+          message: 'WorkspaceTopic store is unavailable',
+        },
+      });
+      return null;
+    }
+    const topic = workspaceTopicStore.get(workspaceTopicId.trim());
+    if (!topic) {
+      res.status(404).json({
+        error: {
+          code: 'WORKSPACE_TOPIC_NOT_FOUND',
+          message: `WorkspaceTopic not found: ${workspaceTopicId}`,
+        },
+      });
+      return null;
+    }
+    if (topic.status === 'archived') {
+      res.status(400).json({
+        error: {
+          code: 'WORKSPACE_TOPIC_ARCHIVED',
+          message: `WorkspaceTopic is archived: ${workspaceTopicId}`,
+        },
+      });
+      return null;
+    }
+    return {
+      body: {
+        ...buildWorkspaceTopicSessionCreateBody({
+          topic,
+          overrides: createBody,
+        }),
+        ...createBody,
+        workspaceTopicId: topic.id,
+      },
+      topic,
+    };
+  }
+
+  function linkWorkspaceTopicSession(
+    topic: WorkspaceTopic | undefined,
+    session: { id: string },
+    workContextId: string | undefined
+  ): void {
+    if (!topic || !workspaceTopicStore) return;
+    const patch = workspaceTopicSessionLinkPatch({
+      topic,
+      sessionId: session.id,
+      workContextId,
+    });
+    if (!patch) return;
+    try {
+      workspaceTopicStore.update(topic.id, patch);
+    } catch (err) {
+      logger.warn(
+        '[index] failed to link session %s to WorkspaceTopic %s: %s',
+        session.id,
+        topic.id,
+        err instanceof Error ? err.message : String(err)
+      );
+    }
   }
 
   const requireAuth: express.RequestHandler = (req, res, next) => {
@@ -4959,8 +5046,15 @@ async function main(): Promise<void> {
 
   // POST /sessions — unified endpoint for agent and terminal sessions
   app.post('/sessions', requireCliGatewayAuth, async (req, res) => {
-    const createBody = sessionCreateBodyFromRequest(req, res);
-    if (!createBody) return;
+    const requestedCreateBody = sessionCreateBodyFromRequest(req, res);
+    if (!requestedCreateBody) return;
+    const topicCreate = resolveWorkspaceTopicSessionCreate(
+      requestedCreateBody,
+      res
+    );
+    if (!topicCreate) return;
+    const createBody = topicCreate.body;
+    const workspaceTopic = topicCreate.topic;
     const {
       repoPath,
       worktreePath,
@@ -5094,6 +5188,7 @@ async function main(): Promise<void> {
         workContextId,
         session
       );
+      linkWorkspaceTopicSession(workspaceTopic, session, workContextId);
       sendSessionCreateSuccess(res, session, associationError, workContextId);
       return;
     }
@@ -5156,6 +5251,7 @@ async function main(): Promise<void> {
           workContextId,
           session
         );
+        linkWorkspaceTopicSession(workspaceTopic, session, workContextId);
         sendSessionCreateSuccess(res, session, associationError, workContextId);
       } catch (err) {
         sendSessionCreateError(res, err, freshConfig.maxPtySessions);
@@ -5235,6 +5331,8 @@ async function main(): Promise<void> {
       workContextId,
       session
     );
+
+    linkWorkspaceTopicSession(workspaceTopic, session, workContextId);
 
     sendSessionCreateSuccess(res, session, associationError, workContextId);
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -2001,11 +2001,11 @@ async function main(): Promise<void> {
     }
     return {
       body: {
+        ...createBody,
         ...buildWorkspaceTopicSessionCreateBody({
           topic,
           overrides: createBody,
         }),
-        ...createBody,
         workspaceTopicId: topic.id,
       },
       topic,

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -1290,6 +1290,11 @@ const createSessionInputSchema: RelayJsonSchema = {
     initialPrompt: stringSchema,
     continuePolicy: { type: 'string', enum: ['always', 'never'] },
     workContextId: stringSchema,
+    workspaceTopicId: {
+      ...stringSchema,
+      description:
+        'WorkspaceTopic id whose routing/prompt defaults seed this session create and whose linked session refs are updated after launch.',
+    },
     controlMode: {
       type: 'string',
       enum: ['agent-driven', 'human-driven'],

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -37,6 +37,7 @@ const createSessionAllowedFields = new Set([
   'initialPrompt',
   'continuePolicy',
   'workContextId',
+  'workspaceTopicId',
   'controlMode',
   'sessionEnvelope',
   'ttlSeconds',
@@ -78,6 +79,7 @@ const stringFields = [
   'branchName',
   'initialPrompt',
   'workContextId',
+  'workspaceTopicId',
   'expiresAt',
   'confirmationToken',
 ] as const;
@@ -103,6 +105,7 @@ const localCreateSupportedFields = [
   'initialPrompt',
   'continuePolicy',
   'workContextId',
+  'workspaceTopicId',
   'controlMode',
 ] as const;
 
@@ -534,7 +537,10 @@ function validateLocalCreateSupport(
       { field: 'controlMode', supported: ['human-driven', undefined] }
     );
   }
-  if (typeof input['repoPath'] !== 'string') {
+  if (
+    typeof input['repoPath'] !== 'string' &&
+    typeof input['workspaceTopicId'] !== 'string'
+  ) {
     return invalidCreateInput('local session creation requires repoPath', {
       field: 'repoPath',
     });

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -135,6 +135,8 @@ export interface WorkspaceTopicListResponse {
   derived: boolean;
 }
 
+export type WorkspaceTopicLaunchOverrides = Record<string, unknown>;
+
 export interface WorkspaceTopicCreateInput {
   id?: WorkspaceTopicId;
   workspaceId: WorkspaceId;
@@ -909,6 +911,144 @@ export function resolveWorkspaceTopicRoutingDefaults(
     ...(input.sessionOverride ?? {}),
     ...(input.explicitSpawnInput ?? {}),
   };
+}
+
+function readLaunchString(
+  overrides: WorkspaceTopicLaunchOverrides,
+  key: string
+): string | undefined {
+  const value = overrides[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readLaunchBoolean(
+  overrides: WorkspaceTopicLaunchOverrides,
+  key: string
+): boolean | undefined {
+  const value = overrides[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readLaunchNumber(
+  overrides: WorkspaceTopicLaunchOverrides,
+  key: string
+): number | undefined {
+  const value = overrides[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function topicPromptForSession(topic: WorkspaceTopic): string | undefined {
+  const parts = [
+    topic.promptDefaults.starterPrompt,
+    topic.promptDefaults.instructions,
+  ].filter(
+    (value): value is string =>
+      typeof value === 'string' && value.trim().length > 0
+  );
+  return parts.length ? parts.join('\n\n') : undefined;
+}
+
+/**
+ * Build the existing `sessions.create` body for a WorkspaceTopic launch.
+ *
+ * This deliberately projects Topic defaults into Relay's provider/session
+ * primitives instead of creating a Hermes-only launch fork. In the v1 local
+ * sessions API `cwd` is represented by `worktreePath`, so a topic-level cwd
+ * that differs from repoPath becomes the session worktree/cwd field unless an
+ * explicit worktreePath override is supplied.
+ */
+export function buildWorkspaceTopicSessionCreateBody(input: {
+  topic: WorkspaceTopic;
+  overrides?: WorkspaceTopicLaunchOverrides;
+}): Record<string, unknown> {
+  const overrides = input.overrides ?? {};
+  const explicitWorktreePath = Object.prototype.hasOwnProperty.call(
+    overrides,
+    'worktreePath'
+  )
+    ? overrides['worktreePath']
+    : undefined;
+  const explicitSpawnInput: WorkspaceTopicRoutingDefaults = {};
+  const explicitProvider = readLaunchString(overrides, 'agent');
+  if (explicitProvider) explicitSpawnInput.providerId = explicitProvider;
+  const explicitRepoPath = readLaunchString(overrides, 'repoPath');
+  if (explicitRepoPath) explicitSpawnInput.repoPath = explicitRepoPath;
+  if (typeof explicitWorktreePath === 'string' && explicitWorktreePath.trim()) {
+    explicitSpawnInput.worktreePath = explicitWorktreePath.trim();
+  }
+  const explicitCwd = readLaunchString(overrides, 'cwd');
+  if (explicitCwd) explicitSpawnInput.cwd = explicitCwd;
+
+  const routing = resolveWorkspaceTopicRoutingDefaults({
+    topicDefaults: input.topic.routingDefaults,
+    explicitSpawnInput,
+  });
+  const body: Record<string, unknown> = { workspaceTopicId: input.topic.id };
+  const repoPath = routing.repoPath ?? routing.cwd;
+  if (repoPath) body['repoPath'] = repoPath;
+  if (explicitWorktreePath === null) {
+    body['worktreePath'] = null;
+  } else {
+    const worktreePath =
+      routing.worktreePath ??
+      (routing.cwd && routing.cwd !== repoPath ? routing.cwd : undefined);
+    if (worktreePath) body['worktreePath'] = worktreePath;
+  }
+  const agent = routing.providerId;
+  if (agent) body['agent'] = agent;
+  for (const key of [
+    'type',
+    'mode',
+    'terminalBackend',
+    'branchName',
+    'continuePolicy',
+    'controlMode',
+  ]) {
+    const value = readLaunchString(overrides, key);
+    if (value) body[key] = value;
+  }
+  const yolo = readLaunchBoolean(overrides, 'yolo');
+  if (yolo !== undefined) body['yolo'] = yolo;
+  for (const key of ['cols', 'rows']) {
+    const value = readLaunchNumber(overrides, key);
+    if (value !== undefined) body[key] = value;
+  }
+  const workContextId =
+    readLaunchString(overrides, 'workContextId') ??
+    input.topic.linkedRefs.workContextIds?.[0];
+  if (workContextId) body['workContextId'] = workContextId;
+  const initialPrompt =
+    readLaunchString(overrides, 'initialPrompt') ??
+    topicPromptForSession(input.topic);
+  if (initialPrompt) body['initialPrompt'] = initialPrompt;
+  return body;
+}
+
+export function workspaceTopicSessionLinkPatch(input: {
+  topic: WorkspaceTopic;
+  sessionId: string;
+  workContextId?: string | undefined;
+}): WorkspaceTopicUpdateInput | undefined {
+  const linkedRefs: WorkspaceTopicLinkedRefs = { ...input.topic.linkedRefs };
+  const sessionIds = Array.from(
+    new Set([...(linkedRefs.sessionIds ?? []), input.sessionId])
+  );
+  linkedRefs.sessionIds = sessionIds;
+  if (input.workContextId) {
+    linkedRefs.workContextIds = Array.from(
+      new Set([...(linkedRefs.workContextIds ?? []), input.workContextId])
+    );
+  }
+  if (
+    sessionIds.length === (input.topic.linkedRefs.sessionIds ?? []).length &&
+    (!input.workContextId ||
+      input.topic.linkedRefs.workContextIds?.includes(input.workContextId))
+  ) {
+    return undefined;
+  }
+  return { linkedRefs };
 }
 
 export function buildWorkspaceTopicRecord(input: {

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -1086,6 +1086,21 @@ describe('CLI gateway contract', () => {
       },
       sessionType: 'terminal',
     });
+
+    const topicLaunch = validateAndSanitizeLocalGatewayCreateInput({
+      workspaceTopicId: 'topic:ws-launch-hermes',
+      type: 'agent',
+      agent: 'hermes',
+    });
+    expect(topicLaunch).toMatchObject({
+      ok: true,
+      input: {
+        workspaceTopicId: 'topic:ws-launch-hermes',
+        type: 'agent',
+        agent: 'hermes',
+      },
+      sessionType: 'agent',
+    });
   });
 
   it('advertises CLI argument and JSON parse errors emitted by gateway commands', () => {

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -254,6 +254,16 @@ describe('workspace topics foundation', () => {
     expect(
       buildWorkspaceTopicSessionCreateBody({
         topic,
+        overrides: { initialPrompt: '', workContextId: '' },
+      })
+    ).toMatchObject({
+      workContextId: 'wc-topic',
+      initialPrompt: 'resume this topic\n\nkeep the workspace context attached',
+    });
+
+    expect(
+      buildWorkspaceTopicSessionCreateBody({
+        topic,
         overrides: { worktreePath: null },
       })
     ).toMatchObject({

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -29,9 +29,11 @@ import type {
 import type { WorkContext } from '../shared/work-context.js';
 import {
   WORKSPACE_TOPICS_MAX_LIST_ENTRIES,
+  buildWorkspaceTopicSessionCreateBody,
   buildWorkspaceTopicRecord,
   parseWorkspaceTopicCreateInput,
   resolveWorkspaceTopicRoutingDefaults,
+  workspaceTopicSessionLinkPatch,
   type WorkspaceTopic,
   type WorkspaceTopicListResponse,
 } from '../shared/workspace-topics.js';
@@ -212,6 +214,65 @@ describe('workspace topics foundation', () => {
       cwd: '/repo/task',
       repoPath: '/repo',
       agentId: 'agent:kani',
+    });
+  });
+
+  it('projects topic defaults into session create bodies and link patches', () => {
+    const topic = buildWorkspaceTopicRecord({
+      create: {
+        workspaceId: 'ws-launch',
+        title: 'Hermes topic launch',
+        promptDefaults: {
+          starterPrompt: 'resume this topic',
+          instructions: 'keep the workspace context attached',
+        },
+        routingDefaults: {
+          providerId: 'hermes',
+          repoPath: '/repo',
+          cwd: '/repo/.worktrees/topic',
+        },
+        linkedRefs: { workContextIds: ['wc-topic'] },
+      },
+      now: '2026-06-26T00:00:00.000Z',
+    });
+
+    expect(
+      buildWorkspaceTopicSessionCreateBody({
+        topic,
+        overrides: { initialPrompt: 'explicit prompt', yolo: true },
+      })
+    ).toMatchObject({
+      workspaceTopicId: topic.id,
+      repoPath: '/repo',
+      worktreePath: '/repo/.worktrees/topic',
+      agent: 'hermes',
+      workContextId: 'wc-topic',
+      initialPrompt: 'explicit prompt',
+      yolo: true,
+    });
+
+    expect(
+      buildWorkspaceTopicSessionCreateBody({
+        topic,
+        overrides: { worktreePath: null },
+      })
+    ).toMatchObject({
+      repoPath: '/repo',
+      worktreePath: null,
+      agent: 'hermes',
+    });
+
+    expect(
+      workspaceTopicSessionLinkPatch({
+        topic,
+        sessionId: 'session-topic',
+        workContextId: 'wc-topic',
+      })
+    ).toEqual({
+      linkedRefs: {
+        workContextIds: ['wc-topic'],
+        sessionIds: ['session-topic'],
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- add `workspaceTopicId` to the v1 sessions create contract/CLI so Topic launches can use the existing Relay session creation primitive
- project WorkspaceTopic routing/prompt defaults into session create bodies, including Hermes provider defaults, cwd/worktree mapping, initial prompt, and WorkContext fallback
- link newly-created Relay sessions back onto the WorkspaceTopic after agent/terminal/web session creation

Refs #1025
Refs #1021

## Verification
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm test -- test/workspace-topics.test.ts test/cli-gateway-contract.test.ts` — 30 passed
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run check` — passed with existing lint warnings
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run build` — passed with existing Vite chunk/dynamic-import warnings

## Notes
- Ran `npm install` because the worktree was missing CodeMirror dependencies required by check/build; no package files changed.
- Simplify pass: risk tier 4 surface (CLI gateway/session launch/context linking). Kept review local because this is a Kanban worker; no extra subagent fanout. One cleanup applied: avoid mapping `routing.agentId` into `sessions.create.agent`, because current session creation expects provider ids like `hermes` there.
