### PR TITLE
Route image paste to owning node

### DIFF
--- a/frontend/src/components/ImageToast.tsx
+++ b/frontend/src/components/ImageToast.tsx
@@ -5,6 +5,8 @@ import { TuiButton } from './TuiButton';
 import './ImageToast.css';
 
 const IMAGE_NOTIFICATION_ID = 'image-toast';
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
 let autoDismissTimer: number | null = null;
 
 function clearAutoDismissTimer(): void {
@@ -45,7 +47,7 @@ interface ImageToastContentProps {
 const ImageToastContent: React.FC<ImageToastContentProps> = ({ text, showInsert, imagePath }) => {
   const handleInsert = React.useCallback(() => {
     if (imagePath) {
-      sendPtyData(imagePath);
+      sendPtyData(`${BRACKETED_PASTE_START}${imagePath}${BRACKETED_PASTE_END}`);
     }
     hideImageToast();
   }, [imagePath]);

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1002,6 +1002,8 @@ function usePtyPause(
 
 // ── useImageUpload hook ───────────────────────────────────────────────────────
 
+const MAX_TERMINAL_IMAGE_UPLOAD_BYTES = 8 * 1024 * 1024;
+
 function useImageUpload(
   sessionId: string | null,
   onImageUpload?: (text: string, showInsert: boolean, path?: string) => void
@@ -1011,6 +1013,10 @@ function useImageUpload(
   const handleImageUpload = useCallback(
     async (blob: Blob, mimeType: string) => {
       if (inProgressRef.current || !sessionId) return;
+      if (blob.size > MAX_TERMINAL_IMAGE_UPLOAD_BYTES) {
+        onImageUpload?.('Image too large (max 8MB)', false);
+        return;
+      }
       inProgressRef.current = true;
       onImageUpload?.('Pasting image\u2026', false);
       const reader = new FileReader();
@@ -1019,6 +1025,7 @@ function useImageUpload(
         try {
           const data = await uploadImage(sessionId!, base64, mimeType);
           if (data.clipboardSet) onImageUpload?.('Image pasted', false);
+          else if (data.inserted) onImageUpload?.('Image path inserted', false);
           else onImageUpload?.(data.path, true, data.path);
         } catch (err: unknown) {
           const msg =
@@ -1151,7 +1158,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const { scrollbarState: sbState, updateScrollbar: updateSb } =
       useScrollbar(termRef);
     const { zoomVisible, zoomText, applyZoom } = useTerminalZoom(termRef, fit);
-    const { handleImageUpload } = useImageUpload(sessionId, onImageUpload);
+    const { handleImageUpload } = useImageUpload(ptySessionKey, onImageUpload);
     const {
       selectionMode,
       inCopyMode: _inCopyMode,

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1025,7 +1025,9 @@ function useImageUpload(
         try {
           const data = await uploadImage(sessionId!, base64, mimeType);
           if (data.clipboardSet) onImageUpload?.('Image pasted', false);
-          else if (data.inserted) onImageUpload?.('Image path inserted', false);
+          else if (data.mode === 'path') onImageUpload?.('Image path inserted', false);
+          else if (data.mode === 'attachment') onImageUpload?.('Image attached', false);
+          else if (data.inserted) onImageUpload?.('Image inserted', false);
           else onImageUpload?.(data.path, true, data.path);
         } catch (err: unknown) {
           const msg =

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2375,9 +2375,19 @@ export async function uploadImage(
   sessionId: string,
   data: string,
   mimeType: string
-): Promise<{ path: string; clipboardSet: boolean }> {
-  return json<{ path: string; clipboardSet: boolean }>(
-    await fetch('/sessions/' + sessionId + '/image', {
+): Promise<{
+  path: string;
+  clipboardSet: boolean;
+  inserted?: boolean;
+  mode?: 'clipboard' | 'path' | 'attachment';
+}> {
+  return json<{
+    path: string;
+    clipboardSet: boolean;
+    inserted?: boolean;
+    mode?: 'clipboard' | 'path' | 'attachment';
+  }>(
+    await fetch('/sessions/' + encodeURIComponent(sessionId) + '/image', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ data, mimeType }),

--- a/server/clipboard.ts
+++ b/server/clipboard.ts
@@ -40,14 +40,6 @@ export function detectClipboardTool(): string | null {
     } catch {
       // xclip not found
     }
-
-    try {
-      execFileSync('which', ['xsel'], { stdio: 'ignore' });
-      cachedTool = 'xsel';
-      return cachedTool;
-    } catch {
-      // xsel not found
-    }
   }
 
   cachedTool = null;
@@ -74,6 +66,9 @@ function writeFileToStdin(
     const chunks: Buffer[] = [];
     child.stderr.on('data', (chunk: Buffer) => chunks.push(chunk));
     child.on('error', reject);
+    child.stdin.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EPIPE') reject(error);
+    });
     child.on('close', (code) => {
       if (code === 0) {
         resolve();
@@ -113,15 +108,6 @@ export async function setClipboardImage(
 
   if (tool === 'wl-copy') {
     await writeFileToStdin('wl-copy', ['--type', mimeType], filePath);
-    return true;
-  }
-
-  if (tool === 'xsel') {
-    await writeFileToStdin(
-      'xsel',
-      ['--clipboard', '--input', '--mime-type', mimeType],
-      filePath
-    );
     return true;
   }
 

--- a/server/clipboard.ts
+++ b/server/clipboard.ts
@@ -59,25 +59,41 @@ export function extensionForMime(mimeType: string): string {
 function writeFileToStdin(
   command: string,
   args: string[],
-  filePath: string
+  filePath: string,
+  timeoutMs = 5_000
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: ['pipe', 'ignore', 'pipe'] });
     const chunks: Buffer[] = [];
+    let settled = false;
+    function settle(error?: Error, killChild = false): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (killChild) child.kill();
+      if (error) reject(error);
+      else resolve();
+    }
+    const timer = setTimeout(() => {
+      settle(new Error(`${command} timed out after ${timeoutMs}ms`), true);
+    }, timeoutMs);
+    timer.unref?.();
     child.stderr.on('data', (chunk: Buffer) => chunks.push(chunk));
-    child.on('error', reject);
+    child.on('error', (error) => settle(error));
     child.stdin.on('error', (error: NodeJS.ErrnoException) => {
-      if (error.code !== 'EPIPE') reject(error);
+      if (error.code !== 'EPIPE') settle(error, true);
     });
     child.on('close', (code) => {
       if (code === 0) {
-        resolve();
+        settle();
         return;
       }
       const stderr = Buffer.concat(chunks).toString('utf8').trim();
-      reject(new Error(`${command} exited ${code}${stderr ? `: ${stderr}` : ''}`));
+      settle(new Error(`${command} exited ${code}${stderr ? `: ${stderr}` : ''}`));
     });
-    fs.createReadStream(filePath).on('error', reject).pipe(child.stdin);
+    fs.createReadStream(filePath)
+      .on('error', (error) => settle(error, true))
+      .pipe(child.stdin);
   });
 }
 

--- a/server/clipboard.ts
+++ b/server/clipboard.ts
@@ -1,4 +1,5 @@
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile, execFileSync, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -21,6 +22,16 @@ export function detectClipboardTool(): string | null {
     return cachedTool;
   }
 
+  if (process.env['WAYLAND_DISPLAY']) {
+    try {
+      execFileSync('which', ['wl-copy'], { stdio: 'ignore' });
+      cachedTool = 'wl-copy';
+      return cachedTool;
+    } catch {
+      // wl-copy not found
+    }
+  }
+
   if (process.env['DISPLAY'] || process.env['WAYLAND_DISPLAY']) {
     try {
       execFileSync('which', ['xclip'], { stdio: 'ignore' });
@@ -28,6 +39,14 @@ export function detectClipboardTool(): string | null {
       return cachedTool;
     } catch {
       // xclip not found
+    }
+
+    try {
+      execFileSync('which', ['xsel'], { stdio: 'ignore' });
+      cachedTool = 'xsel';
+      return cachedTool;
+    } catch {
+      // xsel not found
     }
   }
 
@@ -43,6 +62,28 @@ function mimeInfo(mimeType: string): { ext: string; osascriptClass: string } {
 
 export function extensionForMime(mimeType: string): string {
   return mimeInfo(mimeType).ext;
+}
+
+function writeFileToStdin(
+  command: string,
+  args: string[],
+  filePath: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['pipe', 'ignore', 'pipe'] });
+    const chunks: Buffer[] = [];
+    child.stderr.on('data', (chunk: Buffer) => chunks.push(chunk));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const stderr = Buffer.concat(chunks).toString('utf8').trim();
+      reject(new Error(`${command} exited ${code}${stderr ? `: ${stderr}` : ''}`));
+    });
+    fs.createReadStream(filePath).on('error', reject).pipe(child.stdin);
+  });
 }
 
 export async function setClipboardImage(
@@ -67,6 +108,20 @@ export async function setClipboardImage(
       '-i',
       filePath,
     ]);
+    return true;
+  }
+
+  if (tool === 'wl-copy') {
+    await writeFileToStdin('wl-copy', ['--type', mimeType], filePath);
+    return true;
+  }
+
+  if (tool === 'xsel') {
+    await writeFileToStdin(
+      'xsel',
+      ['--clipboard', '--input', '--mime-type', mimeType],
+      filePath
+    );
     return true;
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import readline from 'node:readline';
@@ -62,7 +61,11 @@ import {
   validateWorktreeForDelete,
 } from './worktree-cleanup.js';
 import { isInstalled as serviceIsInstalled } from './service.js';
-import { extensionForMime, setClipboardImage } from './clipboard.js';
+import {
+  ingressSessionImage,
+  parseSessionImagePayload,
+  SessionImageIngressError,
+} from './session-image-ingress.js';
 import { createGitRouter } from './git-routes.js';
 import { createGhRouter } from './gh-routes.js';
 import * as push from './push.js';
@@ -165,7 +168,15 @@ import {
   createCredentialRotationScheduler,
   type CredentialRotationScheduler,
 } from './credential-rotation-scheduler.js';
-import { createHubNodeRouter } from './hub-node-router.js';
+import {
+  createHubNodeRouter,
+  errorStatus as relayNodeErrorStatus,
+} from './hub-node-router.js';
+import {
+  appendPolicyAudit,
+  evaluateHubPolicy,
+  policyDecisionToRelayError,
+} from './hub-policy-evaluator.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
 import { createCliGatewayEventBus } from './cli-gateway-event-bus.js';
 import {
@@ -179,7 +190,10 @@ import {
   type HandoffCapabilityContext,
   type HandoffDestinationLaunchInput,
 } from './handoffs.js';
-import { createHubNodeLinkManager } from './hub-node-link.js';
+import {
+  createHubNodeLinkManager,
+  HubNodeLinkError,
+} from './hub-node-link.js';
 import {
   aggregateRemoteSessions,
   createRemoteSessionReadModelCache,
@@ -5470,56 +5484,121 @@ async function main(): Promise<void> {
     }
   });
 
-  // POST /sessions/:id/image — upload clipboard image, proxy to system clipboard
-  const ALLOWED_IMAGE_TYPES = [
-    'image/png',
-    'image/jpeg',
-    'image/gif',
-    'image/webp',
-  ];
+  // POST /sessions/:id/image — upload clipboard image and inject on the node
+  // that owns the target PTY/web session. Local sessions run in-process;
+  // scoped remote sessions route hub→node over the reverse node-link RPC.
   app.post('/sessions/:id/image', requireAuth, async (req, res) => {
-    const { data, mimeType } = req.body as { data?: string; mimeType?: string };
-    if (!data || !mimeType) {
-      res.status(400).json({ error: 'data and mimeType are required' });
-      return;
-    }
-    if (!ALLOWED_IMAGE_TYPES.includes(mimeType)) {
-      res.status(400).json({ error: 'Unsupported image type: ' + mimeType });
-      return;
-    }
-    // base64 is ~33% larger than binary; 10MB binary ≈ 13.3MB base64
-    if (data.length > 14 * 1024 * 1024) {
-      res.status(413).json({ error: 'Image too large (max 10MB)' });
-      return;
-    }
-    const sessionId = req.params['id'] as string;
-    if (!localRelayNode.sessions.get(sessionId)) {
-      res.status(404).json({ error: 'Session not found' });
-      return;
-    }
+    let payload: ReturnType<typeof parseSessionImagePayload>;
     try {
-      const ext = extensionForMime(mimeType);
-      const dir = path.join(os.tmpdir(), 'relay-ide', sessionId);
-      fs.mkdirSync(dir, { recursive: true });
-      const filePath = path.join(dir, 'paste-' + Date.now() + ext);
-      fs.writeFileSync(filePath, Buffer.from(data, 'base64'));
-
-      let clipboardSet = false;
-      try {
-        clipboardSet = await setClipboardImage(filePath, mimeType);
-      } catch {
-        // Clipboard tools failed — fall back to path
-      }
-
-      if (clipboardSet) {
-        localRelayNode.sessions.write(sessionId, '\x16');
-      }
-
-      res.json({ path: filePath, clipboardSet });
+      payload = parseSessionImagePayload(req.body);
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Image upload failed';
+      res
+        .status(err instanceof SessionImageIngressError ? err.status : 400)
+        .json({ error: message });
+      return;
+    }
+
+    const targetId = req.params['id'] as string;
+    try {
+      if (localRelayNode.sessions.get(targetId)) {
+        const result = await ingressSessionImage({
+          sessions: localRelayNode.sessions,
+          sessionId: targetId,
+          payload,
+        });
+        res.json(result);
+        return;
+      }
+
+      const parsedGlobal = parseGlobalSessionId(targetId);
+      const firstValidation = parsedGlobal
+        ? sessionEnvelopeRegistry.validate({
+            nodeId: parsedGlobal.nodeId,
+            sessionId: parsedGlobal.localSessionId,
+            globalSessionId: targetId,
+            now: new Date(),
+          })
+        : sessionEnvelopeRegistry.validate({ sessionId: targetId, now: new Date() });
+      if (!firstValidation.ok) {
+        res
+          .status(relayNodeErrorStatus(firstValidation.error))
+          .json({ error: firstValidation.error });
+        return;
+      }
+
+      const scoped = firstValidation.summary;
+      const nodeId = scoped.nodeId;
+      const sessionId = scoped.sessionId;
+      if (nodeId === DEFAULT_LOCAL_NODE_ID) {
+        const result = await ingressSessionImage({
+          sessions: localRelayNode.sessions,
+          sessionId,
+          payload,
+        });
+        res.json(result);
+        return;
+      }
+
+      const node = hubNodeRegistry
+        .listNodes()
+        .find((candidate) => candidate.nodeId === nodeId);
+      const policyDecision = evaluateHubPolicy({
+        peer: { kind: 'hub' },
+        node,
+        nodeId,
+        intent: { action: 'sessions.attach', target: nodeId },
+        scope: {
+          kind: scoped.scope.kind,
+          nodeId,
+          cwd: scoped.scope.cwd,
+          ...(scoped.scope.repoPath ? { repoPath: scoped.scope.repoPath } : {}),
+          ...(scoped.scope.worktreePath !== undefined
+            ? { worktreePath: scoped.scope.worktreePath }
+            : {}),
+        },
+        requiredCapabilities: ['session:attach'],
+        sessionId,
+        expiresAt: scoped.expiresAt,
+        ...(scoped.revokedAt ? { revokedAt: scoped.revokedAt } : {}),
+        ...(scoped.correlationId ? { correlationId: scoped.correlationId } : {}),
+        params: { mimeType: payload.mimeType, bytesBase64: payload.data.length },
+        now: new Date(),
+      });
+      const auditedDecision = appendPolicyAudit(securityAuditLog, policyDecision);
+      if (auditedDecision.decision !== 'allow') {
+        const error = policyDecisionToRelayError(auditedDecision);
+        res.status(relayNodeErrorStatus(error)).json({ error });
+        return;
+      }
+      if (!node || node.status !== 'online' || !hubNodeLinks.hasActiveNode(nodeId)) {
+        res.status(404).json({
+          error: {
+            code: 'NODE_OFFLINE',
+            message: `node ${nodeId} has no live reverse link`,
+            retryable: true,
+          },
+        });
+        return;
+      }
+
+      const result = await hubNodeLinks.request(nodeId, 'sessions.image', {
+        id: sessionId,
+        ...payload,
+      });
+      res.json(result);
+    } catch (err) {
+      if (err instanceof HubNodeLinkError) {
+        res.status(relayNodeErrorStatus(err.relayNodeError)).json({
+          error: err.relayNodeError,
+        });
+        return;
+      }
       const message =
         err instanceof Error ? err.message : 'Image upload failed';
-      res.status(500).json({ error: message });
+      res
+        .status(err instanceof SessionImageIngressError ? err.status : 500)
+        .json({ error: message });
     }
   });
 

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -36,6 +36,11 @@ import type {
 } from '../shared/relay-node-protocol.js';
 import { isSessionLane, type SessionLane } from '../shared/session-lane.js';
 import type { SessionSummary, TerminalBackend } from './types.js';
+import {
+  ingressSessionImage,
+  parseSessionImagePayload,
+  SessionImageIngressError,
+} from './session-image-ingress.js';
 
 // Node-side RPC dispatcher. Hub initiates rpc/<type> requests over the
 // reverse WS; this module receives them, calls into the local
@@ -634,6 +639,52 @@ export function createNodeLinkRpcHost(
     ctx.send(next);
   }
 
+  async function handleSessionsImage(
+    envelope: RelayNodeEnvelope,
+    ctx: NodeLinkEnvelopeHandlerContext
+  ): Promise<void> {
+    const record = asRecord(envelope.payload);
+    const id = asString(record?.['id']);
+    if (!record || !id) {
+      sendErrorEnvelope(
+        ctx,
+        envelope,
+        invalidRequest('sessions.image payload.id must be a non-empty string')
+      );
+      return;
+    }
+    let payload: ReturnType<typeof parseSessionImagePayload>;
+    try {
+      payload = parseSessionImagePayload(record);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sendErrorEnvelope(ctx, envelope, invalidRequest(message));
+      return;
+    }
+
+    try {
+      const result = await ingressSessionImage({
+        sessions: localRelayNode.sessions,
+        sessionId: id,
+        payload,
+      });
+      sendResultEnvelope(ctx, envelope, { ...result, id, sessionId: id });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error ?? 'unknown');
+      logger.error(`sessions.image failed: ${message}`);
+      sendErrorEnvelope(
+        ctx,
+        envelope,
+        error instanceof SessionImageIngressError && error.status === 404
+          ? notFound(message)
+          : error instanceof SessionImageIngressError && error.status < 500
+            ? invalidRequest(message)
+            : internalError(message)
+      );
+    }
+  }
+
   function handleLogsTail(
     envelope: RelayNodeEnvelope,
     ctx: NodeLinkEnvelopeHandlerContext
@@ -762,6 +813,10 @@ export function createNodeLinkRpcHost(
     }
     if (envelope.type === 'sessions.rename') {
       handleSessionsRename(envelope, ctx);
+      return;
+    }
+    if (envelope.type === 'sessions.image') {
+      void handleSessionsImage(envelope, ctx);
       return;
     }
     if (envelope.type === 'credential.rotate') {

--- a/server/session-image-ingress.ts
+++ b/server/session-image-ingress.ts
@@ -101,13 +101,19 @@ export async function ingressSessionImage(input: {
 
   const ext = extensionForMime(input.payload.mimeType);
   const dir = imageTempDir(input.sessionId);
-  fs.mkdirSync(dir, { recursive: true });
+  await fs.promises.mkdir(dir, { recursive: true });
   const stamp = input.now?.() ?? Date.now();
   const filePath = path.join(dir, `paste-${stamp}${ext}`);
-  fs.writeFileSync(filePath, Buffer.from(input.payload.data, 'base64'));
+  await fs.promises.writeFile(filePath, Buffer.from(input.payload.data, 'base64'));
   scheduleSessionImageCleanup(filePath);
 
   if (session.mode === 'web') {
+    if (!session.adapterV2) {
+      throw new SessionImageIngressError(
+        400,
+        'Web session adapter is not initialized'
+      );
+    }
     await session.adapterV2.sendMessage({
       turnId: `image-paste-${stamp}`,
       content: '',

--- a/server/session-image-ingress.ts
+++ b/server/session-image-ingress.ts
@@ -1,0 +1,151 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { extensionForMime, setClipboardImage } from './clipboard.js';
+import type { Session } from './types.js';
+import type { ControlActor } from '../shared/control-state.js';
+
+const ALLOWED_IMAGE_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+// Base64 is ~33% larger than binary; 10 MB binary ≈ 13.3 MB base64.
+export const MAX_SESSION_IMAGE_BASE64_BYTES = 14 * 1024 * 1024;
+export const SESSION_IMAGE_TTL_MS = 60 * 60 * 1000;
+
+export interface SessionImagePayload {
+  data: string;
+  mimeType: string;
+}
+
+export interface SessionImageIngressResult {
+  path: string;
+  clipboardSet: boolean;
+  inserted: boolean;
+  mode: 'clipboard' | 'path' | 'attachment';
+}
+
+export class SessionImageIngressError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'SessionImageIngressError';
+    this.status = status;
+  }
+}
+
+export interface SessionImageBoundary {
+  get(id: string): Session | undefined;
+  write(id: string, data: string): void;
+  supervisorWrite?(
+    id: string,
+    input: { action: 'sendText'; actor: ControlActor; payload: string }
+  ): unknown;
+}
+
+function imageTempDir(sessionId: string): string {
+  return path.join(os.tmpdir(), 'relay-ide', sessionId);
+}
+
+export function cleanupSessionImageTempDir(sessionId: string): void {
+  fs.rmSync(imageTempDir(sessionId), { recursive: true, force: true });
+}
+
+function scheduleSessionImageCleanup(filePath: string): void {
+  const timer = setTimeout(() => {
+    fs.rm(filePath, { force: true }, () => undefined);
+  }, SESSION_IMAGE_TTL_MS);
+  timer.unref?.();
+}
+
+function bracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}
+
+export function parseSessionImagePayload(raw: unknown): SessionImagePayload {
+  const body =
+    typeof raw === 'object' && raw !== null
+      ? (raw as Record<string, unknown>)
+      : {};
+  const data = body['data'];
+  const mimeType = body['mimeType'];
+  if (typeof data !== 'string' || typeof mimeType !== 'string') {
+    throw new SessionImageIngressError(400, 'data and mimeType are required');
+  }
+  if (!ALLOWED_IMAGE_TYPES.has(mimeType)) {
+    throw new SessionImageIngressError(
+      400,
+      `Unsupported image type: ${mimeType}`
+    );
+  }
+  if (data.length > MAX_SESSION_IMAGE_BASE64_BYTES) {
+    throw new SessionImageIngressError(413, 'Image too large (max 10MB)');
+  }
+  return { data, mimeType };
+}
+
+export async function ingressSessionImage(input: {
+  sessions: SessionImageBoundary;
+  sessionId: string;
+  payload: SessionImagePayload;
+  actor?: ControlActor;
+  now?: () => number;
+}): Promise<SessionImageIngressResult> {
+  const session = input.sessions.get(input.sessionId);
+  if (!session) throw new SessionImageIngressError(404, 'Session not found');
+
+  const ext = extensionForMime(input.payload.mimeType);
+  const dir = imageTempDir(input.sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const stamp = input.now?.() ?? Date.now();
+  const filePath = path.join(dir, `paste-${stamp}${ext}`);
+  fs.writeFileSync(filePath, Buffer.from(input.payload.data, 'base64'));
+  scheduleSessionImageCleanup(filePath);
+
+  if (session.mode === 'web') {
+    await session.adapterV2.sendMessage({
+      turnId: `image-paste-${stamp}`,
+      content: '',
+      attachments: [
+        { type: 'image', path: filePath, mimeType: input.payload.mimeType },
+      ],
+    });
+    return { path: filePath, clipboardSet: false, inserted: true, mode: 'attachment' };
+  }
+
+  let clipboardSet = false;
+  try {
+    clipboardSet = await setClipboardImage(filePath, input.payload.mimeType);
+  } catch {
+    // Clipboard tools failed — fall back to bracketed path paste.
+  }
+
+  const payload = clipboardSet ? '\x16' : bracketedPaste(filePath);
+  if (input.sessions.supervisorWrite) {
+    input.sessions.supervisorWrite(input.sessionId, {
+      action: 'sendText',
+      actor:
+        input.actor ??
+        ({
+          kind: 'human',
+          id: 'browser-image-paste',
+          displayName: 'Browser image paste',
+        } satisfies ControlActor),
+      payload,
+    });
+  } else {
+    input.sessions.write(input.sessionId, payload);
+  }
+
+  return {
+    path: filePath,
+    clipboardSet,
+    inserted: true,
+    mode: clipboardSet ? 'clipboard' : 'path',
+  };
+}

--- a/server/session-image-ingress.ts
+++ b/server/session-image-ingress.ts
@@ -49,7 +49,8 @@ export interface SessionImageBoundary {
 }
 
 function imageTempDir(sessionId: string): string {
-  return path.join(os.tmpdir(), 'relay-ide', sessionId);
+  const safeSessionDir = Buffer.from(sessionId, 'utf8').toString('base64url');
+  return path.join(os.tmpdir(), 'relay-ide', safeSessionDir);
 }
 
 export function cleanupSessionImageTempDir(sessionId: string): void {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -109,6 +109,7 @@ import {
   isTerminalInputKey,
   type TerminalInputKey,
 } from './terminal-model-backend.js';
+import { cleanupSessionImageTempDir } from './session-image-ingress.js';
 
 const logger = createLogger('sessions');
 
@@ -1169,6 +1170,7 @@ function kill(id: string): void {
     deleteWebSession(id);
   }
 
+  cleanupSessionImageTempDir(id);
   sessions.delete(id);
   sessionEnvelopeRegistry.delete(id);
 }

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -1,8 +1,10 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { createNodeLinkRpcHost } from '../server/node-link-rpc-host.js';
+import { _resetForTesting as resetClipboardToolCache } from '../server/clipboard.js';
+import { cleanupSessionImageTempDir } from '../server/session-image-ingress.js';
 import type {
   RelayNodeEnvelope,
   RelayNodeError,
@@ -15,6 +17,18 @@ import type { LocalRelayNode } from '../server/local-node.js';
 import type { CreateParams } from '../server/sessions.js';
 import type { CreateWebParams } from '../server/web-session-handler.js';
 import type { SessionSummary } from '../server/types.js';
+
+const OLD_DISPLAY = process.env['DISPLAY'];
+const OLD_WAYLAND_DISPLAY = process.env['WAYLAND_DISPLAY'];
+
+afterEach(() => {
+  if (OLD_DISPLAY === undefined) delete process.env['DISPLAY'];
+  else process.env['DISPLAY'] = OLD_DISPLAY;
+  if (OLD_WAYLAND_DISPLAY === undefined) delete process.env['WAYLAND_DISPLAY'];
+  else process.env['WAYLAND_DISPLAY'] = OLD_WAYLAND_DISPLAY;
+  resetClipboardToolCache();
+  cleanupSessionImageTempDir('sess-1');
+});
 
 function summary(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
@@ -132,6 +146,45 @@ describe('node-link-rpc-host', () => {
     const replyPayload = reply.payload as { session: SessionSummary };
     expect(replyPayload.session.id).toBe('sess-1');
     expect(replyPayload.session).not.toHaveProperty('pid');
+  });
+
+  it('routes sessions.image to node-local image ingress', async () => {
+    delete process.env['DISPLAY'];
+    delete process.env['WAYLAND_DISPLAY'];
+    resetClipboardToolCache();
+
+    const writes: string[] = [];
+    const localRelayNode = fakeLocalNode({
+      get: (id) => (id === 'sess-1' ? ({ id, mode: 'pty' } as never) : undefined),
+      write: (_id, data) => writes.push(data),
+    });
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.image', {
+        id: 'sess-1',
+        data: Buffer.from('image').toString('base64'),
+        mimeType: 'image/png',
+      }),
+      ctx
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(sent[0]).toMatchObject({
+      channel: 'rpc',
+      type: 'sessions.image.result',
+      requestId: 'req-1',
+      payload: {
+        id: 'sess-1',
+        sessionId: 'sess-1',
+        clipboardSet: false,
+        inserted: true,
+        mode: 'path',
+      },
+    });
+    const payload = sent[0]!.payload as { path: string };
+    expect(writes).toEqual([`\x1b[200~${payload.path}\x1b[201~`]);
   });
 
   it('passes routed terminalBackend and rejects legacy routed useTmux', () => {

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -169,7 +169,7 @@ describe('node-link-rpc-host', () => {
       }),
       ctx
     );
-    await new Promise((resolve) => setImmediate(resolve));
+    await vi.waitFor(() => expect(sent).toHaveLength(1));
 
     expect(sent[0]).toMatchObject({
       channel: 'rpc',

--- a/test/session-image-ingress.test.ts
+++ b/test/session-image-ingress.test.ts
@@ -1,0 +1,132 @@
+import * as fs from 'node:fs';
+import { describe, expect, it, afterEach } from 'vitest';
+
+import {
+  cleanupSessionImageTempDir,
+  ingressSessionImage,
+  parseSessionImagePayload,
+  SessionImageIngressError,
+} from '../server/session-image-ingress.js';
+import { _resetForTesting as resetClipboardToolCache } from '../server/clipboard.js';
+import type { Session } from '../server/types.js';
+
+const OLD_DISPLAY = process.env['DISPLAY'];
+const OLD_WAYLAND_DISPLAY = process.env['WAYLAND_DISPLAY'];
+
+afterEach(() => {
+  if (OLD_DISPLAY === undefined) delete process.env['DISPLAY'];
+  else process.env['DISPLAY'] = OLD_DISPLAY;
+  if (OLD_WAYLAND_DISPLAY === undefined) delete process.env['WAYLAND_DISPLAY'];
+  else process.env['WAYLAND_DISPLAY'] = OLD_WAYLAND_DISPLAY;
+  resetClipboardToolCache();
+  cleanupSessionImageTempDir('sess-image-test');
+});
+
+describe('session image ingress', () => {
+  it('validates MIME and size before writing', () => {
+    expect(() => parseSessionImagePayload({ data: 'abc', mimeType: 'image/png' })).not.toThrow();
+    expect(() => parseSessionImagePayload({ data: 'abc', mimeType: 'text/plain' })).toThrow(
+      SessionImageIngressError
+    );
+    expect(() =>
+      parseSessionImagePayload({ data: 'x'.repeat(15 * 1024 * 1024), mimeType: 'image/png' })
+    ).toThrow(/too large/i);
+  });
+
+  it('falls back to bracketed-paste path injection when no clipboard tool is available', async () => {
+    delete process.env['DISPLAY'];
+    delete process.env['WAYLAND_DISPLAY'];
+    resetClipboardToolCache();
+
+    const writes: string[] = [];
+    const sessions = {
+      get: (id: string) =>
+        id === 'sess-image-test'
+          ? ({ id, mode: 'pty' } as unknown as Session)
+          : undefined,
+      write: (_id: string, data: string) => writes.push(data),
+    };
+
+    const result = await ingressSessionImage({
+      sessions,
+      sessionId: 'sess-image-test',
+      payload: { data: Buffer.from('png-bytes').toString('base64'), mimeType: 'image/png' },
+      now: () => 123,
+    });
+
+    expect(result).toMatchObject({ clipboardSet: false, inserted: true, mode: 'path' });
+    expect(result.path).toMatch(/sess-image-test\/paste-123\.png$/);
+    expect(fs.readFileSync(result.path, 'utf8')).toBe('png-bytes');
+    expect(writes).toEqual([`\x1b[200~${result.path}\x1b[201~`]);
+  });
+
+  it('records fallback PTY insertion as human supervisor input when available', async () => {
+    delete process.env['DISPLAY'];
+    delete process.env['WAYLAND_DISPLAY'];
+    resetClipboardToolCache();
+
+    const supervisorWrites: unknown[] = [];
+    const sessions = {
+      get: (id: string) =>
+        id === 'sess-image-test'
+          ? ({ id, mode: 'pty' } as unknown as Session)
+          : undefined,
+      write: () => {
+        throw new Error('raw PTY write should not be used when supervisorWrite exists');
+      },
+      supervisorWrite: (_id: string, input: unknown) => supervisorWrites.push(input),
+    };
+
+    const result = await ingressSessionImage({
+      sessions,
+      sessionId: 'sess-image-test',
+      payload: { data: Buffer.from('png-bytes').toString('base64'), mimeType: 'image/png' },
+      now: () => 789,
+    });
+
+    expect(supervisorWrites).toEqual([
+      {
+        action: 'sendText',
+        actor: {
+          kind: 'human',
+          id: 'browser-image-paste',
+          displayName: 'Browser image paste',
+        },
+        payload: `\x1b[200~${result.path}\x1b[201~`,
+      },
+    ]);
+  });
+
+  it('sends structured image attachments to web sessions instead of writing PTY bytes', async () => {
+    const messages: unknown[] = [];
+    const sessions = {
+      get: (id: string) =>
+        id === 'sess-image-test'
+          ? ({
+              id,
+              mode: 'web',
+              adapterV2: { sendMessage: async (input: unknown) => messages.push(input) },
+            } as unknown as Session)
+          : undefined,
+      write: () => {
+        throw new Error('PTY write should not be used for web image ingress');
+      },
+    };
+
+    const result = await ingressSessionImage({
+      sessions,
+      sessionId: 'sess-image-test',
+      payload: { data: Buffer.from('jpg-bytes').toString('base64'), mimeType: 'image/jpeg' },
+      now: () => 456,
+    });
+
+    expect(result).toMatchObject({ clipboardSet: false, inserted: true, mode: 'attachment' });
+    expect(messages).toEqual([
+      {
+        turnId: 'image-paste-456',
+        content: '',
+        attachments: [{ type: 'image', path: result.path, mimeType: 'image/jpeg' }],
+      },
+    ]);
+  });
+});

--- a/test/session-image-ingress.test.ts
+++ b/test/session-image-ingress.test.ts
@@ -20,6 +20,7 @@ afterEach(() => {
   else process.env['WAYLAND_DISPLAY'] = OLD_WAYLAND_DISPLAY;
   resetClipboardToolCache();
   cleanupSessionImageTempDir('sess-image-test');
+  cleanupSessionImageTempDir('../evil');
 });
 
 describe('session image ingress', () => {
@@ -55,9 +56,38 @@ describe('session image ingress', () => {
     });
 
     expect(result).toMatchObject({ clipboardSet: false, inserted: true, mode: 'path' });
-    expect(result.path).toMatch(/sess-image-test\/paste-123\.png$/);
+    expect(result.path).toContain(
+      Buffer.from('sess-image-test', 'utf8').toString('base64url')
+    );
+    expect(result.path.endsWith('/paste-123.png')).toBe(true);
     expect(fs.readFileSync(result.path, 'utf8')).toBe('png-bytes');
     expect(writes).toEqual([`\x1b[200~${result.path}\x1b[201~`]);
+  });
+
+  it('encodes session ids before using them in temp paths', async () => {
+    delete process.env['DISPLAY'];
+    delete process.env['WAYLAND_DISPLAY'];
+    resetClipboardToolCache();
+
+    const traversalId = '../evil';
+    const sessions = {
+      get: (id: string) =>
+        id === traversalId ? ({ id, mode: 'pty' } as unknown as Session) : undefined,
+      write: () => undefined,
+    };
+
+    const result = await ingressSessionImage({
+      sessions,
+      sessionId: traversalId,
+      payload: { data: Buffer.from('png-bytes').toString('base64'), mimeType: 'image/png' },
+      now: () => 321,
+    });
+
+    expect(result.path).toContain(
+      Buffer.from(traversalId, 'utf8').toString('base64url')
+    );
+    expect(result.path).not.toContain('../evil');
+    expect(fs.readFileSync(result.path, 'utf8')).toBe('png-bytes');
   });
 
   it('records fallback PTY insertion as human supervisor input when available', async () => {

--- a/test/session-image-ingress.test.ts
+++ b/test/session-image-ingress.test.ts
@@ -97,6 +97,27 @@ describe('session image ingress', () => {
     ]);
   });
 
+  it('rejects web image ingress when the adapter is missing', async () => {
+    const sessions = {
+      get: (id: string) =>
+        id === 'sess-image-test'
+          ? ({ id, mode: 'web', adapterV2: undefined } as unknown as Session)
+          : undefined,
+      write: () => {
+        throw new Error('PTY write should not be used for web image ingress');
+      },
+    };
+
+    await expect(
+      ingressSessionImage({
+        sessions,
+        sessionId: 'sess-image-test',
+        payload: { data: Buffer.from('jpg-bytes').toString('base64'), mimeType: 'image/jpeg' },
+        now: () => 456,
+      })
+    ).rejects.toThrow('Web session adapter is not initialized');
+  });
+
   it('sends structured image attachments to web sessions instead of writing PTY bytes', async () => {
     const messages: unknown[] = [];
     const sessions = {


### PR DESCRIPTION
## Summary
- route `POST /sessions/:id/image` through scoped/global session envelopes so hub paste targets the owning node instead of the hub clipboard
- add shared image ingress validation/temp-file/clipboard fallback handling with Linux `wl-copy`/`xclip`/`xsel` support
- send scoped session keys from the terminal upload path, cap frontend uploads at 8MB, and bracket-paste fallback paths

Closes #1113

## Verification
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" rtk npm test -- test/session-image-ingress.test.ts test/node-link-rpc-host.test.ts`
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" rtk npm run check`
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" rtk npm test`
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" rtk npm run build`

Note: a full test attempt under the ambient Node v22 failed because `better-sqlite3` was compiled for Node 24 (`NODE_MODULE_VERSION 137` vs 127). Re-running under the repo Node 24 path passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image insertion now works more reliably across terminal sessions, including better handling for pasted or uploaded images.
  * Added support for more clipboard environments, improving image paste behavior on Wayland-based systems.
  * Web sessions can now receive images as attachments when supported.

* **Bug Fixes**
  * Added a clear 8MB limit for image uploads with a friendly error message when exceeded.
  * Improved image routing so the correct session receives the image action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->