### PR TITLE
feat(palette): hub-wide WorkContext artifact search (#1065)

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -15,6 +15,7 @@ import type {
   GitHubIssuesResponse,
   JiraIssue,
   JiraIssuesResponse,
+  WorkContextActiveGroup,
 } from '../lib/types.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import StatusDot from './StatusDot.js';
@@ -28,6 +29,12 @@ import {
   buildTopicPaletteResults,
   recentTopicPaletteResults,
 } from '../lib/command-palette-topic-results.js';
+import {
+  artifactKindIcon,
+  fetchArtifactPaletteResults,
+  type ArtifactPaletteResult,
+} from '../lib/command-palette-artifact-results.js';
+import type { PipelineHandoffArtifactEnvelope } from '../lib/pipeline-handoff-timeline.js';
 import type {
   WorkspaceTopic,
   WorkspaceTopicListResponse,
@@ -56,6 +63,7 @@ const TABS = [
   'sessions',
   'topics',
   'workspaces',
+  'artifacts',
   'prs',
   'settings',
 ] as const;
@@ -63,6 +71,7 @@ type Tab = (typeof TABS)[number];
 
 const SEC_GENERAL = 'section-general';
 const SEC_INTEGRATIONS = 'section-integrations';
+const SEC_NODES = 'section-nodes';
 const SEC_ADVANCED = 'section-advanced';
 const SEC_ABOUT = 'section-about';
 
@@ -110,6 +119,12 @@ const SETTINGS_ENTRIES = [
     section: SEC_INTEGRATIONS,
   },
   {
+    id: 'setting-nodes',
+    label: 'Nodes',
+    description: 'Pair, rename, or revoke Relay nodes',
+    section: SEC_NODES,
+  },
+  {
     id: 'setting-devtools',
     label: 'Developer Tools',
     description: 'Mobile debug panel',
@@ -154,6 +169,13 @@ type PaletteResult =
       label: string;
       sublabel?: string;
       data: WorkspaceTopic;
+    }
+  | {
+      type: 'artifact';
+      id: string;
+      label: string;
+      sublabel?: string;
+      data: PipelineHandoffArtifactEnvelope;
     }
   | {
       type: 'pr' | 'attention';
@@ -236,6 +258,8 @@ function categoryIcon(type: PaletteResult['type']): string {
       return '▸';
     case 'topic':
       return '◇';
+    case 'artifact':
+      return '▤';
     case 'pr':
     case 'attention':
       return '●';
@@ -255,6 +279,7 @@ function matchesTab(type: PaletteResult['type'], activeTab: Tab): boolean {
   if (activeTab === 'sessions') return type === 'session' || type === 'command';
   if (activeTab === 'topics') return type === 'topic';
   if (activeTab === 'workspaces') return type === 'workspace';
+  if (activeTab === 'artifacts') return type === 'artifact';
   if (activeTab === 'prs') return type === 'pr' || type === 'attention';
   if (activeTab === 'settings') return type === 'setting' || type === 'command';
   return true;
@@ -262,6 +287,24 @@ function matchesTab(type: PaletteResult['type'], activeTab: Tab): boolean {
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolves the workspace path to open for an artifact result (#1065). There
+ * is no direct deep-link into the evidence tab yet (see PR notes) — this is
+ * the cheapest existing open path: the WorkContext's worktree/repo path, so
+ * `onSelectWorkspace` can navigate there and the user opens the evidence tab
+ * manually.
+ */
+function repoPathForWorkContext(
+  activeWork: WorkContextActiveGroup[],
+  workContextId: string
+): string | undefined {
+  const group = activeWork.find((g) => g.context?.id === workContextId);
+  return (
+    group?.context?.anchors.worktree?.localPath ??
+    group?.context?.anchors.repo?.localPath
+  );
 }
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
@@ -291,7 +334,18 @@ function useCachedData(open: boolean) {
         ?.topics ?? [],
     [queryClient, open]
   );
-  return { cachedPrs, cachedGithubIssues, cachedJiraIssues, cachedTopics };
+  const cachedActiveWork = useMemo<WorkContextActiveGroup[]>(
+    () =>
+      queryClient.getQueryData<WorkContextActiveGroup[]>(['active-work']) ?? [],
+    [queryClient, open]
+  );
+  return {
+    cachedPrs,
+    cachedGithubIssues,
+    cachedJiraIssues,
+    cachedTopics,
+    cachedActiveWork,
+  };
 }
 
 /**
@@ -327,7 +381,9 @@ function buildResults(
   degradedCommands: { action: Action; reason: string }[],
   needsAttention: PullRequest[],
   activeTab: Tab,
-  actionContext: ActionContext
+  actionContext: ActionContext,
+  /** Hub-wide artifact search results (#1065) — already fetched+filtered server-side for `q`. */
+  artifactResults: ArtifactPaletteResult[]
 ): PaletteResult[] {
   const items: PaletteResult[] = [];
   if (!q) {
@@ -384,6 +440,9 @@ function buildResults(
   }
   for (const topic of buildTopicPaletteResults(q, cachedTopics, 5)) {
     items.push(topic);
+  }
+  for (const result of artifactResults) {
+    items.push(result);
   }
   for (const pr of cachedPrs
     .filter(
@@ -478,6 +537,7 @@ function useGroupedResults(
           { type: 'workspace', label: 'workspaces' },
           { type: 'session', label: 'sessions' },
           { type: 'topic', label: 'topics' },
+          { type: 'artifact', label: 'artifacts' },
           { type: 'pr', label: 'pull requests' },
           { type: 'ticket', label: 'tickets' },
           { type: 'command', label: 'commands' },
@@ -494,6 +554,46 @@ function useGroupedResults(
       return items.length > 0 ? [{ label, items }] : [];
     });
   }, [results, query]);
+}
+
+/**
+ * Hub-wide artifact search (#1065): fetches once `debouncedQuery` settles
+ * (the palette already debounces the raw query 150ms before this hook sees
+ * it, so no further debouncing is needed here). A monotonically increasing
+ * request id guards against a slow earlier request clobbering a faster
+ * later one.
+ */
+function useArtifactPaletteResults(
+  debouncedQuery: string,
+  cachedTopics: WorkspaceTopic[],
+  open: boolean
+): ArtifactPaletteResult[] {
+  const [results, setResults] = useState<ArtifactPaletteResult[]>([]);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const q = debouncedQuery.trim();
+    if (!open || !q) {
+      setResults([]);
+      return;
+    }
+    const requestId = ++requestIdRef.current;
+    let cancelled = false;
+    void fetchArtifactPaletteResults(q, cachedTopics, 5)
+      .then((next) => {
+        if (cancelled || requestId !== requestIdRef.current) return;
+        setResults(next);
+      })
+      .catch(() => {
+        if (cancelled || requestId !== requestIdRef.current) return;
+        setResults([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery, cachedTopics, open]);
+
+  return results;
 }
 
 // ── usePaletteState hook ───────────────────────────────────────────────────────
@@ -563,6 +663,7 @@ function usePaletteHandlers(
   onSelectSession: (id: string) => void,
   onSelectTopic: ((topic: WorkspaceTopic) => void) | undefined,
   onSelectPr: (pr: PullRequest) => void,
+  cachedActiveWork: WorkContextActiveGroup[],
   onOpenSettings?: (sectionId: string) => void
 ) {
   const scrollFocusedIntoView = useCallback(() => {
@@ -592,7 +693,22 @@ function usePaletteHandlers(
         onSelectSession(scopedSessionKey(item.data as SessionSummary));
       else if (item.type === 'topic')
         onSelectTopic?.(item.data as WorkspaceTopic);
-      else if (item.type === 'attention' || item.type === 'pr')
+      else if (item.type === 'artifact') {
+        // #1065: no direct deep-link into the evidence artifacts tab exists
+        // yet (see PR notes) — copy the artifact reference and navigate to
+        // the owning workspace as the cheapest existing open path so the
+        // user can open the evidence tab manually.
+        const envelope = item.data as PipelineHandoffArtifactEnvelope;
+        const uri = `relay://work-context-artifacts/${encodeURIComponent(envelope.metadata.id)}`;
+        if (globalThis.navigator?.clipboard?.writeText) {
+          void globalThis.navigator.clipboard.writeText(uri);
+        }
+        const repoPath = repoPathForWorkContext(
+          cachedActiveWork,
+          envelope.metadata.workContextId
+        );
+        if (repoPath) onSelectWorkspace(repoPath);
+      } else if (item.type === 'attention' || item.type === 'pr')
         onSelectPr(item.data as PullRequest);
       else if (item.type === 'setting')
         onOpenSettings?.((item.data as SettingEntry).section);
@@ -604,6 +720,7 @@ function usePaletteHandlers(
       onSelectSession,
       onSelectTopic,
       onSelectPr,
+      cachedActiveWork,
       onOpenSettings,
     ]
   );
@@ -865,8 +982,13 @@ export function CommandPalette({
     setDragging,
     dragStartYRef,
   } = usePaletteState(open, inputRef);
-  const { cachedPrs, cachedGithubIssues, cachedJiraIssues, cachedTopics } =
-    useCachedData(open);
+  const {
+    cachedPrs,
+    cachedGithubIssues,
+    cachedJiraIssues,
+    cachedTopics,
+    cachedActiveWork,
+  } = useCachedData(open);
   // Commands that pass `when` — active and invocable.
   const registryCommands = useMemo(
     () => getAllActions().filter((a) => !a.when || a.when(actionContext)),
@@ -897,6 +1019,11 @@ export function CommandPalette({
         .slice(0, 5),
     [cachedPrs]
   );
+  const artifactResults = useArtifactPaletteResults(
+    debouncedQuery,
+    cachedTopics,
+    open
+  );
 
   const results = useMemo(
     () =>
@@ -912,7 +1039,8 @@ export function CommandPalette({
         degradedCommands,
         needsAttention,
         activeTab,
-        actionContext
+        actionContext,
+        artifactResults
       ),
     [
       debouncedQuery,
@@ -927,6 +1055,7 @@ export function CommandPalette({
       needsAttention,
       activeTab,
       actionContext,
+      artifactResults,
     ]
   );
   const groupedResults = useGroupedResults(results, debouncedQuery);
@@ -965,6 +1094,7 @@ export function CommandPalette({
     onSelectSession,
     onSelectTopic,
     onSelectPr,
+    cachedActiveWork,
     onOpenSettings
   );
 
@@ -1254,6 +1384,13 @@ export function CommandPalette({
                           (item.data as Action).icon ? (
                           <span className="item-icon">
                             {(item.data as Action).icon}
+                          </span>
+                        ) : item.type === 'artifact' ? (
+                          <span className="item-icon">
+                            {artifactKindIcon(
+                              (item.data as PipelineHandoffArtifactEnvelope)
+                                .metadata.kind
+                            )}
                           </span>
                         ) : (
                           <span className="item-icon">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1091,6 +1091,29 @@ export async function fetchPipelineHandoffArtifact(
   return data.artifact;
 }
 
+/**
+ * Hub-wide WorkContext artifact search (#1065) — metadata only (title/kind/
+ * taskRef/workContextId), never body/payload content. Hard-capped at 20
+ * results server-side regardless of the requested limit.
+ */
+export async function searchWorkContextArtifacts(
+  q: string,
+  options: { kind?: string; limit?: number } = {}
+): Promise<PipelineHandoffArtifactEnvelope[]> {
+  const trimmed = q.trim();
+  if (!trimmed) return [];
+  const params = new URLSearchParams();
+  params.set('q', trimmed);
+  if (options.kind) params.set('kind', options.kind);
+  params.set('limit', String(options.limit ?? 8));
+  const data = await json<{ artifacts?: PipelineHandoffArtifactEnvelope[] }>(
+    await fetch(`/work-context-artifacts?${params.toString()}`, {
+      headers: HANDOFF_ARTIFACT_HEADERS,
+    })
+  );
+  return Array.isArray(data.artifacts) ? data.artifacts : [];
+}
+
 export interface CopyPipelineHandoffArtifactResult {
   artifact: {
     metadata: PublicPipelineHandoffArtifactSummary;

--- a/frontend/src/lib/command-palette-artifact-results.ts
+++ b/frontend/src/lib/command-palette-artifact-results.ts
@@ -1,0 +1,90 @@
+import type { ArtifactKind } from '../../../shared/work-context.js';
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
+import { searchWorkContextArtifacts } from './api.js';
+import type { PipelineHandoffArtifactEnvelope } from './pipeline-handoff-timeline.js';
+
+export interface ArtifactPaletteResult {
+  type: 'artifact';
+  id: string;
+  label: string;
+  sublabel: string;
+  data: PipelineHandoffArtifactEnvelope;
+}
+
+/** TUI-style glyph per artifact kind (#1065) — distinct from the generic per-type icon. */
+export function artifactKindIcon(kind: ArtifactKind | undefined): string {
+  switch (kind) {
+    case 'diff':
+      return '±';
+    case 'log-ref':
+      return '≣';
+    case 'transcript-ref':
+      return '¶';
+    case 'screenshot':
+      return '▧';
+    case 'report':
+      return '▥';
+    case 'command-output-ref':
+      return '»';
+    case 'external':
+      return '↗';
+    case 'file':
+    default:
+      return '▤';
+  }
+}
+
+/** The topic (channel) a WorkContext is linked to, so results show where to open it (mirrors #1093 for sessions). */
+function topicTitleForWorkContext(
+  workContextId: string,
+  topics: WorkspaceTopic[]
+): string | null {
+  const topic = topics.find((candidate) =>
+    candidate.linkedRefs.workContextIds?.includes(workContextId)
+  );
+  return topic?.display.title ?? null;
+}
+
+function toArtifactPaletteResult(
+  envelope: PipelineHandoffArtifactEnvelope,
+  topics: WorkspaceTopic[]
+): ArtifactPaletteResult {
+  const meta = envelope.metadata;
+  const topicTitle = topicTitleForWorkContext(meta.workContextId, topics);
+  return {
+    type: 'artifact',
+    id: `artifact-${meta.id}`,
+    label: meta.title || meta.id,
+    sublabel: `${topicTitle ?? meta.workContextId} · ${meta.kind}`,
+    data: envelope,
+  };
+}
+
+/** Pure mapping from already-fetched search results to palette result objects. */
+export function buildArtifactPaletteResults(
+  envelopes: PipelineHandoffArtifactEnvelope[],
+  topics: WorkspaceTopic[] = [],
+  limit = 5
+): ArtifactPaletteResult[] {
+  return envelopes
+    .slice(0, limit)
+    .map((envelope) => toArtifactPaletteResult(envelope, topics));
+}
+
+/**
+ * Debounced-fetch entry point for the command palette (#1065): the palette
+ * only calls this once `query` has settled (see CommandPalette's
+ * `debouncedQuery`), so this function itself does a single hub-wide search
+ * request and maps the metadata-only response to palette results. Never
+ * fetches or renders artifact body/payload content.
+ */
+export async function fetchArtifactPaletteResults(
+  query: string,
+  topics: WorkspaceTopic[] = [],
+  limit = 5
+): Promise<ArtifactPaletteResult[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const envelopes = await searchWorkContextArtifacts(trimmed, { limit });
+  return buildArtifactPaletteResults(envelopes, topics, limit);
+}

--- a/server/features/work-context-artifact-router.ts
+++ b/server/features/work-context-artifact-router.ts
@@ -216,6 +216,36 @@ function denyUnauthorizedActorWorkContextScope(
   return true;
 }
 
+/**
+ * Belt-and-suspenders (#1065 review): the hub-wide `q` search lane has no
+ * workContextId to scope-check, so its safety today depends entirely on the
+ * production `scopeForRequest` middleware wiring (`workContextScopeFromQuery`)
+ * rejecting scoped actors before this handler runs. This is an in-handler
+ * second gate that fails closed independent of that middleware wiring: any
+ * scoped CLI actor credential is rejected for a q-only (no workContextId)
+ * list/search request, regardless of what scope the middleware attached.
+ */
+function denyScopedActorHubWideSearch(
+  req: Request,
+  res: Response,
+  operation: string
+): boolean {
+  const credential = authenticatedCliGatewayActorCredential(req);
+  if (!credential?.scope.workContextIds?.length) return false;
+  sendGatewayError(
+    res,
+    'FORBIDDEN',
+    'scoped CLI actor credential rejected: CLI_ACTOR_MISSING_SCOPE',
+    false,
+    {
+      reasonCode: 'CLI_ACTOR_MISSING_SCOPE',
+      operation,
+      credentialId: credential.id,
+    }
+  );
+  return true;
+}
+
 function denyMissingCapability(
   req: Request,
   res: Response,
@@ -1387,6 +1417,13 @@ export function createWorkContextArtifactRouter(
           workContextId: input.workContextId,
           operation: 'list',
         })
+      ) {
+        return;
+      }
+      if (
+        input.q &&
+        !input.workContextId &&
+        denyScopedActorHubWideSearch(req, res, 'list')
       ) {
         return;
       }

--- a/server/features/work-context-artifact-router.ts
+++ b/server/features/work-context-artifact-router.ts
@@ -7,7 +7,9 @@ import type { Request, RequestHandler, Response } from 'express';
 import type { RelayCliGatewayErrorCode } from '../../shared/cli-gateway-contract.js';
 import { stableJsonEquals } from '../../shared/stable-json.js';
 import {
+  ARTIFACT_KINDS,
   createWorkContextPrivacyMetadata,
+  type ArtifactKind,
   type ArtifactRef,
   type TaskRef,
   type WorkContext,
@@ -26,6 +28,7 @@ import {
 import type { WorkContextStore } from '../work-contexts.js';
 import type { CliGatewayEventBus } from '../cli-gateway-event-bus.js';
 import {
+  WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT,
   WorkContextArtifactStoreError,
   type StoreAgentViewArtifactInput,
   type StorePipelineHandoffArtifactInput,
@@ -41,7 +44,8 @@ import {
   type CliGatewayActorWriteCommand,
 } from '../cli-gateway-actor-auth.js';
 
-export const WORK_CONTEXT_ARTIFACT_URI_PREFIX = 'relay://work-context-artifacts/';
+export const WORK_CONTEXT_ARTIFACT_URI_PREFIX =
+  'relay://work-context-artifacts/';
 const CONTEXT_READ = 'context:read';
 const ARTIFACT_WRITE = 'artifact:write';
 const STAGES = new Set(['implementation', 'qa', 'review', 'release']);
@@ -163,7 +167,9 @@ function gatewayErrorBody(
   retryable: boolean,
   details?: Record<string, unknown>
 ): GatewayErrorBody {
-  return { error: { code, message, retryable, ...(details ? { details } : {}) } };
+  return {
+    error: { code, message, retryable, ...(details ? { details } : {}) },
+  };
 }
 
 function sendGatewayError(
@@ -173,13 +179,20 @@ function sendGatewayError(
   retryable = false,
   details?: Record<string, unknown>
 ): void {
-  res.status(statusForCode(code)).json(gatewayErrorBody(code, message, retryable, details));
+  res
+    .status(statusForCode(code))
+    .json(gatewayErrorBody(code, message, retryable, details));
 }
 
 function denyUnauthorizedActorWorkContextScope(
   req: Request,
   res: Response,
-  input: { workContextId: string; operation: string; artifactId?: string; redactWorkContextId?: boolean }
+  input: {
+    workContextId: string;
+    operation: string;
+    artifactId?: string;
+    redactWorkContextId?: boolean;
+  }
 ): boolean {
   const credential = authenticatedCliGatewayActorCredential(req);
   const scopedWorkContextIds = credential?.scope.workContextIds;
@@ -193,7 +206,9 @@ function denyUnauthorizedActorWorkContextScope(
     {
       reasonCode: 'CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE',
       operation: input.operation,
-      ...(input.redactWorkContextId ? {} : { workContextId: input.workContextId }),
+      ...(input.redactWorkContextId
+        ? {}
+        : { workContextId: input.workContextId }),
       ...(input.artifactId ? { artifactId: input.artifactId } : {}),
       credentialId: credential?.id ?? 'unknown',
     }
@@ -208,25 +223,36 @@ function denyMissingCapability(
 ): boolean {
   const provided = parseCapabilityHeader(req.header('x-relay-capabilities'));
   const actorCredential = authenticatedCliGatewayActorCredential(req);
-  for (const capability of actorCredential?.capabilities ?? []) provided.add(capability);
+  for (const capability of actorCredential?.capabilities ?? [])
+    provided.add(capability);
   const missing = required.filter((cap) => !provided.has(cap));
   if (missing.length === 0) return false;
-  sendGatewayError(res, 'FORBIDDEN', `missing required capability: ${missing[0]}`, false, {
-    capability: missing[0],
-    missingCapabilities: missing,
-  });
+  sendGatewayError(
+    res,
+    'FORBIDDEN',
+    `missing required capability: ${missing[0]}`,
+    false,
+    {
+      capability: missing[0],
+      missingCapabilities: missing,
+    }
+  );
   return true;
 }
 
 function bodyRecord(req: Request): Record<string, unknown> {
-  return typeof req.body === 'object' && req.body !== null && !Array.isArray(req.body)
+  return typeof req.body === 'object' &&
+    req.body !== null &&
+    !Array.isArray(req.body)
     ? (req.body as Record<string, unknown>)
     : {};
 }
 
 function writeScopeFromBody(
   req: Request
-): { workContextIds?: string[]; repoIds?: string[]; taskRefs?: string[] } | undefined {
+):
+  | { workContextIds?: string[]; repoIds?: string[]; taskRefs?: string[] }
+  | undefined {
   const body = bodyRecord(req);
   const workContextId = readString(body['workContextId']);
   const repoId = readString(body['repoId']) ?? readString(body['projectId']);
@@ -242,7 +268,9 @@ function writeScopeFromBody(
 }
 
 function readString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+  return typeof value === 'string' && value.trim().length > 0
+    ? value
+    : undefined;
 }
 
 function readBoolean(value: unknown): boolean | undefined {
@@ -263,18 +291,44 @@ function readLimit(value: unknown): number | undefined {
   return Math.min(Math.max(Math.trunc(parsed), 1), 200);
 }
 
+/** Hard cap (#1065): `q`-driven searches never return more than this, regardless of the requested limit. */
+function readSearchLimit(value: unknown): number {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value)
+        : undefined;
+  if (parsed === undefined || !Number.isFinite(parsed)) {
+    return WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT;
+  }
+  return Math.min(
+    Math.max(Math.trunc(parsed), 1),
+    WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT
+  );
+}
+
 function readStage(value: unknown): PipelineHandoffStageName | undefined {
   return typeof value === 'string' && STAGES.has(value)
     ? (value as PipelineHandoffStageName)
     : undefined;
 }
 
-function readVisibility(value: unknown): WorkContextArtifactVisibility | undefined {
+function readArtifactKind(value: unknown): ArtifactKind | undefined {
+  return typeof value === 'string' && ARTIFACT_KINDS.has(value)
+    ? (value as ArtifactKind)
+    : undefined;
+}
+
+function readVisibility(
+  value: unknown
+): WorkContextArtifactVisibility | undefined {
   return value === 'private' || value === 'public' ? value : undefined;
 }
 
 function readTaskRef(value: unknown): TaskRef | undefined {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value))
+    return undefined;
   const record = value as Record<string, unknown>;
   const kind = readString(record['kind']);
   const id = readString(record['id']);
@@ -282,21 +336,32 @@ function readTaskRef(value: unknown): TaskRef | undefined {
   return {
     kind: kind as TaskRef['kind'],
     id,
-    ...(readString(record['title']) ? { title: record['title'] as string } : {}),
+    ...(readString(record['title'])
+      ? { title: record['title'] as string }
+      : {}),
     ...(readString(record['url']) ? { url: record['url'] as string } : {}),
-    ...(readString(record['status']) ? { status: record['status'] as string } : {}),
+    ...(readString(record['status'])
+      ? { status: record['status'] as string }
+      : {}),
   };
 }
 
-function readQueryTaskRef(req: Request): Pick<TaskRef, 'kind' | 'id'> | undefined | 'invalid' {
-  const kind = readString(req.query['taskRefKind'] ?? req.query['task-ref-kind']);
+function readQueryTaskRef(
+  req: Request
+): Pick<TaskRef, 'kind' | 'id'> | undefined | 'invalid' {
+  const kind = readString(
+    req.query['taskRefKind'] ?? req.query['task-ref-kind']
+  );
   const id = readString(req.query['taskRefId'] ?? req.query['task-ref-id']);
   if (!kind && !id) return undefined;
   if (!kind || !id) return 'invalid';
   return { kind: kind as TaskRef['kind'], id };
 }
 
-function currentHeadSha(req: Request, body?: Record<string, unknown>): string | undefined {
+function currentHeadSha(
+  req: Request,
+  body?: Record<string, unknown>
+): string | undefined {
   return (
     readString(body?.['currentHeadSha']) ??
     readString(body?.['expectedHeadSha']) ??
@@ -340,11 +405,15 @@ function readEnvelope(
   };
 }
 
-function persistedArtifactPayloadBytes(artifact: PipelineHandoffArtifact): number {
+function persistedArtifactPayloadBytes(
+  artifact: PipelineHandoffArtifact
+): number {
   return Buffer.byteLength(JSON.stringify(artifact, null, 2), 'utf8');
 }
 
-function persistedViewArtifactPayloadBytes(viewArtifact: ViewArtifactPackage): number {
+function persistedViewArtifactPayloadBytes(
+  viewArtifact: ViewArtifactPackage
+): number {
   return Buffer.byteLength(JSON.stringify(viewArtifact, null, 2), 'utf8');
 }
 
@@ -376,12 +445,18 @@ function ensureAppendOnlySupersedes(
       });
       return false;
     }
-    sendGatewayError(res, 'INTERNAL', 'failed to read superseded WorkContext artifact', true, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
-      operation: input.operation,
-      artifactId: input.artifact.id,
-      supersedesArtifactId,
-    });
+    sendGatewayError(
+      res,
+      'INTERNAL',
+      'failed to read superseded WorkContext artifact',
+      true,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+        operation: input.operation,
+        artifactId: input.artifact.id,
+        supersedesArtifactId,
+      }
+    );
     return false;
   }
   if (!previous?.payload || !isPipelineHandoffArtifact(previous.payload)) {
@@ -394,49 +469,73 @@ function ensureAppendOnlySupersedes(
     return false;
   }
   if (previous.metadata.workContextId !== input.workContextId) {
-    sendGatewayError(res, 'INVALID_ARGUMENT', 'superseded artifact belongs to a different WorkContext', false, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_SCOPE_MISMATCH',
-      operation: input.operation,
-      artifactId: input.artifact.id,
-      supersedesArtifactId,
-      workContextId: input.workContextId,
-      supersededWorkContextId: previous.metadata.workContextId,
-    });
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'superseded artifact belongs to a different WorkContext',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_SCOPE_MISMATCH',
+        operation: input.operation,
+        artifactId: input.artifact.id,
+        supersedesArtifactId,
+        workContextId: input.workContextId,
+        supersededWorkContextId: previous.metadata.workContextId,
+      }
+    );
     return false;
   }
   if (previous.payload.head.headSha !== input.artifact.head.headSha) {
-    sendGatewayError(res, 'SESSION_CONFLICT', 'artifact head is stale for the superseded handoff layer', false, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD',
-      operation: input.operation,
-      artifactId: input.artifact.id,
-      supersedesArtifactId,
-      artifactHeadSha: input.artifact.head.headSha,
-      supersededHeadSha: previous.payload.head.headSha,
-    });
+    sendGatewayError(
+      res,
+      'SESSION_CONFLICT',
+      'artifact head is stale for the superseded handoff layer',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD',
+        operation: input.operation,
+        artifactId: input.artifact.id,
+        supersedesArtifactId,
+        artifactHeadSha: input.artifact.head.headSha,
+        supersededHeadSha: previous.payload.head.headSha,
+      }
+    );
     return false;
   }
   if (input.artifact.stages.length <= previous.payload.stages.length) {
-    sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact must append at least one handoff stage layer', false, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
-      operation: input.operation,
-      artifactId: input.artifact.id,
-      supersedesArtifactId,
-      previousStageCount: previous.payload.stages.length,
-      nextStageCount: input.artifact.stages.length,
-    });
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'artifact must append at least one handoff stage layer',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
+        operation: input.operation,
+        artifactId: input.artifact.id,
+        supersedesArtifactId,
+        previousStageCount: previous.payload.stages.length,
+        nextStageCount: input.artifact.stages.length,
+      }
+    );
     return false;
   }
   for (let index = 0; index < previous.payload.stages.length; index += 1) {
     const stage = previous.payload.stages[index]!;
     if (sameJson(stage, input.artifact.stages[index])) continue;
-    sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact changed an existing handoff stage layer', false, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
-      operation: input.operation,
-      artifactId: input.artifact.id,
-      supersedesArtifactId,
-      stageIndex: index,
-      stage: stage.stage,
-    });
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'artifact changed an existing handoff stage layer',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
+        operation: input.operation,
+        artifactId: input.artifact.id,
+        supersedesArtifactId,
+        stageIndex: index,
+        stage: stage.stage,
+      }
+    );
     return false;
   }
   return true;
@@ -465,29 +564,53 @@ function mapStoreError(
       });
       return;
     case 'public_artifact_sanitization_failed':
-      sendGatewayError(res, 'FORBIDDEN', 'public artifact copy failed sanitizer validation', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_UNSAFE_PUBLIC_COPY',
-        ...details,
-      });
+      sendGatewayError(
+        res,
+        'FORBIDDEN',
+        'public artifact copy failed sanitizer validation',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_UNSAFE_PUBLIC_COPY',
+          ...details,
+        }
+      );
       return;
     case 'stored_payload_sha256_mismatch':
     case 'stored_payload_invalid':
-      sendGatewayError(res, 'INTERNAL', 'stored artifact payload failed integrity validation', true, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_INTEGRITY_FAILED',
-        ...details,
-      });
+      sendGatewayError(
+        res,
+        'INTERNAL',
+        'stored artifact payload failed integrity validation',
+        true,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_INTEGRITY_FAILED',
+          ...details,
+        }
+      );
       return;
     case 'artifact_already_exists':
-      sendGatewayError(res, 'SESSION_CONFLICT', 'artifact already exists', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_ALREADY_EXISTS',
-        ...details,
-      });
+      sendGatewayError(
+        res,
+        'SESSION_CONFLICT',
+        'artifact already exists',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_ALREADY_EXISTS',
+          ...details,
+        }
+      );
       return;
     case 'superseded_artifact_not_found':
-      sendGatewayError(res, 'NOT_FOUND', 'superseded artifact not found', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_NOT_FOUND',
-        ...details,
-      });
+      sendGatewayError(
+        res,
+        'NOT_FOUND',
+        'superseded artifact not found',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_NOT_FOUND',
+          ...details,
+        }
+      );
       return;
     default:
       sendGatewayError(res, 'INVALID_ARGUMENT', err.message, false, {
@@ -504,11 +627,17 @@ function ensureWorkContext(
   operation: string
 ): boolean {
   if (!workContextStore) {
-    sendGatewayError(res, 'SERVER_UNAVAILABLE', 'WorkContext store is unavailable', true, {
-      reasonCode: 'WORK_CONTEXT_STORE_UNAVAILABLE',
-      operation,
-      workContextId,
-    });
+    sendGatewayError(
+      res,
+      'SERVER_UNAVAILABLE',
+      'WorkContext store is unavailable',
+      true,
+      {
+        reasonCode: 'WORK_CONTEXT_STORE_UNAVAILABLE',
+        operation,
+        workContextId,
+      }
+    );
     return false;
   }
   if (workContextStore.get(workContextId)) return true;
@@ -525,10 +654,15 @@ function pinArtifactRef(
   workContextId: WorkContextId,
   metadata: WorkContextArtifactMetadata,
   actorId?: string
-): { workContext: WorkContext | null; artifactRef: ArtifactRef; alreadyPinned: boolean } {
+): {
+  workContext: WorkContext | null;
+  artifactRef: ArtifactRef;
+  alreadyPinned: boolean;
+} {
   const existing = workContextStore.get(workContextId);
   const artifactRef = artifactRefForMetadata(metadata, actorId);
-  if (!existing) return { workContext: null, artifactRef, alreadyPinned: false };
+  if (!existing)
+    return { workContext: null, artifactRef, alreadyPinned: false };
   const alreadyPinned = existing.artifacts.some(
     (item) => item.id === artifactRef.id || item.uri === artifactRef.uri
   );
@@ -575,10 +709,16 @@ function storeOr503(
   operation: string
 ): WorkContextArtifactStore | null {
   if (store) return store;
-  sendGatewayError(res, 'SERVER_UNAVAILABLE', 'WorkContext artifact store is unavailable', true, {
-    reasonCode: 'WORK_CONTEXT_ARTIFACT_STORE_UNAVAILABLE',
-    operation,
-  });
+  sendGatewayError(
+    res,
+    'SERVER_UNAVAILABLE',
+    'WorkContext artifact store is unavailable',
+    true,
+    {
+      reasonCode: 'WORK_CONTEXT_ARTIFACT_STORE_UNAVAILABLE',
+      operation,
+    }
+  );
   return null;
 }
 
@@ -590,12 +730,20 @@ function safeFileSizeBytes(filePath: string): number | undefined {
   }
 }
 
-function dirSizeBytes(root: string): { bytes: number; files: number; largestBytes: number } {
+function dirSizeBytes(root: string): {
+  bytes: number;
+  files: number;
+  largestBytes: number;
+} {
   let bytes = 0;
   let files = 0;
   let largestBytes = 0;
   function walk(dir: string): void {
-    let entries: Array<{ name: string; isDirectory(): boolean; isFile(): boolean }>;
+    let entries: Array<{
+      name: string;
+      isDirectory(): boolean;
+      isFile(): boolean;
+    }>;
     try {
       if (!existsSync(dir)) return;
       entries = readdirSync(dir, { withFileTypes: true });
@@ -624,11 +772,17 @@ function diagnosticsFor(
   diagnostics: WorkContextArtifactRouterDeps['diagnostics']
 ): Record<string, unknown> {
   const all = s.list({ includeSuperseded: true, limit: 200 });
-  const largestFromIndex = Math.max(0, ...all.map((record) => record.metadata.payloadBytes));
+  const largestFromIndex = Math.max(
+    0,
+    ...all.map((record) => record.metadata.payloadBytes)
+  );
   const payload = diagnostics?.payloadRoot
     ? dirSizeBytes(diagnostics.payloadRoot)
     : {
-        bytes: all.reduce((sum, record) => sum + record.metadata.payloadBytes, 0),
+        bytes: all.reduce(
+          (sum, record) => sum + record.metadata.payloadBytes,
+          0
+        ),
         files: all.length,
         largestBytes: largestFromIndex,
       };
@@ -636,7 +790,9 @@ function diagnosticsFor(
     ok: true,
     storage: {
       dbPath: diagnostics?.dbPath ?? null,
-      dbBytes: diagnostics?.dbPath ? (safeFileSizeBytes(diagnostics.dbPath) ?? null) : null,
+      dbBytes: diagnostics?.dbPath
+        ? (safeFileSizeBytes(diagnostics.dbPath) ?? null)
+        : null,
       payloadRoot: diagnostics?.payloadRoot ?? null,
       payloadBytes: payload.bytes,
       payloadFileCount: payload.files,
@@ -644,9 +800,11 @@ function diagnosticsFor(
       artifactCount: all.length,
       integrity: 'read-index-ok',
       maxPublishBytes:
-        diagnostics?.maxPublishBytes ?? DEFAULT_WORK_CONTEXT_ARTIFACT_PUBLISH_MAX_BYTES,
+        diagnostics?.maxPublishBytes ??
+        DEFAULT_WORK_CONTEXT_ARTIFACT_PUBLISH_MAX_BYTES,
       maxExportBytes:
-        diagnostics?.maxExportBytes ?? DEFAULT_WORK_CONTEXT_ARTIFACT_EXPORT_MAX_BYTES,
+        diagnostics?.maxExportBytes ??
+        DEFAULT_WORK_CONTEXT_ARTIFACT_EXPORT_MAX_BYTES,
     },
     recentArtifacts: all.slice(0, 10).map((record) => ({
       id: record.metadata.id,
@@ -665,15 +823,27 @@ export function readWorkContextArtifactQueryWorkContextId(
   return readString(query['workContextId'] ?? query['work-context-id']);
 }
 
-function queryListInput(req: Request): WorkContextArtifactListInput | 'invalid-task-ref' | 'missing-filter' {
+function queryListInput(
+  req: Request
+): WorkContextArtifactListInput | 'invalid-task-ref' | 'missing-filter' {
   const workContextId = readWorkContextArtifactQueryWorkContextId(req.query);
   const taskRef = readQueryTaskRef(req);
   if (taskRef === 'invalid') return 'invalid-task-ref';
-  if (!workContextId && !taskRef) return 'missing-filter';
-  const projectId = readString(req.query['projectId'] ?? req.query['project-id']);
+  // Hub-wide search lane (#1065): a `q` term stands in for the workContextId/taskRef
+  // filter requirement below — it is bounded to a hard <=20 limit instead.
+  const q = readString(req.query['q']);
+  if (!workContextId && !taskRef && !q) return 'missing-filter';
+  const projectId = readString(
+    req.query['projectId'] ?? req.query['project-id']
+  );
   const stage = readStage(req.query['stage']);
-  const includeSuperseded = readBoolean(req.query['includeSuperseded'] ?? req.query['include-superseded']);
-  const limit = readLimit(req.query['limit']);
+  const includeSuperseded = readBoolean(
+    req.query['includeSuperseded'] ?? req.query['include-superseded']
+  );
+  const kind = readArtifactKind(req.query['kind']);
+  const limit = q
+    ? readSearchLimit(req.query['limit'])
+    : readLimit(req.query['limit']);
   return {
     ...(workContextId ? { workContextId } : {}),
     ...(projectId ? { projectId } : {}),
@@ -681,6 +851,8 @@ function queryListInput(req: Request): WorkContextArtifactListInput | 'invalid-t
     ...(stage ? { stage } : {}),
     ...(includeSuperseded !== undefined ? { includeSuperseded } : {}),
     ...(limit ? { limit } : {}),
+    ...(q ? { q } : {}),
+    ...(kind ? { kind } : {}),
   };
 }
 
@@ -707,10 +879,16 @@ function emitArtifactEvent(
       taskRef: metadata.taskRef,
       ...(metadata.stage ? { stage: metadata.stage } : {}),
       ...(metadata.projectId ? { projectId: metadata.projectId } : {}),
-      ...(metadata.provenanceActorId ? { provenanceActorId: metadata.provenanceActorId } : {}),
-      ...(metadata.prNumber !== undefined ? { prNumber: metadata.prNumber } : {}),
+      ...(metadata.provenanceActorId
+        ? { provenanceActorId: metadata.provenanceActorId }
+        : {}),
+      ...(metadata.prNumber !== undefined
+        ? { prNumber: metadata.prNumber }
+        : {}),
       ...(metadata.headSha ? { headSha: metadata.headSha } : {}),
-      ...(metadata.supersedesArtifactId ? { supersedesArtifactId: metadata.supersedesArtifactId } : {}),
+      ...(metadata.supersedesArtifactId
+        ? { supersedesArtifactId: metadata.supersedesArtifactId }
+        : {}),
       ...(pinned !== undefined ? { pinned } : {}),
       rawPayloadAvailable: false,
     },
@@ -728,28 +906,50 @@ function storeViewArtifactPublish(input: {
   maxPublishBytes: number;
   events?: Pick<CliGatewayEventBus, 'publish'>;
 }): void {
-  const { res, store, workContextStore, body, viewArtifact, workContextId, operation, maxPublishBytes, events } = input;
+  const {
+    res,
+    store,
+    workContextStore,
+    body,
+    viewArtifact,
+    workContextId,
+    operation,
+    maxPublishBytes,
+    events,
+  } = input;
   const payloadBytes = persistedViewArtifactPayloadBytes(viewArtifact);
   if (payloadBytes > AGENT_VIEW_MAX_TOTAL_BYTES) {
-    sendGatewayError(res, 'INVALID_ARGUMENT', 'viewArtifact payload exceeds agent view size cap', false, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD',
-      operation,
-      workContextId,
-      artifactId: viewArtifact.manifest.revision.id,
-      payloadBytes,
-      maxBytes: AGENT_VIEW_MAX_TOTAL_BYTES,
-    });
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'viewArtifact payload exceeds agent view size cap',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD',
+        operation,
+        workContextId,
+        artifactId: viewArtifact.manifest.revision.id,
+        payloadBytes,
+        maxBytes: AGENT_VIEW_MAX_TOTAL_BYTES,
+      }
+    );
     return;
   }
   if (payloadBytes > maxPublishBytes) {
-    sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact payload exceeds publish size cap', false, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
-      operation,
-      workContextId,
-      artifactId: viewArtifact.manifest.revision.id,
-      payloadBytes,
-      maxBytes: maxPublishBytes,
-    });
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'artifact payload exceeds publish size cap',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
+        operation,
+        workContextId,
+        artifactId: viewArtifact.manifest.revision.id,
+        payloadBytes,
+        maxBytes: maxPublishBytes,
+      }
+    );
     return;
   }
   const provenanceActorId = readString(body['provenanceActorId']);
@@ -758,7 +958,9 @@ function storeViewArtifactPublish(input: {
   const taskRef = readTaskRef(body['taskRef']);
   const stage = readStage(body['stage']);
   const visibility = readVisibility(body['visibility']);
-  const kind = readString(body['kind']) as StoreAgentViewArtifactInput['kind'] | undefined;
+  const kind = readString(body['kind']) as
+    | StoreAgentViewArtifactInput['kind']
+    | undefined;
   const title = readString(body['title']);
   const summary = readString(body['summary']);
   const capturedAt = readString(body['capturedAt']);
@@ -782,25 +984,48 @@ function storeViewArtifactPublish(input: {
     const stored = store.storeAgentViewArtifact(inputRecord);
     const actorId = readString(body['actorId']) ?? provenanceActorId;
     const shouldPin = readBoolean(body['pin']) ?? false;
-    const pinned = shouldPin && workContextStore
-      ? pinArtifactRef(workContextStore, workContextId, stored.metadata, actorId)
-      : undefined;
-    emitArtifactEvent(events, 'work-context-artifacts', 'artifact.published', stored, actorId, Boolean(pinned && !pinned.alreadyPinned));
+    const pinned =
+      shouldPin && workContextStore
+        ? pinArtifactRef(
+            workContextStore,
+            workContextId,
+            stored.metadata,
+            actorId
+          )
+        : undefined;
+    emitArtifactEvent(
+      events,
+      'work-context-artifacts',
+      'artifact.published',
+      stored,
+      actorId,
+      Boolean(pinned && !pinned.alreadyPinned)
+    );
     res.status(201).json({
       artifact: recordEnvelope(stored),
       ...(pinned ? { pin: pinned } : {}),
     });
   } catch (err) {
     if (err instanceof WorkContextArtifactStoreError) {
-      mapStoreError(res, err, { operation, workContextId, artifactId: viewArtifact.manifest.revision.id });
+      mapStoreError(res, err, {
+        operation,
+        workContextId,
+        artifactId: viewArtifact.manifest.revision.id,
+      });
       return;
     }
-    sendGatewayError(res, 'INTERNAL', 'failed to store WorkContext view artifact', true, {
-      reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
-      operation,
-      workContextId,
-      artifactId: viewArtifact.manifest.revision.id,
-    });
+    sendGatewayError(
+      res,
+      'INTERNAL',
+      'failed to store WorkContext view artifact',
+      true,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+        operation,
+        workContextId,
+        artifactId: viewArtifact.manifest.revision.id,
+      }
+    );
   }
 }
 
@@ -808,14 +1033,21 @@ export function createWorkContextArtifactRouter(
   deps: WorkContextArtifactRouterDeps
 ): Router {
   const router = Router();
-  const auth = deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
+  const auth =
+    deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
   const readAuth = deps.requireReadAuth ?? {};
   const writeAuth = deps.requireWriteAuth ?? auth;
   const writeActorAuth = (
     command: CliGatewayActorWriteCommand,
-    options?: Parameters<NonNullable<WorkContextArtifactRouterDeps['requireWriteActorAuth']>>[1]
-  ): RequestHandler => deps.requireWriteActorAuth?.(command, options) ?? writeAuth;
-  const routeAuth = (fallback: RequestHandler, handoff?: RequestHandler): RequestHandler => {
+    options?: Parameters<
+      NonNullable<WorkContextArtifactRouterDeps['requireWriteActorAuth']>
+    >[1]
+  ): RequestHandler =>
+    deps.requireWriteActorAuth?.(command, options) ?? writeAuth;
+  const routeAuth = (
+    fallback: RequestHandler,
+    handoff?: RequestHandler
+  ): RequestHandler => {
     return (req, res, next) => {
       if (req.path.startsWith('/pipeline-handoff-artifacts')) {
         (handoff ?? fallback)(req, res, next);
@@ -828,342 +1060,503 @@ export function createWorkContextArtifactRouter(
   const showAuth = routeAuth(readAuth.show ?? auth, readAuth.handoffShow);
   const copyAuth = routeAuth(readAuth.export ?? auth, readAuth.handoffCopy);
   const maxPublishBytes =
-    deps.diagnostics?.maxPublishBytes ?? DEFAULT_WORK_CONTEXT_ARTIFACT_PUBLISH_MAX_BYTES;
+    deps.diagnostics?.maxPublishBytes ??
+    DEFAULT_WORK_CONTEXT_ARTIFACT_PUBLISH_MAX_BYTES;
   const maxExportBytes =
-    deps.diagnostics?.maxExportBytes ?? DEFAULT_WORK_CONTEXT_ARTIFACT_EXPORT_MAX_BYTES;
+    deps.diagnostics?.maxExportBytes ??
+    DEFAULT_WORK_CONTEXT_ARTIFACT_EXPORT_MAX_BYTES;
 
-  router.get('/work-context-artifacts/doctor', readAuth.doctor ?? auth, (req, res) => {
-    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
-    const s = storeOr503(res, deps.store, 'doctor');
-    if (!s) return;
-    try {
-      res.json({ diagnostics: diagnosticsFor(s, deps.diagnostics) });
-    } catch (err) {
-      if (err instanceof WorkContextArtifactStoreError) {
-        mapStoreError(res, err, { operation: 'doctor' });
-        return;
+  router.get(
+    '/work-context-artifacts/doctor',
+    readAuth.doctor ?? auth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+      const s = storeOr503(res, deps.store, 'doctor');
+      if (!s) return;
+      try {
+        res.json({ diagnostics: diagnosticsFor(s, deps.diagnostics) });
+      } catch (err) {
+        if (err instanceof WorkContextArtifactStoreError) {
+          mapStoreError(res, err, { operation: 'doctor' });
+          return;
+        }
+        sendGatewayError(
+          res,
+          'INTERNAL',
+          'failed to inspect WorkContext artifact storage',
+          true,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_DIAGNOSTIC_FAILED',
+            operation: 'doctor',
+          }
+        );
       }
-      sendGatewayError(res, 'INTERNAL', 'failed to inspect WorkContext artifact storage', true, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_DIAGNOSTIC_FAILED',
-        operation: 'doctor',
-      });
     }
-  });
+  );
 
   router.post(
     ['/work-context-artifacts', '/pipeline-handoff-artifacts'],
     routeAuth(
-      writeActorAuth('work-context-artifacts.publish', { scopeForRequest: writeScopeFromBody }),
-      writeActorAuth('handoff-artifacts.attach', { scopeForRequest: writeScopeFromBody })
+      writeActorAuth('work-context-artifacts.publish', {
+        scopeForRequest: writeScopeFromBody,
+      }),
+      writeActorAuth('handoff-artifacts.attach', {
+        scopeForRequest: writeScopeFromBody,
+      })
     ),
     // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- publish validates either handoff artifacts or static view artifacts before shared store/pin handling.
     (req, res) => {
-    const operation = req.path.startsWith('/pipeline-handoff-artifacts') ? 'attach' : 'publish';
-    if (denyMissingCapability(req, res, [ARTIFACT_WRITE])) return;
-    const s = storeOr503(res, deps.store, operation);
-    if (!s) return;
-    const body = bodyRecord(req);
-    const workContextId = readString(body['workContextId']);
-    if (!workContextId) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'workContextId is required', false, {
-        reasonCode: 'WORK_CONTEXT_ID_REQUIRED',
-        operation,
-        field: 'workContextId',
-      });
-      return;
-    }
-    if (!ensureWorkContext(res, deps.workContextStore, workContextId, operation)) return;
-    const viewArtifact = body['viewArtifact'];
-    const artifact = body['artifact'];
-    if (viewArtifact !== undefined && artifact !== undefined) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'exactly one of artifact or viewArtifact is allowed', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_CONFLICT',
-        operation,
-        workContextId,
-      });
-      return;
-    }
-    if (req.path.startsWith('/pipeline-handoff-artifacts') && viewArtifact !== undefined) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'pipeline-handoff-artifacts only accepts PipelineHandoffArtifact payloads', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_KIND_MISMATCH',
-        operation,
-        workContextId,
-        field: 'viewArtifact',
-      });
-      return;
-    }
-    if (viewArtifact !== undefined) {
-      const validation = validateAgentViewArtifact(viewArtifact);
-      if (!validation.valid) {
-        const oversized = validation.errors.some((error) => error.code === 'view_oversize');
+      const operation = req.path.startsWith('/pipeline-handoff-artifacts')
+        ? 'attach'
+        : 'publish';
+      if (denyMissingCapability(req, res, [ARTIFACT_WRITE])) return;
+      const s = storeOr503(res, deps.store, operation);
+      if (!s) return;
+      const body = bodyRecord(req);
+      const workContextId = readString(body['workContextId']);
+      if (!workContextId) {
         sendGatewayError(
           res,
           'INVALID_ARGUMENT',
-          oversized
-            ? 'viewArtifact payload exceeds agent view size cap'
-            : 'viewArtifact must be a valid AgentViewArtifact package',
+          'workContextId is required',
           false,
           {
-            reasonCode: oversized
-              ? 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD'
-              : 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+            reasonCode: 'WORK_CONTEXT_ID_REQUIRED',
             operation,
-            workContextId,
-            field: 'viewArtifact',
-            validationErrors: validation.errors,
+            field: 'workContextId',
           }
         );
         return;
       }
-      storeViewArtifactPublish({
-        res,
-        store: s,
-        ...(deps.workContextStore ? { workContextStore: deps.workContextStore } : {}),
-        body,
-        viewArtifact: viewArtifact as ViewArtifactPackage,
-        workContextId,
-        operation,
-        maxPublishBytes,
-        ...(deps.events ? { events: deps.events } : {}),
-      });
-      return;
-    }
-    if (artifact === undefined || !isPipelineHandoffArtifact(artifact)) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact must be a PipelineHandoffArtifact', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
-        operation,
-        workContextId,
-        field: 'artifact',
-      });
-      return;
-    }
-    const payloadBytes = persistedArtifactPayloadBytes(artifact);
-    if (payloadBytes > maxPublishBytes) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact payload exceeds publish size cap', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
-        operation,
-        workContextId,
-        artifactId: artifact.id,
-        payloadBytes,
-        maxBytes: maxPublishBytes,
-      });
-      return;
-    }
-    const current = currentHeadSha(req, body);
-    if (current && artifact.head.headSha !== current) {
-      sendGatewayError(res, 'SESSION_CONFLICT', 'artifact head is stale for the requested current head', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD',
-        operation,
-        workContextId,
-        artifactId: artifact.id,
-        artifactHeadSha: artifact.head.headSha,
-        currentHeadSha: current,
-      });
-      return;
-    }
-    const taskRef = readTaskRef(body['taskRef']);
-    const stage = readStage(body['stage']);
-    const provenanceActorId = readString(body['provenanceActorId']);
-    const visibility = readVisibility(body['visibility']);
-    const artifactIdOverride = readString(body['id']);
-    const projectId = readString(body['projectId']);
-    const kind = readString(body['kind']) as StorePipelineHandoffArtifactInput['kind'] | undefined;
-    const title = readString(body['title']);
-    const summary = readString(body['summary']);
-    const capturedAt = readString(body['capturedAt']);
-    const supersedesArtifactId = readString(body['supersedesArtifactId']);
-    const input: StorePipelineHandoffArtifactInput = {
-      artifact: artifact as PipelineHandoffArtifact,
-      workContextId,
-      ...(artifactIdOverride ? { id: artifactIdOverride } : {}),
-      ...(projectId ? { projectId } : {}),
-      ...(taskRef ? { taskRef } : {}),
-      ...(stage ? { stage } : {}),
-      ...(provenanceActorId ? { provenanceActorId } : {}),
-      ...(visibility ? { visibility } : {}),
-      ...(kind ? { kind } : {}),
-      ...(title ? { title } : {}),
-      ...(summary ? { summary } : {}),
-      ...(capturedAt ? { capturedAt } : {}),
-      ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
-    };
-    try {
       if (
-        !ensureAppendOnlySupersedes(res, s, {
+        !ensureWorkContext(res, deps.workContextStore, workContextId, operation)
+      )
+        return;
+      const viewArtifact = body['viewArtifact'];
+      const artifact = body['artifact'];
+      if (viewArtifact !== undefined && artifact !== undefined) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'exactly one of artifact or viewArtifact is allowed',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_CONFLICT',
+            operation,
+            workContextId,
+          }
+        );
+        return;
+      }
+      if (
+        req.path.startsWith('/pipeline-handoff-artifacts') &&
+        viewArtifact !== undefined
+      ) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'pipeline-handoff-artifacts only accepts PipelineHandoffArtifact payloads',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_KIND_MISMATCH',
+            operation,
+            workContextId,
+            field: 'viewArtifact',
+          }
+        );
+        return;
+      }
+      if (viewArtifact !== undefined) {
+        const validation = validateAgentViewArtifact(viewArtifact);
+        if (!validation.valid) {
+          const oversized = validation.errors.some(
+            (error) => error.code === 'view_oversize'
+          );
+          sendGatewayError(
+            res,
+            'INVALID_ARGUMENT',
+            oversized
+              ? 'viewArtifact payload exceeds agent view size cap'
+              : 'viewArtifact must be a valid AgentViewArtifact package',
+            false,
+            {
+              reasonCode: oversized
+                ? 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD'
+                : 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+              operation,
+              workContextId,
+              field: 'viewArtifact',
+              validationErrors: validation.errors,
+            }
+          );
+          return;
+        }
+        storeViewArtifactPublish({
+          res,
+          store: s,
+          ...(deps.workContextStore
+            ? { workContextStore: deps.workContextStore }
+            : {}),
+          body,
+          viewArtifact: viewArtifact as ViewArtifactPackage,
           workContextId,
-          artifact: artifact as PipelineHandoffArtifact,
-          ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
           operation,
-        })
-      ) {
-        return;
-      }
-      const stored = s.storePipelineHandoffArtifact(input);
-      const actorId = readString(body['actorId']) ?? provenanceActorId;
-      const shouldPin = readBoolean(body['pin']) ?? false;
-      const pinned =
-        shouldPin && deps.workContextStore
-          ? pinArtifactRef(deps.workContextStore, workContextId, stored.metadata, actorId)
-          : undefined;
-      emitArtifactEvent(
-        deps.events,
-        operation === 'attach' ? 'handoff-artifacts' : 'work-context-artifacts',
-        operation === 'attach' ? 'artifact.attached' : 'artifact.published',
-        stored,
-        actorId,
-        Boolean(pinned && !pinned.alreadyPinned)
-      );
-      res.status(201).json({
-        artifact: recordEnvelope(stored, current),
-        ...(pinned ? { pin: pinned } : {}),
-      });
-    } catch (err) {
-      if (err instanceof WorkContextArtifactStoreError) {
-        mapStoreError(res, err, { operation, workContextId, artifactId: artifact.id });
-        return;
-      }
-      sendGatewayError(res, 'INTERNAL', 'failed to store WorkContext artifact', true, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
-        operation,
-        workContextId,
-        artifactId: artifact.id,
-      });
-    }
-  });
-
-  router.get(['/work-context-artifacts', '/pipeline-handoff-artifacts'], listAuth, (req, res) => {
-    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
-    const s = storeOr503(res, deps.store, 'list');
-    if (!s) return;
-    const input = queryListInput(req);
-    if (input === 'invalid-task-ref') {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'taskRefKind and taskRefId are both required when filtering by taskRef', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_TASK_REF_REQUIRED',
-        operation: 'list',
-      });
-      return;
-    }
-    if (input === 'missing-filter') {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'workContextId or taskRef is required', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_FILTER_REQUIRED',
-        operation: 'list',
-      });
-      return;
-    }
-    if (
-      input.workContextId &&
-      denyUnauthorizedActorWorkContextScope(req, res, {
-        workContextId: input.workContextId,
-        operation: 'list',
-      })
-    ) {
-      return;
-    }
-    if (input.workContextId && !ensureWorkContext(res, deps.workContextStore, input.workContextId, 'list')) return;
-    const current = currentHeadSha(req);
-    const listed = s.list(input);
-    const artifacts = req.path.startsWith('/pipeline-handoff-artifacts')
-      ? listed.filter((record) => record.metadata.payloadKind === 'pipeline-handoff-artifact')
-      : listed;
-    res.json({ artifacts: artifacts.map((record) => recordEnvelope(record, current)) });
-  });
-
-  router.get('/work-context-artifacts/:id/view-package', showAuth, (req, res) => {
-    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
-    const s = storeOr503(res, deps.store, 'show-view-package');
-    if (!s) return;
-    const id = req.params['id'] ?? '';
-    try {
-      const metadataRecord = s.get(id);
-      if (
-        metadataRecord &&
-        denyUnauthorizedActorWorkContextScope(req, res, {
-          workContextId: metadataRecord.metadata.workContextId,
-          operation: 'show-view-package',
-          artifactId: id,
-          redactWorkContextId: true,
-        })
-      ) {
-        return;
-      }
-      const record = s.readViewArtifactPackage(id);
-      if (!record) {
-        sendGatewayError(res, 'NOT_FOUND', 'WorkContext view artifact not found', false, {
-          reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
-          operation: 'show-view-package',
-          artifactId: id,
+          maxPublishBytes,
+          ...(deps.events ? { events: deps.events } : {}),
         });
         return;
       }
-      res.json({ artifact: { metadata: record.metadata, viewArtifact: record.payload } });
-    } catch (err) {
-      if (err instanceof WorkContextArtifactStoreError) {
-        mapStoreError(res, err, { operation: 'show-view-package', artifactId: id });
+      if (artifact === undefined || !isPipelineHandoffArtifact(artifact)) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'artifact must be a PipelineHandoffArtifact',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+            operation,
+            workContextId,
+            field: 'artifact',
+          }
+        );
         return;
       }
-      sendGatewayError(res, 'INTERNAL', 'failed to read WorkContext view artifact package', true, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
-        operation: 'show-view-package',
-        artifactId: id,
-      });
+      const payloadBytes = persistedArtifactPayloadBytes(artifact);
+      if (payloadBytes > maxPublishBytes) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'artifact payload exceeds publish size cap',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
+            operation,
+            workContextId,
+            artifactId: artifact.id,
+            payloadBytes,
+            maxBytes: maxPublishBytes,
+          }
+        );
+        return;
+      }
+      const current = currentHeadSha(req, body);
+      if (current && artifact.head.headSha !== current) {
+        sendGatewayError(
+          res,
+          'SESSION_CONFLICT',
+          'artifact head is stale for the requested current head',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD',
+            operation,
+            workContextId,
+            artifactId: artifact.id,
+            artifactHeadSha: artifact.head.headSha,
+            currentHeadSha: current,
+          }
+        );
+        return;
+      }
+      const taskRef = readTaskRef(body['taskRef']);
+      const stage = readStage(body['stage']);
+      const provenanceActorId = readString(body['provenanceActorId']);
+      const visibility = readVisibility(body['visibility']);
+      const artifactIdOverride = readString(body['id']);
+      const projectId = readString(body['projectId']);
+      const kind = readString(body['kind']) as
+        | StorePipelineHandoffArtifactInput['kind']
+        | undefined;
+      const title = readString(body['title']);
+      const summary = readString(body['summary']);
+      const capturedAt = readString(body['capturedAt']);
+      const supersedesArtifactId = readString(body['supersedesArtifactId']);
+      const input: StorePipelineHandoffArtifactInput = {
+        artifact: artifact as PipelineHandoffArtifact,
+        workContextId,
+        ...(artifactIdOverride ? { id: artifactIdOverride } : {}),
+        ...(projectId ? { projectId } : {}),
+        ...(taskRef ? { taskRef } : {}),
+        ...(stage ? { stage } : {}),
+        ...(provenanceActorId ? { provenanceActorId } : {}),
+        ...(visibility ? { visibility } : {}),
+        ...(kind ? { kind } : {}),
+        ...(title ? { title } : {}),
+        ...(summary ? { summary } : {}),
+        ...(capturedAt ? { capturedAt } : {}),
+        ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
+      };
+      try {
+        if (
+          !ensureAppendOnlySupersedes(res, s, {
+            workContextId,
+            artifact: artifact as PipelineHandoffArtifact,
+            ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
+            operation,
+          })
+        ) {
+          return;
+        }
+        const stored = s.storePipelineHandoffArtifact(input);
+        const actorId = readString(body['actorId']) ?? provenanceActorId;
+        const shouldPin = readBoolean(body['pin']) ?? false;
+        const pinned =
+          shouldPin && deps.workContextStore
+            ? pinArtifactRef(
+                deps.workContextStore,
+                workContextId,
+                stored.metadata,
+                actorId
+              )
+            : undefined;
+        emitArtifactEvent(
+          deps.events,
+          operation === 'attach'
+            ? 'handoff-artifacts'
+            : 'work-context-artifacts',
+          operation === 'attach' ? 'artifact.attached' : 'artifact.published',
+          stored,
+          actorId,
+          Boolean(pinned && !pinned.alreadyPinned)
+        );
+        res.status(201).json({
+          artifact: recordEnvelope(stored, current),
+          ...(pinned ? { pin: pinned } : {}),
+        });
+      } catch (err) {
+        if (err instanceof WorkContextArtifactStoreError) {
+          mapStoreError(res, err, {
+            operation,
+            workContextId,
+            artifactId: artifact.id,
+          });
+          return;
+        }
+        sendGatewayError(
+          res,
+          'INTERNAL',
+          'failed to store WorkContext artifact',
+          true,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+            operation,
+            workContextId,
+            artifactId: artifact.id,
+          }
+        );
+      }
     }
