### PR TITLE
feat: add task room create and launch flow

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -66,6 +66,7 @@
 }
 
 .topic-create-panel input,
+.topic-create-panel select,
 .topic-create-panel textarea {
   min-width: 0;
   border: 1px solid var(--border);

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -29,6 +29,81 @@
   color: var(--status-info);
 }
 
+.topic-shell__create,
+.topic-create-panel button {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg-elevated);
+  color: var(--text);
+  font: inherit;
+  text-transform: lowercase;
+}
+
+.topic-shell__create:hover:not(:disabled),
+.topic-create-panel button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.topic-create-panel {
+  display: grid;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-elevated) 60%, transparent);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.topic-create-panel__title {
+  color: var(--text);
+  text-transform: lowercase;
+}
+
+.topic-create-panel label {
+  display: grid;
+  gap: 3px;
+}
+
+.topic-create-panel input,
+.topic-create-panel textarea {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.topic-create-panel textarea {
+  resize: vertical;
+}
+
+.topic-create-preview,
+.topic-create-failure {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--border);
+}
+
+.topic-create-preview {
+  color: var(--text-muted);
+}
+
+.topic-create-failure {
+  border-color: var(--status-error);
+  color: var(--status-error);
+}
+
+.topic-create-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
 .topic-search {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -22,14 +22,17 @@ import {
   type WorkspaceTopic,
   type WorkspaceTopicCreateInput,
   type WorkspaceTopicLaunchIntent,
+  type WorkspaceTopicTemplateKind,
   type WorkspaceTopicSearchResult,
 } from '../../../shared/workspace-topics.js';
 import {
   createWorkspaceTopicRoomAndMaybeLaunch,
+  fetchHubNodes,
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
   launchWorkspaceTopicRoom,
   searchWorkspaceTopics,
+  type CreateSessionBody,
   sendSessionInput,
   type WorkspaceTopicLaunchFailure,
   type WorkspaceTopicRoomCreateResult,
@@ -708,12 +711,129 @@ type TopicRoomDraft = {
   title: string;
   prompt: string;
   taskRef: string;
+  providerId: string;
+  agentId: string;
+  nodeId: string;
+  repoPath: string;
+  worktreePath: string;
+  cwd: string;
+  templateKind: WorkspaceTopicTemplateKind;
 };
+
+const TOPIC_ROOM_DRAFT_EMPTY: TopicRoomDraft = {
+  title: '',
+  prompt: '',
+  taskRef: '',
+  providerId: '',
+  agentId: '',
+  nodeId: '',
+  repoPath: '',
+  worktreePath: '',
+  cwd: '',
+  templateKind: 'agent-task',
+};
+
+const TOPIC_ROOM_TEMPLATE_OPTIONS: Array<{
+  value: WorkspaceTopicTemplateKind;
+  label: string;
+}> = [
+  { value: 'agent-task', label: 'agent task' },
+  { value: 'terminal-task', label: 'terminal task' },
+  { value: 'note', label: 'note / room only' },
+];
+
+const FALLBACK_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
+
+function compactString(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  return Array.from(
+    new Set(values.map((value) => compactString(value)).filter(Boolean))
+  ) as string[];
+}
+
+function launchTypeForTemplate(
+  templateKind: WorkspaceTopicTemplateKind
+): CreateSessionBody['type'] | null {
+  if (templateKind === 'terminal-task') return 'terminal';
+  if (templateKind === 'agent-task') return 'agent';
+  return null;
+}
+
+function buildTopicRoomLaunchBody(
+  create: WorkspaceTopicCreateInput,
+  templateKind: WorkspaceTopicTemplateKind
+): Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'> | null {
+  const type = launchTypeForTemplate(templateKind);
+  if (!type) return null;
+  const routing = create.routingDefaults ?? {};
+  return {
+    type,
+    mode: 'pty',
+    ...(type === 'agent' && routing.providerId
+      ? { agent: routing.providerId }
+      : {}),
+    ...(routing.nodeId ? { nodeId: routing.nodeId } : {}),
+    ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
+    ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
+    ...(routing.cwd ? { cwd: routing.cwd } : {}),
+    controlMode: type === 'agent' ? 'agent-driven' : 'human-driven',
+  };
+}
+
+function buildTopicRoomCreateInput(input: {
+  draft: TopicRoomDraft;
+  workspaceId: string | null;
+  defaultProviderId: string;
+  defaultNodeId?: string | undefined;
+  defaultRepoPath?: string | undefined;
+  defaultWorktreePath?: string | undefined;
+  defaultCwd?: string | undefined;
+  taskRef: ReturnType<typeof taskRefFromDraft>;
+}): WorkspaceTopicCreateInput {
+  const providerId =
+    compactString(input.draft.providerId) ?? input.defaultProviderId;
+  const agentId = compactString(input.draft.agentId);
+  const nodeId = compactString(input.draft.nodeId) ?? input.defaultNodeId;
+  const repoPath = compactString(input.draft.repoPath) ?? input.defaultRepoPath;
+  const worktreePath =
+    compactString(input.draft.worktreePath) ?? input.defaultWorktreePath;
+  const cwd = compactString(input.draft.cwd) ?? input.defaultCwd;
+  const prompt = input.draft.prompt.trim();
+
+  return {
+    workspaceId: input.workspaceId ?? 'workspace:local',
+    title: input.draft.title.trim() || 'Untitled task room',
+    ...(prompt ? { description: prompt.slice(0, 240) } : {}),
+    promptDefaults: {
+      ...(prompt ? { starterPrompt: prompt } : {}),
+    },
+    routingDefaults: {
+      ...(providerId ? { providerId } : {}),
+      ...(agentId ? { agentId } : {}),
+      ...(nodeId ? { nodeId } : {}),
+      ...(repoPath ? { repoPath } : {}),
+      ...(worktreePath ? { worktreePath } : {}),
+      ...(cwd ? { cwd } : {}),
+    },
+    linkedRefs: {
+      ...(input.taskRef ? { taskRefs: [input.taskRef] } : {}),
+    },
+  };
+}
 
 interface TopicRoomCreatePanelProps {
   open: boolean;
   draft: TopicRoomDraft;
   previewCreate: WorkspaceTopicCreateInput;
+  providerOptions: string[];
+  nodeOptions: Array<{ value: string; label: string }>;
+  repoPathOptions: string[];
+  worktreePathOptions: string[];
+  cwdOptions: string[];
   launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
   submittingIntent?: WorkspaceTopicLaunchIntent | null | undefined;
   onDraftChange: (patch: Partial<TopicRoomDraft>) => void;
@@ -725,6 +845,11 @@ function TopicRoomCreatePanel({
   open,
   draft,
   previewCreate,
+  providerOptions,
+  nodeOptions,
+  repoPathOptions,
+  worktreePathOptions,
+  cwdOptions,
   launchFailure,
   submittingIntent,
   onDraftChange,
@@ -735,17 +860,23 @@ function TopicRoomCreatePanel({
     () =>
       buildWorkspaceTopicLaunchPreview({
         create: previewCreate,
-        intent: 'create-and-launch',
-        templateKind: 'agent-task',
+        intent:
+          draft.templateKind === 'note' ? 'create-only' : 'create-and-launch',
+        templateKind: draft.templateKind,
         launchOverrides: {
-          type: 'agent',
+          type: launchTypeForTemplate(draft.templateKind) ?? 'agent',
           mode: 'pty',
           agent: previewCreate.routingDefaults?.providerId,
+          nodeId: previewCreate.routingDefaults?.nodeId,
+          repoPath: previewCreate.routingDefaults?.repoPath,
+          worktreePath: previewCreate.routingDefaults?.worktreePath,
+          cwd: previewCreate.routingDefaults?.cwd,
         },
       }),
-    [previewCreate]
+    [draft.templateKind, previewCreate]
   );
   if (!open) return null;
+  const launchDisabled = draft.templateKind === 'note';
   const disabled = !draft.title.trim() || Boolean(submittingIntent);
   return (
     <form
@@ -753,7 +884,7 @@ function TopicRoomCreatePanel({
       aria-label="create task room"
       onSubmit={(event: FormEvent) => {
         event.preventDefault();
-        if (!disabled) onSubmit('create-and-launch');
+        if (!disabled && !launchDisabled) onSubmit('create-and-launch');
       }}
     >
       <div className="topic-create-panel__title">new task room</div>
@@ -782,8 +913,122 @@ function TopicRoomCreatePanel({
           placeholder="github issue number or URL"
         />
       </label>
+      <label>
+        <span>provider</span>
+        <input
+          list="topic-room-provider-options"
+          value={draft.providerId}
+          onChange={(event) =>
+            onDraftChange({ providerId: event.target.value })
+          }
+          placeholder={
+            previewCreate.routingDefaults?.providerId ?? 'default provider'
+          }
+        />
+        <datalist id="topic-room-provider-options">
+          {providerOptions.map((providerId) => (
+            <option key={providerId} value={providerId} />
+          ))}
+        </datalist>
+      </label>
+      <label>
+        <span>agent id</span>
+        <input
+          value={draft.agentId}
+          onChange={(event) => onDraftChange({ agentId: event.target.value })}
+          placeholder="optional agent identity"
+        />
+      </label>
+      <label>
+        <span>template kind</span>
+        <select
+          value={draft.templateKind}
+          onChange={(event) =>
+            onDraftChange({
+              templateKind: event.target.value as WorkspaceTopicTemplateKind,
+            })
+          }
+        >
+          {TOPIC_ROOM_TEMPLATE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        <span>node</span>
+        <input
+          list="topic-room-node-options"
+          value={draft.nodeId}
+          onChange={(event) => onDraftChange({ nodeId: event.target.value })}
+          placeholder={
+            previewCreate.routingDefaults?.nodeId ?? 'local/default node'
+          }
+        />
+        <datalist id="topic-room-node-options">
+          {nodeOptions.map((node) => (
+            <option key={node.value} value={node.value} label={node.label} />
+          ))}
+        </datalist>
+      </label>
+      <label>
+        <span>repo</span>
+        <input
+          list="topic-room-repo-options"
+          value={draft.repoPath}
+          onChange={(event) => onDraftChange({ repoPath: event.target.value })}
+          placeholder={
+            previewCreate.routingDefaults?.repoPath ?? 'default repo'
+          }
+        />
+        <datalist id="topic-room-repo-options">
+          {repoPathOptions.map((repoPath) => (
+            <option key={repoPath} value={repoPath} />
+          ))}
+        </datalist>
+      </label>
+      <label>
+        <span>worktree</span>
+        <input
+          list="topic-room-worktree-options"
+          value={draft.worktreePath}
+          onChange={(event) =>
+            onDraftChange({ worktreePath: event.target.value })
+          }
+          placeholder={
+            previewCreate.routingDefaults?.worktreePath ?? 'default worktree'
+          }
+        />
+        <datalist id="topic-room-worktree-options">
+          {worktreePathOptions.map((worktreePath) => (
+            <option key={worktreePath} value={worktreePath} />
+          ))}
+        </datalist>
+      </label>
+      <label>
+        <span>cwd</span>
+        <input
+          list="topic-room-cwd-options"
+          value={draft.cwd}
+          onChange={(event) => onDraftChange({ cwd: event.target.value })}
+          placeholder={previewCreate.routingDefaults?.cwd ?? 'default cwd'}
+        />
+        <datalist id="topic-room-cwd-options">
+          {cwdOptions.map((cwd) => (
+            <option key={cwd} value={cwd} />
+          ))}
+        </datalist>
+      </label>
       <div className="topic-create-preview" aria-label="launch preview">
+        <div>template: {preview.templateKind}</div>
         <div>provider: {preview.providerLabel}</div>
+        <div>
+          agent:{' '}
+          {previewCreate.routingDefaults?.agentId ??
+            previewCreate.routingDefaults?.providerId ??
+            'default agent'}
+        </div>
         <div>mode: {preview.modeLabel}</div>
         <div>node: {preview.nodeLabel}</div>
         <div>cwd: {preview.cwdLabel}</div>
@@ -814,14 +1059,16 @@ function TopicRoomCreatePanel({
         >
           {submittingIntent === 'create-only' ? 'creating…' : 'create only'}
         </button>
-        <button type="submit" disabled={disabled}>
+        <button type="submit" disabled={disabled || launchDisabled}>
           {submittingIntent === 'create-and-launch'
             ? 'launching…'
-            : launchFailure
-              ? launchFailure.stage === 'session'
-                ? 'retry launch'
-                : 'retry create + launch'
-              : 'create + launch'}
+            : launchDisabled
+              ? 'note is create-only'
+              : launchFailure
+                ? launchFailure.stage === 'session'
+                  ? 'retry launch'
+                  : 'retry create + launch'
+                : 'create + launch'}
         </button>
       </div>
     </form>
@@ -1121,6 +1368,7 @@ export function TopicSidebarView({
   );
 }
 
+// eslint-disable-next-line complexity -- topic room creation composes query, routing-default, and launch retry state in one shell boundary.
 export function TopicSidebarShell({
   onSelectSession,
 }: {
@@ -1133,17 +1381,16 @@ export function TopicSidebarShell({
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
   const defaultAgent = useConfigStore((s) => s.defaultAgent);
+  const frameworks = useConfigStore((s) => s.frameworks);
   const activeSession = useMemo(
     () => resolveSessionByKey(sessions, activeSessionId),
     [activeSessionId, sessions]
   );
   const [searchQuery, setSearchQuery] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
-  const [createDraft, setCreateDraft] = useState<TopicRoomDraft>({
-    title: '',
-    prompt: '',
-    taskRef: '',
-  });
+  const [createDraft, setCreateDraft] = useState<TopicRoomDraft>(
+    TOPIC_ROOM_DRAFT_EMPTY
+  );
   const [submittingIntent, setSubmittingIntent] =
     useState<WorkspaceTopicLaunchIntent | null>(null);
   const [launchFailure, setLaunchFailure] =
@@ -1168,6 +1415,11 @@ export function TopicSidebarShell({
     queryFn: () => fetchWorkspaceSurfaces(),
     staleTime: 30_000,
   });
+  const nodesQuery = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    staleTime: 60_000,
+  });
   useEffect(() => {
     const openCreate = () => {
       setCreateOpen(true);
@@ -1181,56 +1433,93 @@ export function TopicSidebarShell({
   const searchData = topicSearchQuery.data;
   const searchResults = searchData?.results ?? [];
   const taskRef = taskRefFromDraft(createDraft.taskRef, createDraft.title);
-  const previewCreate = useMemo<WorkspaceTopicCreateInput>(() => {
-    const repoPath = activeSession?.repoPath ?? activeRepoPath ?? undefined;
-    const worktreePath = activeSession?.worktreePath ?? undefined;
-    const cwd = activeSession?.cwd ?? worktreePath ?? repoPath ?? undefined;
-    return {
-      workspaceId: activeWorkspaceId ?? 'workspace:local',
-      title: createDraft.title.trim() || 'Untitled task room',
-      ...(createDraft.prompt.trim()
-        ? { description: createDraft.prompt.trim().slice(0, 240) }
-        : {}),
-      promptDefaults: {
-        ...(createDraft.prompt.trim()
-          ? { starterPrompt: createDraft.prompt.trim() }
-          : {}),
-      },
-      routingDefaults: {
-        ...(defaultAgent ? { providerId: defaultAgent } : {}),
-        ...(activeSession?.nodeId ? { nodeId: activeSession.nodeId } : {}),
-        ...(repoPath ? { repoPath } : {}),
-        ...(worktreePath ? { worktreePath } : {}),
-        ...(cwd ? { cwd } : {}),
-      },
-      linkedRefs: {
-        ...(taskRef ? { taskRefs: [taskRef] } : {}),
-      },
-    };
-  }, [
-    activeRepoPath,
-    activeSession,
-    activeWorkspaceId,
-    createDraft,
-    defaultAgent,
-    taskRef,
-  ]);
+  const defaultRepoPath =
+    activeSession?.repoPath ?? activeRepoPath ?? undefined;
+  const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
+  const defaultCwd =
+    activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
+  const providerOptions = useMemo(
+    () =>
+      uniqueStrings([
+        defaultAgent,
+        ...frameworks.map((framework) => framework.id),
+        ...FALLBACK_PROVIDER_IDS,
+      ]),
+    [defaultAgent, frameworks]
+  );
+  const nodeOptions = useMemo(
+    () =>
+      (nodesQuery.data ?? []).map((node) => ({
+        value: node.nodeId,
+        label: node.displayName
+          ? `${node.displayName} · ${node.status}`
+          : node.status,
+      })),
+    [nodesQuery.data]
+  );
+  const repoPathOptions = useMemo(
+    () =>
+      uniqueStrings([
+        defaultRepoPath,
+        ...sessions.map((session) => session.repoPath),
+      ]),
+    [defaultRepoPath, sessions]
+  );
+  const worktreePathOptions = useMemo(
+    () =>
+      uniqueStrings([
+        defaultWorktreePath,
+        ...sessions.map((session) => session.worktreePath),
+      ]),
+    [defaultWorktreePath, sessions]
+  );
+  const cwdOptions = useMemo(
+    () =>
+      uniqueStrings([defaultCwd, ...sessions.map((session) => session.cwd)]),
+    [defaultCwd, sessions]
+  );
+  const previewCreate = useMemo<WorkspaceTopicCreateInput>(
+    () =>
+      buildTopicRoomCreateInput({
+        draft: createDraft,
+        workspaceId: activeWorkspaceId,
+        defaultProviderId: defaultAgent,
+        defaultNodeId: activeSession?.nodeId,
+        defaultRepoPath,
+        defaultWorktreePath,
+        defaultCwd,
+        taskRef,
+      }),
+    [
+      activeSession?.nodeId,
+      activeWorkspaceId,
+      createDraft,
+      defaultAgent,
+      defaultCwd,
+      defaultRepoPath,
+      defaultWorktreePath,
+      taskRef,
+    ]
+  );
 
   const handleCreateSubmit = useCallback(
     async (intent: WorkspaceTopicLaunchIntent) => {
       if (!createDraft.title.trim()) return;
-      setSubmittingIntent(intent);
+      const launch = buildTopicRoomLaunchBody(
+        previewCreate,
+        createDraft.templateKind
+      );
+      const submitIntent =
+        intent === 'create-and-launch' && launch
+          ? 'create-and-launch'
+          : 'create-only';
+      setSubmittingIntent(submitIntent);
       setLaunchFailure(null);
       try {
-        if (intent === 'create-and-launch' && createdRoom) {
+        if (submitIntent === 'create-and-launch' && createdRoom && launch) {
           const result = await launchWorkspaceTopicRoom({
             room: createdRoom,
-            launch: {
-              type: 'agent',
-              mode: 'pty',
-              agent: defaultAgent,
-              controlMode: 'agent-driven',
-            },
+            launch,
           });
           if (result.status === 'launch_failed') {
             setLaunchFailure(result.failure);
@@ -1241,7 +1530,7 @@ export function TopicSidebarShell({
           onSelectSession?.(result.session.id);
           setCreateOpen(false);
           setCreatedRoom(null);
-          setCreateDraft({ title: '', prompt: '', taskRef: '' });
+          setCreateDraft(TOPIC_ROOM_DRAFT_EMPTY);
           return;
         }
         const result = await createWorkspaceTopicRoomAndMaybeLaunch({
@@ -1249,14 +1538,9 @@ export function TopicSidebarShell({
             topic: previewCreate,
             ...(taskRef ? { taskRef } : {}),
           },
-          ...(intent === 'create-and-launch'
+          ...(submitIntent === 'create-and-launch' && launch
             ? {
-                launch: {
-                  type: 'agent',
-                  mode: 'pty',
-                  agent: defaultAgent,
-                  controlMode: 'agent-driven',
-                },
+                launch,
               }
             : {}),
         });
@@ -1279,7 +1563,7 @@ export function TopicSidebarShell({
         }
         setCreateOpen(false);
         setCreatedRoom(null);
-        setCreateDraft({ title: '', prompt: '', taskRef: '' });
+        setCreateDraft(TOPIC_ROOM_DRAFT_EMPTY);
       } catch (error) {
         const failure = error as WorkspaceTopicLaunchFailure;
         setLaunchFailure({
@@ -1300,8 +1584,8 @@ export function TopicSidebarShell({
     },
     [
       createDraft.title,
+      createDraft.templateKind,
       createdRoom,
-      defaultAgent,
       onSelectSession,
       previewCreate,
       queryClient,
@@ -1315,6 +1599,11 @@ export function TopicSidebarShell({
       open={createOpen}
       draft={createDraft}
       previewCreate={previewCreate}
+      providerOptions={providerOptions}
+      nodeOptions={nodeOptions}
+      repoPathOptions={repoPathOptions}
+      worktreePathOptions={worktreePathOptions}
+      cwdOptions={cwdOptions}
       launchFailure={launchFailure}
       submittingIntent={submittingIntent}
       onDraftChange={(patch) => {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -41,6 +41,7 @@ import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { durabilityDisabledReason } from '../lib/session-durability.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
 import {
   buildTopicNavModel,
   type TopicNavItem,
@@ -1133,7 +1134,7 @@ export function TopicSidebarShell({
   const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
   const defaultAgent = useConfigStore((s) => s.defaultAgent);
   const activeSession = useMemo(
-    () => sessions.find((session) => session.id === activeSessionId),
+    () => resolveSessionByKey(sessions, activeSessionId),
     [activeSessionId, sessions]
   );
   const [searchQuery, setSearchQuery] = useState('');
@@ -1197,6 +1198,7 @@ export function TopicSidebarShell({
       },
       routingDefaults: {
         ...(defaultAgent ? { providerId: defaultAgent } : {}),
+        ...(activeSession?.nodeId ? { nodeId: activeSession.nodeId } : {}),
         ...(repoPath ? { repoPath } : {}),
         ...(worktreePath ? { worktreePath } : {}),
         ...(cwd ? { cwd } : {}),
@@ -1246,22 +1248,6 @@ export function TopicSidebarShell({
           room: {
             topic: previewCreate,
             ...(taskRef ? { taskRef } : {}),
-            workContext: {
-              title: previewCreate.title,
-              anchors: {
-                project: { workspaceId: previewCreate.workspaceId },
-                repo: {
-                  ...(previewCreate.routingDefaults?.repoPath
-                    ? { localPath: previewCreate.routingDefaults.repoPath }
-                    : {}),
-                },
-                worktree: {
-                  ...(previewCreate.routingDefaults?.worktreePath
-                    ? { localPath: previewCreate.routingDefaults.worktreePath }
-                    : {}),
-                },
-              },
-            },
           },
           ...(intent === 'create-and-launch'
             ? {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -5,8 +5,9 @@ import {
   useState,
   type FormEvent,
   type CSSProperties,
+  type ReactNode,
 } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   CircleAlert,
   Folder,
@@ -16,19 +17,29 @@ import {
   TriangleAlert,
 } from 'lucide-react';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
-import type {
-  WorkspaceTopic,
-  WorkspaceTopicSearchResult,
-} from '../../../shared/workspace-topics.js';
 import {
+  buildWorkspaceTopicLaunchPreview,
+  type WorkspaceTopic,
+  type WorkspaceTopicCreateInput,
+  type WorkspaceTopicLaunchIntent,
+  type WorkspaceTopicSearchResult,
+} from '../../../shared/workspace-topics.js';
+import type { TaskRef } from '../../../shared/work-context.js';
+import {
+  createWorkspaceTopicRoomAndMaybeLaunch,
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
+  launchWorkspaceTopicRoom,
   searchWorkspaceTopics,
   sendSessionInput,
+  type WorkspaceTopicLaunchFailure,
+  type WorkspaceTopicRoomCreateResult,
 } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
 import type { SessionSummary } from '../lib/types.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
+import { useUiStore } from '../lib/stores/ui.js';
+import { useConfigStore } from '../lib/stores/config.js';
 import { durabilityDisabledReason } from '../lib/session-durability.js';
 import {
   buildTopicNavModel,
@@ -692,14 +703,140 @@ function topicEmptyStateText(input: {
   return `no topic matches for “${input.searchQuery.trim()}”`;
 }
 
+type TopicRoomDraft = {
+  title: string;
+  prompt: string;
+  taskRef: string;
+};
+
+interface TopicRoomCreatePanelProps {
+  open: boolean;
+  draft: TopicRoomDraft;
+  previewCreate: WorkspaceTopicCreateInput;
+  launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
+  submittingIntent?: WorkspaceTopicLaunchIntent | null | undefined;
+  onDraftChange: (patch: Partial<TopicRoomDraft>) => void;
+  onSubmit: (intent: WorkspaceTopicLaunchIntent) => void;
+  onCancel: () => void;
+}
+
+function TopicRoomCreatePanel({
+  open,
+  draft,
+  previewCreate,
+  launchFailure,
+  submittingIntent,
+  onDraftChange,
+  onSubmit,
+  onCancel,
+}: TopicRoomCreatePanelProps) {
+  const preview = useMemo(
+    () =>
+      buildWorkspaceTopicLaunchPreview({
+        create: previewCreate,
+        intent: 'create-and-launch',
+        templateKind: 'agent-task',
+        launchOverrides: {
+          type: 'agent',
+          mode: 'pty',
+          agent: previewCreate.routingDefaults?.providerId,
+        },
+      }),
+    [previewCreate]
+  );
+  if (!open) return null;
+  const disabled = !draft.title.trim() || Boolean(submittingIntent);
+  return (
+    <form
+      className="topic-create-panel"
+      aria-label="create task room"
+      onSubmit={(event: FormEvent) => {
+        event.preventDefault();
+        if (!disabled) onSubmit('create-and-launch');
+      }}
+    >
+      <div className="topic-create-panel__title">new task room</div>
+      <label>
+        <span>title</span>
+        <input
+          value={draft.title}
+          onChange={(event) => onDraftChange({ title: event.target.value })}
+          placeholder="issue title or task"
+        />
+      </label>
+      <label>
+        <span>starter prompt</span>
+        <textarea
+          value={draft.prompt}
+          onChange={(event) => onDraftChange({ prompt: event.target.value })}
+          placeholder="what should the agent start with?"
+          rows={3}
+        />
+      </label>
+      <label>
+        <span>task ref</span>
+        <input
+          value={draft.taskRef}
+          onChange={(event) => onDraftChange({ taskRef: event.target.value })}
+          placeholder="github issue number or URL"
+        />
+      </label>
+      <div className="topic-create-preview" aria-label="launch preview">
+        <div>provider: {preview.providerLabel}</div>
+        <div>mode: {preview.modeLabel}</div>
+        <div>node: {preview.nodeLabel}</div>
+        <div>cwd: {preview.cwdLabel}</div>
+        <div>prompt: {preview.promptSources.join(', ')}</div>
+        <div>tasks: {preview.taskRefs.join(', ')}</div>
+        <div>side effects: {preview.sideEffects.join(' · ')}</div>
+      </div>
+      {launchFailure ? (
+        <div className="topic-create-failure" role="alert">
+          {launchFailure.stage === 'session'
+            ? 'launch failed after room creation'
+            : 'room creation failed'}{' '}
+          ({launchFailure.stage}): {launchFailure.message}
+        </div>
+      ) : null}
+      <div className="topic-create-panel__actions">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={Boolean(submittingIntent)}
+        >
+          cancel
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onSubmit('create-only')}
+        >
+          {submittingIntent === 'create-only' ? 'creating…' : 'create only'}
+        </button>
+        <button type="submit" disabled={disabled}>
+          {submittingIntent === 'create-and-launch'
+            ? 'launching…'
+            : launchFailure
+              ? launchFailure.stage === 'session'
+                ? 'retry launch'
+                : 'retry create + launch'
+              : 'create + launch'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
 function TopicMobileCockpit({
   mobileItems,
   selectedId,
   onSelect,
+  onCreateTaskRoom,
 }: {
   mobileItems: TopicNavItem[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  onCreateTaskRoom?: (() => void) | undefined;
 }) {
   return (
     <section className="topic-mobile-cockpit" aria-label="mobile topic cockpit">
@@ -712,10 +849,15 @@ function TopicMobileCockpit({
         </span>
         <button
           type="button"
-          disabled
-          title="topic creation flow is routed through workspace-topics.create next"
+          disabled={!onCreateTaskRoom}
+          title={
+            onCreateTaskRoom
+              ? 'create a task room from workspace defaults'
+              : 'topic creation unavailable'
+          }
+          onClick={onCreateTaskRoom}
         >
-          + topic
+          + task
         </button>
       </div>
       <div className="topic-mobile-list" aria-label="attention-sorted topics">
@@ -831,6 +973,8 @@ export function TopicSidebarView({
   onSearchClear,
   onSelectSession,
   onSendInput = sendSessionInput,
+  createPanel,
+  onCreateTaskRoom,
 }: {
   topics: WorkspaceTopic[];
   sessions: SessionSummary[];
@@ -849,6 +993,8 @@ export function TopicSidebarView({
   onSearchClear?: (() => void) | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
   onSendInput?: TopicSendInput | undefined;
+  createPanel?: ReactNode;
+  onCreateTaskRoom?: (() => void) | undefined;
 }) {
   const model = useMemo(
     () => buildTopicNavModel({ topics, sessions, surfaces, derived }),
@@ -907,6 +1053,15 @@ export function TopicSidebarView({
     <div className="topic-shell" data-track="topic-shell">
       <div className="topic-shell__header">
         <span>topics</span>
+        {onCreateTaskRoom ? (
+          <button
+            className="topic-shell__create"
+            type="button"
+            onClick={onCreateTaskRoom}
+          >
+            + task
+          </button>
+        ) : null}
         {searchQuery.trim() ? (
           <span className="topic-shell__derived">search</span>
         ) : model.derived ? (
@@ -917,7 +1072,9 @@ export function TopicSidebarView({
         mobileItems={mobileItems}
         selectedId={selectedId}
         onSelect={select}
+        onCreateTaskRoom={onCreateTaskRoom}
       />
+      {createPanel}
       <TopicSearchPanel
         model={model}
         searchQuery={searchQuery}
@@ -963,13 +1120,51 @@ export function TopicSidebarView({
   );
 }
 
+function taskRefFromDraft(value: string, title: string): TaskRef | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const issueMatch = trimmed.match(/(?:issues\/|#)?(\d+)\b/);
+  if (!issueMatch) {
+    return { kind: 'external', id: trimmed, title };
+  }
+  const issueId = issueMatch[1]!;
+  return {
+    kind: 'github-issue',
+    id: issueId,
+    title,
+    ...(trimmed.startsWith('http') ? { url: trimmed } : {}),
+  };
+}
+
 export function TopicSidebarShell({
   onSelectSession,
 }: {
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
+  const queryClient = useQueryClient();
   const sessions = useSessionsStore((s) => s.sessions);
+  const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+  const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
+  const activeRepoPath = useUiStore((s) => s.activeRepoPath);
+  const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
+  const defaultAgent = useConfigStore((s) => s.defaultAgent);
+  const activeSession = useMemo(
+    () => sessions.find((session) => session.id === activeSessionId),
+    [activeSessionId, sessions]
+  );
   const [searchQuery, setSearchQuery] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createDraft, setCreateDraft] = useState<TopicRoomDraft>({
+    title: '',
+    prompt: '',
+    taskRef: '',
+  });
+  const [submittingIntent, setSubmittingIntent] =
+    useState<WorkspaceTopicLaunchIntent | null>(null);
+  const [launchFailure, setLaunchFailure] =
+    useState<WorkspaceTopicLaunchFailure | null>(null);
+  const [createdRoom, setCreatedRoom] =
+    useState<WorkspaceTopicRoomCreateResult | null>(null);
   const normalizedSearchQuery = searchQuery.trim();
   const topicsQuery = useQuery({
     queryKey: ['workspace-topics'],
@@ -988,9 +1183,182 @@ export function TopicSidebarShell({
     queryFn: () => fetchWorkspaceSurfaces(),
     staleTime: 30_000,
   });
+  useEffect(() => {
+    const openCreate = () => {
+      setCreateOpen(true);
+      setLaunchFailure(null);
+    };
+    window.addEventListener('relay:open-topic-task-room', openCreate);
+    return () =>
+      window.removeEventListener('relay:open-topic-task-room', openCreate);
+  }, []);
   const searchActive = normalizedSearchQuery.length > 0;
   const searchData = topicSearchQuery.data;
   const searchResults = searchData?.results ?? [];
+  const taskRef = taskRefFromDraft(createDraft.taskRef, createDraft.title);
+  const previewCreate = useMemo<WorkspaceTopicCreateInput>(() => {
+    const repoPath = activeSession?.repoPath ?? activeRepoPath ?? undefined;
+    const worktreePath = activeSession?.worktreePath ?? undefined;
+    const cwd = activeSession?.cwd ?? worktreePath ?? repoPath ?? undefined;
+    return {
+      workspaceId: activeWorkspaceId ?? 'workspace:local',
+      title: createDraft.title.trim() || 'Untitled task room',
+      ...(createDraft.prompt.trim()
+        ? { description: createDraft.prompt.trim().slice(0, 240) }
+        : {}),
+      promptDefaults: {
+        ...(createDraft.prompt.trim()
+          ? { starterPrompt: createDraft.prompt.trim() }
+          : {}),
+      },
+      routingDefaults: {
+        ...(defaultAgent ? { providerId: defaultAgent } : {}),
+        ...(repoPath ? { repoPath } : {}),
+        ...(worktreePath ? { worktreePath } : {}),
+        ...(cwd ? { cwd } : {}),
+      },
+      linkedRefs: {
+        ...(taskRef ? { taskRefs: [taskRef] } : {}),
+      },
+    };
+  }, [
+    activeRepoPath,
+    activeSession,
+    activeWorkspaceId,
+    createDraft,
+    defaultAgent,
+    taskRef,
+  ]);
+
+  const handleCreateSubmit = useCallback(
+    async (intent: WorkspaceTopicLaunchIntent) => {
+      if (!createDraft.title.trim()) return;
+      setSubmittingIntent(intent);
+      setLaunchFailure(null);
+      try {
+        if (intent === 'create-and-launch' && createdRoom) {
+          const result = await launchWorkspaceTopicRoom({
+            room: createdRoom,
+            launch: {
+              type: 'agent',
+              mode: 'pty',
+              agent: defaultAgent,
+              controlMode: 'agent-driven',
+            },
+          });
+          if (result.status === 'launch_failed') {
+            setLaunchFailure(result.failure);
+            return;
+          }
+          await useSessionsStore.getState().refreshAll();
+          setActiveSessionId(result.session.id);
+          onSelectSession?.(result.session.id);
+          setCreateOpen(false);
+          setCreatedRoom(null);
+          setCreateDraft({ title: '', prompt: '', taskRef: '' });
+          return;
+        }
+        const result = await createWorkspaceTopicRoomAndMaybeLaunch({
+          room: {
+            topic: previewCreate,
+            ...(taskRef ? { taskRef } : {}),
+            workContext: {
+              title: previewCreate.title,
+              anchors: {
+                project: { workspaceId: previewCreate.workspaceId },
+                repo: {
+                  ...(previewCreate.routingDefaults?.repoPath
+                    ? { localPath: previewCreate.routingDefaults.repoPath }
+                    : {}),
+                },
+                worktree: {
+                  ...(previewCreate.routingDefaults?.worktreePath
+                    ? { localPath: previewCreate.routingDefaults.worktreePath }
+                    : {}),
+                },
+              },
+            },
+          },
+          ...(intent === 'create-and-launch'
+            ? {
+                launch: {
+                  type: 'agent',
+                  mode: 'pty',
+                  agent: defaultAgent,
+                  controlMode: 'agent-driven',
+                },
+              }
+            : {}),
+        });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['workspace-topics'] }),
+          queryClient.invalidateQueries({ queryKey: ['workspace-surfaces'] }),
+        ]);
+        if (result.status === 'launch_failed') {
+          setLaunchFailure(result.failure);
+          setCreatedRoom({
+            topic: result.topic,
+            workContext: result.workContext,
+          });
+          return;
+        }
+        if (result.status === 'launched') {
+          await useSessionsStore.getState().refreshAll();
+          setActiveSessionId(result.session.id);
+          onSelectSession?.(result.session.id);
+        }
+        setCreateOpen(false);
+        setCreatedRoom(null);
+        setCreateDraft({ title: '', prompt: '', taskRef: '' });
+      } catch (error) {
+        const failure = error as WorkspaceTopicLaunchFailure;
+        setLaunchFailure({
+          stage: failure.stage ?? 'topic',
+          message:
+            typeof failure.message === 'string'
+              ? failure.message
+              : error instanceof Error
+                ? error.message
+                : String(error),
+          retryable: failure.retryable ?? false,
+          ...(failure.code ? { code: failure.code } : {}),
+          ...(failure.status ? { status: failure.status } : {}),
+        });
+      } finally {
+        setSubmittingIntent(null);
+      }
+    },
+    [
+      createDraft.title,
+      createdRoom,
+      defaultAgent,
+      onSelectSession,
+      previewCreate,
+      queryClient,
+      setActiveSessionId,
+      taskRef,
+    ]
+  );
+
+  const createPanel = (
+    <TopicRoomCreatePanel
+      open={createOpen}
+      draft={createDraft}
+      previewCreate={previewCreate}
+      launchFailure={launchFailure}
+      submittingIntent={submittingIntent}
+      onDraftChange={(patch) => {
+        setCreateDraft((current) => ({ ...current, ...patch }));
+        setCreatedRoom(null);
+        setLaunchFailure(null);
+      }}
+      onSubmit={(intent) => void handleCreateSubmit(intent)}
+      onCancel={() => {
+        setCreateOpen(false);
+        setLaunchFailure(null);
+      }}
+    />
+  );
 
   return (
     <TopicSidebarView
@@ -1025,6 +1393,11 @@ export function TopicSidebarShell({
       onSearchRetry={() => void topicSearchQuery.refetch()}
       onSearchClear={() => setSearchQuery('')}
       onSelectSession={onSelectSession}
+      createPanel={createPanel}
+      onCreateTaskRoom={() => {
+        setCreateOpen(true);
+        setLaunchFailure(null);
+      }}
     />
   );
 }

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -24,7 +24,6 @@ import {
   type WorkspaceTopicLaunchIntent,
   type WorkspaceTopicSearchResult,
 } from '../../../shared/workspace-topics.js';
-import type { TaskRef } from '../../../shared/work-context.js';
 import {
   createWorkspaceTopicRoomAndMaybeLaunch,
   fetchWorkspaceSurfaces,
@@ -36,6 +35,7 @@ import {
   type WorkspaceTopicRoomCreateResult,
 } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
+import { taskRefFromDraft } from '../lib/topic-task-ref.js';
 import type { SessionSummary } from '../lib/types.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
@@ -1118,22 +1118,6 @@ export function TopicSidebarView({
       ) : null}
     </div>
   );
-}
-
-function taskRefFromDraft(value: string, title: string): TaskRef | undefined {
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  const issueMatch = trimmed.match(/(?:issues\/|#)?(\d+)\b/);
-  if (!issueMatch) {
-    return { kind: 'external', id: trimmed, title };
-  }
-  const issueId = issueMatch[1]!;
-  return {
-    kind: 'github-issue',
-    id: issueId,
-    title,
-    ...(trimmed.startsWith('http') ? { url: trimmed } : {}),
-  };
 }
 
 export function TopicSidebarShell({

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -12,6 +12,7 @@ import {
   sessionKill,
   sessionStartOnRepo,
   sessionStartOnTicket,
+  sessionCreateTaskRoom,
   sessionCustomize,
   sessionSwitchToTab,
   sessionRename,
@@ -209,13 +210,17 @@ async function executeNodeCommandCenterAction(
   }
   if (kind === 'copy-pair-command') {
     await copyText(NODE_PAIR_COMMAND);
-    useToastStore.getState().showToast('copied redaction-safe pair command', 'info');
+    useToastStore
+      .getState()
+      .showToast('copied redaction-safe pair command', 'info');
     openSettingsNodes();
     return;
   }
   if (kind === 'show-install-instructions') {
     await copyText(NODE_INSTALL_INSTRUCTIONS);
-    useToastStore.getState().showToast('copied redaction-safe install instructions', 'info');
+    useToastStore
+      .getState()
+      .showToast('copied redaction-safe install instructions', 'info');
     openSettingsNodes();
     return;
   }
@@ -265,7 +270,8 @@ async function executeNodeCommandCenterAction(
       return;
     await executeNodeActionMutation(
       'node request denial',
-      () => denyNodePairingRequest(request.requestId, 'denied from command center'),
+      () =>
+        denyNodePairingRequest(request.requestId, 'denied from command center'),
       'node request denied'
     );
     return;
@@ -427,6 +433,11 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       },
       { ...sessionStartOnRepo, handler: () => handleQuickAgent() },
       { ...sessionStartOnTicket, handler: () => navigateToDashboard() },
+      {
+        ...sessionCreateTaskRoom,
+        handler: () =>
+          window.dispatchEvent(new Event('relay:open-topic-task-room')),
+      },
       {
         // #630: opens the env picker dialog. The dialog itself owns
         // default-selection + block-on-stale + launch wiring; the action's
@@ -652,11 +663,16 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
             ui.closeSidebar();
             window.setTimeout(() => getActiveTerminalHandle()?.focusTerm(), 0);
             void sessions.refreshAll().then(() => {
-              useUiStore.getState().setActiveRepoPath(target.activationRepoPath);
-              useSessionsStore.getState().setActiveSessionId(target.activationKey);
+              useUiStore
+                .getState()
+                .setActiveRepoPath(target.activationRepoPath);
+              useSessionsStore
+                .getState()
+                .setActiveSessionId(target.activationKey);
             });
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
+            const message =
+              error instanceof Error ? error.message : String(error);
             logger.error('Failed to jump to next active work target', error);
             useToastStore
               .getState()

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -109,6 +109,17 @@ export const sessionStartOnTicket: ActionMeta = {
   descriptor: ticketStartWorkDescriptor,
 };
 
+export const sessionCreateTaskRoom: ActionMeta = {
+  id: 'session.create-task-room',
+  label: 'create task room…',
+  description: 'create a WorkspaceTopic room, optionally launching an agent',
+  aliases: ['+ task', 'task room', 'workspace topic', 'create and launch'],
+  category: 'session',
+  icon: '+',
+  when: (ctx) => !!ctx.workspacePath || !!ctx.cwd,
+  descriptor: launchDescriptor,
+};
+
 export const sessionCustomize: ActionMeta = {
   id: 'session.customize',
   label: 'customize session',
@@ -173,6 +184,7 @@ export const sessionActions: ActionMeta[] = [
   sessionKill,
   sessionStartOnRepo,
   sessionStartOnTicket,
+  sessionCreateTaskRoom,
   sessionCustomize,
   sessionSwitchToTab,
   sessionRename,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,8 @@ import type {
   WorkspaceSurfaceListResponse,
 } from '../../../shared/workspace-surfaces.js';
 import type {
+  WorkspaceTopic,
+  WorkspaceTopicCreateInput,
   WorkspaceTopicListResponse,
   WorkspaceTopicSearchResponse,
 } from '../../../shared/workspace-topics.js';
@@ -43,7 +45,7 @@ import type {
   PipelineHandoffStageName,
 } from '../../../shared/pipeline-handoff-artifact.js';
 import type { ViewArtifactPackage } from '../../../shared/agent-view-artifact.js';
-import type { TaskRef } from '../../../shared/work-context.js';
+import type { TaskRef, WorkContext } from '../../../shared/work-context.js';
 import type {
   PipelineHandoffArtifactEnvelope,
   PublicPipelineHandoffArtifactSummary,
@@ -1637,6 +1639,190 @@ export async function fetchWorkspaceTopics(
   };
 }
 
+export interface WorkContextCreateBody {
+  title?: string;
+  source?: string;
+  anchors?: WorkContext['anchors'];
+  tasks?: TaskRef[];
+  privacy?: WorkContext['privacy'];
+}
+
+export interface WorkspaceTopicRoomCreateInput {
+  topic: WorkspaceTopicCreateInput;
+  workContext?: WorkContextCreateBody;
+  taskRef?: TaskRef;
+}
+
+export interface WorkspaceTopicRoomCreateResult {
+  topic: WorkspaceTopic;
+  workContext: WorkContext;
+}
+
+export interface WorkspaceTopicLaunchFailure {
+  stage: 'work-context' | 'topic' | 'session';
+  code?: string;
+  message: string;
+  retryable: boolean;
+  status?: number;
+}
+
+export type WorkspaceTopicRoomLaunchResult =
+  | {
+      status: 'created';
+      topic: WorkspaceTopic;
+      workContext: WorkContext;
+    }
+  | {
+      status: 'launched';
+      topic: WorkspaceTopic;
+      workContext: WorkContext;
+      session: SessionSummary;
+    }
+  | {
+      status: 'launch_failed';
+      topic: WorkspaceTopic;
+      workContext: WorkContext;
+      failure: WorkspaceTopicLaunchFailure;
+    };
+
+export type WorkspaceTopicRoomSessionLaunchResult = Extract<
+  WorkspaceTopicRoomLaunchResult,
+  { status: 'launched' | 'launch_failed' }
+>;
+
+function launchFailure(
+  stage: WorkspaceTopicLaunchFailure['stage'],
+  err: unknown
+): WorkspaceTopicLaunchFailure {
+  if (err instanceof HttpError) {
+    return {
+      stage,
+      message: err.message,
+      retryable: err.retryable ?? stage === 'session',
+      status: err.status,
+      ...(err.code ? { code: err.code } : {}),
+    };
+  }
+  return {
+    stage,
+    message: err instanceof Error ? err.message : String(err),
+    retryable: stage === 'session',
+  };
+}
+
+export async function createWorkContextForTopicRoom(
+  input: WorkspaceTopicRoomCreateInput
+): Promise<WorkContext> {
+  const taskRef = input.taskRef ?? input.workContext?.tasks?.[0];
+  const body = {
+    title: input.workContext?.title ?? input.topic.title,
+    source: input.workContext?.source ?? 'workspace-topic-room',
+    anchors: input.workContext?.anchors ?? {
+      project: { workspaceId: input.topic.workspaceId },
+      repo: {
+        ...(input.topic.routingDefaults?.repoPath
+          ? { localPath: input.topic.routingDefaults.repoPath }
+          : {}),
+      },
+      worktree: {
+        ...(input.topic.routingDefaults?.worktreePath
+          ? { localPath: input.topic.routingDefaults.worktreePath }
+          : {}),
+      },
+    },
+    tasks: input.workContext?.tasks,
+    privacy: input.workContext?.privacy,
+    ...(taskRef ? { taskRef } : {}),
+  };
+  const path = taskRef ? '/work-contexts/from-task-ref' : '/work-contexts';
+  const data = await json<{ workContext?: WorkContext }>(
+    await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  );
+  if (!data.workContext)
+    throw new Error('work context response missing workContext');
+  return data.workContext;
+}
+
+export async function createWorkspaceTopicRoom(
+  input: WorkspaceTopicRoomCreateInput
+): Promise<WorkspaceTopicRoomCreateResult> {
+  let workContext: WorkContext;
+  try {
+    workContext = await createWorkContextForTopicRoom(input);
+  } catch (err) {
+    throw launchFailure('work-context', err);
+  }
+  const linkedRefs = {
+    ...(input.topic.linkedRefs ?? {}),
+    workContextIds: Array.from(
+      new Set([
+        ...(input.topic.linkedRefs?.workContextIds ?? []),
+        workContext.id,
+      ])
+    ),
+    ...(input.taskRef
+      ? {
+          taskRefs: Array.from(
+            new Map(
+              [...(input.topic.linkedRefs?.taskRefs ?? []), input.taskRef].map(
+                (ref) => [`${ref.kind}:${ref.id}`, ref]
+              )
+            ).values()
+          ),
+        }
+      : {}),
+  };
+  try {
+    const data = await json<{ topic?: WorkspaceTopic }>(
+      await fetch('/workspace-topics', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ ...input.topic, linkedRefs }),
+      })
+    );
+    if (!data.topic) throw new Error('workspace topic response missing topic');
+    return { topic: data.topic, workContext };
+  } catch (err) {
+    throw launchFailure('topic', err);
+  }
+}
+
+export async function createWorkspaceTopicRoomAndMaybeLaunch(input: {
+  room: WorkspaceTopicRoomCreateInput;
+  launch?: Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'>;
+}): Promise<WorkspaceTopicRoomLaunchResult> {
+  const room = await createWorkspaceTopicRoom(input.room);
+  if (!input.launch) return { status: 'created', ...room };
+  return launchWorkspaceTopicRoom({ room, launch: input.launch });
+}
+
+export async function launchWorkspaceTopicRoom(input: {
+  room: WorkspaceTopicRoomCreateResult;
+  launch: Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'>;
+}): Promise<WorkspaceTopicRoomSessionLaunchResult> {
+  try {
+    const session = await createSession({
+      ...input.launch,
+      workspaceTopicId: input.room.topic.id,
+      workContextId: input.room.workContext.id,
+    });
+    return { status: 'launched', ...input.room, session };
+  } catch (err) {
+    return {
+      status: 'launch_failed',
+      ...input.room,
+      failure: launchFailure('session', err),
+    };
+  }
+}
+
 export async function searchWorkspaceTopics(args: {
   q: string;
   workspaceId?: string;
@@ -1898,6 +2084,9 @@ export interface CreateSessionBody {
    */
   initialPrompt?: string | undefined;
   sessionLane?: SessionLane | undefined;
+  workContextId?: string | undefined;
+  workspaceTopicId?: string | undefined;
+  controlMode?: 'agent-driven' | 'human-driven' | 'co-driven' | undefined;
   /** #740: Bench-inherited env overrides applied additively to the PTY env.
    *  Reserved keys (`PATH`, `RELAY_*`) are refused by the backend. */
   envOverrides?: Record<string, string> | undefined;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1714,11 +1714,20 @@ export async function createWorkContextForTopicRoom(
   input: WorkspaceTopicRoomCreateInput
 ): Promise<WorkContext> {
   const taskRef = input.taskRef ?? input.workContext?.tasks?.[0];
+  const nodeId = input.topic.routingDefaults?.nodeId;
   const body = {
     title: input.workContext?.title ?? input.topic.title,
     source: input.workContext?.source ?? 'workspace-topic-room',
     anchors: input.workContext?.anchors ?? {
       project: { workspaceId: input.topic.workspaceId },
+      ...(nodeId
+        ? {
+            node: {
+              nodeId,
+              kind: nodeId === DEFAULT_LOCAL_NODE_ID ? 'local' : 'remote',
+            },
+          }
+        : {}),
       repo: {
         ...(input.topic.routingDefaults?.repoPath
           ? { localPath: input.topic.routingDefaults.repoPath }
@@ -1808,8 +1817,11 @@ export async function launchWorkspaceTopicRoom(input: {
   launch: Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'>;
 }): Promise<WorkspaceTopicRoomSessionLaunchResult> {
   try {
+    const nodeId =
+      input.launch.nodeId ?? input.room.topic.routingDefaults?.nodeId;
     const session = await createSession({
       ...input.launch,
+      ...(nodeId ? { nodeId } : {}),
       workspaceTopicId: input.room.topic.id,
       workContextId: input.room.workContext.id,
     });

--- a/frontend/src/lib/topic-task-ref.ts
+++ b/frontend/src/lib/topic-task-ref.ts
@@ -1,0 +1,40 @@
+import type { TaskRef } from '../../../shared/work-context.js';
+
+export function taskRefFromDraft(
+  value: string,
+  title: string
+): TaskRef | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  let issueId: string | undefined;
+  const pureIssueIdMatch = trimmed.match(/^\d+$/);
+  if (pureIssueIdMatch) issueId = pureIssueIdMatch[0];
+
+  const hashIssueMatch = trimmed.match(/^#(\d+)$/);
+  if (!issueId && hashIssueMatch) issueId = hashIssueMatch[1];
+
+  const issuePathMatch = trimmed.match(/(?:^|\/)issues\/(\d+)(?=$|[/?#])/i);
+  const githubIssueUrl =
+    /^https?:\/\/(?:www\.)?github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+(?:[/?#].*)?$/i.test(
+      trimmed
+    );
+  if (
+    !issueId &&
+    issuePathMatch &&
+    (trimmed.startsWith('issues/') || githubIssueUrl)
+  ) {
+    issueId = issuePathMatch[1];
+  }
+
+  if (!issueId) {
+    return { kind: 'external', id: trimmed, title };
+  }
+
+  return {
+    kind: 'github-issue',
+    id: issueId,
+    title,
+    ...(trimmed.startsWith('http') ? { url: trimmed } : {}),
+  };
+}

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -1129,6 +1129,8 @@ export function buildWorkspaceTopicSessionCreateBody(input: {
   const explicitSpawnInput: WorkspaceTopicRoutingDefaults = {};
   const explicitProvider = readLaunchString(overrides, 'agent');
   if (explicitProvider) explicitSpawnInput.providerId = explicitProvider;
+  const explicitNode = readLaunchString(overrides, 'nodeId');
+  if (explicitNode) explicitSpawnInput.nodeId = explicitNode;
   const explicitRepoPath = readLaunchString(overrides, 'repoPath');
   if (explicitRepoPath) explicitSpawnInput.repoPath = explicitRepoPath;
   if (typeof explicitWorktreePath === 'string' && explicitWorktreePath.trim()) {
@@ -1154,6 +1156,7 @@ export function buildWorkspaceTopicSessionCreateBody(input: {
   }
   const agent = routing.providerId;
   if (agent) body['agent'] = agent;
+  if (routing.nodeId) body['nodeId'] = routing.nodeId;
   for (const key of [
     'type',
     'mode',

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -212,6 +212,115 @@ export interface WorkspaceTopicUpdateInput {
   privacy?: Partial<WorkspaceTopicPrivacyMetadata>;
 }
 
+export type WorkspaceTopicLaunchIntent = 'create-only' | 'create-and-launch';
+export type WorkspaceTopicTemplateKind =
+  | 'agent-task'
+  | 'terminal-task'
+  | 'note';
+
+export interface WorkspaceTopicLaunchPreviewInput {
+  create: WorkspaceTopicCreateInput;
+  intent: WorkspaceTopicLaunchIntent;
+  templateKind?: WorkspaceTopicTemplateKind;
+  launchOverrides?: WorkspaceTopicLaunchOverrides;
+}
+
+export interface WorkspaceTopicLaunchPreview {
+  intent: WorkspaceTopicLaunchIntent;
+  templateKind: WorkspaceTopicTemplateKind;
+  title: string;
+  workspaceId: WorkspaceId;
+  providerLabel: string;
+  modeLabel: string;
+  nodeLabel: string;
+  cwdLabel: string;
+  promptSources: string[];
+  taskRefs: string[];
+  sideEffects: string[];
+}
+
+function launchOverrideString(
+  overrides: WorkspaceTopicLaunchOverrides | undefined,
+  key: string
+): string | undefined {
+  const value = overrides?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function taskRefLabel(
+  ref: NonNullable<WorkspaceTopicLinkedRefs['taskRefs']>[number]
+): string {
+  return ref.title
+    ? `${ref.kind}:${ref.id} · ${ref.title}`
+    : `${ref.kind}:${ref.id}`;
+}
+
+function providerPreviewLabel(provider: string): string {
+  return provider === 'hermes' ? 'hermes (mode explicit)' : provider;
+}
+
+export function buildWorkspaceTopicLaunchPreview(
+  input: WorkspaceTopicLaunchPreviewInput
+): WorkspaceTopicLaunchPreview {
+  const create = input.create;
+  const overrideProvider = launchOverrideString(input.launchOverrides, 'agent');
+  const overrideNode = launchOverrideString(input.launchOverrides, 'nodeId');
+  const overrideRepo = launchOverrideString(input.launchOverrides, 'repoPath');
+  const overrideWorktree = launchOverrideString(
+    input.launchOverrides,
+    'worktreePath'
+  );
+  const overrideCwd = launchOverrideString(input.launchOverrides, 'cwd');
+  const routing = resolveWorkspaceTopicRoutingDefaults({
+    ...(create.routingDefaults
+      ? { topicDefaults: create.routingDefaults }
+      : {}),
+    explicitSpawnInput: {
+      ...(overrideProvider ? { providerId: overrideProvider } : {}),
+      ...(overrideNode ? { nodeId: overrideNode } : {}),
+      ...(overrideRepo ? { repoPath: overrideRepo } : {}),
+      ...(overrideWorktree ? { worktreePath: overrideWorktree } : {}),
+      ...(overrideCwd ? { cwd: overrideCwd } : {}),
+    },
+  });
+  const provider = routing.providerId ?? 'default provider';
+  const mode = launchOverrideString(input.launchOverrides, 'mode') ?? 'pty';
+  const promptSources = [
+    create.promptDefaults?.starterPrompt ? 'starter prompt' : undefined,
+    create.promptDefaults?.instructions ? 'instructions' : undefined,
+    create.promptDefaults?.contextPacketIds?.length
+      ? `${create.promptDefaults.contextPacketIds.length} context packets`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+  const taskRefs = (create.linkedRefs?.taskRefs ?? []).map(taskRefLabel);
+  const sideEffects = [
+    'create WorkspaceTopic room',
+    create.linkedRefs?.workContextIds?.length
+      ? 'link existing WorkContext ref'
+      : 'create WorkContext link for this room',
+    input.intent === 'create-and-launch'
+      ? 'launch provider-neutral session through sessions.create'
+      : undefined,
+    input.intent === 'create-and-launch'
+      ? 'link created session back to WorkspaceTopic/WorkContext'
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+  return {
+    intent: input.intent,
+    templateKind: input.templateKind ?? 'agent-task',
+    title: create.title,
+    workspaceId: create.workspaceId,
+    providerLabel: providerPreviewLabel(provider),
+    modeLabel: mode,
+    nodeLabel: routing.nodeId ?? 'local/default node',
+    cwdLabel:
+      routing.worktreePath ?? routing.cwd ?? routing.repoPath ?? 'default cwd',
+    promptSources: promptSources.length ? promptSources : ['none'],
+    taskRefs: taskRefs.length ? taskRefs : ['none'],
+    sideEffects,
+  };
+}
+
 export interface WorkspaceTopicValidationOptions {
   knownRepoPaths?: readonly string[];
   knownWorktreePaths?: readonly string[];

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -33,16 +33,18 @@ import { workspaceOpenFileBrowser } from '../frontend/src/lib/actions/definition
 import { actionDescriptorFromMeta } from '../frontend/src/lib/actions/descriptors.js';
 import { stableCommandNames } from '../shared/cli-gateway-contract.js';
 
-// Full allowlist: 62 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
-// + workspace.launch from #870 + next-attention WorkContext jump from #933)
+// Full allowlist: 63 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
+// + workspace.launch from #870 + next-attention WorkContext jump from #933
+// + task-room create/launch from #1045)
 const ACTION_ALLOWLIST = [
-  // Session (10)
+  // Session (11)
   'session.new-agent',
   'session.new-terminal',
   'session.close-active',
   'session.kill',
   'session.start-on-repo',
   'session.start-on-ticket',
+  'session.create-task-room',
   'session.start-work-in-env',
   'session.customize',
   'session.switch-to-tab',
@@ -164,9 +166,9 @@ describe('Action Coverage', () => {
   });
 
   it('projects stable CLI gateway commands into disabled Command Center metadata', () => {
-    expect(cliGatewayCommandActions.map((action) => action.relayCommand.name)).toEqual(
-      stableCommandNames()
-    );
+    expect(
+      cliGatewayCommandActions.map((action) => action.relayCommand.name)
+    ).toEqual(stableCommandNames());
     expect(cliGatewayCommandActions.map((action) => action.id)).toEqual(
       stableCommandNames().map((name) => `gateway.${name}`)
     );
@@ -176,10 +178,15 @@ describe('Action Coverage', () => {
       expect(action.label).toBe(action.label.toLowerCase());
       expect(action.description).toBe(action.relayCommand.summary);
       expect(action.aliases).toEqual(
-        expect.arrayContaining([action.relayCommand.name, action.relayCommand.sideEffect])
+        expect.arrayContaining([
+          action.relayCommand.name,
+          action.relayCommand.sideEffect,
+        ])
       );
       expect(action.when?.({ view: 'workspace' })).toBe(false);
-      expect(action.disabledReason?.({ view: 'workspace' })).toContain('relay-ide v1');
+      expect(action.disabledReason?.({ view: 'workspace' })).toContain(
+        'relay-ide v1'
+      );
       expect(action.descriptor.contract?.source).toBe(
         'shared/relay-command-manifest.ts'
       );
@@ -207,7 +214,9 @@ describe('Action Coverage', () => {
     );
     expect(descriptor.availability).toMatchObject({
       state: 'unavailable',
-      reason: expect.stringContaining('Command Center execution is not wired yet'),
+      reason: expect.stringContaining(
+        'Command Center execution is not wired yet'
+      ),
     });
     expect(descriptor.contract).toMatchObject({
       relayCommandName: 'sessions.create',
@@ -417,7 +426,8 @@ describe('Action Coverage', () => {
 
     expect(descriptor.availability).toEqual({
       state: 'unavailable',
-      reason: 'file rpc unavailable on this node — check the node helper status',
+      reason:
+        'file rpc unavailable on this node — check the node helper status',
     });
   });
 

--- a/test/api-error.test.ts
+++ b/test/api-error.test.ts
@@ -2,12 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   ConfirmationRequiredError,
+  createWorkspaceTopicRoomAndMaybeLaunch,
   createSession,
   fetchConfirmationRequesterToken,
   fetchNodeFsList,
   fetchWorkspaceEvidenceList,
   HttpError,
   killSession,
+  launchWorkspaceTopicRoom,
   type ConfirmationChallenge,
 } from '../frontend/src/lib/api.js';
 import {
@@ -87,6 +89,183 @@ describe('frontend api errors', () => {
       code: 'pty_capacity_exhausted',
       message:
         'Too many terminal sessions are already active. Close inactive sessions and try again.',
+    });
+  });
+
+  it('creates task rooms without launching a session', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ workContext: { id: 'wc-topic' } }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            topic: {
+              id: 'topic-task',
+              workspaceId: 'ws-main',
+              linkedRefs: { workContextIds: ['wc-topic'] },
+            },
+          }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await createWorkspaceTopicRoomAndMaybeLaunch({
+      room: {
+        topic: { workspaceId: 'ws-main', title: 'Task room' },
+        taskRef: { kind: 'github-issue', id: '1045' },
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'created',
+      topic: { id: 'topic-task' },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/workspace-topics',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-relay-capabilities': 'context:write',
+        }),
+      })
+    );
+  });
+
+  it('launches sessions with WorkspaceTopic and WorkContext links', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ workContext: { id: 'wc-topic' } }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ topic: { id: 'topic-task' } }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'session-topic' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await createWorkspaceTopicRoomAndMaybeLaunch({
+      room: { topic: { workspaceId: 'ws-main', title: 'Task room' } },
+      launch: { type: 'agent', agent: 'hermes', mode: 'pty' },
+    });
+
+    expect(result).toMatchObject({
+      status: 'launched',
+      topic: { id: 'topic-task' },
+      workContext: { id: 'wc-topic' },
+      session: { id: 'session-topic' },
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith('/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'agent',
+        agent: 'hermes',
+        mode: 'pty',
+        workspaceTopicId: 'topic-task',
+        workContextId: 'wc-topic',
+      }),
+    });
+  });
+
+  it('preserves the created room and returns typed launch failures', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ workContext: { id: 'wc-topic' } }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ topic: { id: 'topic-task' } }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'SESSION_LAUNCH_FAILED',
+              message: 'agent launch failed',
+              retryable: true,
+            },
+          }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await createWorkspaceTopicRoomAndMaybeLaunch({
+      room: { topic: { workspaceId: 'ws-main', title: 'Task room' } },
+      launch: { type: 'agent', agent: 'hermes' },
+    });
+
+    expect(result).toMatchObject({
+      status: 'launch_failed',
+      topic: { id: 'topic-task' },
+      workContext: { id: 'wc-topic' },
+      failure: {
+        stage: 'session',
+        code: 'SESSION_LAUNCH_FAILED',
+        message: 'agent launch failed',
+        retryable: true,
+        status: 503,
+      },
+    });
+  });
+
+  it('retries launch against an existing topic room without recreating it', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ id: 'session-topic' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await launchWorkspaceTopicRoom({
+      room: {
+        topic: { id: 'topic-task' } as never,
+        workContext: { id: 'wc-topic' } as never,
+      },
+      launch: { type: 'agent', agent: 'hermes' },
+    });
+
+    expect(result).toMatchObject({
+      status: 'launched',
+      session: { id: 'session-topic' },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'agent',
+        agent: 'hermes',
+        workspaceTopicId: 'topic-task',
+        workContextId: 'wc-topic',
+      }),
     });
   });
 
@@ -226,21 +405,34 @@ describe('frontend api errors', () => {
       vi.fn(
         async () =>
           new Response(
-            JSON.stringify({ confirmationToken: 'requester-token-1', challenge: approvedChallenge }),
+            JSON.stringify({
+              confirmationToken: 'requester-token-1',
+              challenge: approvedChallenge,
+            }),
             { status: 200, headers: { 'Content-Type': 'application/json' } }
           )
       )
     );
 
-    expect(approverRegistry.getConfirmationRetry('challenge-1')).toBeUndefined();
+    expect(
+      approverRegistry.getConfirmationRetry('challenge-1')
+    ).toBeUndefined();
     const pickup = await fetchConfirmationRequesterToken('challenge-1');
-    await requesterRegistry.retryConfirmedOperation(pickup.challenge, pickup.confirmationToken);
+    await requesterRegistry.retryConfirmedOperation(
+      pickup.challenge,
+      pickup.confirmationToken
+    );
 
-    expect(fetch).toHaveBeenCalledWith('/hub/confirmations/challenge-1/requester-token', {
-      method: 'POST',
-    });
+    expect(fetch).toHaveBeenCalledWith(
+      '/hub/confirmations/challenge-1/requester-token',
+      {
+        method: 'POST',
+      }
+    );
     expect(retry).toHaveBeenCalledWith('requester-token-1');
-    expect(requesterRegistry.getConfirmationRetry('challenge-1')).toBeUndefined();
+    expect(
+      requesterRegistry.getConfirmationRetry('challenge-1')
+    ).toBeUndefined();
   });
 
   it('preserves local session lane markers in create payloads', async () => {
@@ -253,7 +445,11 @@ describe('frontend api errors', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await createSession({ repoPath: '/repo', type: 'agent', sessionLane: 'local-repo' });
+    await createSession({
+      repoPath: '/repo',
+      type: 'agent',
+      sessionLane: 'local-repo',
+    });
 
     expect(fetchMock).toHaveBeenCalledWith('/sessions', {
       method: 'POST',
@@ -325,9 +521,9 @@ describe('frontend api errors', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(killSession('remote-session-1', 'node-a')).rejects.toBeInstanceOf(
-      ConfirmationRequiredError
-    );
+    await expect(
+      killSession('remote-session-1', 'node-a')
+    ).rejects.toBeInstanceOf(ConfirmationRequiredError);
     await getConfirmationRetry('kill-challenge-1')?.retry('kill-token-1');
 
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -463,7 +659,11 @@ describe('frontend api errors', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await fetchNodeFsList({ nodeId: 'nodeB', sessionId: 's1', cwd: '/remote/repo' });
+    await fetchNodeFsList({
+      nodeId: 'nodeB',
+      sessionId: 's1',
+      cwd: '/remote/repo',
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/hub/nodes/nodeB/sessions/s1/files/list',
@@ -493,13 +693,21 @@ describe('frontend api errors', () => {
 
     await expect(
       fetchWorkspaceEvidenceList({
-        rootRef: { id: 'wer:node_remote:%2Fhome%2Frelay', nodeId: 'node_remote', kind: 'directory' },
+        rootRef: {
+          id: 'wer:node_remote:%2Fhome%2Frelay',
+          nodeId: 'node_remote',
+          kind: 'directory',
+        },
       })
     ).rejects.toMatchObject({
       name: 'HttpError',
       status: 503,
       code: 'WORKSPACE_EVIDENCE_NODE_OFFLINE',
-      details: { state: 'offline', reason: 'WORKSPACE_EVIDENCE_NODE_OFFLINE', nodeId: 'node_remote' },
+      details: {
+        state: 'offline',
+        reason: 'WORKSPACE_EVIDENCE_NODE_OFFLINE',
+        nodeId: 'node_remote',
+      },
       workspaceEvidence: {
         error: { state: 'offline', reason: 'WORKSPACE_EVIDENCE_NODE_OFFLINE' },
       },

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -202,6 +202,34 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('no workspace topics yet');
   });
 
+  it('surfaces task-room creation entrypoints and preview panel', async () => {
+    const onCreateTaskRoom = vi.fn();
+    await renderView({
+      createPanel: React.createElement(
+        'form',
+        { className: 'topic-create-panel', 'aria-label': 'create task room' },
+        React.createElement(
+          'div',
+          { className: 'topic-create-preview' },
+          'provider: hermes'
+        ),
+        React.createElement('button', { type: 'button' }, 'create only'),
+        React.createElement('button', { type: 'button' }, 'create + launch')
+      ),
+      onCreateTaskRoom,
+    });
+
+    const createButton = container.querySelector(
+      '.topic-shell__create'
+    ) as HTMLButtonElement;
+    await act(async () => createButton.click());
+
+    expect(onCreateTaskRoom).toHaveBeenCalled();
+    expect(container.textContent).toContain('provider: hermes');
+    expect(container.textContent).toContain('create only');
+    expect(container.textContent).toContain('create + launch');
+  });
+
   it('renders a phone-first attention list sorted before routine topics', async () => {
     await renderView({
       topics: [

--- a/test/topic-task-ref.test.ts
+++ b/test/topic-task-ref.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { taskRefFromDraft } from '../frontend/src/lib/topic-task-ref.js';
+
+describe('topic task ref parsing', () => {
+  it('keeps arbitrary prompts with digits external', () => {
+    expect(taskRefFromDraft('Fix bug in v2', 'Fix bug')).toEqual({
+      kind: 'external',
+      id: 'Fix bug in v2',
+      title: 'Fix bug',
+    });
+
+    expect(taskRefFromDraft('task 999', 'Task phrase')).toEqual({
+      kind: 'external',
+      id: 'task 999',
+      title: 'Task phrase',
+    });
+  });
+
+  it('keeps ticket-like non-GitHub refs external', () => {
+    expect(taskRefFromDraft('JIRA-123', 'Jira task')).toEqual({
+      kind: 'external',
+      id: 'JIRA-123',
+      title: 'Jira task',
+    });
+  });
+
+  it('parses explicit hash issue refs as GitHub issues', () => {
+    expect(taskRefFromDraft('#1045', 'GitHub task')).toEqual({
+      kind: 'github-issue',
+      id: '1045',
+      title: 'GitHub task',
+    });
+  });
+
+  it('parses GitHub issue URLs as GitHub issues with the source URL', () => {
+    const url = 'https://github.com/donovan-yohan/relay-ide/issues/1045';
+
+    expect(taskRefFromDraft(url, 'Issue URL')).toEqual({
+      kind: 'github-issue',
+      id: '1045',
+      title: 'Issue URL',
+      url,
+    });
+  });
+
+  it('parses explicit issues path refs as GitHub issues', () => {
+    expect(taskRefFromDraft('issues/1045', 'Issue path')).toEqual({
+      kind: 'github-issue',
+      id: '1045',
+      title: 'Issue path',
+    });
+  });
+
+  it('parses pure numeric issue ids as GitHub issues', () => {
+    expect(taskRefFromDraft('1045', 'Numeric issue')).toEqual({
+      kind: 'github-issue',
+      id: '1045',
+      title: 'Numeric issue',
+    });
+  });
+});

--- a/test/workspace-topic-room-api.test.ts
+++ b/test/workspace-topic-room-api.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { WorkContext } from '../shared/work-context.js';
+import type {
+  WorkspaceTopic,
+  WorkspaceTopicCreateInput,
+} from '../shared/workspace-topics.js';
+import {
+  createWorkContextForTopicRoom,
+  launchWorkspaceTopicRoom,
+} from '../frontend/src/lib/api.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+const originalFetch = globalThis.fetch;
+const NOW = '2026-06-26T00:00:00Z';
+
+function topic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:remote-launch',
+    workspaceId: 'workspace:remote-devbox',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Remote launch room' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: {
+      providerId: 'hermes',
+      nodeId: 'devbox',
+      repoPath: '/repo/relay',
+      worktreePath: '/repo/relay/.worktrees/1045',
+      cwd: '/repo/relay/.worktrees/1045/frontend',
+    },
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function topicCreate(
+  overrides: Partial<WorkspaceTopicCreateInput> = {}
+): WorkspaceTopicCreateInput {
+  return {
+    workspaceId: 'workspace:remote-devbox',
+    title: 'Remote launch room',
+    routingDefaults: {
+      providerId: 'hermes',
+      nodeId: 'devbox',
+      repoPath: '/repo/relay',
+      worktreePath: '/repo/relay/.worktrees/1045',
+      cwd: '/repo/relay/.worktrees/1045/frontend',
+    },
+    linkedRefs: {},
+    ...overrides,
+  };
+}
+
+function workContext(overrides: Partial<WorkContext> = {}): WorkContext {
+  return {
+    schemaVersion: 1,
+    id: 'wc-topic',
+    title: 'Remote launch room',
+    createdAt: NOW,
+    updatedAt: NOW,
+    source: 'workspace-topic-room',
+    anchors: {},
+    actors: [],
+    tasks: [],
+    artifacts: [],
+    auditRefs: [],
+    capabilityGrants: [],
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      rawPayloadStored: false,
+      redaction: { redacted: false, strategy: 'none', classes: [] },
+    },
+    ...overrides,
+  };
+}
+
+describe('workspace topic room API', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('creates default WorkContext anchors with the topic node target', async () => {
+    const calls: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input, init) => {
+      calls.push({
+        path: String(input),
+        body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+      });
+      return new Response(JSON.stringify({ workContext: workContext() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof globalThis.fetch;
+
+    await createWorkContextForTopicRoom({ topic: topicCreate() });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ path: '/work-contexts' });
+    expect(calls[0]?.body).toMatchObject({
+      title: 'Remote launch room',
+      source: 'workspace-topic-room',
+      anchors: {
+        project: { workspaceId: 'workspace:remote-devbox' },
+        node: { nodeId: 'devbox', kind: 'remote' },
+        repo: { localPath: '/repo/relay' },
+        worktree: { localPath: '/repo/relay/.worktrees/1045' },
+      },
+    });
+  });
+
+  it('launches created rooms on the topic routing node when launch has no override', async () => {
+    const calls: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input, init) => {
+      calls.push({
+        path: String(input),
+        body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+      });
+      return new Response(
+        JSON.stringify(
+          makeSession({
+            id: 'remote-session',
+            nodeId: 'devbox',
+            workContextId: 'wc-topic',
+          })
+        ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    }) as typeof globalThis.fetch;
+
+    await launchWorkspaceTopicRoom({
+      room: { topic: topic(), workContext: workContext() },
+      launch: {
+        type: 'agent',
+        mode: 'pty',
+        agent: 'hermes',
+        controlMode: 'agent-driven',
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ path: '/hub/nodes/devbox/sessions' });
+    expect(calls[0]?.body).toMatchObject({
+      type: 'agent',
+      mode: 'pty',
+      agent: 'hermes',
+      controlMode: 'agent-driven',
+      workspaceTopicId: 'topic:remote-launch',
+      workContextId: 'wc-topic',
+    });
+    expect(calls[0]?.body).not.toHaveProperty('nodeId');
+  });
+});

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -29,6 +29,7 @@ import type {
 import type { WorkContext } from '../shared/work-context.js';
 import {
   WORKSPACE_TOPICS_MAX_LIST_ENTRIES,
+  buildWorkspaceTopicLaunchPreview,
   buildWorkspaceTopicSessionCreateBody,
   buildWorkspaceTopicRecord,
   parseWorkspaceTopicCreateInput,
@@ -292,6 +293,66 @@ describe('workspace topics foundation', () => {
         workContextIds: ['wc-topic'],
         sessionIds: ['session-topic'],
       },
+    });
+  });
+
+  it('previews create-only and create+launch side effects from topic defaults', () => {
+    const create = {
+      workspaceId: 'ws-launch',
+      title: 'Issue 1045 task room',
+      promptDefaults: {
+        starterPrompt: 'start on #1045',
+        contextPacketIds: ['ctx:one', 'ctx:two'],
+      },
+      routingDefaults: {
+        providerId: 'hermes',
+        nodeId: 'devbox',
+        repoPath: '/repo/relay',
+        worktreePath: '/repo/relay/.worktrees/1045',
+      },
+      linkedRefs: {
+        taskRefs: [
+          { kind: 'github-issue' as const, id: '1045', title: 'Launch flow' },
+        ],
+      },
+    };
+
+    expect(
+      buildWorkspaceTopicLaunchPreview({
+        create,
+        intent: 'create-only',
+        templateKind: 'agent-task',
+      })
+    ).toMatchObject({
+      intent: 'create-only',
+      providerLabel: 'hermes (mode explicit)',
+      modeLabel: 'pty',
+      nodeLabel: 'devbox',
+      cwdLabel: '/repo/relay/.worktrees/1045',
+      taskRefs: ['github-issue:1045 · Launch flow'],
+      sideEffects: [
+        'create WorkspaceTopic room',
+        'create WorkContext link for this room',
+      ],
+    });
+
+    expect(
+      buildWorkspaceTopicLaunchPreview({
+        create,
+        intent: 'create-and-launch',
+        launchOverrides: { agent: 'claude', mode: 'web', cwd: '/repo/relay' },
+      })
+    ).toMatchObject({
+      intent: 'create-and-launch',
+      providerLabel: 'claude',
+      modeLabel: 'web',
+      cwdLabel: '/repo/relay/.worktrees/1045',
+      sideEffects: [
+        'create WorkspaceTopic room',
+        'create WorkContext link for this room',
+        'launch provider-neutral session through sessions.create',
+        'link created session back to WorkspaceTopic/WorkContext',
+      ],
     });
   });
 

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -238,6 +238,7 @@ describe('workspace topics foundation', () => {
         },
         routingDefaults: {
           providerId: 'hermes',
+          nodeId: 'devbox',
           repoPath: '/repo',
           cwd: '/repo/.worktrees/topic',
         },
@@ -256,6 +257,7 @@ describe('workspace topics foundation', () => {
       repoPath: '/repo',
       worktreePath: '/repo/.worktrees/topic',
       agent: 'hermes',
+      nodeId: 'devbox',
       workContextId: 'wc-topic',
       initialPrompt: 'explicit prompt',
       yolo: true,
@@ -280,6 +282,7 @@ describe('workspace topics foundation', () => {
       repoPath: '/repo',
       worktreePath: null,
       agent: 'hermes',
+      nodeId: 'devbox',
     });
 
     expect(


### PR DESCRIPTION
## Summary
- add provider-neutral WorkspaceTopic launch preview helpers and frontend task-room API helpers for create-only, create+launch, and retrying launch after room creation
- wire + task entrypoints in the topic sidebar and Command Center, with create/edit/retry state and typed failure display
- cover the flow with workspace-topic, frontend API, topic sidebar, and action coverage tests

Closes #1045

## Verification
- PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm test -- test/workspace-topics.test.ts test/api-error.test.ts test/topic-sidebar-shell.test.ts test/action-coverage.test.ts
- PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run check (0 errors, existing warnings)
- PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run build
- PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm test (388 files, 5027 passed, 9 skipped)
- pre-push changed-test hook with Node 24 PATH (70 files, 563 passed)

## Simplify
- tier 3 simplify pass: launched reuse/quality/efficiency reviewers on the full diff; local self-review found and fixed retry semantics so a launch retry uses the already-created room instead of attempting duplicate topic/work-context creation
- Claude Code delegation skipped because profile-local claude is installed but not logged in
