### PR TITLE
Add WorkContext orchestration cockpit v0 (#158)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -646,6 +646,23 @@
   flex-wrap: wrap;
 }
 
+.topic-orchestration-run__evidence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.topic-orchestration-run__evidence span {
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  padding: 1px 4px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .topic-orchestration-lane__button {
   grid-template-columns: 16px minmax(0, 1fr) minmax(64px, auto) 16px;
   min-height: 34px;

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -522,6 +522,8 @@
 
 .topic-room-session-group,
 .topic-room-session-group ul,
+.topic-orchestration-list,
+.topic-orchestration-run__lanes,
 .topic-room-ref-list,
 .topic-room-surface-list {
   display: grid;
@@ -532,6 +534,7 @@
 }
 
 .topic-room-session__button,
+.topic-orchestration-lane__button,
 .topic-room-surface-list li {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(58px, auto) 16px;
@@ -548,12 +551,14 @@
   text-align: left;
 }
 
-.topic-room-session__button:hover {
+.topic-room-session__button:hover,
+.topic-orchestration-lane__button:hover {
   background: var(--surface-hover);
   color: var(--text);
 }
 
-.topic-room-session__button:focus-visible {
+.topic-room-session__button:focus-visible,
+.topic-orchestration-lane__button:focus-visible {
   background: var(--surface-hover);
   color: var(--text);
   outline: 1px solid var(--accent);
@@ -563,6 +568,10 @@
 
 .topic-room-session__label,
 .topic-room-session__anchor,
+.topic-orchestration-run__title,
+.topic-orchestration-run__summary,
+.topic-orchestration-lane__label,
+.topic-orchestration-lane__state,
 .topic-room-surface-list__label,
 .topic-room-surface-list__safety {
   min-width: 0;
@@ -572,9 +581,92 @@
 }
 
 .topic-room-session--attention .topic-room-session__label,
-.topic-room-session--error .topic-room-session__label {
+.topic-room-session--error .topic-room-session__label,
+.topic-orchestration-lane--attention .topic-orchestration-lane__label,
+.topic-orchestration-lane--error .topic-orchestration-lane__label {
   color: var(--text);
   font-weight: 700;
+}
+
+.topic-orchestration-run {
+  display: grid;
+  gap: 6px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-elevated) 42%, transparent);
+}
+
+.topic-orchestration-run--attention {
+  border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border));
+}
+
+.topic-orchestration-run--error {
+  border-color: color-mix(in srgb, var(--status-error) 45%, var(--border));
+}
+
+.topic-orchestration-run__header,
+.topic-orchestration-run__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  min-width: 0;
+}
+
+.topic-orchestration-run__title {
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.topic-orchestration-run__state,
+.topic-orchestration-run__meta,
+.topic-orchestration-lane__meta,
+.topic-orchestration-lane__state {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  line-height: 1.35;
+}
+
+.topic-orchestration-run__state {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  padding: 1px 4px;
+}
+
+.topic-orchestration-run__summary {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.62rem;
+  line-height: 1.35;
+}
+
+.topic-orchestration-run__meta {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.topic-orchestration-lane__button {
+  grid-template-columns: 16px minmax(0, 1fr) minmax(64px, auto) 16px;
+  min-height: 34px;
+}
+
+.topic-orchestration-lane__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.topic-orchestration-lane__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.topic-orchestration-lane__main {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
 }
 
 .topic-room-session__disabled {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -596,11 +596,11 @@ function orchestrationRunSummary(run: WorkflowRunProjection): string {
   return latest?.summary ?? 'no run journal yet';
 }
 
-function orchestrationRunEvidenceCount(run: WorkflowRunProjection): number {
-  return (
-    (run.links?.artifactIds?.length ?? 0) +
-    (run.links?.handoffArtifactIds?.length ?? 0)
-  );
+function orchestrationRunEvidenceRefs(run: WorkflowRunProjection): string[] {
+  return [
+    ...(run.links?.artifactIds ?? []),
+    ...(run.links?.handoffArtifactIds ?? []),
+  ];
 }
 
 function orchestrationRunMailCount(run: WorkflowRunProjection): number {
@@ -629,7 +629,8 @@ function OrchestrationLaneRow({
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
   const selectKey = orchestrationLaneSelectKey(link);
-  const canOpen = Boolean(selectKey && onSelectSession);
+  const handleSelect =
+    selectKey && onSelectSession ? () => onSelectSession(selectKey) : undefined;
   const tone = orchestrationLaneTone(link);
   return (
     <li
@@ -638,11 +639,10 @@ function OrchestrationLaneRow({
       <button
         type="button"
         className="topic-orchestration-lane__button"
-        disabled={!canOpen}
-        title={canOpen ? `open ${link.role} session` : 'session not linked'}
-        onClick={() => {
-          if (selectKey) onSelectSession?.(selectKey);
-        }}
+        {...(handleSelect ? { onClick: handleSelect } : { disabled: true })}
+        title={
+          handleSelect ? `open ${link.role} session` : 'session not linked'
+        }
       >
         <span className="topic-orchestration-lane__icon" aria-hidden="true">
           <MessageSquare size={12} />
@@ -674,7 +674,7 @@ function OrchestrationRunCard({
   const planner = run.orchestration?.planner;
   const children = run.orchestration?.children ?? [];
   const lanes = (planner ? 1 : 0) + children.length;
-  const evidenceCount = orchestrationRunEvidenceCount(run);
+  const evidenceRefs = orchestrationRunEvidenceRefs(run);
   const mailCount = orchestrationRunMailCount(run);
   return (
     <article
@@ -692,15 +692,28 @@ function OrchestrationRunCard({
       <div className="topic-orchestration-run__meta">
         <span>{lanes} lanes</span>
         <span>{mailCount} mail</span>
-        <span>{evidenceCount} evidence refs</span>
+        <span>{evidenceRefs.length} evidence refs</span>
         <span>updated {formatRelativeTimeCompact(run.updatedAt)}</span>
       </div>
+      {evidenceRefs.length > 0 ? (
+        <div
+          className="topic-orchestration-run__evidence"
+          aria-label="orchestration evidence refs"
+        >
+          {evidenceRefs.slice(0, 3).map((ref) => (
+            <span key={ref}>{ref}</span>
+          ))}
+          {evidenceRefs.length > 3 ? (
+            <span>+{evidenceRefs.length - 3} more</span>
+          ) : null}
+        </div>
+      ) : null}
       <ul className="topic-orchestration-run__lanes">
         {planner ? (
           <OrchestrationLaneRow
             link={planner}
             laneKind="planner"
-            onSelectSession={onSelectSession}
+            {...(onSelectSession ? { onSelectSession } : {})}
           />
         ) : null}
         {children.map((child, index) => (
@@ -712,7 +725,7 @@ function OrchestrationRunCard({
             }
             link={child}
             laneKind="worker"
-            onSelectSession={onSelectSession}
+            {...(onSelectSession ? { onSelectSession } : {})}
           />
         ))}
         {!planner && children.length === 0 ? (
@@ -758,7 +771,7 @@ function TopicRoomOrchestrationRuns({
         <OrchestrationRunCard
           key={run.id}
           run={run}
-          onSelectSession={onSelectSession}
+          {...(onSelectSession ? { onSelectSession } : {})}
         />
       ))}
       {error ? (
@@ -1367,11 +1380,13 @@ function TopicAdvancedDetailGate({
   const workContextId = item?.workContextIds[0] ?? null;
   const workflowRunsQuery = useQuery({
     queryKey: ['workflow-runs', workContextId, WORKFLOW_RUNS_LIMIT],
-    queryFn: () =>
-      fetchWorkflowRuns({
-        workContextId: workContextId!,
+    queryFn: () => {
+      if (!workContextId) return Promise.resolve(EMPTY_WORKFLOW_RUNS);
+      return fetchWorkflowRuns({
+        workContextId,
         limit: WORKFLOW_RUNS_LIMIT,
-      }),
+      });
+    },
     enabled: Boolean(item && show && workContextId),
     staleTime: 10_000,
   });

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -16,6 +16,15 @@ import {
   MessageSquare,
   TriangleAlert,
 } from 'lucide-react';
+import type {
+  WorkflowRunProjection,
+  WorkflowRunSessionLink,
+  WorkflowRunState,
+} from '../../../shared/workflow-run.js';
+import {
+  createGlobalSessionId,
+  DEFAULT_LOCAL_NODE_ID,
+} from '../../../shared/identity.js';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import {
   resolveTopicActiveContext,
@@ -24,6 +33,7 @@ import {
 } from '../../../shared/workspace-topics.js';
 import {
   fetchHubNodes,
+  fetchWorkflowRuns,
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
   restoreWorkspaceTopic,
@@ -51,6 +61,7 @@ import {
   type TopicNavParticipantRef,
   type TopicNavSessionRef,
   type TopicNavSurfaceRef,
+  type TopicNavTone,
 } from '../lib/state/topic-nav.js';
 import { MarqueeText } from './MarqueeText.js';
 import './TopicSidebarShell.css';
@@ -86,6 +97,8 @@ type TopicSendInput = typeof sendSessionInput;
 const DISCONNECTED_SESSION_CONTROL_REASON =
   'session offline/disconnected — controls unavailable until reconnect';
 const TOPIC_LATEST_STATUS_MAX_LENGTH = 96;
+const WORKFLOW_RUNS_LIMIT = 5;
+const EMPTY_WORKFLOW_RUNS: WorkflowRunProjection[] = [];
 
 function boundedTopicLatestStatus(value: string): string {
   const trimmed = value.trim();
@@ -532,6 +545,231 @@ function TopicRoomSessionRow({
   );
 }
 
+function workflowRunTone(state: WorkflowRunState): TopicNavTone {
+  if (state === 'failed' || state === 'cancelled' || state === 'stale') {
+    return 'error';
+  }
+  if (state === 'waiting') return 'attention';
+  if (state === 'queued' || state === 'running') return 'active';
+  if (state === 'succeeded') return 'idle';
+  return 'empty';
+}
+
+function orchestrationLaneTone(link: WorkflowRunSessionLink): TopicNavTone {
+  if (link.attention?.needsAttention) return 'attention';
+  return workflowRunTone(link.state ?? 'unknown');
+}
+
+function orchestrationLaneSelectKey(
+  link: WorkflowRunSessionLink
+): string | null {
+  if (link.globalSessionId) return link.globalSessionId;
+  if (link.nodeId && link.nodeId !== DEFAULT_LOCAL_NODE_ID && link.sessionId) {
+    return createGlobalSessionId(link.nodeId, link.sessionId);
+  }
+  return link.sessionId ?? null;
+}
+
+function orchestrationLaneLabel(link: WorkflowRunSessionLink): string {
+  return (
+    link.displayName ??
+    link.sessionId ??
+    link.globalSessionId ??
+    `${link.role} lane`
+  );
+}
+
+function orchestrationLaneStatus(link: WorkflowRunSessionLink): string {
+  const pending = link.attention?.pendingInboxCount ?? 0;
+  if (pending > 0) return `${pending} pending`;
+  if (link.attention?.needsAttention) {
+    const reasons = link.attention.reasons?.slice(0, 2).join(', ');
+    return reasons ? `attention · ${reasons}` : 'needs attention';
+  }
+  return link.state ?? 'linked';
+}
+
+function orchestrationRunSummary(run: WorkflowRunProjection): string {
+  if (run.errorSummary) return run.errorSummary;
+  if (run.resultSummary) return run.resultSummary;
+  const latest = run.journal?.[run.journal.length - 1];
+  return latest?.summary ?? 'no run journal yet';
+}
+
+function orchestrationRunEvidenceCount(run: WorkflowRunProjection): number {
+  return (
+    (run.links?.artifactIds?.length ?? 0) +
+    (run.links?.handoffArtifactIds?.length ?? 0)
+  );
+}
+
+function orchestrationRunMailCount(run: WorkflowRunProjection): number {
+  const links = [
+    run.orchestration?.planner,
+    ...(run.orchestration?.children ?? []),
+  ].filter((link): link is WorkflowRunSessionLink => Boolean(link));
+  const attentionCount = links.reduce(
+    (sum, link) => sum + (link.attention?.pendingInboxCount ?? 0),
+    0
+  );
+  return Math.max(run.links?.inboxMessageIds?.length ?? 0, attentionCount);
+}
+
+function isOrchestrationWorkflowRun(run: WorkflowRunProjection): boolean {
+  return run.runKind === 'relay-orchestration' || Boolean(run.orchestration);
+}
+
+function OrchestrationLaneRow({
+  link,
+  laneKind,
+  onSelectSession,
+}: {
+  link: WorkflowRunSessionLink;
+  laneKind: 'planner' | 'worker';
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const selectKey = orchestrationLaneSelectKey(link);
+  const canOpen = Boolean(selectKey && onSelectSession);
+  const tone = orchestrationLaneTone(link);
+  return (
+    <li
+      className={`topic-orchestration-lane topic-orchestration-lane--${tone}`}
+    >
+      <button
+        type="button"
+        className="topic-orchestration-lane__button"
+        disabled={!canOpen}
+        title={canOpen ? `open ${link.role} session` : 'session not linked'}
+        onClick={() => {
+          if (selectKey) onSelectSession?.(selectKey);
+        }}
+      >
+        <span className="topic-orchestration-lane__icon" aria-hidden="true">
+          <MessageSquare size={12} />
+        </span>
+        <span className="topic-orchestration-lane__main">
+          <span className="topic-orchestration-lane__label">
+            <MarqueeText>{orchestrationLaneLabel(link)}</MarqueeText>
+          </span>
+          <span className="topic-orchestration-lane__meta">
+            {laneKind} · {link.role} · {link.provider ?? 'provider unknown'}
+          </span>
+        </span>
+        <span className="topic-orchestration-lane__state">
+          {orchestrationLaneStatus(link)}
+        </span>
+        <StatusGlyph tone={tone} />
+      </button>
+    </li>
+  );
+}
+
+function OrchestrationRunCard({
+  run,
+  onSelectSession,
+}: {
+  run: WorkflowRunProjection;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const planner = run.orchestration?.planner;
+  const children = run.orchestration?.children ?? [];
+  const lanes = (planner ? 1 : 0) + children.length;
+  const evidenceCount = orchestrationRunEvidenceCount(run);
+  const mailCount = orchestrationRunMailCount(run);
+  return (
+    <article
+      className={`topic-orchestration-run topic-orchestration-run--${workflowRunTone(run.state)}`}
+    >
+      <div className="topic-orchestration-run__header">
+        <span className="topic-orchestration-run__title">
+          <MarqueeText>{run.definition.templateId ?? run.runId}</MarqueeText>
+        </span>
+        <span className="topic-orchestration-run__state">{run.state}</span>
+      </div>
+      <p className="topic-orchestration-run__summary">
+        {orchestrationRunSummary(run)}
+      </p>
+      <div className="topic-orchestration-run__meta">
+        <span>{lanes} lanes</span>
+        <span>{mailCount} mail</span>
+        <span>{evidenceCount} evidence refs</span>
+        <span>updated {formatRelativeTimeCompact(run.updatedAt)}</span>
+      </div>
+      <ul className="topic-orchestration-run__lanes">
+        {planner ? (
+          <OrchestrationLaneRow
+            link={planner}
+            laneKind="planner"
+            onSelectSession={onSelectSession}
+          />
+        ) : null}
+        {children.map((child, index) => (
+          <OrchestrationLaneRow
+            key={
+              child.globalSessionId ??
+              child.sessionId ??
+              `${child.role}:${child.provider ?? 'worker'}:${index}`
+            }
+            link={child}
+            laneKind="worker"
+            onSelectSession={onSelectSession}
+          />
+        ))}
+        {!planner && children.length === 0 ? (
+          <li className="topic-room-empty">no visible lanes linked yet</li>
+        ) : null}
+      </ul>
+    </article>
+  );
+}
+
+function TopicRoomOrchestrationRuns({
+  item,
+  workflowRuns,
+  loading,
+  error,
+  onSelectSession,
+}: {
+  item: TopicNavItem;
+  workflowRuns: WorkflowRunProjection[];
+  loading: boolean;
+  error: boolean;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const workContextId = item.workContextIds[0];
+  if (!workContextId) {
+    return <p className="topic-room-empty">no WorkContext linked yet</p>;
+  }
+  if (loading && workflowRuns.length === 0) {
+    return <p className="topic-room-empty">orchestration runs loading...</p>;
+  }
+  if (error && workflowRuns.length === 0) {
+    return (
+      <p className="topic-room-empty error">orchestration runs unavailable</p>
+    );
+  }
+  const orchestrationRuns = workflowRuns.filter(isOrchestrationWorkflowRun);
+  if (orchestrationRuns.length === 0) {
+    return <p className="topic-room-empty">no orchestration runs linked yet</p>;
+  }
+  return (
+    <div className="topic-orchestration-list">
+      {orchestrationRuns.map((run) => (
+        <OrchestrationRunCard
+          key={run.id}
+          run={run}
+          onSelectSession={onSelectSession}
+        />
+      ))}
+      {error ? (
+        <p className="topic-room-empty error">
+          orchestration runs partially unavailable
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function TopicRoomTaskRefs({ item }: { item: TopicNavItem }) {
   if (item.taskRefs.length === 0) {
     return <p className="topic-room-empty">no task refs linked yet</p>;
@@ -633,6 +871,9 @@ function TopicDetail({
   workspaceName,
   surfacesError,
   surfacesLoading,
+  workflowRuns,
+  workflowRunsError,
+  workflowRunsLoading,
   onSelectSession,
   onRestoreTopic,
   restoringTopicId,
@@ -642,6 +883,9 @@ function TopicDetail({
   workspaceName?: string | null | undefined;
   surfacesError?: boolean | undefined;
   surfacesLoading?: boolean | undefined;
+  workflowRuns: WorkflowRunProjection[];
+  workflowRunsError: boolean;
+  workflowRunsLoading: boolean;
   onSelectSession?: ((id: string) => void) | undefined;
   onRestoreTopic?: ((topicId: string) => void) | undefined;
   restoringTopicId?: string | undefined;
@@ -650,6 +894,9 @@ function TopicDetail({
   const session = topicPrimarySession(item);
   const topSurface = item.surfaces[0];
   const groupedSessions = topicRoomGroupedSessions(item);
+  const orchestrationRunCount = workflowRuns.filter(
+    isOrchestrationWorkflowRun
+  ).length;
   const primaryDisabled =
     Boolean(action.disabledReason) || (!session && !topSurface?.target);
   return (
@@ -729,6 +976,20 @@ function TopicDetail({
         <span>latest bounded status</span>
         <strong>{topicRoomLatestSummary(item)}</strong>
       </div>
+
+      <section className="topic-room__section" aria-label="orchestration runs">
+        <div className="topic-room__section-header">
+          <span>orchestration</span>
+          <span>{orchestrationRunCount} runs</span>
+        </div>
+        <TopicRoomOrchestrationRuns
+          item={item}
+          workflowRuns={workflowRuns}
+          loading={workflowRunsLoading}
+          error={workflowRunsError}
+          onSelectSession={onSelectSession}
+        />
+      </section>
 
       <section className="topic-room__section" aria-label="grouped sessions">
         <div className="topic-room__section-header">
@@ -1103,6 +1364,17 @@ function TopicAdvancedDetailGate({
   onRestoreTopic?: ((topicId: string) => void) | undefined;
   restoringTopicId?: string | undefined;
 }) {
+  const workContextId = item?.workContextIds[0] ?? null;
+  const workflowRunsQuery = useQuery({
+    queryKey: ['workflow-runs', workContextId, WORKFLOW_RUNS_LIMIT],
+    queryFn: () =>
+      fetchWorkflowRuns({
+        workContextId: workContextId!,
+        limit: WORKFLOW_RUNS_LIMIT,
+      }),
+    enabled: Boolean(item && show && workContextId),
+    staleTime: 10_000,
+  });
   if (!item || !show) return null;
   return (
     <div className="topic-shell__advanced-detail">
@@ -1111,6 +1383,11 @@ function TopicAdvancedDetailGate({
         workspaceName={resolveWorkspaceName(item, workspaceNameById)}
         surfacesError={surfacesError}
         surfacesLoading={surfacesLoading}
+        workflowRuns={workflowRunsQuery.data ?? EMPTY_WORKFLOW_RUNS}
+        workflowRunsError={workflowRunsQuery.isError}
+        workflowRunsLoading={
+          workflowRunsQuery.isLoading || workflowRunsQuery.isFetching
+        }
         onSelectSession={onSelectSession}
         onRestoreTopic={onRestoreTopic}
         restoringTopicId={restoringTopicId}
@@ -2026,6 +2303,7 @@ export function TopicSidebarShell({
       onSearchClear={() => setSearchQuery('')}
       onSelectSession={onSelectSession}
       onCreateTaskRoom={openTopicTaskRoom}
+      showAdvancedDetail={!(surfacesQuery.isLoading && !surfacesQuery.data)}
     />
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -41,6 +41,10 @@ import type {
   WorkspaceTopicSearchResponse,
 } from '../../../shared/workspace-topics.js';
 import type {
+  WorkflowRunProjection,
+  WorkflowRunState,
+} from '../../../shared/workflow-run.js';
+import type {
   PipelineHandoffArtifact,
   PipelineHandoffStageName,
 } from '../../../shared/pipeline-handoff-artifact.js';
@@ -987,6 +991,31 @@ export async function fetchActiveWork(): Promise<WorkContextActiveGroup[]> {
     await fetch('/work-contexts/active')
   );
   return Array.isArray(data.groups) ? data.groups : [];
+}
+
+export interface FetchWorkflowRunsOptions {
+  workContextId: string;
+  state?: WorkflowRunState;
+  providerRuntime?: string;
+  limit?: number;
+}
+
+export async function fetchWorkflowRuns({
+  workContextId,
+  state,
+  providerRuntime,
+  limit = 5,
+}: FetchWorkflowRunsOptions): Promise<WorkflowRunProjection[]> {
+  const params = new URLSearchParams({ workContextId });
+  if (state) params.set('state', state);
+  if (providerRuntime) params.set('providerRuntime', providerRuntime);
+  if (limit > 0) params.set('limit', String(limit));
+  const data = await json<{ workflowRuns?: WorkflowRunProjection[] }>(
+    await fetch(`/workflow-runs?${params.toString()}`, {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  return Array.isArray(data.workflowRuns) ? data.workflowRuns : [];
 }
 
 export interface FetchPipelineHandoffArtifactsOptions {

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -99,6 +99,7 @@ export interface TopicNavItem {
   surfaces: TopicNavSurfaceRef[];
   taskRefs: NonNullable<WorkspaceTopic['linkedRefs']['taskRefs']>;
   artifactIds: NonNullable<WorkspaceTopic['linkedRefs']['artifactIds']>;
+  workContextIds: NonNullable<WorkspaceTopic['linkedRefs']['workContextIds']>;
   childIds: WorkspaceTopicId[];
   routingLabel: string | null;
   lifecycleLabel: WorkspaceTopic['status'];
@@ -690,6 +691,7 @@ export function buildTopicNavModel(input: {
       surfaces,
       taskRefs: topic.linkedRefs.taskRefs ?? [],
       artifactIds: topic.linkedRefs.artifactIds ?? [],
+      workContextIds: topic.linkedRefs.workContextIds ?? [],
       childIds: [],
       routingLabel: routingLabel(topic, nodeNameById),
       lifecycleLabel: topic.status,

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -208,6 +208,19 @@ describe('buildTopicNavModel', () => {
     ]);
   });
 
+  it('preserves WorkContext refs for topic-room orchestration reads', () => {
+    const topic = makeTopic({
+      linkedRefs: { workContextIds: ['wc:relay'] },
+    });
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [],
+      surfaces: [],
+    });
+
+    expect(model.byId.get('topic:alpha')?.workContextIds).toEqual(['wc:relay']);
+  });
+
   it('classifies topic workspace kind from routing defaults', () => {
     const repo = makeTopic({
       id: 'topic:repo',

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceSurface } from '../shared/workspace-surfaces.js';
+import type { WorkflowRunProjection } from '../shared/workflow-run.js';
 import {
   resolveTopicActiveContext,
   type WorkspaceTopic,
@@ -108,15 +109,22 @@ describe('TopicSidebarView', () => {
   async function renderView(
     props: Partial<React.ComponentProps<typeof TopicSidebarView>> = {}
   ) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     await act(async () => {
       root.render(
-        React.createElement(TopicSidebarView, {
-          topics: [makeTopic()],
-          sessions: [makeSession({ id: 's1', displayName: 'Frontend lane' })],
-          surfaces: [makeSurface()],
-          onSelectSession,
-          ...props,
-        })
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(TopicSidebarView, {
+            topics: [makeTopic()],
+            sessions: [makeSession({ id: 's1', displayName: 'Frontend lane' })],
+            surfaces: [makeSurface()],
+            onSelectSession,
+            ...props,
+          })
+        )
       );
     });
   }
@@ -132,6 +140,97 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('Thin-line topic detail');
     expect(container.textContent).toContain('Frontend lane');
     expect(container.textContent).toContain('preview');
+  });
+
+  it('renders WorkContext orchestration runs with clickable visible lanes', async () => {
+    const workflowRun: WorkflowRunProjection = {
+      schemaVersion: 1,
+      id: 'workflow-run:demo',
+      runId: 'relay-orchestration:demo',
+      providerRuntime: 'relay-orchestration',
+      runKind: 'relay-orchestration',
+      workContextId: 'wc:relay',
+      definition: {
+        hash: 'relay-orchestration-launch:v0',
+        templateId: 'relay/orchestration-launch-v0',
+      },
+      state: 'running',
+      links: {
+        artifactIds: ['artifact:demo'],
+        inboxMessageIds: ['inbox:seed'],
+      },
+      orchestration: {
+        planner: {
+          role: 'planner',
+          provider: 'codex',
+          displayName: 'Codex planner',
+          globalSessionId: 'global:planner',
+          state: 'running',
+          attention: { pendingInboxCount: 2 },
+        },
+        children: [
+          {
+            role: 'implementer',
+            provider: 'claude',
+            displayName: 'Claude worker',
+            globalSessionId: 'global:worker',
+            state: 'waiting',
+            attention: {
+              needsAttention: true,
+              reasons: ['message-delivery-failed'],
+              pendingInboxCount: 1,
+            },
+          },
+        ],
+      },
+      createdAt: NOW,
+      updatedAt: NOW,
+      version: 1,
+      redaction: {
+        rawPayloadStored: false,
+        rawTranscriptStored: false,
+        providerPrivateStateStored: false,
+        truncated: false,
+        omittedKeys: [],
+      },
+    };
+    const fetchMock = vi.fn(async () =>
+      Response.json({ workflowRuns: [workflowRun] })
+    ) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    await renderView({
+      showAdvancedDetail: true,
+      topics: [
+        makeTopic({
+          linkedRefs: { workContextIds: ['wc:relay'] },
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+    });
+    await act(async () => {
+      await flushQueryEffects();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/workflow-runs?workContextId=wc%3Arelay&limit=5',
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(container.textContent).toContain('orchestration');
+    expect(container.textContent).toContain('relay/orchestration-launch-v0');
+    expect(container.textContent).toContain('Codex planner');
+    expect(container.textContent).toContain('Claude worker');
+    expect(container.textContent).toContain('2 lanes');
+    expect(container.textContent).toContain('3 mail');
+    expect(container.textContent).toContain('1 evidence refs');
+
+    const workerButton = Array.from(
+      container.querySelectorAll('.topic-orchestration-lane__button')
+    ).find((button) => button.textContent?.includes('Claude worker'));
+    expect(workerButton).toBeTruthy();
+    await act(async () => (workerButton as HTMLButtonElement).click());
+    expect(onSelectSession).toHaveBeenCalledWith('global:worker');
   });
 
   it('keeps collapsed topic rows free of linked-item and recency metadata', async () => {
@@ -1490,7 +1589,7 @@ describe('TopicSidebarView', () => {
       /\.topic-room__primary:not\(:disabled\):focus-visible,\s*\.topic-room-ref-list a:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px[\s\S]*box-shadow:/
     );
     expect(css).toMatch(
-      /\.topic-room-session__button:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px[\s\S]*box-shadow:/
+      /\.topic-room-session__button:focus-visible,\s*\.topic-orchestration-lane__button:focus-visible\s*{[\s\S]*outline:\s*1px solid var\(--accent\)[\s\S]*outline-offset:\s*2px[\s\S]*box-shadow:/
     );
   });
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -224,6 +224,7 @@ describe('TopicSidebarView', () => {
     expect(container.textContent).toContain('2 lanes');
     expect(container.textContent).toContain('3 mail');
     expect(container.textContent).toContain('1 evidence refs');
+    expect(container.textContent).toContain('artifact:demo');
 
     const workerButton = Array.from(
       container.querySelectorAll('.topic-orchestration-lane__button')


### PR DESCRIPTION
## Summary

- add a WorkContext-scoped `fetchWorkflowRuns` frontend helper for `/workflow-runs?workContextId=...`
- carry `workContextIds` through the topic nav model so topic detail can read orchestration runs
- render a compact orchestration section in the topic room with run cards, planner/worker lane rows, mail/evidence counts, attention states, and click-to-open session controls
- enable the normal topic shell detail panel after surfaces settle so the cockpit is visible in the app rather than test-only

## Verification

- `npm test -- topic-sidebar-shell`
- `npm test -- topic-nav`
- `npm run check` (warnings only)
- `npm run build`
- pre-push hook: 71 files / 606 tests

## Notes

This is the read-only cockpit slice for #158. It does not add launcher controls or artifact drilldown yet; it makes the run topology from #1129/#1130 visible and steerable through existing session open controls.