### PR TITLE
feat: supervise Codex app-server stdio sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "relay-factory-core"
 version = "0.1.0"
 
@@ -18,4 +48,77 @@ name = "relay-node"
 version = "0.1.0"
 dependencies = [
  "relay-factory-core",
+ "relay-session",
 ]
+
+[[package]]
+name = "relay-session"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/relay-factory-core",
+  "crates/relay-session",
   "apps/relay-hub",
   "apps/relay-node",
 ]

--- a/apps/relay-node/src/main.rs
+++ b/apps/relay-node/src/main.rs
@@ -1,6 +1,10 @@
 use std::{env, process::ExitCode};
 
 use relay_factory_core::{ServiceIdentity, configured_identity, health_json};
+use relay_session::{
+    DEFAULT_DEADLINE, ProcessTransport, SessionError, Supervisor,
+    codex::{assert_local_stdio_only, codex_command_args},
+};
 
 fn main() -> ExitCode {
     let arguments: Vec<String> = env::args().skip(1).collect();
@@ -18,9 +22,105 @@ fn main() -> ExitCode {
                 }
             }
         }
+        [command, probe_arguments @ ..] if command == "codex-stdio-probe" => {
+            codex_stdio_probe(probe_arguments)
+        }
         _ => {
-            eprintln!("usage: relay-node probe [--identity node]");
+            eprintln!(
+                "usage: relay-node <probe [--identity node]|codex-stdio-probe [--negative-transport|--handshake|--exercise]>"
+            );
             ExitCode::from(64)
         }
     }
+}
+
+/// An executable guard that proves the adapter only constructs local stdio
+/// commands. `--handshake` opens and closes the real app-server; `--exercise`
+/// additionally creates, resumes, prompts, and cancels a native thread.
+fn codex_stdio_probe(arguments: &[String]) -> ExitCode {
+    match arguments {
+        [] => negative_transport_probe(),
+        [flag] if flag == "--negative-transport" => negative_transport_probe(),
+        [flag] if flag == "--handshake" => live_stdio_probe(false),
+        [flag] if flag == "--exercise" => live_stdio_probe(true),
+        _ => {
+            eprintln!(
+                "usage: relay-node codex-stdio-probe [--negative-transport|--handshake|--exercise]"
+            );
+            ExitCode::from(64)
+        }
+    }
+}
+
+fn negative_transport_probe() -> ExitCode {
+    let fixed = codex_command_args();
+    let websocket_attempt = vec![
+        "app-server".to_owned(),
+        "--listen".to_owned(),
+        "ws://127.0.0.1:0".to_owned(),
+    ];
+    if assert_local_stdio_only(&fixed).is_ok()
+        && assert_local_stdio_only(&websocket_attempt).is_err()
+    {
+        println!(
+            "{{\"adapter\":\"codex-app-server-stdio\",\"network_transport\":\"rejected\",\"status\":\"ok\"}}"
+        );
+        ExitCode::SUCCESS
+    } else {
+        eprintln!("{{\"error\":{{\"code\":\"transport_guard_failed\"}}}}");
+        ExitCode::FAILURE
+    }
+}
+
+fn live_stdio_probe(exercise_turn: bool) -> ExitCode {
+    let cwd = env::current_dir().ok();
+    let mut session = match ProcessTransport::spawn(cwd.as_deref()) {
+        Ok(transport) => Supervisor::new(transport),
+        Err(error) => return probe_error(error),
+    };
+    let session_id = match session.create(DEFAULT_DEADLINE) {
+        Ok(session_id) => session_id,
+        Err(error) => return probe_error(error),
+    };
+
+    if !exercise_turn {
+        session.close();
+        println!(
+            "{{\"adapter\":\"codex-app-server-stdio\",\"operation\":\"create\",\"status\":\"ok\"}}"
+        );
+        return ExitCode::SUCCESS;
+    }
+
+    let turn_id = match session.prompt(
+        "Reply with exactly READY and do not use tools.",
+        DEFAULT_DEADLINE,
+    ) {
+        Ok(turn_id) => turn_id,
+        Err(error) => return probe_error(error),
+    };
+    let cancel = match session.cancel(&turn_id, DEFAULT_DEADLINE) {
+        Ok(()) => "acknowledged",
+        Err(SessionError::Raced(_)) => "raced",
+        Err(error) => return probe_error(error),
+    };
+    session.pump();
+    session.close();
+
+    let mut resumed = match ProcessTransport::spawn(cwd.as_deref()) {
+        Ok(transport) => Supervisor::new(transport),
+        Err(error) => return probe_error(error),
+    };
+    if let Err(error) = resumed.resume(session_id.as_str(), DEFAULT_DEADLINE) {
+        return probe_error(error);
+    }
+    resumed.close();
+    println!(
+        r#"{{"adapter":"codex-app-server-stdio","cancel":"{cancel}","operations":["create","prompt","cancel","resume"],"status":"ok"}}"#
+    );
+    ExitCode::SUCCESS
+}
+
+fn probe_error(error: SessionError) -> ExitCode {
+    eprintln!(r#"{{"error":{{"code":"{}"}}}}"#, error.code());
+    ExitCode::FAILURE
 }

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
-name = "relay-node"
+name = "relay-session"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
-relay-factory-core = { path = "../../crates/relay-factory-core" }
-relay-session = { path = "../../crates/relay-session" }
+serde_json = "1.0"
 
 [lints]
 workspace = true

--- a/crates/relay-session/src/codex.rs
+++ b/crates/relay-session/src/codex.rs
@@ -294,9 +294,10 @@ mod tests {
 
     #[test]
     fn only_documented_server_requests_surface_as_approvals() {
-        let frame =
-            scan_line(br#"{"id":5,"method":"item/fileChange/requestApproval","params":{}}"#)
-                .unwrap();
+        let frame = scan_line(
+            br#"{"jsonrpc":"2.0","id":5,"method":"item/fileChange/requestApproval","params":{}}"#,
+        )
+        .unwrap();
         assert_eq!(
             map_frame(&frame),
             Mapped::Event {

--- a/crates/relay-session/src/codex.rs
+++ b/crates/relay-session/src/codex.rs
@@ -1,0 +1,340 @@
+//! Codex app-server adapter.
+//!
+//! Translates the Codex JSONL/JSON-RPC wire vocabulary into the provider-
+//! neutral [`crate::contract`] types. This is the *only* module that knows
+//! Codex method names; nothing it exports carries a raw method string past the
+//! neutral boundary.
+//!
+//! ## Transport
+//!
+//! The single permitted transport is a locally-spawned child running
+//! `codex app-server --stdio` (equivalently `--listen stdio://`), speaking
+//! JSONL on stdin/stdout. Network transports the installed build also exposes
+//! (`--listen ws://…`, the `--ws-*` auth flags, `--listen unix://…`) are
+//! **never** selected. [`codex_command_args`] emits exactly the stdio argv, and
+//! [`assert_local_stdio_only`] rejects any argument vector that would select a
+//! non-stdio transport. The CLI negative probe exercises this at runtime.
+
+use crate::contract::{ApprovalKind, DegradedReason, EventKind};
+use crate::jsonl::{Frame, FrameClass};
+
+/// The Codex subcommand + argument vector for the only permitted transport.
+///
+/// Deliberately fixed. There is no code path that appends a `--listen`,
+/// `--ws-*`, or `unix://` argument.
+pub fn codex_command_args() -> Vec<String> {
+    vec!["app-server".to_owned(), "--stdio".to_owned()]
+}
+
+/// Tokens that would select a non-local or network transport. Presence of any
+/// of these in an argv is a contract violation.
+pub const FORBIDDEN_TRANSPORT_TOKENS: &[&str] = &[
+    "--listen",
+    "ws://",
+    "wss://",
+    "unix://",
+    "--ws-auth",
+    "--ws-token-file",
+    "--ws-token-sha256",
+    "--ws-shared-secret-file",
+    "--ws-issuer",
+    "--ws-audience",
+    "--ws-max-clock-skew-seconds",
+];
+
+/// Reason an argv was rejected by the transport guard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportViolation {
+    pub token: String,
+}
+
+/// Assert that an argument vector selects only the local stdio transport.
+///
+/// Returns `Err` if any forbidden network/socket token appears. The one
+/// tolerated `--stdio`/`stdio://` spelling is explicitly allowed; everything
+/// under `--listen` (including `stdio://` passed *via* `--listen`) is treated
+/// as out of contract for this MVP because it opens the door to the network
+/// spellings — the fixed argv uses the bare `--stdio` flag only.
+pub fn assert_local_stdio_only(args: &[String]) -> Result<(), TransportViolation> {
+    for arg in args {
+        let lowered = arg.to_ascii_lowercase();
+        for forbidden in FORBIDDEN_TRANSPORT_TOKENS {
+            if lowered.contains(forbidden) {
+                return Err(TransportViolation {
+                    token: (*forbidden).to_owned(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A neutral mapping decision for one observed frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mapped {
+    /// A neutral event to surface.
+    Event {
+        kind: EventKind,
+        label: &'static str,
+    },
+    /// A response to an outstanding client request (correlated by id upstream).
+    Response { ok: bool },
+    /// A degraded condition to record (frame understood, but unsupported).
+    Degraded(DegradedReason),
+}
+
+/// A ledger entry describing one wire method the adapter recognizes.
+#[derive(Debug, Clone, Copy)]
+pub struct LedgerEntry {
+    pub method: &'static str,
+    pub kind: EventKind,
+    pub label: &'static str,
+    /// True only when a sanitized real-process probe observed this method. The
+    /// initial adapter maps generated-schema methods without overclaiming live
+    /// turn/event observation.
+    pub observed: bool,
+}
+
+/// Guaranteed / supported notification methods for the installed v2 build.
+///
+/// Every entry below is documented by the generated codex-cli 0.144.1 schema.
+/// The adapter maps it if it arrives; a later real-turn probe can record
+/// sanitized observation separately.
+pub const EVENT_LEDGER: &[LedgerEntry] = &[
+    LedgerEntry {
+        method: "configWarning",
+        kind: EventKind::Diagnostic,
+        label: "config.warning",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "remoteControl/status/changed",
+        kind: EventKind::Diagnostic,
+        label: "remote_control.status",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "thread/started",
+        kind: EventKind::Lifecycle,
+        label: "session.started",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "mcpServer/startupStatus/updated",
+        kind: EventKind::Diagnostic,
+        label: "mcp.startup_status",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "turn/started",
+        kind: EventKind::Lifecycle,
+        label: "turn.started",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "turn/completed",
+        kind: EventKind::Lifecycle,
+        label: "turn.completed",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "item/started",
+        kind: EventKind::Progress,
+        label: "item.started",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "item/completed",
+        kind: EventKind::Progress,
+        label: "item.completed",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "thread/closed",
+        kind: EventKind::Lifecycle,
+        label: "session.closed",
+        observed: false,
+    },
+    LedgerEntry {
+        method: "error",
+        kind: EventKind::Diagnostic,
+        label: "provider.error",
+        observed: false,
+    },
+];
+
+/// Server→client **request** method names that appear in the generated v2
+/// schema's top-level `ServerRequest` union for codex-cli 0.144.1. The two
+/// command/file entries have a documented one-shot `accept` / `decline` /
+/// `cancel` response and are queued by the supervisor; every other entry is
+/// degraded without a fabricated reply. The list is generated-schema evidence,
+/// not a claim of live prompt observation.
+pub const SCHEMA_SERVER_REQUEST_METHODS: &[&str] = &[
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/tool/requestUserInput",
+    "mcpServer/elicitation/request",
+    "item/permissions/requestApproval",
+    "item/tool/call",
+    "account/chatgptAuthTokens/refresh",
+    "attestation/generate",
+    "applyPatchApproval",
+    "execCommandApproval",
+];
+
+/// Current v2 approval requests with an identical, documented bounded decision
+/// result: `accept`, `decline`, or `cancel`. Other server requests remain
+/// explicit unsupported/degraded events in this MVP.
+pub fn approval_kind_for_method(method: &str) -> Option<ApprovalKind> {
+    match method {
+        "item/commandExecution/requestApproval" => Some(ApprovalKind::Command),
+        "item/fileChange/requestApproval" => Some(ApprovalKind::FileChange),
+        _ => None,
+    }
+}
+
+/// Map a scanned frame onto a neutral decision.
+pub fn map_frame(frame: &Frame) -> Mapped {
+    match &frame.class {
+        FrameClass::Response { ok } => Mapped::Response { ok: *ok },
+        FrameClass::Notification => match frame.method.as_deref() {
+            Some(method) => match ledger_lookup(method) {
+                Some(entry) => Mapped::Event {
+                    kind: entry.kind,
+                    label: entry.label,
+                },
+                None => Mapped::Degraded(DegradedReason::UnsupportedEvent),
+            },
+            None => Mapped::Degraded(DegradedReason::UnsupportedEvent),
+        },
+        FrameClass::ServerRequest => match frame.method.as_deref() {
+            Some(method) if approval_kind_for_method(method).is_some() => Mapped::Event {
+                kind: EventKind::ApprovalRequest,
+                label: "approval.request",
+            },
+            _ => Mapped::Degraded(DegradedReason::UnsupportedApproval),
+        },
+    }
+}
+
+fn ledger_lookup(method: &str) -> Option<&'static LedgerEntry> {
+    EVENT_LEDGER.iter().find(|entry| entry.method == method)
+}
+
+/// Whether the adapter has a documented, non-fabricated one-shot response for
+/// this server request. No session-wide approval or policy-amendment response
+/// is exposed by this MVP.
+pub fn can_answer_server_request(method: &str) -> bool {
+    approval_kind_for_method(method).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jsonl::scan_line;
+
+    #[test]
+    fn fixed_argv_is_local_stdio() {
+        let args = codex_command_args();
+        assert_eq!(args, vec!["app-server", "--stdio"]);
+        assert!(assert_local_stdio_only(&args).is_ok());
+    }
+
+    #[test]
+    fn websocket_and_socket_argvs_are_rejected() {
+        for bad in [
+            vec![
+                "app-server".to_owned(),
+                "--listen".to_owned(),
+                "ws://127.0.0.1:9000".to_owned(),
+            ],
+            vec![
+                "app-server".to_owned(),
+                "--listen".to_owned(),
+                "unix:///tmp/s".to_owned(),
+            ],
+            vec![
+                "app-server".to_owned(),
+                "--ws-auth".to_owned(),
+                "signed-bearer-token".to_owned(),
+            ],
+            vec![
+                "app-server".to_owned(),
+                "--listen".to_owned(),
+                "wss://example".to_owned(),
+            ],
+        ] {
+            assert!(
+                assert_local_stdio_only(&bad).is_err(),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn known_notification_maps_to_neutral_event() {
+        let frame = scan_line(br#"{"method":"thread/started","params":{}}"#).unwrap();
+        assert_eq!(
+            map_frame(&frame),
+            Mapped::Event {
+                kind: EventKind::Lifecycle,
+                label: "session.started"
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_notification_is_degraded_not_fatal() {
+        let frame = scan_line(br#"{"method":"totally/unknown","params":{}}"#).unwrap();
+        assert_eq!(
+            map_frame(&frame),
+            Mapped::Degraded(DegradedReason::UnsupportedEvent)
+        );
+    }
+
+    #[test]
+    fn only_documented_server_requests_surface_as_approvals() {
+        let frame =
+            scan_line(br#"{"id":5,"method":"item/fileChange/requestApproval","params":{}}"#)
+                .unwrap();
+        assert_eq!(
+            map_frame(&frame),
+            Mapped::Event {
+                kind: EventKind::ApprovalRequest,
+                label: "approval.request"
+            }
+        );
+        assert!(can_answer_server_request("item/fileChange/requestApproval"));
+        assert!(!can_answer_server_request("openai/form"));
+    }
+
+    #[test]
+    fn ledger_does_not_overclaim_live_observation() {
+        let started = EVENT_LEDGER
+            .iter()
+            .find(|e| e.method == "thread/started")
+            .unwrap();
+        assert!(!started.observed);
+        let turn = EVENT_LEDGER
+            .iter()
+            .find(|e| e.method == "turn/started")
+            .unwrap();
+        assert!(!turn.observed);
+    }
+
+    #[test]
+    fn only_documented_current_approval_shapes_are_supported() {
+        assert_eq!(
+            approval_kind_for_method("item/commandExecution/requestApproval"),
+            Some(ApprovalKind::Command)
+        );
+        assert_eq!(
+            approval_kind_for_method("item/fileChange/requestApproval"),
+            Some(ApprovalKind::FileChange)
+        );
+        assert_eq!(
+            approval_kind_for_method("item/permissions/requestApproval"),
+            None
+        );
+    }
+}

--- a/crates/relay-session/src/contract.rs
+++ b/crates/relay-session/src/contract.rs
@@ -1,0 +1,336 @@
+//! Provider-neutral Session contract.
+//!
+//! This module is the stable seam that downstream issues (#1142 session
+//! surface, #1145 event fan-out) depend on. It deliberately does **not**
+//! reference Codex, JSON-RPC, or any wire method name. Provider adapters
+//! translate their transport into these neutral types; nothing here leaks
+//! the underlying JSONL structure. Diagnostic previews are bounded, redacted
+//! strings only, never raw provider payloads.
+
+use std::fmt;
+
+/// Opaque, provider-neutral session identity.
+///
+/// The inner string is an adapter-assigned handle. Callers must treat it as
+/// opaque and must not parse provider structure out of it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Opaque identifier for one pending approval request.
+///
+/// Callers may correlate it with a later decision but must not infer provider
+/// transport structure from its contents.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ApprovalId(String);
+
+impl ApprovalId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A safe subset of approval requests with a documented response shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalKind {
+    Command,
+    FileChange,
+}
+
+impl ApprovalKind {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Command => "command",
+            Self::FileChange => "file_change",
+        }
+    }
+}
+
+/// A pending approval request surfaced by the adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalRequest {
+    pub id: ApprovalId,
+    pub kind: ApprovalKind,
+}
+
+/// A one-request decision. Persistent grants and policy amendments are outside
+/// this MVP because they add authority and storage scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalDecision {
+    AcceptOnce,
+    Decline,
+    Cancel,
+}
+
+/// Monotonic arrival sequence number.
+///
+/// Every event a session surfaces carries a sequence assigned strictly in the
+/// order the adapter observed it on the transport. Consumers use this to detect
+/// gaps and to preserve ordering independent of wall-clock timing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Sequence(pub u64);
+
+impl fmt::Display for Sequence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+/// Coarse, provider-neutral session status.
+///
+/// Deliberately small: it captures enough for a downstream cockpit to render a
+/// truthful lifecycle without exposing provider internals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionStatus {
+    /// Child spawned; handshake not yet complete.
+    Starting,
+    /// Handshake complete; no active work.
+    Idle,
+    /// A prompt/turn is being processed.
+    Working,
+    /// Still usable, but a bounded fault was observed (see reason).
+    Degraded(DegradedReason),
+    /// Terminal, unrecoverable within this session (see kind).
+    Failed(FailureKind),
+    /// Cleanly shut down and owned child reaped.
+    Closed,
+}
+
+impl SessionStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Failed(_) | Self::Closed)
+    }
+}
+
+/// Typed, bounded degradation reasons. A session in `Degraded` remains usable;
+/// the supervisor escalates to `Failed(TooManyFaults)` once the bounded
+/// tolerance is exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DegradedReason {
+    /// A transport line was not valid framing and was dropped.
+    MalformedFrame,
+    /// A transport line exceeded the byte limit and was dropped/truncated.
+    OverLimitFrame,
+    /// A provider event was recognized as a frame but is not modeled.
+    UnsupportedEvent,
+    /// A provider request required a response shape this build does not
+    /// document as supported (e.g. an approval prompt) — reported, never
+    /// answered with a fabricated decision.
+    UnsupportedApproval,
+    /// The bounded event queue overflowed and old events were shed.
+    Backpressure,
+    /// A cancel arrived after the work it targeted had already finished.
+    CancellationRace,
+}
+
+impl DegradedReason {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::MalformedFrame => "malformed_frame",
+            Self::OverLimitFrame => "over_limit_frame",
+            Self::UnsupportedEvent => "unsupported_event",
+            Self::UnsupportedApproval => "unsupported_approval",
+            Self::Backpressure => "backpressure",
+            Self::CancellationRace => "cancellation_race",
+        }
+    }
+}
+
+/// Typed terminal failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    /// The provider executable could not be launched.
+    ExecutableUnavailable,
+    /// The owned child process exited/was terminated unexpectedly.
+    ProcessTerminated,
+    /// A required protocol step did not complete within its deadline.
+    Timeout,
+    /// The bounded queue overflowed past the recovery tolerance.
+    QueueOverflow,
+    /// The transport produced output that violates the framing contract past
+    /// the recovery tolerance.
+    ProtocolViolation,
+}
+
+impl FailureKind {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::ExecutableUnavailable => "executable_unavailable",
+            Self::ProcessTerminated => "process_terminated",
+            Self::Timeout => "timeout",
+            Self::QueueOverflow => "queue_overflow",
+            Self::ProtocolViolation => "protocol_violation",
+        }
+    }
+}
+
+/// Neutral classification of a surfaced event. The adapter maps provider
+/// method names onto this closed set; downstream code never sees the raw
+/// method string, only `kind` + a neutral `label`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventKind {
+    /// Session/turn lifecycle transition.
+    Lifecycle,
+    /// Opaque incremental work output.
+    Progress,
+    /// Provider asked for a decision. Only emitted for shapes the adapter
+    /// documents as supported; otherwise a `Diagnostic` with
+    /// `UnsupportedApproval` is emitted instead.
+    ApprovalRequest,
+    /// A warning/degradation signal from the provider or adapter.
+    Diagnostic,
+    /// A well-formed frame whose meaning is not modeled by the adapter.
+    Unsupported,
+}
+
+impl EventKind {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Lifecycle => "lifecycle",
+            Self::Progress => "progress",
+            Self::ApprovalRequest => "approval_request",
+            Self::Diagnostic => "diagnostic",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// A single provider-neutral event.
+///
+/// `label` is a stable, human-readable neutral tag chosen by the adapter (for
+/// example `"turn.started"`), *not* the provider's wire method. `preview` is a
+/// bounded, secret-redacted diagnostic string; it never carries structured
+/// provider payload and must not be parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEvent {
+    pub seq: Sequence,
+    pub kind: EventKind,
+    pub label: String,
+    pub preview: String,
+}
+
+impl SessionEvent {
+    pub fn new(
+        seq: Sequence,
+        kind: EventKind,
+        label: impl Into<String>,
+        preview: impl Into<String>,
+    ) -> Self {
+        Self {
+            seq,
+            kind,
+            label: label.into(),
+            preview: preview.into(),
+        }
+    }
+}
+
+/// Backpressure / integrity counters exposed alongside the event stream.
+///
+/// These are cumulative and monotonic for the life of the session. They let a
+/// consumer detect lossy conditions truthfully instead of silently believing
+/// it saw everything.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StreamSignals {
+    /// Frames dropped because the bounded queue was full when they arrived.
+    pub dropped: u64,
+    /// Lines rejected for exceeding the byte limit.
+    pub over_limit: u64,
+    /// Lines rejected as malformed framing.
+    pub malformed: u64,
+    /// Well-formed but unmodeled frames observed.
+    pub unsupported: u64,
+    /// True while the queue is at capacity and shedding.
+    pub backpressured: bool,
+}
+
+/// Errors returned by session control methods (create/resume/prompt/cancel).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionError {
+    /// The provider executable could not be launched.
+    Unavailable,
+    /// The session is in a terminal state and cannot accept the call.
+    Terminal(FailureKind),
+    /// The call could not complete within its deadline.
+    Timeout,
+    /// The call raced a lifecycle transition (e.g. cancel after completion).
+    Raced(DegradedReason),
+    /// The requested operation is not supported by the installed protocol.
+    Unsupported(&'static str),
+    /// The transport rejected the request (write failed / process gone).
+    Transport,
+}
+
+impl SessionError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::Terminal(_) => "terminal",
+            Self::Timeout => "timeout",
+            Self::Raced(_) => "raced",
+            Self::Unsupported(_) => "unsupported",
+            Self::Transport => "transport",
+        }
+    }
+}
+
+impl fmt::Display for SessionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Terminal(kind) => write!(formatter, "terminal:{}", kind.code()),
+            Self::Raced(reason) => write!(formatter, "raced:{}", reason.code()),
+            Self::Unsupported(detail) => write!(formatter, "unsupported:{detail}"),
+            other => formatter.write_str(other.code()),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_terminality_is_explicit() {
+        assert!(SessionStatus::Failed(FailureKind::Timeout).is_terminal());
+        assert!(SessionStatus::Closed.is_terminal());
+        assert!(!SessionStatus::Idle.is_terminal());
+        assert!(!SessionStatus::Degraded(DegradedReason::Backpressure).is_terminal());
+    }
+
+    #[test]
+    fn session_id_is_opaque_but_displayable() {
+        let id = SessionId::new("relay-sess-1");
+        assert_eq!(id.as_str(), "relay-sess-1");
+        assert_eq!(id.to_string(), "relay-sess-1");
+    }
+
+    #[test]
+    fn error_codes_are_stable() {
+        assert_eq!(SessionError::Unavailable.code(), "unavailable");
+        assert_eq!(
+            SessionError::Terminal(FailureKind::ProcessTerminated).to_string(),
+            "terminal:process_terminated"
+        );
+    }
+}

