### PR TITLE
feat: add topic task-room detail

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -507,6 +507,7 @@
   background: color-mix(in srgb, var(--accent) 10%, transparent);
   outline: 1px solid var(--accent);
   outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 .topic-room__section {
@@ -560,7 +561,8 @@
   background: var(--surface-hover);
   color: var(--text);
   outline: 1px solid var(--accent);
-  outline-offset: 1px;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 .topic-room-session__label,

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -498,11 +498,15 @@
 }
 
 .topic-room__primary:not(:disabled):hover,
+.topic-room-ref-list a:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
 .topic-room__primary:not(:disabled):focus-visible,
-.topic-room-ref-list a:hover,
 .topic-room-ref-list a:focus-visible {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
-  outline: none;
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .topic-room__section {
@@ -547,11 +551,16 @@
   text-align: left;
 }
 
-.topic-room-session__button:hover,
+.topic-room-session__button:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
 .topic-room-session__button:focus-visible {
   background: var(--surface-hover);
   color: var(--text);
-  outline: none;
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .topic-room-session__label,

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -381,6 +381,222 @@
   padding: 2px 4px;
 }
 
+.topic-room {
+  display: grid;
+  gap: 8px;
+  max-height: min(56vh, 560px);
+  overflow: auto;
+}
+
+.topic-room__header {
+  position: sticky;
+  top: -8px;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--topic-badge-size);
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 7px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.topic-room__identity,
+.topic-room-session__main {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.topic-room__eyebrow,
+.topic-room__action-band > div > span,
+.topic-room__status-card > span,
+.topic-room__section-header,
+.topic-room-session-group__label,
+.topic-room-session__meta,
+.topic-room-session__disabled,
+.topic-room-surface-list__safety,
+.topic-room__fallback,
+.topic-room-empty {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  line-height: 1.35;
+}
+
+.topic-room__title {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.topic-room__meta {
+  margin-top: 0;
+}
+
+.topic-room__action-band,
+.topic-room__status-card,
+.topic-room__section,
+.topic-room__fallback {
+  border: 1px solid var(--border);
+  padding: 7px;
+}
+
+.topic-room__action-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.topic-room__action-band strong,
+.topic-room__status-card strong {
+  display: block;
+  margin-top: 2px;
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.topic-room__action-band p,
+.topic-room__disabled {
+  grid-column: 1 / -1;
+  margin: 2px 0 0;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  line-height: 1.35;
+}
+
+.topic-room__disabled,
+.topic-room-empty.error {
+  color: var(--status-warning);
+}
+
+.topic-room__primary,
+.topic-room-ref-list a,
+.topic-room-ref-list > li > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  border: 1px solid var(--accent);
+  border-radius: 0;
+  background: transparent;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 0.58rem;
+  text-decoration: none;
+}
+
+.topic-room__primary {
+  padding: 0 8px;
+}
+
+.topic-room__primary:disabled {
+  border-color: var(--border);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.topic-room__primary:not(:disabled):hover,
+.topic-room__primary:not(:disabled):focus-visible,
+.topic-room-ref-list a:hover,
+.topic-room-ref-list a:focus-visible {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  outline: none;
+}
+
+.topic-room__section {
+  display: grid;
+  gap: 7px;
+}
+
+.topic-room__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid var(--border);
+}
+
+.topic-room-session-group,
+.topic-room-session-group ul,
+.topic-room-ref-list,
+.topic-room-surface-list {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.topic-room-session__button,
+.topic-room-surface-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(58px, auto) 16px;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 32px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  text-align: left;
+}
+
+.topic-room-session__button:hover,
+.topic-room-session__button:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text);
+  outline: none;
+}
+
+.topic-room-session__label,
+.topic-room-session__anchor,
+.topic-room-surface-list__label,
+.topic-room-surface-list__safety {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-room-session--attention .topic-room-session__label,
+.topic-room-session--error .topic-room-session__label {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.topic-room-session__disabled {
+  display: block;
+  margin: 2px 0 0 6px;
+  color: var(--status-warning);
+}
+
+.topic-room-ref-list a,
+.topic-room-ref-list > li > span {
+  max-width: 100%;
+  padding: 2px 5px;
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.topic-room-ref-list strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-room-surface-list li {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
 .topic-mobile-cockpit,
 .topic-mobile-detail {
   display: none;

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -415,10 +415,15 @@ function TopicRoomTaskRefs({ item }: { item: TopicNavItem }) {
 function TopicRoomSurfaceStrip({
   item,
   surfacesError,
+  surfacesLoading,
 }: {
   item: TopicNavItem;
   surfacesError?: boolean | undefined;
+  surfacesLoading?: boolean | undefined;
 }) {
+  if (surfacesLoading && item.surfaces.length === 0) {
+    return <p className="topic-room-empty">surfaces loading…</p>;
+  }
   if (surfacesError && item.surfaces.length === 0) {
     return <p className="topic-room-empty error">surfaces unavailable</p>;
   }
@@ -466,10 +471,12 @@ function TopicRoomSurfaceStrip({
 function TopicDetail({
   item,
   surfacesError,
+  surfacesLoading,
   onSelectSession,
 }: {
   item: TopicNavItem;
   surfacesError?: boolean | undefined;
+  surfacesLoading?: boolean | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
   const action = topicPrimaryAction(item);
@@ -526,7 +533,7 @@ function TopicDetail({
               topSurface.openMode === 'direct' &&
               topSurface.target.startsWith('http')
             ) {
-              window.open(topSurface.target, '_blank', 'noreferrer');
+              window.open(topSurface.target, '_blank', 'noopener,noreferrer');
               return;
             }
             void navigator.clipboard?.writeText(topSurface.target);
@@ -589,7 +596,11 @@ function TopicDetail({
           <span>artifacts/surfaces</span>
           <span>{item.surfaces.length + item.artifactIds.length}</span>
         </div>
-        <TopicRoomSurfaceStrip item={item} surfacesError={surfacesError} />
+        <TopicRoomSurfaceStrip
+          item={item}
+          surfacesError={surfacesError}
+          surfacesLoading={surfacesLoading}
+        />
       </section>
 
       <div className="topic-room__fallback">
@@ -691,7 +702,7 @@ function TopicMobileControlPanel({
       topSurface.openMode === 'direct' &&
       topSurface.target.startsWith('http')
     ) {
-      window.open(topSurface.target, '_blank', 'noreferrer');
+      window.open(topSurface.target, '_blank', 'noopener,noreferrer');
       return;
     }
     void navigator.clipboard?.writeText(topSurface.target);
@@ -1141,6 +1152,7 @@ export function TopicSidebarView({
   loading = false,
   error = false,
   derived = false,
+  surfacesLoading = false,
   searchQuery = '',
   searchLoading = false,
   searchError = false,
@@ -1160,6 +1172,7 @@ export function TopicSidebarView({
   loading?: boolean;
   error?: boolean;
   derived?: boolean;
+  surfacesLoading?: boolean;
   searchQuery?: string;
   searchLoading?: boolean;
   searchError?: boolean;
@@ -1277,6 +1290,7 @@ export function TopicSidebarView({
           <TopicDetail
             item={selectedItem}
             surfacesError={surfacesError}
+            surfacesLoading={surfacesLoading}
             onSelectSession={onSelectSession}
           />
           <TopicMobileControlPanel
@@ -1328,12 +1342,9 @@ export function TopicSidebarShell({
       }
       sessions={sessions}
       surfaces={surfacesQuery.data ?? []}
-      loading={
-        !searchActive &&
-        ((topicsQuery.isLoading && !topicsQuery.data) ||
-          (surfacesQuery.isLoading && !surfacesQuery.data))
-      }
+      loading={!searchActive && topicsQuery.isLoading && !topicsQuery.data}
       error={topicsQuery.isError && !topicsQuery.data && !searchActive}
+      surfacesLoading={surfacesQuery.isLoading && !surfacesQuery.data}
       surfacesError={surfacesQuery.isError}
       derived={
         searchActive

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -186,6 +186,99 @@ function TopicBadge({ item }: { item: TopicNavItem }) {
   );
 }
 
+type TopicRoomSessionGroupKey =
+  | 'needs-input'
+  | 'approval'
+  | 'running'
+  | 'idle'
+  | 'stale-offline'
+  | 'crashed';
+
+const TOPIC_ROOM_SESSION_GROUPS: {
+  key: TopicRoomSessionGroupKey;
+  label: string;
+}[] = [
+  { key: 'needs-input', label: 'needs input' },
+  { key: 'approval', label: 'approval' },
+  { key: 'running', label: 'running' },
+  { key: 'idle', label: 'idle' },
+  { key: 'stale-offline', label: 'stale/offline' },
+  { key: 'crashed', label: 'crashed' },
+];
+
+function topicRoomSessionGroup(
+  session: TopicNavSessionRef
+): TopicRoomSessionGroupKey {
+  if (session.displayState === 'error' || session.durability === 'error') {
+    return 'crashed';
+  }
+  if (
+    session.status === 'disconnected' ||
+    session.durability === 'stale-node' ||
+    session.durability === 'ended' ||
+    session.controlFreshness === 'stale'
+  ) {
+    return 'stale-offline';
+  }
+  if (session.displayState === 'needs-answer') return 'needs-input';
+  if (session.displayState === 'permission') return 'approval';
+  if (
+    session.displayState === 'running' ||
+    session.displayState === 'initializing'
+  ) {
+    return 'running';
+  }
+  return 'idle';
+}
+
+function topicRoomGroupedSessions(item: TopicNavItem): {
+  key: TopicRoomSessionGroupKey;
+  label: string;
+  sessions: TopicNavSessionRef[];
+}[] {
+  return TOPIC_ROOM_SESSION_GROUPS.map((group) => ({
+    ...group,
+    sessions: item.sessions.filter(
+      (session) => topicRoomSessionGroup(session) === group.key
+    ),
+  })).filter((group) => group.sessions.length > 0);
+}
+
+function topicRoomFreshnessLabel(item: TopicNavItem): string {
+  const groups = new Set(item.sessions.map(topicRoomSessionGroup));
+  if (groups.has('stale-offline')) return 'stale/offline';
+  if (groups.has('crashed')) return 'crashed';
+  if (groups.has('needs-input') || groups.has('approval')) return 'needs input';
+  if (groups.has('running')) return 'fresh';
+  if (item.surfaces.some((surface) => surface.health === 'unreachable')) {
+    return 'surface error';
+  }
+  if (
+    item.sessions.length === 0 &&
+    item.surfaces.length === 0 &&
+    item.taskRefs.length === 0 &&
+    item.artifactIds.length === 0
+  ) {
+    return 'empty';
+  }
+  return 'last known';
+}
+
+function topicRoomLatestSummary(item: TopicNavItem): string {
+  const session = topicPrimarySession(item);
+  if (session?.currentActivity) return topicLatestStatus(item);
+  if (session) return `${session.label} · ${session.displayState}`;
+  if (item.surfaces[0]) return `newest surface · ${item.surfaces[0].label}`;
+  if (item.taskRefs[0]) {
+    return `task ref · ${item.taskRefs[0].title ?? item.taskRefs[0].id}`;
+  }
+  return 'no sessions linked yet';
+}
+
+function topicRoomAnchorLabel(item: TopicNavItem): string {
+  return item.routingLabel ?? 'no repo binding';
+}
+
 function SurfaceButton({ surface }: { surface: TopicNavSurfaceRef }) {
   const canOpen =
     surface.openMode === 'direct' && surface.target?.startsWith('http');
@@ -249,32 +342,260 @@ function SessionChildRow({
   );
 }
 
-function TopicDetail({ item }: { item: TopicNavItem }) {
+function TopicRoomSessionRow({
+  session,
+  onSelectSession,
+}: {
+  session: TopicNavSessionRef;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const disabledReason = sessionControlDisabledReason(session);
   return (
-    <section className="topic-detail" aria-label={`${item.title} details`}>
-      <div className="topic-detail__title">{item.title}</div>
+    <li className={`topic-room-session topic-room-session--${session.tone}`}>
+      <button
+        type="button"
+        className="topic-room-session__button"
+        title={`open exact session ${session.selectKey}`}
+        onClick={() => onSelectSession?.(session.selectKey)}
+      >
+        <span className="topic-room-session__main">
+          <span className="topic-room-session__label">
+            <MarqueeText>{session.label}</MarqueeText>
+          </span>
+          <span className="topic-room-session__meta">
+            {session.agent} · {session.type} · {session.displayState}
+          </span>
+        </span>
+        <span className="topic-room-session__anchor">
+          {session.nodeId ? `${session.nodeId} · ` : ''}
+          {session.branch ?? session.cwd}
+        </span>
+        <StatusGlyph tone={session.tone} />
+      </button>
+      {disabledReason ? (
+        <span className="topic-room-session__disabled">
+          live controls disabled: {disabledReason}
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+function TopicRoomTaskRefs({ item }: { item: TopicNavItem }) {
+  if (item.taskRefs.length === 0) {
+    return <p className="topic-room-empty">no task refs linked yet</p>;
+  }
+  return (
+    <ul className="topic-room-ref-list" aria-label="task refs">
+      {item.taskRefs.map((taskRef) => {
+        const label = taskRef.title ?? taskRef.id;
+        const content = (
+          <>
+            <span>{taskRef.kind}</span>
+            <strong>{label}</strong>
+            {taskRef.status ? <span>{taskRef.status}</span> : null}
+          </>
+        );
+        return (
+          <li key={`${taskRef.kind}:${taskRef.id}`}>
+            {taskRef.url ? (
+              <a href={taskRef.url} rel="noreferrer" target="_blank">
+                {content}
+              </a>
+            ) : (
+              <span>{content}</span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function TopicRoomSurfaceStrip({
+  item,
+  surfacesError,
+}: {
+  item: TopicNavItem;
+  surfacesError?: boolean | undefined;
+}) {
+  if (surfacesError && item.surfaces.length === 0) {
+    return <p className="topic-room-empty error">surfaces unavailable</p>;
+  }
+  if (item.surfaces.length === 0 && item.artifactIds.length === 0) {
+    return (
+      <p className="topic-room-empty">no artifacts or surfaces linked yet</p>
+    );
+  }
+  return (
+    <ul
+      className="topic-room-surface-list"
+      aria-label="artifact and surface strip"
+    >
+      {item.surfaces.map((surface) => (
+        <li key={surface.id}>
+          <SurfaceButton surface={surface} />
+          <span className="topic-room-surface-list__label">
+            {surface.label}
+          </span>
+          <span className="topic-room-surface-list__safety">
+            {surface.openMode === 'direct'
+              ? 'direct open'
+              : `${surface.openMode} only`}
+          </span>
+        </li>
+      ))}
+      {item.artifactIds.map((artifactId) => (
+        <li key={artifactId}>
+          <span className="topic-action">artifact</span>
+          <span className="topic-room-surface-list__label">{artifactId}</span>
+          <span className="topic-room-surface-list__safety">
+            metadata ref only
+          </span>
+        </li>
+      ))}
+      {surfacesError ? (
+        <li className="topic-room-empty error">
+          surfaces partially unavailable
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+function TopicDetail({
+  item,
+  surfacesError,
+  onSelectSession,
+}: {
+  item: TopicNavItem;
+  surfacesError?: boolean | undefined;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const action = topicPrimaryAction(item);
+  const session = topicPrimarySession(item);
+  const topSurface = item.surfaces[0];
+  const groupedSessions = topicRoomGroupedSessions(item);
+  const primaryDisabled =
+    Boolean(action.disabledReason) || (!session && !topSurface?.target);
+  return (
+    <section
+      className={`topic-detail topic-room topic-room--${item.tone}`}
+      aria-label={`${item.title} task room`}
+    >
+      <header className="topic-room__header">
+        <div className="topic-room__identity">
+          <span className="topic-room__eyebrow">task room</span>
+          <div className="topic-detail__title topic-room__title">
+            <MarqueeText>{item.title}</MarqueeText>
+          </div>
+        </div>
+        <TopicBadge item={item} />
+      </header>
       {item.description ? (
         <p className="topic-detail__description">{item.description}</p>
       ) : (
         <p className="topic-detail__description muted">no topic brief yet</p>
       )}
-      <div className="topic-detail__meta">
-        <span>{item.statusLabel}</span>
-        {item.routingLabel ? <span>{item.routingLabel}</span> : null}
-        {item.taskRefs.length > 0 ? (
-          <span>{item.taskRefs.length} task refs</span>
-        ) : null}
-        {item.surfaces.length > 0 ? (
-          <span>{item.surfaces.length} surfaces</span>
+      <div className="topic-detail__meta topic-room__meta">
+        <span>{item.workspaceId}</span>
+        <span>{item.lifecycleLabel}</span>
+        <span>{topicRoomFreshnessLabel(item)}</span>
+        <span>{topicRoomAnchorLabel(item)}</span>
+        <span>updated {item.updatedAt}</span>
+      </div>
+
+      <div className="topic-room__action-band">
+        <div>
+          <span>primary action</span>
+          <strong>{action.label}</strong>
+          <p>{action.detail}</p>
+        </div>
+        <button
+          type="button"
+          className="topic-room__primary"
+          disabled={primaryDisabled}
+          title={action.disabledReason ?? action.detail}
+          onClick={() => {
+            if (session) {
+              onSelectSession?.(session.selectKey);
+              return;
+            }
+            if (!topSurface?.target) return;
+            if (
+              topSurface.openMode === 'direct' &&
+              topSurface.target.startsWith('http')
+            ) {
+              window.open(topSurface.target, '_blank', 'noreferrer');
+              return;
+            }
+            void navigator.clipboard?.writeText(topSurface.target);
+          }}
+        >
+          {action.label}
+        </button>
+        {action.disabledReason ? (
+          <p className="topic-room__disabled">
+            controls disabled: {action.disabledReason}
+          </p>
         ) : null}
       </div>
-      {item.surfaces.length > 0 ? (
-        <div className="topic-detail__surfaces" aria-label="topic surfaces">
-          {item.surfaces.slice(0, 6).map((surface) => (
-            <SurfaceButton key={surface.id} surface={surface} />
-          ))}
+
+      <div className="topic-room__status-card">
+        <span>latest bounded status</span>
+        <strong>{topicRoomLatestSummary(item)}</strong>
+      </div>
+
+      <section className="topic-room__section" aria-label="grouped sessions">
+        <div className="topic-room__section-header">
+          <span>sessions</span>
+          <span>{item.sessions.length}</span>
         </div>
-      ) : null}
+        {groupedSessions.length > 0 ? (
+          groupedSessions.map((group) => (
+            <div className="topic-room-session-group" key={group.key}>
+              <div className="topic-room-session-group__label">
+                {group.label} · {group.sessions.length}
+              </div>
+              <ul>
+                {group.sessions.map((groupSession) => (
+                  <TopicRoomSessionRow
+                    key={groupSession.id}
+                    session={groupSession}
+                    onSelectSession={onSelectSession}
+                  />
+                ))}
+              </ul>
+            </div>
+          ))
+        ) : (
+          <p className="topic-room-empty">no sessions linked yet</p>
+        )}
+      </section>
+
+      <section className="topic-room__section" aria-label="task refs">
+        <div className="topic-room__section-header">
+          <span>refs</span>
+          <span>{item.taskRefs.length} task refs</span>
+        </div>
+        <TopicRoomTaskRefs item={item} />
+      </section>
+
+      <section
+        className="topic-room__section"
+        aria-label="artifacts and surfaces"
+      >
+        <div className="topic-room__section-header">
+          <span>artifacts/surfaces</span>
+          <span>{item.surfaces.length + item.artifactIds.length}</span>
+        </div>
+        <TopicRoomSurfaceStrip item={item} surfacesError={surfacesError} />
+      </section>
+
+      <div className="topic-room__fallback">
+        raw terminal attach stays secondary; select a session row for exact tab
+        fallback.
+      </div>
     </section>
   );
 }
@@ -826,6 +1147,7 @@ export function TopicSidebarView({
   searchResults = [],
   searchTruncated = false,
   searchUnavailableReason,
+  surfacesError = false,
   onSearchQueryChange,
   onSearchRetry,
   onSearchClear,
@@ -844,6 +1166,7 @@ export function TopicSidebarView({
   searchResults?: WorkspaceTopicSearchResult[];
   searchTruncated?: boolean;
   searchUnavailableReason?: string | undefined;
+  surfacesError?: boolean;
   onSearchQueryChange?: ((query: string) => void) | undefined;
   onSearchRetry?: (() => void) | undefined;
   onSearchClear?: (() => void) | undefined;
@@ -951,7 +1274,11 @@ export function TopicSidebarView({
       </ul>
       {selectedItem ? (
         <>
-          <TopicDetail item={selectedItem} />
+          <TopicDetail
+            item={selectedItem}
+            surfacesError={surfacesError}
+            onSelectSession={onSelectSession}
+          />
           <TopicMobileControlPanel
             item={selectedItem}
             onSelectSession={onSelectSession}
@@ -1006,10 +1333,8 @@ export function TopicSidebarShell({
         ((topicsQuery.isLoading && !topicsQuery.data) ||
           (surfacesQuery.isLoading && !surfacesQuery.data))
       }
-      error={
-        (topicsQuery.isError && !topicsQuery.data && !searchActive) ||
-        (surfacesQuery.isError && !surfacesQuery.data)
-      }
+      error={topicsQuery.isError && !topicsQuery.data && !searchActive}
+      surfacesError={surfacesQuery.isError}
       derived={
         searchActive
           ? (searchData?.derived ?? false)

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -53,6 +53,7 @@ export interface TopicNavSurfaceRef {
 
 export interface TopicNavItem {
   id: WorkspaceTopicId;
+  workspaceId: WorkspaceTopic['workspaceId'];
   parentId: WorkspaceTopicId | null;
   title: string;
   description: string | null;
@@ -68,8 +69,11 @@ export interface TopicNavItem {
   sessions: TopicNavSessionRef[];
   surfaces: TopicNavSurfaceRef[];
   taskRefs: NonNullable<WorkspaceTopic['linkedRefs']['taskRefs']>;
+  artifactIds: NonNullable<WorkspaceTopic['linkedRefs']['artifactIds']>;
   childIds: WorkspaceTopicId[];
   routingLabel: string | null;
+  lifecycleLabel: WorkspaceTopic['status'];
+  updatedAt: string;
 }
 
 export interface TopicNavModel {
@@ -327,6 +331,7 @@ export function buildTopicNavModel(input: {
     const order = topic.grouping.order ?? Number.MAX_SAFE_INTEGER;
     return {
       id: topic.id,
+      workspaceId: topic.workspaceId,
       parentId: topic.grouping.parentTopicId ?? null,
       title: topic.display.title,
       description: topic.display.description ?? null,
@@ -342,8 +347,11 @@ export function buildTopicNavModel(input: {
       sessions,
       surfaces,
       taskRefs: topic.linkedRefs.taskRefs ?? [],
+      artifactIds: topic.linkedRefs.artifactIds ?? [],
       childIds: [],
       routingLabel: routingLabel(topic),
+      lifecycleLabel: topic.status,
+      updatedAt: topic.updatedAt,
     };
   });
 

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -131,6 +131,21 @@ describe('buildTopicNavModel', () => {
     ]);
   });
 
+  it('preserves artifact refs for topic-room metadata without loading payloads', () => {
+    const topic = makeTopic({
+      linkedRefs: { artifactIds: ['artifact:evidence-1'] },
+    });
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [],
+      surfaces: [],
+    });
+
+    expect(model.byId.get('topic:alpha')?.artifactIds).toEqual([
+      'artifact:evidence-1',
+    ]);
+  });
+
   it('classifies topic workspace kind from routing defaults', () => {
     const repo = makeTopic({
       id: 'topic:repo',

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -345,6 +345,15 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('surfaces unavailable');
   });
 
+  it('keeps the room usable while surfaces are still loading', async () => {
+    await renderView({ surfaces: [], surfacesLoading: true });
+
+    expect(container.textContent).not.toContain('loading topic shell');
+    expect(container.querySelector('.topic-room')).not.toBeNull();
+    expect(container.textContent).toContain('Frontend lane');
+    expect(container.textContent).toContain('surfaces loading…');
+  });
+
   it('reports loading, error, and empty states', async () => {
     await renderView({ loading: true, topics: [] });
     expect(container.textContent).toContain('loading topic shell');
@@ -578,6 +587,20 @@ describe('TopicSidebarView', () => {
     expect(css).toContain('.topic-search__input:focus-visible');
     expect(css).toMatch(
       /\.topic-search__input:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)/
+    );
+  });
+
+  it('keeps keyboard-visible focus styling for room controls', () => {
+    const css = fs.readFileSync(
+      'frontend/src/components/TopicSidebarShell.css',
+      'utf8'
+    );
+
+    expect(css).toMatch(
+      /\.topic-room__primary:not\(:disabled\):focus-visible,\s*\.topic-room-ref-list a:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px/
+    );
+    expect(css).toMatch(
+      /\.topic-room-session__button:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*1px/
     );
   });
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -107,7 +107,10 @@ describe('TopicSidebarView', () => {
     await renderView();
 
     expect(container.querySelector('.topic-shell')).not.toBeNull();
+    expect(container.querySelector('.topic-room')).not.toBeNull();
     expect(container.textContent).toContain('Build UI shell');
+    expect(container.textContent).toContain('task room');
+    expect(container.textContent).toContain('primary action');
     expect(container.textContent).toContain('Thin-line topic detail');
     expect(container.textContent).toContain('Frontend lane');
     expect(container.textContent).toContain('preview');
@@ -189,6 +192,157 @@ describe('TopicSidebarView', () => {
       'Thin-line topic detail'
     );
     expect(container.textContent).toContain('1 task refs');
+    expect(container.textContent).toContain('no sessions linked yet');
+    const primary = container.querySelector(
+      '.topic-room__primary'
+    ) as HTMLButtonElement;
+    expect(primary.textContent).toBe('view artifact');
+    expect(primary.disabled).toBe(false);
+  });
+
+  it('renders a task-room panel with grouped sessions, refs, and safe artifacts', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          linkedRefs: {
+            sessionIds: [
+              'question-session',
+              'approval-session',
+              'running-session',
+              'idle-session',
+              'stale-session',
+              'crashed-session',
+            ],
+            taskRefs: [
+              {
+                kind: 'github-issue',
+                id: '1044',
+                title: 'topic room detail',
+                url: 'https://github.com/donovan-yohan/relay-ide/issues/1044',
+                status: 'open',
+              },
+            ],
+            artifactIds: ['artifact:evidence-1'],
+          },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 'question-session',
+          displayName: 'question lane',
+          agentState: 'permission-prompt',
+          permissionType: 'question',
+        }),
+        makeSession({
+          id: 'approval-session',
+          displayName: 'approval lane',
+          agentState: 'permission-prompt',
+          permissionType: 'approval',
+        }),
+        makeSession({
+          id: 'running-session',
+          displayName: 'running lane',
+          agentState: 'processing',
+        }),
+        makeSession({
+          id: 'idle-session',
+          displayName: 'idle lane',
+          agentState: 'idle',
+          idle: true,
+        }),
+        makeSession({
+          id: 'stale-session',
+          displayName: 'stale lane',
+          status: 'disconnected',
+        }),
+        makeSession({
+          id: 'crashed-session',
+          displayName: 'crashed lane',
+          agentState: 'error',
+        }),
+      ],
+      surfaces: [
+        makeSurface(),
+        makeSurface({
+          id: 'surface:copy-only',
+          kind: 'logs',
+          label: 'Build log',
+          openMode: 'copy',
+          url: undefined,
+          logRef: 'artifact:build-log',
+        }),
+      ],
+    });
+
+    expect(container.textContent).toContain('needs input · 1');
+    expect(container.textContent).toContain('approval · 1');
+    expect(container.textContent).toContain('running · 1');
+    expect(container.textContent).toContain('idle · 1');
+    expect(container.textContent).toContain('stale/offline · 1');
+    expect(container.textContent).toContain('crashed · 1');
+    expect(container.textContent).toContain('topic room detail');
+    expect(container.textContent).toContain('metadata ref only');
+    expect(container.textContent).toContain('direct open');
+    expect(container.textContent).toContain('copy only');
+    expect(container.textContent).toContain(
+      'raw terminal attach stays secondary'
+    );
+  });
+
+  it('keeps stale sessions inspectable while disabling live room controls', async () => {
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'offline approval',
+          agentState: 'permission-prompt',
+          permissionType: 'approval',
+          status: 'disconnected',
+        }),
+      ],
+    });
+
+    const primary = container.querySelector(
+      '.topic-room__primary'
+    ) as HTMLButtonElement;
+    const sessionButton = container.querySelector(
+      '.topic-room-session__button'
+    ) as HTMLButtonElement;
+
+    expect(primary.textContent).toBe('approve');
+    expect(primary.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      'controls disabled: session offline/disconnected'
+    );
+    await act(async () => sessionButton.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+  });
+
+  it('selects the exact global session from the task-room session row', async () => {
+    await renderView({
+      topics: [makeTopic({ linkedRefs: { sessionIds: ['global:agent-1'] } })],
+      sessions: [
+        makeSession({
+          id: 'local-session',
+          globalSessionId: 'global:agent-1',
+          displayName: 'global lane',
+        }),
+      ],
+    });
+
+    const roomSessionButton = container.querySelector(
+      '.topic-room-session__button'
+    ) as HTMLButtonElement;
+    expect(roomSessionButton.title).toContain('global:agent-1');
+    await act(async () => roomSessionButton.click());
+    expect(onSelectSession).toHaveBeenCalledWith('global:agent-1');
+  });
+
+  it('keeps the room usable when surface loading fails', async () => {
+    await renderView({ surfaces: [], surfacesError: true });
+
+    expect(container.textContent).toContain('Frontend lane');
+    expect(container.textContent).toContain('surfaces unavailable');
   });
 
   it('reports loading, error, and empty states', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -3,13 +3,19 @@
 import * as fs from 'node:fs';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceSurface } from '../shared/workspace-surfaces.js';
 import type {
   WorkspaceTopic,
+  WorkspaceTopicListResponse,
   WorkspaceTopicSearchResult,
 } from '../shared/workspace-topics.js';
-import { TopicSidebarView } from '../frontend/src/components/TopicSidebarShell.js';
+import {
+  TopicSidebarShell,
+  TopicSidebarView,
+} from '../frontend/src/components/TopicSidebarShell.js';
+import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { makeSession } from './helpers/frontend-factories.js';
 
 (
@@ -23,6 +29,12 @@ class ResizeObserverStub {
 }
 
 const NOW = '2026-06-26T00:00:00Z';
+
+async function flushQueryEffects() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
 
 function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
   return {
@@ -85,6 +97,8 @@ describe('TopicSidebarView', () => {
     act(() => root.unmount());
     container.remove();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    useSessionsStore.setState({ sessions: [] });
   });
 
   async function renderView(
@@ -354,6 +368,45 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('surfaces loading…');
   });
 
+  it('keeps the shell room mounted while surfaces query is still pending', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const topicsResponse: WorkspaceTopicListResponse = {
+      topics: [makeTopic()],
+      truncated: false,
+      derived: false,
+    };
+    queryClient.setQueryData(['workspace-topics'], topicsResponse);
+    useSessionsStore.setState({
+      sessions: [makeSession({ id: 's1', displayName: 'Frontend lane' })],
+    });
+    const fetchMock = vi.fn(
+      () => new Promise<Response>(() => {})
+    ) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(TopicSidebarShell, { onSelectSession })
+        )
+      );
+      await flushQueryEffects();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/workspace-surfaces', {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    });
+    expect(container.textContent).not.toContain('loading topic shell');
+    expect(container.querySelector('.topic-room')).not.toBeNull();
+    expect(container.textContent).toContain('Build UI shell');
+    expect(container.textContent).toContain('surfaces loading…');
+    queryClient.clear();
+  });
+
   it('reports loading, error, and empty states', async () => {
     await renderView({ loading: true, topics: [] });
     expect(container.textContent).toContain('loading topic shell');
@@ -597,10 +650,32 @@ describe('TopicSidebarView', () => {
     );
 
     expect(css).toMatch(
-      /\.topic-room__primary:not\(:disabled\):focus-visible,\s*\.topic-room-ref-list a:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px/
+      /\.topic-room__primary:not\(:disabled\):focus-visible,\s*\.topic-room-ref-list a:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px[\s\S]*box-shadow:/
     );
     expect(css).toMatch(
-      /\.topic-room-session__button:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*1px/
+      /\.topic-room-session__button:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px[\s\S]*box-shadow:/
+    );
+  });
+
+  it('opens direct surfaces with noopener and noreferrer isolation', async () => {
+    const openMock = vi.fn();
+    vi.stubGlobal('open', openMock);
+
+    await renderView({
+      topics: [makeTopic({ linkedRefs: { sessionIds: [] } })],
+      sessions: [],
+      surfaces: [makeSurface()],
+    });
+
+    const primary = container.querySelector(
+      '.topic-room__primary'
+    ) as HTMLButtonElement;
+    await act(async () => primary.click());
+
+    expect(openMock).toHaveBeenCalledWith(
+      'http://localhost:5173',
+      '_blank',
+      'noopener,noreferrer'
     );
   });
 


### PR DESCRIPTION
Closes #1044

## Summary
- adds a topic task-room detail panel in the topic sidebar with grouped session lanes, primary CTA, status card, task refs, and artifacts/surfaces
- carries workspace id, lifecycle, updated timestamp, and artifact ids through the topic nav model for detail rendering without loading artifact payloads
- keeps surface fetch failures scoped to the room artifact strip instead of blanking the topic list

## Verification
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk test npm test -- test/topic-nav.test.ts test/topic-sidebar-shell.test.ts` — 2 files / 29 tests passed
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run check` — exit 0; existing repo lint warnings only, no errors
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run build` — exit 0; existing Vite chunk/dynamic-import warnings only
- browser smoke: `npm run dev` on `127.0.0.1:5199`, unlocked with local test PIN, verified topics sidebar renders with no console errors; topic writes were not seeded because this protected local hub denied missing `context:write`, so rich room states are covered by DOM tests

## Notes
- Simplify tier: 3 (multi-file frontend behavior/UI delta). Ran a three-lane simplify review pass; applied the useful local cleanup around stale-session grouping and primary surface CTA enablement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer topic-room view with grouped session status, freshness details, and a clearer primary action area.
  * Topic navigation now shows additional topic metadata, including linked artifacts and last-updated information.

* **Bug Fixes**
  * Improved handling when related data fails to load, showing a dedicated unavailable state instead of breaking the view.
  * Refined selection behavior so individual sessions in a room can still be opened directly, including disconnected or stale ones.

* **Tests**
  * Added coverage for the new topic-room layout, metadata display, and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->