### PR TITLE
feat(hermes): channel prompt defaults flow to the launched agent (#1086)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -36,7 +36,10 @@ import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from './types.js';
 
 import { setupWebSocket } from './ws.js';
 import { createLocalRelayNode } from './local-node.js';
-import { buildRelayHermesMetadata } from './protocol-adapters/hermes-adapter.js';
+import {
+  buildHermesInstructions,
+  buildRelayHermesMetadata,
+} from './protocol-adapters/hermes-adapter.js';
 import {
   DEFAULT_LOCAL_NODE_ID,
   parseGlobalSessionId,
@@ -347,18 +350,30 @@ const TERMINAL_BACKEND_RELAY_PTY: TerminalBackend = 'relay-pty';
 /**
  * Build the `extra` payload for a Hermes web session so its conversation is
  * tagged with the topic/workspace/repo/node anchors (via the responses
- * `metadata` field). Returns an empty object for non-Hermes agents or when
- * there is no context to attach, so it can be spread into createWeb params.
+ * `metadata` field) and carries the channel's prompt defaults (via the
+ * responses `instructions` field). Returns an empty object for non-Hermes
+ * agents or when there is nothing to attach, so it can be spread into
+ * createWeb params.
  */
 function buildHermesCreateExtra(
   resolvedAgent: string,
   ctx: {
-    workspaceTopic?: { id?: string; workspaceId?: string } | null | undefined;
+    workspaceTopic?:
+      | {
+          id?: string;
+          workspaceId?: string;
+          promptDefaults?: {
+            systemPrompt?: string | null;
+            instructions?: string | null;
+          };
+        }
+      | null
+      | undefined;
     repoPath?: string | null | undefined;
     branchName?: string | null | undefined;
     nodeId?: string | null | undefined;
   }
-): { extra: { metadata: Record<string, string> } } | Record<string, never> {
+): { extra: Record<string, unknown> } | Record<string, never> {
   if (resolvedAgent !== 'hermes') return {};
   const metadata = buildRelayHermesMetadata({
     topicId: ctx.workspaceTopic?.id,
@@ -367,7 +382,13 @@ function buildHermesCreateExtra(
     branchName: ctx.branchName,
     nodeId: ctx.nodeId,
   });
-  return Object.keys(metadata).length > 0 ? { extra: { metadata } } : {};
+  const instructions = buildHermesInstructions(
+    ctx.workspaceTopic?.promptDefaults
+  );
+  const extra: Record<string, unknown> = {};
+  if (Object.keys(metadata).length > 0) extra['metadata'] = metadata;
+  if (instructions) extra['instructions'] = instructions;
+  return Object.keys(extra).length > 0 ? { extra } : {};
 }
 
 const localRelayNode = createLocalRelayNode();

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -494,6 +494,22 @@ export function buildRelayHermesMetadata(input: {
   return md;
 }
 
+/**
+ * Combine a channel/topic's system prompt + instructions into a single
+ * Responses-API `instructions` string, so a channel behaves like a
+ * pre-configured room. Returns undefined when there is nothing to send.
+ */
+export function buildHermesInstructions(
+  promptDefaults:
+    | { systemPrompt?: string | null; instructions?: string | null }
+    | undefined
+): string | undefined {
+  const parts = [promptDefaults?.systemPrompt, promptDefaults?.instructions]
+    .map((part) => (typeof part === 'string' ? part.trim() : ''))
+    .filter((part) => part.length > 0);
+  return parts.length > 0 ? parts.join('\n\n') : undefined;
+}
+
 const MIME_BY_EXTENSION: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -646,6 +662,10 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     );
     if (metadata) {
       body['metadata'] = metadata;
+    }
+    const instructions = this._config?.extra?.['instructions'];
+    if (typeof instructions === 'string' && instructions.trim()) {
+      body['instructions'] = instructions;
     }
 
     try {

--- a/test/hermes-channel-prompt.test.ts
+++ b/test/hermes-channel-prompt.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHermesInstructions,
+  resolveHermesGatewaySettings,
+} from '../server/protocol-adapters/hermes-adapter.js';
+
+describe('buildHermesInstructions', () => {
+  it('combines systemPrompt and instructions', () => {
+    expect(
+      buildHermesInstructions({
+        systemPrompt: 'You are the ops channel bot.',
+        instructions: 'Prefer terse answers.',
+      })
+    ).toBe('You are the ops channel bot.\n\nPrefer terse answers.');
+  });
+
+  it('returns a single part when only one is set', () => {
+    expect(buildHermesInstructions({ systemPrompt: 'sys' })).toBe('sys');
+    expect(buildHermesInstructions({ instructions: 'inst' })).toBe('inst');
+  });
+
+  it('returns undefined when there is nothing to send', () => {
+    expect(buildHermesInstructions({})).toBeUndefined();
+    expect(buildHermesInstructions(undefined)).toBeUndefined();
+    expect(
+      buildHermesInstructions({ systemPrompt: '  ', instructions: null })
+    ).toBeUndefined();
+  });
+});
+
+// Live: proves the gateway accepts channel instructions on a responses request.
+describe('live Hermes gateway channel instructions', () => {
+  it('accepts an instructions-tagged responses request', async () => {
+    const settings = resolveHermesGatewaySettings(undefined);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(settings.apiKey
+        ? { Authorization: `Bearer ${settings.apiKey}` }
+        : {}),
+    };
+    let reachable: boolean;
+    try {
+      const health = await fetch(`${settings.endpoint}/health`, {
+        headers,
+        signal: AbortSignal.timeout(1000),
+      });
+      reachable = health.ok;
+    } catch {
+      reachable = false;
+    }
+    if (!reachable) {
+      // eslint-disable-next-line no-console
+      console.log('[skip] no live Hermes gateway at', settings.endpoint);
+      return;
+    }
+    const instructions = buildHermesInstructions({
+      systemPrompt: 'You are a relay channel assistant.',
+      instructions: 'Reply in one short sentence.',
+    });
+    const res = await fetch(`${settings.endpoint}/v1/responses`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        input: 'ping',
+        stream: false,
+        store: true,
+        session_id: 'relay-channel-instr-itest',
+        instructions,
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+    expect(res.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Slice 4 of epic #1021 — channels carry **behavior**, not just tags. A topic/channel's `promptDefaults` (systemPrompt + instructions) now shape the launched Hermes conversation.

- `buildHermesInstructions` combines a channel's `systemPrompt` + `instructions` into one string.
- `buildHermesCreateExtra` (POST /sessions) adds it as `extra.instructions`; the adapter forwards it as the Responses `instructions` field on each turn.

So opening a chat in the "ops" channel vs the "research" channel gives the agent the channel's pre-configured system behavior. Live-verified against the ebi gateway (`instructions` accepted, HTTP 200).

## Testing
`test/hermes-channel-prompt.test.ts` — 3 pure (`buildHermesInstructions`: combine, single, empty) + 1 live-gated round-trip. `npm run check` clean.

Refs #1021, #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)