### PR TITLE
feat(landing): the landing IS the composer — codex-style topic creation in the main pane

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,6 +181,8 @@ function useTerminalDerivedState() {
   const analyticsView = useUiStore((s) => s.analyticsView);
   const forceOrgCockpit = useUiStore((s) => s.forceOrgCockpit);
   const setForceOrgCockpit = useUiStore((s) => s.setForceOrgCockpit);
+  const topicComposerOpen = useUiStore((s) => s.topicComposerOpen);
+  const setTopicComposerOpen = useUiStore((s) => s.setTopicComposerOpen);
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
@@ -252,8 +254,15 @@ function useTerminalDerivedState() {
         hasActiveSession,
         activeRepoPath,
         forceOrgCockpit,
+        topicComposerOpen,
       }),
-    [analyticsView, hasActiveSession, activeRepoPath, forceOrgCockpit]
+    [
+      analyticsView,
+      hasActiveSession,
+      activeRepoPath,
+      forceOrgCockpit,
+      topicComposerOpen,
+    ]
   );
 
   // #1058: once a session goes active, drop the explicit cockpit override so
@@ -262,6 +271,18 @@ function useTerminalDerivedState() {
   useEffect(() => {
     if (hasActiveSession && forceOrgCockpit) setForceOrgCockpit(false);
   }, [hasActiveSession, forceOrgCockpit, setForceOrgCockpit]);
+
+  // #1058: the composer overlay closes when the active session CHANGES —
+  // a launch from the composer or a sidebar selection navigates to that
+  // session. (The composer can open while a session is still active, so a
+  // mere "session is active" check would close it immediately.)
+  const composerPrevSessionRef = useRef(activeSessionId);
+  useEffect(() => {
+    if (composerPrevSessionRef.current !== activeSessionId) {
+      composerPrevSessionRef.current = activeSessionId;
+      if (topicComposerOpen) setTopicComposerOpen(false);
+    }
+  }, [activeSessionId, topicComposerOpen, setTopicComposerOpen]);
 
   return {
     activeRepoPath,

--- a/frontend/src/components/ChatHome.css
+++ b/frontend/src/components/ChatHome.css
@@ -1,5 +1,5 @@
 /* #1058: chat/topic spine default landing — the panel it hosts
-   (`.active-work-empty`) centers in the open space while keeping its content
+   (`.topic-composer`) centers in the open space while keeping its content
    left-aligned (TUI-native — see DESIGN.md). */
 .chat-home {
   display: flex;

--- a/frontend/src/components/ChatHome.tsx
+++ b/frontend/src/components/ChatHome.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
-import { openTopicTaskRoom } from '../lib/topic-task-room.js';
-import { ActiveWorkEmpty } from './ActiveWorkSurface.js';
+import TopicComposer from './TopicComposer.js';
 import './ChatHome.css';
 
 export interface ChatHomeProps {
@@ -10,13 +9,12 @@ export interface ChatHomeProps {
 }
 
 /**
- * #1058: the chat/topic spine is the default no-session/no-repo landing —
- * replacing the WorkContext cockpit as the first thing an operator sees. The
- * topic sidebar stays primary; this main-pane empty state reuses the
- * cockpit's `ActiveWorkEmpty` panel/CTA pattern so the two surfaces stay
- * visually consistent, and offers a one-tap resume of the most recently
- * active session when one exists. The full cockpit remains reachable via the
- * "open work cockpit" command-palette action.
+ * #1058: the chat/topic spine is the default no-session/no-repo landing — and
+ * the landing IS the composer. No sidebar clicking: type the first prompt into
+ * the main pane and the topic + session are created with that message
+ * (codex-style). One-tap resume of the most recently active session stays as
+ * a secondary affordance; the full cockpit remains reachable via the "open
+ * work cockpit" command-palette action.
  */
 export default function ChatHome({ onSelectSession }: ChatHomeProps) {
   const sessions = useSessionsStore((s) => s.sessions);
@@ -38,19 +36,7 @@ export default function ChatHome({ onSelectSession }: ChatHomeProps) {
 
   return (
     <div className="chat-home" aria-label="chat and topic home">
-      <ActiveWorkEmpty
-        onStartTopic={openTopicTaskRoom}
-        title="start a topic"
-        lede={
-          <>
-            chat with an agent, launch a terminal, or review artifacts — each
-            topic runs in its own node and repo. topics, sessions, and
-            workspaces live in the sidebar; open the work cockpit from the
-            command palette for cross-node prs, tickets, nodes, and audit.
-          </>
-        }
-        {...(resume ? { resume } : {})}
-      />
+      <TopicComposer onSelectSession={onSelectSession} resume={resume} />
     </div>
   );
 }

--- a/frontend/src/components/TopicComposer.css
+++ b/frontend/src/components/TopicComposer.css
@@ -70,8 +70,11 @@
 }
 
 .topic-composer__advanced-toggle {
+  display: inline-flex;
+  align-items: center;
   justify-self: start;
-  padding: 1px 0;
+  min-height: 32px;
+  padding: 4px 8px 4px 0;
   border: none;
   background: none;
   color: var(--text-muted);
@@ -99,6 +102,8 @@
 .topic-composer__advanced input,
 .topic-composer__advanced select {
   min-width: 0;
+  min-height: 30px;
+  padding: 4px 6px;
   border: 1px solid var(--border);
   border-radius: 0;
   background: var(--bg);
@@ -128,22 +133,6 @@
 .topic-composer__advanced-actions {
   display: flex;
   justify-content: flex-end;
-}
-
-.topic-composer__create-only {
-  border: 1px solid var(--border);
-  border-radius: 0;
-  background: var(--bg-elevated);
-  color: var(--text);
-  font: inherit;
-  font-size: var(--font-size-xs);
-  text-transform: lowercase;
-  cursor: pointer;
-}
-
-.topic-composer__create-only:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--accent);
 }
 
 .topic-composer__footer {

--- a/frontend/src/components/TopicComposer.css
+++ b/frontend/src/components/TopicComposer.css
@@ -1,0 +1,159 @@
+/* Codex-style primary entry point: a single message box floated into the
+   vertical center of the main pane. Panel is centered in the void; content
+   stays left-aligned (TUI-native, not a centered consumer hero — DESIGN.md). */
+.topic-composer {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  min-height: 44vh;
+  padding: 24px 16px;
+  font-family: var(--font-mono);
+}
+
+.topic-composer__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 620px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  text-align: left;
+}
+
+.topic-composer__title {
+  color: var(--text);
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+
+.topic-composer__form {
+  display: grid;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.topic-composer__ta {
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.topic-composer__ta:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.topic-composer__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.topic-composer__context {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.topic-composer__advanced-toggle {
+  justify-self: start;
+  padding: 1px 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.topic-composer__advanced-toggle:hover {
+  color: var(--accent);
+}
+
+.topic-composer__advanced {
+  display: grid;
+  gap: 8px;
+  font-size: var(--font-size-xs);
+}
+
+.topic-composer__advanced label {
+  display: grid;
+  gap: 3px;
+}
+
+.topic-composer__advanced input,
+.topic-composer__advanced select {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.topic-composer__preview,
+.topic-composer__failure {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  font-size: var(--font-size-xs);
+}
+
+.topic-composer__preview {
+  color: var(--text-muted);
+}
+
+.topic-composer__failure {
+  border-color: var(--status-error);
+  color: var(--status-error);
+}
+
+.topic-composer__advanced-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.topic-composer__create-only {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg-elevated);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.topic-composer__create-only:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.topic-composer__footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.topic-composer__hint {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useState, type FormEvent } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
 import {
   buildWorkspaceTopicLaunchPreview,
   type WorkspaceTopicTemplateKind,
@@ -10,6 +16,11 @@ import {
   deriveTopicTitleFromPrompt,
   TOPIC_ROOM_TEMPLATE_OPTIONS,
 } from '../lib/topic-create.js';
+import {
+  takeTopicComposerSeed,
+  TOPIC_COMPOSER_FOCUS_EVENT,
+} from '../lib/topic-task-room.js';
+import { isMobileDevice } from '../lib/utils.js';
 import TuiButton from './TuiButton.js';
 import './TopicComposer.css';
 
@@ -28,6 +39,10 @@ export default function TopicComposer({
   onSelectSession?: ((id: string) => void) | undefined;
   resume?: { label: string; onResume: () => void } | undefined;
 }) {
+  // One-shot routing seed captured by openTopicTaskRoom() before it cleared
+  // the active session — keeps "+ task" from inside a session launching into
+  // that session's node/repo/cwd instead of bare workspace defaults.
+  const [seed] = useState(takeTopicComposerSeed);
   const {
     draft,
     updateDraft,
@@ -42,8 +57,17 @@ export default function TopicComposer({
     repoPathOptions,
     worktreePathOptions,
     cwdOptions,
-  } = useTopicRoomCreate({ onLaunched: onSelectSession });
+  } = useTopicRoomCreate({ onLaunched: onSelectSession, seed });
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  // Focus request from openTopicTaskRoom() — covers the already-on-landing
+  // case where the component does not remount so autoFocus never re-fires.
+  useEffect(() => {
+    const focus = () => taRef.current?.focus();
+    window.addEventListener(TOPIC_COMPOSER_FOCUS_EVENT, focus);
+    return () => window.removeEventListener(TOPIC_COMPOSER_FOCUS_EVENT, focus);
+  }, []);
 
   const preview = useMemo(
     () =>
@@ -65,6 +89,9 @@ export default function TopicComposer({
     [draft.templateKind, previewCreate]
   );
   const launchDisabled = draft.templateKind === 'note';
+  // Notes are rooms without a session — the primary action degrades to
+  // create-only instead of dead-ending the keyboard.
+  const primaryIntent = launchDisabled ? 'create-only' : 'create-and-launch';
   const disabled = !effectiveTitle || Boolean(submittingIntent);
   // #1103: never render a raw node id — resolve through the roster or fall
   // back to a generic label.
@@ -83,10 +110,11 @@ export default function TopicComposer({
           aria-label="new topic"
           onSubmit={(event: FormEvent) => {
             event.preventDefault();
-            if (!disabled && !launchDisabled) void submit('create-and-launch');
+            if (!disabled) void submit(primaryIntent);
           }}
         >
           <textarea
+            ref={taRef}
             className="topic-composer__ta"
             value={draft.prompt}
             onChange={(event) => updateDraft({ prompt: event.target.value })}
@@ -95,28 +123,25 @@ export default function TopicComposer({
                 event.key === 'Enter' &&
                 !event.shiftKey &&
                 !event.nativeEvent.isComposing &&
-                !disabled &&
-                !launchDisabled
+                !disabled
               ) {
                 event.preventDefault();
-                void submit('create-and-launch');
+                void submit(primaryIntent);
               }
             }}
             placeholder="what should the agent do?"
             rows={4}
             aria-label="first message"
-            autoFocus
+            // On mobile the landing is the default view; autofocusing would
+            // pop the software keyboard on every app open.
+            autoFocus={!isMobileDevice}
           />
           <div className="topic-composer__bar">
             <span className="topic-composer__context">
               {preview.providerLabel} · {friendlyNodeLabel} ·{' '}
               {preview.cwdLabel}
             </span>
-            <TuiButton
-              variant="primary"
-              type="submit"
-              disabled={disabled || launchDisabled}
-            >
+            <TuiButton variant="primary" type="submit" disabled={disabled}>
               {launchSubmitLabel({
                 submittingIntent,
                 launchDisabled,
@@ -128,13 +153,17 @@ export default function TopicComposer({
             type="button"
             className="topic-composer__advanced-toggle"
             aria-expanded={advancedOpen}
+            aria-controls="topic-composer-advanced"
             onClick={() => setAdvancedOpen((prev) => !prev)}
           >
             <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
             advanced
           </button>
           {advancedOpen ? (
-            <div className="topic-composer__advanced">
+            <div
+              className="topic-composer__advanced"
+              id="topic-composer-advanced"
+            >
               <label>
                 <span>title</span>
                 <input
@@ -298,16 +327,15 @@ export default function TopicComposer({
                 <div>side effects: {preview.sideEffects.join(' · ')}</div>
               </div>
               <div className="topic-composer__advanced-actions">
-                <button
-                  type="button"
-                  className="topic-composer__create-only"
+                <TuiButton
+                  variant="ghost"
                   disabled={disabled}
                   onClick={() => void submit('create-only')}
                 >
                   {submittingIntent === 'create-only'
                     ? 'creating…'
                     : 'create only'}
-                </button>
+                </TuiButton>
               </div>
             </div>
           ) : null}

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -1,0 +1,337 @@
+import { useMemo, useState, type FormEvent } from 'react';
+import {
+  buildWorkspaceTopicLaunchPreview,
+  type WorkspaceTopicTemplateKind,
+} from '../../../shared/workspace-topics.js';
+import { useTopicRoomCreate } from '../hooks/useTopicRoomCreate.js';
+import {
+  launchSubmitLabel,
+  launchTypeForTemplate,
+  deriveTopicTitleFromPrompt,
+  TOPIC_ROOM_TEMPLATE_OPTIONS,
+} from '../lib/topic-create.js';
+import TuiButton from './TuiButton.js';
+import './TopicComposer.css';
+
+/**
+ * #1058: the codex-style primary entry point. Lives in the main pane (not the
+ * sidebar): a single message box centered in the open space — type the first
+ * prompt, hit start, and the topic + session exist with that message. All
+ * routing metadata (provider/agent/node/repo/worktree/cwd/task ref) stays
+ * available behind the advanced disclosure and keeps flowing into
+ * routingDefaults for agent-to-agent use.
+ */
+export default function TopicComposer({
+  onSelectSession,
+  resume,
+}: {
+  onSelectSession?: ((id: string) => void) | undefined;
+  resume?: { label: string; onResume: () => void } | undefined;
+}) {
+  const {
+    draft,
+    updateDraft,
+    submit,
+    submittingIntent,
+    launchFailure,
+    effectiveTitle,
+    previewCreate,
+    nodes,
+    providerOptions,
+    nodeOptions,
+    repoPathOptions,
+    worktreePathOptions,
+    cwdOptions,
+  } = useTopicRoomCreate({ onLaunched: onSelectSession });
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const preview = useMemo(
+    () =>
+      buildWorkspaceTopicLaunchPreview({
+        create: previewCreate,
+        intent:
+          draft.templateKind === 'note' ? 'create-only' : 'create-and-launch',
+        templateKind: draft.templateKind,
+        launchOverrides: {
+          type: launchTypeForTemplate(draft.templateKind) ?? 'agent',
+          mode: 'pty',
+          agent: previewCreate.routingDefaults?.providerId,
+          nodeId: previewCreate.routingDefaults?.nodeId,
+          repoPath: previewCreate.routingDefaults?.repoPath,
+          worktreePath: previewCreate.routingDefaults?.worktreePath,
+          cwd: previewCreate.routingDefaults?.cwd,
+        },
+      }),
+    [draft.templateKind, previewCreate]
+  );
+  const launchDisabled = draft.templateKind === 'note';
+  const disabled = !effectiveTitle || Boolean(submittingIntent);
+  // #1103: never render a raw node id — resolve through the roster or fall
+  // back to a generic label.
+  const routedNodeId = previewCreate.routingDefaults?.nodeId;
+  const friendlyNodeLabel = routedNodeId
+    ? nodes.find((node) => node.nodeId === routedNodeId)?.displayName ||
+      'remote node'
+    : preview.nodeLabel;
+
+  return (
+    <div className="topic-composer">
+      <div className="topic-composer__panel">
+        <span className="topic-composer__title">start a topic</span>
+        <form
+          className="topic-composer__form"
+          aria-label="new topic"
+          onSubmit={(event: FormEvent) => {
+            event.preventDefault();
+            if (!disabled && !launchDisabled) void submit('create-and-launch');
+          }}
+        >
+          <textarea
+            className="topic-composer__ta"
+            value={draft.prompt}
+            onChange={(event) => updateDraft({ prompt: event.target.value })}
+            onKeyDown={(event) => {
+              if (
+                event.key === 'Enter' &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing &&
+                !disabled &&
+                !launchDisabled
+              ) {
+                event.preventDefault();
+                void submit('create-and-launch');
+              }
+            }}
+            placeholder="what should the agent do?"
+            rows={4}
+            aria-label="first message"
+            autoFocus
+          />
+          <div className="topic-composer__bar">
+            <span className="topic-composer__context">
+              {preview.providerLabel} · {friendlyNodeLabel} ·{' '}
+              {preview.cwdLabel}
+            </span>
+            <TuiButton
+              variant="primary"
+              type="submit"
+              disabled={disabled || launchDisabled}
+            >
+              {launchSubmitLabel({
+                submittingIntent,
+                launchDisabled,
+                launchFailure,
+              })}
+            </TuiButton>
+          </div>
+          <button
+            type="button"
+            className="topic-composer__advanced-toggle"
+            aria-expanded={advancedOpen}
+            onClick={() => setAdvancedOpen((prev) => !prev)}
+          >
+            <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
+            advanced
+          </button>
+          {advancedOpen ? (
+            <div className="topic-composer__advanced">
+              <label>
+                <span>title</span>
+                <input
+                  value={draft.title}
+                  onChange={(event) =>
+                    updateDraft({ title: event.target.value })
+                  }
+                  placeholder={
+                    deriveTopicTitleFromPrompt(draft.prompt) ||
+                    'auto from message'
+                  }
+                />
+              </label>
+              <label>
+                <span>task ref</span>
+                <input
+                  value={draft.taskRef}
+                  onChange={(event) =>
+                    updateDraft({ taskRef: event.target.value })
+                  }
+                  placeholder="github issue number or URL"
+                />
+              </label>
+              <label>
+                <span>provider</span>
+                <input
+                  list="topic-composer-provider-options"
+                  value={draft.providerId}
+                  onChange={(event) =>
+                    updateDraft({ providerId: event.target.value })
+                  }
+                  placeholder={
+                    previewCreate.routingDefaults?.providerId ??
+                    'default provider'
+                  }
+                />
+                <datalist id="topic-composer-provider-options">
+                  {providerOptions.map((providerId) => (
+                    <option key={providerId} value={providerId} />
+                  ))}
+                </datalist>
+              </label>
+              <label>
+                <span>agent id</span>
+                <input
+                  value={draft.agentId}
+                  onChange={(event) =>
+                    updateDraft({ agentId: event.target.value })
+                  }
+                  placeholder="optional agent identity"
+                />
+              </label>
+              <label>
+                <span>template kind</span>
+                <select
+                  value={draft.templateKind}
+                  onChange={(event) =>
+                    updateDraft({
+                      templateKind: event.target
+                        .value as WorkspaceTopicTemplateKind,
+                    })
+                  }
+                >
+                  {TOPIC_ROOM_TEMPLATE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>node</span>
+                <input
+                  list="topic-composer-node-options"
+                  value={draft.nodeId}
+                  onChange={(event) =>
+                    updateDraft({ nodeId: event.target.value })
+                  }
+                  placeholder={
+                    previewCreate.routingDefaults?.nodeId ??
+                    'local/default node'
+                  }
+                />
+                <datalist id="topic-composer-node-options">
+                  {nodeOptions.map((node) => (
+                    <option
+                      key={node.value}
+                      value={node.value}
+                      label={node.label}
+                    />
+                  ))}
+                </datalist>
+              </label>
+              <label>
+                <span>repo</span>
+                <input
+                  list="topic-composer-repo-options"
+                  value={draft.repoPath}
+                  onChange={(event) =>
+                    updateDraft({ repoPath: event.target.value })
+                  }
+                  placeholder={
+                    previewCreate.routingDefaults?.repoPath ?? 'default repo'
+                  }
+                />
+                <datalist id="topic-composer-repo-options">
+                  {repoPathOptions.map((repoPath) => (
+                    <option key={repoPath} value={repoPath} />
+                  ))}
+                </datalist>
+              </label>
+              <label>
+                <span>worktree</span>
+                <input
+                  list="topic-composer-worktree-options"
+                  value={draft.worktreePath}
+                  onChange={(event) =>
+                    updateDraft({ worktreePath: event.target.value })
+                  }
+                  placeholder={
+                    previewCreate.routingDefaults?.worktreePath ??
+                    'default worktree'
+                  }
+                />
+                <datalist id="topic-composer-worktree-options">
+                  {worktreePathOptions.map((worktreePath) => (
+                    <option key={worktreePath} value={worktreePath} />
+                  ))}
+                </datalist>
+              </label>
+              <label>
+                <span>cwd</span>
+                <input
+                  list="topic-composer-cwd-options"
+                  value={draft.cwd}
+                  onChange={(event) => updateDraft({ cwd: event.target.value })}
+                  placeholder={
+                    previewCreate.routingDefaults?.cwd ?? 'default cwd'
+                  }
+                />
+                <datalist id="topic-composer-cwd-options">
+                  {cwdOptions.map((cwd) => (
+                    <option key={cwd} value={cwd} />
+                  ))}
+                </datalist>
+              </label>
+              <div className="topic-composer__preview" aria-label="launch preview">
+                <div>template: {preview.templateKind}</div>
+                <div>provider: {preview.providerLabel}</div>
+                <div>
+                  agent:{' '}
+                  {previewCreate.routingDefaults?.agentId ??
+                    previewCreate.routingDefaults?.providerId ??
+                    'default agent'}
+                </div>
+                <div>mode: {preview.modeLabel}</div>
+                <div>node: {friendlyNodeLabel}</div>
+                <div>cwd: {preview.cwdLabel}</div>
+                <div>prompt: {preview.promptSources.join(', ')}</div>
+                <div>tasks: {preview.taskRefs.join(', ')}</div>
+                <div>side effects: {preview.sideEffects.join(' · ')}</div>
+              </div>
+              <div className="topic-composer__advanced-actions">
+                <button
+                  type="button"
+                  className="topic-composer__create-only"
+                  disabled={disabled}
+                  onClick={() => void submit('create-only')}
+                >
+                  {submittingIntent === 'create-only'
+                    ? 'creating…'
+                    : 'create only'}
+                </button>
+              </div>
+            </div>
+          ) : null}
+          {launchFailure ? (
+            <div className="topic-composer__failure" role="alert">
+              {launchFailure.stage === 'session'
+                ? 'launch failed after room creation'
+                : 'room creation failed'}{' '}
+              ({launchFailure.stage}): {launchFailure.message}
+            </div>
+          ) : null}
+        </form>
+        <div className="topic-composer__footer">
+          {resume ? (
+            <TuiButton variant="ghost" onClick={resume.onResume}>
+              {resume.label}
+            </TuiButton>
+          ) : null}
+          <span className="topic-composer__hint">
+            enter to start · shift+enter for a new line · topics and sessions
+            live in the sidebar
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -16,10 +16,8 @@ import {
   deriveTopicTitleFromPrompt,
   TOPIC_ROOM_TEMPLATE_OPTIONS,
 } from '../lib/topic-create.js';
-import {
-  takeTopicComposerSeed,
-  TOPIC_COMPOSER_FOCUS_EVENT,
-} from '../lib/topic-task-room.js';
+import { TOPIC_COMPOSER_FOCUS_EVENT } from '../lib/topic-task-room.js';
+import { useUiStore } from '../lib/stores/ui.js';
 import { isMobileDevice } from '../lib/utils.js';
 import TuiButton from './TuiButton.js';
 import './TopicComposer.css';
@@ -39,10 +37,7 @@ export default function TopicComposer({
   onSelectSession?: ((id: string) => void) | undefined;
   resume?: { label: string; onResume: () => void } | undefined;
 }) {
-  // One-shot routing seed captured by openTopicTaskRoom() before it cleared
-  // the active session — keeps "+ task" from inside a session launching into
-  // that session's node/repo/cwd instead of bare workspace defaults.
-  const [seed] = useState(takeTopicComposerSeed);
+  const setTopicComposerOpen = useUiStore((s) => s.setTopicComposerOpen);
   const {
     draft,
     updateDraft,
@@ -57,7 +52,7 @@ export default function TopicComposer({
     repoPathOptions,
     worktreePathOptions,
     cwdOptions,
-  } = useTopicRoomCreate({ onLaunched: onSelectSession, seed });
+  } = useTopicRoomCreate({ onLaunched: onSelectSession });
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
@@ -127,6 +122,10 @@ export default function TopicComposer({
               ) {
                 event.preventDefault();
                 void submit(primaryIntent);
+              } else if (event.key === 'Escape') {
+                // Composer opened over an active session — Escape returns to
+                // it. No-op on the bare landing (flag already false).
+                setTopicComposerOpen(false);
               }
             }}
             placeholder="what should the agent do?"

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -29,8 +29,7 @@
   color: var(--status-info);
 }
 
-.topic-shell__create,
-.topic-create-panel button {
+.topic-shell__create {
   border: 1px solid var(--border);
   border-radius: 0;
   background: var(--bg-elevated);
@@ -39,87 +38,9 @@
   text-transform: lowercase;
 }
 
-.topic-shell__create:hover:not(:disabled),
-.topic-create-panel button:hover:not(:disabled) {
+.topic-shell__create:hover:not(:disabled) {
   border-color: var(--accent);
   color: var(--accent);
-}
-
-.topic-create-panel {
-  display: grid;
-  gap: 8px;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-elevated) 60%, transparent);
-  color: var(--text-muted);
-  font-size: var(--font-size-xs);
-}
-
-.topic-create-panel__title {
-  color: var(--text);
-  text-transform: lowercase;
-}
-
-.topic-create-panel label {
-  display: grid;
-  gap: 3px;
-}
-
-.topic-create-panel input,
-.topic-create-panel select,
-.topic-create-panel textarea {
-  min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: 0;
-  background: var(--bg);
-  color: var(--text);
-  font-family: inherit;
-  font-size: inherit;
-}
-
-.topic-create-panel textarea {
-  resize: vertical;
-}
-
-.topic-create-panel__context {
-  color: var(--text-muted);
-  overflow-wrap: anywhere;
-}
-
-.topic-create-panel button.topic-create-panel__advanced-toggle {
-  justify-self: start;
-  padding: 1px 6px;
-  border: none;
-  background: none;
-  color: var(--text-muted);
-}
-
-.topic-create-panel button.topic-create-panel__advanced-toggle:hover {
-  color: var(--accent);
-}
-
-.topic-create-preview,
-.topic-create-failure {
-  display: grid;
-  gap: 2px;
-  padding: 6px;
-  border: 1px solid var(--border);
-}
-
-.topic-create-preview {
-  color: var(--text-muted);
-}
-
-.topic-create-failure {
-  border-color: var(--status-error);
-  color: var(--status-error);
-}
-
-.topic-create-panel__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  justify-content: flex-end;
 }
 
 .topic-search {

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -81,6 +81,23 @@
   resize: vertical;
 }
 
+.topic-create-panel__context {
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.topic-create-panel button.topic-create-panel__advanced-toggle {
+  justify-self: start;
+  padding: 1px 6px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+}
+
+.topic-create-panel button.topic-create-panel__advanced-toggle:hover {
+  color: var(--accent);
+}
+
 .topic-create-preview,
 .topic-create-failure {
   display: grid;

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -18,38 +18,27 @@ import {
 } from 'lucide-react';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import {
-  buildWorkspaceTopicLaunchPreview,
   resolveTopicActiveContext,
   type WorkspaceTopic,
-  type WorkspaceTopicCreateInput,
-  type WorkspaceTopicLaunchIntent,
-  type WorkspaceTopicTemplateKind,
   type WorkspaceTopicSearchResult,
 } from '../../../shared/workspace-topics.js';
 import {
-  createWorkspaceTopicRoomAndMaybeLaunch,
   fetchHubNodes,
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
-  launchWorkspaceTopicRoom,
   restoreWorkspaceTopic,
   searchWorkspaceTopics,
-  type CreateSessionBody,
   sendSessionInput,
-  type WorkspaceTopicLaunchFailure,
-  type WorkspaceTopicRoomCreateResult,
 } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
-import { taskRefFromDraft } from '../lib/topic-task-ref.js';
+import { openTopicTaskRoom } from '../lib/topic-task-room.js';
 import type { SessionSummary } from '../lib/types.js';
 import { formatRelativeTimeCompact } from '../lib/utils.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useToastStore } from '../lib/stores/toasts.js';
 import { useIaWorkspacesQuery } from '../lib/hooks/use-ia-workspaces.js';
-import { useConfigStore } from '../lib/stores/config.js';
 import { durabilityDisabledReason } from '../lib/session-durability.js';
-import { resolveSessionByKey } from '../lib/session-keys.js';
 import {
   buildTopicNavModel,
   formatTaskRefLabel,
@@ -1279,455 +1268,6 @@ function topicEmptyStateText(input: {
   return `no topic matches for “${input.searchQuery.trim()}”`;
 }
 
-type TopicRoomDraft = {
-  title: string;
-  prompt: string;
-  taskRef: string;
-  providerId: string;
-  agentId: string;
-  nodeId: string;
-  repoPath: string;
-  worktreePath: string;
-  cwd: string;
-  templateKind: WorkspaceTopicTemplateKind;
-};
-
-const TOPIC_ROOM_DRAFT_EMPTY: TopicRoomDraft = {
-  title: '',
-  prompt: '',
-  taskRef: '',
-  providerId: '',
-  agentId: '',
-  nodeId: '',
-  repoPath: '',
-  worktreePath: '',
-  cwd: '',
-  templateKind: 'agent-task',
-};
-
-const TOPIC_ROOM_TEMPLATE_OPTIONS: Array<{
-  value: WorkspaceTopicTemplateKind;
-  label: string;
-}> = [
-  { value: 'agent-task', label: 'agent task' },
-  { value: 'terminal-task', label: 'terminal task' },
-  { value: 'note', label: 'note / room only' },
-];
-
-const FALLBACK_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
-
-function compactString(value: string | null | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function uniqueStrings(values: Array<string | null | undefined>): string[] {
-  return Array.from(
-    new Set(values.map((value) => compactString(value)).filter(Boolean))
-  ) as string[];
-}
-
-/**
- * #1058: codex-style topic creation — the first message doubles as the room
- * title unless the operator overrides it in the advanced section.
- */
-function deriveTopicTitleFromPrompt(prompt: string): string {
-  const firstLine = prompt.trim().split('\n')[0] ?? '';
-  const collapsed = firstLine.replace(/\s+/g, ' ').trim();
-  if (!collapsed) return '';
-  // Code-point-aware truncation so a trailing emoji is not split in half.
-  const points = Array.from(collapsed);
-  return points.length > 60 ? `${points.slice(0, 59).join('')}…` : collapsed;
-}
-
-/** Title used for create/launch: explicit override wins, else the message. */
-function effectiveDraftTitle(draft: Pick<TopicRoomDraft, 'title' | 'prompt'>) {
-  return draft.title.trim() || deriveTopicTitleFromPrompt(draft.prompt);
-}
-
-function launchSubmitLabel(input: {
-  submittingIntent?: WorkspaceTopicLaunchIntent | null | undefined;
-  launchDisabled: boolean;
-  launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
-}): string {
-  if (input.submittingIntent === 'create-and-launch') return 'launching…';
-  if (input.launchDisabled) return 'note is create-only';
-  if (!input.launchFailure) return 'start';
-  return input.launchFailure.stage === 'session'
-    ? 'retry launch'
-    : 'retry create + launch';
-}
-
-function launchTypeForTemplate(
-  templateKind: WorkspaceTopicTemplateKind
-): CreateSessionBody['type'] | null {
-  if (templateKind === 'terminal-task') return 'terminal';
-  if (templateKind === 'agent-task') return 'agent';
-  return null;
-}
-
-function buildTopicRoomLaunchBody(
-  create: WorkspaceTopicCreateInput,
-  templateKind: WorkspaceTopicTemplateKind
-): Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'> | null {
-  const type = launchTypeForTemplate(templateKind);
-  if (!type) return null;
-  const routing = create.routingDefaults ?? {};
-  return {
-    type,
-    mode: 'pty',
-    ...(type === 'agent' && routing.providerId
-      ? { agent: routing.providerId }
-      : {}),
-    ...(routing.nodeId ? { nodeId: routing.nodeId } : {}),
-    ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
-    ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
-    ...(routing.cwd ? { cwd: routing.cwd } : {}),
-    controlMode: type === 'agent' ? 'agent-driven' : 'human-driven',
-  };
-}
-
-function buildTopicRoomCreateInput(input: {
-  draft: TopicRoomDraft;
-  workspaceId: string | null;
-  defaultProviderId: string;
-  defaultNodeId?: string | undefined;
-  defaultRepoPath?: string | undefined;
-  defaultWorktreePath?: string | undefined;
-  defaultCwd?: string | undefined;
-  taskRef: ReturnType<typeof taskRefFromDraft>;
-}): WorkspaceTopicCreateInput {
-  const providerId =
-    compactString(input.draft.providerId) ?? input.defaultProviderId;
-  const agentId = compactString(input.draft.agentId);
-  const nodeId = compactString(input.draft.nodeId) ?? input.defaultNodeId;
-  const repoPath = compactString(input.draft.repoPath) ?? input.defaultRepoPath;
-  const worktreePath =
-    compactString(input.draft.worktreePath) ?? input.defaultWorktreePath;
-  const cwd = compactString(input.draft.cwd) ?? input.defaultCwd;
-  const prompt = input.draft.prompt.trim();
-
-  return {
-    workspaceId: input.workspaceId ?? 'workspace:local',
-    title: input.draft.title.trim() || 'Untitled task room',
-    ...(prompt ? { description: prompt.slice(0, 240) } : {}),
-    promptDefaults: {
-      ...(prompt ? { starterPrompt: prompt } : {}),
-    },
-    routingDefaults: {
-      ...(providerId ? { providerId } : {}),
-      ...(agentId ? { agentId } : {}),
-      ...(nodeId ? { nodeId } : {}),
-      ...(repoPath ? { repoPath } : {}),
-      ...(worktreePath ? { worktreePath } : {}),
-      ...(cwd ? { cwd } : {}),
-    },
-    linkedRefs: {
-      ...(input.taskRef ? { taskRefs: [input.taskRef] } : {}),
-    },
-  };
-}
-
-interface TopicRoomCreatePanelProps {
-  open: boolean;
-  draft: TopicRoomDraft;
-  previewCreate: WorkspaceTopicCreateInput;
-  providerOptions: string[];
-  nodes: TopicNavNode[];
-  nodeOptions: Array<{ value: string; label: string }>;
-  repoPathOptions: string[];
-  worktreePathOptions: string[];
-  cwdOptions: string[];
-  launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
-  submittingIntent?: WorkspaceTopicLaunchIntent | null | undefined;
-  onDraftChange: (patch: Partial<TopicRoomDraft>) => void;
-  onSubmit: (intent: WorkspaceTopicLaunchIntent) => void;
-  onCancel: () => void;
-}
-
-function TopicRoomCreatePanel({
-  open,
-  draft,
-  previewCreate,
-  providerOptions,
-  nodes,
-  nodeOptions,
-  repoPathOptions,
-  worktreePathOptions,
-  cwdOptions,
-  launchFailure,
-  submittingIntent,
-  onDraftChange,
-  onSubmit,
-  onCancel,
-}: TopicRoomCreatePanelProps) {
-  const preview = useMemo(
-    () =>
-      buildWorkspaceTopicLaunchPreview({
-        create: previewCreate,
-        intent:
-          draft.templateKind === 'note' ? 'create-only' : 'create-and-launch',
-        templateKind: draft.templateKind,
-        launchOverrides: {
-          type: launchTypeForTemplate(draft.templateKind) ?? 'agent',
-          mode: 'pty',
-          agent: previewCreate.routingDefaults?.providerId,
-          nodeId: previewCreate.routingDefaults?.nodeId,
-          repoPath: previewCreate.routingDefaults?.repoPath,
-          worktreePath: previewCreate.routingDefaults?.worktreePath,
-          cwd: previewCreate.routingDefaults?.cwd,
-        },
-      }),
-    [draft.templateKind, previewCreate]
-  );
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  if (!open) return null;
-  const launchDisabled = draft.templateKind === 'note';
-  const disabled = !effectiveDraftTitle(draft) || Boolean(submittingIntent);
-  // #1103: never render a raw node id — resolve through the roster or fall
-  // back to a generic label.
-  const routedNodeId = previewCreate.routingDefaults?.nodeId;
-  const friendlyNodeLabel = routedNodeId
-    ? nodes.find((node) => node.nodeId === routedNodeId)?.displayName ||
-      'remote node'
-    : preview.nodeLabel;
-  return (
-    <form
-      className="topic-create-panel"
-      aria-label="new topic"
-      onSubmit={(event: FormEvent) => {
-        event.preventDefault();
-        if (!disabled && !launchDisabled) onSubmit('create-and-launch');
-      }}
-    >
-      <div className="topic-create-panel__title">new topic</div>
-      <textarea
-        value={draft.prompt}
-        onChange={(event) => onDraftChange({ prompt: event.target.value })}
-        onKeyDown={(event) => {
-          if (
-            event.key === 'Enter' &&
-            !event.shiftKey &&
-            !event.nativeEvent.isComposing &&
-            !disabled &&
-            !launchDisabled
-          ) {
-            event.preventDefault();
-            onSubmit('create-and-launch');
-          }
-        }}
-        placeholder="what should the agent do?"
-        rows={3}
-        aria-label="first message"
-        autoFocus
-      />
-      <div className="topic-create-panel__context">
-        {preview.providerLabel} · {friendlyNodeLabel} · {preview.cwdLabel}
-      </div>
-      <button
-        type="button"
-        className="topic-create-panel__advanced-toggle"
-        aria-expanded={advancedOpen}
-        onClick={() => setAdvancedOpen((prev) => !prev)}
-      >
-        <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
-        advanced
-      </button>
-      {advancedOpen ? (
-        <>
-          <label>
-            <span>title</span>
-            <input
-              value={draft.title}
-              onChange={(event) => onDraftChange({ title: event.target.value })}
-              placeholder={
-                deriveTopicTitleFromPrompt(draft.prompt) || 'auto from message'
-              }
-            />
-          </label>
-          <label>
-            <span>task ref</span>
-            <input
-              value={draft.taskRef}
-              onChange={(event) =>
-                onDraftChange({ taskRef: event.target.value })
-              }
-              placeholder="github issue number or URL"
-            />
-          </label>
-          <label>
-            <span>provider</span>
-            <input
-              list="topic-room-provider-options"
-              value={draft.providerId}
-              onChange={(event) =>
-                onDraftChange({ providerId: event.target.value })
-              }
-              placeholder={
-                previewCreate.routingDefaults?.providerId ?? 'default provider'
-              }
-            />
-            <datalist id="topic-room-provider-options">
-              {providerOptions.map((providerId) => (
-                <option key={providerId} value={providerId} />
-              ))}
-            </datalist>
-          </label>
-          <label>
-            <span>agent id</span>
-            <input
-              value={draft.agentId}
-              onChange={(event) =>
-                onDraftChange({ agentId: event.target.value })
-              }
-              placeholder="optional agent identity"
-            />
-          </label>
-          <label>
-            <span>template kind</span>
-            <select
-              value={draft.templateKind}
-              onChange={(event) =>
-                onDraftChange({
-                  templateKind: event.target
-                    .value as WorkspaceTopicTemplateKind,
-                })
-              }
-            >
-              {TOPIC_ROOM_TEMPLATE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            <span>node</span>
-            <input
-              list="topic-room-node-options"
-              value={draft.nodeId}
-              onChange={(event) =>
-                onDraftChange({ nodeId: event.target.value })
-              }
-              placeholder={
-                previewCreate.routingDefaults?.nodeId ?? 'local/default node'
-              }
-            />
-            <datalist id="topic-room-node-options">
-              {nodeOptions.map((node) => (
-                <option
-                  key={node.value}
-                  value={node.value}
-                  label={node.label}
-                />
-              ))}
-            </datalist>
-          </label>
-          <label>
-            <span>repo</span>
-            <input
-              list="topic-room-repo-options"
-              value={draft.repoPath}
-              onChange={(event) =>
-                onDraftChange({ repoPath: event.target.value })
-              }
-              placeholder={
-                previewCreate.routingDefaults?.repoPath ?? 'default repo'
-              }
-            />
-            <datalist id="topic-room-repo-options">
-              {repoPathOptions.map((repoPath) => (
-                <option key={repoPath} value={repoPath} />
-              ))}
-            </datalist>
-          </label>
-          <label>
-            <span>worktree</span>
-            <input
-              list="topic-room-worktree-options"
-              value={draft.worktreePath}
-              onChange={(event) =>
-                onDraftChange({ worktreePath: event.target.value })
-              }
-              placeholder={
-                previewCreate.routingDefaults?.worktreePath ??
-                'default worktree'
-              }
-            />
-            <datalist id="topic-room-worktree-options">
-              {worktreePathOptions.map((worktreePath) => (
-                <option key={worktreePath} value={worktreePath} />
-              ))}
-            </datalist>
-          </label>
-          <label>
-            <span>cwd</span>
-            <input
-              list="topic-room-cwd-options"
-              value={draft.cwd}
-              onChange={(event) => onDraftChange({ cwd: event.target.value })}
-              placeholder={previewCreate.routingDefaults?.cwd ?? 'default cwd'}
-            />
-            <datalist id="topic-room-cwd-options">
-              {cwdOptions.map((cwd) => (
-                <option key={cwd} value={cwd} />
-              ))}
-            </datalist>
-          </label>
-          <div className="topic-create-preview" aria-label="launch preview">
-            <div>template: {preview.templateKind}</div>
-            <div>provider: {preview.providerLabel}</div>
-            <div>
-              agent:{' '}
-              {previewCreate.routingDefaults?.agentId ??
-                previewCreate.routingDefaults?.providerId ??
-                'default agent'}
-            </div>
-            <div>mode: {preview.modeLabel}</div>
-            <div>node: {friendlyNodeLabel}</div>
-            <div>cwd: {preview.cwdLabel}</div>
-            <div>prompt: {preview.promptSources.join(', ')}</div>
-            <div>tasks: {preview.taskRefs.join(', ')}</div>
-            <div>side effects: {preview.sideEffects.join(' · ')}</div>
-          </div>
-        </>
-      ) : null}
-      {launchFailure ? (
-        <div className="topic-create-failure" role="alert">
-          {launchFailure.stage === 'session'
-            ? 'launch failed after room creation'
-            : 'room creation failed'}{' '}
-          ({launchFailure.stage}): {launchFailure.message}
-        </div>
-      ) : null}
-      <div className="topic-create-panel__actions">
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={Boolean(submittingIntent)}
-        >
-          cancel
-        </button>
-        {advancedOpen || launchDisabled ? (
-          <button
-            type="button"
-            disabled={disabled}
-            onClick={() => onSubmit('create-only')}
-          >
-            {submittingIntent === 'create-only' ? 'creating…' : 'create only'}
-          </button>
-        ) : null}
-        <button type="submit" disabled={disabled || launchDisabled}>
-          {launchSubmitLabel({
-            submittingIntent,
-            launchDisabled,
-            launchFailure,
-          })}
-        </button>
-      </div>
-    </form>
-  );
-}
 
 /** A workspace bucket of mobile topic rows, kept in attention order. */
 interface MobileTopicGroup {
@@ -2030,7 +1570,6 @@ export function TopicSidebarView({
   onSearchClear,
   onSelectSession,
   onSendInput = sendSessionInput,
-  createPanel,
   onCreateTaskRoom,
   workspaces = EMPTY_WORKSPACES,
   nodes,
@@ -2071,7 +1610,6 @@ export function TopicSidebarView({
   onSearchClear?: (() => void) | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
   onSendInput?: TopicSendInput | undefined;
-  createPanel?: ReactNode;
   onCreateTaskRoom?: (() => void) | undefined;
 }) {
   const model = useMemo(
@@ -2247,7 +1785,6 @@ export function TopicSidebarView({
             : undefined
         }
       />
-      {createPanel}
       <TopicSearchPanel
         model={model}
         searchQuery={searchQuery}
@@ -2298,30 +1835,11 @@ export function TopicSidebarShell({
 }) {
   const queryClient = useQueryClient();
   const sessions = useSessionsStore((s) => s.sessions);
-  const activeSessionId = useSessionsStore((s) => s.activeSessionId);
-  const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
-  const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
-  const defaultAgent = useConfigStore((s) => s.defaultAgent);
-  const frameworks = useConfigStore((s) => s.frameworks);
-  const activeSession = useMemo(
-    () => resolveSessionByKey(sessions, activeSessionId),
-    [activeSessionId, sessions]
-  );
   const [searchQuery, setSearchQuery] = useState('');
   const [searchScope, setSearchScope] = useState<'all' | 'workspace'>('all');
   const scopedWorkspaceId =
     searchScope === 'workspace' ? activeWorkspaceId : null;
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createDraft, setCreateDraft] = useState<TopicRoomDraft>(
-    TOPIC_ROOM_DRAFT_EMPTY
-  );
-  const [submittingIntent, setSubmittingIntent] =
-    useState<WorkspaceTopicLaunchIntent | null>(null);
-  const [launchFailure, setLaunchFailure] =
-    useState<WorkspaceTopicLaunchFailure | null>(null);
-  const [createdRoom, setCreatedRoom] =
-    useState<WorkspaceTopicRoomCreateResult | null>(null);
   const normalizedSearchQuery = searchQuery.trim();
   const [showArchived, setShowArchived] = useState(false);
   const topicsQuery = useQuery({
@@ -2377,15 +1895,6 @@ export function TopicSidebarShell({
     queryFn: fetchHubNodes,
     staleTime: 60_000,
   });
-  useEffect(() => {
-    const openCreate = () => {
-      setCreateOpen(true);
-      setLaunchFailure(null);
-    };
-    window.addEventListener('relay:open-topic-task-room', openCreate);
-    return () =>
-      window.removeEventListener('relay:open-topic-task-room', openCreate);
-  }, []);
   const searchActive = normalizedSearchQuery.length > 0;
   const searchData = topicSearchQuery.data;
   const searchResults = useMemo(
@@ -2413,196 +1922,6 @@ export function TopicSidebarShell({
       })),
     [nodesQuery.data]
   );
-  const effectiveCreateTitle = effectiveDraftTitle(createDraft);
-  const taskRef = taskRefFromDraft(createDraft.taskRef, effectiveCreateTitle);
-  const defaultRepoPath =
-    activeSession?.repoPath ?? activeRepoPath ?? undefined;
-  const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
-  const defaultCwd =
-    activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
-  const providerOptions = useMemo(
-    () =>
-      uniqueStrings([
-        defaultAgent,
-        ...frameworks.map((framework) => framework.id),
-        ...FALLBACK_PROVIDER_IDS,
-      ]),
-    [defaultAgent, frameworks]
-  );
-  const nodeOptions = useMemo(
-    () =>
-      (nodesQuery.data ?? []).map((node) => ({
-        value: node.nodeId,
-        label: node.displayName
-          ? `${node.displayName} · ${node.status}`
-          : node.status,
-      })),
-    [nodesQuery.data]
-  );
-  const repoPathOptions = useMemo(
-    () =>
-      uniqueStrings([
-        defaultRepoPath,
-        ...sessions.map((session) => session.repoPath),
-      ]),
-    [defaultRepoPath, sessions]
-  );
-  const worktreePathOptions = useMemo(
-    () =>
-      uniqueStrings([
-        defaultWorktreePath,
-        ...sessions.map((session) => session.worktreePath),
-      ]),
-    [defaultWorktreePath, sessions]
-  );
-  const cwdOptions = useMemo(
-    () =>
-      uniqueStrings([defaultCwd, ...sessions.map((session) => session.cwd)]),
-    [defaultCwd, sessions]
-  );
-  const previewCreate = useMemo<WorkspaceTopicCreateInput>(
-    () =>
-      buildTopicRoomCreateInput({
-        draft: { ...createDraft, title: effectiveCreateTitle },
-        workspaceId: activeWorkspaceId,
-        defaultProviderId: defaultAgent,
-        defaultNodeId: activeSession?.nodeId,
-        defaultRepoPath,
-        defaultWorktreePath,
-        defaultCwd,
-        taskRef,
-      }),
-    [
-      activeSession?.nodeId,
-      activeWorkspaceId,
-      createDraft,
-      defaultAgent,
-      defaultCwd,
-      defaultRepoPath,
-      defaultWorktreePath,
-      effectiveCreateTitle,
-      taskRef,
-    ]
-  );
-
-  const handleCreateSubmit = useCallback(
-    async (intent: WorkspaceTopicLaunchIntent) => {
-      if (!effectiveCreateTitle) return;
-      const launch = buildTopicRoomLaunchBody(
-        previewCreate,
-        createDraft.templateKind
-      );
-      const submitIntent =
-        intent === 'create-and-launch' && launch
-          ? 'create-and-launch'
-          : 'create-only';
-      setSubmittingIntent(submitIntent);
-      setLaunchFailure(null);
-      try {
-        if (submitIntent === 'create-and-launch' && createdRoom && launch) {
-          const result = await launchWorkspaceTopicRoom({
-            room: createdRoom,
-            launch,
-          });
-          if (result.status === 'launch_failed') {
-            setLaunchFailure(result.failure);
-            return;
-          }
-          await useSessionsStore.getState().refreshAll();
-          setActiveSessionId(result.session.id);
-          onSelectSession?.(result.session.id);
-          setCreateOpen(false);
-          setCreatedRoom(null);
-          setCreateDraft(TOPIC_ROOM_DRAFT_EMPTY);
-          return;
-        }
-        const result = await createWorkspaceTopicRoomAndMaybeLaunch({
-          room: {
-            topic: previewCreate,
-            ...(taskRef ? { taskRef } : {}),
-          },
-          ...(submitIntent === 'create-and-launch' && launch
-            ? {
-                launch,
-              }
-            : {}),
-        });
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: ['workspace-topics'] }),
-          queryClient.invalidateQueries({ queryKey: ['workspace-surfaces'] }),
-        ]);
-        if (result.status === 'launch_failed') {
-          setLaunchFailure(result.failure);
-          setCreatedRoom({
-            topic: result.topic,
-            workContext: result.workContext,
-          });
-          return;
-        }
-        if (result.status === 'launched') {
-          await useSessionsStore.getState().refreshAll();
-          setActiveSessionId(result.session.id);
-          onSelectSession?.(result.session.id);
-        }
-        setCreateOpen(false);
-        setCreatedRoom(null);
-        setCreateDraft(TOPIC_ROOM_DRAFT_EMPTY);
-      } catch (error) {
-        const failure = error as WorkspaceTopicLaunchFailure;
-        setLaunchFailure({
-          stage: failure.stage ?? 'topic',
-          message:
-            typeof failure.message === 'string'
-              ? failure.message
-              : error instanceof Error
-                ? error.message
-                : String(error),
-          retryable: failure.retryable ?? false,
-          ...(failure.code ? { code: failure.code } : {}),
-          ...(failure.status ? { status: failure.status } : {}),
-        });
-      } finally {
-        setSubmittingIntent(null);
-      }
-    },
-    [
-      effectiveCreateTitle,
-      createDraft.templateKind,
-      createdRoom,
-      onSelectSession,
-      previewCreate,
-      queryClient,
-      setActiveSessionId,
-      taskRef,
-    ]
-  );
-
-  const createPanel = (
-    <TopicRoomCreatePanel
-      open={createOpen}
-      draft={createDraft}
-      previewCreate={previewCreate}
-      providerOptions={providerOptions}
-      nodes={viewNodes}
-      nodeOptions={nodeOptions}
-      repoPathOptions={repoPathOptions}
-      worktreePathOptions={worktreePathOptions}
-      cwdOptions={cwdOptions}
-      launchFailure={launchFailure}
-      submittingIntent={submittingIntent}
-      onDraftChange={(patch) => {
-        setCreateDraft((current) => ({ ...current, ...patch }));
-        setCreatedRoom(null);
-        setLaunchFailure(null);
-      }}
-      onSubmit={(intent) => void handleCreateSubmit(intent)}
-      onCancel={() => {
-        setCreateOpen(false);
-        setLaunchFailure(null);
-      }}
-    />
-  );
-
   return (
     <TopicSidebarView
       topics={viewTopics}
@@ -2642,11 +1961,7 @@ export function TopicSidebarShell({
       onSearchRetry={() => void topicSearchQuery.refetch()}
       onSearchClear={() => setSearchQuery('')}
       onSelectSession={onSelectSession}
-      createPanel={createPanel}
-      onCreateTaskRoom={() => {
-        setCreateOpen(true);
-        setLaunchFailure(null);
-      }}
+      onCreateTaskRoom={openTopicTaskRoom}
     />
   );
 }

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1327,6 +1327,37 @@ function uniqueStrings(values: Array<string | null | undefined>): string[] {
   ) as string[];
 }
 
+/**
+ * #1058: codex-style topic creation — the first message doubles as the room
+ * title unless the operator overrides it in the advanced section.
+ */
+function deriveTopicTitleFromPrompt(prompt: string): string {
+  const firstLine = prompt.trim().split('\n')[0] ?? '';
+  const collapsed = firstLine.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '';
+  // Code-point-aware truncation so a trailing emoji is not split in half.
+  const points = Array.from(collapsed);
+  return points.length > 60 ? `${points.slice(0, 59).join('')}…` : collapsed;
+}
+
+/** Title used for create/launch: explicit override wins, else the message. */
+function effectiveDraftTitle(draft: Pick<TopicRoomDraft, 'title' | 'prompt'>) {
+  return draft.title.trim() || deriveTopicTitleFromPrompt(draft.prompt);
+}
+
+function launchSubmitLabel(input: {
+  submittingIntent?: WorkspaceTopicLaunchIntent | null | undefined;
+  launchDisabled: boolean;
+  launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
+}): string {
+  if (input.submittingIntent === 'create-and-launch') return 'launching…';
+  if (input.launchDisabled) return 'note is create-only';
+  if (!input.launchFailure) return 'start';
+  return input.launchFailure.stage === 'session'
+    ? 'retry launch'
+    : 'retry create + launch';
+}
+
 function launchTypeForTemplate(
   templateKind: WorkspaceTopicTemplateKind
 ): CreateSessionBody['type'] | null {
@@ -1402,6 +1433,7 @@ interface TopicRoomCreatePanelProps {
   draft: TopicRoomDraft;
   previewCreate: WorkspaceTopicCreateInput;
   providerOptions: string[];
+  nodes: TopicNavNode[];
   nodeOptions: Array<{ value: string; label: string }>;
   repoPathOptions: string[];
   worktreePathOptions: string[];
@@ -1418,6 +1450,7 @@ function TopicRoomCreatePanel({
   draft,
   previewCreate,
   providerOptions,
+  nodes,
   nodeOptions,
   repoPathOptions,
   worktreePathOptions,
@@ -1447,167 +1480,218 @@ function TopicRoomCreatePanel({
       }),
     [draft.templateKind, previewCreate]
   );
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   if (!open) return null;
   const launchDisabled = draft.templateKind === 'note';
-  const disabled = !draft.title.trim() || Boolean(submittingIntent);
+  const disabled = !effectiveDraftTitle(draft) || Boolean(submittingIntent);
+  // #1103: never render a raw node id — resolve through the roster or fall
+  // back to a generic label.
+  const routedNodeId = previewCreate.routingDefaults?.nodeId;
+  const friendlyNodeLabel = routedNodeId
+    ? nodes.find((node) => node.nodeId === routedNodeId)?.displayName ||
+      'remote node'
+    : preview.nodeLabel;
   return (
     <form
       className="topic-create-panel"
-      aria-label="create task room"
+      aria-label="new topic"
       onSubmit={(event: FormEvent) => {
         event.preventDefault();
         if (!disabled && !launchDisabled) onSubmit('create-and-launch');
       }}
     >
-      <div className="topic-create-panel__title">new task room</div>
-      <label>
-        <span>title</span>
-        <input
-          value={draft.title}
-          onChange={(event) => onDraftChange({ title: event.target.value })}
-          placeholder="issue title or task"
-        />
-      </label>
-      <label>
-        <span>starter prompt</span>
-        <textarea
-          value={draft.prompt}
-          onChange={(event) => onDraftChange({ prompt: event.target.value })}
-          placeholder="what should the agent start with?"
-          rows={3}
-        />
-      </label>
-      <label>
-        <span>task ref</span>
-        <input
-          value={draft.taskRef}
-          onChange={(event) => onDraftChange({ taskRef: event.target.value })}
-          placeholder="github issue number or URL"
-        />
-      </label>
-      <label>
-        <span>provider</span>
-        <input
-          list="topic-room-provider-options"
-          value={draft.providerId}
-          onChange={(event) =>
-            onDraftChange({ providerId: event.target.value })
+      <div className="topic-create-panel__title">new topic</div>
+      <textarea
+        value={draft.prompt}
+        onChange={(event) => onDraftChange({ prompt: event.target.value })}
+        onKeyDown={(event) => {
+          if (
+            event.key === 'Enter' &&
+            !event.shiftKey &&
+            !event.nativeEvent.isComposing &&
+            !disabled &&
+            !launchDisabled
+          ) {
+            event.preventDefault();
+            onSubmit('create-and-launch');
           }
-          placeholder={
-            previewCreate.routingDefaults?.providerId ?? 'default provider'
-          }
-        />
-        <datalist id="topic-room-provider-options">
-          {providerOptions.map((providerId) => (
-            <option key={providerId} value={providerId} />
-          ))}
-        </datalist>
-      </label>
-      <label>
-        <span>agent id</span>
-        <input
-          value={draft.agentId}
-          onChange={(event) => onDraftChange({ agentId: event.target.value })}
-          placeholder="optional agent identity"
-        />
-      </label>
-      <label>
-        <span>template kind</span>
-        <select
-          value={draft.templateKind}
-          onChange={(event) =>
-            onDraftChange({
-              templateKind: event.target.value as WorkspaceTopicTemplateKind,
-            })
-          }
-        >
-          {TOPIC_ROOM_TEMPLATE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label>
-        <span>node</span>
-        <input
-          list="topic-room-node-options"
-          value={draft.nodeId}
-          onChange={(event) => onDraftChange({ nodeId: event.target.value })}
-          placeholder={
-            previewCreate.routingDefaults?.nodeId ?? 'local/default node'
-          }
-        />
-        <datalist id="topic-room-node-options">
-          {nodeOptions.map((node) => (
-            <option key={node.value} value={node.value} label={node.label} />
-          ))}
-        </datalist>
-      </label>
-      <label>
-        <span>repo</span>
-        <input
-          list="topic-room-repo-options"
-          value={draft.repoPath}
-          onChange={(event) => onDraftChange({ repoPath: event.target.value })}
-          placeholder={
-            previewCreate.routingDefaults?.repoPath ?? 'default repo'
-          }
-        />
-        <datalist id="topic-room-repo-options">
-          {repoPathOptions.map((repoPath) => (
-            <option key={repoPath} value={repoPath} />
-          ))}
-        </datalist>
-      </label>
-      <label>
-        <span>worktree</span>
-        <input
-          list="topic-room-worktree-options"
-          value={draft.worktreePath}
-          onChange={(event) =>
-            onDraftChange({ worktreePath: event.target.value })
-          }
-          placeholder={
-            previewCreate.routingDefaults?.worktreePath ?? 'default worktree'
-          }
-        />
-        <datalist id="topic-room-worktree-options">
-          {worktreePathOptions.map((worktreePath) => (
-            <option key={worktreePath} value={worktreePath} />
-          ))}
-        </datalist>
-      </label>
-      <label>
-        <span>cwd</span>
-        <input
-          list="topic-room-cwd-options"
-          value={draft.cwd}
-          onChange={(event) => onDraftChange({ cwd: event.target.value })}
-          placeholder={previewCreate.routingDefaults?.cwd ?? 'default cwd'}
-        />
-        <datalist id="topic-room-cwd-options">
-          {cwdOptions.map((cwd) => (
-            <option key={cwd} value={cwd} />
-          ))}
-        </datalist>
-      </label>
-      <div className="topic-create-preview" aria-label="launch preview">
-        <div>template: {preview.templateKind}</div>
-        <div>provider: {preview.providerLabel}</div>
-        <div>
-          agent:{' '}
-          {previewCreate.routingDefaults?.agentId ??
-            previewCreate.routingDefaults?.providerId ??
-            'default agent'}
-        </div>
-        <div>mode: {preview.modeLabel}</div>
-        <div>node: {preview.nodeLabel}</div>
-        <div>cwd: {preview.cwdLabel}</div>
-        <div>prompt: {preview.promptSources.join(', ')}</div>
-        <div>tasks: {preview.taskRefs.join(', ')}</div>
-        <div>side effects: {preview.sideEffects.join(' · ')}</div>
+        }}
+        placeholder="what should the agent do?"
+        rows={3}
+        aria-label="first message"
+        autoFocus
+      />
+      <div className="topic-create-panel__context">
+        {preview.providerLabel} · {friendlyNodeLabel} · {preview.cwdLabel}
       </div>
+      <button
+        type="button"
+        className="topic-create-panel__advanced-toggle"
+        aria-expanded={advancedOpen}
+        onClick={() => setAdvancedOpen((prev) => !prev)}
+      >
+        <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
+        advanced
+      </button>
+      {advancedOpen ? (
+        <>
+          <label>
+            <span>title</span>
+            <input
+              value={draft.title}
+              onChange={(event) => onDraftChange({ title: event.target.value })}
+              placeholder={
+                deriveTopicTitleFromPrompt(draft.prompt) || 'auto from message'
+              }
+            />
+          </label>
+          <label>
+            <span>task ref</span>
+            <input
+              value={draft.taskRef}
+              onChange={(event) =>
+                onDraftChange({ taskRef: event.target.value })
+              }
+              placeholder="github issue number or URL"
+            />
+          </label>
+          <label>
+            <span>provider</span>
+            <input
+              list="topic-room-provider-options"
+              value={draft.providerId}
+              onChange={(event) =>
+                onDraftChange({ providerId: event.target.value })
+              }
+              placeholder={
+                previewCreate.routingDefaults?.providerId ?? 'default provider'
+              }
+            />
+            <datalist id="topic-room-provider-options">
+              {providerOptions.map((providerId) => (
+                <option key={providerId} value={providerId} />
+              ))}
+            </datalist>
+          </label>
+          <label>
+            <span>agent id</span>
+            <input
+              value={draft.agentId}
+              onChange={(event) =>
+                onDraftChange({ agentId: event.target.value })
+              }
+              placeholder="optional agent identity"
+            />
+          </label>
+          <label>
+            <span>template kind</span>
+            <select
+              value={draft.templateKind}
+              onChange={(event) =>
+                onDraftChange({
+                  templateKind: event.target
+                    .value as WorkspaceTopicTemplateKind,
+                })
+              }
+            >
+              {TOPIC_ROOM_TEMPLATE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>node</span>
+            <input
+              list="topic-room-node-options"
+              value={draft.nodeId}
+              onChange={(event) =>
+                onDraftChange({ nodeId: event.target.value })
+              }
+              placeholder={
+                previewCreate.routingDefaults?.nodeId ?? 'local/default node'
+              }
+            />
+            <datalist id="topic-room-node-options">
+              {nodeOptions.map((node) => (
+                <option
+                  key={node.value}
+                  value={node.value}
+                  label={node.label}
+                />
+              ))}
+            </datalist>
+          </label>
+          <label>
+            <span>repo</span>
+            <input
+              list="topic-room-repo-options"
+              value={draft.repoPath}
+              onChange={(event) =>
+                onDraftChange({ repoPath: event.target.value })
+              }
+              placeholder={
+                previewCreate.routingDefaults?.repoPath ?? 'default repo'
+              }
+            />
+            <datalist id="topic-room-repo-options">
+              {repoPathOptions.map((repoPath) => (
+                <option key={repoPath} value={repoPath} />
+              ))}
+            </datalist>
+          </label>
+          <label>
+            <span>worktree</span>
+            <input
+              list="topic-room-worktree-options"
+              value={draft.worktreePath}
+              onChange={(event) =>
+                onDraftChange({ worktreePath: event.target.value })
+              }
+              placeholder={
+                previewCreate.routingDefaults?.worktreePath ??
+                'default worktree'
+              }
+            />
+            <datalist id="topic-room-worktree-options">
+              {worktreePathOptions.map((worktreePath) => (
+                <option key={worktreePath} value={worktreePath} />
+              ))}
+            </datalist>
+          </label>
+          <label>
+            <span>cwd</span>
+            <input
+              list="topic-room-cwd-options"
+              value={draft.cwd}
+              onChange={(event) => onDraftChange({ cwd: event.target.value })}
+              placeholder={previewCreate.routingDefaults?.cwd ?? 'default cwd'}
+            />
+            <datalist id="topic-room-cwd-options">
+              {cwdOptions.map((cwd) => (
+                <option key={cwd} value={cwd} />
+              ))}
+            </datalist>
+          </label>
+          <div className="topic-create-preview" aria-label="launch preview">
+            <div>template: {preview.templateKind}</div>
+            <div>provider: {preview.providerLabel}</div>
+            <div>
+              agent:{' '}
+              {previewCreate.routingDefaults?.agentId ??
+                previewCreate.routingDefaults?.providerId ??
+                'default agent'}
+            </div>
+            <div>mode: {preview.modeLabel}</div>
+            <div>node: {friendlyNodeLabel}</div>
+            <div>cwd: {preview.cwdLabel}</div>
+            <div>prompt: {preview.promptSources.join(', ')}</div>
+            <div>tasks: {preview.taskRefs.join(', ')}</div>
+            <div>side effects: {preview.sideEffects.join(' · ')}</div>
+          </div>
+        </>
+      ) : null}
       {launchFailure ? (
         <div className="topic-create-failure" role="alert">
           {launchFailure.stage === 'session'
@@ -1624,23 +1708,21 @@ function TopicRoomCreatePanel({
         >
           cancel
         </button>
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={() => onSubmit('create-only')}
-        >
-          {submittingIntent === 'create-only' ? 'creating…' : 'create only'}
-        </button>
+        {advancedOpen || launchDisabled ? (
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onSubmit('create-only')}
+          >
+            {submittingIntent === 'create-only' ? 'creating…' : 'create only'}
+          </button>
+        ) : null}
         <button type="submit" disabled={disabled || launchDisabled}>
-          {submittingIntent === 'create-and-launch'
-            ? 'launching…'
-            : launchDisabled
-              ? 'note is create-only'
-              : launchFailure
-                ? launchFailure.stage === 'session'
-                  ? 'retry launch'
-                  : 'retry create + launch'
-                : 'create + launch'}
+          {launchSubmitLabel({
+            submittingIntent,
+            launchDisabled,
+            launchFailure,
+          })}
         </button>
       </div>
     </form>
@@ -2331,7 +2413,8 @@ export function TopicSidebarShell({
       })),
     [nodesQuery.data]
   );
-  const taskRef = taskRefFromDraft(createDraft.taskRef, createDraft.title);
+  const effectiveCreateTitle = effectiveDraftTitle(createDraft);
+  const taskRef = taskRefFromDraft(createDraft.taskRef, effectiveCreateTitle);
   const defaultRepoPath =
     activeSession?.repoPath ?? activeRepoPath ?? undefined;
   const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
@@ -2380,7 +2463,7 @@ export function TopicSidebarShell({
   const previewCreate = useMemo<WorkspaceTopicCreateInput>(
     () =>
       buildTopicRoomCreateInput({
-        draft: createDraft,
+        draft: { ...createDraft, title: effectiveCreateTitle },
         workspaceId: activeWorkspaceId,
         defaultProviderId: defaultAgent,
         defaultNodeId: activeSession?.nodeId,
@@ -2397,13 +2480,14 @@ export function TopicSidebarShell({
       defaultCwd,
       defaultRepoPath,
       defaultWorktreePath,
+      effectiveCreateTitle,
       taskRef,
     ]
   );
 
   const handleCreateSubmit = useCallback(
     async (intent: WorkspaceTopicLaunchIntent) => {
-      if (!createDraft.title.trim()) return;
+      if (!effectiveCreateTitle) return;
       const launch = buildTopicRoomLaunchBody(
         previewCreate,
         createDraft.templateKind
@@ -2482,7 +2566,7 @@ export function TopicSidebarShell({
       }
     },
     [
-      createDraft.title,
+      effectiveCreateTitle,
       createDraft.templateKind,
       createdRoom,
       onSelectSession,
@@ -2499,6 +2583,7 @@ export function TopicSidebarShell({
       draft={createDraft}
       previewCreate={previewCreate}
       providerOptions={providerOptions}
+      nodes={viewNodes}
       nodeOptions={nodeOptions}
       repoPathOptions={repoPathOptions}
       worktreePathOptions={worktreePathOptions}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1328,7 +1328,7 @@ function TopicMobileCockpit({
             disabled={!onCreateTaskRoom}
             title={
               onCreateTaskRoom
-                ? 'create a task room from workspace defaults'
+                ? 'start a new topic in the main pane'
                 : 'topic creation unavailable'
             }
             onClick={onCreateTaskRoom}

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type React from 'react';
 import { registerGlobal } from '../lib/actions/registry.js';
+import { openTopicTaskRoom } from '../lib/topic-task-room.js';
 import {
   registerContextual,
   unregisterContextual,
@@ -449,9 +450,10 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       { ...sessionStartOnRepo, handler: () => handleQuickAgent() },
       { ...sessionStartOnTicket, handler: () => navigateToDashboard() },
       {
+        // #1058: the composer is the landing view — starting a topic is a
+        // navigation, not a sidebar panel.
         ...sessionCreateTaskRoom,
-        handler: () =>
-          window.dispatchEvent(new Event('relay:open-topic-task-room')),
+        handler: () => openTopicTaskRoom(),
       },
       {
         // #630: opens the env picker dialog. The dialog itself owns

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -21,10 +21,10 @@ import {
   type TopicRoomDraft,
 } from '../lib/topic-create.js';
 import { taskRefFromDraft } from '../lib/topic-task-ref.js';
-import type { TopicComposerSeed } from '../lib/topic-task-room.js';
 import { resolveSessionByKey } from '../lib/session-keys.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
+import { useToastStore } from '../lib/stores/toasts.js';
 import { useConfigStore } from '../lib/stores/config.js';
 
 /**
@@ -35,14 +35,12 @@ import { useConfigStore } from '../lib/stores/config.js';
  */
 export function useTopicRoomCreate({
   onLaunched,
-  seed,
 }: {
   onLaunched?: ((sessionId: string) => void) | undefined;
-  /** Routing context captured before navigation cleared the active session. */
-  seed?: TopicComposerSeed | null | undefined;
 } = {}) {
   const queryClient = useQueryClient();
   const sessions = useSessionsStore((s) => s.sessions);
+  const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
   const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
@@ -68,17 +66,18 @@ export function useTopicRoomCreate({
 
   const effectiveTitle = effectiveDraftTitle(draft);
   const taskRef = taskRefFromDraft(draft.taskRef, effectiveTitle);
-  const defaultNodeId = activeSession?.nodeId ?? seed?.nodeId;
+  const defaultNodeId = activeSession?.nodeId ?? undefined;
+  // Fall back to the first configured repo: agent sessions REQUIRE a
+  // configured repoPath server-side (validateSessionCreateRequest), so a
+  // fresh landing with no session/repo context must still launch somewhere.
   const defaultRepoPath =
-    activeSession?.repoPath ?? activeRepoPath ?? seed?.repoPath ?? undefined;
-  const defaultWorktreePath =
-    activeSession?.worktreePath ?? seed?.worktreePath ?? undefined;
-  const defaultCwd =
-    activeSession?.cwd ??
-    seed?.cwd ??
-    defaultWorktreePath ??
-    defaultRepoPath ??
+    activeSession?.repoPath ??
+    activeRepoPath ??
+    repos[0]?.path ??
     undefined;
+  const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
+  const defaultCwd =
+    activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
   const nodes = useMemo(
     () =>
       (nodesQuery.data ?? []).map((node) => ({
@@ -189,6 +188,7 @@ export function useTopicRoomCreate({
           }
           await useSessionsStore.getState().refreshAll();
           setActiveSessionId(result.session.id);
+          useUiStore.getState().setTopicComposerOpen(false);
           onLaunched?.(result.session.id);
           setCreatedRoom(null);
           setDraft(TOPIC_ROOM_DRAFT_EMPTY);
@@ -220,7 +220,15 @@ export function useTopicRoomCreate({
         if (result.status === 'launched') {
           await useSessionsStore.getState().refreshAll();
           setActiveSessionId(result.session.id);
+          useUiStore.getState().setTopicComposerOpen(false);
           onLaunched?.(result.session.id);
+        } else {
+          // create-only success has no navigation — confirm it happened and
+          // surface where the new room lives.
+          useToastStore
+            .getState()
+            .showToast('topic room created — find it in the sidebar', 'info');
+          useUiStore.getState().openSidebar();
         }
         setCreatedRoom(null);
         setDraft(TOPIC_ROOM_DRAFT_EMPTY);

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -21,6 +21,7 @@ import {
   type TopicRoomDraft,
 } from '../lib/topic-create.js';
 import { taskRefFromDraft } from '../lib/topic-task-ref.js';
+import type { TopicComposerSeed } from '../lib/topic-task-room.js';
 import { resolveSessionByKey } from '../lib/session-keys.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
@@ -34,8 +35,11 @@ import { useConfigStore } from '../lib/stores/config.js';
  */
 export function useTopicRoomCreate({
   onLaunched,
+  seed,
 }: {
   onLaunched?: ((sessionId: string) => void) | undefined;
+  /** Routing context captured before navigation cleared the active session. */
+  seed?: TopicComposerSeed | null | undefined;
 } = {}) {
   const queryClient = useQueryClient();
   const sessions = useSessionsStore((s) => s.sessions);
@@ -64,11 +68,17 @@ export function useTopicRoomCreate({
 
   const effectiveTitle = effectiveDraftTitle(draft);
   const taskRef = taskRefFromDraft(draft.taskRef, effectiveTitle);
+  const defaultNodeId = activeSession?.nodeId ?? seed?.nodeId;
   const defaultRepoPath =
-    activeSession?.repoPath ?? activeRepoPath ?? undefined;
-  const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
+    activeSession?.repoPath ?? activeRepoPath ?? seed?.repoPath ?? undefined;
+  const defaultWorktreePath =
+    activeSession?.worktreePath ?? seed?.worktreePath ?? undefined;
   const defaultCwd =
-    activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
+    activeSession?.cwd ??
+    seed?.cwd ??
+    defaultWorktreePath ??
+    defaultRepoPath ??
+    undefined;
   const nodes = useMemo(
     () =>
       (nodesQuery.data ?? []).map((node) => ({
@@ -123,14 +133,14 @@ export function useTopicRoomCreate({
         draft: { ...draft, title: effectiveTitle },
         workspaceId: activeWorkspaceId,
         defaultProviderId: defaultAgent,
-        defaultNodeId: activeSession?.nodeId,
+        defaultNodeId,
         defaultRepoPath,
         defaultWorktreePath,
         defaultCwd,
         taskRef,
       }),
     [
-      activeSession?.nodeId,
+      defaultNodeId,
       activeWorkspaceId,
       draft,
       defaultAgent,

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -1,0 +1,263 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  WorkspaceTopicCreateInput,
+  WorkspaceTopicLaunchIntent,
+} from '../../../shared/workspace-topics.js';
+import {
+  createWorkspaceTopicRoomAndMaybeLaunch,
+  fetchHubNodes,
+  launchWorkspaceTopicRoom,
+  type WorkspaceTopicLaunchFailure,
+  type WorkspaceTopicRoomCreateResult,
+} from '../lib/api.js';
+import {
+  buildTopicRoomCreateInput,
+  buildTopicRoomLaunchBody,
+  effectiveDraftTitle,
+  uniqueStrings,
+  FALLBACK_PROVIDER_IDS,
+  TOPIC_ROOM_DRAFT_EMPTY,
+  type TopicRoomDraft,
+} from '../lib/topic-create.js';
+import { taskRefFromDraft } from '../lib/topic-task-ref.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import { useUiStore } from '../lib/stores/ui.js';
+import { useConfigStore } from '../lib/stores/config.js';
+
+/**
+ * #1058: stateful draft + create/launch plumbing for codex-style topic
+ * creation. Owns the draft, resolves workspace defaults (provider, node,
+ * repo, worktree, cwd) from the active context, and drives the two-step
+ * create → launch flow with retry-after-launch-failure support.
+ */
+export function useTopicRoomCreate({
+  onLaunched,
+}: {
+  onLaunched?: ((sessionId: string) => void) | undefined;
+} = {}) {
+  const queryClient = useQueryClient();
+  const sessions = useSessionsStore((s) => s.sessions);
+  const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+  const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
+  const activeRepoPath = useUiStore((s) => s.activeRepoPath);
+  const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
+  const defaultAgent = useConfigStore((s) => s.defaultAgent);
+  const frameworks = useConfigStore((s) => s.frameworks);
+  const activeSession = useMemo(
+    () => resolveSessionByKey(sessions, activeSessionId),
+    [activeSessionId, sessions]
+  );
+  const [draft, setDraft] = useState<TopicRoomDraft>(TOPIC_ROOM_DRAFT_EMPTY);
+  const [submittingIntent, setSubmittingIntent] =
+    useState<WorkspaceTopicLaunchIntent | null>(null);
+  const [launchFailure, setLaunchFailure] =
+    useState<WorkspaceTopicLaunchFailure | null>(null);
+  const [createdRoom, setCreatedRoom] =
+    useState<WorkspaceTopicRoomCreateResult | null>(null);
+  const nodesQuery = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    staleTime: 60_000,
+  });
+
+  const effectiveTitle = effectiveDraftTitle(draft);
+  const taskRef = taskRefFromDraft(draft.taskRef, effectiveTitle);
+  const defaultRepoPath =
+    activeSession?.repoPath ?? activeRepoPath ?? undefined;
+  const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
+  const defaultCwd =
+    activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
+  const nodes = useMemo(
+    () =>
+      (nodesQuery.data ?? []).map((node) => ({
+        nodeId: node.nodeId,
+        displayName: node.displayName,
+      })),
+    [nodesQuery.data]
+  );
+  const providerOptions = useMemo(
+    () =>
+      uniqueStrings([
+        defaultAgent,
+        ...frameworks.map((framework) => framework.id),
+        ...FALLBACK_PROVIDER_IDS,
+      ]),
+    [defaultAgent, frameworks]
+  );
+  const nodeOptions = useMemo(
+    () =>
+      (nodesQuery.data ?? []).map((node) => ({
+        value: node.nodeId,
+        label: node.displayName
+          ? `${node.displayName} · ${node.status}`
+          : node.status,
+      })),
+    [nodesQuery.data]
+  );
+  const repoPathOptions = useMemo(
+    () =>
+      uniqueStrings([
+        defaultRepoPath,
+        ...sessions.map((session) => session.repoPath),
+      ]),
+    [defaultRepoPath, sessions]
+  );
+  const worktreePathOptions = useMemo(
+    () =>
+      uniqueStrings([
+        defaultWorktreePath,
+        ...sessions.map((session) => session.worktreePath),
+      ]),
+    [defaultWorktreePath, sessions]
+  );
+  const cwdOptions = useMemo(
+    () =>
+      uniqueStrings([defaultCwd, ...sessions.map((session) => session.cwd)]),
+    [defaultCwd, sessions]
+  );
+  const previewCreate = useMemo<WorkspaceTopicCreateInput>(
+    () =>
+      buildTopicRoomCreateInput({
+        draft: { ...draft, title: effectiveTitle },
+        workspaceId: activeWorkspaceId,
+        defaultProviderId: defaultAgent,
+        defaultNodeId: activeSession?.nodeId,
+        defaultRepoPath,
+        defaultWorktreePath,
+        defaultCwd,
+        taskRef,
+      }),
+    [
+      activeSession?.nodeId,
+      activeWorkspaceId,
+      draft,
+      defaultAgent,
+      defaultCwd,
+      defaultRepoPath,
+      defaultWorktreePath,
+      effectiveTitle,
+      taskRef,
+    ]
+  );
+
+  const updateDraft = useCallback((patch: Partial<TopicRoomDraft>) => {
+    setDraft((current) => ({ ...current, ...patch }));
+    setCreatedRoom(null);
+    setLaunchFailure(null);
+  }, []);
+
+  const reset = useCallback(() => {
+    setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+    setCreatedRoom(null);
+    setLaunchFailure(null);
+  }, []);
+
+  const submit = useCallback(
+    async (intent: WorkspaceTopicLaunchIntent) => {
+      if (!effectiveTitle) return;
+      const launch = buildTopicRoomLaunchBody(
+        previewCreate,
+        draft.templateKind
+      );
+      const submitIntent =
+        intent === 'create-and-launch' && launch
+          ? 'create-and-launch'
+          : 'create-only';
+      setSubmittingIntent(submitIntent);
+      setLaunchFailure(null);
+      try {
+        if (submitIntent === 'create-and-launch' && createdRoom && launch) {
+          const result = await launchWorkspaceTopicRoom({
+            room: createdRoom,
+            launch,
+          });
+          if (result.status === 'launch_failed') {
+            setLaunchFailure(result.failure);
+            return;
+          }
+          await useSessionsStore.getState().refreshAll();
+          setActiveSessionId(result.session.id);
+          onLaunched?.(result.session.id);
+          setCreatedRoom(null);
+          setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+          return;
+        }
+        const result = await createWorkspaceTopicRoomAndMaybeLaunch({
+          room: {
+            topic: previewCreate,
+            ...(taskRef ? { taskRef } : {}),
+          },
+          ...(submitIntent === 'create-and-launch' && launch
+            ? {
+                launch,
+              }
+            : {}),
+        });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['workspace-topics'] }),
+          queryClient.invalidateQueries({ queryKey: ['workspace-surfaces'] }),
+        ]);
+        if (result.status === 'launch_failed') {
+          setLaunchFailure(result.failure);
+          setCreatedRoom({
+            topic: result.topic,
+            workContext: result.workContext,
+          });
+          return;
+        }
+        if (result.status === 'launched') {
+          await useSessionsStore.getState().refreshAll();
+          setActiveSessionId(result.session.id);
+          onLaunched?.(result.session.id);
+        }
+        setCreatedRoom(null);
+        setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+      } catch (error) {
+        const failure = error as WorkspaceTopicLaunchFailure;
+        setLaunchFailure({
+          stage: failure.stage ?? 'topic',
+          message:
+            typeof failure.message === 'string'
+              ? failure.message
+              : error instanceof Error
+                ? error.message
+                : String(error),
+          retryable: failure.retryable ?? false,
+          ...(failure.code ? { code: failure.code } : {}),
+          ...(failure.status ? { status: failure.status } : {}),
+        });
+      } finally {
+        setSubmittingIntent(null);
+      }
+    },
+    [
+      createdRoom,
+      draft.templateKind,
+      effectiveTitle,
+      onLaunched,
+      previewCreate,
+      queryClient,
+      setActiveSessionId,
+      taskRef,
+    ]
+  );
+
+  return {
+    draft,
+    updateDraft,
+    reset,
+    submit,
+    submittingIntent,
+    launchFailure,
+    effectiveTitle,
+    previewCreate,
+    nodes,
+    providerOptions,
+    nodeOptions,
+    repoPathOptions,
+    worktreePathOptions,
+    cwdOptions,
+  };
+}

--- a/frontend/src/lib/state/app-view-mode.ts
+++ b/frontend/src/lib/state/app-view-mode.ts
@@ -18,6 +18,13 @@ export interface ResolveAppViewModeInput {
    * explicit repo/project selection still resolves to `dashboard`.
    */
   forceOrgCockpit?: boolean;
+  /**
+   * #1058: the main-pane topic composer was opened explicitly (sidebar
+   * "+ task", palette, cockpit CTA). Routes to the chat landing WITHOUT
+   * requiring the session/repo selection to be cleared, so the composer can
+   * inherit that context as routing defaults.
+   */
+  topicComposerOpen?: boolean;
 }
 
 export function resolveAppViewMode({
@@ -25,8 +32,10 @@ export function resolveAppViewMode({
   hasActiveSession,
   activeRepoPath,
   forceOrgCockpit = false,
+  topicComposerOpen = false,
 }: ResolveAppViewModeInput): AppViewMode {
   if (analyticsView !== null) return 'analytics';
+  if (topicComposerOpen) return 'chat';
   if (hasActiveSession) return 'session';
 
   // The no-session / no-explicit-project landing path defaults to the

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -631,6 +631,14 @@ export interface UiState {
    * a session becomes active so the next empty state defaults back to chat.
    */
   forceOrgCockpit: boolean;
+  /**
+   * #1058: the main-pane topic composer is open. Set by openTopicTaskRoom()
+   * so `resolveAppViewMode` shows the chat landing WITHOUT clearing the
+   * active session/repo selection — the composer inherits that context as
+   * its routing defaults. Cleared when a session becomes active (launch or
+   * sidebar selection). Session-transient; never persisted.
+   */
+  topicComposerOpen: boolean;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
   /** Six-layer navigation surface flag. Default false; backed by localStorage. */
@@ -685,6 +693,7 @@ export interface UiState {
   setAnalyticsView: (v: AnalyticsView) => void;
   setOrgDashboardTab: (tab: OrgDashboardTab) => void;
   setForceOrgCockpit: (v: boolean) => void;
+  setTopicComposerOpen: (v: boolean) => void;
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
@@ -736,6 +745,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   // default to 'prs' so a fresh session never lands on a hidden tab's content.
   orgDashboardTab: loadAdvancedMode() ? 'active-work' : 'prs',
   forceOrgCockpit: false,
+  topicComposerOpen: false,
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
@@ -1163,6 +1173,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   setAnalyticsView: (v) => set({ analyticsView: v }),
   setOrgDashboardTab: (tab) => set({ orgDashboardTab: tab }),
   setForceOrgCockpit: (v) => set({ forceOrgCockpit: v }),
+  setTopicComposerOpen: (v) => set({ topicComposerOpen: v }),
   setActiveModal: (v) => set({ activeModal: v }),
 
   saveRightSidebarWidth: () =>

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -1,0 +1,167 @@
+import type {
+  WorkspaceTopicCreateInput,
+  WorkspaceTopicLaunchIntent,
+  WorkspaceTopicTemplateKind,
+} from '../../../shared/workspace-topics.js';
+import type {
+  CreateSessionBody,
+  WorkspaceTopicLaunchFailure,
+} from './api.js';
+import type { taskRefFromDraft } from './topic-task-ref.js';
+
+/**
+ * #1058: pure draft/build helpers for codex-style topic creation, shared by
+ * the main-pane TopicComposer (primary path) and any future create surfaces.
+ * The first message doubles as the room title unless the operator overrides
+ * it in the advanced section.
+ */
+export type TopicRoomDraft = {
+  title: string;
+  prompt: string;
+  taskRef: string;
+  providerId: string;
+  agentId: string;
+  nodeId: string;
+  repoPath: string;
+  worktreePath: string;
+  cwd: string;
+  templateKind: WorkspaceTopicTemplateKind;
+};
+
+export const TOPIC_ROOM_DRAFT_EMPTY: TopicRoomDraft = {
+  title: '',
+  prompt: '',
+  taskRef: '',
+  providerId: '',
+  agentId: '',
+  nodeId: '',
+  repoPath: '',
+  worktreePath: '',
+  cwd: '',
+  templateKind: 'agent-task',
+};
+
+export const TOPIC_ROOM_TEMPLATE_OPTIONS: Array<{
+  value: WorkspaceTopicTemplateKind;
+  label: string;
+}> = [
+  { value: 'agent-task', label: 'agent task' },
+  { value: 'terminal-task', label: 'terminal task' },
+  { value: 'note', label: 'note / room only' },
+];
+
+export const FALLBACK_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
+
+export function compactString(
+  value: string | null | undefined
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function uniqueStrings(
+  values: Array<string | null | undefined>
+): string[] {
+  return Array.from(
+    new Set(values.map((value) => compactString(value)).filter(Boolean))
+  ) as string[];
+}
+
+export function deriveTopicTitleFromPrompt(prompt: string): string {
+  const firstLine = prompt.trim().split('\n')[0] ?? '';
+  const collapsed = firstLine.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '';
+  // Code-point-aware truncation so a trailing emoji is not split in half.
+  const points = Array.from(collapsed);
+  return points.length > 60 ? `${points.slice(0, 59).join('')}…` : collapsed;
+}
+
+/** Title used for create/launch: explicit override wins, else the message. */
+export function effectiveDraftTitle(
+  draft: Pick<TopicRoomDraft, 'title' | 'prompt'>
+) {
+  return draft.title.trim() || deriveTopicTitleFromPrompt(draft.prompt);
+}
+
+export function launchSubmitLabel(input: {
+  submittingIntent?: WorkspaceTopicLaunchIntent | null | undefined;
+  launchDisabled: boolean;
+  launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
+}): string {
+  if (input.submittingIntent === 'create-and-launch') return 'launching…';
+  if (input.launchDisabled) return 'note is create-only';
+  if (!input.launchFailure) return 'start';
+  return input.launchFailure.stage === 'session'
+    ? 'retry launch'
+    : 'retry create + launch';
+}
+
+export function launchTypeForTemplate(
+  templateKind: WorkspaceTopicTemplateKind
+): CreateSessionBody['type'] | null {
+  if (templateKind === 'terminal-task') return 'terminal';
+  if (templateKind === 'agent-task') return 'agent';
+  return null;
+}
+
+export function buildTopicRoomLaunchBody(
+  create: WorkspaceTopicCreateInput,
+  templateKind: WorkspaceTopicTemplateKind
+): Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'> | null {
+  const type = launchTypeForTemplate(templateKind);
+  if (!type) return null;
+  const routing = create.routingDefaults ?? {};
+  return {
+    type,
+    mode: 'pty',
+    ...(type === 'agent' && routing.providerId
+      ? { agent: routing.providerId }
+      : {}),
+    ...(routing.nodeId ? { nodeId: routing.nodeId } : {}),
+    ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
+    ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
+    ...(routing.cwd ? { cwd: routing.cwd } : {}),
+    controlMode: type === 'agent' ? 'agent-driven' : 'human-driven',
+  };
+}
+
+export function buildTopicRoomCreateInput(input: {
+  draft: TopicRoomDraft;
+  workspaceId: string | null;
+  defaultProviderId: string;
+  defaultNodeId?: string | undefined;
+  defaultRepoPath?: string | undefined;
+  defaultWorktreePath?: string | undefined;
+  defaultCwd?: string | undefined;
+  taskRef: ReturnType<typeof taskRefFromDraft>;
+}): WorkspaceTopicCreateInput {
+  const providerId =
+    compactString(input.draft.providerId) ?? input.defaultProviderId;
+  const agentId = compactString(input.draft.agentId);
+  const nodeId = compactString(input.draft.nodeId) ?? input.defaultNodeId;
+  const repoPath = compactString(input.draft.repoPath) ?? input.defaultRepoPath;
+  const worktreePath =
+    compactString(input.draft.worktreePath) ?? input.defaultWorktreePath;
+  const cwd = compactString(input.draft.cwd) ?? input.defaultCwd;
+  const prompt = input.draft.prompt.trim();
+
+  return {
+    workspaceId: input.workspaceId ?? 'workspace:local',
+    title: input.draft.title.trim() || 'Untitled task room',
+    ...(prompt ? { description: prompt.slice(0, 240) } : {}),
+    promptDefaults: {
+      ...(prompt ? { starterPrompt: prompt } : {}),
+    },
+    routingDefaults: {
+      ...(providerId ? { providerId } : {}),
+      ...(agentId ? { agentId } : {}),
+      ...(nodeId ? { nodeId } : {}),
+      ...(repoPath ? { repoPath } : {}),
+      ...(worktreePath ? { worktreePath } : {}),
+      ...(cwd ? { cwd } : {}),
+    },
+    linkedRefs: {
+      ...(input.taskRef ? { taskRefs: [input.taskRef] } : {}),
+    },
+  };
+}

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -89,7 +89,8 @@ export function launchSubmitLabel(input: {
   launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
 }): string {
   if (input.submittingIntent === 'create-and-launch') return 'launching…';
-  if (input.launchDisabled) return 'note is create-only';
+  if (input.submittingIntent === 'create-only') return 'creating…';
+  if (input.launchDisabled) return 'create room';
   if (!input.launchFailure) return 'start';
   return input.launchFailure.stage === 'session'
     ? 'retry launch'

--- a/frontend/src/lib/topic-task-room.ts
+++ b/frontend/src/lib/topic-task-room.ts
@@ -1,19 +1,57 @@
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
+import { resolveSessionByKey } from './session-keys.js';
+
+/** Routing context captured from the surface the user started the topic from. */
+export interface TopicComposerSeed {
+  nodeId?: string | undefined;
+  repoPath?: string | undefined;
+  worktreePath?: string | undefined;
+  cwd?: string | undefined;
+}
+
+let composerSeed: TopicComposerSeed | null = null;
+
+/** One-shot read of the seed captured by the last openTopicTaskRoom() call. */
+export function takeTopicComposerSeed(): TopicComposerSeed | null {
+  const seed = composerSeed;
+  composerSeed = null;
+  return seed;
+}
+
+export const TOPIC_COMPOSER_FOCUS_EVENT = 'relay:focus-topic-composer';
 
 /**
  * #1058: shared "start a topic" entry point. The composer IS the landing view
  * (TopicComposer inside ChatHome), so starting a topic means navigating to the
  * landing: clear the active session/repo/analytics selection and drop any
- * forced cockpit so resolveAppViewMode returns 'chat'. The composer autofocuses
- * its message box on mount. On mobile the sidebar drawer is closed so the main
- * pane is actually visible.
+ * forced cockpit so resolveAppViewMode returns 'chat'. The active session's
+ * routing context (node/repo/worktree/cwd) is captured as a one-shot seed
+ * BEFORE clearing so the composer keeps launching into the workspace the user
+ * came from. A focus event covers the already-on-the-landing case, where no
+ * remount happens and textarea autoFocus never re-fires. On mobile the sidebar
+ * drawer is closed so the main pane is actually visible.
  */
 export function openTopicTaskRoom(): void {
-  useSessionsStore.getState().setActiveSessionId(null);
+  const sessions = useSessionsStore.getState();
   const ui = useUiStore.getState();
+  const active = resolveSessionByKey(
+    sessions.sessions,
+    sessions.activeSessionId
+  );
+  composerSeed = {
+    nodeId: active?.nodeId ?? undefined,
+    repoPath: active?.repoPath ?? ui.activeRepoPath ?? undefined,
+    worktreePath: active?.worktreePath ?? undefined,
+    cwd: active?.cwd ?? undefined,
+  };
+  sessions.setActiveSessionId(null);
   ui.setActiveRepoPath(null);
   ui.setAnalyticsView(null);
   ui.setForceOrgCockpit(false);
   ui.closeSidebar();
+  window.setTimeout(
+    () => window.dispatchEvent(new Event(TOPIC_COMPOSER_FOCUS_EVENT)),
+    0
+  );
 }

--- a/frontend/src/lib/topic-task-room.ts
+++ b/frontend/src/lib/topic-task-room.ts
@@ -1,52 +1,23 @@
-import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
-import { resolveSessionByKey } from './session-keys.js';
-
-/** Routing context captured from the surface the user started the topic from. */
-export interface TopicComposerSeed {
-  nodeId?: string | undefined;
-  repoPath?: string | undefined;
-  worktreePath?: string | undefined;
-  cwd?: string | undefined;
-}
-
-let composerSeed: TopicComposerSeed | null = null;
-
-/** One-shot read of the seed captured by the last openTopicTaskRoom() call. */
-export function takeTopicComposerSeed(): TopicComposerSeed | null {
-  const seed = composerSeed;
-  composerSeed = null;
-  return seed;
-}
 
 export const TOPIC_COMPOSER_FOCUS_EVENT = 'relay:focus-topic-composer';
 
 /**
  * #1058: shared "start a topic" entry point. The composer IS the landing view
- * (TopicComposer inside ChatHome), so starting a topic means navigating to the
- * landing: clear the active session/repo/analytics selection and drop any
- * forced cockpit so resolveAppViewMode returns 'chat'. The active session's
- * routing context (node/repo/worktree/cwd) is captured as a one-shot seed
- * BEFORE clearing so the composer keeps launching into the workspace the user
- * came from. A focus event covers the already-on-the-landing case, where no
- * remount happens and textarea autoFocus never re-fires. On mobile the sidebar
- * drawer is closed so the main pane is actually visible.
+ * (TopicComposer inside ChatHome). Starting a topic sets the transient
+ * `topicComposerOpen` flag — `resolveAppViewMode` routes to the chat landing
+ * WITHOUT clearing the active session/repo selection, so the composer inherits
+ * that context (node/repo/worktree/cwd) as live routing defaults and nothing
+ * about the operator's selection (including the persisted active-workspace
+ * key) is lost by merely opening and abandoning the composer. The flag clears
+ * when a session becomes active (launch or sidebar selection) or on Escape.
+ * A focus event covers the already-on-the-landing case, where no remount
+ * happens and textarea autoFocus never re-fires. On mobile the sidebar drawer
+ * is closed so the main pane is actually visible.
  */
 export function openTopicTaskRoom(): void {
-  const sessions = useSessionsStore.getState();
   const ui = useUiStore.getState();
-  const active = resolveSessionByKey(
-    sessions.sessions,
-    sessions.activeSessionId
-  );
-  composerSeed = {
-    nodeId: active?.nodeId ?? undefined,
-    repoPath: active?.repoPath ?? ui.activeRepoPath ?? undefined,
-    worktreePath: active?.worktreePath ?? undefined,
-    cwd: active?.cwd ?? undefined,
-  };
-  sessions.setActiveSessionId(null);
-  ui.setActiveRepoPath(null);
+  ui.setTopicComposerOpen(true);
   ui.setAnalyticsView(null);
   ui.setForceOrgCockpit(false);
   ui.closeSidebar();

--- a/frontend/src/lib/topic-task-room.ts
+++ b/frontend/src/lib/topic-task-room.ts
@@ -1,19 +1,19 @@
+import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 
 /**
- * #1058: shared "start a topic" entry point used by both the work-cockpit
- * empty state and the chat-first landing home. The topic create panel lives
- * in TopicSidebarShell, which is unmounted while the sidebar is collapsed —
- * so un-collapse + open first, then dispatch on the next tick once the shell
- * has mounted and registered its listener (otherwise the event fires into
- * the void and the CTA is a no-op in collapsed mode).
+ * #1058: shared "start a topic" entry point. The composer IS the landing view
+ * (TopicComposer inside ChatHome), so starting a topic means navigating to the
+ * landing: clear the active session/repo/analytics selection and drop any
+ * forced cockpit so resolveAppViewMode returns 'chat'. The composer autofocuses
+ * its message box on mount. On mobile the sidebar drawer is closed so the main
+ * pane is actually visible.
  */
 export function openTopicTaskRoom(): void {
+  useSessionsStore.getState().setActiveSessionId(null);
   const ui = useUiStore.getState();
-  if (ui.sidebarCollapsed) ui.toggleSidebarCollapsed();
-  ui.openSidebar();
-  window.setTimeout(
-    () => window.dispatchEvent(new Event('relay:open-topic-task-room')),
-    0
-  );
+  ui.setActiveRepoPath(null);
+  ui.setAnalyticsView(null);
+  ui.setForceOrgCockpit(false);
+  ui.closeSidebar();
 }

--- a/test/app-view-mode.test.ts
+++ b/test/app-view-mode.test.ts
@@ -43,6 +43,27 @@ describe('resolveAppViewMode', () => {
     ).toBe('dashboard');
   });
 
+  it('shows the topic composer over an active session/repo without clearing them (#1058)', () => {
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: true,
+        activeRepoPath: '/repo/relay-ide',
+        topicComposerOpen: true,
+      })
+    ).toBe('chat');
+
+    // analytics still wins — the composer flag only overrides session/repo.
+    expect(
+      resolveAppViewMode({
+        analyticsView: 'dashboard',
+        hasActiveSession: true,
+        activeRepoPath: null,
+        topicComposerOpen: true,
+      })
+    ).toBe('analytics');
+  });
+
   it('preserves session, analytics, and explicit repo dashboard priority', () => {
     expect(
       resolveAppViewMode({

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  deriveTopicTitleFromPrompt,
+  effectiveDraftTitle,
+  TOPIC_ROOM_DRAFT_EMPTY,
+} from '../frontend/src/lib/topic-create.js';
+
+vi.mock('../frontend/src/lib/api.js', async (importOriginal) => {
+  const original = await importOriginal<object>();
+  return {
+    ...original,
+    fetchHubNodes: vi.fn().mockResolvedValue([]),
+    createWorkspaceTopicRoomAndMaybeLaunch: vi.fn(),
+    launchWorkspaceTopicRoom: vi.fn(),
+  };
+});
+
+import { createWorkspaceTopicRoomAndMaybeLaunch } from '../frontend/src/lib/api.js';
+import TopicComposer from '../frontend/src/components/TopicComposer.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setNativeValue(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('topic title derivation', () => {
+  it('derives the title from the first message line, code-point capped', () => {
+    expect(deriveTopicTitleFromPrompt('fix the login bug\nmore detail')).toBe(
+      'fix the login bug'
+    );
+    const long = '💡'.repeat(61) + 'x';
+    const derived = deriveTopicTitleFromPrompt(long);
+    expect(derived.endsWith('…')).toBe(true);
+    expect((derived as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(
+      true
+    );
+  });
+
+  it('prefers an explicit title override over the message', () => {
+    expect(
+      effectiveDraftTitle({ ...TOPIC_ROOM_DRAFT_EMPTY, prompt: 'hello world' })
+    ).toBe('hello world');
+    expect(
+      effectiveDraftTitle({ title: ' custom ', prompt: 'hello world' })
+    ).toBe('custom');
+  });
+});
+
+describe('TopicComposer', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  function renderComposer() {
+    act(() =>
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(TopicComposer, {})
+        )
+      )
+    );
+  }
+
+  it('renders the centered message box with start disabled until typed', () => {
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    expect(ta).not.toBeNull();
+    const start = container.querySelector(
+      '.topic-composer__bar button[type="submit"]'
+    ) as HTMLButtonElement;
+    expect(start.disabled).toBe(true);
+    act(() => setNativeValue(ta, 'ship the thing'));
+    expect(start.disabled).toBe(false);
+  });
+
+  it('keeps the metadata fields behind the advanced disclosure', () => {
+    renderComposer();
+    expect(container.querySelector('.topic-composer__advanced')).toBeNull();
+    const toggle = container.querySelector(
+      '.topic-composer__advanced-toggle'
+    ) as HTMLButtonElement;
+    act(() => toggle.click());
+    const advanced = container.querySelector('.topic-composer__advanced');
+    expect(advanced).not.toBeNull();
+    expect(advanced?.textContent).toContain('provider');
+    expect(advanced?.textContent).toContain('node');
+    expect(advanced?.textContent).toContain('task ref');
+  });
+
+  it('creates and launches with the derived title on submit', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+      status: 'created',
+      topic: { id: 'topic:1' },
+      workContext: { id: 'wc:1' },
+    } as never);
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    act(() => setNativeValue(ta, 'triage the reconnect flake'));
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+    expect(createWorkspaceTopicRoomAndMaybeLaunch).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
+      .calls[0]?.[0] as {
+      room: { topic: { title: string } };
+      launch?: unknown;
+    };
+    expect(call.room.topic.title).toBe('triage the reconnect flake');
+    expect(call.launch).toBeDefined();
+  });
+});

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -851,22 +851,11 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('no workspace topics yet');
   });
 
-  it('surfaces task-room creation entrypoints and preview panel', async () => {
+  it('routes the task-room creation entrypoint to the main-pane composer', async () => {
+    // #1058: creation lives in the main pane (TopicComposer), not a sidebar
+    // panel — the sidebar button only fires the navigation callback.
     const onCreateTaskRoom = vi.fn();
-    await renderView({
-      createPanel: React.createElement(
-        'form',
-        { className: 'topic-create-panel', 'aria-label': 'create task room' },
-        React.createElement(
-          'div',
-          { className: 'topic-create-preview' },
-          'provider: hermes'
-        ),
-        React.createElement('button', { type: 'button' }, 'create only'),
-        React.createElement('button', { type: 'button' }, 'create + launch')
-      ),
-      onCreateTaskRoom,
-    });
+    await renderView({ onCreateTaskRoom });
 
     const createButton = container.querySelector(
       '.topic-shell__create'
@@ -874,9 +863,7 @@ describe('TopicSidebarView', () => {
     await act(async () => createButton.click());
 
     expect(onCreateTaskRoom).toHaveBeenCalled();
-    expect(container.textContent).toContain('provider: hermes');
-    expect(container.textContent).toContain('create only');
-    expect(container.textContent).toContain('create + launch');
+    expect(container.querySelector('.topic-create-panel')).toBeNull();
   });
 
   it('renders a phone-first attention list sorted before routine topics', async () => {


### PR DESCRIPTION
## What

Topic/session creation moves **entirely out of the sidebar**. The landing view is now a codex-style composer centered in the main pane: type your first prompt, hit enter, and the topic + session exist with that message delivered as the agent's initial prompt.

- **`TopicComposer`** (new): message box + `provider · node · cwd` context line + start. Title auto-derives from the first message line (code-point-safe 60-char cap). All routing metadata (title/taskRef/provider/agentId/template/node/repo/worktree/cwd + launch preview) preserved behind an `advanced` disclosure — still populated into `routingDefaults` for agent-to-agent use.
- **`useTopicRoomCreate`** (new hook) + **`lib/topic-create`** (pure helpers): create/launch plumbing extracted from the sidebar shell.
- **Sidebar `TopicRoomCreatePanel` deleted** along with its state and the `relay:open-topic-task-room` event. Sidebar "+ task", mobile cockpit "+ task", the cockpit CTA, and the palette action all route through `openTopicTaskRoom()`.
- **`topicComposerOpen` ui flag**: opening the composer no longer clears the active session/repo — `resolveAppViewMode` routes to the landing while the composer inherits the live context as routing defaults, and the persisted workspace selection survives opening+abandoning it. Flag clears on launch, on sidebar session change, or Escape.
- Launch defaults fall back to the **first configured repo** — agent sessions require a configured `repoPath` server-side, so a fresh landing can always launch.
- First message reaches the launched session via `promptDefaults.starterPrompt → initialPrompt` (`buildWorkspaceTopicSessionCreateBody`).

## Review (two adversarial multi-agent rounds, 42 agents total)

Round 1 (sidebar panel): IME-Enter guard, surrogate-safe truncation, node-id leak (#1103), preventDefault-only-on-submit, aria fixes.
Round 2 (main-pane rework): context-wipe regression + localStorage workspace-key deletion (fixed via the flag approach), fresh-landing launch failure on required repoPath (fixed via first-repo fallback), createdRoom retry state loss on unmount (known limitation — orphan room stays visible in sidebar for manual reuse), create-only silent success (now toast + sidebar), note template Enter dead-end (primary action degrades to create room), mobile autofocus keyboard pop (suppressed), TuiButton + touch-target/aria polish.

Known pre-existing (not introduced): chat `Composer.tsx` lacks the IME-Enter guard; duplicate room possible on create-only after a session-stage launch failure.

## Validation

- `npm run check` 0 errors; 512 affected tests pass incl. new `topic-composer` + `app-view-mode` cases
- Real-chromium E2E (desktop 1280×900 + mobile 390×844): landing composer renders, typed message → create → derived title appears in sidebar row, sidebar "+ task" returns to composer, legacy panel gone, zero console errors

Refs #1058, #1061. Follow-up: #1111 (local-model title/metadata assist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)