### PR TITLE
fix(hermes): harden Responses SSE handling against hangs, dropped tool calls

### DIFF
--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -595,6 +595,15 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
   // path's one-shot typed initial prompt (server/sessions.ts) instead of
   // persisting as system framing for the whole conversation.
   private _initialInstructionsSent = false;
+  /** In-flight function_call items, keyed by the Responses API item id, so
+   * `function_call_arguments.delta/.done` can accumulate arguments before
+   * `output_item.done` emits the completed tool-call. */
+  private _pendingToolCalls = new Map<
+    string,
+    { callId: string; toolName: string; argsBuffer: string }
+  >();
+  /** Accumulated reasoning summary text for the turn currently streaming. */
+  private _reasoningBuffer = '';
 
   get status(): AdapterStatus {
     return this._status;
@@ -610,6 +619,8 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._lastResponseId = null;
     this._turnCounter = 0;
     this._initialInstructionsSent = false;
+    this._pendingToolCalls.clear();
+    this._reasoningBuffer = '';
 
     const settings = resolveHermesGatewaySettings(config.extra);
     this._endpoint = settings.endpoint;
@@ -632,6 +643,8 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._messageAbortController = null;
     this._currentTurnId = null;
     this._lastResponseId = null;
+    this._pendingToolCalls.clear();
+    this._reasoningBuffer = '';
     this._status = 'disconnected';
   }
 
@@ -655,6 +668,8 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
 
     this._messageAbortController = new AbortController();
     this._currentTurnId = turnId;
