### PR TITLE
[codex] Fix chat websocket local session keys

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -31,6 +31,15 @@ const RELAY_CLIENT_COMMANDS: AgentSlashCommandV2[] = [
   },
 ];
 
+function createTurnId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return `turn-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
 interface ChatViewProps {
   sessionId: string | null;
 }
@@ -106,7 +115,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
 
   const handleSend = useCallback(
     (content: string, attachments?: ComposerSendAttachment[]) => {
-      const turnId = crypto.randomUUID();
+      const turnId = createTurnId();
       sendMessage(turnId, content, attachments);
     },
     [sendMessage]
@@ -220,7 +229,9 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
           </div>
         )}
         {!session || session.turns.length === 0 ? (
-          <div className="tl-empty">send the first message to start this chat</div>
+          <div className="tl-empty">
+            send the first message to start this chat
+          </div>
         ) : (
           <div ref={contentRef} className="tl-content">
             {session.turns.map((turn, index) => (

--- a/frontend/src/hooks/useAgentChatSocket.ts
+++ b/frontend/src/hooks/useAgentChatSocket.ts
@@ -5,6 +5,11 @@ import {
   type AgentPatchV2,
   type AgentSessionV2,
 } from '../../../shared/agent-chat-protocol-v2.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  parseGlobalSessionId,
+} from '../../../shared/identity.js';
+import { nodeSessionWebSocketPath } from '../../../shared/node-boundary.js';
 
 const PING_INTERVAL = 30_000;
 const PONG_TIMEOUT = 5_000;
@@ -12,6 +17,15 @@ const MAX_RECONNECT_ATTEMPTS = 10;
 const RECONNECT_DELAY = 3_000;
 const PING_MSG = '{"type":"ping"}';
 const PONG_MSG = '{"type":"pong"}';
+
+export function agentChatWebSocketPath(sessionId: string): string {
+  const parsed = parseGlobalSessionId(sessionId);
+  if (!parsed) return `/ws/${encodeURIComponent(sessionId)}`;
+  if (parsed.nodeId === DEFAULT_LOCAL_NODE_ID) {
+    return `/ws/${encodeURIComponent(parsed.localSessionId)}`;
+  }
+  return nodeSessionWebSocketPath(parsed.nodeId, parsed.localSessionId);
+}
 
 export interface AgentChatSocketState {
   session: AgentSessionV2 | null;
@@ -155,7 +169,9 @@ export function useAgentChatSocket(
       clearPing();
 
       const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const ws = new WebSocket(`${wsProtocol}//${location.host}/ws/${sid}`);
+      const ws = new WebSocket(
+        `${wsProtocol}//${location.host}${agentChatWebSocketPath(sid)}`
+      );
       wsRef.current = ws;
 
       ws.onopen = () => {

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -15,6 +15,10 @@ import { verifyCookieToken } from './auth.js';
 import { createAgentSessionSnapshotPatch } from './web-session-v2-state.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import {
+  DEFAULT_LOCAL_NODE_ID,
+  parseGlobalSessionId,
+} from '../shared/identity.js';
+import {
   MAX_PROMPT_ATTACHMENTS_PER_MESSAGE,
   parsePromptAttachmentList,
 } from '../shared/prompt-attachment.js';
