### PR TITLE
Fix port reconciliation log storm on non-repo paths

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -287,12 +287,16 @@ import { sessionEnvelopeRegistry } from './session-envelope-registry.js';
 import { createLogger, initFileLogging } from './logger.js';
 import { createSecurityAuditLog } from './security-audit-log.js';
 import {
-  initializeDefaultAllocator,
   getDefaultAllocator,
+  initializeDefaultAllocator,
   normalizePortVariables,
   removePortsFromEnvFile,
   upsertPortsInEnvFile,
 } from './port-allocator.js';
+import {
+  createPortReconciliationWarningLogger,
+  filterPortReconciliationRepoPaths,
+} from './port-reconciliation.js';
 import {
   actorFromRequestBody,
   capabilityDecisionFromRequest,
@@ -527,23 +531,7 @@ function getAllocatorOrNull(): ReturnType<typeof getDefaultAllocator> | null {
   }
 }
 
-const portReconciliationWarningKeys = new Set<string>();
-
-function logPortReconciliationOnce(
-  key: string,
-  message: string,
-  ...args: unknown[]
-): void {
-  if (portReconciliationWarningKeys.has(key)) {
-    logger.debug(message, ...args);
-    return;
-  }
-  if (portReconciliationWarningKeys.size > 512) {
-    portReconciliationWarningKeys.clear();
-  }
-  portReconciliationWarningKeys.add(key);
-  logger.warn(message, ...args);
-}
+const logPortReconciliationOnce = createPortReconciliationWarningLogger(logger);
 
 function logPortReconciliationFailure(err: unknown): void {
   logger.warn(
@@ -1715,7 +1703,7 @@ async function main(): Promise<void> {
   }
 
   async function reconcilePortsForAllRepos(repoPaths: string[]): Promise<void> {
-    for (const repoPath of repoPaths) {
+    for (const repoPath of filterPortReconciliationRepoPaths(repoPaths)) {
       await reconcilePortsForRepo(repoPath);
     }
   }

--- a/server/port-reconciliation.ts
+++ b/server/port-reconciliation.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Logger } from './logger.js';
+
+export type PortReconciliationLogger = Pick<Logger, 'warn'>;
+
+export function isGitRepoPathForPortReconciliation(
+  repoPath: string,
+  existsSync: (path: string) => boolean = fs.existsSync
+): boolean {
+  if (typeof repoPath !== 'string' || repoPath.trim() === '') return false;
+  return existsSync(path.join(repoPath, '.git'));
+}
+
+export function filterPortReconciliationRepoPaths(
+  repoPaths: readonly string[],
+  existsSync: (path: string) => boolean = fs.existsSync
+): string[] {
+  const seen = new Set<string>();
+  const filtered: string[] = [];
+  for (const repoPath of repoPaths) {
+    if (typeof repoPath !== 'string') continue;
+    const trimmed = repoPath.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    if (!isGitRepoPathForPortReconciliation(trimmed, existsSync)) continue;
+    filtered.push(trimmed);
+  }
+  return filtered;
+}
+
+export function createPortReconciliationWarningLogger(
+  logger: PortReconciliationLogger,
+  maxWarningKeys = 512
+): (key: string, message: string, ...args: unknown[]) => void {
+  const warnedKeys = new Set<string>();
+  let warnedAboutOverflow = false;
+
+  return (key: string, message: string, ...args: unknown[]): void => {
+    if (warnedKeys.has(key)) return;
+
+    if (warnedKeys.size >= maxWarningKeys) {
+      if (!warnedAboutOverflow) {
+        warnedAboutOverflow = true;
+        logger.warn(
+          'Suppressing additional port reconciliation warnings after %d unique keys.',
+          maxWarningKeys
+        );
+      }
+      return;
+    }
+
+    warnedKeys.add(key);
+    logger.warn(message, ...args);
+  };
+}

--- a/test/port-reconciliation.test.ts
+++ b/test/port-reconciliation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createPortReconciliationWarningLogger,
+  filterPortReconciliationRepoPaths,
+} from '../server/port-reconciliation.js';
+
+describe('filterPortReconciliationRepoPaths', () => {
+  it('keeps only unique configured git repo paths', () => {
+    const existing = new Set([
+      '/repos/relay-ide/.git',
+      '/repos/plugin/.git',
+      '/repos/worktree/.git',
+    ]);
+
+    expect(
+      filterPortReconciliationRepoPaths(
+        [
+          '/repos/relay-ide',
+          '/repos',
+          '/repos/plugin',
+          '/repos/relay-ide',
+          '   /repos/worktree   ',
+          '',
+        ],
+        (candidate) => existing.has(candidate)
+      )
+    ).toEqual(['/repos/relay-ide', '/repos/plugin', '/repos/worktree']);
+  });
+});
+
+describe('createPortReconciliationWarningLogger', () => {
+  it('warns once per key without downgrading repeats into debug spam', () => {
+    const warn = vi.fn();
+    const logOnce = createPortReconciliationWarningLogger({ warn });
+
+    logOnce('list:/repos', 'failed %s', '/repos');
+    logOnce('list:/repos', 'failed %s', '/repos');
+    logOnce('list:/repos/relay-ide', 'failed %s', '/repos/relay-ide');
+
+    expect(warn.mock.calls).toEqual([
+      ['failed %s', '/repos'],
+      ['failed %s', '/repos/relay-ide'],
+    ]);
+  });
+
+  it('does not clear the warning set and re-emit storms after the cap', () => {
+    const warn = vi.fn();
+    const logOnce = createPortReconciliationWarningLogger({ warn }, 2);
+
+    logOnce('a', 'first');
+    logOnce('b', 'second');
+    logOnce('c', 'third');
+    logOnce('d', 'fourth');
+    logOnce('a', 'first again');
+
+    expect(warn.mock.calls).toEqual([
+      ['first'],
+      ['second'],
+      [
+        'Suppressing additional port reconciliation warnings after %d unique keys.',
+        2,
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- skip port reconciliation for configured paths that are not actual git repos/worktrees
- make repeated port reconciliation warnings truly one-shot instead of downgrading to debug output that still hits systemd/journald
- add focused tests for non-repo filtering and warning storm suppression

## Verification
- `npm test -- test/port-reconciliation.test.ts`
- `npm run check`
- `npm run build`

## Dogfood notes
Observed live `relay-devbox-test-hub.service` repeatedly logging `Failed to list worktrees for port reconciliation` for `/home/donovanyohan/Documents/Programs/personal`, which is configured as a parent directory/root but is not itself a git repo. This prevents the hot path from shelling out to `git worktree list` for that non-repo entry and prevents repeat warnings from becoming debug-level stdout/journald spam.