-  });
+  );
 
-  router.get(['/work-context-artifacts/:id', '/pipeline-handoff-artifacts/:id'], showAuth, (req, res) => {
-    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
-    const s = storeOr503(res, deps.store, 'show');
-    if (!s) return;
-    const id = req.params['id'] ?? '';
-    const publicOnly = readBoolean(req.query['public']) ?? false;
-    const current = currentHeadSha(req);
-    try {
-      const metadataRecord = s.get(id);
+  router.get(
+    ['/work-context-artifacts', '/pipeline-handoff-artifacts'],
+    listAuth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+      const s = storeOr503(res, deps.store, 'list');
+      if (!s) return;
+      const input = queryListInput(req);
+      if (input === 'invalid-task-ref') {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'taskRefKind and taskRefId are both required when filtering by taskRef',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_TASK_REF_REQUIRED',
+            operation: 'list',
+          }
+        );
+        return;
+      }
+      if (input === 'missing-filter') {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'workContextId or taskRef is required',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_FILTER_REQUIRED',
+            operation: 'list',
+          }
+        );
+        return;
+      }
       if (
-        metadataRecord &&
+        input.workContextId &&
         denyUnauthorizedActorWorkContextScope(req, res, {
-          workContextId: metadataRecord.metadata.workContextId,
-          operation: 'show',
-          artifactId: id,
-          redactWorkContextId: true,
+          workContextId: input.workContextId,
+          operation: 'list',
         })
       ) {
         return;
       }
