### PR TITLE
feat(sidebar): friendly session labels instead of raw select keys (#1061)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -387,7 +387,7 @@ function ParticipantChildRow({
         type="button"
         className="topic-child-row__button"
         {...(handleSelect ? { onClick: handleSelect } : { disabled: true })}
-        title={`open existing session ${participant.selectKey}`}
+        title={`open existing session ${participant.label}`}
       >
         <span className="topic-child-row__label">
           <MarqueeText>{participant.label}</MarqueeText>
@@ -457,7 +457,7 @@ function ParticipantRoster({
                   {...(handleSelect
                     ? { onClick: handleSelect }
                     : { disabled: true })}
-                  title={`open existing session ${participant.selectKey}`}
+                  title={`open existing session ${participant.label}`}
                 >
                   <span className="topic-participant-card__topline">
                     <span className="topic-participant-card__name">
@@ -505,7 +505,7 @@ function TopicRoomSessionRow({
       <button
         type="button"
         className="topic-room-session__button"
-        title={`open exact session ${session.selectKey}`}
+        title={`open exact session ${session.label}`}
         onClick={() => onSelectSession?.(session.selectKey)}
       >
         <span className="topic-room-session__main">
@@ -969,7 +969,7 @@ function TopicMobileControlPanel({
         <div className="topic-mobile-confirm" role="status">
           <span>confirmation preview</span>
           <code>{pendingValue}</code>
-          <span>{session?.selectKey} · carriage return appended</span>
+          <span>{session?.label} · carriage return appended</span>
         </div>
       ) : null}
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -143,6 +143,21 @@ describe('TopicSidebarView', () => {
     expect(onSelectSession).toHaveBeenCalledWith('s1');
   });
 
+  it('labels open-session affordances with a friendly name, not the raw select key', async () => {
+    await renderView();
+    const tips = Array.from(container.querySelectorAll('[title]'))
+      .map((el) => el.getAttribute('title') ?? '')
+      .filter((title) => title.startsWith('open'));
+    expect(tips.length).toBeGreaterThan(0);
+    expect(
+      tips.some((title) => title === 'open existing session Frontend lane')
+    ).toBe(true);
+    // The internal scoped select key must not leak into any tooltip.
+    for (const title of tips) {
+      expect(title).not.toMatch(/::|worktree:|node:/);
+    }
+  });
+
   it('establishes the topic node/repo context when a topic is selected', async () => {
     await renderView({
       topics: [
@@ -444,7 +459,9 @@ describe('TopicSidebarView', () => {
     const roomSessionButton = container.querySelector(
       '.topic-room-session__button'
     ) as HTMLButtonElement;
-    expect(roomSessionButton.title).toContain('global:agent-1');
+    // Tooltip shows the friendly label; the raw global select key stays internal.
+    expect(roomSessionButton.title).toBe('open exact session global lane');
+    expect(roomSessionButton.title).not.toContain('global:agent-1');
     await act(async () => roomSessionButton.click());
     expect(onSelectSession).toHaveBeenCalledWith('global:agent-1');
   });


### PR DESCRIPTION
## What

Part of epic #1058, advances #1061 acceptance: *main nav avoids low-level session/protocol mechanics.*

Topic-detail affordances exposed internal scoped session **select keys** (e.g. `global:agent-1`, `worktree::…`) in tooltips and the mobile send-input confirmation line. They now show the friendly session **label** (displayName / cwd) instead. Selection handlers still route on the select key, so behavior is unchanged — only the surfaced text is de-mechanized.

Changed: participant/session open-session tooltips + the mobile confirmation "carriage return appended" line.

## Testing

`test/topic-sidebar-shell.test.ts`: new assertion that open-session tooltips use the friendly label and never leak a scoped key; updated the task-room session-row test to expect the label while keeping its functional `onSelectSession('global:agent-1')` check. 38 cases green; `npm run check` clean.

Refs #1058, #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)