### PR TITLE
feat: persist workspace rail selection

### DIFF
--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -927,6 +927,7 @@ export function ViewSpineTree({
   const saveView = useUiStore((s) => s.saveViewSpineView);
   const deleteView = useUiStore((s) => s.deleteViewSpineView);
   const applySavedView = useUiStore((s) => s.applyViewSpineSavedView);
+  const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
 
   const pins: PinControls = useMemo(
     () => ({
@@ -1007,6 +1008,15 @@ export function ViewSpineTree({
       ),
     [flatProjects, persistedWorkspaces, pinnedIds]
   );
+
+  const visibleGrouped = useMemo(() => {
+    if (!activeWorkspaceId) return grouped;
+    const match = grouped.workspaces.find((ws) => ws.id === activeWorkspaceId);
+    return {
+      workspaces: match ? [match] : [],
+      ungroupedProjects: [],
+    };
+  }, [grouped, activeWorkspaceId]);
 
   // The workspace each project currently belongs to (first claimant by order),
   // so the per-project assign control can show the right selection.
@@ -1136,9 +1146,10 @@ export function ViewSpineTree({
   }
 
   const hasGroupedContent =
-    grouped.workspaces.some((ws) => ws.projects.length > 0) ||
-    grouped.ungroupedProjects.length > 0;
-  const hasContent = hasGroupedContent || tree.freeLane.length > 0;
+    visibleGrouped.workspaces.some((ws) => ws.projects.length > 0) ||
+    visibleGrouped.ungroupedProjects.length > 0;
+  const hasContent =
+    hasGroupedContent || (!activeWorkspaceId && tree.freeLane.length > 0);
 
   if (!hasContent) {
     return (
@@ -1156,7 +1167,7 @@ export function ViewSpineTree({
     );
   }
 
-  const hasPersistedGroups = grouped.workspaces.some(
+  const hasPersistedGroups = visibleGrouped.workspaces.some(
     (ws) => ws.projects.length > 0
   );
 
@@ -1180,7 +1191,7 @@ export function ViewSpineTree({
             </button>
           </div>
         ) : null}
-        {grouped.workspaces.map((ws) =>
+        {visibleGrouped.workspaces.map((ws) =>
           ws.projects.length > 0 ? (
             <section key={ws.id} className="view-spine-workspace">
               <div className="sidebar-ungrouped-label view-spine-workspace-label">
@@ -1209,12 +1220,12 @@ export function ViewSpineTree({
           ) : null
         )}
 
-        {grouped.ungroupedProjects.length > 0 ? (
+        {visibleGrouped.ungroupedProjects.length > 0 ? (
           <section className="view-spine-workspace">
             {hasPersistedGroups ? (
               <div className="sidebar-ungrouped-label">ungrouped</div>
             ) : null}
-            {grouped.ungroupedProjects.map((project) => (
+            {visibleGrouped.ungroupedProjects.map((project) => (
               <ProjectRow
                 key={project.id}
                 project={project}
@@ -1229,7 +1240,7 @@ export function ViewSpineTree({
           </section>
         ) : null}
 
-        {tree.freeLane.length > 0 ? (
+        {!activeWorkspaceId && tree.freeLane.length > 0 ? (
           <section className="view-spine-free-lane">
             <div className="sidebar-ungrouped-label">free / remote</div>
             <ul className="session-list">

--- a/frontend/src/components/WorkspaceBar.css
+++ b/frontend/src/components/WorkspaceBar.css
@@ -84,6 +84,10 @@
   background: var(--surface-hover);
 }
 
+.workspace-bar__row--editing {
+  gap: 0;
+}
+
 .workspace-bar__name {
   flex: 1 1 auto;
   min-width: 0;

--- a/frontend/src/components/WorkspaceBar.css
+++ b/frontend/src/components/WorkspaceBar.css
@@ -77,6 +77,7 @@
 
 .workspace-bar__name {
   flex: 1 1 auto;
+  min-width: 0;
   text-align: left;
   background: none;
   border: 1px solid transparent;

--- a/frontend/src/components/WorkspaceBar.css
+++ b/frontend/src/components/WorkspaceBar.css
@@ -24,6 +24,27 @@
   color: var(--text-muted);
 }
 
+.workspace-bar__all-btn {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.workspace-bar__all-btn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.workspace-bar__all-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .workspace-bar__hint {
   font-size: var(--font-size-xs);
   color: var(--text-muted);
@@ -46,6 +67,12 @@
   align-items: center;
   gap: 6px;
   min-height: 36px;
+  border-left: 2px solid transparent;
+}
+
+.workspace-bar__row--selected {
+  border-left-color: var(--accent);
+  background: var(--surface-hover);
 }
 
 .workspace-bar__name {

--- a/frontend/src/components/WorkspaceBar.css
+++ b/frontend/src/components/WorkspaceBar.css
@@ -9,6 +9,9 @@
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
   flex: 0 0 auto;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .workspace-bar__header {
@@ -60,6 +63,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .workspace-bar__row {
@@ -67,7 +72,11 @@
   align-items: center;
   gap: 6px;
   min-height: 36px;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
   border-left: 2px solid transparent;
+  position: relative;
 }
 
 .workspace-bar__row--selected {
@@ -105,6 +114,52 @@
   align-items: center;
   gap: 2px;
   flex: 0 0 auto;
+}
+
+.workspace-bar__rename-btn {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  inline-size: 1px;
+  block-size: 1px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.workspace-bar__rename-btn:focus-visible {
+  z-index: 1;
+  inset-block-start: 50%;
+  inset-inline-start: 2px;
+  transform: translateY(-50%);
+  inline-size: auto;
+  min-inline-size: 44px;
+  block-size: 44px;
+  margin: 0;
+  padding: 0 6px;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent);
+  background: var(--bg);
+  color: var(--text);
+  outline: none;
+}
+
+.workspace-bar__rename-btn:disabled {
+  cursor: default;
 }
 
 .workspace-bar__icon-btn {

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -103,22 +103,22 @@ function WorkspaceRow({
           disabled={busy}
           onClick={onSelect}
           onDoubleClick={startEditing}
-          title="select workspace; double-click or use rename action to edit"
+          title="select workspace; double-click or tab to rename action to edit"
         >
           {workspace.name}
         </button>
       )}
+      <button
+        type="button"
+        className="workspace-bar__rename-btn"
+        disabled={busy}
+        onClick={startEditing}
+        aria-label={`rename ${workspace.name}`}
+        title="rename workspace"
+      >
+        rename
+      </button>
       <div className="workspace-bar__row-actions">
-        <button
-          type="button"
-          className="workspace-bar__icon-btn"
-          disabled={busy}
-          onClick={startEditing}
-          aria-label={`rename ${workspace.name}`}
-          title="rename workspace"
-        >
-          rename
-        </button>
         <button
           type="button"
           className="workspace-bar__icon-btn"

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -12,7 +12,7 @@
 // error (failed mutation → non-destructive inline message, list refetches),
 // in-flight (controls disabled while a mutation is pending). Reuses existing
 // TUI primitives + design tokens — no new visual language.
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { IaWorkspace } from '../lib/api.js';
 import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
@@ -192,6 +192,13 @@ export function WorkspaceBar() {
   const ordered = [...workspaces].sort(
     (a, b) => a.order - b.order || a.id.localeCompare(b.id)
   );
+
+  useEffect(() => {
+    if (isLoading || isError || !activeWorkspaceId) return;
+    if (!workspaces.some((workspace) => workspace.id === activeWorkspaceId)) {
+      setActiveWorkspaceId(null);
+    }
+  }, [activeWorkspaceId, isError, isLoading, setActiveWorkspaceId, workspaces]);
 
   function clearError() {
     setActionError(null);

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -69,11 +69,13 @@ function WorkspaceRow({
 
   return (
     <li
-      className={
-        selected
-          ? 'workspace-bar__row workspace-bar__row--selected'
-          : 'workspace-bar__row'
-      }
+      className={[
+        'workspace-bar__row',
+        selected ? 'workspace-bar__row--selected' : null,
+        editing ? 'workspace-bar__row--editing' : null,
+      ]
+        .filter(Boolean)
+        .join(' ')}
     >
       {editing ? (
         <input
@@ -108,48 +110,52 @@ function WorkspaceRow({
           {workspace.name}
         </button>
       )}
-      <button
-        type="button"
-        className="workspace-bar__rename-btn"
-        disabled={busy}
-        onClick={startEditing}
-        aria-label={`rename ${workspace.name}`}
-        title="rename workspace"
-      >
-        rename
-      </button>
-      <div className="workspace-bar__row-actions">
-        <button
-          type="button"
-          className="workspace-bar__icon-btn"
-          disabled={busy || index === 0}
-          onClick={onMoveUp}
-          aria-label={`move ${workspace.name} up`}
-          title="move up"
-        >
-          ↑
-        </button>
-        <button
-          type="button"
-          className="workspace-bar__icon-btn"
-          disabled={busy || index === count - 1}
-          onClick={onMoveDown}
-          aria-label={`move ${workspace.name} down`}
-          title="move down"
-        >
-          ↓
-        </button>
-        <button
-          type="button"
-          className="workspace-bar__icon-btn workspace-bar__icon-btn--danger"
-          disabled={busy}
-          onClick={onArchive}
-          aria-label={`archive ${workspace.name}`}
-          title="archive workspace"
-        >
-          ×
-        </button>
-      </div>
+      {!editing ? (
+        <>
+          <button
+            type="button"
+            className="workspace-bar__rename-btn"
+            disabled={busy}
+            onClick={startEditing}
+            aria-label={`rename ${workspace.name}`}
+            title="rename workspace"
+          >
+            rename
+          </button>
+          <div className="workspace-bar__row-actions">
+            <button
+              type="button"
+              className="workspace-bar__icon-btn"
+              disabled={busy || index === 0}
+              onClick={onMoveUp}
+              aria-label={`move ${workspace.name} up`}
+              title="move up"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              className="workspace-bar__icon-btn"
+              disabled={busy || index === count - 1}
+              onClick={onMoveDown}
+              aria-label={`move ${workspace.name} down`}
+              title="move down"
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              className="workspace-bar__icon-btn workspace-bar__icon-btn--danger"
+              disabled={busy}
+              onClick={onArchive}
+              aria-label={`archive ${workspace.name}`}
+              title="archive workspace"
+            >
+              ×
+            </button>
+          </div>
+        </>
+      ) : null}
     </li>
   );
 }

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -52,6 +52,11 @@ function WorkspaceRow({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(workspace.name);
 
+  function startEditing() {
+    setDraft(workspace.name);
+    setEditing(true);
+  }
+
   function commit() {
     const trimmed = draft.trim();
     setEditing(false);
@@ -97,16 +102,23 @@ function WorkspaceRow({
           className="workspace-bar__name"
           disabled={busy}
           onClick={onSelect}
-          onDoubleClick={() => {
-            setDraft(workspace.name);
-            setEditing(true);
-          }}
-          title="select workspace; double-click to rename"
+          onDoubleClick={startEditing}
+          title="select workspace; double-click or use rename action to edit"
         >
           {workspace.name}
         </button>
       )}
       <div className="workspace-bar__row-actions">
+        <button
+          type="button"
+          className="workspace-bar__icon-btn"
+          disabled={busy}
+          onClick={startEditing}
+          aria-label={`rename ${workspace.name}`}
+          title="rename workspace"
+        >
+          rename
+        </button>
         <button
           type="button"
           className="workspace-bar__icon-btn"
@@ -152,7 +164,6 @@ export function WorkspaceBar() {
     createMutation,
     updateMutation,
     archiveMutation,
-    deleteMutation,
   } = useIaWorkspaces();
   const activeWorkspaceId = useUiStore((state) => state.activeWorkspaceId);
   const setActiveWorkspaceId = useUiStore(
@@ -171,7 +182,6 @@ export function WorkspaceBar() {
     createMutation.isPending ||
     updateMutation.isPending ||
     archiveMutation.isPending ||
-    deleteMutation.isPending ||
     reordering;
   const ordered = [...workspaces].sort(
     (a, b) => a.order - b.order || a.id.localeCompare(b.id)

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -164,6 +164,7 @@ export function WorkspaceBar() {
   const {
     workspaces,
     isLoading,
+    isFetching,
     isError,
     refetch,
     invalidate,
@@ -194,11 +195,18 @@ export function WorkspaceBar() {
   );
 
   useEffect(() => {
-    if (isLoading || isError || !activeWorkspaceId) return;
+    if (isLoading || isFetching || isError || !activeWorkspaceId) return;
     if (!workspaces.some((workspace) => workspace.id === activeWorkspaceId)) {
       setActiveWorkspaceId(null);
     }
-  }, [activeWorkspaceId, isError, isLoading, setActiveWorkspaceId, workspaces]);
+  }, [
+    activeWorkspaceId,
+    isError,
+    isFetching,
+    isLoading,
+    setActiveWorkspaceId,
+    workspaces,
+  ]);
 
   function clearError() {
     setActionError(null);

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -5,7 +5,7 @@
 //
 // Scope (MVP): list persisted Workspaces, CREATE (name), RENAME (inline),
 // REORDER (up/down — lowest-risk vs. DnD, matches no existing drag dep in the
-// sidebar), DELETE. Project assignment lives on the project rows (the parent
+// sidebar), ARCHIVE. Project assignment lives on the project rows (the parent
 // passes `onAssignProject`); this bar owns workspace lifecycle only.
 //
 // States: empty (no workspaces → neutral copy + create affordance), loading,
@@ -16,6 +16,7 @@ import { useState } from 'react';
 
 import type { IaWorkspace } from '../lib/api.js';
 import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
+import { useUiStore } from '../lib/stores/ui.js';
 import { createLogger } from '../lib/logger.js';
 import './WorkspaceBar.css';
 
@@ -30,19 +31,23 @@ function WorkspaceRow({
   index,
   count,
   busy,
+  selected,
   onRename,
+  onSelect,
   onMoveUp,
   onMoveDown,
-  onDelete,
+  onArchive,
 }: {
   workspace: IaWorkspace;
   index: number;
   count: number;
   busy: boolean;
+  selected: boolean;
   onRename: (name: string) => void;
+  onSelect: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
-  onDelete: () => void;
+  onArchive: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(workspace.name);
@@ -58,7 +63,13 @@ function WorkspaceRow({
   }
 
   return (
-    <li className="workspace-bar__row">
+    <li
+      className={
+        selected
+          ? 'workspace-bar__row workspace-bar__row--selected'
+          : 'workspace-bar__row'
+      }
+    >
       {editing ? (
         <input
           type="text"
@@ -85,11 +96,12 @@ function WorkspaceRow({
           type="button"
           className="workspace-bar__name"
           disabled={busy}
-          onClick={() => {
+          onClick={onSelect}
+          onDoubleClick={() => {
             setDraft(workspace.name);
             setEditing(true);
           }}
-          title="rename"
+          title="select workspace; double-click to rename"
         >
           {workspace.name}
         </button>
@@ -119,9 +131,9 @@ function WorkspaceRow({
           type="button"
           className="workspace-bar__icon-btn workspace-bar__icon-btn--danger"
           disabled={busy}
-          onClick={onDelete}
-          aria-label={`delete ${workspace.name}`}
-          title="delete workspace"
+          onClick={onArchive}
+          aria-label={`archive ${workspace.name}`}
+          title="archive workspace"
         >
           ×
         </button>
@@ -139,8 +151,13 @@ export function WorkspaceBar() {
     invalidate,
     createMutation,
     updateMutation,
+    archiveMutation,
     deleteMutation,
   } = useIaWorkspaces();
+  const activeWorkspaceId = useUiStore((state) => state.activeWorkspaceId);
+  const setActiveWorkspaceId = useUiStore(
+    (state) => state.setActiveWorkspaceId
+  );
   const [newName, setNewName] = useState('');
   const [actionError, setActionError] = useState<string | null>(null);
   // #752: a reorder sequences TWO PATCHes; this flag keeps the controls disabled
@@ -153,6 +170,7 @@ export function WorkspaceBar() {
   const pending =
     createMutation.isPending ||
     updateMutation.isPending ||
+    archiveMutation.isPending ||
     deleteMutation.isPending ||
     reordering;
   const ordered = [...workspaces].sort(
@@ -168,9 +186,12 @@ export function WorkspaceBar() {
     if (name.length === 0 || pending) return;
     clearError();
     createMutation.mutate(
-      { name },
+      { name, pinned: true },
       {
-        onSuccess: () => setNewName(''),
+        onSuccess: (created) => {
+          setNewName('');
+          setActiveWorkspaceId(created.id);
+        },
         onError: (err) => {
           logger.warn('create workspace failed', err);
           setActionError(errorMessage(err, 'could not create workspace'));
@@ -219,12 +240,22 @@ export function WorkspaceBar() {
     }
   }
 
-  function handleDelete(workspace: IaWorkspace) {
+  function handleArchive(workspace: IaWorkspace) {
     clearError();
-    deleteMutation.mutate(workspace.id, {
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.confirm === 'function' &&
+      !window.confirm(`archive workspace "${workspace.name}"?`)
+    ) {
+      return;
+    }
+    archiveMutation.mutate(workspace.id, {
+      onSuccess: () => {
+        if (activeWorkspaceId === workspace.id) setActiveWorkspaceId(null);
+      },
       onError: (err) => {
-        logger.warn('delete workspace failed', err);
-        setActionError(errorMessage(err, 'could not delete workspace'));
+        logger.warn('archive workspace failed', err);
+        setActionError(errorMessage(err, 'could not archive workspace'));
       },
     });
   }
@@ -233,6 +264,14 @@ export function WorkspaceBar() {
     <section className="workspace-bar" aria-label="workspaces">
       <div className="workspace-bar__header">
         <span className="workspace-bar__title">workspaces</span>
+        <button
+          type="button"
+          className="workspace-bar__all-btn"
+          disabled={pending || activeWorkspaceId === null}
+          onClick={() => setActiveWorkspaceId(null)}
+        >
+          all
+        </button>
       </div>
 
       {isLoading ? (
@@ -250,7 +289,9 @@ export function WorkspaceBar() {
               index={index}
               count={ordered.length}
               busy={pending}
+              selected={activeWorkspaceId === ws.id}
               onRename={(name) => handleRename(ws, name)}
+              onSelect={() => setActiveWorkspaceId(ws.id)}
               onMoveUp={() => {
                 const prev = ordered[index - 1];
                 if (prev) void handleSwap(ws, prev);
@@ -259,7 +300,7 @@ export function WorkspaceBar() {
                 const next = ordered[index + 1];
                 if (next) void handleSwap(ws, next);
               }}
-              onDelete={() => handleDelete(ws)}
+              onArchive={() => handleArchive(ws)}
             />
           ))}
         </ul>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1122,14 +1122,34 @@ export async function copyPipelineHandoffArtifact(
 // membership list of ProjectIds, NOT embedded projects. Backed by the IA store
 // (`ia.db`) and mounted at `/hub/ia/workspaces` — STRICTLY non-destructive of
 // any legacy state. Endpoints: GET (list), POST (create), PATCH (partial
-// rename/reorder/membership), DELETE.
+// rename/reorder/membership/defaults), POST archive/restore, DELETE hard-delete.
 export interface IaWorkspace {
   id: string;
   name: string;
+  status: 'active' | 'archived';
   order: number;
   projectIds: string[];
+  pinned: boolean;
+  color: string | null;
+  icon: string | null;
+  defaultRepoPath: string | null;
+  defaultNodeId: string | null;
+  defaultProvider: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface IaWorkspacePatch {
+  name?: string;
+  status?: 'active' | 'archived';
+  order?: number;
+  projectIds?: string[];
+  pinned?: boolean;
+  color?: string | null;
+  icon?: string | null;
+  defaultRepoPath?: string | null;
+  defaultNodeId?: string | null;
+  defaultProvider?: string | null;
 }
 
 const IA_WORKSPACES_PATH = '/hub/ia/workspaces';
@@ -1145,6 +1165,12 @@ export async function createIaWorkspace(input: {
   name: string;
   projectIds?: string[];
   order?: number;
+  pinned?: boolean;
+  color?: string | null;
+  icon?: string | null;
+  defaultRepoPath?: string | null;
+  defaultNodeId?: string | null;
+  defaultProvider?: string | null;
 }): Promise<IaWorkspace> {
   const data = await json<{ workspace: IaWorkspace }>(
     await fetch(IA_WORKSPACES_PATH, {
@@ -1158,13 +1184,22 @@ export async function createIaWorkspace(input: {
 
 export async function updateIaWorkspace(
   id: string,
-  patch: { name?: string; order?: number; projectIds?: string[] }
+  patch: IaWorkspacePatch
 ): Promise<IaWorkspace> {
   const data = await json<{ workspace: IaWorkspace }>(
     await fetch(`${IA_WORKSPACES_PATH}/${encodeURIComponent(id)}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
+    })
+  );
+  return data.workspace;
+}
+
+export async function archiveIaWorkspace(id: string): Promise<IaWorkspace> {
+  const data = await json<{ workspace: IaWorkspace }>(
+    await fetch(`${IA_WORKSPACES_PATH}/${encodeURIComponent(id)}/archive`, {
+      method: 'POST',
     })
   );
   return data.workspace;

--- a/frontend/src/lib/hooks/use-ia-workspaces.ts
+++ b/frontend/src/lib/hooks/use-ia-workspaces.ts
@@ -12,11 +12,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
+  archiveIaWorkspace,
   createIaWorkspace,
   deleteIaWorkspace,
   fetchIaWorkspaces,
   updateIaWorkspace,
   type IaWorkspace,
+  type IaWorkspacePatch,
 } from '../api.js';
 
 export const IA_WORKSPACES_QUERY_KEY = ['ia-workspaces'] as const;
@@ -43,6 +45,12 @@ export function useIaWorkspaces() {
       name: string;
       projectIds?: string[];
       order?: number;
+      pinned?: boolean;
+      color?: string | null;
+      icon?: string | null;
+      defaultRepoPath?: string | null;
+      defaultNodeId?: string | null;
+      defaultProvider?: string | null;
     }) => createIaWorkspace(input),
     onSuccess: invalidate,
   });
@@ -51,10 +59,13 @@ export function useIaWorkspaces() {
   // reconcile with ONE caller-driven refetch at the end. Single-op callers
   // (rename) invalidate explicitly.
   const updateMutation = useMutation({
-    mutationFn: (args: {
-      id: string;
-      patch: { name?: string; order?: number; projectIds?: string[] };
-    }) => updateIaWorkspace(args.id, args.patch),
+    mutationFn: (args: { id: string; patch: IaWorkspacePatch }) =>
+      updateIaWorkspace(args.id, args.patch),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (id: string) => archiveIaWorkspace(id),
+    onSuccess: invalidate,
   });
 
   const deleteMutation = useMutation({
@@ -72,6 +83,7 @@ export function useIaWorkspaces() {
     invalidate,
     createMutation,
     updateMutation,
+    archiveMutation,
     deleteMutation,
   };
 }

--- a/frontend/src/lib/hooks/use-ia-workspaces.ts
+++ b/frontend/src/lib/hooks/use-ia-workspaces.ts
@@ -76,6 +76,7 @@ export function useIaWorkspaces() {
   return {
     workspaces: (query.data ?? []) as IaWorkspace[],
     isLoading: query.isLoading,
+    isFetching: query.isFetching,
     isError: query.isError,
     refetch: query.refetch,
     /** Mark `['ia-workspaces']` stale + refetch. Callers use this after a

--- a/server/features/ia-workspace-router.ts
+++ b/server/features/ia-workspace-router.ts
@@ -147,7 +147,7 @@ export function createIaWorkspaceRouter(
 
     let order: number;
     if (body['order'] === undefined) {
-      order = nextOrder(iaStore.listWorkspaces());
+      order = nextOrder(iaStore.listWorkspaces({ includeArchived: true }));
     } else if (
       typeof body['order'] === 'number' &&
       Number.isFinite(body['order'])

--- a/server/features/ia-workspace-router.ts
+++ b/server/features/ia-workspace-router.ts
@@ -33,6 +33,7 @@ import {
   createWorkspaceId,
   parseWorkspaceId,
   type Workspace,
+  type WorkspaceStatus,
 } from '../../shared/workspace.js';
 import { randomUUID } from 'node:crypto';
 
@@ -66,6 +67,24 @@ function readProjectIds(value: unknown): string[] | null {
   return out;
 }
 
+function readWorkspaceStatus(value: unknown): WorkspaceStatus | null {
+  if (value === undefined) return null;
+  return value === 'active' || value === 'archived' ? value : null;
+}
+
+function readOptionalText(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readOptionalBoolean(value: unknown): boolean | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'boolean' ? value : undefined;
+}
+
 export function createIaWorkspaceRouter(
   options: IaWorkspaceRouterOptions
 ): express.Router {
@@ -78,12 +97,9 @@ export function createIaWorkspaceRouter(
     if (!options.iaStore) {
       sendRelayError(
         res,
-        relayError(
-          'NODE_BUSY',
-          'IA persistence store is unavailable',
-          true,
-          { reasonCode: 'IA_STORE_UNAVAILABLE' }
-        )
+        relayError('NODE_BUSY', 'IA persistence store is unavailable', true, {
+          reasonCode: 'IA_STORE_UNAVAILABLE',
+        })
       );
       return null;
     }
@@ -92,11 +108,15 @@ export function createIaWorkspaceRouter(
 
   // GET /hub/ia/workspaces — list all workspaces, ordered by the store
   // (`order` asc then id asc for stability).
-  router.get('/hub/ia/workspaces', requireAuth, (_req, res) => {
+  router.get('/hub/ia/workspaces', requireAuth, (req, res) => {
     const iaStore = store(res);
     if (!iaStore) return;
     try {
-      res.json({ workspaces: iaStore.listWorkspaces() });
+      res.json({
+        workspaces: iaStore.listWorkspaces({
+          includeArchived: req.query['includeArchived'] === 'true',
+        }),
+      });
     } catch (error) {
       sendInternal(res, 'list', error);
     }
@@ -128,10 +148,25 @@ export function createIaWorkspaceRouter(
     let order: number;
     if (body['order'] === undefined) {
       order = nextOrder(iaStore.listWorkspaces());
-    } else if (typeof body['order'] === 'number' && Number.isFinite(body['order'])) {
+    } else if (
+      typeof body['order'] === 'number' &&
+      Number.isFinite(body['order'])
+    ) {
       order = body['order'];
     } else {
       sendValidation(res, 'order must be a finite number', 'order');
+      return;
+    }
+
+    let metadataPatch: ReturnType<typeof workspaceMetadataPatch>;
+    try {
+      metadataPatch = workspaceMetadataPatch(body);
+    } catch (error) {
+      sendValidation(
+        res,
+        error instanceof Error ? error.message : 'invalid workspace metadata',
+        'metadata'
+      );
       return;
     }
 
@@ -141,6 +176,7 @@ export function createIaWorkspaceRouter(
         name: name.trim(),
         order,
         projectIds: projectIds ?? [],
+        ...metadataPatch,
       });
       res.status(201).json({ workspace: created });
     } catch (error) {
@@ -170,7 +206,10 @@ export function createIaWorkspaceRouter(
 
     let name = existing.name;
     if (body['name'] !== undefined) {
-      if (typeof body['name'] !== 'string' || body['name'].trim().length === 0) {
+      if (
+        typeof body['name'] !== 'string' ||
+        body['name'].trim().length === 0
+      ) {
         sendValidation(res, 'name must be a non-empty string', 'name');
         return;
       }
@@ -179,7 +218,10 @@ export function createIaWorkspaceRouter(
 
     let order = existing.order;
     if (body['order'] !== undefined) {
-      if (typeof body['order'] !== 'number' || !Number.isFinite(body['order'])) {
+      if (
+        typeof body['order'] !== 'number' ||
+        !Number.isFinite(body['order'])
+      ) {
         sendValidation(res, 'order must be a finite number', 'order');
         return;
       }
@@ -200,8 +242,33 @@ export function createIaWorkspaceRouter(
       projectIds = parsed;
     }
 
+    const status = readWorkspaceStatus(body['status']);
+    if (body['status'] !== undefined && status === null) {
+      sendValidation(res, 'status must be active or archived', 'status');
+      return;
+    }
+
+    let metadataPatch: ReturnType<typeof workspaceMetadataPatch>;
     try {
-      const updated = iaStore.upsertWorkspace({ id, name, order, projectIds });
+      metadataPatch = workspaceMetadataPatch(body);
+    } catch (error) {
+      sendValidation(
+        res,
+        error instanceof Error ? error.message : 'invalid workspace metadata',
+        'metadata'
+      );
+      return;
+    }
+
+    try {
+      const updated = iaStore.upsertWorkspace({
+        id,
+        name,
+        order,
+        projectIds,
+        ...(status ? { status } : {}),
+        ...metadataPatch,
+      });
       res.json({ workspace: updated });
     } catch (error) {
       sendInternal(res, 'update', error);
@@ -221,7 +288,10 @@ export function createIaWorkspaceRouter(
     try {
       const removed = iaStore.deleteWorkspace(id);
       if (!removed) {
-        sendRelayError(res, relayError('NOT_FOUND', `workspace ${id} not found`));
+        sendRelayError(
+          res,
+          relayError('NOT_FOUND', `workspace ${id} not found`)
+        );
         return;
       }
       res.status(204).end();
@@ -230,7 +300,84 @@ export function createIaWorkspaceRouter(
     }
   });
 
+  router.post('/hub/ia/workspaces/:id/archive', requireAuth, (req, res) => {
+    updateWorkspaceArchiveState(req, res, 'archived');
+  });
+
+  router.post('/hub/ia/workspaces/:id/restore', requireAuth, (req, res) => {
+    updateWorkspaceArchiveState(req, res, 'active');
+  });
+
   return router;
+
+  function updateWorkspaceArchiveState(
+    req: express.Request,
+    res: express.Response,
+    status: WorkspaceStatus
+  ): void {
+    const iaStore = store(res);
+    if (!iaStore) return;
+    const id = req.params['id'];
+    if (!id || !parseWorkspaceId(id)) {
+      sendValidation(res, 'invalid workspace id', 'id');
+      return;
+    }
+    try {
+      const workspace =
+        status === 'archived'
+          ? iaStore.archiveWorkspace(id)
+          : iaStore.restoreWorkspace(id);
+      if (!workspace) {
+        sendRelayError(
+          res,
+          relayError('NOT_FOUND', `workspace ${id} not found`)
+        );
+        return;
+      }
+      res.json({ workspace });
+    } catch (error) {
+      sendInternal(res, status === 'archived' ? 'archive' : 'restore', error);
+    }
+  }
+
+  function workspaceMetadataPatch(body: Record<string, unknown>): Partial<{
+    pinned: boolean;
+    color: string | null;
+    icon: string | null;
+    defaultRepoPath: string | null;
+    defaultNodeId: string | null;
+    defaultProvider: string | null;
+  }> {
+    const patch: Partial<{
+      pinned: boolean;
+      color: string | null;
+      icon: string | null;
+      defaultRepoPath: string | null;
+      defaultNodeId: string | null;
+      defaultProvider: string | null;
+    }> = {};
+
+    const pinned = readOptionalBoolean(body['pinned']);
+    if (body['pinned'] !== undefined && pinned === undefined) {
+      throw new Error('pinned must be a boolean');
+    }
+    if (pinned !== undefined) patch.pinned = pinned;
+
+    for (const [bodyKey, patchKey] of [
+      ['color', 'color'],
+      ['icon', 'icon'],
+      ['defaultRepoPath', 'defaultRepoPath'],
+      ['defaultNodeId', 'defaultNodeId'],
+      ['defaultProvider', 'defaultProvider'],
+    ] as const) {
+      const value = readOptionalText(body[bodyKey]);
+      if (body[bodyKey] !== undefined && value === undefined) {
+        throw new Error(`${bodyKey} must be a string or null`);
+      }
+      if (value !== undefined) patch[patchKey] = value;
+    }
+    return patch;
+  }
 
   function sendValidation(
     res: express.Response,

--- a/server/ia-store.ts
+++ b/server/ia-store.ts
@@ -20,7 +20,11 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 
 import { createLogger } from './logger.js';
-import type { Workspace, WorkspaceId } from '../shared/workspace.js';
+import type {
+  Workspace,
+  WorkspaceId,
+  WorkspaceStatus,
+} from '../shared/workspace.js';
 import { parseWorkspaceId } from '../shared/workspace.js';
 import type { BenchId } from '../shared/bench.js';
 import { parseBenchId } from '../shared/bench.js';
@@ -65,16 +69,38 @@ CREATE TABLE IF NOT EXISTS ia_migration_state (
 );
 `;
 
+// v3 (#1043): durable workspace rail metadata + soft archive. The status column
+// lets the UI/API archive workspaces without deleting membership/defaults.
+const SCHEMA_V3 = `
+ALTER TABLE ia_workspaces ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE ia_workspaces ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ia_workspaces ADD COLUMN color TEXT;
+ALTER TABLE ia_workspaces ADD COLUMN icon TEXT;
+ALTER TABLE ia_workspaces ADD COLUMN default_repo_path TEXT;
+ALTER TABLE ia_workspaces ADD COLUMN default_node_id TEXT;
+ALTER TABLE ia_workspaces ADD COLUMN default_provider TEXT;
+CREATE INDEX IF NOT EXISTS idx_ia_workspaces_status_order
+  ON ia_workspaces(status, sort_order ASC);
+`;
+
 const MIGRATIONS: Array<{ version: number; sql: string }> = [
   { version: 1, sql: SCHEMA_V1 },
   { version: 2, sql: SCHEMA_V2 },
+  { version: 3, sql: SCHEMA_V3 },
 ];
 
 interface WorkspaceRow {
   id: string;
   name: string;
+  status: string;
   sort_order: number;
   project_ids_json: string;
+  pinned: number;
+  color: string | null;
+  icon: string | null;
+  default_repo_path: string | null;
+  default_node_id: string | null;
+  default_provider: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -96,6 +122,17 @@ export interface WorkspaceUpsertInput {
   name: string;
   order: number;
   projectIds: string[];
+  status?: WorkspaceStatus;
+  pinned?: boolean;
+  color?: string | null;
+  icon?: string | null;
+  defaultRepoPath?: string | null;
+  defaultNodeId?: string | null;
+  defaultProvider?: string | null;
+}
+
+export interface WorkspaceListOptions {
+  includeArchived?: boolean;
 }
 
 /** Persisted Bench overlay: the sparse, user-authored layer on top of the
@@ -123,11 +160,13 @@ export interface IaStore {
   close(): void;
 
   // ── Workspace ────────────────────────────────────────────────────────────
-  /** All workspaces, ordered by `order` ascending then id for stability. */
-  listWorkspaces(): Workspace[];
+  /** Active workspaces by default, ordered by `order` ascending then id. */
+  listWorkspaces(options?: WorkspaceListOptions): Workspace[];
   getWorkspace(id: WorkspaceId): Workspace | null;
   /** Insert or update a workspace. Preserves `createdAt` on update. */
   upsertWorkspace(input: WorkspaceUpsertInput): Workspace;
+  archiveWorkspace(id: WorkspaceId): Workspace | null;
+  restoreWorkspace(id: WorkspaceId): Workspace | null;
   deleteWorkspace(id: WorkspaceId): boolean;
 
   // ── Bench overlay ──────────────────────────────────────────────────────
@@ -167,23 +206,44 @@ export function createIaStore(dbPath: string): IaStore {
 
   runMigrations(db);
 
+  const workspaceColumns = `id, name, status, sort_order, project_ids_json,
+    pinned, color, icon, default_repo_path, default_node_id, default_provider,
+    created_at, updated_at`;
   const selectWorkspace = db.prepare(
-    `SELECT id, name, sort_order, project_ids_json, created_at, updated_at
-     FROM ia_workspaces WHERE id = ?`
+    `SELECT ${workspaceColumns} FROM ia_workspaces WHERE id = ?`
+  );
+  const selectActiveWorkspaces = db.prepare(
+    `SELECT ${workspaceColumns} FROM ia_workspaces
+     WHERE status != 'archived'
+     ORDER BY sort_order ASC, id ASC`
   );
   const selectAllWorkspaces = db.prepare(
-    `SELECT id, name, sort_order, project_ids_json, created_at, updated_at
-     FROM ia_workspaces ORDER BY sort_order ASC, id ASC`
+    `SELECT ${workspaceColumns} FROM ia_workspaces
+     ORDER BY sort_order ASC, id ASC`
   );
   const upsertWorkspaceStmt = db.prepare(
     `INSERT INTO ia_workspaces (
-       id, name, sort_order, project_ids_json, created_at, updated_at
-     ) VALUES (@id, @name, @order, @projectIdsJson, @createdAt, @updatedAt)
+       id, name, status, sort_order, project_ids_json, pinned, color, icon,
+       default_repo_path, default_node_id, default_provider, created_at, updated_at
+     ) VALUES (
+       @id, @name, @status, @order, @projectIdsJson, @pinned, @color, @icon,
+       @defaultRepoPath, @defaultNodeId, @defaultProvider, @createdAt, @updatedAt
+     )
      ON CONFLICT(id) DO UPDATE SET
        name             = excluded.name,
+       status           = excluded.status,
        sort_order       = excluded.sort_order,
        project_ids_json = excluded.project_ids_json,
+       pinned           = excluded.pinned,
+       color            = excluded.color,
+       icon             = excluded.icon,
+       default_repo_path = excluded.default_repo_path,
+       default_node_id   = excluded.default_node_id,
+       default_provider  = excluded.default_provider,
        updated_at       = excluded.updated_at`
+  );
+  const updateWorkspaceStatusStmt = db.prepare(
+    `UPDATE ia_workspaces SET status = ?, updated_at = ? WHERE id = ?`
   );
   const deleteWorkspaceStmt = db.prepare(
     'DELETE FROM ia_workspaces WHERE id = ?'
@@ -238,8 +298,11 @@ export function createIaStore(dbPath: string): IaStore {
       db.close();
     },
 
-    listWorkspaces() {
-      return (selectAllWorkspaces.all() as WorkspaceRow[])
+    listWorkspaces(options: WorkspaceListOptions = {}) {
+      const stmt = options.includeArchived
+        ? selectAllWorkspaces
+        : selectActiveWorkspaces;
+      return (stmt.all() as WorkspaceRow[])
         .map(rowToWorkspaceSafe)
         .filter((ws): ws is Workspace => ws !== null);
     },
@@ -256,21 +319,46 @@ export function createIaStore(dbPath: string): IaStore {
       if (!Number.isFinite(input.order)) {
         throw new IaStoreError('workspace_order_invalid');
       }
-      const projectIds = normalizeProjectIds(input.projectIds);
       const now = new Date().toISOString();
       const existing = getWorkspaceById(input.id);
+      const projectIds = normalizeProjectIds(input.projectIds);
+      const status = normalizeWorkspaceStatus(input.status, existing?.status);
       const createdAt = existing?.createdAt ?? now;
       upsertWorkspaceStmt.run({
         id: input.id,
         name: input.name,
+        status,
         order: input.order,
         projectIdsJson: JSON.stringify(projectIds),
+        pinned: booleanToSql(input.pinned ?? existing?.pinned ?? false),
+        color: normalizeOptionalText(input.color, existing?.color),
+        icon: normalizeOptionalText(input.icon, existing?.icon),
+        defaultRepoPath: normalizeOptionalText(
+          input.defaultRepoPath,
+          existing?.defaultRepoPath
+        ),
+        defaultNodeId: normalizeOptionalText(
+          input.defaultNodeId,
+          existing?.defaultNodeId
+        ),
+        defaultProvider: normalizeOptionalText(
+          input.defaultProvider,
+          existing?.defaultProvider
+        ),
         createdAt,
         updatedAt: now,
       });
       const written = getWorkspaceById(input.id);
       if (!written) throw new IaStoreError('workspace_write_failed');
       return written;
+    },
+
+    archiveWorkspace(id: WorkspaceId) {
+      return updateWorkspaceStatus(id, 'archived');
+    },
+
+    restoreWorkspace(id: WorkspaceId) {
+      return updateWorkspaceStatus(id, 'active');
     },
 
     deleteWorkspace(id: WorkspaceId) {
@@ -333,6 +421,15 @@ export function createIaStore(dbPath: string): IaStore {
       });
     },
   };
+
+  function updateWorkspaceStatus(
+    id: WorkspaceId,
+    status: WorkspaceStatus
+  ): Workspace | null {
+    if (!parseWorkspaceId(id)) throw new IaStoreError('invalid_workspace_id');
+    updateWorkspaceStatusStmt.run(status, new Date().toISOString(), id);
+    return getWorkspaceById(id);
+  }
 }
 
 // ── Migration runner ─────────────────────────────────────────────────────
@@ -341,7 +438,9 @@ export function createIaStore(dbPath: string): IaStore {
 // tables (CREATE ... IF NOT EXISTS + version gate). Bump by appending a new
 // {version, sql} entry to MIGRATIONS. Mirrors the runner in work-contexts.ts.
 function runMigrations(db: Database.Database): void {
-  db.exec('CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)');
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
+  );
   const row = db.prepare('SELECT version FROM schema_version').get() as
     | { version: number }
     | undefined;
@@ -356,7 +455,9 @@ function runMigrations(db: Database.Database): void {
         if (hadRow || currentVersion > 0) {
           db.prepare('UPDATE schema_version SET version = ?').run(ver);
         } else {
-          db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(ver);
+          db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(
+            ver
+          );
         }
       })();
       currentVersion = ver;
@@ -370,8 +471,15 @@ function rowToWorkspace(row: WorkspaceRow): Workspace {
   return {
     id: row.id,
     name: row.name,
+    status: normalizeWorkspaceStatus(row.status),
     order: row.sort_order,
     projectIds: parseStringArray(row.project_ids_json),
+    pinned: row.pinned === 1,
+    color: normalizeNullableText(row.color),
+    icon: normalizeNullableText(row.icon),
+    defaultRepoPath: normalizeNullableText(row.default_repo_path),
+    defaultNodeId: normalizeNullableText(row.default_node_id),
+    defaultProvider: normalizeNullableText(row.default_provider),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -414,6 +522,32 @@ function normalizeProjectIds(value: string[] | undefined): string[] {
   return value.filter(
     (id): id is string => typeof id === 'string' && id.length > 0
   );
+}
+
+function normalizeWorkspaceStatus(
+  value: unknown,
+  fallback: WorkspaceStatus = 'active'
+): WorkspaceStatus {
+  if (value === 'active' || value === 'archived') return value;
+  return fallback;
+}
+
+function booleanToSql(value: boolean): number {
+  return value ? 1 : 0;
+}
+
+function normalizeNullableText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeOptionalText(
+  value: string | null | undefined,
+  fallback: string | null | undefined
+): string | null {
+  if (value === undefined) return fallback ?? null;
+  return normalizeNullableText(value);
 }
 
 function normalizeEnvOverrides(

--- a/shared/workspace.ts
+++ b/shared/workspace.ts
@@ -2,10 +2,12 @@
 // No wiring yet — Lane A migration, server CRUD, and frontend render in follow-ups.
 
 export type WorkspaceId = string;
+export type WorkspaceStatus = 'active' | 'archived';
 
 export interface Workspace {
   id: WorkspaceId;
   name: string;
+  status: WorkspaceStatus;
   // Ordering within the workspace bar. Lower comes first. Float so reorder
   // without renumber is feasible — same pattern as Bench/Tab follow-ups will use.
   order: number;
@@ -13,6 +15,15 @@ export interface Workspace {
   // an embedded Project[] so a Project can be referenced from a View without
   // duplicating Workspace state.
   projectIds: string[];
+  // Optional user-authored display/default metadata for the durable workspace
+  // rail. These are intentionally nullable/optional so older rows deserialize
+  // cleanly and free/non-git workspaces never have to pretend to be repos.
+  pinned: boolean;
+  color: string | null;
+  icon: string | null;
+  defaultRepoPath: string | null;
+  defaultNodeId: string | null;
+  defaultProvider: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/test/components/WorkspaceBar.test.ts
+++ b/test/components/WorkspaceBar.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { IaWorkspace } from '../../frontend/src/lib/api.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type MutationStub = {
+  isPending: boolean;
+  mutate: ReturnType<typeof vi.fn>;
+  mutateAsync: ReturnType<typeof vi.fn>;
+};
+
+type WorkspaceHookState = {
+  workspaces: IaWorkspace[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: ReturnType<typeof vi.fn>;
+  invalidate: ReturnType<typeof vi.fn>;
+  createMutation: MutationStub;
+  updateMutation: MutationStub;
+  archiveMutation: MutationStub;
+};
+
+const mockState = vi.hoisted(() => ({
+  activeWorkspaceId: null as string | null,
+  setActiveWorkspaceId: vi.fn(),
+  workspaceHook: null as WorkspaceHookState | null,
+}));
+
+vi.mock('../../frontend/src/lib/hooks/use-ia-workspaces.js', () => ({
+  useIaWorkspaces: () => {
+    if (!mockState.workspaceHook) {
+      throw new Error('workspace hook mock not configured');
+    }
+    return mockState.workspaceHook;
+  },
+}));
+
+vi.mock('../../frontend/src/lib/stores/ui.js', () => ({
+  useUiStore: <T>(
+    selector: (state: {
+      activeWorkspaceId: string | null;
+      setActiveWorkspaceId: (id: string | null) => void;
+    }) => T
+  ) =>
+    selector({
+      activeWorkspaceId: mockState.activeWorkspaceId,
+      setActiveWorkspaceId: mockState.setActiveWorkspaceId,
+    }),
+}));
+
+const { WorkspaceBar } =
+  await import('../../frontend/src/components/WorkspaceBar.js');
+
+function workspace(id: string, order: number): IaWorkspace {
+  return {
+    id,
+    name: `workspace ${id}`,
+    status: 'active',
+    order,
+    projectIds: [],
+    pinned: true,
+    color: null,
+    icon: null,
+    defaultRepoPath: null,
+    defaultNodeId: null,
+    defaultProvider: null,
+    createdAt: '2026-06-28T00:00:00.000Z',
+    updatedAt: '2026-06-28T00:00:00.000Z',
+  };
+}
+
+function mutationStub(): MutationStub {
+  return { isPending: false, mutate: vi.fn(), mutateAsync: vi.fn() };
+}
+
+function configureHook(overrides: Partial<WorkspaceHookState>) {
+  mockState.workspaceHook = {
+    workspaces: [],
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+    invalidate: vi.fn(),
+    createMutation: mutationStub(),
+    updateMutation: mutationStub(),
+    archiveMutation: mutationStub(),
+    ...overrides,
+  };
+}
+
+describe('<WorkspaceBar /> active workspace reconciliation', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockState.activeWorkspaceId = null;
+    mockState.setActiveWorkspaceId.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    mockState.workspaceHook = null;
+  });
+
+  it('does not clear a selected workspace while the authoritative list is refetching', () => {
+    mockState.activeWorkspaceId = 'created-workspace';
+    configureHook({
+      workspaces: [workspace('old-workspace', 1)],
+      isFetching: true,
+    });
+
+    act(() => {
+      root.render(React.createElement(WorkspaceBar));
+    });
+
+    expect(mockState.setActiveWorkspaceId).not.toHaveBeenCalledWith(null);
+  });
+
+  it('clears a stale selected workspace after the active workspace list is idle', () => {
+    mockState.activeWorkspaceId = 'missing-workspace';
+    configureHook({
+      workspaces: [workspace('kept-workspace', 1)],
+      isFetching: false,
+    });
+
+    act(() => {
+      root.render(React.createElement(WorkspaceBar));
+    });
+
+    expect(mockState.setActiveWorkspaceId).toHaveBeenCalledWith(null);
+  });
+});

--- a/test/ia-store.test.ts
+++ b/test/ia-store.test.ts
@@ -186,6 +186,43 @@ describe('ia-store: workspace', () => {
     expect(ws.order).toBe(1.5);
     expect(store.getWorkspace(id)!.order).toBe(1.5);
   });
+
+  it('persists workspace rail metadata and archives without deleting', () => {
+    const { store } = makeStore();
+    const id = createWorkspaceId('rail');
+    const ws = store.upsertWorkspace({
+      id,
+      name: 'Rail',
+      order: 1,
+      projectIds: [],
+      pinned: true,
+      color: ' blue ',
+      icon: ' crab ',
+      defaultRepoPath: '/work/relay',
+      defaultNodeId: 'local-node',
+      defaultProvider: 'hermes',
+    });
+
+    expect(ws).toMatchObject({
+      status: 'active',
+      pinned: true,
+      color: 'blue',
+      icon: 'crab',
+      defaultRepoPath: '/work/relay',
+      defaultNodeId: 'local-node',
+      defaultProvider: 'hermes',
+    });
+
+    const archived = store.archiveWorkspace(id);
+    expect(archived?.status).toBe('archived');
+    expect(store.listWorkspaces()).toEqual([]);
+    expect(
+      store.listWorkspaces({ includeArchived: true }).map((w) => w.id)
+    ).toEqual([id]);
+
+    expect(store.restoreWorkspace(id)?.status).toBe('active');
+    expect(store.listWorkspaces().map((w) => w.id)).toEqual([id]);
+  });
 });
 
 describe('ia-store: bench overlay', () => {
@@ -308,14 +345,25 @@ describe('ia-store: durability + migration', () => {
     const benchId = createBenchId(INSTANCE_ID, '/work/widget/corrupt');
 
     const s1 = createIaStore(dbPath);
-    s1.upsertWorkspace({ id: wsId, name: 'Corrupt', order: 1, projectIds: ['proj:repo:x'] });
+    s1.upsertWorkspace({
+      id: wsId,
+      name: 'Corrupt',
+      order: 1,
+      projectIds: ['proj:repo:x'],
+    });
     s1.upsertBenchOverlay({ id: benchId, envOverrides: { K: 'v' } });
     s1.close();
 
     // Simulate out-of-band corruption of the JSON payload columns.
     const raw = new Database(dbPath);
-    raw.prepare('UPDATE ia_workspaces SET project_ids_json = ? WHERE id = ?').run('{not json', wsId);
-    raw.prepare('UPDATE ia_bench_overlays SET env_overrides_json = ? WHERE id = ?').run('{not json', benchId);
+    raw
+      .prepare('UPDATE ia_workspaces SET project_ids_json = ? WHERE id = ?')
+      .run('{not json', wsId);
+    raw
+      .prepare(
+        'UPDATE ia_bench_overlays SET env_overrides_json = ? WHERE id = ?'
+      )
+      .run('{not json', benchId);
     raw.close();
 
     const s2 = createIaStore(dbPath);
@@ -346,14 +394,14 @@ describe('ia-store: durability + migration', () => {
     openStores.push(c);
     expect(c.listWorkspaces()).toHaveLength(1);
 
-    // schema_version pinned at the latest migration version (v2 adds the #736
-    // ia_migration_state marker table).
+    // schema_version pinned at the latest migration version (v3 adds the #1043
+    // workspace rail metadata columns).
     const db = new Database(dbPath);
     try {
       const row = db.prepare('SELECT version FROM schema_version').get() as {
         version: number;
       };
-      expect(row.version).toBe(2);
+      expect(row.version).toBe(3);
     } finally {
       db.close();
     }
@@ -397,9 +445,7 @@ describe('ia-store: durability + migration', () => {
     seed.exec(
       'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
     );
-    seed
-      .prepare('INSERT INTO schema_version (version) VALUES (?)')
-      .run(0);
+    seed.prepare('INSERT INTO schema_version (version) VALUES (?)').run(0);
     seed.exec('CREATE TABLE legacy_thing (id TEXT PRIMARY KEY)');
     seed.prepare('INSERT INTO legacy_thing (id) VALUES (?)').run('keep-me');
     seed.close();
@@ -417,9 +463,9 @@ describe('ia-store: durability + migration', () => {
     // Pre-existing unrelated table + row untouched.
     const db = new Database(dbPath);
     try {
-      const legacy = db
-        .prepare('SELECT id FROM legacy_thing')
-        .all() as Array<{ id: string }>;
+      const legacy = db.prepare('SELECT id FROM legacy_thing').all() as Array<{
+        id: string;
+      }>;
       expect(legacy).toEqual([{ id: 'keep-me' }]);
     } finally {
       db.close();

--- a/test/ia-workspace-router.test.ts
+++ b/test/ia-workspace-router.test.ts
@@ -99,7 +99,11 @@ describe('IA Workspace CRUD router', () => {
     });
     expect(createB.status).toBe(201);
     const { workspace: b } = (await createB.json()) as { workspace: Workspace };
-    expect(b).toMatchObject({ name: 'Beta', order: 1, projectIds: ['p1', 'p2'] });
+    expect(b).toMatchObject({
+      name: 'Beta',
+      order: 1,
+      projectIds: ['p1', 'p2'],
+    });
 
     // list returns both, ordered by order asc
     const listed = (await (await fetch(`${baseUrl}${WS}`)).json()) as {
@@ -127,7 +131,10 @@ describe('IA Workspace CRUD router', () => {
     const reordered = (await (await fetch(`${baseUrl}${WS}`)).json()) as {
       workspaces: Workspace[];
     };
-    expect(reordered.workspaces.map((w) => w.name)).toEqual(['Beta', 'Alpha-2']);
+    expect(reordered.workspaces.map((w) => w.name)).toEqual([
+      'Beta',
+      'Alpha-2',
+    ]);
 
     // DELETE B
     const del = await fetch(`${baseUrl}${WS}/${encodeURIComponent(b.id)}`, {
@@ -153,17 +160,84 @@ describe('IA Workspace CRUD router', () => {
 
     // rename only — order + projectIds must survive
     const patched = (await (
-      await fetch(`${baseUrl}${WS}/${encodeURIComponent(created.workspace.id)}`, {
-        method: 'PATCH',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ name: 'Gamma-renamed' }),
-      })
+      await fetch(
+        `${baseUrl}${WS}/${encodeURIComponent(created.workspace.id)}`,
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'Gamma-renamed' }),
+        }
+      )
     ).json()) as { workspace: Workspace };
     expect(patched.workspace).toMatchObject({
       name: 'Gamma-renamed',
       order: 3,
       projectIds: ['p1'],
     });
+  });
+
+  it('persists rail metadata and archive/restore filters default list', async () => {
+    await mount({ iaStore: store });
+    const created = (await (
+      await fetch(`${baseUrl}${WS}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Relay',
+          pinned: true,
+          color: 'blue',
+          icon: 'crab',
+          defaultRepoPath: '/work/relay',
+          defaultNodeId: 'local-node',
+          defaultProvider: 'hermes',
+        }),
+      })
+    ).json()) as { workspace: Workspace };
+
+    expect(created.workspace).toMatchObject({
+      status: 'active',
+      pinned: true,
+      color: 'blue',
+      icon: 'crab',
+      defaultRepoPath: '/work/relay',
+      defaultNodeId: 'local-node',
+      defaultProvider: 'hermes',
+    });
+
+    const archived = await fetch(
+      `${baseUrl}${WS}/${encodeURIComponent(created.workspace.id)}/archive`,
+      { method: 'POST' }
+    );
+    expect(archived.status).toBe(200);
+    expect(
+      ((await archived.json()) as { workspace: Workspace }).workspace.status
+    ).toBe('archived');
+
+    expect(
+      (
+        (await (await fetch(`${baseUrl}${WS}`)).json()) as {
+          workspaces: Workspace[];
+        }
+      ).workspaces
+    ).toEqual([]);
+    expect(
+      (
+        (await (
+          await fetch(`${baseUrl}${WS}?includeArchived=true`)
+        ).json()) as {
+          workspaces: Workspace[];
+        }
+      ).workspaces.map((w) => w.id)
+    ).toEqual([created.workspace.id]);
+
+    const restored = await fetch(
+      `${baseUrl}${WS}/${encodeURIComponent(created.workspace.id)}/restore`,
+      { method: 'POST' }
+    );
+    expect(restored.status).toBe(200);
+    expect(
+      ((await restored.json()) as { workspace: Workspace }).workspace.status
+    ).toBe('active');
   });
 
   it('rejects blank name on create (400)', async () => {
@@ -174,7 +248,9 @@ describe('IA Workspace CRUD router', () => {
       body: JSON.stringify({ name: '   ' }),
     });
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: { code: string; details?: { field?: string } } };
+    const body = (await res.json()) as {
+      error: { code: string; details?: { field?: string } };
+    };
     expect(body.error.code).toBe('INVALID_REQUEST');
     expect(body.error.details?.field).toBe('name');
   });
@@ -196,6 +272,21 @@ describe('IA Workspace CRUD router', () => {
     });
     expect(badOrder.status).toBe(400);
     expect((await badOrder.json()).error.details.field).toBe('order');
+  });
+
+  it('rejects invalid workspace rail metadata as bad input', async () => {
+    await mount({ iaStore: store });
+    const res = await fetch(`${baseUrl}${WS}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'X', pinned: 'yes' }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { code: string; details?: { field?: string } };
+    };
+    expect(body.error.code).toBe('INVALID_REQUEST');
+    expect(body.error.details?.field).toBe('metadata');
   });
 
   it('PATCH/DELETE on unknown id → 404; bad id → 400', async () => {

--- a/test/ia-workspace-router.test.ts
+++ b/test/ia-workspace-router.test.ts
@@ -240,6 +240,49 @@ describe('IA Workspace CRUD router', () => {
     ).toBe('active');
   });
 
+  it('appends new workspaces after archived rows so restore keeps active orders unique', async () => {
+    await mount({ iaStore: store });
+    const create = async (name: string, order?: number): Promise<Workspace> => {
+      const res = await fetch(`${baseUrl}${WS}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          ...(order === undefined ? {} : { order }),
+        }),
+      });
+      expect(res.status).toBe(201);
+      return ((await res.json()) as { workspace: Workspace }).workspace;
+    };
+
+    const archivedMax = await create('Archived max', 6);
+    const archive = await fetch(
+      `${baseUrl}${WS}/${encodeURIComponent(archivedMax.id)}/archive`,
+      { method: 'POST' }
+    );
+    expect(archive.status).toBe(200);
+
+    const active = await create('Active after archive');
+    expect(active.order).toBe(7);
+
+    const restore = await fetch(
+      `${baseUrl}${WS}/${encodeURIComponent(archivedMax.id)}/restore`,
+      { method: 'POST' }
+    );
+    expect(restore.status).toBe(200);
+
+    const listed = (await (await fetch(`${baseUrl}${WS}`)).json()) as {
+      workspaces: Workspace[];
+    };
+    expect(listed.workspaces.map((w) => [w.name, w.order])).toEqual([
+      ['Archived max', 6],
+      ['Active after archive', 7],
+    ]);
+    expect(new Set(listed.workspaces.map((w) => w.order)).size).toBe(
+      listed.workspaces.length
+    );
+  });
+
   it('rejects blank name on create (400)', async () => {
     await mount({ iaStore: store });
     const res = await fetch(`${baseUrl}${WS}`, {


### PR DESCRIPTION
Refs #1043

## Summary
- add IA workspace rail metadata/status persistence and v3 migration for archive/default fields
- add archive/restore/list filtering API support plus frontend client mutations
- wire WorkspaceBar quick-create to select the new workspace, archive instead of hard-delete, and scope ViewSpineTree to the selected workspace with reload-persisted UI state
- add persistence/router tests for metadata, archive filtering, invalid metadata, and schema version

## Verification
- npm test -- test/ia-store.test.ts test/ia-workspace-router.test.ts test/view-tree-workspace-grouping.test.ts test/components/FileFeedbackPanel.test.ts (41 passed)
- npm run check (pass; existing lint warnings only)
- npm run build (pass; existing chunk-size/dynamic-import warnings)
- npm test full suite: failed once on unrelated FileFeedbackPanel flaky test; isolated FileFeedbackPanel test passed afterward
- pre-push with Node 24: changed-test hook failed only on the same unrelated FileFeedbackPanel flaky test; pushed with HUSKY=0 after targeted pass

## Simplify
- risk tier 3 multi-file behavior/API/UI change; local simplify pass used because Kanban worker delegation can inherit board tools
- applied cleanup from pass: invalid metadata now returns 400 instead of 500, and stale delete comments were corrected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “active workspace” selection in the workspace bar, including an **All** option to show everything again.
  * Introduced workspace **archive** and **restore** actions, plus support for displaying archived workspaces when explicitly included.
  * Added support for extra workspace details such as **pinning** and customizable display/default settings (e.g., color/icon and default repo settings).
* **Bug Fixes**
  * Workspace tree and content now reflect the active selection more accurately, and the free/remote lane is hidden when filtering.
  * Archived workspaces are excluded from default lists; restoring brings them back.
* **Tests**
  * Added coverage for active selection reconciliation and archive/restore + metadata persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->