### PR TITLE
fix(chat): preserve legacy bridge listeners

### DIFF
--- a/server/protocol-adapters/legacy-v2-bridge.ts
+++ b/server/protocol-adapters/legacy-v2-bridge.ts
@@ -87,9 +87,9 @@ export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
   }
 
   async reconnect(): Promise<void> {
-    this.subscribePatches();
     try {
       await this.inner.reconnect();
+      this.subscribePatches();
     } catch (error) {
       this.unlisten?.();
       this.unlisten = null;

--- a/test/server/protocol-adapters/legacy-v2-bridge.test.ts
+++ b/test/server/protocol-adapters/legacy-v2-bridge.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { BaseProtocolAdapter } from '../../../server/protocol-adapter.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  Attachment,
+  SessionOptions,
+} from '../../../server/protocol-adapter.js';
+import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
+import type { AgentCapabilitySetV2 } from '../../../shared/agent-chat-protocol-v2.js';
+import type { ChatEventSource } from '../../../shared/chat-events.js';
+
+const BASE_CONFIG: AdapterConfig = {
+  cwd: '/repo',
+  port: 3456,
+  sessionId: 'sess-bridge',
+  hookToken: 'hook-token',
+  configDir: '/config',
+};
+
+const CAPABILITIES: AgentCapabilitySetV2 = {
+  text: true,
+  resume: true,
+};
+
+class ReconnectingLegacyAdapter extends BaseProtocolAdapter {
+  readonly agentType = 'mock';
+  readonly runtimeOwnership = 'attached' as const;
+
+  private config: AdapterConfig | null = null;
+  private turnIndex = 0;
+  private currentStatus: AdapterStatus = 'disconnected';
+
+  get status(): AdapterStatus {
+    return this.currentStatus;
+  }
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this.config = config;
+    this.currentStatus = 'connected';
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this.currentStatus = 'disconnected';
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.config) throw new Error('Cannot reconnect before connect');
+    const config = this.config;
+    await this.disconnect();
+    await this.connect(config);
+  }
+
+  async sendMessage(
+    turnId: string,
+    content: string,
+    _attachments?: Attachment[]
+  ): Promise<void> {
+    const sessionId = this.config?.sessionId;
+    if (!sessionId) throw new Error('No session ID');
+    const timestamp = new Date().toISOString();
+    const source: ChatEventSource = 'mock';
+
+    this.emit({
+      type: 'chat:turn-started',
+      sessionId,
+      timestamp,
+      source,
+      turnId,
+      turnIndex: this.turnIndex++,
+    });
+    this.emit({
+      type: 'chat:message-complete',
+      sessionId,
+      timestamp,
+      source,
+      turnId,
+      messageId: `user-${turnId}`,
+      role: 'user',
+      content,
+    });
+  }
+
+  async interrupt(_turnId: string): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+  async createSession(
+    _cwd: string,
+    _options?: SessionOptions
+  ): Promise<string> {
+    return 'created-session';
+  }
+  async resumeSession(_sessionId: string): Promise<void> {}
+  async forkSession(_sessionId: string): Promise<string> {
+    return 'forked-session';
+  }
+}
+
+describe('LegacyProtocolAdapterV2Bridge reconnect', () => {
+  it('keeps forwarding legacy adapter events after reconnect clears inner listeners', async () => {
+    const bridge = new LegacyProtocolAdapterV2Bridge(
+      new ReconnectingLegacyAdapter(),
+      CAPABILITIES
+    );
+    const patches: string[] = [];
+    bridge.onPatch((patch) => patches.push(patch.type));
+
+    await bridge.connect(BASE_CONFIG);
+    await bridge.reconnect();
+    await bridge.sendMessage({ turnId: 'turn-1', content: 'hello' });
+
+    expect(patches).toContain('agent-turn-started-v2');
+    expect(patches).toContain('agent-item-updated-v2');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes restored Hermes/OpenCode web chats losing their event bridge after reconnect. The legacy-v2 bridge was subscribing to the wrapped legacy adapter before calling `inner.reconnect()`, but legacy adapters clear listeners during reconnect. That meant a restored empty Hermes session could accept a composer send while emitting no v2 patches back to Relay, so the draft cleared and no user turn rendered.

This moves the bridge subscription to after reconnect completes and adds a regression test with a legacy adapter that clears listeners during reconnect.

## Validation

- `npm test -- test/server/protocol-adapters/legacy-v2-bridge.test.ts test/server/protocol-adapters/hermes-adapter.test.ts test/web-session-handler.test.ts`
- `npm run build`
- `npm run check` (passes with existing warnings)
- pre-push suite: 38 files, 387 passed, 9 skipped
- Browser smoke on isolated source build at `127.0.0.1:15670`: created Hermes web session via API, opened `?session=local:<id>`, submitted from the real composer, verified the user message rendered with no bad console/page errors.
- Browser smoke repeated with `crypto.randomUUID` disabled: user message rendered, `hasCryptoRandomUUID: false`, no bad console/page errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where live updates could stop working after a reconnect, ensuring event forwarding continues reliably.
  * Improved reconnect behavior so update listeners are restored only after the connection is successfully re-established.

* **Tests**
  * Added coverage for reconnect scenarios to verify updates keep flowing after reconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->