### PR TITLE
feat(settings): gate substrate surfaces behind an advanced-mode toggle

### DIFF
--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -401,6 +401,26 @@ function tabButtonClass(
     .join(' ');
 }
 
+// #1058: 'active-work' and 'nodes' are mechanics-heavy substrate surfaces
+// hidden from primary chrome unless advanced mode is on (Settings > advanced,
+// or the one-off palette escape hatches navigation.open-nodes-dashboard /
+// navigation.open-active-work).
+const SUBSTRATE_TABS: ReadonlySet<OrgDashboardTab> = new Set([
+  'active-work',
+  'nodes',
+]);
+
+function visibleOrgTabs(advancedMode: boolean): OrgDashboardTab[] {
+  const all: OrgDashboardTab[] = [
+    'active-work',
+    'nodes',
+    'prs',
+    'tickets',
+    'audit',
+  ];
+  return advancedMode ? all : all.filter((tab) => !SUBSTRATE_TABS.has(tab));
+}
+
 // ── NodesTab sub-component ────────────────────────────────────────────────────
 
 function NodesTab() {
@@ -428,6 +448,26 @@ export function OrgDashboard({
 }: OrgDashboardProps) {
   const activeTab = useUiStore((s) => s.orgDashboardTab);
   const setActiveTab = useUiStore((s) => s.setOrgDashboardTab);
+  const advancedMode = useUiStore((s) => s.advancedMode);
+  // #1058: the base visible set is advancedMode-gated, but a one-off palette
+  // action (navigation.open-nodes-dashboard / navigation.open-active-work)
+  // can deep-link to a substrate tab while advancedMode is off — keep that
+  // explicitly-selected tab in the strip so it renders with a real tab
+  // button instead of disappearing content. `setAdvancedMode` (ui.ts) itself
+  // corrects `orgDashboardTab` back to a visible tab when advanced mode is
+  // turned off, so a *stale* hidden tab never lingers as `activeTab` here.
+  const tabs = useMemo(() => {
+    const base = visibleOrgTabs(advancedMode);
+    return base.includes(activeTab) ? base : [activeTab, ...base];
+  }, [advancedMode, activeTab]);
+
+  const tabLabels: Record<OrgDashboardTab, string> = {
+    'active-work': 'active work',
+    nodes: 'nodes',
+    prs: 'prs',
+    tickets: 'tickets',
+    audit: 'audit',
+  };
 
   return (
     <div className="org-dashboard">
@@ -442,36 +482,15 @@ export function OrgDashboard({
       </div>
       {/* tab-strip uses raw buttons intentionally — underline-indicator navigation, not TuiButton actions */}
       <div className="tab-strip">
-        <button
-          className={tabButtonClass(activeTab, 'active-work')}
-          onClick={() => setActiveTab('active-work')}
-        >
-          active work
-        </button>
-        <button
-          className={tabButtonClass(activeTab, 'nodes')}
-          onClick={() => setActiveTab('nodes')}
-        >
-          nodes
-        </button>
-        <button
-          className={tabButtonClass(activeTab, 'prs')}
-          onClick={() => setActiveTab('prs')}
-        >
-          prs
-        </button>
-        <button
-          className={tabButtonClass(activeTab, 'tickets')}
-          onClick={() => setActiveTab('tickets')}
-        >
-          tickets
-        </button>
-        <button
-          className={tabButtonClass(activeTab, 'audit')}
-          onClick={() => setActiveTab('audit')}
-        >
-          audit
-        </button>
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            className={tabButtonClass(activeTab, tab)}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tabLabels[tab]}
+          </button>
+        ))}
       </div>
       {activeTab === 'active-work' && <ActiveWorkSurface />}
       {activeTab === 'nodes' && <NodesTab />}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -84,6 +84,7 @@ export function Sidebar({
   const sidebarWidth = useUiStore((s) => s.sidebarWidth);
   const analyticsView = useUiStore((s) => s.analyticsView);
   const viewSpineEnabled = useUiStore((s) => s.viewSpineEnabled);
+  const advancedMode = useUiStore((s) => s.advancedMode);
   const closeSidebar = useUiStore((s) => s.closeSidebar);
   const toggleSidebarCollapsed = useUiStore((s) => s.toggleSidebarCollapsed);
   const { startResize, resetWidth } = useSidebarResize();
@@ -189,31 +190,33 @@ export function Sidebar({
             >
               + add project
             </TuiButton>
-            <button
-              className={[
-                'sidebar-settings-icon-btn',
-                analyticsView !== null && 'active',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-              data-track="sidebar.analytics"
-              onClick={onOpenAnalytics}
-              aria-label="Analytics"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="square"
-                width="14"
-                height="14"
+            {advancedMode && (
+              <button
+                className={[
+                  'sidebar-settings-icon-btn',
+                  analyticsView !== null && 'active',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                data-track="sidebar.analytics"
+                onClick={onOpenAnalytics}
+                aria-label="Analytics"
               >
-                <rect x="3" y="12" width="4" height="9" />
-                <rect x="10" y="7" width="4" height="14" />
-                <rect x="17" y="3" width="4" height="18" />
-              </svg>
-            </button>
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="square"
+                  width="14"
+                  height="14"
+                >
+                  <rect x="3" y="12" width="4" height="9" />
+                  <rect x="10" y="7" width="4" height="14" />
+                  <rect x="17" y="3" width="4" height="18" />
+                </svg>
+              </button>
+            )}
             <button
               className="sidebar-settings-icon-btn"
               data-track="sidebar.settings"

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import GitHubIntegration from './integrations/GitHubIntegration.js';
 import WebhookIntegration from './integrations/WebhookIntegration.js';
 import JiraIntegration from './integrations/JiraIntegration.js';
 import SettingsNodesSection from './SettingsNodesSection.js';
+import { useUiStore } from '../../lib/stores/ui.js';
 import {
   setDefaultAgent,
   setDefaultContinue,
@@ -126,6 +127,10 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
     'stale',
   ],
   advanced: [
+    'advanced mode',
+    'infrastructure',
+    'nodes',
+    'active work',
     'developer tools',
     'analytics',
     'debug panel',
@@ -303,6 +308,8 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
       NotificationPermission | 'unsupported'
     >(getPermissionState());
     const [devtoolsEnabled, setDevtoolsEnabled] = useState(false);
+    const advancedMode = useUiStore((s) => s.advancedMode);
+    const setAdvancedMode = useUiStore((s) => s.setAdvancedMode);
     const [searchQuery, setSearchQuery] = useState('');
     const [tocOpen, setTocOpen] = useState(false);
 
@@ -491,6 +498,8 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
                 localStorage.setItem('devtools-enabled', v ? 'true' : 'false');
                 window.dispatchEvent(new Event('devtools-changed'));
               }}
+              advancedModeEnabled={advancedMode}
+              onAdvancedModeChange={(v) => setAdvancedMode(v)}
               onClearAnalytics={() => void handleClearAnalytics()}
             />
             <AboutSection
@@ -688,6 +697,8 @@ function AdvancedSection({
   clearing,
   devtoolsEnabled,
   onDevtoolsChange,
+  advancedModeEnabled,
+  onAdvancedModeChange,
   onClearAnalytics,
 }: {
   searchQuery: string;
@@ -695,6 +706,8 @@ function AdvancedSection({
   clearing: boolean;
   devtoolsEnabled: boolean;
   onDevtoolsChange: (v: boolean) => void;
+  advancedModeEnabled: boolean;
+  onAdvancedModeChange: (v: boolean) => void;
   onClearAnalytics: () => void;
 }) {
   return (
@@ -703,6 +716,15 @@ function AdvancedSection({
       className={sectionClass('section-advanced', searchQuery)}
     >
       <h3 className="settings-dialog-section-heading">advanced</h3>
+      <SettingRow
+        name="Advanced mode"
+        description="Show infrastructure surfaces: nodes, analytics, active work detail"
+      >
+        <TuiCheckbox
+          checked={advancedModeEnabled}
+          onChange={(v) => onAdvancedModeChange(v)}
+        />
+      </SettingRow>
       <SettingRow name="Developer Tools" description="Mobile debug panel">
         <TuiCheckbox
           checked={devtoolsEnabled}

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -104,6 +104,9 @@ import {
   navOpenFile,
   navNextAttentionWork,
   navOpenWorkCockpit,
+  navOpenNodesDashboard,
+  navOpenAnalytics,
+  navOpenActiveWork,
 } from '../lib/actions/definitions/navigation.js';
 import { cliGatewayCommandActions } from '../lib/actions/definitions/cli-gateway.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
@@ -396,7 +399,18 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       navSwitchToTab,
     ];
 
-    const noopActions = noopDefs.map((def) => ({ ...def, handler: () => {} }));
+    // #1058: these placeholders exist for keyboard-shortcut/registry
+    // completeness (contextual UI elements — sort headers, tab toggles,
+    // inline row buttons — already handle the real interaction) but do
+    // nothing when invoked from the palette. Selectable-but-inert commands
+    // erode trust in the palette, so they're excluded from its visible
+    // listing via `when: () => false` (CommandPalette.tsx already filters on
+    // `when`) while staying registered for any other registry consumer.
+    const noopActions = noopDefs.map((def) => ({
+      ...def,
+      when: () => false,
+      handler: () => {},
+    }));
 
     registerGlobal([
       // ── Session ─────────────────────────────────────────────────────────────
@@ -695,6 +709,48 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           sessions.setActiveSessionId(null);
           ui.setActiveRepoPath(null);
           ui.setForceOrgCockpit(true);
+        },
+      },
+      {
+        // #1058: one-off escape hatch — opens the work cockpit's nodes tab
+        // without flipping the persistent advancedMode flag, so the tab
+        // strip stays hidden on the next visit unless the user opts in via
+        // Settings.
+        ...navOpenNodesDashboard,
+        handler: () => {
+          const sessions = useSessionsStore.getState();
+          const ui = useUiStore.getState();
+          ui.setAnalyticsView(null);
+          sessions.setActiveSessionId(null);
+          ui.setActiveRepoPath(null);
+          ui.setOrgDashboardTab('nodes');
+          ui.setForceOrgCockpit(true);
+        },
+      },
+      {
+        // #1058: one-off escape hatch — opens the work cockpit's active-work
+        // tab without flipping the persistent advancedMode flag.
+        ...navOpenActiveWork,
+        handler: () => {
+          const sessions = useSessionsStore.getState();
+          const ui = useUiStore.getState();
+          ui.setAnalyticsView(null);
+          sessions.setActiveSessionId(null);
+          ui.setActiveRepoPath(null);
+          ui.setOrgDashboardTab('active-work');
+          ui.setForceOrgCockpit(true);
+        },
+      },
+      {
+        // #1058: one-off escape hatch — opens the analytics dashboard
+        // without flipping the persistent advancedMode flag (mirrors
+        // App.tsx's openAnalytics handler for the sidebar icon).
+        ...navOpenAnalytics,
+        handler: () => {
+          const ui = useUiStore.getState();
+          ui.setAnalyticsView('dashboard');
+          useSessionsStore.getState().setActiveSessionId(null);
+          ui.setActiveRepoPath(null);
         },
       },
       {

--- a/frontend/src/lib/actions/definitions/navigation.ts
+++ b/frontend/src/lib/actions/definitions/navigation.ts
@@ -67,6 +67,39 @@ export const navOpenWorkCockpit: ActionMeta = {
   icon: '▦',
 };
 
+// #1058: advanced-mode substrate surfaces (nodes dashboard, analytics, active
+// work detail) are hidden from primary chrome by default (Settings >
+// advanced). These are the one-off palette escape hatches — each opens its
+// surface without flipping the persistent `advancedMode` flag.
+export const navOpenNodesDashboard: ActionMeta = {
+  id: 'navigation.open-nodes-dashboard',
+  label: 'open nodes dashboard',
+  description:
+    'jump to the nodes tab of the work cockpit without enabling advanced mode',
+  aliases: ['nodes', 'node dashboard', 'hub nodes'],
+  category: 'navigation',
+  icon: '▦',
+};
+
+export const navOpenAnalytics: ActionMeta = {
+  id: 'navigation.open-analytics',
+  label: 'open analytics',
+  description: 'jump to the analytics dashboard without enabling advanced mode',
+  aliases: ['analytics', 'usage stats'],
+  category: 'navigation',
+  icon: '▦',
+};
+
+export const navOpenActiveWork: ActionMeta = {
+  id: 'navigation.open-active-work',
+  label: 'open active work detail',
+  description:
+    'jump to the active work tab of the work cockpit without enabling advanced mode',
+  aliases: ['active work', 'work cockpit active work'],
+  category: 'navigation',
+  icon: '▦',
+};
+
 export const navigationActions: ActionMeta[] = [
   navPreviousTab,
   navNextTab,
@@ -74,4 +107,7 @@ export const navigationActions: ActionMeta[] = [
   navOpenFile,
   navNextAttentionWork,
   navOpenWorkCockpit,
+  navOpenNodesDashboard,
+  navOpenAnalytics,
+  navOpenActiveWork,
 ];

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -17,6 +17,10 @@ const UTILITY_RAIL_STATE_KEY_PREFIX = 'relay-utility-rail::';
 const DIFF_VIEW_MODE_KEY = 'claude-remote-diff-view-mode';
 const WORD_WRAP_KEY = 'claude-remote-word-wrap';
 const COLLAPSED_WORKSPACES_KEY = 'claude-remote-collapsed-workspaces';
+// #1058: persistent "advanced mode" toggle (Settings). Hides mechanics-heavy
+// substrate surfaces (nodes/active-work tabs, analytics icon) from primary
+// chrome by default; each surface stays reachable one-off via a palette action.
+const ADVANCED_MODE_KEY = 'relay-advanced-mode';
 // Flag-gated six-layer navigation surface. Set
 // `localStorage.relay-view-spine = '1'` and reload to opt into the tree.
 const VIEW_SPINE_KEY = 'relay-view-spine';
@@ -171,6 +175,11 @@ function loadDiffViewMode(): DiffViewMode {
 function loadViewSpineEnabled(): boolean {
   // Truthy only for the explicit opt-in value so a stale '0'/'false' reads OFF.
   return ls(VIEW_SPINE_KEY) === '1';
+}
+
+function loadAdvancedMode(): boolean {
+  // Truthy only for the explicit opt-in value so a stale '0'/'false' reads OFF.
+  return ls(ADVANCED_MODE_KEY) === '1';
 }
 
 // ── #738: View-layer persistence (lens / pins / saved Views) ─────────────────
@@ -626,6 +635,13 @@ export interface UiState {
   collapsedWorkspaces: Set<string>;
   /** Six-layer navigation surface flag. Default false; backed by localStorage. */
   viewSpineEnabled: boolean;
+  /**
+   * #1058: hides mechanics-heavy substrate surfaces (nodes/active-work tabs
+   * in the work cockpit, sidebar analytics icon) from primary chrome.
+   * Default false; backed by localStorage. Each gated surface stays
+   * reachable one-off via a command-palette action regardless of this flag.
+   */
+  advancedMode: boolean;
 
   /** #738: active Views lens, persisted across reload (default `recent`). */
   viewSpineLens: ViewLens;
@@ -674,6 +690,8 @@ export interface UiState {
   isWorkspaceCollapsed: (path: string) => boolean;
   setViewSpineEnabled: (enabled: boolean) => void;
   toggleViewSpineEnabled: () => void;
+  setAdvancedMode: (enabled: boolean) => void;
+  toggleAdvancedMode: () => void;
 
   /** #738: persist + set the active lens. */
   setViewSpineLens: (lens: ViewLens) => void;
@@ -714,12 +732,15 @@ export const useUiStore = create<UiState>()((set, get) => ({
   codeTabPendingContent: {},
   sendToTargetSessionId: null,
   analyticsView: null,
-  orgDashboardTab: 'active-work',
+  // #1058: 'active-work' is a substrate tab hidden unless advancedMode is on;
+  // default to 'prs' so a fresh session never lands on a hidden tab's content.
+  orgDashboardTab: loadAdvancedMode() ? 'active-work' : 'prs',
   forceOrgCockpit: false,
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
   viewSpineEnabled: loadViewSpineEnabled(),
+  advancedMode: loadAdvancedMode(),
 
   viewSpineLens: loadViewSpineLens(),
   viewSpinePins: loadViewSpinePins(),
@@ -1335,6 +1356,23 @@ export const useUiStore = create<UiState>()((set, get) => ({
   },
   toggleViewSpineEnabled: () => {
     get().setViewSpineEnabled(!get().viewSpineEnabled);
+  },
+  setAdvancedMode: (enabled) => {
+    if (enabled) lsSave(ADVANCED_MODE_KEY, '1');
+    else lsRemove(ADVANCED_MODE_KEY);
+    // #1058: correct away from a substrate tab the moment advanced mode is
+    // turned off, so the work cockpit never lingers on a now-hidden tab —
+    // one-off palette deep links set the tab afresh and aren't affected by
+    // this (they run after advancedMode is already settled).
+    const current = get().orgDashboardTab;
+    const fallbackTab =
+      !enabled && (current === 'active-work' || current === 'nodes')
+        ? 'prs'
+        : current;
+    set({ advancedMode: enabled, orgDashboardTab: fallbackTab });
+  },
+  toggleAdvancedMode: () => {
+    get().setAdvancedMode(!get().advancedMode);
   },
   setViewSpineLens: (lens) => {
     lsSave(VIEW_SPINE_LENS_KEY, lens);

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -33,9 +33,10 @@ import { workspaceOpenFileBrowser } from '../frontend/src/lib/actions/definition
 import { actionDescriptorFromMeta } from '../frontend/src/lib/actions/descriptors.js';
 import { stableCommandNames } from '../shared/cli-gateway-contract.js';
 
-// Full allowlist: 63 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
+// Full allowlist: 66 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630
 // + workspace.launch from #870 + next-attention WorkContext jump from #933
-// + task-room create/launch from #1045 + open-work-cockpit from #1058)
+// + task-room create/launch from #1045 + open-work-cockpit from #1058
+// + advanced-mode escape hatches (nodes dashboard/analytics/active work) from #1058)
 const ACTION_ALLOWLIST = [
   // Session (11)
   'session.new-agent',
@@ -105,13 +106,16 @@ const ACTION_ALLOWLIST = [
   // Terminal (2)
   'terminal.scroll-top',
   'terminal.scroll-bottom',
-  // Navigation (6)
+  // Navigation (9)
   'navigation.previous-tab',
   'navigation.next-tab',
   'navigation.switch-to-tab',
   'navigation.open-file',
   'navigation.next-attention-work',
   'navigation.open-work-cockpit',
+  'navigation.open-nodes-dashboard',
+  'navigation.open-analytics',
+  'navigation.open-active-work',
 ] as const;
 
 const ALL_META: ActionMeta[] = [

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -67,6 +67,8 @@ function resetStore() {
     lastChangedFiles: [],
     collapsedWorkspaces: new Set(),
     viewSpineEnabled: false,
+    advancedMode: false,
+    orgDashboardTab: 'prs',
   });
 }
 
@@ -712,6 +714,56 @@ describe('ui Zustand store', () => {
       useUiStore.getState().toggleWorkspaceCollapse('/repo/x');
       const stored = JSON.parse(storage['claude-remote-collapsed-workspaces']!);
       expect(stored).toEqual(['/repo/x']);
+    });
+  });
+
+  describe('advanced mode (#1058)', () => {
+    it('setAdvancedMode(true) persists the flag and preserves the current tab', () => {
+      useUiStore.getState().setOrgDashboardTab('tickets');
+      useUiStore.getState().setAdvancedMode(true);
+
+      expect(useUiStore.getState().advancedMode).toBe(true);
+      expect(useUiStore.getState().orgDashboardTab).toBe('tickets');
+      expect(storage['relay-advanced-mode']).toBe('1');
+    });
+
+    it('setAdvancedMode(false) rewrites a substrate tab back to prs', () => {
+      useUiStore.getState().setAdvancedMode(true);
+      useUiStore.getState().setOrgDashboardTab('active-work');
+
+      useUiStore.getState().setAdvancedMode(false);
+
+      expect(useUiStore.getState().advancedMode).toBe(false);
+      expect(useUiStore.getState().orgDashboardTab).toBe('prs');
+      expect(storage['relay-advanced-mode']).toBe(undefined);
+    });
+
+    it('setAdvancedMode(false) rewrites the other substrate tab (nodes) back to prs too', () => {
+      useUiStore.getState().setAdvancedMode(true);
+      useUiStore.getState().setOrgDashboardTab('nodes');
+
+      useUiStore.getState().setAdvancedMode(false);
+
+      expect(useUiStore.getState().orgDashboardTab).toBe('prs');
+    });
+
+    it('setAdvancedMode(false) leaves non-substrate tabs untouched', () => {
+      useUiStore.getState().setAdvancedMode(true);
+      useUiStore.getState().setOrgDashboardTab('audit');
+
+      useUiStore.getState().setAdvancedMode(false);
+
+      expect(useUiStore.getState().orgDashboardTab).toBe('audit');
+    });
+
+    it('toggleAdvancedMode flips the persisted flag', () => {
+      expect(useUiStore.getState().advancedMode).toBe(false);
+      useUiStore.getState().toggleAdvancedMode();
+      expect(useUiStore.getState().advancedMode).toBe(true);
+      expect(storage['relay-advanced-mode']).toBe('1');
+      useUiStore.getState().toggleAdvancedMode();
+      expect(useUiStore.getState().advancedMode).toBe(false);
+      expect(storage['relay-advanced-mode']).toBe(undefined);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a persistent `advancedMode` toggle to the ui store (Settings > advanced, default off), following the same localStorage persistence pattern as `viewSpineEnabled`.
- Hide mechanics-heavy substrate surfaces from primary chrome unless advanced mode is on: the work cockpit's `active work` and `nodes` tabs (`OrgDashboard.tsx`), and the sidebar analytics icon (`Sidebar.tsx`). The cockpit's default/fallback tab resolves sanely (falls back to `prs`) whenever advanced mode is off or gets turned off while viewing a hidden tab.
- Add three one-off palette escape hatches — `navigation.open-nodes-dashboard`, `navigation.open-analytics`, `navigation.open-active-work` — that deep-link to each hidden surface without flipping the persistent `advancedMode` flag, following the `navigation.open-work-cockpit` pattern from #1101.
- Exclude the long-standing noop placeholder actions (`dashboardSortPrs`, `orgSwitchTab`, `sessionSwitchToTab`, etc.) from the palette's visible listing via `when: () => false` (`CommandPalette.tsx` already filters on `when`) — they stay registered for keyboard-shortcut/registry completeness, they just no longer show up as selectable-but-inert commands.

## Test plan
- [x] `npm run check` (0 errors; pre-existing sonarjs warnings only)
- [x] `npm test` — 399/399 test files, 5137 passed / 9 skipped
- [x] Real-browser Playwright pass against a spawned dev hub (chromium, `--no-sandbox`): default state hides nodes/active-work tabs and the analytics icon with zero console errors; toggling "Advanced mode" in Settings restores both; toggling back off + invoking `navigation.open-nodes-dashboard` from the palette opens the nodes tab one-off while the sidebar analytics icon and persisted `advancedMode` flag both stay off. Validation script deleted before commit per repo convention.

Refs #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Advanced mode” setting with a saved toggle in app settings.
  * Introduced new navigation shortcuts for opening the Nodes dashboard, Active Work, and Analytics views.
  * Expanded the org dashboard to show tabs based on the current mode, while still honoring direct links.

* **Bug Fixes**
  * Prevented hidden tabs from disappearing when opened via a direct link.
  * Hid advanced-only sidebar analytics access unless Advanced mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->