@@ -72,6 +76,14 @@ function sendTerminalStreamEnvelope(
 // discovers the session is gone and renders `[session ended]`.
 export const TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE = 4404;
 const TERMINAL_WS_SESSION_NOT_FOUND_REASON = 'session-not-found';
+
+export function resolveLocalWebSocketSessionId(
+  requestedSessionKey: string
+): string | null {
+  const parsed = parseGlobalSessionId(requestedSessionKey);
+  if (!parsed) return requestedSessionKey;
+  return parsed.nodeId === DEFAULT_LOCAL_NODE_ID ? parsed.localSessionId : null;
+}
 
 function isSessionNotFoundError(error: unknown): boolean {
   return (
@@ -704,7 +716,12 @@ function setupWebSocket(
       return true;
     }
     wss.handleUpgrade(request, socket, head, (ws) => {
-      handleHubNodeLink(ws, hubNodeRegistry, authenticated.authenticated, nodeLinks);
+      handleHubNodeLink(
+        ws,
+        hubNodeRegistry,
+        authenticated.authenticated,
+        nodeLinks
+      );
     });
     return true;
   }
@@ -712,7 +729,10 @@ function setupWebSocket(
   server.on('upgrade', (request, socket, head) => {
     const requestUrl = new URL(request.url ?? '/', 'http://relay.local');
     const requestPath = requestUrl.pathname.replace(/\/$/, '');
-    if (requestPath === '/hub/node-link' && handleNodeLinkUpgrade(request, socket, head)) {
+    if (
+      requestPath === '/hub/node-link' &&
+      handleNodeLinkUpgrade(request, socket, head)
+    ) {
       return;
     }
 
@@ -827,14 +847,27 @@ function setupWebSocket(
     }
 
     // PTY channel: /ws/:sessionId
-    const match = requestPath.match(/^\/ws\/([a-f0-9]+)$/);
+    const match = requestPath.match(/^\/ws\/([^/]+)$/);
     if (!match) {
       socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
       socket.destroy();
       return;
     }
 
-    const sessionId = match[1]!;
+    let requestedSessionKey: string;
+    try {
+      requestedSessionKey = decodeURIComponent(match[1]!);
+    } catch {
+      socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    const sessionId = resolveLocalWebSocketSessionId(requestedSessionKey);
+    if (!sessionId) {
+      socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+      socket.destroy();
+      return;
+    }
     const session = sessions.get(sessionId);
     if (!session) {
       socket.write('HTTP/1.1 404 Not Found\r\n\r\n');

--- a/test/agent-chat-socket.test.ts
+++ b/test/agent-chat-socket.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createGlobalSessionId } from '../shared/identity.js';
+import { agentChatWebSocketPath } from '../frontend/src/hooks/useAgentChatSocket.js';
+
+describe('agent chat websocket path', () => {
+  it('uses the local websocket route for raw local session ids', () => {
+    expect(agentChatWebSocketPath('c0dbeb605f82d893')).toBe(
+      '/ws/c0dbeb605f82d893'
+    );
+  });
+
+  it('normalizes local scoped session ids before opening /ws', () => {
+    expect(
+      agentChatWebSocketPath(createGlobalSessionId('local', 'c0dbeb605f82d893'))
+    ).toBe('/ws/c0dbeb605f82d893');
+  });
+
+  it('routes non-local scoped session ids through the node websocket path', () => {
+    expect(
+      agentChatWebSocketPath(
+        createGlobalSessionId('node/dev box', 'session one')
+      )
+    ).toBe('/nodes/node%2Fdev%20box/ws/sessions/session%20one');
+  });
+});

--- a/test/components/chat-v2-rendering.test.ts
+++ b/test/components/chat-v2-rendering.test.ts
@@ -374,6 +374,40 @@ describe('chat v2 rendering against chat.html primitives', () => {
     expect(textarea!.value).toBe('');
   });
 
+  it('sends with a fallback turn id when crypto.randomUUID is unavailable', async () => {
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'crypto'
+    );
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: {},
+    });
+    try {
+      await renderChat();
+
+      const textarea =
+        container.querySelector<HTMLTextAreaElement>('.composer__ta');
+      expect(textarea).toBeTruthy();
+      await setTextareaDraft(textarea!, 'fallback id reply');
+
+      const event = makeBeforeInputEvent('insertLineBreak');
+      await act(async () => {
+        textarea!.dispatchEvent(event);
+      });
+
+      expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+      expect(mocks.sendMessage.mock.calls[0]?.[0]).toMatch(/^turn-/);
+      expect(mocks.sendMessage.mock.calls[0]?.[1]).toBe('fallback id reply');
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', cryptoDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'crypto');
+      }
+    }
+  });
+
   it('applies the highlighted slash command on mobile send-key beforeinput while the palette is visible', async () => {
     mocks.session = makeSession({
       slashCommands: [

--- a/test/ws-session-write-crash.test.ts
+++ b/test/ws-session-write-crash.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { WebSocket } from 'ws';
 import {
   applyTerminalPtyMessage,
+  resolveLocalWebSocketSessionId,
   TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE,
 } from '../server/ws.js';
 
@@ -125,10 +126,15 @@ describe('applyTerminalPtyMessage (#905 reaped-session write crash)', () => {
       },
     };
     expect(() =>
-      applyTerminalPtyMessage(ws as unknown as WebSocket, 'live-session', sink, {
-        kind: 'write',
-        data: 'x',
-      })
+      applyTerminalPtyMessage(
+        ws as unknown as WebSocket,
+        'live-session',
+        sink,
+        {
+          kind: 'write',
+          data: 'x',
+        }
+      )
     ).toThrow('disk on fire');
     expect(ws.closes).toHaveLength(0);
   });
@@ -150,5 +156,25 @@ describe('applyTerminalPtyMessage (#905 reaped-session write crash)', () => {
     expect(outcome).toBe('applied');
     expect(writes).toEqual(['echo hi\n']);
     expect(ws.closes).toHaveLength(0);
+  });
+});
+
+describe('resolveLocalWebSocketSessionId', () => {
+  it('accepts raw local session ids', () => {
+    expect(resolveLocalWebSocketSessionId('c0dbeb605f82d893')).toBe(
+      'c0dbeb605f82d893'
+    );
+  });
+
+  it('accepts scoped local session ids for cached chat bundles', () => {
+    expect(resolveLocalWebSocketSessionId('local:c0dbeb605f82d893')).toBe(
+      'c0dbeb605f82d893'
+    );
+  });
+
+  it('rejects non-local scoped session ids on the local websocket route', () => {
+    expect(
+      resolveLocalWebSocketSessionId('node-a:c0dbeb605f82d893')
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- normalize `local:<session>` agent chat keys back to `/ws/<session>` before opening browser WebSockets
- accept scoped local chat keys server-side so cached bundles or older callers do not 404
- fall back when `crypto.randomUUID` is unavailable in browser contexts

## Validation
- `npm test -- test/agent-chat-socket.test.ts test/components/chat-v2-rendering.test.ts test/ws-session-write-crash.test.ts test/topic-composer.test.ts`
- `npm run check`
- `npm run build`
- pre-push hook with Node 24: 23 files passed, 199 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sends now work even when browser UUID support is unavailable, using a reliable fallback ID.
  * WebSocket connections now route correctly for both local and remote session IDs.

* **Bug Fixes**
  * Improved handling of session-based chat and terminal connections so valid local sessions connect as expected and invalid remote mappings return not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->