### PR TITLE
feat: add passkey-first operator boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository is deliberately a greenfield factory. Work only from the active 
 
 ## Boundaries
 
-The only implemented runtime boundary is `GET /health` on the hub and the matching `relay-node probe` command. Their response is a small versioned liveness record. Do not add process, provider, filesystem, authentication, persistence, PTY, mailbox, browser-control, cross-node, or layout behavior without a later accepted issue.
+The implemented runtime boundaries are `GET /health` on the hub, the matching `relay-node probe` command, and the #1143 passkey-first browser boundary. Do not add process, provider, filesystem beyond #1143's bounded in-memory auth state, PTY, mailbox, browser-control grants, cross-node control, or layout behavior without a later accepted issue.
 
 Product nouns and deferred scope live in `docs/PRODUCT_CONTEXT.md`; design decisions live in `docs/adrs/`. GitHub issues are the source of truth for product scope. Child reboot PRs preserve ancestry, target `reboot/relay-next`, and use `Refs #1136` until a later milestone says otherwise.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,660 @@
 version = 4
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "relay-factory-core"
 version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.3.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "url",
+ "uuid",
+ "webauthn-rs",
+]
 
 [[package]]
 name = "relay-hub"
 version = "0.1.0"
 dependencies = [
  "relay-factory-core",
+ "serde_json",
 ]
 
 [[package]]
@@ -19,3 +665,534 @@ version = "0.1.0"
 dependencies = [
  "relay-factory-core",
 ]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A small, verifiable factory for the Relay reboot. This first slice intentionally
 
 - Rust workspace with separately addressable `relay-hub` and `relay-node` binaries.
 - A bounded, unauthenticated liveness contract: `GET /health` and `relay-node probe`.
-- A static PWA shell that reads only that liveness contract.
+- A static PWA shell with a passkey-first operator flow, typed unsupported/denied/recovery states, and session-device revoke controls.
+- A stable-origin WebAuthn boundary that issues revocable Secure/HttpOnly browser sessions for hub-only protected actions.
 - Checked Rust and Node toolchains, deterministic local commands, and matching CI.
 - A concise product/context map and one baseline boundary ADR.
 
@@ -22,12 +23,22 @@ npm run build
 npm run dev
 ```
 
-`npm run dev` serves the PWA on `http://127.0.0.1:4173` and the hub health probe on `http://127.0.0.1:8787/health`.
+`npm run dev` serves the PWA on `http://127.0.0.1:4173` and the hub health probe on `http://127.0.0.1:8787/health`. Plaintext development is intentionally an unsupported passkey environment. A real passkey flow requires a stable HTTPS reverse-proxy origin and this hub configuration:
+
+```sh
+relay-hub serve --bind 127.0.0.1:8787 \
+  --origin https://relay.example \
+  --recovery-code-hash <sha256-of-out-of-band-recovery-code>
+```
+
+The recovery hash, not its raw code, is accepted on the command line. Provision the raw recovery code from at least 32 random bytes and keep it out of normal logs; the hub cannot establish its entropy from the configured digest. Recovery can authorize replacement-passkey enrollment only; it never creates a browser session.
 
 ## Contract
 
-A successful health response contains only `api`, `service`, `status`, and `version`. Invalid or overlong `--identity` configuration is rejected with a typed, bounded JSON error and the input is never reflected. The smoke test proves both service identities and this rejection behavior.
+A successful health response contains only `api`, `service`, `status`, and `version`. Invalid or overlong `--identity` configuration is rejected with a typed, bounded JSON error and the input is never reflected. The health smoke test proves both service identities and this rejection behavior.
 
-No legacy Relay modules were ported. PTY/RMUX, provider adapters, Hermes, Codex, mail, files, authentication, Workspace persistence, layout, browser control, and cross-node behavior remain deferred.
+The passkey boundary validates one exact HTTPS origin/RP ID, stores active ceremony state only server-side, requires user verification, and consumes each ceremony before verification. Sessions are opaque, Secure, HttpOnly, SameSite=Strict host cookies with separate CSRF tokens; revocation removes their server record and protected hub calls then fail closed. Browser sessions are never node credentials. The credentials and session records are deliberately bounded, process-local MVP state; restart clears them and requires recovery enrollment. `npm run auth:smoke` exercises raw HTTP origin/replay/redaction behavior; `npm run auth:browser` runs the real PWA flow against Chromium's standards-compatible CDP virtual authenticator.
 
-See `AGENTS.md` for contributor rules, `docs/PRODUCT_CONTEXT.md` for reserved nouns and scope, and `docs/adrs/ADR-0001-factory-boundary.md` for the API boundary decision.
+No legacy Relay modules were ported. PTY/RMUX, provider adapters, Hermes, Codex, mail, files, durable Workspace persistence, layout, browser-control grants, node credential rotation, and cross-node behavior remain deferred.
+
+See `AGENTS.md` for contributor rules, `docs/PRODUCT_CONTEXT.md` for reserved nouns and scope, and `docs/adrs/ADR-0001-factory-boundary.md` plus `docs/adrs/ADR-0002-passkey-auth-boundary.md` for boundary decisions.

--- a/apps/relay-hub/Cargo.toml
+++ b/apps/relay-hub/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 relay-factory-core = { path = "../../crates/relay-factory-core" }
+serde_json = "1.0.149"
 
 [lints]
 workspace = true

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -3,17 +3,20 @@ use std::{
     io::{self, Read, Write},
     net::{SocketAddr, TcpListener, TcpStream},
     process::ExitCode,
+    sync::Arc,
     thread,
     time::{Duration, Instant},
 };
 
 use relay_factory_core::{
-    ConfigError, ServiceIdentity, configured_identity, health_http_response, health_json,
-    not_found_http_response,
+    AuthBoundary, AuthError, AuthOrigin, EnrollmentAuthority, ServiceIdentity, configured_identity,
+    health_http_response, health_json, not_found_http_response,
 };
