### PR TITLE
fix: keep task-room resume inspectable

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -124,20 +124,24 @@ function topicPrimaryAction(item: TopicNavItem): {
   disabledReason: string | null;
 } {
   const session = topicPrimarySession(item);
-  const disabledReason = sessionControlDisabledReason(session);
-  const attachDisabledReason = sessionAttachDisabledReason(session);
+  const controlDisabledReason = session
+    ? sessionControlDisabledReason(session)
+    : null;
+  const attachDisabledReason = session
+    ? sessionAttachDisabledReason(session)
+    : null;
   if (session?.displayState === 'permission') {
     return {
       label: 'approve',
       detail: 'send an audited approval reply to the live session',
-      disabledReason,
+      disabledReason: controlDisabledReason,
     };
   }
   if (session?.displayState === 'needs-answer') {
     return {
       label: 'reply',
       detail: 'send a short audited reply without opening the terminal first',
-      disabledReason,
+      disabledReason: controlDisabledReason,
     };
   }
   if (session && attachDisabledReason) {
@@ -152,7 +156,7 @@ function topicPrimaryAction(item: TopicNavItem): {
     return {
       label: 'resume',
       detail: 'open the linked Relay tab; raw PTY remains the fallback',
-      disabledReason,
+      disabledReason: null,
     };
   }
   if (item.surfaces.length > 0) {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -332,6 +332,32 @@ describe('TopicSidebarView', () => {
     expect(onSelectSession).toHaveBeenCalledWith('s1');
   });
 
+  it('keeps desktop resume enabled when only live input control state is unknown', async () => {
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'readable lane',
+          agentState: 'idle',
+          controlFreshness: undefined,
+        }),
+      ],
+    });
+
+    const primary = container.querySelector(
+      '.topic-room__primary'
+    ) as HTMLButtonElement;
+
+    expect(primary.textContent).toBe('resume');
+    expect(primary.disabled).toBe(false);
+    expect(
+      primary.closest('.topic-room__action-band')?.textContent
+    ).not.toContain('controls disabled: unknown control state');
+
+    await act(async () => primary.click());
+    expect(onSelectSession).toHaveBeenCalledWith('s1');
+  });
+
   it('selects the exact global session from the task-room session row', async () => {
     await renderView({
       topics: [makeTopic({ linkedRefs: { sessionIds: ['global:agent-1'] } })],


### PR DESCRIPTION
## Summary
Fixes the desktop task-room primary resume CTA after #1049 by separating read-only session attach from live input safety.

The primary `resume` button now stays enabled when only `controlFreshness` is missing/unknown, matching the mobile split that keeps tab/session inspection available while send/reply/approve controls fail closed.

Refs #1044

## Verification
- `npm install` — worktree dependency sync
- `npm test -- test/topic-sidebar-shell.test.ts` — 31 tests passed
- `npm run check` — exit 0, existing 220 warnings / 0 errors
- `npm run build` — exit 0, existing Vite chunk-size warnings
- pre-commit `npm run check` — exit 0, existing warnings only
- pre-push changed tests — `test/topic-sidebar-shell.test.ts`, 31 tests passed

## Simplify pass
Renamed the local primary-action control gate to `controlDisabledReason` so the desktop `resume` path clearly uses only `attachDisabledReason` while input actions still use live-control freshness.