### PR TITLE
docs: mark rmux helper as historical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,6 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | Self-hosting         | `docs/SELF_HOSTING.md`                       | Build Relay with Relay using isolated dev config/ports/process identity                                                  |
 | Security policy      | `docs/SECURITY_POLICY.md`                    | Trust tiers, capability bits, hub ACL defaults, manifest-vs-policy boundary, exact-operation approvals, handshake grants |
 | Handshake grants     | `docs/OPERATOR_HANDSHAKE_GRANTS.md`          | One-time `relay-ohg-v1` operator handshake grant lane: ceremony, bounded scope, fail-closed validation                   |
-| rmux helper          | `docs/RMUX_HELPER_PROTOCOL.md`               | Experimental #707/#745 JSON/stdin-stdout boundary spec for a throwaway `relay-rmux-helper` prototype                     |
 | Session durability   | `docs/SESSION_DURABILITY.md`                 | Process-owner vs attach-handle, derived durability state machine, transition emission                                    |
 | Hub/node pkg         | `docs/RELAY_HUB_NODE_PACKAGING.md`           | Hub vs node command shape, npm package decision, install/update commands                                                 |
 | Node bootstrap       | `docs/RELAY_NODE_BOOTSTRAP.md`               | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics                                              |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,6 @@ This index separates current source-of-truth docs from historical plans and spik
 | Agent view artifacts  | `AGENT_VIEW_ARTIFACTS.md`               | Static HTML/CSS WorkContext view artifact contract, package route, security model            |
 | Security policy       | `SECURITY_POLICY.md`                    | Trust tiers, capability bits, hub ACL defaults, exact-operation approvals, handshake grants  |
 | Handshake grants      | `OPERATOR_HANDSHAKE_GRANTS.md`          | One-time operator grant ceremony copy, lane separation, validation, audit/redaction contract |
-| rmux helper protocol  | `RMUX_HELPER_PROTOCOL.md`               | Experimental #707 helper JSON/stdin-stdout boundary and prototype gates                      |
 | Session durability    | `SESSION_DURABILITY.md`                 | Process-owner vs attach-handle, derived durability state machine, transition emission        |
 | WSL2 nodes            | `WSL2_RELAY_NODE_SUPPORT.md`            | Windows/WSL2 node bootstrap, service mode, known limits                                      |
 | Web chat              | `WEB_CHAT.md`                           | Experimental adapter-shaped web chat surface for agent CLIs (status, scope, limits)          |
@@ -59,15 +58,16 @@ The six-layer vocabulary is the current product language. Treat repo/worktree/se
 
 These directories are useful evidence, but they are not current product docs by default:
 
-| Directory            | Status                                                                                                                           |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `plans/`             | Historical implementation plans and design proposals. Check code/current docs before treating as shipped.                        |
-| `spikes/`            | Research spikes and proposed protocols. Some findings may be implemented elsewhere; the spike itself is not a current guarantee. |
-| `superpowers/plans/` | Historical plan records for earlier agent/chat protocol work.                                                                    |
-| `superpowers/specs/` | Specs/design records; verify against `shared/`, `server/`, `frontend/`, and tests.                                               |
-| `bug-analyses/`      | Debugging writeups and postmortems. Use as history, not current behavior.                                                        |
-| `refactor/`          | Audit/refactor notes. Use as evidence for cleanup decisions.                                                                     |
-| `adrs/`              | Accepted/current ADR files where present. Older ADR summaries may still live in `federated-relay.md` or `ARCHITECTURE.md`.       |
+| Directory                 | Status                                                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `plans/`                  | Historical implementation plans and design proposals. Check code/current docs before treating as shipped.                                      |
+| `spikes/`                 | Research spikes and proposed protocols. Some findings may be implemented elsewhere; the spike itself is not a current guarantee.               |
+| `superpowers/plans/`      | Historical plan records for earlier agent/chat protocol work.                                                                                  |
+| `superpowers/specs/`      | Specs/design records; verify against `shared/`, `server/`, `frontend/`, and tests.                                                             |
+| `bug-analyses/`           | Debugging writeups and postmortems. Use as history, not current behavior.                                                                      |
+| `refactor/`               | Audit/refactor notes. Use as evidence for cleanup decisions.                                                                                   |
+| `adrs/`                   | Accepted/current ADR files where present. Older ADR summaries may still live in `federated-relay.md` or `ARCHITECTURE.md`.                     |
+| `RMUX_HELPER_PROTOCOL.md` | Historical prototype boundary. Current runtime behavior is `relay-pty`; rmux remains diagnostic/prototype-only unless a new issue promotes it. |
 
 ## Guardrails for future doc edits
 

