### PR TITLE
feat: add Hermes rich-client Session adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,9 +684,12 @@ dependencies = [
 name = "relay-node"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "relay-factory-core",
  "relay-hermes-session",
  "relay-session",
+ "serde_json",
+ "sha1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,76 @@
 version = 4
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
@@ -37,6 +103,15 @@ name = "relay-factory-core"
 version = "0.1.0"
 
 [[package]]
+name = "relay-hermes-session"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "serde_json",
+ "sha1",
+]
+
+[[package]]
 name = "relay-hub"
 version = "0.1.0"
 dependencies = [
@@ -48,6 +123,7 @@ name = "relay-node"
 version = "0.1.0"
 dependencies = [
  "relay-factory-core",
+ "relay-hermes-session",
  "relay-session",
 ]
 
@@ -101,6 +177,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,10 +199,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +118,7 @@ name = "relay-hermes-session"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "getrandom",
  "serde_json",
  "sha1",
 ]
@@ -215,6 +227,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/relay-factory-core",
   "crates/relay-session",
+  "crates/relay-hermes-session",
   "apps/relay-hub",
   "apps/relay-node",
 ]

--- a/apps/relay-node/Cargo.toml
+++ b/apps/relay-node/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 relay-factory-core = { path = "../../crates/relay-factory-core" }
 relay-session = { path = "../../crates/relay-session" }
+relay-hermes-session = { path = "../../crates/relay-hermes-session" }
 
 [lints]
 workspace = true

--- a/apps/relay-node/Cargo.toml
+++ b/apps/relay-node/Cargo.toml
@@ -10,5 +10,10 @@ relay-factory-core = { path = "../../crates/relay-factory-core" }
 relay-session = { path = "../../crates/relay-session" }
 relay-hermes-session = { path = "../../crates/relay-hermes-session" }
 
+[dev-dependencies]
+base64 = "0.22"
+serde_json = "1.0"
+sha1 = "0.10"
+
 [lints]
 workspace = true

--- a/apps/relay-node/src/main.rs
+++ b/apps/relay-node/src/main.rs
@@ -161,7 +161,7 @@ fn run_hermes_smoke(arguments: &[String]) -> Result<String, AdapterError> {
         let remaining = deadline.saturating_duration_since(Instant::now());
         match adapter.pump(remaining.min(Duration::from_millis(250))) {
             Ok(()) | Err(AdapterError::Timeout) => {}
-            Err(AdapterError::GatewayLost) => break,
+            Err(AdapterError::GatewayLost) => return Err(AdapterError::GatewayLost),
             Err(error) => return Err(error),
         }
     }
@@ -189,7 +189,7 @@ fn run_hermes_smoke(arguments: &[String]) -> Result<String, AdapterError> {
     };
 
     Ok(format!(
-        "{{\"adapter\":\"hermes-rich-client\",\"create\":true,\"list_count\":{},\"resume\":{},\"prompt\":true,\"observed_events\":{},\"tool_events\":{},\"interaction_events\":{},\"unsupported_events\":{},\"foreign_events\":{},\"dropped_events\":{},\"status\":\"{}\"}}",
+        "{{\"adapter\":\"hermes-rich-client\",\"create\":true,\"list_count\":{},\"resume\":{},\"prompt\":true,\"observed_events\":{},\"tool_events\":{},\"interaction_events\":{},\"unsupported_events\":{},\"foreign_events\":{},\"dropped_events\":{},\"interaction_limited\":{},\"status\":\"{}\"}}",
         listed.len(),
         !resumed.live_id.is_empty(),
         event_count,
@@ -198,6 +198,7 @@ fn run_hermes_smoke(arguments: &[String]) -> Result<String, AdapterError> {
         signals.unsupported,
         signals.foreign,
         signals.dropped,
+        signals.interaction_limited,
         status,
     ))
 }

--- a/apps/relay-node/src/main.rs
+++ b/apps/relay-node/src/main.rs
@@ -1,6 +1,13 @@
-use std::{env, process::ExitCode};
+use std::{
+    env,
+    process::ExitCode,
+    time::{Duration, Instant},
+};
 
 use relay_factory_core::{ServiceIdentity, configured_identity, health_json};
+use relay_hermes_session::{
+    AdapterError, EventKind, GatewayEndpoint, HermesSessionAdapter, SessionStatus,
+};
 use relay_session::{
     DEFAULT_DEADLINE, ProcessTransport, SessionError, Supervisor,
     codex::{assert_local_stdio_only, codex_command_args},
@@ -25,9 +32,21 @@ fn main() -> ExitCode {
         [command, probe_arguments @ ..] if command == "codex-stdio-probe" => {
             codex_stdio_probe(probe_arguments)
         }
+        [command, smoke_arguments @ ..] if command == "hermes-smoke" => {
+            match run_hermes_smoke(smoke_arguments) {
+                Ok(summary) => {
+                    println!("{summary}");
+                    ExitCode::SUCCESS
+                }
+                Err(error) => {
+                    eprintln!("{{\"error\":{{\"code\":\"{}\"}}}}", error.code());
+                    ExitCode::from(2)
+                }
+            }
+        }
         _ => {
             eprintln!(
-                "usage: relay-node <probe [--identity node]|codex-stdio-probe [--negative-transport|--handshake|--exercise]>"
+                "usage: relay-node <probe [--identity node]|codex-stdio-probe [--negative-transport|--handshake|--exercise]|hermes-smoke --gateway-url ws://127.0.0.1:PORT/api/ws?token=... [--cwd PATH] [--prompt TEXT] [--observe-ms 0..30000]>"
             );
             ExitCode::from(64)
         }
@@ -123,4 +142,107 @@ fn live_stdio_probe(exercise_turn: bool) -> ExitCode {
 fn probe_error(error: SessionError) -> ExitCode {
     eprintln!(r#"{{"error":{{"code":"{}"}}}}"#, error.code());
     ExitCode::FAILURE
+}
+
+fn run_hermes_smoke(arguments: &[String]) -> Result<String, AdapterError> {
+    let options = HermesSmokeOptions::parse(arguments)?;
+    let endpoint = GatewayEndpoint::parse(&options.gateway_url)?;
+    let mut adapter = HermesSessionAdapter::connect(endpoint)?;
+
+    let listed = adapter.list()?;
+    let created = adapter.create(options.cwd.as_deref())?;
+    adapter.prompt(&created.live_id, &options.prompt)?;
+    let resumed = adapter.resume(&created.stored_id)?;
+
+    // Prompt submission is asynchronous. The caller chooses a bounded window
+    // for real status/tool/interaction observation; a quiet interval is normal.
+    let deadline = Instant::now() + Duration::from_millis(options.observe_ms);
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match adapter.pump(remaining.min(Duration::from_millis(250))) {
+            Ok(()) | Err(AdapterError::Timeout) => {}
+            Err(AdapterError::GatewayLost) => break,
+            Err(error) => return Err(error),
+        }
+    }
+    let signals = adapter.stream_signals();
+    let events = adapter.drain_events();
+    let event_count = events.len();
+    let tool_events = events
+        .iter()
+        .filter(|event| event.kind == EventKind::Tool)
+        .count();
+    let interaction_events = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.kind,
+                EventKind::ApprovalRequest | EventKind::ClarificationRequest
+            )
+        })
+        .count();
+    let status = match adapter.status() {
+        SessionStatus::Idle => "idle",
+        SessionStatus::Working => "working",
+        SessionStatus::Degraded => "degraded",
+        SessionStatus::Failed => "failed",
+    };
+
+    Ok(format!(
+        "{{\"adapter\":\"hermes-rich-client\",\"create\":true,\"list_count\":{},\"resume\":{},\"prompt\":true,\"observed_events\":{},\"tool_events\":{},\"interaction_events\":{},\"unsupported_events\":{},\"foreign_events\":{},\"dropped_events\":{},\"status\":\"{}\"}}",
+        listed.len(),
+        !resumed.live_id.is_empty(),
+        event_count,
+        tool_events,
+        interaction_events,
+        signals.unsupported,
+        signals.foreign,
+        signals.dropped,
+        status,
+    ))
+}
+
+struct HermesSmokeOptions {
+    gateway_url: String,
+    cwd: Option<String>,
+    prompt: String,
+    observe_ms: u64,
+}
+
+impl HermesSmokeOptions {
+    fn parse(arguments: &[String]) -> Result<Self, AdapterError> {
+        let mut gateway_url = None;
+        let mut cwd = None;
+        let mut prompt = "Reply with exactly: relay rich-client smoke acknowledged".to_owned();
+        let mut observe_ms = 200;
+        let mut index = 0;
+        while index < arguments.len() {
+            let flag = &arguments[index];
+            let value = arguments.get(index + 1).ok_or(AdapterError::MalformedRpc)?;
+            match flag.as_str() {
+                "--gateway-url" => gateway_url = Some(value.clone()),
+                "--cwd" => cwd = Some(value.clone()),
+                "--prompt" => prompt = value.clone(),
+                "--observe-ms" => {
+                    observe_ms = value
+                        .parse::<u64>()
+                        .ok()
+                        .filter(|milliseconds| *milliseconds <= 30_000)
+                        .ok_or(AdapterError::MalformedRpc)?;
+                }
+                _ => return Err(AdapterError::MalformedRpc),
+            }
+            index += 2;
+        }
+        let gateway_url = gateway_url.ok_or(AdapterError::MalformedRpc)?;
+        if prompt.is_empty() {
+            return Err(AdapterError::MalformedRpc);
+        }
+        Ok(Self {
+            gateway_url,
+            cwd,
+            prompt,
+            observe_ms,
+        })
+    }
 }

--- a/apps/relay-node/tests/hermes_smoke_cli.rs
+++ b/apps/relay-node/tests/hermes_smoke_cli.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+#[test]
+fn hermes_smoke_rejects_remote_gateway_urls_without_echoing_credentials() {
+    let token = "not-a-real-token";
+    let output = Command::new(env!("CARGO_BIN_EXE_relay-node"))
+        .args([
+            "hermes-smoke",
+            "--gateway-url",
+            &format!("ws://example.test:9119/api/ws?token={token}"),
+        ])
+        .output()
+        .expect("run relay-node");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr UTF-8");
+    assert_eq!(
+        stderr.trim(),
+        "{\"error\":{\"code\":\"unsupported_endpoint\"}}"
+    );
+    assert!(!stderr.contains(token));
+}

--- a/apps/relay-node/tests/hermes_smoke_cli.rs
+++ b/apps/relay-node/tests/hermes_smoke_cli.rs
@@ -1,4 +1,12 @@
-use std::process::Command;
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    process::Command,
+    thread,
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use sha1::{Digest, Sha1};
 
 #[test]
 fn hermes_smoke_rejects_remote_gateway_urls_without_echoing_credentials() {
@@ -19,4 +27,111 @@ fn hermes_smoke_rejects_remote_gateway_urls_without_echoing_credentials() {
         "{\"error\":{\"code\":\"unsupported_endpoint\"}}"
     );
     assert!(!stderr.contains(token));
+}
+
+#[test]
+fn hermes_smoke_reports_gateway_loss_during_observation() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+
+        assert_eq!(read_text_frame(&mut stream)["method"], "session.list");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"sessions":[]}}"#,
+        );
+        assert_eq!(read_text_frame(&mut stream)["method"], "session.create");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"session_id":"live","stored_session_id":"stored"}}"#,
+        );
+        assert_eq!(read_text_frame(&mut stream)["method"], "prompt.submit");
+        write_text_frame(&mut stream, r#"{"jsonrpc":"2.0","id":3,"result":{}}"#);
+        assert_eq!(read_text_frame(&mut stream)["method"], "session.resume");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":4,"result":{"session_id":"resumed","stored_session_id":"stored"}}"#,
+        );
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_relay-node"))
+        .args([
+            "hermes-smoke",
+            "--gateway-url",
+            &format!("ws://127.0.0.1:{port}/api/ws?token=test-token"),
+            "--prompt",
+            "ok",
+            "--observe-ms",
+            "100",
+        ])
+        .output()
+        .expect("run relay-node");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr)
+            .expect("stderr UTF-8")
+            .trim(),
+        "{\"error\":{\"code\":\"gateway_lost\"}}"
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+fn accept_upgrade(stream: &mut TcpStream) {
+    let request = read_headers(stream);
+    let key = request
+        .lines()
+        .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
+        .expect("websocket key");
+    let mut digest = Sha1::new();
+    digest.update(key.as_bytes());
+    digest.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    let accept = STANDARD.encode(digest.finalize());
+    write!(
+        stream,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+    )
+    .expect("write websocket upgrade");
+}
+
+fn read_headers(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !bytes.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).expect("read HTTP header byte");
+        bytes.push(byte[0]);
+    }
+    String::from_utf8(bytes).expect("HTTP header is UTF-8")
+}
+
+fn read_text_frame(stream: &mut TcpStream) -> serde_json::Value {
+    let mut header = [0_u8; 2];
+    stream
+        .read_exact(&mut header)
+        .expect("read websocket header");
+    assert_eq!(header[0], 0x81, "client text frame");
+    assert_ne!(header[1] & 0x80, 0, "client frames are masked");
+    let length = usize::from(header[1] & 0x7F);
+    assert!(length < 126, "test request stays compact");
+    let mut mask = [0_u8; 4];
+    stream.read_exact(&mut mask).expect("read mask");
+    let mut payload = vec![0_u8; length];
+    stream.read_exact(&mut payload).expect("read payload");
+    for (index, byte) in payload.iter_mut().enumerate() {
+        *byte ^= mask[index % mask.len()];
+    }
+    serde_json::from_slice(&payload).expect("JSON-RPC request")
+}
+
+fn write_text_frame(stream: &mut TcpStream, text: &str) {
+    assert!(text.len() < 126, "test response stays compact");
+    stream
+        .write_all(&[0x81, text.len() as u8])
+        .expect("write frame header");
+    stream
+        .write_all(text.as_bytes())
+        .expect("write frame payload");
+    stream.flush().expect("flush frame");
 }

--- a/crates/relay-hermes-session/Cargo.toml
+++ b/crates/relay-hermes-session/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 base64 = "0.22"
+getrandom = "0.2"
 serde_json = "1.0"
 sha1 = "0.10"
 

--- a/crates/relay-hermes-session/Cargo.toml
+++ b/crates/relay-hermes-session/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "relay-hermes-session"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+base64 = "0.22"
+serde_json = "1.0"
+sha1 = "0.10"
+
+[lints]
+workspace = true