+    this._reasoningBuffer = '';
+    this._pendingToolCalls.clear();
 
     this.fire({ type: 'chat:session-status', status: 'active' });
     this.fire({
@@ -724,6 +739,16 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
       }
 
       await this.consumeResponsesSse(res.body);
+
+      if (this._currentTurnId === turnId) {
+        // The stream closed without a terminal response event (no
+        // response.completed/failed/error/incomplete). Never leave the turn
+        // hanging forever waiting for an event that will never arrive.
+        this.failCurrentTurn(
+          'Hermes stream ended without a terminal response event',
+          'error'
+        );
+      }
     } catch (err) {
       const isAbort = err instanceof Error && err.name === 'AbortError';
       if (isAbort) {
@@ -911,110 +936,320 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     const turnId = this._currentTurnId ?? 'turn-0';
 
     switch (type) {
-      case 'response.created': {
-        const response = event.data['response'] as
-          | Record<string, unknown>
-          | undefined;
-        const responseId = response?.['id'];
-        if (typeof responseId === 'string') {
-          this._lastResponseId = responseId;
-        }
+      case 'response.created':
+        this.handleResponseCreated(event);
         break;
-      }
-      case 'response.output_text.delta': {
-        const delta = event.data['delta'];
-        if (typeof delta === 'string' && delta) {
-          this.fire({
-            type: 'chat:text-delta',
-            turnId,
-            messageId: `msg-${turnId}`,
-            delta,
-          });
-        }
+      case 'response.output_text.delta':
+        this.handleOutputTextDelta(event, turnId);
         break;
-      }
-      case 'response.output_item.added': {
-        const item = event.data['item'] as Record<string, unknown> | undefined;
-        if (item?.['type'] !== 'function_call') break;
-        this.fire({
-          type: 'chat:tool-call',
-          turnId,
-          toolCallId: String(
-            item['call_id'] ?? item['id'] ?? crypto.randomUUID()
-          ),
-          toolName: String(item['name'] ?? 'unknown'),
-          description: '',
-          input: parseToolArguments(item['arguments']),
-          status: 'running',
-        });
+      case 'response.output_text.done':
+        this.handleOutputTextDone(event, turnId);
         break;
-      }
-      case 'response.completed': {
-        const response = event.data['response'] as
-          | Record<string, unknown>
-          | undefined;
-        const responseId = response?.['id'];
-        if (typeof responseId === 'string') {
-          this._lastResponseId = responseId;
-          // Persist the completed response id so a resumed session (after a
-          // Relay restart) can continue the conversation via
-          // `previous_response_id`. Only completed responses are chainable.
-          this.fire({
-            type: 'chat:provider-session',
-            providerSession: { hermesResponseId: responseId },
-          });
-        }
-        if (this._currentTurnId) {
-          this.fire({
-            type: 'chat:turn-completed',
-            turnId: this._currentTurnId,
-            reason: 'completed',
-            durationMs: 0,
-            toolCallCount: 0,
-            messageCount: 1,
-          });
-          this._currentTurnId = null;
-        }
-        this.fire({ type: 'chat:session-status', status: 'idle' });
+      case 'response.output_item.added':
+        this.handleOutputItemAdded(event, turnId);
         break;
-      }
-      case 'response.failed': {
-        const response = event.data['response'] as
-          | Record<string, unknown>
-          | undefined;
-        const error = response?.['error'] as
-          | Record<string, unknown>
-          | undefined;
-        this._lastResponseId = null;
-        this.fire({
-          type: 'chat:error',
-          kind: 'protocol',
-          message: String(error?.['message'] ?? 'Hermes response failed'),
-          retryable: true,
-          turnId,
-        });
-        if (this._currentTurnId) {
-          this.fire({
-            type: 'chat:turn-completed',
-            turnId: this._currentTurnId,
-            reason: 'failed',
-            durationMs: 0,
-            toolCallCount: 0,
-            messageCount: 0,
-          });
-          this._currentTurnId = null;
-        }
-        this.fire({ type: 'chat:session-status', status: 'error' });
+      case 'response.function_call_arguments.delta':
+        this.handleFunctionCallArgumentsDelta(event);
         break;
-      }
+      case 'response.function_call_arguments.done':
+        this.handleFunctionCallArgumentsDone(event);
+        break;
+      case 'response.output_item.done':
+        this.handleOutputItemDone(event, turnId);
+        break;
+      case 'response.reasoning_summary_text.delta':
+        this.handleReasoningSummaryDelta(event, turnId);
+        break;
+      case 'response.reasoning_summary_text.done':
+        this.handleReasoningSummaryDone(event, turnId);
+        break;
+      case 'response.completed':
+        this.handleResponseCompleted(event, turnId);
+        break;
+      case 'response.failed':
+        this.handleResponseFailed(event);
+        break;
+      case 'response.error':
+      case 'error':
+        this.handleResponseError(event);
+        break;
+      case 'response.incomplete':
+        this.handleResponseIncomplete(event);
+        break;
       case 'permission.requested':
-      case 'permission.asked': {
+      case 'permission.asked':
         this.handlePermissionRequested(event);
         break;
-      }
       default:
         logger.debug('Unhandled Hermes Responses event:', type);
     }
+  }
+
+  private handleResponseCreated(event: SseEvent): void {
+    const response = event.data['response'] as
+      | Record<string, unknown>
+      | undefined;
+    const responseId = response?.['id'];
+    if (typeof responseId === 'string') {
+      this._lastResponseId = responseId;
+    }
+  }
+
+  private handleOutputTextDelta(event: SseEvent, turnId: string): void {
+    const delta = event.data['delta'];
+    if (typeof delta === 'string' && delta) {
+      this.fire({
+        type: 'chat:text-delta',
+        turnId,
+        messageId: `msg-${turnId}`,
+        delta,
+      });
+    }
+  }
+
+  private handleOutputTextDone(event: SseEvent, turnId: string): void {
+    const text = event.data['text'];
+    this.fire({
+      type: 'chat:message-complete',
+      turnId,
+      messageId: `msg-${turnId}`,
+      role: 'assistant',
+      content: typeof text === 'string' ? text : '',
+    });
+  }
+
+  private handleOutputItemAdded(event: SseEvent, turnId: string): void {
+    const item = event.data['item'] as Record<string, unknown> | undefined;
+    if (item?.['type'] !== 'function_call') return;
+    const itemId = String(item['id'] ?? crypto.randomUUID());
+    const callId = String(item['call_id'] ?? itemId);
+    const toolName = String(item['name'] ?? 'unknown');
+    this._pendingToolCalls.set(itemId, {
+      callId,
+      toolName,
+      argsBuffer:
+        typeof item['arguments'] === 'string' ? item['arguments'] : '',
+    });
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: callId,
+      toolName,
+      description: '',
+      input: parseToolArguments(item['arguments']),
+      status: 'running',
+    });
+  }
+
+  private handleFunctionCallArgumentsDelta(event: SseEvent): void {
+    const itemId = event.data['item_id'];
+    const delta = event.data['delta'];
+    if (typeof itemId === 'string' && typeof delta === 'string') {
+      const pending = this._pendingToolCalls.get(itemId);
+      if (pending) pending.argsBuffer += delta;
+    }
+  }
+
+  private handleFunctionCallArgumentsDone(event: SseEvent): void {
+    const itemId = event.data['item_id'];
+    const args = event.data['arguments'];
+    if (typeof itemId === 'string' && typeof args === 'string') {
+      const pending = this._pendingToolCalls.get(itemId);
+      if (pending) pending.argsBuffer = args;
+    }
+  }
+
+  private handleOutputItemDone(event: SseEvent, turnId: string): void {
+    const item = event.data['item'] as Record<string, unknown> | undefined;
+    if (item?.['type'] !== 'function_call') return;
+    const itemId = String(item['id'] ?? '');
+    const pending = this._pendingToolCalls.get(itemId);
+    const callId = String(item['call_id'] ?? pending?.callId ?? itemId);
+    const toolName = String(item['name'] ?? pending?.toolName ?? 'unknown');
+    const rawArgs =
+      typeof item['arguments'] === 'string' && item['arguments']
+        ? item['arguments']
+        : (pending?.argsBuffer ?? '');
+    const isIncomplete = item['status'] === 'incomplete';
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: callId,
+      toolName,
+      description: '',
+      input: parseToolArguments(rawArgs),
+      status: isIncomplete ? 'error' : 'completed',
+    });
+    const output = item['output'];
+    if (output !== undefined && output !== null) {
+      this.fire({
+        type: 'chat:tool-result',
+        turnId,
+        toolCallId: callId,
+        toolName,
+        status: isIncomplete ? 'error' : 'completed',
+        output: typeof output === 'string' ? output : JSON.stringify(output),
+        durationMs: 0,
+      });
+    }
+    this._pendingToolCalls.delete(itemId);
+  }
+
+  private handleReasoningSummaryDelta(event: SseEvent, turnId: string): void {
+    const delta = event.data['delta'];
+    if (typeof delta === 'string' && delta) {
+      this._reasoningBuffer += delta;
+      this.fire({
+        type: 'chat:reasoning',
+        turnId,
+        messageId: `reasoning-${turnId}`,
+        content: this._reasoningBuffer,
+        isDelta: true,
+      });
+    }
+  }
+
+  private handleReasoningSummaryDone(event: SseEvent, turnId: string): void {
+    const text = event.data['text'];
+    const content = typeof text === 'string' ? text : this._reasoningBuffer;
+    this.fire({
+      type: 'chat:reasoning',
+      turnId,
+      messageId: `reasoning-${turnId}`,
+      content,
+      isDelta: false,
+    });
+    this._reasoningBuffer = '';
+  }
+
+  private handleResponseCompleted(event: SseEvent, turnId: string): void {
+    const response = event.data['response'] as
+      | Record<string, unknown>
+      | undefined;
+    const responseId = response?.['id'];
+    if (typeof responseId === 'string') {
+      this._lastResponseId = responseId;
+      // Persist the completed response id so a resumed session (after a
+      // Relay restart) can continue the conversation via
+      // `previous_response_id`. Only completed responses are chainable.
+      this.fire({
+        type: 'chat:provider-session',
+        providerSession: { hermesResponseId: responseId },
+      });
+    }
+    this.emitTelemetryFromResponse(response, turnId);
+    if (this._currentTurnId) {
+      this.fire({
+        type: 'chat:turn-completed',
+        turnId: this._currentTurnId,
+        reason: 'completed',
+        durationMs: 0,
+        toolCallCount: 0,
+        messageCount: 1,
+      });
+      this._currentTurnId = null;
+    }
+    this._pendingToolCalls.clear();
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  private handleResponseFailed(event: SseEvent): void {
+    const response = event.data['response'] as
+      | Record<string, unknown>
+      | undefined;
+    const error = response?.['error'] as Record<string, unknown> | undefined;
+    this._lastResponseId = null;
+    this.failCurrentTurn(
+      String(error?.['message'] ?? 'Hermes response failed'),
+      'failed'
+    );
+  }
+
+  private handleResponseError(event: SseEvent): void {
+    const message = event.data['message'];
+    this._lastResponseId = null;
+    this.failCurrentTurn(
+      typeof message === 'string' ? message : 'Hermes response error',
+      'failed'
+    );
+  }
+
+  private handleResponseIncomplete(event: SseEvent): void {
+    const response = event.data['response'] as
+      | Record<string, unknown>
+      | undefined;
+    const responseId = response?.['id'];
+    if (typeof responseId === 'string') {
+      // Incomplete responses are still chainable via `previous_response_id`,
+      // so keep the anchor for the next turn.
+      this._lastResponseId = responseId;
+    }
+    const details = response?.['incomplete_details'] as
+      | Record<string, unknown>
+      | undefined;
+    const reasonText = details?.['reason'];
+    this.failCurrentTurn(
+      `Hermes response is incomplete${
+        reasonText ? `: ${String(reasonText)}` : ''
+      }`,
+      'error'
+    );
+  }
+
+  /**
+   * Surface a terminal turn failure: emit `chat:error`, complete the active
+   * turn with the given reason, clear in-flight tool-call state, and mark the
+   * session idle-on-error. Used for `response.failed`/`response.error`/
+   * `response.incomplete` and for the stream-end-without-terminal-event
+   * guard in `sendMessage` — every path that would otherwise leave the UI
+   * waiting on a turn that will never resolve.
+   */
+  private failCurrentTurn(message: string, reason: 'failed' | 'error'): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    this.fire({
+      type: 'chat:error',
+      kind: 'protocol',
+      message,
+      retryable: true,
+      turnId,
+    });
+    if (this._currentTurnId) {
+      this.fire({
+        type: 'chat:turn-completed',
+        turnId: this._currentTurnId,
+        reason,
+        durationMs: 0,
+        toolCallCount: 0,
+        messageCount: 0,
+      });
+      this._currentTurnId = null;
+    }
+    this._pendingToolCalls.clear();
+    this.fire({ type: 'chat:session-status', status: 'error' });
+  }
+
+  /** Emit `chat:telemetry` from a completed response's `usage` payload, if present. */
+  private emitTelemetryFromResponse(
+    response: Record<string, unknown> | undefined,
+    turnId: string
+  ): void {
+    const usage = response?.['usage'] as Record<string, unknown> | undefined;
+    if (!usage) return;
+    const inputDetails = usage['input_tokens_details'] as
+      | Record<string, unknown>
+      | undefined;
+    this.fire({
+      type: 'chat:telemetry',
+      turnId,
+      model: String(response?.['model'] ?? ''),
+      inputTokens: Number(usage['input_tokens'] ?? 0),
+      outputTokens: Number(usage['output_tokens'] ?? 0),
+      cacheReadTokens: Number(inputDetails?.['cached_tokens'] ?? 0),
+      cacheWriteTokens: 0,
+      costUsd: null,
+      contextPercent: 0,
+      contextWindowSize: 0,
+    });
   }
 
   private handlePermissionRequested(event: SseEvent): void {

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -54,7 +54,13 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       interrupt: true,
       cancelQueued: false,
       resume: true,
-      telemetry: true,
+      // `HermesProtocolAdapter` emits `chat:telemetry`, but
+      // `mapChatEventToAgentPatchV2` has no case for it yet, so
+      // `LegacyProtocolAdapterV2Bridge` silently drops it before it reaches the
+      // V2 stream/UI (same pre-existing gap as opencode/opencode-attached
+      // above). Keep this `false` until that compat mapping exists so the
+      // capability bit doesn't advertise a feature that can't render.
+      telemetry: false,
     }),
 };
 

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -54,6 +54,7 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       interrupt: true,
       cancelQueued: false,
       resume: true,
