### PR TITLE
fix(sidebar): resolve raw workspace/node ids to friendly labels in topic chrome

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -52,10 +52,12 @@ import { durabilityDisabledReason } from '../lib/session-durability.js';
 import { resolveSessionByKey } from '../lib/session-keys.js';
 import {
   buildTopicNavModel,
+  formatTaskRefLabel,
   groupTopicsByWorkspace,
   type GroupedTopicNav,
   type TopicNavItem,
   type TopicNavModel,
+  type TopicNavNode,
   type TopicNavWorkspace,
   type TopicNavParticipantRef,
   type TopicNavSessionRef,
@@ -416,8 +418,8 @@ function ParticipantChildRow({
         </span>
         <span className="topic-child-row__meta">{participant.statusLabel}</span>
         <span className="topic-child-row__meta">{lastActivityLabel}</span>
-        {participant.nodeId ? (
-          <span className="topic-child-row__meta">{participant.nodeId}</span>
+        {participant.nodeLabel ? (
+          <span className="topic-child-row__meta">{participant.nodeLabel}</span>
         ) : null}
         <span className="topic-child-row__meta">
           {participant.controlLabel}
@@ -488,7 +490,7 @@ function ParticipantRoster({
                   </span>
                   <span className="topic-participant-card__meta">
                     {participant.runtimeLabel}
-                    {participant.nodeId ? ` · ${participant.nodeId}` : ''}
+                    {participant.nodeLabel ? ` · ${participant.nodeLabel}` : ''}
                   </span>
                   <span className="topic-participant-card__meta">
                     {lastActivityLabel} · {participant.controlLabel}
@@ -533,7 +535,7 @@ function TopicRoomSessionRow({
           </span>
         </span>
         <span className="topic-room-session__anchor">
-          {session.nodeId ? `${session.nodeId} · ` : ''}
+          {session.nodeLabel ? `${session.nodeLabel} · ` : ''}
           {session.branch ?? session.cwd}
         </span>
         <StatusGlyph tone={session.tone} />
@@ -554,7 +556,7 @@ function TopicRoomTaskRefs({ item }: { item: TopicNavItem }) {
   return (
     <ul className="topic-room-ref-list" aria-label="task refs">
       {item.taskRefs.map((taskRef) => {
-        const label = taskRef.title ?? taskRef.id;
+        const label = formatTaskRefLabel(taskRef);
         const content = (
           <>
             <span>{taskRef.kind}</span>
@@ -634,8 +636,18 @@ function TopicRoomSurfaceStrip({
   );
 }
 
+/** Friendly workspace name for a topic; `null` (never a raw id) when unresolved. */
+function resolveWorkspaceName(
+  item: TopicNavItem,
+  workspaceNameById: Map<string, string>
+): string | null {
+  if (!item.workspaceId) return null;
+  return workspaceNameById.get(item.workspaceId) ?? null;
+}
+
 function TopicDetail({
   item,
+  workspaceName,
   surfacesError,
   surfacesLoading,
   onSelectSession,
@@ -643,6 +655,8 @@ function TopicDetail({
   restoringTopicId,
 }: {
   item: TopicNavItem;
+  /** Friendly workspace name for the meta strip; omitted entirely (never a raw id) when unresolved. */
+  workspaceName?: string | null | undefined;
   surfacesError?: boolean | undefined;
   surfacesLoading?: boolean | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
@@ -675,7 +689,7 @@ function TopicDetail({
         <p className="topic-detail__description muted">no topic brief yet</p>
       )}
       <div className="topic-detail__meta topic-room__meta">
-        <span>{item.workspaceId}</span>
+        {workspaceName ? <span>{workspaceName}</span> : null}
         <span>{item.lifecycleLabel}</span>
         <span>{topicRoomFreshnessLabel(item)}</span>
         <span>{topicRoomAnchorLabel(item)}</span>
@@ -933,7 +947,7 @@ function TopicMobileControlPanel({
             {session.agent} · {session.type}
           </span>
         ) : null}
-        {session?.nodeId ? <span>{session.nodeId}</span> : null}
+        {session?.nodeLabel ? <span>{session.nodeLabel}</span> : null}
       </div>
       {item.description ? (
         <p className="topic-mobile-detail__description">{item.description}</p>
@@ -1937,6 +1951,7 @@ export function TopicSidebarView({
   createPanel,
   onCreateTaskRoom,
   workspaces = EMPTY_WORKSPACES,
+  nodes,
   activeWorkspaceId = null,
   searchScope = 'all',
   onToggleSearchScope,
@@ -1949,6 +1964,8 @@ export function TopicSidebarView({
   sessions: SessionSummary[];
   surfaces: WorkspaceSurface[];
   workspaces?: TopicNavWorkspace[];
+  /** Known node roster; resolves raw routing node ids to friendly names. */
+  nodes?: TopicNavNode[];
   activeWorkspaceId?: string | null;
   searchScope?: 'all' | 'workspace';
   onToggleSearchScope?: (() => void) | undefined;
@@ -1976,12 +1993,17 @@ export function TopicSidebarView({
   onCreateTaskRoom?: (() => void) | undefined;
 }) {
   const model = useMemo(
-    () => buildTopicNavModel({ topics, sessions, surfaces, derived }),
-    [topics, sessions, surfaces, derived]
+    () => buildTopicNavModel({ topics, sessions, surfaces, derived, nodes }),
+    [topics, sessions, surfaces, derived, nodes]
   );
   const topicsById = useMemo(
     () => new Map(topics.map((topic) => [topic.id, topic])),
     [topics]
+  );
+  const workspaceNameById = useMemo(
+    () =>
+      new Map(workspaces.map((workspace) => [workspace.id, workspace.name])),
+    [workspaces]
   );
   // Grouping always shows every workspace so the full channel list stays
   // visible; the active workspace only scopes search (via the scope chip),
@@ -2166,6 +2188,10 @@ export function TopicSidebarView({
         <>
           <TopicDetail
             item={selectedItem}
+            workspaceName={resolveWorkspaceName(
+              selectedItem,
+              workspaceNameById
+            )}
             surfacesError={surfacesError}
             surfacesLoading={surfacesLoading}
             onSelectSession={onSelectSession}
@@ -2296,6 +2322,14 @@ export function TopicSidebarShell({
   const viewSurfaces = useMemo(
     () => surfacesQuery.data ?? EMPTY_SURFACES,
     [surfacesQuery.data]
+  );
+  const viewNodes = useMemo<TopicNavNode[]>(
+    () =>
+      (nodesQuery.data ?? []).map((node) => ({
+        nodeId: node.nodeId,
+        displayName: node.displayName,
+      })),
+    [nodesQuery.data]
   );
   const taskRef = taskRefFromDraft(createDraft.taskRef, createDraft.title);
   const defaultRepoPath =
@@ -2490,6 +2524,7 @@ export function TopicSidebarShell({
       sessions={sessions}
       surfaces={viewSurfaces}
       workspaces={viewWorkspaces}
+      nodes={viewNodes}
       activeWorkspaceId={activeWorkspaceId}
       searchScope={searchScope}
       onToggleSearchScope={() =>

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -36,7 +36,10 @@ export interface TopicNavSessionRef {
   agentState: SessionSummary['agentState'] | null;
   permissionType: SessionSummary['permissionType'] | null;
   branch: string | null;
+  /** Raw routing node id — only for functional routing, never render directly. */
   nodeId: string | null;
+  /** Friendly node display name, resolved against the known node roster; null when unresolved (never a raw id). */
+  nodeLabel: string | null;
   cwd: string;
   controlFreshness: SessionSummary['controlFreshness'] | null;
   durability: SessionSummary['durability'] | null;
@@ -52,7 +55,10 @@ export interface TopicNavParticipantRef {
   roleLabel: string;
   providerLabel: string;
   runtimeLabel: string;
+  /** Raw routing node id — only for functional routing, never render directly. */
   nodeId: string | null;
+  /** Friendly node display name, resolved against the known node roster; null when unresolved (never a raw id). */
+  nodeLabel: string | null;
   tone: TopicNavTone;
   statusLabel: string;
   controlLabel: string;
@@ -114,6 +120,16 @@ export interface TopicNavWorkspace {
   pinned: boolean;
   color: string | null;
   icon: string | null;
+}
+
+/**
+ * Minimal node identity the topic sidebar resolves raw routing node ids
+ * against for display. Unknown/unpaired node ids simply fail to resolve —
+ * callers must never fall back to rendering the raw id (#1061).
+ */
+export interface TopicNavNode {
+  nodeId: string;
+  displayName: string | null | undefined;
 }
 
 export interface TopicNavWorkspaceGroup {
@@ -284,16 +300,52 @@ function topicKind(topic: WorkspaceTopic): {
   return { kind: 'thread', label: 'topic' };
 }
 
-function routingLabel(topic: WorkspaceTopic): string | null {
+/**
+ * Resolve a raw routing node id to its friendly display name. Never returns
+ * the raw id itself — an unresolved/unknown node id resolves to `null` so
+ * callers omit the node affordance rather than leak a raw substrate id
+ * (#1061).
+ */
+function nodeLabelFor(
+  nodeId: string | null | undefined,
+  nodeNameById: Map<string, string>
+): string | null {
+  if (!nodeId) return null;
+  return nodeNameById.get(nodeId) ?? null;
+}
+
+function routingLabel(
+  topic: WorkspaceTopic,
+  nodeNameById: Map<string, string>
+): string | null {
   const routing = topic.routingDefaults;
   const parts = [
     routing.providerId,
-    routing.nodeId,
+    nodeLabelFor(routing.nodeId, nodeNameById),
     basename(routing.worktreePath) ??
       basename(routing.repoPath) ??
       basename(routing.cwd),
   ].filter((part): part is string => Boolean(part));
   return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+/**
+ * Human-friendly label for a linked task ref. Already-human refs (an
+ * authored `title`, or ids like `PROJ-123` for ticket trackers) render as-is;
+ * kind-specific formatting fills the gap when only a bare id is known (e.g.
+ * a github issue/PR number becomes `#1234` instead of the raw numeric id).
+ */
+export function formatTaskRefLabel(taskRef: {
+  kind: string;
+  id: string;
+  title?: string | null;
+}): string {
+  const title = taskRef.title?.trim();
+  if (title) return title;
+  if (taskRef.kind === 'github-issue' || taskRef.kind === 'github-pr') {
+    return `#${taskRef.id}`;
+  }
+  return taskRef.id;
 }
 
 type TopicParticipantRole = {
@@ -424,7 +476,10 @@ function sessionControlLabel(session: SessionSummary): string {
   return session.controlMode ?? 'control unknown';
 }
 
-function topicParticipantRef(session: SessionSummary): TopicNavParticipantRef {
+function topicParticipantRef(
+  session: SessionSummary,
+  nodeNameById: Map<string, string>
+): TopicNavParticipantRef {
   const status = sessionParticipantStatus(session);
   const selectKey = sessionSelectKey(session);
   return {
@@ -436,6 +491,7 @@ function topicParticipantRef(session: SessionSummary): TopicNavParticipantRef {
     providerLabel: sessionProviderLabel(session),
     runtimeLabel: sessionRuntimeLabel(session),
     nodeId: session.nodeId ?? null,
+    nodeLabel: nodeLabelFor(session.nodeId, nodeNameById),
     tone: sessionTone(session),
     statusLabel: status.label,
     controlLabel: sessionControlLabel(session),
@@ -542,7 +598,14 @@ export function buildTopicNavModel(input: {
   sessions: SessionSummary[];
   surfaces: WorkspaceSurface[];
   derived?: boolean;
+  /** Known node roster, used to resolve raw routing node ids to display names. */
+  nodes?: TopicNavNode[] | undefined;
 }): TopicNavModel {
+  const nodeNameById = new Map<string, string>();
+  for (const node of input.nodes ?? []) {
+    const name = node.displayName?.trim();
+    if (name) nodeNameById.set(node.nodeId, name);
+  }
   const items: TopicNavItem[] = input.topics.map((topic) => {
     const matchedSessions = input.sessions.filter((session) =>
       sessionMatchesTopic(topic, session)
@@ -563,6 +626,7 @@ export function buildTopicNavModel(input: {
           permissionType: session.permissionType ?? null,
           branch: session.branchName ?? null,
           nodeId: session.nodeId ?? null,
+          nodeLabel: nodeLabelFor(session.nodeId, nodeNameById),
           cwd: session.cwd,
           controlFreshness: session.controlFreshness ?? null,
           durability: session.durability ?? null,
@@ -588,7 +652,7 @@ export function buildTopicNavModel(input: {
 
     const tone = topicTone(sessions, surfaces, topic);
     const participants = matchedSessions
-      .map(topicParticipantRef)
+      .map((session) => topicParticipantRef(session, nodeNameById))
       .sort((a, b) => {
         if (a.roleLabel !== b.roleLabel) {
           return a.roleLabel.localeCompare(b.roleLabel);
@@ -624,7 +688,7 @@ export function buildTopicNavModel(input: {
       taskRefs: topic.linkedRefs.taskRefs ?? [],
       artifactIds: topic.linkedRefs.artifactIds ?? [],
       childIds: [],
-      routingLabel: routingLabel(topic),
+      routingLabel: routingLabel(topic, nodeNameById),
       lifecycleLabel: topic.status,
       updatedAt: topic.updatedAt,
     };

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -3,6 +3,7 @@ import type { WorkspaceSurface } from '../shared/workspace-surfaces.js';
 import type { WorkspaceTopic } from '../shared/workspace-topics.js';
 import {
   buildTopicNavModel,
+  formatTaskRefLabel,
   groupTopicsByWorkspace,
   type TopicNavWorkspace,
 } from '../frontend/src/lib/state/topic-nav.js';
@@ -456,6 +457,94 @@ describe('buildTopicNavModel', () => {
     expect(model.byId.get('topic:a')?.childIds).toEqual([]);
     expect(model.byId.get('topic:b')?.childIds).toEqual([]);
     expect(model.byId.get('topic:self')?.childIds).toEqual([]);
+  });
+
+  // #1061: raw substrate node ids (e.g. `node_<random token>`) must never
+  // leak into nav-model fields consumers render directly — only a resolved
+  // friendly name (or `null`, which callers must omit) is exposed.
+  const RAW_NODE_ID = 'node_AbCdEfGh12345678IjKlMnOpQrStUvWx';
+
+  it('resolves session/participant node ids to friendly names from the node roster', () => {
+    const model = buildTopicNavModel({
+      topics: [
+        makeTopic({
+          routingDefaults: { nodeId: RAW_NODE_ID },
+          linkedRefs: { sessionIds: [`${RAW_NODE_ID}:s1`] },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 's1',
+          nodeId: RAW_NODE_ID,
+          displayName: 'remote lane',
+        }),
+      ],
+      surfaces: [],
+      nodes: [{ nodeId: RAW_NODE_ID, displayName: 'Ops Box' }],
+    });
+
+    const item = model.byId.get('topic:alpha');
+    expect(item?.sessions[0]).toMatchObject({
+      nodeId: RAW_NODE_ID,
+      nodeLabel: 'Ops Box',
+    });
+    expect(item?.participants[0]).toMatchObject({
+      nodeId: RAW_NODE_ID,
+      nodeLabel: 'Ops Box',
+    });
+    expect(item?.routingLabel).toContain('Ops Box');
+    expect(item?.routingLabel).not.toContain(RAW_NODE_ID);
+  });
+
+  it('leaves nodeLabel null for an unresolved/unpaired node id instead of falling back to the raw id', () => {
+    const model = buildTopicNavModel({
+      topics: [
+        makeTopic({
+          routingDefaults: { nodeId: RAW_NODE_ID },
+          linkedRefs: { sessionIds: [`${RAW_NODE_ID}:s1`] },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 's1',
+          nodeId: RAW_NODE_ID,
+          displayName: 'remote lane',
+        }),
+      ],
+      surfaces: [],
+      // No matching node roster entry (or no `nodes` input at all).
+    });
+
+    const item = model.byId.get('topic:alpha');
+    expect(item?.sessions[0]?.nodeLabel).toBeNull();
+    expect(item?.participants[0]?.nodeLabel).toBeNull();
+    // Unresolved routing node id with no other routing parts omits entirely
+    // rather than falling back to the raw id.
+    expect(item?.routingLabel).toBeNull();
+  });
+});
+
+describe('formatTaskRefLabel', () => {
+  it('prefers an authored title over any id formatting', () => {
+    expect(
+      formatTaskRefLabel({ kind: 'github-issue', id: '1234', title: 'Fix it' })
+    ).toBe('Fix it');
+  });
+
+  it('formats an untitled github issue/PR ref as #<id>', () => {
+    expect(formatTaskRefLabel({ kind: 'github-issue', id: '1234' })).toBe(
+      '#1234'
+    );
+    expect(formatTaskRefLabel({ kind: 'github-pr', id: '42' })).toBe('#42');
+  });
+
+  it('keeps already-human refs (e.g. ticket keys) as-is when untitled', () => {
+    expect(formatTaskRefLabel({ kind: 'jira-ticket', id: 'REL-1061' })).toBe(
+      'REL-1061'
+    );
+    expect(formatTaskRefLabel({ kind: 'linear-issue', id: 'ENG-42' })).toBe(
+      'ENG-42'
+    );
   });
 });
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -379,6 +379,87 @@ describe('TopicSidebarView', () => {
     }
   });
 
+  it('resolves the topic detail meta strip to the workspace name, never the raw workspace id (#1061)', async () => {
+    const workspaceId = 'ws:3fa85f64-5717-4562-b3fc-2c963f66afa6';
+    await renderView({
+      topics: [
+        makeTopic({
+          workspaceId,
+          display: { title: 'Ugly workspace id topic' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      workspaces: [
+        {
+          id: workspaceId,
+          name: 'Platform Guild',
+          order: 0,
+          pinned: false,
+          color: null,
+          icon: null,
+        },
+      ],
+    });
+
+    expect(container.textContent).toContain('Platform Guild');
+    expect(container.textContent).not.toContain(workspaceId);
+  });
+
+  it('omits the workspace meta span entirely when the workspace name is unresolved, never falling back to the raw id (#1061)', async () => {
+    const workspaceId = 'ws:9c858901-8a57-4791-81fe-4c455b099bc9';
+    await renderView({
+      topics: [
+        makeTopic({
+          workspaceId,
+          display: { title: 'Unmapped workspace topic' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      workspaces: [],
+    });
+
+    expect(container.textContent).not.toContain(workspaceId);
+  });
+
+  it('never renders raw routing node ids in participant/session/mobile-control meta; resolves via the node roster when known (#1061)', async () => {
+    const knownNodeId = 'node_7Kx9QoZmP3vL1nRt5sWyAeBcDfGhIjKl';
+    const unknownNodeId = 'node_Zz01Xy23Wv45Ut67Sr89Qp01On23Ml45';
+    await renderView({
+      topics: [
+        makeTopic({
+          linkedRefs: {
+            sessionIds: [
+              `${knownNodeId}:known-node-session`,
+              `${unknownNodeId}:unknown-node-session`,
+            ],
+          },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 'known-node-session',
+          nodeId: knownNodeId,
+          displayName: 'Known node lane',
+        }),
+        makeSession({
+          id: 'unknown-node-session',
+          nodeId: unknownNodeId,
+          displayName: 'Unknown node lane',
+        }),
+      ],
+      surfaces: [],
+      nodes: [{ nodeId: knownNodeId, displayName: 'Ops Box' }],
+    });
+
+    expect(container.textContent).toContain('Ops Box');
+    expect(container.textContent).not.toContain(knownNodeId);
+    expect(container.textContent).not.toContain(unknownNodeId);
+  });
+
   it('establishes the topic node/repo context when a topic is selected', async () => {
     await renderView({
       topics: [
@@ -608,6 +689,23 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain(
       'raw terminal attach stays secondary'
     );
+  });
+
+  it('formats an untitled github issue task ref as #<id>, not the bare tracker id (#1061)', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          linkedRefs: {
+            taskRefs: [{ kind: 'github-issue', id: '9821', status: 'open' }],
+          },
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+    });
+
+    const refs = container.querySelector('.topic-room-ref-list');
+    expect(refs?.textContent).toContain('#9821');
   });
 
   it('keeps stale sessions inspectable while disabling live room controls', async () => {


### PR DESCRIPTION
## Summary
- `TopicDetail`'s meta strip rendered the raw `ws:<uuid>` workspace id verbatim; it now resolves the workspace name from the known workspace roster and omits the span entirely when unresolved (never a raw id).
- Participant/session node meta (`ParticipantChildRow`, `ParticipantRoster`, `TopicRoomSessionRow`, `TopicMobileControlPanel`) rendered the raw routing `nodeId` (e.g. `node_<random token>`); `buildTopicNavModel` now resolves it against a `nodes` roster (threaded from the existing `/nodes` query) into a new `nodeLabel` field, and every render site uses that instead — unresolved ids are omitted, not shortened/guessed.
- `routingLabel` (topic anchor summary) resolves the node id the same way, so it no longer leaks a raw node id either.
- Task refs with no title (e.g. an untitled linked github issue/PR) now render as `#<id>` via a new `formatTaskRefLabel` helper instead of the bare tracker id; already-human refs (titled, or ticket-key ids like `PROJ-123`) render unchanged.
- `nodeId` is kept alongside `nodeLabel` on `TopicNavSessionRef`/`TopicNavParticipantRef` since the raw id is still needed for functional routing (`onSendInput`, session selection) — only the render sites were changed.

## Test plan
- [x] `npm run check` (typecheck + lint) — 0 errors
- [x] `npm test` — full suite passes (396/396 files, 5110 passed, 9 skipped)
- [x] New unit tests in `test/topic-nav.test.ts`: node-id resolution (known/unresolved), `formatTaskRefLabel` kind-aware formatting
- [x] New component tests in `test/topic-sidebar-shell.test.ts` with realistic ugly fixtures (`ws:<uuid>`, `node_<random token>`) asserting the friendly label renders and the raw id never appears in `container.textContent`

Refs #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)