### PR TITLE
feat(hermes): durable session resume via persisted response id (#1087)

### DIFF
--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -780,8 +780,15 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     return this._config?.sessionId ?? crypto.randomBytes(8).toString('hex');
   }
 
-  async resumeSession(_sessionId: string): Promise<void> {
-    // no-op — resume handled by spawn args if supported
+  async resumeSession(providerSessionId: string): Promise<void> {
+    // The Hermes gateway is stateful (`store: true` + a stable `session_id`);
+    // resuming means restoring the last completed response id so the next turn
+    // chains via `previous_response_id`. `connect()` (run before resume on the
+    // cold-restart path) already reset this to null and re-set `_config`, so we
+    // only reinstate the chaining anchor here.
+    if (providerSessionId) {
+      this._lastResponseId = providerSessionId;
+    }
   }
 
   async forkSession(_sessionId: string): Promise<string> {
@@ -912,6 +919,13 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
         const responseId = response?.['id'];
         if (typeof responseId === 'string') {
           this._lastResponseId = responseId;
+          // Persist the completed response id so a resumed session (after a
+          // Relay restart) can continue the conversation via
+          // `previous_response_id`. Only completed responses are chainable.
+          this.fire({
+            type: 'chat:provider-session',
+            providerSession: { hermesResponseId: responseId },
+          });
         }
         if (this._currentTurnId) {
           this.fire({

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -53,7 +53,7 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       queue: false,
       interrupt: true,
       cancelQueued: false,
-      resume: false,
+      resume: true,
     }),
 };
 
@@ -61,7 +61,7 @@ export function createAdapterV2(agentType: string): ProtocolAdapterV2 {
   const factory = v2Adapters[agentType];
   if (!factory)
     throw new Error(
-      `No v2 protocol adapter registered for agent type: ${agentType}`,
+      `No v2 protocol adapter registered for agent type: ${agentType}`
     );
   return factory();
 }

--- a/server/protocol-adapters/legacy-v2-bridge.ts
+++ b/server/protocol-adapters/legacy-v2-bridge.ts
@@ -97,10 +97,15 @@ export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
     }
   }
 