--- a/docs/RMUX_HELPER_PROTOCOL.md
+++ b/docs/RMUX_HELPER_PROTOCOL.md
@@ -1,13 +1,13 @@
 # relay-rmux-helper protocol and prototype boundary
 
-Status: experimental spec for #707/#745. This is not a supported default runtime and not a promise that Relay will adopt rmux. It defines the minimum Relay-owned JSON/stdin-stdout boundary that a throwaway Rust `relay-rmux-helper` prototype must satisfy before any TypeScript adapter code is written.
+Status: historical prototype spec for #707/#745. Relay's current terminal runtime is `relay-pty`/libghostty-vt; rmux is not adopted as a runtime and remains diagnostic/prototype-only unless a new issue explicitly promotes it. This file records the minimum Relay-owned JSON/stdin-stdout boundary a throwaway Rust `relay-rmux-helper` prototype would have needed before TypeScript adapter work.
 
 ## Sources and invariants
 
 Reviewed before writing this boundary:
 
-- `AGENTS.md` — Relay architecture direction, tmux requirement, CLI gateway/adapter boundary, node capability notes.
-- `docs/ARCHITECTURE.md` — `SessionAttachment`, hub/node routing, REST/WebSocket identities, tmux as process substrate.
+- `AGENTS.md` — Relay architecture direction, `relay-pty` terminal backend, CLI gateway/adapter boundary, node capability notes.
+- `docs/ARCHITECTURE.md` — `SessionAttachment`, hub/node routing, REST/WebSocket identities, `relay-pty` terminal/session execution.
 - `docs/CLI_GATEWAY.md` — adapter-facing commands are versioned Relay JSON contracts, never private node-link/rmux/tmux protocol clients.
 - `docs/SESSION_DURABILITY.md` — attach handles are not process owners; terminal stream v2 replay/lag/resize semantics are the browser/runtime contract.
 - `docs/adrs/ADR-017-brain-as-peer-cli-session-events.md` — agent brains are hub-level peers that act through the CLI gateway.
@@ -19,7 +19,7 @@ Hard invariants:
 
 1. Relay TypeScript must not speak the rmux daemon wire protocol directly. If the prototype proceeds, the Rust helper uses `rmux-sdk`; Relay speaks only this helper protocol.
 2. Relay product/API identity remains `sessionId`, `globalSessionId`, `nodeId`, `SessionAttachment`, `SessionSummary`, and Workbench nouns. rmux pane/session ids are debug-only substrate handles.
-3. The existing tmux/node-pty path remains the default and clean fallback. rmux is opt-in, experimental, and deletable.
+3. The existing `relay-pty` path remains the default. rmux is prototype-only, diagnostic, and deletable; do not add a tmux fallback or treat rmux as a supported runtime.
 4. Raw bytes are not a stable agent-to-agent/supervisor API. `write` and `submit` below are PTY substrate operations only; typed supervisor/handoff work remains in #718/ADR-018 command slices.
 5. No raw prompt, transcript, provider auth, or unbounded terminal history is stored in audit/logs by default.
 
@@ -451,7 +451,7 @@ Relay maps these into existing `SessionSummary`/durability fields:
 | `closing`                      | transitional; disable writes/resizes                                                     |
 | `closed`                       | `ended` then cleanup                                                                     |
 | `errored`, helper crash        | `error`; include typed degraded reason                                                   |
-| rmux unavailable before create | no rmux session; use default tmux/node-pty fallback if policy allows                     |
+| rmux unavailable before create | no rmux session; use the existing `relay-pty` path if policy allows                      |
 | rmux unavailable after create  | `error` or `stale-node`-like degraded state; do not silently re-home an existing session |
 
 ### `close`
@@ -548,10 +548,10 @@ The prototype is reachable only when every gate passes:
 
 Fallback rules:
 
