### PR TITLE
feat(mailbox): compose a local-friend message from the session mailbox (#1079)

### DIFF
--- a/frontend/src/components/SessionMailboxPanel.css
+++ b/frontend/src/components/SessionMailboxPanel.css
@@ -155,3 +155,32 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.session-mailbox-compose {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border);
+}
+
+.session-mailbox-compose__input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  padding: 4px 6px;
+}
+
+.session-mailbox-compose__input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.session-mailbox-compose__error {
+  color: var(--status-error);
+  font-size: var(--font-size-xs);
+}

--- a/frontend/src/components/SessionMailboxPanel.tsx
+++ b/frontend/src/components/SessionMailboxPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { SessionInboxMessageId } from '../../../shared/context-packet.js';
 import type { SessionMailboxAction } from '../hooks/useSessionMailbox.js';
 import { useSessionMailbox } from '../hooks/useSessionMailbox.js';
@@ -5,8 +6,73 @@ import type {
   SessionMailboxMessage,
   SessionMailboxSummary,
 } from '../lib/session-mailbox.js';
+import { sendInboxMessage } from '../lib/api.js';
 import { TuiButton } from './TuiButton.js';
 import './SessionMailboxPanel.css';
+
+interface MailboxComposerProps {
+  targetSessionId: string;
+  onSent: () => void;
+}
+
+/**
+ * Compose a direct message to a LOCAL agent friend — the session that owns this
+ * mailbox — via the inbox (`targetSessionId`). Cross-workspace MAIL
+ * (`targetWorkContextId`) is a separate affordance tracked on #1079.
+ */
+function MailboxComposer({ targetSessionId, onSent }: MailboxComposerProps) {
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const send = async (): Promise<void> => {
+    const text = draft.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      await sendInboxMessage({ targetSessionId, text, contextPacketIds: [] });
+      setDraft('');
+      onSent();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to send message');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="session-mailbox-compose">
+      <input
+        className="session-mailbox-compose__input"
+        value={draft}
+        placeholder="message this agent…"
+        aria-label="message this agent"
+        disabled={sending}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            void send();
+          }
+        }}
+      />
+      <TuiButton
+        size="sm"
+        variant="info"
+        disabled={sending || draft.trim().length === 0}
+        onClick={() => void send()}
+      >
+        {sending ? 'sending' : 'send'}
+      </TuiButton>
+      {error && (
+        <span className="session-mailbox-compose__error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
 
 interface SessionMailboxBadgeProps {
   targetSessionId: string;
@@ -25,7 +91,10 @@ export function SessionMailboxBadge({
   targetSessionId,
   label,
 }: SessionMailboxBadgeProps) {
-  const mailbox = useSessionMailbox(targetSessionId, { mode: 'preview', limit: 6 });
+  const mailbox = useSessionMailbox(targetSessionId, {
+    mode: 'preview',
+    limit: 6,
+  });
   const summary = mailbox.summary;
   const visible =
     mailbox.isLoading ||
@@ -56,7 +125,9 @@ interface SessionMailboxPanelProps {
   compact?: boolean;
 }
 
-function actionForMessage(message: SessionMailboxMessage): SessionMailboxAction[] {
+function actionForMessage(
+  message: SessionMailboxMessage
+): SessionMailboxAction[] {
   if (!message.open) return [];
   const actions: SessionMailboxAction[] = [];
   if (message.ackable) actions.push('ack');
@@ -103,7 +174,10 @@ function SessionMailboxCard({
         {message.createdAt && <span>{message.createdAt}</span>}
       </div>
       {message.artifacts.length > 0 && (
-        <div className="session-mailbox-card__artifacts" aria-label="artifact refs">
+        <div
+          className="session-mailbox-card__artifacts"
+          aria-label="artifact refs"
+        >
           {message.artifacts.map((artifact) => (
             <span key={artifact.packetId} className="session-mailbox-artifact">
               {artifact.kind} · {artifact.label}
@@ -169,15 +243,25 @@ export default function SessionMailboxPanel({
       </div>
       {mailbox.isError ? (
         <div className="session-mailbox-state session-mailbox-state--error">
-          <span>mailbox failed: {mailbox.error?.message ?? 'unknown error'}</span>
-          <TuiButton size="sm" variant="ghost" onClick={() => void mailbox.refetch()}>
+          <span>
+            mailbox failed: {mailbox.error?.message ?? 'unknown error'}
+          </span>
+          <TuiButton
+            size="sm"
+            variant="ghost"
+            onClick={() => void mailbox.refetch()}
+          >
             retry
           </TuiButton>
         </div>
       ) : mailbox.isLoading ? (
-        <div className="session-mailbox-state">loading mailroom messages...</div>
+        <div className="session-mailbox-state">
+          loading mailroom messages...
+        </div>
       ) : mailbox.summary.messages.length === 0 ? (
-        <div className="session-mailbox-state">mailbox clear · no session mail</div>
+        <div className="session-mailbox-state">
+          mailbox clear · no session mail
+        </div>
       ) : (
         <div className="session-mailbox-list">
           {mailbox.summary.messages.map((message) => (
@@ -189,6 +273,12 @@ export default function SessionMailboxPanel({
             />
           ))}
         </div>
+      )}
+      {!compact && (
+        <MailboxComposer
+          targetSessionId={targetSessionId}
+          onSent={() => void mailbox.refetch()}
+        />
       )}
     </section>
   );

--- a/test/session-mailbox-compose.test.ts
+++ b/test/session-mailbox-compose.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  sendInboxMessage: vi.fn(),
+  useSessionMailbox: vi.fn(),
+}));
+
+vi.mock('../frontend/src/lib/api.js', () => ({
+  sendInboxMessage: mocks.sendInboxMessage,
+}));
+
+vi.mock('../frontend/src/hooks/useSessionMailbox.js', () => ({
+  useSessionMailbox: mocks.useSessionMailbox,
+}));
+
+const { default: SessionMailboxPanel } =
+  await import('../frontend/src/components/SessionMailboxPanel.js');
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  mocks.sendInboxMessage.mockReset().mockResolvedValue({});
+  const refetch = vi.fn();
+  mocks.useSessionMailbox.mockReturnValue({
+    summary: {
+      messages: [],
+      unreadCount: 0,
+      openCount: 0,
+      decisionCount: 0,
+      attentionCount: 0,
+      artifactCount: 0,
+      priority: 'normal',
+      latestPreview: null,
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    isUpdating: false,
+    refetch,
+    updateMessage: vi.fn(),
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe('SessionMailboxPanel composer', () => {
+  it('sends a local-friend inbox message to the mailbox session', async () => {
+    act(() =>
+      root.render(
+        React.createElement(SessionMailboxPanel, { targetSessionId: 's1' })
+      )
+    );
+
+    const input = container.querySelector(
+      '.session-mailbox-compose__input'
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+
+    const setValue = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )!.set!;
+    act(() => {
+      setValue.call(input, 'ping from operator');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const sendBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'send'
+    ) as HTMLButtonElement;
+    expect(sendBtn).toBeDefined();
+    act(() => sendBtn.click());
+    await flush();
+
+    expect(mocks.sendInboxMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendInboxMessage).toHaveBeenCalledWith({
+      targetSessionId: 's1',
+      text: 'ping from operator',
+      contextPacketIds: [],
+    });
+    // Input clears after a successful send.
+    expect(
+      (
+        container.querySelector(
+          '.session-mailbox-compose__input'
+        ) as HTMLInputElement
+      ).value
+    ).toBe('');
+  });
+
+  it('does not send an empty message', async () => {
+    act(() =>
+      root.render(
+        React.createElement(SessionMailboxPanel, { targetSessionId: 's1' })
+      )
+    );
+    const sendBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'send'
+    ) as HTMLButtonElement;
+    expect(sendBtn.disabled).toBe(true);
+    act(() => sendBtn.click());
+    await flush();
+    expect(mocks.sendInboxMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Slice 4 (#1079, epic #1075) — first interactive step of the agent messaging surface. The session mailbox panel was **read-only**; it now has a **compose box** to send a direct message to the **LOCAL agent friend** that owns the mailbox — the same-workspace session — via the inbox (`sendInboxMessage({ targetSessionId, text })`), then refreshes.

This makes agent-to-agent messaging usable from the UI, complementing the CLI collaboration prompt (#955 / Slice 3) that already teaches agents to message each other.

## Local-friend vs cross-workspace-MAIL boundary

The inbox send contract already carries the boundary: `targetSessionId` = LOCAL friend (this PR), `targetWorkContextId` = cross-workspace MAIL. The cross-workspace MAIL affordance + an explicit toggle remain on **#1079** (kept open).

## Testing
`test/session-mailbox-compose.test.ts` (2): typing + send calls `sendInboxMessage({ targetSessionId, text, contextPacketIds: [] })` and clears the input; empty message is blocked. `npm run check` clean.

Refs #1075, #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)