### PR TITLE
feat(landing): default landing to the chat/topic spine

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,7 @@ import { getActiveTerminalHandle } from './lib/terminal-refs.js';
 import PrTopBar from './components/PrTopBar.js';
 import RepoDashboard from './components/RepoDashboard.js';
 import OrgDashboard from './components/OrgDashboard.js';
+import ChatHome from './components/ChatHome.js';
 import Toolbar from './components/Toolbar.js';
 import MobileHeader from './components/MobileHeader.js';
 import SessionStatusBar from './components/SessionStatusBar.js';
@@ -178,6 +179,8 @@ function resolveTerminalFilePath(
 function useTerminalDerivedState() {
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const analyticsView = useUiStore((s) => s.analyticsView);
+  const forceOrgCockpit = useUiStore((s) => s.forceOrgCockpit);
+  const setForceOrgCockpit = useUiStore((s) => s.setForceOrgCockpit);
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
@@ -248,9 +251,17 @@ function useTerminalDerivedState() {
         analyticsView,
         hasActiveSession,
         activeRepoPath,
+        forceOrgCockpit,
       }),
-    [analyticsView, hasActiveSession, activeRepoPath]
+    [analyticsView, hasActiveSession, activeRepoPath, forceOrgCockpit]
   );
+
+  // #1058: once a session goes active, drop the explicit cockpit override so
+  // the next no-session/no-repo landing defaults back to the chat spine
+  // instead of leaving the operator stuck in the legacy cockpit.
+  useEffect(() => {
+    if (hasActiveSession && forceOrgCockpit) setForceOrgCockpit(false);
+  }, [hasActiveSession, forceOrgCockpit, setForceOrgCockpit]);
 
   return {
     activeRepoPath,
@@ -698,6 +709,8 @@ function TerminalAreaContent({
         onRightSidebarClick={handleToggleUtilityRail}
         hidden={keyboardOpen}
       />
+      {viewMode === 'chat' && <ChatHome onSelectSession={onSelectSession} />}
+
       {viewMode === 'org' && (
         <OrgDashboard
           onOpenPrSession={onOpenPrSession}

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type FormEvent,
+  type ReactNode,
 } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
@@ -28,6 +29,7 @@ import SessionMailboxPanel, {
   SessionMailboxBadge,
 } from './SessionMailboxPanel.js';
 import { TuiButton } from './TuiButton.js';
+import { openTopicTaskRoom } from '../lib/topic-task-room.js';
 import './ActiveWorkSurface.css';
 
 const ACTIVE_WORK_REFETCH_MS = 15_000;
@@ -605,30 +607,45 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
 }
 
 /**
- * Empty-cockpit state: a single bordered panel floated into the open space that
+ * Empty-state panel: a single bordered panel floated into the open space that
  * drives the primary next action (start a topic) instead of leaving a void.
  * Content is left-aligned (TUI-native, not a centered hero — see DESIGN.md).
+ * Shared between the work-cockpit empty state and the chat-first landing
+ * home (#1058) — `title`/`lede` let each caller tailor the copy, and an
+ * optional `resume` action surfaces a one-tap "resume last topic" affordance.
  */
 export function ActiveWorkEmpty({
   onStartTopic,
+  title = 'no active work yet',
+  lede = (
+    <>
+      start a topic to chat with an agent, launch a terminal, or review
+      artifacts — each runs in its own node and repo. workcontexts, mailboxes,
+      and stale/offline node state show up here once work begins; prs, tickets,
+      nodes, and audit stay available above as secondary context.
+    </>
+  ),
+  resume,
 }: {
   onStartTopic: () => void;
+  title?: string;
+  lede?: ReactNode;
+  resume?: { label: string; onResume: () => void };
 }) {
   return (
     <div className="active-work-empty">
       <div className="active-work-empty__panel">
-        <span className="active-work-empty__title">no active work yet</span>
-        <p className="active-work-empty__lede">
-          start a topic to chat with an agent, launch a terminal, or review
-          artifacts — each runs in its own node and repo. workcontexts,
-          mailboxes, and stale/offline node state show up here once work begins;
-          prs, tickets, nodes, and audit stay available above as secondary
-          context.
-        </p>
+        <span className="active-work-empty__title">{title}</span>
+        <p className="active-work-empty__lede">{lede}</p>
         <div className="active-work-empty__actions">
           <TuiButton variant="primary" onClick={onStartTopic}>
             + new topic
           </TuiButton>
+          {resume && (
+            <TuiButton variant="ghost" onClick={resume.onResume}>
+              {resume.label}
+            </TuiButton>
+          )}
           <span className="active-work-empty__hint">
             or search topics, tasks, and artifacts from the sidebar
           </span>
@@ -640,20 +657,6 @@ export function ActiveWorkEmpty({
 
 export default function ActiveWorkSurface() {
   const queryClient = useQueryClient();
-  // Drive the same primary next action as the sidebar's create affordance. The
-  // create panel lives in TopicSidebarShell, which is unmounted while the
-  // sidebar is collapsed — so un-collapse + open first, then dispatch on the
-  // next tick once the shell has mounted and registered its listener (otherwise
-  // the event fires into the void and the CTA is a no-op in collapsed mode).
-  const startTopic = useCallback(() => {
-    const ui = useUiStore.getState();
-    if (ui.sidebarCollapsed) ui.toggleSidebarCollapsed();
-    ui.openSidebar();
-    setTimeout(
-      () => window.dispatchEvent(new Event('relay:open-topic-task-room')),
-      0
-    );
-  }, []);
   const {
     data = [],
     isLoading,
@@ -731,7 +734,7 @@ export default function ActiveWorkSurface() {
         </div>
       </div>
       {groups.length === 0 ? (
-        <ActiveWorkEmpty onStartTopic={startTopic} />
+        <ActiveWorkEmpty onStartTopic={openTopicTaskRoom} />
       ) : (
         <div className="active-work-list">
           {groups.map((group) => (

--- a/frontend/src/components/ChatHome.css
+++ b/frontend/src/components/ChatHome.css
@@ -1,0 +1,11 @@
+/* #1058: chat/topic spine default landing — the panel it hosts
+   (`.active-work-empty`) centers in the open space while keeping its content
+   left-aligned (TUI-native — see DESIGN.md). */
+.chat-home {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  padding: 20px;
+  overflow-y: auto;
+}

--- a/frontend/src/components/ChatHome.tsx
+++ b/frontend/src/components/ChatHome.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
+import { openTopicTaskRoom } from '../lib/topic-task-room.js';
+import { ActiveWorkEmpty } from './ActiveWorkSurface.js';
+import './ChatHome.css';
+
+export interface ChatHomeProps {
+  onSelectSession: (id: string) => void;
+}
+
+/**
+ * #1058: the chat/topic spine is the default no-session/no-repo landing —
+ * replacing the WorkContext cockpit as the first thing an operator sees. The
+ * topic sidebar stays primary; this main-pane empty state reuses the
+ * cockpit's `ActiveWorkEmpty` panel/CTA pattern so the two surfaces stay
+ * visually consistent, and offers a one-tap resume of the most recently
+ * active session when one exists. The full cockpit remains reachable via the
+ * "open work cockpit" command-palette action.
+ */
+export default function ChatHome({ onSelectSession }: ChatHomeProps) {
+  const sessions = useSessionsStore((s) => s.sessions);
+
+  const mostRecentSession = useMemo(() => {
+    let best: (typeof sessions)[number] | undefined;
+    for (const session of sessions) {
+      if (!best || session.lastActivity > best.lastActivity) best = session;
+    }
+    return best;
+  }, [sessions]);
+
+  const resume = mostRecentSession
+    ? {
+        label: `resume "${mostRecentSession.displayName}"`,
+        onResume: () => onSelectSession(scopedSessionKey(mostRecentSession)),
+      }
+    : undefined;
+
+  return (
+    <div className="chat-home" aria-label="chat and topic home">
+      <ActiveWorkEmpty
+        onStartTopic={openTopicTaskRoom}
+        title="start a topic"
+        lede={
+          <>
+            chat with an agent, launch a terminal, or review artifacts — each
+            topic runs in its own node and repo. topics, sessions, and
+            workspaces live in the sidebar; open the work cockpit from the
+            command palette for cross-node prs, tickets, nodes, and audit.
+          </>
+        }
+        {...(resume ? { resume } : {})}
+      />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -103,6 +103,7 @@ import {
   navSwitchToTab,
   navOpenFile,
   navNextAttentionWork,
+  navOpenWorkCockpit,
 } from '../lib/actions/definitions/navigation.js';
 import { cliGatewayCommandActions } from '../lib/actions/definitions/cli-gateway.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
@@ -678,6 +679,22 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
               .getState()
               .showToast(`could not load active work: ${message}`);
           }
+        },
+      },
+      {
+        // #1058: the chat/topic spine is the default no-session/no-repo
+        // landing; this is the escape hatch back to the legacy WorkContext
+        // cockpit. Clears the active session/repo/analytics view so
+        // resolveAppViewMode's no-session/no-repo branch is reached, then
+        // sets forceOrgCockpit so it resolves to 'org' instead of 'chat'.
+        ...navOpenWorkCockpit,
+        handler: () => {
+          const sessions = useSessionsStore.getState();
+          const ui = useUiStore.getState();
+          ui.setAnalyticsView(null);
+          sessions.setActiveSessionId(null);
+          ui.setActiveRepoPath(null);
+          ui.setForceOrgCockpit(true);
         },
       },
       {

--- a/frontend/src/lib/actions/definitions/navigation.ts
+++ b/frontend/src/lib/actions/definitions/navigation.ts
@@ -54,10 +54,24 @@ export const navNextAttentionWork: ActionMeta = {
   icon: '◆',
 };
 
+// #1058: the chat/topic spine is the default no-session/no-repo landing;
+// this keeps the legacy WorkContext cockpit (PRs, tickets, nodes, audit)
+// reachable rather than deleting it outright.
+export const navOpenWorkCockpit: ActionMeta = {
+  id: 'navigation.open-work-cockpit',
+  label: 'open work cockpit',
+  description:
+    'switch to the WorkContext cockpit — active work, prs, tickets, nodes, and audit across all workspaces',
+  aliases: ['org dashboard', 'active work cockpit', 'work cockpit'],
+  category: 'navigation',
+  icon: '▦',
+};
+
 export const navigationActions: ActionMeta[] = [
   navPreviousTab,
   navNextTab,
   navSwitchToTab,
   navOpenFile,
   navNextAttentionWork,
+  navOpenWorkCockpit,
 ];

--- a/frontend/src/lib/state/app-view-mode.ts
+++ b/frontend/src/lib/state/app-view-mode.ts
@@ -1,24 +1,38 @@
 import type { AnalyticsView } from '../stores/ui.js';
 
-export type AppViewMode = 'org' | 'dashboard' | 'session' | 'analytics';
+export type AppViewMode =
+  | 'chat'
+  | 'org'
+  | 'dashboard'
+  | 'session'
+  | 'analytics';
 
 export interface ResolveAppViewModeInput {
   analyticsView: AnalyticsView;
   hasActiveSession: boolean;
   activeRepoPath: string | null;
+  /**
+   * #1058: explicit escape hatch back to the legacy WorkContext cockpit
+   * (`OrgDashboard`), set via the "open work cockpit" command-palette
+   * action. Only relevant for the no-session/no-repo landing path — an
+   * explicit repo/project selection still resolves to `dashboard`.
+   */
+  forceOrgCockpit?: boolean;
 }
 
 export function resolveAppViewMode({
   analyticsView,
   hasActiveSession,
   activeRepoPath,
+  forceOrgCockpit = false,
 }: ResolveAppViewModeInput): AppViewMode {
   if (analyticsView !== null) return 'analytics';
   if (hasActiveSession) return 'session';
 
-  // The no-session / no-explicit-project landing path is the WorkContext
-  // cockpit, even before a local repo has been added. RepoDashboard remains
-  // reserved for an explicit repo/project selection.
-  if (!activeRepoPath) return 'org';
+  // The no-session / no-explicit-project landing path defaults to the
+  // chat/topic spine (#1058). The legacy WorkContext cockpit remains
+  // reachable via forceOrgCockpit. RepoDashboard remains reserved for an
+  // explicit repo/project selection.
+  if (!activeRepoPath) return forceOrgCockpit ? 'org' : 'chat';
   return 'dashboard';
 }

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -614,6 +614,14 @@ export interface UiState {
   lastChangedFiles: string[];
   analyticsView: AnalyticsView;
   orgDashboardTab: OrgDashboardTab;
+  /**
+   * #1058: the chat/topic spine is the default no-session/no-repo landing.
+   * The legacy WorkContext cockpit (`OrgDashboard`) stays reachable via the
+   * "open work cockpit" command-palette action, which sets this flag so
+   * `resolveAppViewMode` routes there instead of the chat home. Cleared once
+   * a session becomes active so the next empty state defaults back to chat.
+   */
+  forceOrgCockpit: boolean;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
   /** Six-layer navigation surface flag. Default false; backed by localStorage. */
@@ -660,6 +668,7 @@ export interface UiState {
   setLastChangedFiles: (files: string[]) => void;
   setAnalyticsView: (v: AnalyticsView) => void;
   setOrgDashboardTab: (tab: OrgDashboardTab) => void;
+  setForceOrgCockpit: (v: boolean) => void;
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
@@ -706,6 +715,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   sendToTargetSessionId: null,
   analyticsView: null,
   orgDashboardTab: 'active-work',
+  forceOrgCockpit: false,
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
@@ -1131,6 +1141,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   setLastChangedFiles: (files) => set({ lastChangedFiles: files }),
   setAnalyticsView: (v) => set({ analyticsView: v }),
   setOrgDashboardTab: (tab) => set({ orgDashboardTab: tab }),
+  setForceOrgCockpit: (v) => set({ forceOrgCockpit: v }),
   setActiveModal: (v) => set({ activeModal: v }),
 
   saveRightSidebarWidth: () =>

--- a/frontend/src/lib/topic-task-room.ts
+++ b/frontend/src/lib/topic-task-room.ts
@@ -1,0 +1,19 @@
+import { useUiStore } from './stores/ui.js';
+
+/**
+ * #1058: shared "start a topic" entry point used by both the work-cockpit
+ * empty state and the chat-first landing home. The topic create panel lives
+ * in TopicSidebarShell, which is unmounted while the sidebar is collapsed —
+ * so un-collapse + open first, then dispatch on the next tick once the shell
+ * has mounted and registered its listener (otherwise the event fires into
+ * the void and the CTA is a no-op in collapsed mode).
+ */
+export function openTopicTaskRoom(): void {
+  const ui = useUiStore.getState();
+  if (ui.sidebarCollapsed) ui.toggleSidebarCollapsed();
+  ui.openSidebar();
+  window.setTimeout(
+    () => window.dispatchEvent(new Event('relay:open-topic-task-room')),
+    0
+  );
+}

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -35,7 +35,7 @@ import { stableCommandNames } from '../shared/cli-gateway-contract.js';
 
 // Full allowlist: 63 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
 // + workspace.launch from #870 + next-attention WorkContext jump from #933
-// + task-room create/launch from #1045)
+// + task-room create/launch from #1045 + open-work-cockpit from #1058)
 const ACTION_ALLOWLIST = [
   // Session (11)
   'session.new-agent',
@@ -105,12 +105,13 @@ const ACTION_ALLOWLIST = [
   // Terminal (2)
   'terminal.scroll-top',
   'terminal.scroll-bottom',
-  // Navigation (5)
+  // Navigation (6)
   'navigation.previous-tab',
   'navigation.next-tab',
   'navigation.switch-to-tab',
   'navigation.open-file',
   'navigation.next-attention-work',
+  'navigation.open-work-cockpit',
 ] as const;
 
 const ALL_META: ActionMeta[] = [

--- a/test/app-view-mode.test.ts
+++ b/test/app-view-mode.test.ts
@@ -2,14 +2,45 @@ import { describe, expect, it } from 'vitest';
 import { resolveAppViewMode } from '../frontend/src/lib/state/app-view-mode.js';
 
 describe('resolveAppViewMode', () => {
-  it('routes the no-project/no-session landing path to the WorkContext cockpit', () => {
+  it('routes the no-project/no-session landing path to the chat/topic spine', () => {
     expect(
       resolveAppViewMode({
         analyticsView: null,
         hasActiveSession: false,
         activeRepoPath: null,
       })
+    ).toBe('chat');
+  });
+
+  it('routes back to the WorkContext cockpit when forceOrgCockpit is set', () => {
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        activeRepoPath: null,
+        forceOrgCockpit: true,
+      })
     ).toBe('org');
+  });
+
+  it('ignores forceOrgCockpit once a session or explicit repo takes priority', () => {
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: true,
+        activeRepoPath: null,
+        forceOrgCockpit: true,
+      })
+    ).toBe('session');
+
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        activeRepoPath: '/repo/relay-ide',
+        forceOrgCockpit: true,
+      })
+    ).toBe('dashboard');
   });
 
   it('preserves session, analytics, and explicit repo dashboard priority', () => {


### PR DESCRIPTION
## Summary
- Product decision (2026-07-01): the topic/chat spine is now the default no-session/no-repo landing, replacing the WorkContext cockpit as the first thing operators see.
- `resolveAppViewMode` gains a `'chat'` mode (returned instead of `'org'` for the no-session/no-repo case) plus an explicit `forceOrgCockpit` escape hatch back to `'org'`.
- New `ChatHome` component renders the main pane for the chat mode: topic sidebar stays primary, and the empty state reuses the cockpit's `ActiveWorkEmpty` "+ new topic" CTA panel (now generalized with optional `title`/`lede`/`resume` props) — panel centered in the void, content left-aligned per DESIGN.md. A one-tap "resume `<topic>`" affordance appears when a resumable session exists (most-recently-active session across the sessions store).
- The legacy cockpit stays fully reachable (not deleted) via a new "open work cockpit" command-palette action (`navigation.open-work-cockpit`), which sets a `forceOrgCockpit` flag in the ui store; the flag clears automatically once a session goes active so the next empty landing defaults back to chat.
- Extracted the shared "start a topic" sidebar-open + event-dispatch logic into `frontend/src/lib/topic-task-room.ts` so both the cockpit's empty state and the new chat home use the same helper.
- Did not touch `TopicSidebarShell.tsx` or `docs/CHAT_FIRST_SIMPLIFICATION.md` (owned by other lanes); did not delete `OrgDashboard`/`ActiveWorkSurface`.

## Test plan
- [x] `npm run check` (0 errors; pre-existing sonarjs warnings only)
- [x] `npm test` — 396 test files / 5103 tests passed (updated `test/app-view-mode.test.ts` for the new `chat` default + `forceOrgCockpit` override, and `test/action-coverage.test.ts` allowlist for the new action id)
- [x] `npm run build` succeeded
- [x] Manual Playwright validation against a real built hub (system chromium, `--no-sandbox`) on a fresh config (no repos/sessions): desktop (1280x900) and mobile (390x844) both show the chat-first home (`.chat-home` present, no `.tab-strip`), zero console errors; the "open work cockpit" palette action correctly switches to the legacy cockpit (`.tab-strip` visible, `.chat-home` gone). Validation script deleted before commit.

Refs #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)