### PR TITLE
Add TopicComposer provider selector

### DIFF
--- a/frontend/src/components/TopicComposer.css
+++ b/frontend/src/components/TopicComposer.css
@@ -55,6 +55,45 @@
   outline: none;
 }
 
+.topic-composer__provider-row {
+  display: grid;
+  grid-template-columns: minmax(96px, auto) minmax(160px, 220px) minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+}
+
+.topic-composer__provider-label,
+.topic-composer__provider-status {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.topic-composer__provider-select {
+  min-width: 0;
+  min-height: 32px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+}
+
+.topic-composer__provider-select:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.topic-composer__provider-status {
+  overflow-wrap: anywhere;
+}
+
+.topic-composer__provider-status--error {
+  color: var(--status-error);
+}
+
 .topic-composer__bar {
   display: flex;
   align-items: center;
@@ -145,4 +184,27 @@
 .topic-composer__hint {
   color: var(--text-muted);
   font-size: var(--font-size-xs);
+}
+
+@media (max-width: 640px) {
+  .topic-composer {
+    align-items: stretch;
+    min-height: 0;
+    padding: 12px 8px;
+  }
+
+  .topic-composer__panel {
+    max-width: none;
+    padding: 12px;
+  }
+
+  .topic-composer__provider-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+    gap: 4px;
+  }
+
+  .topic-composer__provider-select {
+    width: 100%;
+  }
 }

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -88,9 +88,11 @@ function primaryIntentForTemplate(templateKind: WorkspaceTopicTemplateKind) {
 function composerSubmitDisabled(input: {
   effectiveTitle: string;
   submitting: boolean;
-  providerUnavailable: boolean;
+  launchProviderUnavailable: boolean;
 }) {
-  return !input.effectiveTitle || input.submitting || input.providerUnavailable;
+  return (
+    !input.effectiveTitle || input.submitting || input.launchProviderUnavailable
+  );
 }
 
 function friendlyTopicNodeLabel(input: {
@@ -174,10 +176,12 @@ export default function TopicComposer({
   // create-only instead of dead-ending the keyboard.
   const primaryIntent = primaryIntentForTemplate(draft.templateKind);
   const providerUnavailable = Boolean(selectedProviderOption?.disabled);
+  const createOnlyDisabled = !effectiveTitle || Boolean(submittingIntent);
   const disabled = composerSubmitDisabled({
     effectiveTitle,
     submitting: Boolean(submittingIntent),
-    providerUnavailable,
+    launchProviderUnavailable:
+      primaryIntent === 'create-and-launch' && providerUnavailable,
   });
   // #1103: never render a raw node id — resolve through the roster or fall
   // back to a generic label.
@@ -410,7 +414,7 @@ export default function TopicComposer({
               <div className="topic-composer__advanced-actions">
                 <TuiButton
                   variant="ghost"
-                  disabled={disabled}
+                  disabled={createOnlyDisabled}
                   onClick={() => void submit('create-only')}
                 >
                   {submittingIntent === 'create-only'

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -15,12 +15,85 @@ import {
   launchTypeForTemplate,
   deriveTopicTitleFromPrompt,
   TOPIC_ROOM_TEMPLATE_OPTIONS,
+  type TopicProviderOption,
 } from '../lib/topic-create.js';
 import { TOPIC_COMPOSER_FOCUS_EVENT } from '../lib/topic-task-room.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { isMobileDevice } from '../lib/utils.js';
 import TuiButton from './TuiButton.js';
 import './TopicComposer.css';
+
+function TopicComposerProviderRow({
+  providerOptions,
+  selectedProviderId,
+  selectedProviderOption,
+  providerUnavailable,
+  onProviderChange,
+}: {
+  providerOptions: TopicProviderOption[];
+  selectedProviderId: string;
+  selectedProviderOption?: TopicProviderOption | undefined;
+  providerUnavailable: boolean;
+  onProviderChange: (providerId: string) => void;
+}) {
+  return (
+    <label className="topic-composer__provider-row">
+      <span className="topic-composer__provider-label">coding agent</span>
+      <select
+        className="topic-composer__provider-select"
+        value={selectedProviderId}
+        onChange={(event) => onProviderChange(event.currentTarget.value)}
+        aria-describedby="topic-composer-provider-status"
+      >
+        {providerOptions.map((option) => (
+          <option
+            key={option.id}
+            value={option.id}
+            disabled={option.disabled && option.id !== selectedProviderId}
+          >
+            {option.label}
+            {option.isDefault ? ' (default)' : ''}
+            {option.disabled ? ' (unavailable)' : ''}
+          </option>
+        ))}
+      </select>
+      <span
+        className={
+          providerUnavailable
+            ? 'topic-composer__provider-status topic-composer__provider-status--error'
+            : 'topic-composer__provider-status'
+        }
+        id="topic-composer-provider-status"
+      >
+        {selectedProviderOption?.status ?? 'global default · tui launch'}
+      </span>
+    </label>
+  );
+}
+
+function primaryIntentForTemplate(templateKind: WorkspaceTopicTemplateKind) {
+  return templateKind === 'note' ? 'create-only' : 'create-and-launch';
+}
+
+function composerSubmitDisabled(input: {
+  effectiveTitle: string;
+  submitting: boolean;
+  providerUnavailable: boolean;
+}) {
+  return !input.effectiveTitle || input.submitting || input.providerUnavailable;
+}
+
+function friendlyTopicNodeLabel(input: {
+  routedNodeId?: string | undefined;
+  nodes: Array<{ nodeId: string; displayName?: string | undefined }>;
+  fallbackLabel: string;
+}) {
+  if (!input.routedNodeId) return input.fallbackLabel;
+  return (
+    input.nodes.find((node) => node.nodeId === input.routedNodeId)
+      ?.displayName || 'remote node'
+  );
+}
 
 /**
  * #1058: the codex-style primary entry point. Lives in the main pane (not the
@@ -48,6 +121,9 @@ export default function TopicComposer({
     previewCreate,
     nodes,
     providerOptions,
+    selectedProviderId,
+    selectedProviderOption,
+    launchMode,
     nodeOptions,
     repoPathOptions,
     worktreePathOptions,
@@ -73,7 +149,7 @@ export default function TopicComposer({
         templateKind: draft.templateKind,
         launchOverrides: {
           type: launchTypeForTemplate(draft.templateKind) ?? 'agent',
-          mode: 'pty',
+          mode: launchMode ?? 'pty',
           agent: previewCreate.routingDefaults?.providerId,
           nodeId: previewCreate.routingDefaults?.nodeId,
           repoPath: previewCreate.routingDefaults?.repoPath,
@@ -81,20 +157,26 @@ export default function TopicComposer({
           cwd: previewCreate.routingDefaults?.cwd,
         },
       }),
-    [draft.templateKind, previewCreate]
+    [draft.templateKind, launchMode, previewCreate]
   );
   const launchDisabled = draft.templateKind === 'note';
   // Notes are rooms without a session — the primary action degrades to
   // create-only instead of dead-ending the keyboard.
-  const primaryIntent = launchDisabled ? 'create-only' : 'create-and-launch';
-  const disabled = !effectiveTitle || Boolean(submittingIntent);
+  const primaryIntent = primaryIntentForTemplate(draft.templateKind);
+  const providerUnavailable = Boolean(selectedProviderOption?.disabled);
+  const disabled = composerSubmitDisabled({
+    effectiveTitle,
+    submitting: Boolean(submittingIntent),
+    providerUnavailable,
+  });
   // #1103: never render a raw node id — resolve through the roster or fall
   // back to a generic label.
   const routedNodeId = previewCreate.routingDefaults?.nodeId;
-  const friendlyNodeLabel = routedNodeId
-    ? nodes.find((node) => node.nodeId === routedNodeId)?.displayName ||
-      'remote node'
-    : preview.nodeLabel;
+  const friendlyNodeLabel = friendlyTopicNodeLabel({
+    routedNodeId,
+    nodes,
+    fallbackLabel: preview.nodeLabel,
+  });
 
   return (
     <div className="topic-composer">
@@ -135,10 +217,17 @@ export default function TopicComposer({
             // pop the software keyboard on every app open.
             autoFocus={!isMobileDevice}
           />
+          <TopicComposerProviderRow
+            providerOptions={providerOptions}
+            selectedProviderId={selectedProviderId}
+            selectedProviderOption={selectedProviderOption}
+            providerUnavailable={providerUnavailable}
+            onProviderChange={(providerId) => updateDraft({ providerId })}
+          />
           <div className="topic-composer__bar">
             <span className="topic-composer__context">
-              {preview.providerLabel} · {friendlyNodeLabel} ·{' '}
-              {preview.cwdLabel}
+              {selectedProviderOption?.label ?? preview.providerLabel} ·{' '}
+              {preview.modeLabel} · {friendlyNodeLabel} · {preview.cwdLabel}
             </span>
             <TuiButton variant="primary" type="submit" disabled={disabled}>
               {launchSubmitLabel({
@@ -185,25 +274,6 @@ export default function TopicComposer({
                   }
                   placeholder="github issue number or URL"
                 />
-              </label>
-              <label>
-                <span>provider</span>
-                <input
-                  list="topic-composer-provider-options"
-                  value={draft.providerId}
-                  onChange={(event) =>
-                    updateDraft({ providerId: event.target.value })
-                  }
-                  placeholder={
-                    previewCreate.routingDefaults?.providerId ??
-                    'default provider'
-                  }
-                />
-                <datalist id="topic-composer-provider-options">
-                  {providerOptions.map((providerId) => (
-                    <option key={providerId} value={providerId} />
-                  ))}
-                </datalist>
               </label>
               <label>
                 <span>agent id</span>
@@ -311,7 +381,9 @@ export default function TopicComposer({
               </label>
               <div className="topic-composer__preview" aria-label="launch preview">
                 <div>template: {preview.templateKind}</div>
-                <div>provider: {preview.providerLabel}</div>
+                <div>
+                  provider: {selectedProviderOption?.label ?? preview.providerLabel}
+                </div>
                 <div>
                   agent:{' '}
                   {previewCreate.routingDefaults?.agentId ??

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -36,14 +37,23 @@ function TopicComposerProviderRow({
   providerUnavailable: boolean;
   onProviderChange: (providerId: string) => void;
 }) {
+  const providerSelectId = useId();
+  const providerStatusId = useId();
+
   return (
-    <label className="topic-composer__provider-row">
-      <span className="topic-composer__provider-label">coding agent</span>
+    <div className="topic-composer__provider-row">
+      <label
+        className="topic-composer__provider-label"
+        htmlFor={providerSelectId}
+      >
+        coding agent
+      </label>
       <select
         className="topic-composer__provider-select"
+        id={providerSelectId}
         value={selectedProviderId}
         onChange={(event) => onProviderChange(event.currentTarget.value)}
-        aria-describedby="topic-composer-provider-status"
+        aria-describedby={providerStatusId}
       >
         {providerOptions.map((option) => (
           <option
@@ -63,11 +73,11 @@ function TopicComposerProviderRow({
             ? 'topic-composer__provider-status topic-composer__provider-status--error'
             : 'topic-composer__provider-status'
         }
-        id="topic-composer-provider-status"
+        id={providerStatusId}
       >
         {selectedProviderOption?.status ?? 'global default · tui launch'}
       </span>
-    </label>
+    </div>
   );
 }
 

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -26,6 +26,15 @@ import {
   buildEnvironmentOptions,
   firstDegradedReasonMessage,
 } from '../../lib/environment-options.js';
+import {
+  defaultSessionModeForAgent,
+  getSessionModeOptions,
+  isFrameworkAvailable,
+  isFrameworkWebAvailable,
+  selectLaunchAgent,
+  type SessionLaunchMode,
+  type SessionModeOption,
+} from '../../lib/session-launch-mode.js';
 import type {
   AgentType,
   AggregatedRepoInventoryGroup,
@@ -48,6 +57,14 @@ import { pickDefaultEnvironment } from '../../../../shared/safe-defaults.js';
 import type { SessionLane } from '../../../../shared/session-lane.js';
 import './CustomizeSessionDialog.css';
 
+export {
+  defaultSessionModeForAgent,
+  getSessionModeOptions,
+  isFrameworkAvailable,
+  isFrameworkWebAvailable,
+  selectLaunchAgent,
+};
+
 export interface CustomizeSessionDialogHandle {
   open(
     workspace: { name: string; path: string; isGitRepo?: boolean },
@@ -59,64 +76,6 @@ export interface CustomizeSessionDialogHandle {
 
 interface Props {
   onSessionCreated?: (sessionId: string) => void;
-}
-
-type SessionLaunchMode = 'pty' | 'web';
-
-export interface SessionModeOption {
-  value: SessionLaunchMode;
-  label: string;
-  disabled?: boolean;
-  reason?: string;
-}
-
-export function isFrameworkAvailable(framework: FrameworkInfo): boolean {
-  return framework.availability?.installed !== false;
-}
-
-export function isFrameworkWebAvailable(framework: FrameworkInfo): boolean {
-  return framework.webAvailability?.available !== false;
-}
-
-export function selectLaunchAgent(
-  frameworks: FrameworkInfo[],
-  preferredAgent: AgentType
-): AgentType {
-  const preferred = frameworks.find((f) => f.id === preferredAgent);
-  if (!preferred || isFrameworkAvailable(preferred)) return preferredAgent;
-  return frameworks.find(isFrameworkAvailable)?.id ?? preferredAgent;
-}
-
-export function getSessionModeOptions(
-  frameworks: FrameworkInfo[],
-  selectedAgent: AgentType
-): SessionModeOption[] {
-  const selectedFramework = frameworks.find((f) => f.id === selectedAgent);
-  if (selectedFramework?.capabilities.supportsWebSessions === true) {
-    const webAvailable = isFrameworkWebAvailable(selectedFramework);
-    return [
-      { value: 'pty', label: 'tui' },
-      {
-        value: 'web',
-        label: webAvailable ? 'web' : 'web (unavailable)',
-        ...(!webAvailable ? { disabled: true } : {}),
-        ...(selectedFramework.webAvailability?.reason
-          ? { reason: selectedFramework.webAvailability.reason }
-          : {}),
-      },
-    ];
-  }
-  return [{ value: 'pty', label: 'tui' }];
-}
-
-export function defaultSessionModeForAgent(
-  frameworks: FrameworkInfo[],
-  selectedAgent: AgentType
-): SessionLaunchMode {
-  const supportsWeb = getSessionModeOptions(frameworks, selectedAgent).some(
-    (option) => option.value === 'web' && !option.disabled
-  );
-  return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
 }
 
 type EnvironmentChoice = {

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -543,7 +543,7 @@ function GeneralSection({
       <h3 className="settings-dialog-section-heading">general</h3>
       <SettingRow
         name="Default Coding Agent"
-        description="Which AI agent to use for new sessions"
+        description="Seeds new topic composer sessions; per-topic overrides do not change this setting"
       >
         <select
           className="settings-dialog-select"

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -14,9 +14,10 @@ import {
 import {
   buildTopicRoomCreateInput,
   buildTopicRoomLaunchBody,
+  deriveTopicProviderLaunchMode,
+  deriveTopicProviderOptions,
   effectiveDraftTitle,
   uniqueStrings,
-  FALLBACK_PROVIDER_IDS,
   TOPIC_ROOM_DRAFT_EMPTY,
   type TopicRoomDraft,
 } from '../lib/topic-create.js';
@@ -78,6 +79,7 @@ export function useTopicRoomCreate({
   const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
   const defaultCwd =
     activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
+  const selectedProviderId = draft.providerId.trim() || defaultAgent;
   const nodes = useMemo(
     () =>
       (nodesQuery.data ?? []).map((node) => ({
@@ -88,12 +90,19 @@ export function useTopicRoomCreate({
   );
   const providerOptions = useMemo(
     () =>
-      uniqueStrings([
-        defaultAgent,
-        ...frameworks.map((framework) => framework.id),
-        ...FALLBACK_PROVIDER_IDS,
-      ]),
-    [defaultAgent, frameworks]
+      deriveTopicProviderOptions({
+        frameworks,
+        defaultProviderId: defaultAgent,
+        selectedProviderId,
+        templateKind: draft.templateKind,
+      }),
+    [defaultAgent, draft.templateKind, frameworks, selectedProviderId]
+  );
+  const selectedProviderOption = useMemo(
+    () =>
+      providerOptions.find((option) => option.id === selectedProviderId) ??
+      providerOptions[0],
+    [providerOptions, selectedProviderId]
   );
   const nodeOptions = useMemo(
     () =>
@@ -150,6 +159,15 @@ export function useTopicRoomCreate({
       taskRef,
     ]
   );
+  const launchMode = useMemo(
+    () =>
+      deriveTopicProviderLaunchMode(
+        previewCreate.routingDefaults?.providerId ?? defaultAgent,
+        draft.templateKind,
+        frameworks
+      ),
+    [defaultAgent, draft.templateKind, frameworks, previewCreate.routingDefaults]
+  );
 
   const updateDraft = useCallback((patch: Partial<TopicRoomDraft>) => {
     setDraft((current) => ({ ...current, ...patch }));
@@ -168,7 +186,8 @@ export function useTopicRoomCreate({
       if (!effectiveTitle) return;
       const launch = buildTopicRoomLaunchBody(
         previewCreate,
-        draft.templateKind
+        draft.templateKind,
+        frameworks
       );
       const submitIntent =
         intent === 'create-and-launch' && launch
@@ -254,6 +273,7 @@ export function useTopicRoomCreate({
       createdRoom,
       draft.templateKind,
       effectiveTitle,
+      frameworks,
       onLaunched,
       previewCreate,
       queryClient,
@@ -273,6 +293,9 @@ export function useTopicRoomCreate({
     previewCreate,
     nodes,
     providerOptions,
+    selectedProviderId,
+    selectedProviderOption,
+    launchMode,
     nodeOptions,
     repoPathOptions,
     worktreePathOptions,

--- a/frontend/src/lib/session-launch-mode.ts
+++ b/frontend/src/lib/session-launch-mode.ts
@@ -1,0 +1,61 @@
+import type { AgentType, FrameworkInfo } from './types.js';
+
+export type SessionLaunchMode = 'pty' | 'web';
+
+export interface SessionModeOption {
+  value: SessionLaunchMode;
+  label: string;
+  disabled?: boolean;
+  reason?: string;
+}
+
+export function isFrameworkAvailable(framework: FrameworkInfo): boolean {
+  return framework.availability?.installed !== false;
+}
+
+export function isFrameworkWebAvailable(
+  framework: FrameworkInfo | undefined
+): boolean {
+  return framework?.webAvailability?.available !== false;
+}
+
+export function selectLaunchAgent(
+  frameworks: FrameworkInfo[],
+  preferredAgent: AgentType
+): AgentType {
+  const preferred = frameworks.find((f) => f.id === preferredAgent);
+  if (!preferred || isFrameworkAvailable(preferred)) return preferredAgent;
+  return frameworks.find(isFrameworkAvailable)?.id ?? preferredAgent;
+}
+
+export function getSessionModeOptions(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType
+): SessionModeOption[] {
+  const selectedFramework = frameworks.find((f) => f.id === selectedAgent);
+  if (selectedFramework?.capabilities.supportsWebSessions === true) {
+    const webAvailable = isFrameworkWebAvailable(selectedFramework);
+    return [
+      { value: 'pty', label: 'tui' },
+      {
+        value: 'web',
+        label: webAvailable ? 'web' : 'web (unavailable)',
+        ...(!webAvailable ? { disabled: true } : {}),
+        ...(selectedFramework.webAvailability?.reason
+          ? { reason: selectedFramework.webAvailability.reason }
+          : {}),
+      },
+    ];
+  }
+  return [{ value: 'pty', label: 'tui' }];
+}
+
+export function defaultSessionModeForAgent(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType
+): SessionLaunchMode {
+  const supportsWeb = getSessionModeOptions(frameworks, selectedAgent).some(
+    (option) => option.value === 'web' && !option.disabled
+  );
+  return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
+}

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -7,6 +7,11 @@ import type {
   CreateSessionBody,
   WorkspaceTopicLaunchFailure,
 } from './api.js';
+import {
+  defaultSessionModeForAgent,
+  isFrameworkAvailable,
+  isFrameworkWebAvailable,
+} from './session-launch-mode.js';
 import type { FrameworkInfo } from './types.js';
 import type { taskRefFromDraft } from './topic-task-ref.js';
 
@@ -130,14 +135,6 @@ function frameworkDisplayName(
   return frameworkForProvider(frameworks, providerId)?.displayName ?? providerId;
 }
 
-function isFrameworkInstalled(framework: FrameworkInfo | undefined): boolean {
-  return framework?.availability?.installed !== false;
-}
-
-function isFrameworkWebAvailable(framework: FrameworkInfo | undefined): boolean {
-  return framework?.webAvailability?.available !== false;
-}
-
 export function deriveTopicProviderLaunchMode(
   providerId: string,
   templateKind: WorkspaceTopicTemplateKind,
@@ -146,11 +143,7 @@ export function deriveTopicProviderLaunchMode(
   const type = launchTypeForTemplate(templateKind);
   if (!type) return null;
   if (type === 'terminal') return 'pty';
-  const framework = frameworkForProvider(frameworks, providerId);
-  return framework?.capabilities?.supportsWebSessions === true &&
-    isFrameworkWebAvailable(framework)
-    ? 'web'
-    : 'pty';
+  return defaultSessionModeForAgent(frameworks, providerId);
 }
 
 export function topicProviderStatus(input: {
@@ -181,7 +174,7 @@ export function deriveTopicProviderOptions(input: {
   ]);
   return providerIds.map((providerId) => {
     const framework = frameworkForProvider(input.frameworks, providerId);
-    const installed = isFrameworkInstalled(framework);
+    const installed = framework ? isFrameworkAvailable(framework) : true;
     const launchMode =
       deriveTopicProviderLaunchMode(
         providerId,
@@ -189,7 +182,10 @@ export function deriveTopicProviderOptions(input: {
         input.frameworks
       ) ?? 'pty';
     const webUnavailableReason =
-      framework?.capabilities?.supportsWebSessions === true && launchMode !== 'web'
+      providerId === 'hermes' &&
+      framework?.capabilities?.supportsWebSessions === true &&
+      launchMode !== 'web' &&
+      !isFrameworkWebAvailable(framework)
         ? (framework.webAvailability?.reason ?? 'web runtime unavailable')
         : undefined;
     const missingReason = installed

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -147,7 +147,7 @@ export function deriveTopicProviderLaunchMode(
   if (!type) return null;
   if (type === 'terminal') return 'pty';
   const framework = frameworkForProvider(frameworks, providerId);
-  return framework?.capabilities.supportsWebSessions === true &&
+  return framework?.capabilities?.supportsWebSessions === true &&
     isFrameworkWebAvailable(framework)
     ? 'web'
     : 'pty';
@@ -189,7 +189,7 @@ export function deriveTopicProviderOptions(input: {
         input.frameworks
       ) ?? 'pty';
     const webUnavailableReason =
-      framework?.capabilities.supportsWebSessions === true && launchMode !== 'web'
+      framework?.capabilities?.supportsWebSessions === true && launchMode !== 'web'
         ? (framework.webAvailability?.reason ?? 'web runtime unavailable')
         : undefined;
     const missingReason = installed

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -7,6 +7,7 @@ import type {
   CreateSessionBody,
   WorkspaceTopicLaunchFailure,
 } from './api.js';
+import type { FrameworkInfo } from './types.js';
 import type { taskRefFromDraft } from './topic-task-ref.js';
 
 /**
@@ -51,6 +52,16 @@ export const TOPIC_ROOM_TEMPLATE_OPTIONS: Array<{
 ];
 
 export const FALLBACK_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
+
+export type TopicProviderOption = {
+  id: string;
+  label: string;
+  status: string;
+  disabled: boolean;
+  isDefault: boolean;
+  launchMode: CreateSessionBody['mode'];
+  reason?: string;
+};
 
 export function compactString(
   value: string | null | undefined
@@ -105,16 +116,116 @@ export function launchTypeForTemplate(
   return null;
 }
 
+function frameworkForProvider(
+  frameworks: FrameworkInfo[],
+  providerId: string
+): FrameworkInfo | undefined {
+  return frameworks.find((framework) => framework.id === providerId);
+}
+
+function frameworkDisplayName(
+  frameworks: FrameworkInfo[],
+  providerId: string
+): string {
+  return frameworkForProvider(frameworks, providerId)?.displayName ?? providerId;
+}
+
+function isFrameworkInstalled(framework: FrameworkInfo | undefined): boolean {
+  return framework?.availability?.installed !== false;
+}
+
+function isFrameworkWebAvailable(framework: FrameworkInfo | undefined): boolean {
+  return framework?.webAvailability?.available !== false;
+}
+
+export function deriveTopicProviderLaunchMode(
+  providerId: string,
+  templateKind: WorkspaceTopicTemplateKind,
+  frameworks: FrameworkInfo[]
+): CreateSessionBody['mode'] | null {
+  const type = launchTypeForTemplate(templateKind);
+  if (!type) return null;
+  if (type === 'terminal') return 'pty';
+  const framework = frameworkForProvider(frameworks, providerId);
+  return framework?.capabilities.supportsWebSessions === true &&
+    isFrameworkWebAvailable(framework)
+    ? 'web'
+    : 'pty';
+}
+
+export function topicProviderStatus(input: {
+  option: Pick<
+    TopicProviderOption,
+    'isDefault' | 'launchMode' | 'disabled' | 'reason'
+  >;
+}): string {
+  const prefix = input.option.isDefault ? 'global default' : 'one-off override';
+  if (input.option.disabled) {
+    return `${prefix} · unavailable${input.option.reason ? `: ${input.option.reason}` : ''}`;
+  }
+  const mode = input.option.launchMode === 'web' ? 'web launch' : 'tui launch';
+  return `${prefix} · ${mode}${input.option.reason ? ` · ${input.option.reason}` : ''}`;
+}
+
+export function deriveTopicProviderOptions(input: {
+  frameworks: FrameworkInfo[];
+  defaultProviderId: string;
+  selectedProviderId?: string | undefined;
+  templateKind: WorkspaceTopicTemplateKind;
+}): TopicProviderOption[] {
+  const providerIds = uniqueStrings([
+    input.selectedProviderId,
+    input.defaultProviderId,
+    ...input.frameworks.map((framework) => framework.id),
+    ...FALLBACK_PROVIDER_IDS,
+  ]);
+  return providerIds.map((providerId) => {
+    const framework = frameworkForProvider(input.frameworks, providerId);
+    const installed = isFrameworkInstalled(framework);
+    const launchMode =
+      deriveTopicProviderLaunchMode(
+        providerId,
+        input.templateKind,
+        input.frameworks
+      ) ?? 'pty';
+    const webUnavailableReason =
+      framework?.capabilities.supportsWebSessions === true && launchMode !== 'web'
+        ? (framework.webAvailability?.reason ?? 'web runtime unavailable')
+        : undefined;
+    const missingReason = installed
+      ? undefined
+      : (framework?.availability?.reason ?? `${providerId} CLI not found on PATH`);
+    const option: TopicProviderOption = {
+      id: providerId,
+      label: frameworkDisplayName(input.frameworks, providerId),
+      disabled: !installed,
+      isDefault: providerId === input.defaultProviderId,
+      launchMode,
+      ...(missingReason ?? webUnavailableReason
+        ? { reason: missingReason ?? `web unavailable: ${webUnavailableReason}` }
+        : {}),
+      status: '',
+    };
+    return { ...option, status: topicProviderStatus({ option }) };
+  });
+}
+
 export function buildTopicRoomLaunchBody(
   create: WorkspaceTopicCreateInput,
-  templateKind: WorkspaceTopicTemplateKind
+  templateKind: WorkspaceTopicTemplateKind,
+  frameworks: FrameworkInfo[] = []
 ): Omit<CreateSessionBody, 'workspaceTopicId' | 'workContextId'> | null {
   const type = launchTypeForTemplate(templateKind);
   if (!type) return null;
   const routing = create.routingDefaults ?? {};
+  const mode = deriveTopicProviderLaunchMode(
+    routing.providerId ?? '',
+    templateKind,
+    frameworks
+  );
   return {
     type,
-    mode: 'pty',
+    mode: mode ?? 'pty',
     ...(type === 'agent' && routing.providerId
       ? { agent: routing.providerId }
       : {}),

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -216,6 +216,12 @@ describe('CustomizeSessionDialog session mode options', () => {
     expect(defaultSessionModeForAgent([framework('claude')], 'claude')).toBe(
       'pty'
     );
+    expect(defaultSessionModeForAgent([framework('codex')], 'codex')).toBe(
+      'pty'
+    );
+    expect(defaultSessionModeForAgent([framework('opencode')], 'opencode')).toBe(
+      'pty'
+    );
   });
 
   it('disables web mode when an installed agent runtime is unavailable', () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -5,6 +5,10 @@ import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  buildTopicRoomCreateInput,
+  buildTopicRoomLaunchBody,
+  deriveTopicProviderLaunchMode,
+  deriveTopicProviderOptions,
   deriveTopicTitleFromPrompt,
   effectiveDraftTitle,
   TOPIC_ROOM_DRAFT_EMPTY,
@@ -20,7 +24,9 @@ vi.mock('../frontend/src/lib/api.js', async (importOriginal) => {
   };
 });
 
-import { createWorkspaceTopicRoomAndMaybeLaunch } from '../frontend/src/lib/api.js';
+import { createWorkspaceTopicRoomAndMaybeLaunch, launchWorkspaceTopicRoom } from '../frontend/src/lib/api.js';
+import { useConfigStore } from '../frontend/src/lib/stores/config.js';
+import type { FrameworkInfo } from '../frontend/src/lib/types.js';
 import TopicComposer from '../frontend/src/components/TopicComposer.js';
 
 (
@@ -34,6 +40,37 @@ function setNativeValue(el: HTMLTextAreaElement, value: string) {
   )?.set;
   setter?.call(el, value);
   el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function setSelectValue(el: HTMLSelectElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLSelectElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function framework(
+  id: string,
+  overrides: Partial<FrameworkInfo> = {}
+): FrameworkInfo {
+  return {
+    id,
+    displayName: overrides.displayName ?? id,
+    command: id,
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: false,
+      supportsWebSessions: false,
+      ...overrides.capabilities,
+    },
+    eventSource: 'hooks',
+    availability: { installed: true, path: `/usr/local/bin/${id}` },
+    ...overrides,
+  };
 }
 
 describe('topic title derivation', () => {
@@ -59,12 +96,159 @@ describe('topic title derivation', () => {
   });
 });
 
+describe('topic provider launch helpers', () => {
+  it('seeds provider options from the settings default and framework metadata', () => {
+    const options = deriveTopicProviderOptions({
+      frameworks: [
+        framework('claude', { displayName: 'Claude Code' }),
+        framework('hermes', {
+          displayName: 'Hermes',
+          capabilities: {
+            supportsContinue: true,
+            supportsYolo: true,
+            supportsHooks: false,
+            supportsTelemetry: true,
+            supportsWebSessions: true,
+          },
+        }),
+      ],
+      defaultProviderId: 'hermes',
+      selectedProviderId: 'hermes',
+      templateKind: 'agent-task',
+    });
+
+    expect(options[0]).toMatchObject({
+      id: 'hermes',
+      label: 'Hermes',
+      isDefault: true,
+      launchMode: 'web',
+      status: 'global default · web launch',
+    });
+    expect(options.find((option) => option.id === 'claude')).toMatchObject({
+      label: 'Claude Code',
+      launchMode: 'pty',
+    });
+  });
+
+  it('derives web only for verified web-capable providers and keeps terminal/custom fallback on pty', () => {
+    const frameworks = [
+      framework('hermes', {
+        capabilities: {
+          supportsContinue: true,
+          supportsYolo: true,
+          supportsHooks: false,
+          supportsTelemetry: true,
+          supportsWebSessions: true,
+        },
+      }),
+      framework('codex'),
+      framework('custom:local'),
+    ];
+
+    expect(deriveTopicProviderLaunchMode('hermes', 'agent-task', frameworks)).toBe(
+      'web'
+    );
+    expect(deriveTopicProviderLaunchMode('codex', 'agent-task', frameworks)).toBe(
+      'pty'
+    );
+    expect(
+      deriveTopicProviderLaunchMode('custom:local', 'agent-task', frameworks)
+    ).toBe('pty');
+    expect(
+      deriveTopicProviderLaunchMode('hermes', 'terminal-task', frameworks)
+    ).toBe('pty');
+  });
+
+  it('surfaces unavailable framework copy and falls Hermes web back to pty when degraded', () => {
+    const options = deriveTopicProviderOptions({
+      frameworks: [
+        framework('hermes', {
+          capabilities: {
+            supportsContinue: true,
+            supportsYolo: true,
+            supportsHooks: false,
+            supportsTelemetry: true,
+            supportsWebSessions: true,
+          },
+          webAvailability: {
+            available: false,
+            reason: 'Hermes API server is not reachable',
+          },
+        }),
+        framework('claude', {
+          availability: { installed: false, reason: 'claude CLI missing' },
+        }),
+      ],
+      defaultProviderId: 'claude',
+      selectedProviderId: 'claude',
+      templateKind: 'agent-task',
+    });
+
+    expect(options.find((option) => option.id === 'hermes')).toMatchObject({
+      launchMode: 'pty',
+      status:
+        'one-off override · tui launch · web unavailable: Hermes API server is not reachable',
+    });
+    expect(options.find((option) => option.id === 'claude')).toMatchObject({
+      disabled: true,
+      status: 'global default · unavailable: claude CLI missing',
+    });
+  });
+
+  it('puts the derived launch mode into the session body', () => {
+    const frameworks = [
+      framework('hermes', {
+        capabilities: {
+          supportsContinue: true,
+          supportsYolo: true,
+          supportsHooks: false,
+          supportsTelemetry: true,
+          supportsWebSessions: true,
+        },
+      }),
+    ];
+    const create = buildTopicRoomCreateInput({
+      draft: { ...TOPIC_ROOM_DRAFT_EMPTY, prompt: 'run it' },
+      workspaceId: null,
+      defaultProviderId: 'hermes',
+      taskRef: null,
+    });
+
+    expect(buildTopicRoomLaunchBody(create, 'agent-task', frameworks)).toMatchObject({
+      type: 'agent',
+      mode: 'web',
+      agent: 'hermes',
+    });
+    expect(buildTopicRoomLaunchBody(create, 'terminal-task', frameworks)).toMatchObject({
+      type: 'terminal',
+      mode: 'pty',
+    });
+  });
+});
+
 describe('TopicComposer', () => {
   let container: HTMLDivElement;
   let root: Root;
   let queryClient: QueryClient;
 
   beforeEach(() => {
+    useConfigStore.setState({
+      defaultAgent: 'claude',
+      frameworks: [
+        framework('claude', { displayName: 'Claude Code' }),
+        framework('codex', { displayName: 'Codex' }),
+        framework('hermes', {
+          displayName: 'Hermes',
+          capabilities: {
+            supportsContinue: true,
+            supportsYolo: true,
+            supportsHooks: false,
+            supportsTelemetry: true,
+            supportsWebSessions: true,
+          },
+        }),
+      ],
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -106,6 +290,53 @@ describe('TopicComposer', () => {
     expect(start.disabled).toBe(false);
   });
 
+  it('shows the settings-seeded provider control outside advanced', () => {
+    renderComposer();
+    const provider = container.querySelector(
+      '.topic-composer__provider-select'
+    ) as HTMLSelectElement;
+    expect(provider).not.toBeNull();
+    expect(provider.value).toBe('claude');
+    expect(provider.textContent).toContain('Claude Code (default)');
+    expect(container.querySelector('#topic-composer-provider-status')?.textContent).toBe(
+      'global default · tui launch'
+    );
+    expect(container.querySelector('.topic-composer__advanced')).toBeNull();
+  });
+
+  it('blocks start when the selected provider is unavailable', () => {
+    useConfigStore.setState({
+      defaultAgent: 'opencode',
+      frameworks: [
+        framework('opencode', {
+          displayName: 'OpenCode',
+          availability: { installed: false, reason: 'opencode CLI missing' },
+        }),
+      ],
+    });
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const provider = container.querySelector(
+      '.topic-composer__provider-select'
+    ) as HTMLSelectElement;
+    const start = container.querySelector(
+      '.topic-composer__bar button[type="submit"]'
+    ) as HTMLButtonElement;
+
+    act(() => setNativeValue(ta, 'try unavailable provider'));
+
+    expect(provider.value).toBe('opencode');
+    expect(provider.selectedOptions[0]?.textContent).toContain(
+      'OpenCode (default) (unavailable)'
+    );
+    expect(container.querySelector('#topic-composer-provider-status')?.textContent).toBe(
+      'global default · unavailable: opencode CLI missing'
+    );
+    expect(start.disabled).toBe(true);
+  });
+
   it('keeps the metadata fields behind the advanced disclosure', () => {
     renderComposer();
     expect(container.querySelector('.topic-composer__advanced')).toBeNull();
@@ -115,9 +346,12 @@ describe('TopicComposer', () => {
     act(() => toggle.click());
     const advanced = container.querySelector('.topic-composer__advanced');
     expect(advanced).not.toBeNull();
-    expect(advanced?.textContent).toContain('provider');
+    expect(advanced?.textContent).toContain('agent id');
     expect(advanced?.textContent).toContain('node');
     expect(advanced?.textContent).toContain('task ref');
+    expect(
+      advanced?.querySelector('input[list="topic-composer-provider-options"]')
+    ).toBeNull();
   });
 
   it('creates and launches with the derived title on submit', async () => {
@@ -145,5 +379,97 @@ describe('TopicComposer', () => {
     };
     expect(call.room.topic.title).toBe('triage the reconnect flake');
     expect(call.launch).toBeDefined();
+  });
+
+  it('uses a one-off provider override without mutating settings', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+      status: 'created',
+      topic: { id: 'topic:1' },
+      workContext: { id: 'wc:1' },
+    } as never);
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const provider = container.querySelector(
+      '.topic-composer__provider-select'
+    ) as HTMLSelectElement;
+    act(() => {
+      setNativeValue(ta, 'ship through hermes');
+      setSelectValue(provider, 'hermes');
+    });
+    expect(useConfigStore.getState().defaultAgent).toBe('claude');
+    expect(container.querySelector('#topic-composer-provider-status')?.textContent).toBe(
+      'one-off override · web launch'
+    );
+
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+    const call = vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
+      .calls[0]?.[0] as {
+      room: { topic: { routingDefaults?: { providerId?: string } } };
+      launch?: { mode?: string; agent?: string };
+    };
+    expect(call.room.topic.routingDefaults?.providerId).toBe('hermes');
+    expect(call.launch).toMatchObject({ mode: 'web', agent: 'hermes' });
+    expect(useConfigStore.getState().defaultAgent).toBe('claude');
+  });
+
+  it('keeps the created room and provider launch mode when retrying after session launch failure', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValueOnce({
+      status: 'launch_failed',
+      topic: { id: 'topic:retry' },
+      workContext: { id: 'wc:retry' },
+      failure: {
+        stage: 'session',
+        message: 'provider temporarily unavailable',
+        retryable: true,
+      },
+    } as never);
+    vi.mocked(launchWorkspaceTopicRoom).mockResolvedValueOnce({
+      status: 'launch_failed',
+      topic: { id: 'topic:retry' },
+      workContext: { id: 'wc:retry' },
+      failure: {
+        stage: 'session',
+        message: 'still unavailable',
+        retryable: true,
+      },
+    } as never);
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const provider = container.querySelector(
+      '.topic-composer__provider-select'
+    ) as HTMLSelectElement;
+    act(() => {
+      setNativeValue(ta, 'retry this launch');
+      setSelectValue(provider, 'hermes');
+    });
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+    expect(container.querySelector('.topic-composer__failure')?.textContent).toContain(
+      'provider temporarily unavailable'
+    );
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+    expect(launchWorkspaceTopicRoom).toHaveBeenCalledWith({
+      room: {
+        topic: { id: 'topic:retry' },
+        workContext: { id: 'wc:retry' },
+      },
+      launch: expect.objectContaining({ mode: 'web', agent: 'hermes' }),
+    });
   });
 });

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -130,7 +130,7 @@ describe('topic provider launch helpers', () => {
     });
   });
 
-  it('derives web only for verified web-capable providers and keeps terminal/custom fallback on pty', () => {
+  it('derives the shared default launch mode and keeps terminal/custom fallback on pty', () => {
     const frameworks = [
       framework('hermes', {
         capabilities: {
@@ -138,6 +138,15 @@ describe('topic provider launch helpers', () => {
           supportsYolo: true,
           supportsHooks: false,
           supportsTelemetry: true,
+          supportsWebSessions: true,
+        },
+      }),
+      framework('opencode', {
+        capabilities: {
+          supportsContinue: true,
+          supportsYolo: true,
+          supportsHooks: false,
+          supportsTelemetry: false,
           supportsWebSessions: true,
         },
       }),
@@ -151,6 +160,9 @@ describe('topic provider launch helpers', () => {
     expect(deriveTopicProviderLaunchMode('codex', 'agent-task', frameworks)).toBe(
       'pty'
     );
+    expect(
+      deriveTopicProviderLaunchMode('opencode', 'agent-task', frameworks)
+    ).toBe('pty');
     expect(
       deriveTopicProviderLaunchMode('custom:local', 'agent-task', frameworks)
     ).toBe('pty');
@@ -222,6 +234,45 @@ describe('topic provider launch helpers', () => {
     expect(buildTopicRoomLaunchBody(create, 'terminal-task', frameworks)).toMatchObject({
       type: 'terminal',
       mode: 'pty',
+    });
+  });
+
+  it('keeps OpenCode on tui launch by default even when it exposes web mode', () => {
+    const frameworks = [
+      framework('opencode', {
+        displayName: 'OpenCode',
+        capabilities: {
+          supportsContinue: true,
+          supportsYolo: true,
+          supportsHooks: false,
+          supportsTelemetry: false,
+          supportsWebSessions: true,
+        },
+      }),
+    ];
+    const create = buildTopicRoomCreateInput({
+      draft: { ...TOPIC_ROOM_DRAFT_EMPTY, prompt: 'run it' },
+      workspaceId: null,
+      defaultProviderId: 'opencode',
+      taskRef: null,
+    });
+
+    expect(
+      deriveTopicProviderOptions({
+        frameworks,
+        defaultProviderId: 'opencode',
+        selectedProviderId: 'opencode',
+        templateKind: 'agent-task',
+      })[0]
+    ).toMatchObject({
+      id: 'opencode',
+      launchMode: 'pty',
+      status: 'global default · tui launch',
+    });
+    expect(buildTopicRoomLaunchBody(create, 'agent-task', frameworks)).toMatchObject({
+      type: 'agent',
+      mode: 'pty',
+      agent: 'opencode',
     });
   });
 });
@@ -345,6 +396,96 @@ describe('TopicComposer', () => {
       'global default · unavailable: opencode CLI missing'
     );
     expect(start.disabled).toBe(true);
+  });
+
+  it('allows note room creation when the default provider is unavailable', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+      status: 'created',
+      topic: { id: 'topic:note' },
+      workContext: { id: 'wc:note' },
+    } as never);
+    useConfigStore.setState({
+      defaultAgent: 'opencode',
+      frameworks: [
+        framework('opencode', {
+          displayName: 'OpenCode',
+          availability: { installed: false, reason: 'opencode CLI missing' },
+        }),
+      ],
+    });
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const toggle = container.querySelector(
+      '.topic-composer__advanced-toggle'
+    ) as HTMLButtonElement;
+    act(() => {
+      setNativeValue(ta, 'capture the note');
+      toggle.click();
+    });
+    const templateSelect = Array.from(
+      container.querySelectorAll('select')
+    ).find((select) =>
+      Array.from(select.options).some((option) => option.value === 'note')
+    ) as HTMLSelectElement;
+    act(() => setSelectValue(templateSelect, 'note'));
+    const start = container.querySelector(
+      '.topic-composer__bar button[type="submit"]'
+    ) as HTMLButtonElement;
+
+    expect(start.textContent).toBe('create room');
+    expect(start.disabled).toBe(false);
+
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+    const call = vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
+      .calls[0]?.[0] as { launch?: unknown };
+    expect(call.launch).toBeUndefined();
+  });
+
+  it('allows advanced create-only when the selected provider is unavailable', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+      status: 'created',
+      topic: { id: 'topic:create-only' },
+      workContext: { id: 'wc:create-only' },
+    } as never);
+    useConfigStore.setState({
+      defaultAgent: 'opencode',
+      frameworks: [
+        framework('opencode', {
+          displayName: 'OpenCode',
+          availability: { installed: false, reason: 'opencode CLI missing' },
+        }),
+      ],
+    });
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const toggle = container.querySelector(
+      '.topic-composer__advanced-toggle'
+    ) as HTMLButtonElement;
+    act(() => {
+      setNativeValue(ta, 'create the room first');
+      toggle.click();
+    });
+    const createOnly = container.querySelector(
+      '.topic-composer__advanced-actions button'
+    ) as HTMLButtonElement;
+
+    expect(createOnly.disabled).toBe(false);
+
+    await act(async () => {
+      createOnly.click();
+    });
+    const call = vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
+      .calls[0]?.[0] as { launch?: unknown };
+    expect(call.launch).toBeUndefined();
   });
 
   it('keeps the metadata fields behind the advanced disclosure', () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -276,6 +276,11 @@ describe('TopicComposer', () => {
     );
   }
 
+  function getProviderStatus(provider: HTMLSelectElement): HTMLElement | null {
+    const describedBy = provider.getAttribute('aria-describedby');
+    return describedBy ? document.getElementById(describedBy) : null;
+  }
+
   it('renders the centered message box with start disabled until typed', () => {
     renderComposer();
     const ta = container.querySelector(
@@ -297,10 +302,15 @@ describe('TopicComposer', () => {
     ) as HTMLSelectElement;
     expect(provider).not.toBeNull();
     expect(provider.value).toBe('claude');
-    expect(provider.textContent).toContain('Claude Code (default)');
-    expect(container.querySelector('#topic-composer-provider-status')?.textContent).toBe(
+    expect(provider.labels?.[0]?.textContent).toBe('coding agent');
+    expect(provider.labels?.[0]?.textContent).not.toContain('Claude Code');
+    expect(getProviderStatus(provider)?.textContent).toBe(
       'global default · tui launch'
     );
+    expect(provider.getAttribute('aria-describedby')).toBe(
+      getProviderStatus(provider)?.id
+    );
+    expect(provider.textContent).toContain('Claude Code (default)');
     expect(container.querySelector('.topic-composer__advanced')).toBeNull();
   });
 
@@ -331,7 +341,7 @@ describe('TopicComposer', () => {
     expect(provider.selectedOptions[0]?.textContent).toContain(
       'OpenCode (default) (unavailable)'
     );
-    expect(container.querySelector('#topic-composer-provider-status')?.textContent).toBe(
+    expect(getProviderStatus(provider)?.textContent).toBe(
       'global default · unavailable: opencode CLI missing'
     );
     expect(start.disabled).toBe(true);
@@ -399,7 +409,7 @@ describe('TopicComposer', () => {
       setSelectValue(provider, 'hermes');
     });
     expect(useConfigStore.getState().defaultAgent).toBe('claude');
-    expect(container.querySelector('#topic-composer-provider-status')?.textContent).toBe(
+    expect(getProviderStatus(provider)?.textContent).toBe(
       'one-off override · web launch'
     );
 


### PR DESCRIPTION
## Summary
- Move the TopicComposer coding-agent choice into the primary composer controls, seeded from Settings -> Default Coding Agent without mutating that setting.
- Derive provider options/status from framework metadata, including display names, unavailable CLI copy, Hermes web availability, and safe pty fallback for TUI/custom providers.
- Derive launch mode for create/retry payloads instead of hardcoding pty, and update preview/settings copy plus tests for override/non-mutation behavior.

Closes #1117

## Verification
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/topic-composer.test.ts test/customize-session-dialog.test.ts` — 47 tests passed
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` — passed with existing lint warnings
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` — passed with existing Vite chunk warnings
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test` — baseline failure in live Hermes gateway acceptance tests (`hermes-channel-prompt`, `hermes-image-input`, `hermes-metadata` returned non-ok responses); unrelated to changed TopicComposer/frontend files

## Browser evidence
- Dev app at `http://127.0.0.1:5173/`: provider select is visible outside Advanced; switching to Hermes shows `Hermes · pty · local/default node · default cwd` with web-unavailable status copy; start becomes enabled after prompt text.
- Browser console after the smoke was clean (0 messages/errors). Playwright mobile smoke could not run because the local browser binary is not installed in this profile; mobile behavior is covered by the responsive CSS path and component tests for primary-row visibility.

## Simplify / risk tier
- Risk tier: multi-file frontend behavior change.
- Simplify pass: extracted provider row and small helpers to clear complexity lint, then added the unavailable-provider component test; no broader refactor applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible provider selector in the topic composer.
  * Provider availability and launch mode now adapt based on the selected provider and workspace settings.
  * The composer preview now shows the chosen provider more clearly.

* **Bug Fixes**
  * Disabled starting a topic when the selected provider is unavailable.
  * Retains the selected provider and launch settings when retrying a failed launch.

* **Documentation**
  * Updated the default agent setting description to clarify how it applies to new topic composer sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->