### PR TITLE
feat(sidebar): group topics under workspace channel headers (#1083)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1199,3 +1199,35 @@
     word-break: break-word;
   }
 }
+
+/* #1083: workspace-first channel grouping */
+.topic-workspace-group {
+  display: block;
+}
+
+.topic-workspace-group__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px 2px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  text-transform: lowercase;
+}
+
+.topic-workspace-group__icon {
+  flex-shrink: 0;
+}
+
+.topic-workspace-group__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-tree__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -44,13 +44,16 @@ import type { SessionSummary } from '../lib/types.js';
 import { formatRelativeTimeCompact } from '../lib/utils.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
+import { useIaWorkspacesQuery } from '../lib/hooks/use-ia-workspaces.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { durabilityDisabledReason } from '../lib/session-durability.js';
 import { resolveSessionByKey } from '../lib/session-keys.js';
 import {
   buildTopicNavModel,
+  groupTopicsByWorkspace,
   type TopicNavItem,
   type TopicNavModel,
+  type TopicNavWorkspace,
   type TopicNavParticipantRef,
   type TopicNavSessionRef,
   type TopicNavSurfaceRef,
@@ -1733,6 +1736,7 @@ function TopicSearchPanel({
 const EMPTY_TOPICS: WorkspaceTopic[] = [];
 const EMPTY_SURFACES: WorkspaceSurface[] = [];
 const EMPTY_SEARCH_RESULTS: WorkspaceTopicSearchResult[] = [];
+const EMPTY_WORKSPACES: TopicNavWorkspace[] = [];
 
 export function TopicSidebarView({
   topics,
@@ -1756,10 +1760,14 @@ export function TopicSidebarView({
   onSendInput = sendSessionInput,
   createPanel,
   onCreateTaskRoom,
+  workspaces = EMPTY_WORKSPACES,
+  activeWorkspaceId = null,
 }: {
   topics: WorkspaceTopic[];
   sessions: SessionSummary[];
   surfaces: WorkspaceSurface[];
+  workspaces?: TopicNavWorkspace[];
+  activeWorkspaceId?: string | null;
   loading?: boolean;
   error?: boolean;
   derived?: boolean;
@@ -1786,6 +1794,10 @@ export function TopicSidebarView({
   const topicsById = useMemo(
     () => new Map(topics.map((topic) => [topic.id, topic])),
     [topics]
+  );
+  const grouped = useMemo(
+    () => groupTopicsByWorkspace(model, workspaces, activeWorkspaceId),
+    [model, workspaces, activeWorkspaceId]
   );
   const firstId = model.rootIds[0] ?? model.items[0]?.id ?? null;
   const [selectedId, setSelectedId] = useState<string | null>(firstId);
@@ -1829,6 +1841,22 @@ export function TopicSidebarView({
     },
     [topicsById]
   );
+  const renderTopicRow = (id: string): ReactNode => {
+    const item = model.byId.get(id);
+    return item ? (
+      <TopicRow
+        key={item.id}
+        item={item}
+        depth={0}
+        model={model}
+        expandedIds={expandedIds}
+        selectedId={selectedId}
+        onToggle={toggle}
+        onSelect={select}
+        onSelectSession={onSelectSession}
+      />
+    ) : null;
+  };
   const selectedItem = selectedId ? model.byId.get(selectedId) : undefined;
   const mobileItems = useMemo(
     () =>
@@ -1890,24 +1918,47 @@ export function TopicSidebarView({
         onSearchClear={onSearchClear}
         onSelectSession={onSelectSession}
       />
-      <ul className="topic-tree" aria-label="workspace topics">
-        {model.rootIds.map((id) => {
-          const item = model.byId.get(id);
-          return item ? (
-            <TopicRow
-              key={item.id}
-              item={item}
-              depth={0}
-              model={model}
-              expandedIds={expandedIds}
-              selectedId={selectedId}
-              onToggle={toggle}
-              onSelect={select}
-              onSelectSession={onSelectSession}
-            />
-          ) : null;
-        })}
-      </ul>
+      <div className="topic-tree" aria-label="workspace topics">
+        {grouped.groups.map((group) => (
+          <section
+            key={group.id}
+            className="topic-workspace-group"
+            aria-label={group.title}
+          >
+            <div className="topic-workspace-group__header">
+              {group.icon ? (
+                <span
+                  className="topic-workspace-group__icon"
+                  aria-hidden="true"
+                >
+                  {group.icon}
+                </span>
+              ) : null}
+              <span className="topic-workspace-group__name">{group.title}</span>
+            </div>
+            <ul className="topic-tree__list">
+              {group.rootIds.map((id) => renderTopicRow(id))}
+            </ul>
+          </section>
+        ))}
+        {grouped.orphanRootIds.length > 0 ? (
+          <section
+            className="topic-workspace-group topic-workspace-group--orphan"
+            aria-label="no workspace"
+          >
+            {grouped.groups.length > 0 ? (
+              <div className="topic-workspace-group__header">
+                <span className="topic-workspace-group__name">
+                  no workspace
+                </span>
+              </div>
+            ) : null}
+            <ul className="topic-tree__list">
+              {grouped.orphanRootIds.map((id) => renderTopicRow(id))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
       {selectedItem ? (
         <>
           <TopicDetail
@@ -1961,6 +2012,11 @@ export function TopicSidebarShell({
     queryFn: () => fetchWorkspaceTopics(),
     staleTime: 30_000,
   });
+  const workspacesQuery = useIaWorkspacesQuery();
+  const viewWorkspaces = useMemo<TopicNavWorkspace[]>(
+    () => workspacesQuery.data ?? EMPTY_WORKSPACES,
+    [workspacesQuery.data]
+  );
   const topicSearchQuery = useQuery({
     queryKey: ['workspace-topics', 'search', normalizedSearchQuery],
     queryFn: () =>
@@ -2198,6 +2254,7 @@ export function TopicSidebarShell({
       topics={viewTopics}
       sessions={sessions}
       surfaces={viewSurfaces}
+      workspaces={viewWorkspaces}
       loading={!searchActive && topicsQuery.isLoading && !topicsQuery.data}
       error={topicsQuery.isError && !topicsQuery.data && !searchActive}
       surfacesLoading={surfacesQuery.isLoading && !surfacesQuery.data}

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -101,6 +101,88 @@ export interface TopicNavModel {
   derived: boolean;
 }
 
+/** Minimal workspace shape the topic sidebar groups channels under. */
+export interface TopicNavWorkspace {
+  id: string;
+  name: string;
+  order: number;
+  pinned: boolean;
+  color: string | null;
+  icon: string | null;
+}
+
+export interface TopicNavWorkspaceGroup {
+  id: string;
+  title: string;
+  color: string | null;
+  icon: string | null;
+  pinned: boolean;
+  rootIds: WorkspaceTopicId[];
+}
+
+export interface GroupedTopicNav {
+  groups: TopicNavWorkspaceGroup[];
+  /** Root topics whose workspace is unknown/unset (the "no workspace" lane). */
+  orphanRootIds: WorkspaceTopicId[];
+}
+
+/**
+ * Group the model's root topics under their workspace (the Discord
+ * server→channel shape). Workspaces sort pinned-first then by `order`. When
+ * `activeWorkspaceId` is set, collapse to just that workspace (orphans hidden);
+ * when null, every workspace group plus the orphan lane is returned. Pure and
+ * backward-compatible: with no workspaces, all roots fall into `orphanRootIds`.
+ */
+export function groupTopicsByWorkspace(
+  model: TopicNavModel,
+  workspaces: TopicNavWorkspace[],
+  activeWorkspaceId: string | null
+): GroupedTopicNav {
+  const rootsByWorkspace = new Map<string, WorkspaceTopicId[]>();
+  const orphanRootIds: WorkspaceTopicId[] = [];
+  const knownIds = new Set(workspaces.map((w) => w.id));
+  for (const id of model.rootIds) {
+    const workspaceId = model.byId.get(id)?.workspaceId;
+    if (workspaceId && knownIds.has(workspaceId)) {
+      const bucket = rootsByWorkspace.get(workspaceId);
+      if (bucket) bucket.push(id);
+      else rootsByWorkspace.set(workspaceId, [id]);
+    } else {
+      orphanRootIds.push(id);
+    }
+  }
+
+  const ordered = [...workspaces].sort(
+    (a, b) =>
+      Number(b.pinned) - Number(a.pinned) ||
+      a.order - b.order ||
+      a.id.localeCompare(b.id)
+  );
+
+  const visible =
+    activeWorkspaceId != null
+      ? ordered.filter((w) => w.id === activeWorkspaceId)
+      : ordered;
+
+  const groups: TopicNavWorkspaceGroup[] = visible
+    .map((w) => ({
+      id: w.id,
+      title: w.name,
+      color: w.color,
+      icon: w.icon,
+      pinned: w.pinned,
+      rootIds: rootsByWorkspace.get(w.id) ?? [],
+    }))
+    // Hide empty workspace groups only in the all-workspaces view; keep the
+    // active workspace visible even when it has no channels yet.
+    .filter((g) => activeWorkspaceId != null || g.rootIds.length > 0);
+
+  return {
+    groups,
+    orphanRootIds: activeWorkspaceId != null ? [] : orphanRootIds,
+  };
+}
+
 function basename(path: string | undefined): string | null {
   if (!path) return null;
   const trimmed = path.replace(/[\\/]+$/, '');

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import type { WorkspaceSurface } from '../shared/workspace-surfaces.js';
 import type { WorkspaceTopic } from '../shared/workspace-topics.js';
-import { buildTopicNavModel } from '../frontend/src/lib/state/topic-nav.js';
+import {
+  buildTopicNavModel,
+  groupTopicsByWorkspace,
+  type TopicNavWorkspace,
+} from '../frontend/src/lib/state/topic-nav.js';
 import { makeSession } from './helpers/frontend-factories.js';
+
+function makeWorkspace(
+  overrides: Partial<TopicNavWorkspace> = {}
+): TopicNavWorkspace {
+  return {
+    id: 'ws:a',
+    name: 'workspace a',
+    order: 0,
+    pinned: false,
+    color: null,
+    icon: null,
+    ...overrides,
+  };
+}
 
 const NOW = '2026-06-26T00:00:00Z';
 
@@ -438,5 +456,79 @@ describe('buildTopicNavModel', () => {
     expect(model.byId.get('topic:a')?.childIds).toEqual([]);
     expect(model.byId.get('topic:b')?.childIds).toEqual([]);
     expect(model.byId.get('topic:self')?.childIds).toEqual([]);
+  });
+});
+
+describe('groupTopicsByWorkspace', () => {
+  const model = () =>
+    buildTopicNavModel({
+      topics: [
+        makeTopic({ id: 't:a1', workspaceId: 'ws:a' }),
+        makeTopic({ id: 't:b1', workspaceId: 'ws:b' }),
+        makeTopic({ id: 't:orphan', workspaceId: 'ws:unknown' }),
+      ],
+      sessions: [],
+      surfaces: [],
+      derived: false,
+    });
+
+  it('groups roots under their workspace and orphans the rest', () => {
+    const grouped = groupTopicsByWorkspace(
+      model(),
+      [
+        makeWorkspace({ id: 'ws:a', name: 'A', order: 1 }),
+        makeWorkspace({ id: 'ws:b', name: 'B', order: 0 }),
+      ],
+      null
+    );
+    // Sorted by order: B (0) before A (1).
+    expect(grouped.groups.map((g) => g.id)).toEqual(['ws:b', 'ws:a']);
+    expect(grouped.groups[0]!.rootIds).toEqual(['t:b1']);
+    expect(grouped.groups[1]!.rootIds).toEqual(['t:a1']);
+    expect(grouped.orphanRootIds).toEqual(['t:orphan']);
+  });
+
+  it('floats pinned workspaces before order', () => {
+    const grouped = groupTopicsByWorkspace(
+      model(),
+      [
+        makeWorkspace({ id: 'ws:a', order: 0, pinned: false }),
+        makeWorkspace({ id: 'ws:b', order: 9, pinned: true }),
+      ],
+      null
+    );
+    expect(grouped.groups.map((g) => g.id)).toEqual(['ws:b', 'ws:a']);
+  });
+
+  it('collapses to a single workspace and hides orphans when active', () => {
+    const grouped = groupTopicsByWorkspace(
+      model(),
+      [makeWorkspace({ id: 'ws:a' }), makeWorkspace({ id: 'ws:b' })],
+      'ws:a'
+    );
+    expect(grouped.groups.map((g) => g.id)).toEqual(['ws:a']);
+    expect(grouped.orphanRootIds).toEqual([]);
+  });
+
+  it('drops empty groups in the all view but keeps the active one', () => {
+    const grouped = groupTopicsByWorkspace(
+      model(),
+      [makeWorkspace({ id: 'ws:a' }), makeWorkspace({ id: 'ws:empty' })],
+      null
+    );
+    expect(grouped.groups.map((g) => g.id)).toEqual(['ws:a']);
+    const active = groupTopicsByWorkspace(
+      model(),
+      [makeWorkspace({ id: 'ws:empty' })],
+      'ws:empty'
+    );
+    expect(active.groups.map((g) => g.id)).toEqual(['ws:empty']);
+    expect(active.groups[0]!.rootIds).toEqual([]);
+  });
+
+  it('puts every root in the orphan lane when there are no workspaces', () => {
+    const grouped = groupTopicsByWorkspace(model(), [], null);
+    expect(grouped.groups).toEqual([]);
+    expect(grouped.orphanRootIds).toEqual(['t:a1', 't:b1', 't:orphan']);
   });
 });

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -134,6 +134,52 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('preview');
   });
 
+  it('groups topics under workspace channel headers', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:a',
+          workspaceId: 'ws:a',
+          display: { title: 'Alpha channel' },
+          linkedRefs: {},
+        }),
+        makeTopic({
+          id: 'topic:b',
+          workspaceId: 'ws:b',
+          display: { title: 'Beta channel' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      workspaces: [
+        {
+          id: 'ws:a',
+          name: 'engineering',
+          order: 0,
+          pinned: false,
+          color: null,
+          icon: null,
+        },
+        {
+          id: 'ws:b',
+          name: 'research',
+          order: 1,
+          pinned: false,
+          color: null,
+          icon: null,
+        },
+      ],
+    });
+    const headers = Array.from(
+      container.querySelectorAll('.topic-workspace-group__name')
+    ).map((el) => el.textContent);
+    expect(headers).toContain('engineering');
+    expect(headers).toContain('research');
+    expect(container.textContent).toContain('Alpha channel');
+    expect(container.textContent).toContain('Beta channel');
+  });
+
   it('selects linked sessions using the existing sidebar callback', async () => {
     await renderView();
     const sessionButton = container.querySelector(


### PR DESCRIPTION
## What

Slice 1 (keystone) of epic #1021 — the Discord **server → channel** scan. The topic sidebar rendered a flat topic list; it now groups root topics under their **workspace**, with a "no workspace" lane for orphan/derived topics.

- New pure `groupTopicsByWorkspace(model, workspaces, activeWorkspaceId)` in `topic-nav.ts` — partitions the existing nav model by each item's `workspaceId`, sorts workspaces pinned-first then by `order`, drops empty groups in the all view, and can collapse to a single active workspace (for a future rail selection).
- `TopicSidebarShell` fetches workspaces (`useIaWorkspacesQuery`) and renders workspace-header sections; each topic still uses the existing `TopicRow`.

## Backward-compatible

With no workspaces, every root falls into the orphan lane → the current flat list is preserved. No schema change; substrate (`WorkspaceBar` + persisted `activeWorkspaceId` + `workspaceId` on every `TopicNavItem`) already on nightly.

## Scope note

This ships the **grouping**. Active-workspace *filtering* (collapse to one) is wired + tested in the pure fn but not driven yet — it activates when the workspace rail is integrated into the chat-first sidebar (follow-up slice). Left as `null` here so nothing is hidden.

## Testing
`test/topic-nav.test.ts` +5 (grouping, pin-float, active-collapse, empty-group drop, no-workspace orphan lane); `test/topic-sidebar-shell.test.ts` +1 (workspace headers render). 56 green. `npm run check` clean.

Refs #1021, #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)