### PR TITLE
feat(topics): channel-type facet + icon/color on topics (#1085)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -225,15 +225,25 @@ function topicLatestStatus(item: TopicNavItem): string {
 }
 
 function TopicBadge({ item }: { item: TopicNavItem }) {
+  const background = item.color ?? deriveColor(item.badgeSeed);
+  const label = item.channelKind
+    ? `${item.channelKind} channel`
+    : `${item.kindLabel} workspace`;
   return (
     <span
       className="topic-row__badge"
-      data-kind={item.kind}
-      style={{ background: deriveColor(item.badgeSeed) }}
-      aria-label={`${item.kindLabel} workspace`}
-      title={`${item.kindLabel} workspace`}
+      data-kind={item.channelKind ?? item.kind}
+      style={{ background }}
+      aria-label={label}
+      title={label}
     >
-      <TopicKindIcon kind={item.kind} />
+      {item.icon ? (
+        <span className="topic-row__channel-icon" aria-hidden="true">
+          {item.icon}
+        </span>
+      ) : (
+        <TopicKindIcon kind={item.kind} />
+      )}
     </span>
   );
 }

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceSurface } from '../../../../shared/workspace-surfaces.js';
 import type {
   WorkspaceTopic,
+  WorkspaceTopicChannelKind,
   WorkspaceTopicId,
 } from '../../../../shared/workspace-topics.js';
 import type { SessionSummary } from '../types.js';
