### PR TITLE
feat(landing): chat-first entry banner on the no-session landing (#1058)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,7 @@ import { getActiveTerminalHandle } from './lib/terminal-refs.js';
 import PrTopBar from './components/PrTopBar.js';
 import RepoDashboard from './components/RepoDashboard.js';
 import OrgDashboard from './components/OrgDashboard.js';
+import ChatFirstLanding from './components/ChatFirstLanding.js';
 import Toolbar from './components/Toolbar.js';
 import MobileHeader from './components/MobileHeader.js';
 import SessionStatusBar from './components/SessionStatusBar.js';
@@ -699,10 +700,13 @@ function TerminalAreaContent({
         hidden={keyboardOpen}
       />
       {viewMode === 'org' && (
-        <OrgDashboard
-          onOpenPrSession={onOpenPrSession}
-          onPrAction={onPrAction}
-        />
+        <>
+          <ChatFirstLanding />
+          <OrgDashboard
+            onOpenPrSession={onOpenPrSession}
+            onPrAction={onPrAction}
+          />
+        </>
       )}
 
       {viewMode === 'analytics' && <AnalyticsViewContent />}

--- a/frontend/src/components/ChatFirstLanding.css
+++ b/frontend/src/components/ChatFirstLanding.css
@@ -1,0 +1,55 @@
+.chat-first-landing {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--accent);
+  margin: 12px 16px 0;
+  font-family: var(--font-mono);
+}
+
+.chat-first-landing__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-first-landing__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 500;
+  color: var(--text);
+}
+
+.chat-first-landing__lede {
+  margin: 4px 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.chat-first-landing__cta {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.chat-first-landing__cta:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+@media (max-width: 767px) {
+  .chat-first-landing {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chat-first-landing__cta {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/ChatFirstLanding.tsx
+++ b/frontend/src/components/ChatFirstLanding.tsx
@@ -1,0 +1,36 @@
+import './ChatFirstLanding.css';
+import { useUiStore } from '../lib/stores/ui.js';
+
+/**
+ * Chat-first entry banner shown on the no-session/no-repo landing. Nudges the
+ * user toward the topic → chat flow (the primary experience) without hiding the
+ * work dashboard rendered below it. "new topic" opens the sidebar create panel
+ * via the same window event the topic shell listens for.
+ */
+export function ChatFirstLanding() {
+  const openSidebar = useUiStore((s) => s.openSidebar);
+  const startTopic = () => {
+    openSidebar();
+    window.dispatchEvent(new Event('relay:open-topic-task-room'));
+  };
+  return (
+    <section className="chat-first-landing" aria-label="chat-first workspace">
+      <div className="chat-first-landing__body">
+        <h2 className="chat-first-landing__title">start with a topic</h2>
+        <p className="chat-first-landing__lede">
+          pick a topic in the sidebar to chat with an agent, launch a terminal,
+          or review artifacts — each runs in the topic&apos;s node and repo.
+        </p>
+      </div>
+      <button
+        type="button"
+        className="chat-first-landing__cta"
+        onClick={startTopic}
+      >
+        new topic
+      </button>
+    </section>
+  );
+}
+
+export default ChatFirstLanding;

--- a/test/chat-first-landing.test.ts
+++ b/test/chat-first-landing.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import ChatFirstLanding from '../frontend/src/components/ChatFirstLanding.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useUiStore.getState().closeSidebar();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('ChatFirstLanding', () => {
+  it('renders a chat-first entry with a new-topic action', () => {
+    act(() => root.render(React.createElement(ChatFirstLanding)));
+    expect(container.querySelector('.chat-first-landing')).not.toBeNull();
+    expect(container.textContent).toContain('start with a topic');
+    const cta = container.querySelector('.chat-first-landing__cta');
+    expect(cta?.textContent).toBe('new topic');
+  });
+
+  it('opens the sidebar create panel when new-topic is clicked', () => {
+    let opened = false;
+    const listener = () => {
+      opened = true;
+    };
+    window.addEventListener('relay:open-topic-task-room', listener);
+    try {
+      act(() => root.render(React.createElement(ChatFirstLanding)));
+      const cta = container.querySelector(
+        '.chat-first-landing__cta'
+      ) as HTMLButtonElement;
+      act(() => cta.click());
+      expect(opened).toBe(true);
+      expect(useUiStore.getState().sidebarOpen).toBe(true);
+    } finally {
+      window.removeEventListener('relay:open-topic-task-room', listener);
+    }
+  });
+});


### PR DESCRIPTION
## What

Part of epic #1058's "chat + terminals + artifacts as the default experience." Adds a compact **chat-first banner** at the top of the no-session/no-repo landing (`viewMode === 'org'`) that nudges toward the topic → chat flow with a **new topic** action.

- `new topic` opens the sidebar create panel via the existing `relay:open-topic-task-room` event (+ opens the sidebar on mobile).
- On-brand: mono, lowercase, outline CTA, accent left-rule, zero border-radius (`DESIGN.md`).

## Deliberately minimal / reversible

This is the **low-risk** interpretation of "chat-first landing": it adds a chat-first entry point **without hiding or reordering** the work dashboard (PRs/tickets/audit) below it. The more aggressive moves — changing the default `active-work` tab and relocating the nodes/analytics mechanics into Settings (the "settings + advanced toggle, keep discoverable" decision) — are the separate substrate-hiding lane and not in this PR.

**@donovan-yohan** — if you'd rather the landing fully replace the org cockpit (vs. banner-above), say so and I'll adjust; this shape is intentionally the safe first step.

## Testing

New `test/chat-first-landing.test.ts` (2): renders the entry + `new topic` opens the create panel (event fired + sidebar opened). `npm run check` clean.

Refs #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chat-first landing banner in the org dashboard for users without an active session.
  * Included a clear “new topic” call to action that opens the chat experience from the landing area.

* **Bug Fixes**
  * Updated the org dashboard flow so the landing banner appears before the main dashboard content in the org view.
  * Preserved existing dashboard actions and behavior while adding the new entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->