### PR TITLE
feat(chat): image attachments — upload, clipboard paste, drag-drop

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import './ChatView.css';
 import { useAgentChatSocket } from '../../hooks/useAgentChatSocket.js';
-import { Composer, type ClientCommandHandler } from './Composer.js';
+import {
+  Composer,
+  type ClientCommandHandler,
+  type ComposerSendAttachment,
+} from './Composer.js';
 import { QueueChips } from './QueueChips.js';
 import { Turn, type EventVerbosity } from './Turn.js';
 import type { AgentSlashCommandV2 } from '../../../../shared/agent-chat-protocol-v2.js';
@@ -78,9 +82,9 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
   }, [session]);
 
   const handleSend = useCallback(
-    (content: string) => {
+    (content: string, attachments?: ComposerSendAttachment[]) => {
       const turnId = crypto.randomUUID();
-      sendMessage(turnId, content);
+      sendMessage(turnId, content, attachments);
     },
     [sendMessage]
   );

--- a/frontend/src/components/chat/Composer.css
+++ b/frontend/src/components/chat/Composer.css
@@ -340,3 +340,63 @@
     padding: 4px 8px;
   }
 }
+
+.composer__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 8px 0;
+}
+
+.composer__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.composer__chip-thumb {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+}
+
+.composer__chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer__chip-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.composer__chip-remove:hover {
+  color: var(--status-error);
+}
+
+.composer__attach {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.composer__attach:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -20,8 +20,27 @@ export type ClientCommandHandler = (
   args: string
 ) => { ok: true } | { ok: false; error: string };
 
+/** Wire-shaped image attachment forwarded to the adapter (server Attachment). */
+export interface ComposerSendAttachment {
+  type: 'image';
+  /** data: URI carrying the image bytes. */
+  path: string;
+  mimeType?: string;
+}
+
+/** Composer-local attachment state (richer than the wire shape, for chips). */
+interface ComposerAttachment {
+  id: string;
+  dataUri: string;
+  mimeType: string;
+  name: string;
+}
+
+/** Reject images above this size to keep WebSocket frames sane. */
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
 interface ComposerProps {
-  onSend: (content: string) => void;
+  onSend: (content: string, attachments?: ComposerSendAttachment[]) => void;
   onInterrupt: () => void;
   isActive: boolean;
   capabilities?: AgentCapabilitySetV2 | undefined;
@@ -56,6 +75,17 @@ function buildCommandIndex(commands: AgentSlashCommandV2[]): Set<string> {
   return index;
 }
 
+function toSendAttachments(
+  attachments: ComposerAttachment[]
+): ComposerSendAttachment[] | undefined {
+  if (attachments.length === 0) return undefined;
+  return attachments.map((a) => ({
+    type: 'image' as const,
+    path: a.dataUri,
+    mimeType: a.mimeType,
+  }));
+}
+
 export const Composer: React.FC<ComposerProps> = ({
   onSend,
   onInterrupt,
@@ -73,6 +103,80 @@ export const Composer: React.FC<ComposerProps> = ({
   const [caret, setCaret] = useState(0);
   const [activeIndex, setActiveIndex] = useState(0);
   const [, setSendError] = useState<string | null>(null);
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const addImageFiles = useCallback(
+    (files: FileList | File[]) => {
+      const images = Array.from(files).filter((f) =>
+        f.type.startsWith('image/')
+      );
+      for (const file of images) {
+        if (file.size > MAX_IMAGE_BYTES) {
+          pushClientError?.(
+            `image too large: ${file.name} (max 8MB)`,
+            'attach'
+          );
+          continue;
+        }
+        const reader = new FileReader();
+        reader.onload = () => {
+          const dataUri =
+            typeof reader.result === 'string' ? reader.result : '';
+          if (!dataUri) return;
+          setAttachments((prev) => [
+            ...prev,
+            {
+              id: crypto.randomUUID(),
+              dataUri,
+              mimeType: file.type,
+              name: file.name || 'image',
+            },
+          ]);
+        };
+        reader.readAsDataURL(file);
+      }
+    },
+    [pushClientError]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const files: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) files.push(file);
+        }
+      }
+      if (files.length > 0) {
+        e.preventDefault();
+        addImageFiles(files);
+      }
+    },
+    [addImageFiles]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLTextAreaElement>) => {
+      const dropped = e.dataTransfer?.files;
+      if (!dropped || dropped.length === 0) return;
+      const images = Array.from(dropped).filter((f) =>
+        f.type.startsWith('image/')
+      );
+      if (images.length > 0) {
+        e.preventDefault();
+        addImageFiles(images);
+      }
+    },
+    [addImageFiles]
+  );
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  }, []);
 
   const filteredCommands = useSlashCommands(
     capabilities,
@@ -144,66 +248,58 @@ export const Composer: React.FC<ComposerProps> = ({
     [capabilities.slashCommands, commandIndex, pushClientError]
   );
 
+  // Intercept client-dispatch slash commands (handled in-frontend, never sent
+  // to the adapter). Returns true when it fully handled the input.
+  const tryClientCommand = useCallback(
+    (content: string): boolean => {
+      if (!clientHandlers || !slashCommands) return false;
+      const leadingMatch = /^[/$](\S+)(?:\s+([\s\S]*))?$/.exec(content);
+      if (!leadingMatch) return false;
+      const name = (leadingMatch[1] ?? '').toLowerCase();
+      const args = leadingMatch[2] ?? '';
+      const matched = slashCommands.find(
+        (cmd) =>
+          cmd.dispatch === 'client' &&
+          (cmd.name.replace(/^[/$]/, '').toLowerCase() === name ||
+            (cmd.aliases ?? []).some(
+              (a) => a.replace(/^[/$]/, '').toLowerCase() === name
+            ))
+      );
+      if (!matched) return false;
+      const handler =
+        clientHandlers[matched.name.replace(/^[/$]/, '').toLowerCase()];
+      if (!handler) {
+        const missingMsg = `handler not implemented for ${matched.name}`;
+        if (pushClientError) pushClientError(missingMsg, matched.name);
+        else setSendError(missingMsg);
+        return true;
+      }
+      const result = handler(args);
+      if (!result.ok) {
+        if (pushClientError) pushClientError(result.error, matched.name);
+        else setSendError(result.error);
+        return true;
+      }
+      setDraft('');
+      setCaret(0);
+      setSendError(null);
+      return true;
+    },
+    [clientHandlers, slashCommands, pushClientError]
+  );
+
   const submitDraft = useCallback(() => {
     const content = draft.trim();
-    if (!content) return;
+    if (!content && attachments.length === 0) return;
     if (!validateAndSend(content)) return;
+    if (tryClientCommand(content)) return;
 
-    // Intercept client-dispatch commands (handled in frontend, never sent to adapter).
-    if (clientHandlers && slashCommands) {
-      const leadingMatch = /^[/$](\S+)(?:\s+([\s\S]*))?$/.exec(content);
-      if (leadingMatch) {
-        const name = (leadingMatch[1] ?? '').toLowerCase();
-        const args = leadingMatch[2] ?? '';
-        const matched = slashCommands.find(
-          (cmd) =>
-            cmd.dispatch === 'client' &&
-            (cmd.name.replace(/^[/$]/, '').toLowerCase() === name ||
-              (cmd.aliases ?? []).some(
-                (a) => a.replace(/^[/$]/, '').toLowerCase() === name
-              ))
-        );
-        if (matched) {
-          const handler =
-            clientHandlers[matched.name.replace(/^[/$]/, '').toLowerCase()];
-          if (handler) {
-            const result = handler(args);
-            if (!result.ok) {
-              if (pushClientError) {
-                pushClientError(result.error, matched.name);
-              } else {
-                setSendError(result.error);
-              }
-              return;
-            }
-            setDraft('');
-            setCaret(0);
-            setSendError(null);
-            return;
-          }
-          const missingMsg = `handler not implemented for ${matched.name}`;
-          if (pushClientError) {
-            pushClientError(missingMsg, matched.name);
-          } else {
-            setSendError(missingMsg);
-          }
-          return;
-        }
-      }
-    }
-
-    onSend(content);
+    onSend(content, toSendAttachments(attachments));
     setDraft('');
     setCaret(0);
     setSendError(null);
-  }, [
-    draft,
-    onSend,
-    validateAndSend,
-    clientHandlers,
-    slashCommands,
-    pushClientError,
-  ]);
+    setAttachments([]);
+  }, [draft, attachments, onSend, validateAndSend, tryClientCommand]);
 
   const applySelectedCommand = useCallback(() => {
     const cmd = filteredCommands[activeIndex];
@@ -391,13 +487,58 @@ export const Composer: React.FC<ComposerProps> = ({
             onKeyUp={updateCaret}
             onClick={updateCaret}
             onSelect={updateCaret}
+            onPaste={handlePaste}
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
             value={draft}
             rows={1}
             data-streaming={isActive ? 'true' : 'false'}
             aria-label="message input"
           />
         </div>
+        {attachments.length > 0 && (
+          <div className="composer__attachments" aria-label="attachments">
+            {attachments.map((a) => (
+              <span key={a.id} className="composer__chip" title={a.name}>
+                <img
+                  className="composer__chip-thumb"
+                  src={a.dataUri}
+                  alt={a.name}
+                />
+                <span className="composer__chip-name">{a.name}</span>
+                <button
+                  type="button"
+                  className="composer__chip-remove"
+                  aria-label={`remove ${a.name}`}
+                  onClick={() => removeAttachment(a.id)}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
         <div className="composer__bar">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            hidden
+            onChange={(e) => {
+              if (e.currentTarget.files) addImageFiles(e.currentTarget.files);
+              e.currentTarget.value = '';
+            }}
+          />
+          <button
+            type="button"
+            className="composer__attach"
+            aria-label="attach image"
+            title="attach image"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            +img
+          </button>
           <span className="composer__hint">{hintContent}</span>
           <span className="right ctx-pop-anchor" ref={ctxAnchorRef}>
             {modelName && (

--- a/frontend/src/hooks/useAgentChatSocket.ts
+++ b/frontend/src/hooks/useAgentChatSocket.ts
@@ -17,7 +17,11 @@ export interface AgentChatSocketState {
   session: AgentSessionV2 | null;
   connected: boolean;
   send: (msg: Record<string, unknown>) => boolean;
-  sendMessage: (turnId: string, content: string) => void;
+  sendMessage: (
+    turnId: string,
+    content: string,
+    attachments?: Array<{ type: 'image'; path: string; mimeType?: string }>
+  ) => void;
   interrupt: (turnId?: string) => void;
   approve: (requestId: string, decision: AgentApprovalDecisionV2) => void;
   answer: (requestId: string, answers: Record<string, string[]>) => void;
@@ -86,8 +90,17 @@ export function useAgentChatSocket(
   }, []);
 
   const sendMessage = useCallback(
-    (turnId: string, content: string) => {
-      send({ type: 'agent-send-message-v2', turnId, content });
+    (
+      turnId: string,
+      content: string,
+      attachments?: Array<{ type: 'image'; path: string; mimeType?: string }>
+    ) => {
+      send({
+        type: 'agent-send-message-v2',
+        turnId,
+        content,
+        ...(attachments && attachments.length > 0 ? { attachments } : {}),
+      });
     },
     [send]
   );

--- a/test/composer-attachments.test.ts
+++ b/test/composer-attachments.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Composer } from '../frontend/src/components/chat/Composer.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      await Promise.resolve();
+    });
+  }
+}
+
+function pngFile(name = 'pic.png'): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type: 'image/png' });
+}
+
+describe('Composer image attachments', () => {
+  it('shows a chip after selecting an image and sends it as an attachment', async () => {
+    const onSend = vi.fn();
+    act(() =>
+      root.render(
+        React.createElement(Composer, {
+          onSend,
+          onInterrupt: () => {},
+          isActive: false,
+        })
+      )
+    );
+
+    const fileInput = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    expect(fileInput).not.toBeNull();
+
+    // happy-dom lets us define a read-only files list on the input.
+    Object.defineProperty(fileInput, 'files', {
+      value: [pngFile()],
+      configurable: true,
+    });
+    act(() => fileInput.dispatchEvent(new Event('change', { bubbles: true })));
+    await flush();
+
+    const chip = container.querySelector('.composer__chip');
+    expect(chip).not.toBeNull();
+    expect(chip?.querySelector('img')?.getAttribute('src')).toMatch(
+      /^data:image\/png;base64,/
+    );
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [content, attachments] = onSend.mock.calls[0]!;
+    expect(content).toBe('');
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+    });
+    expect(attachments[0].path).toMatch(/^data:image\/png;base64,/);
+
+    // Chip is cleared after send.
+    expect(container.querySelector('.composer__chip')).toBeNull();
+  });
+
+  it('removes an attachment when its remove button is clicked', async () => {
+    act(() =>
+      root.render(
+        React.createElement(Composer, {
+          onSend: () => {},
+          onInterrupt: () => {},
+          isActive: false,
+        })
+      )
+    );
+    const fileInput = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    Object.defineProperty(fileInput, 'files', {
+      value: [pngFile('a.png')],
+      configurable: true,
+    });
+    act(() => fileInput.dispatchEvent(new Event('change', { bubbles: true })));
+    await flush();
+    expect(container.querySelector('.composer__chip')).not.toBeNull();
+
+    const remove = container.querySelector(
+      '.composer__chip-remove'
+    ) as HTMLButtonElement;
+    act(() => remove.click());
+    expect(container.querySelector('.composer__chip')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Chat-first prototype (epic #1058): the Composer can now **attach images** to a message via
- an **+img** file picker (`image/*`, multiple),
- **clipboard paste** of images,
- **drag-and-drop** onto the input.

Attachments render as removable thumbnail **chips**; image-only sends are allowed. They ride the `agent-send-message-v2` frame as `attachments` (data-URI image parts). The server already parses `attachments`, and the Hermes adapter (PR #1073) forwards them to the gateway as `input_image` — so a pasted image reaches the model end-to-end.

## Changes
- `Composer`: attachment state, capture handlers (paste/drop/file), chips, `+img` button; extracted the client-command interception into `tryClientCommand` to keep `submitDraft` within complexity limits.
- `ChatView.handleSend` + `useAgentChatSocket.sendMessage`: thread the optional `attachments` through (backward-compatible — every existing caller is content-only).
- 8MB per-image guard to keep WS frames sane.

## Testing
`test/composer-attachments.test.ts` — selecting an image shows a chip and sends it as an `image` attachment (data URI); chips clear on send and can be removed. `npm run check` clean.

Pairs with #1073 (adapter forwarding) for the full paste-image → model round-trip.

Refs #1058, #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)