### PR TITLE
feat(chat): rich cards for web-search and image timeline items (#1063)

### DIFF
--- a/frontend/src/components/chat/MediaCard.css
+++ b/frontend/src/components/chat/MediaCard.css
@@ -1,0 +1,72 @@
+.mcard {
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.mcard__h {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 10px;
+  color: var(--text);
+}
+
+.mcard__label {
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.mcard__query {
+  color: var(--text);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mcard__desc {
+  color: var(--text-muted);
+  flex: 1;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
+.mcard__meta {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.mcard__body {
+  border-top: 1px solid var(--border);
+  padding: 8px 10px;
+  background: var(--bg);
+}
+
+.mcard__img {
+  display: block;
+  max-width: 100%;
+  max-height: 320px;
+  object-fit: contain;
+}
+
+.mcard__src {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+@media (max-width: 767px) {
+  .mcard__img {
+    max-height: 200px;
+  }
+}

--- a/frontend/src/components/chat/MediaCard.tsx
+++ b/frontend/src/components/chat/MediaCard.tsx
@@ -33,6 +33,18 @@ interface InlineImageProps {
   alt: string;
 }
 
+/**
+ * Fallback text shown when an image fails to load. `data:`/`blob:` sources can
+ * be megabytes of encoded data (and blob URLs are opaque anyway), so show a
+ * short message rather than dumping the raw string into the DOM; a readable
+ * path/URL is kept for debuggability.
+ */
+function imageFallbackText(src: string): string {
+  return src.startsWith('data:') || src.startsWith('blob:')
+    ? 'image unavailable'
+    : src;
+}
+
 /** Inline image with an error fallback to the source string. */
 const InlineImage: React.FC<InlineImageProps> = ({ src, alt }) => {
   const [failed, setFailed] = useState(false);
@@ -40,7 +52,7 @@ const InlineImage: React.FC<InlineImageProps> = ({ src, alt }) => {
   // the item first rendered) rather than showing the fallback forever.
   useEffect(() => setFailed(false), [src]);
   if (failed) {
-    return <span className="mcard__src">{src}</span>;
+    return <span className="mcard__src">{imageFallbackText(src)}</span>;
   }
   return (
     <img

--- a/frontend/src/components/chat/MediaCard.tsx
+++ b/frontend/src/components/chat/MediaCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './MediaCard.css';
 import type {
   AgentImageGenerationItemV2,
@@ -36,6 +36,9 @@ interface InlineImageProps {
 /** Inline image with an error fallback to the source string. */
 const InlineImage: React.FC<InlineImageProps> = ({ src, alt }) => {
   const [failed, setFailed] = useState(false);
+  // Retry when the source changes (e.g. a generated image URL arrives after
+  // the item first rendered) rather than showing the fallback forever.
+  useEffect(() => setFailed(false), [src]);
   if (failed) {
     return <span className="mcard__src">{src}</span>;
   }

--- a/frontend/src/components/chat/MediaCard.tsx
+++ b/frontend/src/components/chat/MediaCard.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import './MediaCard.css';
+import type {
+  AgentImageGenerationItemV2,
+  AgentImageViewItemV2,
+  AgentWebSearchItemV2,
+} from '../../../../shared/agent-chat-protocol-v2.js';
+
+/**
+ * Media/artifact cards for the chat timeline. Renders web searches, viewed
+ * images, and generated images as compact product-quality cards instead of
+ * the raw `<pre>` fallbacks. Follows the ToolCard visual pattern: 1px outline,
+ * lowercase labels, monospace, no filled backgrounds (see DESIGN.md).
+ */
+
+/**
+ * Only schemes the browser can safely render inline as an image. Agent image
+ * items frequently carry a sandbox file path (e.g. codex `imageView` emits the
+ * local `path`), which the browser cannot load — those fall back to a path chip
+ * rather than a broken-image icon.
+ */
+function isRenderableImageUrl(src: string | undefined): src is string {
+  if (!src) return false;
+  return (
+    /^https?:\/\//i.test(src) ||
+    /^data:image\//i.test(src) ||
+    src.startsWith('blob:')
+  );
+}
+
+interface InlineImageProps {
+  src: string;
+  alt: string;
+}
+
+/** Inline image with an error fallback to the source string. */
+const InlineImage: React.FC<InlineImageProps> = ({ src, alt }) => {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return <span className="mcard__src">{src}</span>;
+  }
+  return (
+    <img
+      className="mcard__img"
+      src={src}
+      alt={alt}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+};
+
+export const WebSearchCard: React.FC<{ item: AgentWebSearchItemV2 }> = ({
+  item,
+}) => {
+  return (
+    <div className="mcard mcard--search" role="article" aria-label="web search">
+      <div className="mcard__h">
+        <span className="mcard__label">web search</span>
+        <span className="mcard__query">{item.query}</span>
+        {item.action && <span className="mcard__meta">{item.action}</span>}
+      </div>
+    </div>
+  );
+};
+
+export const ImageViewCard: React.FC<{ item: AgentImageViewItemV2 }> = ({
+  item,
+}) => {
+  const alt = item.description || 'image';
+  return (
+    <div className="mcard mcard--image" role="article" aria-label="image">
+      <div className="mcard__h">
+        <span className="mcard__label">image</span>
+        {item.description && (
+          <span className="mcard__desc">{item.description}</span>
+        )}
+      </div>
+      <div className="mcard__body">
+        {isRenderableImageUrl(item.source) ? (
+          <InlineImage src={item.source} alt={alt} />
+        ) : (
+          <span className="mcard__src">{item.source}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const ImageGenerationCard: React.FC<{
+  item: AgentImageGenerationItemV2;
+}> = ({ item }) => {
+  return (
+    <div
+      className="mcard mcard--imagegen"
+      role="article"
+      aria-label="generated image"
+    >
+      <div className="mcard__h">
+        <span className="mcard__label">generated image</span>
+        {item.prompt && <span className="mcard__desc">{item.prompt}</span>}
+      </div>
+      {isRenderableImageUrl(item.imageUrl) && (
+        <div className="mcard__body">
+          <InlineImage
+            src={item.imageUrl}
+            alt={item.prompt || 'generated image'}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/chat/Turn.tsx
+++ b/frontend/src/components/chat/Turn.tsx
@@ -8,6 +8,11 @@ import type {
 } from '../../../../shared/agent-chat-protocol-v2.js';
 import { ApprovalCard } from './ApprovalCard.js';
 import { FileChangeRow } from './FileChangeRow.js';
+import {
+  ImageGenerationCard,
+  ImageViewCard,
+  WebSearchCard,
+} from './MediaCard.js';
 import { ToolCard } from './ToolCard.js';
 import { TurnFooter } from './TurnFooter.js';
 import { TurnHeader } from './TurnHeader.js';
@@ -125,11 +130,11 @@ function renderItem(
         </div>
       );
     case 'webSearch':
-      return <pre className="tl-text">{item.query}</pre>;
+      return <WebSearchCard item={item} />;
     case 'imageView':
-      return <pre className="tl-text">{item.source}</pre>;
+      return <ImageViewCard item={item} />;
     case 'imageGeneration':
-      return <pre className="tl-text">{item.prompt}</pre>;
+      return <ImageGenerationCard item={item} />;
     case 'hookPrompt':
       return <pre className="tl-text">{item.prompt}</pre>;
     case 'errorMessage':

--- a/test/chat-media-cards.test.ts
+++ b/test/chat-media-cards.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  AgentImageGenerationItemV2,
+  AgentImageViewItemV2,
+  AgentWebSearchItemV2,
+} from '../shared/agent-chat-protocol-v2.js';
+import {
+  ImageGenerationCard,
+  ImageViewCard,
+  WebSearchCard,
+} from '../frontend/src/components/chat/MediaCard.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(node: React.ReactElement): void {
+  act(() => root.render(node));
+}
+
+function webSearch(
+  overrides: Partial<AgentWebSearchItemV2> = {}
+): AgentWebSearchItemV2 {
+  return {
+    type: 'webSearch',
+    id: 'search-1',
+    query: 'relay ide',
+    ...overrides,
+  };
+}
+
+function imageView(
+  overrides: Partial<AgentImageViewItemV2> = {}
+): AgentImageViewItemV2 {
+  return {
+    type: 'imageView',
+    id: 'image-1',
+    source: '/tmp/screenshot.png',
+    ...overrides,
+  };
+}
+
+function imageGeneration(
+  overrides: Partial<AgentImageGenerationItemV2> = {}
+): AgentImageGenerationItemV2 {
+  return {
+    type: 'imageGeneration',
+    id: 'gen-1',
+    prompt: 'a red terminal',
+    ...overrides,
+  };
+}
+
+describe('WebSearchCard', () => {
+  it('renders a labeled card with the query, not raw text', () => {
+    render(React.createElement(WebSearchCard, { item: webSearch() }));
+    const card = container.querySelector('.mcard--search');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('aria-label')).toBe('web search');
+    expect(container.querySelector('.mcard__label')?.textContent).toBe(
+      'web search'
+    );
+    expect(container.querySelector('.mcard__query')?.textContent).toBe(
+      'relay ide'
+    );
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
+  it('shows the action when present', () => {
+    render(
+      React.createElement(WebSearchCard, {
+        item: webSearch({ action: 'open' }),
+      })
+    );
+    expect(container.querySelector('.mcard__meta')?.textContent).toBe('open');
+  });
+});
+
+describe('ImageViewCard', () => {
+  it('renders a file-path source as a chip, not an <img>', () => {
+    render(React.createElement(ImageViewCard, { item: imageView() }));
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('.mcard__src')?.textContent).toBe(
+      '/tmp/screenshot.png'
+    );
+  });
+
+  it('renders an http(s) source as an inline <img> with alt text', () => {
+    render(
+      React.createElement(ImageViewCard, {
+        item: imageView({
+          source: 'https://example.com/a.png',
+          description: 'a diagram',
+        }),
+      })
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('https://example.com/a.png');
+    expect(img?.getAttribute('alt')).toBe('a diagram');
+    expect(container.querySelector('.mcard__desc')?.textContent).toBe(
+      'a diagram'
+    );
+  });
+});
+
+describe('ImageGenerationCard', () => {
+  it('renders the prompt caption and no body without an imageUrl', () => {
+    render(
+      React.createElement(ImageGenerationCard, { item: imageGeneration() })
+    );
+    expect(container.querySelector('.mcard__label')?.textContent).toBe(
+      'generated image'
+    );
+    expect(container.querySelector('.mcard__desc')?.textContent).toBe(
+      'a red terminal'
+    );
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders an inline <img> when imageUrl is a data URI', () => {
+    render(
+      React.createElement(ImageGenerationCard, {
+        item: imageGeneration({
+          imageUrl: 'data:image/png;base64,iVBORw0KGgo=',
+        }),
+      })
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('a red terminal');
+  });
+
+  it('ignores a non-renderable imageUrl scheme', () => {
+    render(
+      React.createElement(ImageGenerationCard, {
+        item: imageGeneration({ imageUrl: 'file:///etc/passwd' }),
+      })
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('.mcard__body')).toBeNull();
+  });
+});

--- a/test/chat-media-cards.test.ts
+++ b/test/chat-media-cards.test.ts
@@ -120,6 +120,45 @@ describe('ImageViewCard', () => {
       'a diagram'
     );
   });
+
+  it('falls back to the source chip when the image fails to load', () => {
+    render(
+      React.createElement(ImageViewCard, {
+        item: imageView({ source: 'https://example.com/broken.png' }),
+      })
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    act(() => {
+      img?.dispatchEvent(new Event('error'));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('.mcard__src')?.textContent).toBe(
+      'https://example.com/broken.png'
+    );
+  });
+
+  it('retries (clears the failed state) when the source changes', () => {
+    render(
+      React.createElement(ImageViewCard, {
+        item: imageView({ source: 'https://example.com/broken.png' }),
+      })
+    );
+    act(() => {
+      container.querySelector('img')?.dispatchEvent(new Event('error'));
+    });
+    expect(container.querySelector('img')).toBeNull();
+    // Same component position → same InlineImage instance; a new src must
+    // reset the failed state and attempt to render the image again.
+    render(
+      React.createElement(ImageViewCard, {
+        item: imageView({ source: 'https://example.com/fresh.png' }),
+      })
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('https://example.com/fresh.png');
+  });
 });
 
 describe('ImageGenerationCard', () => {

--- a/test/chat-media-cards.test.ts
+++ b/test/chat-media-cards.test.ts
@@ -188,6 +188,21 @@ describe('ImageGenerationCard', () => {
     expect(img?.getAttribute('alt')).toBe('a red terminal');
   });
 
+  it('shows a short message instead of the raw data URI on load failure', () => {
+    const bigDataUri = `data:image/png;base64,${'A'.repeat(4096)}`;
+    render(
+      React.createElement(ImageGenerationCard, {
+        item: imageGeneration({ imageUrl: bigDataUri }),
+      })
+    );
+    act(() => {
+      container.querySelector('img')?.dispatchEvent(new Event('error'));
+    });
+    const fallback = container.querySelector('.mcard__src');
+    expect(fallback?.textContent).toBe('image unavailable');
+    expect(fallback?.textContent).not.toContain('AAAA');
+  });
+
   it('ignores a non-renderable imageUrl scheme', () => {
     render(
       React.createElement(ImageGenerationCard, {


### PR DESCRIPTION
## What

Part of epic #1058 (chat-first Relay). Advances #1063 acceptance: *tool calls / artifacts render as compact cards, not raw logs.*

`webSearch`, `imageView`, and `imageGeneration` timeline items previously rendered as a raw `<pre>` dump of one field. They now render as compact product-quality cards (`MediaCard.tsx`) matching the existing `ToolCard` aesthetic — 1px outline, lowercase labels, monospace, no filled backgrounds (per `DESIGN.md`).

- **WebSearchCard** — labeled query + optional action.
- **ImageViewCard** — inline `<img>` for `http(s)`/`data:image/`/`blob:` sources; path chip fallback for sandbox file paths (what the codex `imageView` emitter actually produces — `item.path`) and on image load error.
- **ImageGenerationCard** — prompt caption + inline generated image when a renderable `imageUrl` is present.

Only known-safe image URL schemes render inline, so `file:`/other schemes and sandbox paths never produce a broken-image icon.

## Scope

Tight, additive slice of #1063. Deferred (no producer exists yet, would be speculative): brand-new PR-link / check-link / terminal-excerpt item types. Tracked as follow-up on #1063.

## Testing

- New `test/chat-media-cards.test.ts` (7 cases): query rendering, action, path-chip vs inline-img, data-URI img, non-renderable scheme rejection.
- `npm run check` green (0 errors).
- `npm test` full suite (see CI).

Refs #1058, #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)