### PR TITLE
feat(workspace): keep Session identity separate from layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Relay factory
 
-A small, verifiable factory for the Relay reboot. This first slice intentionally contains no product workflows or legacy compatibility layer.
+A small, verifiable factory for the Relay reboot. The current slice proves a local Workspace can arrange opaque Session references without acquiring process authority or importing legacy Relay behavior.
 
 ## What exists
 
 - Rust workspace with separately addressable `relay-hub` and `relay-node` binaries.
 - A bounded, unauthenticated liveness contract: `GET /health` and `relay-node probe`.
-- A static PWA shell that reads only that liveness contract.
+- A PWA Workspace workbench bound to one local Node and one approved root (including valid non-repo roots).
+- A versioned, bounded browser-persisted layout tree with tab/pane/recovery controls that only reference stable opaque Session IDs.
+- A one-node supervised Codex `app-server --stdio` Session seam with no network transport or raw provider transcript storage.
 - Checked Rust and Node toolchains, deterministic local commands, and matching CI.
-- A concise product/context map and one baseline boundary ADR.
 
 ## Start here
 
@@ -24,10 +25,10 @@ npm run dev
 
 `npm run dev` serves the PWA on `http://127.0.0.1:4173` and the hub health probe on `http://127.0.0.1:8787/health`.
 
-## Contract
+## Contracts
 
 A successful health response contains only `api`, `service`, `status`, and `version`. Invalid or overlong `--identity` configuration is rejected with a typed, bounded JSON error and the input is never reflected. The smoke test proves both service identities and this rejection behavior.
 
-No legacy Relay modules were ported. PTY/RMUX, provider adapters, Hermes, Codex, mail, files, authentication, Workspace persistence, layout, browser control, and cross-node behavior remain deferred.
+Workspace layout persistence contains only a versioned Workspace binding, bounded presentation tree, and opaque Session references. It has no Session control path: a split, move, hide, close, reopen, cap error, or deterministic layout recovery cannot start, duplicate, input to, or end a Session. When the one-node liveness check is unavailable, the PWA shows a typed unavailable state and does not substitute stale context.
 
-See `AGENTS.md` for contributor rules, `docs/PRODUCT_CONTEXT.md` for reserved nouns and scope, and `docs/adrs/ADR-0001-factory-boundary.md` for the API boundary decision.
+See `AGENTS.md` for contributor rules, `docs/PRODUCT_CONTEXT.md` for current authority boundaries, and `docs/adrs/` for accepted decisions.

--- a/docs/PRODUCT_CONTEXT.md
+++ b/docs/PRODUCT_CONTEXT.md
@@ -4,9 +4,9 @@
 
 Later issues may introduce these terms only with explicit ownership and storage decisions:
 
-- **Node** — a future execution location, not yet a remote control plane.
-- **Workspace** — a future mission grouping, not yet persisted.
-- **Session** — a future work execution identity, not yet a process or provider adapter.
+- **Node** — the current PWA binds one local Node identity and reports its bounded liveness signal; it is not a remote control plane.
+- **Workspace** — one local mission grouping, persisted only as bounded presentation metadata (Node binding, approved root, layout tree, and opaque content references).
+- **Session** — a node-owned work execution identity. The Workspace layout may reference its opaque ID but has no lifecycle authority.
 - **Message** — a future scoped communication record, not yet a mailbox.
 - **TaskRun** — a future observable unit of work, not yet telemetry or analytics.
 
@@ -14,21 +14,14 @@ Later issues may introduce these terms only with explicit ownership and storage 
 
 - `relay-hub` serves `GET /health` with a bounded liveness record.
 - `relay-node probe` prints the same record for the node identity.
-- The PWA shell renders that record and nothing else.
-- `relay-node codex-stdio-probe` owns a one-node, local `codex app-server
-  --stdio` Session seam. Its explicit exercise mode creates, resumes, prompts,
-  and cancels native Codex threads through bounded JSONL; it exposes neither a
-  network transport nor raw provider transcripts.
+- The PWA renders one local Workspace bound to one Node and an approved local root. Non-repo roots are valid.
+- The PWA persists a versioned, bounded layout tree in browser storage. Its tabs and panes contain only opaque Session references; local state never records Session runtime status or commands.
+- `relay-node codex-stdio-probe` owns a one-node, local `codex app-server --stdio` Session seam. Its explicit exercise mode creates, resumes, prompts, and cancels native Codex threads through bounded JSONL; it exposes neither a network transport nor raw provider transcripts.
 
 ## Authority and data path
 
-The node owns the child process identity/lifecycle for the Codex stdio seam.
-The adapter bounds/redacts event previews and does not persist raw provider
-transcripts, credentials, approval grants, or thread data. The web shell still
-reads the hub health endpoint only; it has no client write path or persistence.
+The node owns the child process identity/lifecycle for the Codex stdio seam. The adapter bounds/redacts event previews and does not persist raw provider transcripts, credentials, approval grants, or thread data. The PWA's Workspace layout is presentation-only: split, move, tab, hide, close, reopen, and recovery mutations never launch, duplicate, input to, or end a Session. Node liveness is checked afresh through `/health`; an unavailable or unknown state disables live-session affordances without historical/local fallback.
 
 ## Deferred scope
 
-PTY/RMUX, Hermes, other provider adapters, mailbox, passkeys, files, Workspace
-persistence, layout, browser control, cross-node behavior, approval-grant
-persistence, and legacy API compatibility remain deferred.
+PTY/RMUX, Hermes, other provider adapters, mailbox, passkeys, files, multi-node Workspaces, Session-control API wiring, browser control, cross-node behavior, approval-grant persistence, and legacy API compatibility remain deferred.

--- a/docs/adrs/ADR-0003-workspace-layout-is-presentation-only.md
+++ b/docs/adrs/ADR-0003-workspace-layout-is-presentation-only.md
@@ -1,0 +1,18 @@
+# ADR-0003: persist Workspace layout as bounded presentation-only references
+
+- **Status:** accepted
+- **Date:** 2026-07-12
+
+## Context
+
+Issue #1139 requires one operator-visible Workspace that can be reopened and arranged in tabs and panes without coupling presentation changes to the Node-owned Session lifecycle. The existing Session seam is intentionally direct-PTY/owned-runtime and provider-neutral at its public boundary. The PWA has only the hub liveness boundary, so it cannot truthfully issue Session control commands.
+
+## Decision
+
+The PWA stores one local Workspace binding (one Node identity and approved local root) plus a versioned layout tree in browser storage. The tree has explicit caps: depth 3, four panes, six tabs, 256-character Workspace metadata, and 128-character opaque Session references. Layout content contains opaque Session references only; splits create another reference to the same ID, never a Session. Runtime availability is never persisted and is checked afresh through the existing `/health` liveness record.
+
+Malformed, unsupported-version, invalid/cap-exceeding, and overlong saved trees recover to a deterministic default with a visible recovery message. Closing or moving a pane and showing or hiding a tab strip are presentation mutations. Session input and end actions remain distinct Node/runtime authority and are not exposed by this PWA slice.
+
+## Consequences
+
+The PWA can prove stable Session identity before and after layout changes without creating a Session API, terminal implementation, file browser, cross-node Workspace, provider adapter, or browser-control surface. A later accepted Session-control issue must add its own Node-bound authority contract; it must not reuse the layout persistence path as a capability channel.

