### PR TITLE
feat(topics): restore archived topics — reversible archive (#1087)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1674,6 +1674,19 @@ export async function fetchWorkspaceTopics(
   };
 }
 
+/** Reactivate an archived topic (clears its archivedAt marker). */
+export async function restoreWorkspaceTopic(
+  id: string
+): Promise<WorkspaceTopic> {
+  const data = await json<{ topic: WorkspaceTopic }>(
+    await fetch(`/workspace-topics/${encodeURIComponent(id)}/restore`, {
+      method: 'POST',
+      headers: { 'x-relay-capabilities': 'context:write' },
+    })
+  );
+  return data.topic;
+}
+
 export interface WorkContextCreateBody {
   title?: string;
   source?: string;

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -98,6 +98,7 @@ export const CLI_GATEWAY_ACTOR_WRITE_COMMANDS = [
   'workspace-topics.create',
   'workspace-topics.update',
   'workspace-topics.archive',
+  'workspace-topics.restore',
 ] as const;
 export type CliGatewayActorWriteCommand =
   (typeof CLI_GATEWAY_ACTOR_WRITE_COMMANDS)[number];

--- a/server/workspace-topics.ts
+++ b/server/workspace-topics.ts
@@ -19,6 +19,7 @@ import {
   WorkspaceTopicValidationError,
   applyWorkspaceTopicUpdate,
   archiveWorkspaceTopicRecord,
+  restoreWorkspaceTopicRecord,
   assertWorkspaceTopicId,
   buildWorkspaceTopicRecord,
   createWorkspaceTopicId,
@@ -92,6 +93,7 @@ export interface WorkspaceTopicStore {
   create(input: WorkspaceTopicCreateInput): WorkspaceTopic;
   update(id: string, patch: WorkspaceTopicUpdateInput): WorkspaceTopic | null;
   archive(id: string): WorkspaceTopic | null;
+  restore(id: string): WorkspaceTopic | null;
   get(id: string): WorkspaceTopic | null;
   list(filter?: WorkspaceTopicListFilter): WorkspaceTopic[];
 }
@@ -224,6 +226,12 @@ export function createWorkspaceTopicStore(input: {
       const existing = parseRow(getStmt.get(id) as TopicRow | undefined);
       if (!existing) return null;
       return persist(archiveWorkspaceTopicRecord(existing, clock()));
+    },
+
+    restore(id) {
+      const existing = parseRow(getStmt.get(id) as TopicRow | undefined);
+      if (!existing) return null;
+      return persist(restoreWorkspaceTopicRecord(existing, clock()));
     },
 
     get(id) {
@@ -1455,6 +1463,60 @@ export function createWorkspaceTopicsRouter(
           res,
           'INTERNAL',
           'workspace topic archive failed',
+          true
+        );
+      }
+    }
+  );
+
+  router.post(
+    '/workspace-topics/:id/restore',
+    writeAuth('workspace-topics.restore', (req) =>
+      topicWorkContextScopeFromPersistedTopic({ store: options.store, req })
+    ),
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+      if (!options.store) {
+        sendGatewayError(
+          res,
+          'SERVER_UNAVAILABLE',
+          'workspace topic store is unavailable',
+          true,
+          {
+            reasonCode: 'WORKSPACE_TOPIC_STORE_UNAVAILABLE',
+          }
+        );
+        return;
+      }
+      const id = req.params['id'] ?? '';
+      try {
+        assertWorkspaceTopicId(id);
+        const topic = options.store.restore(id);
+        if (!topic) {
+          sendGatewayError(
+            res,
+            'NOT_FOUND',
+            'workspace topic not found',
+            false,
+            {
+              id,
+            }
+          );
+          return;
+        }
+        res.json({ topic, mutationPolicy: mutationPolicy('update') });
+      } catch (error) {
+        if (error instanceof WorkspaceTopicValidationError) {
+          sendGatewayError(res, 'INVALID_ARGUMENT', error.message, false, {
+            reasonCode: 'WORKSPACE_TOPIC_VALIDATION_FAILED',
+            ...error.details,
+          });
+          return;
+        }
+        sendGatewayError(
+          res,
+          'INTERNAL',
+          'workspace topic restore failed',
           true
         );
       }

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -1365,3 +1365,18 @@ export function archiveWorkspaceTopicRecord(
     updatedAt: now,
   };
 }
+
+/** Inverse of archive: reactivate a topic and clear its archivedAt marker. */
+export function restoreWorkspaceTopicRecord(
+  topic: WorkspaceTopic,
+  now: string
+): WorkspaceTopic {
+  const state = { ...topic.state };
+  delete state.archivedAt;
+  return {
+    ...topic,
+    status: 'active',
+    state,
+    updatedAt: now,
+  };
+}

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -451,6 +451,7 @@ test('classifies explicitly scoped CLI gateway actor write routes into the actor
     'workspace-topics.create',
     'workspace-topics.update',
     'workspace-topics.archive',
+    'workspace-topics.restore',
   ]);
 
   for (const command of CLI_GATEWAY_ACTOR_WRITE_COMMANDS) {

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -558,6 +558,24 @@ describe('workspace topics foundation', () => {
     expect(includeArchived.body.topics.map((topic) => topic.status)).toEqual([
       'archived',
     ]);
+
+    const restore = await writeJson<{
+      topic: WorkspaceTopic;
+      mutationPolicy: unknown;
+    }>({
+      port,
+      method: 'POST',
+      url: '/workspace-topics/topic%3Abuild-lane/restore',
+      body: {},
+    });
+    expect(restore.status).toBe(200);
+    expect(restore.body.topic.status).toBe('active');
+    expect(restore.body.topic.state).not.toHaveProperty('archivedAt');
+    const activeAgain = await getJson<WorkspaceTopicListResponse>(
+      port,
+      '/workspace-topics?workspaceId=ws-1'
+    );
+    expect(activeAgain.body.topics).toHaveLength(1);
   });
 
   it('authorizes update and archive against persisted topic workContext refs', async () => {


### PR DESCRIPTION
## What

Part of Slice 5 (#1087, epic #1021). Archiving a topic was one-way; this adds the inverse so **archived channels are reversible** (epic non-goal: "archive is reversible").

- `restoreWorkspaceTopicRecord` (status→active, clears `archivedAt`).
- Store `restore(id)` method.
- `POST /workspace-topics/:id/restore` route (scoped write, new `workspace-topics.restore` actor-auth command).
- Frontend `restoreWorkspaceTopic(id)` api.

## Testing
`test/workspace-topics.test.ts`: archive → list hides it → **restore** → status back to `active`, `archivedAt` cleared, active list includes it again. Actor-auth write-command snapshot updated. Full suite green (5088). `npm run check` clean.

## Remaining on #1087
Sidebar archived-browse toggle UI + Hermes `resumeSession` are the remaining follow-ups; this ships the reversible-archive substrate + api.

Refs #1021, #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)