-      if (publicOnly) {
-        const publicCopy = s.publicSummary(id);
-        if (!publicCopy) {
-          sendGatewayError(res, 'NOT_FOUND', 'public WorkContext artifact not found', false, {
-            reasonCode: 'WORK_CONTEXT_ARTIFACT_PUBLIC_COPY_NOT_FOUND',
-            operation: 'show',
+      if (
+        input.workContextId &&
+        !ensureWorkContext(
+          res,
+          deps.workContextStore,
+          input.workContextId,
+          'list'
+        )
+      )
+        return;
+      const current = currentHeadSha(req);
+      const listed = s.list(input);
+      const artifacts = req.path.startsWith('/pipeline-handoff-artifacts')
+        ? listed.filter(
+            (record) =>
+              record.metadata.payloadKind === 'pipeline-handoff-artifact'
+          )
+        : listed;
+      res.json({
+        artifacts: artifacts.map((record) => recordEnvelope(record, current)),
+      });
+    }
+  );
+
+  router.get(
+    '/work-context-artifacts/:id/view-package',
+    showAuth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+      const s = storeOr503(res, deps.store, 'show-view-package');
+      if (!s) return;
+      const id = req.params['id'] ?? '';
+      try {
+        const metadataRecord = s.get(id);
+        if (
+          metadataRecord &&
+          denyUnauthorizedActorWorkContextScope(req, res, {
+            workContextId: metadataRecord.metadata.workContextId,
+            operation: 'show-view-package',
+            artifactId: id,
+            redactWorkContextId: true,
+          })
+        ) {
+          return;
+        }
+        const record = s.readViewArtifactPackage(id);
+        if (!record) {
+          sendGatewayError(
+            res,
+            'NOT_FOUND',
+            'WorkContext view artifact not found',
+            false,
+            {
+              reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
+              operation: 'show-view-package',
+              artifactId: id,
+            }
+          );
+          return;
+        }
+        res.json({
+          artifact: { metadata: record.metadata, viewArtifact: record.payload },
+        });
+      } catch (err) {
+        if (err instanceof WorkContextArtifactStoreError) {
+          mapStoreError(res, err, {
+            operation: 'show-view-package',
             artifactId: id,
           });
           return;
         }
-        res.json({ artifact: publicCopy });
-        return;
+        sendGatewayError(
+          res,
+          'INTERNAL',
+          'failed to read WorkContext view artifact package',
+          true,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+            operation: 'show-view-package',
+            artifactId: id,
+          }
+        );
       }
-      const record = s.read(id);
-      if (!record || (req.path.startsWith('/pipeline-handoff-artifacts') && record.metadata.payloadKind !== 'pipeline-handoff-artifact')) {
-        sendGatewayError(res, 'NOT_FOUND', 'WorkContext artifact not found', false, {
-          reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
-          operation: 'show',
-          artifactId: id,
-        });
-        return;
-      }
-      res.json({ artifact: readEnvelope(record, current) });
-    } catch (err) {
-      if (err instanceof WorkContextArtifactStoreError) {
-        mapStoreError(res, err, { operation: 'show', artifactId: id });
-        return;
-      }
-      sendGatewayError(res, 'INTERNAL', 'failed to read WorkContext artifact', true, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
-        operation: 'show',
-        artifactId: id,
-      });
     }