@@ -77,6 +78,10 @@ export interface TopicNavItem {
   badgeSeed: string;
   kind: TopicNavKind;
   kindLabel: string;
+  /** User-chosen Discord-style channel taxonomy (repo/product-area/…). */
+  channelKind: WorkspaceTopicChannelKind | null;
+  icon: string | null;
+  color: string | null;
   pinned: boolean;
   muted: boolean;
   order: number;
@@ -604,6 +609,9 @@ export function buildTopicNavModel(input: {
       badgeSeed: topic.workspaceId || topic.display.title,
       kind: kind.kind,
       kindLabel: kind.label,
+      channelKind: topic.display.kind ?? null,
+      icon: topic.display.icon ?? null,
+      color: topic.display.color ?? null,
       pinned: topic.state.pinned,
       muted: topic.state.muted,
       order,

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -56,11 +56,37 @@ export interface WorkspaceTopicPrivacyMetadata {
   rawDefaultsStored: false;
 }
 
+/**
+ * Discord-style channel taxonomy for a topic — a semantic facet chosen by the
+ * user, distinct from the routing-derived structural kind (repo/folder/thread).
+ */
+export type WorkspaceTopicChannelKind =
+  | 'repo'
+  | 'product-area'
+  | 'journal'
+  | 'ops'
+  | 'research'
+  | 'topic';
+
+export const WORKSPACE_TOPIC_CHANNEL_KINDS: readonly WorkspaceTopicChannelKind[] =
+  ['repo', 'product-area', 'journal', 'ops', 'research', 'topic'] as const;
+
+export function isWorkspaceTopicChannelKind(
+  value: unknown
+): value is WorkspaceTopicChannelKind {
+  return (
+    typeof value === 'string' &&
+    (WORKSPACE_TOPIC_CHANNEL_KINDS as readonly string[]).includes(value)
+  );
+}
+
 export interface WorkspaceTopicDisplay {
   title: string;
   description?: string;
   icon?: string;
   color?: string;
+  /** Optional channel taxonomy (repo/product-area/journal/ops/research/topic). */
+  kind?: WorkspaceTopicChannelKind;
 }
 
 export interface WorkspaceTopicGrouping {
@@ -189,6 +215,7 @@ export interface WorkspaceTopicCreateInput {
   workspaceId: WorkspaceId;
   title: string;
   description?: string;
+  channelKind?: WorkspaceTopicChannelKind;
   visibility?: WorkspaceTopicVisibility;
   grouping?: WorkspaceTopicGrouping;
   promptDefaults?: WorkspaceTopicPromptDefaults;
@@ -202,6 +229,7 @@ export interface WorkspaceTopicCreateInput {
 export interface WorkspaceTopicUpdateInput {
   title?: string;
   description?: string | null;
+  channelKind?: WorkspaceTopicChannelKind | null;
   visibility?: WorkspaceTopicVisibility;
   grouping?: WorkspaceTopicGrouping;
   promptDefaults?: WorkspaceTopicPromptDefaults;
@@ -339,6 +367,7 @@ export class WorkspaceTopicValidationError extends Error {
 
 const TOPIC_ID_PATTERN = /^topic:[A-Za-z0-9._~%-]{1,160}$/;
 const VISIBILITIES = new Set<string>(['default', 'private', 'shared']);
+const CHANNEL_KINDS = new Set<string>(WORKSPACE_TOPIC_CHANNEL_KINDS);
 const PRIVACY_CLASSES = new Set<string>(['public', 'internal', 'sensitive']);
 const RETENTION_CLASSES = new Set<string>([
   'ephemeral',
@@ -922,6 +951,14 @@ export function parseWorkspaceTopicCreateInput(
     WORKSPACE_TOPIC_DESCRIPTION_MAX
   );
   if (description) out.description = description;
+  if (record['channelKind'] !== undefined && record['channelKind'] !== null) {
+    out.channelKind = readEnum<WorkspaceTopicChannelKind>(
+      record['channelKind'],
+      'channelKind',
+      CHANNEL_KINDS,
+      'topic'
+    );
+  }
   out.visibility = readEnum<WorkspaceTopicVisibility>(
     record['visibility'],
     'visibility',
@@ -958,6 +995,16 @@ export function parseWorkspaceTopicUpdateInput(
       WORKSPACE_TOPIC_DESCRIPTION_MAX
     );
     if (description) out.description = description;
+  }
+  if (record['channelKind'] === null) {
+    out.channelKind = null;
+  } else if (record['channelKind'] !== undefined) {
+    out.channelKind = readEnum<WorkspaceTopicChannelKind>(
+      record['channelKind'],
+      'channelKind',
+      CHANNEL_KINDS,
+      'topic'
+    );
   }
   if (record['visibility'] !== undefined) {
     out.visibility = readEnum<WorkspaceTopicVisibility>(
@@ -1247,6 +1294,7 @@ export function buildWorkspaceTopicRecord(input: {
       ...(input.create.description
         ? { description: input.create.description }
         : {}),
+      ...(input.create.channelKind ? { kind: input.create.channelKind } : {}),
     },
     grouping: input.create.grouping ?? {},
     promptDefaults: input.create.promptDefaults ?? {},
@@ -1274,6 +1322,8 @@ export function applyWorkspaceTopicUpdate(input: {
   if (patch.description === null) delete display.description;
   else if (patch.description !== undefined)
     display.description = patch.description;
+  if (patch.channelKind === null) delete display.kind;
+  else if (patch.channelKind !== undefined) display.kind = patch.channelKind;
   return {
     ...topic,
     display,

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -532,3 +532,29 @@ describe('groupTopicsByWorkspace', () => {
     expect(grouped.orphanRootIds).toEqual(['t:a1', 't:b1', 't:orphan']);
   });
 });
+
+describe('topic nav channel identity', () => {
+  it('threads channelKind, icon, and color from display into the nav item', () => {
+    const model = buildTopicNavModel({
+      topics: [
+        makeTopic({
+          id: 'topic:chan',
+          display: { title: 'Ops', kind: 'ops', icon: '⚙', color: '#f00' },
+        }),
+        makeTopic({ id: 'topic:plain', display: { title: 'Plain' } }),
+      ],
+      sessions: [],
+      surfaces: [],
+    });
+    expect(model.byId.get('topic:chan')).toMatchObject({
+      channelKind: 'ops',
+      icon: '⚙',
+      color: '#f00',
+    });
+    expect(model.byId.get('topic:plain')).toMatchObject({
+      channelKind: null,
+      icon: null,
+      color: null,
+    });
+  });
+});

--- a/test/workspace-topic-channel-kind.test.ts
+++ b/test/workspace-topic-channel-kind.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyWorkspaceTopicUpdate,
+  buildWorkspaceTopicRecord,
+  parseWorkspaceTopicCreateInput,
+  parseWorkspaceTopicUpdateInput,
+  WorkspaceTopicValidationError,
+} from '../shared/workspace-topics.js';
+
+const NOW = '2026-07-01T00:00:00Z';
+
+describe('workspace topic channelKind', () => {
+  it('parses and persists a valid channelKind onto display.kind', () => {
+    const create = parseWorkspaceTopicCreateInput({
+      workspaceId: 'ws:a',
+      title: 'Ops room',
+      channelKind: 'ops',
+    });
+    expect(create.channelKind).toBe('ops');
+    const record = buildWorkspaceTopicRecord({ create, now: NOW });
+    expect(record.display.kind).toBe('ops');
+  });
+
+  it('omits display.kind when no channelKind is given', () => {
+    const create = parseWorkspaceTopicCreateInput({
+      workspaceId: 'ws:a',
+      title: 'Plain topic',
+    });
+    expect(create.channelKind).toBeUndefined();
+    expect(buildWorkspaceTopicRecord({ create, now: NOW }).display.kind).toBe(
+      undefined
+    );
+  });
+
+  it('rejects an invalid channelKind', () => {
+    expect(() =>
+      parseWorkspaceTopicCreateInput({
+        workspaceId: 'ws:a',
+        title: 'Bad',
+        channelKind: 'nonsense',
+      })
+    ).toThrow(WorkspaceTopicValidationError);
+  });
+
+  it('update sets and clears display.kind', () => {
+    const base = buildWorkspaceTopicRecord({
+      create: parseWorkspaceTopicCreateInput({
+        workspaceId: 'ws:a',
+        title: 'T',
+        channelKind: 'research',
+      }),
+      now: NOW,
+    });
+    expect(base.display.kind).toBe('research');
+
+    const setJournal = applyWorkspaceTopicUpdate({
+      topic: base,
+      patch: parseWorkspaceTopicUpdateInput({ channelKind: 'journal' }),
+      now: NOW,
+    });
+    expect(setJournal.display.kind).toBe('journal');
+
+    const cleared = applyWorkspaceTopicUpdate({
+      topic: setJournal,
+      patch: parseWorkspaceTopicUpdateInput({ channelKind: null }),
+      now: NOW,
+    });
+    expect(cleared.display.kind).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Slice 3 of epic #1021 — the Discord channel taxonomy + per-channel visual identity.

- **Schema**: optional `WorkspaceTopicDisplay.kind` (`repo`/`product-area`/`journal`/`ops`/`research`/`topic`) — a user-chosen facet, distinct from the routing-derived structural kind. Create/update inputs accept `channelKind` (validated, clears on `null`); persisted on the record.
- **Nav model**: `TopicNavItem` carries `channelKind` + `icon` + `color` from `display`.
- **Render**: `TopicBadge` shows the channel icon + color when set, else the structural kind icon + derived color.

Additive + backward-compatible — older rows deserialize; topics without a `kind` render exactly as before.

## Testing
`test/workspace-topic-channel-kind.test.ts` (parse/persist/reject/update-set-clear) + `test/topic-nav.test.ts` (nav item threads channelKind/icon/color). 22 green. `npm run check` clean.

Refs #1021, #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)