--- a/scripts/cdp-endpoint.mjs
+++ b/scripts/cdp-endpoint.mjs
@@ -1,0 +1,3 @@
+export function devToolsEndpointFromOutput(output) {
+  return output.match(/(?:^|\r?\n)DevTools listening on (ws:\/\/[^\r\n]+)\r?\n/)?.[1];
+}

--- a/scripts/lint-web.mjs
+++ b/scripts/lint-web.mjs
@@ -3,6 +3,7 @@ import { access, constants, readFile } from "node:fs/promises";
 const requiredFiles = [
   "web/src/index.html",
   "web/src/main.js",
+  "web/src/workspace-layout.js",
   "web/public/manifest.webmanifest",
 ];
 
@@ -10,17 +11,26 @@ for (const file of requiredFiles) {
   await access(file, constants.R_OK);
 }
 
-const [page, app, manifest] = await Promise.all(requiredFiles.map((file) => readFile(file, "utf8")));
+const [page, app, layout, manifest] = await Promise.all(requiredFiles.map((file) => readFile(file, "utf8")));
 const errors = [];
 
-if (!page.includes("manifest.webmanifest")) {
-  errors.push("PWA shell must link its manifest");
+if (!page.includes("manifest.webmanifest") || !page.includes("data-workspace-shell")) {
+  errors.push("PWA shell must render the versioned Workspace presentation surface");
 }
 if (!app.includes('const HEALTH_URL = "http://127.0.0.1:8787/health"')) {
   errors.push("PWA shell must use the documented liveness boundary");
 }
-if (/localStorage|document\.cookie|WebSocket|\/api\//.test(app)) {
-  errors.push("PWA shell must not acquire product-state or control authority");
+if (!app.includes('const STORAGE_KEY = "relay-factory/workspace-layout/v1"')) {
+  errors.push("PWA shell must scope persistence to the versioned layout key");
+}
+if (!app.includes("serializeWorkspaceLayout") || !app.includes("setNodeAvailability")) {
+  errors.push("PWA shell must persist only layout state and render typed Node availability");
+}
+if (/document\.cookie|WebSocket|\/api\/|sendInput|terminate/.test(app)) {
+  errors.push("PWA shell must not acquire Session or transport control authority");
+}
+if (/fetch|localStorage|document\.cookie|WebSocket|sendInput|terminate|ProcessTransport/.test(layout)) {
+  errors.push("Workspace layout contract must stay presentation-only and transport-free");
 }
 if (!manifest.includes('"display": "standalone"')) {
   errors.push("PWA manifest must declare standalone display");

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -16,7 +16,6 @@ const publicRoot = resolve("web/public");
 const scratch = await mkdtemp(`${tmpdir()}/relay-passkey-browser-`);
 const recoveryHash = createHash("sha256").update(recoveryCode).digest("hex");
 const httpsPort = await reservePort();
-const debugPort = await reservePort();
 const origin = `https://relay.test:${httpsPort}`;
 let hub;
 let proxy;
@@ -74,14 +73,14 @@ try {
       "--headless=new",
       "--no-sandbox",
       "--disable-gpu",
-      `--remote-debugging-port=${debugPort}`,
+      "--remote-debugging-port=0",
       `--user-data-dir=${scratch}/chrome-profile`,
       "--ignore-certificate-errors",
       "--host-resolver-rules=MAP relay.test 127.0.0.1",
     ],
     { stdio: ["ignore", "pipe", "pipe"] },
   );
-  browser = await connectBrowser();
+  browser = await connectBrowser(chromiumProcess, captureProcessOutput(chromiumProcess));
   const { targetId } = await browser.command("Target.createTarget", { url: "about:blank" });
   const { sessionId } = await browser.command("Target.attachToTarget", { targetId, flatten: true });
   await browser.command("Page.enable", {}, sessionId);
@@ -362,17 +361,47 @@ async function reservePort() {
   return port;
 }
 
-async function connectBrowser() {
-  await waitFor(async () => {
-    try {
-      const response = await fetch(`http://127.0.0.1:${debugPort}/json/version`);
-      return response.ok;
-    } catch {
+function captureProcessOutput(process_) {
+  let output = "";
+  for (const stream of [process_.stdout, process_.stderr]) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      output = `${output}${chunk}`.slice(-4_096);
+    });
+  }
+  return () => output;
+}
+
+async function connectBrowser(process_, output) {
+  const debuggerUrl = await waitFor(
+    () => {
+      const match = output().match(/DevTools listening on (ws:\/\/\S+)/);
+      if (match) return match[1];
+      if (process_.exitCode !== null || process_.signalCode !== null) {
+        throw new Error(`Chromium exited before exposing a DevTools endpoint: ${processOutputSummary(process_, output())}`);
+      }
       return false;
-    }
-  });
-  const version = await fetch(`http://127.0.0.1:${debugPort}/json/version`).then((response) => response.json());
-  return Cdp.connect(version.webSocketDebuggerUrl);
+    },
+    () => `Chromium DevTools endpoint: ${processOutputSummary(process_, output())}`,
+  );
+  try {
+    return await Cdp.connect(debuggerUrl);
+  } catch (error) {
+    throw new Error(`could not connect to Chromium DevTools at ${debuggerUrl}: ${processOutputSummary(process_, output())}`, {
+      cause: error,
+    });
+  }
+}
+
+function processOutputSummary(process_, output) {
+  const status =
+    process_.exitCode !== null
+      ? `exited with ${process_.exitCode}`
+      : process_.signalCode !== null
+        ? `exited from ${process_.signalCode}`
+        : "running";
+  const compactOutput = output.trim().replace(/\s+/g, " ").slice(0, 1_000) || "(no Chromium output)";
+  return `Chromium ${status}; output: ${compactOutput}`;
 }
 
 async function evaluate(sessionId, expression) {
@@ -385,12 +414,12 @@ async function evaluate(sessionId, expression) {
   return response.result.value;
 }
 
-async function waitFor(predicate) {
+async function waitFor(predicate, timeoutDescription = "browser matrix state") {
   const deadline = Date.now() + 15_000;
   while (Date.now() < deadline) {
     const result = await predicate();
     if (result) return result;
     await new Promise((resolve_) => setTimeout(resolve_, 50));
   }
-  throw new Error("timed out waiting for browser matrix state");
+  throw new Error(`timed out waiting for ${typeof timeoutDescription === "function" ? timeoutDescription() : timeoutDescription}`);
 }

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -8,6 +8,8 @@ import { access, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, resolve, sep } from "node:path";
 
+import { devToolsEndpointFromOutput } from "./cdp-endpoint.mjs";
+
 
 const chromium = "/usr/bin/chromium";
 const recoveryCode = "browser-virtual-authenticator-recovery";
@@ -375,8 +377,8 @@ function captureProcessOutput(process_) {
 async function connectBrowser(process_, output) {
   const debuggerUrl = await waitFor(
     () => {
-      const match = output().match(/DevTools listening on (ws:\/\/\S+)/);
-      if (match) return match[1];
+      const endpoint = devToolsEndpointFromOutput(output());
+      if (endpoint) return endpoint;
       if (process_.exitCode !== null || process_.signalCode !== null) {
         throw new Error(`Chromium exited before exposing a DevTools endpoint: ${processOutputSummary(process_, output())}`);
       }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -3,14 +3,272 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#152334" />
+    <meta name="theme-color" content="#111827" />
     <link rel="manifest" href="./manifest.webmanifest" />
-    <title>Relay factory</title>
+    <title>Relay workspace</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        background: #0b1020;
+        color: #edf2ff;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        min-width: 320px;
+        background:
+          radial-gradient(circle at top right, rgb(63 81 181 / 24%), transparent 34rem),
+          #0b1020;
+      }
+
+      button {
+        border: 1px solid #39476b;
+        border-radius: 0.5rem;
+        background: #18233f;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        min-height: 2.5rem;
+        padding: 0.5rem 0.75rem;
+      }
+
+      button:hover:not(:disabled) { background: #26355b; }
+      button:focus-visible { outline: 3px solid #82aaff; outline-offset: 2px; }
+      button:disabled { color: #9aa7c6; cursor: not-allowed; opacity: 0.72; }
+
+      .workspace-shell {
+        display: grid;
+        gap: 1rem;
+        margin: 0 auto;
+        max-width: 90rem;
+        min-height: 100vh;
+        padding: 1rem;
+      }
+
+      .app-header, .meta-card, .workbench, .notice, .pane {
+        border: 1px solid #273553;
+        border-radius: 0.9rem;
+        background: rgb(16 25 45 / 90%);
+        box-shadow: 0 0.75rem 2.25rem rgb(0 0 0 / 18%);
+      }
+
+      .app-header {
+        align-items: center;
+        display: flex;
+        gap: 1rem;
+        justify-content: space-between;
+        padding: 1rem 1.25rem;
+      }
+
+      .eyebrow, .meta-label, .pane-label {
+        color: #aab8d8;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        margin: 0;
+        text-transform: uppercase;
+      }
+
+      h1, h2, h3, p { margin-top: 0; }
+      h1 { font-size: clamp(1.25rem, 3vw, 1.65rem); margin-bottom: 0.2rem; }
+      h2 { font-size: 1rem; margin-bottom: 0.85rem; }
+      h3 { font-size: 0.9rem; margin: 0; }
+
+      .node-status {
+        align-items: center;
+        border-radius: 999px;
+        display: inline-flex;
+        font-size: 0.85rem;
+        font-weight: 700;
+        gap: 0.45rem;
+        padding: 0.45rem 0.7rem;
+        white-space: nowrap;
+      }
+
+      .node-status::before {
+        background: currentColor;
+        border-radius: 50%;
+        content: "";
+        height: 0.55rem;
+        width: 0.55rem;
+      }
+
+      .node-status[data-state="available"] { background: #123f36; color: #8bf0cf; }
+      .node-status[data-state="unavailable"] { background: #50243a; color: #ffb6ce; }
+      .node-status[data-state="unknown"] { background: #483819; color: #ffe29a; }
+
+      .workspace-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
+      }
+
+      .workspace-rail { display: grid; gap: 1rem; }
+      .meta-card { padding: 1rem; }
+      .meta-value { margin: 0.25rem 0 0; overflow-wrap: anywhere; }
+      .meta-card dl { display: grid; gap: 0.85rem; margin: 0; }
+      .meta-card dt { color: #aab8d8; font-size: 0.8rem; }
+      .meta-card dd { margin: 0.2rem 0 0; }
+      .root-kind { color: #8bf0cf; font-size: 0.85rem; }
+
+      .layer-list {
+        color: #c5d1ed;
+        display: grid;
+        font-size: 0.85rem;
+        gap: 0.45rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      .layer-list li::before { color: #82aaff; content: "→"; margin-right: 0.45rem; }
+      .layer-list strong { color: #edf2ff; }
+
+      .workbench { min-width: 0; padding: 1rem; }
+      .workbench-header { align-items: start; display: flex; gap: 1rem; justify-content: space-between; }
+      .workbench-header p { color: #c5d1ed; font-size: 0.9rem; margin-bottom: 0; }
+      .toolbar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 1rem 0; }
+      .toolbar button[data-action="new-tab"] { background: #344d91; border-color: #5975c8; }
+
+      .notice { border-left: 0.35rem solid #ffe29a; color: #ffe9b8; margin-bottom: 1rem; padding: 0.75rem 0.9rem; }
+      .notice[hidden] { display: none; }
+      .notice[data-kind="error"] { border-left-color: #ff9ab7; color: #ffd0dd; }
+
+      .layout { display: grid; gap: 0.75rem; min-height: 25rem; }
+      .split { display: grid; gap: 0.75rem; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+      .pane { display: grid; gap: 0.75rem; min-width: 0; padding: 0.8rem; }
+      .pane[data-selected="true"] { border-color: #82aaff; box-shadow: 0 0 0 1px #82aaff inset; }
+      .pane-head { align-items: center; display: flex; gap: 0.5rem; justify-content: space-between; }
+      .pane-select { background: transparent; border: 0; min-height: auto; padding: 0.15rem; text-align: left; }
+      .pane-id { color: #9faccc; font-size: 0.78rem; }
+      .tab-strip { display: flex; gap: 0.35rem; overflow-x: auto; padding-bottom: 0.15rem; }
+      .tab-strip[hidden] { display: none; }
+      .tab { border-radius: 0.4rem; min-height: 2.15rem; white-space: nowrap; }
+      .tab[aria-selected="true"] { background: #344d91; border-color: #82aaff; }
+
+      .session-card {
+        background: #0d162b;
+        border: 1px dashed #43537b;
+        border-radius: 0.65rem;
+        display: grid;
+        gap: 0.65rem;
+        min-height: 9rem;
+        padding: 0.9rem;
+      }
+
+      .session-card code, .identity-list code {
+        background: #151f38;
+        border-radius: 0.35rem;
+        color: #b9caff;
+        overflow-wrap: anywhere;
+        padding: 0.2rem 0.35rem;
+      }
+
+      .session-note { color: #c5d1ed; font-size: 0.85rem; margin: 0; }
+      .identity-list { color: #c5d1ed; font-size: 0.85rem; margin: 1rem 0 0; }
+      .authority { border-top: 1px solid #273553; margin-top: 1rem; padding-top: 1rem; }
+      .authority p { color: #c5d1ed; font-size: 0.85rem; margin-bottom: 0.65rem; }
+      .authority button { width: 100%; }
+
+      @media (max-width: 52rem) {
+        .app-header, .workbench-header { align-items: stretch; flex-direction: column; }
+        .workspace-grid { grid-template-columns: 1fr; }
+        .workspace-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .workspace-rail .meta-card:last-child { grid-column: 1 / -1; }
+      }
+
+      @media (max-width: 36rem) {
+        .workspace-shell { padding: 0.7rem; }
+        .workspace-rail { grid-template-columns: 1fr; }
+        .workspace-rail .meta-card:last-child { grid-column: auto; }
+        .split { grid-template-columns: 1fr; }
+        .toolbar button { flex: 1 1 8.5rem; }
+      }
+    </style>
   </head>
   <body>
-    <main>
-      <h1>Relay factory</h1>
-      <p id="status" aria-live="polite">Checking hub liveness…</p>
+    <main class="workspace-shell" data-workspace-shell>
+      <header class="app-header">
+        <div>
+          <p class="eyebrow">View / Workspace</p>
+          <h1>Local workspace layout</h1>
+          <p class="meta-value">Presentation is separate from the Node-owned Session lifecycle.</p>
+        </div>
+        <p class="node-status" data-node-status data-state="unknown" aria-live="polite">Checking Node</p>
+      </header>
+
+      <div class="workspace-grid">
+        <aside class="workspace-rail" aria-label="Workspace context">
+          <section class="meta-card">
+            <p class="meta-label">Workspace</p>
+            <h2 data-workspace-name>Local workspace</h2>
+            <dl>
+              <div>
+                <dt>Node</dt>
+                <dd data-node-binding>Local Node</dd>
+              </div>
+              <div>
+                <dt>Approved local root</dt>
+                <dd><code data-root-path>/home/relay/scratch</code></dd>
+                <dd class="root-kind" data-root-kind>Non-repo roots are valid</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="meta-card">
+            <p class="meta-label">Vocabulary</p>
+            <ol class="layer-list">
+              <li>View</li>
+              <li><strong>Workspace</strong></li>
+              <li>Project</li>
+              <li>Instance</li>
+              <li>Bench</li>
+              <li>Tab</li>
+            </ol>
+          </section>
+
+          <section class="meta-card">
+            <p class="meta-label">Stable references</p>
+            <p class="identity-list" data-session-identity>No Session references yet.</p>
+          </section>
+        </aside>
+
+        <section class="workbench" aria-labelledby="workbench-heading">
+          <div class="workbench-header">
+            <div>
+              <p class="meta-label">Workbench</p>
+              <h2 id="workbench-heading">Bounded layout</h2>
+              <p data-layout-summary>Loading layout…</p>
+            </div>
+            <span class="pane-id">Layout-only controls</span>
+          </div>
+
+          <div class="toolbar" role="toolbar" aria-label="Layout controls">
+            <button type="button" data-action="new-tab">New Session tab</button>
+            <button type="button" data-action="split">Split pane</button>
+            <button type="button" data-action="move">Move pane</button>
+            <button type="button" data-action="toggle-strip">Show/hide tabs</button>
+            <button type="button" data-action="close">Close pane</button>
+          </div>
+
+          <aside class="notice" data-layout-notice hidden aria-live="polite"></aside>
+          <div class="layout" data-layout aria-label="Workspace layout"></div>
+
+          <section class="authority" aria-label="Session authority boundary">
+            <p>
+              Pane and tab changes only alter local presentation references. Session input and end actions
+              require a separate Node/runtime authority and are not exposed by this layout slice.
+            </p>
+            <button type="button" id="end-session" disabled aria-describedby="session-authority-note">
+              End Session (Node authority required)
+            </button>
+            <p id="session-authority-note" class="session-note" data-session-authority></p>
+          </section>
+        </section>
+      </div>
     </main>
     <script type="module" src="./main.js"></script>
   </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,22 +1,276 @@
+import {
+  MAX_PANE_COUNT,
+  MAX_TAB_COUNT,
+  addSessionTab,
+  closeSelectedPane,
+  createWorkspaceLayout,
+  layoutMetrics,
+  moveSelectedPane,
+  resetWorkspaceLayout,
+  restoreWorkspaceLayout,
+  selectTab,
+  selectedPane,
+  serializeWorkspaceLayout,
+  sessionIds,
+  setNodeAvailability,
+  splitSelectedPane,
+  toggleSelectedTabStrip,
+} from "./workspace-layout.js";
+
 const HEALTH_URL = "http://127.0.0.1:8787/health";
-const status = document.querySelector("#status");
+const STORAGE_KEY = "relay-factory/workspace-layout/v1";
 
-async function renderLiveness() {
+const nodeStatus = document.querySelector("[data-node-status]");
+const workspaceName = document.querySelector("[data-workspace-name]");
+const nodeBinding = document.querySelector("[data-node-binding]");
+const rootPath = document.querySelector("[data-root-path]");
+const rootKind = document.querySelector("[data-root-kind]");
+const layoutSummary = document.querySelector("[data-layout-summary]");
+const layoutNotice = document.querySelector("[data-layout-notice]");
+const layoutRoot = document.querySelector("[data-layout]");
+const sessionIdentity = document.querySelector("[data-session-identity]");
+const sessionAuthority = document.querySelector("[data-session-authority]");
+
+let state = loadLayout();
+let transientNotice = null;
+
+for (const button of document.querySelectorAll("[data-action]")) {
+  button.addEventListener("click", () => applyAction(button.dataset.action));
+}
+
+layoutRoot.addEventListener("click", (event) => {
+  const tab = event.target.closest("[data-select-tab]");
+  if (tab) {
+    apply(() => selectTab(state, tab.dataset.paneId, tab.dataset.tabId));
+    return;
+  }
+
+  const pane = event.target.closest("[data-select-pane]");
+  if (pane) {
+    apply(() => ({ ...state, selectedPaneId: pane.dataset.selectPane }));
+  }
+});
+
+render();
+void refreshNodeAvailability();
+
+function loadLayout() {
   try {
-    const response = await fetch(HEALTH_URL);
-    if (!response.ok) {
-      throw new Error("liveness request failed");
-    }
-
-    const health = await response.json();
-    if (health.api !== "relay-factory/v1" || health.service !== "hub" || health.status !== "ok") {
-      throw new Error("unexpected liveness response");
-    }
-
-    status.textContent = `${health.service} is ${health.status} (${health.version})`;
+    return restoreWorkspaceLayout(window.localStorage.getItem(STORAGE_KEY)).state;
   } catch {
-    status.textContent = "Hub liveness is unavailable.";
+    return {
+      ...createWorkspaceLayout(),
+      nodeAvailability: "unknown",
+      recovery: {
+        code: "storage-unavailable",
+        message: "Browser storage is unavailable. Layout changes will not survive a reopen.",
+      },
+    };
   }
 }
 
-void renderLiveness();
+function applyAction(action) {
+  const operations = {
+    "new-tab": addSessionTab,
+    split: splitSelectedPane,
+    move: moveSelectedPane,
+    "toggle-strip": toggleSelectedTabStrip,
+    close: closeSelectedPane,
+    "reset-layout": resetWorkspaceLayout,
+  };
+  apply(operations[action]);
+}
+
+function apply(operation) {
+  transientNotice = null;
+  try {
+    state = operation(state);
+    persistLayout();
+  } catch (error) {
+    transientNotice = { kind: "error", message: error.message };
+  }
+  render();
+}
+
+function persistLayout() {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, serializeWorkspaceLayout(state));
+  } catch {
+    transientNotice = {
+      kind: "error",
+      message: "Layout changed for this view, but browser storage could not save it.",
+    };
+  }
+}
+
+async function refreshNodeAvailability() {
+  try {
+    const response = await fetch(HEALTH_URL);
+    const health = await response.json();
+    if (!response.ok || health.api !== "relay-factory/v1" || health.service !== "hub" || health.status !== "ok") {
+      throw new Error("unexpected liveness response");
+    }
+    state = setNodeAvailability(state, "available");
+  } catch {
+    state = setNodeAvailability(state, "unavailable");
+  }
+  render();
+}
+
+function render() {
+  const metrics = layoutMetrics(state);
+  const activePane = selectedPane(state);
+
+  workspaceName.textContent = state.workspace.name;
+  nodeBinding.textContent = `${state.workspace.node.label} · ${state.workspace.node.id}`;
+  rootPath.textContent = state.workspace.root.path;
+  rootKind.textContent = state.workspace.root.kind === "non-repo" ? "Non-repo roots are valid" : "Repository root";
+  layoutSummary.textContent = `${metrics.paneCount}/${MAX_PANE_COUNT} panes · ${metrics.tabCount}/${MAX_TAB_COUNT} tabs · versioned layout v${state.version}`;
+
+  renderNodeStatus();
+  renderNotice();
+  renderSessionIdentity();
+  renderLayout(state.layout, layoutRoot);
+
+  for (const button of document.querySelectorAll("[data-action]")) {
+    const action = button.dataset.action;
+    button.disabled =
+      (action === "new-tab" && metrics.tabCount >= MAX_TAB_COUNT) ||
+      (action === "split" && metrics.paneCount >= MAX_PANE_COUNT) ||
+      (action === "move" && metrics.paneCount < 2) ||
+      (action === "close" && metrics.paneCount === 1 && activePane.tabs.length === 1);
+  }
+
+  sessionAuthority.textContent = sessionAuthorityMessage();
+}
+
+function renderNodeStatus() {
+  nodeStatus.dataset.state = state.nodeAvailability;
+  if (state.nodeAvailability === "available") {
+    nodeStatus.textContent = "Node liveness confirmed";
+    return;
+  }
+  if (state.nodeAvailability === "unavailable") {
+    nodeStatus.textContent = "Node unavailable";
+    return;
+  }
+  nodeStatus.textContent = "Node status unknown";
+}
+
+function renderNotice() {
+  const notice = transientNotice ?? state.recovery;
+  layoutNotice.hidden = !notice;
+  if (!notice) {
+    return;
+  }
+  layoutNotice.dataset.kind = notice.kind ?? "warning";
+  layoutNotice.replaceChildren();
+  layoutNotice.append(
+    textElement("strong", "Layout recovery"),
+    document.createTextNode(` — ${notice.message} `),
+  );
+  if (state.recovery) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.dataset.action = "reset-layout";
+    button.textContent = "Reset layout";
+    button.addEventListener("click", () => applyAction("reset-layout"));
+    layoutNotice.append(button);
+  }
+}
+
+function renderSessionIdentity() {
+  const references = [...new Set(sessionIds(state))];
+  sessionIdentity.replaceChildren();
+  if (references.length === 0) {
+    sessionIdentity.textContent = "No Session references in this layout.";
+    return;
+  }
+  sessionIdentity.append(document.createTextNode("Referenced Session ID: "));
+  references.forEach((sessionId, index) => {
+    if (index > 0) {
+      sessionIdentity.append(document.createTextNode(", "));
+    }
+    sessionIdentity.append(textElement("code", sessionId));
+  });
+}
+
+function renderLayout(node, container) {
+  container.replaceChildren(renderLayoutNode(node));
+}
+
+function renderLayoutNode(node) {
+  if (node.kind === "split") {
+    const split = document.createElement("div");
+    split.className = "split";
+    split.append(renderLayoutNode(node.first), renderLayoutNode(node.second));
+    return split;
+  }
+
+  const pane = document.createElement("section");
+  pane.className = "pane";
+  pane.dataset.selected = String(node.id === state.selectedPaneId);
+
+  const header = document.createElement("div");
+  header.className = "pane-head";
+  const select = document.createElement("button");
+  select.type = "button";
+  select.className = "pane-select";
+  select.dataset.selectPane = node.id;
+  select.append(textElement("span", "Pane", "pane-label"), document.createTextNode(" "), textElement("strong", node.id));
+  header.append(select, textElement("span", "Presentation only", "pane-id"));
+  pane.append(header);
+
+  const tabs = document.createElement("div");
+  tabs.className = "tab-strip";
+  tabs.role = "tablist";
+  tabs.hidden = !node.showTabStrip;
+  for (const tab of node.tabs) {
+    const tabButton = document.createElement("button");
+    tabButton.type = "button";
+    tabButton.className = "tab";
+    tabButton.role = "tab";
+    tabButton.dataset.selectTab = "true";
+    tabButton.dataset.paneId = node.id;
+    tabButton.dataset.tabId = tab.id;
+    tabButton.setAttribute("aria-selected", String(tab.id === node.activeTabId));
+    tabButton.textContent = tab.title;
+    tabs.append(tabButton);
+  }
+  pane.append(tabs);
+
+  const activeTab = node.tabs.find((tab) => tab.id === node.activeTabId);
+  const session = document.createElement("article");
+  session.className = "session-card";
+  session.append(
+    textElement("p", "Session reference", "meta-label"),
+    textElement("code", activeTab.content.sessionId),
+    textElement(
+      "p",
+      "This tab references the same opaque Session ID. Layout actions do not start, duplicate, input to, or end it.",
+      "session-note",
+    ),
+  );
+  pane.append(session);
+
+  return pane;
+}
+
+function sessionAuthorityMessage() {
+  if (state.nodeAvailability === "unavailable") {
+    return "Node unavailable: live Session actions stay disabled and no historical context is substituted.";
+  }
+  if (state.nodeAvailability === "unknown") {
+    return "Node status is unknown: live Session actions stay disabled until the one-node liveness check completes.";
+  }
+  return "The one-node liveness check passed. This presentation surface still has no Session control endpoint.";
+}
+
+function textElement(tag, text, className) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  element.textContent = text;
+  return element;
+}

--- a/web/src/workspace-layout.js
+++ b/web/src/workspace-layout.js
@@ -1,0 +1,387 @@
+export const LAYOUT_VERSION = 1;
+export const MAX_LAYOUT_DEPTH = 3;
+export const MAX_PANE_COUNT = 4;
+export const MAX_TAB_COUNT = 6;
+export const MAX_SESSION_REFERENCE_LENGTH = 128;
+
+const MAX_WORKSPACE_TEXT_LENGTH = 256;
+const NODE_AVAILABILITY = new Set(["available", "unavailable", "unknown"]);
+
+export class LayoutLimitError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+    this.name = "LayoutLimitError";
+  }
+}
+
+export function createWorkspaceLayout({
+  workspaceId = "workspace-local",
+  workspaceName = "Local workspace",
+  nodeId = "node-local",
+  nodeLabel = "Local Node",
+  root = "/home/relay/scratch",
+  rootKind = "non-repo",
+  sessionId = "session-local-1",
+} = {}) {
+  const tab = createSessionTab("tab-1", sessionId, "Session");
+  const state = {
+    version: LAYOUT_VERSION,
+    workspace: {
+      id: workspaceId,
+      name: workspaceName,
+      node: { id: nodeId, label: nodeLabel },
+      root: { path: root, kind: rootKind },
+    },
+    layout: {
+      kind: "tabs",
+      id: "pane-1",
+      showTabStrip: true,
+      activeTabId: tab.id,
+      tabs: [tab],
+    },
+    selectedPaneId: "pane-1",
+    nodeAvailability: "available",
+    recovery: null,
+  };
+  assertSnapshot(state);
+  return state;
+}
+
+export function addSessionTab(state) {
+  const metrics = layoutMetrics(state);
+  if (metrics.tabCount >= MAX_TAB_COUNT) {
+    throw new LayoutLimitError("tab-cap", `This Workspace is limited to ${MAX_TAB_COUNT} tabs.`);
+  }
+
+  const pane = selectedPane(state);
+  const tab = createSessionTab(nextId(state.layout, "tab"), activeSessionId(pane), "Session view");
+  return withLayout(state, replacePane(state.layout, pane.id, {
+    ...pane,
+    activeTabId: tab.id,
+    tabs: [...pane.tabs, tab],
+  }), pane.id);
+}
+
+export function selectTab(state, paneId, tabId) {
+  const pane = findPane(state.layout, paneId);
+  if (!pane || !pane.tabs.some((tab) => tab.id === tabId)) {
+    throw new TypeError("Selected tab does not exist in the Workspace layout.");
+  }
+  return withLayout(state, replacePane(state.layout, pane.id, { ...pane, activeTabId: tabId }), pane.id);
+}
+
+export function splitSelectedPane(state) {
+  const metrics = layoutMetrics(state);
+  if (metrics.paneCount >= MAX_PANE_COUNT) {
+    throw new LayoutLimitError("pane-cap", `This Workspace is limited to ${MAX_PANE_COUNT} panes.`);
+  }
+
+  const pane = selectedPane(state);
+  if (paneDepth(state.layout, pane.id) >= MAX_LAYOUT_DEPTH) {
+    throw new LayoutLimitError("depth-cap", `This Workspace is limited to ${MAX_LAYOUT_DEPTH} layout splits.`);
+  }
+
+  const activeTab = pane.tabs.find((tab) => tab.id === pane.activeTabId);
+  const mirrorTab = { ...clone(activeTab), id: nextId(state.layout, "tab"), title: `${activeTab.title} mirror` };
+  const mirrorPane = {
+    kind: "tabs",
+    id: nextId(state.layout, "pane"),
+    showTabStrip: true,
+    activeTabId: mirrorTab.id,
+    tabs: [mirrorTab],
+  };
+  const layout = replacePane(state.layout, pane.id, {
+    kind: "split",
+    id: nextId(state.layout, "split"),
+    direction: "row",
+    first: clone(pane),
+    second: mirrorPane,
+  });
+  return withLayout(state, layout, mirrorPane.id);
+}
+
+export function moveSelectedPane(state) {
+  const pane = selectedPane(state);
+  const moved = swapPaneWithSibling(state.layout, pane.id);
+  if (!moved) {
+    throw new LayoutLimitError("move-unavailable", "Split a pane before moving it.");
+  }
+  return withLayout(state, moved, pane.id);
+}
+
+export function toggleSelectedTabStrip(state) {
+  const pane = selectedPane(state);
+  return withLayout(state, replacePane(state.layout, pane.id, { ...pane, showTabStrip: !pane.showTabStrip }), pane.id);
+}
+
+export function closeSelectedPane(state) {
+  const pane = selectedPane(state);
+  if (pane.tabs.length > 1) {
+    const removedIndex = pane.tabs.findIndex((tab) => tab.id === pane.activeTabId);
+    const tabs = pane.tabs.filter((tab) => tab.id !== pane.activeTabId);
+    const nextTab = tabs[Math.min(removedIndex, tabs.length - 1)];
+    return withLayout(state, replacePane(state.layout, pane.id, { ...pane, tabs, activeTabId: nextTab.id }), pane.id);
+  }
+
+  const layout = removePane(state.layout, pane.id);
+  if (!layout) {
+    throw new LayoutLimitError("root-pane", "Keep one pane open to preserve the Workspace view.");
+  }
+  return withLayout(state, layout, firstPaneId(layout));
+}
+
+export function resetWorkspaceLayout(state) {
+  const sessionId = sessionIds(state)[0] ?? "session-local-1";
+  return {
+    ...createWorkspaceLayout({
+      workspaceId: state.workspace.id,
+      workspaceName: state.workspace.name,
+      nodeId: state.workspace.node.id,
+      nodeLabel: state.workspace.node.label,
+      root: state.workspace.root.path,
+      rootKind: state.workspace.root.kind,
+      sessionId,
+    }),
+    nodeAvailability: state.nodeAvailability,
+  };
+}
+
+export function setNodeAvailability(state, nodeAvailability) {
+  if (!NODE_AVAILABILITY.has(nodeAvailability)) {
+    throw new TypeError(`Unsupported Node availability: ${nodeAvailability}`);
+  }
+  return { ...state, nodeAvailability };
+}
+
+export function canUseLiveSessionActions(state) {
+  return state.nodeAvailability === "available";
+}
+
+export function serializeWorkspaceLayout(state) {
+  assertSnapshot(state);
+  const { version, workspace, layout, selectedPaneId } = state;
+  return JSON.stringify({ version, workspace, layout, selectedPaneId });
+}
+
+export function restoreWorkspaceLayout(serialized) {
+  const fallback = { ...createWorkspaceLayout(), nodeAvailability: "unknown" };
+  if (serialized === null || serialized === undefined) {
+    return { state: fallback, recovered: false };
+  }
+
+  let snapshot;
+  try {
+    snapshot = JSON.parse(serialized);
+  } catch {
+    return recovery(fallback, "invalid-json", "Saved layout could not be read.");
+  }
+  if (snapshot?.version !== LAYOUT_VERSION) {
+    return recovery(fallback, "unsupported-version", "Saved layout uses an unsupported version.");
+  }
+  try {
+    assertSnapshot(snapshot);
+  } catch {
+    return recovery(fallback, "invalid-layout", "Saved layout is invalid or exceeds current limits.");
+  }
+  return { state: { ...clone(snapshot), nodeAvailability: "unknown", recovery: null }, recovered: false };
+}
+
+export function sessionIds(state) {
+  const ids = [];
+  visitPanes(state.layout, (pane) => {
+    for (const tab of pane.tabs) {
+      if (tab.content.kind === "session") ids.push(tab.content.sessionId);
+    }
+  });
+  return ids;
+}
+
+export function layoutMetrics(state) {
+  let paneCount = 0;
+  let tabCount = 0;
+  let maxDepth = 0;
+  visitLayout(state.layout, 0, (node, depth) => {
+    maxDepth = Math.max(maxDepth, depth);
+    if (node.kind === "tabs") {
+      paneCount += 1;
+      tabCount += node.tabs.length;
+    }
+  });
+  return { paneCount, tabCount, maxDepth };
+}
+
+export function selectedPane(state) {
+  const pane = findPane(state.layout, state.selectedPaneId);
+  if (!pane) throw new TypeError("Selected pane does not exist in the Workspace layout.");
+  return pane;
+}
+
+function recovery(fallback, code, message) {
+  return { state: { ...fallback, recovery: { code, message } }, recovered: true };
+}
+
+function createSessionTab(id, sessionId, title) {
+  return { id, title, content: { kind: "session", sessionId } };
+}
+
+function withLayout(state, layout, selectedPaneId) {
+  const next = { ...state, layout, selectedPaneId, recovery: null };
+  assertSnapshot(next);
+  return next;
+}
+
+function assertSnapshot(snapshot) {
+  if (!snapshot || snapshot.version !== LAYOUT_VERSION) {
+    throw new TypeError("Workspace layout uses an unsupported version.");
+  }
+  assertWorkspace(snapshot.workspace);
+  assertText(snapshot.selectedPaneId, "selected pane");
+
+  const tabIds = new Set();
+  const paneIds = new Set();
+  const layoutIds = new Set();
+  const metrics = { paneCount: 0, tabCount: 0 };
+  assertLayout(snapshot.layout, 0, { tabIds, paneIds, layoutIds, metrics });
+  if (metrics.paneCount > MAX_PANE_COUNT || metrics.tabCount > MAX_TAB_COUNT) {
+    throw new TypeError("Workspace layout exceeds the bounded presentation caps.");
+  }
+  if (!paneIds.has(snapshot.selectedPaneId)) {
+    throw new TypeError("Workspace layout selects a missing pane.");
+  }
+}
+
+function assertWorkspace(workspace) {
+  if (!workspace) throw new TypeError("Workspace identity is invalid.");
+  assertText(workspace.id, "Workspace id");
+  assertText(workspace.name, "Workspace name");
+  if (!workspace.node) throw new TypeError("Workspace must bind one visible Node.");
+  assertText(workspace.node.id, "Node id");
+  assertText(workspace.node.label, "Node label");
+  if (!workspace.root || !["repo", "non-repo"].includes(workspace.root.kind)) {
+    throw new TypeError("Workspace must bind an approved repo or non-repo root.");
+  }
+  assertText(workspace.root.path, "Workspace root");
+}
+
+function assertLayout(node, depth, context) {
+  if (!node || typeof node !== "object" || depth > MAX_LAYOUT_DEPTH) {
+    throw new TypeError("Workspace layout depth is invalid.");
+  }
+  assertUniqueId(node.id, context.layoutIds, "layout node");
+
+  if (node.kind === "tabs") {
+    assertUniqueId(node.id, context.paneIds, "pane");
+    if (typeof node.showTabStrip !== "boolean" || !Array.isArray(node.tabs) || node.tabs.length === 0) {
+      throw new TypeError("Tab pane is invalid.");
+    }
+    assertText(node.activeTabId, "active tab");
+    context.metrics.paneCount += 1;
+    context.metrics.tabCount += node.tabs.length;
+    let active = false;
+    for (const tab of node.tabs) {
+      if (!tab) throw new TypeError("Tab identity is invalid.");
+      assertUniqueId(tab.id, context.tabIds, "tab");
+      assertText(tab.title, "tab title");
+      active ||= tab.id === node.activeTabId;
+      if (!tab.content || tab.content.kind !== "session") {
+        throw new TypeError("This MVP only permits opaque Session references in layout tabs.");
+      }
+      assertText(tab.content.sessionId, "Session reference", MAX_SESSION_REFERENCE_LENGTH);
+    }
+    if (!active) throw new TypeError("Tab pane selects a missing tab.");
+    return;
+  }
+
+  if (node.kind !== "split" || node.direction !== "row") {
+    throw new TypeError("Layout node is invalid.");
+  }
+  assertLayout(node.first, depth + 1, context);
+  assertLayout(node.second, depth + 1, context);
+}
+
+function assertUniqueId(id, ids, label) {
+  assertText(id, label);
+  if (ids.has(id)) throw new TypeError(`Workspace ${label} identity is invalid.`);
+  ids.add(id);
+}
+
+function assertText(value, label, limit = MAX_WORKSPACE_TEXT_LENGTH) {
+  if (typeof value !== "string" || value.length === 0 || value.length > limit) {
+    throw new TypeError(`Workspace ${label} is invalid.`);
+  }
+}
+
+function activeSessionId(pane) {
+  return pane.tabs.find((tab) => tab.id === pane.activeTabId).content.sessionId;
+}
+
+function findPane(node, paneId) {
+  if (node.kind === "tabs") return node.id === paneId ? node : null;
+  return findPane(node.first, paneId) ?? findPane(node.second, paneId);
+}
+
+function paneDepth(node, paneId, depth = 0) {
+  if (node.kind === "tabs") return node.id === paneId ? depth : -1;
+  return Math.max(paneDepth(node.first, paneId, depth + 1), paneDepth(node.second, paneId, depth + 1));
+}
+
+function replacePane(node, paneId, replacement) {
+  if (node.kind === "tabs") return node.id === paneId ? replacement : node;
+  return { ...node, first: replacePane(node.first, paneId, replacement), second: replacePane(node.second, paneId, replacement) };
+}
+
+function swapPaneWithSibling(node, paneId) {
+  if (node.kind === "tabs") return null;
+  if (node.first.kind === "tabs" && node.first.id === paneId) return { ...node, first: node.second, second: node.first };
+  if (node.second.kind === "tabs" && node.second.id === paneId) return { ...node, first: node.second, second: node.first };
+  const first = swapPaneWithSibling(node.first, paneId);
+  if (first) return { ...node, first };
+  const second = swapPaneWithSibling(node.second, paneId);
+  return second ? { ...node, second } : null;
+}
+
+function removePane(node, paneId) {
+  if (node.kind === "tabs") return node.id === paneId ? null : node;
+  if (node.first.kind === "tabs" && node.first.id === paneId) return node.second;
+  if (node.second.kind === "tabs" && node.second.id === paneId) return node.first;
+  const first = removePane(node.first, paneId);
+  if (first !== node.first) return first ? { ...node, first } : node.second;
+  const second = removePane(node.second, paneId);
+  return second !== node.second ? (second ? { ...node, second } : node.first) : node;
+}
+
+function firstPaneId(node) {
+  return node.kind === "tabs" ? node.id : firstPaneId(node.first);
+}
+
+function nextId(layout, prefix) {
+  let highest = 0;
+  visitLayout(layout, 0, (node) => {
+    const match = new RegExp(`^${prefix}-(\\d+)$`).exec(node.id);
+    if (match) highest = Math.max(highest, Number(match[1]));
+    if (node.kind === "tabs") {
+      for (const tab of node.tabs) {
+        const tabMatch = new RegExp(`^${prefix}-(\\d+)$`).exec(tab.id);
+        if (tabMatch) highest = Math.max(highest, Number(tabMatch[1]));
+      }
+    }
+  });
+  return `${prefix}-${highest + 1}`;
+}
+
+function visitPanes(node, visit) {
+  visitLayout(node, 0, (candidate) => { if (candidate.kind === "tabs") visit(candidate); });
+}
+
+function visitLayout(node, depth, visit) {
+  visit(node, depth);
+  if (node.kind === "split") {
+    visitLayout(node.first, depth + 1, visit);
+    visitLayout(node.second, depth + 1, visit);
+  }
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -4,14 +4,19 @@ import test from "node:test";
 
 const source = new URL("../src/", import.meta.url);
 
-test("the PWA shell consumes only the hub liveness boundary", async () => {
-  const [page, app] = await Promise.all([
+test("the PWA shell keeps Workspace layout presentation separate from Session control", async () => {
+  const [page, app, layout] = await Promise.all([
     readFile(new URL("index.html", source), "utf8"),
     readFile(new URL("main.js", source), "utf8"),
+    readFile(new URL("workspace-layout.js", source), "utf8"),
   ]);
 
   assert.match(page, /manifest\.webmanifest/);
+  assert.match(page, /data-workspace-shell/);
   assert.match(app, /http:\/\/127\.0\.0\.1:8787\/health/);
-  assert.match(app, /health\.service !== "hub"/);
-  assert.doesNotMatch(app, /localStorage|document\.cookie|WebSocket|\/api\//);
+  assert.match(app, /workspace-layout\.js/);
+  assert.match(app, /localStorage/);
+  assert.match(app, /fetch\(HEALTH_URL\)/);
+  assert.doesNotMatch(app, /document\.cookie|WebSocket|\/api\/|terminate|sendInput/);
+  assert.doesNotMatch(layout, /fetch|localStorage|document\.cookie|WebSocket|terminate|sendInput/);
 });

--- a/web/test/cdp-endpoint.test.mjs
+++ b/web/test/cdp-endpoint.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { devToolsEndpointFromOutput } from "../../scripts/cdp-endpoint.mjs";
+
+test("waits for the complete DevTools endpoint line before returning it", () => {
+  const endpoint = "ws://127.0.0.1:9222/devtools/browser/01234567-89ab-cdef-0123-456789abcdef";
+  const chunks = [
+    "[123:456:INFO] startup\nDevTools listening on ws://127.0.0.1:9222/devtools/browser/01234567-89ab-",
+    "cdef-0123-456789abcdef",
+    "\n",
+  ];
+  let output = "";
+
+  for (const chunk of chunks.slice(0, -1)) {
+    output += chunk;
+    assert.equal(devToolsEndpointFromOutput(output), undefined);
+  }
+
+  output += chunks.at(-1);
+  assert.equal(devToolsEndpointFromOutput(output), endpoint);
+});

--- a/web/test/workspace-layout.test.mjs
+++ b/web/test/workspace-layout.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LAYOUT_VERSION,
+  MAX_LAYOUT_DEPTH,
+  MAX_PANE_COUNT,
+  MAX_SESSION_REFERENCE_LENGTH,
+  MAX_TAB_COUNT,
+  LayoutLimitError,
+  addSessionTab,
+  canUseLiveSessionActions,
+  closeSelectedPane,
+  createWorkspaceLayout,
+  moveSelectedPane,
+  resetWorkspaceLayout,
+  restoreWorkspaceLayout,
+  selectTab,
+  serializeWorkspaceLayout,
+  setNodeAvailability,
+  sessionIds,
+  splitSelectedPane,
+  toggleSelectedTabStrip,
+} from "../src/workspace-layout.js";
+
+function uniqueSessionIds(state) {
+  return [...new Set(sessionIds(state))];
+}
+
+test("a non-repo Workspace preserves an opaque Session identity through layout-only mutations and reopen", () => {
+  const initial = createWorkspaceLayout({
+    nodeId: "node-local",
+    root: "/home/relay/scratch",
+    rootKind: "non-repo",
+    sessionId: "session-opaque-7",
+  });
+  const expectedSessionIds = uniqueSessionIds(initial);
+
+  assert.equal(initial.workspace.root.kind, "non-repo");
+  assert.deepEqual(expectedSessionIds, ["session-opaque-7"]);
+
+  const withTab = addSessionTab(initial);
+  const split = splitSelectedPane(withTab);
+  const moved = moveSelectedPane(split);
+  const hidden = toggleSelectedTabStrip(moved);
+  const closed = closeSelectedPane(hidden);
+  const reopened = restoreWorkspaceLayout(serializeWorkspaceLayout(closed)).state;
+
+  for (const state of [withTab, split, moved, hidden, closed, reopened]) {
+    assert.deepEqual(uniqueSessionIds(state), expectedSessionIds);
+  }
+  assert.equal(reopened.workspace.node.id, "node-local");
+  assert.equal(reopened.workspace.root.path, "/home/relay/scratch");
+});
+
+test("layout persistence is versioned, bounded, and never persists runtime authority", () => {
+  let state = createWorkspaceLayout({ sessionId: "session-opaque-9" });
+
+  for (let count = 1; count < MAX_TAB_COUNT; count += 1) {
+    state = addSessionTab(state);
+  }
+  assert.throws(() => addSessionTab(state), (error) => {
+    assert.ok(error instanceof LayoutLimitError);
+    assert.equal(error.code, "tab-cap");
+    return true;
+  });
+
+  state = createWorkspaceLayout({ sessionId: "session-opaque-9" });
+  for (let count = 1; count < MAX_PANE_COUNT; count += 1) {
+    state = splitSelectedPane(state);
+  }
+  assert.throws(() => splitSelectedPane(state), (error) => {
+    assert.ok(error instanceof LayoutLimitError);
+    assert.ok(["pane-cap", "depth-cap"].includes(error.code));
+    return true;
+  });
+
+  const serialized = JSON.parse(serializeWorkspaceLayout(state));
+  assert.equal(serialized.version, LAYOUT_VERSION);
+  assert.equal("nodeAvailability" in serialized, false);
+  assert.equal("runtime" in serialized, false);
+  assert.ok(MAX_LAYOUT_DEPTH >= 1);
+});
+
+test("invalid, corrupt, overlong, or version-mismatched persisted layouts recover deterministically without a historical availability fallback", () => {
+  const snapshot = JSON.parse(serializeWorkspaceLayout(createWorkspaceLayout()));
+  const malformed = restoreWorkspaceLayout("{not json");
+  const incompatible = restoreWorkspaceLayout(
+    JSON.stringify({ version: LAYOUT_VERSION + 1, workspace: {}, layout: {} }),
+  );
+  const corrupt = restoreWorkspaceLayout(
+    JSON.stringify({
+      ...snapshot,
+      layout: { kind: "tabs", id: "pane-corrupt", showTabStrip: true, activeTabId: "tab-missing", tabs: [] },
+    }),
+  );
+  const overlong = restoreWorkspaceLayout(
+    JSON.stringify({
+      ...snapshot,
+      layout: {
+        ...snapshot.layout,
+        tabs: [{ ...snapshot.layout.tabs[0], content: { kind: "session", sessionId: "x".repeat(MAX_SESSION_REFERENCE_LENGTH + 1) } }],
+      },
+    }),
+  );
+
+  assert.equal(malformed.recovered, true);
+  assert.equal(malformed.state.recovery.code, "invalid-json");
+  assert.equal(incompatible.recovered, true);
+  assert.equal(incompatible.state.recovery.code, "unsupported-version");
+  assert.equal(corrupt.recovered, true);
+  assert.equal(corrupt.state.recovery.code, "invalid-layout");
+  assert.equal(overlong.recovered, true);
+  assert.equal(overlong.state.recovery.code, "invalid-layout");
+  assert.equal(malformed.state.nodeAvailability, "unknown");
+  assert.equal(incompatible.state.nodeAvailability, "unknown");
+  assert.equal(corrupt.state.nodeAvailability, "unknown");
+  assert.equal(overlong.state.nodeAvailability, "unknown");
+});
+
+test("unavailable Nodes disable live Session actions and presentation mutations expose no termination operation", () => {
+  const unavailable = setNodeAvailability(createWorkspaceLayout(), "unavailable");
+
+  assert.equal(canUseLiveSessionActions(unavailable), false);
+  assert.equal("terminateSession" in unavailable, false);
+  assert.equal("terminateSession" in addSessionTab(unavailable), false);
+  assert.deepEqual(uniqueSessionIds(addSessionTab(unavailable)), uniqueSessionIds(unavailable));
+});
+
+test("selecting a tab changes only the presentation selection", () => {
+  const initial = createWorkspaceLayout({ sessionId: "session-opaque-10" });
+  const withTab = addSessionTab(initial);
+  const nextTabId = withTab.layout.tabs[1].id;
+  const selected = selectTab(withTab, withTab.selectedPaneId, nextTabId);
+
+  assert.equal(selected.layout.activeTabId, nextTabId);
+  assert.deepEqual(uniqueSessionIds(selected), uniqueSessionIds(withTab));
+});
+
+test("resetting a valid Workspace layout keeps its opaque Session reference and clears recovery state", () => {
+  const initial = createWorkspaceLayout({
+    nodeId: "node-local",
+    root: "/home/relay/non-repo",
+    rootKind: "non-repo",
+    sessionId: "session-opaque-11",
+  });
+  const reset = resetWorkspaceLayout(splitSelectedPane(addSessionTab(initial)));
+
+  assert.deepEqual(uniqueSessionIds(reset), ["session-opaque-11"]);
+  assert.equal(reset.recovery, null);
+  assert.equal(reset.workspace.node.id, "node-local");
+  assert.equal(reset.workspace.root.path, "/home/relay/non-repo");
+});


### PR DESCRIPTION
## Summary
- persist one Node-bound Workspace layout with bounded tabs and panes
- keep opaque Session references stable across presentation-only mutations
- show recovery and unavailable-Node states without Session control authority

## Verification
- npm test
- npm run lint
- npm run build
- npm run bench
- desktop and mobile PWA interaction evidence

Refs #1136
Refs #1139