### PR TITLE
docs: realign design kit terminal copy

### DIFF
--- a/docs/design-system/ui_kits/relay-web/README.md
+++ b/docs/design-system/ui_kits/relay-web/README.md
@@ -13,9 +13,9 @@ The Relay IDE web app — the only product surface. This kit shows the design sy
 
 - **Sidebar** — wordmark + connection status, three tabs (repos / worktrees / prs), filter input with `>` cursor, repo list grouped by workspace, expand/collapse, status dots, attention pulse, `+ add` rows, scanline overlay (drift disabled at `prefers-reduced-motion`).
 - **Session tabs** — square, edge-to-edge, terracotta top-border for active, attention pulse, hover-only close `×`.
-- **Breadcrumb** — repo badge → branch → agent + status dot, action buttons aligned right (resume / attach tmux / + branch).
+- **Breadcrumb** — repo badge → branch → agent + status dot, action buttons aligned right (resume / attach terminal / + branch).
 - **Terminal** — color tokens used as ANSI roles: `--text-muted` for prose, `--status-success` for OK, `--status-warning` for permission prompts, `--status-info` for paths, `--accent` for `claude` mark and `>` prompt. Block cursor blinks at 1.06s.
-- **Status bar** — bottom rail with tmux session, geometry, shell, diff stats, `⌘P` hint.
+- **Status bar** — bottom rail with `relay-pty` session/backend, geometry, shell, diff stats, `⌘P` hint.
 - **Command palette** — `surface` background, `0 4 16 rgba(0,0,0,.5)` shadow, FZF `>` cursor on the active row, `<em>` matches in `--accent`.
 
 ## Not mocked (yet)

--- a/docs/design-system/ui_kits/relay-web/chat.html
+++ b/docs/design-system/ui_kits/relay-web/chat.html
@@ -749,7 +749,7 @@ mark { background: transparent; color: var(--accent); font-weight: 600; text-dec
       <span id="hdr-status">idle</span>
       <div class="actions">
         <button class="tui-btn tui-btn--ghost">resume</button>
-        <button class="tui-btn tui-btn--info">attach tmux</button>
+        <button class="tui-btn tui-btn--info">attach terminal</button>
       </div>
     </div>
 
@@ -1016,7 +1016,7 @@ mark { background: transparent; color: var(--accent); font-weight: 600; text-dec
 
     <div class="sb-foot" style="border-left:0;">
       <span class="dot dot--success"></span>
-      <span>pty · tmux:0.0</span>
+      <span>pty · relay-pty</span>
       <span style="margin-left:auto;">196×48</span>
     </div>
     </div><!-- /.ctx__panel -->


### PR DESCRIPTION
## Summary

Refs #1035.

Fourth power-wash slice: remove stale tmux wording from the Relay web design-system mock.

- changes the mock breadcrumb action from `attach tmux` to `attach terminal`
- changes the mock status rail from `pty · tmux:0.0` to `pty · relay-pty`
- updates the UI-kit README so the static mock reflects the current `relay-pty` terminal backend direction

## Verification

- `grep -RIn "attach tmux\|tmux session\|pty · tmux" docs/design-system/ui_kits/relay-web` — no hits
- `git diff --check` — passed
- `npm run check` — passed, existing warnings only
- `npm run build` — passed, existing Vite chunk warnings only

No targeted runtime tests for this docs/static HTML mock-only slice; CI still runs the normal repo gate on the PR head.
