### PR TITLE
feat(frontend): default to topic sidebar shell

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -641,8 +641,9 @@ export function Sidebar({
               />
             </div>
           ) : topicShellEnabled ? (
-            // Thin-line WorkspaceTopic shell remains opt-in until #1032 parity
-            // and #1027 QA make it safe to retire the repo sidebar fallback.
+            // Default thin-line WorkspaceTopic shell. The repo sidebar below is
+            // kept only as an explicit localStorage fallback until #1032 deletes
+            // the duplicate implementation.
             <div className="sidebar-workspace-list">
               <TopicSidebarShell onSelectSession={onSelectSession} />
             </div>

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -174,9 +174,12 @@ function loadViewSpineEnabled(): boolean {
   return ls(VIEW_SPINE_KEY) === '1';
 }
 
-function loadTopicShellEnabled(): boolean {
-  // Separate opt-in while topic-shell parity remains tracked by #1032/#1027.
-  return ls(TOPIC_SHELL_KEY) === '1';
+export function loadTopicShellEnabled(): boolean {
+  // The thin-line WorkspaceTopic shell is the default desktop sidebar. Keep an
+  // explicit localStorage opt-out so operators can recover the legacy fallback
+  // while #1032 tracks deleting the duplicate implementation.
+  const stored = ls(TOPIC_SHELL_KEY);
+  return stored !== '0' && stored !== 'false';
 }
 
 // ── #738: View-layer persistence (lens / pins / saved Views) ─────────────────
@@ -624,7 +627,7 @@ export interface UiState {
   collapsedWorkspaces: Set<string>;
   /** Six-layer navigation surface flag. Default false; backed by localStorage. */
   viewSpineEnabled: boolean;
-  /** Thin-line WorkspaceTopic sidebar/detail shell flag. Default false. */
+  /** Thin-line WorkspaceTopic sidebar/detail shell flag. Default true. */
   topicShellEnabled: boolean;
   /** #738: active Views lens, persisted across reload (default `recent`). */
   viewSpineLens: ViewLens;
@@ -1335,7 +1338,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   },
   setTopicShellEnabled: (enabled) => {
     if (enabled) lsSave(TOPIC_SHELL_KEY, '1');
-    else lsRemove(TOPIC_SHELL_KEY);
+    else lsSave(TOPIC_SHELL_KEY, '0');
     set({ topicShellEnabled: enabled });
   },
   toggleTopicShellEnabled: () =>

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -27,6 +27,7 @@ if (typeof globalThis.localStorage === 'undefined') {
 import {
   useUiStore,
   fileTabKey,
+  loadTopicShellEnabled,
   DEFAULT_SIDEBAR_WIDTH,
   DEFAULT_RIGHT_SIDEBAR_WIDTH,
   DEFAULT_TERMINAL_FONT_SIZE,
@@ -66,6 +67,8 @@ function resetStore() {
     sendToTargetSessionId: null,
     lastChangedFiles: [],
     collapsedWorkspaces: new Set(),
+    viewSpineEnabled: false,
+    topicShellEnabled: true,
   });
 }
 
@@ -120,6 +123,31 @@ describe('ui Zustand store', () => {
       expect(storage['claude-remote-sidebar-collapsed']).toBe('true');
       useUiStore.getState().toggleSidebarCollapsed();
       expect(storage['claude-remote-sidebar-collapsed']).toBe('false');
+    });
+  });
+
+  describe('topic shell flag', () => {
+    it('defaults to enabled when no explicit sidebar fallback opt-out exists', () => {
+      delete storage['relay-topic-shell'];
+      expect(loadTopicShellEnabled()).toBe(true);
+    });
+
+    it('honors explicit legacy sidebar fallback opt-out values', () => {
+      storage['relay-topic-shell'] = '0';
+      expect(loadTopicShellEnabled()).toBe(false);
+
+      storage['relay-topic-shell'] = 'false';
+      expect(loadTopicShellEnabled()).toBe(false);
+    });
+
+    it('persists disabling the topic shell as an explicit opt-out', () => {
+      useUiStore.getState().setTopicShellEnabled(false);
+      expect(storage['relay-topic-shell']).toBe('0');
+      expect(useUiStore.getState().topicShellEnabled).toBe(false);
+
+      useUiStore.getState().setTopicShellEnabled(true);
+      expect(storage['relay-topic-shell']).toBe('1');
+      expect(useUiStore.getState().topicShellEnabled).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Make the thin-line WorkspaceTopic sidebar shell the default desktop sidebar experience.
- Keep the legacy repo sidebar available as an explicit `localStorage.relay-topic-shell = '0'` fallback while #1032 tracks deleting the duplicate implementation.
- Add UI-store coverage for default-on behavior and explicit opt-out persistence.

## Verification
- `npm test -- test/stores/ui-store.test.ts test/topic-sidebar-shell.test.ts test/topic-nav.test.ts` — 71 passed.
- `npm run check` — passed, existing lint warnings only (`/tmp/relay-topic-sidebar-default-check.log`).
- `npm run build` — passed, existing Vite chunk-size warnings (`/tmp/relay-topic-sidebar-default-build.log`).
- Pre-push changed-tests hook — 53 files / 463 tests passed.

Refs #1021
Refs #1032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The new workspace/topic shell experience is now enabled by default for users, while still allowing an opt-out setting.
* **Bug Fixes**
  * Saved preferences now persist more reliably across reloads, so the shell choice stays consistent after changing it.
  * Updated fallback behavior to better preserve the previous sidebar experience during transition periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->