### PR TITLE
feat(hermes): forward image attachments to the gateway (input_image)

### DIFF
--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -494,6 +494,58 @@ export function buildRelayHermesMetadata(input: {
   return md;
 }
 
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+/** Turn an image Attachment into a Responses `image_url` (data URI or passthrough). */
+export function attachmentToResponsesImageUrl(
+  attachment: Attachment,
+  readFile: (p: string) => Buffer = (p) => fs.readFileSync(p)
+): string | null {
+  const source = attachment.path;
+  if (!source) return null;
+  if (/^(data:|https?:|blob:)/i.test(source)) return source;
+  try {
+    const bytes = readFile(source);
+    const ext = path.extname(source).toLowerCase();
+    const mime = attachment.mimeType ?? MIME_BY_EXTENSION[ext] ?? 'image/png';
+    return `data:${mime};base64,${bytes.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}
+
+type ResponsesContentPart =
+  | { type: 'input_text'; text: string }
+  | { type: 'input_image'; image_url: string };
+
+/**
+ * Build the Responses API `input`. With no image attachments this is the plain
+ * prompt string (unchanged behaviour); with images it becomes a single user
+ * message whose content interleaves the text and each `input_image` part.
+ */
+export function buildResponsesInput(
+  content: string,
+  attachments?: Attachment[],
+  readFile?: (p: string) => Buffer
+): string | Array<{ role: 'user'; content: ResponsesContentPart[] }> {
+  const images = (attachments ?? []).filter((a) => a.type === 'image');
+  if (images.length === 0) return content;
+  const parts: ResponsesContentPart[] = [{ type: 'input_text', text: content }];
+  for (const image of images) {
+    const url = readFile
+      ? attachmentToResponsesImageUrl(image, readFile)
+      : attachmentToResponsesImageUrl(image);
+    if (url) parts.push({ type: 'input_image', image_url: url });
+  }
+  return [{ role: 'user', content: parts }];
+}
+
 /**
  * Hermes protocol adapter.
  *
@@ -565,7 +617,7 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
   async sendMessage(
     turnId: string,
     content: string,
-    _attachments?: Attachment[]
+    attachments?: Attachment[]
   ): Promise<void> {
     const sessionId = this._config?.sessionId;
     if (!sessionId) throw new Error('No session ID');
@@ -581,7 +633,7 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     });
 
     const body: Record<string, unknown> = {
-      input: content,
+      input: buildResponsesInput(content, attachments),
       stream: true,
       store: true,
       session_id: sessionId,

--- a/test/hermes-image-input.test.ts
+++ b/test/hermes-image-input.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attachmentToResponsesImageUrl,
+  buildResponsesInput,
+  resolveHermesGatewaySettings,
+} from '../server/protocol-adapters/hermes-adapter.js';
+import type { Attachment } from '../server/protocol-adapter.js';
+
+const DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+describe('buildResponsesInput', () => {
+  it('returns the plain string when there are no image attachments', () => {
+    expect(buildResponsesInput('hello')).toBe('hello');
+    expect(
+      buildResponsesInput('hello', [{ type: 'file', path: '/tmp/x.txt' }])
+    ).toBe('hello');
+  });
+
+  it('builds an interleaved user message for image attachments', () => {
+    const input = buildResponsesInput('describe', [
+      { type: 'image', path: DATA_URI },
+    ]);
+    expect(input).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'describe' },
+          { type: 'input_image', image_url: DATA_URI },
+        ],
+      },
+    ]);
+  });
+
+  it('reads a file-path image via the injected reader', () => {
+    const input = buildResponsesInput(
+      'q',
+      [{ type: 'image', path: '/tmp/pic.png', mimeType: 'image/png' }],
+      () => Buffer.from('PNGBYTES')
+    );
+    expect(input).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'q' },
+          {
+            type: 'input_image',
+            image_url: `data:image/png;base64,${Buffer.from('PNGBYTES').toString('base64')}`,
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('attachmentToResponsesImageUrl', () => {
+  const img = (path: string, mimeType?: string): Attachment =>
+    mimeType ? { type: 'image', path, mimeType } : { type: 'image', path };
+
+  it('passes through data/http/blob urls unchanged', () => {
+    expect(attachmentToResponsesImageUrl(img(DATA_URI))).toBe(DATA_URI);
+    expect(attachmentToResponsesImageUrl(img('https://x/y.png'))).toBe(
+      'https://x/y.png'
+    );
+  });
+
+  it('encodes a readable file to a data uri, inferring mime from extension', () => {
+    expect(
+      attachmentToResponsesImageUrl(img('/tmp/a.jpg'), () => Buffer.from('JJ'))
+    ).toBe(`data:image/jpeg;base64,${Buffer.from('JJ').toString('base64')}`);
+  });
+
+  it('returns null for an unreadable path', () => {
+    expect(
+      attachmentToResponsesImageUrl(img('/tmp/missing.png'), () => {
+        throw new Error('nope');
+      })
+    ).toBeNull();
+  });
+});
+
+// Live: proves the real gateway accepts our image-input shape. Skips in CI.
+describe('live Hermes gateway image input', () => {
+  it('accepts an input_image responses request', async () => {
+    const settings = resolveHermesGatewaySettings(undefined);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(settings.apiKey
+        ? { Authorization: `Bearer ${settings.apiKey}` }
+        : {}),
+    };
+    let reachable: boolean;
+    try {
+      const health = await fetch(`${settings.endpoint}/health`, {
+        headers,
+        signal: AbortSignal.timeout(1000),
+      });
+      reachable = health.ok;
+    } catch {
+      reachable = false;
+    }
+    if (!reachable) {
+      // eslint-disable-next-line no-console
+      console.log('[skip] no live Hermes gateway at', settings.endpoint);
+      return;
+    }
+    const res = await fetch(`${settings.endpoint}/v1/responses`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        input: buildResponsesInput('What is in this image?', [
+          { type: 'image', path: DATA_URI },
+        ]),
+        stream: false,
+        store: true,
+        session_id: 'relay-image-itest',
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+    expect(res.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Part of the chat-first prototype (epic #1058). The Hermes adapter previously **ignored** its `attachments` argument, so images never reached the model. It now encodes image attachments into the OpenAI-compatible Responses `input` as interleaved `input_text` + `input_image` content parts.

- `data:`/`http(s):`/`blob:` sources pass through as `image_url`.
- Local file-path attachments are read and base64-encoded (mime inferred from extension).
- Text-only prompts are unchanged (plain string `input`).

Pure helpers `buildResponsesInput` + `attachmentToResponsesImageUrl` (injectable file reader for tests).

## Verified against the live gateway

curl + a live-gated integration test confirm the real Hermes gateway (ebi, `hermes-agent` 0.17.0) **accepts the array `input` with `input_image`** and returns a vision response. The live test skips when no gateway is reachable (CI unaffected).

This is the backend half of image chat support; the Composer capture/paste/upload UI (send-path threading) follows in a frontend PR.

## Testing

`test/hermes-image-input.test.ts` — 6 pure cases (string passthrough, interleaved image message, file-read via injected reader, url passthrough, mime inference, unreadable→null) + 1 live-gated round-trip. `npm run check` clean.

Refs #1058, #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)