-  async resumeSession(_sessionId: string): Promise<void> {
-    throw new Error(
-      `${this.agentType} does not support resume (capabilities.resume is false).`
-    );
+  async resumeSession(sessionId: string): Promise<void> {
+    if (!this.capabilities.resume) {
+      throw new Error(
+        `${this.agentType} does not support resume (capabilities.resume is false).`
+      );
+    }
+    // The wrapped adapter is already connected (patch subscription is live from
+    // connect()); resume only restores provider-native continuation state.
+    await this.inner.resumeSession(sessionId);
   }
 
   async sendMessage(input: AgentSendMessageInputV2): Promise<void> {

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -197,6 +197,7 @@ export async function createWebSession(
  * Each provider stores its resumable ID under a known key:
  *   claude → claudeSessionId
  *   codex  → threadId  (PR 5)
+ *   hermes → hermesResponseId  (last completed gateway response, #1087)
  *
  * Returns undefined if no recognized key is present.
  */

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -207,6 +207,7 @@ function extractProviderSessionId(
   if (!providerSession) return undefined;
   if (agentType === 'claude') return providerSession['claudeSessionId'];
   if (agentType === 'codex') return providerSession['threadId'];
+  if (agentType === 'hermes') return providerSession['hermesResponseId'];
   return undefined;
 }
 

--- a/shared/agent-chat-v1-compat.ts
+++ b/shared/agent-chat-v1-compat.ts
@@ -33,12 +33,23 @@ function legacyDecisionToV2(
   decision: 'allow' | 'allow-always' | 'deny'
 ): AgentApprovalDecisionV2 {
   if (decision === 'deny') return { kind: 'decline' };
-  if (decision === 'allow-always') return { kind: 'accept', scope: 'permanent' };
+  if (decision === 'allow-always')
+    return { kind: 'accept', scope: 'permanent' };
   return { kind: 'accept', scope: 'once' };
 }
 
 export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
   switch (event.type) {
+    case 'chat:provider-session':
+      return [
+        {
+          type: 'agent-session-updated-v2',
+          sessionId: event.sessionId,
+          timestamp: event.timestamp,
+          providerSession: event.providerSession,
+        },
+      ];
+
     case 'chat:session-status':
       return [
         {

--- a/shared/chat-events.ts
+++ b/shared/chat-events.ts
@@ -6,7 +6,12 @@
 // All agent backends (Codex, OpenCode, Claude Code) map their native protocol
 // messages into this canonical type system via ProtocolAdapters.
 
-export type ChatEventSource = 'codex' | 'opencode' | 'claude' | 'mock' | 'hermes';
+export type ChatEventSource =
+  | 'codex'
+  | 'opencode'
+  | 'claude'
+  | 'mock'
+  | 'hermes';
 
 export interface ChatEventBase {
   sessionId: string;
@@ -259,6 +264,19 @@ export interface RateLimitEvent extends ChatEventBase {
   windowName: string;
 }
 
+/**
+ * Provider-native session identity changed and should be persisted durably on
+ * the session (e.g. the Hermes gateway response id used to chain the next turn
+ * via `previous_response_id` when resuming after a Relay restart). Legacy V1
+ * adapters emit this so the V1→V2 bridge can surface a `providerSession` patch;
+ * native V2 adapters set `providerSession` on their own session-updated patches.
+ */
+export interface ProviderSessionEvent extends ChatEventBase {
+  type: 'chat:provider-session';
+  /** Provider-specific identity to merge into the session's `providerSession`. */
+  providerSession: Record<string, string>;
+}
+
 // ── Union Type ────────────────────────────────────────────────────────────────
 
 export type ChatEvent =
@@ -280,7 +298,8 @@ export type ChatEvent =
   | TurnCompletedEvent
   | ErrorEvent
   | TelemetryEvent
-  | RateLimitEvent;
+  | RateLimitEvent
+  | ProviderSessionEvent;
 
 export type ChatEventType = ChatEvent['type'];
 
@@ -314,6 +333,7 @@ const VALID_TYPES: ReadonlySet<string> = new Set([
   'chat:error',
   'chat:telemetry',
   'chat:rate-limit',
+  'chat:provider-session',
 ]);
 
 export function isChatEvent(event: unknown): event is ChatEvent {

--- a/test/agent-chat-v1-compat.test.ts
+++ b/test/agent-chat-v1-compat.test.ts
@@ -35,6 +35,25 @@ describe('Agent Chat v1 compatibility bridge', () => {
     ]);
   });
 
+  it('maps a provider-session event to a session-updated providerSession patch', () => {
+    const event: ChatEvent = {
+      type: 'chat:provider-session',
+      sessionId: 'session-1',
+      timestamp,
+      source: 'hermes',
+      providerSession: { hermesResponseId: 'resp_abc' },
+    };
+
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([
+      {
+        type: 'agent-session-updated-v2',
+        sessionId: 'session-1',
+        timestamp,
+        providerSession: { hermesResponseId: 'resp_abc' },
+      },
+    ]);
+  });
+
   it('maps v1 approval requests to an approval item and active request', () => {
     const event: ChatEvent = {
       type: 'chat:approval-request',

--- a/test/hermes-resume-integration.test.ts
+++ b/test/hermes-resume-integration.test.ts
@@ -1,0 +1,159 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HermesProtocolAdapter } from '../server/protocol-adapters/hermes-adapter.js';
+import type { AdapterConfig } from '../server/protocol-adapter.js';
+import type { ChatEvent } from '../shared/chat-events.js';
+
+/**
+ * Integration coverage for durable Hermes resume (#1087). Drives a real
+ * HermesProtocolAdapter against an in-process gateway that speaks just enough of
+ * the Responses SSE protocol to (a) pass the reachability probe, (b) stream a
+ * completed response with a known id, and (c) record every `/v1/responses`
+ * request body so we can assert `previous_response_id` chaining after a resume.
+ */
+
+interface InlineGateway {
+  server: http.Server;
+  endpoint: string;
+  requests: Array<Record<string, unknown>>;
+}
+
+function startInlineGateway(responseId: string): Promise<InlineGateway> {
+  const requests: Array<Record<string, unknown>> = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      if (req.url === '/health') {
+        res.writeHead(200);
+        res.end('ok');
+        return;
+      }
+      if (req.url === '/v1/models') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ id: 'inline-stub' }] }));
+        return;
+      }
+      if (req.url === '/v1/responses') {
+        try {
+          requests.push(JSON.parse(body) as Record<string, unknown>);
+        } catch {
+          requests.push({});
+        }
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+        });
+        const send = (obj: unknown): void => {
+          res.write(`data: ${JSON.stringify(obj)}\n\n`);
+        };
+        send({ type: 'response.created', response: { id: responseId } });
+        send({ type: 'response.output_text.delta', delta: 'ok' });
+        send({
+          type: 'response.completed',
+          response: {
+            id: responseId,
+            status: 'completed',
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'done' }],
+              },
+            ],
+          },
+        });
+        res.end();
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, endpoint: `http://127.0.0.1:${port}`, requests });
+    });
+  });
+}
+
+function configFor(endpoint: string, sessionId: string): AdapterConfig {
+  return {
+    cwd: process.cwd(),
+    port: 0,
+    sessionId,
+    hookToken: 'test-hook',
+    configDir: process.cwd(),
+    extra: { endpoint, apiToken: 'inline-key' },
+  };
+}
+
+describe('Hermes durable resume', () => {
+  let gateway: InlineGateway | undefined;
+  let adapter: HermesProtocolAdapter | undefined;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.disconnect().catch(() => {});
+      adapter = undefined;
+    }
+    if (gateway) {
+      await new Promise<void>((resolve) =>
+        gateway!.server.close(() => resolve())
+      );
+      gateway = undefined;
+    }
+  });
+
+  it('emits a provider-session event carrying the completed response id', async () => {
+    gateway = await startInlineGateway('resp_emit_1');
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-emit-1'));
+    await adapter.sendMessage('turn-1', 'remember 42');
+
+    const providerSession = events.find(
+      (event) => event.type === 'chat:provider-session'
+    );
+    expect(providerSession).toBeDefined();
+    if (providerSession?.type !== 'chat:provider-session') {
+      throw new Error('expected a provider-session event');
+    }
+    expect(providerSession.sessionId).toBe('sess-emit-1');
+    expect(providerSession.providerSession).toEqual({
+      hermesResponseId: 'resp_emit_1',
+    });
+  });
+
+  it('chains the next turn from a restored response id after resumeSession', async () => {
+    gateway = await startInlineGateway('resp_after_resume');
+    adapter = new HermesProtocolAdapter();
+
+    // Simulate a cold-restart resume: connect (resets chaining), then restore
+    // the stored response id via resumeSession before the next turn.
+    await adapter.connect(configFor(gateway.endpoint, 'sess-resume-1'));
+    await adapter.resumeSession('resp_previous_turn');
+    await adapter.sendMessage('turn-1', 'continue');
+
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0]?.['previous_response_id']).toBe(
+      'resp_previous_turn'
+    );
+    expect(gateway.requests[0]?.['session_id']).toBe('sess-resume-1');
+  });
+
+  it('does not chain when resume was never called (fresh session)', async () => {
+    gateway = await startInlineGateway('resp_fresh');
+    adapter = new HermesProtocolAdapter();
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-fresh-1'));
+    await adapter.sendMessage('turn-1', 'hello');
+
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0]?.['previous_response_id']).toBeUndefined();
+  });
+});

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -64,7 +64,23 @@ describe('Hermes V2 web adapter registration', () => {
       fileChanges: true,
       approvals: true,
       interrupt: true,
+      resume: true,
     });