--- a/crates/relay-session/src/jsonl.rs
+++ b/crates/relay-session/src/jsonl.rs
@@ -39,6 +39,10 @@ pub struct Frame {
     pub result_thread_id: Option<String>,
     /// For a successful response, the `result.turn.id` string, if present.
     pub result_turn_id: Option<String>,
+    /// Whether this frame carries a structured top-level `params` member.
+    pub has_params: bool,
+    /// For a turn notification, the `params.turn.id` string, if present.
+    pub event_turn_id: Option<String>,
     /// Bounded, secret-redacted diagnostic preview of the line.
     pub preview: String,
 }
@@ -101,18 +105,30 @@ pub fn scan_line(line: &[u8]) -> Result<Frame, ScanError> {
         Some(_) => return Err(ScanError::Malformed),
     };
     let id = match object.get("id") {
-        None | Some(Value::Null) => None,
-        Some(id @ (Value::String(_) | Value::Number(_))) => {
+        None => None,
+        Some(Value::String(id)) => {
+            Some(serde_json::to_string(id).map_err(|_| ScanError::Malformed)?)
+        }
+        Some(Value::Number(id)) if id.is_i64() || id.is_u64() => {
             Some(serde_json::to_string(id).map_err(|_| ScanError::Malformed)?)
         }
         Some(_) => return Err(ScanError::Malformed),
     };
     let has_result = object.contains_key("result");
     let has_error = object.contains_key("error");
+    let params = object.get("params");
+    let has_params = params.is_some();
+    let params_are_structured = params.is_none_or(|params| params.is_object() || params.is_array());
+    let json_rpc_2 =
+        matches!(object.get("jsonrpc"), Some(Value::String(version)) if version == "2.0");
     let class = match (&method, &id) {
-        (Some(_), Some(_)) => FrameClass::ServerRequest,
-        (Some(_), None) => FrameClass::Notification,
-        (None, Some(_)) if has_result || has_error => FrameClass::Response { ok: has_result },
+        (Some(_), Some(_)) if json_rpc_2 && !has_result && !has_error && params_are_structured => {
+            FrameClass::ServerRequest
+        }
+        (Some(_), None) if !has_result && !has_error => FrameClass::Notification,
+        (None, Some(_)) if json_rpc_2 && (has_result != has_error) => {
+            FrameClass::Response { ok: has_result }
+        }
         _ => return Err(ScanError::Malformed),
     };
 
@@ -126,12 +142,20 @@ pub fn scan_line(line: &[u8]) -> Result<Frame, ScanError> {
         (None, None)
     };
 
+    let event_turn_id = if matches!(class, FrameClass::Notification) {
+        nested_result_id(params, "turn")
+    } else {
+        None
+    };
+
     Ok(Frame {
         class,
         method,
         id,
         result_thread_id,
         result_turn_id,
+        has_params,
+        event_turn_id,
         preview: redacted_preview(trimmed),
     })
 }
@@ -451,6 +475,21 @@ mod tests {
             scan_line(br#"{"id":{},"result":{}}"#),
             Err(ScanError::Malformed)
         );
+    }
+
+    #[test]
+    fn unsupported_json_rpc_request_and_response_shapes_are_rejected() {
+        let invalid: &[&[u8]] = &[
+            br#"{"id":1,"result":{}}"#,
+            br#"{"jsonrpc":"2.0","id":1.5,"result":{}}"#,
+            br#"{"jsonrpc":"2.0","id":1,"result":{},"error":{}}"#,
+            br#"{"jsonrpc":"2.0","id":1.5,"method":"item/fileChange/requestApproval","params":{}}"#,
+            br#"{"jsonrpc":"2.0","id":1,"method":"item/fileChange/requestApproval","params":"not-structured"}"#,
+        ];
+
+        for line in invalid {
+            assert_eq!(scan_line(line), Err(ScanError::Malformed));
+        }
     }
 
     #[test]

