### PR TITLE
feat(chat): interactive QuestionCard + structured PlanCard + compact cards

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -41,6 +41,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
     sendMessage,
     interrupt,
     approve,
+    answer,
     resume,
     continueHere,
     pushClientError,
@@ -230,6 +231,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
                 session={session}
                 eventVerbosity={eventVerbosity}
                 onApprove={approve}
+                onAnswer={answer}
                 slashCommands={mergedSlashCommands}
               />
             ))}

--- a/frontend/src/components/chat/MediaCard.tsx
+++ b/frontend/src/components/chat/MediaCard.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import './MediaCard.css';
 import type {
+  AgentCompactionItemV2,
+  AgentHookPromptItemV2,
   AgentImageGenerationItemV2,
   AgentImageViewItemV2,
   AgentWebSearchItemV2,
 } from '../../../../shared/agent-chat-protocol-v2.js';
 
 /**
- * Media/artifact cards for the chat timeline. Renders web searches, viewed
- * images, and generated images as compact product-quality cards instead of
- * the raw `<pre>` fallbacks. Follows the ToolCard visual pattern: 1px outline,
- * lowercase labels, monospace, no filled backgrounds (see DESIGN.md).
+ * Media/compact-message cards for the chat timeline. Renders web searches,
+ * viewed images, generated images, compaction summaries, and hook prompts as
+ * compact product-quality cards instead of the raw `<pre>` fallbacks. Follows
+ * the ToolCard visual pattern: 1px outline, lowercase labels, monospace, no
+ * filled backgrounds (see DESIGN.md).
  */
 
 /**
@@ -123,6 +126,54 @@ export const ImageGenerationCard: React.FC<{
           />
         </div>
       )}
+    </div>
+  );
+};
+
+export const CompactionCard: React.FC<{ item: AgentCompactionItemV2 }> = ({
+  item,
+}) => {
+  const hasTokens =
+    item.tokensBefore !== undefined && item.tokensAfter !== undefined;
+  return (
+    <div
+      className="mcard mcard--compaction"
+      role="article"
+      aria-label="compaction"
+    >
+      <div className="mcard__h">
+        <span className="mcard__label">compaction</span>
+        {hasTokens && (
+          <span className="mcard__meta">
+            {item.tokensBefore} → {item.tokensAfter} tokens
+          </span>
+        )}
+      </div>
+      {item.summary && (
+        <div className="mcard__body">
+          <span className="mcard__src">{item.summary}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const HookPromptCard: React.FC<{ item: AgentHookPromptItemV2 }> = ({
+  item,
+}) => {
+  return (
+    <div
+      className="mcard mcard--hookprompt"
+      role="article"
+      aria-label="hook prompt"
+    >
+      <div className="mcard__h">
+        <span className="mcard__label">hook prompt</span>
+        {item.source && <span className="mcard__meta">{item.source}</span>}
+      </div>
+      <div className="mcard__body">
+        <span className="mcard__src">{item.prompt}</span>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/chat/PlanCard.css
+++ b/frontend/src/components/chat/PlanCard.css
@@ -1,0 +1,83 @@
+.pcard {
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.pcard__h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.pcard__label {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.pcard__approval {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.pcard__approval--pending {
+  color: var(--status-warning);
+}
+
+.pcard__approval--approved {
+  color: var(--status-success);
+}
+
+.pcard__approval--rejected {
+  color: var(--status-error);
+}
+
+.pcard__approval--revising {
+  color: var(--text-muted);
+}
+
+.pcard__steps {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.pcard__step {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 10px;
+}
+
+.pcard__glyph {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.pcard__step--completed .pcard__glyph {
+  color: var(--status-success);
+}
+
+.pcard__step--inProgress .pcard__glyph {
+  color: var(--accent);
+}
+
+.pcard__step-text {
+  color: var(--text);
+}
+
+.pcard__step--completed .pcard__step-text {
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+
+.pcard__text {
+  margin: 0;
+  padding: 6px 10px;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/frontend/src/components/chat/PlanCard.tsx
+++ b/frontend/src/components/chat/PlanCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import './PlanCard.css';
+import type { AgentPlanItemV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+
+/** TUI-style checklist glyph per Codex plan step status. */
+function stepGlyph(status: 'pending' | 'inProgress' | 'completed'): string {
+  switch (status) {
+    case 'completed':
+      return '[x]';
+    case 'inProgress':
+      return '[~]';
+    case 'pending':
+    default:
+      return '[ ]';
+  }
+}
+
+interface PlanCardProps {
+  item: AgentPlanItemV2;
+}
+
+/**
+ * Structured plan card for `AgentPlanItemV2` (codex `turn/plan/updated`
+ * steps). Renders a checklist with a status glyph per step and an
+ * approval-state badge when present; falls back to the free-text `item.text`
+ * when the adapter has not sent a structured `steps[]` yet.
+ */
+export const PlanCard: React.FC<PlanCardProps> = ({ item }) => {
+  const hasSteps = Boolean(item.steps && item.steps.length > 0);
+
+  return (
+    <div className="pcard" role="article" aria-label="plan">
+      <div className="pcard__h">
+        <span className="pcard__label">plan</span>
+        {item.approvalState && (
+          <span
+            className={`pcard__approval pcard__approval--${item.approvalState}`}
+          >
+            {item.approvalState}
+          </span>
+        )}
+      </div>
+      {hasSteps ? (
+        <ul className="pcard__steps">
+          {item.steps!.map((step, index) => (
+            <li
+              key={index}
+              className={`pcard__step pcard__step--${step.status}`}
+            >
+              <span className="pcard__glyph">{stepGlyph(step.status)}</span>
+              <span className="pcard__step-text">{step.step}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        item.text && <pre className="pcard__text">{item.text}</pre>
+      )}
+    </div>
+  );
+};
+
+export default PlanCard;

--- a/frontend/src/components/chat/QuestionCard.css
+++ b/frontend/src/components/chat/QuestionCard.css
@@ -1,0 +1,143 @@
+.qcard {
+  border: 1px solid var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.qcard__h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--accent);
+}
+
+.qcard__label {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.qcard__status {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.qcard__question {
+  padding: 6px 10px 0;
+  color: var(--text);
+}
+
+.qcard__fields {
+  padding: 4px 0;
+}
+
+.qcard__field {
+  padding: 6px 10px;
+}
+
+.qcard__field + .qcard__field {
+  border-top: 1px dashed var(--border);
+}
+
+.qcard__prompt {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  padding-bottom: 4px;
+}
+
+.qcard__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.qcard__opt {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 4px 10px;
+  text-transform: lowercase;
+  transition:
+    border-style 0.1s,
+    filter 0.1s,
+    background 0.1s;
+}
+
+.qcard__opt:hover {
+  border-width: 3px;
+  border-style: double;
+  padding: 2px 8px;
+  filter: brightness(1.3);
+}
+
+.qcard__opt--selected {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.qcard__other {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 4px 8px;
+  width: 100%;
+  max-width: 320px;
+  margin-top: 6px;
+}
+
+.qcard__other:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.qcard__answer {
+  color: var(--text);
+}
+
+.qcard__actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+}
+
+.qcard__submit {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 4px 10px;
+  text-transform: lowercase;
+  transition:
+    border-style 0.1s,
+    filter 0.1s,
+    background 0.1s;
+}
+
+.qcard__submit:hover:not(:disabled) {
+  border-width: 3px;
+  border-style: double;
+  padding: 2px 8px;
+  filter: brightness(1.3);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.qcard__submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (max-width: 767px) {
+  .qcard__options {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/components/chat/QuestionCard.tsx
+++ b/frontend/src/components/chat/QuestionCard.tsx
@@ -12,7 +12,12 @@ import type { AgentQuestionItemV2 } from '../../../../shared/agent-chat-protocol
  * The codex adapter's `agent-item-updated-v2` completion patch does not
  * re-send `fields` (only `answers`), so this component caches the last
  * non-empty `fields` array in a ref keyed by item id to keep the read-only
- * view legible (field prompts, not just raw ids).
+ * view legible (field prompts, not just raw ids) for the lifetime of a
+ * mounted instance. A fresh mount (reload, navigate-away-and-back, a second
+ * client) has no cache to draw on, so the answered view falls back to
+ * iterating `item.answers` directly (field id + joined values) whenever
+ * `fields` is empty — the answers still render, just without the original
+ * prompt text.
  */
 
 interface QuestionField {
@@ -104,63 +109,73 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({
       </div>
       {item.question && <div className="qcard__question">{item.question}</div>}
       <div className="qcard__fields">
-        {fields.map((field) => (
-          <div className="qcard__field" key={field.id}>
-            {field.prompt && (
-              <div className="qcard__prompt">{field.prompt}</div>
-            )}
-            {answered ? (
-              <div className="qcard__answer">
-                {(item.answers?.[field.id] ?? []).join(', ') || '(no answer)'}
+        {answered && fields.length === 0
+          ? Object.entries(item.answers ?? {}).map(([fieldId, values]) => (
+              <div className="qcard__field" key={fieldId}>
+                <div className="qcard__prompt">{fieldId}</div>
+                <div className="qcard__answer">
+                  {values.join(', ') || '(no answer)'}
+                </div>
               </div>
-            ) : (
-              <>
-                {field.options && field.options.length > 0 && (
-                  <div
-                    className="qcard__options"
-                    role="radiogroup"
-                    aria-label={field.prompt}
-                  >
-                    {field.options.map((option) => (
-                      <button
-                        key={option}
-                        type="button"
-                        role="radio"
-                        aria-checked={selections[field.id] === option}
-                        className={`qcard__opt${
-                          selections[field.id] === option
-                            ? ' qcard__opt--selected'
-                            : ''
-                        }`}
-                        onClick={() => handleSelect(field.id, option)}
-                      >
-                        {option}
-                      </button>
-                    ))}
+            ))
+          : fields.map((field) => (
+              <div className="qcard__field" key={field.id}>
+                {field.prompt && (
+                  <div className="qcard__prompt">{field.prompt}</div>
+                )}
+                {answered ? (
+                  <div className="qcard__answer">
+                    {(item.answers?.[field.id] ?? []).join(', ') ||
+                      '(no answer)'}
                   </div>
+                ) : (
+                  <>
+                    {field.options && field.options.length > 0 && (
+                      <div
+                        className="qcard__options"
+                        role="radiogroup"
+                        aria-label={field.prompt}
+                      >
+                        {field.options.map((option) => (
+                          <button
+                            key={option}
+                            type="button"
+                            role="radio"
+                            aria-checked={selections[field.id] === option}
+                            className={`qcard__opt${
+                              selections[field.id] === option
+                                ? ' qcard__opt--selected'
+                                : ''
+                            }`}
+                            onClick={() => handleSelect(field.id, option)}
+                          >
+                            {option}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    {(field.isOther ||
+                      !field.options ||
+                      field.options.length === 0) && (
+                      <input
+                        type="text"
+                        className="qcard__other"
+                        placeholder={
+                          field.options && field.options.length > 0
+                            ? 'other…'
+                            : 'your answer'
+                        }
+                        value={otherText[field.id] ?? ''}
+                        onChange={(e) =>
+                          handleOtherChange(field.id, e.target.value)
+                        }
+                        aria-label={`${field.prompt || field.id} (other)`}
+                      />
+                    )}
+                  </>
                 )}
-                {(field.isOther ||
-                  !field.options ||
-                  field.options.length === 0) && (
-                  <input
-                    type="text"
-                    className="qcard__other"
-                    placeholder={
-                      field.options && field.options.length > 0
-                        ? 'other…'
-                        : 'your answer'
-                    }
-                    value={otherText[field.id] ?? ''}
-                    onChange={(e) =>
-                      handleOtherChange(field.id, e.target.value)
-                    }
-                    aria-label={`${field.prompt || field.id} (other)`}
-                  />
-                )}
-              </>
-            )}
-          </div>
-        ))}
+              </div>
+            ))}
       </div>
       {!answered && (
         <div className="qcard__actions">

--- a/frontend/src/components/chat/QuestionCard.tsx
+++ b/frontend/src/components/chat/QuestionCard.tsx
@@ -1,0 +1,181 @@
+import React, { useMemo, useRef, useState } from 'react';
+import './QuestionCard.css';
+import type { AgentQuestionItemV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+
+/**
+ * Interactive question card for `AgentQuestionItemV2` (codex `handleUserInputRequest`
+ * user-input elicitations). Renders per-field option buttons (single select),
+ * an "other" free-text input when the field allows it (or has no preset
+ * options), and submits via the `onAnswer(requestId, answers)` socket
+ * callback. Once answered, renders a read-only summary of chosen values.
+ *
+ * The codex adapter's `agent-item-updated-v2` completion patch does not
+ * re-send `fields` (only `answers`), so this component caches the last
+ * non-empty `fields` array in a ref keyed by item id to keep the read-only
+ * view legible (field prompts, not just raw ids).
+ */
+
+interface QuestionField {
+  id: string;
+  prompt: string;
+  isOther?: boolean;
+  options?: string[];
+}
+
+function normalizeField(
+  raw: Record<string, unknown>,
+  index: number
+): QuestionField {
+  const id = typeof raw.id === 'string' ? raw.id : `field-${index}`;
+  const prompt = typeof raw.prompt === 'string' ? raw.prompt : id;
+  const isOther = raw.isOther === true;
+  const options = Array.isArray(raw.options)
+    ? raw.options.filter((opt): opt is string => typeof opt === 'string')
+    : undefined;
+  return {
+    id,
+    prompt,
+    isOther,
+    ...(options !== undefined ? { options } : {}),
+  };
+}
+
+interface QuestionCardProps {
+  item: AgentQuestionItemV2;
+  onAnswer: (requestId: string, answers: Record<string, string[]>) => void;
+}
+
+export const QuestionCard: React.FC<QuestionCardProps> = ({
+  item,
+  onAnswer,
+}) => {
+  const cachedFields = useRef<Map<string, QuestionField[]>>(new Map());
+
+  if (item.fields && item.fields.length > 0) {
+    cachedFields.current.set(
+      item.id,
+      item.fields.map((field, index) => normalizeField(field, index))
+    );
+  }
+
+  const fields = useMemo(
+    () => cachedFields.current.get(item.id) ?? [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [item.id, item.fields]
+  );
+
+  const answered = item.status === 'completed' || item.answers !== undefined;
+
+  const [selections, setSelections] = useState<Record<string, string>>({});
+  const [otherText, setOtherText] = useState<Record<string, string>>({});
+
+  const valueFor = (fieldId: string): string => {
+    const other = otherText[fieldId]?.trim();
+    if (other) return other;
+    return selections[fieldId] ?? '';
+  };
+
+  const allAnswered =
+    fields.length > 0 && fields.every((field) => valueFor(field.id).length > 0);
+
+  const handleSelect = (fieldId: string, option: string) => {
+    setSelections((prev) => ({ ...prev, [fieldId]: option }));
+    setOtherText((prev) => ({ ...prev, [fieldId]: '' }));
+  };
+
+  const handleOtherChange = (fieldId: string, value: string) => {
+    setOtherText((prev) => ({ ...prev, [fieldId]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (!allAnswered) return;
+    const answers: Record<string, string[]> = {};
+    for (const field of fields) {
+      answers[field.id] = [valueFor(field.id)];
+    }
+    onAnswer(item.requestId, answers);
+  };
+
+  return (
+    <div className="qcard" role="article" aria-label="question">
+      <div className="qcard__h">
+        <span className="qcard__label">question</span>
+        {answered && <span className="qcard__status">answered</span>}
+      </div>
+      {item.question && <div className="qcard__question">{item.question}</div>}
+      <div className="qcard__fields">
+        {fields.map((field) => (
+          <div className="qcard__field" key={field.id}>
+            {field.prompt && (
+              <div className="qcard__prompt">{field.prompt}</div>
+            )}
+            {answered ? (
+              <div className="qcard__answer">
+                {(item.answers?.[field.id] ?? []).join(', ') || '(no answer)'}
+              </div>
+            ) : (
+              <>
+                {field.options && field.options.length > 0 && (
+                  <div
+                    className="qcard__options"
+                    role="radiogroup"
+                    aria-label={field.prompt}
+                  >
+                    {field.options.map((option) => (
+                      <button
+                        key={option}
+                        type="button"
+                        role="radio"
+                        aria-checked={selections[field.id] === option}
+                        className={`qcard__opt${
+                          selections[field.id] === option
+                            ? ' qcard__opt--selected'
+                            : ''
+                        }`}
+                        onClick={() => handleSelect(field.id, option)}
+                      >
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {(field.isOther ||
+                  !field.options ||
+                  field.options.length === 0) && (
+                  <input
+                    type="text"
+                    className="qcard__other"
+                    placeholder={
+                      field.options && field.options.length > 0
+                        ? 'other…'
+                        : 'your answer'
+                    }
+                    value={otherText[field.id] ?? ''}
+                    onChange={(e) =>
+                      handleOtherChange(field.id, e.target.value)
+                    }
+                    aria-label={`${field.prompt || field.id} (other)`}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+      {!answered && (
+        <div className="qcard__actions">
+          <button
+            type="button"
+            className="qcard__submit"
+            disabled={!allAnswered}
+            onClick={handleSubmit}
+          >
+            submit
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QuestionCard;

--- a/frontend/src/components/chat/Turn.tsx
+++ b/frontend/src/components/chat/Turn.tsx
@@ -10,10 +10,14 @@ import { ApprovalCard } from './ApprovalCard.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
 import { FileChangeRow } from './FileChangeRow.js';
 import {
+  CompactionCard,
+  HookPromptCard,
   ImageGenerationCard,
   ImageViewCard,
   WebSearchCard,
 } from './MediaCard.js';
+import { PlanCard } from './PlanCard.js';
+import { QuestionCard } from './QuestionCard.js';
 import { ToolCard } from './ToolCard.js';
 import { TurnFooter } from './TurnFooter.js';
 import { TurnHeader } from './TurnHeader.js';
@@ -28,6 +32,7 @@ interface TurnProps {
   session: AgentSessionV2;
   eventVerbosity?: EventVerbosity;
   onApprove: (requestId: string, decision: AgentApprovalDecisionV2) => void;
+  onAnswer: (requestId: string, answers: Record<string, string[]>) => void;
   /** Slash command catalog for skill token highlighting in user messages. */
   slashCommands?: AgentSlashCommandV2[];
 }
@@ -97,6 +102,7 @@ function renderItem(
   item: AgentItemV2,
   eventVerbosity: EventVerbosity,
   onApprove: (requestId: string, decision: AgentApprovalDecisionV2) => void,
+  onAnswer: (requestId: string, answers: Record<string, string[]>) => void,
   commandIndex: Set<string>
 ): React.ReactNode {
   if (!shouldRenderItem(item, eventVerbosity)) return null;
@@ -126,11 +132,11 @@ function renderItem(
     case 'providerExtension':
       return renderProviderExtension(item);
     case 'question':
-      return <pre className="tl-text">{item.question}</pre>;
+      return <QuestionCard item={item} onAnswer={onAnswer} />;
     case 'plan':
-      return <pre className="tl-text">{item.text}</pre>;
+      return <PlanCard item={item} />;
     case 'compaction':
-      return <pre className="tl-text">{item.summary}</pre>;
+      return <CompactionCard item={item} />;
     case 'sessionBreak':
       return (
         <div
@@ -150,7 +156,7 @@ function renderItem(
     case 'imageGeneration':
       return <ImageGenerationCard item={item} />;
     case 'hookPrompt':
-      return <pre className="tl-text">{item.prompt}</pre>;
+      return <HookPromptCard item={item} />;
     case 'errorMessage':
       return (
         <div
@@ -187,6 +193,7 @@ export const Turn: React.FC<TurnProps> = ({
   session,
   eventVerbosity = 'normal',
   onApprove,
+  onAnswer,
   slashCommands,
 }) => {
   const commandIndex = slashCommands
@@ -198,7 +205,7 @@ export const Turn: React.FC<TurnProps> = ({
       <TurnHeader turn={turn} />
       {turn.items.map((item) => (
         <React.Fragment key={item.id}>
-          {renderItem(item, eventVerbosity, onApprove, commandIndex)}
+          {renderItem(item, eventVerbosity, onApprove, onAnswer, commandIndex)}
         </React.Fragment>
       ))}
       {turn.error && (

--- a/test/components/chat-v2-rendering.test.ts
+++ b/test/components/chat-v2-rendering.test.ts
@@ -8,6 +8,7 @@ import type { AgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
 const mocks = vi.hoisted(() => ({
   session: null as AgentSessionV2 | null,
   approve: vi.fn(),
+  answer: vi.fn(),
   sendMessage: vi.fn(),
   interrupt: vi.fn(),
 }));
@@ -20,7 +21,7 @@ vi.mock('../../frontend/src/hooks/useAgentChatSocket.js', () => ({
     sendMessage: mocks.sendMessage,
     interrupt: mocks.interrupt,
     approve: mocks.approve,
-    answer: vi.fn(),
+    answer: mocks.answer,
   }),
 }));
 
@@ -172,6 +173,7 @@ describe('chat v2 rendering against chat.html primitives', () => {
   beforeEach(() => {
     mocks.session = makeSession();
     mocks.approve.mockClear();
+    mocks.answer.mockClear();
     mocks.sendMessage.mockClear();
     mocks.interrupt.mockClear();
     container = document.createElement('div');
@@ -253,6 +255,56 @@ describe('chat v2 rendering against chat.html primitives', () => {
     expect(mocks.approve).toHaveBeenCalledWith('approval-1', {
       kind: 'decline',
     });
+  });
+
+  it('forwards question-card submissions through the v2 socket answer callback', async () => {
+    mocks.session = makeSession({
+      turns: [
+        {
+          id: 'turn-question',
+          status: 'waiting',
+          inputMessageId: 'user-question',
+          startedAt: timestamp(),
+          items: [
+            {
+              id: 'user-question',
+              type: 'userMessage',
+              text: 'go ahead',
+              status: 'completed',
+            },
+            {
+              id: 'question-1',
+              type: 'question',
+              requestId: 'input-1',
+              question: 'pick one',
+              fields: [
+                { id: 'choice', prompt: 'pick one', options: ['a', 'b'] },
+              ],
+              status: 'pending',
+            },
+          ],
+        },
+      ],
+    });
+
+    await renderChat();
+
+    const optionButton = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent === 'a'
+    );
+    expect(optionButton).toBeTruthy();
+    await act(async () => {
+      optionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const submitButton = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent === 'submit'
+    );
+    await act(async () => {
+      submitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(mocks.answer).toHaveBeenCalledWith('input-1', { choice: ['a'] });
   });
 
   it('hides queued-message cancel buttons when the provider cannot cancel queued messages', async () => {

--- a/test/components/question-plan-rendering.test.ts
+++ b/test/components/question-plan-rendering.test.ts
@@ -200,6 +200,39 @@ describe('QuestionCard rendering', () => {
     expect(container.textContent).toContain('Pick an approach');
     expect(container.textContent).toContain('rewrite');
   });
+
+  it('falls back to raw answers when a fields-less completed item is mounted fresh (reload/reconnect)', async () => {
+    // Simulates a reload/second-client scenario: no prior render exists to
+    // seed the fields cache, so the ref is empty on first mount. The
+    // completed item never carries `fields` (mirrors the real codex
+    // completion patch), only `answers`. The read-only summary must still
+    // surface the answers instead of rendering nothing.
+    const freshContainer = document.createElement('div');
+    document.body.appendChild(freshContainer);
+    const freshRoot = createRoot(freshContainer);
+
+    try {
+      await act(async () => {
+        freshRoot.render(
+          React.createElement(QuestionCard, {
+            item: makeQuestionItem({
+              fields: undefined,
+              status: 'completed',
+              answers: { approach: ['rewrite'] },
+              completedAt: timestamp(),
+            }),
+            onAnswer,
+          })
+        );
+      });
+
+      expect(freshContainer.textContent).toContain('answered');
+      expect(freshContainer.textContent).toContain('rewrite');
+    } finally {
+      act(() => freshRoot.unmount());
+      freshContainer.remove();
+    }
+  });
 });
 
 function makePlanItem(

--- a/test/components/question-plan-rendering.test.ts
+++ b/test/components/question-plan-rendering.test.ts
@@ -1,0 +1,374 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  AgentCompactionItemV2,
+  AgentHookPromptItemV2,
+  AgentPlanItemV2,
+  AgentQuestionItemV2,
+} from '../../shared/agent-chat-protocol-v2.js';
+
+const { QuestionCard } =
+  await import('../../frontend/src/components/chat/QuestionCard.js');
+const { PlanCard } =
+  await import('../../frontend/src/components/chat/PlanCard.js');
+const { CompactionCard, HookPromptCard } =
+  await import('../../frontend/src/components/chat/MediaCard.js');
+
+function timestamp(): string {
+  return new Date(Date.UTC(2026, 3, 28, 12, 0, 0)).toISOString();
+}
+
+function makeQuestionItem(
+  overrides: Partial<AgentQuestionItemV2> = {}
+): AgentQuestionItemV2 {
+  return {
+    id: 'question-test',
+    type: 'question',
+    requestId: 'input-1',
+    question: 'Which approach should I take?',
+    fields: [
+      {
+        id: 'approach',
+        prompt: 'Pick an approach',
+        options: ['refactor', 'rewrite'],
+        isOther: true,
+      },
+    ],
+    status: 'pending',
+    startedAt: timestamp(),
+    ...overrides,
+  };
+}
+
+describe('QuestionCard rendering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onAnswer = vi.fn<[string, Record<string, string[]>], void>();
+
+  beforeEach(() => {
+    onAnswer.mockClear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(item: AgentQuestionItemV2) {
+    await act(async () => {
+      root.render(React.createElement(QuestionCard, { item, onAnswer }));
+    });
+  }
+
+  function optionButton(text: string): HTMLButtonElement | undefined {
+    return Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === text
+    );
+  }
+
+  it('renders per-field option buttons instead of raw text', async () => {
+    await render(makeQuestionItem());
+
+    expect(container.querySelector('pre')).toBeNull();
+    expect(container.textContent).toContain('Which approach should I take?');
+    expect(container.textContent).toContain('Pick an approach');
+    expect(optionButton('refactor')).toBeTruthy();
+    expect(optionButton('rewrite')).toBeTruthy();
+  });
+
+  it('renders a free-text "other" input when isOther is set', async () => {
+    await render(makeQuestionItem());
+
+    const otherInput =
+      container.querySelector<HTMLInputElement>('.qcard__other');
+    expect(otherInput).toBeTruthy();
+  });
+
+  it('submits per-field answers through onAnswer when an option is selected', async () => {
+    await render(makeQuestionItem());
+
+    await act(async () => {
+      optionButton('refactor')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    const submit = optionButton('submit');
+    expect(submit?.hasAttribute('disabled')).toBe(false);
+    await act(async () => {
+      submit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onAnswer).toHaveBeenCalledWith('input-1', {
+      approach: ['refactor'],
+    });
+  });
+
+  it('disables submit until every field has a selection', async () => {
+    await render(
+      makeQuestionItem({
+        fields: [
+          { id: 'a', prompt: 'field a', options: ['x', 'y'] },
+          { id: 'b', prompt: 'field b', options: ['1', '2'] },
+        ],
+      })
+    );
+
+    expect(optionButton('submit')?.hasAttribute('disabled')).toBe(true);
+
+    await act(async () => {
+      optionButton('x')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+    });
+    expect(optionButton('submit')?.hasAttribute('disabled')).toBe(true);
+
+    await act(async () => {
+      optionButton('1')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+    });
+    expect(optionButton('submit')?.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('accepts a free-text answer with no preset options', async () => {
+    await render(
+      makeQuestionItem({
+        fields: [{ id: 'freeform', prompt: 'anything else?' }],
+      })
+    );
+
+    const input = container.querySelector<HTMLInputElement>('.qcard__other');
+    expect(input).toBeTruthy();
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value'
+      )?.set;
+      setter?.call(input, 'ship it as-is');
+      input?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await act(async () => {
+      optionButton('submit')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(onAnswer).toHaveBeenCalledWith('input-1', {
+      freeform: ['ship it as-is'],
+    });
+  });
+
+  it('renders a read-only answered state with chosen values and no submit button', async () => {
+    await render(
+      makeQuestionItem({
+        status: 'completed',
+        answers: { approach: ['rewrite'] },
+      })
+    );
+
+    expect(container.textContent).toContain('answered');
+    expect(container.textContent).toContain('rewrite');
+    expect(optionButton('submit')).toBeUndefined();
+    expect(container.querySelectorAll('.qcard__opt').length).toBe(0);
+  });
+
+  it('preserves field prompts in the answered view even when the completion patch drops fields', async () => {
+    // Mirrors the real codex-native-adapter behavior: the agent-item-updated-v2
+    // completion patch only carries {type, id, requestId, question, answers,
+    // status, completedAt} — no `fields`. The component must cache the last
+    // seen fields (by item id) to keep the read-only view legible.
+    await render(makeQuestionItem());
+
+    await render(
+      makeQuestionItem({
+        fields: undefined,
+        status: 'completed',
+        answers: { approach: ['rewrite'] },
+        completedAt: timestamp(),
+      })
+    );
+
+    expect(container.textContent).toContain('Pick an approach');
+    expect(container.textContent).toContain('rewrite');
+  });
+});
+
+function makePlanItem(
+  overrides: Partial<AgentPlanItemV2> = {}
+): AgentPlanItemV2 {
+  return {
+    id: 'plan-test',
+    type: 'plan',
+    text: 'fallback plan text',
+    status: 'running',
+    startedAt: timestamp(),
+    ...overrides,
+  };
+}
+
+describe('PlanCard rendering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(item: AgentPlanItemV2) {
+    await act(async () => {
+      root.render(React.createElement(PlanCard, { item }));
+    });
+  }
+
+  it('renders a checklist with a status glyph per step', async () => {
+    await render(
+      makePlanItem({
+        steps: [
+          { step: 'read the file', status: 'completed' },
+          { step: 'apply the patch', status: 'inProgress' },
+          { step: 'run the tests', status: 'pending' },
+        ],
+      })
+    );
+
+    expect(container.querySelector('pre')).toBeNull();
+    const steps = Array.from(container.querySelectorAll('.pcard__step'));
+    expect(steps).toHaveLength(3);
+    expect(steps[0]?.textContent).toContain('[x]');
+    expect(steps[0]?.textContent).toContain('read the file');
+    expect(steps[1]?.textContent).toContain('[~]');
+    expect(steps[2]?.textContent).toContain('[ ]');
+  });
+
+  it('shows an approval-state badge when present', async () => {
+    await render(
+      makePlanItem({
+        steps: [{ step: 'do the thing', status: 'pending' }],
+        approvalState: 'approved',
+      })
+    );
+
+    expect(container.textContent).toContain('approved');
+  });
+
+  it('falls back to item.text when steps[] is empty', async () => {
+    await render(makePlanItem({ steps: [] }));
+
+    expect(container.querySelector('.pcard__steps')).toBeNull();
+    expect(container.textContent).toContain('fallback plan text');
+  });
+});
+
+describe('CompactionCard rendering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function makeCompactionItem(
+    overrides: Partial<AgentCompactionItemV2> = {}
+  ): AgentCompactionItemV2 {
+    return {
+      id: 'compaction-test',
+      type: 'compaction',
+      summary: 'condensed the last 40 turns',
+      status: 'completed',
+      startedAt: timestamp(),
+      ...overrides,
+    };
+  }
+
+  it('renders the summary and no raw <pre>', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(CompactionCard, { item: makeCompactionItem() })
+      );
+    });
+
+    expect(container.querySelector('pre')).toBeNull();
+    expect(container.textContent).toContain('condensed the last 40 turns');
+  });
+
+  it('shows tokensBefore -> tokensAfter when present', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(CompactionCard, {
+          item: makeCompactionItem({ tokensBefore: 42000, tokensAfter: 1200 }),
+        })
+      );
+    });
+
+    expect(container.textContent).toContain('42000');
+    expect(container.textContent).toContain('1200');
+  });
+});
+
+describe('HookPromptCard rendering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function makeHookPromptItem(
+    overrides: Partial<AgentHookPromptItemV2> = {}
+  ): AgentHookPromptItemV2 {
+    return {
+      id: 'hookprompt-test',
+      type: 'hookPrompt',
+      prompt: 'pre-commit hook wants confirmation',
+      status: 'completed',
+      startedAt: timestamp(),
+      ...overrides,
+    };
+  }
+
+  it('renders the prompt and source label, no raw <pre>', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(HookPromptCard, {
+          item: makeHookPromptItem({ source: 'pre-commit' }),
+        })
+      );
+    });
+
+    expect(container.querySelector('pre')).toBeNull();
+    expect(container.textContent).toContain(
+      'pre-commit hook wants confirmation'
+    );
+    expect(container.textContent).toContain('pre-commit');
+  });
+});


### PR DESCRIPTION
## Summary
- Build an interactive `QuestionCard` for `AgentQuestionItemV2` (codex `handleUserInputRequest` user-input elicitations): per-field option buttons (single select), a free-text "other" input, submit wired through the existing `answer(requestId, answers)` socket callback (threaded `ChatView` -> `Turn` -> `QuestionCard`), and a read-only answered state.
- Build a checklist-style `PlanCard` for `AgentPlanItemV2`: per-step status glyph (`[ ]` / `[~]` / `[x]`), an approval-state badge when present, falling back to `item.text` when `steps[]` is empty.
- Add compact `CompactionCard` / `HookPromptCard` to `MediaCard.tsx` for the remaining bare-`<pre>` item types (summary + tokensBefore→tokensAfter; prompt + source label).
- `Turn.tsx` now renders all four item types with the new components instead of `<pre>{item.field}</pre>`.

Note: the codex adapter's `agent-item-updated-v2` completion patch for a question item does not re-send `fields` — only `answers` — so `QuestionCard` caches the last non-empty `fields[]` by item id to keep the read-only view legible (shows field prompts, not just raw ids/values).

## Test plan
- [x] `npm run check` (tsc x2 + typecheck:test + lint) passes
- [x] `npm test` — full suite passes (5151 passed / 9 skipped); one flaky rerun of `relayctl-preturn`/`cli-gateway-events` under parallel CPU contention, isolated rerun and full-suite rerun both green (unrelated to this diff)
- [x] New `test/components/question-plan-rendering.test.ts`: QuestionCard option rendering/submission/disabled-until-all-answered/free-text/answered read-only/fields-caching-across-completion; PlanCard step glyphs/approval badge/text fallback; CompactionCard/HookPromptCard rendering
- [x] Extended `test/components/chat-v2-rendering.test.ts` with an end-to-end wiring test asserting a QuestionCard submit calls the socket `answer` callback with the right requestId/answers shape

Refs #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)