### PR TITLE
fix: allow mobile topic resume for web sessions

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -92,7 +92,7 @@ function topicPrimarySession(
   })[0];
 }
 
-function sessionControlDisabledReason(
+function sessionAttachDisabledReason(
   session: TopicNavSessionRef | undefined
 ): string | null {
   if (!session) return 'no session linked to this topic';
@@ -103,6 +103,15 @@ function sessionControlDisabledReason(
     session.durability ?? undefined
   );
   if (durabilityReason) return durabilityReason;
+  return null;
+}
+
+function sessionControlDisabledReason(
+  session: TopicNavSessionRef | undefined
+): string | null {
+  if (!session) return 'no session linked to this topic';
+  const attachReason = sessionAttachDisabledReason(session);
+  if (attachReason) return attachReason;
   if (session.controlFreshness === 'stale') return 'stale control state';
   if (session.controlFreshness && session.controlFreshness !== 'fresh') {
     return 'unknown control state';
@@ -118,6 +127,7 @@ function topicPrimaryAction(item: TopicNavItem): {
 } {
   const session = topicPrimarySession(item);
   const disabledReason = sessionControlDisabledReason(session);
+  const attachDisabledReason = sessionAttachDisabledReason(session);
   if (session?.displayState === 'permission') {
     return {
       label: 'approve',
@@ -132,19 +142,19 @@ function topicPrimaryAction(item: TopicNavItem): {
       disabledReason,
     };
   }
-  if (session && disabledReason) {
+  if (session && attachDisabledReason) {
     return {
       label: 'waiting',
       detail:
         'last known session context remains readable; live controls are disabled',
-      disabledReason,
+      disabledReason: attachDisabledReason,
     };
   }
   if (session) {
     return {
       label: 'resume',
       detail: 'open the linked Relay tab; raw PTY remains the fallback',
-      disabledReason: null,
+      disabledReason,
     };
   }
   if (item.surfaces.length > 0) {
@@ -334,8 +344,8 @@ function TopicMobileControlPanel({
   const [sending, setSending] = useState(false);
   const needsInput = action.label === 'approve' || action.label === 'reply';
   const canSend = Boolean(session && needsInput && !action.disabledReason);
-  const liveControlDisabledReason = sessionControlDisabledReason(session);
-  const canResume = Boolean(session && !liveControlDisabledReason);
+  const resumeDisabledReason = sessionAttachDisabledReason(session);
+  const canResume = Boolean(session && !resumeDisabledReason);
   const topSurface = item.surfaces[0];
   const approvalPresets =
     action.label === 'approve'
@@ -503,8 +513,7 @@ function TopicMobileControlPanel({
           disabled={!canResume}
           onClick={handleResume}
           title={
-            liveControlDisabledReason ??
-            'open the linked Relay tab for this topic'
+            resumeDisabledReason ?? 'open the linked Relay tab for this topic'
           }
         >
           resume topic
@@ -514,7 +523,7 @@ function TopicMobileControlPanel({
           disabled={!canResume}
           onClick={handleResume}
           title={
-            liveControlDisabledReason ??
+            resumeDisabledReason ??
             'same linked Relay tab as resume; raw PTY is the fallback once open'
           }
         >

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -113,9 +113,7 @@ function sessionControlDisabledReason(
   const attachReason = sessionAttachDisabledReason(session);
   if (attachReason) return attachReason;
   if (session.controlFreshness === 'stale') return 'stale control state';
-  if (session.controlFreshness && session.controlFreshness !== 'fresh') {
-    return 'unknown control state';
-  }
+  if (session.controlFreshness !== 'fresh') return 'unknown control state';
   if (session.mode === 'web') return 'web session input is unsupported here';
   return null;
 }

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -467,14 +467,111 @@ describe('TopicSidebarView', () => {
     expect(onSelectSession).not.toHaveBeenCalled();
   });
 
+  it('keeps permission/question mobile input fail-closed when control freshness is omitted', async () => {
+    const onSendInput = vi.fn().mockResolvedValue({ ok: true });
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'approval awaiting freshness',
+          agentState: 'permission-prompt',
+          permissionType: 'approval',
+          status: 'active',
+        }),
+      ],
+      onSendInput,
+    });
+
+    expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
+      'approve'
+    );
+    expect(container.textContent).toContain(
+      'controls disabled: unknown control state'
+    );
+
+    const input = container.querySelector(
+      '.topic-mobile-control input'
+    ) as HTMLInputElement;
+    const submit = container.querySelector(
+      '.topic-mobile-control__primary'
+    ) as HTMLButtonElement;
+    const presets = Array.from(
+      container.querySelectorAll('.topic-mobile-control__preset')
+    ) as HTMLButtonElement[];
+    const buttons = Array.from(
+      container.querySelectorAll('.topic-mobile-actions button')
+    ) as HTMLButtonElement[];
+    const resume = buttons.find(
+      (button) => button.textContent === 'resume topic'
+    ) as HTMLButtonElement;
+    const terminal = buttons.find(
+      (button) => button.textContent === 'open terminal tab'
+    ) as HTMLButtonElement;
+
+    expect(input.disabled).toBe(true);
+    expect(submit.disabled).toBe(true);
+    expect(submit.title).toContain('unknown control state');
+    expect(presets.map((preset) => preset.disabled)).toEqual([true, true]);
+    expect(resume.disabled).toBe(false);
+    expect(resume.title).toContain('open the linked Relay tab');
+    expect(terminal.disabled).toBe(false);
+
+    await act(async () => terminal.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+    expect(onSendInput).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'question awaiting freshness',
+          agentState: 'permission-prompt',
+          permissionType: 'question',
+          status: 'active',
+        }),
+      ],
+      onSendInput,
+    });
+
+    expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
+      'reply'
+    );
+    expect(container.textContent).toContain(
+      'controls disabled: unknown control state'
+    );
+
+    const questionInput = container.querySelector(
+      '.topic-mobile-control input'
+    ) as HTMLInputElement;
+    const questionSubmit = container.querySelector(
+      '.topic-mobile-control__primary'
+    ) as HTMLButtonElement;
+    const questionTerminal = Array.from(
+      container.querySelectorAll('.topic-mobile-actions button')
+    ).find(
+      (button) => button.textContent === 'open terminal tab'
+    ) as HTMLButtonElement;
+
+    expect(questionInput.disabled).toBe(true);
+    expect(questionSubmit.disabled).toBe(true);
+    expect(
+      container.querySelectorAll('.topic-mobile-control__preset')
+    ).toHaveLength(0);
+    expect(questionTerminal.disabled).toBe(false);
+
+    await act(async () => questionTerminal.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+    expect(onSendInput).not.toHaveBeenCalled();
+  });
+
   it('keeps mobile resume enabled when only live input control state is unsafe', async () => {
     const onSendInput = vi.fn().mockResolvedValue({ ok: true });
     await renderView({
       sessions: [
         makeSession({
           id: 's1',
-          displayName: 'live Hermes web session',
-          mode: 'web',
+          displayName: 'live Hermes pty session',
           status: 'active',
           controlFreshness: 'unknown',
         }),

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -467,6 +467,85 @@ describe('TopicSidebarView', () => {
     expect(onSelectSession).not.toHaveBeenCalled();
   });
 
+  it('keeps mobile resume enabled when only live input control state is unsafe', async () => {
+    const onSendInput = vi.fn().mockResolvedValue({ ok: true });
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'live Hermes web session',
+          mode: 'web',
+          status: 'active',
+          controlFreshness: 'unknown',
+        }),
+      ],
+      onSendInput,
+    });
+
+    expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
+      'resume'
+    );
+    expect(container.textContent).toContain(
+      'controls disabled: unknown control state'
+    );
+
+    const input = container.querySelector(
+      '.topic-mobile-control input'
+    ) as HTMLInputElement;
+    const submit = container.querySelector(
+      '.topic-mobile-control__primary'
+    ) as HTMLButtonElement;
+    const buttons = Array.from(
+      container.querySelectorAll('.topic-mobile-actions button')
+    ) as HTMLButtonElement[];
+    const resume = buttons.find(
+      (button) => button.textContent === 'resume topic'
+    ) as HTMLButtonElement;
+    const terminal = buttons.find(
+      (button) => button.textContent === 'open terminal tab'
+    ) as HTMLButtonElement;
+
+    expect(input.disabled).toBe(true);
+    expect(submit.disabled).toBe(true);
+    expect(resume.disabled).toBe(false);
+    expect(resume.title).toContain('open the linked Relay tab');
+    expect(terminal.disabled).toBe(false);
+
+    await act(async () => terminal.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+    expect(onSendInput).not.toHaveBeenCalled();
+  });
+
+  it('keeps web session input disabled while allowing mobile tab resume', async () => {
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'fresh Hermes web session',
+          mode: 'web',
+          status: 'active',
+          controlFreshness: 'fresh',
+        }),
+      ],
+    });
+
+    expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
+      'resume'
+    );
+    expect(container.textContent).toContain(
+      'controls disabled: web session input is unsupported here'
+    );
+
+    const resume = Array.from(
+      container.querySelectorAll('.topic-mobile-actions button')
+    ).find(
+      (button) => button.textContent === 'resume topic'
+    ) as HTMLButtonElement;
+    expect(resume.disabled).toBe(false);
+    await act(async () => resume.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+  });
+
   it('makes the resume and terminal-tab mobile controls explicit', async () => {
     await renderView();
 


### PR DESCRIPTION
## summary
- split mobile topic navigation disablement from live input/control disablement
- keep `resume topic` / `open terminal tab` enabled for active linked web/unknown-control sessions
- preserve disabled audited input controls with explicit `unknown control state` / `web session input is unsupported here` reasons

Closes #1027

## verification
- `npm test -- test/topic-sidebar-shell.test.ts`
- `npm run check` (passes with existing warnings)
- `npm run build` (passes; existing chunk-size / CodeMirror dynamic-import warnings)
- push hook reran changed tests: `test/topic-sidebar-shell.test.ts`

## QA handoff
- rerun the mobile Hermes topic resume/control slice at exact PR head
- verify the linked Hermes web session shows `resume topic` and `open terminal tab` enabled
- verify raw audited input/control remains disabled with the accurate unsafe-control reason

## simplify
- tier 2 local simplify/self-review after primary verification: kept the narrow helper split and only reordered the session null guard; no broader refactor applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile topic controls so action buttons now show the correct enabled/disabled state and message when a live session can’t be attached or resumed.
  * Updated the primary action behavior to distinguish between “waiting” and “resume” states more accurately.
  * Fixed resume-related actions so they select the current session without accidentally sending input when control is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->