--- a/crates/relay-session/src/jsonl.rs
+++ b/crates/relay-session/src/jsonl.rs
@@ -163,20 +163,6 @@ pub fn redacted_preview(line: &[u8]) -> String {
 
 /// Mask secret-looking JSON values, bare Bearer values, and `sk-` tokens.
 pub fn redact_secrets(input: &str) -> String {
-    const SECRET_KEYS: &[&str] = &[
-        "token",
-        "secret",
-        "password",
-        "authorization",
-        "apikey",
-        "api_key",
-        "bearer",
-        "access_token",
-        "refresh_token",
-        "id_token",
-        "client_secret",
-    ];
-
     let bytes = input.as_bytes();
     let mut output = String::with_capacity(input.len());
     let mut i = 0;
@@ -189,11 +175,7 @@ pub fn redact_secrets(input: &str) -> String {
                     && bytes[after_key] == b':'
                     && value_start < bytes.len()
                     && bytes[value_start] == b'"'
-                    && SECRET_KEYS.contains(
-                        &unescape_ascii(&bytes[i + 1..key_end - 1])
-                            .to_ascii_lowercase()
-                            .as_str(),
-                    )
+                    && is_secret_json_key(&bytes[i + 1..key_end - 1])
                     && let Some(value_end) = string_end(bytes, value_start)
                 {
                     output.push_str(&input[i..value_start]);
@@ -222,6 +204,94 @@ pub fn redact_secrets(input: &str) -> String {
         }
     }
     output
+}
+
+/// Recognize secret JSON keys after decoding ASCII JSON escapes, folding ASCII
+/// case, and removing underscores. This keeps snake_case and camelCase forms
+/// equivalent without broadening matching beyond the known credential fields.
+fn is_secret_json_key(bytes: &[u8]) -> bool {
+    const SECRET_KEYS: &[&[u8]] = &[
+        b"token",
+        b"secret",
+        b"password",
+        b"authorization",
+        b"apikey",
+        b"bearer",
+        b"accesstoken",
+        b"refreshtoken",
+        b"idtoken",
+        b"clientsecret",
+    ];
+
+    let mut canonical = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = if bytes[i] == b'\\' {
+            let Some(&escape) = bytes.get(i + 1) else {
+                return false;
+            };
+            match escape {
+                b'"' | b'\\' | b'/' => {
+                    i += 2;
+                    escape
+                }
+                b'b' => {
+                    i += 2;
+                    b'\x08'
+                }
+                b'f' => {
+                    i += 2;
+                    b'\x0c'
+                }
+                b'n' => {
+                    i += 2;
+                    b'\n'
+                }
+                b'r' => {
+                    i += 2;
+                    b'\r'
+                }
+                b't' => {
+                    i += 2;
+                    b'\t'
+                }
+                b'u' => {
+                    let Some(escape_bytes) = bytes.get(i + 2..i + 6) else {
+                        return false;
+                    };
+                    let Some(byte) = decode_ascii_unicode_escape(escape_bytes) else {
+                        return false;
+                    };
+                    i += 6;
+                    byte
+                }
+                _ => return false,
+            }
+        } else {
+            let byte = bytes[i];
+            i += 1;
+            byte
+        };
+
+        if byte != b'_' {
+            canonical.push(byte.to_ascii_lowercase());
+        }
+    }
+
+    SECRET_KEYS.contains(&canonical.as_slice())
+}
+
+fn decode_ascii_unicode_escape(bytes: &[u8]) -> Option<u8> {
+    let codepoint = bytes.iter().try_fold(0_u16, |value, byte| {
+        let digit = match byte {
+            b'0'..=b'9' => byte - b'0',
+            b'a'..=b'f' => byte - b'a' + 10,
+            b'A'..=b'F' => byte - b'A' + 10,
+            _ => return None,
+        };
+        Some(value * 16 + u16::from(digit))
+    })?;
+    u8::try_from(codepoint).ok()
 }
 
 fn append_redacted_tokens(input: &str, mut i: usize, end: usize, output: &mut String) {
@@ -259,33 +329,6 @@ fn string_end(bytes: &[u8], start: usize) -> Option<usize> {
         }
     }
     None
-}
-
-fn unescape_ascii(bytes: &[u8]) -> String {
-    let mut output = String::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'\\' && i + 1 < bytes.len() {
-            match bytes[i + 1] {
-                b'n' => output.push('\n'),
-                b't' => output.push('\t'),
-                b'r' => output.push('\r'),
-                b'"' => output.push('"'),
-                b'\\' => output.push('\\'),
-                b'/' => output.push('/'),
-                other => {
-                    output.push('\\');
-                    output.push(other as char);
-                }
-            }
-            i += 2;
-        } else {
-            let end = (i + utf8_len(bytes[i])).min(bytes.len());
-            output.push_str(&String::from_utf8_lossy(&bytes[i..end]));
-            i = end;
-        }
-    }
-    output
 }
 
 fn skip_ws(bytes: &[u8], mut i: usize) -> usize {
@@ -432,6 +475,18 @@ mod tests {
         assert!(!preview.contains("XYZ123"));
         assert!(preview.contains("Bearer [redacted]"));
         assert!(preview.contains("sk-[redacted]"));
+    }
+
+    #[test]
+    fn frame_preview_masks_camel_case_credential_keys_and_escaped_forms() {
+        let frame = scan_line(
+            br#"{"method":"auth","params":{"accessToken":"mask-me-a","refreshToken":"mask-me-b","idToken":"mask-me-c","client\u0053ecret":"mask-me-\u0064"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(frame.preview.matches("\"[redacted]\"").count(), 4);
+        assert!(!frame.preview.contains("mask-me"));
+        assert!(serde_json::from_str::<Value>(&frame.preview).is_ok());
     }
 
     #[test]

--- a/crates/relay-session/src/jsonl.rs
+++ b/crates/relay-session/src/jsonl.rs
@@ -182,49 +182,71 @@ pub fn redact_secrets(input: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'"' {
-            if let Some((key_end, key)) = read_json_key(bytes, i) {
+            if let Some(key_end) = string_end(bytes, i) {
                 let after_key = skip_ws(bytes, key_end);
                 let value_start = skip_ws(bytes, after_key.saturating_add(1));
                 if after_key < bytes.len()
                     && bytes[after_key] == b':'
                     && value_start < bytes.len()
                     && bytes[value_start] == b'"'
-                    && SECRET_KEYS.contains(&key.to_ascii_lowercase().as_str())
+                    && SECRET_KEYS.contains(
+                        &unescape_ascii(&bytes[i + 1..key_end - 1])
+                            .to_ascii_lowercase()
+                            .as_str(),
+                    )
                     && let Some(value_end) = string_end(bytes, value_start)
                 {
-                    output.push('"');
-                    output.push_str(&key);
-                    output.push('"');
-                    output.push_str(&input[key_end..after_key + 1]);
+                    output.push_str(&input[i..value_start]);
                     output.push_str("\"[redacted]\"");
                     i = value_end;
                     continue;
                 }
+
+                output.push('"');
+                append_redacted_tokens(input, i + 1, key_end - 1, &mut output);
+                output.push('"');
+                i = key_end;
+                continue;
             }
         }
-        if starts_with_ci(&bytes[i..], b"bearer ") {
-            output.push_str("Bearer [redacted]");
-            i += 7;
-            while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b'"' {
-                i += 1;
-            }
-            continue;
+        let end = bytes[i..]
+            .iter()
+            .position(|byte| *byte == b'"')
+            .map_or(bytes.len(), |offset| i + offset);
+        if end == i {
+            output.push('"');
+            i += 1;
+        } else {
+            append_redacted_tokens(input, i, end, &mut output);
+            i = end;
         }
-        if starts_with_ci(&bytes[i..], b"sk-") && is_token_boundary(bytes, i) {
-            output.push_str("sk-[redacted]");
-            i += 3;
-            while i < bytes.len()
-                && (bytes[i].is_ascii_alphanumeric() || matches!(bytes[i], b'-' | b'_'))
-            {
-                i += 1;
-            }
-            continue;
-        }
-        let end = (i + utf8_len(bytes[i])).min(bytes.len());
-        output.push_str(&input[i..end]);
-        i = end;
     }
     output
+}
+
+fn append_redacted_tokens(input: &str, mut i: usize, end: usize, output: &mut String) {
+    let bytes = input.as_bytes();
+    while i < end {
+        if starts_with_ci(&bytes[i..end], b"bearer ") {
+            output.push_str("Bearer [redacted]");
+            i += 7;
+            while i < end && !bytes[i].is_ascii_whitespace() && bytes[i] != b'"' {
+                i += 1;
+            }
+            continue;
+        }
+        if starts_with_ci(&bytes[i..end], b"sk-") && is_token_boundary(bytes, i) {
+            output.push_str("sk-[redacted]");
+            i += 3;
+            while i < end && (bytes[i].is_ascii_alphanumeric() || matches!(bytes[i], b'-' | b'_')) {
+                i += 1;
+            }
+            continue;
+        }
+        let character_end = (i + utf8_len(bytes[i])).min(end);
+        output.push_str(&input[i..character_end]);
+        i = character_end;
+    }
 }
 
 fn string_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -237,11 +259,6 @@ fn string_end(bytes: &[u8], start: usize) -> Option<usize> {
         }
     }
     None
-}
-
-fn read_json_key(bytes: &[u8], start: usize) -> Option<(usize, String)> {
-    let end = string_end(bytes, start)?;
-    Some((end, unescape_ascii(&bytes[start + 1..end - 1])))
 }
 
 fn unescape_ascii(bytes: &[u8]) -> String {
@@ -315,6 +332,7 @@ const fn utf8_len(first: u8) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn classifies_notification_response_and_server_request() {
@@ -341,6 +359,40 @@ mod tests {
         let frame = scan_line(br#"{"method":"item/completed","params":{"text":"a } { \" nested","obj":{"k":[1,2,{"z":"}"}]}}}"#).unwrap();
         assert_eq!(frame.class, FrameClass::Notification);
         assert_eq!(frame.method.as_deref(), Some("item/completed"));
+    }
+
+    #[test]
+    fn escaped_quotes_in_non_secret_notifications_scale_linearly() {
+        fn notification(escaped_quotes: usize) -> Vec<u8> {
+            let mut line = b"{\"method\":\"item/completed\",\"params\":{\"note\":\"".to_vec();
+            for _ in 0..escaped_quotes {
+                line.push(b'\\');
+                line.push(b'\"');
+            }
+            line.extend_from_slice(b"\"}}");
+            line
+        }
+
+        let small = notification(15_000);
+        let large = notification(30_000);
+        assert!(large.len() < MAX_LINE_BYTES);
+
+        let started = Instant::now();
+        let small_frame = scan_line(&small).unwrap();
+        let small_elapsed = started.elapsed();
+        assert_eq!(small_frame.class, FrameClass::Notification);
+
+        let started = Instant::now();
+        let large_frame = scan_line(&large).unwrap();
+        let large_elapsed = started.elapsed();
+        assert_eq!(large_frame.class, FrameClass::Notification);
+
+        assert!(
+            large_elapsed <= small_elapsed.saturating_mul(3) + Duration::from_millis(50),
+            "expected linear scaling, got {small_elapsed:?} for {} bytes and {large_elapsed:?} for {} bytes",
+            small.len(),
+            large.len(),
+        );
     }
 
     #[test]

--- a/crates/relay-session/src/jsonl.rs
+++ b/crates/relay-session/src/jsonl.rs
@@ -1,0 +1,394 @@
+//! Bounded JSONL framing for the Codex app-server stdio transport.
+//!
+//! The Codex `app-server --stdio` transport speaks newline-delimited JSON
+//! (JSONL): exactly one JSON-RPC object per `\n`-terminated stdout line. A
+//! bounded frame is classified as a response, notification, or server request.
+//! The parser retains only a method, JSON-RPC id, two non-secret result handles,
+//! and a bounded redacted preview. It never retains raw provider payloads.
+
+use serde_json::Value;
+
+/// Maximum accepted length of a single transport line, in bytes.
+pub const MAX_LINE_BYTES: usize = 64 * 1024;
+
+/// Maximum length of a retained diagnostic preview, in bytes.
+pub const MAX_PREVIEW_BYTES: usize = 256;
+
+/// Classification of a framed line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameClass {
+    /// Server response to a client request (`id` + `result`/`error`).
+    Response { ok: bool },
+    /// Server-initiated notification / event (`method`, no `id`).
+    Notification,
+    /// Server-initiated request expecting a reply (`method` + `id`).
+    ServerRequest,
+}
+
+/// A successfully classified frame. Holds only what the neutral contract needs
+/// plus a bounded redacted preview — never the raw structured payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    pub class: FrameClass,
+    /// Wire method name, if present. It is mapped before crossing the neutral
+    /// Session contract boundary.
+    pub method: Option<String>,
+    /// Raw top-level JSON-RPC id token (number or quoted string), if present.
+    pub id: Option<String>,
+    /// For a successful response, the `result.thread.id` string, if present.
+    pub result_thread_id: Option<String>,
+    /// For a successful response, the `result.turn.id` string, if present.
+    pub result_turn_id: Option<String>,
+    /// Bounded, secret-redacted diagnostic preview of the line.
+    pub preview: String,
+}
+
+/// Field selector for [`Frame::result_field`].
+#[derive(Debug, Clone, Copy)]
+pub enum ResultField {
+    ThreadId,
+    TurnId,
+}
+
+impl Frame {
+    /// The pre-extracted result id for `field`, if this frame carried it.
+    pub fn result_field(&self, field: ResultField) -> Option<String> {
+        match field {
+            ResultField::ThreadId => self.result_thread_id.clone(),
+            ResultField::TurnId => self.result_turn_id.clone(),
+        }
+    }
+}
+
+/// Typed scan failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanError {
+    /// Line exceeded [`MAX_LINE_BYTES`].
+    OverLimit { len: usize },
+    /// Line was not a well-formed top-level JSON object we can classify.
+    Malformed,
+    /// Empty / whitespace-only line.
+    Empty,
+}
+
+impl ScanError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::OverLimit { .. } => "over_limit",
+            Self::Malformed => "malformed",
+            Self::Empty => "empty",
+        }
+    }
+}
+
+/// Scan and classify one bounded JSONL frame.
+pub fn scan_line(line: &[u8]) -> Result<Frame, ScanError> {
+    if line.len() > MAX_LINE_BYTES {
+        return Err(ScanError::OverLimit { len: line.len() });
+    }
+    let trimmed = trim_ascii_ws(line);
+    if trimmed.is_empty() {
+        return Err(ScanError::Empty);
+    }
+
+    // Deserialize only after enforcing the transport bound. This fully rejects
+    // malformed JSON and trailing garbage; `value` is dropped at function exit.
+    let value: Value = serde_json::from_slice(trimmed).map_err(|_| ScanError::Malformed)?;
+    let object = value.as_object().ok_or(ScanError::Malformed)?;
+    let method = match object.get("method") {
+        None => None,
+        Some(Value::String(method)) => Some(method.clone()),
+        Some(_) => return Err(ScanError::Malformed),
+    };
+    let id = match object.get("id") {
+        None | Some(Value::Null) => None,
+        Some(id @ (Value::String(_) | Value::Number(_))) => {
+            Some(serde_json::to_string(id).map_err(|_| ScanError::Malformed)?)
+        }
+        Some(_) => return Err(ScanError::Malformed),
+    };
+    let has_result = object.contains_key("result");
+    let has_error = object.contains_key("error");
+    let class = match (&method, &id) {
+        (Some(_), Some(_)) => FrameClass::ServerRequest,
+        (Some(_), None) => FrameClass::Notification,
+        (None, Some(_)) if has_result || has_error => FrameClass::Response { ok: has_result },
+        _ => return Err(ScanError::Malformed),
+    };
+
+    let (result_thread_id, result_turn_id) = if matches!(class, FrameClass::Response { ok: true }) {
+        let result = object.get("result");
+        (
+            nested_result_id(result, "thread"),
+            nested_result_id(result, "turn"),
+        )
+    } else {
+        (None, None)
+    };
+
+    Ok(Frame {
+        class,
+        method,
+        id,
+        result_thread_id,
+        result_turn_id,
+        preview: redacted_preview(trimmed),
+    })
+}
+
+/// Extract `result.<outer>.id` without retaining the result object.
+fn nested_result_id(result: Option<&Value>, outer: &str) -> Option<String> {
+    result?
+        .as_object()?
+        .get(outer)?
+        .as_object()?
+        .get("id")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Redact obvious secrets, then bound the string to [`MAX_PREVIEW_BYTES`].
+pub fn redacted_preview(line: &[u8]) -> String {
+    let mut text = redact_secrets(&String::from_utf8_lossy(line));
+    if text.len() > MAX_PREVIEW_BYTES {
+        let mut end = MAX_PREVIEW_BYTES;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+        text.push_str("…[truncated]");
+    }
+    text
+}
+
+/// Mask secret-looking JSON values, bare Bearer values, and `sk-` tokens.
+pub fn redact_secrets(input: &str) -> String {
+    const SECRET_KEYS: &[&str] = &[
+        "token",
+        "secret",
+        "password",
+        "authorization",
+        "apikey",
+        "api_key",
+        "bearer",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "client_secret",
+    ];
+
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            if let Some((key_end, key)) = read_json_key(bytes, i) {
+                let after_key = skip_ws(bytes, key_end);
+                let value_start = skip_ws(bytes, after_key.saturating_add(1));
+                if after_key < bytes.len()
+                    && bytes[after_key] == b':'
+                    && value_start < bytes.len()
+                    && bytes[value_start] == b'"'
+                    && SECRET_KEYS.contains(&key.to_ascii_lowercase().as_str())
+                    && let Some(value_end) = string_end(bytes, value_start)
+                {
+                    output.push('"');
+                    output.push_str(&key);
+                    output.push('"');
+                    output.push_str(&input[key_end..after_key + 1]);
+                    output.push_str("\"[redacted]\"");
+                    i = value_end;
+                    continue;
+                }
+            }
+        }
+        if starts_with_ci(&bytes[i..], b"bearer ") {
+            output.push_str("Bearer [redacted]");
+            i += 7;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b'"' {
+                i += 1;
+            }
+            continue;
+        }
+        if starts_with_ci(&bytes[i..], b"sk-") && is_token_boundary(bytes, i) {
+            output.push_str("sk-[redacted]");
+            i += 3;
+            while i < bytes.len()
+                && (bytes[i].is_ascii_alphanumeric() || matches!(bytes[i], b'-' | b'_'))
+            {
+                i += 1;
+            }
+            continue;
+        }
+        let end = (i + utf8_len(bytes[i])).min(bytes.len());
+        output.push_str(&input[i..end]);
+        i = end;
+    }
+    output
+}
+
+fn string_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => return Some(i + 1),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+fn read_json_key(bytes: &[u8], start: usize) -> Option<(usize, String)> {
+    let end = string_end(bytes, start)?;
+    Some((end, unescape_ascii(&bytes[start + 1..end - 1])))
+}
+
+fn unescape_ascii(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'n' => output.push('\n'),
+                b't' => output.push('\t'),
+                b'r' => output.push('\r'),
+                b'"' => output.push('"'),
+                b'\\' => output.push('\\'),
+                b'/' => output.push('/'),
+                other => {
+                    output.push('\\');
+                    output.push(other as char);
+                }
+            }
+            i += 2;
+        } else {
+            let end = (i + utf8_len(bytes[i])).min(bytes.len());
+            output.push_str(&String::from_utf8_lossy(&bytes[i..end]));
+            i = end;
+        }
+    }
+    output
+}
+
+fn skip_ws(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+fn trim_ascii_ws(bytes: &[u8]) -> &[u8] {
+    let mut start = 0;
+    let mut end = bytes.len();
+    while start < end && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    while end > start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    &bytes[start..end]
+}
+
+fn starts_with_ci(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.len() >= needle.len()
+        && haystack[..needle.len()]
+            .iter()
+            .zip(needle)
+            .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected))
+}
+
+fn is_token_boundary(bytes: &[u8], index: usize) -> bool {
+    index == 0
+        || !matches!(bytes[index - 1], byte if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+const fn utf8_len(first: u8) -> usize {
+    match first {
+        0x00..=0x7f => 1,
+        0xc0..=0xdf => 2,
+        0xe0..=0xef => 3,
+        _ => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_notification_response_and_server_request() {
+        let notification =
+            scan_line(br#"{"jsonrpc":"2.0","method":"thread/started","params":{"a":1}}"#).unwrap();
+        assert_eq!(notification.class, FrameClass::Notification);
+        assert_eq!(notification.method.as_deref(), Some("thread/started"));
+
+        let response =
+            scan_line(br#"{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"x"}}}"#).unwrap();
+        assert_eq!(response.class, FrameClass::Response { ok: true });
+        assert_eq!(response.id.as_deref(), Some("2"));
+        assert_eq!(response.result_thread_id.as_deref(), Some("x"));
+
+        let request =
+            scan_line(br#"{"jsonrpc":"2.0","id":"abc","method":"openai/form","params":{}}"#)
+                .unwrap();
+        assert_eq!(request.class, FrameClass::ServerRequest);
+        assert_eq!(request.id.as_deref(), Some("\"abc\""));
+    }
+
+    #[test]
+    fn nested_values_and_escaped_strings_are_valid_json() {
+        let frame = scan_line(br#"{"method":"item/completed","params":{"text":"a } { \" nested","obj":{"k":[1,2,{"z":"}"}]}}}"#).unwrap();
+        assert_eq!(frame.class, FrameClass::Notification);
+        assert_eq!(frame.method.as_deref(), Some("item/completed"));
+    }
+
+    #[test]
+    fn malformed_empty_trailing_and_invalid_ids_are_typed() {
+        assert_eq!(scan_line(b"not json"), Err(ScanError::Malformed));
+        assert_eq!(scan_line(b"   "), Err(ScanError::Empty));
+        assert_eq!(scan_line(br#"{"method":"x""#), Err(ScanError::Malformed));
+        assert_eq!(
+            scan_line(br#"{"id":1,"result":{}} trailing"#),
+            Err(ScanError::Malformed)
+        );
+        assert_eq!(
+            scan_line(br#"{"id":{},"result":{}}"#),
+            Err(ScanError::Malformed)
+        );
+    }
+
+    #[test]
+    fn over_limit_line_is_rejected_before_parsing() {
+        let mut line = Vec::from(&b"{\"method\":\""[..]);
+        line.extend(std::iter::repeat_n(b'a', MAX_LINE_BYTES + 10));
+        line.extend_from_slice(b"\"}");
+        assert!(matches!(scan_line(&line), Err(ScanError::OverLimit { .. })));
+    }
+
+    #[test]
+    fn secret_values_bearers_and_sk_tokens_are_masked() {
+        let frame =
+            scan_line(br#"{"method":"auth","params":{"access_token":"sk-DEADBEEF","note":"ok"}}"#)
+                .unwrap();
+        assert!(!frame.preview.contains("DEADBEEF"));
+        assert!(frame.preview.contains("[redacted]"));
+        assert!(frame.preview.contains("\"note\":\"ok\""));
+
+        let preview = redact_secrets("Authorization: Bearer abc.def.ghi and key sk-XYZ123");
+        assert!(!preview.contains("abc.def.ghi"));
+        assert!(!preview.contains("XYZ123"));
+        assert!(preview.contains("Bearer [redacted]"));
+        assert!(preview.contains("sk-[redacted]"));
+    }
+
+    #[test]
+    fn preview_is_bounded() {
+        let mut line = Vec::from(&b"{\"method\":\"x\",\"params\":\""[..]);
+        line.extend(std::iter::repeat_n(b'z', MAX_PREVIEW_BYTES * 4));
+        line.extend_from_slice(b"\"}");
+        let preview = redacted_preview(&line);
+        assert!(preview.len() <= MAX_PREVIEW_BYTES + "…[truncated]".len());
+        assert!(preview.ends_with("…[truncated]"));
+    }
+}

--- a/crates/relay-session/src/jsonl.rs
+++ b/crates/relay-session/src/jsonl.rs
@@ -1,8 +1,10 @@
 //! Bounded JSONL framing for the Codex app-server stdio transport.
 //!
 //! The Codex `app-server --stdio` transport speaks newline-delimited JSON
-//! (JSONL): exactly one JSON-RPC object per `\n`-terminated stdout line. A
-//! bounded frame is classified as a response, notification, or server request.
+//! (JSONL): exactly one bounded object per `\n`-terminated stdout line. Codex
+//! 0.144.1 omits `jsonrpc` from its response and notification envelopes, while
+//! server requests retain the JSON-RPC 2.0 marker. A bounded frame is
+//! classified as a response, notification, or server request.
 //! The parser retains only a method, JSON-RPC id, two non-secret result handles,
 //! and a bounded redacted preview. It never retains raw provider payloads.
 
@@ -116,17 +118,32 @@ pub fn scan_line(line: &[u8]) -> Result<Frame, ScanError> {
     };
     let has_result = object.contains_key("result");
     let has_error = object.contains_key("error");
+    let error_is_structured = object.get("error").is_none_or(Value::is_object);
     let params = object.get("params");
     let has_params = params.is_some();
     let params_are_structured = params.is_none_or(|params| params.is_object() || params.is_array());
     let json_rpc_2 =
         matches!(object.get("jsonrpc"), Some(Value::String(version)) if version == "2.0");
+    let codex_envelope = object.get("jsonrpc").is_none() || json_rpc_2;
     let class = match (&method, &id) {
         (Some(_), Some(_)) if json_rpc_2 && !has_result && !has_error && params_are_structured => {
             FrameClass::ServerRequest
         }
-        (Some(_), None) if !has_result && !has_error => FrameClass::Notification,
-        (None, Some(_)) if json_rpc_2 && (has_result != has_error) => {
+        (Some(_), None)
+            if codex_envelope
+                && !has_result
+                && !has_error
+                && has_params
+                && params_are_structured =>
+        {
+            FrameClass::Notification
+        }
+        (None, Some(_))
+            if codex_envelope
+                && !has_params
+                && error_is_structured
+                && (has_result != has_error) =>
+        {
             FrameClass::Response { ok: has_result }
         }
         _ => return Err(ScanError::Malformed),
@@ -422,6 +439,32 @@ mod tests {
     }
 
     #[test]
+    fn classifies_observed_codex_response_without_jsonrpc() {
+        let frame = scan_line(
+            br#"{"id":1,"result":{"userAgent":"relay-node/0.144.1","platformFamily":"unix"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(frame.class, FrameClass::Response { ok: true });
+        assert_eq!(frame.id.as_deref(), Some("1"));
+
+        let error = scan_line(br#"{"id":2,"error":{"code":-32600}}"#).unwrap();
+        assert_eq!(error.class, FrameClass::Response { ok: false });
+        assert_eq!(error.id.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_malformed_codex_notifications() {
+        for line in [
+            br#"{"method":"thread/started"}"# as &[u8],
+            br#"{"method":"thread/started","params":"not-structured"}"#,
+            br#"{"jsonrpc":"1.0","method":"thread/started","params":{}}"#,
+        ] {
+            assert_eq!(scan_line(line), Err(ScanError::Malformed));
+        }
+    }
+
+    #[test]
     fn nested_values_and_escaped_strings_are_valid_json() {
         let frame = scan_line(br#"{"method":"item/completed","params":{"text":"a } { \" nested","obj":{"k":[1,2,{"z":"}"}]}}}"#).unwrap();
         assert_eq!(frame.class, FrameClass::Notification);
@@ -480,7 +523,8 @@ mod tests {
     #[test]
     fn unsupported_json_rpc_request_and_response_shapes_are_rejected() {
         let invalid: &[&[u8]] = &[
-            br#"{"id":1,"result":{}}"#,
+            br#"{"jsonrpc":"1.0","id":1,"result":{}}"#,
+            br#"{"id":1,"error":"not-structured"}"#,
             br#"{"jsonrpc":"2.0","id":1.5,"result":{}}"#,
             br#"{"jsonrpc":"2.0","id":1,"result":{},"error":{}}"#,
             br#"{"jsonrpc":"2.0","id":1.5,"method":"item/fileChange/requestApproval","params":{}}"#,

--- a/crates/relay-session/src/lib.rs
+++ b/crates/relay-session/src/lib.rs
@@ -1,0 +1,38 @@
+//! `relay-session`: a minimal, one-node **supervised Codex app-server session
+//! adapter** (Relay issue #1140).
+//!
+//! ## What this crate is
+//!
+//! - [`contract`] — a small, provider-neutral Session identity/status/event
+//!   contract that downstream issues (#1142, #1145) can build on. It never
+//!   mentions Codex, JSON-RPC, or wire methods; Codex JSONL does not leak into
+//!   it.
+//! - [`jsonl`] — bounded JSONL framing for the Codex stdio transport: complete
+//!   JSON validation with hard line/preview limits and secret redaction.
+//! - [`codex`] — the Codex adapter: the fixed local `codex app-server --stdio`
+//!   argv, a websocket/socket transport guard, the guaranteed/unsupported event
+//!   ledger, and honest handling of server-initiated (approval) requests.
+//! - [`supervisor`] — child-process supervision and the create / resume /
+//!   prompt / cancel / close lifecycle, with monotonic arrival sequencing,
+//!   bounded queues, backpressure/lag signals, and typed degraded/failed states
+//!   with bounded recovery.
+//!
+//! ## What this crate is not
+//!
+//! It is not a generic multi-provider framework, not a network client (there is
+//! no WebSocket path — see [`codex::assert_local_stdio_only`]), and it does not
+//! persist raw provider transcripts. Diagnostic previews are bounded and
+//! redacted.
+
+pub mod codex;
+pub mod contract;
+pub mod jsonl;
+pub mod supervisor;
+
+pub use contract::{
+    ApprovalDecision, ApprovalId, ApprovalKind, ApprovalRequest, DegradedReason, EventKind,
+    FailureKind, Sequence, SessionError, SessionEvent, SessionId, SessionStatus, StreamSignals,
+};
+pub use supervisor::{
+    DEFAULT_DEADLINE, ProcessTransport, ScriptedTransport, Supervisor, Transport,
+};

--- a/crates/relay-session/src/supervisor.rs
+++ b/crates/relay-session/src/supervisor.rs
@@ -281,6 +281,7 @@ pub struct Supervisor<T: Transport> {
     degraded_count: u64,
     session: Option<SessionId>,
     active_turn: Option<String>,
+    completed_turns: VecDeque<String>,
 }
 
 impl<T: Transport> Supervisor<T> {
@@ -296,6 +297,7 @@ impl<T: Transport> Supervisor<T> {
             degraded_count: 0,
             session: None,
             active_turn: None,
+            completed_turns: VecDeque::with_capacity(EVENT_QUEUE_CAP),
         }
     }
 
@@ -406,8 +408,13 @@ impl<T: Transport> Supervisor<T> {
         );
         let turn = self.send_request("turn/start", &params)?;
         let turn_id = self.await_result_turn_id(&turn, Instant::now() + deadline)?;
-        self.active_turn = Some(turn_id.clone());
-        self.status = SessionStatus::Working;
+        if self.take_completed_turn(&turn_id) {
+            self.active_turn = None;
+            self.status = SessionStatus::Idle;
+        } else {
+            self.active_turn = Some(turn_id.clone());
+            self.status = SessionStatus::Working;
+        }
         Ok(turn_id)
     }
 
@@ -418,7 +425,9 @@ impl<T: Transport> Supervisor<T> {
             .clone()
             .ok_or(SessionError::Unsupported("no active session"))?;
         if self.active_turn.as_deref() != Some(turn_id) {
-            self.record_degraded(DegradedReason::CancellationRace);
+            if let Some(error) = self.record_degraded(DegradedReason::CancellationRace) {
+                return Err(error);
+            }
             return Err(SessionError::Raced(DegradedReason::CancellationRace));
         }
         let params = format!(
@@ -438,7 +447,9 @@ impl<T: Transport> Supervisor<T> {
             // a reason to fabricate successful cancellation.
             Err(SessionError::Unsupported(_)) => {
                 self.active_turn = None;
-                self.record_degraded(DegradedReason::CancellationRace);
+                if let Some(error) = self.record_degraded(DegradedReason::CancellationRace) {
+                    return Err(error);
+                }
                 Err(SessionError::Raced(DegradedReason::CancellationRace))
             }
             Err(error) => Err(error),
@@ -490,6 +501,7 @@ impl<T: Transport> Supervisor<T> {
 
     fn await_response(&mut self, id: &str, deadline: Instant) -> Result<(), SessionError> {
         loop {
+            self.ensure_live()?;
             match self.next_response_or_event(id, deadline)? {
                 Some(true) => return Ok(()),
                 Some(false) => return Err(SessionError::Unsupported("provider error response")),
@@ -521,6 +533,7 @@ impl<T: Transport> Supervisor<T> {
         field: ResultField,
     ) -> Result<String, SessionError> {
         loop {
+            self.ensure_live()?;
             let remaining = self.remaining(deadline)?;
             match self.transport.items().recv_timeout(remaining) {
                 Ok(TransportItem::Line(Ok(frame))) if is_response_for(&frame, id) => {
@@ -578,17 +591,18 @@ impl<T: Transport> Supervisor<T> {
     }
 
     fn absorb(&mut self, item: TransportItem) -> Option<SessionError> {
+        if self.status.is_terminal() {
+            return self.ensure_live().err();
+        }
         match item {
             TransportItem::Exit => Some(self.process_terminated()),
             TransportItem::Line(Err(ScanError::OverLimit { .. })) => {
                 self.signals.over_limit += 1;
-                self.record_degraded(DegradedReason::OverLimitFrame);
-                None
+                self.record_degraded(DegradedReason::OverLimitFrame)
             }
             TransportItem::Line(Err(ScanError::Malformed)) => {
                 self.signals.malformed += 1;
-                self.record_degraded(DegradedReason::MalformedFrame);
-                None
+                self.record_degraded(DegradedReason::MalformedFrame)
             }
             TransportItem::Line(Err(ScanError::Empty)) => None,
             TransportItem::Line(Ok(frame)) => {
@@ -598,6 +612,14 @@ impl<T: Transport> Supervisor<T> {
                         frame.method.as_deref().and_then(approval_kind_for_method),
                     )
                 {
+                    if !frame.has_params {
+                        self.enqueue_event(
+                            EventKind::Diagnostic,
+                            DegradedReason::UnsupportedApproval.code(),
+                            &frame,
+                        );
+                        return self.record_degraded(DegradedReason::UnsupportedApproval);
+                    }
                     self.enqueue_approval(
                         ApprovalRequest {
                             id: ApprovalId::new(id),
@@ -611,10 +633,7 @@ impl<T: Transport> Supervisor<T> {
                     Mapped::Event { kind, label } => {
                         self.enqueue_event(kind, label, &frame);
                         if label == "turn.completed" {
-                            self.active_turn = None;
-                            if !self.status.is_terminal() {
-                                self.status = SessionStatus::Idle;
-                            }
+                            return self.record_turn_completed(frame.event_turn_id.as_deref());
                         }
                     }
                     Mapped::Response { .. } => {}
@@ -628,12 +647,47 @@ impl<T: Transport> Supervisor<T> {
                             EventKind::Unsupported
                         };
                         self.enqueue_event(kind, reason.code(), &frame);
-                        self.record_degraded(reason);
+                        return self.record_degraded(reason);
                     }
                 }
                 None
             }
         }
+    }
+
+    fn record_turn_completed(&mut self, turn_id: Option<&str>) -> Option<SessionError> {
+        let Some(turn_id) = turn_id else {
+            return self.record_degraded(DegradedReason::UnsupportedEvent);
+        };
+        if self.active_turn.as_deref() == Some(turn_id) {
+            self.active_turn = None;
+            if !self.status.is_terminal() {
+                self.status = SessionStatus::Idle;
+            }
+            return None;
+        }
+        if self.completed_turns.len() >= EVENT_QUEUE_CAP {
+            self.completed_turns.pop_front();
+            self.signals.dropped += 1;
+            self.signals.backpressured = true;
+            if self.signals.dropped > DROP_TOLERANCE {
+                self.status = SessionStatus::Failed(FailureKind::QueueOverflow);
+                return Some(SessionError::Terminal(FailureKind::QueueOverflow));
+            }
+            if let Some(error) = self.record_degraded(DegradedReason::Backpressure) {
+                return Some(error);
+            }
+        }
+        self.completed_turns.push_back(turn_id.to_owned());
+        None
+    }
+
+    fn take_completed_turn(&mut self, turn_id: &str) -> bool {
+        self.completed_turns
+            .iter()
+            .position(|completed| completed == turn_id)
+            .and_then(|index| self.completed_turns.remove(index))
+            .is_some()
     }
 
     fn enqueue_event(&mut self, kind: EventKind, label: &str, frame: &Frame) {
@@ -670,12 +724,16 @@ impl<T: Transport> Supervisor<T> {
         self.enqueue_event(EventKind::ApprovalRequest, "approval.request", frame);
     }
 
-    fn record_degraded(&mut self, reason: DegradedReason) {
+    fn record_degraded(&mut self, reason: DegradedReason) -> Option<SessionError> {
         self.degraded_count += 1;
         if self.degraded_count > DEGRADED_TOLERANCE {
             self.status = SessionStatus::Failed(FailureKind::ProtocolViolation);
+            Some(SessionError::Terminal(FailureKind::ProtocolViolation))
         } else if !self.status.is_terminal() {
             self.status = SessionStatus::Degraded(reason);
+            None
+        } else {
+            None
         }
     }
 }
@@ -779,6 +837,43 @@ mod tests {
     }
 
     #[test]
+    fn degraded_frames_past_tolerance_abort_active_await_without_later_idle() {
+        let mut items: Vec<_> = (0..=DEGRADED_TOLERANCE)
+            .map(|_| TransportItem::Line(Err(ScanError::Malformed)))
+            .collect();
+        items.push(TransportItem::Line(scan_line(response(1, "{}").as_bytes())));
+        items.push(TransportItem::Line(scan_line(
+            response(2, "{\"thread\":{\"id\":\"thread-1\"}}").as_bytes(),
+        )));
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_items(items));
+
+        assert_eq!(
+            supervisor.create(DEFAULT_DEADLINE),
+            Err(SessionError::Terminal(FailureKind::ProtocolViolation))
+        );
+        assert_eq!(
+            supervisor.status(),
+            &SessionStatus::Failed(FailureKind::ProtocolViolation)
+        );
+    }
+
+    #[test]
+    fn terminal_protocol_violation_survives_followup_transport_exit() {
+        let mut items: Vec<_> = (0..=DEGRADED_TOLERANCE)
+            .map(|_| TransportItem::Line(Err(ScanError::Malformed)))
+            .collect();
+        items.push(TransportItem::Exit);
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_items(items));
+
+        supervisor.pump();
+
+        assert_eq!(
+            supervisor.status(),
+            &SessionStatus::Failed(FailureKind::ProtocolViolation)
+        );
+    }
+
+    #[test]
     fn output_flood_sheds_oldest_and_signals_backpressure() {
         let items = (0..EVENT_QUEUE_CAP + 10).map(|_| {
             TransportItem::Line(Ok(scan_line(
@@ -810,8 +905,25 @@ mod tests {
     }
 
     #[test]
+    fn approval_without_params_is_rejected_before_approval_handling() {
+        let request =
+            b"{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"item/fileChange/requestApproval\"}";
+        let mut supervisor =
+            Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Line(
+                scan_line(request),
+            )]));
+
+        supervisor.pump();
+
+        assert!(supervisor.next_approval().is_none());
+        let event = supervisor.next_event().unwrap();
+        assert_eq!(event.kind, EventKind::Diagnostic);
+        assert_eq!(event.label, DegradedReason::UnsupportedApproval.code());
+    }
+
+    #[test]
     fn unsupported_server_request_is_diagnostic_not_auto_approved() {
-        let request = b"{\"id\":9,\"method\":\"item/permissions/requestApproval\",\"params\":{}}";
+        let request = b"{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"item/permissions/requestApproval\",\"params\":{}}";
         let mut supervisor =
             Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Line(
                 scan_line(request),
@@ -821,6 +933,27 @@ mod tests {
         assert_eq!(event.kind, EventKind::Diagnostic);
         assert_eq!(event.label, DegradedReason::UnsupportedApproval.code());
         assert!(supervisor.next_approval().is_none());
+    }
+
+    #[test]
+    fn completion_before_turn_start_response_is_not_cancellable() {
+        let completion = "{\"jsonrpc\":\"2.0\",\"method\":\"turn/completed\",\"params\":{\"turn\":{\"id\":\"turn-1\"}}}";
+        let start_response = response(1, "{\"turn\":{\"id\":\"turn-1\"}}");
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines([
+            completion,
+            start_response.as_str(),
+        ]));
+        supervisor.session = Some(SessionId::new("thread-1"));
+
+        assert_eq!(
+            supervisor.prompt("hello", DEFAULT_DEADLINE).unwrap(),
+            "turn-1"
+        );
+        assert_eq!(supervisor.status(), &SessionStatus::Idle);
+        assert_eq!(
+            supervisor.cancel("turn-1", DEFAULT_DEADLINE),
+            Err(SessionError::Raced(DegradedReason::CancellationRace))
+        );
     }
 
     #[test]

--- a/crates/relay-session/src/supervisor.rs
+++ b/crates/relay-session/src/supervisor.rs
@@ -1,0 +1,884 @@
+//! One-node supervised Codex app-server session.
+//!
+//! `Supervisor` owns one local child transport and drives the documented
+//! `initialize` → `initialized` → `thread/start` / `thread/resume` →
+//! `turn/start` / `turn/interrupt` lifecycle. It uses finite deadlines,
+//! ordered event sequencing, bounded queues, and explicit degraded/failed state.
+
+use std::collections::VecDeque;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crate::codex::{Mapped, approval_kind_for_method, codex_command_args, map_frame};
+use crate::contract::{
+    ApprovalDecision, ApprovalId, ApprovalRequest, DegradedReason, EventKind, FailureKind,
+    Sequence, SessionError, SessionEvent, SessionId, SessionStatus, StreamSignals,
+};
+use crate::jsonl::{Frame, FrameClass, MAX_LINE_BYTES, ResultField, ScanError, scan_line};
+
+/// Bounded neutral event queue capacity.
+pub const EVENT_QUEUE_CAP: usize = 1024;
+/// Bounded child-reader to supervisor hand-off capacity.
+pub const INBOUND_QUEUE_CAP: usize = 1024;
+/// Degraded frames tolerated before terminal protocol failure.
+pub const DEGRADED_TOLERANCE: u64 = 64;
+/// Dropped neutral events tolerated before terminal queue failure.
+pub const DROP_TOLERANCE: u64 = 4096;
+/// Default deadline for one control request.
+pub const DEFAULT_DEADLINE: Duration = Duration::from_secs(10);
+
+/// One arrival-ordered transport item.
+#[derive(Debug)]
+pub enum TransportItem {
+    Line(Result<Frame, ScanError>),
+    Exit,
+}
+
+/// A writable JSONL transport with owned lifecycle control.
+pub trait Transport: Send {
+    fn write_line(&mut self, line: &str) -> io::Result<()>;
+    fn items(&self) -> &Receiver<TransportItem>;
+    fn shutdown(&mut self);
+}
+
+/// The real, fixed-command local process transport.
+pub struct ProcessTransport {
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    rx: Receiver<TransportItem>,
+    reader: Option<JoinHandle<()>>,
+    stopping: Arc<AtomicBool>,
+}
+
+impl ProcessTransport {
+    /// Spawns exactly `codex app-server --stdio`; callers cannot supply an
+    /// alternative executable or transport.
+    pub fn spawn(cwd: Option<&Path>) -> Result<Self, SessionError> {
+        Self::spawn_program("codex", cwd)
+    }
+
+    fn spawn_program(program: &str, cwd: Option<&Path>) -> Result<Self, SessionError> {
+        let mut command = Command::new(program);
+        command
+            .args(codex_command_args())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        if let Some(cwd) = cwd {
+            command.current_dir(cwd);
+        }
+        let mut child = command.spawn().map_err(|_| SessionError::Unavailable)?;
+        let stdin = child.stdin.take().ok_or(SessionError::Transport)?;
+        let stdout = child.stdout.take().ok_or(SessionError::Transport)?;
+        let (tx, rx) = mpsc::sync_channel(INBOUND_QUEUE_CAP);
+        let stopping = Arc::new(AtomicBool::new(false));
+        let reader_stopping = Arc::clone(&stopping);
+        let reader = thread::Builder::new()
+            .name("relay-codex-reader".into())
+            .spawn(move || reader_loop(stdout, tx, reader_stopping))
+            .map_err(|_| SessionError::Transport)?;
+        Ok(Self {
+            child: Some(child),
+            stdin: Some(stdin),
+            rx,
+            reader: Some(reader),
+            stopping,
+        })
+    }
+}
+
+/// Send an item without allowing shutdown to deadlock on a full bounded queue.
+fn send_item(
+    tx: &SyncSender<TransportItem>,
+    mut item: TransportItem,
+    stopping: &AtomicBool,
+) -> bool {
+    loop {
+        if stopping.load(Ordering::Acquire) {
+            return false;
+        }
+        match tx.try_send(item) {
+            Ok(()) => return true,
+            Err(TrySendError::Disconnected(_)) => return false,
+            Err(TrySendError::Full(returned)) => {
+                item = returned;
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+}
+
+/// Read bounded lines in arrival order. A full hand-off queue applies OS-level
+/// backpressure to stdout rather than retaining unbounded provider output.
+fn reader_loop<R: io::Read>(stdout: R, tx: SyncSender<TransportItem>, stopping: Arc<AtomicBool>) {
+    let mut reader = BufReader::new(stdout);
+    let mut buffer = Vec::with_capacity(4096);
+    loop {
+        buffer.clear();
+        match read_bounded_line(&mut reader, &mut buffer) {
+            Ok(0) | Err(_) => {
+                let _ = send_item(&tx, TransportItem::Exit, &stopping);
+                return;
+            }
+            Ok(_) => {
+                if !send_item(&tx, TransportItem::Line(scan_line(&buffer)), &stopping) {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Read one line while retaining no more than `MAX_LINE_BYTES + 1` bytes. The
+/// rest of an over-limit line is drained before the next frame is read.
+fn read_bounded_line<R: BufRead>(reader: &mut R, buffer: &mut Vec<u8>) -> io::Result<usize> {
+    let limit = MAX_LINE_BYTES + 1;
+    let mut total = 0;
+    loop {
+        let available = match reader.fill_buf() {
+            Ok(available) => available,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        if available.is_empty() {
+            return Ok(total);
+        }
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            if buffer.len() < limit {
+                let take = newline.min(limit - buffer.len());
+                buffer.extend_from_slice(&available[..take]);
+            }
+            reader.consume(newline + 1);
+            return Ok(total + newline + 1);
+        }
+        if buffer.len() < limit {
+            let take = available.len().min(limit - buffer.len());
+            buffer.extend_from_slice(&available[..take]);
+        }
+        total += available.len();
+        let consumed = available.len();
+        reader.consume(consumed);
+    }
+}
+
+impl Transport for ProcessTransport {
+    fn write_line(&mut self, line: &str) -> io::Result<()> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "stdin closed"))?;
+        stdin.write_all(line.as_bytes())?;
+        stdin.write_all(b"\n")?;
+        stdin.flush()
+    }
+
+    fn items(&self) -> &Receiver<TransportItem> {
+        &self.rx
+    }
+
+    fn shutdown(&mut self) {
+        self.stopping.store(true, Ordering::Release);
+        self.stdin.take();
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+impl Drop for ProcessTransport {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Deterministic no-process transport for contract/failure tests.
+pub struct ScriptedTransport {
+    rx: Receiver<TransportItem>,
+    writes: Vec<String>,
+    write_fails: bool,
+}
+
+impl ScriptedTransport {
+    pub fn from_lines<I, S>(lines: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<[u8]>,
+    {
+        let (tx, rx) = mpsc::channel();
+        for line in lines {
+            let _ = tx.send(TransportItem::Line(scan_line(line.as_ref())));
+        }
+        let _ = tx.send(TransportItem::Exit);
+        drop(tx);
+        Self {
+            rx,
+            writes: Vec::new(),
+            write_fails: false,
+        }
+    }
+
+    pub fn from_items<I: IntoIterator<Item = TransportItem>>(items: I) -> Self {
+        let (tx, rx) = mpsc::channel();
+        for item in items {
+            let _ = tx.send(item);
+        }
+        drop(tx);
+        Self {
+            rx,
+            writes: Vec::new(),
+            write_fails: false,
+        }
+    }
+
+    pub fn with_write_failure(mut self) -> Self {
+        self.write_fails = true;
+        self
+    }
+
+    pub fn writes(&self) -> &[String] {
+        &self.writes
+    }
+}
+
+impl Transport for ScriptedTransport {
+    fn write_line(&mut self, line: &str) -> io::Result<()> {
+        if self.write_fails {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "scripted write failure",
+            ));
+        }
+        self.writes.push(line.to_owned());
+        Ok(())
+    }
+
+    fn items(&self) -> &Receiver<TransportItem> {
+        &self.rx
+    }
+
+    fn shutdown(&mut self) {}
+}
+
+/// Owns one session's state, local process, and bounded neutral event stream.
+pub struct Supervisor<T: Transport> {
+    transport: T,
+    status: SessionStatus,
+    signals: StreamSignals,
+    queue: VecDeque<SessionEvent>,
+    approvals: VecDeque<ApprovalRequest>,
+    next_seq: u64,
+    next_id: u64,
+    degraded_count: u64,
+    session: Option<SessionId>,
+    active_turn: Option<String>,
+}
+
+impl<T: Transport> Supervisor<T> {
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            status: SessionStatus::Starting,
+            signals: StreamSignals::default(),
+            queue: VecDeque::with_capacity(EVENT_QUEUE_CAP),
+            approvals: VecDeque::with_capacity(EVENT_QUEUE_CAP),
+            next_seq: 0,
+            next_id: 1,
+            degraded_count: 0,
+            session: None,
+            active_turn: None,
+        }
+    }
+
+    pub fn status(&self) -> &SessionStatus {
+        &self.status
+    }
+
+    pub fn signals(&self) -> StreamSignals {
+        self.signals
+    }
+
+    pub fn session_id(&self) -> Option<&SessionId> {
+        self.session.as_ref()
+    }
+
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    pub fn next_event(&mut self) -> Option<SessionEvent> {
+        self.queue.pop_front()
+    }
+
+    pub fn queued(&self) -> usize {
+        self.queue.len()
+    }
+
+    pub fn next_approval(&self) -> Option<ApprovalRequest> {
+        self.approvals.front().cloned()
+    }
+
+    /// Reply once to a documented command/file approval. The only accept form
+    /// is `accept`; session/policy amendment responses are deliberately absent.
+    pub fn respond_to_approval(
+        &mut self,
+        approval: &ApprovalRequest,
+        decision: ApprovalDecision,
+    ) -> Result<(), SessionError> {
+        self.ensure_live()?;
+        let index = self
+            .approvals
+            .iter()
+            .position(|pending| pending == approval)
+            .ok_or(SessionError::Unsupported("unknown approval"))?;
+        let decision = match decision {
+            ApprovalDecision::AcceptOnce => "accept",
+            ApprovalDecision::Decline => "decline",
+            ApprovalDecision::Cancel => "cancel",
+        };
+        let response = format!(
+            "{{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"decision\":\"{decision}\"}}}}",
+            approval.id.as_str()
+        );
+        self.transport
+            .write_line(&response)
+            .map_err(|_| SessionError::Transport)?;
+        self.approvals.remove(index);
+        Ok(())
+    }
+
+    pub fn create(&mut self, deadline: Duration) -> Result<SessionId, SessionError> {
+        self.ensure_live()?;
+        let overall = Instant::now() + deadline;
+        let initialize = self.send_request("initialize", INITIALIZE_PARAMS)?;
+        self.await_response(&initialize, overall)?;
+        self.send_notification("initialized")?;
+        let start = self.send_request("thread/start", "{}")?;
+        let thread_id = self.await_result_thread_id(&start, overall)?;
+        let session = SessionId::new(thread_id);
+        self.session = Some(session.clone());
+        self.status = SessionStatus::Idle;
+        Ok(session)
+    }
+
+    pub fn resume(
+        &mut self,
+        thread_id: &str,
+        deadline: Duration,
+    ) -> Result<SessionId, SessionError> {
+        self.ensure_live()?;
+        let overall = Instant::now() + deadline;
+        let initialize = self.send_request("initialize", INITIALIZE_PARAMS)?;
+        self.await_response(&initialize, overall)?;
+        self.send_notification("initialized")?;
+        let params = format!("{{\"threadId\":{}}}", json_string(thread_id));
+        let resume = self.send_request("thread/resume", &params)?;
+        let resumed_id = self.await_result_thread_id(&resume, overall)?;
+        if resumed_id != thread_id {
+            self.status = SessionStatus::Failed(FailureKind::ProtocolViolation);
+            return Err(SessionError::Terminal(FailureKind::ProtocolViolation));
+        }
+        let session = SessionId::new(resumed_id);
+        self.session = Some(session.clone());
+        self.status = SessionStatus::Idle;
+        Ok(session)
+    }
+
+    pub fn prompt(&mut self, text: &str, deadline: Duration) -> Result<String, SessionError> {
+        self.ensure_live()?;
+        let session = self
+            .session
+            .clone()
+            .ok_or(SessionError::Unsupported("no active session"))?;
+        let params = format!(
+            "{{\"threadId\":{},\"input\":[{{\"type\":\"text\",\"text\":{}}}]}}",
+            json_string(session.as_str()),
+            json_string(text)
+        );
+        let turn = self.send_request("turn/start", &params)?;
+        let turn_id = self.await_result_turn_id(&turn, Instant::now() + deadline)?;
+        self.active_turn = Some(turn_id.clone());
+        self.status = SessionStatus::Working;
+        Ok(turn_id)
+    }
+
+    pub fn cancel(&mut self, turn_id: &str, deadline: Duration) -> Result<(), SessionError> {
+        self.ensure_live()?;
+        let session = self
+            .session
+            .clone()
+            .ok_or(SessionError::Unsupported("no active session"))?;
+        if self.active_turn.as_deref() != Some(turn_id) {
+            self.record_degraded(DegradedReason::CancellationRace);
+            return Err(SessionError::Raced(DegradedReason::CancellationRace));
+        }
+        let params = format!(
+            "{{\"threadId\":{},\"turnId\":{}}}",
+            json_string(session.as_str()),
+            json_string(turn_id)
+        );
+        let interrupt = self.send_request("turn/interrupt", &params)?;
+        match self.await_response(&interrupt, Instant::now() + deadline) {
+            Ok(()) => {
+                self.active_turn = None;
+                self.status = SessionStatus::Idle;
+                Ok(())
+            }
+            // The real app-server rejects an interrupt that loses to terminal
+            // completion. This is observable as a provider error response, not
+            // a reason to fabricate successful cancellation.
+            Err(SessionError::Unsupported(_)) => {
+                self.active_turn = None;
+                self.record_degraded(DegradedReason::CancellationRace);
+                Err(SessionError::Raced(DegradedReason::CancellationRace))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Nonblocking stream drain for UI/status consumers.
+    pub fn pump(&mut self) {
+        while let Ok(item) = self.transport.items().try_recv() {
+            let _ = self.absorb(item);
+        }
+    }
+
+    /// Close/reap the owned process. Recovery is an explicit new create/resume.
+    pub fn close(&mut self) {
+        self.transport.shutdown();
+        if !self.status.is_terminal() {
+            self.status = SessionStatus::Closed;
+        }
+    }
+
+    fn ensure_live(&self) -> Result<(), SessionError> {
+        match self.status {
+            SessionStatus::Failed(kind) => Err(SessionError::Terminal(kind)),
+            SessionStatus::Closed => Err(SessionError::Terminal(FailureKind::ProcessTerminated)),
+            _ => Ok(()),
+        }
+    }
+
+    fn send_request(&mut self, method: &str, params: &str) -> Result<String, SessionError> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let request = format!(
+            "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":{},\"params\":{params}}}",
+            json_string(method)
+        );
+        self.transport
+            .write_line(&request)
+            .map_err(|_| SessionError::Transport)?;
+        Ok(id.to_string())
+    }
+
+    fn send_notification(&mut self, method: &str) -> Result<(), SessionError> {
+        let notification = format!("{{\"jsonrpc\":\"2.0\",\"method\":{}}}", json_string(method));
+        self.transport
+            .write_line(&notification)
+            .map_err(|_| SessionError::Transport)
+    }
+
+    fn await_response(&mut self, id: &str, deadline: Instant) -> Result<(), SessionError> {
+        loop {
+            match self.next_response_or_event(id, deadline)? {
+                Some(true) => return Ok(()),
+                Some(false) => return Err(SessionError::Unsupported("provider error response")),
+                None => {}
+            }
+        }
+    }
+
+    fn await_result_thread_id(
+        &mut self,
+        id: &str,
+        deadline: Instant,
+    ) -> Result<String, SessionError> {
+        self.await_result_field(id, deadline, ResultField::ThreadId)
+    }
+
+    fn await_result_turn_id(
+        &mut self,
+        id: &str,
+        deadline: Instant,
+    ) -> Result<String, SessionError> {
+        self.await_result_field(id, deadline, ResultField::TurnId)
+    }
+
+    fn await_result_field(
+        &mut self,
+        id: &str,
+        deadline: Instant,
+        field: ResultField,
+    ) -> Result<String, SessionError> {
+        loop {
+            let remaining = self.remaining(deadline)?;
+            match self.transport.items().recv_timeout(remaining) {
+                Ok(TransportItem::Line(Ok(frame))) if is_response_for(&frame, id) => {
+                    if !response_ok(&frame) {
+                        return Err(SessionError::Unsupported("provider error response"));
+                    }
+                    return frame
+                        .result_field(field)
+                        .ok_or(SessionError::Unsupported("missing id field in result"));
+                }
+                Ok(item) => {
+                    if let Some(error) = self.absorb(item) {
+                        return Err(error);
+                    }
+                }
+                Err(RecvTimeoutError::Timeout) => return Err(self.timeout()),
+                Err(RecvTimeoutError::Disconnected) => return Err(self.process_terminated()),
+            }
+        }
+    }
+
+    fn next_response_or_event(
+        &mut self,
+        id: &str,
+        deadline: Instant,
+    ) -> Result<Option<bool>, SessionError> {
+        let remaining = self.remaining(deadline)?;
+        match self.transport.items().recv_timeout(remaining) {
+            Ok(TransportItem::Line(Ok(frame))) if is_response_for(&frame, id) => {
+                Ok(Some(response_ok(&frame)))
+            }
+            Ok(item) => match self.absorb(item) {
+                Some(error) => Err(error),
+                None => Ok(None),
+            },
+            Err(RecvTimeoutError::Timeout) => Err(self.timeout()),
+            Err(RecvTimeoutError::Disconnected) => Err(self.process_terminated()),
+        }
+    }
+
+    fn remaining(&mut self, deadline: Instant) -> Result<Duration, SessionError> {
+        deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| self.timeout())
+    }
+
+    fn timeout(&mut self) -> SessionError {
+        self.status = SessionStatus::Failed(FailureKind::Timeout);
+        SessionError::Timeout
+    }
+
+    fn process_terminated(&mut self) -> SessionError {
+        self.status = SessionStatus::Failed(FailureKind::ProcessTerminated);
+        SessionError::Terminal(FailureKind::ProcessTerminated)
+    }
+
+    fn absorb(&mut self, item: TransportItem) -> Option<SessionError> {
+        match item {
+            TransportItem::Exit => Some(self.process_terminated()),
+            TransportItem::Line(Err(ScanError::OverLimit { .. })) => {
+                self.signals.over_limit += 1;
+                self.record_degraded(DegradedReason::OverLimitFrame);
+                None
+            }
+            TransportItem::Line(Err(ScanError::Malformed)) => {
+                self.signals.malformed += 1;
+                self.record_degraded(DegradedReason::MalformedFrame);
+                None
+            }
+            TransportItem::Line(Err(ScanError::Empty)) => None,
+            TransportItem::Line(Ok(frame)) => {
+                if matches!(frame.class, FrameClass::ServerRequest)
+                    && let (Some(id), Some(kind)) = (
+                        frame.id.as_deref(),
+                        frame.method.as_deref().and_then(approval_kind_for_method),
+                    )
+                {
+                    self.enqueue_approval(
+                        ApprovalRequest {
+                            id: ApprovalId::new(id),
+                            kind,
+                        },
+                        &frame,
+                    );
+                    return None;
+                }
+                match map_frame(&frame) {
+                    Mapped::Event { kind, label } => {
+                        self.enqueue_event(kind, label, &frame);
+                        if label == "turn.completed" {
+                            self.active_turn = None;
+                            if !self.status.is_terminal() {
+                                self.status = SessionStatus::Idle;
+                            }
+                        }
+                    }
+                    Mapped::Response { .. } => {}
+                    Mapped::Degraded(reason) => {
+                        if reason == DegradedReason::UnsupportedEvent {
+                            self.signals.unsupported += 1;
+                        }
+                        let kind = if reason == DegradedReason::UnsupportedApproval {
+                            EventKind::Diagnostic
+                        } else {
+                            EventKind::Unsupported
+                        };
+                        self.enqueue_event(kind, reason.code(), &frame);
+                        self.record_degraded(reason);
+                    }
+                }
+                None
+            }
+        }
+    }
+
+    fn enqueue_event(&mut self, kind: EventKind, label: &str, frame: &Frame) {
+        let event = SessionEvent::new(
+            Sequence(self.next_seq),
+            kind,
+            label.to_owned(),
+            frame.preview.clone(),
+        );
+        self.next_seq += 1;
+        if self.queue.len() >= EVENT_QUEUE_CAP {
+            self.queue.pop_front();
+            self.signals.dropped += 1;
+            self.signals.backpressured = true;
+            if self.signals.dropped > DROP_TOLERANCE {
+                self.status = SessionStatus::Failed(FailureKind::QueueOverflow);
+            } else {
+                self.record_degraded(DegradedReason::Backpressure);
+            }
+        } else if self.queue.len() + 1 < EVENT_QUEUE_CAP {
+            self.signals.backpressured = false;
+        }
+        self.queue.push_back(event);
+    }
+
+    fn enqueue_approval(&mut self, approval: ApprovalRequest, frame: &Frame) {
+        if self.approvals.len() >= EVENT_QUEUE_CAP {
+            self.status = SessionStatus::Failed(FailureKind::QueueOverflow);
+            self.signals.dropped += 1;
+            self.signals.backpressured = true;
+            return;
+        }
+        self.approvals.push_back(approval);
+        self.enqueue_event(EventKind::ApprovalRequest, "approval.request", frame);
+    }
+
+    fn record_degraded(&mut self, reason: DegradedReason) {
+        self.degraded_count += 1;
+        if self.degraded_count > DEGRADED_TOLERANCE {
+            self.status = SessionStatus::Failed(FailureKind::ProtocolViolation);
+        } else if !self.status.is_terminal() {
+            self.status = SessionStatus::Degraded(reason);
+        }
+    }
+}
+
+fn is_response_for(frame: &Frame, id: &str) -> bool {
+    frame.method.is_none() && frame.id.as_deref() == Some(id)
+}
+
+fn response_ok(frame: &Frame) -> bool {
+    matches!(frame.class, FrameClass::Response { ok: true })
+}
+
+/// Escape and quote a string as JSON without retaining a raw provider payload.
+pub fn json_string(value: &str) -> String {
+    let mut output = String::with_capacity(value.len() + 2);
+    output.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            control if (control as u32) < 0x20 => {
+                output.push_str(&format!("\\u{:04x}", control as u32))
+            }
+            character => output.push(character),
+        }
+    }
+    output.push('"');
+    output
+}
+
+const INITIALIZE_PARAMS: &str = "{\"clientInfo\":{\"name\":\"relay-node\",\"version\":\"0.1.0\"}}";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response(id: u64, body: &str) -> String {
+        format!("{{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{body}}}")
+    }
+
+    #[test]
+    fn create_preserves_handshake_order() {
+        let lines = vec![
+            response(1, "{}"),
+            response(2, "{\"thread\":{\"id\":\"thread-1\"}}"),
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines(lines));
+        assert_eq!(
+            supervisor.create(DEFAULT_DEADLINE).unwrap().as_str(),
+            "thread-1"
+        );
+        let writes = supervisor.transport().writes();
+        assert!(writes[0].contains("\"method\":\"initialize\""));
+        assert!(writes[1].contains("\"method\":\"initialized\""));
+        assert!(writes[2].contains("\"method\":\"thread/start\""));
+    }
+
+    #[test]
+    fn resume_requires_provider_to_confirm_same_thread() {
+        let lines = vec![
+            response(1, "{}"),
+            response(2, "{\"thread\":{\"id\":\"other\"}}"),
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines(lines));
+        assert_eq!(
+            supervisor.resume("requested", DEFAULT_DEADLINE),
+            Err(SessionError::Terminal(FailureKind::ProtocolViolation))
+        );
+    }
+
+    #[test]
+    fn events_preserve_arrival_order() {
+        let lines = vec![
+            "{\"method\":\"thread/started\",\"params\":{}}",
+            "{\"method\":\"item/started\",\"params\":{}}",
+            "{\"method\":\"item/completed\",\"params\":{}}",
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines(lines));
+        supervisor.pump();
+        let sequence: Vec<_> =
+            std::iter::from_fn(|| supervisor.next_event().map(|event| event.seq.0)).collect();
+        assert_eq!(sequence, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn malformed_over_limit_and_unknown_frames_degrade() {
+        let oversized = vec![b'x'; MAX_LINE_BYTES + 1];
+        let items = vec![
+            TransportItem::Line(scan_line(b"not-json")),
+            TransportItem::Line(scan_line(&oversized)),
+            TransportItem::Line(scan_line(b"{\"method\":\"unknown/event\",\"params\":{}}")),
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_items(items));
+        supervisor.pump();
+        assert_eq!(supervisor.signals().malformed, 1);
+        assert_eq!(supervisor.signals().over_limit, 1);
+        assert_eq!(supervisor.signals().unsupported, 1);
+    }
+
+    #[test]
+    fn output_flood_sheds_oldest_and_signals_backpressure() {
+        let items = (0..EVENT_QUEUE_CAP + 10).map(|_| {
+            TransportItem::Line(Ok(scan_line(
+                b"{\"method\":\"thread/started\",\"params\":{}}",
+            )
+            .unwrap()))
+        });
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_items(items));
+        supervisor.pump();
+        assert_eq!(supervisor.queued(), EVENT_QUEUE_CAP);
+        assert!(supervisor.signals().dropped >= 10);
+        assert!(supervisor.signals().backpressured);
+    }
+
+    #[test]
+    fn documented_approval_requires_explicit_one_shot_response() {
+        let request = b"{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"item/fileChange/requestApproval\",\"params\":{}}";
+        let mut supervisor =
+            Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Line(
+                scan_line(request),
+            )]));
+        supervisor.pump();
+        let approval = supervisor.next_approval().unwrap();
+        supervisor
+            .respond_to_approval(&approval, ApprovalDecision::Decline)
+            .unwrap();
+        assert!(supervisor.transport().writes()[0].contains("\"decision\":\"decline\""));
+        assert!(supervisor.next_approval().is_none());
+    }
+
+    #[test]
+    fn unsupported_server_request_is_diagnostic_not_auto_approved() {
+        let request = b"{\"id\":9,\"method\":\"item/permissions/requestApproval\",\"params\":{}}";
+        let mut supervisor =
+            Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Line(
+                scan_line(request),
+            )]));
+        supervisor.pump();
+        let event = supervisor.next_event().unwrap();
+        assert_eq!(event.kind, EventKind::Diagnostic);
+        assert_eq!(event.label, DegradedReason::UnsupportedApproval.code());
+        assert!(supervisor.next_approval().is_none());
+    }
+
+    #[test]
+    fn exit_timeout_write_failure_and_unavailable_executable_are_typed() {
+        let mut exited = Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Exit]));
+        assert_eq!(
+            exited.create(DEFAULT_DEADLINE),
+            Err(SessionError::Terminal(FailureKind::ProcessTerminated))
+        );
+
+        let (sender, receiver) = mpsc::channel();
+        let transport = ScriptedTransport {
+            rx: receiver,
+            writes: Vec::new(),
+            write_fails: false,
+        };
+        let mut timed_out = Supervisor::new(transport);
+        assert_eq!(
+            timed_out.create(Duration::from_millis(5)),
+            Err(SessionError::Timeout)
+        );
+        assert_eq!(
+            timed_out.status(),
+            &SessionStatus::Failed(FailureKind::Timeout)
+        );
+        drop(sender);
+
+        let mut write_failure =
+            Supervisor::new(ScriptedTransport::from_items(vec![]).with_write_failure());
+        assert_eq!(
+            write_failure.create(DEFAULT_DEADLINE),
+            Err(SessionError::Transport)
+        );
+        assert!(matches!(
+            ProcessTransport::spawn_program("relay-missing-codex", None),
+            Err(SessionError::Unavailable)
+        ));
+    }
+
+    #[test]
+    fn cancellation_races_are_typed() {
+        let mut inactive = Supervisor::new(ScriptedTransport::from_items(vec![]));
+        inactive.session = Some(SessionId::new("thread"));
+        assert_eq!(
+            inactive.cancel("turn", DEFAULT_DEADLINE),
+            Err(SessionError::Raced(DegradedReason::CancellationRace))
+        );
+
+        let error = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32600}}";
+        let mut rejected =
+            Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Line(
+                scan_line(error),
+            )]));
+        rejected.session = Some(SessionId::new("thread"));
+        rejected.active_turn = Some("turn".into());
+        assert_eq!(
+            rejected.cancel("turn", DEFAULT_DEADLINE),
+            Err(SessionError::Raced(DegradedReason::CancellationRace))
+        );
+    }
+}

--- a/crates/relay-session/src/supervisor.rs
+++ b/crates/relay-session/src/supervisor.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, SyncSender, TrySendError};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -63,6 +63,12 @@ struct OutboundWrite {
     complete: SyncSender<io::Result<()>>,
 }
 
+struct ReapTask {
+    child: Child,
+    writer: JoinHandle<()>,
+    reader: JoinHandle<()>,
+}
+
 /// The real, fixed-command local process transport.
 pub struct ProcessTransport {
     child: Option<Child>,
@@ -70,6 +76,8 @@ pub struct ProcessTransport {
     rx: Receiver<TransportItem>,
     writer: Option<JoinHandle<()>>,
     reader: Option<JoinHandle<()>>,
+    reap_tx: Option<Sender<ReapTask>>,
+    reaper: Option<JoinHandle<()>>,
     stopping: Arc<AtomicBool>,
 }
 
@@ -96,6 +104,18 @@ impl ProcessTransport {
         let (tx, rx) = mpsc::sync_channel(INBOUND_QUEUE_CAP);
         let (write_tx, write_rx) = mpsc::sync_channel(OUTBOUND_QUEUE_CAP);
         let stopping = Arc::new(AtomicBool::new(false));
+        let (reap_tx, reap_rx) = mpsc::channel();
+        let reaper = match thread::Builder::new()
+            .name("relay-codex-reaper".into())
+            .spawn(move || reaper_loop(reap_rx))
+        {
+            Ok(reaper) => reaper,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(SessionError::Transport);
+            }
+        };
         let writer_stopping = Arc::clone(&stopping);
         let writer = match thread::Builder::new()
             .name("relay-codex-writer".into())
@@ -103,8 +123,10 @@ impl ProcessTransport {
         {
             Ok(writer) => writer,
             Err(_) => {
+                drop(reap_tx);
                 let _ = child.kill();
                 let _ = child.wait();
+                let _ = reaper.join();
                 return Err(SessionError::Transport);
             }
         };
@@ -117,9 +139,11 @@ impl ProcessTransport {
             Err(_) => {
                 stopping.store(true, Ordering::Release);
                 drop(write_tx);
+                drop(reap_tx);
                 let _ = child.kill();
                 let _ = child.wait();
                 let _ = writer.join();
+                let _ = reaper.join();
                 return Err(SessionError::Transport);
             }
         };
@@ -129,6 +153,8 @@ impl ProcessTransport {
             rx,
             writer: Some(writer),
             reader: Some(reader),
+            reap_tx: Some(reap_tx),
+            reaper: Some(reaper),
             stopping,
         })
     }
@@ -200,6 +226,17 @@ fn writer_loop(mut stdin: ChildStdin, rx: Receiver<OutboundWrite>, stopping: Arc
     }
 }
 
+/// Reap a killed child and join its IO workers without delaying the supervisor
+/// past the control operation's deadline.
+fn reaper_loop(rx: Receiver<ReapTask>) {
+    while let Ok(task) = rx.recv() {
+        let mut child = task.child;
+        let _ = child.wait();
+        let _ = task.writer.join();
+        let _ = task.reader.join();
+    }
+}
+
 /// Read one line while retaining no more than `MAX_LINE_BYTES + 1` bytes. The
 /// rest of an over-limit line is drained before the next frame is read.
 fn read_bounded_line<R: BufRead>(reader: &mut R, buffer: &mut Vec<u8>) -> io::Result<usize> {
@@ -257,9 +294,34 @@ impl Transport for ProcessTransport {
     fn abort_write(&mut self) {
         self.stopping.store(true, Ordering::Release);
         self.write_tx.take();
-        if let Some(child) = self.child.as_mut() {
-            let _ = child.kill();
-        }
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let _ = child.kill();
+        let task = ReapTask {
+            child,
+            writer: self
+                .writer
+                .take()
+                .expect("live process transport has a writer"),
+            reader: self
+                .reader
+                .take()
+                .expect("live process transport has a reader"),
+        };
+        let reap_tx = self
+            .reap_tx
+            .take()
+            .expect("live process transport has a reaper");
+        let reaper = self
+            .reaper
+            .take()
+            .expect("live process transport has a reaper handle");
+        reap_tx
+            .send(task)
+            .expect("live process transport reaper is receiving");
+        drop(reap_tx);
+        drop(reaper);
     }
 
     fn items(&self) -> &Receiver<TransportItem> {
@@ -269,6 +331,7 @@ impl Transport for ProcessTransport {
     fn shutdown(&mut self) {
         self.stopping.store(true, Ordering::Release);
         self.write_tx.take();
+        self.reap_tx.take();
         if let Some(mut child) = self.child.take() {
             let _ = child.kill();
             let _ = child.wait();
@@ -278,6 +341,9 @@ impl Transport for ProcessTransport {
         }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
+        }
+        if let Some(reaper) = self.reaper.take() {
+            let _ = reaper.join();
         }
     }
 }
@@ -428,7 +494,7 @@ impl<T: Transport> Supervisor<T> {
         decision: ApprovalDecision,
     ) -> Result<(), SessionError> {
         self.ensure_live()?;
-        let deadline = Instant::now() + DEFAULT_DEADLINE;
+        let deadline = self.deadline_after(DEFAULT_DEADLINE)?;
         let index = self
             .approvals
             .iter()
@@ -450,7 +516,7 @@ impl<T: Transport> Supervisor<T> {
 
     pub fn create(&mut self, deadline: Duration) -> Result<SessionId, SessionError> {
         self.ensure_live()?;
-        let overall = Instant::now() + deadline;
+        let overall = self.deadline_after(deadline)?;
         let initialize = self.send_request("initialize", INITIALIZE_PARAMS, overall)?;
         self.await_response(&initialize, overall)?;
         self.send_notification("initialized", overall)?;
@@ -468,7 +534,7 @@ impl<T: Transport> Supervisor<T> {
         deadline: Duration,
     ) -> Result<SessionId, SessionError> {
         self.ensure_live()?;
-        let overall = Instant::now() + deadline;
+        let overall = self.deadline_after(deadline)?;
         let initialize = self.send_request("initialize", INITIALIZE_PARAMS, overall)?;
         self.await_response(&initialize, overall)?;
         self.send_notification("initialized", overall)?;
@@ -487,7 +553,7 @@ impl<T: Transport> Supervisor<T> {
 
     pub fn prompt(&mut self, text: &str, deadline: Duration) -> Result<String, SessionError> {
         self.ensure_live()?;
-        let overall = Instant::now() + deadline;
+        let overall = self.deadline_after(deadline)?;
         let session = self
             .session
             .clone()
@@ -511,7 +577,7 @@ impl<T: Transport> Supervisor<T> {
 
     pub fn cancel(&mut self, turn_id: &str, deadline: Duration) -> Result<(), SessionError> {
         self.ensure_live()?;
-        let overall = Instant::now() + deadline;
+        let overall = self.deadline_after(deadline)?;
         let session = self
             .session
             .clone()
@@ -569,6 +635,12 @@ impl<T: Transport> Supervisor<T> {
             SessionStatus::Closed => Err(SessionError::Terminal(FailureKind::ProcessTerminated)),
             _ => Ok(()),
         }
+    }
+
+    fn deadline_after(&mut self, duration: Duration) -> Result<Instant, SessionError> {
+        Instant::now()
+            .checked_add(duration)
+            .ok_or_else(|| self.timeout())
     }
 
     fn send_request(
@@ -1007,6 +1079,18 @@ mod tests {
         assert_eq!(
             supervisor.prompt(&"x".repeat(MAX_LINE_BYTES - 2), DEFAULT_DEADLINE),
             Err(SessionError::Unsupported(OUTBOUND_CONTROL_LINE_TOO_LARGE))
+        );
+        assert!(supervisor.transport().writes().is_empty());
+    }
+
+    #[test]
+    fn overflowing_deadline_fails_typed_before_transport_submission() {
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_items(vec![]));
+
+        assert_eq!(supervisor.create(Duration::MAX), Err(SessionError::Timeout));
+        assert_eq!(
+            supervisor.status(),
+            &SessionStatus::Failed(FailureKind::Timeout)
         );
         assert!(supervisor.transport().writes().is_empty());
     }

--- a/crates/relay-session/src/supervisor.rs
+++ b/crates/relay-session/src/supervisor.rs
@@ -33,6 +33,11 @@ pub const DROP_TOLERANCE: u64 = 4096;
 /// Default deadline for one control request.
 pub const DEFAULT_DEADLINE: Duration = Duration::from_secs(10);
 
+/// Bounded number of control writes awaiting the process writer.
+pub const OUTBOUND_QUEUE_CAP: usize = 16;
+
+const OUTBOUND_CONTROL_LINE_TOO_LARGE: &str = "outbound control line exceeds limit";
+
 /// One arrival-ordered transport item.
 #[derive(Debug)]
 pub enum TransportItem {
@@ -41,17 +46,29 @@ pub enum TransportItem {
 }
 
 /// A writable JSONL transport with owned lifecycle control.
+///
+/// `write_line` queues one bounded line and returns a completion receiver. It
+/// must not wait for the child to consume the line; the supervisor applies the
+/// control operation's deadline while waiting for that completion.
 pub trait Transport: Send {
-    fn write_line(&mut self, line: &str) -> io::Result<()>;
+    fn write_line(&mut self, line: String) -> io::Result<Receiver<io::Result<()>>>;
+    /// Interrupt a pending control write without waiting for thread teardown.
+    fn abort_write(&mut self);
     fn items(&self) -> &Receiver<TransportItem>;
     fn shutdown(&mut self);
+}
+
+struct OutboundWrite {
+    line: String,
+    complete: SyncSender<io::Result<()>>,
 }
 
 /// The real, fixed-command local process transport.
 pub struct ProcessTransport {
     child: Option<Child>,
-    stdin: Option<ChildStdin>,
+    write_tx: Option<SyncSender<OutboundWrite>>,
     rx: Receiver<TransportItem>,
+    writer: Option<JoinHandle<()>>,
     reader: Option<JoinHandle<()>>,
     stopping: Arc<AtomicBool>,
 }
@@ -77,16 +94,40 @@ impl ProcessTransport {
         let stdin = child.stdin.take().ok_or(SessionError::Transport)?;
         let stdout = child.stdout.take().ok_or(SessionError::Transport)?;
         let (tx, rx) = mpsc::sync_channel(INBOUND_QUEUE_CAP);
+        let (write_tx, write_rx) = mpsc::sync_channel(OUTBOUND_QUEUE_CAP);
         let stopping = Arc::new(AtomicBool::new(false));
+        let writer_stopping = Arc::clone(&stopping);
+        let writer = match thread::Builder::new()
+            .name("relay-codex-writer".into())
+            .spawn(move || writer_loop(stdin, write_rx, writer_stopping))
+        {
+            Ok(writer) => writer,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(SessionError::Transport);
+            }
+        };
         let reader_stopping = Arc::clone(&stopping);
-        let reader = thread::Builder::new()
+        let reader = match thread::Builder::new()
             .name("relay-codex-reader".into())
             .spawn(move || reader_loop(stdout, tx, reader_stopping))
-            .map_err(|_| SessionError::Transport)?;
+        {
+            Ok(reader) => reader,
+            Err(_) => {
+                stopping.store(true, Ordering::Release);
+                drop(write_tx);
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = writer.join();
+                return Err(SessionError::Transport);
+            }
+        };
         Ok(Self {
             child: Some(child),
-            stdin: Some(stdin),
+            write_tx: Some(write_tx),
             rx,
+            writer: Some(writer),
             reader: Some(reader),
             stopping,
         })
@@ -135,6 +176,30 @@ fn reader_loop<R: io::Read>(stdout: R, tx: SyncSender<TransportItem>, stopping: 
     }
 }
 
+/// Write control lines on a dedicated bounded worker. The supervisor waits on
+/// each completion receiver, so a child that stops reading stdin cannot block
+/// its control deadline.
+fn writer_loop(mut stdin: ChildStdin, rx: Receiver<OutboundWrite>, stopping: Arc<AtomicBool>) {
+    while let Ok(write) = rx.recv() {
+        let result = if stopping.load(Ordering::Acquire) {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "transport stopping",
+            ))
+        } else {
+            stdin
+                .write_all(write.line.as_bytes())
+                .and_then(|()| stdin.write_all(b"\n"))
+                .and_then(|()| stdin.flush())
+        };
+        let failed = result.is_err();
+        let _ = write.complete.send(result);
+        if failed {
+            return;
+        }
+    }
+}
+
 /// Read one line while retaining no more than `MAX_LINE_BYTES + 1` bytes. The
 /// rest of an over-limit line is drained before the next frame is read.
 fn read_bounded_line<R: BufRead>(reader: &mut R, buffer: &mut Vec<u8>) -> io::Result<usize> {
@@ -168,14 +233,33 @@ fn read_bounded_line<R: BufRead>(reader: &mut R, buffer: &mut Vec<u8>) -> io::Re
 }
 
 impl Transport for ProcessTransport {
-    fn write_line(&mut self, line: &str) -> io::Result<()> {
-        let stdin = self
-            .stdin
-            .as_mut()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "stdin closed"))?;
-        stdin.write_all(line.as_bytes())?;
-        stdin.write_all(b"\n")?;
-        stdin.flush()
+    fn write_line(&mut self, line: String) -> io::Result<Receiver<io::Result<()>>> {
+        let (complete_tx, complete_rx) = mpsc::sync_channel(1);
+        let write = OutboundWrite {
+            line,
+            complete: complete_tx,
+        };
+        self.write_tx
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "stdin closed"))?
+            .try_send(write)
+            .map_err(|error| match error {
+                TrySendError::Full(_) => {
+                    io::Error::new(io::ErrorKind::WouldBlock, "outbound queue full")
+                }
+                TrySendError::Disconnected(_) => {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "writer stopped")
+                }
+            })?;
+        Ok(complete_rx)
+    }
+
+    fn abort_write(&mut self) {
+        self.stopping.store(true, Ordering::Release);
+        self.write_tx.take();
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+        }
     }
 
     fn items(&self) -> &Receiver<TransportItem> {
@@ -184,10 +268,13 @@ impl Transport for ProcessTransport {
 
     fn shutdown(&mut self) {
         self.stopping.store(true, Ordering::Release);
-        self.stdin.take();
+        self.write_tx.take();
         if let Some(mut child) = self.child.take() {
             let _ = child.kill();
             let _ = child.wait();
+        }
+        if let Some(writer) = self.writer.take() {
+            let _ = writer.join();
         }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
@@ -251,16 +338,20 @@ impl ScriptedTransport {
 }
 
 impl Transport for ScriptedTransport {
-    fn write_line(&mut self, line: &str) -> io::Result<()> {
+    fn write_line(&mut self, line: String) -> io::Result<Receiver<io::Result<()>>> {
         if self.write_fails {
             return Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "scripted write failure",
             ));
         }
-        self.writes.push(line.to_owned());
-        Ok(())
+        self.writes.push(line);
+        let (complete_tx, complete_rx) = mpsc::sync_channel(1);
+        let _ = complete_tx.send(Ok(()));
+        Ok(complete_rx)
     }
+
+    fn abort_write(&mut self) {}
 
     fn items(&self) -> &Receiver<TransportItem> {
         &self.rx
@@ -337,6 +428,7 @@ impl<T: Transport> Supervisor<T> {
         decision: ApprovalDecision,
     ) -> Result<(), SessionError> {
         self.ensure_live()?;
+        let deadline = Instant::now() + DEFAULT_DEADLINE;
         let index = self
             .approvals
             .iter()
@@ -351,9 +443,7 @@ impl<T: Transport> Supervisor<T> {
             "{{\"jsonrpc\":\"2.0\",\"id\":{},\"result\":{{\"decision\":\"{decision}\"}}}}",
             approval.id.as_str()
         );
-        self.transport
-            .write_line(&response)
-            .map_err(|_| SessionError::Transport)?;
+        self.write_control_line(&response, deadline)?;
         self.approvals.remove(index);
         Ok(())
     }
@@ -361,10 +451,10 @@ impl<T: Transport> Supervisor<T> {
     pub fn create(&mut self, deadline: Duration) -> Result<SessionId, SessionError> {
         self.ensure_live()?;
         let overall = Instant::now() + deadline;
-        let initialize = self.send_request("initialize", INITIALIZE_PARAMS)?;
+        let initialize = self.send_request("initialize", INITIALIZE_PARAMS, overall)?;
         self.await_response(&initialize, overall)?;
-        self.send_notification("initialized")?;
-        let start = self.send_request("thread/start", "{}")?;
+        self.send_notification("initialized", overall)?;
+        let start = self.send_request("thread/start", "{}", overall)?;
         let thread_id = self.await_result_thread_id(&start, overall)?;
         let session = SessionId::new(thread_id);
         self.session = Some(session.clone());
@@ -379,11 +469,11 @@ impl<T: Transport> Supervisor<T> {
     ) -> Result<SessionId, SessionError> {
         self.ensure_live()?;
         let overall = Instant::now() + deadline;
-        let initialize = self.send_request("initialize", INITIALIZE_PARAMS)?;
+        let initialize = self.send_request("initialize", INITIALIZE_PARAMS, overall)?;
         self.await_response(&initialize, overall)?;
-        self.send_notification("initialized")?;
-        let params = format!("{{\"threadId\":{}}}", json_string(thread_id));
-        let resume = self.send_request("thread/resume", &params)?;
+        self.send_notification("initialized", overall)?;
+        let params = format!("{{\"threadId\":{}}}", json_string_bounded(thread_id)?);
+        let resume = self.send_request("thread/resume", &params, overall)?;
         let resumed_id = self.await_result_thread_id(&resume, overall)?;
         if resumed_id != thread_id {
             self.status = SessionStatus::Failed(FailureKind::ProtocolViolation);
@@ -397,17 +487,18 @@ impl<T: Transport> Supervisor<T> {
 
     pub fn prompt(&mut self, text: &str, deadline: Duration) -> Result<String, SessionError> {
         self.ensure_live()?;
+        let overall = Instant::now() + deadline;
         let session = self
             .session
             .clone()
             .ok_or(SessionError::Unsupported("no active session"))?;
         let params = format!(
             "{{\"threadId\":{},\"input\":[{{\"type\":\"text\",\"text\":{}}}]}}",
-            json_string(session.as_str()),
-            json_string(text)
+            json_string_bounded(session.as_str())?,
+            json_string_bounded(text)?
         );
-        let turn = self.send_request("turn/start", &params)?;
-        let turn_id = self.await_result_turn_id(&turn, Instant::now() + deadline)?;
+        let turn = self.send_request("turn/start", &params, overall)?;
+        let turn_id = self.await_result_turn_id(&turn, overall)?;
         if self.take_completed_turn(&turn_id) {
             self.active_turn = None;
             self.status = SessionStatus::Idle;
@@ -420,6 +511,7 @@ impl<T: Transport> Supervisor<T> {
 
     pub fn cancel(&mut self, turn_id: &str, deadline: Duration) -> Result<(), SessionError> {
         self.ensure_live()?;
+        let overall = Instant::now() + deadline;
         let session = self
             .session
             .clone()
@@ -432,11 +524,11 @@ impl<T: Transport> Supervisor<T> {
         }
         let params = format!(
             "{{\"threadId\":{},\"turnId\":{}}}",
-            json_string(session.as_str()),
-            json_string(turn_id)
+            json_string_bounded(session.as_str())?,
+            json_string_bounded(turn_id)?
         );
-        let interrupt = self.send_request("turn/interrupt", &params)?;
-        match self.await_response(&interrupt, Instant::now() + deadline) {
+        let interrupt = self.send_request("turn/interrupt", &params, overall)?;
+        match self.await_response(&interrupt, overall) {
             Ok(()) => {
                 self.active_turn = None;
                 self.status = SessionStatus::Idle;
@@ -479,24 +571,47 @@ impl<T: Transport> Supervisor<T> {
         }
     }
 
-    fn send_request(&mut self, method: &str, params: &str) -> Result<String, SessionError> {
+    fn send_request(
+        &mut self,
+        method: &str,
+        params: &str,
+        deadline: Instant,
+    ) -> Result<String, SessionError> {
         let id = self.next_id;
-        self.next_id += 1;
         let request = format!(
             "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":{},\"params\":{params}}}",
             json_string(method)
         );
-        self.transport
-            .write_line(&request)
-            .map_err(|_| SessionError::Transport)?;
+        self.write_control_line(&request, deadline)?;
+        self.next_id += 1;
         Ok(id.to_string())
     }
 
-    fn send_notification(&mut self, method: &str) -> Result<(), SessionError> {
+    fn send_notification(&mut self, method: &str, deadline: Instant) -> Result<(), SessionError> {
         let notification = format!("{{\"jsonrpc\":\"2.0\",\"method\":{}}}", json_string(method));
-        self.transport
-            .write_line(&notification)
-            .map_err(|_| SessionError::Transport)
+        self.write_control_line(&notification, deadline)
+    }
+
+    fn write_control_line(&mut self, line: &str, deadline: Instant) -> Result<(), SessionError> {
+        if line.len() > MAX_LINE_BYTES {
+            return Err(SessionError::Unsupported(OUTBOUND_CONTROL_LINE_TOO_LARGE));
+        }
+        let remaining = self.remaining(deadline)?;
+        let complete = self
+            .transport
+            .write_line(line.to_owned())
+            .map_err(|_| SessionError::Transport)?;
+        match complete.recv_timeout(remaining) {
+            Ok(Ok(())) => {
+                self.remaining(deadline)?;
+                Ok(())
+            }
+            Ok(Err(_)) | Err(RecvTimeoutError::Disconnected) => Err(SessionError::Transport),
+            Err(RecvTimeoutError::Timeout) => {
+                self.transport.abort_write();
+                Err(self.timeout())
+            }
+        }
     }
 
     fn await_response(&mut self, id: &str, deadline: Instant) -> Result<(), SessionError> {
@@ -749,6 +864,38 @@ fn response_ok(frame: &Frame) -> bool {
 /// Escape and quote a string as JSON without retaining a raw provider payload.
 pub fn json_string(value: &str) -> String {
     let mut output = String::with_capacity(value.len() + 2);
+    append_json_string(value, &mut output);
+    output
+}
+
+/// Escape and quote a JSON string only when its encoded value is safe to place
+/// on a bounded control line. This stops oversized prompt/session input before
+/// cloning it into an outbound payload.
+fn json_string_bounded(value: &str) -> Result<String, SessionError> {
+    let capacity = escaped_json_string_len(value, MAX_LINE_BYTES)
+        .ok_or(SessionError::Unsupported(OUTBOUND_CONTROL_LINE_TOO_LARGE))?;
+    let mut output = String::with_capacity(capacity);
+    append_json_string(value, &mut output);
+    Ok(output)
+}
+
+fn escaped_json_string_len(value: &str, limit: usize) -> Option<usize> {
+    let mut length: usize = 2;
+    for character in value.chars() {
+        let encoded = match character {
+            '"' | '\\' | '\n' | '\r' | '\t' => 2,
+            control if (control as u32) < 0x20 => 6,
+            character => character.len_utf8(),
+        };
+        length = length.checked_add(encoded)?;
+        if length > limit {
+            return None;
+        }
+    }
+    Some(length)
+}
+
+fn append_json_string(value: &str, output: &mut String) {
     output.push('"');
     for character in value.chars() {
         match character {
@@ -764,7 +911,6 @@ pub fn json_string(value: &str) -> String {
         }
     }
     output.push('"');
-    output
 }
 
 const INITIALIZE_PARAMS: &str = "{\"clientInfo\":{\"name\":\"relay-node\",\"version\":\"0.1.0\"}}";
@@ -775,6 +921,46 @@ mod tests {
 
     fn response(id: u64, body: &str) -> String {
         format!("{{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{body}}}")
+    }
+
+    struct StalledWriteTransport {
+        rx: Receiver<TransportItem>,
+        pending: Vec<SyncSender<io::Result<()>>>,
+        aborted: Arc<AtomicBool>,
+    }
+
+    impl StalledWriteTransport {
+        fn new() -> (Self, Arc<AtomicBool>) {
+            let (_tx, rx) = mpsc::channel();
+            let aborted = Arc::new(AtomicBool::new(false));
+            (
+                Self {
+                    rx,
+                    pending: Vec::new(),
+                    aborted: Arc::clone(&aborted),
+                },
+                aborted,
+            )
+        }
+    }
+
+    impl Transport for StalledWriteTransport {
+        fn write_line(&mut self, _line: String) -> io::Result<Receiver<io::Result<()>>> {
+            let (complete_tx, complete_rx) = mpsc::sync_channel(1);
+            self.pending.push(complete_tx);
+            Ok(complete_rx)
+        }
+
+        fn abort_write(&mut self) {
+            self.aborted.store(true, Ordering::Release);
+            self.pending.clear();
+        }
+
+        fn items(&self) -> &Receiver<TransportItem> {
+            &self.rx
+        }
+
+        fn shutdown(&mut self) {}
     }
 
     #[test]
@@ -792,6 +978,37 @@ mod tests {
         assert!(writes[0].contains("\"method\":\"initialize\""));
         assert!(writes[1].contains("\"method\":\"initialized\""));
         assert!(writes[2].contains("\"method\":\"thread/start\""));
+    }
+
+    #[test]
+    fn prompt_write_deadline_interrupts_a_stalled_transport() {
+        let (transport, aborted) = StalledWriteTransport::new();
+        let mut supervisor = Supervisor::new(transport);
+        supervisor.session = Some(SessionId::new("thread-1"));
+
+        let started = Instant::now();
+        assert_eq!(
+            supervisor.prompt("hello", Duration::from_millis(10)),
+            Err(SessionError::Timeout)
+        );
+        assert!(started.elapsed() < Duration::from_millis(100));
+        assert!(aborted.load(Ordering::Acquire));
+        assert_eq!(
+            supervisor.status(),
+            &SessionStatus::Failed(FailureKind::Timeout)
+        );
+    }
+
+    #[test]
+    fn oversized_prompt_is_rejected_before_transport_submission() {
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_items(vec![]));
+        supervisor.session = Some(SessionId::new("thread-1"));
+
+        assert_eq!(
+            supervisor.prompt(&"x".repeat(MAX_LINE_BYTES - 2), DEFAULT_DEADLINE),
+            Err(SessionError::Unsupported(OUTBOUND_CONTROL_LINE_TOO_LARGE))
+        );
+        assert!(supervisor.transport().writes().is_empty());
     }
 
     #[test]

--- a/crates/relay-session/src/supervisor.rs
+++ b/crates/relay-session/src/supervisor.rs
@@ -600,11 +600,12 @@ impl<T: Transport> Supervisor<T> {
                 self.status = SessionStatus::Idle;
                 Ok(())
             }
-            // The real app-server rejects an interrupt that loses to terminal
-            // completion. This is observable as a provider error response, not
-            // a reason to fabricate successful cancellation.
-            Err(SessionError::Unsupported(_)) => {
-                self.active_turn = None;
+            // During response waiting, only a matching completion clears the
+            // active turn. That validates this race; other provider errors
+            // preserve their typed error and active-turn state.
+            Err(SessionError::Unsupported("provider error response"))
+                if self.active_turn.is_none() =>
+            {
                 if let Some(error) = self.record_degraded(DegradedReason::CancellationRace) {
                     return Err(error);
                 }
@@ -1295,24 +1296,53 @@ mod tests {
     }
 
     #[test]
-    fn cancellation_races_are_typed() {
-        let mut inactive = Supervisor::new(ScriptedTransport::from_items(vec![]));
-        inactive.session = Some(SessionId::new("thread"));
+    fn cancel_preserves_provider_error_without_matching_completion() {
+        let start = response(3, "{\"turn\":{\"id\":\"turn-1\"}}");
+        let interrupt_error = "{\"jsonrpc\":\"2.0\",\"id\":4,\"error\":{\"code\":-32600}}";
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines([
+            start.as_str(),
+            interrupt_error,
+        ]));
+        supervisor.session = Some(SessionId::new("thread-1"));
+        supervisor.next_id = 3;
+
         assert_eq!(
-            inactive.cancel("turn", DEFAULT_DEADLINE),
+            supervisor.prompt("hello", DEFAULT_DEADLINE).unwrap(),
+            "turn-1"
+        );
+        assert_eq!(
+            supervisor.cancel("turn-1", DEFAULT_DEADLINE),
+            Err(SessionError::Unsupported("provider error response"))
+        );
+        assert_eq!(supervisor.active_turn.as_deref(), Some("turn-1"));
+        assert_eq!(supervisor.status(), &SessionStatus::Working);
+    }
+
+    #[test]
+    fn cancel_after_matching_completion_error_is_a_typed_race() {
+        let start = response(3, "{\"turn\":{\"id\":\"turn-1\"}}");
+        let completion = "{\"jsonrpc\":\"2.0\",\"method\":\"turn/completed\",\"params\":{\"turn\":{\"id\":\"turn-1\"}}}";
+        let interrupt_error = "{\"jsonrpc\":\"2.0\",\"id\":4,\"error\":{\"code\":-32600}}";
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines([
+            start.as_str(),
+            completion,
+            interrupt_error,
+        ]));
+        supervisor.session = Some(SessionId::new("thread-1"));
+        supervisor.next_id = 3;
+
+        assert_eq!(
+            supervisor.prompt("hello", DEFAULT_DEADLINE).unwrap(),
+            "turn-1"
+        );
+        assert_eq!(
+            supervisor.cancel("turn-1", DEFAULT_DEADLINE),
             Err(SessionError::Raced(DegradedReason::CancellationRace))
         );
-
-        let error = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32600}}";
-        let mut rejected =
-            Supervisor::new(ScriptedTransport::from_items(vec![TransportItem::Line(
-                scan_line(error),
-            )]));
-        rejected.session = Some(SessionId::new("thread"));
-        rejected.active_turn = Some("turn".into());
+        assert!(supervisor.active_turn.is_none());
         assert_eq!(
-            rejected.cancel("turn", DEFAULT_DEADLINE),
-            Err(SessionError::Raced(DegradedReason::CancellationRace))
+            supervisor.status(),
+            &SessionStatus::Degraded(DegradedReason::CancellationRace)
         );
     }
 }

--- a/docs/CODEX_SESSION_ADAPTER.md
+++ b/docs/CODEX_SESSION_ADAPTER.md
@@ -1,0 +1,99 @@
+# Codex app-server Session adapter
+
+## Boundary
+
+`relay-session` supervises exactly one local child command:
+
+```text
+codex app-server --stdio
+```
+
+The child communicates over newline-delimited JSON-RPC 2.0 on stdin/stdout.
+Relay never selects `--listen`, `ws://`, `wss://`, `unix://`, or `--ws-*`
+arguments. `relay-node codex-stdio-probe --negative-transport` is an executable
+negative probe for that invariant.
+
+The adapter owns the child lifecycle, writes requests, reads stdout in arrival
+order, and assigns monotonic neutral event sequence numbers. It does not
+persist raw provider frames, provider credentials, or full transcripts.
+Diagnostics retain only a 256-byte secret-redacted preview. Input lines are
+capped at 64 KiB; both the child-reader hand-off and neutral queue hold 1,024
+events. A full reader hand-off applies OS pipe backpressure rather than growing
+Relay memory; neutral-event shedding is surfaced through typed signals/status.
+Truncation, malformed frames, unsupported events, and backpressure are never
+silently hidden.
+
+## Downstream Session contract
+
+`relay-session::contract` is provider-neutral:
+
+- `SessionId` is opaque.
+- `SessionStatus` is `Starting`, `Idle`, `Working`, `Degraded`, `Failed`, or
+  `Closed`.
+- `SessionEvent` has monotonic `Sequence`, neutral `EventKind`, label, and
+  bounded redacted preview.
+- `StreamSignals` reports dropped, over-limit, malformed, unsupported, and
+  backpressure conditions.
+- `ApprovalRequest`/`ApprovalDecision` expose only safe one-request command and
+  file-change decisions. There is no persistent approval cache or policy
+  amendment surface.
+
+Codex method names are contained in the adapter; generic Session consumers do
+not parse JSONL or method names.
+
+## Guaranteed mapping ledger
+
+The codex-cli 0.144.1 generated schema documents the mappings below. They are
+mapped when received but are not claimed as real-turn observations until the
+opt-in live probe succeeds.
+
+| Codex event | Neutral event |
+| --- | --- |
+| `thread/started`, `thread/closed` | lifecycle: `session.started`, `session.closed` |
+| `turn/started`, `turn/completed` | lifecycle: `turn.started`, `turn.completed` |
+| `item/started`, `item/completed` | progress: `item.started`, `item.completed` |
+| `configWarning`, `remoteControl/status/changed`, `error`, `mcpServer/startupStatus/updated` | diagnostic |
+
+Supported current approval requests are
+`item/commandExecution/requestApproval` and
+`item/fileChange/requestApproval`. Relay exposes them as pending neutral
+requests and sends only an explicit per-request `accept`, `decline`, or
+`cancel` result chosen by its caller. It never auto-approves.
+
+All other server requests—including permission profile changes, tool input,
+MCP elicitation, token refresh, dynamic tools, attestation, and legacy approval
+methods—remain unsupported. They produce typed degraded diagnostics and no
+fabricated reply. Unknown notifications do the same.
+
+## Recovery and failure behavior
+
+| Condition | Result |
+| --- | --- |
+| Executable missing or stdin write fails | typed unavailable/transport error |
+| Child exit | terminal `process_terminated` |
+| Request deadline | typed timeout |
+| Malformed or over-limit JSONL | degraded signal; terminal protocol failure only after bounded tolerance |
+| Queue saturation | oldest event shed with drop/backpressure signal; terminal queue overflow past bounded tolerance |
+| Cancel after completion/wrong turn | typed cancellation-race degradation |
+| Provider error response | typed unsupported provider response |
+
+No automatic restart occurs. The bounded recovery action is to close/reap the
+owned child and create or resume a new Session explicitly.
+
+## Probes
+
+Run with the profile-local authenticated Codex environment:
+
+```sh
+HOME=/home/donovanyohan/.hermes/profiles/kani-backend/home \
+PATH="$HOME/.local/bin:$PATH" \
+cargo run -p relay-node -- codex-stdio-probe --negative-transport
+
+HOME=/home/donovanyohan/.hermes/profiles/kani-backend/home \
+PATH="$HOME/.local/bin:$PATH" \
+cargo run -p relay-node -- codex-stdio-probe --handshake
+```
+
+`--exercise` additionally executes create, prompt, cancel, and resume. It is
+opt-in because a real provider turn can consume account quota. Its output is a
+small status record and deliberately excludes thread ids and transcripts.

--- a/docs/PRODUCT_CONTEXT.md
+++ b/docs/PRODUCT_CONTEXT.md
@@ -15,11 +15,20 @@ Later issues may introduce these terms only with explicit ownership and storage 
 - `relay-hub` serves `GET /health` with a bounded liveness record.
 - `relay-node probe` prints the same record for the node identity.
 - The PWA shell renders that record and nothing else.
+- `relay-node codex-stdio-probe` owns a one-node, local `codex app-server
+  --stdio` Session seam. Its explicit exercise mode creates, resumes, prompts,
+  and cancels native Codex threads through bounded JSONL; it exposes neither a
+  network transport nor raw provider transcripts.
 
 ## Authority and data path
 
-The factory owns no process, provider, filesystem, authentication, browser-control, cross-node, or product-state authority. The web shell reads the hub health endpoint only. No client write path or persistence exists.
+The node owns the child process identity/lifecycle for the Codex stdio seam.
+The adapter bounds/redacts event previews and does not persist raw provider
+transcripts, credentials, approval grants, or thread data. The web shell still
+reads the hub health endpoint only; it has no client write path or persistence.
 
 ## Deferred scope
 
-PTY/RMUX, Codex, Hermes, provider adapters, mailbox, passkeys, files, Workspace persistence, layout, browser control, cross-node behavior, and legacy API compatibility are outside #1137.
+PTY/RMUX, Hermes, other provider adapters, mailbox, passkeys, files, Workspace
+persistence, layout, browser control, cross-node behavior, approval-grant
+persistence, and legacy API compatibility remain deferred.

--- a/docs/adrs/ADR-0002-codex-stdio-session-adapter.md
+++ b/docs/adrs/ADR-0002-codex-stdio-session-adapter.md
@@ -1,0 +1,34 @@
+# ADR-0002: supervise Codex only through local app-server stdio
+
+- **Status:** accepted
+- **Date:** 2026-07-11
+
+## Context
+
+Issue #1140 needs a native Codex Session seam after the liveness-only factory
+foundation. The installed Codex CLI exposes experimental app-server transports,
+including stdio and transports that could become network/socket control paths.
+A Relay adapter that chooses a network path, retains raw provider output, or
+silently answers approvals would acquire unreviewed authority.
+
+## Decision
+
+The node supervises one local `codex app-server --stdio` child per Session. The
+adapter uses bounded JSONL/JSON-RPC framing, fixed stdio argv, process reaping,
+finite control deadlines, ordered neutral events, redacted bounded diagnostics,
+and bounded queues. Network/socket flags and transport selections are rejected
+by an executable negative probe.
+
+The generic Session contract keeps identities, statuses, events, stream signals,
+and a small per-request approval seam provider-neutral. Only current documented
+command/file approval requests can be surfaced and explicitly answered once.
+Persistent grants, policy changes, unknown server requests, and legacy approval
+shapes are unsupported/degraded rather than guessed or auto-approved.
+
+## Consequences
+
+Relay can truthfully create, resume, prompt, cancel, and observe a local Codex
+Session without creating a generic adapter platform, browser control, provider
+state copy, cross-node routing, or transcript store. Process recovery is
+explicit close/reap plus a new create/resume; automatic restarts and approval
+persistence require later accepted scope.


### PR DESCRIPTION
## Summary
- add a provider-neutral Session contract and a supervised local `codex app-server --stdio` adapter
- bound JSONL parsing, reader/event queues, previews, and recovery state while preserving ordered neutral events
- expose executable local-stdio negative, handshake, and opt-in create/prompt/cancel/resume probes; network WebSocket selection remains rejected
- document the supported/unsupported event and approval ledger without persisting provider transcripts or credentials

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run bench`
- `cargo clippy --workspace --all-targets -- -D warnings`
- authenticated local Codex stdio probes: `--negative-transport`, `--handshake`, and `--exercise`

## Scope
One-node, local Codex stdio Session adapter only. No network transport, provider-state sync, generic adapter platform, UI layout, browser control, or cross-node routing.

Refs #1136
Refs #1140
