### PR TITLE
Fix mobile task-room approval and stale controls

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -588,6 +588,7 @@
 
   .topic-mobile-cockpit__bar button,
   .topic-mobile-control__primary,
+  .topic-mobile-control__preset,
   .topic-mobile-actions button {
     min-height: 44px;
     border: 1px solid var(--border);
@@ -601,6 +602,7 @@
 
   .topic-mobile-cockpit__bar button:not(:disabled),
   .topic-mobile-control__primary:not(:disabled),
+  .topic-mobile-control__preset:not(:disabled),
   .topic-mobile-actions button:not(:disabled) {
     color: var(--accent);
     border-color: color-mix(in srgb, var(--accent) 72%, transparent);
@@ -609,6 +611,7 @@
 
   .topic-mobile-cockpit__bar button:disabled,
   .topic-mobile-control__primary:disabled,
+  .topic-mobile-control__preset:disabled,
   .topic-mobile-actions button:disabled,
   .topic-mobile-control input:disabled {
     opacity: 0.45;
@@ -749,6 +752,13 @@
     grid-column: 1 / -1;
     color: var(--text-muted);
     font-size: var(--font-size-xs);
+  }
+
+  .topic-mobile-control__presets {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
   }
 
   .topic-mobile-confirm {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -132,6 +132,14 @@ function topicPrimaryAction(item: TopicNavItem): {
       disabledReason,
     };
   }
+  if (session && disabledReason) {
+    return {
+      label: 'waiting',
+      detail:
+        'last known session context remains readable; live controls are disabled',
+      disabledReason,
+    };
+  }
   if (session) {
     return {
       label: 'resume',
@@ -326,7 +334,16 @@ function TopicMobileControlPanel({
   const [sending, setSending] = useState(false);
   const needsInput = action.label === 'approve' || action.label === 'reply';
   const canSend = Boolean(session && needsInput && !action.disabledReason);
+  const liveControlDisabledReason = sessionControlDisabledReason(session);
+  const canResume = Boolean(session && !liveControlDisabledReason);
   const topSurface = item.surfaces[0];
+  const approvalPresets =
+    action.label === 'approve'
+      ? [
+          { label: 'approve', value: 'y' },
+          { label: 'deny', value: 'n' },
+        ]
+      : [];
 
   useEffect(() => {
     setInputValue('');
@@ -373,8 +390,20 @@ function TopicMobileControlPanel({
       window.open(topSurface.target, '_blank', 'noreferrer');
       return;
     }
-    void navigator.clipboard?.writeText(topSurface.target);
-    setStatus('surface target copied for safe mobile handoff');
+    const clipboard = navigator.clipboard;
+    setStatus(`surface target ready to copy: ${topSurface.target}`);
+    if (clipboard?.writeText) {
+      void clipboard.writeText(topSurface.target).then(
+        () => setStatus('surface target copied for safe mobile handoff'),
+        (error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          setStatus(
+            `surface copy unavailable: ${message}; target ${topSurface.target}`
+          );
+        }
+      );
+    }
   };
 
   return (
@@ -424,6 +453,30 @@ function TopicMobileControlPanel({
           }
           maxLength={1000}
         />
+        {approvalPresets.length > 0 ? (
+          <div
+            className="topic-mobile-control__presets"
+            aria-label="approval reply presets"
+          >
+            {approvalPresets.map((preset) => (
+              <button
+                key={preset.label}
+                type="button"
+                className="topic-mobile-control__preset"
+                disabled={!canSend || sending}
+                onClick={() => {
+                  setInputValue(preset.value);
+                  setPendingValue(null);
+                  setStatus(
+                    `${preset.label} selected · preview before sending`
+                  );
+                }}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
         <button
           type="submit"
           className="topic-mobile-control__primary"
@@ -445,14 +498,25 @@ function TopicMobileControlPanel({
       ) : null}
 
       <div className="topic-mobile-actions" aria-label="topic quick actions">
-        <button type="button" disabled={!session} onClick={handleResume}>
+        <button
+          type="button"
+          disabled={!canResume}
+          onClick={handleResume}
+          title={
+            liveControlDisabledReason ??
+            'open the linked Relay tab for this topic'
+          }
+        >
           resume topic
         </button>
         <button
           type="button"
-          disabled={!session}
+          disabled={!canResume}
           onClick={handleResume}
-          title="same linked Relay tab as resume; raw PTY is the fallback once open"
+          title={
+            liveControlDisabledReason ??
+            'same linked Relay tab as resume; raw PTY is the fallback once open'
+          }
         >
           open terminal tab
         </button>

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -296,6 +296,43 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('sent · audit/intervention trail');
   });
 
+  it('offers explicit approve and deny presets before audited mobile approval send', async () => {
+    const onSendInput = vi.fn().mockResolvedValue({ ok: true });
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'approval',
+          agentState: 'permission-prompt',
+          permissionType: 'approval',
+          controlFreshness: 'fresh',
+        }),
+      ],
+      onSendInput,
+    });
+
+    const denyPreset = Array.from(
+      container.querySelectorAll('.topic-mobile-control__preset')
+    ).find((button) => button.textContent === 'deny') as HTMLButtonElement;
+    const input = container.querySelector(
+      '.topic-mobile-control input'
+    ) as HTMLInputElement;
+    const form = container.querySelector(
+      '.topic-mobile-control'
+    ) as HTMLFormElement;
+
+    await act(async () => denyPreset.click());
+    expect(input.value).toBe('n');
+    expect(container.textContent).toContain(
+      'deny selected · preview before sending'
+    );
+    await act(async () => form.requestSubmit());
+    expect(onSendInput).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('confirmation preview');
+    await act(async () => form.requestSubmit());
+    expect(onSendInput).toHaveBeenCalledWith('s1', 'n\r', undefined);
+  });
+
   it('sends audited mobile replies to the local session id when linked by global id', async () => {
     const onSendInput = vi.fn().mockResolvedValue({ ok: true });
     await renderView({
@@ -374,6 +411,60 @@ describe('TopicSidebarView', () => {
 
     await act(async () => form.requestSubmit());
     expect(onSendInput).not.toHaveBeenCalled();
+  });
+
+  it('disables stale/offline mobile resume while preserving artifact handoff', async () => {
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'offline idle session',
+          agentState: 'idle',
+          idle: true,
+          status: 'disconnected',
+          controlFreshness: 'fresh',
+        }),
+      ],
+      surfaces: [
+        makeSurface({
+          id: 'surface:log',
+          kind: 'logs',
+          label: 'Last known artifact',
+          openMode: 'copy',
+          command: 'relay artifact show surface:log',
+        }),
+      ],
+    });
+
+    expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
+      'waiting'
+    );
+    expect(container.textContent).toContain(
+      'controls disabled: session offline/disconnected'
+    );
+
+    const buttons = Array.from(
+      container.querySelectorAll('.topic-mobile-actions button')
+    ) as HTMLButtonElement[];
+    const resume = buttons.find(
+      (button) => button.textContent === 'resume topic'
+    ) as HTMLButtonElement;
+    const terminal = buttons.find(
+      (button) => button.textContent === 'open terminal tab'
+    ) as HTMLButtonElement;
+    const artifact = buttons.find((button) =>
+      button.textContent?.includes('logs artifact')
+    ) as HTMLButtonElement;
+
+    expect(resume.disabled).toBe(true);
+    expect(resume.title).toContain('offline/disconnected');
+    expect(terminal.disabled).toBe(true);
+    expect(artifact.disabled).toBe(false);
+    await act(async () => artifact.click());
+    expect(container.textContent).toMatch(
+      /surface (target ready to copy|target copied|copy unavailable)/
+    );
+    expect(onSelectSession).not.toHaveBeenCalled();
   });
 
   it('makes the resume and terminal-tab mobile controls explicit', async () => {


### PR DESCRIPTION
## Summary
- Adds explicit approve/deny preset controls to the mobile task-room approval composer while preserving the two-step audited preview/send flow.
- Disables mobile resume/open-terminal controls when the linked session is stale/offline/disconnected, while keeping last-known context and artifact handoff visible.
- Handles copy-only artifact actions without unhandled clipboard promise errors; if clipboard is blocked, the target remains visible in status copy.

## QA / evidence
- Base/head before work: origin/nightly and worktree HEAD both `8751feb25ec8e14c52f3169ba20277ef24d902cb`.
- Baseline exact-nightly gap: mobile offline/idle session still exposed enabled `resume topic` / `open terminal tab`; artifact copy could throw an unhandled clipboard page error. Cute, still unverified, so I patched the small blockers.
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk test npm test -- test/topic-sidebar-shell.test.ts test/topic-nav.test.ts` → exit 0, 26 tests passed (`/tmp/relay-1047-targeted-tests.log`).
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk test npm test` → exit 0 (`/tmp/relay-1047-full-tests.log`; tail is expected worktree-cleanup stderr fixture noise).
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run check` → exit 0, existing warnings only (`/tmp/relay-1047-check.log`).
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH rtk npm run build` → exit 0, existing Vite chunk/dynamic import warnings (`/tmp/relay-1047-build.log`).
- Temporary Vite/mobile Playwright QA fixture at `http://127.0.0.1:5207/qa-mobile-topic.html` → exit 0 (`/tmp/relay-1047-mobile-qa-final.log`), screenshots:
  - `/tmp/relay-1047-mobile-screens/375-approval-deny-preview-send.png`
  - `/tmp/relay-1047-mobile-screens/375-reply-preview-send.png`
  - `/tmp/relay-1047-mobile-screens/375-offline-artifact-stale-controls.png`
  - `/tmp/relay-1047-mobile-screens/430-resume-correct-session.png`

Closes #1047.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick approval presets on mobile, making it easier to send common responses with a tap.
  * Improved the mobile topic control layout with a two-column preset grid.

* **Bug Fixes**
  * Updated resume and live-control actions to be correctly enabled or disabled based on current session status.
  * Improved clipboard sharing feedback so success and failure are both reflected properly.

* **Tests**
  * Added coverage for mobile approval flows and offline/resume action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->