### PR TITLE
feat(palette): search topics in the command palette (#1065)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import {
   resubscribeIfNeeded,
 } from './lib/notifications.js';
 import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
+import { resolveTopicActiveContext } from '../../shared/workspace-topics.js';
 import { estimateTerminalDimensions } from './lib/utils.js';
 import { createSessionWithoutActivation } from './lib/session-utils.js';
 import {
@@ -736,15 +737,15 @@ function TerminalAreaContent({
           {activeRepoPath &&
             activeSession?.repoPath === activeRepoPath &&
             activeWorkspace?.kind === 'repo' && (
-            <PrTopBar
-              workspacePath={activeRepoPath}
-              utilityRailWorkspacePath={utilityRailStateKey}
-              branchName={activeSession?.branchName ?? ''}
-              sessionId={activeSessionId}
-              agentRunning={activeSession?.agentState === 'processing'}
-              onArchive={onArchive}
-            />
-          )}
+              <PrTopBar
+                workspacePath={activeRepoPath}
+                utilityRailWorkspacePath={utilityRailStateKey}
+                branchName={activeSession?.branchName ?? ''}
+                sessionId={activeSessionId}
+                agentRunning={activeSession?.agentState === 'processing'}
+                onArchive={onArchive}
+              />
+            )}
           <SplitPaneLayout
             rightSidebarCollapsed={!utilityRailState.visible}
             rightSidebarWidth={utilityRailWidth}
@@ -1376,6 +1377,13 @@ export default function App() {
           closeSidebar();
         }}
         onSelectSession={(id) => handleSelectSession(id)}
