### PR TITLE
Fix mobile chat send key

### DIFF
--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -38,6 +38,7 @@ interface ComposerAttachment {
 
 /** Reject images above this size to keep WebSocket frames sane. */
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const LINE_BREAK_INPUT_TYPES = new Set(['insertLineBreak', 'insertParagraph']);
 
 interface ComposerProps {
   onSend: (content: string, attachments?: ComposerSendAttachment[]) => void;
@@ -99,6 +100,7 @@ export const Composer: React.FC<ComposerProps> = ({
   pushClientError,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const skipNextLineBreakBeforeInputRef = useRef(false);
   const [draft, setDraft] = useState('');
   const [caret, setCaret] = useState(0);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -327,6 +329,7 @@ export const Composer: React.FC<ComposerProps> = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const nativeEvent = e.nativeEvent as KeyboardEvent;
       if (paletteVisible) {
         if (e.key === 'ArrowDown') {
           e.preventDefault();
@@ -338,7 +341,7 @@ export const Composer: React.FC<ComposerProps> = ({
           setActiveIndex((i) => Math.max(i - 1, 0));
           return;
         }
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && !nativeEvent.isComposing) {
           e.preventDefault();
           applySelectedCommand();
           return;
@@ -356,7 +359,17 @@ export const Composer: React.FC<ComposerProps> = ({
         }
       }
 
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && nativeEvent.isComposing) return;
+
+      if (e.key === 'Enter' && e.shiftKey) {
+        skipNextLineBreakBeforeInputRef.current = true;
+        window.setTimeout(() => {
+          skipNextLineBreakBeforeInputRef.current = false;
+        }, 0);
+        return;
+      }
+
+      if (e.key === 'Enter') {
         e.preventDefault();
         submitDraft();
         return;
@@ -376,6 +389,34 @@ export const Composer: React.FC<ComposerProps> = ({
       onInterrupt,
     ]
   );
+
+  const handleBeforeInput = useCallback(
+    (inputEvent: InputEvent) => {
+      if (!LINE_BREAK_INPUT_TYPES.has(inputEvent.inputType)) return;
+
+      if (inputEvent.isComposing) return;
+      if (skipNextLineBreakBeforeInputRef.current) {
+        skipNextLineBreakBeforeInputRef.current = false;
+        return;
+      }
+
+      // Some mobile IMEs do not emit a reliable keydown for the textarea send
+      // key; they only report a beforeinput line-break intent. Treat that as
+      // send before the newline mutates the controlled draft.
+      inputEvent.preventDefault();
+      submitDraft();
+    },
+    [submitDraft]
+  );
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.addEventListener('beforeinput', handleBeforeInput);
+    return () => {
+      textarea.removeEventListener('beforeinput', handleBeforeInput);
+    };
+  }, [handleBeforeInput]);
 
   const ctxInput = usage?.inputTokens ?? 0;
   const ctxCached = usage?.cachedInputTokens ?? usage?.cacheReadTokens ?? 0;
@@ -492,6 +533,7 @@ export const Composer: React.FC<ComposerProps> = ({
             onDragOver={(e) => e.preventDefault()}
             value={draft}
             rows={1}
+            enterKeyHint="send"
             data-streaming={isActive ? 'true' : 'false'}
             aria-label="message input"
           />

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -404,9 +404,13 @@ export const Composer: React.FC<ComposerProps> = ({
       // key; they only report a beforeinput line-break intent. Treat that as
       // send before the newline mutates the controlled draft.
       inputEvent.preventDefault();
+      if (paletteVisible) {
+        applySelectedCommand();
+        return;
+      }
       submitDraft();
     },
-    [submitDraft]
+    [paletteVisible, applySelectedCommand, submitDraft]
   );
 
   useEffect(() => {

--- a/test/components/chat-v2-rendering.test.ts
+++ b/test/components/chat-v2-rendering.test.ts
@@ -203,6 +203,7 @@ describe('chat v2 rendering against chat.html primitives', () => {
         'value'
       )?.set;
       setter?.call(textarea, value);
+      textarea.setSelectionRange(value.length, value.length);
       textarea.dispatchEvent(new Event('input', { bubbles: true }));
     });
   }
@@ -371,6 +372,35 @@ describe('chat v2 rendering against chat.html primitives', () => {
     expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
     expect(mocks.sendMessage.mock.calls[0]?.[1]).toBe('mobile reply');
     expect(textarea!.value).toBe('');
+  });
+
+  it('applies the highlighted slash command on mobile send-key beforeinput while the palette is visible', async () => {
+    mocks.session = makeSession({
+      slashCommands: [
+        {
+          name: 'review',
+          description: 'Pre-landing PR review.',
+          argumentHint: '<scope>',
+        },
+      ],
+    });
+    await renderChat();
+
+    const textarea =
+      container.querySelector<HTMLTextAreaElement>('.composer__ta');
+    expect(textarea).toBeTruthy();
+
+    await setTextareaDraft(textarea!, '/rev');
+    expect(container.textContent).toContain('/review');
+
+    const event = makeBeforeInputEvent('insertLineBreak');
+    await act(async () => {
+      textarea!.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(textarea!.value).toBe('/review');
   });
 
   it('keeps Shift+Enter available for composer newlines', async () => {

--- a/test/components/chat-v2-rendering.test.ts
+++ b/test/components/chat-v2-rendering.test.ts
@@ -193,6 +193,40 @@ describe('chat v2 rendering against chat.html primitives', () => {
     });
   }
 
+  async function setTextareaDraft(
+    textarea: HTMLTextAreaElement,
+    value: string
+  ) {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value'
+      )?.set;
+      setter?.call(textarea, value);
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  function makeBeforeInputEvent(inputType: string): InputEvent {
+    if (typeof InputEvent === 'function') {
+      return new InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        data: null,
+        inputType,
+      });
+    }
+
+    const event = new Event('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+    }) as InputEvent;
+    Object.defineProperty(event, 'inputType', { value: inputType });
+    Object.defineProperty(event, 'data', { value: null });
+    Object.defineProperty(event, 'isComposing', { value: false });
+    return event;
+  }
+
   it('renders the chat.html timeline, tool, file, approval, live, queue, slash, and composer primitives', async () => {
     await renderChat();
 
@@ -316,6 +350,55 @@ describe('chat v2 rendering against chat.html primitives', () => {
 
     expect(container.querySelector('.queue')).toBeTruthy();
     expect(container.querySelector('.queue__cancel')).toBeNull();
+  });
+
+  it('submits mobile textarea send-key beforeinput line-break intents', async () => {
+    await renderChat();
+
+    const textarea =
+      container.querySelector<HTMLTextAreaElement>('.composer__ta');
+    expect(textarea).toBeTruthy();
+    expect(textarea?.getAttribute('enterkeyhint')).toBe('send');
+
+    await setTextareaDraft(textarea!, 'mobile reply');
+
+    const event = makeBeforeInputEvent('insertLineBreak');
+    await act(async () => {
+      textarea!.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage.mock.calls[0]?.[1]).toBe('mobile reply');
+    expect(textarea!.value).toBe('');
+  });
+
+  it('keeps Shift+Enter available for composer newlines', async () => {
+    await renderChat();
+
+    const textarea =
+      container.querySelector<HTMLTextAreaElement>('.composer__ta');
+    expect(textarea).toBeTruthy();
+
+    await setTextareaDraft(textarea!, 'line one');
+    await act(async () => {
+      textarea!.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    const event = makeBeforeInputEvent('insertLineBreak');
+    await act(async () => {
+      textarea!.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
   });
 
   it('hides trace provider events by default and reveals them via /relay-verbosity trace', async () => {


### PR DESCRIPTION
## Summary
Closes #1120.
Refs #1021.

Mobile chat replies could miss the textarea Enter/Send path because the composer only submitted on `keydown` Enter. Some mobile IMEs report the keyboard send action as a `beforeinput` line-break intent instead, so the draft never reached `submitDraft()`.

This adds a native `beforeinput` line-break handler for the chat composer, advertises `enterKeyHint="send"`, keeps IME composition safe, and preserves Shift+Enter as the newline path for hardware keyboards.

## Reproduction fixed
1. Open a Relay Hermes chat on mobile.
2. Type a reply into the message composer.
3. Tap the mobile keyboard Enter/Send key.
4. Before: no submitted reply.
5. After: `insertLineBreak`/`insertParagraph` beforeinput submits the reply before a newline mutates the draft.

## Verification
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npx vitest run test/components/chat-v2-rendering.test.ts test/mobile-input.test.ts --reporter=dot` — 39 passed
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run check` — exit 0; existing warning-only lint baseline
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run build` — exit 0; existing large chunk warnings
- pre-push hook changed-tests run — 6 files / 28 tests passed

## Simplify pass
- Renamed the line-break suppression ref to describe the actual Shift+Enter skip behavior.
- Collapsed mobile line-break input types into a single constant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat composer behavior so Enter, Shift+Enter, and IME composition work more reliably.
  * Enter key handling now better distinguishes between sending a message and inserting a line break.
  * The message box now shows a “send” hint on supported keyboards.

* **Tests**
  * Added coverage for line-break and send behavior in the chat composer.
  * Verified that mobile-style line breaks submit once, while Shift+Enter keeps the draft intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->