+      telemetry: true,
     }),
 };
 

--- a/shared/agent-chat-v1-compat.ts
+++ b/shared/agent-chat-v1-compat.ts
@@ -13,6 +13,7 @@ import type {
   ChatEvent,
   ChatEventSource,
   MessageCompleteEvent,
+  ToolCallStatus,
 } from './chat-events.js';
 
 type CompatAgentPatchV2 = AgentPatchV2 & {
@@ -36,6 +37,24 @@ function legacyDecisionToV2(
   if (decision === 'allow-always')
     return { kind: 'accept', scope: 'permanent' };
   return { kind: 'accept', scope: 'once' };
+}
+
+/** Stable v2 item id for a legacy tool-call/tool-result pair sharing `toolCallId`. */
+function toolCallItemId(toolCallId: string): string {
+  return `tool-${toolCallId}`;
+}
+
+function toolCallStatusToItemStatus(
+  status: ToolCallStatus
+): 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' {
+  switch (status) {
+    case 'declined':
+      return 'cancelled';
+    case 'error':
+      return 'failed';
+    default:
+      return status;
+  }
 }
 
 export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
@@ -135,6 +154,61 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
           timestamp: event.timestamp,
           turnId: event.turnId,
           item: messageCompleteToItem(event),
+        },
+      ];
+
+    case 'chat:tool-call':
+      return [
+        {
+          type: 'agent-item-updated-v2',
+          sessionId: event.sessionId,
+          timestamp: event.timestamp,
+          turnId: event.turnId,
+          item: {
+            type: 'dynamicToolCall',
+            id: toolCallItemId(event.toolCallId),
+            namespace: event.source,
+            tool: event.toolName,
+            arguments: event.input,
+            status: toolCallStatusToItemStatus(event.status),
+            metadata: compactMetadata({
+              source: event.source,
+              description: event.description || undefined,
+            }),
+          },
+        },
+      ];
+
+    case 'chat:tool-result': {
+      const content = event.output || event.error || '';
+      if (!content) return [];
+      return [
+        {
+          type: 'agent-item-delta-v2',
+          sessionId: event.sessionId,
+          timestamp: event.timestamp,
+          turnId: event.turnId,
+          itemId: toolCallItemId(event.toolCallId),
+          delta: { content },
+        },
+      ];
+    }
+
+    case 'chat:reasoning':
+      return [
+        {
+          type: 'agent-item-updated-v2',
+          sessionId: event.sessionId,
+          timestamp: event.timestamp,
+          turnId: event.turnId,
+          item: {
+            type: 'reasoning',
+            id: event.messageId,
+            summary: event.content,
+            visibility: 'summary',
+            status: event.isDelta ? 'running' : 'completed',
+            metadata: { source: event.source },
+          },
         },
       ];
 