+        onSelectTopic={(topic) => {
+          const context = resolveTopicActiveContext(topic);
+          const ui = useUiStore.getState();
+          ui.setActiveWorkspaceId(context.workspaceId);
+          if (context.repoPath) ui.setActiveRepoPath(context.repoPath);
+          closeSidebar();
+        }}
         onSelectPr={handlePaletteSelectPr}
         onOpenSettings={(sectionId) => {
           setSpotlightOpen(false);

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -25,6 +25,14 @@ import { isMobileDevice, isMac } from '../lib/utils.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
 import { buildSessionPaletteResults } from '../lib/command-palette-session-results.js';
 import {
+  buildTopicPaletteResults,
+  recentTopicPaletteResults,
+} from '../lib/command-palette-topic-results.js';
+import type {
+  WorkspaceTopic,
+  WorkspaceTopicListResponse,
+} from '../../../shared/workspace-topics.js';
+import {
   executeCommandCenterAssistantCommand,
   resolveCommandCenterAssistantIntent,
 } from '../lib/api.js';
@@ -43,7 +51,14 @@ import './CommandPalette.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const TABS = ['all', 'sessions', 'workspaces', 'prs', 'settings'] as const;
+const TABS = [
+  'all',
+  'sessions',
+  'topics',
+  'workspaces',
+  'prs',
+  'settings',
+] as const;
 type Tab = (typeof TABS)[number];
 
 const SEC_GENERAL = 'section-general';
@@ -134,6 +149,13 @@ type PaletteResult =
       data: SessionSummary;
     }
   | {
+      type: 'topic';
+      id: string;
+      label: string;
+      sublabel?: string;
+      data: WorkspaceTopic;
+    }
+  | {
       type: 'pr' | 'attention';
       id: string;
       label: string;
@@ -177,6 +199,7 @@ export interface CommandPaletteProps {
   onClose: () => void;
   onSelectWorkspace: (path: string) => void;
   onSelectSession: (id: string) => void;
+  onSelectTopic?: (topic: WorkspaceTopic) => void;
   onSelectPr: (pr: PullRequest) => void;
   onOpenSettings?: (sectionId: string) => void;
   resolveAssistantIntent?: (
@@ -211,6 +234,8 @@ function categoryIcon(type: PaletteResult['type']): string {
       return '■';
     case 'session':
       return '▸';
+    case 'topic':
+      return '◇';
     case 'pr':
     case 'attention':
       return '●';
@@ -228,6 +253,7 @@ function categoryIcon(type: PaletteResult['type']): string {
 function matchesTab(type: PaletteResult['type'], activeTab: Tab): boolean {
   if (activeTab === 'all') return true;
   if (activeTab === 'sessions') return type === 'session' || type === 'command';
+  if (activeTab === 'topics') return type === 'topic';
   if (activeTab === 'workspaces') return type === 'workspace';
   if (activeTab === 'prs') return type === 'pr' || type === 'attention';
   if (activeTab === 'settings') return type === 'setting' || type === 'command';
@@ -259,7 +285,13 @@ function useCachedData(open: boolean) {
       [],
     [queryClient, open]
   );
-  return { cachedPrs, cachedGithubIssues, cachedJiraIssues };
+  const cachedTopics = useMemo<WorkspaceTopic[]>(
+    () =>
+      queryClient.getQueryData<WorkspaceTopicListResponse>(['workspace-topics'])
+        ?.topics ?? [],
+    [queryClient, open]
+  );
+  return { cachedPrs, cachedGithubIssues, cachedJiraIssues, cachedTopics };
 }
 
 /**
@@ -289,6 +321,7 @@ function buildResults(
   cachedPrs: PullRequest[],
   cachedGithubIssues: GitHubIssue[],
   cachedJiraIssues: JiraIssue[],
+  cachedTopics: WorkspaceTopic[],
   registryCommands: Action[],
   /** Actions that have a disabledReason but failed `when` — shown greyed-out. */
   degradedCommands: { action: Action; reason: string }[],
@@ -314,6 +347,8 @@ function buildResults(
         sublabel: ws.path,
         data: ws,
       });
+    for (const topic of recentTopicPaletteResults(cachedTopics, 5))
+      items.push(topic);
     for (const a of registryCommands)
       items.push(actionToPaletteCommand(a, actionContext));
     for (const { action, reason } of degradedCommands.filter(
@@ -341,6 +376,9 @@ function buildResults(
     });
   for (const result of buildSessionPaletteResults(q, sessions, 5)) {
     items.push(result);
+  }
+  for (const topic of buildTopicPaletteResults(q, cachedTopics, 5)) {
+    items.push(topic);
   }
   for (const pr of cachedPrs
     .filter(
@@ -434,6 +472,7 @@ function useGroupedResults(
       ? [
           { type: 'workspace', label: 'workspaces' },
           { type: 'session', label: 'sessions' },
+          { type: 'topic', label: 'topics' },
           { type: 'pr', label: 'pull requests' },
           { type: 'ticket', label: 'tickets' },
           { type: 'command', label: 'commands' },
@@ -442,6 +481,7 @@ function useGroupedResults(
       : [
           { type: 'attention', label: 'needs attention' },
           { type: 'workspace', label: 'workspaces' },
+          { type: 'topic', label: 'topics' },
           { type: 'command', label: 'commands' },
         ];
     return typeOrder.flatMap(({ type, label }) => {
@@ -516,6 +556,7 @@ function usePaletteHandlers(
   onClose: () => void,
   onSelectWorkspace: (path: string) => void,
   onSelectSession: (id: string) => void,
+  onSelectTopic: ((topic: WorkspaceTopic) => void) | undefined,
   onSelectPr: (pr: PullRequest) => void,
   onOpenSettings?: (sectionId: string) => void
 ) {
@@ -544,6 +585,8 @@ function usePaletteHandlers(
         onSelectWorkspace((item.data as Repo).path);
       else if (item.type === 'session')
         onSelectSession(scopedSessionKey(item.data as SessionSummary));
+      else if (item.type === 'topic')
+        onSelectTopic?.(item.data as WorkspaceTopic);
       else if (item.type === 'attention' || item.type === 'pr')
         onSelectPr(item.data as PullRequest);
       else if (item.type === 'setting')
@@ -554,6 +597,7 @@ function usePaletteHandlers(
       onClose,
       onSelectWorkspace,
       onSelectSession,
+      onSelectTopic,
       onSelectPr,
       onOpenSettings,
     ]
@@ -785,6 +829,7 @@ export function CommandPalette({
   onClose,
   onSelectWorkspace,
   onSelectSession,
+  onSelectTopic,
   onSelectPr,
   onOpenSettings,
   resolveAssistantIntent = resolveCommandCenterAssistantIntent,
@@ -815,7 +860,7 @@ export function CommandPalette({
     setDragging,
     dragStartYRef,
   } = usePaletteState(open, inputRef);
-  const { cachedPrs, cachedGithubIssues, cachedJiraIssues } =
+  const { cachedPrs, cachedGithubIssues, cachedJiraIssues, cachedTopics } =
     useCachedData(open);
   // Commands that pass `when` — active and invocable.
   const registryCommands = useMemo(
@@ -857,6 +902,7 @@ export function CommandPalette({
         cachedPrs,
         cachedGithubIssues,
         cachedJiraIssues,
+        cachedTopics,
         registryCommands,
         degradedCommands,
         needsAttention,
@@ -870,6 +916,7 @@ export function CommandPalette({
       cachedPrs,
       cachedGithubIssues,
       cachedJiraIssues,
+      cachedTopics,
       registryCommands,
       degradedCommands,
       needsAttention,
@@ -911,6 +958,7 @@ export function CommandPalette({
     onClose,
     onSelectWorkspace,
     onSelectSession,
+    onSelectTopic,
     onSelectPr,
     onOpenSettings
   );

--- a/frontend/src/lib/command-palette-topic-results.ts
+++ b/frontend/src/lib/command-palette-topic-results.ts
@@ -1,0 +1,55 @@
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
+
+export interface TopicPaletteResult {
+  type: 'topic';
+  id: string;
+  label: string;
+  sublabel: string;
+  data: WorkspaceTopic;
+}
+
+function searchableText(topic: WorkspaceTopic): string[] {
+  return [
+    topic.display.title ?? '',
+    topic.display.description ?? '',
+    topic.routingDefaults.repoPath ?? '',
+    topic.routingDefaults.nodeId ?? '',
+  ];
+}
+
+function toResult(topic: WorkspaceTopic): TopicPaletteResult {
+  return {
+    type: 'topic',
+    id: `topic-${topic.id}`,
+    label: topic.display.title || topic.id,
+    sublabel: topic.routingDefaults.repoPath ?? topic.workspaceId,
+    data: topic,
+  };
+}
+
+/** Active, non-archived topics ordered as provided, for the empty-query view. */
+export function recentTopicPaletteResults(
+  topics: WorkspaceTopic[],
+  limit = 5
+): TopicPaletteResult[] {
+  return topics
+    .filter((topic) => topic.status !== 'archived')
+    .slice(0, limit)
+    .map(toResult);
+}
+
+/** Topics whose title/description/repo/node match the query. */
+export function buildTopicPaletteResults(
+  query: string,
+  topics: WorkspaceTopic[],
+  limit = 5
+): TopicPaletteResult[] {
+  const q = query.toLowerCase();
+  return topics
+    .filter((topic) => topic.status !== 'archived')
+    .filter((topic) =>
+      searchableText(topic).some((value) => value.toLowerCase().includes(q))
+    )
+    .slice(0, limit)
+    .map(toResult);
+}

--- a/test/command-palette-topic-results.test.ts
+++ b/test/command-palette-topic-results.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTopicPaletteResults,
+  recentTopicPaletteResults,
+} from '../frontend/src/lib/command-palette-topic-results.js';
+import type { WorkspaceTopic } from '../shared/workspace-topics.js';
+
+const NOW = '2026-07-01T00:00:00Z';
+
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:alpha',
+    workspaceId: 'workspace:alpha',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Frontend lane', description: 'chat-first surface' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: { nodeId: 'devbox', repoPath: '/repo/relay' },
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('buildTopicPaletteResults', () => {
+  it('matches on title, description, repo path, and node', () => {
+    const topic = makeTopic();
+    expect(buildTopicPaletteResults('frontend', [topic])).toHaveLength(1);
+    expect(buildTopicPaletteResults('chat-first', [topic])).toHaveLength(1);
+    expect(buildTopicPaletteResults('/repo/relay', [topic])).toHaveLength(1);
+    expect(buildTopicPaletteResults('devbox', [topic])).toHaveLength(1);
+    expect(buildTopicPaletteResults('nomatch', [topic])).toHaveLength(0);
+  });
+
+  it('renders a topic-prefixed id, title label, and repo sublabel', () => {
+    const results = buildTopicPaletteResults('frontend', [makeTopic()]);
+    expect(results[0]).toMatchObject({
+      type: 'topic',
+      id: 'topic-topic:alpha',
+      label: 'Frontend lane',
+      sublabel: '/repo/relay',
+    });
+  });
+
+  it('falls back to the workspace id as sublabel when there is no repo', () => {
+    const topic = makeTopic({ routingDefaults: {} });
+    expect(buildTopicPaletteResults('frontend', [topic])[0]?.sublabel).toBe(
+      'workspace:alpha'
+    );
+  });
+
+  it('excludes archived topics and respects the limit', () => {
+    const archived = makeTopic({ id: 'topic:old', status: 'archived' });
+    expect(buildTopicPaletteResults('frontend', [archived])).toHaveLength(0);
+
+    const many = Array.from({ length: 8 }, (_, i) =>
+      makeTopic({ id: `topic:${i}` })
+    );
+    expect(buildTopicPaletteResults('frontend', many, 5)).toHaveLength(5);
+  });
+});
+
+describe('recentTopicPaletteResults', () => {
+  it('returns active topics in order, up to the limit', () => {
+    const topics = [
+      makeTopic({ id: 'topic:1', display: { title: 'One' } }),
+      makeTopic({
+        id: 'topic:2',
+        display: { title: 'Two' },
+        status: 'archived',
+      }),
+      makeTopic({ id: 'topic:3', display: { title: 'Three' } }),
+    ];
+    const results = recentTopicPaletteResults(topics, 5);
+    expect(results.map((r) => r.label)).toEqual(['One', 'Three']);
+  });
+});


### PR DESCRIPTION
## What

Part of epic #1058. Advances #1065 acceptance: *palette can search workspaces/topics/sessions/artifacts/actions.* Adds **topics** as a first-class command-palette category.

- New pure builders `command-palette-topic-results.ts`:
  - `buildTopicPaletteResults(q, topics, limit)` — matches title/description/repo/node, active-only, limited.
  - `recentTopicPaletteResults(topics, limit)` — empty-query view.
- `CommandPalette` reads cached topics from the `['workspace-topics']` query cache (same pattern as PRs/issues), adds a `topics` tab, result group, and `◇` icon, and dispatches selection to a new `onSelectTopic`.
- `App` wires `onSelectTopic` to establish the topic's workspace/repo context via the shared `resolveTopicActiveContext` — consistent with sidebar selection (#1068).

## Scope

Focused on the search + select slice of #1065. The remaining intent actions (attach-context, show-diff, open-diagnostics) and artifact search stay open on #1065; attach-context in particular needs cross-node capability validation and is deferred.

## Testing

New `test/command-palette-topic-results.test.ts` (5 cases): title/description/repo/node matching, id/label/sublabel shape, workspace-id sublabel fallback, archived-exclusion + limit, recent ordering. `npm run check` clean (0 errors).

Refs #1058, #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)