+use serde_json::Value;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
-const MAX_REQUEST_BYTES: usize = 1024;
+const MAX_REQUEST_BYTES: usize = 65_536;
+const MAX_BODY_BYTES: usize = 48_000;
 
 fn main() -> ExitCode {
     match run() {
@@ -22,12 +25,18 @@ fn main() -> ExitCode {
             eprintln!("{}", error.to_json());
             ExitCode::from(2)
         }
+        Err(RunError::Auth(error)) => {
+            eprintln!("{}", auth_error_json(error.code()));
+            ExitCode::from(2)
+        }
         Err(RunError::Usage) => {
-            eprintln!("usage: relay-hub <probe|serve --bind <address>> [--identity hub]");
+            eprintln!(
+                "usage: relay-hub <probe|serve --bind <address> [--identity hub] [--origin https://relay.example] [--recovery-code-hash sha256hex]>"
+            );
             ExitCode::from(64)
         }
         Err(RunError::Io) => {
-            eprintln!("relay-hub could not serve the liveness boundary");
+            eprintln!("relay-hub could not serve the configured boundary");
             ExitCode::FAILURE
         }
     }
@@ -35,7 +44,8 @@ fn main() -> ExitCode {
 
 #[derive(Debug)]
 enum RunError {
-    Config(ConfigError),
+    Config(relay_factory_core::ConfigError),
+    Auth(AuthError),
     Usage,
     Io,
 }
@@ -90,29 +100,79 @@ fn run() -> Result<(), RunError> {
 }
 
 fn serve(arguments: &[String]) -> Result<(), RunError> {
-    let (address, identity_arguments) = match arguments {
-        [bind_flag, address] if bind_flag == "--bind" => (address, &[][..]),
-        [bind_flag, address, identity_flag, _]
-            if bind_flag == "--bind" && identity_flag == "--identity" =>
-        {
-            (address, &arguments[2..])
-        }
-        _ => return Err(RunError::Usage),
-    };
-    let identity =
-        configured_identity(identity_arguments, ServiceIdentity::Hub).map_err(RunError::Config)?;
-    let address: SocketAddr = address.parse().map_err(|_| RunError::Usage)?;
-    let listener = TcpListener::bind(address).map_err(|_| RunError::Io)?;
+    let options = ServeOptions::parse(arguments)?;
+    let listener = TcpListener::bind(options.address).map_err(|_| RunError::Io)?;
 
     println!(
         "relay-hub liveness listening on {}",
         listener.local_addr().map_err(|_| RunError::Io)?
     );
-    serve_connections(identity, || listener.accept().map(|(stream, _)| stream))
+    serve_connections_with_auth(options.identity, options.auth, || {
+        listener.accept().map(|(stream, _)| stream)
+    })
 }
 
-fn serve_connections(
+struct ServeOptions {
+    address: SocketAddr,
     identity: ServiceIdentity,
+    auth: Option<Arc<AuthBoundary>>,
+}
+
+impl ServeOptions {
+    fn parse(arguments: &[String]) -> Result<Self, RunError> {
+        let mut bind = None;
+        let mut identity_arguments = None;
+        let mut origin = None;
+        let mut recovery_hash = None;
+        let mut index = 0;
+
+        while index < arguments.len() {
+            let flag = &arguments[index];
+            let value = arguments.get(index + 1).ok_or(RunError::Usage)?;
+            match flag.as_str() {
+                "--bind" if bind.is_none() => bind = Some(value.clone()),
+                "--identity" if identity_arguments.is_none() => {
+                    identity_arguments = Some(vec![flag.clone(), value.clone()]);
+                }
+                "--origin" if origin.is_none() => origin = Some(value.clone()),
+                "--recovery-code-hash" if recovery_hash.is_none() => {
+                    recovery_hash = Some(value.clone());
+                }
+                _ => return Err(RunError::Usage),
+            }
+            index += 2;
+        }
+
+        let address = bind.ok_or(RunError::Usage)?;
+        let address = address.parse().map_err(|_| RunError::Usage)?;
+        let identity = configured_identity(
+            identity_arguments.as_deref().unwrap_or_default(),
+            ServiceIdentity::Hub,
+        )
+        .map_err(RunError::Config)?;
+        let auth = match (origin, recovery_hash) {
+            (None, None) => None,
+            (Some(origin), Some(recovery_hash)) => Some(Arc::new(
+                AuthBoundary::from_recovery_hash_hex(
+                    AuthOrigin::parse(&origin).map_err(RunError::Auth)?,
+                    &recovery_hash,
+                )
+                .map_err(RunError::Auth)?,
+            )),
+            _ => return Err(RunError::Usage),
+        };
+
+        Ok(Self {
+            address,
+            identity,
+            auth,
+        })
+    }
+}
+
+fn serve_connections_with_auth(
+    identity: ServiceIdentity,
+    auth: Option<Arc<AuthBoundary>>,
     mut accept: impl FnMut() -> io::Result<TcpStream>,
 ) -> Result<(), RunError> {
     loop {
@@ -123,9 +183,10 @@ fn serve_connections(
                 return Err(RunError::Io);
             }
         };
+        let auth = auth.clone();
         thread::Builder::new()
             .spawn(move || {
-                if let Err(error) = handle_connection(stream, identity) {
+                if let Err(error) = handle_connection(stream, identity, auth.as_deref()) {
                     eprintln!("relay-hub connection error: {error}");
                 }
             })
@@ -139,16 +200,17 @@ fn serve_connections(
 fn handle_connection(
     mut stream: TcpStream,
     identity: ServiceIdentity,
+    auth: Option<&AuthBoundary>,
 ) -> Result<(), ConnectionError> {
     stream
         .set_write_timeout(Some(CONNECTION_TIMEOUT))
         .map_err(ConnectionError::Write)?;
     let mut request = [0_u8; MAX_REQUEST_BYTES];
     let response = match read_request(&mut stream, &mut request) {
-        Ok(length) if request[..length].starts_with(b"GET /health ") => {
-            health_http_response(identity)
-        }
-        Ok(_) | Err(RequestReadError::TooLarge) => not_found_http_response(),
+        Ok(length) => HttpRequest::parse(&request[..length])
+            .map(|request| route_request(&request, identity, auth))
+            .unwrap_or_else(not_found_http_response),
+        Err(RequestReadError::TooLarge) => not_found_http_response(),
         Err(error) => return Err(ConnectionError::Request(error)),
     };
 
@@ -157,16 +219,288 @@ fn handle_connection(
         .map_err(ConnectionError::Write)
 }
 
+struct HttpRequest<'a> {
+    method: &'a str,
+    path: &'a str,
+    headers: Vec<(&'a str, &'a str)>,
+    body: &'a str,
+}
+
+impl<'a> HttpRequest<'a> {
+    fn parse(bytes: &'a [u8]) -> Option<Self> {
+        let request = std::str::from_utf8(bytes).ok()?;
+        let (head, body) = request.split_once("\r\n\r\n")?;
+        let mut lines = head.split("\r\n");
+        let request_line = lines.next()?;
+        let mut request_parts = request_line.split_ascii_whitespace();
+        let method = request_parts.next()?;
+        let path = request_parts.next()?;
+        if request_parts.next()? != "HTTP/1.1" || path.len() > 256 {
+            return None;
+        }
+        let mut headers = Vec::new();
+        for line in lines {
+            let (name, value) = line.split_once(':')?;
+            if name.is_empty() || value.len() > 4096 {
+                return None;
+            }
+            headers.push((name, value.trim()));
+        }
+        Some(Self {
+            method,
+            path,
+            headers,
+            body,
+        })
+    }
+
+    fn header(&self, name: &str) -> Option<&str> {
+        let mut result = None;
+        for (candidate, value) in &self.headers {
+            if candidate.eq_ignore_ascii_case(name) {
+                if result.is_some() {
+                    return None;
+                }
+                result = Some(*value);
+            }
+        }
+        result
+    }
+
+    fn cookie(&self, name: &str) -> Option<&str> {
+        let cookies = self.header("cookie")?;
+        let mut result = None;
+        for cookie in cookies.split(';') {
+            let (candidate, value) = cookie.trim().split_once('=')?;
+            if candidate == name {
+                if result.is_some() || value.is_empty() || value.len() > 256 {
+                    return None;
+                }
+                result = Some(value);
+            }
+        }
+        result
+    }
+}
+
+fn route_request(
+    request: &HttpRequest<'_>,
+    identity: ServiceIdentity,
+    auth: Option<&AuthBoundary>,
+) -> String {
+    match (request.method, request.path) {
+        ("GET", "/health") => health_http_response(identity),
+        ("POST", "/auth/passkeys/enroll/options") => start_enrollment_response(request, auth),
+        ("POST", "/auth/passkeys/enroll/verify") => finish_enrollment_response(request, auth),
+        ("POST", "/auth/passkeys/sign-in/options") => start_sign_in_response(request, auth),
+        ("POST", "/auth/passkeys/sign-in/verify") => finish_sign_in_response(request, auth),
+        ("GET", "/auth/sessions") => list_sessions_response(request, auth),
+        ("POST", "/auth/sessions/revoke") => revoke_session_response(request, auth),
+        ("GET", "/protected/hub") => protected_hub_response(request, auth),
+        (_, "/protected/node") => auth_error_response(403, "node_authority_required", &[]),
+        _ => not_found_http_response(),
+    }
+}
+
+fn start_enrollment_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match state_change_auth(request, auth) {
+        Ok(auth) => auth,
+        Err(response) => return response,
+    };
+    let authority = match request.header("x-relay-recovery-code") {
+        Some(code) => EnrollmentAuthority::RecoveryCode(code),
+        None => {
+            let session = match request.cookie("__Host-relay_session") {
+                Some(session) => session,
+                None => return auth_error_response(401, "session_missing", &[]),
+            };
+            let csrf = match request.header("x-relay-csrf") {
+                Some(csrf) => csrf,
+                None => return auth_error_response(403, "csrf_denied", &[]),
+            };
+            if let Err(error) = auth.require_csrf(session, csrf) {
+                return auth_error_response(auth_error_status(&error), error.code(), &[]);
+            }
+            EnrollmentAuthority::ExistingSession(session)
+        }
+    };
+    match auth.start_registration(authority) {
+        Ok(ceremony) => json_response(
+            200,
+            &ceremony.options_json,
+            &[ceremony_cookie(&ceremony.ceremony_id)],
+        ),
+        Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
+    }
+}
+
+fn finish_enrollment_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match state_change_auth(request, auth) {
+        Ok(auth) => auth,
+        Err(response) => return response,
+    };
+    let ceremony = match request.cookie("__Host-relay_ceremony") {
+        Some(ceremony) => ceremony,
+        None => return auth_error_response(403, "unknown_ceremony", &[]),
+    };
+    match auth.finish_registration(ceremony, request.body) {
+        Ok(()) => json_response(
+            200,
+            "{\"status\":\"passkey_enrolled\"}",
+            &[clear_ceremony_cookie()],
+        ),
+        Err(error) => auth_error_response(
+            auth_error_status(&error),
+            error.code(),
+            &[clear_ceremony_cookie()],
+        ),
+    }
+}
+
+fn start_sign_in_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match state_change_auth(request, auth) {
+        Ok(auth) => auth,
+        Err(response) => return response,
+    };
+    match auth.start_authentication() {
+        Ok(ceremony) => json_response(
+            200,
+            &ceremony.options_json,
+            &[ceremony_cookie(&ceremony.ceremony_id)],
+        ),
+        Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
+    }
+}
+
+fn finish_sign_in_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match state_change_auth(request, auth) {
+        Ok(auth) => auth,
+        Err(response) => return response,
+    };
+    let ceremony = match request.cookie("__Host-relay_ceremony") {
+        Some(ceremony) => ceremony,
+        None => return auth_error_response(403, "unknown_ceremony", &[]),
+    };
+    match auth.finish_authentication(ceremony, request.body) {
+        Ok(session) => json_response(
+            200,
+            &format!("{{\"deviceId\":\"{}\"}}", session.device_id),
+            &[
+                clear_ceremony_cookie(),
+                session_cookie(&session.session_token),
+                csrf_cookie(&session.csrf_token),
+            ],
+        ),
+        Err(error) => auth_error_response(
+            auth_error_status(&error),
+            error.code(),
+            &[clear_ceremony_cookie()],
+        ),
+    }
+}
+
+fn list_sessions_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match auth {
+        Some(auth) => auth,
+        None => return auth_error_response(404, "auth_unavailable", &[]),
+    };
+    let session = match request.cookie("__Host-relay_session") {
+        Some(session) => session,
+        None => return auth_error_response(401, "session_missing", &[]),
+    };
+    match auth.list_sessions(session) {
+        Ok(sessions) => match serde_json::to_string(&serde_json::json!({ "sessions": sessions })) {
+            Ok(body) => json_response(200, &body, &[]),
+            Err(_) => auth_error_response(500, "internal", &[]),
+        },
+        Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
+    }
+}
+
+fn revoke_session_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match state_change_auth(request, auth) {
+        Ok(auth) => auth,
+        Err(response) => return response,
+    };
+    let session = match request.cookie("__Host-relay_session") {
+        Some(session) => session,
+        None => return auth_error_response(401, "session_missing", &[]),
+    };
+    let csrf = match request.header("x-relay-csrf") {
+        Some(csrf) => csrf,
+        None => return auth_error_response(403, "csrf_denied", &[]),
+    };
+    let device_id = match device_id_from_body(request.body) {
+        Some(device_id) => device_id,
+        None => return auth_error_response(400, "invalid_request", &[]),
+    };
+    match auth.revoke_session(session, csrf, &device_id) {
+        Ok(()) => json_response(200, "{\"status\":\"revoked\"}", &[]),
+        Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
+    }
+}
+
+fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
+    let auth = match auth {
+        Some(auth) => auth,
+        None => return auth_error_response(404, "auth_unavailable", &[]),
+    };
+    match request
+        .cookie("__Host-relay_session")
+        .ok_or(AuthError::SessionMissing)
+        .and_then(|session| auth.require_session(session))
+    {
+        Ok(()) => json_response(200, "{\"status\":\"operator_authorized\"}", &[]),
+        Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
+    }
+}
+
+fn state_change_auth<'a>(
+    request: &HttpRequest<'_>,
+    auth: Option<&'a AuthBoundary>,
+) -> Result<&'a AuthBoundary, String> {
+    let auth = auth.ok_or_else(|| auth_error_response(404, "auth_unavailable", &[]))?;
+    auth.enforce_origin(request.header("origin"))
+        .map_err(|error| auth_error_response(auth_error_status(&error), error.code(), &[]))?;
+    Ok(auth)
+}
+
+fn device_id_from_body(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let device_id = value.get("deviceId")?.as_str()?;
+    if device_id.is_empty() || device_id.len() > 64 || !device_id.is_ascii() {
+        return None;
+    }
+    Some(device_id.to_owned())
+}
+
 fn read_request(stream: &mut TcpStream, request: &mut [u8]) -> Result<usize, RequestReadError> {
     let deadline = Instant::now() + CONNECTION_TIMEOUT;
     let mut length = 0;
+    let mut expected_length = None;
 
     loop {
-        if request[..length]
-            .windows(4)
-            .any(|bytes| bytes == b"\r\n\r\n")
-        {
-            return Ok(length);
+        if expected_length.is_none() {
+            if let Some(header_end) = request[..length]
+                .windows(4)
+                .position(|bytes| bytes == b"\r\n\r\n")
+                .map(|index| index + 4)
+            {
+                let body_length = content_length(&request[..header_end])?;
+                if body_length > MAX_BODY_BYTES {
+                    return Err(RequestReadError::TooLarge);
+                }
+                let total = header_end
+                    .checked_add(body_length)
+                    .filter(|total| *total <= request.len())
+                    .ok_or(RequestReadError::TooLarge)?;
+                expected_length = Some(total);
+            }
+        }
+        if let Some(expected_length) = expected_length {
+            if length >= expected_length {
+                return Ok(expected_length);
+            }
         }
         if length == request.len() {
             return Err(RequestReadError::TooLarge);
@@ -198,6 +532,86 @@ fn read_request(stream: &mut TcpStream, request: &mut [u8]) -> Result<usize, Req
     }
 }
 
+fn content_length(headers: &[u8]) -> Result<usize, RequestReadError> {
+    let headers = std::str::from_utf8(headers)
+        .map_err(|_| RequestReadError::Read(io::Error::from(io::ErrorKind::InvalidData)))?;
+    let mut content_length = None;
+    for line in headers.split("\r\n").skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("content-length") {
+            if content_length.is_some() {
+                return Err(RequestReadError::Read(io::Error::from(
+                    io::ErrorKind::InvalidData,
+                )));
+            }
+            content_length = Some(value.trim().parse().map_err(|_| {
+                RequestReadError::Read(io::Error::from(io::ErrorKind::InvalidData))
+            })?);
+        }
+    }
+    Ok(content_length.unwrap_or(0))
+}
+
+fn auth_error_status(error: &AuthError) -> u16 {
+    match error {
+        AuthError::SessionMissing => 401,
+        AuthError::Internal => 500,
+        _ => 403,
+    }
+}
+
+fn ceremony_cookie(value: &str) -> String {
+    format!(
+        "Set-Cookie: __Host-relay_ceremony={value}; Path=/; Max-Age=300; Secure; HttpOnly; SameSite=Strict"
+    )
+}
+
+fn clear_ceremony_cookie() -> String {
+    "Set-Cookie: __Host-relay_ceremony=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Strict"
+        .to_owned()
+}
+
+fn session_cookie(value: &str) -> String {
+    format!(
+        "Set-Cookie: __Host-relay_session={value}; Path=/; Max-Age=1800; Secure; HttpOnly; SameSite=Strict"
+    )
+}
+
+fn csrf_cookie(value: &str) -> String {
+    format!("Set-Cookie: __Host-relay_csrf={value}; Path=/; Max-Age=1800; Secure; SameSite=Strict")
+}
+
+fn auth_error_json(code: &str) -> String {
+    format!("{{\"error\":{{\"code\":\"{code}\"}}}}")
+}
+
+fn auth_error_response(status: u16, code: &str, extra_headers: &[String]) -> String {
+    json_response(status, &auth_error_json(code), extra_headers)
+}
+
+fn json_response(status: u16, body: &str, extra_headers: &[String]) -> String {
+    let reason = match status {
+        200 => "200 OK",
+        400 => "400 Bad Request",
+        401 => "401 Unauthorized",
+        403 => "403 Forbidden",
+        404 => "404 Not Found",
+        _ => "500 Internal Server Error",
+    };
+    let mut headers = vec![
+        format!("HTTP/1.1 {reason}"),
+        "Content-Type: application/json".to_owned(),
+        "Cache-Control: no-store".to_owned(),
+        "X-Content-Type-Options: nosniff".to_owned(),
+        format!("Content-Length: {}", body.len()),
+        "Connection: close".to_owned(),
+    ];
+    headers.extend(extra_headers.iter().cloned());
+    format!("{}\r\n\r\n{body}", headers.join("\r\n"))
+}
+
 #[cfg(test)]
 mod tests {
     use std::io;
@@ -206,7 +620,7 @@ mod tests {
 
     #[test]
     fn listener_accept_failure_stops_serving() {
-        let result = serve_connections(ServiceIdentity::Hub, || {
+        let result = serve_connections_with_auth(ServiceIdentity::Hub, None, || {
             Err(io::Error::other("injected listener failure"))
         });
 

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -271,7 +271,13 @@ impl<'a> HttpRequest<'a> {
         let cookies = self.header("cookie")?;
         let mut result = None;
         for cookie in cookies.split(';') {
-            let (candidate, value) = cookie.trim().split_once('=')?;
+            let cookie = cookie.trim();
+            let Some((candidate, value)) = cookie.split_once('=') else {
+                if cookie == name {
+                    return None;
+                }
+                continue;
+            };
             if candidate == name {
                 if result.is_some() || value.is_empty() || value.len() > 256 {
                     return None;
@@ -625,5 +631,41 @@ mod tests {
         });
 
         assert!(matches!(result, Err(RunError::Io)));
+    }
+
+    #[test]
+    fn cookie_skips_valueless_unrelated_segments() {
+        let request = HttpRequest::parse(
+            b"GET /protected/hub HTTP/1.1\r\nHost: relay.example.test\r\nCookie: __Host-relay_session=valid-session; legacy\r\n\r\n",
+        )
+        .expect("the request is well formed");
+
+        assert_eq!(
+            request.cookie("__Host-relay_session"),
+            Some("valid-session")
+        );
+    }
+
+    #[test]
+    fn cookie_rejects_invalid_or_ambiguous_target_segments() {
+        let oversized = format!("__Host-relay_session={}", "a".repeat(257));
+        for cookie in [
+            "__Host-relay_session",
+            "__Host-relay_session=",
+            "__Host-relay_session=first; __Host-relay_session=second",
+            oversized.as_str(),
+        ] {
+            let request = format!(
+                "GET /protected/hub HTTP/1.1\r\nHost: relay.example.test\r\nCookie: {cookie}\r\n\r\n"
+            );
+            let request =
+                HttpRequest::parse(request.as_bytes()).expect("the request is well formed");
+
+            assert_eq!(
+                request.cookie("__Host-relay_session"),
+                None,
+                "cookie: {cookie}"
+            );
+        }
     }
 }

--- a/crates/relay-factory-core/Cargo.toml
+++ b/crates/relay-factory-core/Cargo.toml
@@ -8,5 +8,16 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[dependencies]
+base64 = "0.22.1"
+getrandom = "0.3.4"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+sha2 = "0.10.9"
+subtle = "2.6.1"
+url = "2.5.4"
+uuid = { version = "1.18.1", features = ["v4"] }
+webauthn-rs = { version = "0.5.1", default-features = false }
+
 [lints]
 workspace = true

--- a/crates/relay-factory-core/src/auth.rs
+++ b/crates/relay-factory-core/src/auth.rs
@@ -1,0 +1,512 @@
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use uuid::Uuid;
+use webauthn_rs::prelude::{
+    Passkey, PasskeyAuthentication, PasskeyRegistration, PublicKeyCredential,
+    RegisterPublicKeyCredential, Webauthn, WebauthnBuilder,
+};
+
+use crate::{AuthError, AuthOrigin};
+
+const CEREMONY_TTL: Duration = Duration::from_secs(5 * 60);
+const SESSION_TTL: Duration = Duration::from_secs(30 * 60);
+const MAX_CEREMONIES: usize = 16;
+const MAX_PASSKEYS: usize = 8;
+const MAX_SESSIONS: usize = 8;
+const MAX_RECOVERY_CODE_BYTES: usize = 256;
+const OPERATOR_NAME: &str = "operator";
+const OPERATOR_DISPLAY_NAME: &str = "Relay operator";
+
+pub struct AuthBoundary {
+    origin: AuthOrigin,
+    recovery_hash: [u8; 32],
+    operator_id: Uuid,
+    webauthn: Webauthn,
+    state: Mutex<AuthState>,
+}
+
+pub enum EnrollmentAuthority<'a> {
+    RecoveryCode(&'a str),
+    ExistingSession(&'a str),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CeremonyStart {
+    pub ceremony_id: String,
+    pub options_json: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionGrant {
+    pub session_token: String,
+    pub csrf_token: String,
+    pub device_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionDevice {
+    pub device_id: String,
+    pub current: bool,
+}
+
+struct AuthState {
+    passkeys: Vec<Passkey>,
+    ceremonies: HashMap<[u8; 32], PendingCeremony>,
+    sessions: HashMap<[u8; 32], StoredSession>,
+}
+
+impl AuthState {
+    fn new() -> Self {
+        Self {
+            passkeys: Vec::new(),
+            ceremonies: HashMap::new(),
+            sessions: HashMap::new(),
+        }
+    }
+
+    fn discard_expired(&mut self, now: Instant) {
+        self.ceremonies
+            .retain(|_, ceremony| ceremony.expires_at() > now);
+        self.sessions.retain(|_, session| session.expires_at > now);
+    }
+}
+
+enum PendingCeremony {
+    Registration {
+        state: PasskeyRegistration,
+        expires_at: Instant,
+    },
+    Authentication {
+        state: PasskeyAuthentication,
+        expires_at: Instant,
+    },
+}
+
+impl PendingCeremony {
+    const fn expires_at(&self) -> Instant {
+        match self {
+            Self::Registration { expires_at, .. } | Self::Authentication { expires_at, .. } => {
+                *expires_at
+            }
+        }
+    }
+}
+
+struct StoredSession {
+    csrf_hash: [u8; 32],
+    device_id: String,
+    created_at: Instant,
+    expires_at: Instant,
+}
+
+impl AuthBoundary {
+    pub fn new(origin: AuthOrigin, recovery_code: &str) -> Result<Self, AuthError> {
+        if recovery_code.is_empty() || recovery_code.len() > MAX_RECOVERY_CODE_BYTES {
+            return Err(AuthError::InvalidRecoveryConfig);
+        }
+        Self::with_recovery_hash(origin, hash_secret(recovery_code.as_bytes()))
+    }
+
+    pub fn from_recovery_hash_hex(origin: AuthOrigin, value: &str) -> Result<Self, AuthError> {
+        let bytes = decode_sha256_hex(value)?;
+        Self::with_recovery_hash(origin, bytes)
+    }
+
+    fn with_recovery_hash(origin: AuthOrigin, recovery_hash: [u8; 32]) -> Result<Self, AuthError> {
+        let webauthn = WebauthnBuilder::new(origin.rp_id(), origin.as_url())
+            .map_err(|_| AuthError::InvalidOrigin)?
+            .rp_name("Relay")
+            .timeout(CEREMONY_TTL)
+            .build()
+            .map_err(|_| AuthError::InvalidOrigin)?;
+
+        Ok(Self {
+            origin,
+            recovery_hash,
+            operator_id: Uuid::new_v4(),
+            webauthn,
+            state: Mutex::new(AuthState::new()),
+        })
+    }
+
+    pub fn enforce_origin(&self, value: Option<&str>) -> Result<(), AuthError> {
+        let value = value.ok_or(AuthError::OriginMismatch)?;
+        let origin = AuthOrigin::parse(value).map_err(|_| AuthError::OriginMismatch)?;
+        if origin == self.origin {
+            Ok(())
+        } else {
+            Err(AuthError::OriginMismatch)
+        }
+    }
+
+    pub fn start_registration(
+        &self,
+        authority: EnrollmentAuthority<'_>,
+    ) -> Result<CeremonyStart, AuthError> {
+        let passkeys = {
+            let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+            state.discard_expired(Instant::now());
+            self.enrollment_is_authorized(&state, authority)?;
+            if state.passkeys.len() >= MAX_PASSKEYS {
+                return Err(AuthError::CredentialLimit);
+            }
+            state.passkeys.clone()
+        };
+
+        let excluded_credentials = passkeys
+            .iter()
+            .map(|passkey| passkey.cred_id().clone())
+            .collect::<Vec<_>>();
+        let (options, registration) = self
+            .webauthn
+            .start_passkey_registration(
+                self.operator_id,
+                OPERATOR_NAME,
+                OPERATOR_DISPLAY_NAME,
+                Some(excluded_credentials),
+            )
+            .map_err(|_| AuthError::PasskeyDenied)?;
+        let options_json = serde_json::to_string(&options).map_err(|_| AuthError::Internal)?;
+
+        self.store_ceremony(PendingCeremony::Registration {
+            state: registration,
+            expires_at: Instant::now() + CEREMONY_TTL,
+        })
+        .map(|ceremony_id| CeremonyStart {
+            ceremony_id,
+            options_json,
+        })
+    }
+
+    pub fn finish_registration(&self, ceremony_id: &str, response: &str) -> Result<(), AuthError> {
+        let registration = match self.take_ceremony(ceremony_id)? {
+            PendingCeremony::Registration { state, .. } => state,
+            PendingCeremony::Authentication { .. } => return Err(AuthError::PasskeyDenied),
+        };
+        let response = serde_json::from_str::<RegisterPublicKeyCredential>(response)
+            .map_err(|_| AuthError::PasskeyDenied)?;
+        let passkey = self
+            .webauthn
+            .finish_passkey_registration(&response, &registration)
+            .map_err(|_| AuthError::PasskeyDenied)?;
+
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        if state.passkeys.len() >= MAX_PASSKEYS {
+            return Err(AuthError::CredentialLimit);
+        }
+        if state
+            .passkeys
+            .iter()
+            .any(|existing| existing.cred_id() == passkey.cred_id())
+        {
+            return Err(AuthError::PasskeyDenied);
+        }
+        state.passkeys.push(passkey);
+        Ok(())
+    }
+
+    pub fn start_authentication(&self) -> Result<CeremonyStart, AuthError> {
+        let passkeys = {
+            let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+            state.discard_expired(Instant::now());
+            if state.passkeys.is_empty() {
+                return Err(AuthError::RecoveryRequired);
+            }
+            state.passkeys.clone()
+        };
+        let (options, authentication) = self
+            .webauthn
+            .start_passkey_authentication(&passkeys)
+            .map_err(|_| AuthError::PasskeyDenied)?;
+        let options_json = serde_json::to_string(&options).map_err(|_| AuthError::Internal)?;
+
+        self.store_ceremony(PendingCeremony::Authentication {
+            state: authentication,
+            expires_at: Instant::now() + CEREMONY_TTL,
+        })
+        .map(|ceremony_id| CeremonyStart {
+            ceremony_id,
+            options_json,
+        })
+    }
+
+    pub fn finish_authentication(
+        &self,
+        ceremony_id: &str,
+        response: &str,
+    ) -> Result<SessionGrant, AuthError> {
+        let authentication = match self.take_ceremony(ceremony_id)? {
+            PendingCeremony::Authentication { state, .. } => state,
+            PendingCeremony::Registration { .. } => return Err(AuthError::PasskeyDenied),
+        };
+        let response = serde_json::from_str::<PublicKeyCredential>(response)
+            .map_err(|_| AuthError::PasskeyDenied)?;
+        let result = self
+            .webauthn
+            .finish_passkey_authentication(&response, &authentication)
+            .map_err(|_| AuthError::PasskeyDenied)?;
+
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        let mut matched_credential = false;
+        for passkey in &mut state.passkeys {
+            if passkey.update_credential(&result).is_some() {
+                matched_credential = true;
+                break;
+            }
+        }
+        if !matched_credential {
+            return Err(AuthError::PasskeyDenied);
+        }
+        issue_session(&mut state)
+    }
+
+    pub fn require_session(&self, session_token: &str) -> Result<(), AuthError> {
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        let key = hash_secret(session_token.as_bytes());
+        if state.sessions.contains_key(&key) {
+            Ok(())
+        } else {
+            Err(AuthError::SessionMissing)
+        }
+    }
+
+    pub fn require_csrf(&self, session_token: &str, csrf_token: &str) -> Result<(), AuthError> {
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        let session_key = hash_secret(session_token.as_bytes());
+        let session = state
+            .sessions
+            .get(&session_key)
+            .ok_or(AuthError::SessionMissing)?;
+        if session
+            .csrf_hash
+            .ct_eq(&hash_secret(csrf_token.as_bytes()))
+            .into()
+        {
+            Ok(())
+        } else {
+            Err(AuthError::CsrfDenied)
+        }
+    }
+
+    pub fn list_sessions(&self, session_token: &str) -> Result<Vec<SessionDevice>, AuthError> {
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        let current = hash_secret(session_token.as_bytes());
+        if !state.sessions.contains_key(&current) {
+            return Err(AuthError::SessionMissing);
+        }
+
+        Ok(state
+            .sessions
+            .iter()
+            .map(|(key, session)| SessionDevice {
+                device_id: session.device_id.clone(),
+                current: key.ct_eq(&current).into(),
+            })
+            .collect())
+    }
+
+    pub fn revoke_session(
+        &self,
+        session_token: &str,
+        csrf_token: &str,
+        device_id: &str,
+    ) -> Result<(), AuthError> {
+        self.require_csrf(session_token, csrf_token)?;
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        let before = state.sessions.len();
+        state
+            .sessions
+            .retain(|_, session| session.device_id != device_id);
+        if state.sessions.len() == before {
+            Err(AuthError::SessionMissing)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn enrollment_is_authorized(
+        &self,
+        state: &AuthState,
+        authority: EnrollmentAuthority<'_>,
+    ) -> Result<(), AuthError> {
+        match authority {
+            EnrollmentAuthority::RecoveryCode(recovery_code)
+                if recovery_code.len() <= MAX_RECOVERY_CODE_BYTES
+                    && self
+                        .recovery_hash
+                        .ct_eq(&hash_secret(recovery_code.as_bytes()))
+                        .into() =>
+            {
+                Ok(())
+            }
+            EnrollmentAuthority::RecoveryCode(_) => Err(AuthError::RecoveryDenied),
+            EnrollmentAuthority::ExistingSession(session_token)
+                if state
+                    .sessions
+                    .contains_key(&hash_secret(session_token.as_bytes())) =>
+            {
+                Ok(())
+            }
+            EnrollmentAuthority::ExistingSession(_) => Err(AuthError::SessionMissing),
+        }
+    }
+
+    fn store_ceremony(&self, ceremony: PendingCeremony) -> Result<String, AuthError> {
+        let id = random_token(32)?;
+        let key = hash_secret(id.as_bytes());
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        if state.ceremonies.len() >= MAX_CEREMONIES {
+            return Err(AuthError::CeremonyLimit);
+        }
+        state.ceremonies.insert(key, ceremony);
+        Ok(id)
+    }
+
+    fn take_ceremony(&self, ceremony_id: &str) -> Result<PendingCeremony, AuthError> {
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        let now = Instant::now();
+        let key = hash_secret(ceremony_id.as_bytes());
+        let ceremony = state
+            .ceremonies
+            .remove(&key)
+            .ok_or(AuthError::UnknownCeremony)?;
+        state.discard_expired(now);
+        if ceremony.expires_at() <= now {
+            Err(AuthError::CeremonyExpired)
+        } else {
+            Ok(ceremony)
+        }
+    }
+}
+
+fn issue_session(state: &mut AuthState) -> Result<SessionGrant, AuthError> {
+    while state.sessions.len() >= MAX_SESSIONS {
+        let oldest = state
+            .sessions
+            .iter()
+            .min_by_key(|(_, session)| session.created_at)
+            .map(|(key, _)| *key)
+            .ok_or(AuthError::Internal)?;
+        state.sessions.remove(&oldest);
+    }
+
+    let session_token = random_token(32)?;
+    let csrf_token = random_token(32)?;
+    let device_id = random_token(12)?;
+    let now = Instant::now();
+    state.sessions.insert(
+        hash_secret(session_token.as_bytes()),
+        StoredSession {
+            csrf_hash: hash_secret(csrf_token.as_bytes()),
+            device_id: device_id.clone(),
+            created_at: now,
+            expires_at: now + SESSION_TTL,
+        },
+    );
+
+    Ok(SessionGrant {
+        session_token,
+        csrf_token,
+        device_id,
+    })
+}
+
+fn random_token(bytes: usize) -> Result<String, AuthError> {
+    let mut token = vec![0_u8; bytes];
+    getrandom::fill(&mut token).map_err(|_| AuthError::Internal)?;
+    Ok(URL_SAFE_NO_PAD.encode(token))
+}
+
+fn hash_secret(value: &[u8]) -> [u8; 32] {
+    Sha256::digest(value).into()
+}
+
+fn decode_sha256_hex(value: &str) -> Result<[u8; 32], AuthError> {
+    if value.len() != 64 || !value.is_ascii() {
+        return Err(AuthError::InvalidRecoveryConfig);
+    }
+
+    let mut output = [0_u8; 32];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        let pair = std::str::from_utf8(pair).map_err(|_| AuthError::InvalidRecoveryConfig)?;
+        output[index] =
+            u8::from_str_radix(pair, 16).map_err(|_| AuthError::InvalidRecoveryConfig)?;
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn boundary() -> AuthBoundary {
+        AuthBoundary::new(
+            AuthOrigin::parse("https://relay.example.test").expect("stable origin"),
+            "recovery-test-secret",
+        )
+        .expect("auth boundary")
+    }
+
+    #[test]
+    fn bounds_pending_ceremonies() {
+        let boundary = boundary();
+
+        for _ in 0..MAX_CEREMONIES {
+            boundary
+                .start_registration(EnrollmentAuthority::RecoveryCode("recovery-test-secret"))
+                .expect("bounded ceremony slot");
+        }
+        assert_eq!(
+            boundary
+                .start_registration(EnrollmentAuthority::RecoveryCode("recovery-test-secret"))
+                .unwrap_err(),
+            AuthError::CeremonyLimit
+        );
+    }
+
+    #[test]
+    fn expired_ceremony_is_consumed_without_attempting_verification() {
+        let boundary = boundary();
+        let ceremony = boundary
+            .start_registration(EnrollmentAuthority::RecoveryCode("recovery-test-secret"))
+            .expect("ceremony");
+        let mut state = boundary.state.lock().expect("auth state");
+        let key = hash_secret(ceremony.ceremony_id.as_bytes());
+        match state.ceremonies.get_mut(&key).expect("stored ceremony") {
+            PendingCeremony::Registration { expires_at, .. } => {
+                *expires_at = Instant::now() - Duration::from_secs(1);
+            }
+            PendingCeremony::Authentication { .. } => panic!("expected registration ceremony"),
+        }
+        drop(state);
+
+        assert_eq!(
+            boundary
+                .finish_registration(&ceremony.ceremony_id, "{}")
+                .unwrap_err(),
+            AuthError::CeremonyExpired
+        );
+        assert_eq!(
+            boundary
+                .finish_registration(&ceremony.ceremony_id, "{}")
+                .unwrap_err(),
+            AuthError::UnknownCeremony
+        );
+    }
+}

--- a/crates/relay-factory-core/src/lib.rs
+++ b/crates/relay-factory-core/src/lib.rs
@@ -1,7 +1,97 @@
 use std::fmt;
 
+use url::Url;
+
+mod auth;
+
+pub use auth::{AuthBoundary, CeremonyStart, EnrollmentAuthority, SessionDevice, SessionGrant};
+
 pub const API_VERSION: &str = "relay-factory/v1";
 pub const MAX_CONFIG_INPUT_BYTES: usize = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthError {
+    InsecureOrigin,
+    InvalidOrigin,
+    OriginMismatch,
+    InvalidRecoveryConfig,
+    RecoveryRequired,
+    RecoveryDenied,
+    PasskeyDenied,
+    UnknownCeremony,
+    CeremonyExpired,
+    CeremonyLimit,
+    CredentialLimit,
+    SessionMissing,
+    CsrfDenied,
+    Internal,
+}
+
+impl AuthError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::InsecureOrigin => "insecure_origin",
+            Self::InvalidOrigin => "invalid_origin",
+            Self::OriginMismatch => "origin_mismatch",
+            Self::InvalidRecoveryConfig => "invalid_recovery_config",
+            Self::RecoveryRequired => "recovery_required",
+            Self::RecoveryDenied => "recovery_denied",
+            Self::PasskeyDenied => "passkey_denied",
+            Self::UnknownCeremony => "unknown_ceremony",
+            Self::CeremonyExpired => "ceremony_expired",
+            Self::CeremonyLimit => "ceremony_limit",
+            Self::CredentialLimit => "credential_limit",
+            Self::SessionMissing => "session_missing",
+            Self::CsrfDenied => "csrf_denied",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthOrigin {
+    origin: Url,
+    rp_id: String,
+}
+
+impl AuthOrigin {
+    pub fn parse(value: &str) -> Result<Self, AuthError> {
+        let origin = Url::parse(value).map_err(|_| AuthError::InvalidOrigin)?;
+
+        if origin.scheme() != "https" {
+            return Err(AuthError::InsecureOrigin);
+        }
+        if origin.cannot_be_a_base()
+            || origin.username() != ""
+            || origin.password().is_some()
+            || origin.query().is_some()
+            || origin.fragment().is_some()
+            || origin.path() != "/"
+        {
+            return Err(AuthError::InvalidOrigin);
+        }
+
+        let rp_id = origin
+            .host_str()
+            .filter(|host| !host.is_empty())
+            .ok_or(AuthError::InvalidOrigin)?
+            .to_owned();
+
+        Ok(Self { origin, rp_id })
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.origin.as_str()
+    }
+
+    pub fn rp_id(&self) -> &str {
+        &self.rp_id
+    }
+
+    pub(crate) fn as_url(&self) -> &Url {
+        &self.origin
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServiceIdentity {

--- a/crates/relay-factory-core/tests/auth_boundary.rs
+++ b/crates/relay-factory-core/tests/auth_boundary.rs
@@ -1,0 +1,53 @@
+use relay_factory_core::{AuthBoundary, AuthError, AuthOrigin, EnrollmentAuthority};
+
+fn boundary() -> AuthBoundary {
+    AuthBoundary::new(
+        AuthOrigin::parse("https://relay.example.test").expect("stable origin"),
+        "recovery-test-secret",
+    )
+    .expect("auth boundary")
+}
+
+#[test]
+fn recovery_can_begin_only_a_passkey_enrollment_and_never_a_session() {
+    let boundary = boundary();
+
+    assert_eq!(
+        boundary.start_authentication().unwrap_err(),
+        AuthError::RecoveryRequired
+    );
+    assert_eq!(
+        boundary
+            .start_registration(EnrollmentAuthority::RecoveryCode("wrong"))
+            .unwrap_err(),
+        AuthError::RecoveryDenied
+    );
+
+    let ceremony = boundary
+        .start_registration(EnrollmentAuthority::RecoveryCode("recovery-test-secret"))
+        .expect("recovery authorizes only enrollment");
+    assert!(ceremony.options_json.contains("publicKey"));
+    assert!(!ceremony.options_json.contains("recovery-test-secret"));
+    assert!(!ceremony.ceremony_id.is_empty());
+}
+
+#[test]
+fn an_attempted_registration_is_consumed_before_verification_to_prevent_replay() {
+    let boundary = boundary();
+    let ceremony = boundary
+        .start_registration(EnrollmentAuthority::RecoveryCode("recovery-test-secret"))
+        .expect("ceremony");
+
+    assert_eq!(
+        boundary
+            .finish_registration(&ceremony.ceremony_id, "{}")
+            .unwrap_err(),
+        AuthError::PasskeyDenied
+    );
+    assert_eq!(
+        boundary
+            .finish_registration(&ceremony.ceremony_id, "{}")
+            .unwrap_err(),
+        AuthError::UnknownCeremony
+    );
+}

--- a/crates/relay-factory-core/tests/auth_origin.rs
+++ b/crates/relay-factory-core/tests/auth_origin.rs
@@ -1,0 +1,21 @@
+use relay_factory_core::{AuthError, AuthOrigin};
+
+#[test]
+fn accepts_a_stable_https_rp_origin_and_derives_its_rp_id() {
+    let origin = AuthOrigin::parse("https://relay.example.test:8443").expect("valid stable origin");
+
+    assert_eq!(origin.as_str(), "https://relay.example.test:8443/");
+    assert_eq!(origin.rp_id(), "relay.example.test");
+}
+
+#[test]
+fn rejects_insecure_or_non_origin_rp_configuration() {
+    assert_eq!(
+        AuthOrigin::parse("http://relay.example.test").unwrap_err(),
+        AuthError::InsecureOrigin
+    );
+    assert_eq!(
+        AuthOrigin::parse("https://relay.example.test/auth").unwrap_err(),
+        AuthError::InvalidOrigin
+    );
+}

--- a/docs/PRODUCT_CONTEXT.md
+++ b/docs/PRODUCT_CONTEXT.md
@@ -4,7 +4,8 @@
 
 Later issues may introduce these terms only with explicit ownership and storage decisions:
 
-- **Node** — a future execution location, not yet a remote control plane.
+- **Operator session** — a scoped, revocable browser authority created only after WebAuthn passkey verification; never a node credential.
+- **Node** — an execution location whose identity/credentials remain distinct from browser authority and are not remotely controlled by this slice.
 - **Workspace** — a future mission grouping, not yet persisted.
 - **Session** — a future work execution identity, not yet a process or provider adapter.
 - **Message** — a future scoped communication record, not yet a mailbox.
@@ -14,12 +15,13 @@ Later issues may introduce these terms only with explicit ownership and storage 
 
 - `relay-hub` serves `GET /health` with a bounded liveness record.
 - `relay-node probe` prints the same record for the node identity.
-- The PWA shell renders that record and nothing else.
+- The PWA shell renders liveness plus passkey enrollment, sign-in, typed unsupported/denied/recovery, and trusted-browser revoke controls.
+- The hub validates WebAuthn at one configured HTTPS origin, issues revocable browser sessions for protected hub actions, and denies browser sessions at the node boundary.
 
 ## Authority and data path
 
-The factory owns no process, provider, filesystem, authentication, browser-control, cross-node, or product-state authority. The web shell reads the hub health endpoint only. No client write path or persistence exists.
+The factory owns no process, provider, browser-control grant, cross-node, or product-state authority. The #1143 client write path is limited to server-side passkey ceremonies and browser-session revocation at the configured origin. Credentials, ceremonies, and session/device records are bounded in-memory state; no browser session becomes node authority.
 
 ## Deferred scope
 
-PTY/RMUX, Codex, Hermes, provider adapters, mailbox, passkeys, files, Workspace persistence, layout, browser control, cross-node behavior, and legacy API compatibility are outside #1137.
+PTY/RMUX, Codex, Hermes, provider adapters, mailbox, files, durable Workspace persistence, layout, browser-control grants, node credential rotation, cross-node behavior, and legacy API compatibility remain deferred.

--- a/docs/adrs/ADR-0002-passkey-auth-boundary.md
+++ b/docs/adrs/ADR-0002-passkey-auth-boundary.md
@@ -1,0 +1,24 @@
+# ADR-0002: passkey-first operator boundary
+
+- **Status:** accepted
+- **Date:** 2026-07-12
+
+## Context
+
+The factory now needs a human operator boundary without reintroducing repeated PIN prompts, anonymous browser control, or ambient browser-to-node authority. A passkey ceremony is only meaningful when the relying-party origin is stable and the server retains its challenge state.
+
+## Decision
+
+`relay-hub serve` accepts authentication only when both `--origin https://…` and `--recovery-code-hash <sha256hex>` are configured. The origin must be a single HTTPS origin with no path, credentials, query, or fragment; its host becomes the RP ID. State-changing authentication endpoints require the exact browser `Origin` header.
+
+The hub uses `webauthn-rs` passkey ceremonies with required user verification. Registration and sign-in state remains server-side, expires after five minutes, and is removed before verification, making replay and concurrent duplicate verification fail closed. Credentials are capped at eight and are process-local in this MVP. A restart clears credentials and browser sessions; the out-of-band recovery code can authorize only replacement-passkey enrollment and never issues a session.
+
+A successful assertion creates a fresh, opaque, 30-minute `__Host-relay_session` cookie. The server stores only a SHA-256 digest of that token and an independent CSRF-token digest. Cookies are Secure, SameSite=Strict, scoped to the host, and the session cookie is HttpOnly. State-changing session/device requests require exact-origin checks plus the double-submit CSRF token. Session records are capped at eight; the oldest is invalidated before a new session is issued. Revocation removes the server-side record, so later protected-hub calls fail closed. The recovery-code digest cannot prove input entropy, so operators must provision the raw recovery value from at least 32 random bytes and protect it from normal logs.
+
+Browser session endpoints authorize hub actions only. The node route returns `node_authority_required`; no browser session is accepted as a node credential, and the PWA makes no node-identity or credential-rotation request.
+
+## Consequences
+
+The raw factory listener does not terminate TLS. A stable HTTPS reverse proxy must serve the PWA and proxy the auth endpoints at the configured origin; plaintext local development intentionally presents the unsupported browser state. This slice does not add durable credential storage, pairing, multi-node trust, provider credential sync, or a PIN-primary fallback.
+
+The browser matrix uses Chromium's CDP virtual authenticator behind a test-only self-signed HTTPS proxy. It exercises the real PWA WebAuthn API and verifier while clearly remaining a virtual-authenticator seam rather than device-hardware evidence.

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   "scripts": {
     "toolchain:check": "node scripts/check-toolchains.mjs",
     "dev": "node scripts/dev.mjs",
-    "test": "npm run toolchain:check && sh scripts/cargo.sh test --workspace --locked && node --test web/test/*.test.mjs && npm run smoke",
+    "test": "npm run toolchain:check && sh scripts/cargo.sh test --workspace --locked && node --test web/test/*.test.mjs && npm run smoke && npm run auth:smoke && npm run auth:browser",
     "lint": "npm run toolchain:check && sh scripts/cargo.sh fmt --all -- --check && sh scripts/cargo.sh clippy --workspace --all-targets --locked -- -D warnings && node scripts/lint-web.mjs",
     "build": "npm run toolchain:check && sh scripts/cargo.sh build --workspace --locked && node scripts/build-web.mjs",
     "bench": "npm run toolchain:check && sh scripts/cargo.sh bench --workspace --no-run --locked",
-    "smoke": "node scripts/smoke.mjs"
+    "smoke": "node scripts/smoke.mjs",
+    "auth:smoke": "node scripts/auth-smoke.mjs",
+    "auth:browser": "node scripts/passkey-browser-smoke.mjs"
   }
 }

--- a/scripts/auth-smoke.mjs
+++ b/scripts/auth-smoke.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createConnection } from "node:net";
+
+const recoveryCode = "test-recovery-code";
+const recoveryHash = createHash("sha256").update(recoveryCode).digest("hex");
+const origin = "https://relay.example.test";
+const hub = spawn(
+  "cargo",
+  [
+    "run",
+    "--quiet",
+    "-p",
+    "relay-hub",
+    "--",
+    "serve",
+    "--bind",
+    "127.0.0.1:0",
+    "--origin",
+    origin,
+    "--recovery-code-hash",
+    recoveryHash,
+  ],
+  { stdio: ["ignore", "pipe", "pipe"] },
+);
+const exited = once(hub, "exit");
+let output = "";
+hub.stdout.setEncoding("utf8");
+hub.stdout.on("data", (chunk) => {
+  output += chunk;
+});
+hub.stderr.setEncoding("utf8");
+hub.stderr.on("data", (chunk) => {
+  output += chunk;
+});
+
+try {
+  const address = await waitForListener();
+
+  await assertError(address, "GET /protected/hub HTTP/1.1\r\nHost: relay.example.test\r\n\r\n", 401, "session_missing");
+  await assertError(
+    address,
+    post("/auth/passkeys/enroll/options", { "x-relay-recovery-code": recoveryCode }),
+    403,
+    "origin_mismatch",
+  );
+  await assertError(
+    address,
+    post("/auth/passkeys/enroll/options", {
+      origin: "https://wrong.example.test",
+      "x-relay-recovery-code": recoveryCode,
+    }),
+    403,
+    "origin_mismatch",
+  );
+  await assertError(
+    address,
+    post("/auth/passkeys/enroll/options", {
+      origin,
+      "x-relay-recovery-code": "wrong-recovery-code",
+    }),
+    403,
+    "recovery_denied",
+  );
+
+  const enrollment = await request(
+    address,
+    post("/auth/passkeys/enroll/options", {
+      origin,
+      "x-relay-recovery-code": recoveryCode,
+    }),
+  );
+  assert.equal(enrollment.status, 200);
+  assert.ok(enrollment.headers["set-cookie"]?.includes("__Host-relay_ceremony="));
+  assert.ok(enrollment.headers["set-cookie"]?.includes("HttpOnly"));
+  assert.ok(enrollment.headers["set-cookie"]?.includes("Secure"));
+  assert.ok(enrollment.headers["set-cookie"]?.includes("SameSite=Strict"));
+  assert.ok(enrollment.body.includes("publicKey"));
+  assert.doesNotMatch(enrollment.body, new RegExp(recoveryCode));
+
+  const ceremonyCookie = enrollment.headers["set-cookie"].split(";", 1)[0];
+  await assertError(
+    address,
+    post("/auth/passkeys/enroll/verify", { cookie: ceremonyCookie, origin }, "{}"),
+    403,
+    "passkey_denied",
+  );
+  await assertError(
+    address,
+    post("/auth/passkeys/enroll/verify", { cookie: ceremonyCookie, origin }, "{}"),
+    403,
+    "unknown_ceremony",
+  );
+  const concurrentEnrollment = await request(
+    address,
+    post("/auth/passkeys/enroll/options", {
+      origin,
+      "x-relay-recovery-code": recoveryCode,
+    }),
+  );
+  const concurrentCookie = concurrentEnrollment.headers["set-cookie"].split(";", 1)[0];
+  const concurrentResponses = await Promise.all(
+    ["first", "second"].map(() =>
+      request(address, post("/auth/passkeys/enroll/verify", { cookie: concurrentCookie, origin }, "{}")),
+    ),
+  );
+  assert.deepEqual(
+    concurrentResponses.map((response) => JSON.parse(response.body).error.code).sort(),
+    ["passkey_denied", "unknown_ceremony"],
+    "one raced verifier consumes the ceremony and the other must fail closed",
+  );
+  await assertError(
+    address,
+    "GET /protected/node HTTP/1.1\r\nHost: relay.example.test\r\nCookie: __Host-relay_session=not-a-node-credential\r\n\r\n",
+    403,
+    "node_authority_required",
+  );
+  assert.match(
+    output,
+    /^relay-hub liveness listening on 127\.0\.0\.1:\d+\n$/,
+    "the exercised recovery, ceremony, and denied-node path must not append secret-bearing auth data to hub logs",
+  );
+
+  console.log("passkey boundary HTTP smoke passed");
+} finally {
+  if (hub.exitCode === null) {
+    hub.kill("SIGTERM");
+  }
+  await exited;
+}
+
+async function waitForListener() {
+  const deadline = Date.now() + 10_000;
+  while (!output.includes("relay-hub liveness listening")) {
+    if (hub.exitCode !== null || Date.now() > deadline) {
+      throw new Error(`hub did not start: ${output}`);
+    }
+    await delay(25);
+  }
+  const address = output.match(/relay-hub liveness listening on (127\.0\.0\.1:\d+)/)?.[1];
+  if (!address) {
+    throw new Error(`hub reported an unsupported listener address: ${output}`);
+  }
+  return address;
+}
+
+function post(path, headers = {}, body = "") {
+  const fields = [
+    `POST ${path} HTTP/1.1`,
+    "Host: relay.example.test",
+    "Content-Type: application/json",
+    `Content-Length: ${Buffer.byteLength(body)}`,
+  ];
+  for (const [name, value] of Object.entries(headers)) {
+    fields.push(`${name}: ${value}`);
+  }
+  return `${fields.join("\r\n")}\r\n\r\n${body}`;
+}
+
+async function assertError(address, request_, status, code) {
+  const response = await request(address, request_);
+  assert.equal(response.status, status, response.raw);
+  assert.deepEqual(JSON.parse(response.body), { error: { code } });
+}
+
+async function request(address, request_) {
+  const [host, port] = address.split(":");
+  const socket = createConnection({ host, port: Number(port) });
+  let raw = "";
+  socket.setEncoding("utf8");
+  const closed = new Promise((resolve, reject) => {
+    socket.on("data", (chunk) => {
+      raw += chunk;
+    });
+    socket.once("error", reject);
+    socket.once("close", resolve);
+  });
+  await once(socket, "connect");
+  socket.end(request_);
+  await closed;
+
+  const [head, body = ""] = raw.split("\r\n\r\n", 2);
+  const [statusLine, ...headers] = head.split("\r\n");
+  const status = Number(statusLine.split(" ")[1]);
+  const parsedHeaders = Object.fromEntries(
+    headers.map((line) => {
+      const [name, ...value] = line.split(":");
+      return [name.toLowerCase(), value.join(":").trim()];
+    }),
+  );
+  return { body, headers: parsedHeaders, raw, status };
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/scripts/lint-web.mjs
+++ b/scripts/lint-web.mjs
@@ -3,6 +3,7 @@ import { access, constants, readFile } from "node:fs/promises";
 const requiredFiles = [
   "web/src/index.html",
   "web/src/main.js",
+  "web/src/auth.js",
   "web/public/manifest.webmanifest",
 ];
 
@@ -10,7 +11,7 @@ for (const file of requiredFiles) {
   await access(file, constants.R_OK);
 }
 
-const [page, app, manifest] = await Promise.all(requiredFiles.map((file) => readFile(file, "utf8")));
+const [page, app, auth, manifest] = await Promise.all(requiredFiles.map((file) => readFile(file, "utf8")));
 const errors = [];
 
 if (!page.includes("manifest.webmanifest")) {
@@ -19,8 +20,14 @@ if (!page.includes("manifest.webmanifest")) {
 if (!app.includes('const HEALTH_URL = "http://127.0.0.1:8787/health"')) {
   errors.push("PWA shell must use the documented liveness boundary");
 }
-if (/localStorage|document\.cookie|WebSocket|\/api\//.test(app)) {
-  errors.push("PWA shell must not acquire product-state or control authority");
+if (!app.includes("__Host-relay_csrf") || !app.includes("navigator.credentials")) {
+  errors.push("PWA shell must invoke only the passkey boundary with CSRF protection");
+}
+if (/localStorage|WebSocket|\/api\/|Authorization:/.test(app)) {
+  errors.push("PWA shell must not acquire ambient product or node authority");
+}
+if (!auth.includes("recovery_required") || !auth.includes("passkey_denied")) {
+  errors.push("PWA auth adapter must expose typed recovery and denied states");
 }
 if (!manifest.includes('"display": "standalone"')) {
   errors.push("PWA manifest must declare standalone display");

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -1,0 +1,329 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { createServer as createHttpServer, request as httpRequest } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import { access, mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, extname, resolve, sep } from "node:path";
+
+
+const chromium = "/usr/bin/chromium";
+const recoveryCode = "browser-virtual-authenticator-recovery";
+const root = resolve("web/src");
+const publicRoot = resolve("web/public");
+const scratch = await mkdtemp(`${tmpdir()}/relay-passkey-browser-`);
+const recoveryHash = createHash("sha256").update(recoveryCode).digest("hex");
+const httpsPort = await reservePort();
+const debugPort = await reservePort();
+const origin = `https://relay.test:${httpsPort}`;
+let hub;
+let proxy;
+let chromiumProcess;
+let browser;
+
+class Cdp {
+  static async connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolve_, reject) => {
+      socket.addEventListener("open", resolve_, { once: true });
+      socket.addEventListener("error", reject, { once: true });
+    });
+    return new Cdp(socket);
+  }
+
+  constructor(socket) {
+    this.socket = socket;
+    this.nextId = 1;
+    this.pending = new Map();
+    socket.addEventListener("message", (message) => {
+      const response = JSON.parse(message.data);
+      const pending = this.pending.get(response.id);
+      if (!pending) return;
+      this.pending.delete(response.id);
+      if (response.error) pending.reject(new Error(response.error.message));
+      else pending.resolve(response.result);
+    });
+  }
+
+  command(method, params = {}, sessionId) {
+    const id = this.nextId++;
+    this.socket.send(JSON.stringify({ id, method, params, ...(sessionId ? { sessionId } : {}) }));
+    return new Promise((resolve_, reject) => this.pending.set(id, { resolve: resolve_, reject }));
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+if (spawnSync(chromium, ["--version"], { encoding: "utf8" }).status !== 0) {
+  console.log("passkey browser matrix skipped: Chromium is unavailable");
+  process.exit(0);
+}
+
+try {
+  await createCertificate();
+  hub = startHub();
+  const hubAddress = await waitForHub(hub);
+  proxy = await startProxy(hubAddress.port);
+  chromiumProcess = spawn(
+    chromium,
+    [
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-gpu",
+      `--remote-debugging-port=${debugPort}`,
+      `--user-data-dir=${scratch}/chrome-profile`,
+      "--ignore-certificate-errors",
+      "--host-resolver-rules=MAP relay.test 127.0.0.1",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  browser = await connectBrowser();
+  const { targetId } = await browser.command("Target.createTarget", { url: "about:blank" });
+  const { sessionId } = await browser.command("Target.attachToTarget", { targetId, flatten: true });
+  await browser.command("Page.enable", {}, sessionId);
+  await browser.command("WebAuthn.enable", {}, sessionId);
+  await browser.command(
+    "WebAuthn.addVirtualAuthenticator",
+    {
+      options: {
+        protocol: "ctap2",
+        transport: "internal",
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    },
+    sessionId,
+  );
+  await browser.command("Page.navigate", { url: `${origin}/` }, sessionId);
+  await waitFor(async () => (await evaluate(sessionId, "document.readyState")) === "complete");
+
+  await evaluate(
+    sessionId,
+    `document.querySelector("#recovery-code").value = ${JSON.stringify(recoveryCode)}; document.querySelector("#enroll-passkey").click();`,
+  );
+  await waitFor(async () => (await evaluate(sessionId, "document.querySelector('#auth-status').textContent"))?.includes("Passkey enrolled"));
+
+  await evaluate(sessionId, "document.querySelector('#sign-in').click()");
+  await waitFor(async () => (await evaluate(sessionId, "document.querySelector('#auth-status').textContent"))?.includes("Passkey verified"));
+  assert.equal(
+    await evaluate(sessionId, "fetch('/protected/hub', { credentials: 'same-origin' }).then((response) => response.status)"),
+    200,
+    "a verified passkey must authorize the protected hub route",
+  );
+
+  const revokeStatuses = await evaluate(
+    sessionId,
+    `Promise.all(["first", "second"].map(async () => {
+      const sessions = await fetch("/auth/sessions", { credentials: "same-origin" }).then((response) => response.json());
+      const deviceId = sessions.sessions.find((session) => session.current).deviceId;
+      const csrf = document.cookie.split("; ").find((cookie) => cookie.startsWith("__Host-relay_csrf=")).slice("__Host-relay_csrf=".length);
+      return fetch("/auth/sessions/revoke", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json", "X-Relay-CSRF": csrf },
+        body: JSON.stringify({ deviceId }),
+      }).then((response) => response.status);
+    }))`,
+  );
+  assert.deepEqual(
+    revokeStatuses.sort(),
+    [200, 401],
+    "exactly one concurrent revoke must consume the session",
+  );
+  assert.equal(
+    await evaluate(sessionId, "fetch('/protected/hub', { credentials: 'same-origin' }).then((response) => response.status)"),
+    401,
+    "a concurrently revoked browser session must fail closed",
+  );
+  assert.equal(
+    await evaluate(sessionId, "fetch('/protected/node', { credentials: 'same-origin' }).then((response) => response.status)"),
+    403,
+    "a browser session must never become node authority",
+  );
+  assert.match(
+    hubAddress.output(),
+    /^relay-hub liveness listening on 127\.0\.0\.1:\d+\n$/,
+    "the real WebAuthn enrollment, assertion, session, and revoke path must not append credential or session material to hub logs",
+  );
+
+  console.log("passkey browser matrix passed with Chromium CDP virtual authenticator");
+} finally {
+  browser?.close();
+  proxy?.close();
+  if (hub?.exitCode === null) hub.kill("SIGTERM");
+  if (chromiumProcess?.exitCode === null) chromiumProcess.kill("SIGTERM");
+}
+
+function startHub() {
+  return spawn(
+    "cargo",
+    [
+      "run",
+      "--quiet",
+      "-p",
+      "relay-hub",
+      "--",
+      "serve",
+      "--bind",
+      "127.0.0.1:0",
+      "--origin",
+      origin,
+      "--recovery-code-hash",
+      recoveryHash,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+}
+
+async function waitForHub(process_) {
+  let output = "";
+  process_.stdout.setEncoding("utf8");
+  process_.stderr.setEncoding("utf8");
+  process_.stdout.on("data", (chunk) => {
+    output += chunk;
+  });
+  process_.stderr.on("data", (chunk) => {
+    output += chunk;
+  });
+  await waitFor(() => {
+    const match = output.match(/relay-hub liveness listening on 127\.0\.0\.1:(\d+)/);
+    if (match) return { port: Number(match[1]) };
+    if (process_.exitCode !== null) throw new Error(`hub exited before startup: ${output}`);
+    return false;
+  });
+  return {
+    output: () => output,
+    port: Number(output.match(/relay-hub liveness listening on 127\.0\.0\.1:(\d+)/)[1]),
+  };
+}
+
+async function createCertificate() {
+  const result = spawnSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      `${scratch}/key.pem`,
+      "-out",
+      `${scratch}/cert.pem`,
+      "-days",
+      "1",
+      "-subj",
+      "/CN=relay.test",
+      "-addext",
+      "subjectAltName=DNS:relay.test",
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) throw new Error(`could not create browser test certificate: ${result.stderr}`);
+}
+
+async function startProxy(hubPort) {
+  const [key, cert] = await Promise.all([readFile(`${scratch}/key.pem`), readFile(`${scratch}/cert.pem`)]);
+  const server = createHttpsServer({ key, cert }, (request, response) => {
+    const path = new URL(request.url ?? "/", origin).pathname;
+    if (path.startsWith("/auth/") || path.startsWith("/protected/")) {
+      const upstream = httpRequest(
+        {
+          host: "127.0.0.1",
+          port: hubPort,
+          method: request.method,
+          path: request.url,
+          headers: request.headers,
+        },
+        (upstreamResponse) => {
+          response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+          upstreamResponse.pipe(response);
+        },
+      );
+      upstream.on("error", () => response.writeHead(502).end());
+      request.pipe(upstream);
+      return;
+    }
+    void serveStatic(path, response);
+  });
+  server.listen(httpsPort, "127.0.0.1");
+  await once(server, "listening");
+  return server;
+}
+
+async function serveStatic(path, response) {
+  const relative = path === "/" ? "index.html" : path.slice(1);
+  const base = relative === "manifest.webmanifest" ? publicRoot : root;
+  const file = resolve(base, relative);
+  if (!file.startsWith(`${base}${sep}`) && file !== base) {
+    response.writeHead(404).end();
+    return;
+  }
+  try {
+    await access(file);
+    const content = await readFile(file);
+    response.writeHead(200, {
+      "Cache-Control": "no-store",
+      "Content-Type": contentType(extname(file)),
+    });
+    response.end(content);
+  } catch {
+    response.writeHead(404).end();
+  }
+}
+
+function contentType(extension) {
+  return new Map([
+    [".html", "text/html; charset=utf-8"],
+    [".js", "text/javascript; charset=utf-8"],
+    [".webmanifest", "application/manifest+json"],
+  ]).get(extension) ?? "application/octet-stream";
+}
+
+async function reservePort() {
+  const server = createHttpServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  await new Promise((resolve_) => server.close(resolve_));
+  return port;
+}
+
+async function connectBrowser() {
+  await waitFor(async () => {
+    try {
+      const response = await fetch(`http://127.0.0.1:${debugPort}/json/version`);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  });
+  const version = await fetch(`http://127.0.0.1:${debugPort}/json/version`).then((response) => response.json());
+  return Cdp.connect(version.webSocketDebuggerUrl);
+}
+
+async function evaluate(sessionId, expression) {
+  const response = await browser.command(
+    "Runtime.evaluate",
+    { expression, awaitPromise: true, returnByValue: true },
+    sessionId,
+  );
+  if (response.exceptionDetails) throw new Error(response.exceptionDetails.text);
+  return response.result.value;
+}
+
+async function waitFor(predicate) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await predicate();
+    if (result) return result;
+    await new Promise((resolve_) => setTimeout(resolve_, 50));
+  }
+  throw new Error("timed out waiting for browser matrix state");
+}

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -105,6 +105,37 @@ try {
 
   await evaluate(
     sessionId,
+    `Object.defineProperty(navigator.credentials, "create", { configurable: true, value: async () => null });`,
+  );
+  assert.equal(
+    await recoveryValueAfterFailedEnrollment(sessionId),
+    "",
+    "recovery code must clear when WebAuthn enrollment returns no credential",
+  );
+  await evaluate(sessionId, "delete navigator.credentials.create");
+  await evaluate(
+    sessionId,
+    `Object.defineProperty(navigator.credentials, "create", { configurable: true, value: async () => { throw new DOMException("denied", "NotAllowedError"); } });`,
+  );
+  assert.equal(
+    await recoveryValueAfterFailedEnrollment(sessionId),
+    "",
+    "recovery code must clear when WebAuthn enrollment rejects",
+  );
+  await evaluate(sessionId, "delete navigator.credentials.create");
+  await evaluate(
+    sessionId,
+    `window.relayOriginalFetch = window.fetch; window.fetch = async (input, init) => { if (new URL(typeof input === "string" ? input : input.url, window.location.href).pathname === "/auth/passkeys/enroll/options") throw new TypeError("network unavailable"); return window.relayOriginalFetch(input, init); };`,
+  );
+  assert.equal(
+    await recoveryValueAfterFailedEnrollment(sessionId),
+    "",
+    "recovery code must clear when enrollment options fail over the network",
+  );
+  await evaluate(sessionId, "window.fetch = window.relayOriginalFetch; delete window.relayOriginalFetch");
+
+  await evaluate(
+    sessionId,
     `document.querySelector("#recovery-code").value = ${JSON.stringify(recoveryCode)}; document.querySelector("#enroll-passkey").click();`,
   );
   await waitFor(async () => (await evaluate(sessionId, "document.querySelector('#auth-status').textContent"))?.includes("Passkey enrolled"));
@@ -115,6 +146,14 @@ try {
     await evaluate(sessionId, "fetch('/protected/hub', { credentials: 'same-origin' }).then((response) => response.status)"),
     200,
     "a verified passkey must authorize the protected hub route",
+  );
+  const { cookies } = await browser.command("Network.getAllCookies", {}, sessionId);
+  const sessionCookie = cookies.find((cookie) => cookie.name === "__Host-relay_session")?.value;
+  assert.ok(sessionCookie, "a verified passkey must create an HttpOnly browser session cookie");
+  assert.equal(
+    await protectedHubStatus(hubAddress.port, sessionCookie),
+    200,
+    "a valueless unrelated Cookie segment must not invalidate a valid browser session",
   );
 
   const revokeStatuses = await evaluate(
@@ -201,6 +240,34 @@ async function waitForHub(process_) {
     output: () => output,
     port: Number(output.match(/relay-hub liveness listening on 127\.0\.0\.1:(\d+)/)[1]),
   };
+}
+
+async function protectedHubStatus(port, sessionCookie) {
+  return new Promise((resolve_, reject) => {
+    const request = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/protected/hub",
+        headers: { Cookie: `__Host-relay_session=${sessionCookie}; legacy` },
+      },
+      (response) => {
+        response.resume();
+        response.once("end", () => resolve_(response.statusCode));
+      },
+    );
+    request.once("error", reject);
+    request.end();
+  });
+}
+
+async function recoveryValueAfterFailedEnrollment(sessionId) {
+  await evaluate(
+    sessionId,
+    `document.querySelector("#auth-status").textContent = ""; document.querySelector("#recovery-code").value = ${JSON.stringify(recoveryCode)}; document.querySelector("#enroll-passkey").click();`,
+  );
+  await waitFor(async () => Boolean(await evaluate(sessionId, "document.querySelector('#auth-status').textContent")));
+  return evaluate(sessionId, "document.querySelector('#recovery-code').value");
 }
 
 async function createCertificate() {

--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -1,0 +1,92 @@
+function base64UrlToBuffer(value) {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (character) => character.codePointAt(0)).buffer;
+}
+
+function bufferToBase64Url(value) {
+  const bytes = new Uint8Array(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function decodeCredentialDescriptors(descriptors) {
+  return descriptors?.map((descriptor) => ({ ...descriptor, id: base64UrlToBuffer(descriptor.id) }));
+}
+
+export function decodePublicKeyOptions(options) {
+  const publicKey = { ...options.publicKey, challenge: base64UrlToBuffer(options.publicKey.challenge) };
+  if (publicKey.user) {
+    publicKey.user = { ...publicKey.user, id: base64UrlToBuffer(publicKey.user.id) };
+  }
+  publicKey.excludeCredentials = decodeCredentialDescriptors(publicKey.excludeCredentials);
+  publicKey.allowCredentials = decodeCredentialDescriptors(publicKey.allowCredentials);
+  return publicKey;
+}
+
+export function credentialToJson(credential) {
+  const response = credential.response;
+  const common = {
+    id: credential.id,
+    rawId: bufferToBase64Url(credential.rawId),
+    type: credential.type,
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+  if ("attestationObject" in response) {
+    return {
+      ...common,
+      response: {
+        attestationObject: bufferToBase64Url(response.attestationObject),
+        clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+        transports: response.getTransports?.(),
+      },
+    };
+  }
+  return {
+    ...common,
+    response: {
+      authenticatorData: bufferToBase64Url(response.authenticatorData),
+      clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+      signature: bufferToBase64Url(response.signature),
+      userHandle: response.userHandle ? bufferToBase64Url(response.userHandle) : null,
+    },
+  };
+}
+
+export function isPasskeySupported(environment) {
+  return Boolean(environment.isSecureContext && environment.navigator?.credentials?.create && environment.navigator?.credentials?.get);
+}
+
+export function presentationForAuthError(error) {
+  const code = error?.code ?? (error?.name === "NotAllowedError" ? "passkey_denied" : "unsupported");
+  switch (code) {
+    case "passkey_denied":
+      return {
+        code,
+        message: "The passkey ceremony was cancelled or denied. No weaker sign-in method was used.",
+      };
+    case "recovery_required":
+      return {
+        code,
+        message: "No enrolled passkey is available. Recovery can enroll a replacement passkey but cannot sign you in.",
+      };
+    case "origin_mismatch":
+      return {
+        code,
+        message: "This page is not at Relay's configured secure origin, so passkey requests are blocked.",
+      };
+    case "recovery_denied":
+      return {
+        code,
+        message: "Recovery was denied. It never falls back to a PIN or anonymous session.",
+      };
+    default:
+      return {
+        code: "unsupported",
+        message: "This browser or origin cannot run a secure passkey ceremony.",
+      };
+  }
+}

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -11,6 +11,23 @@
     <main>
       <h1>Relay factory</h1>
       <p id="status" aria-live="polite">Checking hub liveness…</p>
+      <section aria-labelledby="passkey-heading">
+        <h2 id="passkey-heading">Operator passkey</h2>
+        <p id="auth-status" aria-live="polite">Checking passkey support…</p>
+        <label for="recovery-code">Recovery code (enrollment only)</label>
+        <input id="recovery-code" type="password" autocomplete="off" />
+        <p>Recovery can enroll a replacement passkey. It never signs an operator in.</p>
+        <button id="enroll-passkey" type="button">Enroll passkey</button>
+        <button id="sign-in" type="button">Sign in with passkey</button>
+        <button id="refresh-sessions" type="button">Refresh trusted devices</button>
+        <button id="revoke-current" type="button" disabled>Revoke this browser session</button>
+        <p id="session-status" aria-live="polite"></p>
+        <ul id="trusted-devices" aria-label="Trusted browser sessions"></ul>
+      </section>
+      <section aria-labelledby="node-heading">
+        <h2 id="node-heading">Node authority</h2>
+        <p>Node credentials remain separate from the browser session. This screen cannot rotate, mint, or export node authority.</p>
+      </section>
     </main>
     <script type="module" src="./main.js"></script>
   </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -52,6 +52,7 @@ revokeCurrent.addEventListener("click", () => void revokeCurrentSession());
 
 async function enroll() {
   const recovery = recoveryCode.value;
+  recoveryCode.value = "";
   const headers = {};
   if (recovery) {
     headers["X-Relay-Recovery-Code"] = recovery;
@@ -61,7 +62,6 @@ async function enroll() {
   if (!(await runCeremony("/auth/passkeys/enroll/options", "/auth/passkeys/enroll/verify", "create", headers))) {
     return;
   }
-  recoveryCode.value = "";
   authStatus.textContent = "Passkey enrolled. Sign in with that passkey to create a browser session.";
 }
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,5 +1,21 @@
+import {
+  credentialToJson,
+  decodePublicKeyOptions,
+  isPasskeySupported,
+  presentationForAuthError,
+} from "./auth.js";
+
 const HEALTH_URL = "http://127.0.0.1:8787/health";
 const status = document.querySelector("#status");
+const authStatus = document.querySelector("#auth-status");
+const recoveryCode = document.querySelector("#recovery-code");
+const enrollPasskey = document.querySelector("#enroll-passkey");
+const signIn = document.querySelector("#sign-in");
+const refreshSessions = document.querySelector("#refresh-sessions");
+const revokeCurrent = document.querySelector("#revoke-current");
+const sessionStatus = document.querySelector("#session-status");
+const trustedDevices = document.querySelector("#trusted-devices");
+let currentDeviceId = null;
 
 async function renderLiveness() {
   try {
@@ -20,3 +36,138 @@ async function renderLiveness() {
 }
 
 void renderLiveness();
+
+if (isPasskeySupported(window)) {
+  authStatus.textContent = "This browser can use a passkey at Relay's configured secure origin.";
+} else {
+  authStatus.textContent = presentationForAuthError().message;
+  enrollPasskey.disabled = true;
+  signIn.disabled = true;
+}
+
+enrollPasskey.addEventListener("click", () => void enroll().catch(() => {}));
+signIn.addEventListener("click", () => void signInWithPasskey().catch(() => {}));
+refreshSessions.addEventListener("click", () => void refreshTrustedDevices());
+revokeCurrent.addEventListener("click", () => void revokeCurrentSession());
+
+async function enroll() {
+  const recovery = recoveryCode.value;
+  const headers = {};
+  if (recovery) {
+    headers["X-Relay-Recovery-Code"] = recovery;
+  } else {
+    headers["X-Relay-CSRF"] = csrfToken();
+  }
+  if (!(await runCeremony("/auth/passkeys/enroll/options", "/auth/passkeys/enroll/verify", "create", headers))) {
+    return;
+  }
+  recoveryCode.value = "";
+  authStatus.textContent = "Passkey enrolled. Sign in with that passkey to create a browser session.";
+}
+
+async function signInWithPasskey() {
+  if (!(await runCeremony("/auth/passkeys/sign-in/options", "/auth/passkeys/sign-in/verify", "get"))) {
+    return;
+  }
+  authStatus.textContent = "Passkey verified. This browser session is scoped to hub actions only.";
+  await refreshTrustedDevices();
+}
+
+async function runCeremony(optionsPath, verifyPath, operation, headers = {}) {
+  try {
+    const options = await request(optionsPath, { method: "POST", headers });
+    const credential = await navigator.credentials[operation]({ publicKey: decodePublicKeyOptions(options) });
+    if (!credential) {
+      throw { name: "NotAllowedError" };
+    }
+    await request(verifyPath, {
+      method: "POST",
+      body: JSON.stringify(credentialToJson(credential)),
+    });
+    return true;
+  } catch (error) {
+    const presentation = presentationForAuthError(error);
+    authStatus.textContent = presentation.message;
+    return false;
+  }
+}
+
+async function refreshTrustedDevices() {
+  try {
+    const response = await request("/auth/sessions");
+    const current = response.sessions.find((session) => session.current);
+    currentDeviceId = current?.deviceId ?? null;
+    revokeCurrent.disabled = !currentDeviceId;
+    renderTrustedDevices(response.sessions);
+    sessionStatus.textContent = currentDeviceId
+      ? `${response.sessions.length} trusted browser session(s).`
+      : "No active browser session.";
+  } catch (error) {
+    const presentation = presentationForAuthError(error);
+    sessionStatus.textContent = presentation.code === "unsupported" ? "No active browser session." : presentation.message;
+    revokeCurrent.disabled = true;
+    trustedDevices.replaceChildren();
+  }
+}
+
+async function revokeCurrentSession() {
+  if (!currentDeviceId) {
+    return;
+  }
+  await revokeSession(currentDeviceId);
+}
+
+function renderTrustedDevices(sessions) {
+  trustedDevices.replaceChildren(
+    ...sessions.map((session) => {
+      const item = document.createElement("li");
+      const revoke = document.createElement("button");
+      revoke.type = "button";
+      revoke.textContent = session.current ? "Revoke this browser session" : "Revoke browser session";
+      revoke.addEventListener("click", () => void revokeSession(session.deviceId));
+      item.append(session.current ? "This browser session " : "Other browser session ", revoke);
+      return item;
+    }),
+  );
+}
+
+async function revokeSession(deviceId) {
+  const revokingCurrent = deviceId === currentDeviceId;
+  try {
+    await request("/auth/sessions/revoke", {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: JSON.stringify({ deviceId }),
+    });
+    if (revokingCurrent) {
+      currentDeviceId = null;
+      revokeCurrent.disabled = true;
+      trustedDevices.replaceChildren();
+      sessionStatus.textContent = "This browser session was revoked. Protected hub calls now fail closed.";
+    } else {
+      await refreshTrustedDevices();
+    }
+  } catch (error) {
+    authStatus.textContent = presentationForAuthError(error).message;
+  }
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(path, {
+    ...options,
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json", ...options.headers },
+  });
+  const body = await response.json();
+  if (!response.ok) {
+    throw body.error;
+  }
+  return body;
+}
+
+function csrfToken() {
+  return document.cookie
+    .split("; ")
+    .find((value) => value.startsWith("__Host-relay_csrf="))
+    ?.slice("__Host-relay_csrf=".length) ?? "";
+}

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -4,14 +4,24 @@ import test from "node:test";
 
 const source = new URL("../src/", import.meta.url);
 
-test("the PWA shell consumes only the hub liveness boundary", async () => {
-  const [page, app] = await Promise.all([
+test("the PWA shell exposes typed passkey and node-boundary states", async () => {
+  const [page, app, auth] = await Promise.all([
     readFile(new URL("index.html", source), "utf8"),
     readFile(new URL("main.js", source), "utf8"),
+    readFile(new URL("auth.js", source), "utf8"),
   ]);
 
   assert.match(page, /manifest\.webmanifest/);
+  assert.match(page, /id="enroll-passkey"/);
+  assert.match(page, /id="sign-in"/);
+  assert.match(page, /id="trusted-devices"/);
+  assert.match(page, /Node credentials remain separate/);
   assert.match(app, /http:\/\/127\.0\.0\.1:8787\/health/);
-  assert.match(app, /health\.service !== "hub"/);
-  assert.doesNotMatch(app, /localStorage|document\.cookie|WebSocket|\/api\//);
+  assert.match(app, /__Host-relay_csrf/);
+  assert.match(app, /function renderTrustedDevices/);
+  assert.match(app, /function revokeSession/);
+  assert.match(app, /navigator\.credentials\[operation\]/);
+  assert.match(auth, /recovery_required/);
+  assert.doesNotMatch(app, /localStorage|WebSocket|\/api\/|Authorization:/);
+  assert.doesNotMatch(page, /PIN.*sign-in/i);
 });

--- a/web/test/auth.test.mjs
+++ b/web/test/auth.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  credentialToJson,
+  decodePublicKeyOptions,
+  isPasskeySupported,
+  presentationForAuthError,
+} from "../src/auth.js";
+
+const base64Url = Buffer.from([0, 1, 2, 253, 254, 255]).toString("base64url");
+
+test("decodes WebAuthn challenge fields into browser binary options", () => {
+  const options = decodePublicKeyOptions({
+    publicKey: {
+      challenge: base64Url,
+      user: { id: base64Url, name: "operator", displayName: "Relay operator" },
+      excludeCredentials: [{ id: base64Url, type: "public-key" }],
+    },
+  });
+
+  assert.deepEqual([...new Uint8Array(options.challenge)], [0, 1, 2, 253, 254, 255]);
+  assert.deepEqual([...new Uint8Array(options.user.id)], [0, 1, 2, 253, 254, 255]);
+  assert.deepEqual([...new Uint8Array(options.excludeCredentials[0].id)], [0, 1, 2, 253, 254, 255]);
+});
+
+test("serializes a credential response without retaining browser secrets", () => {
+  const credential = {
+    id: "credential-id",
+    rawId: Uint8Array.from([1, 2, 3]).buffer,
+    type: "public-key",
+    getClientExtensionResults: () => ({ credProps: { rk: false } }),
+    response: {
+      clientDataJSON: Uint8Array.from([4, 5]).buffer,
+      attestationObject: Uint8Array.from([6, 7]).buffer,
+      getTransports: () => ["internal"],
+    },
+  };
+
+  assert.deepEqual(credentialToJson(credential), {
+    id: "credential-id",
+    rawId: "AQID",
+    response: {
+      attestationObject: "Bgc",
+      clientDataJSON: "BAU",
+      transports: ["internal"],
+    },
+    clientExtensionResults: { credProps: { rk: false } },
+    type: "public-key",
+  });
+});
+
+test("classifies unsupported, denied, and recovery flows without PIN fallback", () => {
+  assert.equal(isPasskeySupported({ isSecureContext: false, navigator: {} }), false);
+  assert.equal(isPasskeySupported({ isSecureContext: true, navigator: { credentials: {} } }), false);
+  assert.deepEqual(presentationForAuthError({ name: "NotAllowedError" }), {
+    code: "passkey_denied",
+    message: "The passkey ceremony was cancelled or denied. No weaker sign-in method was used.",
+  });
+  assert.deepEqual(presentationForAuthError({ code: "recovery_required" }), {
+    code: "recovery_required",
+    message: "No enrolled passkey is available. Recovery can enroll a replacement passkey but cannot sign you in.",
+  });
+});


### PR DESCRIPTION
## Summary
- add stable-origin WebAuthn enrollment and sign-in with server-side, one-time ceremonies
- issue revocable Secure/HttpOnly browser sessions with CSRF protection; browser authority is explicitly denied at the node boundary
- add typed PWA unsupported/denied/recovery states, trusted-browser session management, raw HTTP redaction/replay checks, and a Chromium virtual-authenticator matrix

## Security decisions
- recovery can authorize replacement-passkey enrollment only and never mints a browser session
- credentials, ceremonies, and sessions are bounded process-local MVP state; restart requires recovery enrollment
- recovery values must be generated from at least 32 random bytes and kept out of normal logs

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run bench`
- Chromium CDP virtual-authenticator path exercised by `npm run auth:browser`

Refs #1136
Refs #1143