--- a/test/agent-chat-v1-compat.test.ts
+++ b/test/agent-chat-v1-compat.test.ts
@@ -193,6 +193,111 @@ describe('Agent Chat v1 compatibility bridge', () => {
     ]);
   });
 
+  it('maps v1 tool-call events to a dynamicToolCall item update', () => {
+    const event: ChatEvent = {
+      type: 'chat:tool-call',
+      sessionId: 'session-1',
+      timestamp,
+      source: 'hermes',
+      turnId: 'turn-1',
+      toolCallId: 'call-1',
+      toolName: 'read_file',
+      description: '',
+      input: { path: 'a.txt' },
+      status: 'completed',
+    };
+
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([
+      {
+        type: 'agent-item-updated-v2',
+        sessionId: 'session-1',
+        timestamp,
+        turnId: 'turn-1',
+        item: {
+          type: 'dynamicToolCall',
+          id: 'tool-call-1',
+          namespace: 'hermes',
+          tool: 'read_file',
+          arguments: { path: 'a.txt' },
+          status: 'completed',
+          metadata: { source: 'hermes' },
+        },
+      },
+    ]);
+  });
+
+  it('maps v1 tool-result events to a content-appending item delta keyed by the same tool item id', () => {
+    const event: ChatEvent = {
+      type: 'chat:tool-result',
+      sessionId: 'session-1',
+      timestamp,
+      source: 'hermes',
+      turnId: 'turn-1',
+      toolCallId: 'call-1',
+      toolName: 'read_file',
+      status: 'completed',
+      output: 'file contents',
+      durationMs: 12,
+    };
+
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([
+      {
+        type: 'agent-item-delta-v2',
+        sessionId: 'session-1',
+        timestamp,
+        turnId: 'turn-1',
+        itemId: 'tool-call-1',
+        delta: { content: 'file contents' },
+      },
+    ]);
+  });
+
+  it('drops tool-result events with no output or error to avoid a no-op patch', () => {
+    const event: ChatEvent = {
+      type: 'chat:tool-result',
+      sessionId: 'session-1',
+      timestamp,
+      source: 'hermes',
+      turnId: 'turn-1',
+      toolCallId: 'call-1',
+      toolName: 'read_file',
+      status: 'completed',
+      durationMs: 12,
+    };
+
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([]);
+  });
+
+  it('maps v1 reasoning events to a reasoning item update', () => {
+    const event: ChatEvent = {
+      type: 'chat:reasoning',
+      sessionId: 'session-1',
+      timestamp,
+      source: 'hermes',
+      turnId: 'turn-1',
+      messageId: 'reasoning-turn-1',
+      content: 'Thinking it through',
+      isDelta: false,
+    };
+
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([
+      {
+        type: 'agent-item-updated-v2',
+        sessionId: 'session-1',
+        timestamp,
+        turnId: 'turn-1',
+        item: {
+          type: 'reasoning',
+          id: 'reasoning-turn-1',
+          summary: 'Thinking it through',
+          visibility: 'summary',
+          status: 'completed',
+          metadata: { source: 'hermes' },
+        },
+      },
+    ]);
+  });
+
   it('maps v2 assistant message deltas back to v1 text deltas with preserved source for legacy UI', () => {
     const patch: AgentPatchV2 & { metadata: { source: 'opencode' } } = {
       type: 'agent-item-delta-v2',

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -72,7 +72,9 @@ describe('Hermes V2 web adapter registration', () => {
       approvals: true,
       interrupt: true,
       resume: true,
-      telemetry: true,
+      // chat:telemetry isn't mapped by mapChatEventToAgentPatchV2 yet, so the
+      // bridge can't deliver it to the V2 stream/UI (see index.ts comment).
+      telemetry: false,
     });
   });
 

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -1,10 +1,17 @@
 import fs from 'node:fs';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
-import { resolveHermesGatewaySettings } from '../../../server/protocol-adapters/hermes-adapter.js';
+import {
+  HermesProtocolAdapter,
+  resolveHermesGatewaySettings,
+} from '../../../server/protocol-adapters/hermes-adapter.js';
+import type { AdapterConfig } from '../../../server/protocol-adapter.js';
+import type { ChatEvent } from '../../../shared/chat-events.js';
 
 const ENV_KEYS = [
   'HOME',
@@ -65,6 +72,7 @@ describe('Hermes V2 web adapter registration', () => {
       approvals: true,
       interrupt: true,
       resume: true,
+      telemetry: true,
     });
   });
 
