### PR TITLE
feat(palette): session results show their parent channel (#1087)

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -374,7 +374,12 @@ function buildResults(
       sublabel: ws.path,
       data: ws,
     });
-  for (const result of buildSessionPaletteResults(q, sessions, 5)) {
+  for (const result of buildSessionPaletteResults(
+    q,
+    sessions,
+    5,
+    cachedTopics
+  )) {
     items.push(result);
   }
   for (const topic of buildTopicPaletteResults(q, cachedTopics, 5)) {

--- a/frontend/src/lib/command-palette-session-results.ts
+++ b/frontend/src/lib/command-palette-session-results.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
+import { sessionMatchesTopic } from './state/topic-nav.js';
 import type { SessionSummary } from './types.js';
 
 export interface SessionPaletteResult {
@@ -9,23 +11,48 @@ export interface SessionPaletteResult {
 }
 
 function searchableText(session: SessionSummary): string[] {
-  return [session.displayName, session.branchName ?? '', session.repoName ?? ''];
+  return [
+    session.displayName,
+    session.branchName ?? '',
+    session.repoName ?? '',
+  ];
+}
+
+/** The channel a session lives in, so palette results show where to resume. */
+function parentChannelTitle(
+  session: SessionSummary,
+  topics: WorkspaceTopic[]
+): string | null {
+  const topic = topics.find((candidate) =>
+    sessionMatchesTopic(candidate, session)
+  );
+  return topic?.display.title ?? null;
 }
 
 export function buildSessionPaletteResults(
   query: string,
   sessions: SessionSummary[],
-  limit = 5
+  limit = 5,
+  topics: WorkspaceTopic[] = []
 ): SessionPaletteResult[] {
   const q = query.toLowerCase();
   return sessions
-    .filter((session) => searchableText(session).some((value) => value.toLowerCase().includes(q)))
+    .filter((session) =>
+      searchableText(session).some((value) => value.toLowerCase().includes(q))
+    )
     .slice(0, limit)
     .map((session) => ({
       type: 'session',
       id: `sess-${session.id}`,
-      label: session.displayName || session.branchName || session.repoName || session.cwd || session.id,
-      sublabel: session.repoName ?? '',
+      label:
+        session.displayName ||
+        session.branchName ||
+        session.repoName ||
+        session.cwd ||
+        session.id,
+      // Prefer the parent channel (topic) so the user sees where to resume;
+      // fall back to the repo name.
+      sublabel: parentChannelTitle(session, topics) ?? session.repoName ?? '',
       data: session,
     }));
 }

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -228,7 +228,7 @@ function sessionDisplayState(session: SessionSummary): DisplayState {
   return 'seen-idle';
 }
 
-function sessionMatchesTopic(
+export function sessionMatchesTopic(
   topic: WorkspaceTopic,
   session: SessionSummary
 ): boolean {

--- a/test/command-palette-session-fields.test.ts
+++ b/test/command-palette-session-fields.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, it } from 'vitest';
 import { buildSessionPaletteResults } from '../frontend/src/lib/command-palette-session-results.js';
 import type { SessionSummary } from '../frontend/src/lib/types.js';
+import type { WorkspaceTopic } from '../shared/workspace-topics.js';
 import { makeSession } from './helpers/frontend-factories.js';
 
-function makeFreeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:a',
+    workspaceId: 'ws:a',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'auth channel' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: {},
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeFreeSession(
+  overrides: Partial<SessionSummary> = {}
+): SessionSummary {
   const {
     repoName: _repoName,
     repoPath: _repoPath,
@@ -42,7 +71,35 @@ describe('buildSessionPaletteResults', () => {
       displayName: 'repo tab',
     });
 
-    expect(buildSessionPaletteResults('null-repo', [repoSession], 5)).toHaveLength(1);
-    expect(buildSessionPaletteResults('relay', [repoSession], 5)).toHaveLength(1);
+    expect(
+      buildSessionPaletteResults('null-repo', [repoSession], 5)
+    ).toHaveLength(1);
+    expect(buildSessionPaletteResults('relay', [repoSession], 5)).toHaveLength(
+      1
+    );
+  });
+
+  it('shows the parent channel as sublabel when a session matches a topic', () => {
+    const session = makeSession({
+      id: 'repo-session',
+      repoName: 'relay-ide',
+      repoPath: '/repo/relay',
+      displayName: 'repo tab',
+    });
+    const topic = makeTopic({ routingDefaults: { repoPath: '/repo/relay' } });
+    const results = buildSessionPaletteResults('repo', [session], 5, [topic]);
+    expect(results[0]?.sublabel).toBe('auth channel');
+  });
+
+  it('falls back to the repo name when no topic matches', () => {
+    const session = makeSession({
+      id: 'repo-session',
+      repoName: 'relay-ide',
+      repoPath: '/repo/other',
+      displayName: 'repo tab',
+    });
+    const topic = makeTopic({ routingDefaults: { repoPath: '/repo/relay' } });
+    const results = buildSessionPaletteResults('repo', [session], 5, [topic]);
+    expect(results[0]?.sublabel).toBe('relay-ide');
   });
 });


### PR DESCRIPTION
## What

Part of Slice 5 (#1087, epic #1021) — findable/resumable sessions. Command-palette **session results now show the parent channel** (topic) as the sublabel when a session matches one, so you see *where* to resume it; falls back to the repo name otherwise.

- Exposes `sessionMatchesTopic` for the reverse session→topic lookup.
- `buildSessionPaletteResults` takes optional `topics` and prefers the matched channel title.
- `CommandPalette` passes its cached topics through.

## Remaining on #1087
Archived-channel **browse/restore** (needs a restore route + frontend api) and Hermes **resumeSession** (touches the shared `LegacyProtocolAdapterV2Bridge` — cross-adapter risk) are deliberately left for focused follow-ups; this ships the clean, self-contained findability core.

## Testing
`test/command-palette-session-fields.test.ts` +2 — parent-channel sublabel on match; repo-name fallback otherwise. `npm run check` clean.

Refs #1021, #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)