### PR TITLE
feat(hermes): tag conversations with topic/workspace/repo metadata (#1062)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from './types.js';
 
 import { setupWebSocket } from './ws.js';
 import { createLocalRelayNode } from './local-node.js';
+import { buildRelayHermesMetadata } from './protocol-adapters/hermes-adapter.js';
 import {
   DEFAULT_LOCAL_NODE_ID,
   parseGlobalSessionId,
@@ -342,6 +343,33 @@ const __dirname = path.dirname(__filename);
 const execFileAsync = promisify(execFile);
 const logger = createLogger('index');
 const TERMINAL_BACKEND_RELAY_PTY: TerminalBackend = 'relay-pty';
+
+/**
+ * Build the `extra` payload for a Hermes web session so its conversation is
+ * tagged with the topic/workspace/repo/node anchors (via the responses
+ * `metadata` field). Returns an empty object for non-Hermes agents or when
+ * there is no context to attach, so it can be spread into createWeb params.
+ */
+function buildHermesCreateExtra(
+  resolvedAgent: string,
+  ctx: {
+    workspaceTopic?: { id?: string; workspaceId?: string } | null | undefined;
+    repoPath?: string | null | undefined;
+    branchName?: string | null | undefined;
+    nodeId?: string | null | undefined;
+  }
+): { extra: { metadata: Record<string, string> } } | Record<string, never> {
+  if (resolvedAgent !== 'hermes') return {};
+  const metadata = buildRelayHermesMetadata({
+    topicId: ctx.workspaceTopic?.id,
+    workspaceId: ctx.workspaceTopic?.workspaceId,
+    repoPath: ctx.repoPath,
+    branchName: ctx.branchName,
+    nodeId: ctx.nodeId,
+  });
+  return Object.keys(metadata).length > 0 ? { extra: { metadata } } : {};
+}
+
 const localRelayNode = createLocalRelayNode();
 const cliGatewayActorRegistry = createCliGatewayActorRegistry();
 const cliGatewayHandshakeGrantRegistry =
@@ -5245,6 +5273,12 @@ async function main(): Promise<void> {
           port: startupConfig.port,
           configDir,
           sessionLane,
+          ...buildHermesCreateExtra(resolvedAgent, {
+            workspaceTopic,
+            repoPath: checkedRepoPath,
+            branchName: requestBranchName,
+            nodeId: DEFAULT_LOCAL_NODE_ID,
+          }),
         });
         gitWatcher.watch(session.cwd);
         const associationError = associateSessionWithWorkContext(

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -450,6 +450,50 @@ function parseToolArguments(value: unknown): Record<string, unknown> {
   }
 }
 
+const RESPONSES_METADATA_MAX_KEYS = 16;
+const RESPONSES_METADATA_KEY_MAX = 64;
+const RESPONSES_METADATA_VALUE_MAX = 512;
+
+/**
+ * Coerce an `extra.metadata` object into the string-keyed/string-valued shape
+ * the OpenAI-compatible Responses API accepts (≤16 pairs, bounded lengths).
+ * Returns undefined when there is nothing to send.
+ */
+export function sanitizeResponsesMetadata(
+  raw: unknown
+): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (value === null || value === undefined) continue;
+    if (Object.keys(out).length >= RESPONSES_METADATA_MAX_KEYS) break;
+    const k = key.slice(0, RESPONSES_METADATA_KEY_MAX);
+    out[k] = String(value).slice(0, RESPONSES_METADATA_VALUE_MAX);
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+/**
+ * Build the Relay workspace/topic anchors that tag a Hermes conversation so the
+ * gateway (and any audit/observer) can associate the session with its topic,
+ * repo, and node. Empty fields are omitted.
+ */
+export function buildRelayHermesMetadata(input: {
+  topicId?: string | null | undefined;
+  workspaceId?: string | null | undefined;
+  repoPath?: string | null | undefined;
+  branchName?: string | null | undefined;
+  nodeId?: string | null | undefined;
+}): Record<string, string> {
+  const md: Record<string, string> = {};
+  if (input.topicId) md['relay_topic_id'] = input.topicId;
+  if (input.workspaceId) md['relay_workspace_id'] = input.workspaceId;
+  if (input.repoPath) md['relay_repo_path'] = input.repoPath;
+  if (input.branchName) md['relay_branch'] = input.branchName;
+  if (input.nodeId) md['relay_node_id'] = input.nodeId;
+  return md;
+}
+
 /**
  * Hermes protocol adapter.
  *
@@ -544,6 +588,12 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     };
     if (this._lastResponseId) {
       body['previous_response_id'] = this._lastResponseId;
+    }
+    const metadata = sanitizeResponsesMetadata(
+      this._config?.extra?.['metadata']
+    );
+    if (metadata) {
+      body['metadata'] = metadata;
     }
 
     try {

--- a/test/hermes-metadata.test.ts
+++ b/test/hermes-metadata.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRelayHermesMetadata,
+  resolveHermesGatewaySettings,
+  sanitizeResponsesMetadata,
+} from '../server/protocol-adapters/hermes-adapter.js';
+
+describe('sanitizeResponsesMetadata', () => {
+  it('coerces an object to a bounded string map', () => {
+    expect(sanitizeResponsesMetadata({ a: 'x', n: 3, b: true })).toEqual({
+      a: 'x',
+      n: '3',
+      b: 'true',
+    });
+  });
+
+  it('drops null/undefined values and returns undefined when empty', () => {
+    expect(
+      sanitizeResponsesMetadata({ a: null, b: undefined })
+    ).toBeUndefined();
+    expect(sanitizeResponsesMetadata({})).toBeUndefined();
+  });
+
+  it('rejects non-objects', () => {
+    expect(sanitizeResponsesMetadata('nope')).toBeUndefined();
+    expect(sanitizeResponsesMetadata(['a'])).toBeUndefined();
+    expect(sanitizeResponsesMetadata(null)).toBeUndefined();
+  });
+
+  it('caps at 16 keys and bounds value length', () => {
+    const many: Record<string, number> = {};
+    for (let i = 0; i < 40; i++) many[`k${i}`] = i;
+    expect(Object.keys(sanitizeResponsesMetadata(many) ?? {})).toHaveLength(16);
+    const long = sanitizeResponsesMetadata({ big: 'a'.repeat(1000) });
+    expect(long?.big.length).toBe(512);
+  });
+});
+
+describe('buildRelayHermesMetadata', () => {
+  it('includes only present anchors under relay_ keys', () => {
+    expect(
+      buildRelayHermesMetadata({
+        topicId: 'topic:alpha',
+        workspaceId: 'ws:alpha',
+        repoPath: '/repo/relay',
+        branchName: 'nightly',
+        nodeId: 'local',
+      })
+    ).toEqual({
+      relay_topic_id: 'topic:alpha',
+      relay_workspace_id: 'ws:alpha',
+      relay_repo_path: '/repo/relay',
+      relay_branch: 'nightly',
+      relay_node_id: 'local',
+    });
+  });
+
+  it('omits absent anchors', () => {
+    expect(
+      buildRelayHermesMetadata({ topicId: 'topic:x', repoPath: null })
+    ).toEqual({ relay_topic_id: 'topic:x' });
+  });
+});
+
+// Live integration: only runs when a real Hermes gateway is reachable (skips in
+// CI). Proves the live gateway accepts our metadata shape on /v1/responses.
+describe('live Hermes gateway metadata acceptance', () => {
+  it('accepts a metadata-tagged responses request', async () => {
+    const settings = resolveHermesGatewaySettings(undefined);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(settings.apiKey
+        ? { Authorization: `Bearer ${settings.apiKey}` }
+        : {}),
+    };
+    let reachable: boolean;
+    try {
+      const health = await fetch(`${settings.endpoint}/health`, {
+        headers,
+        signal: AbortSignal.timeout(1000),
+      });
+      reachable = health.ok;
+    } catch {
+      reachable = false;
+    }
+    if (!reachable) {
+      // eslint-disable-next-line no-console
+      console.log('[skip] no live Hermes gateway at', settings.endpoint);
+      return;
+    }
+    const metadata = buildRelayHermesMetadata({
+      topicId: 'topic:relay-test',
+      repoPath: '/repo/relay',
+      nodeId: 'local',
+    });
+    const res = await fetch(`${settings.endpoint}/v1/responses`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        input: 'ok',
+        stream: false,
+        store: true,
+        session_id: 'relay-metadata-itest',
+        metadata,
+      }),
+      signal: AbortSignal.timeout(30000),
+    });
+    expect(res.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Advances #1062: *maps Relay topic/workspace context into Hermes launch/session metadata.* **Verified end-to-end against a live Hermes gateway** (ebi profile, `hermes-agent` 0.17.0).

- Adapter `sendMessage` forwards a sanitized `extra.metadata` object as the OpenAI-compatible Responses `metadata` field (string-coerced, ≤16 keys, bounded lengths — `sanitizeResponsesMetadata`).
- `POST /sessions` builds `relay_*` anchors (topic id, workspace id, repo path, branch, node) for Hermes web sessions and passes them via `createWeb` `extra` (`buildRelayHermesMetadata` + `buildHermesCreateExtra`).

## Verification

Confirmed against the real gateway via curl and a live-gated integration test: `POST /v1/responses` accepts the `metadata` object (HTTP 200), and session state is retained by `session_id` alone.

## Testing

`test/hermes-metadata.test.ts` — 6 pure unit cases + 1 live-gated integration test (skips when no gateway reachable, so CI is unaffected). `npm run check` clean; existing Hermes suites green.

Refs #1058, #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)