### PR TITLE
Add topic participant roster

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -435,7 +435,7 @@
 
 .topic-child-row__button {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto 18px;
+  grid-template-columns: minmax(0, 1fr) auto auto auto auto 18px;
   align-items: center;
   gap: 6px;
   width: 100%;
@@ -492,6 +492,115 @@
 .topic-child-row__button:hover .topic-child-row__meta,
 .topic-child-row__button:focus-visible .topic-child-row__meta {
   opacity: 1;
+}
+
+.topic-child-row__role {
+  color: var(--accent);
+}
+
+.topic-participants {
+  display: grid;
+  gap: 7px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.topic-participants__header,
+.topic-participant-group__label {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.topic-participants__header > span:first-child,
+.topic-participant-group__label {
+  color: var(--accent);
+}
+
+.topic-participant-group {
+  display: grid;
+  gap: 4px;
+}
+
+.topic-participant-group__grid {
+  display: grid;
+  gap: 4px;
+}
+
+.topic-participant-card {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  min-height: 44px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  text-align: left;
+}
+
+.topic-participant-card:not(:disabled) {
+  cursor: pointer;
+}
+
+.topic-participant-card:hover,
+.topic-participant-card:focus-visible {
+  border-color: var(--accent);
+  color: var(--text);
+  outline: none;
+}
+
+.topic-participant-card--attention {
+  border-color: color-mix(in srgb, var(--status-warning) 62%, transparent);
+}
+
+.topic-participant-card--error {
+  border-color: color-mix(in srgb, var(--status-error) 62%, transparent);
+}
+
+.topic-participant-card__topline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.topic-participant-card__name,
+.topic-participant-card__status,
+.topic-participant-card__meta,
+.topic-participant-card__summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-participant-card__name {
+  color: var(--text);
+  font-weight: 650;
+}
+
+.topic-participant-card__status {
+  color: var(--accent);
+}
+
+.topic-participant-card--attention .topic-participant-card__status {
+  color: var(--status-warning);
+}
+
+.topic-participant-card--error .topic-participant-card__status {
+  color: var(--status-error);
+}
+
+.topic-participant-card__meta,
+.topic-participant-card__summary {
+  color: var(--text-muted);
+  font-size: 0.58rem;
 }
 
 .topic-shell-state {

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -435,7 +435,7 @@
 
 .topic-child-row__button {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto auto auto 18px;
+  grid-template-columns: minmax(0, 1fr) repeat(6, auto) 18px;
   align-items: center;
   gap: 6px;
   width: 100%;
@@ -451,11 +451,21 @@
   cursor: pointer;
 }
 
+.topic-child-row__button:disabled {
+  cursor: default;
+}
+
 .topic-child-row__button:hover,
 .topic-child-row__button:focus-visible {
   background: var(--surface-hover);
   color: var(--text);
   outline: none;
+}
+
+.topic-child-row__button:disabled:hover,
+.topic-child-row__button:disabled:focus-visible {
+  background: transparent;
+  color: var(--text-muted);
 }
 
 .topic-child-row--idle .topic-child-row__button {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -34,6 +34,7 @@ import {
   buildTopicNavModel,
   type TopicNavItem,
   type TopicNavModel,
+  type TopicNavParticipantRef,
   type TopicNavSessionRef,
   type TopicNavSurfaceRef,
 } from '../lib/state/topic-nav.js';
@@ -218,38 +219,117 @@ function SurfaceButton({ surface }: { surface: TopicNavSurfaceRef }) {
   );
 }
 
-function SessionChildRow({
+function ParticipantChildRow({
+  participant,
   session,
   onSelectSession,
 }: {
-  session: TopicNavSessionRef;
+  participant: TopicNavParticipantRef;
+  session?: TopicNavSessionRef | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
   return (
-    <li className={`topic-child-row topic-child-row--${session.tone}`}>
+    <li className={`topic-child-row topic-child-row--${participant.tone}`}>
       <button
         type="button"
         className="topic-child-row__button"
         {...(onSelectSession
-          ? { onClick: () => onSelectSession(session.selectKey) }
+          ? { onClick: () => onSelectSession(participant.selectKey) }
           : {})}
+        title={`open existing session ${participant.selectKey}`}
       >
         <span className="topic-child-row__label">
-          <MarqueeText>{session.label}</MarqueeText>
+          <MarqueeText>{participant.label}</MarqueeText>
         </span>
-        {session.branch ? (
+        <span className="topic-child-row__meta topic-child-row__role">
+          {participant.roleLabel}
+        </span>
+        <span className="topic-child-row__meta">{participant.statusLabel}</span>
+        {session?.branch ? (
           <span className="topic-child-row__meta">{session.branch}</span>
         ) : null}
-        {session.nodeId ? (
-          <span className="topic-child-row__meta">{session.nodeId}</span>
+        {participant.nodeId ? (
+          <span className="topic-child-row__meta">{participant.nodeId}</span>
         ) : null}
-        <StatusGlyph tone={session.tone} />
+        <StatusGlyph tone={participant.tone} />
       </button>
     </li>
   );
 }
 
-function TopicDetail({ item }: { item: TopicNavItem }) {
+function participantGroups(participants: TopicNavParticipantRef[]) {
+  const groups = new Map<string, TopicNavParticipantRef[]>();
+  for (const participant of participants) {
+    const key = `${participant.roleLabel} · ${participant.providerLabel}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(participant);
+    groups.set(key, existing);
+  }
+  return Array.from(groups.entries());
+}
+
+function ParticipantRoster({
+  item,
+  onSelectSession,
+}: {
+  item: TopicNavItem;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  if (item.participants.length === 0) return null;
+  return (
+    <section className="topic-participants" aria-label="participant roster">
+      <div className="topic-participants__header">
+        <span>participants</span>
+        <span>{item.participants.length} linked</span>
+      </div>
+      {participantGroups(item.participants).map(([group, participants]) => (
+        <div className="topic-participant-group" key={group}>
+          <div className="topic-participant-group__label">{group}</div>
+          <div className="topic-participant-group__grid">
+            {participants.map((participant) => (
+              <button
+                key={participant.id}
+                type="button"
+                className={`topic-participant-card topic-participant-card--${participant.tone}`}
+                onClick={() => onSelectSession?.(participant.selectKey)}
+                title={`open existing session ${participant.selectKey}`}
+              >
+                <span className="topic-participant-card__topline">
+                  <span className="topic-participant-card__name">
+                    {participant.label}
+                  </span>
+                  <span className="topic-participant-card__status">
+                    {participant.statusLabel}
+                  </span>
+                </span>
+                <span className="topic-participant-card__meta">
+                  {participant.runtimeLabel}
+                  {participant.nodeId ? ` · ${participant.nodeId}` : ''}
+                </span>
+                <span className="topic-participant-card__meta">
+                  {participant.controlLabel}
+                </span>
+                {participant.summaryLabel ? (
+                  <span className="topic-participant-card__summary">
+                    {participant.summaryLabel}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function TopicDetail({
+  item,
+  onSelectSession,
+}: {
+  item: TopicNavItem;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
   return (
     <section className="topic-detail" aria-label={`${item.title} details`}>
       <div className="topic-detail__title">{item.title}</div>
@@ -275,6 +355,7 @@ function TopicDetail({ item }: { item: TopicNavItem }) {
           ))}
         </div>
       ) : null}
+      <ParticipantRoster item={item} onSelectSession={onSelectSession} />
     </section>
   );
 }
@@ -497,11 +578,11 @@ function TopicRow({
   onSelect: (id: string) => void;
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
-  const hasNested = item.childIds.length > 0 || item.sessions.length > 0;
+  const hasNested = item.childIds.length > 0 || item.participants.length > 0;
   const expanded = expandedIds.has(item.id);
   const selected = selectedId === item.id;
   const affordanceCount =
-    item.sessions.length + item.surfaces.length + item.taskRefs.length;
+    item.participants.length + item.surfaces.length + item.taskRefs.length;
 
   const activate = () => {
     onSelect(item.id);
@@ -552,8 +633,8 @@ function TopicRow({
           aria-label={`${item.statusLabel}, ${affordanceCount} linked items`}
         >
           <span className="topic-row__hover-actions" aria-hidden="true">
-            {item.sessions.length > 0 ? (
-              <span className="topic-chip">s{item.sessions.length}</span>
+            {item.participants.length > 0 ? (
+              <span className="topic-chip">p{item.participants.length}</span>
             ) : null}
             {item.surfaces.slice(0, 2).map((surface) => (
               <SurfaceButton key={surface.id} surface={surface} />
@@ -567,12 +648,15 @@ function TopicRow({
       </div>
       {expanded ? (
         <>
-          {item.sessions.length > 0 ? (
+          {item.participants.length > 0 ? (
             <ul className="topic-child-list">
-              {item.sessions.map((session) => (
-                <SessionChildRow
-                  key={session.id}
-                  session={session}
+              {item.participants.map((participant) => (
+                <ParticipantChildRow
+                  key={participant.id}
+                  participant={participant}
+                  session={item.sessions.find(
+                    (session) => session.selectKey === participant.selectKey
+                  )}
                   onSelectSession={onSelectSession}
                 />
               ))}
@@ -951,7 +1035,7 @@ export function TopicSidebarView({
       </ul>
       {selectedItem ? (
         <>
-          <TopicDetail item={selectedItem} />
+          <TopicDetail item={selectedItem} onSelectSession={onSelectSession} />
           <TopicMobileControlPanel
             item={selectedItem}
             onSelectSession={onSelectSession}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -28,6 +28,7 @@ import {
 } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
 import type { SessionSummary } from '../lib/types.js';
+import { formatRelativeTimeCompact } from '../lib/utils.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { durabilityDisabledReason } from '../lib/session-durability.js';
 import {
@@ -219,6 +220,14 @@ function SurfaceButton({ surface }: { surface: TopicNavSurfaceRef }) {
   );
 }
 
+function participantLastActivityLabel(
+  participant: TopicNavParticipantRef
+): string {
+  return participant.lastActivity
+    ? `last ${formatRelativeTimeCompact(participant.lastActivity)}`
+    : 'last unknown';
+}
+
 function ParticipantChildRow({
   participant,
   session,
@@ -228,29 +237,37 @@ function ParticipantChildRow({
   session?: TopicNavSessionRef | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
+  const lastActivityLabel = participantLastActivityLabel(participant);
+  const handleSelect = onSelectSession
+    ? () => onSelectSession(participant.selectKey)
+    : undefined;
   return (
     <li className={`topic-child-row topic-child-row--${participant.tone}`}>
       <button
         type="button"
         className="topic-child-row__button"
-        {...(onSelectSession
-          ? { onClick: () => onSelectSession(participant.selectKey) }
-          : {})}
+        {...(handleSelect ? { onClick: handleSelect } : { disabled: true })}
         title={`open existing session ${participant.selectKey}`}
       >
         <span className="topic-child-row__label">
           <MarqueeText>{participant.label}</MarqueeText>
         </span>
         <span className="topic-child-row__meta topic-child-row__role">
-          {participant.roleLabel}
+          {participant.roleLabel} · {participant.providerLabel}
+        </span>
+        <span className="topic-child-row__meta">
+          {participant.runtimeLabel}
         </span>
         <span className="topic-child-row__meta">{participant.statusLabel}</span>
-        {session?.branch ? (
-          <span className="topic-child-row__meta">{session.branch}</span>
-        ) : null}
+        <span className="topic-child-row__meta">{lastActivityLabel}</span>
         {participant.nodeId ? (
           <span className="topic-child-row__meta">{participant.nodeId}</span>
         ) : null}
+        <span className="topic-child-row__meta">
+          {participant.controlLabel}
+          {participant.summaryLabel ? ` · ${participant.summaryLabel}` : ''}
+          {session?.branch ? ` · ${session.branch}` : ''}
+        </span>
         <StatusGlyph tone={participant.tone} />
       </button>
     </li>
@@ -286,36 +303,48 @@ function ParticipantRoster({
         <div className="topic-participant-group" key={group}>
           <div className="topic-participant-group__label">{group}</div>
           <div className="topic-participant-group__grid">
-            {participants.map((participant) => (
-              <button
-                key={participant.id}
-                type="button"
-                className={`topic-participant-card topic-participant-card--${participant.tone}`}
-                onClick={() => onSelectSession?.(participant.selectKey)}
-                title={`open existing session ${participant.selectKey}`}
-              >
-                <span className="topic-participant-card__topline">
-                  <span className="topic-participant-card__name">
-                    {participant.label}
+            {participants.map((participant) => {
+              const handleSelect = onSelectSession
+                ? () => onSelectSession(participant.selectKey)
+                : undefined;
+              const lastActivityLabel =
+                participantLastActivityLabel(participant);
+              return (
+                <button
+                  key={participant.id}
+                  type="button"
+                  className={`topic-participant-card topic-participant-card--${participant.tone}`}
+                  {...(handleSelect
+                    ? { onClick: handleSelect }
+                    : { disabled: true })}
+                  title={`open existing session ${participant.selectKey}`}
+                >
+                  <span className="topic-participant-card__topline">
+                    <span className="topic-participant-card__name">
+                      {participant.label}
+                    </span>
+                    <span className="topic-participant-card__status">
+                      {participant.statusLabel}
+                    </span>
                   </span>
-                  <span className="topic-participant-card__status">
-                    {participant.statusLabel}
+                  <span className="topic-participant-card__meta">
+                    {participant.roleLabel} · {participant.providerLabel}
                   </span>
-                </span>
-                <span className="topic-participant-card__meta">
-                  {participant.runtimeLabel}
-                  {participant.nodeId ? ` · ${participant.nodeId}` : ''}
-                </span>
-                <span className="topic-participant-card__meta">
-                  {participant.controlLabel}
-                </span>
-                {participant.summaryLabel ? (
-                  <span className="topic-participant-card__summary">
-                    {participant.summaryLabel}
+                  <span className="topic-participant-card__meta">
+                    {participant.runtimeLabel}
+                    {participant.nodeId ? ` · ${participant.nodeId}` : ''}
                   </span>
-                ) : null}
-              </button>
-            ))}
+                  <span className="topic-participant-card__meta">
+                    {lastActivityLabel} · {participant.controlLabel}
+                  </span>
+                  {participant.summaryLabel ? (
+                    <span className="topic-participant-card__summary">
+                      {participant.summaryLabel}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
           </div>
         </div>
       ))}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -72,6 +72,14 @@ type TopicSendInput = typeof sendSessionInput;
 
 const DISCONNECTED_SESSION_CONTROL_REASON =
   'session offline/disconnected — controls unavailable until reconnect';
+const TOPIC_LATEST_STATUS_MAX_LENGTH = 96;
+
+function boundedTopicLatestStatus(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.length > TOPIC_LATEST_STATUS_MAX_LENGTH
+    ? `${trimmed.slice(0, TOPIC_LATEST_STATUS_MAX_LENGTH - 3)}...`
+    : trimmed;
+}
 
 function topicPrimarySession(
   item: TopicNavItem
@@ -158,20 +166,23 @@ function topicPrimaryAction(item: TopicNavItem): {
 function topicLatestStatus(item: TopicNavItem): string {
   const session = topicPrimarySession(item);
   if (session?.agentState === 'permission-prompt') {
-    return session.currentActivity?.detail
+    const status = session.currentActivity?.detail
       ? `${item.statusLabel} · ${session.currentActivity.detail}`
       : item.statusLabel;
+    return boundedTopicLatestStatus(status);
   }
   if (session?.currentActivity) {
     const detail = session.currentActivity.detail
       ? ` · ${session.currentActivity.detail}`
       : '';
-    return `${session.currentActivity.tool}${detail}`;
+    return boundedTopicLatestStatus(`${session.currentActivity.tool}${detail}`);
   }
   if (item.surfaces.length > 0) {
-    return `${item.statusLabel} · ${item.surfaces[0]!.label}`;
+    return boundedTopicLatestStatus(
+      `${item.statusLabel} · ${item.surfaces[0]!.label}`
+    );
   }
-  return item.routingLabel ?? item.statusLabel;
+  return boundedTopicLatestStatus(item.routingLabel ?? item.statusLabel);
 }
 
 function TopicBadge({ item }: { item: TopicNavItem }) {

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -6,6 +6,7 @@ import type {
 import type { SessionSummary } from '../types.js';
 import { isAttentionState, type DisplayState } from './display-state.js';
 import { highestPriorityState } from './attention.js';
+import { scopedSessionKey, sessionKeyMatches } from '../session-keys.js';
 
 export type TopicNavTone = 'active' | 'attention' | 'idle' | 'empty' | 'error';
 export type TopicNavKind = 'repo' | 'folder' | 'thread';
@@ -42,6 +43,22 @@ export interface TopicNavSessionRef {
   lastActivity: string | null;
 }
 
+export interface TopicNavParticipantRef {
+  id: string;
+  sessionId: string;
+  selectKey: string;
+  label: string;
+  roleLabel: string;
+  providerLabel: string;
+  runtimeLabel: string;
+  nodeId: string | null;
+  tone: TopicNavTone;
+  statusLabel: string;
+  controlLabel: string;
+  summaryLabel: string | null;
+  lastActivity: string | null;
+}
+
 export interface TopicNavSurfaceRef {
   id: string;
   label: string;
@@ -66,6 +83,7 @@ export interface TopicNavItem {
   statusLabel: string;
   attentionPriority: number;
   sessions: TopicNavSessionRef[];
+  participants: TopicNavParticipantRef[];
   surfaces: TopicNavSurfaceRef[];
   taskRefs: NonNullable<WorkspaceTopic['linkedRefs']['taskRefs']>;
   childIds: WorkspaceTopicId[];
@@ -87,12 +105,15 @@ function basename(path: string | undefined): string | null {
 }
 
 function sessionSelectKey(session: SessionSummary): string {
-  return session.globalSessionId ?? session.id;
+  return scopedSessionKey(session);
 }
 
 function sessionTone(session: SessionSummary): TopicNavTone {
   if (session.agentState === 'error') return 'error';
   if (session.agentState === 'permission-prompt') return 'attention';
+  if (session.agentState === 'waiting-for-input') return 'attention';
+  if (session.status === 'disconnected') return 'error';
+  if (session.controlFreshness === 'stale') return 'attention';
   if (
     session.agentState === 'processing' ||
     session.agentState === 'initializing'
@@ -108,7 +129,9 @@ function sessionDisplayState(session: SessionSummary): DisplayState {
       ? 'needs-answer'
       : 'permission';
   }
+  if (session.agentState === 'waiting-for-input') return 'needs-answer';
   if (session.agentState === 'error') return 'error';
+  if (session.status === 'disconnected') return 'error';
   if (session.agentState === 'processing') return 'running';
   if (session.agentState === 'initializing') return 'initializing';
   return 'seen-idle';
@@ -119,11 +142,7 @@ function sessionMatchesTopic(
   session: SessionSummary
 ): boolean {
   const linked = topic.linkedRefs;
-  if (
-    linked.sessionIds?.some(
-      (id) => id === session.id || id === session.globalSessionId
-    )
-  ) {
+  if (linked.sessionIds?.some((id) => sessionKeyMatches(session, id))) {
     return true;
   }
   if (
@@ -186,6 +205,156 @@ function routingLabel(topic: WorkspaceTopic): string | null {
   return parts.length > 0 ? parts.join(' · ') : null;
 }
 
+type TopicParticipantRole = {
+  label: string;
+  patterns: RegExp[];
+};
+
+const TOPIC_PARTICIPANT_ROLES: TopicParticipantRole[] = [
+  { label: 'product', patterns: [/\bkoi\b/i, /product/i] },
+  { label: 'planner', patterns: [/\btako\b/i, /planner/i, /plan/i] },
+  { label: 'frontend', patterns: [/\bika\b/i, /front.?end/i, /ui/i] },
+  { label: 'backend', patterns: [/\bkani\b/i, /back.?end/i, /server/i] },
+  { label: 'qa', patterns: [/\bkame\b/i, /\bqa\b/i, /test/i] },
+  { label: 'review', patterns: [/\bfugu\b/i, /review/i] },
+  { label: 'ops', patterns: [/\bkujira\b/i, /ops/i, /release/i] },
+  { label: 'design', patterns: [/\bhotate\b/i, /design/i] },
+];
+
+function actorLabel(
+  actor: NonNullable<SessionSummary['activeActors']>[number] | undefined
+): string | null {
+  if (!actor) return null;
+  return actor.displayName ?? actor.id ?? actor.kind ?? null;
+}
+
+function sessionRoleLabel(session: SessionSummary): string {
+  const peer = session.sessionEnvelope?.peerIdentity;
+  const candidates = [
+    actorLabel(session.activeWorker),
+    ...((session.activeActors ?? [])
+      .map(actorLabel)
+      .filter(Boolean) as string[]),
+    peer && 'displayName' in peer ? peer.displayName : undefined,
+    peer && 'id' in peer ? peer.id : undefined,
+    peer && 'adapter' in peer ? peer.adapter : undefined,
+    session.displayName,
+    session.agent,
+  ].filter((value): value is string => Boolean(value));
+
+  for (const candidate of candidates) {
+    for (const role of TOPIC_PARTICIPANT_ROLES) {
+      if (role.patterns.some((pattern) => pattern.test(candidate))) {
+        return role.label;
+      }
+    }
+  }
+
+  if (session.type === 'terminal') return 'terminal';
+  return 'agent';
+}
+
+function sessionProviderLabel(session: SessionSummary): string {
+  const peer = session.sessionEnvelope?.peerIdentity;
+  if (peer?.kind === 'agent') return peer.adapter;
+  if (peer?.kind === 'local-user') return 'local user';
+  if (peer?.kind === 'relay-node') return 'relay node';
+  return session.agent || session.type;
+}
+
+function sessionRuntimeLabel(session: SessionSummary): string {
+  const mode = session.mode ?? 'pty';
+  return `${session.type} · ${mode}`;
+}
+
+function boundedSummary(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed.length > 96 ? `${trimmed.slice(0, 93)}...` : trimmed;
+}
+
+function sessionParticipantStatus(session: SessionSummary): {
+  label: string;
+  summary: string | null;
+} {
+  if (session.status === 'disconnected') {
+    return { label: 'offline', summary: 'session disconnected' };
+  }
+  if (session.controlFreshness === 'stale') {
+    return {
+      label: 'stale',
+      summary: boundedSummary(session.controlReason) ?? 'stale control state',
+    };
+  }
+  if (session.agentState === 'permission-prompt') {
+    return {
+      label:
+        session.permissionType === 'question'
+          ? 'needs answer'
+          : 'needs approval',
+      summary:
+        boundedSummary(session.currentActivity?.detail) ??
+        session.currentActivity?.tool ??
+        null,
+    };
+  }
+  if (session.agentState === 'waiting-for-input') {
+    return {
+      label: 'needs input',
+      summary:
+        boundedSummary(session.currentActivity?.detail) ??
+        session.currentActivity?.tool ??
+        null,
+    };
+  }
+  if (session.agentState === 'error') {
+    return { label: 'error', summary: boundedSummary(session.controlReason) };
+  }
+  if (session.agentState === 'processing') {
+    return {
+      label: 'running',
+      summary: boundedSummary(
+        session.currentActivity?.detail ?? session.currentActivity?.tool
+      ),
+    };
+  }
+  if (session.agentState === 'initializing') {
+    return { label: 'starting', summary: 'initializing session' };
+  }
+  return {
+    label: session.idle ? 'idle' : 'active',
+    summary: boundedSummary(
+      session.currentActivity?.detail ?? session.controlReason
+    ),
+  };
+}
+
+function sessionControlLabel(session: SessionSummary): string {
+  if (session.controlFreshness === 'stale') return 'control stale';
+  if (session.controlFreshness === 'unknown') return 'control unknown';
+  return session.controlMode ?? 'control unknown';
+}
+
+function topicParticipantRef(session: SessionSummary): TopicNavParticipantRef {
+  const status = sessionParticipantStatus(session);
+  const selectKey = sessionSelectKey(session);
+  return {
+    id: selectKey,
+    sessionId: session.id,
+    selectKey,
+    label: session.displayName || basename(session.cwd) || session.id,
+    roleLabel: sessionRoleLabel(session),
+    providerLabel: sessionProviderLabel(session),
+    runtimeLabel: sessionRuntimeLabel(session),
+    nodeId: session.nodeId ?? null,
+    tone: sessionTone(session),
+    statusLabel: status.label,
+    controlLabel: sessionControlLabel(session),
+    summaryLabel: status.summary,
+    lastActivity: session.lastActivity ?? null,
+  };
+}
+
 function topicTone(
   sessions: TopicNavSessionRef[],
   surfaces: TopicNavSurfaceRef[],
@@ -211,7 +380,11 @@ function topicTone(
     };
   }
   if (attentionState === 'error') {
-    return { tone: 'error', label: 'error', priority: DISPLAY_PRIORITY.error };
+    return {
+      tone: 'error',
+      label: 'blocked',
+      priority: DISPLAY_PRIORITY.error,
+    };
   }
   if (attentionState === 'unseen-idle') {
     return {
@@ -282,8 +455,10 @@ export function buildTopicNavModel(input: {
   derived?: boolean;
 }): TopicNavModel {
   const items: TopicNavItem[] = input.topics.map((topic) => {
-    const sessions = input.sessions
-      .filter((session) => sessionMatchesTopic(topic, session))
+    const matchedSessions = input.sessions.filter((session) =>
+      sessionMatchesTopic(topic, session)
+    );
+    const sessions = matchedSessions
       .map(
         (session): TopicNavSessionRef => ({
           id: session.id,
@@ -323,6 +498,17 @@ export function buildTopicNavModel(input: {
       .sort((a, b) => a.label.localeCompare(b.label));
 
     const tone = topicTone(sessions, surfaces, topic);
+    const participants = matchedSessions
+      .map(topicParticipantRef)
+      .sort((a, b) => {
+        if (a.roleLabel !== b.roleLabel) {
+          return a.roleLabel.localeCompare(b.roleLabel);
+        }
+        if (a.providerLabel !== b.providerLabel) {
+          return a.providerLabel.localeCompare(b.providerLabel);
+        }
+        return a.label.localeCompare(b.label);
+      });
     const kind = topicKind(topic);
     const order = topic.grouping.order ?? Number.MAX_SAFE_INTEGER;
     return {
@@ -340,6 +526,7 @@ export function buildTopicNavModel(input: {
       statusLabel: tone.label,
       attentionPriority: tone.priority,
       sessions,
+      participants,
       surfaces,
       taskRefs: topic.linkedRefs.taskRefs ?? [],
       childIds: [],

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -292,19 +292,17 @@ function sessionParticipantStatus(session: SessionSummary): {
         session.permissionType === 'question'
           ? 'needs answer'
           : 'needs approval',
-      summary:
-        boundedSummary(session.currentActivity?.detail) ??
-        session.currentActivity?.tool ??
-        null,
+      summary: boundedSummary(
+        session.currentActivity?.detail ?? session.currentActivity?.tool
+      ),
     };
   }
   if (session.agentState === 'waiting-for-input') {
     return {
       label: 'needs input',
-      summary:
-        boundedSummary(session.currentActivity?.detail) ??
-        session.currentActivity?.tool ??
-        null,
+      summary: boundedSummary(
+        session.currentActivity?.detail ?? session.currentActivity?.tool
+      ),
     };
   }
   if (session.agentState === 'error') {

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -234,6 +234,137 @@ describe('buildTopicNavModel', () => {
     });
   });
 
+  it('projects a participant roster with role, provider, runtime, and bounded status summary', () => {
+    const topic = makeTopic({
+      linkedRefs: { sessionIds: ['global:ika', 'global:kame'] },
+    });
+    const longSummary = `${'reviewing '.repeat(20)}approval prompt`;
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [
+        makeSession({
+          id: 'ika-local',
+          globalSessionId: 'global:ika',
+          displayName: 'Ika frontend lane',
+          agent: 'claude',
+          mode: 'pty',
+          activeWorker: { kind: 'agent', displayName: 'ika-frontend' },
+          agentState: 'processing',
+          currentActivity: { tool: 'npm', detail: longSummary },
+        }),
+        makeSession({
+          id: 'kame-local',
+          globalSessionId: 'global:kame',
+          displayName: 'Kame QA gate',
+          agent: 'codex',
+          mode: 'web',
+          activeWorker: { kind: 'agent', displayName: 'kame-qa' },
+          agentState: 'idle',
+          idle: true,
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const item = model.byId.get('topic:alpha');
+    expect(item?.participants).toMatchObject([
+      {
+        label: 'Ika frontend lane',
+        roleLabel: 'frontend',
+        providerLabel: 'claude',
+        runtimeLabel: 'agent · pty',
+        statusLabel: 'running',
+        selectKey: 'global:ika',
+      },
+      {
+        label: 'Kame QA gate',
+        roleLabel: 'qa',
+        providerLabel: 'codex',
+        runtimeLabel: 'agent · web',
+        statusLabel: 'idle',
+        selectKey: 'global:kame',
+      },
+    ]);
+    expect(item?.participants[0]?.summaryLabel?.length).toBeLessThanOrEqual(96);
+  });
+
+  it('aggregates room status in task-room priority order', () => {
+    const model = buildTopicNavModel({
+      topics: [
+        makeTopic({
+          id: 'topic:mixed',
+          linkedRefs: { sessionIds: ['running', 'prompt'] },
+        }),
+        makeTopic({
+          id: 'topic:blocker',
+          linkedRefs: { sessionIds: ['offline'] },
+        }),
+      ],
+      sessions: [
+        makeSession({ id: 'running', agentState: 'processing' }),
+        makeSession({
+          id: 'prompt',
+          agentState: 'waiting-for-input',
+          currentActivity: { tool: 'question', detail: 'pick route' },
+        }),
+        makeSession({ id: 'offline', status: 'disconnected' }),
+      ],
+      surfaces: [],
+    });
+
+    expect(model.byId.get('topic:mixed')).toMatchObject({
+      tone: 'attention',
+      statusLabel: 'needs input',
+    });
+    expect(model.byId.get('topic:blocker')).toMatchObject({
+      tone: 'error',
+      statusLabel: 'blocked',
+    });
+  });
+
+  it('marks stale/offline participants without losing exact selection keys', () => {
+    const model = buildTopicNavModel({
+      topics: [
+        makeTopic({
+          linkedRefs: {
+            sessionIds: ['devbox:remote-session', 'stale-session'],
+          },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 'remote-session',
+          nodeId: 'devbox',
+          displayName: 'remote lane',
+          status: 'disconnected',
+        }),
+        makeSession({
+          id: 'stale-session',
+          displayName: 'stale lane',
+          controlFreshness: 'stale',
+          controlReason: 'node heartbeat expired',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const participants = model.byId.get('topic:alpha')?.participants ?? [];
+    expect(participants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'remote lane',
+          statusLabel: 'offline',
+          selectKey: 'devbox:remote-session',
+        }),
+        expect.objectContaining({
+          label: 'stale lane',
+          statusLabel: 'stale',
+          controlLabel: 'control stale',
+        }),
+      ])
+    );
+  });
+
   it('breaks cyclic parent links into roots instead of recursive children', () => {
     const a = makeTopic({
       id: 'topic:a',

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -288,6 +288,37 @@ describe('buildTopicNavModel', () => {
     expect(item?.participants[0]?.summaryLabel?.length).toBeLessThanOrEqual(96);
   });
 
+  it('bounds participant attention summaries when only tool names are available', () => {
+    const topic = makeTopic({
+      linkedRefs: { sessionIds: ['approval', 'question'] },
+    });
+    const longToolName = 'tool-name-'.repeat(30);
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [
+        makeSession({
+          id: 'approval',
+          agentState: 'permission-prompt',
+          permissionType: 'approval',
+          currentActivity: { tool: longToolName },
+        }),
+        makeSession({
+          id: 'question',
+          agentState: 'waiting-for-input',
+          currentActivity: { tool: longToolName },
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const participants = model.byId.get('topic:alpha')?.participants ?? [];
+    expect(participants).toHaveLength(2);
+    for (const participant of participants) {
+      expect(participant.summaryLabel?.length).toBeLessThanOrEqual(96);
+      expect(participant.summaryLabel).toBe(`${longToolName.slice(0, 93)}...`);
+    }
+  });
+
   it('aggregates room status in task-room priority order', () => {
     const model = buildTopicNavModel({
       topics: [

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -243,6 +243,38 @@ describe('TopicSidebarView', () => {
     expect(mobileRows[1]?.textContent).toContain('Routine lane');
   });
 
+  it('bounds mobile topic latest status from raw activity text', async () => {
+    const longToolName = 'tool-name-'.repeat(30);
+    await renderView({
+      topics: [
+        makeTopic({
+          linkedRefs: { sessionIds: ['waiting-session'] },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 'waiting-session',
+          displayName: 'waiting lane',
+          agentState: 'waiting-for-input',
+          currentActivity: { tool: longToolName },
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const mobileRowStatus = container.querySelector(
+      '.topic-mobile-row__status'
+    )?.textContent;
+    const mobileDetailLatest = container.querySelector(
+      '.topic-mobile-detail__latest'
+    )?.textContent;
+
+    expect(mobileRowStatus).toBe(`${longToolName.slice(0, 93)}...`);
+    expect(mobileDetailLatest).toBe(`${longToolName.slice(0, 93)}...`);
+    expect(mobileRowStatus?.length).toBeLessThanOrEqual(96);
+    expect(mobileDetailLatest?.length).toBeLessThanOrEqual(96);
+  });
+
   it('uses the bounded topic search as the only mobile search surface', async () => {
     await renderView();
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -493,6 +493,8 @@ describe('TopicSidebarView', () => {
             tool: 'edit',
             detail: 'wiring participant roster',
           },
+          controlMode: 'agent-driven',
+          lastActivity: '2026-06-25T23:44:00Z',
         }),
         makeSession({
           id: 'kame-local',
@@ -501,6 +503,8 @@ describe('TopicSidebarView', () => {
           agent: 'codex',
           activeWorker: { kind: 'agent', displayName: 'kame-qa' },
           status: 'disconnected',
+          controlMode: 'human-driven',
+          lastActivity: '2026-06-24T12:00:00Z',
         }),
       ],
       surfaces: [],
@@ -510,8 +514,19 @@ describe('TopicSidebarView', () => {
     expect(roster?.textContent).toContain('participants');
     expect(roster?.textContent).toContain('frontend · claude');
     expect(roster?.textContent).toContain('qa · codex');
+    expect(roster?.textContent).toContain('last 25-06-26');
+    expect(roster?.textContent).toContain('agent-driven');
+    expect(roster?.textContent).toContain('wiring participant roster');
     expect(roster?.textContent).toContain('running');
     expect(roster?.textContent).toContain('offline');
+
+    const childRows = Array.from(
+      container.querySelectorAll('.topic-child-row')
+    );
+    expect(childRows[0]?.textContent).toContain('agent · pty');
+    expect(childRows[0]?.textContent).toContain('last 25-06-26');
+    expect(childRows[0]?.textContent).toContain('agent-driven');
+    expect(childRows[0]?.textContent).toContain('wiring participant roster');
 
     const ikaCard = Array.from(
       container.querySelectorAll('.topic-participant-card')

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -474,6 +474,54 @@ describe('TopicSidebarView', () => {
     expect(onSearchClear).toHaveBeenCalledTimes(1);
   });
 
+  it('renders participant roster cards grouped by role/runtime and opens exact existing sessions', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          linkedRefs: { sessionIds: ['devbox:remote-ika', 'global:kame'] },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 'remote-ika',
+          nodeId: 'devbox',
+          displayName: 'Ika frontend',
+          agent: 'claude',
+          activeWorker: { kind: 'agent', displayName: 'ika-frontend' },
+          agentState: 'processing',
+          currentActivity: {
+            tool: 'edit',
+            detail: 'wiring participant roster',
+          },
+        }),
+        makeSession({
+          id: 'kame-local',
+          globalSessionId: 'global:kame',
+          displayName: 'Kame QA',
+          agent: 'codex',
+          activeWorker: { kind: 'agent', displayName: 'kame-qa' },
+          status: 'disconnected',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const roster = container.querySelector('.topic-participants');
+    expect(roster?.textContent).toContain('participants');
+    expect(roster?.textContent).toContain('frontend · claude');
+    expect(roster?.textContent).toContain('qa · codex');
+    expect(roster?.textContent).toContain('running');
+    expect(roster?.textContent).toContain('offline');
+
+    const ikaCard = Array.from(
+      container.querySelectorAll('.topic-participant-card')
+    ).find((card) =>
+      card.textContent?.includes('Ika frontend')
+    ) as HTMLButtonElement;
+    await act(async () => ikaCard.click());
+    expect(onSelectSession).toHaveBeenCalledWith('devbox:remote-ika');
+  });
+
   it('renders search result explanation, freshness, disabled action, and truncation metadata', async () => {
     const staleTopic = makeTopic({
       id: 'topic:stale',


### PR DESCRIPTION
Closes #1046.

## Summary
- add participant projection for topic task rooms from linked sessions, including role/provider/runtime labels and bounded per-participant status summaries
- aggregate room status from linked participant/session state so stale/offline/needs-input/error states surface at the room level
- route participant clicks through scoped session keys so opening a participant resumes the exact existing session instead of matching only local/global ids
- update the topic sidebar roster UI and tests for participant cards, role/runtime display, stale/offline status, and exact selection

## Verification
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk test npm test -- test/topic-nav.test.ts test/topic-sidebar-shell.test.ts` → exit 0; 2 files / 28 tests passed
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run check` → exit 0; typecheck/lint passed with existing warnings only
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run build` → exit 0; build passed with existing Vite chunk/dynamic-import warnings
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk test npm test` → exit 0; full suite passed (rtk tail only captured expected worktree-cleanup stderr fixture lines)
- browser smoke at `http://127.0.0.1:5197/`: rendered seeded topic roster with frontend/qa participants, running/offline statuses, blocked aggregate room state, no JS errors, and participant click recorded exact scoped key `devbox:ika`

## Notes
- simplify pass: applied one material cleanup from reviewer-style inspection by reusing the matched-session list for both sessions and participants; no broader UI refactor taken
