### PR TITLE
fix: echo Hermes web chat user messages

### DIFF
--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -677,6 +677,13 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
       turnId,
       turnIndex: this._turnCounter++,
     });
+    this.fire({
+      type: 'chat:message-complete',
+      turnId,
+      messageId: `user-${turnId}`,
+      role: 'user',
+      content,
+    });
 
     const body: Record<string, unknown> = {
       input: buildResponsesInput(content, attachments),

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -470,6 +470,39 @@ describe('Hermes Responses SSE hardening', () => {
     });
   });
 
+  it('echoes the submitted user message when the turn starts', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_user_echo' } });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_user_echo', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-user-echo'));
+    await adapter.sendMessage('turn-1', 'hi from enter');
+
+    const turnStartedIndex = events.findIndex(
+      (event) => event.type === 'chat:turn-started'
+    );
+    const userEchoIndex = events.findIndex(
+      (event) => event.type === 'chat:message-complete' && event.role === 'user'
+    );
+    expect(turnStartedIndex).toBeGreaterThanOrEqual(0);
+    expect(userEchoIndex).toBeGreaterThan(turnStartedIndex);
+    expect(events[userEchoIndex]).toMatchObject({
+      type: 'chat:message-complete',
+      turnId: 'turn-1',
+      messageId: 'user-turn-1',
+      role: 'user',
+      content: 'hi from enter',
+    });
+  });
+
   it('completes the assistant message on response.output_text.done', async () => {
     gateway = await startInlineGateway((send, res) => {
       send({ type: 'response.created', response: { id: 'resp_msg' } });
@@ -490,7 +523,8 @@ describe('Hermes Responses SSE hardening', () => {
     await adapter.sendMessage('turn-1', 'hi');
 
     const complete = events.find(
-      (event) => event.type === 'chat:message-complete'
+      (event) =>
+        event.type === 'chat:message-complete' && event.role === 'assistant'
     );
     expect(complete).toMatchObject({ role: 'assistant', content: 'Hello' });
   });


### PR DESCRIPTION
## Summary
Fixes the Hermes web chat feeling like Enter does nothing by echoing the submitted user message into the chat timeline as soon as the turn starts.

Hermes was starting the turn and sending the prompt over the socket, but unlike other web adapters it did not emit a user `chat:message-complete` event. The UI therefore cleared the composer and only showed a spinner until Hermes eventually responded.

## Reproduction fixed
1. Open Relay, choose Hermes, start a web chat.
2. Type in the Hermes message composer and press Enter.
3. Before: the composer cleared and the timeline did not show the submitted text, so it looked like nothing happened.
4. After: the submitted user message appears immediately, followed by the working state/assistant response.

## Verification
- `npm ci`
- `rtk npm test -- test/server/protocol-adapters/hermes-adapter.test.ts` — 16 passed
- `rtk npm run check` — passed with existing warnings only
- `rtk npm run build` — passed
- Playwright UI smoke against built local server on `127.0.0.1:3458`: selected Hermes, started chat, typed a second message, pressed Enter; timeline immediately contained the submitted text and the websocket emitted `agent-item-updated-v2` with `type: userMessage`.
- pre-push changed-test hook with Node 24 PATH — 52 files passed, 546 tests passed, 9 skipped