-  });
+  );
+
+  router.get(
+    ['/work-context-artifacts/:id', '/pipeline-handoff-artifacts/:id'],
+    showAuth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+      const s = storeOr503(res, deps.store, 'show');
+      if (!s) return;
+      const id = req.params['id'] ?? '';
+      const publicOnly = readBoolean(req.query['public']) ?? false;
+      const current = currentHeadSha(req);
+      try {
+        const metadataRecord = s.get(id);
+        if (
+          metadataRecord &&
+          denyUnauthorizedActorWorkContextScope(req, res, {
+            workContextId: metadataRecord.metadata.workContextId,
+            operation: 'show',
+            artifactId: id,
+            redactWorkContextId: true,
+          })
+        ) {
+          return;
+        }
+        if (publicOnly) {
+          const publicCopy = s.publicSummary(id);
+          if (!publicCopy) {
+            sendGatewayError(
+              res,
+              'NOT_FOUND',
+              'public WorkContext artifact not found',
+              false,
+              {
+                reasonCode: 'WORK_CONTEXT_ARTIFACT_PUBLIC_COPY_NOT_FOUND',
+                operation: 'show',
+                artifactId: id,
+              }
+            );
+            return;
+          }
+          res.json({ artifact: publicCopy });
+          return;
+        }
+        const record = s.read(id);
+        if (
+          !record ||
+          (req.path.startsWith('/pipeline-handoff-artifacts') &&
+            record.metadata.payloadKind !== 'pipeline-handoff-artifact')
+        ) {
+          sendGatewayError(
+            res,
+            'NOT_FOUND',
+            'WorkContext artifact not found',
+            false,
+            {
+              reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
+              operation: 'show',
+              artifactId: id,
+            }
+          );
+          return;
+        }
+        res.json({ artifact: readEnvelope(record, current) });
+      } catch (err) {
+        if (err instanceof WorkContextArtifactStoreError) {
+          mapStoreError(res, err, { operation: 'show', artifactId: id });
+          return;
+        }
+        sendGatewayError(
+          res,
+          'INTERNAL',
+          'failed to read WorkContext artifact',
+          true,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+            operation: 'show',
+            artifactId: id,
+          }
+        );
+      }
+    }
+  );
 
   const transferHandler = (operation: 'copy' | 'export'): RequestHandler => {
     return (req, res) => {
@@ -1174,11 +1567,17 @@ export function createWorkContextArtifactRouter(
       try {
         const record = s.get(id);
         if (!record) {
-          sendGatewayError(res, 'NOT_FOUND', 'WorkContext artifact not found', false, {
-            reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
-            operation,
-            artifactId: id,
-          });
+          sendGatewayError(
+            res,
+            'NOT_FOUND',
+            'WorkContext artifact not found',
+            false,
+            {
+              reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
+              operation,
+              artifactId: id,
+            }
+          );
           return;
         }
         if (
@@ -1193,22 +1592,37 @@ export function createWorkContextArtifactRouter(
         }
         const publicCopy = s.publicSummary(id);
         if (!publicCopy) {
-          sendGatewayError(res, 'FORBIDDEN', 'artifact is not available for public export', false, {
-            reasonCode: 'WORK_CONTEXT_ARTIFACT_UNSAFE_PUBLIC_COPY',
-            operation,
-            artifactId: id,
-          });
+          sendGatewayError(
+            res,
+            'FORBIDDEN',
+            'artifact is not available for public export',
+            false,
+            {
+              reasonCode: 'WORK_CONTEXT_ARTIFACT_UNSAFE_PUBLIC_COPY',
+              operation,
+              artifactId: id,
+            }
+          );
           return;
         }
-        const exportBytes = Buffer.byteLength(JSON.stringify(publicCopy, null, 2), 'utf8');
+        const exportBytes = Buffer.byteLength(
+          JSON.stringify(publicCopy, null, 2),
+          'utf8'
+        );
         if (exportBytes > maxExportBytes) {
-          sendGatewayError(res, 'INVALID_ARGUMENT', 'artifact export exceeds public export size cap', false, {
-            reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_EXPORT',
-            operation,
-            artifactId: id,
-            exportBytes,
-            maxBytes: maxExportBytes,
-          });
+          sendGatewayError(
+            res,
+            'INVALID_ARGUMENT',
+            'artifact export exceeds public export size cap',
+            false,
+            {
+              reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_EXPORT',
+              operation,
+              artifactId: id,
+              exportBytes,
+              maxBytes: maxExportBytes,
+            }
+          );
           return;
         }
         res.json({
@@ -1225,119 +1639,196 @@ export function createWorkContextArtifactRouter(
           mapStoreError(res, err, { operation, artifactId: id });
           return;
         }
-        sendGatewayError(res, 'INTERNAL', 'failed to export WorkContext artifact', true, {
-          reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
-          operation,
-          artifactId: id,
-        });
+        sendGatewayError(
+          res,
+          'INTERNAL',
+          'failed to export WorkContext artifact',
+          true,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_INTERNAL_ERROR',
+            operation,
+            artifactId: id,
+          }
+        );
       }
     };
   };
 
-  router.get('/work-context-artifacts/:id/export', copyAuth, transferHandler('export'));
-  router.get([
-    '/work-context-artifacts/:id/copy',
-    '/pipeline-handoff-artifacts/:id/copy',
-  ], copyAuth, transferHandler('copy'));
+  router.get(
+    '/work-context-artifacts/:id/export',
+    copyAuth,
+    transferHandler('export')
+  );
+  router.get(
+    [
+      '/work-context-artifacts/:id/copy',
+      '/pipeline-handoff-artifacts/:id/copy',
+    ],
+    copyAuth,
+    transferHandler('copy')
+  );
 
-  router.post('/work-context-artifacts/:id/pin', writeActorAuth('work-context-artifacts.pin', { deferWorkContextScope: true }), (req, res) => {
-    if (denyMissingCapability(req, res, [ARTIFACT_WRITE])) return;
-    const s = storeOr503(res, deps.store, 'pin');
-    if (!s) return;
-    const body = bodyRecord(req);
-    const workContextId = readString(body['workContextId']);
-    const artifactId = req.params['id'] ?? '';
-    if (!workContextId) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'workContextId is required', false, {
-        reasonCode: 'WORK_CONTEXT_ID_REQUIRED',
-        operation: 'pin',
-        artifactId,
-        field: 'workContextId',
-      });
-      return;
-    }
-    if (
-      denyUnauthorizedActorWorkContextScope(req, res, {
+  router.post(
+    '/work-context-artifacts/:id/pin',
+    writeActorAuth('work-context-artifacts.pin', {
+      deferWorkContextScope: true,
+    }),
+    (req, res) => {
+      if (denyMissingCapability(req, res, [ARTIFACT_WRITE])) return;
+      const s = storeOr503(res, deps.store, 'pin');
+      if (!s) return;
+      const body = bodyRecord(req);
+      const workContextId = readString(body['workContextId']);
+      const artifactId = req.params['id'] ?? '';
+      if (!workContextId) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'workContextId is required',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ID_REQUIRED',
+            operation: 'pin',
+            artifactId,
+            field: 'workContextId',
+          }
+        );
+        return;
+      }
+      if (
+        denyUnauthorizedActorWorkContextScope(req, res, {
+          workContextId,
+          operation: 'pin',
+          artifactId,
+        })
+      ) {
+        return;
+      }
+      if (!ensureWorkContext(res, deps.workContextStore, workContextId, 'pin'))
+        return;
+      const record = s.get(artifactId);
+      if (!record) {
+        sendGatewayError(
+          res,
+          'NOT_FOUND',
+          'WorkContext artifact not found',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
+            operation: 'pin',
+            artifactId,
+            workContextId,
+          }
+        );
+        return;
+      }
+      if (
+        denyUnauthorizedActorWorkContextScope(req, res, {
+          workContextId: record.metadata.workContextId,
+          operation: 'pin',
+          artifactId,
+          redactWorkContextId: true,
+        })
+      ) {
+        return;
+      }
+      const pinned = pinArtifactRef(
+        deps.workContextStore!,
         workContextId,
-        operation: 'pin',
-        artifactId,
-      })
-    ) {
-      return;
-    }
-    if (!ensureWorkContext(res, deps.workContextStore, workContextId, 'pin')) return;
-    const record = s.get(artifactId);
-    if (!record) {
-      sendGatewayError(res, 'NOT_FOUND', 'WorkContext artifact not found', false, {
-        reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
-        operation: 'pin',
-        artifactId,
-        workContextId,
+        record.metadata,
+        readString(body['actorId'])
+      );
+      emitArtifactEvent(
+        deps.events,
+        'work-context-artifacts',
+        'artifact.pinned',
+        record,
+        readString(body['actorId']),
+        !pinned.alreadyPinned
+      );
+      res.status(pinned.alreadyPinned ? 200 : 201).json({
+        artifact: recordEnvelope(record),
+        artifactRef: pinned.artifactRef,
+        workContext: pinned.workContext,
+        alreadyPinned: pinned.alreadyPinned,
       });
-      return;
     }
-    if (
-      denyUnauthorizedActorWorkContextScope(req, res, {
-        workContextId: record.metadata.workContextId,
-        operation: 'pin',
-        artifactId,
-        redactWorkContextId: true,
-      })
-    ) {
-      return;
-    }
-    const pinned = pinArtifactRef(deps.workContextStore!, workContextId, record.metadata, readString(body['actorId']));
-    emitArtifactEvent(deps.events, 'work-context-artifacts', 'artifact.pinned', record, readString(body['actorId']), !pinned.alreadyPinned);
-    res.status(pinned.alreadyPinned ? 200 : 201).json({
-      artifact: recordEnvelope(record),
-      artifactRef: pinned.artifactRef,
-      workContext: pinned.workContext,
-      alreadyPinned: pinned.alreadyPinned,
-    });
-  });
+  );
 
-  router.post('/work-context-artifacts/:id/unpin', writeActorAuth('work-context-artifacts.unpin', { deferWorkContextScope: true }), (req, res) => {
-    if (denyMissingCapability(req, res, [ARTIFACT_WRITE])) return;
-    const s = storeOr503(res, deps.store, 'unpin');
-    if (!s) return;
-    const body = bodyRecord(req);
-    const workContextId = readString(body['workContextId']);
-    const artifactId = req.params['id'] ?? '';
-    if (!workContextId) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'workContextId is required', false, {
-        reasonCode: 'WORK_CONTEXT_ID_REQUIRED',
-        operation: 'unpin',
-        artifactId,
-        field: 'workContextId',
-      });
-      return;
-    }
-    if (
-      denyUnauthorizedActorWorkContextScope(req, res, {
+  router.post(
+    '/work-context-artifacts/:id/unpin',
+    writeActorAuth('work-context-artifacts.unpin', {
+      deferWorkContextScope: true,
+    }),
+    (req, res) => {
+      if (denyMissingCapability(req, res, [ARTIFACT_WRITE])) return;
+      const s = storeOr503(res, deps.store, 'unpin');
+      if (!s) return;
+      const body = bodyRecord(req);
+      const workContextId = readString(body['workContextId']);
+      const artifactId = req.params['id'] ?? '';
+      if (!workContextId) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'workContextId is required',
+          false,
+          {
+            reasonCode: 'WORK_CONTEXT_ID_REQUIRED',
+            operation: 'unpin',
+            artifactId,
+            field: 'workContextId',
+          }
+        );
+        return;
+      }
+      if (
+        denyUnauthorizedActorWorkContextScope(req, res, {
+          workContextId,
+          operation: 'unpin',
+          artifactId,
+        })
+      ) {
+        return;
+      }
+      if (
+        !ensureWorkContext(res, deps.workContextStore, workContextId, 'unpin')
+      )
+        return;
+      const record = s.get(artifactId);
+      if (
+        record &&
+        denyUnauthorizedActorWorkContextScope(req, res, {
+          workContextId: record.metadata.workContextId,
+          operation: 'unpin',
+          artifactId,
+          redactWorkContextId: true,
+        })
+      ) {
+        return;
+      }
+      const result = unpinArtifactRef(
+        deps.workContextStore!,
         workContextId,
-        operation: 'unpin',
         artifactId,
-      })
-    ) {
-      return;
+        readString(body['actorId'])
+      );
+      if (record && result.removed)
+        emitArtifactEvent(
+          deps.events,
+          'work-context-artifacts',
+          'artifact.unpinned',
+          record,
+          readString(body['actorId']),
+          false
+        );
+      res.json({
+        workContext: result.workContext,
+        removed: result.removed,
+        lifecycle: { artifactDeleted: false },
+      });
     }
-    if (!ensureWorkContext(res, deps.workContextStore, workContextId, 'unpin')) return;
-    const record = s.get(artifactId);
-    if (
-      record &&
-      denyUnauthorizedActorWorkContextScope(req, res, {
-        workContextId: record.metadata.workContextId,
-        operation: 'unpin',
-        artifactId,
-        redactWorkContextId: true,
-      })
-    ) {
-      return;
-    }
-    const result = unpinArtifactRef(deps.workContextStore!, workContextId, artifactId, readString(body['actorId']));
-    if (record && result.removed) emitArtifactEvent(deps.events, 'work-context-artifacts', 'artifact.unpinned', record, readString(body['actorId']), false);
-    res.json({ workContext: result.workContext, removed: result.removed, lifecycle: { artifactDeleted: false } });
-  });
+  );
 
   return router;
 }

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -29,6 +29,8 @@ import {
 } from '../shared/work-context.js';
 
 const SCHEMA_VERSION = 2;
+/** Hard cap for `q`-driven searches (#1065) — hub-wide, so keep results tight. */
+export const WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT = 20;
 const DEFAULT_PAYLOAD_MEDIA_TYPE = 'application/json';
 const DEFAULT_VISIBILITY: WorkContextArtifactVisibility = 'private';
 const VISIBILITIES = new Set<string>(['private', 'public']);
@@ -41,7 +43,8 @@ const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
 const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
 const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
 const STRICT_ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-const AGENT_VIEW_ISO_TIMESTAMP_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
+const AGENT_VIEW_ISO_TIMESTAMP_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS work_context_artifacts (
@@ -97,7 +100,9 @@ CREATE INDEX IF NOT EXISTS idx_work_context_artifact_task_refs_lookup
 `;
 
 export type WorkContextArtifactVisibility = 'private' | 'public';
-export type WorkContextArtifactPayloadKind = 'pipeline-handoff-artifact' | 'agent-view-artifact';
+export type WorkContextArtifactPayloadKind =
+  | 'pipeline-handoff-artifact'
+  | 'agent-view-artifact';
 
 export interface WorkContextArtifactIndexInput {
   id?: string;
@@ -197,12 +202,24 @@ export interface WorkContextArtifactListInput {
   stage?: PipelineHandoffStageName;
   includeSuperseded?: boolean;
   limit?: number;
+  /**
+   * Free-text hub-wide search over metadata only (title/kind/taskRef/workContextId) —
+   * never body/payload content (#1065). Presence of `q` puts `list()` into
+   * search mode, which enforces a tighter hard limit (<=20, see
+   * WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT) regardless of the requested limit.
+   */
+  q?: string;
+  kind?: ArtifactKind;
 }
 
 export interface WorkContextArtifactStore {
   close(): void;
-  storePipelineHandoffArtifact(input: StorePipelineHandoffArtifactInput): WorkContextArtifactRecord;
-  storeAgentViewArtifact(input: StoreAgentViewArtifactInput): WorkContextArtifactRecord;
+  storePipelineHandoffArtifact(
+    input: StorePipelineHandoffArtifactInput
+  ): WorkContextArtifactRecord;
+  storeAgentViewArtifact(
+    input: StoreAgentViewArtifactInput
+  ): WorkContextArtifactRecord;
   get(id: string): WorkContextArtifactRecord | null;
   read(id: string): WorkContextArtifactReadResult | null;
   readViewArtifactPackage(id: string): AgentViewArtifactReadResult | null;
@@ -242,7 +259,9 @@ interface PersistedMetadataJson {
   taskRef: TaskRef;
 }
 
-type IndexedTaskRef = Pick<TaskRef, 'id' | 'title' | 'url' | 'status'> & { kind: string };
+type IndexedTaskRef = Pick<TaskRef, 'id' | 'title' | 'url' | 'status'> & {
+  kind: string;
+};
 
 export class WorkContextArtifactStoreError extends Error {
   readonly status: number;
@@ -270,24 +289,32 @@ export function createWorkContextArtifactStore(input: {
   payloadRoot?: string;
 }): WorkContextArtifactStore {
   mkdirSync(path.dirname(input.dbPath), { recursive: true });
-  const payloadRoot = input.payloadRoot ?? path.join(path.dirname(input.dbPath), 'work-context-artifacts', 'payloads');
+  const payloadRoot =
+    input.payloadRoot ??
+    path.join(path.dirname(input.dbPath), 'work-context-artifacts', 'payloads');
   mkdirSync(payloadRoot, { recursive: true });
 
   const db = new Database(input.dbPath);
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
-  db.exec('CREATE TABLE IF NOT EXISTS work_context_artifact_schema_version (version INTEGER NOT NULL)');
-  const schemaRow = db.prepare('SELECT version FROM work_context_artifact_schema_version').get() as
-    | { version: number }
-    | undefined;
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS work_context_artifact_schema_version (version INTEGER NOT NULL)'
+  );
+  const schemaRow = db
+    .prepare('SELECT version FROM work_context_artifact_schema_version')
+    .get() as { version: number } | undefined;
   const hadSchemaRow = schemaRow !== undefined;
   if ((schemaRow?.version ?? 0) < SCHEMA_VERSION) {
     db.transaction(() => {
       db.exec(SCHEMA_SQL);
       if (hadSchemaRow) {
-        db.prepare('UPDATE work_context_artifact_schema_version SET version = ?').run(SCHEMA_VERSION);
+        db.prepare(
+          'UPDATE work_context_artifact_schema_version SET version = ?'
+        ).run(SCHEMA_VERSION);
       } else {
-        db.prepare('INSERT INTO work_context_artifact_schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+        db.prepare(
+          'INSERT INTO work_context_artifact_schema_version (version) VALUES (?)'
+        ).run(SCHEMA_VERSION);
       }
     })();
   }
@@ -315,7 +342,9 @@ export function createWorkContextArtifactStore(input: {
     )
   `);
   backfillArtifactTaskRefs(db, insertTaskRef);
