### PR TITLE
feat(sidebar): browse and restore archived channels (#1087)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1248,3 +1248,37 @@
   border-color: var(--accent);
   color: var(--accent);
 }
+
+/* #1087: archived-channel browse + restore */
+.topic-archived-toggle {
+  padding: 2px 10px 4px;
+}
+
+.topic-archived-toggle__btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 1px 6px;
+  cursor: pointer;
+}
+
+.topic-archived-toggle__btn.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.topic-row.archived {
+  opacity: 0.55;
+}
+
+.topic-detail__restore {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 1px 8px;
+  cursor: pointer;
+}

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1282,3 +1282,8 @@
   padding: 1px 8px;
   cursor: pointer;
 }
+
+.topic-detail__restore:disabled {
+  opacity: 0.55;
+  cursor: default;
+}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -640,12 +640,14 @@ function TopicDetail({
   surfacesLoading,
   onSelectSession,
   onRestoreTopic,
+  restoringTopicId,
 }: {
   item: TopicNavItem;
   surfacesError?: boolean | undefined;
   surfacesLoading?: boolean | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
   onRestoreTopic?: ((topicId: string) => void) | undefined;
+  restoringTopicId?: string | undefined;
 }) {
   const action = topicPrimaryAction(item);
   const session = topicPrimarySession(item);
@@ -682,9 +684,10 @@ function TopicDetail({
           <button
             type="button"
             className="topic-detail__restore"
+            disabled={restoringTopicId === item.id}
             onClick={() => onRestoreTopic(item.id)}
           >
-            restore
+            {restoringTopicId === item.id ? 'restoring…' : 'restore'}
           </button>
         ) : null}
       </div>
@@ -1884,6 +1887,7 @@ export function TopicSidebarView({
   showArchived = false,
   onToggleArchived,
   onRestoreTopic,
+  restoringTopicId,
 }: {
   topics: WorkspaceTopic[];
   sessions: SessionSummary[];
@@ -1895,6 +1899,7 @@ export function TopicSidebarView({
   showArchived?: boolean;
   onToggleArchived?: (() => void) | undefined;
   onRestoreTopic?: ((topicId: string) => void) | undefined;
+  restoringTopicId?: string | undefined;
   loading?: boolean;
   error?: boolean;
   derived?: boolean;
@@ -2061,6 +2066,7 @@ export function TopicSidebarView({
             surfacesLoading={surfacesLoading}
             onSelectSession={onSelectSession}
             onRestoreTopic={onRestoreTopic}
+            restoringTopicId={restoringTopicId}
           />
           <TopicMobileControlPanel
             item={selectedItem}
@@ -2388,6 +2394,11 @@ export function TopicSidebarShell({
       showArchived={showArchived}
       onToggleArchived={() => setShowArchived((prev) => !prev)}
       onRestoreTopic={(topicId) => restoreTopicMutation.mutate(topicId)}
+      restoringTopicId={
+        restoreTopicMutation.isPending
+          ? restoreTopicMutation.variables
+          : undefined
+      }
       loading={!searchActive && topicsQuery.isLoading && !topicsQuery.data}
       error={topicsQuery.isError && !topicsQuery.data && !searchActive}
       surfacesLoading={surfacesQuery.isLoading && !surfacesQuery.data}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -7,7 +7,7 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   CircleAlert,
   Folder,
@@ -32,6 +32,7 @@ import {
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
   launchWorkspaceTopicRoom,
+  restoreWorkspaceTopic,
   searchWorkspaceTopics,
   type CreateSessionBody,
   sendSessionInput,
@@ -44,6 +45,7 @@ import type { SessionSummary } from '../lib/types.js';
 import { formatRelativeTimeCompact } from '../lib/utils.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
+import { useToastStore } from '../lib/stores/toasts.js';
 import { useIaWorkspacesQuery } from '../lib/hooks/use-ia-workspaces.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { durabilityDisabledReason } from '../lib/session-durability.js';
@@ -51,6 +53,7 @@ import { resolveSessionByKey } from '../lib/session-keys.js';
 import {
   buildTopicNavModel,
   groupTopicsByWorkspace,
+  type GroupedTopicNav,
   type TopicNavItem,
   type TopicNavModel,
   type TopicNavWorkspace,
@@ -636,11 +639,13 @@ function TopicDetail({
   surfacesError,
   surfacesLoading,
   onSelectSession,
+  onRestoreTopic,
 }: {
   item: TopicNavItem;
   surfacesError?: boolean | undefined;
   surfacesLoading?: boolean | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
+  onRestoreTopic?: ((topicId: string) => void) | undefined;
 }) {
   const action = topicPrimaryAction(item);
   const session = topicPrimarySession(item);
@@ -673,6 +678,15 @@ function TopicDetail({
         <span>{topicRoomFreshnessLabel(item)}</span>
         <span>{topicRoomAnchorLabel(item)}</span>
         <span>updated {item.updatedAt}</span>
+        {item.lifecycleLabel === 'archived' && onRestoreTopic ? (
+          <button
+            type="button"
+            className="topic-detail__restore"
+            onClick={() => onRestoreTopic(item.id)}
+          >
+            restore
+          </button>
+        ) : null}
       </div>
 
       <div className="topic-room__action-band">
@@ -1066,6 +1080,7 @@ function TopicRow({
     `topic-row--${item.tone}`,
     selected && 'selected',
     item.muted && 'muted',
+    item.lifecycleLabel === 'archived' && 'archived',
   ]
     .filter(Boolean)
     .join(' ');
@@ -1769,6 +1784,77 @@ const EMPTY_SURFACES: WorkspaceSurface[] = [];
 const EMPTY_SEARCH_RESULTS: WorkspaceTopicSearchResult[] = [];
 const EMPTY_WORKSPACES: TopicNavWorkspace[] = [];
 
+/** Show/hide archived channels toggle; renders nothing without a handler. */
+function ArchivedToggle({
+  showArchived,
+  onToggle,
+}: {
+  showArchived: boolean;
+  onToggle?: (() => void) | undefined;
+}) {
+  if (!onToggle) return null;
+  return (
+    <div className="topic-archived-toggle">
+      <button
+        type="button"
+        className={`topic-archived-toggle__btn${showArchived ? ' is-active' : ''}`}
+        aria-pressed={showArchived}
+        onClick={onToggle}
+      >
+        {showArchived ? 'hide archived' : 'show archived'}
+      </button>
+    </div>
+  );
+}
+
+/** The workspace-grouped topic tree: a section per workspace + an orphan lane. */
+function GroupedTopicTree({
+  grouped,
+  renderRow,
+}: {
+  grouped: GroupedTopicNav;
+  renderRow: (id: string) => ReactNode;
+}) {
+  return (
+    <div className="topic-tree" aria-label="workspace topics">
+      {grouped.groups.map((group) => (
+        <section
+          key={group.id}
+          className="topic-workspace-group"
+          aria-label={group.title}
+        >
+          <div className="topic-workspace-group__header">
+            {group.icon ? (
+              <span className="topic-workspace-group__icon" aria-hidden="true">
+                {group.icon}
+              </span>
+            ) : null}
+            <span className="topic-workspace-group__name">{group.title}</span>
+          </div>
+          <ul className="topic-tree__list">
+            {group.rootIds.map((id) => renderRow(id))}
+          </ul>
+        </section>
+      ))}
+      {grouped.orphanRootIds.length > 0 ? (
+        <section
+          className="topic-workspace-group topic-workspace-group--orphan"
+          aria-label="no workspace"
+        >
+          {grouped.groups.length > 0 ? (
+            <div className="topic-workspace-group__header">
+              <span className="topic-workspace-group__name">no workspace</span>
+            </div>
+          ) : null}
+          <ul className="topic-tree__list">
+            {grouped.orphanRootIds.map((id) => renderRow(id))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
 export function TopicSidebarView({
   topics,
   sessions,
@@ -1795,6 +1881,9 @@ export function TopicSidebarView({
   activeWorkspaceId = null,
   searchScope = 'all',
   onToggleSearchScope,
+  showArchived = false,
+  onToggleArchived,
+  onRestoreTopic,
 }: {
   topics: WorkspaceTopic[];
   sessions: SessionSummary[];
@@ -1803,6 +1892,9 @@ export function TopicSidebarView({
   activeWorkspaceId?: string | null;
   searchScope?: 'all' | 'workspace';
   onToggleSearchScope?: (() => void) | undefined;
+  showArchived?: boolean;
+  onToggleArchived?: (() => void) | undefined;
+  onRestoreTopic?: ((topicId: string) => void) | undefined;
   loading?: boolean;
   error?: boolean;
   derived?: boolean;
@@ -1959,47 +2051,8 @@ export function TopicSidebarView({
         onToggleSearchScope={onToggleSearchScope}
         canScope={activeWorkspaceId != null}
       />
-      <div className="topic-tree" aria-label="workspace topics">
-        {grouped.groups.map((group) => (
-          <section
-            key={group.id}
-            className="topic-workspace-group"
-            aria-label={group.title}
-          >
-            <div className="topic-workspace-group__header">
-              {group.icon ? (
-                <span
-                  className="topic-workspace-group__icon"
-                  aria-hidden="true"
-                >
-                  {group.icon}
-                </span>
-              ) : null}
-              <span className="topic-workspace-group__name">{group.title}</span>
-            </div>
-            <ul className="topic-tree__list">
-              {group.rootIds.map((id) => renderTopicRow(id))}
-            </ul>
-          </section>
-        ))}
-        {grouped.orphanRootIds.length > 0 ? (
-          <section
-            className="topic-workspace-group topic-workspace-group--orphan"
-            aria-label="no workspace"
-          >
-            {grouped.groups.length > 0 ? (
-              <div className="topic-workspace-group__header">
-                <span className="topic-workspace-group__name">
-                  no workspace
-                </span>
-              </div>
-            ) : null}
-            <ul className="topic-tree__list">
-              {grouped.orphanRootIds.map((id) => renderTopicRow(id))}
-            </ul>
-          </section>
-        ) : null}
-      </div>
+      <ArchivedToggle showArchived={showArchived} onToggle={onToggleArchived} />
+      <GroupedTopicTree grouped={grouped} renderRow={renderTopicRow} />
       {selectedItem ? (
         <>
           <TopicDetail
@@ -2007,6 +2060,7 @@ export function TopicSidebarView({
             surfacesError={surfacesError}
             surfacesLoading={surfacesLoading}
             onSelectSession={onSelectSession}
+            onRestoreTopic={onRestoreTopic}
           />
           <TopicMobileControlPanel
             item={selectedItem}
@@ -2051,10 +2105,28 @@ export function TopicSidebarShell({
   const [createdRoom, setCreatedRoom] =
     useState<WorkspaceTopicRoomCreateResult | null>(null);
   const normalizedSearchQuery = searchQuery.trim();
+  const [showArchived, setShowArchived] = useState(false);
   const topicsQuery = useQuery({
-    queryKey: ['workspace-topics'],
-    queryFn: () => fetchWorkspaceTopics(),
+    // Keep the canonical key for the default (active) view so shared cache and
+    // invalidations still hit; the archived view uses a distinct key.
+    queryKey: showArchived
+      ? ['workspace-topics', 'with-archived']
+      : ['workspace-topics'],
+    queryFn: () => fetchWorkspaceTopics({ includeArchived: showArchived }),
     staleTime: 30_000,
+  });
+  const restoreTopicMutation = useMutation({
+    mutationFn: (topicId: string) => restoreWorkspaceTopic(topicId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['workspace-topics'] });
+    },
+    onError: (err: unknown) => {
+      useToastStore
+        .getState()
+        .showToast(
+          err instanceof Error ? err.message : 'failed to restore topic'
+        );
+    },
   });
   const workspacesQuery = useIaWorkspacesQuery();
   const viewWorkspaces = useMemo<TopicNavWorkspace[]>(
@@ -2313,6 +2385,9 @@ export function TopicSidebarShell({
       onToggleSearchScope={() =>
         setSearchScope((scope) => (scope === 'all' ? 'workspace' : 'all'))
       }
+      showArchived={showArchived}
+      onToggleArchived={() => setShowArchived((prev) => !prev)}
+      onRestoreTopic={(topicId) => restoreTopicMutation.mutate(topicId)}
       loading={!searchActive && topicsQuery.isLoading && !topicsQuery.data}
       error={topicsQuery.isError && !topicsQuery.data && !searchActive}
       surfacesLoading={surfacesQuery.isLoading && !surfacesQuery.data}

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -237,6 +237,32 @@ describe('TopicSidebarView', () => {
     expect(onRestoreTopic).toHaveBeenCalledWith('topic:old');
   });
 
+  it('disables the restore button while its restore is in flight', async () => {
+    const onRestoreTopic = vi.fn();
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:old',
+          workspaceId: 'ws:a',
+          status: 'archived',
+          display: { title: 'Archived lane' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      onRestoreTopic,
+      restoringTopicId: 'topic:old',
+    });
+    const restore = container.querySelector(
+      '.topic-detail__restore'
+    ) as HTMLButtonElement;
+    expect(restore.disabled).toBe(true);
+    expect(restore.textContent).toContain('restoring');
+    await act(async () => restore.click());
+    expect(onRestoreTopic).not.toHaveBeenCalled();
+  });
+
   it('selects linked sessions using the existing sidebar callback', async () => {
     await renderView();
     const sessionButton = container.querySelector(

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -200,6 +200,43 @@ describe('TopicSidebarView', () => {
     expect(chip?.getAttribute('aria-pressed')).toBe('true');
   });
 
+  it('toggles the show-archived control', async () => {
+    const onToggleArchived = vi.fn();
+    await renderView({ onToggleArchived });
+    const btn = container.querySelector(
+      '.topic-archived-toggle__btn'
+    ) as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toBe('show archived');
+    await act(async () => btn.click());
+    expect(onToggleArchived).toHaveBeenCalled();
+  });
+
+  it('restores an archived topic from its detail panel', async () => {
+    const onRestoreTopic = vi.fn();
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:old',
+          workspaceId: 'ws:a',
+          status: 'archived',
+          display: { title: 'Archived lane' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      onRestoreTopic,
+    });
+    expect(container.querySelector('.topic-row.archived')).not.toBeNull();
+    const restore = container.querySelector(
+      '.topic-detail__restore'
+    ) as HTMLButtonElement;
+    expect(restore).not.toBeNull();
+    await act(async () => restore.click());
+    expect(onRestoreTopic).toHaveBeenCalledWith('topic:old');
+  });
+
   it('selects linked sessions using the existing sidebar callback', async () => {
     await renderView();
     const sessionButton = container.querySelector(


### PR DESCRIPTION
## What

Completes the **archived-channel browse + restore** half of Slice 5 (#1087).

- **Show-archived toggle** in the topic sidebar — fetches with `includeArchived`, keyed distinctly (`['workspace-topics','with-archived']`) from the active view (`['workspace-topics']`).
- **Dimmed archived rows** (`.topic-row.archived`).
- **Restore action** in the channel detail panel for archived channels → `POST /workspace-topics/:id/restore` (backend landed in #1094). Prefix cache invalidation refreshes both active and with-archived views.
- Extracted `GroupedTopicTree` + `ArchivedToggle` out of `TopicSidebarView` to stay under the complexity budget (behavior-preserving).

## Acceptance mapping (#1087)

- [x] archive filter hides then restores — **this PR** (+ restore backend #1094)
- [x] session-result shows parent channel — landed in #1093
- [ ] Resume returns a reattach handle — **remaining** (Hermes `resumeSession`, tracked to follow-up)

## Test

- 2 new tests in `test/topic-sidebar-shell.test.ts`: show-archived toggle control + restore-from-detail.
- `npm run check` green; full sidebar suite 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an archived-topics view toggle in the topic sidebar so users can switch between active and archived items.
  * Added a restore action for archived topics directly from the topic details panel.

* **Bug Fixes**
  * Archived topics now appear visually distinct, making their status easier to recognize.
  * Updated topic browsing behavior to refresh correctly after a topic is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->