### PR TITLE
feat(mobile): workspace-grouped topic cockpit + one-tap resume-last (#1088)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1040,10 +1040,38 @@
     cursor: not-allowed;
   }
 
+  .topic-mobile-cockpit__actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   .topic-mobile-list {
     display: flex;
     flex-direction: column;
     padding: 4px 0;
+  }
+
+  .topic-mobile-group {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .topic-mobile-group__header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px 2px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .topic-mobile-group__name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .topic-mobile-row {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1633,17 +1633,37 @@ function TopicRoomCreatePanel({
   );
 }
 
+/** A workspace bucket of mobile topic rows, kept in attention order. */
+interface MobileTopicGroup {
+  id: string;
+  title: string;
+  icon: string | null;
+  items: TopicNavItem[];
+}
+
 function TopicMobileCockpit({
-  mobileItems,
+  groups,
+  ungrouped,
   selectedId,
   onSelect,
   onCreateTaskRoom,
+  onResumeLast,
 }: {
-  mobileItems: TopicNavItem[];
+  groups: MobileTopicGroup[];
+  ungrouped: TopicNavItem[];
   selectedId: string | null;
   onSelect: (id: string) => void;
   onCreateTaskRoom?: (() => void) | undefined;
+  onResumeLast?: (() => void) | undefined;
 }) {
+  const renderRow = (item: TopicNavItem): ReactNode => (
+    <TopicMobileAttentionRow
+      key={item.id}
+      item={item}
+      selected={selectedId === item.id}
+      onSelect={onSelect}
+    />
+  );
   return (
     <section className="topic-mobile-cockpit" aria-label="mobile topic cockpit">
       <div
@@ -1653,28 +1673,64 @@ function TopicMobileCockpit({
         <span className="topic-mobile-cockpit__hint">
           use / search for topic history
         </span>
-        <button
-          type="button"
-          disabled={!onCreateTaskRoom}
-          title={
-            onCreateTaskRoom
-              ? 'create a task room from workspace defaults'
-              : 'topic creation unavailable'
-          }
-          onClick={onCreateTaskRoom}
-        >
-          + task
-        </button>
+        <div className="topic-mobile-cockpit__actions">
+          <button
+            type="button"
+            className="topic-mobile-cockpit__resume"
+            disabled={!onResumeLast}
+            title={
+              onResumeLast
+                ? 'resume your most recent session'
+                : 'no recent session to resume'
+            }
+            onClick={onResumeLast}
+          >
+            resume last
+          </button>
+          <button
+            type="button"
+            disabled={!onCreateTaskRoom}
+            title={
+              onCreateTaskRoom
+                ? 'create a task room from workspace defaults'
+                : 'topic creation unavailable'
+            }
+            onClick={onCreateTaskRoom}
+          >
+            + task
+          </button>
+        </div>
       </div>
-      <div className="topic-mobile-list" aria-label="attention-sorted topics">
-        {mobileItems.map((item) => (
-          <TopicMobileAttentionRow
-            key={item.id}
-            item={item}
-            selected={selectedId === item.id}
-            onSelect={onSelect}
-          />
+      <div className="topic-mobile-list" aria-label="workspace-grouped topics">
+        {groups.map((group) => (
+          <section
+            key={group.id}
+            className="topic-mobile-group"
+            aria-label={group.title}
+          >
+            <div className="topic-mobile-group__header">
+              {group.icon ? (
+                <span className="topic-mobile-group__icon" aria-hidden="true">
+                  {group.icon}
+                </span>
+              ) : null}
+              <span className="topic-mobile-group__name">{group.title}</span>
+            </div>
+            {group.items.map(renderRow)}
+          </section>
         ))}
+        {ungrouped.length > 0 && groups.length > 0 ? (
+          <section
+            className="topic-mobile-group topic-mobile-group--orphan"
+            aria-label="no workspace"
+          >
+            <div className="topic-mobile-group__header">
+              <span className="topic-mobile-group__name">no workspace</span>
+            </div>
+            {ungrouped.map(renderRow)}
+          </section>
+        ) : null}
+        {groups.length === 0 ? ungrouped.map(renderRow) : null}
       </div>
     </section>
   );
@@ -2003,6 +2059,48 @@ export function TopicSidebarView({
       }),
     [model.items]
   );
+  // Bucket the attention-sorted mobile rows under their workspace, in the same
+  // pinned-first workspace order the desktop tree uses, so mobile exposes the
+  // same workspace→topic nav (#1088). Rows keep attention order within a group.
+  const { mobileGroups, mobileUngrouped } = useMemo(() => {
+    const groupOrder = new Map(grouped.groups.map((g, index) => [g.id, index]));
+    const buckets = new Map<string, TopicNavItem[]>();
+    const ungrouped: TopicNavItem[] = [];
+    for (const item of mobileItems) {
+      const workspaceId = item.workspaceId;
+      if (workspaceId && groupOrder.has(workspaceId)) {
+        const list = buckets.get(workspaceId);
+        if (list) list.push(item);
+        else buckets.set(workspaceId, [item]);
+      } else {
+        ungrouped.push(item);
+      }
+    }
+    const groups: MobileTopicGroup[] = grouped.groups
+      .filter((g) => buckets.has(g.id))
+      .map((g) => ({
+        id: g.id,
+        title: g.title,
+        icon: g.icon,
+        items: buckets.get(g.id) ?? [],
+      }));
+    return { mobileGroups: groups, mobileUngrouped: ungrouped };
+  }, [mobileItems, grouped.groups]);
+  // One-tap resume-last: the select key of the most recently active session
+  // across every topic. Null when nothing resumable exists yet.
+  const resumeLastSelectKey = useMemo(() => {
+    let bestKey: string | null = null;
+    let bestAt = '';
+    for (const item of model.items) {
+      for (const session of item.sessions) {
+        if (session.lastActivity && session.lastActivity > bestAt) {
+          bestAt = session.lastActivity;
+          bestKey = session.selectKey;
+        }
+      }
+    }
+    return bestKey;
+  }, [model.items]);
   const activeSearchLoading = Boolean(searchQuery.trim() && searchLoading);
 
   if (loading && !activeSearchLoading) {
@@ -2034,10 +2132,16 @@ export function TopicSidebarView({
         ) : null}
       </div>
       <TopicMobileCockpit
-        mobileItems={mobileItems}
+        groups={mobileGroups}
+        ungrouped={mobileUngrouped}
         selectedId={selectedId}
         onSelect={select}
         onCreateTaskRoom={onCreateTaskRoom}
+        onResumeLast={
+          resumeLastSelectKey && onSelectSession
+            ? () => onSelectSession(resumeLastSelectKey)
+            : undefined
+        }
       />
       {createPanel}
       <TopicSearchPanel

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -180,6 +180,98 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('Beta channel');
   });
 
+  it('groups the mobile cockpit under the same workspace headers (#1088)', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:a',
+          workspaceId: 'ws:a',
+          display: { title: 'Alpha channel' },
+          linkedRefs: {},
+        }),
+        makeTopic({
+          id: 'topic:b',
+          workspaceId: 'ws:b',
+          display: { title: 'Beta channel' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      workspaces: [
+        {
+          id: 'ws:a',
+          name: 'engineering',
+          order: 0,
+          pinned: false,
+          color: null,
+          icon: null,
+        },
+        {
+          id: 'ws:b',
+          name: 'research',
+          order: 1,
+          pinned: false,
+          color: null,
+          icon: null,
+        },
+      ],
+    });
+    const mobileHeaders = Array.from(
+      container.querySelectorAll('.topic-mobile-group__name')
+    ).map((el) => el.textContent);
+    expect(mobileHeaders).toContain('engineering');
+    expect(mobileHeaders).toContain('research');
+  });
+
+  it('resumes the most recent session in one tap from the mobile cockpit (#1088)', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:a',
+          workspaceId: 'ws:a',
+          display: { title: 'Alpha channel' },
+          linkedRefs: { sessionIds: ['s-old', 's-new'] },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 's-old',
+          displayName: 'older',
+          lastActivity: '2026-06-01T00:00:00Z',
+        }),
+        makeSession({
+          id: 's-new',
+          displayName: 'newer',
+          lastActivity: '2026-06-25T00:00:00Z',
+        }),
+      ],
+      surfaces: [],
+    });
+    const resume = container.querySelector(
+      '.topic-mobile-cockpit__resume'
+    ) as HTMLButtonElement;
+    expect(resume).not.toBeNull();
+    expect(resume.disabled).toBe(false);
+    await act(async () => resume.click());
+    expect(onSelectSession).toHaveBeenCalledTimes(1);
+    const key = onSelectSession.mock.calls[0][0] as string;
+    expect(key).toContain('s-new');
+  });
+
+  it('disables mobile resume-last when no session has activity yet (#1088)', async () => {
+    await renderView({
+      topics: [makeTopic({ id: 'topic:a', linkedRefs: {} })],
+      sessions: [],
+      surfaces: [],
+    });
+    const resume = container.querySelector(
+      '.topic-mobile-cockpit__resume'
+    ) as HTMLButtonElement;
+    expect(resume).not.toBeNull();
+    expect(resume.disabled).toBe(true);
+  });
+
   it('shows a search scope toggle only when a workspace is active', async () => {
     const onToggleSearchScope = vi.fn();
     await renderView({ activeWorkspaceId: 'ws:a', onToggleSearchScope });


### PR DESCRIPTION
## What

Slice 6 of #1021 — brings the **mobile** topic cockpit to parity with the desktop sidebar nav.

- **Grouped nav**: the mobile cockpit's attention-sorted rows are now bucketed under workspace headers, in the same pinned-first workspace order the desktop tree uses (reuses `groupTopicsByWorkspace`). Rows keep attention order within a group. Topics whose workspace has no group fall into a "no workspace" lane; with no workspace groups at all it renders flat as before — **every row stays visible, none dropped**.
- **One-tap resume-last**: a "resume last" button jumps straight to the most recently active session across all topics (max session `lastActivity` → its `selectKey` → `onSelectSession`). Disabled when nothing resumable exists. `+ task` quick-create stays alongside it.

## Acceptance mapping (#1088)

- [x] Mobile shows grouped workspace→topic nav — grouped cockpit
- [x] one-tap resume-last — resume-last button
- [x] quick-create — existing `+ task` (kept)

> Note on the "add fixture to test/fixtures/mobile-input/" line: that directory is the mobile **keyboard-input** pipeline (per CLAUDE.md — fixtures for gboard/iOS autocorrect/paste). This change adds no keyboard-input surface, so coverage is component-level (grouped headers + resume-last one-tap + disabled state) rather than an artificial input fixture.

## Blast radius

`TopicSidebarShell` is shared (desktop + mobile; CSS media queries show/hide the mobile cockpit). The change is confined to `TopicMobileCockpit` + two shell memos — the desktop `GroupedTopicTree` path is untouched. `mobileItems` is still consumed (by the new grouping memo).

## Test

- 3 new tests: mobile cockpit groups under workspace headers; resume-last one-tap selects the most-recent session's key; resume-last disabled with no activity.
- `npm run check` green; 47/47 sidebar suite, 74/74 across topic/nav/sidebar suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)