-- When the feature flag is off, no helper process is spawned and the existing tmux/node-pty path remains unchanged.
-- When the flag is on but the rmux probe is unacceptable, Relay reports a degraded rmux capability and creates sessions with the default tmux/node-pty path unless the user explicitly requested rmux-only behavior for a prototype test.
-- If helper spawn/hello fails during create, Relay may fall back to tmux/node-pty for that create only when the request did not require rmux-only. The response/session metadata must show `runtime: "tmux"`/existing mode, not pretend rmux succeeded.
-- Once a session is created on rmux, Relay must not silently migrate it to tmux after helper/rmux failure. Mark it degraded/error, preserve bounded snapshot if available, and require explicit operator recovery.
+- When the feature flag is off, no helper process is spawned and the existing `relay-pty` path remains unchanged.
+- When the flag is on but the rmux probe is unacceptable, Relay reports a degraded rmux capability and creates sessions through the existing `relay-pty` path unless the user explicitly requested rmux-only behavior for a prototype test.
+- If helper spawn/hello fails during create, Relay may fall back to `relay-pty` for that create only when the request did not require rmux-only. The response/session metadata must show the existing `relay-pty` mode, not pretend rmux succeeded.
+- Once a session is created on rmux, Relay must not silently migrate it to another backend after helper/rmux failure. Mark it degraded/error, preserve bounded snapshot if available, and require explicit operator recovery.
 
 ## Security and audit boundaries
 
@@ -585,7 +585,7 @@ Audit/logging:
 
 | Failure                                        | Expected behavior                                                                                                                        |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Helper process exits before `hello`            | Mark rmux helper unavailable; fallback to tmux/node-pty if create was not rmux-only.                                                     |
+| Helper process exits before `hello`            | Mark rmux helper unavailable; fall back to `relay-pty` if create was not rmux-only.                                                      |
 | Helper exits with live sessions                | Emit/derive `error` for affected sessions, close helper attach streams, keep Relay process alive, do not auto-migrate existing sessions. |
 | rmux daemon unavailable before create          | `RMUX_UNAVAILABLE`; fallback only for non-rmux-only create.                                                                              |
 | rmux daemon timeout during attach/write/resize | Typed `DAEMON_TIMEOUT`; session becomes degraded until `status` recovers or operator kills/recreates.                                    |
@@ -600,7 +600,7 @@ Audit/logging:
 
 A prototype PR that implements this boundary must include evidence for:
 
-- feature flag off: no helper spawn, existing tmux/node-pty path still works;
+- feature flag off: no helper spawn, existing `relay-pty` path still works;
 - probe gate pass: `available-experimental` permits helper in explicit dev mode;
 - probe gate fail: unavailable/unsupported/probe-failed status falls back cleanly;
 - create/attach/output/snapshot/write/submit/resize/status/close/kill happy path;


### PR DESCRIPTION
## Summary

Refs #1035.

Follow-up to Kyle's mid-run note that the rmux/rmux-helper docs were out of date.

- removes `RMUX_HELPER_PROTOCOL.md` from the current source-of-truth docs table and moves it into historical/prototype material
- removes the rmux helper row from the top-level `AGENTS.md` docs map so agents do not treat it as a current runtime path
- updates `docs/RMUX_HELPER_PROTOCOL.md` to state that current runtime behavior is `relay-pty` and rmux remains diagnostic/prototype-only
- replaces current-looking tmux/node-pty fallback wording in the rmux prototype doc with `relay-pty` fallback wording

## Verification

- `npx prettier --write AGENTS.md docs/README.md docs/RMUX_HELPER_PROTOCOL.md`
- focused stale scan over touched docs for:
  - `rmux helper protocol  |`
  - `rmux helper          |`
  - `tmux requirement`
  - `tmux as process substrate`
  - `existing tmux/node-pty`
  - `default tmux/node-pty`
  - `runtime: "tmux"`
  - `migrate it to tmux`
- `npm test -- --run test/rmux-probe.test.ts` — 1 file / 8 tests passed
- `npm run check` — passed, existing warnings only
- `npm run build` — passed, existing Vite chunk warnings only
- `git diff --check` — passed

## Note

This does not delete rmux diagnostic code. `server/rmux-probe.ts` and bootstrap docs still describe rmux as an optional diagnostic capability, which matches current code. The cleanup here is about not presenting the helper prototype as a current runtime/docs source of truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation indexes and protocol notes to reflect the current runtime behavior and clarify that the helper protocol is historical/prototype material.
  * Refreshed fallback and status references so the docs consistently point to the current terminal runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->