@@ -175,6 +183,385 @@ describe('Hermes gateway settings resolution', () => {
       endpoint: 'http://127.0.0.1:2222',
       apiKey: 'custom-profile-secret',
       source: 'environment',
+    });
+  });
+});
+
+/**
+ * SSE hardening coverage (#1062). Drives a real `HermesProtocolAdapter`
+ * against an in-process gateway that streams a caller-scripted sequence of
+ * Responses API SSE events, so we can assert the adapter never leaves a turn
+ * hanging and correctly maps tool-call/reasoning/telemetry events.
+ */
+
+interface InlineGateway {
+  server: http.Server;
+  endpoint: string;
+  requests: Array<Record<string, unknown>>;
+}
+
+function startInlineGateway(
+  writeEvents: (send: (obj: unknown) => void, res: http.ServerResponse) => void
+): Promise<InlineGateway> {
+  const requests: Array<Record<string, unknown>> = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      if (req.url === '/health') {
+        res.writeHead(200);
+        res.end('ok');
+        return;
+      }
+      if (req.url === '/v1/models') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ id: 'inline-stub' }] }));
+        return;
+      }
+      if (req.url === '/v1/responses') {
+        try {
+          requests.push(JSON.parse(body) as Record<string, unknown>);
+        } catch {
+          requests.push({});
+        }
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+        });
+        const send = (obj: unknown): void => {
+          res.write(`data: ${JSON.stringify(obj)}\n\n`);
+        };
+        writeEvents(send, res);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, endpoint: `http://127.0.0.1:${port}`, requests });
+    });
+  });
+}
+
+function configFor(endpoint: string, sessionId: string): AdapterConfig {
+  return {
+    cwd: process.cwd(),
+    port: 0,
+    sessionId,
+    hookToken: 'test-hook',
+    configDir: process.cwd(),
+    extra: { endpoint, apiToken: 'inline-key' },
+  };
+}
+
+describe('Hermes Responses SSE hardening', () => {
+  let gateway: InlineGateway | undefined;
+  let adapter: HermesProtocolAdapter | undefined;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.disconnect().catch(() => {});
+      adapter = undefined;
+    }
+    if (gateway) {
+      await new Promise<void>((resolve) =>
+        gateway!.server.close(() => resolve())
+      );
+      gateway = undefined;
+    }
+  });
+
+  it('maps response.error to a chat:error and fails the turn instead of hanging', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_err' } });
+      send({ type: 'response.error', message: 'gateway blew up' });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-error'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const errorEvent = events.find((event) => event.type === 'chat:error');
+    expect(errorEvent).toMatchObject({
+      type: 'chat:error',
+      message: 'gateway blew up',
+      turnId: 'turn-1',
+    });
+    const completed = events.find(
+      (event) => event.type === 'chat:turn-completed'
+    );
+    expect(completed).toMatchObject({
+      type: 'chat:turn-completed',
+      turnId: 'turn-1',
+      reason: 'failed',
+    });
+    const lastStatus = events
+      .filter((event) => event.type === 'chat:session-status')
+      .pop();
+    expect(lastStatus).toMatchObject({ status: 'error' });
+  });
+
+  it('fails the turn when response.failed carries an error message', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_failed' } });
+      send({
+        type: 'response.failed',
+        response: { id: 'resp_failed', error: { message: 'model overloaded' } },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-failed'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const errorEvent = events.find((event) => event.type === 'chat:error');
+    expect(errorEvent).toMatchObject({ message: 'model overloaded' });
+    const completed = events.find(
+      (event) => event.type === 'chat:turn-completed'
+    );
+    expect(completed).toMatchObject({ reason: 'failed' });
+  });
+
+  it('fails the turn but keeps a chainable response id on response.incomplete', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_incomplete' } });
+      send({
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+        },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-incomplete'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const errorEvent = events.find((event) => event.type === 'chat:error');
+    expect(errorEvent?.message).toMatch(/incomplete/i);
+    const completed = events.find(
+      (event) => event.type === 'chat:turn-completed'
+    );
+    expect(completed).toMatchObject({ reason: 'error' });
+
+    // The response id is still chainable — the next turn should carry it.
+    await adapter.sendMessage('turn-2', 'continue');
+    expect(gateway.requests[1]?.['previous_response_id']).toBe(
+      'resp_incomplete'
+    );
+  });
+
+  it('fails the turn when the stream closes without a terminal event', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_hang' } });
+      send({ type: 'response.output_text.delta', delta: 'partial answer' });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-hang'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const errorEvent = events.find((event) => event.type === 'chat:error');
+    expect(errorEvent?.message).toMatch(/terminal/i);
+    const completed = events.find(
+      (event) => event.type === 'chat:turn-completed'
+    );
+    expect(completed).toMatchObject({ reason: 'error' });
+    const lastStatus = events
+      .filter((event) => event.type === 'chat:session-status')
+      .pop();
+    expect(lastStatus).toMatchObject({ status: 'error' });
+  });
+
+  it('accumulates function_call_arguments deltas and emits a completed tool call + result', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_tool' } });
+      send({
+        type: 'response.output_item.added',
+        item: {
+          id: 'item_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'read_file',
+          arguments: '',
+        },
+      });
+      send({
+        type: 'response.function_call_arguments.delta',
+        item_id: 'item_1',
+        delta: '{"path":',
+      });
+      send({
+        type: 'response.function_call_arguments.delta',
+        item_id: 'item_1',
+        delta: '"a.txt"}',
+      });
+      send({
+        type: 'response.function_call_arguments.done',
+        item_id: 'item_1',
+        arguments: '{"path":"a.txt"}',
+      });
+      send({
+        type: 'response.output_item.done',
+        item: {
+          id: 'item_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'read_file',
+          arguments: '{"path":"a.txt"}',
+          status: 'completed',
+          output: 'file contents',
+        },
+      });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_tool', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-tool'));
+    await adapter.sendMessage('turn-1', 'read a.txt');
+
+    const toolCalls = events.filter((event) => event.type === 'chat:tool-call');
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]).toMatchObject({
+      status: 'running',
+      toolCallId: 'call_1',
+      toolName: 'read_file',
+      input: {},
+    });
+    expect(toolCalls[1]).toMatchObject({
+      status: 'completed',
+      toolCallId: 'call_1',
+      toolName: 'read_file',
+      input: { path: 'a.txt' },
+    });
+
+    const toolResult = events.find(
+      (event) => event.type === 'chat:tool-result'
+    );
+    expect(toolResult).toMatchObject({
+      toolCallId: 'call_1',
+      toolName: 'read_file',
+      status: 'completed',
+      output: 'file contents',
+    });
+  });
+
+  it('completes the assistant message on response.output_text.done', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_msg' } });
+      send({ type: 'response.output_text.delta', delta: 'Hel' });
+      send({ type: 'response.output_text.delta', delta: 'lo' });
+      send({ type: 'response.output_text.done', text: 'Hello' });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_msg', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-msg'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const complete = events.find(
+      (event) => event.type === 'chat:message-complete'
+    );
+    expect(complete).toMatchObject({ role: 'assistant', content: 'Hello' });
+  });
+
+  it('streams reasoning summary deltas and completes on done', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_reason' } });
+      send({
+        type: 'response.reasoning_summary_text.delta',
+        delta: 'Thinking',
+      });
+      send({
+        type: 'response.reasoning_summary_text.delta',
+        delta: ' it through',
+      });
+      send({
+        type: 'response.reasoning_summary_text.done',
+        text: 'Thinking it through',
+      });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_reason', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-reason'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const reasoningEvents = events.filter(
+      (event) => event.type === 'chat:reasoning'
+    );
+    expect(reasoningEvents.length).toBeGreaterThanOrEqual(3);
+    expect(reasoningEvents[reasoningEvents.length - 1]).toMatchObject({
+      isDelta: false,
+      content: 'Thinking it through',
+    });
+  });
+
+  it('emits chat:telemetry from response.completed usage', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_usage' } });
+      send({
+        type: 'response.completed',
+        response: {
+          id: 'resp_usage',
+          status: 'completed',
+          model: 'gpt-test',
+          usage: {
+            input_tokens: 12,
+            output_tokens: 34,
+            input_tokens_details: { cached_tokens: 5 },
+          },
+        },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-usage'));
+    await adapter.sendMessage('turn-1', 'hi');
+
+    const telemetry = events.find((event) => event.type === 'chat:telemetry');
+    expect(telemetry).toMatchObject({
+      model: 'gpt-test',
+      inputTokens: 12,
+      outputTokens: 34,
+      cacheReadTokens: 5,
     });
   });
 });