-  const selectById = db.prepare('SELECT * FROM work_context_artifacts WHERE id = ?');
+  const selectById = db.prepare(
+    'SELECT * FROM work_context_artifacts WHERE id = ?'
+  );
 
   function mustNotAlreadyExist(id: string): void {
     if (selectById.get(id)) {
@@ -330,10 +359,16 @@ export function createWorkContextArtifactStore(input: {
     if (!id) return;
     const row = selectById.get(id) as WorkContextArtifactRow | undefined;
     if (!row) {
-      throw new WorkContextArtifactStoreError(400, 'superseded_artifact_not_found');
+      throw new WorkContextArtifactStoreError(
+        400,
+        'superseded_artifact_not_found'
+      );
     }
     if (row.work_context_id !== workContextId) {
-      throw new WorkContextArtifactStoreError(400, 'superseded_artifact_scope_mismatch');
+      throw new WorkContextArtifactStoreError(
+        400,
+        'superseded_artifact_scope_mismatch'
+      );
     }
   }
 
@@ -367,7 +402,9 @@ export function createWorkContextArtifactStore(input: {
       db.close();
     },
 
-    storePipelineHandoffArtifact(storeInput: StorePipelineHandoffArtifactInput) {
+    storePipelineHandoffArtifact(
+      storeInput: StorePipelineHandoffArtifactInput
+    ) {
       assertNonEmptyString(storeInput.workContextId, 'workContextId');
       if (storeInput.projectId !== undefined)
         assertNonEmptyString(storeInput.projectId, 'projectId');
@@ -376,7 +413,8 @@ export function createWorkContextArtifactStore(input: {
         assertNonEmptyString(storeInput.provenanceActorId, 'provenanceActorId');
       if (storeInput.visibility !== undefined)
         assertValidVisibility(storeInput.visibility);
-      if (storeInput.kind !== undefined) assertValidArtifactKind(storeInput.kind);
+      if (storeInput.kind !== undefined)
+        assertValidArtifactKind(storeInput.kind);
       if (storeInput.title !== undefined)
         assertNonEmptyString(storeInput.title, 'title');
       if (storeInput.summary !== undefined)
@@ -391,23 +429,34 @@ export function createWorkContextArtifactStore(input: {
       }
       if (storeInput.id !== undefined) {
         assertNonEmptyString(storeInput.id, 'id');
-        if (storeInput.artifact.id !== undefined && storeInput.id !== storeInput.artifact.id) {
+        if (
+          storeInput.artifact.id !== undefined &&
+          storeInput.id !== storeInput.artifact.id
+        ) {
           throw new WorkContextArtifactStoreError(400, 'artifact_id_mismatch');
         }
       }
-      const artifactId = storeInput.id ?? storeInput.artifact.id ?? `artifact:${randomUUID()}`;
+      const artifactId =
+        storeInput.id ?? storeInput.artifact.id ?? `artifact:${randomUUID()}`;
       mustNotAlreadyExist(artifactId);
-      mustValidateSupersedes(storeInput.supersedesArtifactId, storeInput.workContextId);
+      mustValidateSupersedes(
+        storeInput.supersedesArtifactId,
+        storeInput.workContextId
+      );
 
       const taskRef = storeInput.taskRef ?? firstTaskRef(storeInput.artifact);
       if (!taskRef) {
         throw new WorkContextArtifactStoreError(400, 'task_ref_required');
       }
       assertValidTaskRef(taskRef);
-      const taskRefs = dedupeTaskRefs([taskRef, ...storeInput.artifact.scope.taskRefs]);
+      const taskRefs = dedupeTaskRefs([
+        taskRef,
+        ...storeInput.artifact.scope.taskRefs,
+      ]);
       for (const indexedTaskRef of taskRefs) assertValidTaskRef(indexedTaskRef);
       const now = new Date().toISOString();
-      const capturedAt = storeInput.capturedAt ?? storeInput.artifact.head.capturedAt;
+      const capturedAt =
+        storeInput.capturedAt ?? storeInput.artifact.head.capturedAt;
       assertIsoTimestamp(capturedAt, 'capturedAt');
       const payloadJson = JSON.stringify(storeInput.artifact, null, 2);
       const payloadSha256 = sha256Hex(payloadJson);
@@ -419,7 +468,9 @@ export function createWorkContextArtifactStore(input: {
         ...(storeInput.projectId ? { projectId: storeInput.projectId } : {}),
         taskRef,
         ...(storeInput.stage ? { stage: storeInput.stage } : {}),
-        ...(storeInput.provenanceActorId ? { provenanceActorId: storeInput.provenanceActorId } : {}),
+        ...(storeInput.provenanceActorId
+          ? { provenanceActorId: storeInput.provenanceActorId }
+          : {}),
         kind: storeInput.kind ?? 'report',
         title: storeInput.title ?? storeInput.artifact.title,
         summary: storeInput.summary ?? storeInput.artifact.scope.summary,
@@ -431,11 +482,17 @@ export function createWorkContextArtifactStore(input: {
         payloadMediaType: DEFAULT_PAYLOAD_MEDIA_TYPE,
         payloadSha256,
         payloadBytes,
-        ...(storeInput.artifact.head.pr?.number ? { prNumber: storeInput.artifact.head.pr.number } : {}),
+        ...(storeInput.artifact.head.pr?.number
+          ? { prNumber: storeInput.artifact.head.pr.number }
+          : {}),
         headSha: storeInput.artifact.head.headSha,
         baseName: storeInput.artifact.head.base.name,
-        ...(storeInput.artifact.head.branch?.name ? { branchName: storeInput.artifact.head.branch.name } : {}),
-        ...(storeInput.supersedesArtifactId ? { supersedesArtifactId: storeInput.supersedesArtifactId } : {}),
+        ...(storeInput.artifact.head.branch?.name
+          ? { branchName: storeInput.artifact.head.branch.name }
+          : {}),
+        ...(storeInput.supersedesArtifactId
+          ? { supersedesArtifactId: storeInput.supersedesArtifactId }
+          : {}),
       };
       db.transaction(() => {
         insertArtifact.run({
@@ -463,7 +520,9 @@ export function createWorkContextArtifactStore(input: {
           baseName: metadata.baseName ?? null,
           branchName: metadata.branchName ?? null,
           supersedesArtifactId: metadata.supersedesArtifactId ?? null,
-          metadataJson: JSON.stringify({ taskRef: metadata.taskRef } satisfies PersistedMetadataJson),
+          metadataJson: JSON.stringify({
+            taskRef: metadata.taskRef,
+          } satisfies PersistedMetadataJson),
         });
         for (const indexedTaskRef of taskRefs) {
           insertTaskRef.run({
@@ -488,7 +547,8 @@ export function createWorkContextArtifactStore(input: {
         assertNonEmptyString(storeInput.provenanceActorId, 'provenanceActorId');
       if (storeInput.visibility !== undefined)
         assertValidVisibility(storeInput.visibility);
-      if (storeInput.kind !== undefined) assertValidArtifactKind(storeInput.kind);
+      if (storeInput.kind !== undefined)
+        assertValidArtifactKind(storeInput.kind);
       if (storeInput.title !== undefined)
         assertNonEmptyString(storeInput.title, 'title');
       if (storeInput.summary !== undefined)
@@ -507,25 +567,35 @@ export function createWorkContextArtifactStore(input: {
           throw new WorkContextArtifactStoreError(400, 'artifact_id_mismatch');
         }
       }
-      const artifactId = storeInput.id ?? storeInput.viewArtifact.manifest.revision.id;
+      const artifactId =
+        storeInput.id ?? storeInput.viewArtifact.manifest.revision.id;
       mustNotAlreadyExist(artifactId);
-      const manifestSupersedesArtifactId = storeInput.viewArtifact.manifest.revision.supersedes;
-      const supersedesArtifactId = storeInput.supersedesArtifactId ?? manifestSupersedesArtifactId;
+      const manifestSupersedesArtifactId =
+        storeInput.viewArtifact.manifest.revision.supersedes;
+      const supersedesArtifactId =
+        storeInput.supersedesArtifactId ?? manifestSupersedesArtifactId;
       mustValidateSupersedes(supersedesArtifactId, storeInput.workContextId);
       if (
         storeInput.supersedesArtifactId &&
         manifestSupersedesArtifactId &&
         manifestSupersedesArtifactId !== storeInput.supersedesArtifactId
       ) {
-        throw new WorkContextArtifactStoreError(400, 'artifact_supersedes_mismatch');
+        throw new WorkContextArtifactStoreError(
+          400,
+          'artifact_supersedes_mismatch'
+        );
       }
 
-      const taskRef = storeInput.taskRef ?? firstTaskRef(storeInput.viewArtifact);
+      const taskRef =
+        storeInput.taskRef ?? firstTaskRef(storeInput.viewArtifact);
       if (!taskRef) {
         throw new WorkContextArtifactStoreError(400, 'task_ref_required');
       }
       assertValidTaskRef(taskRef);
-      const taskRefs = dedupeTaskRefs([taskRef, ...storeInput.viewArtifact.manifest.scope.taskRefs]);
+      const taskRefs = dedupeTaskRefs([
+        taskRef,
+        ...storeInput.viewArtifact.manifest.scope.taskRefs,
+      ]);
       for (const indexedTaskRef of taskRefs) assertValidTaskRef(indexedTaskRef);
       const now = new Date().toISOString();
       const capturedAt = normalizeAgentViewIsoTimestamp(
@@ -533,8 +603,14 @@ export function createWorkContextArtifactStore(input: {
         'capturedAt'
       );
       const visibility = storeInput.viewArtifact.manifest.export.policy;
-      if (storeInput.visibility !== undefined && storeInput.visibility !== visibility) {
-        throw new WorkContextArtifactStoreError(400, 'artifact_visibility_mismatch');
+      if (
+        storeInput.visibility !== undefined &&
+        storeInput.visibility !== visibility
+      ) {
+        throw new WorkContextArtifactStoreError(
+          400,
+          'artifact_visibility_mismatch'
+        );
       }
       const payloadJson = JSON.stringify(storeInput.viewArtifact, null, 2);
       const payloadSha256 = sha256Hex(payloadJson);
@@ -546,10 +622,15 @@ export function createWorkContextArtifactStore(input: {
         ...(storeInput.projectId ? { projectId: storeInput.projectId } : {}),
         taskRef,
         ...(storeInput.stage ? { stage: storeInput.stage } : {}),
-        ...(storeInput.provenanceActorId ? { provenanceActorId: storeInput.provenanceActorId } : {}),
+        ...(storeInput.provenanceActorId
+          ? { provenanceActorId: storeInput.provenanceActorId }
+          : {}),
         kind: storeInput.kind ?? 'report',
         title: storeInput.title ?? storeInput.viewArtifact.manifest.title,
-        summary: storeInput.summary ?? storeInput.viewArtifact.manifest.description ?? storeInput.viewArtifact.manifest.title,
+        summary:
+          storeInput.summary ??
+          storeInput.viewArtifact.manifest.description ??
+          storeInput.viewArtifact.manifest.title,
         visibility,
         createdAt: now,
         updatedAt: now,
@@ -586,7 +667,9 @@ export function createWorkContextArtifactStore(input: {
           baseName: null,
           branchName: null,
           supersedesArtifactId: metadata.supersedesArtifactId ?? null,
-          metadataJson: JSON.stringify({ taskRef: metadata.taskRef } satisfies PersistedMetadataJson),
+          metadataJson: JSON.stringify({
+            taskRef: metadata.taskRef,
+          } satisfies PersistedMetadataJson),
         });
         for (const indexedTaskRef of taskRefs) {
           insertTaskRef.run({
@@ -616,13 +699,19 @@ export function createWorkContextArtifactStore(input: {
       const payload = JSON.parse(raw) as unknown;
       if (row.payload_kind === 'pipeline-handoff-artifact') {
         if (!isPipelineHandoffArtifact(payload)) {
-          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+          throw new WorkContextArtifactStoreError(
+            500,
+            'stored_payload_invalid'
+          );
         }
         return { ...record, payload };
       }
       if (row.payload_kind === 'agent-view-artifact') {
         if (!isAgentViewArtifact(payload)) {
-          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+          throw new WorkContextArtifactStoreError(
+            500,
+            'stored_payload_invalid'
+          );
         }
         return { ...record, payload };
       }
@@ -633,7 +722,10 @@ export function createWorkContextArtifactStore(input: {
       const row = getRow(id);
       if (!row) return null;
       if (row.payload_kind !== 'agent-view-artifact') {
-        throw new WorkContextArtifactStoreError(400, 'artifact_payload_kind_mismatch');
+        throw new WorkContextArtifactStoreError(
+          400,
+          'artifact_payload_kind_mismatch'
+        );
       }
       const record = rowToRecord(row);
       const raw = readFileSync(row.payload_path, 'utf8');
@@ -646,7 +738,13 @@ export function createWorkContextArtifactStore(input: {
     },
 
     list(input: WorkContextArtifactListInput = {}) {
-      const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+      const searchMode = Boolean(input.q);
+      const limit = searchMode
+        ? Math.min(
+            Math.max(input.limit ?? WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT, 1),
+            WORK_CONTEXT_ARTIFACT_SEARCH_MAX_LIMIT
+          )
+        : Math.min(Math.max(input.limit ?? 50, 1), 200);
       const clauses: string[] = [];
       const params: Record<string, unknown> = { limit };
       if (input.workContextId) {
@@ -656,6 +754,22 @@ export function createWorkContextArtifactStore(input: {
       if (input.projectId) {
         clauses.push('project_id = @projectId');
         params.projectId = input.projectId;
+      }
+      if (input.kind) {
+        clauses.push('kind = @kind');
+        params.kind = input.kind;
+      }
+      if (input.q) {
+        // Metadata-only search (#1065): title/kind/taskRef/workContextId. Never
+        // body/payload content — the payload lives on disk, not in this table.
+        clauses.push(`(
+          title LIKE @q ESCAPE '\\' OR
+          kind LIKE @q ESCAPE '\\' OR
+          work_context_id LIKE @q ESCAPE '\\' OR
+          task_ref_kind LIKE @q ESCAPE '\\' OR
+          task_ref_id LIKE @q ESCAPE '\\'
+        )`);
+        params.q = `%${escapeSqlLikeWildcards(input.q)}%`;
       }
       if (input.taskRef) {
         clauses.push(`EXISTS (
@@ -681,7 +795,11 @@ export function createWorkContextArtifactStore(input: {
         )`);
       }
       const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
-      const rows = db.prepare(`SELECT * FROM work_context_artifacts ${where} ORDER BY captured_at DESC, created_at DESC LIMIT @limit`).all(params) as WorkContextArtifactRow[];
+      const rows = db
+        .prepare(
+          `SELECT * FROM work_context_artifacts ${where} ORDER BY captured_at DESC, created_at DESC LIMIT @limit`
+        )
+        .all(params) as WorkContextArtifactRow[];
       return rows.map(rowToRecord);
     },
 
@@ -695,7 +813,10 @@ export function createWorkContextArtifactStore(input: {
       const parsed = JSON.parse(raw) as unknown;
       if (row.payload_kind === 'pipeline-handoff-artifact') {
         if (!isPipelineHandoffArtifact(parsed)) {
-          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+          throw new WorkContextArtifactStoreError(
+            500,
+            'stored_payload_invalid'
+          );
         }
         const payload = sanitizePipelineHandoffArtifactForPublic(parsed);
         const publicValidation = validatePublicPipelineHandoffArtifact(payload);
@@ -710,7 +831,10 @@ export function createWorkContextArtifactStore(input: {
       }
       if (row.payload_kind === 'agent-view-artifact') {
         if (!isAgentViewArtifact(parsed)) {
-          throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+          throw new WorkContextArtifactStoreError(
+            500,
+            'stored_payload_invalid'
+          );
         }
         const manifest = sanitizeAgentViewManifestForPublic(parsed.manifest);
         const publicValidation = validatePublicAgentViewManifest(manifest);
@@ -732,10 +856,15 @@ function backfillArtifactTaskRefs(
   db: Database.Database,
   insertTaskRef: Database.Statement
 ): void {
-  const rows = db.prepare('SELECT * FROM work_context_artifacts').all() as WorkContextArtifactRow[];
+  const rows = db
+    .prepare('SELECT * FROM work_context_artifacts')
+    .all() as WorkContextArtifactRow[];
   db.transaction(() => {
     for (const row of rows) {
-      const taskRefs = dedupeTaskRefs([legacyTaskRef(row), ...payloadTaskRefs(row)]);
+      const taskRefs = dedupeTaskRefs([
+        legacyTaskRef(row),
+        ...payloadTaskRefs(row),
+      ]);
       for (const taskRef of taskRefs) {
         insertTaskRef.run({
           artifactId: row.id,
@@ -763,19 +892,23 @@ function payloadTaskRefs(row: WorkContextArtifactRow): IndexedTaskRef[] {
     const directScope = parsed.scope;
     const manifest = parsed.manifest;
     const manifestScope = isRecord(manifest) ? manifest.scope : undefined;
-    const directRefs = isRecord(directScope) && Array.isArray(directScope.taskRefs)
-      ? directScope.taskRefs
-      : [];
-    const manifestRefs = isRecord(manifestScope) && Array.isArray(manifestScope.taskRefs)
-      ? manifestScope.taskRefs
-      : [];
+    const directRefs =
+      isRecord(directScope) && Array.isArray(directScope.taskRefs)
+        ? directScope.taskRefs
+        : [];
+    const manifestRefs =
+      isRecord(manifestScope) && Array.isArray(manifestScope.taskRefs)
+        ? manifestScope.taskRefs
+        : [];
     return [...directRefs, ...manifestRefs].filter(isIndexableTaskRef);
   } catch {
     return [];
   }
 }
 
-function rowToMetadata(row: WorkContextArtifactRow): WorkContextArtifactMetadata {
+function rowToMetadata(
+  row: WorkContextArtifactRow
+): WorkContextArtifactMetadata {
   const json = JSON.parse(row.metadata_json) as PersistedMetadataJson;
   return {
     id: row.id,
@@ -783,7 +916,9 @@ function rowToMetadata(row: WorkContextArtifactRow): WorkContextArtifactMetadata
     ...(row.project_id ? { projectId: row.project_id } : {}),
     taskRef: json.taskRef,
     ...(row.stage ? { stage: row.stage as PipelineHandoffStageName } : {}),
-    ...(row.provenance_actor_id ? { provenanceActorId: row.provenance_actor_id } : {}),
+    ...(row.provenance_actor_id
+      ? { provenanceActorId: row.provenance_actor_id }
+      : {}),
     kind: row.kind as ArtifactKind,
     title: row.title,
     summary: row.summary,
@@ -799,7 +934,9 @@ function rowToMetadata(row: WorkContextArtifactRow): WorkContextArtifactMetadata
     ...(row.head_sha ? { headSha: row.head_sha } : {}),
     ...(row.base_name ? { baseName: row.base_name } : {}),
     ...(row.branch_name ? { branchName: row.branch_name } : {}),
-    ...(row.supersedes_artifact_id ? { supersedesArtifactId: row.supersedes_artifact_id } : {}),
+    ...(row.supersedes_artifact_id
+      ? { supersedesArtifactId: row.supersedes_artifact_id }
+      : {}),
   };
 }
 
@@ -810,15 +947,23 @@ function publicMetadata(
     ? {
         kind: metadata.taskRef.kind,
         id: sanitizePublicText(metadata.taskRef.id),
-        ...(metadata.taskRef.title ? { title: sanitizePublicText(metadata.taskRef.title) } : {}),
-        ...(metadata.taskRef.url ? { url: sanitizePublicText(metadata.taskRef.url) } : {}),
-        ...(metadata.taskRef.status ? { status: sanitizePublicText(metadata.taskRef.status) } : {}),
+        ...(metadata.taskRef.title
+          ? { title: sanitizePublicText(metadata.taskRef.title) }
+          : {}),
+        ...(metadata.taskRef.url
+          ? { url: sanitizePublicText(metadata.taskRef.url) }
+          : {}),
+        ...(metadata.taskRef.status
+          ? { status: sanitizePublicText(metadata.taskRef.status) }
+          : {}),
       }
     : undefined;
   return {
     id: sanitizePublicText(metadata.id),
     workContextId: sanitizePublicText(metadata.workContextId),
-    ...(metadata.projectId ? { projectId: sanitizePublicText(metadata.projectId) } : {}),
+    ...(metadata.projectId
+      ? { projectId: sanitizePublicText(metadata.projectId) }
+      : {}),
     ...(taskRef ? { taskRef } : {}),
     ...(metadata.stage ? { stage: metadata.stage } : {}),
     kind: metadata.kind,
@@ -831,15 +976,25 @@ function publicMetadata(
     payloadBytes: metadata.payloadBytes,
     ...(metadata.prNumber ? { prNumber: metadata.prNumber } : {}),
     ...(metadata.headSha ? { headSha: metadata.headSha } : {}),
-    ...(metadata.baseName ? { baseName: sanitizePublicText(metadata.baseName) } : {}),
-    ...(metadata.branchName ? { branchName: sanitizePublicText(metadata.branchName) } : {}),
+    ...(metadata.baseName
+      ? { baseName: sanitizePublicText(metadata.baseName) }
+      : {}),
+    ...(metadata.branchName
+      ? { branchName: sanitizePublicText(metadata.branchName) }
+      : {}),
     ...(metadata.supersedesArtifactId
-      ? { supersedesArtifactId: sanitizePublicText(metadata.supersedesArtifactId) }
+      ? {
+          supersedesArtifactId: sanitizePublicText(
+            metadata.supersedesArtifactId
+          ),
+        }
       : {}),
   };
 }
 
-function firstTaskRef(artifact: PipelineHandoffArtifact | ViewArtifactPackage): TaskRef | undefined {
+function firstTaskRef(
+  artifact: PipelineHandoffArtifact | ViewArtifactPackage
+): TaskRef | undefined {
   const taskRefs = isAgentViewArtifact(artifact)
     ? artifact.manifest.scope.taskRefs
     : artifact.scope.taskRefs;
@@ -850,7 +1005,9 @@ function firstTaskRef(artifact: PipelineHandoffArtifact | ViewArtifactPackage): 
   );
 }
 
-function dedupeTaskRefs<T extends { kind: string; id: string }>(taskRefs: T[]): T[] {
+function dedupeTaskRefs<T extends { kind: string; id: string }>(
+  taskRefs: T[]
+): T[] {
   const seen = new Set<string>();
   const unique: T[] = [];
   for (const taskRef of taskRefs) {
@@ -866,9 +1023,17 @@ function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
+/** Escapes SQLite LIKE wildcards (`%`, `_`) so free-text search terms match literally. */
+function escapeSqlLikeWildcards(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
 function assertPayloadSha256(raw: string, row: WorkContextArtifactRow): void {
   if (sha256Hex(raw) !== row.payload_sha256) {
-    throw new WorkContextArtifactStoreError(500, 'stored_payload_sha256_mismatch');
+    throw new WorkContextArtifactStoreError(
+      500,
+      'stored_payload_sha256_mismatch'
+    );
   }
 }
 
@@ -893,7 +1058,16 @@ function normalizeAgentViewIsoTimestamp(value: string, label: string): string {
 function parseAgentViewIsoTimestamp(value: string): Date | null {
   const match = AGENT_VIEW_ISO_TIMESTAMP_RE.exec(value);
   if (!match) return null;
-  const [, rawYear, rawMonth, rawDay, rawHour, rawMinute, rawSecond, rawFraction] = match;
+  const [
+    ,
+    rawYear,
+    rawMonth,
+    rawDay,
+    rawHour,
+    rawMinute,
+    rawSecond,
+    rawFraction,
+  ] = match;
   const year = Number(rawYear);
   const month = Number(rawMonth);
   const day = Number(rawDay);
@@ -901,7 +1075,9 @@ function parseAgentViewIsoTimestamp(value: string): Date | null {
   const minute = Number(rawMinute);
   const second = Number(rawSecond);
   const milliseconds = rawFraction ? Number(rawFraction.padEnd(3, '0')) : 0;
-  const parsed = new Date(Date.UTC(year, month - 1, day, hour, minute, second, milliseconds));
+  const parsed = new Date(
+    Date.UTC(year, month - 1, day, hour, minute, second, milliseconds)
+  );
   if (
     parsed.getUTCFullYear() !== year ||
     parsed.getUTCMonth() + 1 !== month ||
@@ -971,15 +1147,15 @@ function sanitizePublicText(value: string): string {
   return value
     .replace(SECRET_TEXT_RE, '[redacted-secret]')
     .replace(ABSOLUTE_LOCAL_PATH_RE, (match) => {
-      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      const prefix = ' \t:=(\'"'.includes(match[0] ?? '') ? match[0] : '';
       return `${prefix}[redacted-local-path]`;
     })
     .replace(WINDOWS_ABSOLUTE_PATH_RE, (match) => {
-      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      const prefix = ' \t:=(\'"'.includes(match[0] ?? '') ? match[0] : '';
       return `${prefix}[redacted-local-path]`;
     })
     .replace(UNC_PATH_RE, (match) => {
-      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      const prefix = ' \t:=(\'"'.includes(match[0] ?? '') ? match[0] : '';
       return `${prefix}[redacted-local-path]`;
     })
     .replace(KANBAN_TASK_ID_RE, '[redacted-kanban-task]');

--- a/test/command-palette-artifact-results.test.ts
+++ b/test/command-palette-artifact-results.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  artifactKindIcon,
+  buildArtifactPaletteResults,
+  fetchArtifactPaletteResults,
+} from '../frontend/src/lib/command-palette-artifact-results.js';
+import type { PipelineHandoffArtifactEnvelope } from '../frontend/src/lib/pipeline-handoff-timeline.js';
+import type { WorkspaceTopic } from '../shared/workspace-topics.js';
+
+const NOW = '2026-07-01T00:00:00Z';
+
+function envelope(
+  overrides: Partial<PipelineHandoffArtifactEnvelope['metadata']> = {}
+): PipelineHandoffArtifactEnvelope {
+  return {
+    metadata: {
+      id: 'pipeline-handoff:artifact:aaaaaaaa',
+      workContextId: 'wc:alpha',
+      taskRef: { kind: 'github-issue', id: '1065' },
+      kind: 'report',
+      title: 'Router artifact search handoff',
+      summary: 'router and CLI/API support for artifact search',
+      visibility: 'private',
+      capturedAt: NOW,
+      payloadKind: 'pipeline-handoff-artifact',
+      payloadSha256: 'a'.repeat(64),
+      payloadBytes: 42,
+      ...overrides,
+    },
+  };
+}
+
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:alpha',
+    workspaceId: 'workspace:alpha',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Frontend lane', description: 'chat-first surface' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: { nodeId: 'devbox', repoPath: '/repo/relay' },
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function mockFetch(response: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async () => ({
+    ok,
+    status,
+    text: async () => JSON.stringify(response),
+    json: async () => response,
+  })) as unknown as typeof fetch;
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock as unknown as ReturnType<typeof vi.fn>;
+}
+
+describe('artifactKindIcon', () => {
+  it('renders a distinct glyph per artifact kind', () => {
+    expect(artifactKindIcon('diff')).not.toBe(artifactKindIcon('screenshot'));
+    expect(artifactKindIcon('file')).toBe(artifactKindIcon(undefined));
+  });
+});
+
+describe('buildArtifactPaletteResults', () => {
+  it('maps title, id, and the linked topic sublabel when a topic links the WorkContext', () => {
+    const topic = makeTopic({ linkedRefs: { workContextIds: ['wc:alpha'] } });
+    const results = buildArtifactPaletteResults([envelope()], [topic]);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: 'artifact',
+      id: 'artifact-pipeline-handoff:artifact:aaaaaaaa',
+      label: 'Router artifact search handoff',
+      sublabel: 'Frontend lane · report',
+    });
+  });
+
+  it('falls back to the workContextId as sublabel when no topic links it', () => {
+    const results = buildArtifactPaletteResults([envelope()], []);
+    expect(results[0]?.sublabel).toBe('wc:alpha · report');
+  });
+
+  it('respects the limit', () => {
+    const many = Array.from({ length: 8 }, (_, i) =>
+      envelope({ id: `pipeline-handoff:artifact:${i}` })
+    );
+    expect(buildArtifactPaletteResults(many, [], 5)).toHaveLength(5);
+  });
+});
+
+describe('fetchArtifactPaletteResults', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns [] without fetching for an empty query', async () => {
+    const fetchMock = mockFetch({ artifacts: [] });
+    const results = await fetchArtifactPaletteResults('   ');
+    expect(results).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requests the hub-wide search endpoint with the query and maps results', async () => {
+    const fetchMock = mockFetch({ artifacts: [envelope()] });
+    const results = await fetchArtifactPaletteResults('router');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain('/work-context-artifacts?');
+    expect(url).toContain('q=router');
+    expect(results).toHaveLength(1);
+    expect(results[0]?.label).toBe('Router artifact search handoff');
+  });
+
+  it('propagates HTTP errors from the search endpoint', async () => {
+    mockFetch({ error: { code: 'FORBIDDEN' } }, false, 403);
+    await expect(fetchArtifactPaletteResults('router')).rejects.toThrow();
+  });
+});

--- a/test/work-context-artifact-router.test.ts
+++ b/test/work-context-artifact-router.test.ts
@@ -71,13 +71,21 @@ type ArtifactReadCommand =
 function loadLiveWorkerPatternFixture(): LiveWorkerPatternFixture {
   return JSON.parse(
     fs.readFileSync(
-      path.join(process.cwd(), 'test', 'fixtures', 'pipeline-handoff', 'live-worker-pattern.json'),
+      path.join(
+        process.cwd(),
+        'test',
+        'fixtures',
+        'pipeline-handoff',
+        'live-worker-pattern.json'
+      ),
       'utf8'
     )
   ) as LiveWorkerPatternFixture;
 }
 
-function appendQaArtifact(fixture: LiveWorkerPatternFixture): PipelineHandoffArtifact {
+function appendQaArtifact(
+  fixture: LiveWorkerPatternFixture
+): PipelineHandoffArtifact {
   return {
     ...fixture.implementationArtifact,
     id: fixture.qaArtifactId,
@@ -86,7 +94,9 @@ function appendQaArtifact(fixture: LiveWorkerPatternFixture): PipelineHandoffArt
   };
 }
 
-function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoffArtifact {
+function artifact(
+  input: Partial<PipelineHandoffArtifact> = {}
+): PipelineHandoffArtifact {
   return {
     schemaVersion: PIPELINE_HANDOFF_ARTIFACT_SCHEMA_VERSION,
     id: 'pipeline-handoff:router:aaaaaaaa',
@@ -104,7 +114,10 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
       repo: { ownerRepo: 'example-org/example-project' },
       base: { name: 'nightly' },
       branch: { name: 'issue-890-workcontext-artifact-cli-api' },
-      pr: { number: 890, url: 'https://github.com/example-org/example-project/pull/890' },
+      pr: {
+        number: 890,
+        url: 'https://github.com/example-org/example-project/pull/890',
+      },
       headSha,
       staleIf: { headShaChanges: true },
       capturedAt: now,
@@ -116,10 +129,20 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
         actorId: 'agent:kani-backend',
         summary: 'added API router coverage for WorkContext artifacts',
         acceptanceEvidence: [
-          { label: 'router', disposition: 'provided', summary: 'express routes exercised' },
+          {
+            label: 'router',
+            disposition: 'provided',
+            summary: 'express routes exercised',
+          },
         ],
         commands: [
-          { label: 'test', command: 'vitest', status: 'passed', summary: 'router test', exitCode: 0 },
+          {
+            label: 'test',
+            command: 'vitest',
+            status: 'passed',
+            summary: 'router test',
+            exitCode: 0,
+          },
         ],
         downstreamFocus: ['verify CLI gateway contract shape'],
         nonGoals: ['UI support'],
@@ -132,7 +155,9 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
   };
 }
 
-function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPackage {
+function viewArtifact(
+  input: Partial<ViewArtifactPackage> = {}
+): ViewArtifactPackage {
   const manifest = {
     kind: AGENT_VIEW_MANIFEST_KIND,
     schemaVersion: AGENT_VIEW_SCHEMA_VERSION,
@@ -144,9 +169,21 @@ function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPac
     updatedAt: now,
     scope: {
       repo: 'example-org/example-project',
-      taskRefs: [{ kind: 'github-issue', id: '830', url: 'https://github.com/example-org/example-project/issues/830' }],
+      taskRefs: [
+        {
+          kind: 'github-issue',
+          id: '830',
+          url: 'https://github.com/example-org/example-project/issues/830',
+        },
+      ],
     },
-    sources: [{ label: 'Issue 830', url: 'https://github.com/example-org/example-project/issues/830', kind: 'github-issue' }],
+    sources: [
+      {
+        label: 'Issue 830',
+        url: 'https://github.com/example-org/example-project/issues/830',
+        kind: 'github-issue',
+      },
+    ],
     capabilities: [],
     export: { policy: 'private' },
     revision: { id: 'agent-view:router:aaaaaaaa' },
@@ -163,7 +200,8 @@ function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPac
 
 function reorderJsonObjectKeys(value: unknown): unknown {
   if (!value || typeof value !== 'object') return value;
-  if (Array.isArray(value)) return value.map((item) => reorderJsonObjectKeys(item));
+  if (Array.isArray(value))
+    return value.map((item) => reorderJsonObjectKeys(item));
   const record = value as Record<string, unknown>;
   return Object.fromEntries(
     Object.keys(record)
@@ -192,7 +230,9 @@ function createWorkContext(id: WorkContextId): WorkContext {
 }
 
 function fakeWorkContextStore(...contexts: WorkContext[]): WorkContextStore {
-  const byId = new Map<WorkContextId, WorkContext>(contexts.map((ctx) => [ctx.id, ctx]));
+  const byId = new Map<WorkContextId, WorkContext>(
+    contexts.map((ctx) => [ctx.id, ctx])
+  );
   const store = {
     close: () => undefined,
     create: () => {
@@ -207,12 +247,17 @@ function fakeWorkContextStore(...contexts: WorkContext[]): WorkContextStore {
       byId.set(id, updated);
       return updated;
     },
-    recordLifecycleEvent(id: WorkContextId, event: WorkContextLifecycleEventInput): WorkContext {
+    recordLifecycleEvent(
+      id: WorkContextId,
+      event: WorkContextLifecycleEventInput
+    ): WorkContext {
       const existing = byId.get(id);
       if (!existing) throw new Error(`missing WorkContext ${id}`);
       const updated: WorkContext = {
         ...existing,
-        artifacts: event.artifacts ? [...existing.artifacts, ...event.artifacts] : existing.artifacts,
+        artifacts: event.artifacts
+          ? [...existing.artifacts, ...event.artifacts]
+          : existing.artifacts,
         updatedAt: now,
       };
       byId.set(id, updated);
@@ -223,7 +268,9 @@ function fakeWorkContextStore(...contexts: WorkContext[]): WorkContextStore {
 }
 
 function tmpStore(): { root: string; store: WorkContextArtifactStore } {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'work-context-artifact-router-'));
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'work-context-artifact-router-')
+  );
   cleanup.push(() => fs.rmSync(root, { recursive: true, force: true }));
   const store = createWorkContextArtifactStore({
     dbPath: path.join(root, 'work-context-artifacts.db'),
@@ -239,9 +286,13 @@ async function serve(input: {
   root: string;
   maxPublishBytes?: number;
   maxExportBytes?: number;
-  requireReadAuth?: Parameters<typeof createWorkContextArtifactRouter>[0]['requireReadAuth'];
+  requireReadAuth?: Parameters<
+    typeof createWorkContextArtifactRouter
+  >[0]['requireReadAuth'];
   requireWriteAuth?: express.RequestHandler;
-  requireWriteActorAuth?: Parameters<typeof createWorkContextArtifactRouter>[0]['requireWriteActorAuth'];
+  requireWriteActorAuth?: Parameters<
+    typeof createWorkContextArtifactRouter
+  >[0]['requireWriteActorAuth'];
 }): Promise<{ baseUrl: string; server: http.Server }> {
   const app = express();
   app.use(express.json({ limit: '2mb' }));
@@ -249,16 +300,24 @@ async function serve(input: {
     createWorkContextArtifactRouter({
       store: input.store,
       workContextStore: input.workContextStore,
-      ...(input.requireReadAuth ? { requireReadAuth: input.requireReadAuth } : {}),
-      ...(input.requireWriteAuth ? { requireWriteAuth: input.requireWriteAuth } : {}),
+      ...(input.requireReadAuth
+        ? { requireReadAuth: input.requireReadAuth }
+        : {}),
+      ...(input.requireWriteAuth
+        ? { requireWriteAuth: input.requireWriteAuth }
+        : {}),
       ...(input.requireWriteActorAuth
         ? { requireWriteActorAuth: input.requireWriteActorAuth }
         : {}),
       diagnostics: {
         dbPath: path.join(input.root, 'work-context-artifacts.db'),
         payloadRoot: path.join(input.root, 'payloads'),
-        ...(input.maxPublishBytes !== undefined ? { maxPublishBytes: input.maxPublishBytes } : {}),
-        ...(input.maxExportBytes !== undefined ? { maxExportBytes: input.maxExportBytes } : {}),
+        ...(input.maxPublishBytes !== undefined
+          ? { maxPublishBytes: input.maxPublishBytes }
+          : {}),
+        ...(input.maxExportBytes !== undefined
+          ? { maxExportBytes: input.maxExportBytes }
+          : {}),
       },
     })
   );
@@ -266,7 +325,8 @@ async function serve(input: {
   cleanup.push(() => server.close());
   await new Promise<void>((resolve) => server.once('listening', resolve));
   const address = server.address();
-  if (typeof address !== 'object' || !address) throw new Error('server did not bind');
+  if (typeof address !== 'object' || !address)
+    throw new Error('server did not bind');
   return { baseUrl: `http://127.0.0.1:${address.port}`, server };
 }
 
@@ -274,7 +334,10 @@ async function json(res: Response): Promise<Record<string, unknown>> {
   return (await res.json()) as Record<string, unknown>;
 }
 
-function actorHeaders(command: string, capabilities = 'context:read'): Record<string, string> {
+function actorHeaders(
+  command: string,
+  capabilities = 'context:read'
+): Record<string, string> {
   return {
     authorization: 'Bearer relay-sac-v1.test-credential.[REDACTED]',
     'x-relay-cli-gateway': 'v1',
@@ -284,7 +347,9 @@ function actorHeaders(command: string, capabilities = 'context:read'): Record<st
   };
 }
 
-function actorReadAuth(expectedCommand: ArtifactReadCommand): express.RequestHandler {
+function actorReadAuth(
+  expectedCommand: ArtifactReadCommand
+): express.RequestHandler {
   return (req, res, next) => {
     if (req.header('x-relay-cli-actor-token') !== 'v1') {
       next();
@@ -302,7 +367,10 @@ function actorReadAuth(expectedCommand: ArtifactReadCommand): express.RequestHan
   };
 }
 
-function actorHeadersWithToken(command: string, token: string): Record<string, string> {
+function actorHeadersWithToken(
+  command: string,
+  token: string
+): Record<string, string> {
   return { ...actorHeaders(command), authorization: `Bearer ${token}` };
 }
 
@@ -310,7 +378,9 @@ function scopedActorReadAuth(
   registry: ScopedActorCredentialRegistry,
   expectedCommand: string,
   options: {
-    scopeForRequest?: (req: express.Request) => { workContextIds?: string[] } | undefined;
+    scopeForRequest?: (
+      req: express.Request
+    ) => { workContextIds?: string[] } | undefined;
     deferWorkContextScope?: boolean;
     capabilities?: readonly RelayCapabilityBit[];
   } = {}
@@ -321,19 +391,33 @@ function scopedActorReadAuth(
       return;
     }
     if (req.header('x-relay-cli-command') !== expectedCommand) {
-      res.status(401).json({ error: { code: 'UNAUTHORIZED', expectedCommand } });
+      res
+        .status(401)
+        .json({ error: { code: 'UNAUTHORIZED', expectedCommand } });
       return;
     }
     const validation = validateCliGatewayActorCredential(registry, {
       token: bearerActorToken(req),
       capabilities: options.capabilities ?? ['session:read'],
-      ...(options.scopeForRequest ? { scope: options.scopeForRequest(req) } : {}),
+      ...(options.scopeForRequest
+        ? { scope: options.scopeForRequest(req) }
+        : {}),
       ...(options.deferWorkContextScope ? { deferWorkContextScope: true } : {}),
     });
     if ('reason' in validation) {
-      res.status(validation.reason === 'missing_scope' || validation.reason.startsWith('wrong_') ? 403 : 401).json({
-        error: cliGatewayActorFailure({ reason: validation.reason, credentialId: validation.credentialId }),
-      });
+      res
+        .status(
+          validation.reason === 'missing_scope' ||
+            validation.reason.startsWith('wrong_')
+            ? 403
+            : 401
+        )
+        .json({
+          error: cliGatewayActorFailure({
+            reason: validation.reason,
+            credentialId: validation.credentialId,
+          }),
+        });
       return;
     }
     attachAuthenticatedCliGatewayActorCredential(req, validation.credential);
@@ -360,7 +444,9 @@ describe('WorkContext artifact router', () => {
   it('accepts actor-token reads and rejects actor-token writes through route-specific auth', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router-actor-token';
-    const workContextStore = fakeWorkContextStore(createWorkContext(workContextId));
+    const workContextStore = fakeWorkContextStore(
+      createWorkContext(workContextId)
+    );
     const stored = store.storePipelineHandoffArtifact({
       workContextId,
       visibility: 'public',
@@ -391,7 +477,9 @@ describe('WorkContext artifact router', () => {
       { headers: actorHeaders('work-context-artifacts.show') }
     );
     expect(show.status).toBe(200);
-    expect(await json(show)).toMatchObject({ artifact: { metadata: { id: stored.metadata.id } } });
+    expect(await json(show)).toMatchObject({
+      artifact: { metadata: { id: stored.metadata.id } },
+    });
 
     const exported = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}/export`,
@@ -411,12 +499,20 @@ describe('WorkContext artifact router', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...actorHeaders('work-context-artifacts.publish', 'artifact:write,context:read'),
+        ...actorHeaders(
+          'work-context-artifacts.publish',
+          'artifact:write,context:read'
+        ),
       },
-      body: JSON.stringify({ workContextId, artifact: artifact({ id: 'pipeline-handoff:router:denied' }) }),
+      body: JSON.stringify({
+        workContextId,
+        artifact: artifact({ id: 'pipeline-handoff:router:denied' }),
+      }),
     });
     expect(publish.status).toBe(403);
-    expect(await json(publish)).toMatchObject({ code: 'CLI_GATEWAY_ACTOR_WRITE_UNSUPPORTED' });
+    expect(await json(publish)).toMatchObject({
+      code: 'CLI_GATEWAY_ACTOR_WRITE_UNSUPPORTED',
+    });
 
     const pin = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}/pin`,
@@ -424,7 +520,10 @@ describe('WorkContext artifact router', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...actorHeaders('work-context-artifacts.pin', 'artifact:write,context:read'),
+          ...actorHeaders(
+            'work-context-artifacts.pin',
+            'artifact:write,context:read'
+          ),
         },
         body: JSON.stringify({ workContextId }),
       }
@@ -437,7 +536,10 @@ describe('WorkContext artifact router', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...actorHeaders('work-context-artifacts.unpin', 'artifact:write,context:read'),
+          ...actorHeaders(
+            'work-context-artifacts.unpin',
+            'artifact:write,context:read'
+          ),
         },
         body: JSON.stringify({ workContextId }),
       }
@@ -467,16 +569,22 @@ describe('WorkContext artifact router', () => {
     const denied = issueCliGatewayActorCredential(registry, {
       scope: { workContextIds: [wrongWorkContextId] },
     });
-    const scopeForRequest = (req: express.Request): { workContextIds?: string[] } | undefined => {
+    const scopeForRequest = (
+      req: express.Request
+    ): { workContextIds?: string[] } | undefined => {
       const raw = req.query['workContextId'];
-      return typeof raw === 'string' && raw ? { workContextIds: [raw] } : undefined;
+      return typeof raw === 'string' && raw
+        ? { workContextIds: [raw] }
+        : undefined;
     };
     const { baseUrl } = await serve({
       root,
       store,
       workContextStore,
       requireReadAuth: {
-        list: scopedActorReadAuth(registry, 'work-context-artifacts.list', { scopeForRequest }),
+        list: scopedActorReadAuth(registry, 'work-context-artifacts.list', {
+          scopeForRequest,
+        }),
         show: scopedActorReadAuth(registry, 'work-context-artifacts.show', {
           deferWorkContextScope: true,
         }),
@@ -485,14 +593,24 @@ describe('WorkContext artifact router', () => {
 
     const list = await fetch(
       `${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
-      { headers: actorHeadersWithToken('work-context-artifacts.list', allowed.token) }
+      {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.list',
+          allowed.token
+        ),
+      }
     );
     expect(list.status).toBe(200);
     expect((await json(list)).artifacts).toHaveLength(1);
 
     const wrongList = await fetch(
       `${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
-      { headers: actorHeadersWithToken('work-context-artifacts.list', denied.token) }
+      {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.list',
+          denied.token
+        ),
+      }
     );
     expect(wrongList.status).toBe(403);
     expect(await json(wrongList)).toMatchObject({
@@ -501,14 +619,26 @@ describe('WorkContext artifact router', () => {
 
     const show = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}`,
-      { headers: actorHeadersWithToken('work-context-artifacts.show', allowed.token) }
+      {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.show',
+          allowed.token
+        ),
+      }
     );
     expect(show.status).toBe(200);
-    expect(await json(show)).toMatchObject({ artifact: { metadata: { workContextId } } });
+    expect(await json(show)).toMatchObject({
+      artifact: { metadata: { workContextId } },
+    });
 
     const wrongShow = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}`,
-      { headers: actorHeadersWithToken('work-context-artifacts.show', denied.token) }
+      {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.show',
+          denied.token
+        ),
+      }
     );
     expect(wrongShow.status).toBe(403);
     expect(await json(wrongShow)).toMatchObject({
@@ -570,7 +700,9 @@ describe('WorkContext artifact router', () => {
     expect(await json(pin)).toMatchObject({
       error: { details: { reasonCode: 'CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE' } },
     });
-    expect(workContextStore.get(deniedWorkContextId)?.artifacts).toHaveLength(0);
+    expect(workContextStore.get(deniedWorkContextId)?.artifacts).toHaveLength(
+      0
+    );
 
     const unpin = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}/unpin`,
@@ -578,7 +710,10 @@ describe('WorkContext artifact router', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...actorHeadersWithToken('work-context-artifacts.unpin', allowed.token),
+          ...actorHeadersWithToken(
+            'work-context-artifacts.unpin',
+            allowed.token
+          ),
         },
         body: JSON.stringify({ workContextId: deniedWorkContextId }),
       }
@@ -587,7 +722,9 @@ describe('WorkContext artifact router', () => {
     expect(await json(unpin)).toMatchObject({
       error: { details: { reasonCode: 'CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE' } },
     });
-    expect(workContextStore.get(deniedWorkContextId)?.artifacts).toHaveLength(0);
+    expect(workContextStore.get(deniedWorkContextId)?.artifacts).toHaveLength(
+      0
+    );
   });
 
   it('denies scoped actor pin and unpin writes when stored artifact metadata is outside the credential WorkContext scope', async () => {
@@ -644,7 +781,10 @@ describe('WorkContext artifact router', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...actorHeadersWithToken('work-context-artifacts.pin', allowedWrite.token),
+          ...actorHeadersWithToken(
+            'work-context-artifacts.pin',
+            allowedWrite.token
+          ),
         },
         body: JSON.stringify({ workContextId: allowedWorkContextId }),
       }
@@ -654,20 +794,33 @@ describe('WorkContext artifact router', () => {
     expect(crossContextPinBody).toMatchObject({
       error: { details: { reasonCode: 'CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE' } },
     });
-    expect((crossContextPinBody.error as { details: Record<string, unknown> }).details.workContextId).toBeUndefined();
+    expect(
+      (crossContextPinBody.error as { details: Record<string, unknown> })
+        .details.workContextId
+    ).toBeUndefined();
     expect(crossContextPinBody.artifact).toBeUndefined();
-    expect(workContextStore.get(allowedWorkContextId)?.artifacts).toHaveLength(0);
+    expect(workContextStore.get(allowedWorkContextId)?.artifacts).toHaveLength(
+      0
+    );
 
     const crossContextShow = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}`,
-      { headers: actorHeadersWithToken('work-context-artifacts.show', allowedRead.token) }
+      {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.show',
+          allowedRead.token
+        ),
+      }
     );
     expect(crossContextShow.status).toBe(403);
     const crossContextShowBody = await json(crossContextShow);
     expect(crossContextShowBody).toMatchObject({
       error: { details: { reasonCode: 'CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE' } },
     });
-    expect((crossContextShowBody.error as { details: Record<string, unknown> }).details.workContextId).toBeUndefined();
+    expect(
+      (crossContextShowBody.error as { details: Record<string, unknown> })
+        .details.workContextId
+    ).toBeUndefined();
     expect(crossContextShowBody.artifact).toBeUndefined();
 
     const operatorPin = await fetch(
@@ -682,7 +835,9 @@ describe('WorkContext artifact router', () => {
       }
     );
     expect(operatorPin.status).toBe(201);
-    expect(workContextStore.get(allowedWorkContextId)?.artifacts).toHaveLength(1);
+    expect(workContextStore.get(allowedWorkContextId)?.artifacts).toHaveLength(
+      1
+    );
 
     const crossContextUnpin = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(stored.metadata.id)}/unpin`,
@@ -690,7 +845,10 @@ describe('WorkContext artifact router', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...actorHeadersWithToken('work-context-artifacts.unpin', allowedWrite.token),
+          ...actorHeadersWithToken(
+            'work-context-artifacts.unpin',
+            allowedWrite.token
+          ),
         },
         body: JSON.stringify({ workContextId: allowedWorkContextId }),
       }
@@ -700,14 +858,21 @@ describe('WorkContext artifact router', () => {
     expect(crossContextUnpinBody).toMatchObject({
       error: { details: { reasonCode: 'CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE' } },
     });
-    expect((crossContextUnpinBody.error as { details: Record<string, unknown> }).details.workContextId).toBeUndefined();
-    expect(workContextStore.get(allowedWorkContextId)?.artifacts).toHaveLength(1);
+    expect(
+      (crossContextUnpinBody.error as { details: Record<string, unknown> })
+        .details.workContextId
+    ).toBeUndefined();
+    expect(workContextStore.get(allowedWorkContextId)?.artifacts).toHaveLength(
+      1
+    );
   });
 
   it('attaches, lists, shows, and copies handoff artifacts on dedicated route/auth names', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router-handoff';
-    const workContextStore = fakeWorkContextStore(createWorkContext(workContextId));
+    const workContextStore = fakeWorkContextStore(
+      createWorkContext(workContextId)
+    );
     const { baseUrl } = await serve({
       root,
       store,
@@ -719,7 +884,9 @@ describe('WorkContext artifact router', () => {
       },
       requireWriteAuth: actorWriteAuth,
     });
-    const attachedArtifact = artifact({ id: 'pipeline-handoff:router:handoff-attach' });
+    const attachedArtifact = artifact({
+      id: 'pipeline-handoff:router:handoff-attach',
+    });
     const attach = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
       method: 'POST',
       headers: {
@@ -736,7 +903,13 @@ describe('WorkContext artifact router', () => {
     });
     expect(attach.status).toBe(201);
     expect(await json(attach)).toMatchObject({
-      artifact: { metadata: { id: attachedArtifact.id, workContextId, stage: 'implementation' } },
+      artifact: {
+        metadata: {
+          id: attachedArtifact.id,
+          workContextId,
+          stage: 'implementation',
+        },
+      },
     });
 
     const wrongLane = await fetch(
@@ -744,7 +917,9 @@ describe('WorkContext artifact router', () => {
       { headers: actorHeaders('work-context-artifacts.list') }
     );
     expect(wrongLane.status).toBe(401);
-    expect(await json(wrongLane)).toMatchObject({ error: { expectedCommand: 'handoff-artifacts.list' } });
+    expect(await json(wrongLane)).toMatchObject({
+      error: { expectedCommand: 'handoff-artifacts.list' },
+    });
 
     const list = await fetch(
       `${baseUrl}/pipeline-handoff-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
@@ -753,11 +928,16 @@ describe('WorkContext artifact router', () => {
     expect(list.status).toBe(200);
     expect((await json(list)).artifacts).toHaveLength(1);
 
-    const show = await fetch(`${baseUrl}/pipeline-handoff-artifacts/${encodeURIComponent(attachedArtifact.id)}`, {
-      headers: actorHeaders('handoff-artifacts.show'),
-    });
+    const show = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts/${encodeURIComponent(attachedArtifact.id)}`,
+      {
+        headers: actorHeaders('handoff-artifacts.show'),
+      }
+    );
     expect(show.status).toBe(200);
-    expect(await json(show)).toMatchObject({ artifact: { payload: { id: attachedArtifact.id } } });
+    expect(await json(show)).toMatchObject({
+      artifact: { payload: { id: attachedArtifact.id } },
+    });
 
     const copied = await fetch(
       `${baseUrl}/pipeline-handoff-artifacts/${encodeURIComponent(attachedArtifact.id)}/copy`,
@@ -785,7 +965,11 @@ describe('WorkContext artifact router', () => {
       actorId: 'agent:kame-qa',
       summary: 'added qa layer',
       acceptanceEvidence: [
-        { label: 'router', disposition: 'provided', summary: 'append-only route exercised' },
+        {
+          label: 'router',
+          disposition: 'provided',
+          summary: 'append-only route exercised',
+        },
       ],
       commands: [],
       downstreamFocus: ['review handoff artifact lane'],
@@ -798,46 +982,62 @@ describe('WorkContext artifact router', () => {
     const appendEquivalentArtifact = artifact({
       id: 'pipeline-handoff:router:handoff-append-reordered',
       stages: [
-        reorderJsonObjectKeys(attachedArtifact.stages[0]) as PipelineHandoffArtifact['stages'][number],
+        reorderJsonObjectKeys(
+          attachedArtifact.stages[0]
+        ) as PipelineHandoffArtifact['stages'][number],
         qaStage,
       ],
     });
-    const appendEquivalent = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-relay-capabilities': 'artifact:write,context:read',
-      },
-      body: JSON.stringify({
-        workContextId,
-        artifact: appendEquivalentArtifact,
-        supersedesArtifactId: attachedArtifact.id,
-      }),
-    });
+    const appendEquivalent = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'artifact:write,context:read',
+        },
+        body: JSON.stringify({
+          workContextId,
+          artifact: appendEquivalentArtifact,
+          supersedesArtifactId: attachedArtifact.id,
+        }),
+      }
+    );
     expect(appendEquivalent.status).toBe(201);
 
     const appendViolationArtifact = artifact({
       id: 'pipeline-handoff:router:handoff-append-violation',
       stages: [
-        { ...attachedArtifact.stages[0]!, summary: 'mutated original implementation layer' },
+        {
+          ...attachedArtifact.stages[0]!,
+          summary: 'mutated original implementation layer',
+        },
         qaStage,
       ],
     });
-    const appendViolation = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-relay-capabilities': 'artifact:write,context:read',
-      },
-      body: JSON.stringify({
-        workContextId,
-        artifact: appendViolationArtifact,
-        supersedesArtifactId: attachedArtifact.id,
-      }),
-    });
+    const appendViolation = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'artifact:write,context:read',
+        },
+        body: JSON.stringify({
+          workContextId,
+          artifact: appendViolationArtifact,
+          supersedesArtifactId: attachedArtifact.id,
+        }),
+      }
+    );
     expect(appendViolation.status).toBe(400);
     expect(await json(appendViolation)).toMatchObject({
-      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION', operation: 'attach' } },
+      error: {
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
+          operation: 'attach',
+        },
+      },
     });
   });
 
@@ -845,7 +1045,9 @@ describe('WorkContext artifact router', () => {
     const fixture = loadLiveWorkerPatternFixture();
     const qaArtifact = appendQaArtifact(fixture);
     const { root, store } = tmpStore();
-    const workContextStore = fakeWorkContextStore(createWorkContext(fixture.workContextId));
+    const workContextStore = fakeWorkContextStore(
+      createWorkContext(fixture.workContextId)
+    );
     const { baseUrl } = await serve({ root, store, workContextStore });
     const headers = {
       'Content-Type': 'application/json',
@@ -853,27 +1055,37 @@ describe('WorkContext artifact router', () => {
     };
 
     for (const artifactLayer of [fixture.implementationArtifact, qaArtifact]) {
-      const publicValidation = validatePublicPipelineHandoffArtifact(artifactLayer);
+      const publicValidation =
+        validatePublicPipelineHandoffArtifact(artifactLayer);
       expect(publicValidation.errors).toEqual([]);
       expect(publicValidation.valid).toBe(true);
-      expect(artifactLayer.head.pr).toEqual(fixture.implementationArtifact.head.pr);
+      expect(artifactLayer.head.pr).toEqual(
+        fixture.implementationArtifact.head.pr
+      );
       expect(artifactLayer.head.headSha).toBe(fixture.currentHeadSha);
       expect(artifactLayer.head.staleIf).toEqual({ headShaChanges: true });
-      expect(isPipelineHandoffArtifactStale(artifactLayer, fixture.currentHeadSha)).toBe(false);
-      expect(JSON.stringify(artifactLayer)).not.toMatch(/\/home\/|\/Users\/|t_[0-9a-f]{8}|OPENAI_API_KEY|rawTranscript|dispatcher/i);
+      expect(
+        isPipelineHandoffArtifactStale(artifactLayer, fixture.currentHeadSha)
+      ).toBe(false);
+      expect(JSON.stringify(artifactLayer)).not.toMatch(
+        /\/home\/|\/Users\/|t_[0-9a-f]{8}|OPENAI_API_KEY|rawTranscript|dispatcher/i
+      );
     }
 
-    const implementationAttach = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        workContextId: fixture.workContextId,
-        artifact: fixture.implementationArtifact,
-        stage: 'implementation',
-        visibility: 'public',
-        currentHeadSha: fixture.currentHeadSha,
-      }),
-    });
+    const implementationAttach = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          workContextId: fixture.workContextId,
+          artifact: fixture.implementationArtifact,
+          stage: 'implementation',
+          visibility: 'public',
+          currentHeadSha: fixture.currentHeadSha,
+        }),
+      }
+    );
     expect(implementationAttach.status).toBe(201);
     expect(await json(implementationAttach)).toMatchObject({
       artifact: {
@@ -929,7 +1141,9 @@ describe('WorkContext artifact router', () => {
   it('publishes, lists, shows, pins, unpins, exports, and doctors artifacts', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router';
-    const workContextStore = fakeWorkContextStore(createWorkContext(workContextId));
+    const workContextStore = fakeWorkContextStore(
+      createWorkContext(workContextId)
+    );
     const { baseUrl } = await serve({ root, store, workContextStore });
     const headers = {
       'Content-Type': 'application/json',
@@ -953,12 +1167,15 @@ describe('WorkContext artifact router', () => {
     const publishBody = await json(publish);
     expect(publishBody.pin).toMatchObject({ alreadyPinned: false });
 
-    const list = await fetch(`${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`, {
-      headers: { 'x-relay-capabilities': 'context:read' },
-    });
+    const list = await fetch(
+      `${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
+      {
+        headers: { 'x-relay-capabilities': 'context:read' },
+      }
+    );
     expect(list.status).toBe(200);
     const listBody = await json(list);
-    expect((listBody.artifacts as unknown[])).toHaveLength(1);
+    expect(listBody.artifacts as unknown[]).toHaveLength(1);
 
     const show = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent('pipeline-handoff:router:aaaaaaaa')}?currentHeadSha=${nextHeadSha}`,
@@ -968,7 +1185,11 @@ describe('WorkContext artifact router', () => {
     const showBody = await json(show);
     expect(showBody.artifact).toMatchObject({
       metadata: { id: 'pipeline-handoff:router:aaaaaaaa', workContextId },
-      staleness: { stale: true, artifactHeadSha: headSha, currentHeadSha: nextHeadSha },
+      staleness: {
+        stale: true,
+        artifactHeadSha: headSha,
+        currentHeadSha: nextHeadSha,
+      },
     });
 
     const exported = await fetch(
@@ -977,14 +1198,19 @@ describe('WorkContext artifact router', () => {
     );
     expect(exported.status).toBe(200);
     const exportBody = await json(exported);
-    expect(exportBody.export).toMatchObject({ mode: 'public-summary', rawPayloadAvailable: false });
+    expect(exportBody.export).toMatchObject({
+      mode: 'public-summary',
+      rawPayloadAvailable: false,
+    });
 
     const doctor = await fetch(`${baseUrl}/work-context-artifacts/doctor`, {
       headers: { 'x-relay-capabilities': 'context:read' },
     });
     expect(doctor.status).toBe(200);
     expect(await json(doctor)).toMatchObject({
-      diagnostics: { storage: { artifactCount: 1, integrity: 'read-index-ok' } },
+      diagnostics: {
+        storage: { artifactCount: 1, integrity: 'read-index-ok' },
+      },
     });
 
     const unpin = await fetch(
@@ -996,13 +1222,18 @@ describe('WorkContext artifact router', () => {
       }
     );
     expect(unpin.status).toBe(200);
-    expect(await json(unpin)).toMatchObject({ removed: true, lifecycle: { artifactDeleted: false } });
+    expect(await json(unpin)).toMatchObject({
+      removed: true,
+      lifecycle: { artifactDeleted: false },
+    });
   });
 
   it('publishes agent view artifacts and exposes an authenticated package route', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router-view';
-    const workContextStore = fakeWorkContextStore(createWorkContext(workContextId));
+    const workContextStore = fakeWorkContextStore(
+      createWorkContext(workContextId)
+    );
     const { baseUrl } = await serve({ root, store, workContextStore });
     const pkg = viewArtifact();
 
@@ -1032,9 +1263,10 @@ describe('WorkContext artifact router', () => {
       pin: { alreadyPinned: false },
     });
     const payloadJson = JSON.stringify(pkg, null, 2);
-    expect((publishBody.artifact as { metadata: Record<string, unknown> }).metadata.payloadSha256).toBe(
-      createHash('sha256').update(payloadJson).digest('hex')
-    );
+    expect(
+      (publishBody.artifact as { metadata: Record<string, unknown> }).metadata
+        .payloadSha256
+    ).toBe(createHash('sha256').update(payloadJson).digest('hex'));
 
     const packageRead = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(pkg.manifest.revision.id)}/view-package`,
@@ -1043,8 +1275,14 @@ describe('WorkContext artifact router', () => {
     expect(packageRead.status).toBe(200);
     expect(await json(packageRead)).toMatchObject({
       artifact: {
-        metadata: { id: pkg.manifest.revision.id, payloadKind: 'agent-view-artifact' },
-        viewArtifact: { manifest: { revision: { id: pkg.manifest.revision.id } }, files: pkg.files },
+        metadata: {
+          id: pkg.manifest.revision.id,
+          payloadKind: 'agent-view-artifact',
+        },
+        viewArtifact: {
+          manifest: { revision: { id: pkg.manifest.revision.id } },
+          files: pkg.files,
+        },
       },
     });
   });
@@ -1065,11 +1303,17 @@ describe('WorkContext artifact router', () => {
     const conflict = await fetch(`${baseUrl}/work-context-artifacts`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ workContextId, artifact: artifact(), viewArtifact: viewArtifact() }),
+      body: JSON.stringify({
+        workContextId,
+        artifact: artifact(),
+        viewArtifact: viewArtifact(),
+      }),
     });
     expect(conflict.status).toBe(400);
     expect(await json(conflict)).toMatchObject({
-      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_CONFLICT' } },
+      error: {
+        details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_PAYLOAD_CONFLICT' },
+      },
     });
 
     const wrongSurface = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
@@ -1079,15 +1323,26 @@ describe('WorkContext artifact router', () => {
     });
     expect(wrongSurface.status).toBe(400);
     expect(await json(wrongSurface)).toMatchObject({
-      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_KIND_MISMATCH', operation: 'attach' } },
+      error: {
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_KIND_MISMATCH',
+          operation: 'attach',
+        },
+      },
     });
   });
 
   it('keeps agent view artifacts out of pipeline handoff list/show surfaces', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router-handoff-filter';
-    const handoff = store.storePipelineHandoffArtifact({ workContextId, artifact: artifact() });
-    const view = store.storeAgentViewArtifact({ workContextId, viewArtifact: viewArtifact() });
+    const handoff = store.storePipelineHandoffArtifact({
+      workContextId,
+      artifact: artifact(),
+    });
+    const view = store.storeAgentViewArtifact({
+      workContextId,
+      viewArtifact: viewArtifact(),
+    });
     const { baseUrl } = await serve({
       root,
       store,
@@ -1095,24 +1350,35 @@ describe('WorkContext artifact router', () => {
     });
     const readHeaders = { 'x-relay-capabilities': 'context:read' };
 
-    const handoffList = await fetch(`${baseUrl}/pipeline-handoff-artifacts?workContextId=${encodeURIComponent(workContextId)}`, {
-      headers: readHeaders,
-    });
+    const handoffList = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
+      {
+        headers: readHeaders,
+      }
+    );
     expect(handoffList.status).toBe(200);
     const handoffListBody = await json(handoffList);
-    expect((handoffListBody.artifacts as Array<{ metadata: { id: string } }>).map((entry) => entry.metadata.id)).toEqual([
-      handoff.metadata.id,
-    ]);
+    expect(
+      (handoffListBody.artifacts as Array<{ metadata: { id: string } }>).map(
+        (entry) => entry.metadata.id
+      )
+    ).toEqual([handoff.metadata.id]);
 
-    const allList = await fetch(`${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`, {
-      headers: readHeaders,
-    });
+    const allList = await fetch(
+      `${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
+      {
+        headers: readHeaders,
+      }
+    );
     expect(allList.status).toBe(200);
     expect((await json(allList)).artifacts as unknown[]).toHaveLength(2);
 
-    const viewViaHandoffRoute = await fetch(`${baseUrl}/pipeline-handoff-artifacts/${encodeURIComponent(view.metadata.id)}`, {
-      headers: readHeaders,
-    });
+    const viewViaHandoffRoute = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts/${encodeURIComponent(view.metadata.id)}`,
+      {
+        headers: readHeaders,
+      }
+    );
     expect(viewViaHandoffRoute.status).toBe(404);
   });
 
@@ -1130,7 +1396,11 @@ describe('WorkContext artifact router', () => {
     };
 
     const withCapabilities = viewArtifact({
-      manifest: { ...viewArtifact().manifest, revision: { id: 'agent-view:router:capabilities' }, capabilities: ['network'] },
+      manifest: {
+        ...viewArtifact().manifest,
+        revision: { id: 'agent-view:router:capabilities' },
+        capabilities: ['network'],
+      },
     });
     const denied = await fetch(`${baseUrl}/work-context-artifacts`, {
       method: 'POST',
@@ -1139,14 +1409,25 @@ describe('WorkContext artifact router', () => {
     });
     expect(denied.status).toBe(400);
     expect(await json(denied)).toMatchObject({
-      error: { details: { field: 'viewArtifact', reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED' } },
+      error: {
+        details: {
+          field: 'viewArtifact',
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+        },
+      },
     });
 
     const oversizedFiles = Object.fromEntries(
-      Array.from({ length: 14 }, (_, index) => [`chunk-${index}.css`, 'x'.repeat(40 * 1024)])
+      Array.from({ length: 14 }, (_, index) => [
+        `chunk-${index}.css`,
+        'x'.repeat(40 * 1024),
+      ])
     );
     const oversized = viewArtifact({
-      manifest: { ...viewArtifact().manifest, revision: { id: 'agent-view:router:oversized' } },
+      manifest: {
+        ...viewArtifact().manifest,
+        revision: { id: 'agent-view:router:oversized' },
+      },
       files: { 'index.html': '<main>oversized</main>', ...oversizedFiles },
     });
     const oversizedPublish = await fetch(`${baseUrl}/work-context-artifacts`, {
@@ -1156,7 +1437,9 @@ describe('WorkContext artifact router', () => {
     });
     expect(oversizedPublish.status).toBe(400);
     expect(await json(oversizedPublish)).toMatchObject({
-      error: { details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD' } },
+      error: {
+        details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_VIEW_OVERSIZE_PAYLOAD' },
+      },
     });
   });
 
@@ -1170,7 +1453,12 @@ describe('WorkContext artifact router', () => {
     });
     const privateStored = store.storeAgentViewArtifact({
       workContextId,
-      viewArtifact: viewArtifact({ manifest: { ...viewArtifact().manifest, revision: { id: 'agent-view:router:private-export' } } }),
+      viewArtifact: viewArtifact({
+        manifest: {
+          ...viewArtifact().manifest,
+          revision: { id: 'agent-view:router:private-export' },
+        },
+      }),
     });
     const privateExport = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(privateStored.metadata.id)}/export`,
@@ -1181,13 +1469,20 @@ describe('WorkContext artifact router', () => {
     const publicPkg = viewArtifact({
       manifest: {
         ...viewArtifact().manifest,
-        description: 'Public route from /home/operator/relay with t_12345678 scratch id',
+        description:
+          'Public route from /home/operator/relay with t_12345678 scratch id',
         export: { policy: 'public' },
         revision: { id: 'agent-view:router:public-export' },
       },
-      files: { 'index.html': '<main>private raw html /home/operator/relay t_12345678</main>' },
+      files: {
+        'index.html':
+          '<main>private raw html /home/operator/relay t_12345678</main>',
+      },
     });
-    const publicStored = store.storeAgentViewArtifact({ workContextId, viewArtifact: publicPkg });
+    const publicStored = store.storeAgentViewArtifact({
+      workContextId,
+      viewArtifact: publicPkg,
+    });
     const publicExport = await fetch(
       `${baseUrl}/work-context-artifacts/${encodeURIComponent(publicStored.metadata.id)}/export`,
       { headers: { 'x-relay-capabilities': 'context:read' } }
@@ -1196,8 +1491,13 @@ describe('WorkContext artifact router', () => {
     const publicBody = await json(publicExport);
     expect(publicBody).toMatchObject({
       artifact: {
-        metadata: { id: publicStored.metadata.id, payloadKind: 'agent-view-artifact' },
-        payload: { manifest: { revision: { id: 'agent-view:router:public-export' } } },
+        metadata: {
+          id: publicStored.metadata.id,
+          payloadKind: 'agent-view-artifact',
+        },
+        payload: {
+          manifest: { revision: { id: 'agent-view:router:public-export' } },
+        },
       },
       export: { mode: 'public-summary', rawPayloadAvailable: false },
     });
@@ -1210,12 +1510,20 @@ describe('WorkContext artifact router', () => {
   it('enforces publish and export guardrails with persisted public bytes', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router-guardrails';
-    const workContextStore = fakeWorkContextStore(createWorkContext(workContextId));
+    const workContextStore = fakeWorkContextStore(
+      createWorkContext(workContextId)
+    );
     const publishArtifact = artifact({
       id: 'pipeline-handoff:router:guardrails',
     });
-    const minifiedBytes = Buffer.byteLength(JSON.stringify(publishArtifact), 'utf8');
-    const persistedBytes = Buffer.byteLength(JSON.stringify(publishArtifact, null, 2), 'utf8');
+    const minifiedBytes = Buffer.byteLength(
+      JSON.stringify(publishArtifact),
+      'utf8'
+    );
+    const persistedBytes = Buffer.byteLength(
+      JSON.stringify(publishArtifact, null, 2),
+      'utf8'
+    );
     expect(persistedBytes).toBeGreaterThan(minifiedBytes);
     const { baseUrl } = await serve({
       root,
@@ -1259,7 +1567,10 @@ describe('WorkContext artifact router', () => {
     expect(await json(oversizedExport)).toMatchObject({
       error: {
         code: 'INVALID_ARGUMENT',
-        details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_EXPORT', maxBytes: 16 },
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_EXPORT',
+          maxBytes: 16,
+        },
       },
     });
   });
@@ -1273,14 +1584,20 @@ describe('WorkContext artifact router', () => {
       workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
     });
 
-    const missing = await fetch(`${baseUrl}/work-context-artifacts/missing/export`, {
-      headers: { 'x-relay-capabilities': 'context:read' },
-    });
+    const missing = await fetch(
+      `${baseUrl}/work-context-artifacts/missing/export`,
+      {
+        headers: { 'x-relay-capabilities': 'context:read' },
+      }
+    );
     expect(missing.status).toBe(404);
     expect(await json(missing)).toMatchObject({
       error: {
         code: 'NOT_FOUND',
-        details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND', operation: 'export' },
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_NOT_FOUND',
+          operation: 'export',
+        },
       },
     });
 
@@ -1311,9 +1628,13 @@ describe('WorkContext artifact router', () => {
       workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
     });
 
-    const forbidden = await fetch(`${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`);
+    const forbidden = await fetch(
+      `${baseUrl}/work-context-artifacts?workContextId=${encodeURIComponent(workContextId)}`
+    );
     expect(forbidden.status).toBe(403);
-    expect(await json(forbidden)).toMatchObject({ error: { code: 'FORBIDDEN' } });
+    expect(await json(forbidden)).toMatchObject({
+      error: { code: 'FORBIDDEN' },
+    });
 
     const stale = await fetch(`${baseUrl}/work-context-artifacts`, {
       method: 'POST',
@@ -1321,7 +1642,11 @@ describe('WorkContext artifact router', () => {
         'Content-Type': 'application/json',
         'x-relay-capabilities': 'artifact:write',
       },
-      body: JSON.stringify({ workContextId, artifact: artifact(), currentHeadSha: nextHeadSha }),
+      body: JSON.stringify({
+        workContextId,
+        artifact: artifact(),
+        currentHeadSha: nextHeadSha,
+      }),
     });
     expect(stale.status).toBe(409);
     expect(await json(stale)).toMatchObject({
@@ -1329,6 +1654,154 @@ describe('WorkContext artifact router', () => {
         code: 'SESSION_CONFLICT',
         details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD' },
       },
+    });
+  });
+
+  describe('hub-wide `q` search lane (#1065)', () => {
+    it('rejects unauthorized (missing capability) search calls the same as list', async () => {
+      const { root, store } = tmpStore();
+      const workContextId = 'wc:router-search-auth';
+      const { baseUrl } = await serve({
+        root,
+        store,
+        workContextStore: fakeWorkContextStore(
+          createWorkContext(workContextId)
+        ),
+      });
+
+      const noCapability = await fetch(
+        `${baseUrl}/work-context-artifacts?q=widget`
+      );
+      expect(noCapability.status).toBe(403);
+      expect(await json(noCapability)).toMatchObject({
+        error: { code: 'FORBIDDEN' },
+      });
+    });
+
+    it('matches title/kind/taskRef/workContextId but never body/summary content', async () => {
+      const { root, store } = tmpStore();
+      const workContextId = 'wc:router-search-match';
+      store.storePipelineHandoffArtifact({
+        workContextId,
+        artifact: artifact({
+          id: 'pipeline-handoff:router-search:aaaaaaaa',
+          title: 'Widget rollout handoff',
+        }),
+      });
+      const { baseUrl } = await serve({
+        root,
+        store,
+        workContextStore: fakeWorkContextStore(
+          createWorkContext(workContextId)
+        ),
+      });
+
+      const byTitle = await fetch(
+        `${baseUrl}/work-context-artifacts?q=widget`,
+        {
+          headers: { 'x-relay-capabilities': 'context:read' },
+        }
+      );
+      expect(byTitle.status).toBe(200);
+      const byTitleBody = (await json(byTitle)) as {
+        artifacts: Array<{ metadata: { id: string } }>;
+      };
+      expect(byTitleBody.artifacts.map((a) => a.metadata.id)).toEqual([
+        'pipeline-handoff:router-search:aaaaaaaa',
+      ]);
+
+      const byBodyContent = await fetch(
+        `${baseUrl}/work-context-artifacts?q=${encodeURIComponent('router and CLI/API support for WorkContext artifacts')}`,
+        { headers: { 'x-relay-capabilities': 'context:read' } }
+      );
+      expect(byBodyContent.status).toBe(200);
+      expect((await json(byBodyContent)).artifacts).toEqual([]);
+
+      const noQueryNoFilter = await fetch(`${baseUrl}/work-context-artifacts`, {
+        headers: { 'x-relay-capabilities': 'context:read' },
+      });
+      expect(noQueryNoFilter.status).toBe(400);
+      expect(await json(noQueryNoFilter)).toMatchObject({
+        error: {
+          details: { reasonCode: 'WORK_CONTEXT_ARTIFACT_FILTER_REQUIRED' },
+        },
+      });
+    });
+
+    it('enforces a hard <=20 result limit regardless of the requested limit', async () => {
+      const { root, store } = tmpStore();
+      const workContextId = 'wc:router-search-limit';
+      for (let i = 0; i < 25; i += 1) {
+        store.storePipelineHandoffArtifact({
+          workContextId,
+          artifact: artifact({
+            id: `pipeline-handoff:router-search-limit:${i.toString().padStart(8, '0')}`,
+            title: `Search limit fixture #${i}`,
+          }),
+        });
+      }
+      const { baseUrl } = await serve({
+        root,
+        store,
+        workContextStore: fakeWorkContextStore(
+          createWorkContext(workContextId)
+        ),
+      });
+
+      const res = await fetch(
+        `${baseUrl}/work-context-artifacts?q=${encodeURIComponent('search limit fixture')}&limit=200`,
+        { headers: { 'x-relay-capabilities': 'context:read' } }
+      );
+      expect(res.status).toBe(200);
+      expect((await json(res)).artifacts).toHaveLength(20);
+    });
+
+    it('rejects hub-wide search for actor credentials scoped to specific WorkContexts', async () => {
+      const { root, store } = tmpStore();
+      const workContextId = 'wc:router-search-scoped';
+      store.storePipelineHandoffArtifact({
+        workContextId,
+        artifact: artifact({
+          id: 'pipeline-handoff:router-search-scoped:aaaaaaaa',
+        }),
+      });
+      const registry = new ScopedActorCredentialRegistry({
+        secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+      });
+      const scoped = issueCliGatewayActorCredential(registry, {
+        scope: { workContextIds: [workContextId] },
+      });
+      const scopeForRequest = (
+        req: express.Request
+      ): { workContextIds?: string[] } | undefined => {
+        const raw = req.query['workContextId'];
+        return typeof raw === 'string' && raw
+          ? { workContextIds: [raw] }
+          : undefined;
+      };
+      const { baseUrl } = await serve({
+        root,
+        store,
+        workContextStore: fakeWorkContextStore(
+          createWorkContext(workContextId)
+        ),
+        requireReadAuth: {
+          list: scopedActorReadAuth(registry, 'work-context-artifacts.list', {
+            scopeForRequest,
+          }),
+        },
+      });
+
+      const res = await fetch(`${baseUrl}/work-context-artifacts?q=widget`, {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.list',
+          scoped.token
+        ),
+      });
+      expect(res.status).toBe(403);
+      expect(await json(res)).toMatchObject({
+        error: { reasonCode: 'CLI_ACTOR_MISSING_SCOPE' },
+      });
     });
   });
 });

--- a/test/work-context-artifact-router.test.ts
+++ b/test/work-context-artifact-router.test.ts
@@ -1803,5 +1803,52 @@ describe('WorkContext artifact router', () => {
         error: { reasonCode: 'CLI_ACTOR_MISSING_SCOPE' },
       });
     });
+
+    it('rejects hub-wide search in-handler even when the auth middleware defers WorkContext scope validation', async () => {
+      // Defense-in-depth (#1065 review): this test does NOT pass a
+      // `scopeForRequest` to `scopedActorReadAuth` for the `list` command, and
+      // sets `deferWorkContextScope: true` instead — simulating a future/
+      // misconfigured wiring where the production `scopeForRequest` middleware
+      // no longer catches a hub-wide `q` search for a scoped actor. The
+      // handler's own `denyScopedActorHubWideSearch` check must still reject
+      // it independently.
+      const { root, store } = tmpStore();
+      const workContextId = 'wc:router-search-defer-scoped';
+      store.storePipelineHandoffArtifact({
+        workContextId,
+        artifact: artifact({
+          id: 'pipeline-handoff:router-search-defer-scoped:aaaaaaaa',
+        }),
+      });
+      const registry = new ScopedActorCredentialRegistry({
+        secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+      });
+      const scoped = issueCliGatewayActorCredential(registry, {
+        scope: { workContextIds: [workContextId] },
+      });
+      const { baseUrl } = await serve({
+        root,
+        store,
+        workContextStore: fakeWorkContextStore(
+          createWorkContext(workContextId)
+        ),
+        requireReadAuth: {
+          list: scopedActorReadAuth(registry, 'work-context-artifacts.list', {
+            deferWorkContextScope: true,
+          }),
+        },
+      });
+
+      const res = await fetch(`${baseUrl}/work-context-artifacts?q=widget`, {
+        headers: actorHeadersWithToken(
+          'work-context-artifacts.list',
+          scoped.token
+        ),
+      });
+      expect(res.status).toBe(403);
+      expect(await json(res)).toMatchObject({
+        error: { details: { reasonCode: 'CLI_ACTOR_MISSING_SCOPE' } },
+      });
+    });
   });
 });

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -29,7 +29,9 @@ const nextHeadSha = 'b'.repeat(40);
 const cleanup: Array<() => void> = [];
 
 function tmpStore(): { root: string; store: WorkContextArtifactStore } {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'work-context-artifacts-'));
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'work-context-artifacts-')
+  );
   cleanup.push(() => fs.rmSync(root, { recursive: true, force: true }));
   const store = createWorkContextArtifactStore({
     dbPath: path.join(root, 'index.db'),
@@ -49,7 +51,9 @@ afterEach(() => {
   for (const dispose of cleanup.splice(0).reverse()) dispose();
 });
 
-function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoffArtifact {
+function artifact(
+  input: Partial<PipelineHandoffArtifact> = {}
+): PipelineHandoffArtifact {
   return {
     schemaVersion: PIPELINE_HANDOFF_ARTIFACT_SCHEMA_VERSION,
     id: 'pipeline-handoff:example:aaaaaaaa',
@@ -75,7 +79,10 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
         'payload files are separate from indexed metadata',
         'list queries are bounded by the metadata index',
       ],
-      nonGoals: ['no raw transcript ingestion', 'no internal dispatcher or local worktree public copy'],
+      nonGoals: [
+        'no raw transcript ingestion',
+        'no internal dispatcher or local worktree public copy',
+      ],
     },
     head: {
       repo: { ownerRepo: 'example-org/example-project' },
@@ -94,7 +101,8 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
         stage: 'implementation',
         addedAt: now,
         actorId: 'agent:kani-backend',
-        summary: 'stored payload file from /home/operator/example while keeping index metadata bounded',
+        summary:
+          'stored payload file from /home/operator/example while keeping index metadata bounded',
         acceptanceEvidence: [
           {
             label: 'storage/index',
@@ -111,18 +119,23 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
             exitCode: 0,
           },
         ],
-        downstreamFocus: ['verify append-only metadata and public sanitizer boundaries'],
+        downstreamFocus: [
+          'verify append-only metadata and public sanitizer boundaries',
+        ],
         nonGoals: ['no UI or resume-packet integration in this slice'],
         decision: 'implemented',
         changedFiles: ['server/work-context-artifacts.ts'],
-        migrationOrStateRisk: 'new isolated SQLite index and payload directory only',
+        migrationOrStateRisk:
+          'new isolated SQLite index and payload directory only',
       },
     ],
     ...input,
   };
 }
 
-function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPackage {
+function viewArtifact(
+  input: Partial<ViewArtifactPackage> = {}
+): ViewArtifactPackage {
   const manifest = {
     kind: AGENT_VIEW_MANIFEST_KIND,
     schemaVersion: AGENT_VIEW_SCHEMA_VERSION,
@@ -134,9 +147,21 @@ function viewArtifact(input: Partial<ViewArtifactPackage> = {}): ViewArtifactPac
     updatedAt: now,
     scope: {
       repo: 'example-org/example-project',
-      taskRefs: [{ kind: 'github-issue', id: '830', url: 'https://github.com/example-org/example-project/issues/830' }],
+      taskRefs: [
+        {
+          kind: 'github-issue',
+          id: '830',
+          url: 'https://github.com/example-org/example-project/issues/830',
+        },
+      ],
     },
-    sources: [{ label: 'Issue 830', url: 'https://github.com/example-org/example-project/issues/830', kind: 'github-issue' }],
+    sources: [
+      {
+        label: 'Issue 830',
+        url: 'https://github.com/example-org/example-project/issues/830',
+        kind: 'github-issue',
+      },
+    ],
     capabilities: [],
     export: { policy: 'private' },
     revision: { id: 'agent-view:example:aaaaaaaa' },
@@ -201,7 +226,8 @@ function createLegacyV1Store(input: {
       CHECK (visibility IN ('private', 'public'))
     );
   `);
-  db.prepare(`
+  db.prepare(
+    `
     INSERT INTO work_context_artifacts (
       id, work_context_id, project_id, task_ref_kind, task_ref_id, stage,
       provenance_actor_id, kind, title, summary, visibility, created_at,
@@ -215,7 +241,8 @@ function createLegacyV1Store(input: {
       @payloadSha256, @payloadBytes, @prNumber, @headSha, @baseName,
       @branchName, @supersedesArtifactId, @metadataJson
     )
-  `).run({
+  `
+  ).run({
     id: input.payload.id,
     workContextId: 'wc:legacy-v1',
     projectId: 'project:example-org/example-project',
@@ -277,12 +304,16 @@ describe('WorkContext artifact store/index', () => {
       baseName: 'nightly',
       branchName: 'issue-42-artifact-store',
     });
-    expect(stored.payloadPath.startsWith(path.join(root, 'payloads'))).toBe(true);
+    expect(stored.payloadPath.startsWith(path.join(root, 'payloads'))).toBe(
+      true
+    );
     expect(fs.existsSync(stored.payloadPath)).toBe(true);
 
     const byContext = store.list({ workContextId: 'wc:example' });
     expect(byContext).toHaveLength(1);
-    expect(byContext[0]?.metadata.payloadSha256).toBe(stored.metadata.payloadSha256);
+    expect(byContext[0]?.metadata.payloadSha256).toBe(
+      stored.metadata.payloadSha256
+    );
 
     const byTask = store.list({ taskRef: { kind: 'github-issue', id: '42' } });
     expect(byTask.map((entry) => entry.metadata.id)).toEqual([
@@ -290,7 +321,9 @@ describe('WorkContext artifact store/index', () => {
     ]);
 
     const read = store.read(stored.metadata.id);
-    expect((read?.payload as PipelineHandoffArtifact | undefined)?.title).toBe('Example Project implementation handoff');
+    expect((read?.payload as PipelineHandoffArtifact | undefined)?.title).toBe(
+      'Example Project implementation handoff'
+    );
   });
 
   it('stores agent view artifacts with agent-view payload kind and sha-addressed packages', () => {
@@ -316,19 +349,31 @@ describe('WorkContext artifact store/index', () => {
       payloadSha256: sha256Hex(payloadJson),
       payloadBytes: Buffer.byteLength(payloadJson, 'utf8'),
     });
-    expect(stored.payloadPath.startsWith(path.join(root, 'payloads'))).toBe(true);
-    expect(JSON.parse(fs.readFileSync(stored.payloadPath, 'utf8'))).toEqual(pkg);
-    expect(store.readViewArtifactPackage(stored.metadata.id)?.payload).toEqual(pkg);
+    expect(stored.payloadPath.startsWith(path.join(root, 'payloads'))).toBe(
+      true
+    );
+    expect(JSON.parse(fs.readFileSync(stored.payloadPath, 'utf8'))).toEqual(
+      pkg
+    );
+    expect(store.readViewArtifactPackage(stored.metadata.id)?.payload).toEqual(
+      pkg
+    );
     expect(store.read(stored.metadata.id)?.payload).toEqual(pkg);
   });
 
   it('normalizes agent view timestamps accepted by the shared contract', () => {
     const { store } = tmpStore();
     const pkg = viewArtifact({
-      manifest: { ...viewArtifact().manifest, updatedAt: '2026-06-08T12:00:03Z' },
+      manifest: {
+        ...viewArtifact().manifest,
+        updatedAt: '2026-06-08T12:00:03Z',
+      },
     });
 
-    const stored = store.storeAgentViewArtifact({ workContextId: 'wc:view-timestamp', viewArtifact: pkg });
+    const stored = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-timestamp',
+      viewArtifact: pkg,
+    });
 
     expect(stored.metadata.capturedAt).toBe('2026-06-08T12:00:03.000Z');
   });
@@ -336,11 +381,17 @@ describe('WorkContext artifact store/index', () => {
   it('rejects impossible agent view timestamps without date rollover', () => {
     const { store } = tmpStore();
     const pkg = viewArtifact({
-      manifest: { ...viewArtifact().manifest, updatedAt: '2026-02-30T12:00:03Z' },
+      manifest: {
+        ...viewArtifact().manifest,
+        updatedAt: '2026-02-30T12:00:03Z',
+      },
     });
 
     expect(() =>
-      store.storeAgentViewArtifact({ workContextId: 'wc:view-invalid-timestamp', viewArtifact: pkg })
+      store.storeAgentViewArtifact({
+        workContextId: 'wc:view-invalid-timestamp',
+        viewArtifact: pkg,
+      })
     ).toThrow(WorkContextArtifactStoreError);
   });
 
@@ -354,7 +405,10 @@ describe('WorkContext artifact store/index', () => {
       manifest: {
         ...viewArtifact().manifest,
         updatedAt: '2026-06-08T12:10:00.000Z',
-        revision: { id: 'agent-view:example:manifest-supersedes', supersedes: first.metadata.id },
+        revision: {
+          id: 'agent-view:example:manifest-supersedes',
+          supersedes: first.metadata.id,
+        },
       },
     });
 
@@ -364,9 +418,11 @@ describe('WorkContext artifact store/index', () => {
     });
 
     expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
-    expect(store.list({ workContextId: 'wc:view-manifest-supersede' }).map((entry) => entry.metadata.id)).toEqual([
-      replacement.metadata.id,
-    ]);
+    expect(
+      store
+        .list({ workContextId: 'wc:view-manifest-supersede' })
+        .map((entry) => entry.metadata.id)
+    ).toEqual([replacement.metadata.id]);
   });
 
   it('rejects top-level visibility that disagrees with an agent view export policy', () => {
@@ -395,7 +451,10 @@ describe('WorkContext artifact store/index', () => {
       manifest: {
         ...viewArtifact().manifest,
         updatedAt: '2026-06-08T12:10:00.000Z',
-        revision: { id: 'agent-view:example:bbbbbbbb', supersedes: first.metadata.id },
+        revision: {
+          id: 'agent-view:example:bbbbbbbb',
+          supersedes: first.metadata.id,
+        },
       },
     });
 
@@ -406,12 +465,18 @@ describe('WorkContext artifact store/index', () => {
     });
 
     expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
-    expect(store.get(first.metadata.id)?.metadata.payloadKind).toBe('agent-view-artifact');
-    expect(store.get(handoff.metadata.id)?.metadata.payloadKind).toBe('pipeline-handoff-artifact');
-    expect(store.list({ workContextId: 'wc:view-supersede' }).map((entry) => entry.metadata.id).sort()).toEqual([
-      handoff.metadata.id,
-      replacement.metadata.id,
-    ].sort());
+    expect(store.get(first.metadata.id)?.metadata.payloadKind).toBe(
+      'agent-view-artifact'
+    );
+    expect(store.get(handoff.metadata.id)?.metadata.payloadKind).toBe(
+      'pipeline-handoff-artifact'
+    );
+    expect(
+      store
+        .list({ workContextId: 'wc:view-supersede' })
+        .map((entry) => entry.metadata.id)
+        .sort()
+    ).toEqual([handoff.metadata.id, replacement.metadata.id].sort());
   });
 
   it('backfills agent view task refs from manifest scope during migration', () => {
@@ -428,10 +493,15 @@ describe('WorkContext artifact store/index', () => {
         },
       },
     });
-    const stored = store.storeAgentViewArtifact({ workContextId: 'wc:view-backfill', viewArtifact: pkg });
+    const stored = store.storeAgentViewArtifact({
+      workContextId: 'wc:view-backfill',
+      viewArtifact: pkg,
+    });
     const db = new Database(path.join(root, 'index.db'));
     cleanup.push(() => db.close());
-    db.prepare('DELETE FROM work_context_artifact_task_refs WHERE artifact_id = ?').run(stored.metadata.id);
+    db.prepare(
+      'DELETE FROM work_context_artifact_task_refs WHERE artifact_id = ?'
+    ).run(stored.metadata.id);
 
     const reopened = createWorkContextArtifactStore({
       dbPath: path.join(root, 'index.db'),
@@ -439,9 +509,10 @@ describe('WorkContext artifact store/index', () => {
     });
     cleanup.push(() => reopened.close());
 
-    expect(reopened.list({ taskRef: { kind: 'github-pr', id: '920' } })[0]?.metadata.id).toBe(
-      stored.metadata.id
-    );
+    expect(
+      reopened.list({ taskRef: { kind: 'github-pr', id: '920' } })[0]?.metadata
+        .id
+    ).toBe(stored.metadata.id);
   });
 
   it('indexes every task ref from a handoff artifact payload', () => {
@@ -476,11 +547,15 @@ describe('WorkContext artifact store/index', () => {
       artifact: multiRefArtifact,
     });
 
-    expect(store.list({ taskRef: { kind: 'github-issue', id: '889' } })).toHaveLength(1);
-    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(1);
-    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id).toBe(
-      stored.metadata.id
-    );
+    expect(
+      store.list({ taskRef: { kind: 'github-issue', id: '889' } })
+    ).toHaveLength(1);
+    expect(
+      store.list({ taskRef: { kind: 'github-pr', id: '893' } })
+    ).toHaveLength(1);
+    expect(
+      store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id
+    ).toBe(stored.metadata.id);
   });
 
   it('backfills v1 artifact rows from every valid payload task ref during migration', () => {
@@ -521,11 +596,15 @@ describe('WorkContext artifact store/index', () => {
     });
     cleanup.push(() => store.close());
 
-    expect(store.list({ taskRef: { kind: 'github-issue', id: '889' } })).toHaveLength(1);
-    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(1);
-    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id).toBe(
-      legacyPayload.id
-    );
+    expect(
+      store.list({ taskRef: { kind: 'github-issue', id: '889' } })
+    ).toHaveLength(1);
+    expect(
+      store.list({ taskRef: { kind: 'github-pr', id: '893' } })
+    ).toHaveLength(1);
+    expect(
+      store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id
+    ).toBe(legacyPayload.id);
   });
 
   it('falls back to the legacy primary task ref when a v1 payload is tampered', () => {
@@ -545,15 +624,22 @@ describe('WorkContext artifact store/index', () => {
       payload: legacyPayload,
       primaryTaskRef: { kind: 'github-issue', id: '889' },
     });
-    fs.writeFileSync(payloadPath, '{"scope":{"taskRefs":[{"kind":"github-pr","id":"893"}]}}');
+    fs.writeFileSync(
+      payloadPath,
+      '{"scope":{"taskRefs":[{"kind":"github-pr","id":"893"}]}}'
+    );
     const store = createWorkContextArtifactStore({
       dbPath,
       payloadRoot: path.join(root, 'payloads'),
     });
     cleanup.push(() => store.close());
 
-    expect(store.list({ taskRef: { kind: 'github-issue', id: '889' } })).toHaveLength(1);
-    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(0);
+    expect(
+      store.list({ taskRef: { kind: 'github-issue', id: '889' } })
+    ).toHaveLength(1);
+    expect(
+      store.list({ taskRef: { kind: 'github-pr', id: '893' } })
+    ).toHaveLength(0);
   });
 
   it('lists from the SQLite index without reading payload files', () => {
@@ -569,7 +655,103 @@ describe('WorkContext artifact store/index', () => {
     expect(listed[0]?.metadata.summary).toBe(
       'artifact store foundation for generic project work'
     );
-    expect(() => store.read(stored.metadata.id)).toThrow(WorkContextArtifactStoreError);
+    expect(() => store.read(stored.metadata.id)).toThrow(
+      WorkContextArtifactStoreError
+    );
+  });
+
+  it('supports hub-wide q search over metadata only, most-recent-first, capped at 20', () => {
+    const { store } = tmpStore();
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:search-alpha',
+      artifact: artifact({
+        id: 'pipeline-handoff:search:aaaaaaaa',
+        title: 'Alpha widget rollout handoff',
+        createdAt: now,
+        updatedAt: now,
+      }),
+    });
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:search-beta',
+      artifact: artifact({
+        id: 'pipeline-handoff:search:bbbbbbbb',
+        title: 'Beta gadget rollout handoff',
+        createdAt: '2026-06-08T12:00:01.000Z',
+        updatedAt: '2026-06-08T12:00:01.000Z',
+        head: {
+          ...artifact().head,
+          capturedAt: '2026-06-08T12:00:01.000Z',
+        },
+      }),
+    });
+
+    const byTitle = store.list({ q: 'widget' });
+    expect(byTitle.map((entry) => entry.metadata.id)).toEqual([
+      'pipeline-handoff:search:aaaaaaaa',
+    ]);
+
+    const byWorkContext = store.list({ q: 'search-beta' });
+    expect(byWorkContext.map((entry) => entry.metadata.id)).toEqual([
+      'pipeline-handoff:search:bbbbbbbb',
+    ]);
+
+    // Never matches on body/summary content — metadata only.
+    const bySummaryContent = store.list({
+      q: 'foundation for generic project work',
+    });
+    expect(bySummaryContent).toHaveLength(0);
+
+    // Most-recent-first across matching contexts.
+    const both = store.list({ q: 'rollout handoff' });
+    expect(both.map((entry) => entry.metadata.id)).toEqual([
+      'pipeline-handoff:search:bbbbbbbb',
+      'pipeline-handoff:search:aaaaaaaa',
+    ]);
+  });
+
+  it('caps q search at 20 results even when 25 rows match and a larger limit is requested', () => {
+    const { store } = tmpStore();
+    for (let i = 0; i < 25; i += 1) {
+      store.storePipelineHandoffArtifact({
+        workContextId: `wc:search-cap-${i}`,
+        artifact: artifact({
+          id: `pipeline-handoff:search-cap:${i.toString().padStart(8, '0')}`,
+          title: `Search cap fixture #${i}`,
+        }),
+      });
+    }
+
+    const uncapped = store.list({ q: 'search cap fixture', limit: 200 });
+    expect(uncapped).toHaveLength(20);
+
+    const defaultLimit = store.list({ q: 'search cap fixture' });
+    expect(defaultLimit).toHaveLength(20);
+  });
+
+  it('narrows q search results with an exact kind filter', () => {
+    const { store } = tmpStore();
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:search-kind',
+      artifact: artifact({ id: 'pipeline-handoff:search-kind:aaaaaaaa' }),
+    });
+    const view = store.storeAgentViewArtifact({
+      workContextId: 'wc:search-kind',
+      kind: 'screenshot',
+      viewArtifact: viewArtifact(),
+    });
+
+    const anyKind = store.list({ q: 'search-kind' });
+    expect(anyKind.map((entry) => entry.metadata.id).sort()).toEqual(
+      ['pipeline-handoff:search-kind:aaaaaaaa', view.metadata.id].sort()
+    );
+
+    const onlyScreenshots = store.list({
+      q: 'search-kind',
+      kind: 'screenshot',
+    });
+    expect(onlyScreenshots.map((entry) => entry.metadata.id)).toEqual([
+      view.metadata.id,
+    ]);
   });
 
   it('preserves append-only history and models superseded refs without rewriting prior rows', () => {
@@ -603,9 +785,11 @@ describe('WorkContext artifact store/index', () => {
 
     expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
     expect(store.get(first.metadata.id)?.metadata.headSha).toBe(headSha);
-    expect(store.list({ workContextId: 'wc:append-only' }).map((entry) => entry.metadata.id)).toEqual([
-      replacement.metadata.id,
-    ]);
+    expect(
+      store
+        .list({ workContextId: 'wc:append-only' })
+        .map((entry) => entry.metadata.id)
+    ).toEqual([replacement.metadata.id]);
     expect(
       store
         .list({ workContextId: 'wc:append-only', includeSuperseded: true })
@@ -650,7 +834,9 @@ describe('WorkContext artifact store/index', () => {
     });
 
     const publicCopy = store.publicSummary(stored.metadata.id);
-    const publicPayload = publicCopy?.payload as PipelineHandoffArtifact | undefined;
+    const publicPayload = publicCopy?.payload as
+      | PipelineHandoffArtifact
+      | undefined;
     expect(publicCopy?.metadata).not.toHaveProperty('payloadPath');
     expect(publicCopy?.metadata.taskRef).toMatchObject({
       kind: 'github-issue',
@@ -664,11 +850,19 @@ describe('WorkContext artifact store/index', () => {
       },
     ]);
     expect(publicPayload?.stages[0]?.actorId).toBe('agent');
-    expect(publicPayload?.stages[0]?.summary).toContain('[redacted-local-path]');
+    expect(publicPayload?.stages[0]?.summary).toContain(
+      '[redacted-local-path]'
+    );
     expect(
-      publicPayload?.scope.nonGoals.some((item) => /kanban|dispatcher|worktree/i.test(item))
+      publicPayload?.scope.nonGoals.some((item) =>
+        /kanban|dispatcher|worktree/i.test(item)
+      )
     ).toBe(false);
-    expect(validatePublicPipelineHandoffArtifact(publicPayload as PipelineHandoffArtifact).valid).toBe(true);
+    expect(
+      validatePublicPipelineHandoffArtifact(
+        publicPayload as PipelineHandoffArtifact
+      ).valid
+    ).toBe(true);
   });
 
   it('returns public summaries for agent view artifacts with sanitized manifest only', () => {
@@ -676,12 +870,14 @@ describe('WorkContext artifact store/index', () => {
     const pkg = viewArtifact({
       manifest: {
         ...viewArtifact().manifest,
-        description: 'Public view from /home/operator/relay with t_12345678 internal scratch id',
+        description:
+          'Public view from /home/operator/relay with t_12345678 internal scratch id',
         export: { policy: 'public' },
         revision: { id: 'agent-view:example:public' },
       },
       files: {
-        'index.html': '<main>raw html bytes mention /home/operator/relay and t_12345678</main>',
+        'index.html':
+          '<main>raw html bytes mention /home/operator/relay and t_12345678</main>',
       },
     });
     const stored = store.storeAgentViewArtifact({
@@ -732,8 +928,12 @@ describe('WorkContext artifact store/index', () => {
       )
     );
 
-    expect(() => store.read(stored.metadata.id)).toThrow(WorkContextArtifactStoreError);
-    expect(() => store.publicSummary(stored.metadata.id)).toThrow(WorkContextArtifactStoreError);
+    expect(() => store.read(stored.metadata.id)).toThrow(
+      WorkContextArtifactStoreError
+    );
+    expect(() => store.publicSummary(stored.metadata.id)).toThrow(
+      WorkContextArtifactStoreError
+    );
   });
 
   it('rejects supersedes edges across WorkContexts', () => {
@@ -753,9 +953,9 @@ describe('WorkContext artifact store/index', () => {
         supersedesArtifactId: first.metadata.id,
       })
     ).toThrow(WorkContextArtifactStoreError);
-    expect(store.list({ workContextId: 'wc:a' }).map((entry) => entry.metadata.id)).toEqual([
-      first.metadata.id,
-    ]);
+    expect(
+      store.list({ workContextId: 'wc:a' }).map((entry) => entry.metadata.id)
+    ).toEqual([first.metadata.id]);
   });
 
   it('rejects loose timestamps and mismatched store ids', () => {


### PR DESCRIPTION
## Summary
- Adds a bounded, capability-gated `q` search lane to `GET /work-context-artifacts` (reused for `/pipeline-handoff-artifacts` too): metadata-only (title/kind/taskRef/workContextId — never body/payload content), hard-capped at 20 results, most-recent-first, optional exact `kind` filter. Auth reuses the *exact* existing `listAuth`/`CONTEXT_READ` capability path, so scoped CLI actor credentials without a `workContextId` in scope are still rejected (`missing_scope`) the same way unscoped `list` calls already are.
- Wires an `artifacts` category into the command palette: `frontend/src/lib/command-palette-artifact-results.ts` fetches the new endpoint once the palette's debounced query settles and maps results to palette entries (title, kind glyph, linked-topic/workContext sublabel — mirrors #1093's session sublabel pattern).
- Adds the missing "Nodes" row to `SETTINGS_ENTRIES` (pointed at `SettingsDialog`'s existing `section-nodes`/`SECTION_KEYWORDS.nodes`) — a one-line palette gap in the same file.
- Selecting an artifact copies its `relay://work-context-artifacts/<id>` reference to the clipboard and navigates to the owning workspace (resolved via the `['active-work']` WorkContext read model). **Known gap:** there is no direct deep-link into the evidence artifacts tab yet (`RepoDashboard`'s evidence tab is local component state, not URL-addressable) — this is the cheapest existing open path per the slice instructions; the user opens the evidence tab manually from there. A follow-up could add a `?tab=evidence&workContextId=` style deep link.

## Test plan
- [x] `npm run check` (typecheck + lint) passes
- [x] `npm test` — full suite green (400 files / 5151 tests)
- [x] New backend tests in `test/work-context-artifact-router.test.ts`: unauthorized (missing capability) rejected, title/kind/taskRef/workContextId match works, summary/body content never matches, hard <=20 limit enforced even with `limit=200` and 25 matching rows, scoped actor credentials without workContext scope rejected
- [x] New store tests in `test/work-context-artifacts.test.ts`: `q` search ordering (most-recent-first), `kind` filter, hard cap enforcement
- [x] New provider tests in `test/command-palette-artifact-results.test.ts` (mocked `fetch`, mirrors `command-palette-topic-results.test.ts`): empty-query short-circuit, request/response mapping, HTTP error propagation, sublabel fallback (topic vs workContextId), limit

Refs #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)