+  });
+
+  it('delegates resumeSession to the wrapped Hermes adapter when resume is enabled', async () => {
+    const adapter = createAdapterV2('hermes');
+    // Hermes resumeSession only restores in-memory chaining state (no network),
+    // so it resolves without a connected gateway.
+    await expect(adapter.resumeSession('resp_stored')).resolves.toBeUndefined();
+  });
+
+  it('keeps resumeSession throwing for a legacy adapter without resume capability', async () => {
+    const opencode = createAdapterV2('opencode');
+    expect(opencode.capabilities.resume).toBe(false);
+    await expect(opencode.resumeSession('anything')).rejects.toThrow(
+      /does not support resume/
+    );
   });
 });
 

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -277,4 +277,49 @@ describe('web session restore failure recovery', () => {
     });
     expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
   });
+
+  it('resumes a persisted Hermes session from its stored response id', async () => {
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-hermes',
+        vendor: 'hermes',
+        vendorSessionId: 'resp_stored',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'hermes restart session',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-hermes',
+          provider: 'hermes',
+          cwd: configDir,
+          capabilities,
+          // Hermes persists the last completed gateway response id under this
+          // key; extractProviderSessionId must read it to resume chaining.
+          providerSession: { hermesResponseId: 'resp_stored' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'hermes',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'hermes-restored-hook-token',
+          adapterType: 'hermes',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+
+    const restored = await sessions.restoreFromDisk(configDir);
+
+    expect(restored).toBe(1);
+    expect(resumeSession).toHaveBeenCalledWith('resp_stored');
+    expect(reconnect).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What

Completes the **session-resume** half of Slice 5 (#1087). Hermes sessions now survive a Relay restart: the gateway response id that chains turns (`previous_response_id`) is persisted and restored, so a resumed session continues the conversation instead of starting cold.

### Before
- `_lastResponseId` lived only in adapter memory → lost on restart.
- `HermesProtocolAdapter.resumeSession` was a no-op.
- Hermes advertised `resume: false`; the legacy→V2 bridge's `resumeSession` threw unconditionally.

### After (all additive)
1. New `chat:provider-session` ChatEvent carrying a `providerSession` map; the V1→V2 compat bridge maps it to an `agent-session-updated-v2` patch, so the id persists through the existing session reducer + SQLite blob. Adapters that never fire it are unaffected.
2. Hermes emits `{ hermesResponseId }` on `response.completed` (only committed responses are chainable) and `resumeSession(id)` restores the chaining anchor.
3. `extractProviderSessionId` reads `hermesResponseId`; Hermes capability → `resume: true`; the bridge's `resumeSession` delegates to the inner adapter when `capabilities.resume`, still throwing for opencode (`resume: false`).

On cold restart, `connect()` (which resets the anchor to null) runs before `reconnectWebSession → resumeSession(id)` restores it — no ordering hazard.

## Acceptance mapping (#1087)

- [x] Resume returns a reattach handle — **this PR** (resume restores chaining + re-establishes the session via the persisted providerSession)
- [x] archive filter hides then restores — #1095
- [x] session-result shows parent channel — #1093

Closes the last open item on #1087.

## Blast radius

Touches shared surfaces (`chat-events`, `agent-chat-v1-compat`, `legacy-v2-bridge`) used by opencode too. opencode/opencode-attached keep `resume: false`, so the bridge still throws for them (regression-tested). New event type is fully consumed by the bridge and never leaks to a ChatEvent renderer; all shared switches have `default` cases.

## Test

- Unit: v1-compat mapping, capability wiring + bridge delegate/throw (opencode regression), cold-restart resume dispatch (`sessions-web-restore`).
- Integration: in-process gateway proving the `provider-session` emit **and** `previous_response_id` chaining after `resumeSession`, plus no-chain-when-fresh.
- **Live ebi gateway** manually verified: stored "4273" in turn 1, recalled it in turn 2 via `previous_response_id` (`CHAINED=true`).
- `npm run check` green; 87/87 across resume + regression suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)