### PR TITLE
feat(mailbox): local-friend vs cross-workspace-mail toggle (#1079)

### DIFF
--- a/frontend/src/components/SessionMailboxPanel.css
+++ b/frontend/src/components/SessionMailboxPanel.css
@@ -158,13 +158,40 @@
 
 .session-mailbox-compose {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 6px;
   padding: 6px 8px;
   border-top: 1px solid var(--border);
 }
 
-.session-mailbox-compose__input {
+.session-mailbox-compose__mode {
+  display: flex;
+  gap: 4px;
+}
+
+.session-mailbox-compose__tab {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 1px 8px;
+  cursor: pointer;
+}
+
+.session-mailbox-compose__tab.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.session-mailbox-compose__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.session-mailbox-compose__input,
+.session-mailbox-compose__target {
   flex: 1;
   min-width: 0;
   background: var(--bg);
@@ -175,7 +202,8 @@
   padding: 4px 6px;
 }
 
-.session-mailbox-compose__input:focus {
+.session-mailbox-compose__input:focus,
+.session-mailbox-compose__target:focus {
   outline: none;
   border-color: var(--accent);
 }

--- a/frontend/src/components/SessionMailboxPanel.tsx
+++ b/frontend/src/components/SessionMailboxPanel.tsx
@@ -15,23 +15,41 @@ interface MailboxComposerProps {
   onSent: () => void;
 }
 
+type ComposeMode = 'friend' | 'mail';
+
 /**
- * Compose a direct message to a LOCAL agent friend — the session that owns this
- * mailbox — via the inbox (`targetSessionId`). Cross-workspace MAIL
- * (`targetWorkContextId`) is a separate affordance tracked on #1079.
+ * Compose a message with an explicit local-vs-remote boundary:
+ * - **friend**: a direct message to the LOCAL agent that owns this mailbox
+ *   (same workspace), routed by `targetSessionId`.
+ * - **mail**: cross-workspace MAIL to another work context, routed by
+ *   `targetWorkContextId`.
+ * Both go through the same inbox send contract.
  */
 function MailboxComposer({ targetSessionId, onSent }: MailboxComposerProps) {
+  const [mode, setMode] = useState<ComposeMode>('friend');
   const [draft, setDraft] = useState('');
+  const [mailTarget, setMailTarget] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const targetReady = mode === 'friend' || mailTarget.trim().length > 0;
+  const canSend = draft.trim().length > 0 && targetReady && !sending;
+
   const send = async (): Promise<void> => {
     const text = draft.trim();
-    if (!text || sending) return;
+    if (!text || !targetReady || sending) return;
     setSending(true);
     setError(null);
     try {
-      await sendInboxMessage({ targetSessionId, text, contextPacketIds: [] });
+      await sendInboxMessage(
+        mode === 'mail'
+          ? {
+              targetWorkContextId: mailTarget.trim(),
+              text,
+              contextPacketIds: [],
+            }
+          : { targetSessionId, text, contextPacketIds: [] }
+      );
       setDraft('');
       onSent();
     } catch (err) {
@@ -43,28 +61,66 @@ function MailboxComposer({ targetSessionId, onSent }: MailboxComposerProps) {
 
   return (
     <div className="session-mailbox-compose">
-      <input
-        className="session-mailbox-compose__input"
-        value={draft}
-        placeholder="message this agent…"
-        aria-label="message this agent"
-        disabled={sending}
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault();
-            void send();
-          }
-        }}
-      />
-      <TuiButton
-        size="sm"
-        variant="info"
-        disabled={sending || draft.trim().length === 0}
-        onClick={() => void send()}
+      <div
+        className="session-mailbox-compose__mode"
+        role="group"
+        aria-label="message target"
       >
-        {sending ? 'sending' : 'send'}
-      </TuiButton>
+        <button
+          type="button"
+          className={`session-mailbox-compose__tab${mode === 'friend' ? ' is-active' : ''}`}
+          aria-pressed={mode === 'friend'}
+          onClick={() => setMode('friend')}
+        >
+          friend
+        </button>
+        <button
+          type="button"
+          className={`session-mailbox-compose__tab${mode === 'mail' ? ' is-active' : ''}`}
+          aria-pressed={mode === 'mail'}
+          onClick={() => setMode('mail')}
+        >
+          mail
+        </button>
+      </div>
+      {mode === 'mail' && (
+        <input
+          className="session-mailbox-compose__target"
+          value={mailTarget}
+          placeholder="work-context id…"
+          aria-label="mail target work context"
+          disabled={sending}
+          onChange={(e) => setMailTarget(e.target.value)}
+        />
+      )}
+      <div className="session-mailbox-compose__row">
+        <input
+          className="session-mailbox-compose__input"
+          value={draft}
+          placeholder={
+            mode === 'mail' ? 'mail another workspace…' : 'message this agent…'
+          }
+          aria-label={
+            mode === 'mail' ? 'mail another workspace' : 'message this agent'
+          }
+          disabled={sending}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void send();
+            }
+          }}
+        />
+        <TuiButton
+          size="sm"
+          variant="info"
+          disabled={!canSend}
+          onClick={() => void send()}
+        >
+          {sending ? 'sending' : 'send'}
+        </TuiButton>
+      </div>
       {error && (
         <span className="session-mailbox-compose__error" role="alert">
           {error}

--- a/test/session-mailbox-compose.test.ts
+++ b/test/session-mailbox-compose.test.ts
@@ -110,6 +110,48 @@ describe('SessionMailboxPanel composer', () => {
     ).toBe('');
   });
 
+  it('sends cross-workspace MAIL to a work context when in mail mode', async () => {
+    act(() =>
+      root.render(
+        React.createElement(SessionMailboxPanel, { targetSessionId: 's1' })
+      )
+    );
+    const setValue = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )!.set!;
+
+    const mailTab = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'mail'
+    ) as HTMLButtonElement;
+    act(() => mailTab.click());
+
+    const target = container.querySelector(
+      '.session-mailbox-compose__target'
+    ) as HTMLInputElement;
+    const input = container.querySelector(
+      '.session-mailbox-compose__input'
+    ) as HTMLInputElement;
+    act(() => {
+      setValue.call(target, 'wc-other-workspace');
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      setValue.call(input, 'mail across workspaces');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const sendBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'send'
+    ) as HTMLButtonElement;
+    act(() => sendBtn.click());
+    await flush();
+
+    expect(mocks.sendInboxMessage).toHaveBeenCalledWith({
+      targetWorkContextId: 'wc-other-workspace',
+      text: 'mail across workspaces',
+      contextPacketIds: [],
+    });
+  });
+
   it('does not send an empty message', async () => {
     act(() =>
       root.render(


### PR DESCRIPTION
## What

Completes Slice 4 (#1079, epic #1075): the mailbox composer now makes the **local-vs-remote boundary** explicit with a `friend` / `mail` toggle.

- **friend** — direct message to the LOCAL agent that owns this mailbox (same workspace), routed by `targetSessionId`.
- **mail** — cross-workspace MAIL to another work context, routed by `targetWorkContextId`; mail mode reveals a work-context-id target field.

Both go through the same inbox send contract (`sendInboxMessage`), so the boundary is a routing choice the user makes explicitly — exactly the "message a local agent friend vs post mail to another workspace" distinction from the epic.

## Testing
`test/session-mailbox-compose.test.ts` (3): friend → `{ targetSessionId }`; mail → `{ targetWorkContextId }`; empty blocked. `npm run check` clean.

Closes #1079
Refs #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)