### PR TITLE
feat: spawn Hermes chats side-by-side (New Chat + openTabBeside) (#1076, #1077)

### DIFF
--- a/frontend/src/components/WorkspaceArea.css
+++ b/frontend/src/components/WorkspaceArea.css
@@ -75,3 +75,24 @@
   justify-content: flex-end;
   gap: 8px;
 }
+
+.ws-pane-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ws-pane-add__chat {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 1px 5px;
+  cursor: pointer;
+}
+
+.ws-pane-add__chat:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -650,6 +650,7 @@ export function WorkspaceArea({
   const layout = useWorkspaceLayoutStore((s) => s.layout);
   const activePaneId = useWorkspaceLayoutStore((s) => s.activePaneId);
   const addTab = useWorkspaceLayoutStore((s) => s.addTab);
+  const openTabBeside = useWorkspaceLayoutStore((s) => s.openTabBeside);
   const closeTab = useWorkspaceLayoutStore((s) => s.closeTab);
   const selectTab = useWorkspaceLayoutStore((s) => s.selectTab);
   const resetLayout = useWorkspaceLayoutStore((s) => s.resetLayout);
@@ -899,65 +900,120 @@ export function WorkspaceArea({
     [pendingRemoteTerminal, remoteTerminalCreating]
   );
 
+  // #1076/#1077: spawn a native Hermes chat and place it in a split pane
+  // beside the pane whose control was used, so agents can be watched together.
+  const spawnHermesBeside = useCallback(
+    async (paneId: string) => {
+      const { currentActiveWorkspace, currentWorktreePath } =
+        getCurrentSessionContext();
+      if (!currentActiveWorkspace) {
+        useUiStore.getState().setActiveModal({ modal: 'env-picker' });
+        return;
+      }
+      setActivePane(paneId);
+      const { session, error } = await createAgentSession({
+        agent: 'hermes',
+        type: 'agent',
+        mode: 'web',
+        repoPath: currentActiveWorkspace.path,
+        worktreePath: currentWorktreePath,
+        sessionLane: 'local-repo',
+      });
+      if (error && !(error instanceof ConflictError)) {
+        workspaceLogger.error('failed to create hermes chat', error);
+        useToastStore
+          .getState()
+          .showToast(
+            error instanceof Error
+              ? error.message
+              : 'failed to create hermes chat'
+          );
+        return;
+      }
+      if (session?.id) {
+        useSessionsStore.getState().setActiveSessionId(session.id);
+        openTabBeside({
+          kind: 'session',
+          sessionId: session.id,
+          sessionType: 'agent',
+        });
+      }
+    },
+    [setActivePane, openTabBeside]
+  );
+
   const renderAddControl = useCallback(
     (paneId: string) => (
-      <TerminalNodePicker
-        onSelect={async (nodeId) => {
-          // Resolve repoPath + worktreePath from the live session context.
-          // workspacePath is the active worktree's cwd, which the
-          // `/sessions` route would reject as a repoPath; mirror the same
-          // split that handleQuickTerminal uses.
-          const { currentActiveWorkspace, currentWorktreePath } =
-            getCurrentSessionContext();
-          if (!currentActiveWorkspace) {
-            // #862: no active workspace (repo-less hub) — route through the
-            // env-picker so the user can pick a node/cwd to launch a terminal
-            // against, instead of silently bailing. The picker derives its
-            // options from the canonical env inventory and launches a bare
-            // terminal (launchOverrides={{ type: 'terminal' }} wired in App).
-            useUiStore.getState().setActiveModal({ modal: 'env-picker' });
-            return;
-          }
-          // The new session lands in whichever pane is active; activate
-          // the pane whose `+` was used before the create call so the
-          // layout reconciler routes the tab to the correct pane.
-          setActivePane(paneId);
-          const isRemoteNode = nodeId !== DEFAULT_LOCAL_NODE_ID;
-          if (isRemoteNode) {
-            const node = hubNodes?.find(
-              (candidate) => candidate.nodeId === nodeId
-            );
-            setRemoteTerminalError(null);
-            setPendingRemoteTerminal({
-              nodeId,
-              label: node?.displayName || nodeId,
-              ...(node?.homeDir ? { homeDir: node.homeDir } : {}),
-            });
-            return;
-          }
-          const { session, error } = await createAgentSession({
-            repoPath: currentActiveWorkspace.path,
-            worktreePath: currentWorktreePath,
-            type: 'terminal',
-            sessionLane: 'local-repo',
-          });
-          if (error && !(error instanceof ConflictError)) {
-            workspaceLogger.error('failed to create terminal session', error);
-            useToastStore
-              .getState()
-              .showToast(
-                error instanceof Error
-                  ? error.message
-                  : 'failed to create terminal session'
+      <span className="ws-pane-add">
+        <button
+          type="button"
+          className="ws-pane-add__chat"
+          title="new hermes chat beside"
+          aria-label="new hermes chat beside"
+          onClick={() => {
+            void spawnHermesBeside(paneId);
+          }}
+        >
+          +chat
+        </button>
+        <TerminalNodePicker
+          onSelect={async (nodeId) => {
+            // Resolve repoPath + worktreePath from the live session context.
+            // workspacePath is the active worktree's cwd, which the
+            // `/sessions` route would reject as a repoPath; mirror the same
+            // split that handleQuickTerminal uses.
+            const { currentActiveWorkspace, currentWorktreePath } =
+              getCurrentSessionContext();
+            if (!currentActiveWorkspace) {
+              // #862: no active workspace (repo-less hub) — route through the
+              // env-picker so the user can pick a node/cwd to launch a terminal
+              // against, instead of silently bailing. The picker derives its
+              // options from the canonical env inventory and launches a bare
+              // terminal (launchOverrides={{ type: 'terminal' }} wired in App).
+              useUiStore.getState().setActiveModal({ modal: 'env-picker' });
+              return;
+            }
+            // The new session lands in whichever pane is active; activate
+            // the pane whose `+` was used before the create call so the
+            // layout reconciler routes the tab to the correct pane.
+            setActivePane(paneId);
+            const isRemoteNode = nodeId !== DEFAULT_LOCAL_NODE_ID;
+            if (isRemoteNode) {
+              const node = hubNodes?.find(
+                (candidate) => candidate.nodeId === nodeId
               );
-          }
-          if (session?.id) {
-            useSessionsStore.getState().setActiveSessionId(session.id);
-          }
-        }}
-      />
+              setRemoteTerminalError(null);
+              setPendingRemoteTerminal({
+                nodeId,
+                label: node?.displayName || nodeId,
+                ...(node?.homeDir ? { homeDir: node.homeDir } : {}),
+              });
+              return;
+            }
+            const { session, error } = await createAgentSession({
+              repoPath: currentActiveWorkspace.path,
+              worktreePath: currentWorktreePath,
+              type: 'terminal',
+              sessionLane: 'local-repo',
+            });
+            if (error && !(error instanceof ConflictError)) {
+              workspaceLogger.error('failed to create terminal session', error);
+              useToastStore
+                .getState()
+                .showToast(
+                  error instanceof Error
+                    ? error.message
+                    : 'failed to create terminal session'
+                );
+            }
+            if (session?.id) {
+              useSessionsStore.getState().setActiveSessionId(session.id);
+            }
+          }}
+        />
+      </span>
     ),
-    [setActivePane, hubNodes]
+    [setActivePane, hubNodes, spawnHermesBeside]
   );
 
   const renderTab = useCallback(

--- a/frontend/src/lib/stores/workspace-layout-store.ts
+++ b/frontend/src/lib/stores/workspace-layout-store.ts
@@ -42,6 +42,13 @@ interface WorkspaceLayoutState {
     tab: WorkspaceTab,
     opts?: { activate?: boolean; index?: number }
   ) => void;
+  /**
+   * Open a tab in a new pane beside the active pane (splitting it). If the
+   * active pane is empty the tab simply opens in place. Idempotent against the
+   * WorkspaceArea reconciler: a tab already present elsewhere is moved beside
+   * rather than duplicated.
+   */
+  openTabBeside: (tab: WorkspaceTab, direction?: SplitDirection) => void;
   setSplitSizes: (splitId: string, sizes: number[]) => void;
   resetLayout: (tabs: WorkspaceTab[]) => void;
   setLayout: (layout: WorkspaceLayoutNode) => void;
@@ -137,6 +144,40 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutState>()(
         return {
           layout: next,
           activePaneId: opts?.activate === false ? state.activePaneId : paneId,
+        };
+      }),
+
+    openTabBeside: (tab, direction = 'horizontal') =>
+      set((state) => {
+        const paneId =
+          state.activePaneId ?? listPanes(state.layout)[0]?.id ?? null;
+        if (!paneId) return state;
+        const tabId = workspaceTabId(tab);
+        // Ensure the tab exists in the active pane (moves it there if it was
+        // already added elsewhere, e.g. by the WorkspaceArea reconciler).
+        const withTab = addTabToPane(state.layout, paneId, tab, {
+          activate: true,
+        });
+        // Split it out beside the active pane. A single-tab active pane is a
+        // no-op split, so the first agent just opens in place.
+        const next = splitPaneWithTab(
+          withTab,
+          paneId,
+          tabId,
+          direction,
+          'after'
+        );
+        let activePaneId = paneId;
+        for (const pane of listPanes(next)) {
+          if (pane.tabs.some((t) => workspaceTabId(t) === tabId)) {
+            activePaneId = pane.id;
+            break;
+          }
+        }
+        return {
+          layout: next,
+          activePaneId,
+          splitSizes: gcSplitSizes(next, state.splitSizes),
         };
       }),
 

--- a/test/workspace-layout-store.test.ts
+++ b/test/workspace-layout-store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   _resetIdCounters,
   createDefaultWorkspaceLayout,
+  listPanes,
   workspaceTabId,
   type WorkspaceLayoutNode,
   type WorkspacePane,
@@ -153,5 +154,52 @@ describe('workspace-layout-store', () => {
     expect(
       useWorkspaceLayoutStore.getState().splitSizes[split.id]
     ).toBeUndefined();
+  });
+
+  it('openTabBeside splits a new tab beside the active pane', () => {
+    const { setLayout, openTabBeside } = useWorkspaceLayoutStore.getState();
+    setLayout(createDefaultWorkspaceLayout([sessionTab('a')]));
+    openTabBeside(sessionTab('b'));
+
+    const state = useWorkspaceLayoutStore.getState();
+    expect(state.layout.type).toBe('split');
+    const panes = listPanes(state.layout);
+    expect(panes).toHaveLength(2);
+    const paneWithA = panes.find((p) =>
+      p.tabs.some((t) => workspaceTabId(t) === workspaceTabId(sessionTab('a')))
+    );
+    const paneWithB = panes.find((p) =>
+      p.tabs.some((t) => workspaceTabId(t) === workspaceTabId(sessionTab('b')))
+    );
+    expect(paneWithA).toBeDefined();
+    expect(paneWithB).toBeDefined();
+    expect(paneWithA!.id).not.toBe(paneWithB!.id);
+    // Active pane follows the newly opened tab.
+    expect(state.activePaneId).toBe(paneWithB!.id);
+  });
+
+  it('openTabBeside opens in place when the active pane is empty', () => {
+    const { openTabBeside } = useWorkspaceLayoutStore.getState();
+    openTabBeside(sessionTab('solo'));
+    const state = useWorkspaceLayoutStore.getState();
+    expect(state.layout.type).toBe('pane');
+    expect(listPanes(state.layout)).toHaveLength(1);
+    expect((state.layout as WorkspacePane).tabs).toHaveLength(1);
+  });
+
+  it('openTabBeside does not duplicate a tab already open elsewhere', () => {
+    const { setLayout, openTabBeside } = useWorkspaceLayoutStore.getState();
+    setLayout(createDefaultWorkspaceLayout([sessionTab('a')]));
+    openTabBeside(sessionTab('b'));
+    // Calling again with the same tab keeps two panes, no duplicate.
+    openTabBeside(sessionTab('b'));
+    const panes = listPanes(useWorkspaceLayoutStore.getState().layout);
+    expect(panes).toHaveLength(2);
+    const bCount = panes
+      .flatMap((p) => p.tabs)
+      .filter(
+        (t) => workspaceTabId(t) === workspaceTabId(sessionTab('b'))
+      ).length;
+    expect(bCount).toBe(1);
   });
 });


### PR DESCRIPTION
## What

Slices 1 + 2 of the multi-agent prototype (epic #1075): spawn native Hermes chats and watch them **side-by-side**.

- **`openTabBeside(tab, direction?)`** store action — opens a tab in a new pane beside the active pane (composes `addTab` + `splitPaneWithTab`). First tab into an empty pane opens in place; next splits beside. **Idempotent against the WorkspaceArea reconciler** (a tab already open elsewhere is moved, never duplicated).
- **"+chat" pane control** — next to the terminal add-control, creates a native Hermes agent session in the workspace context (`createAgentSession({ agent: 'hermes', type: 'agent', mode: 'web' })`) and places it beside via `openTabBeside`. One-click New Hermes chat (#1076) + side-by-side agents (#1077).

## Testing
`test/workspace-layout-store.test.ts` +3 (`openTabBeside`: splits beside; opens in place when empty; no duplicate). Trigger mirrors the proven terminal-create path; `npm run check` clean; full suite + e2e in CI.

Closes #1076
Closes #1077
Refs #1075, #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)