### PR TITLE
feat(sidebar): workspace-scoped topic search (#1084)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1231,3 +1231,20 @@
   margin: 0;
   padding: 0;
 }
+
+/* #1084: search scope toggle */
+.topic-search__scope {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 1px 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.topic-search__scope.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1674,6 +1674,9 @@ function TopicSearchPanel({
   onSearchRetry,
   onSearchClear,
   onSelectSession,
+  searchScope = 'all',
+  onToggleSearchScope,
+  canScope = false,
 }: {
   model: TopicNavModel;
   searchQuery: string;
@@ -1686,6 +1689,9 @@ function TopicSearchPanel({
   onSearchRetry?: (() => void) | undefined;
   onSearchClear?: (() => void) | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
+  searchScope?: 'all' | 'workspace';
+  onToggleSearchScope?: (() => void) | undefined;
+  canScope?: boolean;
 }) {
   const searchActive = searchQuery.trim().length > 0;
   return (
@@ -1699,6 +1705,21 @@ function TopicSearchPanel({
           placeholder="search topics, tasks, artifacts..."
           spellCheck={false}
         />
+        {canScope ? (
+          <button
+            type="button"
+            className={`topic-search__scope${searchScope === 'workspace' ? ' is-active' : ''}`}
+            aria-pressed={searchScope === 'workspace'}
+            title={
+              searchScope === 'workspace'
+                ? 'searching this workspace'
+                : 'searching all workspaces'
+            }
+            onClick={onToggleSearchScope}
+          >
+            {searchScope === 'workspace' ? 'this workspace' : 'all'}
+          </button>
+        ) : null}
         {searchLoading ? <span className="topic-search__state">…</span> : null}
       </label>
       {searchError ? (
@@ -1772,12 +1793,16 @@ export function TopicSidebarView({
   onCreateTaskRoom,
   workspaces = EMPTY_WORKSPACES,
   activeWorkspaceId = null,
+  searchScope = 'all',
+  onToggleSearchScope,
 }: {
   topics: WorkspaceTopic[];
   sessions: SessionSummary[];
   surfaces: WorkspaceSurface[];
   workspaces?: TopicNavWorkspace[];
   activeWorkspaceId?: string | null;
+  searchScope?: 'all' | 'workspace';
+  onToggleSearchScope?: (() => void) | undefined;
   loading?: boolean;
   error?: boolean;
   derived?: boolean;
@@ -1805,9 +1830,12 @@ export function TopicSidebarView({
     () => new Map(topics.map((topic) => [topic.id, topic])),
     [topics]
   );
+  // Grouping always shows every workspace so the full channel list stays
+  // visible; the active workspace only scopes search (via the scope chip),
+  // not the tree. (The filter arg is exercised for a future rail selection.)
   const grouped = useMemo(
-    () => groupTopicsByWorkspace(model, workspaces, activeWorkspaceId),
-    [model, workspaces, activeWorkspaceId]
+    () => groupTopicsByWorkspace(model, workspaces, null),
+    [model, workspaces]
   );
   const firstId = model.rootIds[0] ?? model.items[0]?.id ?? null;
   const [selectedId, setSelectedId] = useState<string | null>(firstId);
@@ -1927,6 +1955,9 @@ export function TopicSidebarView({
         onSearchRetry={onSearchRetry}
         onSearchClear={onSearchClear}
         onSelectSession={onSelectSession}
+        searchScope={searchScope}
+        onToggleSearchScope={onToggleSearchScope}
+        canScope={activeWorkspaceId != null}
       />
       <div className="topic-tree" aria-label="workspace topics">
         {grouped.groups.map((group) => (
@@ -2006,6 +2037,9 @@ export function TopicSidebarShell({
     [activeSessionId, sessions]
   );
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchScope, setSearchScope] = useState<'all' | 'workspace'>('all');
+  const scopedWorkspaceId =
+    searchScope === 'workspace' ? activeWorkspaceId : null;
   const [createOpen, setCreateOpen] = useState(false);
   const [createDraft, setCreateDraft] = useState<TopicRoomDraft>(
     TOPIC_ROOM_DRAFT_EMPTY
@@ -2028,9 +2062,18 @@ export function TopicSidebarShell({
     [workspacesQuery.data]
   );
   const topicSearchQuery = useQuery({
-    queryKey: ['workspace-topics', 'search', normalizedSearchQuery],
+    queryKey: [
+      'workspace-topics',
+      'search',
+      normalizedSearchQuery,
+      scopedWorkspaceId ?? 'all',
+    ],
     queryFn: () =>
-      searchWorkspaceTopics({ q: normalizedSearchQuery, limit: 20 }),
+      searchWorkspaceTopics({
+        q: normalizedSearchQuery,
+        limit: 20,
+        ...(scopedWorkspaceId ? { workspaceId: scopedWorkspaceId } : {}),
+      }),
     enabled: normalizedSearchQuery.length > 0,
     staleTime: 10_000,
   });
@@ -2265,6 +2308,11 @@ export function TopicSidebarShell({
       sessions={sessions}
       surfaces={viewSurfaces}
       workspaces={viewWorkspaces}
+      activeWorkspaceId={activeWorkspaceId}
+      searchScope={searchScope}
+      onToggleSearchScope={() =>
+        setSearchScope((scope) => (scope === 'all' ? 'workspace' : 'all'))
+      }
       loading={!searchActive && topicsQuery.isLoading && !topicsQuery.data}
       error={topicsQuery.isError && !topicsQuery.data && !searchActive}
       surfacesLoading={surfacesQuery.isLoading && !surfacesQuery.data}

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -180,6 +180,26 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('Beta channel');
   });
 
+  it('shows a search scope toggle only when a workspace is active', async () => {
+    const onToggleSearchScope = vi.fn();
+    await renderView({ activeWorkspaceId: 'ws:a', onToggleSearchScope });
+    const chip = container.querySelector('.topic-search__scope');
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toBe('all');
+    await act(async () => (chip as HTMLButtonElement).click());
+    expect(onToggleSearchScope).toHaveBeenCalled();
+
+    await renderView({ activeWorkspaceId: null });
+    expect(container.querySelector('.topic-search__scope')).toBeNull();
+  });
+
+  it('reflects the workspace scope on the toggle label', async () => {
+    await renderView({ activeWorkspaceId: 'ws:a', searchScope: 'workspace' });
+    const chip = container.querySelector('.topic-search__scope');
+    expect(chip?.textContent).toBe('this workspace');
+    expect(chip?.getAttribute('aria-pressed')).toBe('true');
+  });
+
   it('selects linked sessions using the existing sidebar callback', async () => {
     await renderView();
     const sessionButton = container.querySelector(


### PR DESCRIPTION
## What

Slice 2 of epic #1021 — channel-aware search. The sidebar search gains a **scope toggle**: when a workspace is active, a "this workspace / all" chip scopes `searchWorkspaceTopics` to that workspace (the API already accepts `workspaceId`) or searches globally.

- Defaults to **all** (current behavior); the chip appears only when there's an active workspace to scope to.
- Grouping still shows every workspace — the active workspace scopes **search only**, not the tree (decoupled per the Slice 1 note).

## Testing
`test/topic-sidebar-shell.test.ts` +2 — chip shows/hides on active workspace + toggles; label/`aria-pressed` reflect the scope. 41 green. `npm run check` clean.

Refs #1021, #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a topic search scope toggle so users can switch between searching all workspaces or just the current one.
  * Workspace grouping in the topic list now shows all workspaces, while search results can be narrowed to the active workspace.
* **Bug Fixes**
  * Improved search behavior so the selected scope is consistently reflected in results and the toggle state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->