### PR TITLE
Fix port assignment no-op write churn

### DIFF
--- a/server/port-allocator.ts
+++ b/server/port-allocator.ts
@@ -190,6 +190,7 @@ export class PortAllocator {
   private readonly skipVerifyVariableNames: Set<string>;
   private assignments: PortAssignmentsFile;
   private initialized = false;
+  private lastSavedAssignmentsText: string | null = null;
 
   constructor(options: PortAllocatorOptions) {
     this.assignmentsPath = resolvePortAssignmentsPath(options.configPath);
@@ -395,6 +396,9 @@ export class PortAllocator {
       const raw = fs.readFileSync(filePath, 'utf8');
       const data = JSON.parse(raw) as PortAssignmentsFile;
       if (data.version === 1 && Array.isArray(data.assignments)) {
+        if (filePath === this.assignmentsPath) {
+          this.lastSavedAssignmentsText = raw;
+        }
         return data;
       }
       logWarn(
@@ -425,11 +429,22 @@ export class PortAllocator {
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      fs.writeFileSync(
-        this.assignmentsPath,
-        JSON.stringify(this.assignments, null, 2),
-        'utf8'
-      );
+      const next = JSON.stringify(this.assignments, null, 2);
+      if (
+        this.lastSavedAssignmentsText === next &&
+        fs.existsSync(this.assignmentsPath)
+      ) {
+        return;
+      }
+      if (
+        fs.existsSync(this.assignmentsPath) &&
+        fs.readFileSync(this.assignmentsPath, 'utf8') === next
+      ) {
+        this.lastSavedAssignmentsText = next;
+        return;
+      }
+      fs.writeFileSync(this.assignmentsPath, next, 'utf8');
+      this.lastSavedAssignmentsText = next;
     } catch (err) {
       logWarn(this.logger, 'Failed to save port assignments:', err);
       throw err;
@@ -693,7 +708,9 @@ export function removeEnvBlockVariables(
   const existing = parseEnvBlock(content);
   if (!existing) return content;
 
-  const variablesToRemove = new Set(sanitizeOptionalPortVariables(variableNames));
+  const variablesToRemove = new Set(
+    sanitizeOptionalPortVariables(variableNames)
+  );
   const remaining = Object.fromEntries(
     Object.entries(existing).filter(
       ([variableName]) => !variablesToRemove.has(variableName)
@@ -716,6 +733,7 @@ export function upsertPortsInEnvFile(
     ? fs.readFileSync(envPath, 'utf8')
     : '';
   const next = upsertEnvBlock(current, portMapping);
+  if (next === current) return;
   fs.writeFileSync(envPath, next, 'utf8');
 }
 
@@ -729,6 +747,7 @@ export function removePortsFromEnvFile(
   const next = variableNames
     ? removeEnvBlockVariables(current, variableNames)
     : removeEnvBlock(current);
+  if (next === current) return;
   if (next.length === 0) {
     fs.rmSync(envPath, { force: true });
     return;

--- a/test/port-allocator.test.ts
+++ b/test/port-allocator.test.ts
@@ -6,6 +6,7 @@ import {
   afterEach,
   expect,
   describe,
+  vi,
 } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -278,9 +279,7 @@ describe('PortAllocator', () => {
       RELAY_IDE_DEV_FRONTEND_PORT: initial.RELAY_IDE_DEV_FRONTEND_PORT,
       PORT: expect.any(Number),
     });
-    expect(allocator.getPortsForWorktree('repo-1', 'wt-1')).toEqual(
-      reconciled
-    );
+    expect(allocator.getPortsForWorktree('repo-1', 'wt-1')).toEqual(reconciled);
   });
 
   test('returns same port for repeated allocation of same variable', async () => {
@@ -298,6 +297,31 @@ describe('PortAllocator', () => {
     ]);
 
     expect(ports1.PORT).toBe(ports2.PORT);
+  });
+
+  test('does not rewrite port assignments when repeated allocation is unchanged', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+    await allocator.allocatePortsForWorktree('repo-1', 'wt-1', ['PORT']);
+
+    const assignmentsPath = resolvePortAssignmentsPath(configPath);
+    const before = fs.readFileSync(assignmentsPath, 'utf8');
+    const writeSpy = vi.spyOn(fs, 'writeFileSync');
+    try {
+      await allocator.allocatePortsForWorktree('repo-1', 'wt-1', ['PORT']);
+      await allocator.reconcilePortsForWorktree('repo-1', 'wt-1', ['PORT']);
+      const assignmentWrites = writeSpy.mock.calls.filter(
+        ([target]) => String(target) === assignmentsPath
+      );
+      expect(assignmentWrites).toHaveLength(0);
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    expect(fs.readFileSync(assignmentsPath, 'utf8')).toBe(before);
   });
 
   test('assigns different ports to different variables', async () => {
@@ -936,6 +960,27 @@ describe('Port allocator + .env block integration', () => {
       'utf8'
     );
     expect(withoutPorts.trim()).toBe('EXISTING=true');
+  });
+
+  test('env file helpers skip disk writes when managed block is unchanged', () => {
+    const worktreeDir = fs.mkdtempSync(path.join(tmpDir, 'wt-'));
+    const envPath = path.join(worktreeDir, '.env');
+    upsertPortsInEnvFile(worktreeDir, { PORT: 10001, API_PORT: 10002 });
+    const before = fs.readFileSync(envPath, 'utf8');
+
+    const writeSpy = vi.spyOn(fs, 'writeFileSync');
+    try {
+      upsertPortsInEnvFile(worktreeDir, { PORT: 10001, API_PORT: 10002 });
+      removePortsFromEnvFile(worktreeDir, ['MISSING_PORT']);
+      const envWrites = writeSpy.mock.calls.filter(
+        ([target]) => String(target) === envPath
+      );
+      expect(envWrites).toHaveLength(0);
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(before);
   });
 
   test('env file helper can remove one stale variable without deleting self-host ports', () => {


### PR DESCRIPTION
## Summary
- skip port assignment persistence when serialized allocator state is unchanged
- cache the last persisted assignment payload so hot-path no-op saves avoid disk reads/writes
- skip .env managed-port writes/removals when content would not change

## Verification
- PATH="/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.local/bin:/opt/android-sdk/platform-tools:/home/donovanyohan/.hermes/profiles/ebi/home/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games" rtk npm test -- test/port-allocator.test.ts
- PATH="/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.local/bin:/opt/android-sdk/platform-tools:/home/donovanyohan/.hermes/profiles/ebi/home/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games" rtk npm run check
- PATH="/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.hermes/profiles/ebi/home/.local/opt/node-v24.16.0-linux-x64/bin:/home/donovanyohan/.local/bin:/opt/android-sdk/platform-tools:/home/donovanyohan/.hermes/profiles/ebi/home/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games" rtk npm run build
- npm rebuild better-sqlite3 && rtk npm test -- test/hub-node-routes.test.ts test/ws-pty-intervention.test.ts
- pre-push changed-test hook: 41 files passed, 497 passed, 9 skipped
- emergency-installed local tarball on relay-devbox-test-hub.service and verified /health
- live post-restart 20s sample: port-assignments.json mtime changes 0; relay write_bytes 167936