### PR TITLE
feat: focus relay on chat loop shell

### DIFF
--- a/frontend/dev-server.ts
+++ b/frontend/dev-server.ts
@@ -15,6 +15,7 @@ export const backendProxyPaths = [
   '/branches',
   '/worktrees',
   '/workspaces',
+  '/work-contexts',
   '/workspace-surfaces',
   '/workspace-topics',
   '/workspace-groups',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import {
 import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
 import { resolveTopicActiveContext } from '../../shared/workspace-topics.js';
 import { estimateTerminalDimensions } from './lib/utils.js';
+import { openTopicTaskRoom } from './lib/topic-task-room.js';
 import { createSessionWithoutActivation } from './lib/session-utils.js';
 import {
   resolveSessionByKey,
@@ -726,6 +727,7 @@ function TerminalAreaContent({
       <MobileHeader
         title={sessionTitle}
         onMenuClick={openSidebar}
+        onNewChatClick={openTopicTaskRoom}
         onCommandClick={() => setSpotlightOpen(true)}
         onRightSidebarClick={handleToggleUtilityRail}
         hidden={keyboardOpen}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,7 +181,6 @@ function useTerminalDerivedState() {
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const analyticsView = useUiStore((s) => s.analyticsView);
   const forceOrgCockpit = useUiStore((s) => s.forceOrgCockpit);
-  const setForceOrgCockpit = useUiStore((s) => s.setForceOrgCockpit);
   const topicComposerOpen = useUiStore((s) => s.topicComposerOpen);
   const setTopicComposerOpen = useUiStore((s) => s.setTopicComposerOpen);
   const sessions = useSessionsStore((s) => s.sessions);
@@ -265,13 +264,6 @@ function useTerminalDerivedState() {
       topicComposerOpen,
     ]
   );
-
-  // #1058: once a session goes active, drop the explicit cockpit override so
-  // the next no-session/no-repo landing defaults back to the chat spine
-  // instead of leaving the operator stuck in the legacy cockpit.
-  useEffect(() => {
-    if (hasActiveSession && forceOrgCockpit) setForceOrgCockpit(false);
-  }, [hasActiveSession, forceOrgCockpit, setForceOrgCockpit]);
 
   // #1058: the composer overlay closes when the active session CHANGES —
   // a launch from the composer or a sidebar selection navigates to that

--- a/frontend/src/components/ChatHome.tsx
+++ b/frontend/src/components/ChatHome.tsx
@@ -9,9 +9,9 @@ export interface ChatHomeProps {
 }
 
 /**
- * #1058: the chat/topic spine is the default no-session/no-repo landing — and
- * the landing IS the composer. No sidebar clicking: type the first prompt into
- * the main pane and the topic + session are created with that message
+ * #1058/#1122: the chat/workspace spine is the default no-session/no-repo landing — and
+ * the landing IS the composer. No sidebar clicking: type the first prompt, hit
+ * send, and the chat + session are created with that message.
  * (codex-style). One-tap resume of the most recently active session stays as
  * a secondary affordance; the full cockpit remains reachable via the "open
  * work cockpit" command-palette action.
@@ -35,7 +35,7 @@ export default function ChatHome({ onSelectSession }: ChatHomeProps) {
     : undefined;
 
   return (
-    <div className="chat-home" aria-label="chat and topic home">
+    <div className="chat-home" aria-label="chat home">
       <TopicComposer onSelectSession={onSelectSession} resume={resume} />
     </div>
   );

--- a/frontend/src/components/ChatHome.tsx
+++ b/frontend/src/components/ChatHome.tsx
@@ -36,7 +36,10 @@ export default function ChatHome({ onSelectSession }: ChatHomeProps) {
 
   return (
     <div className="chat-home" aria-label="chat home">
-      <TopicComposer onSelectSession={onSelectSession} resume={resume} />
+      {/* Launches are already selected by useTopicRoomCreate. Keep the session
+          selection callback reserved for explicit resume/sidebar clicks so a
+          fresh chat does not inherit repo-dashboard routing. */}
+      <TopicComposer resume={resume} />
     </div>
   );
 }

--- a/frontend/src/components/MobileHeader.css
+++ b/frontend/src/components/MobileHeader.css
@@ -29,14 +29,15 @@
 }
 
 .icon-btn {
-  background: none;
-  border: none;
+  background: transparent;
+  border: 1px solid var(--border);
   color: var(--text);
-  font-size: var(--font-size-lg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
   cursor: pointer;
-  padding: 8px;
-  min-width: 36px;
-  min-height: 36px;
+  padding: 4px 10px;
+  min-width: 44px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -44,12 +45,16 @@
   touch-action: manipulation;
 }
 
-.icon-btn:hover {
-  background: var(--border);
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
 }
 
-.command-trigger {
-  background: none;
+.command-trigger,
+.mobile-new-chat {
+  background: transparent;
   border: 1px solid var(--accent);
   color: var(--accent);
   font-family: var(--font-mono);
@@ -65,9 +70,9 @@
   flex-shrink: 0;
 }
 
-.command-trigger:active {
-  background: var(--accent);
-  color: var(--surface);
+.command-trigger:active,
+.mobile-new-chat:active {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .mobile-header-actions {
@@ -78,16 +83,16 @@
 }
 
 .right-sidebar-btn {
-  background: none;
-  border: none;
-  color: var(--text);
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-family: var(--font-mono);
   text-transform: lowercase;
   cursor: pointer;
-  padding: 8px;
-  min-width: 36px;
-  min-height: 36px;
+  padding: 4px 10px;
+  min-width: 44px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -96,6 +101,9 @@
   flex-shrink: 0;
 }
 
-.right-sidebar-btn:hover {
-  background: var(--border);
+.right-sidebar-btn:hover,
+.right-sidebar-btn:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
 }

--- a/frontend/src/components/MobileHeader.tsx
+++ b/frontend/src/components/MobileHeader.tsx
@@ -3,6 +3,7 @@ import './MobileHeader.css';
 export interface MobileHeaderProps {
   title: string;
   onMenuClick: () => void;
+  onNewChatClick?: () => void;
   onCommandClick: () => void;
   onRightSidebarClick?: () => void;
   hidden?: boolean;
@@ -11,27 +12,45 @@ export interface MobileHeaderProps {
 export function MobileHeader({
   title,
   onMenuClick,
+  onNewChatClick,
   onCommandClick,
   onRightSidebarClick,
   hidden = false,
 }: MobileHeaderProps) {
   return (
     <div className={`mobile-header${hidden ? ' hidden' : ''}`}>
-      <button className="icon-btn" aria-label="Open sessions menu" onClick={onMenuClick}>
-        ☰
+      <button
+        className="icon-btn"
+        aria-label="open chats switcher"
+        onClick={onMenuClick}
+      >
+        chats
       </button>
       <span className="mobile-title">{title}</span>
       <div className="mobile-header-actions">
         {onRightSidebarClick && (
           <button
             className="right-sidebar-btn"
-            aria-label="Open file sidebar"
+            aria-label="open file sidebar"
             onClick={onRightSidebarClick}
           >
             files
           </button>
         )}
-        <button className="command-trigger" aria-label="Open command palette" onClick={onCommandClick}>
+        {onNewChatClick && (
+          <button
+            className="mobile-new-chat"
+            aria-label="new chat"
+            onClick={onNewChatClick}
+          >
+            new
+          </button>
+        )}
+        <button
+          className="command-trigger"
+          aria-label="open command palette"
+          onClick={onCommandClick}
+        >
           {'> command'}
         </button>
       </div>

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -195,10 +195,10 @@ export default function TopicComposer({
   return (
     <div className="topic-composer">
       <div className="topic-composer__panel">
-        <span className="topic-composer__title">start a topic</span>
+        <span className="topic-composer__title">new chat</span>
         <form
           className="topic-composer__form"
-          aria-label="new topic"
+          aria-label="new chat"
           onSubmit={(event: FormEvent) => {
             event.preventDefault();
             if (!disabled) void submit(primaryIntent);
@@ -240,8 +240,8 @@ export default function TopicComposer({
           />
           <div className="topic-composer__bar">
             <span className="topic-composer__context">
-              {selectedProviderOption?.label ?? preview.providerLabel} ·{' '}
-              {preview.modeLabel} · {friendlyNodeLabel} · {preview.cwdLabel}
+              using {selectedProviderOption?.label ?? preview.providerLabel} in{' '}
+              {preview.cwdLabel}
             </span>
             <TuiButton variant="primary" type="submit" disabled={disabled}>
               {launchSubmitLabel({
@@ -259,7 +259,7 @@ export default function TopicComposer({
             onClick={() => setAdvancedOpen((prev) => !prev)}
           >
             <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
-            advanced
+            route/context
           </button>
           {advancedOpen ? (
             <div
@@ -280,7 +280,7 @@ export default function TopicComposer({
                 />
               </label>
               <label>
-                <span>task ref</span>
+                <span>reference</span>
                 <input
                   value={draft.taskRef}
                   onChange={(event) =>
@@ -427,9 +427,9 @@ export default function TopicComposer({
           {launchFailure ? (
             <div className="topic-composer__failure" role="alert">
               {launchFailure.stage === 'session'
-                ? 'launch failed after room creation'
-                : 'room creation failed'}{' '}
-              ({launchFailure.stage}): {launchFailure.message}
+                ? 'chat created, but agent launch failed'
+                : 'could not create chat'}{' '}
+              — {launchFailure.message}
             </div>
           ) : null}
         </form>
@@ -440,8 +440,8 @@ export default function TopicComposer({
             </TuiButton>
           ) : null}
           <span className="topic-composer__hint">
-            enter to start · shift+enter for a new line · topics and sessions
-            live in the sidebar
+            enter to send · shift+enter for a new line · chats live in the
+            sidebar
           </span>
         </div>
       </div>

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1011,8 +1011,6 @@
     padding: 8px 10px 2px;
     color: var(--text-muted);
     font-size: var(--font-size-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
   }
 
   .topic-mobile-group__name {

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -298,6 +298,15 @@
   color: transparent;
 }
 
+.topic-row__recency {
+  display: inline-flex;
+  justify-content: flex-end;
+  min-width: 2.5em;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  white-space: nowrap;
+}
+
 .topic-status svg {
   width: 13px;
   height: 13px;

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -218,6 +218,19 @@ function topicLatestStatus(item: TopicNavItem): string {
   return boundedTopicLatestStatus(item.routingLabel ?? item.statusLabel);
 }
 
+function topicRowRecencyLabel(item: TopicNavItem): string | null {
+  if (
+    item.tone === 'active' ||
+    item.tone === 'attention' ||
+    item.tone === 'error'
+  ) {
+    return null;
+  }
+  const session = topicPrimarySession(item);
+  const at = session?.lastActivity ?? item.updatedAt;
+  return at ? formatRelativeTimeCompact(at) : null;
+}
+
 function TopicBadge({ item }: { item: TopicNavItem }) {
   const background = item.color ?? deriveColor(item.badgeSeed);
   const label = item.channelKind
@@ -1090,6 +1103,7 @@ function TopicRow({
   ]
     .filter(Boolean)
     .join(' ');
+  const recencyLabel = topicRowRecencyLabel(item);
 
   return (
     <li
@@ -1122,7 +1136,11 @@ function TopicRow({
         </button>
         <span
           className="topic-row__trail"
-          aria-label={`${item.statusLabel}, ${affordanceCount} linked items`}
+          aria-label={
+            recencyLabel
+              ? `updated ${recencyLabel}`
+              : `${item.statusLabel}, ${affordanceCount} linked items`
+          }
         >
           <span className="topic-row__hover-actions" aria-hidden="true">
             {item.participants.length > 0 ? (
@@ -1135,7 +1153,11 @@ function TopicRow({
               <span className="topic-chip">t{item.taskRefs.length}</span>
             ) : null}
           </span>
-          <StatusGlyph tone={item.tone} />
+          {recencyLabel ? (
+            <span className="topic-row__recency">{recencyLabel}</span>
+          ) : (
+            <StatusGlyph tone={item.tone} />
+          )}
         </span>
       </div>
       {expanded ? (
@@ -1182,7 +1204,7 @@ function TopicRow({
 
 function searchMatchSummary(result: WorkspaceTopicSearchResult): string {
   const primary = result.matches[0];
-  if (!primary) return 'matched topic metadata';
+  if (!primary) return 'matched chat metadata';
   return `${primary.label}: ${primary.value}`;
 }
 
@@ -1199,17 +1221,14 @@ function TopicSearchResults({
   return (
     <div
       className="topic-search-results"
-      aria-label="topic search result details"
+      aria-label="chat search result details"
     >
       {results.map((result) => {
         const disabledReason = result.action.disabledReason;
         const primarySessionId = result.action.primarySessionId;
         const actionDisabled = Boolean(disabledReason) || !primarySessionId;
         const actionTitle =
-          disabledReason ??
-          (primarySessionId
-            ? `open session ${primarySessionId}`
-            : 'no linked session');
+          disabledReason ?? (primarySessionId ? 'open chat' : 'no linked chat');
         return (
           <div
             key={result.topic.id}
@@ -1261,11 +1280,11 @@ function topicEmptyStateText(input: {
   searchUnavailableReason?: string | undefined;
   searchQuery: string;
 }): string {
-  if (!input.searchActive) return 'no workspace topics yet';
+  if (!input.searchActive) return 'no chats yet';
   if (input.searchUnavailableReason === 'empty_query') {
-    return 'type to search bounded topic history';
+    return 'type to search chat history';
   }
-  return `no topic matches for “${input.searchQuery.trim()}”`;
+  return `no chat matches for “${input.searchQuery.trim()}”`;
 }
 
 
@@ -1301,13 +1320,13 @@ function TopicMobileCockpit({
     />
   );
   return (
-    <section className="topic-mobile-cockpit" aria-label="mobile topic cockpit">
+    <section className="topic-mobile-cockpit" aria-label="mobile chat switcher">
       <div
         className="topic-mobile-cockpit__bar"
-        aria-label="mobile topic actions"
+        aria-label="mobile chat actions"
       >
         <span className="topic-mobile-cockpit__hint">
-          use / search for topic history
+          search chat history
         </span>
         <div className="topic-mobile-cockpit__actions">
           <button
@@ -1328,16 +1347,16 @@ function TopicMobileCockpit({
             disabled={!onCreateTaskRoom}
             title={
               onCreateTaskRoom
-                ? 'start a new topic in the main pane'
-                : 'topic creation unavailable'
+                ? 'start a new chat in the main pane'
+                : 'chat creation unavailable'
             }
             onClick={onCreateTaskRoom}
           >
-            + task
+            new
           </button>
         </div>
       </div>
-      <div className="topic-mobile-list" aria-label="workspace-grouped topics">
+      <div className="topic-mobile-list" aria-label="workspace-grouped chats">
         {groups.map((group) => (
           <section
             key={group.id}
@@ -1406,13 +1425,13 @@ function TopicSearchPanel({
   const searchActive = searchQuery.trim().length > 0;
   return (
     <>
-      <label className="topic-search" aria-label="search topic history">
+      <label className="topic-search" aria-label="search chat history">
         <span className="topic-search__prompt">/</span>
         <input
           className="topic-search__input"
           value={searchQuery}
           onChange={(event) => onSearchQueryChange?.(event.target.value)}
-          placeholder="search topics, tasks, artifacts..."
+          placeholder="search chats..."
           spellCheck={false}
         />
         {canScope ? (
@@ -1434,7 +1453,7 @@ function TopicSearchPanel({
       </label>
       {searchError ? (
         <div className="topic-shell-state topic-search-state error">
-          <span>topic search unavailable</span>
+          <span>chat search unavailable</span>
           <span className="topic-search-state__actions">
             {onSearchRetry ? (
               <button type="button" onClick={onSearchRetry}>
@@ -1451,7 +1470,7 @@ function TopicSearchPanel({
       ) : null}
       {searchLoading && model.items.length === 0 ? (
         <div className="topic-shell-state topic-search-state">
-          searching topic history…
+          searching chat history…
         </div>
       ) : null}
       {model.items.length === 0 && !searchLoading && !searchError ? (
@@ -1479,7 +1498,7 @@ const EMPTY_SURFACES: WorkspaceSurface[] = [];
 const EMPTY_SEARCH_RESULTS: WorkspaceTopicSearchResult[] = [];
 const EMPTY_WORKSPACES: TopicNavWorkspace[] = [];
 
-/** Show/hide archived channels toggle; renders nothing without a handler. */
+/** Show/hide older chats toggle; renders nothing without a handler. */
 function ArchivedToggle({
   showArchived,
   onToggle,
@@ -1496,13 +1515,13 @@ function ArchivedToggle({
         aria-pressed={showArchived}
         onClick={onToggle}
       >
-        {showArchived ? 'hide archived' : 'show archived'}
+        {showArchived ? 'hide older chats' : 'show older chats'}
       </button>
     </div>
   );
 }
 
-/** The workspace-grouped topic tree: a section per workspace + an orphan lane. */
+/** The workspace-grouped chat tree: a section per workspace + an orphan lane. */
 function GroupedTopicTree({
   grouped,
   renderRow,
@@ -1511,7 +1530,7 @@ function GroupedTopicTree({
   renderRow: (id: string) => ReactNode;
 }) {
   return (
-    <div className="topic-tree" aria-label="workspace topics">
+    <div className="topic-tree" aria-label="workspace chats">
       {grouped.groups.map((group) => (
         <section
           key={group.id}
@@ -1746,25 +1765,25 @@ export function TopicSidebarView({
   const activeSearchLoading = Boolean(searchQuery.trim() && searchLoading);
 
   if (loading && !activeSearchLoading) {
-    return <div className="topic-shell-state">loading topic shell…</div>;
+    return <div className="topic-shell-state">loading chats…</div>;
   }
   if (error) {
     return (
-      <div className="topic-shell-state error">topic shell unavailable</div>
+      <div className="topic-shell-state error">chat list unavailable</div>
     );
   }
 
   return (
     <div className="topic-shell" data-track="topic-shell">
       <div className="topic-shell__header">
-        <span>topics</span>
+        <span>chats</span>
         {onCreateTaskRoom ? (
           <button
             className="topic-shell__create"
             type="button"
             onClick={onCreateTaskRoom}
           >
-            + task
+            new chat
           </button>
         ) : null}
         {searchQuery.trim() ? (
@@ -1805,18 +1824,20 @@ export function TopicSidebarView({
       <GroupedTopicTree grouped={grouped} renderRow={renderTopicRow} />
       {selectedItem ? (
         <>
-          <TopicDetail
-            item={selectedItem}
-            workspaceName={resolveWorkspaceName(
-              selectedItem,
-              workspaceNameById
-            )}
-            surfacesError={surfacesError}
-            surfacesLoading={surfacesLoading}
-            onSelectSession={onSelectSession}
-            onRestoreTopic={onRestoreTopic}
-            restoringTopicId={restoringTopicId}
-          />
+          <div className="topic-shell__advanced-detail" hidden aria-hidden="true">
+            <TopicDetail
+              item={selectedItem}
+              workspaceName={resolveWorkspaceName(
+                selectedItem,
+                workspaceNameById
+              )}
+              surfacesError={surfacesError}
+              surfacesLoading={surfacesLoading}
+              onSelectSession={onSelectSession}
+              onRestoreTopic={onRestoreTopic}
+              restoringTopicId={restoringTopicId}
+            />
+          </div>
           <TopicMobileControlPanel
             item={selectedItem}
             onSelectSession={onSelectSession}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1138,7 +1138,7 @@ function TopicRow({
           className="topic-row__trail"
           aria-label={
             recencyLabel
-              ? `updated ${recencyLabel}`
+              ? `${item.statusLabel}, ${affordanceCount} linked items, updated ${recencyLabel}`
               : `${item.statusLabel}, ${affordanceCount} linked items`
           }
         >
@@ -1824,7 +1824,7 @@ export function TopicSidebarView({
       <GroupedTopicTree grouped={grouped} renderRow={renderTopicRow} />
       {selectedItem ? (
         <>
-          <div className="topic-shell__advanced-detail" hidden aria-hidden="true">
+          <div className="topic-shell__advanced-detail" hidden>
             <TopicDetail
               item={selectedItem}
               workspaceName={resolveWorkspaceName(

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -196,6 +196,16 @@ function topicPrimaryAction(item: TopicNavItem): {
   };
 }
 
+function shouldShowMobileControlPanel(item: TopicNavItem | undefined): boolean {
+  if (!item) return false;
+  const action = topicPrimaryAction(item);
+  return (
+    action.label === 'approve' ||
+    action.label === 'reply' ||
+    action.label === 'waiting'
+  );
+}
+
 function topicLatestStatus(item: TopicNavItem): string {
   const session = topicPrimarySession(item);
   if (session?.agentState === 'permission-prompt') {
@@ -813,17 +823,35 @@ function TopicMobileAttentionRow({
   item,
   selected,
   onSelect,
+  onSelectSession,
 }: {
   item: TopicNavItem;
   selected: boolean;
   onSelect: (id: string) => void;
+  onSelectSession?: ((id: string) => void) | undefined;
 }) {
   const action = topicPrimaryAction(item);
+  const session = topicPrimarySession(item);
+  const resumeDisabledReason = sessionAttachDisabledReason(session);
+  const canResume = Boolean(
+    action.label === 'resume' && session && !resumeDisabledReason && onSelectSession
+  );
   return (
     <button
       type="button"
       className={`topic-mobile-row topic-mobile-row--${item.tone}${selected ? ' selected' : ''}`}
-      onClick={() => onSelect(item.id)}
+      onClick={() => {
+        if (canResume && session) {
+          onSelectSession?.(session.selectKey);
+          return;
+        }
+        onSelect(item.id);
+      }}
+      title={
+        canResume && session
+          ? `resume chat ${session.label}`
+          : (resumeDisabledReason ?? action.detail)
+      }
       aria-current={selected ? 'page' : undefined}
     >
       <TopicBadge item={item} />
@@ -1060,6 +1088,25 @@ function TopicMobileControlPanel({
         </p>
       ) : null}
     </section>
+  );
+}
+
+function TopicMobileControlPanelGate({
+  item,
+  onSelectSession,
+  onSendInput,
+}: {
+  item: TopicNavItem | undefined;
+  onSelectSession?: ((id: string) => void) | undefined;
+  onSendInput: TopicSendInput;
+}) {
+  if (!item || !shouldShowMobileControlPanel(item)) return null;
+  return (
+    <TopicMobileControlPanel
+      item={item}
+      onSelectSession={onSelectSession}
+      onSendInput={onSendInput}
+    />
   );
 }
 
@@ -1301,6 +1348,7 @@ function TopicMobileCockpit({
   ungrouped,
   selectedId,
   onSelect,
+  onSelectSession,
   onCreateTaskRoom,
   onResumeLast,
 }: {
@@ -1308,6 +1356,7 @@ function TopicMobileCockpit({
   ungrouped: TopicNavItem[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  onSelectSession?: ((id: string) => void) | undefined;
   onCreateTaskRoom?: (() => void) | undefined;
   onResumeLast?: (() => void) | undefined;
 }) {
@@ -1317,6 +1366,7 @@ function TopicMobileCockpit({
       item={item}
       selected={selectedId === item.id}
       onSelect={onSelect}
+      onSelectSession={onSelectSession}
     />
   );
   return (
@@ -1797,6 +1847,7 @@ export function TopicSidebarView({
         ungrouped={mobileUngrouped}
         selectedId={selectedId}
         onSelect={select}
+        onSelectSession={onSelectSession}
         onCreateTaskRoom={onCreateTaskRoom}
         onResumeLast={
           resumeLastSelectKey && onSelectSession
@@ -1838,7 +1889,7 @@ export function TopicSidebarView({
               restoringTopicId={restoringTopicId}
             />
           </div>
-          <TopicMobileControlPanel
+          <TopicMobileControlPanelGate
             item={selectedItem}
             onSelectSession={onSelectSession}
             onSendInput={onSendInput}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1110,6 +1110,41 @@ function TopicMobileControlPanelGate({
   );
 }
 
+function TopicAdvancedDetailGate({
+  item,
+  show,
+  workspaceNameById,
+  surfacesError,
+  surfacesLoading,
+  onSelectSession,
+  onRestoreTopic,
+  restoringTopicId,
+}: {
+  item: TopicNavItem | undefined;
+  show: boolean;
+  workspaceNameById: Map<string, string>;
+  surfacesError: boolean;
+  surfacesLoading: boolean;
+  onSelectSession?: ((id: string) => void) | undefined;
+  onRestoreTopic?: ((topicId: string) => void) | undefined;
+  restoringTopicId?: string | undefined;
+}) {
+  if (!item || !show) return null;
+  return (
+    <div className="topic-shell__advanced-detail">
+      <TopicDetail
+        item={item}
+        workspaceName={resolveWorkspaceName(item, workspaceNameById)}
+        surfacesError={surfacesError}
+        surfacesLoading={surfacesLoading}
+        onSelectSession={onSelectSession}
+        onRestoreTopic={onRestoreTopic}
+        restoringTopicId={restoringTopicId}
+      />
+    </div>
+  );
+}
+
 function TopicRow({
   item,
   depth,
@@ -1649,6 +1684,7 @@ export function TopicSidebarView({
   onToggleArchived,
   onRestoreTopic,
   restoringTopicId,
+  showAdvancedDetail = false,
 }: {
   topics: WorkspaceTopic[];
   sessions: SessionSummary[];
@@ -1680,6 +1716,7 @@ export function TopicSidebarView({
   onSelectSession?: ((id: string) => void) | undefined;
   onSendInput?: TopicSendInput | undefined;
   onCreateTaskRoom?: (() => void) | undefined;
+  showAdvancedDetail?: boolean | undefined;
 }) {
   const model = useMemo(
     () => buildTopicNavModel({ topics, sessions, surfaces, derived, nodes }),
@@ -1873,29 +1910,21 @@ export function TopicSidebarView({
       />
       <ArchivedToggle showArchived={showArchived} onToggle={onToggleArchived} />
       <GroupedTopicTree grouped={grouped} renderRow={renderTopicRow} />
-      {selectedItem ? (
-        <>
-          <div className="topic-shell__advanced-detail" hidden>
-            <TopicDetail
-              item={selectedItem}
-              workspaceName={resolveWorkspaceName(
-                selectedItem,
-                workspaceNameById
-              )}
-              surfacesError={surfacesError}
-              surfacesLoading={surfacesLoading}
-              onSelectSession={onSelectSession}
-              onRestoreTopic={onRestoreTopic}
-              restoringTopicId={restoringTopicId}
-            />
-          </div>
-          <TopicMobileControlPanelGate
-            item={selectedItem}
-            onSelectSession={onSelectSession}
-            onSendInput={onSendInput}
-          />
-        </>
-      ) : null}
+      <TopicAdvancedDetailGate
+        item={selectedItem}
+        show={showAdvancedDetail}
+        workspaceNameById={workspaceNameById}
+        surfacesError={surfacesError}
+        surfacesLoading={surfacesLoading}
+        onSelectSession={onSelectSession}
+        onRestoreTopic={onRestoreTopic}
+        restoringTopicId={restoringTopicId}
+      />
+      <TopicMobileControlPanelGate
+        item={selectedItem}
+        onSelectSession={onSelectSession}
+        onSendInput={onSendInput}
+      />
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -186,7 +186,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
           <div className="tl-resume-banner">
             <span className="tl-resume-hint">
               {resumeFailed
-                ? 'resume failed — retry or start a new context'
+                ? 'could not resume this chat — retry or continue here'
                 : 'session paused — resume where you left off'}
             </span>
             {resumeFailed ? (
@@ -220,7 +220,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
           </div>
         )}
         {!session || session.turns.length === 0 ? (
-          <div className="tl-empty">no messages yet</div>
+          <div className="tl-empty">send the first message to start this chat</div>
         ) : (
           <div ref={contentRef} className="tl-content">
             {session.turns.map((turn, index) => (

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -87,6 +87,7 @@ export function useSessionHandlers({
 
   const navigateToSession = useCallback(
     (sessionId: string, _sessionType: string) => {
+      useUiStore.getState().setForceOrgCockpit(false);
       useSessionsStore.getState().setActiveSessionId(sessionId);
       const session = resolveSessionByKey(
         useSessionsStore.getState().sessions,
@@ -125,6 +126,7 @@ export function useSessionHandlers({
   const handleSelectSession = useCallback(
     (id: string) => {
       setAnalyticsView(null);
+      useUiStore.getState().setForceOrgCockpit(false);
       useSessionsStore.getState().setActiveSessionId(id);
       const session = resolveSessionByKey(
         useSessionsStore.getState().sessions,

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -22,11 +22,12 @@ import {
   type TopicRoomDraft,
 } from '../lib/topic-create.js';
 import { taskRefFromDraft } from '../lib/topic-task-ref.js';
-import { resolveSessionByKey } from '../lib/session-keys.js';
+import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useToastStore } from '../lib/stores/toasts.js';
 import { useConfigStore } from '../lib/stores/config.js';
+import type { SessionSummary } from '../lib/types.js';
 
 /**
  * #1058: stateful draft + create/launch plumbing for codex-style topic
@@ -181,6 +182,44 @@ export function useTopicRoomCreate({
     setLaunchFailure(null);
   }, []);
 
+  const selectLaunchedSession = useCallback(
+    async (session: SessionSummary) => {
+      await useSessionsStore.getState().refreshAll();
+      const sessionsState = useSessionsStore.getState();
+      const launchedKey = scopedSessionKey(session);
+      const refreshedSession =
+        resolveSessionByKey(sessionsState.sessions, launchedKey) ??
+        resolveSessionByKey(sessionsState.sessions, session.id);
+      const selectedKey = refreshedSession
+        ? scopedSessionKey(refreshedSession)
+        : launchedKey;
+      const ui = useUiStore.getState();
+
+      // #1123: topic launches are chat-first even when they inherit repo
+      // routing defaults. Keep the workspace recall map warm, but do not bind
+      // the primary route to the repo dashboard; the cockpit remains an
+      // explicit escape hatch.
+      if (refreshedSession?.repoPath) {
+        sessionsState.rememberSessionForWorkspace(
+          refreshedSession.repoPath,
+          selectedKey
+        );
+      }
+      ui.setActiveRepoPath(null);
+
+      setActiveSessionId(selectedKey);
+      ui.setForceOrgCockpit(false);
+      ui.setTopicComposerOpen(false);
+      onLaunched?.(selectedKey);
+      // App-level launch handlers historically select the session and restore
+      // its repo route. Re-assert chat-first routing after those sync handlers
+      // run so start/resume cannot bounce into dashboard chrome.
+      useUiStore.getState().setActiveRepoPath(null);
+      useUiStore.getState().setForceOrgCockpit(false);
+    },
+    [onLaunched, setActiveSessionId]
+  );
+
   const submit = useCallback(
     async (intent: WorkspaceTopicLaunchIntent) => {
       if (!effectiveTitle) return;
@@ -205,10 +244,7 @@ export function useTopicRoomCreate({
             setLaunchFailure(result.failure);
             return;
           }
-          await useSessionsStore.getState().refreshAll();
-          setActiveSessionId(result.session.id);
-          useUiStore.getState().setTopicComposerOpen(false);
-          onLaunched?.(result.session.id);
+          await selectLaunchedSession(result.session);
           setCreatedRoom(null);
           setDraft(TOPIC_ROOM_DRAFT_EMPTY);
           return;
@@ -237,10 +273,7 @@ export function useTopicRoomCreate({
           return;
         }
         if (result.status === 'launched') {
-          await useSessionsStore.getState().refreshAll();
-          setActiveSessionId(result.session.id);
-          useUiStore.getState().setTopicComposerOpen(false);
-          onLaunched?.(result.session.id);
+          await selectLaunchedSession(result.session);
         } else {
           // create-only success has no navigation — confirm it happened and
           // surface where the new room lives.
@@ -274,10 +307,9 @@ export function useTopicRoomCreate({
       draft.templateKind,
       effectiveTitle,
       frameworks,
-      onLaunched,
       previewCreate,
       queryClient,
-      setActiveSessionId,
+      selectLaunchedSession,
       taskRef,
     ]
   );

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -111,9 +111,9 @@ export const sessionStartOnTicket: ActionMeta = {
 
 export const sessionCreateTaskRoom: ActionMeta = {
   id: 'session.create-task-room',
-  label: 'create task room…',
-  description: 'create a WorkspaceTopic room, optionally launching an agent',
-  aliases: ['+ task', 'task room', 'workspace topic', 'create and launch'],
+  label: 'new chat…',
+  description: 'start a workspace chat, optionally launching an agent',
+  aliases: ['new chat', '+ chat', 'chat', 'workspace chat', 'create and launch'],
   category: 'session',
   icon: '+',
   when: (ctx) => !!ctx.workspacePath || !!ctx.cwd,

--- a/frontend/src/lib/state/app-view-mode.ts
+++ b/frontend/src/lib/state/app-view-mode.ts
@@ -12,10 +12,10 @@ export interface ResolveAppViewModeInput {
   hasActiveSession: boolean;
   activeRepoPath: string | null;
   /**
-   * #1058: explicit escape hatch back to the legacy WorkContext cockpit
-   * (`OrgDashboard`), set via the "open work cockpit" command-palette
-   * action. Only relevant for the no-session/no-repo landing path — an
-   * explicit repo/project selection still resolves to `dashboard`.
+   * #1058/#1123: explicit escape hatch back to the legacy WorkContext/session
+   * cockpit, set via the "open work cockpit" command-palette action. Primary
+   * start/resume/message flows stay in the chat shell even after a session is
+   * selected so raw terminal/workspace chrome is never the default landing.
    */
   forceOrgCockpit?: boolean;
   /**
@@ -36,7 +36,7 @@ export function resolveAppViewMode({
 }: ResolveAppViewModeInput): AppViewMode {
   if (analyticsView !== null) return 'analytics';
   if (topicComposerOpen) return 'chat';
-  if (hasActiveSession) return 'session';
+  if (hasActiveSession) return forceOrgCockpit ? 'session' : 'chat';
 
   // The no-session / no-explicit-project landing path defaults to the
   // chat/topic spine (#1058). The legacy WorkContext cockpit remains

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -38,6 +38,7 @@ import {
   type TabControlEvent,
 } from '../../../../shared/control-state.js';
 import type { SessionDurabilityState } from '../../../../shared/session-durability.js';
+import { useUiStore } from './ui.js';
 
 const NOTIFICATIONS_STORAGE_KEY = 'claude-remote-notifications';
 const ACTIVE_SESSION_KEY = 'claude-remote-active-session';
@@ -415,6 +416,12 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
 
   setActiveSessionId: (id) => {
     const key = id === null ? null : resolveSessionKey(get().sessions, id);
+    if (key !== null) {
+      // `forceOrgCockpit` is a one-off escape hatch for the explicit Work
+      // cockpit commands. Any normal session activation should return to the
+      // chat/session shell instead of inheriting a stale forced cockpit mode.
+      useUiStore.getState().setForceOrgCockpit(false);
+    }
     saveActiveSessionId(key);
     set({ activeSessionId: key });
   },

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -627,8 +627,8 @@ export interface UiState {
    * #1058: the chat/topic spine is the default no-session/no-repo landing.
    * The legacy WorkContext cockpit (`OrgDashboard`) stays reachable via the
    * "open work cockpit" command-palette action, which sets this flag so
-   * `resolveAppViewMode` routes there instead of the chat home. Cleared once
-   * a session becomes active so the next empty state defaults back to chat.
+   * `resolveAppViewMode` routes there instead of the chat home/session shell.
+   * Session-transient; never persisted.
    */
   forceOrgCockpit: boolean;
   /**

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -104,13 +104,13 @@ export function launchSubmitLabel(input: {
   launchDisabled: boolean;
   launchFailure?: WorkspaceTopicLaunchFailure | null | undefined;
 }): string {
-  if (input.submittingIntent === 'create-and-launch') return 'launching…';
+  if (input.submittingIntent === 'create-and-launch') return 'starting…';
   if (input.submittingIntent === 'create-only') return 'creating…';
-  if (input.launchDisabled) return 'create room';
-  if (!input.launchFailure) return 'start';
+  if (input.launchDisabled) return 'create chat';
+  if (!input.launchFailure) return 'start chat';
   return input.launchFailure.stage === 'session'
-    ? 'retry launch'
-    : 'retry create + launch';
+    ? 'retry start'
+    : 'retry create + start';
 }
 
 export function launchTypeForTemplate(
@@ -255,7 +255,7 @@ export function buildTopicRoomCreateInput(input: {
 
   return {
     workspaceId: input.workspaceId ?? 'workspace:local',
-    title: input.draft.title.trim() || 'Untitled task room',
+    title: input.draft.title.trim() || 'Untitled chat',
     ...(prompt ? { description: prompt.slice(0, 240) } : {}),
     promptDefaults: {
       ...(prompt ? { starterPrompt: prompt } : {}),

--- a/test/app-view-mode.test.ts
+++ b/test/app-view-mode.test.ts
@@ -23,7 +23,7 @@ describe('resolveAppViewMode', () => {
     ).toBe('org');
   });
 
-  it('ignores forceOrgCockpit once a session or explicit repo takes priority', () => {
+  it('uses forceOrgCockpit as the only escape hatch back to the session cockpit', () => {
     expect(
       resolveAppViewMode({
         analyticsView: null,
@@ -64,7 +64,7 @@ describe('resolveAppViewMode', () => {
     ).toBe('analytics');
   });
 
-  it('preserves session, analytics, and explicit repo dashboard priority', () => {
+  it('keeps start/resume in the chat shell while preserving analytics and explicit repo dashboard priority', () => {
     expect(
       resolveAppViewMode({
         analyticsView: { sessionId: 'session-1' },
@@ -87,7 +87,15 @@ describe('resolveAppViewMode', () => {
         hasActiveSession: true,
         activeRepoPath: null,
       })
-    ).toBe('session');
+    ).toBe('chat');
+
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: true,
+        activeRepoPath: '/repo/relay-ide',
+      })
+    ).toBe('chat');
 
     expect(
       resolveAppViewMode({

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -4,12 +4,14 @@ import * as React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SessionSummary } from '../frontend/src/lib/types.js';
+import type { Repo, SessionSummary } from '../frontend/src/lib/types.js';
 import { useSessionHandlers } from '../frontend/src/hooks/useSessionHandlers.js';
 import { useActionRegistry } from '../frontend/src/hooks/useActionRegistry.js';
+import { useUrlNav } from '../frontend/src/hooks/useUrlNav.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
 import { resolveAppViewMode } from '../frontend/src/lib/state/app-view-mode.js';
+import { hashPath } from '../frontend/src/lib/url-nav.js';
 import {
   _resetForTesting,
   getAction,
@@ -42,6 +44,18 @@ function makeSession(
     createdAt: '2026-05-14T00:00:00.000Z',
     lastActivity: '2026-05-14T00:00:00.000Z',
     idle: false,
+    ...overrides,
+  };
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    path: '/repo/relay-ide',
+    name: 'relay-ide',
+    isGitRepo: true,
+    kind: 'repo',
+    defaultBranch: 'nightly',
+    currentBranch: 'nightly',
     ...overrides,
   };
 }
@@ -93,6 +107,7 @@ function ActionRegistryHarness() {
     handleCloseSession: vi.fn(),
     handleSelectSession: vi.fn(),
     handleNewWorktree: vi.fn(),
+    handleLaunchWorkspaceSession: vi.fn(),
     handleOpenSettings: vi.fn(),
     handleRenameActiveSession: vi.fn(),
     handleArchive: vi.fn(),
@@ -102,6 +117,16 @@ function ActionRegistryHarness() {
     workspaceSettingsDialogRef: React.createRef(),
     setFilePickerOpen: vi.fn(),
   });
+  return null;
+}
+
+function UrlNavHarness({
+  onReady,
+}: {
+  onReady: (nav: ReturnType<typeof useUrlNav>) => void;
+}) {
+  const nav = useUrlNav();
+  onReady(nav);
   return null;
 }
 
@@ -133,6 +158,7 @@ describe('session lifecycle handlers', () => {
       topicComposerOpen: false,
       sidebarOpen: false,
     });
+    window.history.replaceState(null, '', '/');
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -166,6 +192,97 @@ describe('session lifecycle handlers', () => {
     });
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('clears a stale forced cockpit flag when restoring a session URL', async () => {
+    const repo = makeRepo();
+    const local = makeSession({ id: 'url-session-1' });
+    useSessionsStore.setState({
+      repos: [repo],
+      sessions: [local],
+      activeSessionId: null,
+    });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: true,
+    });
+    window.history.replaceState(
+      null,
+      '',
+      `/${hashPath(repo.path)}/${local.id}`
+    );
+
+    let nav: ReturnType<typeof useUrlNav> | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(UrlNavHarness, {
+          onReady: (next) => {
+            nav = next;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      nav!.restoreFromUrl();
+    });
+
+    const ui = useUiStore.getState();
+    expect(useSessionsStore.getState().activeSessionId).toBe(local.id);
+    expect(ui.forceOrgCockpit).toBe(false);
+    expect(ui.activeRepoPath).toBe(repo.path);
+    expect(
+      resolveAppViewMode({
+        analyticsView: ui.analyticsView,
+        hasActiveSession: true,
+        activeRepoPath: ui.activeRepoPath,
+        forceOrgCockpit: ui.forceOrgCockpit,
+        topicComposerOpen: ui.topicComposerOpen,
+      })
+    ).toBe('chat');
+  });
+
+  it('clears a stale forced cockpit flag when browser history activates a session', async () => {
+    const repo = makeRepo();
+    const local = makeSession({ id: 'popstate-session-1' });
+    useSessionsStore.setState({
+      repos: [repo],
+      sessions: [local],
+      activeSessionId: null,
+    });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: true,
+    });
+
+    await act(async () => {
+      root!.render(
+        React.createElement(UrlNavHarness, {
+          onReady: () => undefined,
+        })
+      );
+    });
+    window.history.pushState(null, '', `/${hashPath(repo.path)}/${local.id}`);
+
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    const ui = useUiStore.getState();
+    expect(useSessionsStore.getState().activeSessionId).toBe(local.id);
+    expect(ui.forceOrgCockpit).toBe(false);
+    expect(ui.activeRepoPath).toBe(repo.path);
+    expect(
+      resolveAppViewMode({
+        analyticsView: ui.analyticsView,
+        hasActiveSession: true,
+        activeRepoPath: ui.activeRepoPath,
+        forceOrgCockpit: ui.forceOrgCockpit,
+        topicComposerOpen: ui.topicComposerOpen,
+      })
+    ).toBe('chat');
   });
 
   it('clears a stale forced cockpit flag when selecting an existing session', async () => {
@@ -446,6 +563,72 @@ describe('session lifecycle handlers', () => {
       '/hub/nodes/node-a/sessions/archive-session-1',
       { method: 'DELETE' }
     );
+  });
+
+  it('clears a stale forced cockpit flag when jumping to next attention work', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+      jsonResponse({
+        groups: [
+          {
+            id: 'active-work-1',
+            node: { nodeId: 'local', displayName: 'local', status: 'online' },
+            staleReadModel: false,
+            sessions: [
+              {
+                id: 'next-attention-session-1',
+                type: 'agent',
+                agent: 'claude',
+                repoPath: '/repo/relay-ide',
+                cwd: '/repo/relay-ide',
+                live: true,
+                agentState: 'waiting-for-input',
+                controlFreshness: 'fresh',
+                durability: 'running-attached',
+                associatedAt: '2026-05-14T00:00:00.000Z',
+                lastActivity: '2026-05-14T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    useSessionsStore.setState({ sessions: [], activeSessionId: null });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: true,
+      sidebarOpen: true,
+    });
+
+    await act(async () => {
+      root!.render(React.createElement(ActionRegistryHarness));
+    });
+    await flushPromises();
+
+    const action = getAction('navigation.next-attention-work');
+    expect(action).toBeDefined();
+    await act(async () => {
+      await action!.handler({ view: 'org' });
+    });
+    await flushPromises();
+
+    const ui = useUiStore.getState();
+    expect(useSessionsStore.getState().activeSessionId).toContain(
+      'next-attention-session-1'
+    );
+    expect(ui.forceOrgCockpit).toBe(false);
+    expect(ui.activeRepoPath).toBe('/repo/relay-ide');
+    expect(ui.sidebarOpen).toBe(false);
+    expect(
+      resolveAppViewMode({
+        analyticsView: ui.analyticsView,
+        hasActiveSession: true,
+        activeRepoPath: ui.activeRepoPath,
+        forceOrgCockpit: ui.forceOrgCockpit,
+        topicComposerOpen: ui.topicComposerOpen,
+      })
+    ).toBe('chat');
   });
 
   it('routes command-palette kill for remote sessions through the owning node', async () => {

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -8,6 +8,8 @@ import type { SessionSummary } from '../frontend/src/lib/types.js';
 import { useSessionHandlers } from '../frontend/src/hooks/useSessionHandlers.js';
 import { useActionRegistry } from '../frontend/src/hooks/useActionRegistry.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import { resolveAppViewMode } from '../frontend/src/lib/state/app-view-mode.js';
 import {
   _resetForTesting,
   getAction,
@@ -124,6 +126,13 @@ describe('session lifecycle handlers', () => {
       backendConnectionStatus: 'connected',
       refreshAll: refreshAll as unknown as typeof originalRefreshAll,
     });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: false,
+      topicComposerOpen: false,
+      sidebarOpen: false,
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -148,8 +157,103 @@ describe('session lifecycle handlers', () => {
       backendConnectionStatus: 'connected',
       refreshAll: originalRefreshAll,
     });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: false,
+      topicComposerOpen: false,
+      sidebarOpen: false,
+    });
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('clears a stale forced cockpit flag when selecting an existing session', async () => {
+    const local = makeSession({ id: 'select-session-1' });
+    useSessionsStore.setState({
+      sessions: [local],
+      activeSessionId: null,
+    });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: true,
+      sidebarOpen: true,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      handlers!.handleSelectSession(local.id);
+    });
+
+    const ui = useUiStore.getState();
+    expect(useSessionsStore.getState().activeSessionId).toBe(local.id);
+    expect(ui.forceOrgCockpit).toBe(false);
+    expect(ui.activeRepoPath).toBe(local.repoPath);
+    expect(ui.sidebarOpen).toBe(false);
+    expect(
+      resolveAppViewMode({
+        analyticsView: ui.analyticsView,
+        hasActiveSession: true,
+        activeRepoPath: ui.activeRepoPath,
+        forceOrgCockpit: ui.forceOrgCockpit,
+        topicComposerOpen: ui.topicComposerOpen,
+      })
+    ).toBe('chat');
+  });
+
+  it('clears a stale forced cockpit flag when resuming a session by id', async () => {
+    const local = makeSession({ id: 'resume-session-1' });
+    useSessionsStore.setState({
+      sessions: [local],
+      activeSessionId: null,
+    });
+    useUiStore.setState({
+      activeRepoPath: null,
+      analyticsView: null,
+      forceOrgCockpit: true,
+      sidebarOpen: true,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      handlers!.navigateToSession(local.id, local.type);
+    });
+
+    const ui = useUiStore.getState();
+    expect(useSessionsStore.getState().activeSessionId).toBe(local.id);
+    expect(ui.forceOrgCockpit).toBe(false);
+    expect(ui.activeRepoPath).toBe(local.repoPath);
+    expect(ui.sidebarOpen).toBe(false);
+    expect(
+      resolveAppViewMode({
+        analyticsView: ui.analyticsView,
+        hasActiveSession: true,
+        activeRepoPath: ui.activeRepoPath,
+        forceOrgCockpit: ui.forceOrgCockpit,
+        topicComposerOpen: ui.topicComposerOpen,
+      })
+    ).toBe('chat');
   });
 
   it('routes tab close for remote sessions through the owning node', async () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -434,7 +434,7 @@ describe('TopicComposer', () => {
       '.topic-composer__bar button[type="submit"]'
     ) as HTMLButtonElement;
 
-    expect(start.textContent).toBe('create room');
+    expect(start.textContent).toBe('create chat');
     expect(start.disabled).toBe(false);
 
     const form = container.querySelector(
@@ -499,7 +499,7 @@ describe('TopicComposer', () => {
     expect(advanced).not.toBeNull();
     expect(advanced?.textContent).toContain('agent id');
     expect(advanced?.textContent).toContain('node');
-    expect(advanced?.textContent).toContain('task ref');
+    expect(advanced?.textContent).toContain('reference');
     expect(
       advanced?.querySelector('input[list="topic-composer-provider-options"]')
     ).toBeNull();

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -26,8 +26,11 @@ vi.mock('../frontend/src/lib/api.js', async (importOriginal) => {
 
 import { createWorkspaceTopicRoomAndMaybeLaunch, launchWorkspaceTopicRoom } from '../frontend/src/lib/api.js';
 import { useConfigStore } from '../frontend/src/lib/stores/config.js';
+import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
 import type { FrameworkInfo } from '../frontend/src/lib/types.js';
 import TopicComposer from '../frontend/src/components/TopicComposer.js';
+import ChatHome from '../frontend/src/components/ChatHome.js';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -278,6 +281,7 @@ describe('topic provider launch helpers', () => {
 });
 
 describe('TopicComposer', () => {
+  const originalRefreshAll = useSessionsStore.getState().refreshAll;
   let container: HTMLDivElement;
   let root: Root;
   let queryClient: QueryClient;
@@ -300,6 +304,18 @@ describe('TopicComposer', () => {
         }),
       ],
     });
+    useSessionsStore.setState({
+      sessions: [],
+      repos: [],
+      activeSessionId: null,
+      workspaceLastSession: {},
+      refreshAll: originalRefreshAll,
+    });
+    useUiStore.setState({
+      activeRepoPath: null,
+      forceOrgCockpit: false,
+      topicComposerOpen: false,
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -313,15 +329,30 @@ describe('TopicComposer', () => {
     container.remove();
     queryClient.clear();
     vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
-  function renderComposer() {
+  function renderComposer(onSelectSession?: (id: string) => void) {
     act(() =>
       root.render(
         React.createElement(
           QueryClientProvider,
           { client: queryClient },
-          React.createElement(TopicComposer, {})
+          React.createElement(TopicComposer, {
+            ...(onSelectSession ? { onSelectSession } : {}),
+          })
+        )
+      )
+    );
+  }
+
+  function renderChatHome(onSelectSession: (id: string) => void) {
+    act(() =>
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChatHome, { onSelectSession })
         )
       )
     );
@@ -568,6 +599,118 @@ describe('TopicComposer', () => {
     expect(call.room.topic.routingDefaults?.providerId).toBe('hermes');
     expect(call.launch).toMatchObject({ mode: 'web', agent: 'hermes' });
     expect(useConfigStore.getState().defaultAgent).toBe('claude');
+  });
+
+  it('keeps a launched chat in the chat shell while the sessions feed catches up', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+      status: 'launched',
+      topic: { id: 'topic:launched' },
+      workContext: { id: 'wc:launched' },
+      session: {
+        id: 'session-late',
+        type: 'agent',
+        agent: 'claude',
+        mode: 'pty',
+        repoPath: '/repo/relay-ide',
+        cwd: '/repo/relay-ide',
+        displayName: 'late session',
+        createdAt: '2026-07-03T00:00:00.000Z',
+        lastActivity: '2026-07-03T00:00:00.000Z',
+        idle: false,
+      },
+    } as never);
+    const refreshAll = vi.fn(async () => {});
+    useSessionsStore.setState({
+      sessions: [],
+      repos: [
+        {
+          path: '/repo/relay-ide',
+          name: 'relay-ide',
+          isGitRepo: true,
+          kind: 'repo',
+          defaultBranch: 'nightly',
+          currentBranch: 'issue-1122-ruthless-core-loop',
+        },
+      ],
+      activeSessionId: null,
+      refreshAll,
+    });
+    useUiStore.setState({
+      activeRepoPath: '/repo/relay-ide',
+      forceOrgCockpit: true,
+    });
+    const onSelectSession = vi.fn(() => {
+      useUiStore.getState().setActiveRepoPath('/repo/relay-ide');
+    });
+    renderComposer(onSelectSession);
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    act(() => setNativeValue(ta, 'start from repo context'));
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(refreshAll).toHaveBeenCalledTimes(1);
+    expect(useSessionsStore.getState().activeSessionId).toBe('session-late');
+    expect(useUiStore.getState().activeRepoPath).toBeNull();
+    expect(useUiStore.getState().forceOrgCockpit).toBe(false);
+    expect(onSelectSession).toHaveBeenCalledWith('session-late');
+  });
+
+  it('does not route ChatHome launches through repo session selection', async () => {
+    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+      status: 'launched',
+      topic: { id: 'topic:chat-home' },
+      workContext: { id: 'wc:chat-home' },
+      session: {
+        id: 'session-chat-home',
+        type: 'agent',
+        agent: 'claude',
+        mode: 'pty',
+        repoPath: '/repo/relay-ide',
+        cwd: '/repo/relay-ide',
+        displayName: 'chat home session',
+        createdAt: '2026-07-03T00:00:00.000Z',
+        lastActivity: '2026-07-03T00:00:00.000Z',
+        idle: false,
+      },
+    } as never);
+    useSessionsStore.setState({
+      sessions: [],
+      activeSessionId: null,
+      refreshAll: vi.fn(async () => {}),
+    });
+    useUiStore.setState({
+      activeRepoPath: '/repo/relay-ide',
+      forceOrgCockpit: true,
+    });
+    const onSelectSession = vi.fn(() => {
+      useUiStore.getState().setActiveRepoPath('/repo/relay-ide');
+    });
+    renderChatHome(onSelectSession);
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    act(() => setNativeValue(ta, 'start from chat home'));
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(useSessionsStore.getState().activeSessionId).toBe(
+      'session-chat-home'
+    );
+    expect(useUiStore.getState().activeRepoPath).toBeNull();
+    expect(useUiStore.getState().forceOrgCockpit).toBe(false);
+    expect(onSelectSession).not.toHaveBeenCalled();
   });
 
   it('keeps the created room and provider launch mode when retrying after session launch failure', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -121,8 +121,8 @@ describe('TopicSidebarView', () => {
     });
   }
 
-  it('renders a topic row, inline detail, linked session, and surface affordance', async () => {
-    await renderView();
+  it('renders a topic row plus explicit advanced detail, linked session, and surface affordance', async () => {
+    await renderView({ showAdvancedDetail: true });
 
     expect(container.querySelector('.topic-shell')).not.toBeNull();
     expect(container.querySelector('.topic-room')).not.toBeNull();
@@ -134,16 +134,15 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('preview');
   });
 
-  it('keeps recency row labels contextual and avoids aria-hidden interactive detail', async () => {
+  it('keeps recency row labels contextual without mounting default advanced detail chrome', async () => {
     await renderView();
 
     const trail = container.querySelector('.topic-row__trail');
     expect(trail?.getAttribute('aria-label')).toContain('idle');
     expect(trail?.getAttribute('aria-label')).toContain('linked items');
     expect(trail?.getAttribute('aria-label')).toContain('updated');
-    expect(
-      container.querySelector('.topic-shell__advanced-detail[aria-hidden="true"]')
-    ).toBeNull();
+    expect(container.querySelector('.topic-shell__advanced-detail')).toBeNull();
+    expect(container.querySelector('.topic-room')).toBeNull();
   });
 
   it('groups topics under workspace channel headers', async () => {
@@ -236,6 +235,20 @@ describe('TopicSidebarView', () => {
     expect(mobileHeaders).toContain('research');
   });
 
+  it('keeps mobile workspace headers natural-case without uppercase styling', () => {
+    const css = fs.readFileSync(
+      'frontend/src/components/TopicSidebarShell.css',
+      'utf8'
+    );
+    const headerBlock = css.match(
+      /\.topic-mobile-group__header\s*{[\s\S]*?\n\s*}/
+    )?.[0];
+
+    expect(headerBlock).toBeTruthy();
+    expect(headerBlock).not.toMatch(/text-transform\s*:\s*uppercase/i);
+    expect(headerBlock).not.toMatch(/letter-spacing\s*:/i);
+  });
+
   it('resumes the most recent session in one tap from the mobile cockpit (#1088)', async () => {
     await renderView({
       topics: [
@@ -323,6 +336,8 @@ describe('TopicSidebarView', () => {
     await renderView();
 
     expect(container.querySelector('.topic-mobile-detail')).toBeNull();
+    expect(container.querySelector('.topic-shell__advanced-detail')).toBeNull();
+    expect(container.querySelector('.topic-room')).toBeNull();
     expect(container.textContent).not.toContain('resume topic');
     expect(container.textContent).not.toContain('open terminal tab');
   });
@@ -380,6 +395,7 @@ describe('TopicSidebarView', () => {
   it('restores an archived topic from its detail panel', async () => {
     const onRestoreTopic = vi.fn();
     await renderView({
+      showAdvancedDetail: true,
       topics: [
         makeTopic({
           id: 'topic:old',
@@ -405,6 +421,7 @@ describe('TopicSidebarView', () => {
   it('disables the restore button while its restore is in flight', async () => {
     const onRestoreTopic = vi.fn();
     await renderView({
+      showAdvancedDetail: true,
       topics: [
         makeTopic({
           id: 'topic:old',
@@ -651,6 +668,7 @@ describe('TopicSidebarView', () => {
 
   it('shows detail for a selected topic even when it has no nested sessions', async () => {
     await renderView({
+      showAdvancedDetail: true,
       topics: [
         makeTopic({
           linkedRefs: {
@@ -677,6 +695,7 @@ describe('TopicSidebarView', () => {
 
   it('renders a task-room panel with grouped sessions, refs, and safe artifacts', async () => {
     await renderView({
+      showAdvancedDetail: true,
       topics: [
         makeTopic({
           linkedRefs: {
@@ -766,6 +785,7 @@ describe('TopicSidebarView', () => {
 
   it('formats an untitled github issue task ref as #<id>, not the bare tracker id (#1061)', async () => {
     await renderView({
+      showAdvancedDetail: true,
       topics: [
         makeTopic({
           linkedRefs: {
@@ -783,6 +803,7 @@ describe('TopicSidebarView', () => {
 
   it('keeps stale sessions inspectable while disabling live room controls', async () => {
     await renderView({
+      showAdvancedDetail: true,
       sessions: [
         makeSession({
           id: 's1',
@@ -812,6 +833,7 @@ describe('TopicSidebarView', () => {
 
   it('keeps desktop resume enabled when only live input control state is unknown', async () => {
     await renderView({
+      showAdvancedDetail: true,
       sessions: [
         makeSession({
           id: 's1',
@@ -838,6 +860,7 @@ describe('TopicSidebarView', () => {
 
   it('selects the exact global session from the task-room session row', async () => {
     await renderView({
+      showAdvancedDetail: true,
       topics: [makeTopic({ linkedRefs: { sessionIds: ['global:agent-1'] } })],
       sessions: [
         makeSession({
@@ -859,14 +882,14 @@ describe('TopicSidebarView', () => {
   });
 
   it('keeps the room usable when surface loading fails', async () => {
-    await renderView({ surfaces: [], surfacesError: true });
+    await renderView({ surfaces: [], surfacesError: true, showAdvancedDetail: true });
 
     expect(container.textContent).toContain('Frontend lane');
     expect(container.textContent).toContain('surfaces unavailable');
   });
 
   it('keeps the room usable while surfaces are still loading', async () => {
-    await renderView({ surfaces: [], surfacesLoading: true });
+    await renderView({ surfaces: [], surfacesLoading: true, showAdvancedDetail: true });
 
     expect(container.textContent).not.toContain('loading topic shell');
     expect(container.querySelector('.topic-room')).not.toBeNull();
@@ -874,7 +897,7 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('surfaces loading…');
   });
 
-  it('keeps the shell room mounted while surfaces query is still pending', async () => {
+  it('keeps the chat list mounted without advanced detail while surfaces query is still pending', async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -907,9 +930,10 @@ describe('TopicSidebarView', () => {
       headers: { 'x-relay-capabilities': 'context:read' },
     });
     expect(container.textContent).not.toContain('loading topic shell');
-    expect(container.querySelector('.topic-room')).not.toBeNull();
+    expect(container.querySelector('.topic-shell')).not.toBeNull();
+    expect(container.querySelector('.topic-shell__advanced-detail')).toBeNull();
+    expect(container.querySelector('.topic-room')).toBeNull();
     expect(container.textContent).toContain('Build UI shell');
-    expect(container.textContent).toContain('surfaces loading…');
     queryClient.clear();
   });
 
@@ -1447,6 +1471,7 @@ describe('TopicSidebarView', () => {
     vi.stubGlobal('open', openMock);
 
     await renderView({
+      showAdvancedDetail: true,
       topics: [makeTopic({ linkedRefs: { sessionIds: [] } })],
       sessions: [],
       surfaces: [makeSurface()],
@@ -1513,6 +1538,7 @@ describe('TopicSidebarView', () => {
 
   it('renders participant roster cards grouped by role/runtime and opens exact existing sessions', async () => {
     await renderView({
+      showAdvancedDetail: true,
       topics: [
         makeTopic({
           linkedRefs: { sessionIds: ['devbox:remote-ika', 'global:kame'] },

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -299,7 +299,7 @@ describe('TopicSidebarView', () => {
       '.topic-archived-toggle__btn'
     ) as HTMLButtonElement;
     expect(btn).not.toBeNull();
-    expect(btn.textContent).toBe('show archived');
+    expect(btn.textContent).toBe('show older chats');
     await act(async () => btn.click());
     expect(onToggleArchived).toHaveBeenCalled();
   });
@@ -842,13 +842,13 @@ describe('TopicSidebarView', () => {
 
   it('reports loading, error, and empty states', async () => {
     await renderView({ loading: true, topics: [] });
-    expect(container.textContent).toContain('loading topic shell');
+    expect(container.textContent).toContain('loading chats');
 
     await renderView({ loading: false, error: true, topics: [] });
-    expect(container.textContent).toContain('topic shell unavailable');
+    expect(container.textContent).toContain('chat list unavailable');
 
     await renderView({ loading: false, error: false, topics: [] });
-    expect(container.textContent).toContain('no workspace topics yet');
+    expect(container.textContent).toContain('no chats yet');
   });
 
   it('routes the task-room creation entrypoint to the main-pane composer', async () => {
@@ -946,7 +946,7 @@ describe('TopicSidebarView', () => {
     expect(
       container.querySelector('.topic-mobile-cockpit__bar input')
     ).toBeNull();
-    expect(container.textContent).toContain('use / search for topic history');
+    expect(container.textContent).toContain('search chat history');
   });
 
   it('uses a two-step audited mobile reply preview before sending input', async () => {
@@ -1460,7 +1460,7 @@ describe('TopicSidebarView', () => {
 
     expect(container.querySelector('.topic-shell')).not.toBeNull();
     expect(container.querySelector('.topic-search__input')).not.toBeNull();
-    expect(container.textContent).toContain('topic search unavailable');
+    expect(container.textContent).toContain('chat search unavailable');
     const retryButton = Array.from(container.querySelectorAll('button')).find(
       (button) => button.textContent === 'retry'
     ) as HTMLButtonElement;

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -284,6 +284,67 @@ describe('TopicSidebarView', () => {
     expect(resume.disabled).toBe(true);
   });
 
+  it('resumes a chat when tapping its mobile switcher row instead of opening detail chrome (#1122)', async () => {
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:a',
+          workspaceId: 'ws:a',
+          routingDefaults: { repoPath: '/repo/mobile-detail' },
+          display: { title: 'Mobile resume target' },
+          linkedRefs: { sessionIds: ['s-old', 's-new'] },
+        }),
+      ],
+      sessions: [
+        makeSession({
+          id: 's-old',
+          displayName: 'older',
+          lastActivity: '2026-06-01T00:00:00Z',
+        }),
+        makeSession({
+          id: 's-new',
+          displayName: 'newer',
+          lastActivity: '2026-06-25T00:00:00Z',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    const row = container.querySelector('.topic-mobile-row') as HTMLButtonElement;
+    expect(row).not.toBeNull();
+    await act(async () => row.click());
+
+    expect(onSelectSession).toHaveBeenCalledTimes(1);
+    expect(onSelectSession).toHaveBeenCalledWith('s-new');
+    expect(useUiStore.getState().activeRepoPath).toBeNull();
+  });
+
+  it('hides the mobile detail/control chrome for resumable chat rows (#1122)', async () => {
+    await renderView();
+
+    expect(container.querySelector('.topic-mobile-detail')).toBeNull();
+    expect(container.textContent).not.toContain('resume topic');
+    expect(container.textContent).not.toContain('open terminal tab');
+  });
+
+  it('keeps the mobile control panel available for reply/approval states', async () => {
+    await renderView({
+      sessions: [
+        makeSession({
+          id: 's1',
+          displayName: 'Frontend lane',
+          agentState: 'waiting-for-input',
+          controlFreshness: 'fresh',
+          mode: 'pty',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    expect(container.querySelector('.topic-mobile-detail')).not.toBeNull();
+    expect(container.textContent).toContain('reply');
+  });
+
   it('shows a search scope toggle only when a workspace is active', async () => {
     const onToggleSearchScope = vi.fn();
     await renderView({ activeWorkspaceId: 'ws:a', onToggleSearchScope });
@@ -1290,38 +1351,16 @@ describe('TopicSidebarView', () => {
     expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
       'resume'
     );
-    expect(container.textContent).toContain(
-      'controls disabled: unknown control state'
-    );
+    expect(container.querySelector('.topic-mobile-detail')).toBeNull();
 
-    const input = container.querySelector(
-      '.topic-mobile-control input'
-    ) as HTMLInputElement;
-    const submit = container.querySelector(
-      '.topic-mobile-control__primary'
-    ) as HTMLButtonElement;
-    const buttons = Array.from(
-      container.querySelectorAll('.topic-mobile-actions button')
-    ) as HTMLButtonElement[];
-    const resume = buttons.find(
-      (button) => button.textContent === 'resume topic'
-    ) as HTMLButtonElement;
-    const terminal = buttons.find(
-      (button) => button.textContent === 'open terminal tab'
-    ) as HTMLButtonElement;
-
-    expect(input.disabled).toBe(true);
-    expect(submit.disabled).toBe(true);
-    expect(resume.disabled).toBe(false);
-    expect(resume.title).toContain('open the linked Relay tab');
-    expect(terminal.disabled).toBe(false);
-
-    await act(async () => terminal.click());
+    const row = container.querySelector('.topic-mobile-row') as HTMLButtonElement;
+    expect(row.title).toContain('resume chat');
+    await act(async () => row.click());
     expect(onSelectSession).toHaveBeenCalledWith('s1');
     expect(onSendInput).not.toHaveBeenCalled();
   });
 
-  it('keeps web session input disabled while allowing mobile tab resume', async () => {
+  it('keeps web session input hidden while allowing mobile row resume', async () => {
     await renderView({
       sessions: [
         makeSession({
@@ -1337,34 +1376,21 @@ describe('TopicSidebarView', () => {
     expect(container.querySelector('.topic-mobile-row')?.textContent).toContain(
       'resume'
     );
-    expect(container.textContent).toContain(
-      'controls disabled: web session input is unsupported here'
-    );
+    expect(container.querySelector('.topic-mobile-detail')).toBeNull();
 
-    const resume = Array.from(
-      container.querySelectorAll('.topic-mobile-actions button')
-    ).find(
-      (button) => button.textContent === 'resume topic'
-    ) as HTMLButtonElement;
-    expect(resume.disabled).toBe(false);
-    await act(async () => resume.click());
+    const row = container.querySelector('.topic-mobile-row') as HTMLButtonElement;
+    await act(async () => row.click());
     expect(onSelectSession).toHaveBeenCalledWith('s1');
   });
 
-  it('makes the resume and terminal-tab mobile controls explicit', async () => {
+  it('makes the mobile row itself the explicit resume affordance', async () => {
     await renderView();
 
-    const quickActions = container.querySelector('.topic-mobile-actions');
-    expect(quickActions?.textContent).toContain('resume topic');
-    expect(quickActions?.textContent).toContain('open terminal tab');
-
-    const terminalTab = Array.from(
-      quickActions?.querySelectorAll('button') ?? []
-    ).find(
-      (button) => button.textContent === 'open terminal tab'
-    ) as HTMLButtonElement;
-    expect(terminalTab.title).toContain('same linked Relay tab as resume');
-    await act(async () => terminalTab.click());
+    const row = container.querySelector('.topic-mobile-row') as HTMLButtonElement;
+    expect(container.querySelector('.topic-mobile-actions')).toBeNull();
+    expect(row.textContent).toContain('resume');
+    expect(row.title).toContain('resume chat');
+    await act(async () => row.click());
     expect(onSelectSession).toHaveBeenCalledWith('s1');
   });
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -134,6 +134,18 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('preview');
   });
 
+  it('keeps recency row labels contextual and avoids aria-hidden interactive detail', async () => {
+    await renderView();
+
+    const trail = container.querySelector('.topic-row__trail');
+    expect(trail?.getAttribute('aria-label')).toContain('idle');
+    expect(trail?.getAttribute('aria-label')).toContain('linked items');
+    expect(trail?.getAttribute('aria-label')).toContain('updated');
+    expect(
+      container.querySelector('.topic-shell__advanced-detail[aria-hidden="true"]')
+    ).toBeNull();
+  });
+
   it('groups topics under workspace channel headers', async () => {
     await renderView({
       topics: [


### PR DESCRIPTION
## Summary
- Makes the default Relay chrome open into the chat/workspace shell with `new chat`, chat search, older-chat affordance, and bounded row-at-rest status/recency instead of config-first/topic-first copy.
- Tightens the first-message TopicComposer flow around chat language, provider selection, route/context disclosure, and explicit retry/copy/open-diagnostics states in the chat view/session actions.
- Adds the missing Vite dev proxy for `/work-contexts` so the browser start-chat flow can create WorkContext + WorkspaceTopic records during local/dev verification.
- Adds mobile chat switcher affordances (`Chats`, `New`, compact mobile row controls) and updates component tests around the chat-first wording.

## Verification
- `npm test -- test/topic-sidebar-shell.test.ts test/topic-composer.test.ts test/components/chat-v2-rendering.test.ts` — 77 passed.
- `npm run check` — passed with existing repo warnings only (0 errors, 228 warnings).
- `npm run build` — passed; existing Vite chunk-size/dynamic import warnings.
- Browser manual desktop smoke on `npm run dev:self` at `http://127.0.0.1:10021/`: default route showed chat shell (`chats`, `new chat`, `search chat history`, `no chats yet`), created chat after adding project, sidebar row appeared, selected/launched session, terminal input accepted text. Browser console had no JS errors; observed existing non-fatal warnings for remote-host/node status and WebGPU fallback.
- Mobile 375px Playwright smoke (`/tmp/relay-1122-mobile-smoke.mjs`): verified `chatsVisible=true`, `newVisible=true`, `noRawChrome=true`, `resumed=true`, `sent=true`; screenshot saved at `/tmp/relay-1122-mobile-smoke.png`.

## Notes / risks
- No backend slice-2 contract needed for this PR beyond the dev proxy fix; the manual start-chat flow does require a configured project because agent session validation rejects unconfigured repo paths.
- The full rich artifact gallery, terminal cockpit redesign, adapter platform work, #444 IA migration, Discord visual clone, and smart/model search remain intentionally out of scope for slice 1.
- Simplify pass: ran the required post-implementation cleanup pass; applied a small self-cleanup rename in `TopicSidebarShell.tsx`. Background advisory reviewers were dispatched; no blocking findings were available before PR handoff.

Closes #1122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer chat-first experience across the app, including new chat entry points and updated labels.
  * Mobile navigation now includes a dedicated “new chat” action and improved chat switching behavior.
  * Chat lists now show more helpful recency information and better sidebar controls on mobile.

* **Bug Fixes**
  * Resuming existing chats now works more reliably from mobile and sidebar views.
  * Updated routing and landing behavior so active chats open in the expected chat shell.
  * Improved status and error messages for chat creation, launching, and resume failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->