### PR DESCRIPTION
## Summary

Hardens the Hermes protocol adapter's OpenAI-compatible Responses API SSE handling per the recon in #1062. Previously the adapter could leave a chat turn hanging forever, silently dropped completed tool-call results, never transitioned assistant messages to `completed`, and discarded reasoning/telemetry data.

- **Silent-hang fallback (HIGH):** `response.error`/`response.failed`/`response.incomplete` now route through a shared `failCurrentTurn` helper that emits `chat:error` + a failed/error turn completion instead of being dropped by the `default` branch. A new stream-end guard in `sendMessage` also fires the same failure path if the SSE stream closes without any terminal event, so a turn can never hang indefinitely.
- **Tool-call pipeline (HIGH):** `function_call_arguments.delta`/`.done` are now accumulated per item id (keyed off the Responses API item id), and `output_item.done` emits a completed `chat:tool-call` with the full arguments plus a `chat:tool-result` when the payload carries output — replacing the old single `running` call with stale/empty arguments that never resolved.
- **Message-complete (MED):** `response.output_text.done` now emits `chat:message-complete` so the assistant message item transitions `running` → `completed` in the v2 item stream.
- **Reasoning (LOW):** added handling for `response.reasoning_summary_text.delta`/`.done` → `chat:reasoning`.
- **Telemetry (LOW):** `response.completed` now emits `chat:telemetry` from the response's `usage` payload, and the Hermes v2 registration gained the `telemetry` capability.
- **Compat shim:** `shared/agent-chat-v1-compat.ts` previously dropped `chat:tool-call`/`chat:tool-result`/`chat:reasoning` events in its `default: return []` branch — these are now mapped to `agent-item-updated-v2`/`agent-item-delta-v2` patches so `ToolCard` (and reasoning) actually render for Hermes turns routed through the legacy V1→V2 bridge.

## Test plan

- [x] `npm run check` — 0 errors (pre-existing sonarjs/no-duplicate-string warnings only)
- [x] `npm test` — 396 test files / 5113 tests passing
- [x] New adapter-level SSE fixture tests in `test/server/protocol-adapters/hermes-adapter.test.ts` covering: `response.error`, `response.failed`, `response.incomplete` (with chainable response id), stream-end-without-terminal-event, tool call with `function_call_arguments` deltas + result, `output_text.done` message completion, reasoning summary streaming, and `chat:telemetry` from usage.
- [x] New compat-shim unit tests in `test/agent-chat-v1-compat.test.ts` covering `chat:tool-call`/`chat:tool-result`/`chat:reasoning` mapping.

Refs #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)