### PR TITLE
fix(chat): guard browser id generation

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import './ChatView.css';
 import { useAgentChatSocket } from '../../hooks/useAgentChatSocket.js';
+import { createBrowserId } from '../../lib/browserId.js';
 import {
   Composer,
   type ClientCommandHandler,
@@ -30,15 +31,6 @@ const RELAY_CLIENT_COMMANDS: AgentSlashCommandV2[] = [
     collisionKey: 'relay-verbosity',
   },
 ];
-
-function createTurnId(): string {
-  if (typeof globalThis.crypto?.randomUUID === 'function') {
-    return globalThis.crypto.randomUUID();
-  }
-  return `turn-${Date.now().toString(36)}-${Math.random()
-    .toString(36)
-    .slice(2, 10)}`;
-}
 
 interface ChatViewProps {
   sessionId: string | null;
@@ -115,7 +107,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
 
   const handleSend = useCallback(
     (content: string, attachments?: ComposerSendAttachment[]) => {
-      const turnId = createTurnId();
+      const turnId = createBrowserId('turn');
       sendMessage(turnId, content, attachments);
     },
     [sendMessage]

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -12,6 +12,7 @@ import type {
   AgentSlashCommandV2,
   AgentUsageV2,
 } from '../../../../shared/agent-chat-protocol-v2.js';
+import { createBrowserId } from '../../lib/browserId.js';
 import { SlashPalette, useSlashCommands } from './SlashPalette.js';
 import { detectSlashTrigger } from './slashTrigger.js';
 import { renderInlineSkillTokens } from './skillTokens.js';
@@ -129,7 +130,7 @@ export const Composer: React.FC<ComposerProps> = ({
           setAttachments((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: createBrowserId('attachment'),
               dataUri,
               mimeType: file.type,
               name: file.name || 'image',

--- a/frontend/src/lib/browserId.ts
+++ b/frontend/src/lib/browserId.ts
@@ -1,0 +1,18 @@
+type BrowserIdCrypto = Pick<Crypto, 'randomUUID'> | undefined;
+
+export function createBrowserIdWithCrypto(
+  prefix: string,
+  crypto: BrowserIdCrypto
+): string {
+  if (typeof crypto?.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${prefix}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)
+    .padEnd(8, '0')}`;
+}
+
+export function createBrowserId(prefix: string): string {
+  return createBrowserIdWithCrypto(prefix, globalThis.crypto);
+}

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -4,6 +4,7 @@ import {
   type SavedView,
   type ViewLens,
 } from '../state/view-tree.js';
+import { createBrowserId } from '../browserId.js';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 const SIDEBAR_WIDTH_KEY = 'claude-remote-sidebar-width';
@@ -1404,11 +1405,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
     const trimmed = name.trim();
     if (!trimmed) return null;
     const view: SavedView = {
-      // Local id; crypto.randomUUID where available, else a time+rand fallback.
-      id:
-        typeof crypto !== 'undefined' && 'randomUUID' in crypto
-          ? crypto.randomUUID()
-          : `sv-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      id: createBrowserId('sv'),
       name: trimmed,
       lens: get().viewSpineLens,
     };

--- a/frontend/src/workbench/WorkbenchCanvas.tsx
+++ b/frontend/src/workbench/WorkbenchCanvas.tsx
@@ -44,6 +44,7 @@ import type {
   EnvironmentHistoryEntry,
 } from '../../../shared/safe-defaults.js';
 import { fetchWorkbenchLayout, putWorkbenchLayout } from '../lib/api.js';
+import { createBrowserId } from '../lib/browserId.js';
 import { BlockHost } from './BlockHost.js';
 import {
   WorkbenchBlockCreateDialog,
@@ -555,10 +556,7 @@ export function WorkbenchCanvas({
     (req: WorkbenchBlockCreateRequest) => {
       const descriptor = buildBlockDescriptor({
         request: req,
-        idFactory: () =>
-          typeof crypto !== 'undefined' && 'randomUUID' in crypto
-            ? crypto.randomUUID()
-            : `block-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        idFactory: () => createBrowserId('block'),
       });
       const existing = layoutRef.current;
       const blockCount = existing?.blocks.length ?? 0;

--- a/test/browser-id.test.ts
+++ b/test/browser-id.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBrowserIdWithCrypto } from '../frontend/src/lib/browserId.js';
+
+describe('createBrowserIdWithCrypto', () => {
+  it('uses crypto.randomUUID when available', () => {
+    const randomUUID = vi.fn(() => 'uuid-1');
+
+    expect(createBrowserIdWithCrypto('turn', { randomUUID })).toBe('uuid-1');
+    expect(randomUUID).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a prefixed id when randomUUID is unavailable', () => {
+    expect(createBrowserIdWithCrypto('turn', undefined)).toMatch(
+      /^turn-[a-z0-9]+-[a-z0-9]{8}$/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a browser-safe ID helper that falls back when `crypto.randomUUID` is unavailable
- route chat turn IDs, image attachment IDs, saved view IDs, and workbench block IDs through the helper
- cover native and fallback ID generation in unit tests

## Root cause
Plain HTTP/no-secure-context deployments can expose `crypto` without `crypto.randomUUID`, so frontend code that called it directly could throw before chat send/render flows completed.

## Validation
- `rtk npm test -- test/browser-id.test.ts test/agent-chat-socket.test.ts test/components/chat-v2-rendering.test.ts test/ws-session-write-crash.test.ts test/topic-composer.test.ts`
- `rtk npm run check`
- `rtk npm run build`
- pre-push hook: 61 test files, 574 tests