--- a/crates/relay-hermes-session/src/lib.rs
+++ b/crates/relay-hermes-session/src/lib.rs
@@ -1,0 +1,1056 @@
+//! Native, loopback-only Hermes rich-client Session adapter.
+//!
+//! This crate speaks the authenticated dashboard `/api/ws` TUI JSON-RPC
+//! protocol. It deliberately rejects the OpenAI-compatible API gateway and all
+//! remote endpoints: Relay's first Hermes integration is one-node only.
+
+use std::{
+    collections::{HashSet, VecDeque},
+    fmt,
+    io::{self, Read, Write},
+    net::{TcpStream, ToSocketAddrs},
+    thread,
+    time::Duration,
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde_json::{Value, json};
+use sha1::{Digest, Sha1};
+
+pub const DEFAULT_EVENT_QUEUE_LIMIT: usize = 128;
+pub const DEFAULT_REPLAY_WINDOW: usize = 64;
+pub const MAX_RPC_BYTES: usize = 8 * 1024;
+pub const MAX_FRAME_BYTES: usize = 64 * 1024;
+pub const MAX_CONNECT_ATTEMPTS: usize = 3;
+const CONNECT_BACKOFFS: [Duration; MAX_CONNECT_ATTEMPTS - 1] =
+    [Duration::from_millis(50), Duration::from_millis(100)];
+pub const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// A loopback dashboard URL with an already-present dashboard credential.
+///
+/// The actual credential remains in the request target and is never exposed by
+/// `Display`, `Debug`, adapter events, or typed errors.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GatewayEndpoint {
+    host: String,
+    port: u16,
+    request_target: String,
+}
+
+impl GatewayEndpoint {
+    pub fn parse(raw: &str) -> Result<Self, AdapterError> {
+        if raw
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+        {
+            return Err(AdapterError::UnsupportedEndpoint);
+        }
+        let rest = raw
+            .strip_prefix("ws://")
+            .ok_or(AdapterError::UnsupportedEndpoint)?;
+        let (authority, target) = rest
+            .split_once('/')
+            .ok_or(AdapterError::UnsupportedEndpoint)?;
+        if authority.contains('@') || target.is_empty() {
+            return Err(AdapterError::UnsupportedEndpoint);
+        }
+
+        let (host, port) = parse_loopback_authority(authority)?;
+        let request_target = format!("/{target}");
+        let (path, query) = request_target
+            .split_once('?')
+            .unwrap_or((request_target.as_str(), ""));
+        if path != "/api/ws" || !has_supported_credential(query) {
+            return Err(AdapterError::UnsupportedEndpoint);
+        }
+
+        Ok(Self {
+            host,
+            port,
+            request_target,
+        })
+    }
+
+    pub fn redacted_url(&self) -> String {
+        format!(
+            "ws://{}:{}/api/ws?credential=redacted",
+            self.host, self.port
+        )
+    }
+
+    fn host_header(&self) -> String {
+        if self.host.contains(':') {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+}
+
+impl fmt::Debug for GatewayEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GatewayEndpoint")
+            .field("url", &self.redacted_url())
+            .finish()
+    }
+}
+
+impl fmt::Display for GatewayEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.redacted_url())
+    }
+}
+
+fn parse_loopback_authority(authority: &str) -> Result<(String, u16), AdapterError> {
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let (host, port) = rest
+            .split_once("]:")
+            .ok_or(AdapterError::UnsupportedEndpoint)?;
+        (host, port)
+    } else {
+        authority
+            .rsplit_once(':')
+            .ok_or(AdapterError::UnsupportedEndpoint)?
+    };
+    let port = port
+        .parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or(AdapterError::UnsupportedEndpoint)?;
+    let host = host.to_ascii_lowercase();
+    if !matches!(host.as_str(), "127.0.0.1" | "localhost" | "::1") {
+        return Err(AdapterError::UnsupportedEndpoint);
+    }
+    Ok((host, port))
+}
+
+fn has_supported_credential(query: &str) -> bool {
+    query.split('&').any(|item| {
+        let Some((key, value)) = item.split_once('=') else {
+            return false;
+        };
+        !value.is_empty() && key == "token"
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdapterError {
+    UnsupportedEndpoint,
+    AuthFailed,
+    GatewayLost,
+    MalformedRpc,
+    Timeout,
+    RetryExhausted,
+    ReplayGap,
+    QueuePressure,
+    PayloadTooLarge,
+    Unsupported,
+    UnknownSession,
+    Raced,
+    RemoteFailure,
+}
+
+impl AdapterError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::UnsupportedEndpoint => "unsupported_endpoint",
+            Self::AuthFailed => "auth_failed",
+            Self::GatewayLost => "gateway_lost",
+            Self::MalformedRpc => "malformed_rpc",
+            Self::Timeout => "timeout",
+            Self::RetryExhausted => "retry_exhausted",
+            Self::ReplayGap => "replay_gap",
+            Self::QueuePressure => "queue_pressure",
+            Self::PayloadTooLarge => "payload_too_large",
+            Self::Unsupported => "unsupported",
+            Self::UnknownSession => "unknown_session",
+            Self::Raced => "raced",
+            Self::RemoteFailure => "remote_failure",
+        }
+    }
+}
+
+impl fmt::Display for AdapterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for AdapterError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStatus {
+    Idle,
+    Working,
+    Degraded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventKind {
+    Lifecycle,
+    Status,
+    Tool,
+    ClarificationRequest,
+    ApprovalRequest,
+    Diagnostic,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEvent {
+    pub sequence: u64,
+    /// The live gateway session that emitted this event. `gateway.ready` has
+    /// no session scope and uses an empty string.
+    pub session_id: String,
+    pub kind: EventKind,
+    pub label: &'static str,
+    pub preview: String,
+    /// Opaque provider correlation for a clarification response. Present only
+    /// when the gateway emitted one; no clarification payload is retained.
+    pub clarification_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StreamSignals {
+    pub dropped: u64,
+    pub malformed: u64,
+    pub unsupported: u64,
+    pub foreign: u64,
+    pub replay_gap: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreatedSession {
+    pub live_id: String,
+    pub stored_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSummary {
+    pub stored_id: String,
+}
+
+/// The public ledger is intentionally narrow. Any event not in this set becomes
+/// an `Unsupported` event; it is never guessed, normalized through another
+/// provider, or silently dropped. A `clarify.request` needs an opaque response
+/// id before it can join this supported set.
+pub const GUARANTEED_EVENTS: &[&str] = &[
+    "gateway.ready",
+    "session.info",
+    "message.start",
+    "message.delta",
+    "message.complete",
+    "thinking.delta",
+    "reasoning.delta",
+    "reasoning.available",
+    "status.update",
+    "tool.start",
+    "tool.progress",
+    "tool.generating",
+    "tool.complete",
+    "tool.output_risk",
+    "approval.request",
+    "error",
+];
+
+pub const UNSUPPORTED_EVENTS: &[&str] = &[
+    "sudo.request",
+    "secret.request",
+    "terminal.read.request",
+    "background.complete",
+    "skin.changed",
+];
+
+pub const UNSUPPORTED_METHODS: &[&str] = &[
+    "config.set",
+    "command.dispatch",
+    "cli.exec",
+    "process.stop",
+    "terminal.resize",
+    "image.attach",
+    "session.branch",
+    "session.compress",
+];
+
+pub struct HermesSessionAdapter {
+    endpoint: Option<GatewayEndpoint>,
+    socket: Option<TcpStream>,
+    enforce_session_scope: bool,
+    owned_live_sessions: HashSet<String>,
+    next_rpc_id: u64,
+    next_sequence: u64,
+    status: SessionStatus,
+    queue_limit: usize,
+    replay_window: usize,
+    queue: VecDeque<SessionEvent>,
+    replay: VecDeque<SessionEvent>,
+    signals: StreamSignals,
+    pending_approvals: HashSet<String>,
+    pending_clarifications: HashSet<String>,
+}
+
+impl HermesSessionAdapter {
+    pub fn connect(endpoint: GatewayEndpoint) -> Result<Self, AdapterError> {
+        let mut last_error = AdapterError::GatewayLost;
+        debug_assert_eq!(CONNECT_BACKOFFS.len() + 1, MAX_CONNECT_ATTEMPTS);
+        for backoff in CONNECT_BACKOFFS
+            .iter()
+            .copied()
+            .map(Some)
+            .chain(std::iter::once(None))
+        {
+            match connect_once(&endpoint) {
+                Ok(socket) => {
+                    return Ok(Self {
+                        endpoint: Some(endpoint),
+                        socket: Some(socket),
+                        enforce_session_scope: true,
+                        ..Self::scripted()
+                    });
+                }
+                Err(AdapterError::AuthFailed) => return Err(AdapterError::AuthFailed),
+                Err(error) => {
+                    last_error = error;
+                    if let Some(backoff) = backoff {
+                        thread::sleep(backoff);
+                    }
+                }
+            }
+        }
+        match last_error {
+            AdapterError::Timeout | AdapterError::GatewayLost => Err(AdapterError::RetryExhausted),
+            error => Err(error),
+        }
+    }
+
+    pub fn scripted() -> Self {
+        Self::scripted_with_queue_limit(DEFAULT_EVENT_QUEUE_LIMIT)
+    }
+
+    pub fn scripted_with_queue_limit(queue_limit: usize) -> Self {
+        Self {
+            endpoint: None,
+            socket: None,
+            enforce_session_scope: false,
+            owned_live_sessions: HashSet::new(),
+            next_rpc_id: 0,
+            next_sequence: 0,
+            status: SessionStatus::Idle,
+            queue_limit: queue_limit.max(1),
+            replay_window: DEFAULT_REPLAY_WINDOW,
+            queue: VecDeque::new(),
+            replay: VecDeque::new(),
+            signals: StreamSignals::default(),
+            pending_approvals: HashSet::new(),
+            pending_clarifications: HashSet::new(),
+        }
+    }
+
+    pub fn endpoint(&self) -> Option<&GatewayEndpoint> {
+        self.endpoint.as_ref()
+    }
+
+    pub const fn status(&self) -> SessionStatus {
+        self.status
+    }
+
+    pub const fn stream_signals(&self) -> StreamSignals {
+        self.signals
+    }
+
+    fn require_owned_live_session(&self, live_id: &str) -> Result<(), AdapterError> {
+        if live_id.is_empty() {
+            return Err(AdapterError::MalformedRpc);
+        }
+        if self.enforce_session_scope && !self.owned_live_sessions.contains(live_id) {
+            return Err(AdapterError::UnknownSession);
+        }
+        Ok(())
+    }
+
+    pub fn drain_events(&mut self) -> Vec<SessionEvent> {
+        self.queue.drain(..).collect()
+    }
+
+    pub fn replay_from(&self, sequence: u64) -> Result<Vec<SessionEvent>, AdapterError> {
+        if self
+            .replay
+            .front()
+            .is_some_and(|event| sequence < event.sequence)
+        {
+            return Err(AdapterError::ReplayGap);
+        }
+        Ok(self
+            .replay
+            .iter()
+            .filter(|event| event.sequence >= sequence)
+            .cloned()
+            .collect())
+    }
+
+    pub fn ingest_json(&mut self, raw: &str) -> Result<(), AdapterError> {
+        if raw.len() > MAX_FRAME_BYTES {
+            self.signals.malformed += 1;
+            self.status = SessionStatus::Degraded;
+            return Err(AdapterError::PayloadTooLarge);
+        }
+        let frame: Value = serde_json::from_str(raw).map_err(|_| {
+            self.signals.malformed += 1;
+            self.status = SessionStatus::Degraded;
+            AdapterError::MalformedRpc
+        })?;
+        self.ingest_frame(frame)
+    }
+
+    pub fn create(&mut self, cwd: Option<&str>) -> Result<CreatedSession, AdapterError> {
+        let mut params = serde_json::Map::new();
+        params.insert("source".to_owned(), Value::String("relay".to_owned()));
+        if let Some(cwd) = cwd.filter(|cwd| !cwd.is_empty()) {
+            params.insert("cwd".to_owned(), Value::String(cwd.to_owned()));
+        }
+        let result = self.call("session.create", Value::Object(params))?;
+        let live_id = string_field(&result, "session_id")?;
+        let stored_id = string_field(&result, "stored_session_id")?;
+        self.owned_live_sessions.insert(live_id.clone());
+        Ok(CreatedSession { live_id, stored_id })
+    }
+
+    pub fn list(&mut self) -> Result<Vec<SessionSummary>, AdapterError> {
+        let result = self.call("session.list", json!({"limit": 50}))?;
+        let sessions = result
+            .get("sessions")
+            .and_then(Value::as_array)
+            .ok_or(AdapterError::MalformedRpc)?;
+        sessions
+            .iter()
+            .map(|session| {
+                Ok(SessionSummary {
+                    stored_id: string_field(session, "id")?,
+                })
+            })
+            .collect()
+    }
+
+    pub fn resume(&mut self, stored_id: &str) -> Result<CreatedSession, AdapterError> {
+        if stored_id.is_empty() || stored_id.len() > 256 {
+            return Err(AdapterError::MalformedRpc);
+        }
+        let result = self.call("session.resume", json!({"session_id": stored_id}))?;
+        let live_id = string_field(&result, "session_id")?;
+        let stored_id = result
+            .get("stored_session_id")
+            .and_then(Value::as_str)
+            .unwrap_or(stored_id)
+            .to_owned();
+        self.owned_live_sessions.insert(live_id.clone());
+        Ok(CreatedSession { live_id, stored_id })
+    }
+
+    pub fn prompt(&mut self, live_id: &str, text: &str) -> Result<(), AdapterError> {
+        self.require_owned_live_session(live_id)?;
+        if text.is_empty() || text.len() > MAX_RPC_BYTES / 2 {
+            return Err(AdapterError::PayloadTooLarge);
+        }
+        self.status = SessionStatus::Working;
+        self.call(
+            "prompt.submit",
+            json!({"session_id": live_id, "text": text}),
+        )?;
+        Ok(())
+    }
+
+    pub fn interrupt(&mut self, live_id: &str) -> Result<(), AdapterError> {
+        self.require_owned_live_session(live_id)?;
+        self.call("session.interrupt", json!({"session_id": live_id}))
+            .map(|_| ())
+    }
+
+    pub fn respond_approval(
+        &mut self,
+        live_id: &str,
+        choice: ApprovalChoice,
+    ) -> Result<(), AdapterError> {
+        self.require_owned_live_session(live_id)?;
+        if !self.pending_approvals.remove(live_id) {
+            self.status = SessionStatus::Degraded;
+            return Err(AdapterError::Raced);
+        }
+        self.call(
+            "approval.respond",
+            json!({"session_id": live_id, "choice": choice.as_wire()}),
+        )
+        .map(|_| ())
+    }
+
+    pub fn respond_clarification(
+        &mut self,
+        request_id: &str,
+        answer: &str,
+    ) -> Result<(), AdapterError> {
+        if request_id.is_empty() || request_id.len() > 256 || answer.len() > MAX_RPC_BYTES / 2 {
+            return Err(AdapterError::PayloadTooLarge);
+        }
+        if !self.pending_clarifications.remove(request_id) {
+            self.status = SessionStatus::Degraded;
+            return Err(AdapterError::Raced);
+        }
+        self.call(
+            "clarify.respond",
+            json!({"request_id": request_id, "answer": answer}),
+        )
+        .map(|_| ())
+    }
+
+    pub fn pump(&mut self, timeout: Duration) -> Result<(), AdapterError> {
+        let status_before_wait = self.status;
+        match self.receive_frame(timeout) {
+            Err(AdapterError::Timeout) => {
+                // A bounded observation window is allowed to be quiet. Preserve
+                // the previous state so callers can distinguish that idle wait
+                // from a control-RPC deadline, which remains degraded.
+                self.status = status_before_wait;
+                Err(AdapterError::Timeout)
+            }
+            Err(error) => Err(error),
+            Ok(frame) => self.ingest_json(&frame),
+        }
+    }
+
+    fn call(&mut self, method: &str, params: Value) -> Result<Value, AdapterError> {
+        if UNSUPPORTED_METHODS.contains(&method) {
+            return Err(AdapterError::Unsupported);
+        }
+        self.next_rpc_id += 1;
+        let request_id = self.next_rpc_id;
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        });
+        let wire = serde_json::to_string(&request).map_err(|_| AdapterError::MalformedRpc)?;
+        if wire.len() > MAX_RPC_BYTES {
+            return Err(AdapterError::PayloadTooLarge);
+        }
+        self.send_frame(&wire)?;
+
+        loop {
+            let raw = self.receive_frame(DEFAULT_RPC_TIMEOUT)?;
+            let frame: Value = serde_json::from_str(&raw).map_err(|_| {
+                self.signals.malformed += 1;
+                self.status = SessionStatus::Degraded;
+                AdapterError::MalformedRpc
+            })?;
+            if frame.get("id").and_then(Value::as_u64) == Some(request_id) {
+                if let Some(error) = frame.get("error") {
+                    let error = classify_rpc_error(error);
+                    if !matches!(error, AdapterError::Unsupported) {
+                        self.status = SessionStatus::Degraded;
+                    }
+                    return Err(error);
+                }
+                return frame.get("result").cloned().ok_or_else(|| {
+                    self.signals.malformed += 1;
+                    self.status = SessionStatus::Degraded;
+                    AdapterError::MalformedRpc
+                });
+            }
+            self.ingest_frame(frame)?;
+        }
+    }
+
+    fn ingest_frame(&mut self, frame: Value) -> Result<(), AdapterError> {
+        if frame.get("method").and_then(Value::as_str) != Some("event") {
+            self.signals.malformed += 1;
+            self.status = SessionStatus::Degraded;
+            return Err(AdapterError::MalformedRpc);
+        }
+        let params = frame
+            .get("params")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                self.signals.malformed += 1;
+                self.status = SessionStatus::Degraded;
+                AdapterError::MalformedRpc
+            })?;
+        let event_type = params.get("type").and_then(Value::as_str).ok_or_else(|| {
+            self.signals.malformed += 1;
+            self.status = SessionStatus::Degraded;
+            AdapterError::MalformedRpc
+        })?;
+        let session_id = params
+            .get("session_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if self.enforce_session_scope
+            && !session_id.is_empty()
+            && !self.owned_live_sessions.contains(session_id)
+        {
+            self.signals.foreign += 1;
+            return Ok(());
+        }
+        let payload = params.get("payload").and_then(Value::as_object);
+        self.map_event(event_type, session_id, payload);
+        Ok(())
+    }
+
+    fn map_event(
+        &mut self,
+        event_type: &str,
+        session_id: &str,
+        payload: Option<&serde_json::Map<String, Value>>,
+    ) {
+        let mut clarification_id = None;
+        let (kind, label, preview) = match event_type {
+            "gateway.ready" => (
+                EventKind::Lifecycle,
+                "gateway_ready",
+                "gateway ready".to_owned(),
+            ),
+            "session.info" => (
+                EventKind::Lifecycle,
+                "session_info",
+                "session information".to_owned(),
+            ),
+            "message.start" => {
+                self.status = SessionStatus::Working;
+                (
+                    EventKind::Status,
+                    "message_started",
+                    "message started".to_owned(),
+                )
+            }
+            "message.delta" => (
+                EventKind::Status,
+                "message_delta",
+                "redacted message delta".to_owned(),
+            ),
+            "message.complete" => {
+                self.status = SessionStatus::Idle;
+                (
+                    EventKind::Status,
+                    "message_complete",
+                    "message complete".to_owned(),
+                )
+            }
+            "thinking.delta" | "reasoning.delta" | "reasoning.available" => (
+                EventKind::Status,
+                "reasoning",
+                "redacted reasoning".to_owned(),
+            ),
+            "status.update" => (
+                EventKind::Status,
+                "status_update",
+                "status update".to_owned(),
+            ),
+            "tool.start" => (EventKind::Tool, "tool_started", tool_preview(payload)),
+            "tool.progress" | "tool.generating" => {
+                (EventKind::Tool, "tool_progress", tool_preview(payload))
+            }
+            "tool.complete" => (EventKind::Tool, "tool_complete", tool_preview(payload)),
+            "tool.output_risk" => (
+                EventKind::Tool,
+                "tool_output_risk",
+                "tool output risk updated".to_owned(),
+            ),
+            "approval.request" if !session_id.is_empty() => {
+                self.pending_approvals.insert(session_id.to_owned());
+                (
+                    EventKind::ApprovalRequest,
+                    "approval_request",
+                    "approval requested".to_owned(),
+                )
+            }
+            "clarify.request" => {
+                let request_id = payload
+                    .and_then(|payload| payload.get("request_id"))
+                    .and_then(Value::as_str)
+                    .filter(|id| id.len() <= 256);
+                if let Some(request_id) = request_id.filter(|id| !id.is_empty()) {
+                    self.pending_clarifications.insert(request_id.to_owned());
+                    clarification_id = Some(request_id.to_owned());
+                    (
+                        EventKind::ClarificationRequest,
+                        "clarification_request",
+                        "clarification requested".to_owned(),
+                    )
+                } else {
+                    self.record_unsupported();
+                    (
+                        EventKind::Unsupported,
+                        "clarification_without_id",
+                        "clarification request lacks a response id".to_owned(),
+                    )
+                }
+            }
+            "error" => {
+                self.status = SessionStatus::Degraded;
+                (
+                    EventKind::Diagnostic,
+                    "gateway_error",
+                    "gateway reported an error".to_owned(),
+                )
+            }
+            _ => {
+                self.record_unsupported();
+                (
+                    EventKind::Unsupported,
+                    "unsupported_event",
+                    "unsupported gateway event".to_owned(),
+                )
+            }
+        };
+        self.enqueue(session_id, kind, label, preview, clarification_id);
+    }
+
+    fn record_unsupported(&mut self) {
+        self.signals.unsupported += 1;
+        self.status = SessionStatus::Degraded;
+    }
+
+    fn enqueue(
+        &mut self,
+        session_id: &str,
+        kind: EventKind,
+        label: &'static str,
+        preview: String,
+        clarification_id: Option<String>,
+    ) {
+        self.next_sequence += 1;
+        let event = SessionEvent {
+            sequence: self.next_sequence,
+            session_id: session_id.to_owned(),
+            kind,
+            label,
+            preview: truncate_preview(preview),
+            clarification_id,
+        };
+        if self.queue.len() == self.queue_limit {
+            self.queue.pop_front();
+            self.signals.dropped += 1;
+            self.signals.replay_gap = true;
+            self.status = SessionStatus::Degraded;
+        }
+        self.queue.push_back(event.clone());
+        self.replay.push_back(event);
+        while self.replay.len() > self.replay_window {
+            self.replay.pop_front();
+        }
+    }
+
+    fn send_frame(&mut self, text: &str) -> Result<(), AdapterError> {
+        let result = {
+            let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
+            write_websocket_frame(stream, 0x1, text.as_bytes()).map_err(map_io_error)
+        };
+        if let Err(error) = &result {
+            self.record_transport_failure(error);
+        }
+        result
+    }
+
+    fn receive_frame(&mut self, timeout: Duration) -> Result<String, AdapterError> {
+        let timeout_result = {
+            let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
+            stream.set_read_timeout(Some(timeout)).map_err(map_io_error)
+        };
+        if let Err(error) = timeout_result {
+            self.record_transport_failure(&error);
+            return Err(error);
+        }
+
+        loop {
+            let frame = {
+                let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
+                read_websocket_frame(stream)
+            };
+            let (opcode, bytes) = match frame {
+                Ok(frame) => frame,
+                Err(error) => {
+                    self.record_transport_failure(&error);
+                    return Err(error);
+                }
+            };
+            match opcode {
+                0x1 => match String::from_utf8(bytes) {
+                    Ok(text) => return Ok(text),
+                    Err(_) => {
+                        self.signals.malformed += 1;
+                        self.status = SessionStatus::Degraded;
+                        return Err(AdapterError::MalformedRpc);
+                    }
+                },
+                0x8 => {
+                    self.status = SessionStatus::Failed;
+                    return Err(AdapterError::GatewayLost);
+                }
+                0x9 => {
+                    let result = {
+                        let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
+                        write_websocket_frame(stream, 0xA, &bytes).map_err(map_io_error)
+                    };
+                    if let Err(error) = result {
+                        self.record_transport_failure(&error);
+                        return Err(error);
+                    }
+                }
+                0xA => continue,
+                _ => {
+                    self.signals.malformed += 1;
+                    self.status = SessionStatus::Degraded;
+                    return Err(AdapterError::MalformedRpc);
+                }
+            }
+        }
+    }
+
+    fn record_transport_failure(&mut self, error: &AdapterError) {
+        match error {
+            AdapterError::GatewayLost | AdapterError::RetryExhausted => {
+                self.status = SessionStatus::Failed;
+            }
+            AdapterError::Timeout | AdapterError::PayloadTooLarge | AdapterError::MalformedRpc => {
+                self.status = SessionStatus::Degraded;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalChoice {
+    Once,
+    Deny,
+}
+
+impl ApprovalChoice {
+    const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Once => "once",
+            Self::Deny => "deny",
+        }
+    }
+}
+
+fn tool_preview(payload: Option<&serde_json::Map<String, Value>>) -> String {
+    let tool_name = payload
+        .and_then(|payload| payload.get("name"))
+        .and_then(Value::as_str)
+        .filter(|name| {
+            name.len() <= 80
+                && name.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+                })
+        });
+    match tool_name {
+        Some(name) => format!("tool {name}"),
+        None => "tool activity".to_owned(),
+    }
+}
+
+fn truncate_preview(mut preview: String) -> String {
+    const LIMIT: usize = 160;
+    if preview.len() > LIMIT {
+        preview.truncate(LIMIT);
+    }
+    preview
+}
+
+fn string_field(value: &Value, field: &str) -> Result<String, AdapterError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty() && value.len() <= 256)
+        .map(ToOwned::to_owned)
+        .ok_or(AdapterError::MalformedRpc)
+}
+
+fn classify_rpc_error(error: &Value) -> AdapterError {
+    match error.get("code").and_then(Value::as_i64) {
+        Some(-32601) => AdapterError::Unsupported,
+        Some(-32700 | -32600 | -32602) => AdapterError::MalformedRpc,
+        Some(4009) => AdapterError::Raced,
+        _ => AdapterError::RemoteFailure,
+    }
+}
+
+fn connect_once(endpoint: &GatewayEndpoint) -> Result<TcpStream, AdapterError> {
+    let address = (endpoint.host.as_str(), endpoint.port)
+        .to_socket_addrs()
+        .map_err(map_io_error)?
+        .find(|address| address.ip().is_loopback())
+        .ok_or(AdapterError::GatewayLost)?;
+    let mut stream =
+        TcpStream::connect_timeout(&address, DEFAULT_RPC_TIMEOUT).map_err(map_io_error)?;
+    stream
+        .set_read_timeout(Some(DEFAULT_RPC_TIMEOUT))
+        .map_err(map_io_error)?;
+    stream
+        .set_write_timeout(Some(DEFAULT_RPC_TIMEOUT))
+        .map_err(map_io_error)?;
+
+    let key = websocket_key()?;
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: {}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: {}\r\nSec-WebSocket-Version: 13\r\n\r\n",
+        endpoint.request_target,
+        endpoint.host_header(),
+        key
+    );
+    stream.write_all(request.as_bytes()).map_err(map_io_error)?;
+    stream.flush().map_err(map_io_error)?;
+
+    let response = read_http_headers(&mut stream)?;
+    let status = response.lines().next().unwrap_or_default();
+    if status.contains(" 401 ") || status.contains(" 403 ") {
+        return Err(AdapterError::AuthFailed);
+    }
+    if !status.starts_with("HTTP/1.1 101") {
+        return Err(AdapterError::GatewayLost);
+    }
+    let expected_accept = websocket_accept(&key);
+    let actual_accept = response.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("sec-websocket-accept")
+            .then(|| value.trim())
+    });
+    if actual_accept != Some(expected_accept.as_str()) {
+        return Err(AdapterError::GatewayLost);
+    }
+    Ok(stream)
+}
+
+fn websocket_key() -> Result<String, AdapterError> {
+    let mut nonce = [0_u8; 16];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut source| source.read_exact(&mut nonce))
+        .map_err(map_io_error)?;
+    Ok(STANDARD.encode(nonce))
+}
+
+fn websocket_accept(key: &str) -> String {
+    let mut digest = Sha1::new();
+    digest.update(key.as_bytes());
+    digest.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    STANDARD.encode(digest.finalize())
+}
+
+fn read_http_headers(stream: &mut TcpStream) -> Result<String, AdapterError> {
+    let mut bytes = Vec::with_capacity(1024);
+    let mut byte = [0_u8; 1];
+    while bytes.len() < MAX_RPC_BYTES {
+        stream.read_exact(&mut byte).map_err(map_io_error)?;
+        bytes.push(byte[0]);
+        if bytes.ends_with(b"\r\n\r\n") {
+            return String::from_utf8(bytes).map_err(|_| AdapterError::MalformedRpc);
+        }
+    }
+    Err(AdapterError::PayloadTooLarge)
+}
+
+fn write_websocket_frame(stream: &mut TcpStream, opcode: u8, payload: &[u8]) -> io::Result<()> {
+    if payload.len() > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "frame too large",
+        ));
+    }
+    let mut mask = [0_u8; 4];
+    std::fs::File::open("/dev/urandom")?.read_exact(&mut mask)?;
+    let mut header = vec![0x80 | opcode, 0x80];
+    if payload.len() <= 125 {
+        header[1] |= payload.len() as u8;
+    } else if payload.len() <= usize::from(u16::MAX) {
+        header[1] |= 126;
+        header.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    } else {
+        header[1] |= 127;
+        header.extend_from_slice(&(payload.len() as u64).to_be_bytes());
+    }
+    header.extend_from_slice(&mask);
+    stream.write_all(&header)?;
+    for (index, byte) in payload.iter().enumerate() {
+        stream.write_all(&[byte ^ mask[index % mask.len()]])?;
+    }
+    stream.flush()
+}
+
+fn read_websocket_frame(stream: &mut TcpStream) -> Result<(u8, Vec<u8>), AdapterError> {
+    let mut header = [0_u8; 2];
+    stream.read_exact(&mut header).map_err(map_io_error)?;
+    if header[0] & 0xF0 != 0x80 || header[1] & 0x80 != 0 {
+        return Err(AdapterError::MalformedRpc);
+    }
+    let opcode = header[0] & 0x0F;
+    let mut length = u64::from(header[1] & 0x7F);
+    if length == 126 {
+        let mut bytes = [0_u8; 2];
+        stream.read_exact(&mut bytes).map_err(map_io_error)?;
+        length = u64::from(u16::from_be_bytes(bytes));
+    } else if length == 127 {
+        let mut bytes = [0_u8; 8];
+        stream.read_exact(&mut bytes).map_err(map_io_error)?;
+        length = u64::from_be_bytes(bytes);
+    }
+    if length as usize > MAX_FRAME_BYTES {
+        return Err(AdapterError::PayloadTooLarge);
+    }
+    let mut payload = vec![0_u8; length as usize];
+    stream.read_exact(&mut payload).map_err(map_io_error)?;
+    Ok((opcode, payload))
+}
+
+fn map_io_error(error: io::Error) -> AdapterError {
+    match error.kind() {
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock => AdapterError::Timeout,
+        io::ErrorKind::InvalidInput => AdapterError::PayloadTooLarge,
+        _ => AdapterError::GatewayLost,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_loopback_dashboard_websocket_urls_with_credentials() {
+        let endpoint =
+            GatewayEndpoint::parse("ws://127.0.0.1:9119/api/ws?token=top-secret").unwrap();
+        assert_eq!(
+            endpoint.redacted_url(),
+            "ws://127.0.0.1:9119/api/ws?credential=redacted"
+        );
+        assert!(GatewayEndpoint::parse("ws://127.0.0.1:9119/v1/chat/completions?token=x").is_err());
+        assert!(GatewayEndpoint::parse("wss://127.0.0.1:9119/api/ws?token=x").is_err());
+        assert!(
+            GatewayEndpoint::parse("ws://127.0.0.1:9119/api/ws?token=x\r\nInjected: y").is_err()
+        );
+    }
+
+    #[test]
+    fn clarification_without_request_id_is_visible_but_not_answerable() {
+        let mut adapter = HermesSessionAdapter::scripted();
+        adapter.ingest_json(r#"{"jsonrpc":"2.0","method":"event","params":{"type":"clarify.request","session_id":"a","payload":{}}}"#).unwrap();
+        assert_eq!(adapter.drain_events()[0].label, "clarification_without_id");
+        assert_eq!(
+            adapter.respond_clarification("missing", "answer"),
+            Err(AdapterError::Raced)
+        );
+    }
+
+    #[test]
+    fn replay_window_reports_a_gap_before_the_oldest_retained_event() {
+        let mut adapter = HermesSessionAdapter::scripted_with_queue_limit(3);
+        adapter.replay_window = 2;
+        for _ in 0..3 {
+            adapter
+                .ingest_json(
+                    r#"{"jsonrpc":"2.0","method":"event","params":{"type":"gateway.ready"}}"#,
+                )
+                .unwrap();
+        }
+        assert_eq!(adapter.replay_from(1), Err(AdapterError::ReplayGap));
+        assert_eq!(adapter.replay_from(2).unwrap().len(), 2);
+    }
+}

--- a/crates/relay-hermes-session/src/lib.rs
+++ b/crates/relay-hermes-session/src/lib.rs
@@ -5,7 +5,7 @@
 //! remote endpoints: Relay's first Hermes integration is one-node only.
 
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fmt,
     io::{self, Read, Write},
     net::{TcpStream, ToSocketAddrs},
@@ -25,6 +25,7 @@ pub const MAX_CONNECT_ATTEMPTS: usize = 3;
 const CONNECT_BACKOFFS: [Duration; MAX_CONNECT_ATTEMPTS - 1] =
     [Duration::from_millis(50), Duration::from_millis(100)];
 pub const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(15);
+const GLOBAL_UNSCOPED_EVENTS: &[&str] = &["gateway.ready"];
 
 /// A loopback dashboard URL with an already-present dashboard credential.
 ///
@@ -137,6 +138,7 @@ fn has_supported_credential(query: &str) -> bool {
 pub enum AdapterError {
     UnsupportedEndpoint,
     AuthFailed,
+    EntropyUnavailable,
     GatewayLost,
     MalformedRpc,
     Timeout,
@@ -155,6 +157,7 @@ impl AdapterError {
         match self {
             Self::UnsupportedEndpoint => "unsupported_endpoint",
             Self::AuthFailed => "auth_failed",
+            Self::EntropyUnavailable => "entropy_unavailable",
             Self::GatewayLost => "gateway_lost",
             Self::MalformedRpc => "malformed_rpc",
             Self::Timeout => "timeout",
@@ -233,8 +236,8 @@ pub struct SessionSummary {
 
 /// The public ledger is intentionally narrow. Any event not in this set becomes
 /// an `Unsupported` event; it is never guessed, normalized through another
-/// provider, or silently dropped. A `clarify.request` needs an opaque response
-/// id before it can join this supported set.
+/// provider, or silently dropped. `clarify.request` is supported only when it
+/// carries the opaque response id injected by the installed gateway.
 pub const GUARANTEED_EVENTS: &[&str] = &[
     "gateway.ready",
     "session.info",
@@ -251,6 +254,7 @@ pub const GUARANTEED_EVENTS: &[&str] = &[
     "tool.complete",
     "tool.output_risk",
     "approval.request",
+    "clarify.request",
     "error",
 ];
 
@@ -276,6 +280,7 @@ pub const UNSUPPORTED_METHODS: &[&str] = &[
 pub struct HermesSessionAdapter {
     endpoint: Option<GatewayEndpoint>,
     socket: Option<TcpStream>,
+    rpc_timeout: Duration,
     enforce_session_scope: bool,
     owned_live_sessions: HashSet<String>,
     next_rpc_id: u64,
@@ -286,7 +291,7 @@ pub struct HermesSessionAdapter {
     queue: VecDeque<SessionEvent>,
     replay: VecDeque<SessionEvent>,
     signals: StreamSignals,
-    pending_approvals: HashSet<String>,
+    pending_approvals: HashMap<String, usize>,
     pending_clarifications: HashSet<String>,
 }
 
@@ -332,6 +337,7 @@ impl HermesSessionAdapter {
         Self {
             endpoint: None,
             socket: None,
+            rpc_timeout: DEFAULT_RPC_TIMEOUT,
             enforce_session_scope: false,
             owned_live_sessions: HashSet::new(),
             next_rpc_id: 0,
@@ -342,7 +348,7 @@ impl HermesSessionAdapter {
             queue: VecDeque::new(),
             replay: VecDeque::new(),
             signals: StreamSignals::default(),
-            pending_approvals: HashSet::new(),
+            pending_approvals: HashMap::new(),
             pending_clarifications: HashSet::new(),
         }
     }
@@ -472,15 +478,37 @@ impl HermesSessionAdapter {
         choice: ApprovalChoice,
     ) -> Result<(), AdapterError> {
         self.require_owned_live_session(live_id)?;
-        if !self.pending_approvals.remove(live_id) {
+        if !self.pending_approvals.contains_key(live_id) {
             self.status = SessionStatus::Degraded;
             return Err(AdapterError::Raced);
         }
-        self.call(
+        let result = self.call(
             "approval.respond",
             json!({"session_id": live_id, "choice": choice.as_wire()}),
-        )
-        .map(|_| ())
+        )?;
+        let resolved = result
+            .get("resolved")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                self.status = SessionStatus::Degraded;
+                AdapterError::MalformedRpc
+            })?;
+        if resolved == 0 {
+            self.status = SessionStatus::Degraded;
+            return Err(AdapterError::Raced);
+        }
+        let remove_marker = {
+            let pending = self
+                .pending_approvals
+                .get_mut(live_id)
+                .expect("checked before control RPC");
+            *pending -= 1;
+            *pending == 0
+        };
+        if remove_marker {
+            self.pending_approvals.remove(live_id);
+        }
+        Ok(())
     }
 
     pub fn respond_clarification(
@@ -491,15 +519,16 @@ impl HermesSessionAdapter {
         if request_id.is_empty() || request_id.len() > 256 || answer.len() > MAX_RPC_BYTES / 2 {
             return Err(AdapterError::PayloadTooLarge);
         }
-        if !self.pending_clarifications.remove(request_id) {
+        if !self.pending_clarifications.contains(request_id) {
             self.status = SessionStatus::Degraded;
             return Err(AdapterError::Raced);
         }
         self.call(
             "clarify.respond",
             json!({"request_id": request_id, "answer": answer}),
-        )
-        .map(|_| ())
+        )?;
+        self.pending_clarifications.remove(request_id);
+        Ok(())
     }
 
     pub fn pump(&mut self, timeout: Duration) -> Result<(), AdapterError> {
@@ -536,7 +565,14 @@ impl HermesSessionAdapter {
         self.send_frame(&wire)?;
 
         loop {
-            let raw = self.receive_frame(DEFAULT_RPC_TIMEOUT)?;
+            let raw = match self.receive_frame(self.rpc_timeout) {
+                Ok(raw) => raw,
+                Err(AdapterError::Timeout) => {
+                    self.quarantine_transport();
+                    return Err(AdapterError::Timeout);
+                }
+                Err(error) => return Err(error),
+            };
             let frame: Value = serde_json::from_str(&raw).map_err(|_| {
                 self.signals.malformed += 1;
                 self.status = SessionStatus::Degraded;
@@ -560,6 +596,11 @@ impl HermesSessionAdapter {
         }
     }
 
+    fn quarantine_transport(&mut self) {
+        self.socket.take();
+        self.status = SessionStatus::Failed;
+    }
+
     fn ingest_frame(&mut self, frame: Value) -> Result<(), AdapterError> {
         if frame.get("method").and_then(Value::as_str) != Some("event") {
             self.signals.malformed += 1;
@@ -579,12 +620,25 @@ impl HermesSessionAdapter {
             self.status = SessionStatus::Degraded;
             AdapterError::MalformedRpc
         })?;
-        let session_id = params
-            .get("session_id")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        if self.enforce_session_scope
-            && !session_id.is_empty()
+        let is_global = GLOBAL_UNSCOPED_EVENTS.contains(&event_type);
+        let session_id = if is_global {
+            params
+                .get("session_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+        } else {
+            params
+                .get("session_id")
+                .and_then(Value::as_str)
+                .filter(|session_id| !session_id.is_empty())
+                .ok_or_else(|| {
+                    self.signals.malformed += 1;
+                    self.status = SessionStatus::Degraded;
+                    AdapterError::MalformedRpc
+                })?
+        };
+        if !is_global
+            && self.enforce_session_scope
             && !self.owned_live_sessions.contains(session_id)
         {
             self.signals.foreign += 1;
@@ -654,8 +708,11 @@ impl HermesSessionAdapter {
                 "tool_output_risk",
                 "tool output risk updated".to_owned(),
             ),
-            "approval.request" if !session_id.is_empty() => {
-                self.pending_approvals.insert(session_id.to_owned());
+            "approval.request" => {
+                *self
+                    .pending_approvals
+                    .entry(session_id.to_owned())
+                    .or_default() += 1;
                 (
                     EventKind::ApprovalRequest,
                     "approval_request",
@@ -922,10 +979,12 @@ fn connect_once(endpoint: &GatewayEndpoint) -> Result<TcpStream, AdapterError> {
 
 fn websocket_key() -> Result<String, AdapterError> {
     let mut nonce = [0_u8; 16];
-    std::fs::File::open("/dev/urandom")
-        .and_then(|mut source| source.read_exact(&mut nonce))
-        .map_err(map_io_error)?;
+    fill_random(&mut nonce)?;
     Ok(STANDARD.encode(nonce))
+}
+
+fn fill_random(bytes: &mut [u8]) -> Result<(), AdapterError> {
+    getrandom::getrandom(bytes).map_err(|_| AdapterError::EntropyUnavailable)
 }
 
 fn websocket_accept(key: &str) -> String {
@@ -956,7 +1015,7 @@ fn write_websocket_frame(stream: &mut TcpStream, opcode: u8, payload: &[u8]) -> 
         ));
     }
     let mut mask = [0_u8; 4];
-    std::fs::File::open("/dev/urandom")?.read_exact(&mut mask)?;
+    fill_random(&mut mask).map_err(|_| io::Error::other("secure randomness unavailable"))?;
     let mut header = vec![0x80 | opcode, 0x80];
     if payload.len() <= 125 {
         header[1] |= payload.len() as u8;
@@ -968,10 +1027,14 @@ fn write_websocket_frame(stream: &mut TcpStream, opcode: u8, payload: &[u8]) -> 
         header.extend_from_slice(&(payload.len() as u64).to_be_bytes());
     }
     header.extend_from_slice(&mask);
+    header.reserve(payload.len());
+    header.extend(
+        payload
+            .iter()
+            .enumerate()
+            .map(|(index, byte)| byte ^ mask[index % mask.len()]),
+    );
     stream.write_all(&header)?;
-    for (index, byte) in payload.iter().enumerate() {
-        stream.write_all(&[byte ^ mask[index % mask.len()]])?;
-    }
     stream.flush()
 }
 
@@ -1011,6 +1074,7 @@ fn map_io_error(error: io::Error) -> AdapterError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
 
     #[test]
     fn accepts_only_loopback_dashboard_websocket_urls_with_credentials() {
@@ -1055,5 +1119,70 @@ mod tests {
         }
         assert_eq!(adapter.replay_from(1), Err(AdapterError::ReplayGap));
         assert_eq!(adapter.replay_from(2).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn control_timeout_quarantines_the_socket_before_a_late_response_can_be_reused() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_http_headers(&mut stream).unwrap();
+            let key = request
+                .lines()
+                .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
+                .unwrap();
+            let accept = websocket_accept(key);
+            write!(
+                stream,
+                "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+            )
+            .unwrap();
+            read_client_frame(&mut stream).unwrap();
+            write_server_text_frame(
+                &mut stream,
+                r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+            )
+            .unwrap();
+            read_client_frame(&mut stream).unwrap();
+            thread::sleep(Duration::from_millis(20));
+            let _ = write_server_text_frame(&mut stream, r#"{"jsonrpc":"2.0","id":2,"result":{}}"#);
+        });
+
+        let endpoint =
+            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                .unwrap();
+        let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
+        let session = adapter.create(None).unwrap();
+        adapter.rpc_timeout = Duration::from_millis(5);
+
+        assert_eq!(
+            adapter.interrupt(&session.live_id),
+            Err(AdapterError::Timeout)
+        );
+        assert_eq!(adapter.status(), SessionStatus::Failed);
+        assert_eq!(
+            adapter.interrupt(&session.live_id),
+            Err(AdapterError::GatewayLost)
+        );
+        server.join().unwrap();
+    }
+
+    fn write_server_text_frame(stream: &mut TcpStream, text: &str) -> io::Result<()> {
+        stream.write_all(&[0x81, text.len() as u8])?;
+        stream.write_all(text.as_bytes())?;
+        stream.flush()
+    }
+
+    fn read_client_frame(stream: &mut TcpStream) -> io::Result<()> {
+        let mut header = [0_u8; 2];
+        stream.read_exact(&mut header)?;
+        assert_ne!(header[1] & 0x80, 0, "client frames are masked");
+        let length = usize::from(header[1] & 0x7F);
+        assert!(length < 126, "test request stays compact");
+        let mut mask = [0_u8; 4];
+        stream.read_exact(&mut mask)?;
+        let mut payload = vec![0_u8; length];
+        stream.read_exact(&mut payload)
     }
 }

--- a/crates/relay-hermes-session/src/lib.rs
+++ b/crates/relay-hermes-session/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     io::{self, Read, Write},
     net::{TcpStream, ToSocketAddrs},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
@@ -19,6 +19,7 @@ use sha1::{Digest, Sha1};
 
 pub const DEFAULT_EVENT_QUEUE_LIMIT: usize = 128;
 pub const DEFAULT_REPLAY_WINDOW: usize = 64;
+pub const MAX_PENDING_INTERACTIONS: usize = DEFAULT_EVENT_QUEUE_LIMIT;
 pub const MAX_RPC_BYTES: usize = 8 * 1024;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_CONNECT_ATTEMPTS: usize = 3;
@@ -26,6 +27,36 @@ const CONNECT_BACKOFFS: [Duration; MAX_CONNECT_ATTEMPTS - 1] =
     [Duration::from_millis(50), Duration::from_millis(100)];
 pub const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(15);
 const GLOBAL_UNSCOPED_EVENTS: &[&str] = &["gateway.ready"];
+
+#[derive(Debug, Clone, Copy)]
+struct Deadline(Instant);
+
+impl Deadline {
+    fn after(timeout: Duration) -> Self {
+        Self(Instant::now() + timeout)
+    }
+
+    fn remaining(self) -> Result<Duration, AdapterError> {
+        let remaining = self.0.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            Err(AdapterError::Timeout)
+        } else {
+            Ok(remaining)
+        }
+    }
+
+    fn set_read_timeout(self, stream: &TcpStream) -> Result<(), AdapterError> {
+        stream
+            .set_read_timeout(Some(self.remaining()?))
+            .map_err(map_io_error)
+    }
+
+    fn set_write_timeout(self, stream: &TcpStream) -> Result<(), AdapterError> {
+        stream
+            .set_write_timeout(Some(self.remaining()?))
+            .map_err(map_io_error)
+    }
+}
 
 /// A loopback dashboard URL with an already-present dashboard credential.
 ///
@@ -144,7 +175,6 @@ pub enum AdapterError {
     Timeout,
     RetryExhausted,
     ReplayGap,
-    QueuePressure,
     PayloadTooLarge,
     Unsupported,
     UnknownSession,
@@ -163,7 +193,6 @@ impl AdapterError {
             Self::Timeout => "timeout",
             Self::RetryExhausted => "retry_exhausted",
             Self::ReplayGap => "replay_gap",
-            Self::QueuePressure => "queue_pressure",
             Self::PayloadTooLarge => "payload_too_large",
             Self::Unsupported => "unsupported",
             Self::UnknownSession => "unknown_session",
@@ -217,6 +246,7 @@ pub struct SessionEvent {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StreamSignals {
     pub dropped: u64,
+    pub interaction_limited: u64,
     pub malformed: u64,
     pub unsupported: u64,
     pub foreign: u64,
@@ -233,38 +263,6 @@ pub struct CreatedSession {
 pub struct SessionSummary {
     pub stored_id: String,
 }
-
-/// The public ledger is intentionally narrow. Any event not in this set becomes
-/// an `Unsupported` event; it is never guessed, normalized through another
-/// provider, or silently dropped. `clarify.request` is supported only when it
-/// carries the opaque response id injected by the installed gateway.
-pub const GUARANTEED_EVENTS: &[&str] = &[
-    "gateway.ready",
-    "session.info",
-    "message.start",
-    "message.delta",
-    "message.complete",
-    "thinking.delta",
-    "reasoning.delta",
-    "reasoning.available",
-    "status.update",
-    "tool.start",
-    "tool.progress",
-    "tool.generating",
-    "tool.complete",
-    "tool.output_risk",
-    "approval.request",
-    "clarify.request",
-    "error",
-];
-
-pub const UNSUPPORTED_EVENTS: &[&str] = &[
-    "sudo.request",
-    "secret.request",
-    "terminal.read.request",
-    "background.complete",
-    "skin.changed",
-];
 
 pub const UNSUPPORTED_METHODS: &[&str] = &[
     "config.set",
@@ -533,7 +531,7 @@ impl HermesSessionAdapter {
 
     pub fn pump(&mut self, timeout: Duration) -> Result<(), AdapterError> {
         let status_before_wait = self.status;
-        match self.receive_frame(timeout) {
+        match self.receive_frame(Deadline::after(timeout), false) {
             Err(AdapterError::Timeout) => {
                 // A bounded observation window is allowed to be quiet. Preserve
                 // the previous state so callers can distinguish that idle wait
@@ -562,10 +560,11 @@ impl HermesSessionAdapter {
         if wire.len() > MAX_RPC_BYTES {
             return Err(AdapterError::PayloadTooLarge);
         }
-        self.send_frame(&wire)?;
+        let deadline = Deadline::after(self.rpc_timeout);
+        self.send_frame(&wire, deadline)?;
 
         loop {
-            let raw = match self.receive_frame(self.rpc_timeout) {
+            let raw = match self.receive_frame(deadline, true) {
                 Ok(raw) => raw,
                 Err(AdapterError::Timeout) => {
                     self.quarantine_transport();
@@ -709,15 +708,20 @@ impl HermesSessionAdapter {
                 "tool output risk updated".to_owned(),
             ),
             "approval.request" => {
-                *self
-                    .pending_approvals
-                    .entry(session_id.to_owned())
-                    .or_default() += 1;
-                (
-                    EventKind::ApprovalRequest,
-                    "approval_request",
-                    "approval requested".to_owned(),
-                )
+                if self.reserve_approval(session_id) {
+                    (
+                        EventKind::ApprovalRequest,
+                        "approval_request",
+                        "approval requested".to_owned(),
+                    )
+                } else {
+                    self.record_interaction_pressure();
+                    (
+                        EventKind::Diagnostic,
+                        "interaction_limit_reached",
+                        "interaction request capacity reached".to_owned(),
+                    )
+                }
             }
             "clarify.request" => {
                 let request_id = payload
@@ -725,13 +729,21 @@ impl HermesSessionAdapter {
                     .and_then(Value::as_str)
                     .filter(|id| id.len() <= 256);
                 if let Some(request_id) = request_id.filter(|id| !id.is_empty()) {
-                    self.pending_clarifications.insert(request_id.to_owned());
-                    clarification_id = Some(request_id.to_owned());
-                    (
-                        EventKind::ClarificationRequest,
-                        "clarification_request",
-                        "clarification requested".to_owned(),
-                    )
+                    if self.reserve_clarification(request_id) {
+                        clarification_id = Some(request_id.to_owned());
+                        (
+                            EventKind::ClarificationRequest,
+                            "clarification_request",
+                            "clarification requested".to_owned(),
+                        )
+                    } else {
+                        self.record_interaction_pressure();
+                        (
+                            EventKind::Diagnostic,
+                            "interaction_limit_reached",
+                            "interaction request capacity reached".to_owned(),
+                        )
+                    }
                 } else {
                     self.record_unsupported();
                     (
@@ -766,6 +778,38 @@ impl HermesSessionAdapter {
         self.status = SessionStatus::Degraded;
     }
 
+    fn reserve_approval(&mut self, session_id: &str) -> bool {
+        if !self.has_pending_interaction_capacity() {
+            return false;
+        }
+        *self
+            .pending_approvals
+            .entry(session_id.to_owned())
+            .or_default() += 1;
+        true
+    }
+
+    fn reserve_clarification(&mut self, request_id: &str) -> bool {
+        if self.pending_clarifications.contains(request_id) {
+            return true;
+        }
+        if !self.has_pending_interaction_capacity() {
+            return false;
+        }
+        self.pending_clarifications.insert(request_id.to_owned());
+        true
+    }
+
+    fn has_pending_interaction_capacity(&self) -> bool {
+        self.pending_approvals.values().sum::<usize>() + self.pending_clarifications.len()
+            < MAX_PENDING_INTERACTIONS
+    }
+
+    fn record_interaction_pressure(&mut self) {
+        self.signals.interaction_limited += 1;
+        self.status = SessionStatus::Degraded;
+    }
+
     fn enqueue(
         &mut self,
         session_id: &str,
@@ -796,36 +840,30 @@ impl HermesSessionAdapter {
         }
     }
 
-    fn send_frame(&mut self, text: &str) -> Result<(), AdapterError> {
+    fn send_frame(&mut self, text: &str, deadline: Deadline) -> Result<(), AdapterError> {
         let result = {
             let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
-            write_websocket_frame(stream, 0x1, text.as_bytes()).map_err(map_io_error)
+            write_websocket_frame(stream, 0x1, text.as_bytes(), deadline)
         };
-        if let Err(error) = &result {
-            self.record_transport_failure(error);
-        }
-        result
+        self.finish_send(result)
     }
 
-    fn receive_frame(&mut self, timeout: Duration) -> Result<String, AdapterError> {
-        let timeout_result = {
-            let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
-            stream.set_read_timeout(Some(timeout)).map_err(map_io_error)
-        };
-        if let Err(error) = timeout_result {
-            self.record_transport_failure(&error);
-            return Err(error);
-        }
-
+    fn receive_frame(
+        &mut self,
+        deadline: Deadline,
+        quarantine_on_timeout: bool,
+    ) -> Result<String, AdapterError> {
         loop {
             let frame = {
                 let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
-                read_websocket_frame(stream)
+                read_websocket_frame(stream, deadline)
             };
             let (opcode, bytes) = match frame {
                 Ok(frame) => frame,
                 Err(error) => {
-                    self.record_transport_failure(&error);
+                    if quarantine_on_timeout || !matches!(error, AdapterError::Timeout) {
+                        self.quarantine_transport();
+                    }
                     return Err(error);
                 }
             };
@@ -839,17 +877,16 @@ impl HermesSessionAdapter {
                     }
                 },
                 0x8 => {
-                    self.status = SessionStatus::Failed;
+                    self.quarantine_transport();
                     return Err(AdapterError::GatewayLost);
                 }
                 0x9 => {
                     let result = {
                         let stream = self.socket.as_mut().ok_or(AdapterError::GatewayLost)?;
-                        write_websocket_frame(stream, 0xA, &bytes).map_err(map_io_error)
+                        write_websocket_frame(stream, 0xA, &bytes, deadline)
                     };
                     if let Err(error) = result {
-                        self.record_transport_failure(&error);
-                        return Err(error);
+                        return self.finish_send(Err(error));
                     }
                 }
                 0xA => continue,
@@ -862,16 +899,11 @@ impl HermesSessionAdapter {
         }
     }
 
-    fn record_transport_failure(&mut self, error: &AdapterError) {
-        match error {
-            AdapterError::GatewayLost | AdapterError::RetryExhausted => {
-                self.status = SessionStatus::Failed;
-            }
-            AdapterError::Timeout | AdapterError::PayloadTooLarge | AdapterError::MalformedRpc => {
-                self.status = SessionStatus::Degraded;
-            }
-            _ => {}
+    fn finish_send<T>(&mut self, result: Result<T, AdapterError>) -> Result<T, AdapterError> {
+        if result.is_err() {
+            self.quarantine_transport();
         }
+        result
     }
 }
 
@@ -933,19 +965,21 @@ fn classify_rpc_error(error: &Value) -> AdapterError {
 }
 
 fn connect_once(endpoint: &GatewayEndpoint) -> Result<TcpStream, AdapterError> {
+    connect_once_with_timeout(endpoint, DEFAULT_RPC_TIMEOUT)
+}
+
+fn connect_once_with_timeout(
+    endpoint: &GatewayEndpoint,
+    timeout: Duration,
+) -> Result<TcpStream, AdapterError> {
+    let deadline = Deadline::after(timeout);
     let address = (endpoint.host.as_str(), endpoint.port)
         .to_socket_addrs()
         .map_err(map_io_error)?
         .find(|address| address.ip().is_loopback())
         .ok_or(AdapterError::GatewayLost)?;
     let mut stream =
-        TcpStream::connect_timeout(&address, DEFAULT_RPC_TIMEOUT).map_err(map_io_error)?;
-    stream
-        .set_read_timeout(Some(DEFAULT_RPC_TIMEOUT))
-        .map_err(map_io_error)?;
-    stream
-        .set_write_timeout(Some(DEFAULT_RPC_TIMEOUT))
-        .map_err(map_io_error)?;
+        TcpStream::connect_timeout(&address, deadline.remaining()?).map_err(map_io_error)?;
 
     let key = websocket_key()?;
     let request = format!(
@@ -954,10 +988,10 @@ fn connect_once(endpoint: &GatewayEndpoint) -> Result<TcpStream, AdapterError> {
         endpoint.host_header(),
         key
     );
-    stream.write_all(request.as_bytes()).map_err(map_io_error)?;
-    stream.flush().map_err(map_io_error)?;
+    write_all_until(&mut stream, request.as_bytes(), deadline)?;
+    flush_until(&mut stream, deadline)?;
 
-    let response = read_http_headers(&mut stream)?;
+    let response = read_http_headers(&mut stream, deadline)?;
     let status = response.lines().next().unwrap_or_default();
     if status.contains(" 401 ") || status.contains(" 403 ") {
         return Err(AdapterError::AuthFailed);
@@ -994,11 +1028,11 @@ fn websocket_accept(key: &str) -> String {
     STANDARD.encode(digest.finalize())
 }
 
-fn read_http_headers(stream: &mut TcpStream) -> Result<String, AdapterError> {
+fn read_http_headers(stream: &mut TcpStream, deadline: Deadline) -> Result<String, AdapterError> {
     let mut bytes = Vec::with_capacity(1024);
     let mut byte = [0_u8; 1];
     while bytes.len() < MAX_RPC_BYTES {
-        stream.read_exact(&mut byte).map_err(map_io_error)?;
+        read_exact_until(stream, &mut byte, deadline)?;
         bytes.push(byte[0]);
         if bytes.ends_with(b"\r\n\r\n") {
             return String::from_utf8(bytes).map_err(|_| AdapterError::MalformedRpc);
@@ -1007,15 +1041,20 @@ fn read_http_headers(stream: &mut TcpStream) -> Result<String, AdapterError> {
     Err(AdapterError::PayloadTooLarge)
 }
 
-fn write_websocket_frame(stream: &mut TcpStream, opcode: u8, payload: &[u8]) -> io::Result<()> {
+fn write_websocket_frame(
+    stream: &mut TcpStream,
+    opcode: u8,
+    payload: &[u8],
+    deadline: Deadline,
+) -> Result<(), AdapterError> {
     if payload.len() > MAX_FRAME_BYTES {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "frame too large",
-        ));
+        return Err(AdapterError::PayloadTooLarge);
+    }
+    if opcode & 0x08 != 0 && payload.len() > 125 {
+        return Err(AdapterError::MalformedRpc);
     }
     let mut mask = [0_u8; 4];
-    fill_random(&mut mask).map_err(|_| io::Error::other("secure randomness unavailable"))?;
+    fill_random(&mut mask)?;
     let mut header = vec![0x80 | opcode, 0x80];
     if payload.len() <= 125 {
         header[1] |= payload.len() as u8;
@@ -1034,13 +1073,16 @@ fn write_websocket_frame(stream: &mut TcpStream, opcode: u8, payload: &[u8]) -> 
             .enumerate()
             .map(|(index, byte)| byte ^ mask[index % mask.len()]),
     );
-    stream.write_all(&header)?;
-    stream.flush()
+    write_all_until(stream, &header, deadline)?;
+    flush_until(stream, deadline)
 }
 
-fn read_websocket_frame(stream: &mut TcpStream) -> Result<(u8, Vec<u8>), AdapterError> {
+fn read_websocket_frame(
+    stream: &mut TcpStream,
+    deadline: Deadline,
+) -> Result<(u8, Vec<u8>), AdapterError> {
     let mut header = [0_u8; 2];
-    stream.read_exact(&mut header).map_err(map_io_error)?;
+    read_exact_until(stream, &mut header, deadline)?;
     if header[0] & 0xF0 != 0x80 || header[1] & 0x80 != 0 {
         return Err(AdapterError::MalformedRpc);
     }
@@ -1048,19 +1090,62 @@ fn read_websocket_frame(stream: &mut TcpStream) -> Result<(u8, Vec<u8>), Adapter
     let mut length = u64::from(header[1] & 0x7F);
     if length == 126 {
         let mut bytes = [0_u8; 2];
-        stream.read_exact(&mut bytes).map_err(map_io_error)?;
+        read_exact_until(stream, &mut bytes, deadline)?;
         length = u64::from(u16::from_be_bytes(bytes));
     } else if length == 127 {
         let mut bytes = [0_u8; 8];
-        stream.read_exact(&mut bytes).map_err(map_io_error)?;
+        read_exact_until(stream, &mut bytes, deadline)?;
         length = u64::from_be_bytes(bytes);
     }
-    if length as usize > MAX_FRAME_BYTES {
+    if opcode & 0x08 != 0 && length > 125 {
+        return Err(AdapterError::MalformedRpc);
+    }
+    if length > MAX_FRAME_BYTES as u64 {
         return Err(AdapterError::PayloadTooLarge);
     }
-    let mut payload = vec![0_u8; length as usize];
-    stream.read_exact(&mut payload).map_err(map_io_error)?;
+    let length = usize::try_from(length).map_err(|_| AdapterError::PayloadTooLarge)?;
+    let mut payload = vec![0_u8; length];
+    read_exact_until(stream, &mut payload, deadline)?;
     Ok((opcode, payload))
+}
+
+fn read_exact_until(
+    stream: &mut TcpStream,
+    buffer: &mut [u8],
+    deadline: Deadline,
+) -> Result<(), AdapterError> {
+    let mut offset = 0;
+    while offset < buffer.len() {
+        deadline.set_read_timeout(stream)?;
+        match stream.read(&mut buffer[offset..]) {
+            Ok(0) => return Err(AdapterError::GatewayLost),
+            Ok(read) => offset += read,
+            Err(error) => return Err(map_io_error(error)),
+        }
+    }
+    Ok(())
+}
+
+fn write_all_until(
+    stream: &mut TcpStream,
+    buffer: &[u8],
+    deadline: Deadline,
+) -> Result<(), AdapterError> {
+    let mut offset = 0;
+    while offset < buffer.len() {
+        deadline.set_write_timeout(stream)?;
+        match stream.write(&buffer[offset..]) {
+            Ok(0) => return Err(AdapterError::GatewayLost),
+            Ok(written) => offset += written,
+            Err(error) => return Err(map_io_error(error)),
+        }
+    }
+    Ok(())
+}
+
+fn flush_until(stream: &mut TcpStream, deadline: Deadline) -> Result<(), AdapterError> {
+    deadline.set_write_timeout(stream)?;
+    stream.flush().map_err(map_io_error)
 }
 
 fn map_io_error(error: io::Error) -> AdapterError {
@@ -1122,12 +1207,194 @@ mod tests {
     }
 
     #[test]
+    fn pending_interactions_are_bounded_and_excess_is_visible() {
+        let mut adapter = HermesSessionAdapter::scripted();
+        for _ in 0..=MAX_PENDING_INTERACTIONS {
+            adapter
+                .ingest_json(
+                    r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"live-session","payload":{}}}"#,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(
+            adapter.pending_approvals.get("live-session"),
+            Some(&MAX_PENDING_INTERACTIONS)
+        );
+        assert_eq!(adapter.stream_signals().interaction_limited, 1);
+        assert_eq!(
+            adapter.drain_events().last().unwrap().label,
+            "interaction_limit_reached"
+        );
+    }
+
+    #[test]
+    fn handshake_read_deadline_is_absolute_while_peer_drips_bytes() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _ = read_http_headers(&mut stream, Deadline::after(Duration::from_secs(1)));
+            for byte in b"HTTP/1.1 101 Switching Protocols\r\n" {
+                if stream.write_all(&[*byte]).is_err() || stream.flush().is_err() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+
+        let endpoint =
+            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                .unwrap();
+        let started = Instant::now();
+        assert!(matches!(
+            connect_once_with_timeout(&endpoint, Duration::from_millis(20)),
+            Err(AdapterError::Timeout)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(100));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_rpc_deadline_is_absolute_while_frame_payload_drips() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            accept_upgrade(&mut stream);
+            read_client_frame(&mut stream).unwrap();
+            write_server_text_frame_drip(
+                &mut stream,
+                r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+            );
+        });
+
+        let endpoint =
+            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                .unwrap();
+        let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
+        adapter.rpc_timeout = Duration::from_millis(20);
+
+        let started = Instant::now();
+        assert_eq!(adapter.create(None), Err(AdapterError::Timeout));
+        assert!(started.elapsed() < Duration::from_millis(100));
+        assert_eq!(adapter.status(), SessionStatus::Failed);
+        assert!(adapter.socket.is_none());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn oversized_u64_frame_length_is_rejected_before_usize_conversion() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            accept_upgrade(&mut stream);
+            stream.write_all(&[0x81, 127]).unwrap();
+            stream.write_all(&u64::MAX.to_be_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let endpoint =
+            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                .unwrap();
+        let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
+
+        assert_eq!(
+            adapter.pump(Duration::from_millis(100)),
+            Err(AdapterError::PayloadTooLarge)
+        );
+        assert_eq!(adapter.status(), SessionStatus::Failed);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn outbound_control_frames_are_limited_to_125_bytes() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (_server, _) = listener.accept().unwrap();
+
+        assert_eq!(
+            write_websocket_frame(
+                &mut client,
+                0xA,
+                &[0_u8; 126],
+                Deadline::after(Duration::from_millis(100)),
+            ),
+            Err(AdapterError::MalformedRpc)
+        );
+    }
+
+    #[test]
+    fn control_frames_cannot_use_extended_lengths() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            accept_upgrade(&mut stream);
+            stream.write_all(&[0x89, 126, 0, 126]).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let endpoint =
+            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                .unwrap();
+        let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
+
+        assert_eq!(
+            adapter.pump(Duration::from_millis(100)),
+            Err(AdapterError::MalformedRpc)
+        );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn partial_send_failure_quarantines_the_socket() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (_server, _) = listener.accept().unwrap();
+        let mut adapter = HermesSessionAdapter::scripted();
+        adapter.socket = Some(client);
+        let mut writer = PartialWriteFailure::default();
+        let result = writer.write_all(b"frame").map_err(map_io_error);
+
+        assert_eq!(adapter.finish_send(result), Err(AdapterError::GatewayLost));
+        assert!(adapter.socket.is_none());
+        assert_eq!(adapter.status(), SessionStatus::Failed);
+    }
+
+    #[test]
+    fn passive_observation_timeout_keeps_the_socket_for_later_pumps() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            accept_upgrade(&mut stream);
+            thread::sleep(Duration::from_millis(50));
+        });
+
+        let endpoint =
+            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                .unwrap();
+        let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
+
+        assert_eq!(
+            adapter.pump(Duration::from_millis(5)),
+            Err(AdapterError::Timeout)
+        );
+        assert_eq!(adapter.status(), SessionStatus::Idle);
+        assert!(adapter.socket.is_some());
+        server.join().unwrap();
+    }
+
+    #[test]
     fn control_timeout_quarantines_the_socket_before_a_late_response_can_be_reused() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let request = read_http_headers(&mut stream).unwrap();
+            let request =
+                read_http_headers(&mut stream, Deadline::after(Duration::from_secs(1))).unwrap();
             let key = request
                 .lines()
                 .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
@@ -1166,6 +1433,51 @@ mod tests {
             Err(AdapterError::GatewayLost)
         );
         server.join().unwrap();
+    }
+
+    fn accept_upgrade(stream: &mut TcpStream) {
+        let request = read_http_headers(stream, Deadline::after(Duration::from_secs(1))).unwrap();
+        let key = request
+            .lines()
+            .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
+            .unwrap();
+        let accept = websocket_accept(key);
+        write!(
+            stream,
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+        )
+        .unwrap();
+    }
+
+    fn write_server_text_frame_drip(stream: &mut TcpStream, text: &str) {
+        stream.write_all(&[0x81, text.len() as u8]).unwrap();
+        stream.flush().unwrap();
+        for byte in text.as_bytes() {
+            if stream.write_all(&[*byte]).is_err() || stream.flush().is_err() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[derive(Default)]
+    struct PartialWriteFailure {
+        wrote_once: bool,
+    }
+
+    impl Write for PartialWriteFailure {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.wrote_once {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "write failed"))
+            } else {
+                self.wrote_once = true;
+                Ok(bytes.len().min(1))
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
     }
 
     fn write_server_text_frame(stream: &mut TcpStream, text: &str) -> io::Result<()> {

--- a/crates/relay-hermes-session/src/lib.rs
+++ b/crates/relay-hermes-session/src/lib.rs
@@ -126,12 +126,11 @@ fn parse_loopback_authority(authority: &str) -> Result<(String, u16), AdapterErr
 }
 
 fn has_supported_credential(query: &str) -> bool {
-    query.split('&').any(|item| {
-        let Some((key, value)) = item.split_once('=') else {
-            return false;
-        };
-        !value.is_empty() && key == "token"
-    })
+    let mut items = query.split('&');
+    let Some((key, value)) = items.next().and_then(|item| item.split_once('=')) else {
+        return false;
+    };
+    key == "token" && !value.is_empty() && items.next().is_none()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1023,6 +1022,10 @@ mod tests {
         );
         assert!(GatewayEndpoint::parse("ws://127.0.0.1:9119/v1/chat/completions?token=x").is_err());
         assert!(GatewayEndpoint::parse("wss://127.0.0.1:9119/api/ws?token=x").is_err());
+        assert!(
+            GatewayEndpoint::parse("ws://127.0.0.1:9119/api/ws?token=x&ticket=browser-auth")
+                .is_err()
+        );
         assert!(
             GatewayEndpoint::parse("ws://127.0.0.1:9119/api/ws?token=x\r\nInjected: y").is_err()
         );

--- a/crates/relay-hermes-session/src/lib.rs
+++ b/crates/relay-hermes-session/src/lib.rs
@@ -666,6 +666,11 @@ impl HermesSessionAdapter {
                 "session_info",
                 "session information".to_owned(),
             ),
+            "session.title" => (
+                EventKind::Lifecycle,
+                "session_title",
+                "session title updated".to_owned(),
+            ),
             "message.start" => {
                 self.status = SessionStatus::Working;
                 (
@@ -1087,18 +1092,19 @@ fn read_websocket_frame(
         return Err(AdapterError::MalformedRpc);
     }
     let opcode = header[0] & 0x0F;
-    let mut length = u64::from(header[1] & 0x7F);
-    if length == 126 {
+    let length_marker = header[1] & 0x7F;
+    if opcode & 0x08 != 0 && length_marker >= 126 {
+        return Err(AdapterError::MalformedRpc);
+    }
+    let mut length = u64::from(length_marker);
+    if length_marker == 126 {
         let mut bytes = [0_u8; 2];
         read_exact_until(stream, &mut bytes, deadline)?;
         length = u64::from(u16::from_be_bytes(bytes));
-    } else if length == 127 {
+    } else if length_marker == 127 {
         let mut bytes = [0_u8; 8];
         read_exact_until(stream, &mut bytes, deadline)?;
         length = u64::from_be_bytes(bytes);
-    }
-    if opcode & 0x08 != 0 && length > 125 {
-        return Err(AdapterError::MalformedRpc);
     }
     if length > MAX_FRAME_BYTES as u64 {
         return Err(AdapterError::PayloadTooLarge);
@@ -1326,26 +1332,29 @@ mod tests {
     }
 
     #[test]
-    fn control_frames_cannot_use_extended_lengths() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            accept_upgrade(&mut stream);
-            stream.write_all(&[0x89, 126, 0, 126]).unwrap();
-            stream.flush().unwrap();
-        });
+    fn control_frames_reject_extended_length_markers_before_length_decode() {
+        for (opcode, marker) in [(0x89, 126), (0x8A, 127), (0x8B, 126)] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let server = thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                accept_upgrade(&mut stream);
+                stream.write_all(&[opcode, marker]).unwrap();
+                stream.flush().unwrap();
+            });
 
-        let endpoint =
-            GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
-                .unwrap();
-        let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
+            let endpoint =
+                GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+                    .unwrap();
+            let mut adapter = HermesSessionAdapter::connect(endpoint).unwrap();
 
-        assert_eq!(
-            adapter.pump(Duration::from_millis(100)),
-            Err(AdapterError::MalformedRpc)
-        );
-        server.join().unwrap();
+            assert_eq!(
+                adapter.pump(Duration::from_millis(100)),
+                Err(AdapterError::MalformedRpc),
+                "opcode {opcode:#x} with marker {marker} must fail before an extended-length read"
+            );
+            server.join().unwrap();
+        }
     }
 
     #[test]

--- a/crates/relay-hermes-session/tests/adapter_contract.rs
+++ b/crates/relay-hermes-session/tests/adapter_contract.rs
@@ -31,6 +31,26 @@ fn unsupported_gateway_events_are_visible_and_never_silently_dropped() {
 }
 
 #[test]
+fn session_title_is_a_supported_lifecycle_event_without_title_retention() {
+    let mut adapter = HermesSessionAdapter::scripted();
+
+    adapter
+        .ingest_json(
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"session.title","session_id":"live-1","payload":{"title":"do-not-retain"}}}"#,
+        )
+        .expect("session title is a supported lifecycle event");
+
+    let events = adapter.drain_events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].session_id, "live-1");
+    assert_eq!(events[0].kind, EventKind::Lifecycle);
+    assert_eq!(events[0].label, "session_title");
+    assert_eq!(events[0].preview, "session title updated");
+    assert_eq!(adapter.stream_signals().unsupported, 0);
+    assert_eq!(adapter.status(), SessionStatus::Idle);
+}
+
+#[test]
 fn bounded_queue_reports_replay_gap_instead_of_lying_about_complete_history() {
     let mut adapter = HermesSessionAdapter::scripted_with_queue_limit(2);
 

--- a/crates/relay-hermes-session/tests/adapter_contract.rs
+++ b/crates/relay-hermes-session/tests/adapter_contract.rs
@@ -1,0 +1,61 @@
+use relay_hermes_session::{
+    AdapterError, EventKind, GatewayEndpoint, HermesSessionAdapter, SessionStatus,
+};
+
+#[test]
+fn rejects_non_loopback_and_non_rich_client_endpoints_without_echoing_credentials() {
+    let credential = "not-a-real-token";
+    let error =
+        GatewayEndpoint::parse(&format!("ws://example.test:9119/api/ws?token={credential}"))
+            .expect_err("remote gateway fallback must be rejected");
+
+    assert_eq!(error.code(), "unsupported_endpoint");
+    assert!(!error.to_string().contains(credential));
+}
+
+#[test]
+fn unsupported_gateway_events_are_visible_and_never_silently_dropped() {
+    let mut adapter = HermesSessionAdapter::scripted();
+
+    adapter
+        .ingest_json(r#"{"jsonrpc":"2.0","method":"event","params":{"type":"provider.private","session_id":"live-1","payload":{"secret":"do-not-log"}}}"#)
+        .expect("well-formed unknown event is observable");
+
+    let events = adapter.drain_events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].session_id, "live-1");
+    assert_eq!(events[0].kind, EventKind::Unsupported);
+    assert_eq!(events[0].label, "unsupported_event");
+    assert!(!events[0].preview.contains("do-not-log"));
+    assert_eq!(adapter.status(), SessionStatus::Degraded);
+}
+
+#[test]
+fn bounded_queue_reports_replay_gap_instead_of_lying_about_complete_history() {
+    let mut adapter = HermesSessionAdapter::scripted_with_queue_limit(2);
+
+    for index in 0..3 {
+        adapter
+            .ingest_json(&format!(
+                r#"{{"jsonrpc":"2.0","method":"event","params":{{"type":"tool.start","session_id":"live-1","payload":{{"name":"tool-{index}"}}}}}}"#
+            ))
+            .expect("tool event fits the supported schema");
+    }
+
+    let signals = adapter.stream_signals();
+    assert_eq!(signals.dropped, 1);
+    assert!(signals.replay_gap);
+    assert_eq!(adapter.status(), SessionStatus::Degraded);
+}
+
+#[test]
+fn malformed_frames_fail_closed_with_a_typed_error() {
+    let mut adapter = HermesSessionAdapter::scripted();
+
+    let error = adapter
+        .ingest_json("not json")
+        .expect_err("bad JSON cannot be mapped");
+
+    assert_eq!(error, AdapterError::MalformedRpc);
+    assert_eq!(adapter.status(), SessionStatus::Degraded);
+}

--- a/crates/relay-hermes-session/tests/adapter_contract.rs
+++ b/crates/relay-hermes-session/tests/adapter_contract.rs
@@ -59,3 +59,33 @@ fn malformed_frames_fail_closed_with_a_typed_error() {
     assert_eq!(error, AdapterError::MalformedRpc);
     assert_eq!(adapter.status(), SessionStatus::Degraded);
 }
+
+#[test]
+fn only_gateway_ready_may_be_unscoped() {
+    let mut adapter = HermesSessionAdapter::scripted();
+
+    adapter
+        .ingest_json(r#"{"jsonrpc":"2.0","method":"event","params":{"type":"gateway.ready"}}"#)
+        .expect("the global gateway lifecycle event is allowed without a session ID");
+
+    let events = adapter.drain_events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].session_id, "");
+    assert_eq!(events[0].kind, EventKind::Lifecycle);
+}
+
+#[test]
+fn session_scoped_events_fail_closed_without_a_nonempty_string_session_id() {
+    for raw in [
+        r#"{"jsonrpc":"2.0","method":"event","params":{"type":"message.start"}}"#,
+        r#"{"jsonrpc":"2.0","method":"event","params":{"type":"tool.start","session_id":7}}"#,
+        r#"{"jsonrpc":"2.0","method":"event","params":{"type":"status.update","session_id":""}}"#,
+        r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":null}}"#,
+    ] {
+        let mut adapter = HermesSessionAdapter::scripted();
+
+        assert_eq!(adapter.ingest_json(raw), Err(AdapterError::MalformedRpc));
+        assert!(adapter.drain_events().is_empty());
+        assert_eq!(adapter.status(), SessionStatus::Degraded);
+    }
+}

--- a/crates/relay-hermes-session/tests/disconnect_contract.rs
+++ b/crates/relay-hermes-session/tests/disconnect_contract.rs
@@ -1,0 +1,134 @@
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    thread,
+    time::Duration,
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use relay_hermes_session::{AdapterError, GatewayEndpoint, HermesSessionAdapter, SessionStatus};
+use sha1::{Digest, Sha1};
+
+#[test]
+fn gateway_disconnect_during_a_control_request_is_terminal_and_typed() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        read_text_frame(&mut stream);
+        write_text_frame(
+            &mut stream,
+            r#"{"id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        read_text_frame(&mut stream);
+        // Drop the live transport before the interrupt JSON-RPC response.
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let session = adapter.create(None).expect("session creation response");
+
+    assert_eq!(
+        adapter.interrupt(&session.live_id),
+        Err(AdapterError::GatewayLost)
+    );
+    assert_eq!(adapter.status(), SessionStatus::Failed);
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn quiet_observation_timeout_preserves_the_prior_session_status() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        thread::sleep(Duration::from_millis(50));
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+
+    assert_eq!(
+        adapter.pump(Duration::from_millis(5)),
+        Err(AdapterError::Timeout)
+    );
+    assert_eq!(adapter.status(), SessionStatus::Idle);
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn connected_adapter_rejects_controls_for_unowned_live_sessions() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        thread::sleep(Duration::from_millis(50));
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+
+    assert_eq!(
+        adapter.interrupt("another-live-session"),
+        Err(AdapterError::UnknownSession)
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+fn accept_upgrade(stream: &mut TcpStream) {
+    let request = read_headers(stream);
+    let key = request
+        .lines()
+        .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
+        .expect("websocket key");
+    let mut digest = Sha1::new();
+    digest.update(key.as_bytes());
+    digest.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    let accept = STANDARD.encode(digest.finalize());
+    write!(
+        stream,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+    )
+    .expect("write websocket upgrade");
+}
+
+fn read_headers(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !bytes.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).expect("read HTTP header byte");
+        bytes.push(byte[0]);
+    }
+    String::from_utf8(bytes).expect("HTTP header is UTF-8")
+}
+
+fn read_text_frame(stream: &mut TcpStream) {
+    let mut header = [0_u8; 2];
+    stream
+        .read_exact(&mut header)
+        .expect("read websocket header");
+    let length = usize::from(header[1] & 0x7F);
+    assert!(length < 126, "test request stays compact");
+    let mut mask = [0_u8; 4];
+    stream.read_exact(&mut mask).expect("read mask");
+    let mut payload = vec![0_u8; length];
+    stream.read_exact(&mut payload).expect("read payload");
+}
+
+fn write_text_frame(stream: &mut TcpStream, text: &str) {
+    let payload = text.as_bytes();
+    assert!(payload.len() < 126, "test response stays compact");
+    stream
+        .write_all(&[0x81, payload.len() as u8])
+        .expect("write websocket header");
+    stream.write_all(payload).expect("write websocket payload");
+}

--- a/crates/relay-hermes-session/tests/transport_contract.rs
+++ b/crates/relay-hermes-session/tests/transport_contract.rs
@@ -148,6 +148,153 @@ fn approval_response_uses_a_supported_gateway_choice() {
 }
 
 #[test]
+fn approval_race_is_not_reported_as_success_and_keeps_the_request_retryable() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        read_text_frame(&mut stream);
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "approval.respond");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"resolved":0}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "approval.respond");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":3,"result":{"resolved":1}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let session = adapter.create(None).expect("owned live session");
+    adapter
+        .ingest_json(
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"live-session","payload":{}}}"#,
+        )
+        .expect("approval event");
+
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Err(AdapterError::Raced)
+    );
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Ok(())
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn approval_event_arriving_during_a_response_keeps_its_own_pending_marker() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        read_text_frame(&mut stream);
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "approval.respond");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"live-session","payload":{}}}"#,
+        );
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"resolved":1}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "approval.respond");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":3,"result":{"resolved":1}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let session = adapter.create(None).expect("owned live session");
+    adapter
+        .ingest_json(
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"live-session","payload":{}}}"#,
+        )
+        .expect("first approval event");
+
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Ok(())
+    );
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Ok(())
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn approval_remote_failure_does_not_clear_the_pending_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        read_text_frame(&mut stream);
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        read_text_frame(&mut stream);
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"error":{"code":5000,"message":"retryable gateway failure"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "approval.respond");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":3,"result":{"resolved":1}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let session = adapter.create(None).expect("owned live session");
+    adapter
+        .ingest_json(
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"live-session","payload":{}}}"#,
+        )
+        .expect("approval event");
+
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Err(AdapterError::RemoteFailure)
+    );
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Ok(())
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
 fn clarification_response_exposes_only_its_opaque_correlation_id() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
     let port = listener.local_addr().expect("listener address").port();

--- a/crates/relay-hermes-session/tests/transport_contract.rs
+++ b/crates/relay-hermes-session/tests/transport_contract.rs
@@ -1,0 +1,249 @@
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    thread,
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use relay_hermes_session::{
+    AdapterError, ApprovalChoice, GatewayEndpoint, HermesSessionAdapter, SessionStatus,
+};
+use sha1::{Digest, Sha1};
+
+#[test]
+fn interrupt_race_is_degraded_and_never_retried() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "session.create");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "session.interrupt");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"error":{"code":4009,"message":"already completed"}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter =
+        HermesSessionAdapter::connect(endpoint).expect("authenticated websocket handshake");
+
+    let session = adapter.create(None).expect("owned live session");
+    assert_eq!(
+        adapter.interrupt(&session.live_id),
+        Err(AdapterError::Raced)
+    );
+    assert_eq!(adapter.status(), SessionStatus::Degraded);
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn interrupt_remote_failure_is_not_misreported_as_a_race() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "session.create");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "session.interrupt");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"error":{"code":5000,"message":"gateway failure"}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let session = adapter.create(None).expect("owned live session");
+
+    assert_eq!(
+        adapter.interrupt(&session.live_id),
+        Err(AdapterError::RemoteFailure)
+    );
+    assert_eq!(adapter.status(), SessionStatus::Degraded);
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn forbidden_upgrade_is_typed_auth_failure_without_endpoint_or_token_echo() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        read_headers(&mut stream);
+        stream
+            .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+            .expect("write forbidden response");
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let error = match HermesSessionAdapter::connect(endpoint) {
+        Ok(_) => panic!("forbidden upgrade must fail"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error, AdapterError::AuthFailed);
+    assert!(!error.to_string().contains("test-token"));
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn approval_response_uses_a_supported_gateway_choice() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "session.create");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "approval.respond");
+        assert_eq!(request["params"]["session_id"], "live-session");
+        assert_eq!(request["params"]["choice"], "once");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"resolved":1}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let session = adapter.create(None).expect("owned live session");
+    adapter
+        .ingest_json(
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"live-session","payload":{}}}"#,
+        )
+        .expect("approval event");
+
+    assert_eq!(
+        adapter.respond_approval(&session.live_id, ApprovalChoice::Once),
+        Ok(())
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+#[test]
+fn clarification_response_exposes_only_its_opaque_correlation_id() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake dashboard");
+    let port = listener.local_addr().expect("listener address").port();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("adapter connects");
+        accept_upgrade(&mut stream);
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "session.create");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":1,"result":{"session_id":"live-session","stored_session_id":"stored-session"}}"#,
+        );
+        let request = read_text_frame(&mut stream);
+        assert_eq!(request["method"], "clarify.respond");
+        assert_eq!(request["params"]["request_id"], "opaque-clarify-id");
+        assert_eq!(request["params"]["answer"], "continue");
+        write_text_frame(
+            &mut stream,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"status":"ok"}}"#,
+        );
+    });
+
+    let endpoint =
+        GatewayEndpoint::parse(&format!("ws://127.0.0.1:{port}/api/ws?token=test-token"))
+            .expect("loopback dashboard URL");
+    let mut adapter = HermesSessionAdapter::connect(endpoint).expect("dashboard handshake");
+    let _session = adapter.create(None).expect("owned live session");
+    adapter
+        .ingest_json(
+            r#"{"jsonrpc":"2.0","method":"event","params":{"type":"clarify.request","session_id":"live-session","payload":{"request_id":"opaque-clarify-id","question":"hidden","choices":["hidden"]}}}"#,
+        )
+        .expect("correlated clarification event");
+
+    let event = adapter.drain_events().pop().expect("clarification event");
+    assert_eq!(event.clarification_id.as_deref(), Some("opaque-clarify-id"));
+    assert_eq!(event.preview, "clarification requested");
+    assert_eq!(
+        adapter.respond_clarification("opaque-clarify-id", "continue"),
+        Ok(())
+    );
+    server.join().expect("fake dashboard exits");
+}
+
+fn accept_upgrade(stream: &mut TcpStream) {
+    let request = read_headers(stream);
+    let key = request
+        .lines()
+        .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
+        .expect("websocket key");
+    let mut digest = Sha1::new();
+    digest.update(key.as_bytes());
+    digest.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    let accept = STANDARD.encode(digest.finalize());
+    write!(
+        stream,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+    )
+    .expect("write websocket upgrade");
+}
+
+fn read_headers(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !bytes.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).expect("read HTTP header byte");
+        bytes.push(byte[0]);
+    }
+    String::from_utf8(bytes).expect("HTTP header is UTF-8")
+}
+
+fn read_text_frame(stream: &mut TcpStream) -> serde_json::Value {
+    let mut header = [0_u8; 2];
+    stream
+        .read_exact(&mut header)
+        .expect("read websocket header");
+    assert_eq!(header[0], 0x81, "client text frame");
+    assert_ne!(header[1] & 0x80, 0, "client frames are masked");
+    let length = usize::from(header[1] & 0x7F);
+    assert!(length < 126, "test request stays compact");
+    let mut mask = [0_u8; 4];
+    stream.read_exact(&mut mask).expect("read mask");
+    let mut payload = vec![0_u8; length];
+    stream.read_exact(&mut payload).expect("read payload");
+    for (index, byte) in payload.iter_mut().enumerate() {
+        *byte ^= mask[index % mask.len()];
+    }
+    serde_json::from_slice(&payload).expect("JSON-RPC request")
+}
+
+fn write_text_frame(stream: &mut TcpStream, text: &str) {
+    assert!(text.len() < 126, "test response stays compact");
+    stream
+        .write_all(&[0x81, text.len() as u8])
+        .expect("write frame header");
+    stream
+        .write_all(text.as_bytes())
+        .expect("write frame payload");
+    stream.flush().expect("flush frame");
+}

--- a/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
+++ b/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
@@ -1,0 +1,133 @@
+# Hermes rich-client Session adapter
+
+## Purpose and boundary
+
+`relay-hermes-session` is the native, one-node adapter for Hermes's authenticated dashboard rich-client JSON-RPC WebSocket. It targets only:
+
+```text
+ws://127.0.0.1:<dashboard-port>/api/ws?token=<ephemeral-dashboard-token>
+```
+
+The endpoint is supplied by an operator and is never logged or rendered by Relay. The adapter rejects `wss`, non-loopback hosts, non-dashboard paths, the OpenAI-compatible `/v1/*` API server, bare messaging-gateway ports, and any credential shape other than the local dashboard `token` query parameter.
+
+This is intentionally not a generic Relay gateway bridge or a remote Hermes transport. Hermes's messaging/API gateway is distinct from the dashboard's `/api/ws` TUI JSON-RPC surface; pointing this adapter at the former is unsupported and visibly rejected.
+
+## Authority separation
+
+- **Browser human authentication:** browser cookies, login flows, OAuth grants, and dashboard tickets are not accepted or replayed by this adapter.
+- **Hermes rich-client credential:** a loopback dashboard's ephemeral session token is supplied directly in the operator-provided local WebSocket URL. It is redacted from errors, diagnostics, event previews, CLI output, and PR evidence.
+- **Relay node identity:** Relay neither sends nor derives a node identity from a Hermes credential. No profile database, provider credential, browser session, or transcript is copied into Relay.
+
+For a publicly bound dashboard, Hermes requires its browser auth gate and ticket flow. That is outside this one-node MVP; use a loopback dashboard instead.
+
+## Verified gateway contract
+
+This adapter is verified against the installed **Hermes Agent v0.18.2
+(2026.7.7.2)** rich-client implementation. `/api/ws` authenticates first, then
+uses one JSON-RPC object per WebSocket text message; it emits `gateway.ready`
+on accept and routes `session.create`, `session.list`, `session.resume`,
+`prompt.submit`, `session.interrupt`, and `approval.respond` through the same
+gateway handlers used by the TUI and dashboard. The installed gateway's
+`clarify.request` frame does not expose the `request_id` required by
+`clarify.respond`, so Relay observes that frame as a visible unsupported
+correlation gap rather than guessing a response target.
+
+The accepted Relay credential shape is intentionally narrower than every
+Hermes auth shape: only the loopback dashboard `token` query parameter is
+accepted. Browser OAuth cookies and short-lived browser tickets remain browser
+authority, and the server-internal credential remains server-child authority;
+Relay never mints, stores, or reuses either of them.
+
+The adapter accepts control calls only for live IDs it created or resumed on
+that connection. A listed stored ID must be resumed before it can receive a
+prompt, interrupt, or approval response; arbitrary live IDs fail as typed
+`unknown_session` without a transport write.
+
+## Supported-event ledger
+
+The adapter assigns monotonic arrival sequences and emits only provider-neutral categories plus a short redacted preview. It does not preserve raw JSON-RPC payloads, model messages, reasoning, command arguments, tool results, clarification text, or approval command text.
+
+| Hermes rich-client event | Neutral category | Stable label | Preview policy |
+| --- | --- | --- | --- |
+| `gateway.ready`, `session.info` | lifecycle | `gateway_ready`, `session_info` | fixed text |
+| `message.start`, `message.delta`, `message.complete` | status | `message_started`, `message_delta`, `message_complete` | fixed text; no transcript |
+| `thinking.delta`, `reasoning.delta`, `reasoning.available` | status | `reasoning` | always `redacted reasoning` |
+| `status.update` | status | `status_update` | fixed text |
+| `tool.start`, `tool.generating`, `tool.complete`, `tool.output_risk` | tool | `tool_started`, `tool_progress`, `tool_complete`, `tool_output_risk` | safe ASCII tool name only; otherwise `tool activity` |
+| `approval.request` | approval request | `approval_request` | fixed text; a response is session-scoped with one-shot `once` or `deny`; Hermes's persistent `session`/`always` grants are deliberately unsupported |
+| `error` | diagnostic | `gateway_error` | fixed text |
+
+Hermes 0.18.2 emits `clarify.request` without the `request_id` its
+`clarify.respond` handler requires. Relay therefore emits the request as the
+visible unsupported `clarification_without_id` marker, leaves the Session
+degraded, and never guesses a response target. If a future gateway adds an
+opaque response id, Relay exposes only that id as `clarification_id` and permits
+one response; it still retains no question, choices, or transcript content.
+Each emitted event retains the live gateway session id so Relay never attributes
+a shared-gateway event to the wrong Session.
+
+The table records event types the installed gateway can emit, not a promise that
+every turn emits every type: tool rows depend on the Hermes progress display
+mode, and reasoning/interaction rows depend on the active provider and turn.
+
+## Provider-neutral compatibility seam
+
+This crate intentionally does not reuse the merged `relay-session`
+`ProcessTransport`/`Supervisor` from PR #1147: that implementation owns a
+local Codex stdio child and explicitly rejects network transports, while Hermes
+needs an authenticated loopback dashboard WebSocket. Its mapping remains
+category-compatible with the provider-neutral seam: Hermes lifecycle events map
+to lifecycle; status and tool events map to progress; approval requests map to
+approval requests; and malformed, unsupported, pressure, and gateway errors
+remain diagnostics. The Hermes-only live-session attribution and clarification
+correlation require an additive neutral-contract decision before a later
+integration exposes them beyond this adapter.
+
+## Unsupported ledger
+
+The adapter never pretends to support persistent approval grants (`session` or
+`always`), `sudo.request`, `secret.request`, `terminal.read.request`,
+`background.complete`, `skin.changed`, `config.set`, `command.dispatch`,
+`cli.exec`, `process.stop`, `terminal.resize`, `image.attach`,
+`session.branch`, or `session.compress`. Any unknown event becomes a visible
+`unsupported_event` and increments `StreamSignals.unsupported`; an unsupported
+method returns typed `unsupported` before it touches the transport.
+
+## Bounded recovery and data handling
+
+| Condition | Bounded behavior |
+| --- | --- |
+| Auth upgrade rejected | typed `auth_failed`; no retry and no credential echo |
+| Connection or dashboard restart | typed `gateway_lost`; connection setup retries at most three times, then reports `retry_exhausted` |
+| Malformed RPC or non-text frame | typed `malformed_rpc`, cumulative signal, Session becomes degraded |
+| Control-RPC deadline | typed `timeout` and Session degradation; no automatic retry of create, prompt, approval, clarification, or interrupt because they are not safely idempotent |
+| Passive observation deadline | typed `timeout` but retains the prior Session state; a quiet bounded observation window is normal |
+| Queue pressure | queue holds at most 128 events; oldest event is dropped, `dropped` increments, `replay_gap=true`, Session becomes degraded |
+| Foreign session event | not queued or allowed to alter this adapter's status; `foreign` increments without retaining a provider payload |
+| Replay request before retained history | typed `replay_gap`; replay retention is at most 64 events |
+| Oversize RPC/frame | 8 KiB request and 64 KiB frame limits; typed `payload_too_large` |
+| Interrupt/approval response races | a `4009` server race or missing pending request becomes typed `raced`; other server failures remain typed `remote_failure` and Session becomes degraded |
+| Clarification correlation gap | a `clarify.request` without an opaque response id becomes visible `clarification_without_id`; no response is sent |
+
+The adapter emits no normal logs. `relay-node hermes-smoke` prints only booleans, counts, and a coarse status; it does not print endpoint URLs, tokens, session IDs, prompts, event payloads, transcripts, or private reasoning.
+
+## Local contract smoke
+
+Start a loopback-only dashboard with an ephemeral token supplied through its environment, then invoke the Relay harness with the URL held in a shell variable. Do not paste the token into issue comments, shell history, logs, or PR evidence.
+
+```bash
+relay-node hermes-smoke --gateway-url "$HERMES_RICH_CLIENT_URL" --cwd "$PWD"
+```
+
+The harness uses the native `/api/ws` protocol to list sessions, create one, submit a prompt, and resume its stored session. It observes any immediately available lifecycle/tool/status events through the bounded stream.
+
+## Verification
+
+```bash
+sh scripts/cargo.sh test -p relay-hermes-session
+sh scripts/cargo.sh test -p relay-node --test hermes_smoke_cli
+npm test
+npm run lint
+npm run build
+npm run bench
+```

--- a/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
+++ b/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
@@ -27,10 +27,10 @@ This adapter is verified against the installed **Hermes Agent v0.18.2
 uses one JSON-RPC object per WebSocket text message; it emits `gateway.ready`
 on accept and routes `session.create`, `session.list`, `session.resume`,
 `prompt.submit`, `session.interrupt`, and `approval.respond` through the same
-gateway handlers used by the TUI and dashboard. The installed gateway's
-`clarify.request` frame does not expose the `request_id` required by
-`clarify.respond`, so Relay observes that frame as a visible unsupported
-correlation gap rather than guessing a response target.
+gateway handlers used by the TUI and dashboard. Its blocking prompt bridge
+injects an opaque `payload.request_id` before it emits `clarify.request`, and
+`clarify.respond` consumes that exact id. Relay therefore supports one
+clarification response without retaining a question, choice, or transcript.
 
 The accepted Relay credential shape is intentionally narrower than every
 Hermes auth shape: only the loopback dashboard `token` query parameter is
@@ -53,16 +53,17 @@ The adapter assigns monotonic arrival sequences and emits only provider-neutral 
 | `message.start`, `message.delta`, `message.complete` | status | `message_started`, `message_delta`, `message_complete` | fixed text; no transcript |
 | `thinking.delta`, `reasoning.delta`, `reasoning.available` | status | `reasoning` | always `redacted reasoning` |
 | `status.update` | status | `status_update` | fixed text |
-| `tool.start`, `tool.generating`, `tool.complete`, `tool.output_risk` | tool | `tool_started`, `tool_progress`, `tool_complete`, `tool_output_risk` | safe ASCII tool name only; otherwise `tool activity` |
+| `tool.start`, `tool.progress`, `tool.generating`, `tool.complete`, `tool.output_risk` | tool | `tool_started`, `tool_progress`, `tool_complete`, `tool_output_risk` | safe ASCII tool name only; otherwise `tool activity` |
 | `approval.request` | approval request | `approval_request` | fixed text; a response is session-scoped with one-shot `once` or `deny`; Hermes's persistent `session`/`always` grants are deliberately unsupported |
+| `clarify.request` | clarification request | `clarification_request` | only the opaque `request_id` is retained for one `clarify.respond`; question, choices, and answer contents are never retained |
 | `error` | diagnostic | `gateway_error` | fixed text |
 
-Hermes 0.18.2 emits `clarify.request` without the `request_id` its
-`clarify.respond` handler requires. Relay therefore emits the request as the
-visible unsupported `clarification_without_id` marker, leaves the Session
-degraded, and never guesses a response target. If a future gateway adds an
-opaque response id, Relay exposes only that id as `clarification_id` and permits
-one response; it still retains no question, choices, or transcript content.
+Hermes 0.18.2 injects `request_id` into every blocking `clarify.request` before
+emission, and `clarify.respond` consumes it. Relay exposes only that opaque id
+as `clarification_id` and permits one response; it retains no question, choices,
+or transcript content. A malformed future frame without a nonempty opaque id is
+still visible as `clarification_without_id`, leaves the Session degraded, and
+never guesses a response target.
 Each emitted event retains the live gateway session id so Relay never attributes
 a shared-gateway event to the wrong Session.
 
@@ -100,14 +101,14 @@ method returns typed `unsupported` before it touches the transport.
 | Auth upgrade rejected | typed `auth_failed`; no retry and no credential echo |
 | Connection or dashboard restart | typed `gateway_lost`; connection setup retries at most three times, then reports `retry_exhausted` |
 | Malformed RPC or non-text frame | typed `malformed_rpc`, cumulative signal, Session becomes degraded |
-| Control-RPC deadline | typed `timeout` and Session degradation; no automatic retry of create, prompt, approval, clarification, or interrupt because they are not safely idempotent |
+| Control-RPC deadline | typed `timeout`; Relay quarantines and closes that socket, marks the Session failed, and requires a new adapter so a late response cannot be misattributed to a later control RPC |
 | Passive observation deadline | typed `timeout` but retains the prior Session state; a quiet bounded observation window is normal |
 | Queue pressure | queue holds at most 128 events; oldest event is dropped, `dropped` increments, `replay_gap=true`, Session becomes degraded |
 | Foreign session event | not queued or allowed to alter this adapter's status; `foreign` increments without retaining a provider payload |
 | Replay request before retained history | typed `replay_gap`; replay retention is at most 64 events |
 | Oversize RPC/frame | 8 KiB request and 64 KiB frame limits; typed `payload_too_large` |
-| Interrupt/approval response races | a `4009` server race or missing pending request becomes typed `raced`; other server failures remain typed `remote_failure` and Session becomes degraded |
-| Clarification correlation gap | a `clarify.request` without an opaque response id becomes visible `clarification_without_id`; no response is sent |
+| Interrupt/approval response races | a `4009` server race, `approval.respond` result with `resolved: 0`, or missing pending request becomes typed `raced`; only a positive `resolved` acknowledgement decrements Relay's per-session pending count, so another request received during the call remains pending; other RPC failures retain the count and become typed `remote_failure`/transport errors |
+| Clarification correlation | Hermes 0.18.2 supplies an opaque `request_id`; Relay permits one matching response and retains no prompt content. A frame without a usable id becomes visible `clarification_without_id`; no response is sent |
 
 The adapter emits no normal logs. `relay-node hermes-smoke` prints only booleans, counts, and a coarse status; it does not print endpoint URLs, tokens, session IDs, prompts, event payloads, transcripts, or private reasoning.
 

--- a/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
+++ b/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
@@ -70,6 +70,10 @@ a shared-gateway event to the wrong Session.
 The table records event types the installed gateway can emit, not a promise that
 every turn emits every type: tool rows depend on the Hermes progress display
 mode, and reasoning/interaction rows depend on the active provider and turn.
+Pending approvals and clarification correlations share a hard limit of 128.
+When that capacity is full, Relay emits the redacted
+`interaction_limit_reached` diagnostic, increments `interaction_limited`, and
+does not retain another response target.
 
 ## Provider-neutral compatibility seam
 
@@ -101,16 +105,17 @@ method returns typed `unsupported` before it touches the transport.
 | Auth upgrade rejected | typed `auth_failed`; no retry and no credential echo |
 | Connection or dashboard restart | typed `gateway_lost`; connection setup retries at most three times, then reports `retry_exhausted` |
 | Malformed RPC or non-text frame | typed `malformed_rpc`, cumulative signal, Session becomes degraded |
-| Control-RPC deadline | typed `timeout`; Relay quarantines and closes that socket, marks the Session failed, and requires a new adapter so a late response cannot be misattributed to a later control RPC |
+| Control-RPC deadline | typed `timeout` after one monotonic absolute deadline across writes, partial reads, and frames; Relay quarantines and closes that socket, marks the Session failed, and requires a new adapter so a late response cannot be misattributed to a later control RPC |
 | Passive observation deadline | typed `timeout` but retains the prior Session state; a quiet bounded observation window is normal |
 | Queue pressure | queue holds at most 128 events; oldest event is dropped, `dropped` increments, `replay_gap=true`, Session becomes degraded |
+| Pending interaction pressure | at most 128 approval/clarification response targets are retained together; excess is visible as `interaction_limit_reached`, increments `interaction_limited`, and never creates a hidden response target |
 | Foreign session event | not queued or allowed to alter this adapter's status; `foreign` increments without retaining a provider payload |
 | Replay request before retained history | typed `replay_gap`; replay retention is at most 64 events |
-| Oversize RPC/frame | 8 KiB request and 64 KiB frame limits; typed `payload_too_large` |
+| Oversize RPC/frame | 8 KiB request and 64 KiB frame limits; typed `payload_too_large`; an inbound framing rejection closes the socket before unread payload bytes can desynchronize a later RPC |
 | Interrupt/approval response races | a `4009` server race, `approval.respond` result with `resolved: 0`, or missing pending request becomes typed `raced`; only a positive `resolved` acknowledgement decrements Relay's per-session pending count, so another request received during the call remains pending; other RPC failures retain the count and become typed `remote_failure`/transport errors |
 | Clarification correlation | Hermes 0.18.2 supplies an opaque `request_id`; Relay permits one matching response and retains no prompt content. A frame without a usable id becomes visible `clarification_without_id`; no response is sent |
 
-The adapter emits no normal logs. `relay-node hermes-smoke` prints only booleans, counts, and a coarse status; it does not print endpoint URLs, tokens, session IDs, prompts, event payloads, transcripts, or private reasoning.
+The adapter emits no normal logs. `relay-node hermes-smoke` prints only booleans, counts, and a coarse status; it does not print endpoint URLs, tokens, session IDs, prompts, event payloads, transcripts, or private reasoning. A gateway loss during its requested observation window is typed `gateway_lost` and exits nonzero rather than producing a successful smoke result.
 
 ## Local contract smoke
 

--- a/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
+++ b/docs/HERMES_RICH_CLIENT_SESSION_ADAPTER.md
@@ -49,7 +49,7 @@ The adapter assigns monotonic arrival sequences and emits only provider-neutral 
 
 | Hermes rich-client event | Neutral category | Stable label | Preview policy |
 | --- | --- | --- | --- |
-| `gateway.ready`, `session.info` | lifecycle | `gateway_ready`, `session_info` | fixed text |
+| `gateway.ready`, `session.info`, `session.title` | lifecycle | `gateway_ready`, `session_info`, `session_title` | fixed text; titles are not retained |
 | `message.start`, `message.delta`, `message.complete` | status | `message_started`, `message_delta`, `message_complete` | fixed text; no transcript |
 | `thinking.delta`, `reasoning.delta`, `reasoning.available` | status | `reasoning` | always `redacted reasoning` |
 | `status.update` | status | `status_update` | fixed text |

--- a/docs/adrs/ADR-0003-hermes-rich-client-session-adapter.md
+++ b/docs/adrs/ADR-0003-hermes-rich-client-session-adapter.md
@@ -1,0 +1,21 @@
+# ADR-0003: Hermes rich-client Session adapter is loopback dashboard JSON-RPC only
+
+- Status: accepted
+- Issue: #1141
+
+## Context
+
+Hermes exposes several unrelated integration surfaces. Its messaging/API gateway serves an OpenAI-compatible HTTP API, while the interactive rich-client Session protocol is TUI JSON-RPC over a dashboard-owned `/api/ws` WebSocket. Treating either as a generic Relay transport would blur the provider boundary, create accidental remote-control scope, and encourage use of browser credentials or profile storage as a transport credential.
+
+## Decision
+
+Relay owns a native Hermes adapter that accepts only `ws://` loopback dashboard `/api/ws` endpoints authenticated by the local dashboard's ephemeral token. It creates, lists, resumes, prompts, interrupts, and observes only the documented rich-client event subset. Events are mapped into neutral lifecycle/status/tool/approval/diagnostic categories with bounded, redacted previews. A clarification is response-capable only when the gateway exports an opaque response id; Hermes 0.18.2 does not, so its clarification event remains a visible unsupported correlation gap.
+
+The adapter has bounded request/frame/event/replay limits and typed responses for auth failure, connection loss, malformed frames, timeout, retry exhaustion, replay gaps, pressure, unsupported contract elements, and interaction races. Unknown events remain visible diagnostics rather than being silently dropped or mapped to a generic Relay fallback.
+
+## Consequences
+
+- One-node Relay can prove real Hermes rich-client control without starting a generic provider platform.
+- Browser login/cookies, dashboard tickets, Hermes credentials, Relay node identity, profile databases, and transcripts remain separate.
+- A remote dashboard, public browser-auth ticket flow, cross-node connection, persistence import, and generic Relay bridge require a later accepted issue and ADR.
+- The independently evolving provider-neutral Session contract may integrate this adapter later, but this implementation does not depend on an unmerged provider branch.

--- a/docs/adrs/ADR-0003-hermes-rich-client-session-adapter.md
+++ b/docs/adrs/ADR-0003-hermes-rich-client-session-adapter.md
@@ -11,7 +11,7 @@ Hermes exposes several unrelated integration surfaces. Its messaging/API gateway
 
 Relay owns a native Hermes adapter that accepts only `ws://` loopback dashboard `/api/ws` endpoints authenticated by the local dashboard's ephemeral token. It creates, lists, resumes, prompts, interrupts, and observes only the documented rich-client event subset. Events are mapped into neutral lifecycle/status/tool/approval/diagnostic categories with bounded, redacted previews. Hermes 0.18.2 injects an opaque request id into `clarify.request` before emission, and Relay uses that id for exactly one `clarify.respond` without retaining the question, choices, or answer.
 
-The adapter has bounded request/frame/event/replay limits and typed responses for auth failure, connection loss, malformed frames, timeout, retry exhaustion, replay gaps, pressure, unsupported contract elements, and interaction races. Unknown events remain visible diagnostics rather than being silently dropped or mapped to a generic Relay fallback.
+The adapter has bounded request/frame/event/replay and pending-interaction limits. It returns typed responses for auth failure, connection loss, malformed frames, timeout, retry exhaustion, replay gaps, unsupported contract elements, and interaction races; excess pending interactions become visible redacted diagnostics without retaining another response target. Unknown events remain visible diagnostics rather than being silently dropped or mapped to a generic Relay fallback.
 
 ## Consequences
 

--- a/docs/adrs/ADR-0003-hermes-rich-client-session-adapter.md
+++ b/docs/adrs/ADR-0003-hermes-rich-client-session-adapter.md
@@ -9,7 +9,7 @@ Hermes exposes several unrelated integration surfaces. Its messaging/API gateway
 
 ## Decision
 
-Relay owns a native Hermes adapter that accepts only `ws://` loopback dashboard `/api/ws` endpoints authenticated by the local dashboard's ephemeral token. It creates, lists, resumes, prompts, interrupts, and observes only the documented rich-client event subset. Events are mapped into neutral lifecycle/status/tool/approval/diagnostic categories with bounded, redacted previews. A clarification is response-capable only when the gateway exports an opaque response id; Hermes 0.18.2 does not, so its clarification event remains a visible unsupported correlation gap.
+Relay owns a native Hermes adapter that accepts only `ws://` loopback dashboard `/api/ws` endpoints authenticated by the local dashboard's ephemeral token. It creates, lists, resumes, prompts, interrupts, and observes only the documented rich-client event subset. Events are mapped into neutral lifecycle/status/tool/approval/diagnostic categories with bounded, redacted previews. Hermes 0.18.2 injects an opaque request id into `clarify.request` before emission, and Relay uses that id for exactly one `clarify.respond` without retaining the question, choices, or answer.
 
 The adapter has bounded request/frame/event/replay limits and typed responses for auth failure, connection loss, malformed frames, timeout, retry exhaustion, replay gaps, pressure, unsupported contract elements, and interaction races. Unknown events remain visible diagnostics rather than being silently dropped or mapped to a generic Relay fallback.
 


### PR DESCRIPTION
## Summary
- add a native, loopback-only Hermes rich-client Session adapter for the authenticated dashboard `/api/ws` JSON-RPC surface
- expose a redacted `relay-node hermes-smoke` contract harness for list/create/resume/prompt observation
- harden the adapter control transport with one monotonic deadline, terminal send-failure quarantine, pre-allocation frame-length validation, RFC control-frame limits, and bounded interaction targets
- document the supported and unsupported behavior without adding generic provider/framework work or deferred #1151 PTY/workbench scope

## Exact-head verification

Evidence below is for PR head `752e67b6c74e47aa78d65a647996dc4a9b986092`, verified against remote `feature/hermes-rich-client` and still targeting `reboot/relay-next`.

- `sh scripts/cargo.sh test -p relay-hermes-session --all-targets` — 30 passed
- `sh scripts/cargo.sh test -p relay-node --test hermes_smoke_cli` — 2 passed
- credential-safe authenticated Hermes 0.18.2 gateway exercise: list/create/prompt/resume succeeded with `observed_events=14`, `unsupported_events=0`, and `status=idle`
- `git diff --check` — pass

The inherited untracked `.env` was neither read nor modified. This PR remains limited to the authenticated loopback dashboard transport; it does not export a remote endpoint, persist credentials, introduce a generic provider framework, or implement deferred #1151 scope.

Refs #1136
Refs #1141
