### PR TITLE
fix(pty): retain retryable teardown ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +459,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -746,8 +762,10 @@ dependencies = [
 name = "relay-session"
 version = "0.1.0"
 dependencies = [
+ "filedescriptor",
  "nix",
  "portable-pty",
+ "rustix",
  "serde_json",
 ]
 
@@ -758,6 +776,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -106,6 +118,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cpufeatures"
@@ -177,6 +195,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]
@@ -422,6 +457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +473,18 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -498,7 +551,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -552,6 +605,27 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "potential_utf"
@@ -656,6 +730,7 @@ name = "relay-hub"
 version = "0.1.0"
 dependencies = [
  "relay-factory-core",
+ "relay-session",
  "serde_json",
 ]
 
@@ -671,6 +746,8 @@ dependencies = [
 name = "relay-session"
 version = "0.1.0"
 dependencies = [
+ "nix",
+ "portable-pty",
  "serde_json",
 ]
 
@@ -743,6 +820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +840,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1071,6 +1175,52 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,16 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,12 +460,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -790,7 +774,6 @@ dependencies = [
  "filedescriptor",
  "nix",
  "portable-pty",
- "rustix",
  "serde_json",
 ]
 
@@ -801,19 +784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]

--- a/apps/relay-hub/Cargo.toml
+++ b/apps/relay-hub/Cargo.toml
@@ -10,5 +10,8 @@ relay-factory-core = { path = "../../crates/relay-factory-core" }
 relay-session = { path = "../../crates/relay-session" }
 serde_json = "1.0.149"
 
+[dev-dependencies]
+relay-session = { path = "../../crates/relay-session", features = ["test-fixtures"] }
+
 [lints]
 workspace = true

--- a/apps/relay-hub/Cargo.toml
+++ b/apps/relay-hub/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 relay-factory-core = { path = "../../crates/relay-factory-core" }
+relay-session = { path = "../../crates/relay-session" }
 serde_json = "1.0.149"
 
 [lints]

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -353,7 +353,7 @@ fn route_request(
     runtime: &HubRuntime,
 ) -> String {
     let auth = runtime.auth.as_deref();
-    match (request.method, request.path) {
+    let response = match (request.method, request.path) {
         ("GET", "/health") => health_http_response(identity),
         ("POST", "/auth/passkeys/enroll/options") => start_enrollment_response(request, auth),
         ("POST", "/auth/passkeys/enroll/verify") => finish_enrollment_response(request, auth),
@@ -380,7 +380,9 @@ fn route_request(
             close_claude_session_response(request, runtime)
         }
         _ => not_found_http_response(),
-    }
+    };
+    reap_invalidated_owner_sessions(runtime);
+    response
 }
 
 fn start_enrollment_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
@@ -522,12 +524,37 @@ fn revoke_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> S
         Some(device_id) => device_id,
         None => return auth_error_response(400, "invalid_request", &[]),
     };
-    match auth.revoke_session(session, csrf, &device_id) {
-        Ok(()) => {
-            pty.close_owner_sessions(&device_id);
-            json_response(200, "{\"status\":\"revoked\"}", &[])
-        }
+    let result = auth.revoke_session(session, csrf, &device_id);
+    reap_invalidated_owner_sessions_locked(&mut pty, auth);
+    match result {
+        Ok(()) => json_response(200, "{\"status\":\"revoked\"}", &[]),
         Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
+    }
+}
+
+fn reap_invalidated_owner_sessions(runtime: &HubRuntime) {
+    let Some(auth) = runtime.auth.as_deref() else {
+        return;
+    };
+    let owner_ids = match auth.take_invalidated_device_ids() {
+        Ok(owner_ids) => owner_ids,
+        Err(_) => return,
+    };
+    if owner_ids.is_empty() {
+        return;
+    }
+    if let Ok(mut pty) = runtime.pty.lock() {
+        for owner_id in owner_ids {
+            pty.close_owner_sessions(&owner_id);
+        }
+    }
+}
+
+fn reap_invalidated_owner_sessions_locked(pty: &mut NodePtyRuntime, auth: &AuthBoundary) {
+    if let Ok(owner_ids) = auth.take_invalidated_device_ids() {
+        for owner_id in owner_ids {
+            pty.close_owner_sessions(&owner_id);
+        }
     }
 }
 
@@ -551,7 +578,11 @@ fn create_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntim
         Ok(pty) => pty,
         Err(_) => return auth_error_response(500, "internal", &[]),
     };
-    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+    let owner = terminal_owner(request, runtime.auth.as_deref(), true);
+    if let Some(auth) = runtime.auth.as_deref() {
+        reap_invalidated_owner_sessions_locked(&mut pty, auth);
+    }
+    let owner = match owner {
         Ok(owner) => owner,
         Err(response) => return response,
     };
@@ -772,7 +803,9 @@ fn claude_pty_error_response(error: ClaudePtyError) -> String {
         ClaudePtyError::Forbidden => 403,
         ClaudePtyError::InvalidInput | ClaudePtyError::InvalidResize => 400,
         ClaudePtyError::Capacity | ClaudePtyError::StaleHandle => 409,
-        ClaudePtyError::Unavailable | ClaudePtyError::Transport => 503,
+        ClaudePtyError::Backpressure | ClaudePtyError::Unavailable | ClaudePtyError::Transport => {
+            503
+        }
     };
     auth_error_response(status, error.code(), &[])
 }

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -639,7 +639,7 @@ fn input_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime
         .map_err(|_| ClaudePtyError::Transport)
         .and_then(|mut pty| pty.input(session_id, &owner, &data))
     {
-        Ok(()) => json_response(200, "{\"status\":\"accepted\"}", &[]),
+        Ok(()) => json_response(200, "{\"status\":\"queued\"}", &[]),
         Err(error) => claude_pty_error_response(error),
     }
 }
@@ -802,7 +802,7 @@ fn claude_pty_error_response(error: ClaudePtyError) -> String {
     let status = match error {
         ClaudePtyError::Forbidden => 403,
         ClaudePtyError::InvalidInput | ClaudePtyError::InvalidResize => 400,
-        ClaudePtyError::Capacity | ClaudePtyError::StaleHandle => 409,
+        ClaudePtyError::Capacity | ClaudePtyError::StaleHandle | ClaudePtyError::InputLost => 409,
         ClaudePtyError::Backpressure | ClaudePtyError::Unavailable | ClaudePtyError::Transport => {
             503
         }
@@ -1028,5 +1028,13 @@ mod tests {
         assert_eq!(terminal_cursor(Some("trace=browser")), Some(0));
         assert_eq!(terminal_cursor(Some("cursor=not-a-number")), None);
         assert_eq!(terminal_cursor(Some("cursor=1&cursor=2")), None);
+    }
+
+    #[test]
+    fn input_delivery_loss_is_an_explicit_nonretryable_conflict() {
+        let response = claude_pty_error_response(ClaudePtyError::InputLost);
+
+        assert!(response.starts_with("HTTP/1.1 409 Conflict"));
+        assert!(response.contains("input_delivery_lost"));
     }
 }

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -1037,4 +1037,25 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 409 Conflict"));
         assert!(response.contains("input_delivery_lost"));
     }
+
+    #[test]
+    fn terminal_capacity_and_transport_remain_typed_api_failures() {
+        for (error, status, code) in [
+            (
+                ClaudePtyError::Capacity,
+                "HTTP/1.1 409 Conflict",
+                "session_capacity",
+            ),
+            (
+                ClaudePtyError::Transport,
+                "HTTP/1.1 503 Service Unavailable",
+                "pty_transport",
+            ),
+        ] {
+            let response = claude_pty_error_response(error);
+
+            assert!(response.starts_with(status));
+            assert!(response.contains(code));
+        }
+    }
 }

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -360,7 +360,7 @@ fn route_request(
         ("POST", "/auth/passkeys/sign-in/options") => start_sign_in_response(request, auth),
         ("POST", "/auth/passkeys/sign-in/verify") => finish_sign_in_response(request, auth),
         ("GET", "/auth/sessions") => list_sessions_response(request, auth),
-        ("POST", "/auth/sessions/revoke") => revoke_session_response(request, auth),
+        ("POST", "/auth/sessions/revoke") => revoke_session_response(request, runtime),
         ("GET", "/protected/hub") => protected_hub_response(request, auth),
         (_, "/protected/node") => auth_error_response(403, "node_authority_required", &[]),
         ("POST", "/node/claude/sessions") => create_claude_session_response(request, runtime),
@@ -498,8 +498,15 @@ fn list_sessions_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
     }
 }
 
-fn revoke_session_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
-    let auth = match state_change_auth(request, auth) {
+fn revoke_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    // Serialize revocation against PTY creation. A request authenticated just
+    // before revocation must not create a new owner-bound process after the
+    // revoked owner's existing sessions have been reaped.
+    let mut pty = match runtime.pty.lock() {
+        Ok(pty) => pty,
+        Err(_) => return auth_error_response(500, "internal", &[]),
+    };
+    let auth = match state_change_auth(request, runtime.auth.as_deref()) {
         Ok(auth) => auth,
         Err(response) => return response,
     };
@@ -516,7 +523,10 @@ fn revoke_session_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary
         None => return auth_error_response(400, "invalid_request", &[]),
     };
     match auth.revoke_session(session, csrf, &device_id) {
-        Ok(()) => json_response(200, "{\"status\":\"revoked\"}", &[]),
+        Ok(()) => {
+            pty.close_owner_sessions(&device_id);
+            json_response(200, "{\"status\":\"revoked\"}", &[])
+        }
         Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
     }
 }
@@ -537,13 +547,13 @@ fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
 }
 
 fn create_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
-    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
-        Ok(owner) => owner,
-        Err(response) => return response,
-    };
     let mut pty = match runtime.pty.lock() {
         Ok(pty) => pty,
         Err(_) => return auth_error_response(500, "internal", &[]),
+    };
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+        Ok(owner) => owner,
+        Err(response) => return response,
     };
     let session = match pty.create(&owner) {
         Ok(session) => session,

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, Read, Write},
     net::{SocketAddr, TcpListener, TcpStream},
     process::ExitCode,
-    sync::Arc,
+    sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant},
 };
@@ -12,11 +12,17 @@ use relay_factory_core::{
     AuthBoundary, AuthError, AuthOrigin, EnrollmentAuthority, ServiceIdentity, configured_identity,
     health_http_response, health_json, not_found_http_response,
 };
+use relay_session::claude_pty::{ClaudePtyError, NodePtyRuntime, TerminalSnapshot};
 use serde_json::Value;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_REQUEST_BYTES: usize = 65_536;
 const MAX_BODY_BYTES: usize = 48_000;
+
+struct HubRuntime {
+    auth: Option<Arc<AuthBoundary>>,
+    pty: Mutex<NodePtyRuntime>,
+}
 
 fn main() -> ExitCode {
     match run() {
@@ -102,12 +108,24 @@ fn run() -> Result<(), RunError> {
 fn serve(arguments: &[String]) -> Result<(), RunError> {
     let options = ServeOptions::parse(arguments)?;
     let listener = TcpListener::bind(options.address).map_err(|_| RunError::Io)?;
+    #[cfg(debug_assertions)]
+    let pty = if options.test_claude_fixture {
+        NodePtyRuntime::test_fixture_cat()
+    } else {
+        NodePtyRuntime::default()
+    };
+    #[cfg(not(debug_assertions))]
+    let pty = NodePtyRuntime::default();
+    let runtime = Arc::new(HubRuntime {
+        auth: options.auth,
+        pty: Mutex::new(pty),
+    });
 
     println!(
         "relay-hub liveness listening on {}",
         listener.local_addr().map_err(|_| RunError::Io)?
     );
-    serve_connections_with_auth(options.identity, options.auth, || {
+    serve_connections(options.identity, runtime, || {
         listener.accept().map(|(stream, _)| stream)
     })
 }
@@ -116,6 +134,8 @@ struct ServeOptions {
     address: SocketAddr,
     identity: ServiceIdentity,
     auth: Option<Arc<AuthBoundary>>,
+    #[cfg(debug_assertions)]
+    test_claude_fixture: bool,
 }
 
 impl ServeOptions {
@@ -124,6 +144,8 @@ impl ServeOptions {
         let mut identity_arguments = None;
         let mut origin = None;
         let mut recovery_hash = None;
+        #[cfg(debug_assertions)]
+        let mut test_claude_fixture = false;
         let mut index = 0;
 
         while index < arguments.len() {
@@ -137,6 +159,19 @@ impl ServeOptions {
                 "--origin" if origin.is_none() => origin = Some(value.clone()),
                 "--recovery-code-hash" if recovery_hash.is_none() => {
                     recovery_hash = Some(value.clone());
+                }
+                "--test-claude-fixture" if value == "cat" => {
+                    #[cfg(debug_assertions)]
+                    {
+                        if test_claude_fixture {
+                            return Err(RunError::Usage);
+                        }
+                        test_claude_fixture = true;
+                    }
+                    #[cfg(not(debug_assertions))]
+                    {
+                        return Err(RunError::Usage);
+                    }
                 }
                 _ => return Err(RunError::Usage),
             }
@@ -166,13 +201,31 @@ impl ServeOptions {
             address,
             identity,
             auth,
+            #[cfg(debug_assertions)]
+            test_claude_fixture,
         })
     }
 }
 
+#[cfg(test)]
 fn serve_connections_with_auth(
     identity: ServiceIdentity,
     auth: Option<Arc<AuthBoundary>>,
+    accept: impl FnMut() -> io::Result<TcpStream>,
+) -> Result<(), RunError> {
+    serve_connections(
+        identity,
+        Arc::new(HubRuntime {
+            auth,
+            pty: Mutex::new(NodePtyRuntime::default()),
+        }),
+        accept,
+    )
+}
+
+fn serve_connections(
+    identity: ServiceIdentity,
+    runtime: Arc<HubRuntime>,
     mut accept: impl FnMut() -> io::Result<TcpStream>,
 ) -> Result<(), RunError> {
     loop {
@@ -183,10 +236,10 @@ fn serve_connections_with_auth(
                 return Err(RunError::Io);
             }
         };
-        let auth = auth.clone();
+        let runtime = Arc::clone(&runtime);
         thread::Builder::new()
             .spawn(move || {
-                if let Err(error) = handle_connection(stream, identity, auth.as_deref()) {
+                if let Err(error) = handle_connection(stream, identity, &runtime) {
                     eprintln!("relay-hub connection error: {error}");
                 }
             })
@@ -200,7 +253,7 @@ fn serve_connections_with_auth(
 fn handle_connection(
     mut stream: TcpStream,
     identity: ServiceIdentity,
-    auth: Option<&AuthBoundary>,
+    runtime: &HubRuntime,
 ) -> Result<(), ConnectionError> {
     stream
         .set_write_timeout(Some(CONNECTION_TIMEOUT))
@@ -208,7 +261,7 @@ fn handle_connection(
     let mut request = [0_u8; MAX_REQUEST_BYTES];
     let response = match read_request(&mut stream, &mut request) {
         Ok(length) => HttpRequest::parse(&request[..length])
-            .map(|request| route_request(&request, identity, auth))
+            .map(|request| route_request(&request, identity, runtime))
             .unwrap_or_else(not_found_http_response),
         Err(RequestReadError::TooLarge) => not_found_http_response(),
         Err(error) => return Err(ConnectionError::Request(error)),
@@ -222,6 +275,7 @@ fn handle_connection(
 struct HttpRequest<'a> {
     method: &'a str,
     path: &'a str,
+    query: Option<&'a str>,
     headers: Vec<(&'a str, &'a str)>,
     body: &'a str,
 }
@@ -234,10 +288,13 @@ impl<'a> HttpRequest<'a> {
         let request_line = lines.next()?;
         let mut request_parts = request_line.split_ascii_whitespace();
         let method = request_parts.next()?;
-        let path = request_parts.next()?;
-        if request_parts.next()? != "HTTP/1.1" || path.len() > 256 {
+        let target = request_parts.next()?;
+        if request_parts.next()? != "HTTP/1.1" || target.len() > 256 {
             return None;
         }
+        let (path, query) = target
+            .split_once('?')
+            .map_or((target, None), |(path, query)| (path, Some(query)));
         let mut headers = Vec::new();
         for line in lines {
             let (name, value) = line.split_once(':')?;
@@ -249,6 +306,7 @@ impl<'a> HttpRequest<'a> {
         Some(Self {
             method,
             path,
+            query,
             headers,
             body,
         })
@@ -292,8 +350,9 @@ impl<'a> HttpRequest<'a> {
 fn route_request(
     request: &HttpRequest<'_>,
     identity: ServiceIdentity,
-    auth: Option<&AuthBoundary>,
+    runtime: &HubRuntime,
 ) -> String {
+    let auth = runtime.auth.as_deref();
     match (request.method, request.path) {
         ("GET", "/health") => health_http_response(identity),
         ("POST", "/auth/passkeys/enroll/options") => start_enrollment_response(request, auth),
@@ -304,6 +363,22 @@ fn route_request(
         ("POST", "/auth/sessions/revoke") => revoke_session_response(request, auth),
         ("GET", "/protected/hub") => protected_hub_response(request, auth),
         (_, "/protected/node") => auth_error_response(403, "node_authority_required", &[]),
+        ("POST", "/node/claude/sessions") => create_claude_session_response(request, runtime),
+        ("GET", path) if claude_session_id(path, "").is_some() => {
+            poll_claude_session_response(request, runtime)
+        }
+        ("POST", path) if claude_session_id(path, "/input").is_some() => {
+            input_claude_session_response(request, runtime)
+        }
+        ("POST", path) if claude_session_id(path, "/resize").is_some() => {
+            resize_claude_session_response(request, runtime)
+        }
+        ("POST", path) if claude_session_id(path, "/interrupt").is_some() => {
+            interrupt_claude_session_response(request, runtime)
+        }
+        ("POST", path) if claude_session_id(path, "/close").is_some() => {
+            close_claude_session_response(request, runtime)
+        }
         _ => not_found_http_response(),
     }
 }
@@ -461,6 +536,225 @@ fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
     }
 }
 
+fn create_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+        Ok(owner) => owner,
+        Err(response) => return response,
+    };
+    let mut pty = match runtime.pty.lock() {
+        Ok(pty) => pty,
+        Err(_) => return auth_error_response(500, "internal", &[]),
+    };
+    let session = match pty.create(&owner) {
+        Ok(session) => session,
+        Err(error) => return claude_pty_error_response(error),
+    };
+    match pty.poll(session.as_str(), &owner, 0) {
+        Ok(snapshot) => terminal_snapshot_response(snapshot),
+        Err(error) => claude_pty_error_response(error),
+    }
+}
+
+fn poll_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), false) {
+        Ok(owner) => owner,
+        Err(response) => return response,
+    };
+    let session_id = match claude_session_id(request.path, "") {
+        Some(session_id) => session_id,
+        None => return not_found_http_response(),
+    };
+    let cursor = match terminal_cursor(request.query) {
+        Some(cursor) => cursor,
+        None => return auth_error_response(400, "invalid_request", &[]),
+    };
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.poll(session_id, &owner, cursor))
+    {
+        Ok(snapshot) => terminal_snapshot_response(snapshot),
+        Err(error) => claude_pty_error_response(error),
+    }
+}
+
+fn input_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+        Ok(owner) => owner,
+        Err(response) => return response,
+    };
+    let session_id = match claude_session_id(request.path, "/input") {
+        Some(session_id) => session_id,
+        None => return not_found_http_response(),
+    };
+    let data = match terminal_input(request.body) {
+        Some(data) => data,
+        None => return auth_error_response(400, "invalid_request", &[]),
+    };
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.input(session_id, &owner, &data))
+    {
+        Ok(()) => json_response(200, "{\"status\":\"accepted\"}", &[]),
+        Err(error) => claude_pty_error_response(error),
+    }
+}
+
+fn resize_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+        Ok(owner) => owner,
+        Err(response) => return response,
+    };
+    let session_id = match claude_session_id(request.path, "/resize") {
+        Some(session_id) => session_id,
+        None => return not_found_http_response(),
+    };
+    let (cols, rows) = match terminal_size(request.body) {
+        Some(size) => size,
+        None => return auth_error_response(400, "invalid_request", &[]),
+    };
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.resize(session_id, &owner, cols, rows))
+    {
+        Ok(()) => json_response(200, "{\"status\":\"accepted\"}", &[]),
+        Err(error) => claude_pty_error_response(error),
+    }
+}
+
+fn interrupt_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+        Ok(owner) => owner,
+        Err(response) => return response,
+    };
+    let session_id = match claude_session_id(request.path, "/interrupt") {
+        Some(session_id) => session_id,
+        None => return not_found_http_response(),
+    };
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.interrupt(session_id, &owner))
+    {
+        Ok(()) => json_response(200, "{\"status\":\"interrupted\"}", &[]),
+        Err(error) => claude_pty_error_response(error),
+    }
+}
+
+fn close_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+        Ok(owner) => owner,
+        Err(response) => return response,
+    };
+    let session_id = match claude_session_id(request.path, "/close") {
+        Some(session_id) => session_id,
+        None => return not_found_http_response(),
+    };
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.close(session_id, &owner))
+    {
+        Ok(snapshot) => terminal_snapshot_response(snapshot),
+        Err(error) => claude_pty_error_response(error),
+    }
+}
+
+fn terminal_owner(
+    request: &HttpRequest<'_>,
+    auth: Option<&AuthBoundary>,
+    state_change: bool,
+) -> Result<String, String> {
+    let auth = if state_change {
+        state_change_auth(request, auth)?
+    } else {
+        auth.ok_or_else(|| auth_error_response(404, "auth_unavailable", &[]))?
+    };
+    let session = request
+        .cookie("__Host-relay_session")
+        .ok_or_else(|| auth_error_response(401, "session_missing", &[]))?;
+    if state_change {
+        let csrf = request
+            .header("x-relay-csrf")
+            .ok_or_else(|| auth_error_response(403, "csrf_denied", &[]))?;
+        auth.require_csrf(session, csrf)
+            .map_err(|error| auth_error_response(auth_error_status(&error), error.code(), &[]))?;
+    }
+    auth.current_device_id(session)
+        .map_err(|error| auth_error_response(auth_error_status(&error), error.code(), &[]))
+}
+
+fn claude_session_id<'a>(path: &'a str, suffix: &str) -> Option<&'a str> {
+    let session_id = path
+        .strip_prefix("/node/claude/sessions/")?
+        .strip_suffix(suffix)?;
+    if session_id.is_empty()
+        || session_id.len() > 64
+        || !session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return None;
+    }
+    Some(session_id)
+}
+
+fn terminal_cursor(query: Option<&str>) -> Option<u64> {
+    match query {
+        None => Some(0),
+        Some(query) => query.strip_prefix("cursor=")?.parse().ok(),
+    }
+}
+
+fn terminal_input(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    value.get("data")?.as_str().map(str::to_owned)
+}
+
+fn terminal_size(body: &str) -> Option<(u16, u16)> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let cols = u16::try_from(value.get("cols")?.as_u64()?).ok()?;
+    let rows = u16::try_from(value.get("rows")?.as_u64()?).ok()?;
+    Some((cols, rows))
+}
+
+fn terminal_snapshot_response(snapshot: TerminalSnapshot) -> String {
+    let output = snapshot
+        .output
+        .into_iter()
+        .map(|chunk| serde_json::json!({ "sequence": chunk.sequence, "text": chunk.text }))
+        .collect::<Vec<_>>();
+    match serde_json::to_string(&serde_json::json!({
+        "sessionId": snapshot.session_id.as_str(),
+        "status": snapshot.status.code(),
+        "output": output,
+        "nextCursor": snapshot.next_cursor,
+        "hasMore": snapshot.has_more,
+        "truncated": snapshot.truncated,
+        "droppedChunks": snapshot.dropped_chunks,
+    })) {
+        Ok(body) => json_response(200, &body, &[]),
+        Err(_) => auth_error_response(500, "internal", &[]),
+    }
+}
+
+fn claude_pty_error_response(error: ClaudePtyError) -> String {
+    let status = match error {
+        ClaudePtyError::Forbidden => 403,
+        ClaudePtyError::InvalidInput | ClaudePtyError::InvalidResize => 400,
+        ClaudePtyError::Capacity | ClaudePtyError::StaleHandle => 409,
+        ClaudePtyError::Unavailable | ClaudePtyError::Transport => 503,
+    };
+    auth_error_response(status, error.code(), &[])
+}
+
 fn state_change_auth<'a>(
     request: &HttpRequest<'_>,
     auth: Option<&'a AuthBoundary>,
@@ -604,6 +898,8 @@ fn json_response(status: u16, body: &str, extra_headers: &[String]) -> String {
         401 => "401 Unauthorized",
         403 => "403 Forbidden",
         404 => "404 Not Found",
+        409 => "409 Conflict",
+        503 => "503 Service Unavailable",
         _ => "500 Internal Server Error",
     };
     let mut headers = vec![

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -12,7 +12,9 @@ use relay_factory_core::{
     AuthBoundary, AuthError, AuthOrigin, EnrollmentAuthority, ServiceIdentity, configured_identity,
     health_http_response, health_json, not_found_http_response,
 };
-use relay_session::claude_pty::{ClaudePtyError, NodePtyRuntime, PtyTermination, TerminalSnapshot};
+use relay_session::claude_pty::{
+    ClaudePtyError, NodePtyRuntime, OwnerSessionCloseDisposition, PtyTermination, TerminalSnapshot,
+};
 use serde_json::Value;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -22,6 +24,12 @@ const MAX_BODY_BYTES: usize = 48_000;
 struct HubRuntime {
     auth: Option<Arc<AuthBoundary>>,
     pty: Mutex<NodePtyRuntime>,
+}
+
+struct InvalidatedOwnerReap {
+    owner_ids: Vec<String>,
+    terminations: Vec<PtyTermination>,
+    retry: bool,
 }
 
 fn main() -> ExitCode {
@@ -501,37 +509,30 @@ fn list_sessions_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
 }
 
 fn revoke_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
-    // Remove revoked-owner PTYs while holding the runtime lock, then finish
-    // their bounded TERM/KILL grace after releasing it. This still prevents a
-    // revoked identity from retaining a runtime handle without serializing the
-    // hub's unrelated terminal controls behind every close.
-    let (result, terminations) = {
-        let mut pty = match runtime.pty.lock() {
-            Ok(pty) => pty,
-            Err(_) => return auth_error_response(500, "internal", &[]),
-        };
-        let auth = match state_change_auth(request, runtime.auth.as_deref()) {
-            Ok(auth) => auth,
-            Err(response) => return response,
-        };
-        let session = match request.cookie("__Host-relay_session") {
-            Some(session) => session,
-            None => return auth_error_response(401, "session_missing", &[]),
-        };
-        let csrf = match request.header("x-relay-csrf") {
-            Some(csrf) => csrf,
-            None => return auth_error_response(403, "csrf_denied", &[]),
-        };
-        let device_id = match device_id_from_body(request.body) {
-            Some(device_id) => device_id,
-            None => return auth_error_response(400, "invalid_request", &[]),
-        };
-        let result = auth.revoke_session(session, csrf, &device_id);
-        let terminations = take_invalidated_owner_sessions_locked(&mut pty, auth);
-        (result, terminations)
+    let auth = match state_change_auth(request, runtime.auth.as_deref()) {
+        Ok(auth) => auth,
+        Err(response) => return response,
     };
-    finish_terminations(terminations);
+    let session = match request.cookie("__Host-relay_session") {
+        Some(session) => session,
+        None => return auth_error_response(401, "session_missing", &[]),
+    };
+    let csrf = match request.header("x-relay-csrf") {
+        Some(csrf) => csrf,
+        None => return auth_error_response(403, "csrf_denied", &[]),
+    };
+    let device_id = match device_id_from_body(request.body) {
+        Some(device_id) => device_id,
+        None => return auth_error_response(400, "invalid_request", &[]),
+    };
+    let result = auth.revoke_session(session, csrf, &device_id);
+    let cleanup_pending = begin_invalidated_owner_reap(runtime, auth)
+        .map(|reap| finish_invalidated_owner_reap(auth, reap))
+        .unwrap_or(true);
     match result {
+        Ok(()) if cleanup_pending => {
+            json_response(200, "{\"status\":\"revoked\",\"cleanup\":\"pending\"}", &[])
+        }
         Ok(()) => json_response(200, "{\"status\":\"revoked\"}", &[]),
         Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
     }
@@ -541,48 +542,52 @@ fn reap_invalidated_owner_sessions(runtime: &HubRuntime) {
     let Some(auth) = runtime.auth.as_deref() else {
         return;
     };
-    let owner_ids = match auth.take_invalidated_device_ids() {
-        Ok(owner_ids) => owner_ids,
-        Err(_) => return,
-    };
-    if owner_ids.is_empty() {
+    let Ok(reap) = begin_invalidated_owner_reap(runtime, auth) else {
         return;
-    }
-    let terminations = match runtime.pty.lock() {
-        Ok(mut pty) => {
-            let mut terminations = Vec::new();
-            for owner_id in owner_ids {
-                terminations.extend(pty.begin_owner_session_closes(&owner_id));
-            }
-            terminations
-        }
-        Err(_) => return,
     };
-    finish_terminations(terminations);
-}
-
-fn take_invalidated_owner_sessions_locked(
-    pty: &mut NodePtyRuntime,
-    auth: &AuthBoundary,
-) -> Vec<PtyTermination> {
-    match auth.take_invalidated_device_ids() {
-        Ok(owner_ids) => {
-            let mut terminations = Vec::new();
-            for owner_id in owner_ids {
-                terminations.extend(pty.begin_owner_session_closes(&owner_id));
-            }
-            terminations
-        }
-        Err(_) => Vec::new(),
+    if finish_invalidated_owner_reap(auth, reap) {
+        eprintln!("relay Claude PTY owner cleanup remains pending for retry");
     }
 }
 
-fn finish_terminations(terminations: Vec<PtyTermination>) {
+fn begin_invalidated_owner_reap(
+    runtime: &HubRuntime,
+    auth: &AuthBoundary,
+) -> Result<InvalidatedOwnerReap, ()> {
+    let owner_ids = auth.invalidated_device_ids().map_err(|_| ())?;
+    let mut pty = runtime.pty.lock().map_err(|_| ())?;
+    let mut terminations = Vec::new();
+    let mut retry = false;
+    for owner_id in &owner_ids {
+        let closures = pty.begin_owner_session_closes(owner_id);
+        terminations.extend(closures.terminations);
+        retry |= closures.disposition == OwnerSessionCloseDisposition::Retry;
+    }
+    Ok(InvalidatedOwnerReap {
+        owner_ids,
+        terminations,
+        retry,
+    })
+}
+
+fn finish_invalidated_owner_reap(auth: &AuthBoundary, reap: InvalidatedOwnerReap) -> bool {
+    let finished = finish_terminations(reap.terminations);
+    if reap.retry || !finished {
+        return true;
+    }
+    auth.acknowledge_invalidated_device_ids(&reap.owner_ids)
+        .is_err()
+}
+
+fn finish_terminations(terminations: Vec<PtyTermination>) -> bool {
+    let mut finished = true;
     for termination in terminations {
         if termination.finish().is_err() {
             eprintln!("relay Claude PTY teardown could not verify foreground cleanup");
+            finished = false;
         }
     }
+    finished
 }
 
 fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
@@ -604,20 +609,26 @@ fn create_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntim
     // Terminations may include a bounded grace. Drain invalidated owners before
     // taking the lock needed for this create request.
     reap_invalidated_owner_sessions(runtime);
-    let mut pty = match runtime.pty.lock() {
-        Ok(pty) => pty,
-        Err(_) => return auth_error_response(500, "internal", &[]),
-    };
-    let owner = terminal_owner(request, runtime.auth.as_deref(), true);
-    let owner = match owner {
+    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
         Ok(owner) => owner,
         Err(response) => return response,
     };
-    let session = match pty.create(&owner) {
+    let creation = match runtime.pty.lock() {
+        Ok(mut pty) => pty.begin_create(&owner),
+        Err(_) => return auth_error_response(500, "internal", &[]),
+    };
+    let (session, terminations) = creation.into_parts();
+    let _ = finish_terminations(terminations);
+    let session = match session {
         Ok(session) => session,
         Err(error) => return claude_pty_error_response(error),
     };
-    match pty.poll(session.as_str(), &owner, 0) {
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.poll(session.as_str(), &owner, 0))
+    {
         Ok(snapshot) => terminal_snapshot_response(snapshot),
         Err(error) => claude_pty_error_response(error),
     }

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -12,7 +12,7 @@ use relay_factory_core::{
     AuthBoundary, AuthError, AuthOrigin, EnrollmentAuthority, ServiceIdentity, configured_identity,
     health_http_response, health_json, not_found_http_response,
 };
-use relay_session::claude_pty::{ClaudePtyError, NodePtyRuntime, TerminalSnapshot};
+use relay_session::claude_pty::{ClaudePtyError, NodePtyRuntime, PtyTermination, TerminalSnapshot};
 use serde_json::Value;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -501,31 +501,36 @@ fn list_sessions_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
 }
 
 fn revoke_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
-    // Serialize revocation against PTY creation. A request authenticated just
-    // before revocation must not create a new owner-bound process after the
-    // revoked owner's existing sessions have been reaped.
-    let mut pty = match runtime.pty.lock() {
-        Ok(pty) => pty,
-        Err(_) => return auth_error_response(500, "internal", &[]),
+    // Remove revoked-owner PTYs while holding the runtime lock, then finish
+    // their bounded TERM/KILL grace after releasing it. This still prevents a
+    // revoked identity from retaining a runtime handle without serializing the
+    // hub's unrelated terminal controls behind every close.
+    let (result, terminations) = {
+        let mut pty = match runtime.pty.lock() {
+            Ok(pty) => pty,
+            Err(_) => return auth_error_response(500, "internal", &[]),
+        };
+        let auth = match state_change_auth(request, runtime.auth.as_deref()) {
+            Ok(auth) => auth,
+            Err(response) => return response,
+        };
+        let session = match request.cookie("__Host-relay_session") {
+            Some(session) => session,
+            None => return auth_error_response(401, "session_missing", &[]),
+        };
+        let csrf = match request.header("x-relay-csrf") {
+            Some(csrf) => csrf,
+            None => return auth_error_response(403, "csrf_denied", &[]),
+        };
+        let device_id = match device_id_from_body(request.body) {
+            Some(device_id) => device_id,
+            None => return auth_error_response(400, "invalid_request", &[]),
+        };
+        let result = auth.revoke_session(session, csrf, &device_id);
+        let terminations = take_invalidated_owner_sessions_locked(&mut pty, auth);
+        (result, terminations)
     };
-    let auth = match state_change_auth(request, runtime.auth.as_deref()) {
-        Ok(auth) => auth,
-        Err(response) => return response,
-    };
-    let session = match request.cookie("__Host-relay_session") {
-        Some(session) => session,
-        None => return auth_error_response(401, "session_missing", &[]),
-    };
-    let csrf = match request.header("x-relay-csrf") {
-        Some(csrf) => csrf,
-        None => return auth_error_response(403, "csrf_denied", &[]),
-    };
-    let device_id = match device_id_from_body(request.body) {
-        Some(device_id) => device_id,
-        None => return auth_error_response(400, "invalid_request", &[]),
-    };
-    let result = auth.revoke_session(session, csrf, &device_id);
-    reap_invalidated_owner_sessions_locked(&mut pty, auth);
+    finish_terminations(terminations);
     match result {
         Ok(()) => json_response(200, "{\"status\":\"revoked\"}", &[]),
         Err(error) => auth_error_response(auth_error_status(&error), error.code(), &[]),
@@ -543,17 +548,39 @@ fn reap_invalidated_owner_sessions(runtime: &HubRuntime) {
     if owner_ids.is_empty() {
         return;
     }
-    if let Ok(mut pty) = runtime.pty.lock() {
-        for owner_id in owner_ids {
-            pty.close_owner_sessions(&owner_id);
+    let terminations = match runtime.pty.lock() {
+        Ok(mut pty) => {
+            let mut terminations = Vec::new();
+            for owner_id in owner_ids {
+                terminations.extend(pty.begin_owner_session_closes(&owner_id));
+            }
+            terminations
         }
+        Err(_) => return,
+    };
+    finish_terminations(terminations);
+}
+
+fn take_invalidated_owner_sessions_locked(
+    pty: &mut NodePtyRuntime,
+    auth: &AuthBoundary,
+) -> Vec<PtyTermination> {
+    match auth.take_invalidated_device_ids() {
+        Ok(owner_ids) => {
+            let mut terminations = Vec::new();
+            for owner_id in owner_ids {
+                terminations.extend(pty.begin_owner_session_closes(&owner_id));
+            }
+            terminations
+        }
+        Err(_) => Vec::new(),
     }
 }
 
-fn reap_invalidated_owner_sessions_locked(pty: &mut NodePtyRuntime, auth: &AuthBoundary) {
-    if let Ok(owner_ids) = auth.take_invalidated_device_ids() {
-        for owner_id in owner_ids {
-            pty.close_owner_sessions(&owner_id);
+fn finish_terminations(terminations: Vec<PtyTermination>) {
+    for termination in terminations {
+        if termination.finish().is_err() {
+            eprintln!("relay Claude PTY teardown could not verify foreground cleanup");
         }
     }
 }
@@ -574,14 +601,14 @@ fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
 }
 
 fn create_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
+    // Terminations may include a bounded grace. Drain invalidated owners before
+    // taking the lock needed for this create request.
+    reap_invalidated_owner_sessions(runtime);
     let mut pty = match runtime.pty.lock() {
         Ok(pty) => pty,
         Err(_) => return auth_error_response(500, "internal", &[]),
     };
     let owner = terminal_owner(request, runtime.auth.as_deref(), true);
-    if let Some(auth) = runtime.auth.as_deref() {
-        reap_invalidated_owner_sessions_locked(&mut pty, auth);
-    }
     let owner = match owner {
         Ok(owner) => owner,
         Err(response) => return response,
@@ -697,12 +724,12 @@ fn close_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime
         Some(session_id) => session_id,
         None => return not_found_http_response(),
     };
-    match runtime
+    let termination = runtime
         .pty
         .lock()
         .map_err(|_| ClaudePtyError::Transport)
-        .and_then(|mut pty| pty.close(session_id, &owner))
-    {
+        .and_then(|mut pty| pty.begin_close(session_id, &owner));
+    match termination.and_then(PtyTermination::finish) {
         Ok(snapshot) => terminal_snapshot_response(snapshot),
         Err(error) => claude_pty_error_response(error),
     }

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -13,23 +13,29 @@ use relay_factory_core::{
     health_http_response, health_json, not_found_http_response,
 };
 use relay_session::claude_pty::{
-    ClaudePtyError, NodePtyRuntime, OwnerSessionCloseDisposition, PtyTermination, TerminalSnapshot,
+    ClaudePtyError, NodePtyRuntime, OwnerSessionCloseDisposition, PtyTermination,
+    PtyTerminationOutcome, TerminalSnapshot,
 };
 use serde_json::Value;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_REQUEST_BYTES: usize = 65_536;
 const MAX_BODY_BYTES: usize = 48_000;
+// Eight capacity-consuming records, three bounded attempts, and the accepted
+// TERM/reap windows fit below this single controlled-shutdown ceiling.
+const PTY_SHUTDOWN_BUDGET: Duration = Duration::from_secs(35);
+const PTY_LIFECYCLE_POLL: Duration = Duration::from_millis(10);
+
+#[derive(Default)]
+struct PtyRetryDriver {
+    running: bool,
+}
 
 struct HubRuntime {
     auth: Option<Arc<AuthBoundary>>,
+    owner_lifecycle: Mutex<()>,
     pty: Mutex<NodePtyRuntime>,
-}
-
-struct InvalidatedOwnerReap {
-    owner_ids: Vec<String>,
-    terminations: Vec<PtyTermination>,
-    retry: bool,
+    retry_driver: Mutex<PtyRetryDriver>,
 }
 
 fn main() -> ExitCode {
@@ -126,7 +132,9 @@ fn serve(arguments: &[String]) -> Result<(), RunError> {
     let pty = NodePtyRuntime::default();
     let runtime = Arc::new(HubRuntime {
         auth: options.auth,
+        owner_lifecycle: Mutex::new(()),
         pty: Mutex::new(pty),
+        retry_driver: Mutex::new(PtyRetryDriver::default()),
     });
 
     println!(
@@ -225,7 +233,9 @@ fn serve_connections_with_auth(
         identity,
         Arc::new(HubRuntime {
             auth,
+            owner_lifecycle: Mutex::new(()),
             pty: Mutex::new(NodePtyRuntime::default()),
+            retry_driver: Mutex::new(PtyRetryDriver::default()),
         }),
         accept,
     )
@@ -236,32 +246,35 @@ fn serve_connections(
     runtime: Arc<HubRuntime>,
     mut accept: impl FnMut() -> io::Result<TcpStream>,
 ) -> Result<(), RunError> {
-    loop {
+    let result = loop {
         let stream = match accept() {
             Ok(stream) => stream,
             Err(error) => {
                 eprintln!("relay-hub accept error: {error}");
-                return Err(RunError::Io);
+                break Err(RunError::Io);
             }
         };
         let runtime = Arc::clone(&runtime);
-        thread::Builder::new()
-            .spawn(move || {
-                if let Err(error) = handle_connection(stream, identity, &runtime) {
-                    eprintln!("relay-hub connection error: {error}");
-                }
-            })
-            .map_err(|error| {
-                eprintln!("relay-hub connection handler error: {error}");
-                RunError::Io
-            })?;
+        if let Err(error) = thread::Builder::new().spawn(move || {
+            if let Err(error) = handle_connection(stream, identity, runtime) {
+                eprintln!("relay-hub connection error: {error}");
+            }
+        }) {
+            eprintln!("relay-hub connection handler error: {error}");
+            break Err(RunError::Io);
+        }
+    };
+
+    if !shutdown_pty_runtime(&runtime) {
+        eprintln!("relay Claude PTY shutdown incomplete; retained resources did not reach Closed");
     }
+    result
 }
 
 fn handle_connection(
     mut stream: TcpStream,
     identity: ServiceIdentity,
-    runtime: &HubRuntime,
+    runtime: Arc<HubRuntime>,
 ) -> Result<(), ConnectionError> {
     stream
         .set_write_timeout(Some(CONNECTION_TIMEOUT))
@@ -269,7 +282,7 @@ fn handle_connection(
     let mut request = [0_u8; MAX_REQUEST_BYTES];
     let response = match read_request(&mut stream, &mut request) {
         Ok(length) => HttpRequest::parse(&request[..length])
-            .map(|request| route_request(&request, identity, runtime))
+            .map(|request| route_request(&request, identity, &runtime))
             .unwrap_or_else(not_found_http_response),
         Err(RequestReadError::TooLarge) => not_found_http_response(),
         Err(error) => return Err(ConnectionError::Request(error)),
@@ -358,8 +371,11 @@ impl<'a> HttpRequest<'a> {
 fn route_request(
     request: &HttpRequest<'_>,
     identity: ServiceIdentity,
-    runtime: &HubRuntime,
+    runtime: &Arc<HubRuntime>,
 ) -> String {
+    // A request is also the bounded retry driver: lease selection and result
+    // reinsertion hold the mutex briefly, while TERM/KILL/reap run outside it.
+    drive_pty_terminations(runtime);
     let auth = runtime.auth.as_deref();
     let response = match (request.method, request.path) {
         ("GET", "/health") => health_http_response(identity),
@@ -390,6 +406,7 @@ fn route_request(
         _ => not_found_http_response(),
     };
     reap_invalidated_owner_sessions(runtime);
+    ensure_pty_retry_driver(runtime);
     response
 }
 
@@ -526,8 +543,10 @@ fn revoke_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> S
         None => return auth_error_response(400, "invalid_request", &[]),
     };
     let result = auth.revoke_session(session, csrf, &device_id);
-    let cleanup_pending = begin_invalidated_owner_reap(runtime, auth)
-        .map(|reap| finish_invalidated_owner_reap(auth, reap))
+    reap_invalidated_owner_sessions(runtime);
+    let cleanup_pending = auth
+        .invalidated_device_ids()
+        .map(|owners| owners.contains(&device_id))
         .unwrap_or(true);
     match result {
         Ok(()) if cleanup_pending => {
@@ -542,52 +561,176 @@ fn reap_invalidated_owner_sessions(runtime: &HubRuntime) {
     let Some(auth) = runtime.auth.as_deref() else {
         return;
     };
-    let Ok(reap) = begin_invalidated_owner_reap(runtime, auth) else {
+    {
+        let _owner_lifecycle = owner_lifecycle_lock(runtime);
+        let Ok(owner_ids) = auth.invalidated_device_ids() else {
+            return;
+        };
+        if owner_ids.is_empty() {
+            return;
+        }
+        let mut pty = pty_lifecycle_lock(runtime);
+        for owner_id in &owner_ids {
+            pty.begin_owner_session_closes(owner_id);
+        }
+    }
+
+    drive_pty_terminations(runtime);
+    acknowledge_ready_invalidated_owners(runtime);
+}
+
+fn acknowledge_ready_invalidated_owners(runtime: &HubRuntime) {
+    let Some(auth) = runtime.auth.as_deref() else {
         return;
     };
-    if finish_invalidated_owner_reap(auth, reap) {
-        eprintln!("relay Claude PTY owner cleanup remains pending for retry");
+    let _owner_lifecycle = owner_lifecycle_lock(runtime);
+    let Ok(owner_ids) = auth.invalidated_device_ids() else {
+        return;
+    };
+    let ready = {
+        let pty = pty_lifecycle_lock(runtime);
+        owner_ids
+            .iter()
+            .filter(|owner_id| invalidated_owner_ready_for_acknowledgement(&pty, owner_id))
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    if !ready.is_empty() {
+        let _ = auth.acknowledge_invalidated_device_ids(&ready);
     }
 }
 
-fn begin_invalidated_owner_reap(
-    runtime: &HubRuntime,
-    auth: &AuthBoundary,
-) -> Result<InvalidatedOwnerReap, ()> {
-    let owner_ids = auth.invalidated_device_ids().map_err(|_| ())?;
-    let mut pty = runtime.pty.lock().map_err(|_| ())?;
-    let mut terminations = Vec::new();
-    let mut retry = false;
-    for owner_id in &owner_ids {
-        let closures = pty.begin_owner_session_closes(owner_id);
-        terminations.extend(closures.terminations);
-        retry |= closures.disposition == OwnerSessionCloseDisposition::Retry;
-    }
-    Ok(InvalidatedOwnerReap {
-        owner_ids,
-        terminations,
-        retry,
+fn invalidated_owner_ready_for_acknowledgement(pty: &NodePtyRuntime, owner_id: &str) -> bool {
+    pty.owner_close_disposition(owner_id) == OwnerSessionCloseDisposition::Complete
+}
+
+fn pty_lifecycle_lock(runtime: &HubRuntime) -> std::sync::MutexGuard<'_, NodePtyRuntime> {
+    runtime.pty.lock().unwrap_or_else(|poisoned| {
+        eprintln!("relay Claude PTY lifecycle recovered its poisoned owner lock");
+        poisoned.into_inner()
     })
 }
 
-fn finish_invalidated_owner_reap(auth: &AuthBoundary, reap: InvalidatedOwnerReap) -> bool {
-    let finished = finish_terminations(reap.terminations);
-    if reap.retry || !finished {
-        return true;
-    }
-    auth.acknowledge_invalidated_device_ids(&reap.owner_ids)
-        .is_err()
+fn owner_lifecycle_lock(runtime: &HubRuntime) -> std::sync::MutexGuard<'_, ()> {
+    runtime.owner_lifecycle.lock().unwrap_or_else(|poisoned| {
+        eprintln!("relay Claude PTY owner lifecycle recovered its poisoned gate");
+        poisoned.into_inner()
+    })
 }
 
-fn finish_terminations(terminations: Vec<PtyTermination>) -> bool {
-    let mut finished = true;
-    for termination in terminations {
-        if termination.finish().is_err() {
-            eprintln!("relay Claude PTY teardown could not verify foreground cleanup");
-            finished = false;
+fn retry_driver_lock(runtime: &HubRuntime) -> std::sync::MutexGuard<'_, PtyRetryDriver> {
+    runtime.retry_driver.lock().unwrap_or_else(|poisoned| {
+        eprintln!("relay Claude PTY retry driver recovered its poisoned state");
+        poisoned.into_inner()
+    })
+}
+
+fn drive_pty_terminations(runtime: &HubRuntime) {
+    drive_pty_terminations_with(runtime, PtyTermination::finish);
+}
+
+fn drive_pty_terminations_with(
+    runtime: &HubRuntime,
+    mut finish: impl FnMut(PtyTermination) -> PtyTerminationOutcome,
+) {
+    let leases = pty_lifecycle_lock(runtime).claim_due_terminations();
+    for termination in leases {
+        let outcome = finish(termination);
+        pty_lifecycle_lock(runtime).complete_termination(outcome);
+    }
+}
+
+fn ensure_pty_retry_driver(runtime: &Arc<HubRuntime>) {
+    if !pty_lifecycle_lock(runtime).has_pending_terminations() {
+        return;
+    }
+    let mut state = retry_driver_lock(runtime);
+    if state.running {
+        return;
+    }
+    state.running = true;
+    let worker_runtime = Arc::clone(runtime);
+    match thread::Builder::new()
+        .name("relay-claude-pty-retry".into())
+        .spawn(move || run_pty_retry_driver(worker_runtime))
+    {
+        Ok(_) => {}
+        Err(error) => {
+            eprintln!("relay Claude PTY retry worker spawn failed: {error}; running inline");
+            drop(state);
+            run_pty_retry_driver(Arc::clone(runtime));
         }
     }
-    finished
+}
+
+fn run_pty_retry_driver(runtime: Arc<HubRuntime>) {
+    run_retry_loop(
+        || {
+            drive_pty_terminations(&runtime);
+            acknowledge_ready_invalidated_owners(&runtime);
+        },
+        || {
+            let mut state = retry_driver_lock(&runtime);
+            if pty_lifecycle_lock(&runtime).has_pending_terminations() {
+                true
+            } else {
+                state.running = false;
+                false
+            }
+        },
+        || thread::sleep(PTY_LIFECYCLE_POLL),
+    );
+}
+
+fn run_retry_loop(
+    mut drive: impl FnMut(),
+    mut still_pending: impl FnMut() -> bool,
+    mut wait: impl FnMut(),
+) {
+    loop {
+        drive();
+        if !still_pending() {
+            return;
+        }
+        wait();
+    }
+}
+
+/// Drain the one-node PTY owner when the server loop exits normally through a
+/// controlled error path. Abrupt process termination remains explicitly
+/// outside this in-memory guarantee.
+fn shutdown_pty_runtime(runtime: &HubRuntime) -> bool {
+    let deadline = Instant::now() + PTY_SHUTDOWN_BUDGET;
+    let scheduled = {
+        let _owner_lifecycle = owner_lifecycle_lock(runtime);
+        pty_lifecycle_lock(runtime).begin_shutdown()
+    };
+    acknowledge_ready_invalidated_owners(runtime);
+    if scheduled == OwnerSessionCloseDisposition::Complete && !retry_driver_lock(runtime).running {
+        return true;
+    }
+
+    loop {
+        drive_pty_terminations(runtime);
+        acknowledge_ready_invalidated_owners(runtime);
+        let disposition = {
+            let pty = pty_lifecycle_lock(runtime);
+            (pty.shutdown_disposition(), pty.has_terminal_failures())
+        };
+        let driver_running = retry_driver_lock(runtime).running;
+        match disposition {
+            (OwnerSessionCloseDisposition::Complete, _) if !driver_running => return true,
+            (_, true) if !driver_running => return false,
+            (OwnerSessionCloseDisposition::Complete, _)
+            | (_, true)
+            | (OwnerSessionCloseDisposition::Retry, false) => {}
+        }
+
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+        thread::sleep(remaining.min(PTY_LIFECYCLE_POLL));
+    }
 }
 
 fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>) -> String {
@@ -606,19 +749,36 @@ fn protected_hub_response(request: &HttpRequest<'_>, auth: Option<&AuthBoundary>
 }
 
 fn create_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime) -> String {
-    // Terminations may include a bounded grace. Drain invalidated owners before
-    // taking the lock needed for this create request.
     reap_invalidated_owner_sessions(runtime);
-    let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
-        Ok(owner) => owner,
-        Err(response) => return response,
+    let (owner, mut session) = {
+        // Serialize auth resolution plus admission with invalidation
+        // acknowledgement. Outside-lock teardown is deliberately not inside
+        // this gate, so unrelated owner operations still make progress.
+        let _owner_lifecycle = owner_lifecycle_lock(runtime);
+        let owner = match terminal_owner(request, runtime.auth.as_deref(), true) {
+            Ok(owner) => owner,
+            Err(response) => return response,
+        };
+        let session = match runtime.pty.lock() {
+            Ok(mut pty) => pty.begin_create(&owner).into_result(),
+            Err(_) => return auth_error_response(500, "internal", &[]),
+        };
+        (owner, session)
     };
-    let creation = match runtime.pty.lock() {
-        Ok(mut pty) => pty.begin_create(&owner),
-        Err(_) => return auth_error_response(500, "internal", &[]),
-    };
-    let (session, terminations) = creation.into_parts();
-    let _ = finish_terminations(terminations);
+    drive_pty_terminations(runtime);
+    if session == Err(ClaudePtyError::Capacity) {
+        session = {
+            let _owner_lifecycle = owner_lifecycle_lock(runtime);
+            if let Err(response) = terminal_owner(request, runtime.auth.as_deref(), true) {
+                return response;
+            }
+            match runtime.pty.lock() {
+                Ok(mut pty) => pty.begin_create(&owner).into_result(),
+                Err(_) => return auth_error_response(500, "internal", &[]),
+            }
+        };
+        drive_pty_terminations(runtime);
+    }
     let session = match session {
         Ok(session) => session,
         Err(error) => return claude_pty_error_response(error),
@@ -735,12 +895,21 @@ fn close_claude_session_response(request: &HttpRequest<'_>, runtime: &HubRuntime
         Some(session_id) => session_id,
         None => return not_found_http_response(),
     };
-    let termination = runtime
+    let requested = runtime
         .pty
         .lock()
         .map_err(|_| ClaudePtyError::Transport)
-        .and_then(|mut pty| pty.begin_close(session_id, &owner));
-    match termination.and_then(PtyTermination::finish) {
+        .and_then(|mut pty| pty.request_close(session_id, &owner));
+    if let Err(error) = requested {
+        return claude_pty_error_response(error);
+    }
+    drive_pty_terminations(runtime);
+    match runtime
+        .pty
+        .lock()
+        .map_err(|_| ClaudePtyError::Transport)
+        .and_then(|mut pty| pty.poll(session_id, &owner, 0))
+    {
         Ok(snapshot) => terminal_snapshot_response(snapshot),
         Err(error) => claude_pty_error_response(error),
     }
@@ -822,6 +991,11 @@ fn terminal_snapshot_response(snapshot: TerminalSnapshot) -> String {
         .into_iter()
         .map(|chunk| serde_json::json!({ "sequence": chunk.sequence, "text": chunk.text }))
         .collect::<Vec<_>>();
+    let status = if snapshot.status == relay_session::claude_pty::ClaudePtyStatus::Closing {
+        202
+    } else {
+        200
+    };
     match serde_json::to_string(&serde_json::json!({
         "sessionId": snapshot.session_id.as_str(),
         "status": snapshot.status.code(),
@@ -831,7 +1005,7 @@ fn terminal_snapshot_response(snapshot: TerminalSnapshot) -> String {
         "truncated": snapshot.truncated,
         "droppedChunks": snapshot.dropped_chunks,
     })) {
-        Ok(body) => json_response(200, &body, &[]),
+        Ok(body) => json_response(status, &body, &[]),
         Err(_) => auth_error_response(500, "internal", &[]),
     }
 }
@@ -841,9 +1015,10 @@ fn claude_pty_error_response(error: ClaudePtyError) -> String {
         ClaudePtyError::Forbidden => 403,
         ClaudePtyError::InvalidInput | ClaudePtyError::InvalidResize => 400,
         ClaudePtyError::Capacity | ClaudePtyError::StaleHandle | ClaudePtyError::InputLost => 409,
-        ClaudePtyError::Backpressure | ClaudePtyError::Unavailable | ClaudePtyError::Transport => {
-            503
-        }
+        ClaudePtyError::Backpressure
+        | ClaudePtyError::Unavailable
+        | ClaudePtyError::Transport
+        | ClaudePtyError::TeardownFailed => 503,
     };
     auth_error_response(status, error.code(), &[])
 }
@@ -987,6 +1162,7 @@ fn auth_error_response(status: u16, code: &str, extra_headers: &[String]) -> Str
 fn json_response(status: u16, body: &str, extra_headers: &[String]) -> String {
     let reason = match status {
         200 => "200 OK",
+        202 => "202 Accepted",
         400 => "400 Bad Request",
         401 => "401 Unauthorized",
         403 => "403 Forbidden",
@@ -1020,6 +1196,193 @@ mod tests {
         });
 
         assert!(matches!(result, Err(RunError::Io)));
+    }
+
+    #[test]
+    fn listener_exit_drains_and_latches_the_pty_runtime() {
+        let runtime = Arc::new(HubRuntime {
+            auth: None,
+            owner_lifecycle: Mutex::new(()),
+            pty: Mutex::new(NodePtyRuntime::test_fixture_cat()),
+            retry_driver: Mutex::new(PtyRetryDriver::default()),
+        });
+        let session = runtime
+            .pty
+            .lock()
+            .unwrap()
+            .begin_create("device-a")
+            .into_result()
+            .expect("the fixed test PTY starts");
+        let observed = Arc::clone(&runtime);
+
+        let result = serve_connections(ServiceIdentity::Hub, runtime, || {
+            Err(io::Error::other("injected listener failure"))
+        });
+
+        assert!(matches!(result, Err(RunError::Io)));
+        let mut pty = observed.pty.lock().unwrap();
+        assert_eq!(
+            pty.poll(session.as_str(), "device-a", 0)
+                .expect("controlled shutdown retains terminal truth")
+                .status,
+            relay_session::claude_pty::ClaudePtyStatus::Closed
+        );
+        assert_eq!(
+            pty.begin_create("device-a").into_result(),
+            Err(ClaudePtyError::Unavailable),
+            "controlled shutdown must latch against concurrent admission"
+        );
+    }
+
+    #[test]
+    fn close_is_accepted_then_reaped_without_another_request() {
+        let runtime = Arc::new(HubRuntime {
+            auth: None,
+            owner_lifecycle: Mutex::new(()),
+            pty: Mutex::new(NodePtyRuntime::test_fixture_cat()),
+            retry_driver: Mutex::new(PtyRetryDriver::default()),
+        });
+        let session = runtime
+            .pty
+            .lock()
+            .unwrap()
+            .begin_create("device-a")
+            .into_result()
+            .expect("the fixed test PTY starts");
+        let closing = {
+            let mut pty = runtime.pty.lock().unwrap();
+            pty.request_close(session.as_str(), "device-a")
+                .expect("explicit close enters the lifecycle");
+            pty.poll(session.as_str(), "device-a", 0)
+                .expect("Closing remains observable")
+        };
+
+        let response = terminal_snapshot_response(closing);
+        assert!(response.starts_with("HTTP/1.1 202 Accepted"));
+        assert!(response.contains("\"status\":\"closing\""));
+
+        ensure_pty_retry_driver(&runtime);
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let closed = loop {
+            let snapshot = runtime
+                .pty
+                .lock()
+                .unwrap()
+                .poll(session.as_str(), "device-a", 0)
+                .expect("terminal truth remains observable");
+            if snapshot.status == relay_session::claude_pty::ClaudePtyStatus::Closed {
+                break snapshot;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the autonomous retry driver did not finish the close"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+        let response = terminal_snapshot_response(closed);
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"status\":\"closed\""));
+        while retry_driver_lock(&runtime).running {
+            assert!(Instant::now() < deadline, "the retry worker did not exit");
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn retry_loop_runs_all_bounded_attempts_without_a_client_request() {
+        let attempts = std::cell::Cell::new(0_usize);
+        let waits = std::cell::Cell::new(0_usize);
+
+        run_retry_loop(
+            || attempts.set(attempts.get().saturating_add(1)),
+            || attempts.get() < 3,
+            || waits.set(waits.get().saturating_add(1)),
+        );
+
+        assert_eq!(attempts.get(), 3);
+        assert_eq!(waits.get(), 2);
+    }
+
+    #[test]
+    fn teardown_lease_allows_unrelated_admission_progress() {
+        let runtime = HubRuntime {
+            auth: None,
+            owner_lifecycle: Mutex::new(()),
+            pty: Mutex::new(NodePtyRuntime::test_fixture_cat()),
+            retry_driver: Mutex::new(PtyRetryDriver::default()),
+        };
+        let closing = runtime
+            .pty
+            .lock()
+            .unwrap()
+            .begin_create("device-a")
+            .into_result()
+            .expect("the closing fixture starts");
+        runtime
+            .pty
+            .lock()
+            .unwrap()
+            .request_close(closing.as_str(), "device-a")
+            .unwrap();
+        let mut unrelated = None;
+
+        drive_pty_terminations_with(&runtime, |termination| {
+            let owner_lifecycle = runtime
+                .owner_lifecycle
+                .try_lock()
+                .expect("teardown does not retain the owner lifecycle gate");
+            let session = runtime
+                .pty
+                .try_lock()
+                .expect("teardown does not retain the PTY mutex")
+                .begin_create("device-b")
+                .into_result()
+                .expect("an unrelated owner can make admission progress");
+            unrelated = Some(session);
+            drop(owner_lifecycle);
+            termination.finish()
+        });
+
+        let unrelated = unrelated.expect("the outside-lock callback ran");
+        runtime
+            .pty
+            .lock()
+            .unwrap()
+            .request_close(unrelated.as_str(), "device-b")
+            .unwrap();
+        drive_pty_terminations(&runtime);
+    }
+
+    #[test]
+    fn invalidated_owner_acknowledgement_waits_for_verified_closed() {
+        let runtime = HubRuntime {
+            auth: None,
+            owner_lifecycle: Mutex::new(()),
+            pty: Mutex::new(NodePtyRuntime::test_fixture_cat()),
+            retry_driver: Mutex::new(PtyRetryDriver::default()),
+        };
+        let owners = ["device-a".to_owned()];
+        runtime
+            .pty
+            .lock()
+            .unwrap()
+            .begin_create(&owners[0])
+            .into_result()
+            .expect("the fixed test PTY starts");
+        {
+            let mut pty = runtime.pty.lock().unwrap();
+            pty.begin_owner_session_closes(&owners[0]);
+            assert!(
+                !invalidated_owner_ready_for_acknowledgement(&pty, &owners[0]),
+                "Closing must retain the auth invalidation"
+            );
+        }
+
+        drive_pty_terminations(&runtime);
+        assert!(invalidated_owner_ready_for_acknowledgement(
+            &runtime.pty.lock().unwrap(),
+            &owners[0]
+        ));
     }
 
     #[test]
@@ -1077,7 +1440,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_capacity_and_transport_remain_typed_api_failures() {
+    fn terminal_capacity_transport_and_teardown_failure_remain_typed_api_failures() {
         for (error, status, code) in [
             (
                 ClaudePtyError::Capacity,
@@ -1088,6 +1451,11 @@ mod tests {
                 ClaudePtyError::Transport,
                 "HTTP/1.1 503 Service Unavailable",
                 "pty_transport",
+            ),
+            (
+                ClaudePtyError::TeardownFailed,
+                "HTTP/1.1 503 Service Unavailable",
+                "pty_teardown_failed",
             ),
         ] {
             let response = claude_pty_error_response(error);

--- a/apps/relay-hub/src/main.rs
+++ b/apps/relay-hub/src/main.rs
@@ -707,10 +707,22 @@ fn claude_session_id<'a>(path: &'a str, suffix: &str) -> Option<&'a str> {
 }
 
 fn terminal_cursor(query: Option<&str>) -> Option<u64> {
-    match query {
-        None => Some(0),
-        Some(query) => query.strip_prefix("cursor=")?.parse().ok(),
+    let Some(query) = query else {
+        return Some(0);
+    };
+    let mut cursor = None;
+    for parameter in query.split('&') {
+        let Some((key, value)) = parameter.split_once('=') else {
+            continue;
+        };
+        if key != "cursor" {
+            continue;
+        }
+        if cursor.replace(value.parse().ok()?).is_some() {
+            return None;
+        }
     }
+    Some(cursor.unwrap_or(0))
 }
 
 fn terminal_input(body: &str) -> Option<String> {
@@ -963,5 +975,15 @@ mod tests {
                 "cookie: {cookie}"
             );
         }
+    }
+
+    #[test]
+    fn terminal_cursor_accepts_unrelated_parameters_and_rejects_ambiguous_cursor_values() {
+        assert_eq!(terminal_cursor(None), Some(0));
+        assert_eq!(terminal_cursor(Some("trace=browser&cursor=42")), Some(42));
+        assert_eq!(terminal_cursor(Some("cursor=42&trace=browser")), Some(42));
+        assert_eq!(terminal_cursor(Some("trace=browser")), Some(0));
+        assert_eq!(terminal_cursor(Some("cursor=not-a-number")), None);
+        assert_eq!(terminal_cursor(Some("cursor=1&cursor=2")), None);
     }
 }

--- a/apps/relay-node/Cargo.toml
+++ b/apps/relay-node/Cargo.toml
@@ -12,6 +12,7 @@ relay-hermes-session = { path = "../../crates/relay-hermes-session" }
 
 [dev-dependencies]
 base64 = "0.22"
+relay-session = { path = "../../crates/relay-session", features = ["test-fixtures"] }
 serde_json = "1.0"
 sha1 = "0.10"
 

--- a/apps/relay-node/src/main.rs
+++ b/apps/relay-node/src/main.rs
@@ -9,7 +9,9 @@ use relay_factory_core::{ServiceIdentity, configured_identity, health_json};
 use relay_hermes_session::{
     AdapterError, EventKind, GatewayEndpoint, HermesSessionAdapter, SessionStatus,
 };
-use relay_session::claude_pty::{ClaudePtyStatus, NodePtyRuntime};
+use relay_session::claude_pty::{
+    ClaudePtyError, ClaudePtyStatus, NodePtyRuntime, OwnerSessionCloseDisposition,
+};
 use relay_session::{
     DEFAULT_DEADLINE, ProcessTransport, SessionError, Supervisor,
     codex::{assert_local_stdio_only, codex_command_args},
@@ -63,7 +65,10 @@ fn claude_pty_probe() -> ExitCode {
     let mut runtime = NodePtyRuntime::default();
     let session = match runtime.create("relay-node-probe") {
         Ok(session) => session,
-        Err(error) => return claude_pty_probe_error(error.code()),
+        Err(error) => {
+            let code = error.code();
+            return claude_pty_probe_error_after_drain(&mut runtime, code);
+        }
     };
     let deadline = Instant::now() + Duration::from_secs(5);
     let status = loop {
@@ -71,27 +76,69 @@ fn claude_pty_probe() -> ExitCode {
             Ok(snapshot) if snapshot.status != ClaudePtyStatus::Starting => break snapshot.status,
             Ok(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(25)),
             Ok(_) => {
-                let _ = runtime.close(session.as_str(), "relay-node-probe");
-                return claude_pty_probe_error("startup_timeout");
+                return claude_pty_probe_error_after_drain(&mut runtime, "startup_timeout");
             }
-            Err(error) => return claude_pty_probe_error(error.code()),
+            Err(error) => {
+                let code = error.code();
+                return claude_pty_probe_error_after_drain(&mut runtime, code);
+            }
         }
     };
     let resize = runtime.resize(session.as_str(), "relay-node-probe", 100, 40);
     let interrupt = runtime.interrupt(session.as_str(), "relay-node-probe");
-    let close = runtime.close(session.as_str(), "relay-node-probe");
-    match (resize, interrupt, close) {
-        (Ok(()), Ok(()), Ok(closed)) if closed.status == ClaudePtyStatus::Closed => {
+    let close = runtime.request_close(session.as_str(), "relay-node-probe");
+    let operation_error = resize
+        .err()
+        .or_else(|| interrupt.err())
+        .or_else(|| close.err());
+    if !drain_claude_pty_runtime(&mut runtime) {
+        return claude_pty_probe_error(ClaudePtyError::TeardownFailed.code());
+    }
+    if let Some(error) = operation_error {
+        return claude_pty_probe_error(error.code());
+    }
+    match runtime.poll(session.as_str(), "relay-node-probe", 0) {
+        Ok(closed) if closed.status == ClaudePtyStatus::Closed => {
             println!(
                 r#"{{"adapter":"claude-pty","operations":["spawn","resize","interrupt","close"],"ownerHome":"/home/donovanyohan","startup":"{}","status":"ok"}}"#,
                 status.code()
             );
             ExitCode::SUCCESS
         }
-        (Err(error), _, _) | (_, Err(error), _) | (_, _, Err(error)) => {
-            claude_pty_probe_error(error.code())
+        Ok(_) => claude_pty_probe_error("close_failed"),
+        Err(error) => claude_pty_probe_error(error.code()),
+    }
+}
+
+fn claude_pty_probe_error_after_drain(runtime: &mut NodePtyRuntime, code: &str) -> ExitCode {
+    if drain_claude_pty_runtime(runtime) {
+        claude_pty_probe_error(code)
+    } else {
+        claude_pty_probe_error(ClaudePtyError::TeardownFailed.code())
+    }
+}
+
+fn drain_claude_pty_runtime(runtime: &mut NodePtyRuntime) -> bool {
+    const BUDGET: Duration = Duration::from_secs(5);
+    const POLL: Duration = Duration::from_millis(10);
+
+    let deadline = Instant::now() + BUDGET;
+    runtime.begin_shutdown();
+    loop {
+        for termination in runtime.claim_due_terminations() {
+            let outcome = termination.finish();
+            runtime.complete_termination(outcome);
         }
-        _ => claude_pty_probe_error("close_failed"),
+        if runtime.shutdown_disposition() == OwnerSessionCloseDisposition::Complete {
+            return true;
+        }
+        if runtime.has_terminal_failures() {
+            return false;
+        }
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+        thread::sleep(remaining.min(POLL));
     }
 }
 
@@ -292,5 +339,33 @@ impl HermesSmokeOptions {
             prompt,
             observe_ms,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_drain_reaps_the_fixture_and_latches_admission() {
+        let mut runtime = NodePtyRuntime::test_fixture_cat();
+        let session = runtime
+            .begin_create("relay-node-probe")
+            .into_result()
+            .expect("the fixed probe fixture starts");
+
+        assert!(drain_claude_pty_runtime(&mut runtime));
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "relay-node-probe", 0)
+                .expect("the drained terminal truth remains observable")
+                .status,
+            ClaudePtyStatus::Closed
+        );
+        assert_eq!(
+            runtime.begin_create("relay-node-probe").into_result(),
+            Err(ClaudePtyError::Unavailable),
+            "the controlled drain must reject later admission"
+        );
     }
 }

--- a/apps/relay-node/src/main.rs
+++ b/apps/relay-node/src/main.rs
@@ -1,6 +1,12 @@
-use std::{env, process::ExitCode};
+use std::{
+    env,
+    process::ExitCode,
+    thread,
+    time::{Duration, Instant},
+};
 
 use relay_factory_core::{ServiceIdentity, configured_identity, health_json};
+use relay_session::claude_pty::{ClaudePtyStatus, NodePtyRuntime};
 use relay_session::{
     DEFAULT_DEADLINE, ProcessTransport, SessionError, Supervisor,
     codex::{assert_local_stdio_only, codex_command_args},
@@ -25,13 +31,58 @@ fn main() -> ExitCode {
         [command, probe_arguments @ ..] if command == "codex-stdio-probe" => {
             codex_stdio_probe(probe_arguments)
         }
+        [command] if command == "claude-pty-probe" => claude_pty_probe(),
         _ => {
             eprintln!(
-                "usage: relay-node <probe [--identity node]|codex-stdio-probe [--negative-transport|--handshake|--exercise]>"
+                "usage: relay-node <probe [--identity node]|codex-stdio-probe [--negative-transport|--handshake|--exercise]|claude-pty-probe>"
             );
             ExitCode::from(64)
         }
     }
+}
+
+/// Opt-in owner-context smoke for the fixed Claude PTY runtime. The probe
+/// deliberately emits lifecycle facts only: never terminal bytes, OAuth data,
+/// or a Session handle.
+fn claude_pty_probe() -> ExitCode {
+    let mut runtime = NodePtyRuntime::default();
+    let session = match runtime.create("relay-node-probe") {
+        Ok(session) => session,
+        Err(error) => return claude_pty_probe_error(error.code()),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        match runtime.poll(session.as_str(), "relay-node-probe", 0) {
+            Ok(snapshot) if snapshot.status != ClaudePtyStatus::Starting => break snapshot.status,
+            Ok(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(25)),
+            Ok(_) => {
+                let _ = runtime.close(session.as_str(), "relay-node-probe");
+                return claude_pty_probe_error("startup_timeout");
+            }
+            Err(error) => return claude_pty_probe_error(error.code()),
+        }
+    };
+    let resize = runtime.resize(session.as_str(), "relay-node-probe", 100, 40);
+    let interrupt = runtime.interrupt(session.as_str(), "relay-node-probe");
+    let close = runtime.close(session.as_str(), "relay-node-probe");
+    match (resize, interrupt, close) {
+        (Ok(()), Ok(()), Ok(closed)) if closed.status == ClaudePtyStatus::Closed => {
+            println!(
+                r#"{{"adapter":"claude-pty","operations":["spawn","resize","interrupt","close"],"ownerHome":"/home/donovanyohan","startup":"{}","status":"ok"}}"#,
+                status.code()
+            );
+            ExitCode::SUCCESS
+        }
+        (Err(error), _, _) | (_, Err(error), _) | (_, _, Err(error)) => {
+            claude_pty_probe_error(error.code())
+        }
+        _ => claude_pty_probe_error("close_failed"),
+    }
+}
+
+fn claude_pty_probe_error(code: &str) -> ExitCode {
+    eprintln!("{{\"error\":{{\"code\":\"{code}\"}}}}");
+    ExitCode::FAILURE
 }
 
 /// An executable guard that proves the adapter only constructs local stdio

--- a/crates/relay-factory-core/src/auth.rs
+++ b/crates/relay-factory-core/src/auth.rs
@@ -96,8 +96,9 @@ impl AuthState {
         }
     }
 
-    fn take_invalidated_device_ids(&mut self) -> Vec<String> {
-        std::mem::take(&mut self.invalidated_device_ids)
+    fn acknowledge_invalidated_device_ids(&mut self, device_ids: &[String]) {
+        self.invalidated_device_ids
+            .retain(|device_id| !device_ids.contains(device_id));
     }
 }
 
@@ -320,12 +321,23 @@ impl AuthBoundary {
     }
 
     /// Return device identities whose browser authority was removed by TTL,
-    /// explicit revocation, or oldest-session eviction. Resource owners can
-    /// reap their handles without receiving an opaque browser session token.
-    pub fn take_invalidated_device_ids(&self) -> Result<Vec<String>, AuthError> {
+    /// explicit revocation, or oldest-session eviction. Resource owners must
+    /// acknowledge only identities whose owned resources were actually reaped,
+    /// so a fail-closed teardown refusal remains eligible for retry.
+    pub fn invalidated_device_ids(&self) -> Result<Vec<String>, AuthError> {
         self.state
             .lock()
-            .map(|mut state| state.take_invalidated_device_ids())
+            .map(|state| state.invalidated_device_ids.clone())
+            .map_err(|_| AuthError::Internal)
+    }
+
+    pub fn acknowledge_invalidated_device_ids(
+        &self,
+        device_ids: &[String],
+    ) -> Result<(), AuthError> {
+        self.state
+            .lock()
+            .map(|mut state| state.acknowledge_invalidated_device_ids(device_ids))
             .map_err(|_| AuthError::Internal)
     }
 
@@ -581,9 +593,17 @@ mod tests {
             Err(AuthError::SessionMissing)
         );
         assert_eq!(
-            boundary.take_invalidated_device_ids().unwrap(),
+            boundary.invalidated_device_ids().unwrap(),
             vec!["expired-device"]
         );
+        assert_eq!(
+            boundary.invalidated_device_ids().unwrap(),
+            vec!["expired-device"],
+            "a failed owner teardown must leave invalidation pending for retry"
+        );
+        boundary
+            .acknowledge_invalidated_device_ids(&["expired-device".into()])
+            .unwrap();
 
         {
             let mut state = boundary.state.lock().expect("auth state");
@@ -611,9 +631,12 @@ mod tests {
             .revoke_session("requester", "requester-csrf", "revoked-device")
             .expect("live session can revoke the target device");
         assert_eq!(
-            boundary.take_invalidated_device_ids().unwrap(),
+            boundary.invalidated_device_ids().unwrap(),
             vec!["revoked-device"]
         );
+        boundary
+            .acknowledge_invalidated_device_ids(&["revoked-device".into()])
+            .unwrap();
 
         let capacity_boundary = self::boundary();
         {
@@ -634,7 +657,7 @@ mod tests {
             issue_session(&mut state).expect("capacity eviction issues a replacement");
         }
         assert_eq!(
-            capacity_boundary.take_invalidated_device_ids().unwrap(),
+            capacity_boundary.invalidated_device_ids().unwrap(),
             vec!["device-0"]
         );
     }

--- a/crates/relay-factory-core/src/auth.rs
+++ b/crates/relay-factory-core/src/auth.rs
@@ -282,6 +282,22 @@ impl AuthBoundary {
         }
     }
 
+    /// Return the opaque authenticated-browser identity for a live session.
+    ///
+    /// Node-owned Session handles bind to this value rather than accepting a
+    /// browser-supplied owner field. The raw browser session token remains
+    /// confined to this authentication boundary.
+    pub fn current_device_id(&self, session_token: &str) -> Result<String, AuthError> {
+        let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
+        state.discard_expired(Instant::now());
+        let key = hash_secret(session_token.as_bytes());
+        state
+            .sessions
+            .get(&key)
+            .map(|session| session.device_id.clone())
+            .ok_or(AuthError::SessionMissing)
+    }
+
     pub fn require_csrf(&self, session_token: &str, csrf_token: &str) -> Result<(), AuthError> {
         let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
         state.discard_expired(Instant::now());

--- a/crates/relay-factory-core/src/auth.rs
+++ b/crates/relay-factory-core/src/auth.rs
@@ -62,6 +62,7 @@ struct AuthState {
     passkeys: Vec<Passkey>,
     ceremonies: HashMap<[u8; 32], PendingCeremony>,
     sessions: HashMap<[u8; 32], StoredSession>,
+    invalidated_device_ids: Vec<String>,
 }
 
 impl AuthState {
@@ -70,13 +71,33 @@ impl AuthState {
             passkeys: Vec::new(),
             ceremonies: HashMap::new(),
             sessions: HashMap::new(),
+            invalidated_device_ids: Vec::new(),
         }
     }
 
     fn discard_expired(&mut self, now: Instant) {
         self.ceremonies
             .retain(|_, ceremony| ceremony.expires_at() > now);
+        let expired_devices = self
+            .sessions
+            .values()
+            .filter(|session| session.expires_at <= now)
+            .map(|session| session.device_id.clone())
+            .collect::<Vec<_>>();
         self.sessions.retain(|_, session| session.expires_at > now);
+        for device_id in expired_devices {
+            self.invalidate_device(device_id);
+        }
+    }
+
+    fn invalidate_device(&mut self, device_id: String) {
+        if !self.invalidated_device_ids.contains(&device_id) {
+            self.invalidated_device_ids.push(device_id);
+        }
+    }
+
+    fn take_invalidated_device_ids(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.invalidated_device_ids)
     }
 }
 
@@ -298,6 +319,16 @@ impl AuthBoundary {
             .ok_or(AuthError::SessionMissing)
     }
 
+    /// Return device identities whose browser authority was removed by TTL,
+    /// explicit revocation, or oldest-session eviction. Resource owners can
+    /// reap their handles without receiving an opaque browser session token.
+    pub fn take_invalidated_device_ids(&self) -> Result<Vec<String>, AuthError> {
+        self.state
+            .lock()
+            .map(|mut state| state.take_invalidated_device_ids())
+            .map_err(|_| AuthError::Internal)
+    }
+
     pub fn require_csrf(&self, session_token: &str, csrf_token: &str) -> Result<(), AuthError> {
         let mut state = self.state.lock().map_err(|_| AuthError::Internal)?;
         state.discard_expired(Instant::now());
@@ -351,6 +382,7 @@ impl AuthBoundary {
         if state.sessions.len() == before {
             Err(AuthError::SessionMissing)
         } else {
+            state.invalidate_device(device_id.to_owned());
             Ok(())
         }
     }
@@ -419,7 +451,9 @@ fn issue_session(state: &mut AuthState) -> Result<SessionGrant, AuthError> {
             .min_by_key(|(_, session)| session.created_at)
             .map(|(key, _)| *key)
             .ok_or(AuthError::Internal)?;
-        state.sessions.remove(&oldest);
+        if let Some(evicted) = state.sessions.remove(&oldest) {
+            state.invalidate_device(evicted.device_id);
+        }
     }
 
     let session_token = random_token(32)?;
@@ -523,6 +557,85 @@ mod tests {
                 .finish_registration(&ceremony.ceremony_id, "{}")
                 .unwrap_err(),
             AuthError::UnknownCeremony
+        );
+    }
+
+    #[test]
+    fn session_invalidations_record_ttl_expiry_and_capacity_eviction() {
+        let boundary = boundary();
+        let expired_token = "expired-session";
+        {
+            let mut state = boundary.state.lock().expect("auth state");
+            state.sessions.insert(
+                hash_secret(expired_token.as_bytes()),
+                StoredSession {
+                    csrf_hash: hash_secret(b"expired-csrf"),
+                    device_id: "expired-device".into(),
+                    created_at: Instant::now() - Duration::from_secs(2),
+                    expires_at: Instant::now() - Duration::from_secs(1),
+                },
+            );
+        }
+        assert_eq!(
+            boundary.require_session(expired_token),
+            Err(AuthError::SessionMissing)
+        );
+        assert_eq!(
+            boundary.take_invalidated_device_ids().unwrap(),
+            vec!["expired-device"]
+        );
+
+        {
+            let mut state = boundary.state.lock().expect("auth state");
+            let now = Instant::now();
+            state.sessions.insert(
+                hash_secret(b"requester"),
+                StoredSession {
+                    csrf_hash: hash_secret(b"requester-csrf"),
+                    device_id: "requester-device".into(),
+                    created_at: now,
+                    expires_at: now + SESSION_TTL,
+                },
+            );
+            state.sessions.insert(
+                hash_secret(b"revoked"),
+                StoredSession {
+                    csrf_hash: hash_secret(b"revoked-csrf"),
+                    device_id: "revoked-device".into(),
+                    created_at: now,
+                    expires_at: now + SESSION_TTL,
+                },
+            );
+        }
+        boundary
+            .revoke_session("requester", "requester-csrf", "revoked-device")
+            .expect("live session can revoke the target device");
+        assert_eq!(
+            boundary.take_invalidated_device_ids().unwrap(),
+            vec!["revoked-device"]
+        );
+
+        let capacity_boundary = self::boundary();
+        {
+            let mut state = capacity_boundary.state.lock().expect("auth state");
+            let now = Instant::now();
+            for index in 0..MAX_SESSIONS {
+                let token = format!("session-{index}");
+                state.sessions.insert(
+                    hash_secret(token.as_bytes()),
+                    StoredSession {
+                        csrf_hash: hash_secret(token.as_bytes()),
+                        device_id: format!("device-{index}"),
+                        created_at: now + Duration::from_secs(index as u64),
+                        expires_at: now + SESSION_TTL,
+                    },
+                );
+            }
+            issue_session(&mut state).expect("capacity eviction issues a replacement");
+        }
+        assert_eq!(
+            capacity_boundary.take_invalidated_device_ids().unwrap(),
+            vec!["device-0"]
         );
     }
 }

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -9,7 +9,11 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+portable-pty = "0.9.0"
 serde_json = "1.0"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.28", features = ["process", "signal"] }
 
 [lints]
 workspace = true

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 filedescriptor = "0.8.3"
-nix = { version = "0.28", features = ["process", "signal"] }
+nix = { version = "0.28", features = ["process", "signal", "term"] }
 
 [lints]
 workspace = true

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0"
 [target.'cfg(unix)'.dependencies]
 filedescriptor = "0.8.3"
 nix = { version = "0.28", features = ["process", "signal"] }
-rustix = { version = "1.1.4", features = ["process"] }
+rustix = { version = "1.1.4", features = ["event", "process"] }
 
 [lints]
 workspace = true

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -13,7 +13,9 @@ portable-pty = "0.9.0"
 serde_json = "1.0"
 
 [target.'cfg(unix)'.dependencies]
+filedescriptor = "0.8.3"
 nix = { version = "0.28", features = ["process", "signal"] }
+rustix = { version = "1.1.4", features = ["process"] }
 
 [lints]
 workspace = true

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[features]
+test-fixtures = []
+
 [dependencies]
 portable-pty = "0.9.0"
 serde_json = "1.0"

--- a/crates/relay-session/Cargo.toml
+++ b/crates/relay-session/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = "1.0"
 [target.'cfg(unix)'.dependencies]
 filedescriptor = "0.8.3"
 nix = { version = "0.28", features = ["process", "signal"] }
-rustix = { version = "1.1.4", features = ["event", "process"] }
 
 [lints]
 workspace = true

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{self, Receiver, TryRecvError, TrySendError};
+use std::sync::mpsc::{self, Receiver, TrySendError};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -175,7 +175,6 @@ pub struct TerminalSnapshot {
 #[derive(Debug)]
 enum ReaderEvent {
     Output(Vec<u8>),
-    Exit,
 }
 
 #[derive(Debug)]
@@ -284,6 +283,7 @@ struct ManagedSession {
     reader: Option<JoinHandle<()>>,
     reader_rx: Receiver<ReaderEvent>,
     reader_stop: Arc<AtomicBool>,
+    reader_terminal: Arc<AtomicBool>,
     reader_dropped: Arc<AtomicU64>,
     output: VecDeque<ScrollbackChunk>,
     output_bytes: usize,
@@ -420,11 +420,13 @@ impl NodePtyRuntime {
         };
         let (reader_tx, reader_rx) = mpsc::sync_channel(PTY_INBOUND_CAP);
         let reader_stop = Arc::new(AtomicBool::new(false));
+        let reader_terminal = Arc::new(AtomicBool::new(false));
         let reader_dropped = Arc::new(AtomicU64::new(0));
         let reader_thread = match spawn_reader(
             reader,
             reader_tx,
             Arc::clone(&reader_stop),
+            Arc::clone(&reader_terminal),
             Arc::clone(&reader_dropped),
         ) {
             Ok(reader_thread) => reader_thread,
@@ -453,6 +455,7 @@ impl NodePtyRuntime {
                 reader: Some(reader_thread),
                 reader_rx,
                 reader_stop,
+                reader_terminal,
                 reader_dropped,
                 output: VecDeque::new(),
                 output_bytes: 0,
@@ -652,15 +655,12 @@ impl NodePtyRuntime {
 
 impl ManagedSession {
     fn pump(&mut self) {
-        loop {
-            match self.reader_rx.try_recv() {
-                Ok(ReaderEvent::Output(bytes)) => self.append_output(bytes),
-                Ok(ReaderEvent::Exit) => {
-                    self.flush_pending_output();
-                    self.terminal_seen = true;
-                }
-                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
-            }
+        while let Ok(ReaderEvent::Output(bytes)) = self.reader_rx.try_recv() {
+            self.append_output(bytes);
+        }
+        if self.reader_terminal.load(Ordering::Acquire) {
+            self.flush_pending_output();
+            self.terminal_seen = true;
         }
         if self.status == ClaudePtyStatus::Closed {
             return;
@@ -801,6 +801,7 @@ fn spawn_reader(
     mut reader: Box<dyn Read + Send>,
     sender: mpsc::SyncSender<ReaderEvent>,
     stop: Arc<AtomicBool>,
+    terminal: Arc<AtomicBool>,
     dropped: Arc<AtomicU64>,
 ) -> Result<JoinHandle<()>, ClaudePtyError> {
     thread::Builder::new()
@@ -813,7 +814,7 @@ fn spawn_reader(
                 }
                 match reader.read(&mut buffer) {
                     Ok(0) => {
-                        let _ = sender.try_send(ReaderEvent::Exit);
+                        terminal.store(true, Ordering::Release);
                         break;
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
@@ -821,7 +822,7 @@ fn spawn_reader(
                         thread::sleep(PTY_INPUT_POLL_INTERVAL);
                     }
                     Err(_) => {
-                        let _ = sender.try_send(ReaderEvent::Exit);
+                        terminal.store(true, Ordering::Release);
                         break;
                     }
                     Ok(length) => {
@@ -1274,6 +1275,43 @@ mod tests {
         assert_eq!(reattached.session_id, session);
         assert!(reattached.next_cursor >= first.next_cursor);
         runtime.close(session.as_str(), "device-a").unwrap();
+    }
+
+    #[test]
+    fn saturated_reader_queue_still_releases_a_naturally_exited_session() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &["-c", "yes saturated-terminal-output | head -c 1048576"],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+
+        loop {
+            let managed = &runtime.sessions[session.as_str()];
+            if managed.reader_dropped.load(Ordering::Acquire) > 0
+                && managed.reader.as_ref().is_some_and(JoinHandle::is_finished)
+            {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "fixture did not fill and drain the non-polling reader queue"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let status = {
+            let managed = runtime.sessions.get_mut(session.as_str()).unwrap();
+            managed.pump();
+            managed.status
+        };
+        assert_eq!(status, ClaudePtyStatus::Exited);
+
+        runtime.prune_finished_sessions();
+        assert!(
+            !runtime.sessions.contains_key(session.as_str()),
+            "reader EOF must make a saturated non-polling session prunable"
+        );
     }
 
     #[test]

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -1521,8 +1521,18 @@ mod tests {
         // The direct shell exits after reporting the child. The reader may
         // report terminal EOF, but that status probe must not reap the shell
         // and release its process-group ID before close can safely signal it.
-        thread::sleep(Duration::from_millis(50));
-        let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let snapshot = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if snapshot.status == ClaudePtyStatus::Exited {
+                break snapshot;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "test PTY did not report reader EOF after its direct leader exited"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
         assert_eq!(snapshot.status, ClaudePtyStatus::Exited);
         assert_eq!(
             kill(Pid::from_raw(leader_pid), None),

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError, TrySendError};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 #[cfg(all(unix, test))]
 use nix::{errno::Errno, sys::signal::kill};
@@ -57,6 +58,7 @@ const MIN_ROWS: u16 = 4;
 const MAX_ROWS: u16 = 300;
 const MIN_COLS: u16 = 20;
 const MAX_COLS: u16 = 500;
+const PTY_TERMINATION_GRACE: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeOwnerContext {
@@ -177,6 +179,7 @@ struct ManagedSession {
     output: VecDeque<ScrollbackChunk>,
     output_bytes: usize,
     next_sequence: u64,
+    pending_utf8: Vec<u8>,
     terminal_seen: bool,
 }
 
@@ -187,6 +190,7 @@ struct ManagedSession {
 /// command, cwd, PID, or environment.
 pub struct NodePtyRuntime {
     owner: NodeOwnerContext,
+    launch_directory: PathBuf,
     /// Empty in production. Tests may inject a fixed fixture argument vector;
     /// no browser/API request can influence this field.
     arguments: Vec<String>,
@@ -202,8 +206,10 @@ impl Default for NodePtyRuntime {
 
 impl NodePtyRuntime {
     pub fn new(owner: NodeOwnerContext) -> Self {
+        let launch_directory = owner.home.clone();
         Self {
             owner,
+            launch_directory,
             arguments: Vec::new(),
             sessions: HashMap::new(),
             next_id: 1,
@@ -223,6 +229,7 @@ impl NodePtyRuntime {
     pub fn test_fixture_cat() -> Self {
         let mut runtime = Self::default();
         runtime.owner.claude_path = PathBuf::from("/bin/sh");
+        runtime.launch_directory = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
         runtime.arguments = vec![
             "-c".into(),
             "trap 'exit 0' INT; while IFS= read -r line; do printf '%s\\n' \"$line\"; done".into(),
@@ -250,7 +257,7 @@ impl NodePtyRuntime {
         for argument in &self.arguments {
             command.arg(argument);
         }
-        command.cwd(self.owner.home());
+        command.cwd(&self.launch_directory);
         command.env("HOME", self.owner.home());
         command.env("USER", "donovanyohan");
         command.env("LOGNAME", "donovanyohan");
@@ -314,6 +321,7 @@ impl NodePtyRuntime {
                 output: VecDeque::new(),
                 output_bytes: 0,
                 next_sequence: 1,
+                pending_utf8: Vec::new(),
                 terminal_seen: false,
             },
         );
@@ -473,15 +481,12 @@ impl NodePtyRuntime {
 
     #[cfg(test)]
     fn new_with_program(owner: NodeOwnerContext, program: PathBuf, arguments: Vec<String>) -> Self {
-        Self {
-            owner: NodeOwnerContext {
-                home: owner.home,
-                claude_path: program,
-            },
-            arguments,
-            sessions: HashMap::new(),
-            next_id: 1,
-        }
+        let mut runtime = Self::new(owner);
+        runtime.owner.claude_path = program;
+        runtime.launch_directory =
+            std::env::current_dir().expect("test process has a working directory");
+        runtime.arguments = arguments;
+        runtime
     }
 }
 
@@ -490,7 +495,10 @@ impl ManagedSession {
         loop {
             match self.reader_rx.try_recv() {
                 Ok(ReaderEvent::Output(bytes)) => self.append_output(bytes),
-                Ok(ReaderEvent::Exit) => self.terminal_seen = true,
+                Ok(ReaderEvent::Exit) => {
+                    self.flush_pending_output();
+                    self.terminal_seen = true;
+                }
                 Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
             }
         }
@@ -511,11 +519,18 @@ impl ManagedSession {
     }
 
     fn append_output(&mut self, bytes: Vec<u8>) {
-        if bytes.is_empty() {
+        self.append_output_chunk(bytes, false);
+    }
+
+    fn flush_pending_output(&mut self) {
+        self.append_output_chunk(Vec::new(), true);
+    }
+
+    fn append_output_chunk(&mut self, bytes: Vec<u8>, finish: bool) {
+        let (text, bytes_len) = decode_terminal_output(&mut self.pending_utf8, bytes, finish);
+        if text.is_empty() {
             return;
         }
-        let bytes_len = bytes.len();
-        let text = String::from_utf8_lossy(&bytes).into_owned();
         let chunk = ScrollbackChunk {
             sequence: self.next_sequence,
             text,
@@ -546,6 +561,8 @@ impl ManagedSession {
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }
+        self.pump();
+        self.flush_pending_output();
         self.status = ClaudePtyStatus::Closed;
     }
 }
@@ -563,6 +580,53 @@ fn default_size() -> PtySize {
         pixel_width: 0,
         pixel_height: 0,
     }
+}
+
+fn decode_terminal_output(
+    pending: &mut Vec<u8>,
+    incoming: Vec<u8>,
+    finish: bool,
+) -> (String, usize) {
+    let mut bytes = std::mem::take(pending);
+    bytes.extend(incoming);
+
+    let mut input = bytes.as_slice();
+    let mut text = String::new();
+    let mut consumed: usize = 0;
+    while !input.is_empty() {
+        match std::str::from_utf8(input) {
+            Ok(valid) => {
+                text.push_str(valid);
+                consumed = consumed.saturating_add(input.len());
+                break;
+            }
+            Err(error) => {
+                let valid_up_to = error.valid_up_to();
+                text.push_str(
+                    std::str::from_utf8(&input[..valid_up_to])
+                        .expect("UTF-8 error valid prefix is valid UTF-8"),
+                );
+                consumed = consumed.saturating_add(valid_up_to);
+                match error.error_len() {
+                    Some(invalid_len) => {
+                        text.push('\u{FFFD}');
+                        consumed = consumed.saturating_add(invalid_len);
+                        input = &input[valid_up_to + invalid_len..];
+                    }
+                    None if finish => {
+                        text.push('\u{FFFD}');
+                        consumed = consumed.saturating_add(input.len() - valid_up_to);
+                        break;
+                    }
+                    None => {
+                        pending.extend_from_slice(&input[valid_up_to..]);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    (text, consumed)
 }
 
 fn spawn_reader(
@@ -623,11 +687,18 @@ fn session_process_group(process_id: u32) -> Option<i32> {
 fn terminate_child(child: &mut Box<dyn Child + Send + Sync>, process_group: Option<i32>) {
     #[cfg(unix)]
     if let Some(process_group) = process_group {
-        // Terminate both the session leader and its PTY descendants. The
-        // immediate SIGKILL prevents a child that ignores SIGTERM from being
-        // orphaned after Relay closes the only retained handle.
+        // Terminate both the session leader and its PTY descendants. Give a
+        // cooperative TUI a bounded chance to handle SIGTERM before the final
+        // group kill guarantees Relay does not orphan descendants.
         let process_group = Pid::from_raw(process_group);
         let _ = killpg(process_group, Signal::SIGTERM);
+        let deadline = Instant::now() + PTY_TERMINATION_GRACE;
+        while Instant::now() < deadline {
+            if child.try_wait().ok().flatten().is_some() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
         let _ = killpg(process_group, Signal::SIGKILL);
     }
     let _ = child.kill();
@@ -714,6 +785,19 @@ mod tests {
         let runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "printf READY; cat"]);
         assert_eq!(runtime.owner().home(), Path::new(NODE_OWNER_HOME));
         assert_eq!(runtime.owner().claude_path(), Path::new("/bin/sh"));
+        assert!(runtime.launch_directory.is_dir());
+        assert_ne!(runtime.launch_directory, runtime.owner().home());
+    }
+
+    #[test]
+    fn production_runtime_fails_closed_when_the_owner_runtime_is_unavailable() {
+        let mut runtime = NodePtyRuntime::new(NodeOwnerContext {
+            home: PathBuf::from("/definitely/not/a-relay-owner-home"),
+            claude_path: PathBuf::from("/bin/sh"),
+        });
+
+        assert_eq!(runtime.create("device-a"), Err(ClaudePtyError::Unavailable));
+        assert!(runtime.sessions.is_empty());
     }
 
     #[test]
@@ -763,6 +847,35 @@ mod tests {
 
         assert_eq!(runtime.create("device-a"), Err(ClaudePtyError::Unavailable));
         assert!(runtime.sessions.is_empty());
+    }
+
+    #[test]
+    fn split_utf8_output_is_reassembled_without_replacement_characters() {
+        let mut pending = Vec::new();
+        let (first, first_bytes) =
+            decode_terminal_output(&mut pending, b"before \xF0\x9F".to_vec(), false);
+        assert_eq!(first, "before ");
+        assert_eq!(first_bytes, 7);
+        assert_eq!(pending, vec![0xF0, 0x9F]);
+
+        let (second, second_bytes) =
+            decode_terminal_output(&mut pending, b"\x98\x80 after".to_vec(), false);
+        assert_eq!(second, "😀 after");
+        assert_eq!(second_bytes, 10);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn incomplete_utf8_at_terminal_exit_is_replaced_once() {
+        let mut pending = Vec::new();
+        let (first, first_bytes) = decode_terminal_output(&mut pending, vec![0xF0, 0x9F], false);
+        assert_eq!(first, "");
+        assert_eq!(first_bytes, 0);
+
+        let (last, last_bytes) = decode_terminal_output(&mut pending, Vec::new(), true);
+        assert_eq!(last, "�");
+        assert_eq!(last_bytes, 2);
+        assert!(pending.is_empty());
     }
 
     #[test]

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -1,0 +1,897 @@
+//! Relay-owned Claude Code PTY sessions.
+//!
+//! This module is intentionally a narrow one-node runtime, not a generic shell
+//! service. It launches only the configured Claude Code executable in the
+//! node-owner context, keeps the opaque Session handle server-side, and bounds
+//! both the PTY-reader hand-off and retained scrollback. Browser clients poll a
+//! cursor; they never receive a process handle or ambient shell authority.
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, TryRecvError, TrySendError};
+use std::thread::{self, JoinHandle};
+
+#[cfg(all(unix, test))]
+use nix::{errno::Errno, sys::signal::kill};
+#[cfg(unix)]
+use nix::{
+    sys::signal::{Signal, killpg},
+    unistd::{Pid, getpgid},
+};
+use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+use crate::contract::SessionId;
+
+/// Explicit owner home used by the first one-node Claude Session slice.
+///
+/// It is deliberately not derived from the worker process environment: a Relay
+/// worker profile must never become the provider's runtime/auth context.
+pub const NODE_OWNER_HOME: &str = "/home/donovanyohan";
+/// Fixed installed Claude Code path for the node-owner runtime.
+pub const NODE_OWNER_CLAUDE: &str = "/home/donovanyohan/.local/bin/claude";
+/// Minimal owner-controlled lookup path needed by the fixed Claude launcher.
+pub const NODE_OWNER_PATH: &str = "/home/donovanyohan/.local/bin:/usr/local/bin:/usr/bin:/bin";
+/// Fixed shell descriptor supplied to PTY-aware programs.
+pub const NODE_OWNER_SHELL: &str = "/bin/bash";
+
+/// A browser-facing PTY read is bounded to this number of bytes.
+pub const PTY_READ_BYTES: usize = 4 * 1024;
+/// The reader keeps draining this many chunks even when no browser is polling.
+pub const PTY_INBOUND_CAP: usize = 64;
+/// Scrollback retained by Relay for one live Session. Older data is explicitly
+/// truncated rather than making a disconnected browser able to consume memory.
+pub const PTY_SCROLLBACK_BYTES: usize = 256 * 1024;
+/// One browser poll receives at most this much source output. JSON escaping can
+/// expand individual bytes, so this stays below the hub's response envelope
+/// even for hostile terminal output.
+pub const PTY_DELIVERY_BYTES: usize = 4 * 1024;
+/// Input is a keystroke payload, not an unbounded upload channel.
+pub const PTY_INPUT_BYTES: usize = 8 * 1024;
+/// One small node runtime is deliberately capped before it becomes a terminal
+/// platform or a hidden process farm.
+pub const MAX_PTY_SESSIONS: usize = 8;
+const MIN_ROWS: u16 = 4;
+const MAX_ROWS: u16 = 300;
+const MIN_COLS: u16 = 20;
+const MAX_COLS: u16 = 500;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeOwnerContext {
+    home: PathBuf,
+    claude_path: PathBuf,
+}
+
+impl NodeOwnerContext {
+    pub fn fixed() -> Self {
+        Self {
+            home: PathBuf::from(NODE_OWNER_HOME),
+            claude_path: PathBuf::from(NODE_OWNER_CLAUDE),
+        }
+    }
+
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    pub fn claude_path(&self) -> &Path {
+        &self.claude_path
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudePtyStatus {
+    Starting,
+    Running,
+    Exited,
+    Closed,
+}
+
+impl ClaudePtyStatus {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Exited => "exited",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaudePtyError {
+    Unavailable,
+    Capacity,
+    StaleHandle,
+    Forbidden,
+    InvalidInput,
+    InvalidResize,
+    Transport,
+}
+
+impl ClaudePtyError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Unavailable => "claude_unavailable",
+            Self::Capacity => "session_capacity",
+            Self::StaleHandle => "stale_session",
+            Self::Forbidden => "session_forbidden",
+            Self::InvalidInput => "invalid_input",
+            Self::InvalidResize => "invalid_resize",
+            Self::Transport => "pty_transport",
+        }
+    }
+}
+
+impl std::fmt::Display for ClaudePtyError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for ClaudePtyError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalOutput {
+    pub sequence: u64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalSnapshot {
+    pub session_id: SessionId,
+    pub status: ClaudePtyStatus,
+    pub output: Vec<TerminalOutput>,
+    pub next_cursor: u64,
+    pub has_more: bool,
+    pub truncated: bool,
+    pub dropped_chunks: u64,
+}
+
+#[derive(Debug)]
+enum ReaderEvent {
+    Output(Vec<u8>),
+    Exit,
+}
+
+#[derive(Debug)]
+struct ScrollbackChunk {
+    sequence: u64,
+    text: String,
+    bytes: usize,
+}
+
+struct ManagedSession {
+    owner_device_id: String,
+    status: ClaudePtyStatus,
+    child: Option<Box<dyn Child + Send + Sync>>,
+    process_group: Option<i32>,
+    master: Option<Box<dyn MasterPty + Send>>,
+    writer: Option<Box<dyn Write + Send>>,
+    reader: Option<JoinHandle<()>>,
+    reader_rx: Receiver<ReaderEvent>,
+    reader_stop: Arc<AtomicBool>,
+    reader_dropped: Arc<AtomicU64>,
+    output: VecDeque<ScrollbackChunk>,
+    output_bytes: usize,
+    next_sequence: u64,
+    terminal_seen: bool,
+}
+
+/// The node-local source of truth for Relay-owned Claude PTY Session handles.
+///
+/// It is expected to live behind the hub/node's internal mutex. The browser
+/// receives only opaque IDs and bounded snapshots; it cannot name an arbitrary
+/// command, cwd, PID, or environment.
+pub struct NodePtyRuntime {
+    owner: NodeOwnerContext,
+    /// Empty in production. Tests may inject a fixed fixture argument vector;
+    /// no browser/API request can influence this field.
+    arguments: Vec<String>,
+    sessions: HashMap<String, ManagedSession>,
+    next_id: u64,
+}
+
+impl Default for NodePtyRuntime {
+    fn default() -> Self {
+        Self::new(NodeOwnerContext::fixed())
+    }
+}
+
+impl NodePtyRuntime {
+    pub fn new(owner: NodeOwnerContext) -> Self {
+        Self {
+            owner,
+            arguments: Vec::new(),
+            sessions: HashMap::new(),
+            next_id: 1,
+        }
+    }
+
+    pub fn owner(&self) -> &NodeOwnerContext {
+        &self.owner
+    }
+
+    /// Deterministic development fixture for browser integration tests.
+    ///
+    /// This is deliberately compiled only for debug builds and runs one fixed
+    /// echo fixture with an explicit interrupt trap. It is not a configurable
+    /// shell command surface and cannot be enabled in a release build.
+    #[cfg(debug_assertions)]
+    pub fn test_fixture_cat() -> Self {
+        let mut runtime = Self::default();
+        runtime.owner.claude_path = PathBuf::from("/bin/sh");
+        runtime.arguments = vec![
+            "-c".into(),
+            "trap 'exit 0' INT; while IFS= read -r line; do printf '%s\\n' \"$line\"; done".into(),
+        ];
+        runtime
+    }
+
+    /// Start the fixed Claude Code TUI in a real PTY. No caller-controlled
+    /// command, arguments, HOME, PATH, or working directory enter this path.
+    pub fn create(&mut self, owner_device_id: &str) -> Result<SessionId, ClaudePtyError> {
+        if owner_device_id.is_empty() || owner_device_id.len() > 64 {
+            return Err(ClaudePtyError::Forbidden);
+        }
+        self.prune_closed();
+        if self.sessions.len() >= MAX_PTY_SESSIONS {
+            return Err(ClaudePtyError::Capacity);
+        }
+
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(default_size())
+            .map_err(|_| ClaudePtyError::Transport)?;
+        let mut command = CommandBuilder::new(self.owner.claude_path());
+        command.env_clear();
+        for argument in &self.arguments {
+            command.arg(argument);
+        }
+        command.cwd(self.owner.home());
+        command.env("HOME", self.owner.home());
+        command.env("USER", "donovanyohan");
+        command.env("LOGNAME", "donovanyohan");
+        command.env("PATH", NODE_OWNER_PATH);
+        command.env("SHELL", NODE_OWNER_SHELL);
+        command.env("TERM", "xterm-256color");
+        command.env("COLORTERM", "truecolor");
+
+        let mut child = pair
+            .slave
+            .spawn_command(command)
+            .map_err(|_| ClaudePtyError::Unavailable)?;
+        drop(pair.slave);
+        let process_group = child.process_id().and_then(session_process_group);
+        let reader = match pair.master.try_clone_reader() {
+            Ok(reader) => reader,
+            Err(_) => {
+                terminate_child(&mut child, process_group);
+                return Err(ClaudePtyError::Transport);
+            }
+        };
+        let writer = match pair.master.take_writer() {
+            Ok(writer) => writer,
+            Err(_) => {
+                terminate_child(&mut child, process_group);
+                return Err(ClaudePtyError::Transport);
+            }
+        };
+        let (reader_tx, reader_rx) = mpsc::sync_channel(PTY_INBOUND_CAP);
+        let reader_stop = Arc::new(AtomicBool::new(false));
+        let reader_dropped = Arc::new(AtomicU64::new(0));
+        let reader_thread = match spawn_reader(
+            reader,
+            reader_tx,
+            Arc::clone(&reader_stop),
+            Arc::clone(&reader_dropped),
+        ) {
+            Ok(reader_thread) => reader_thread,
+            Err(error) => {
+                drop(writer);
+                terminate_child(&mut child, process_group);
+                return Err(error);
+            }
+        };
+
+        let id = format!("claude-pty-{}", self.next_id);
+        self.next_id = self.next_id.saturating_add(1);
+        self.sessions.insert(
+            id.clone(),
+            ManagedSession {
+                owner_device_id: owner_device_id.to_owned(),
+                status: ClaudePtyStatus::Starting,
+                child: Some(child),
+                process_group,
+                master: Some(pair.master),
+                writer: Some(writer),
+                reader: Some(reader_thread),
+                reader_rx,
+                reader_stop,
+                reader_dropped,
+                output: VecDeque::new(),
+                output_bytes: 0,
+                next_sequence: 1,
+                terminal_seen: false,
+            },
+        );
+        Ok(SessionId::new(id))
+    }
+
+    /// Return an incremental, loss-aware output snapshot. Disconnection merely
+    /// stops polling; it never blocks the PTY reader or closes the Session.
+    pub fn poll(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+        cursor: u64,
+    ) -> Result<TerminalSnapshot, ClaudePtyError> {
+        let session = self.session_mut(session_id, owner_device_id)?;
+        session.pump();
+        let first_sequence = session
+            .output
+            .front()
+            .map_or(session.next_sequence, |chunk| chunk.sequence);
+        let truncated = cursor.saturating_add(1) < first_sequence;
+        let mut output = Vec::new();
+        let mut output_bytes: usize = 0;
+        let mut next_cursor = cursor;
+        let mut has_more = false;
+        for chunk in session
+            .output
+            .iter()
+            .filter(|chunk| chunk.sequence > cursor)
+        {
+            if !output.is_empty() && output_bytes.saturating_add(chunk.bytes) > PTY_DELIVERY_BYTES {
+                has_more = true;
+                break;
+            }
+            output_bytes = output_bytes.saturating_add(chunk.bytes);
+            next_cursor = chunk.sequence;
+            output.push(TerminalOutput {
+                sequence: chunk.sequence,
+                text: chunk.text.clone(),
+            });
+        }
+        Ok(TerminalSnapshot {
+            session_id: SessionId::new(session_id),
+            status: session.status,
+            output,
+            next_cursor,
+            has_more,
+            truncated,
+            dropped_chunks: session.reader_dropped.load(Ordering::Acquire),
+        })
+    }
+
+    pub fn input(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+        data: &str,
+    ) -> Result<(), ClaudePtyError> {
+        if data.is_empty() || data.len() > PTY_INPUT_BYTES || data.contains('\0') {
+            return Err(ClaudePtyError::InvalidInput);
+        }
+        let session = self.session_mut(session_id, owner_device_id)?;
+        session.pump();
+        if session.status == ClaudePtyStatus::Closed || session.status == ClaudePtyStatus::Exited {
+            return Err(ClaudePtyError::StaleHandle);
+        }
+        let writer = session.writer.as_mut().ok_or(ClaudePtyError::StaleHandle)?;
+        writer
+            .write_all(data.as_bytes())
+            .and_then(|()| writer.flush())
+            .map_err(|_| ClaudePtyError::Transport)
+    }
+
+    pub fn resize(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), ClaudePtyError> {
+        if !(MIN_COLS..=MAX_COLS).contains(&cols) || !(MIN_ROWS..=MAX_ROWS).contains(&rows) {
+            return Err(ClaudePtyError::InvalidResize);
+        }
+        let session = self.session_mut(session_id, owner_device_id)?;
+        session.pump();
+        let master = session.master.as_mut().ok_or(ClaudePtyError::StaleHandle)?;
+        master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|_| ClaudePtyError::Transport)
+    }
+
+    /// Send terminal interrupt (`Ctrl-C`) to the PTY foreground process group.
+    pub fn interrupt(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+    ) -> Result<(), ClaudePtyError> {
+        self.input(session_id, owner_device_id, "\u{3}")
+    }
+
+    /// Explicit close owns child termination/reaping. Layout close must call
+    /// detach instead; this is intentionally a distinct endpoint.
+    pub fn close(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+    ) -> Result<TerminalSnapshot, ClaudePtyError> {
+        let session = self.session_mut(session_id, owner_device_id)?;
+        session.close();
+        Ok(TerminalSnapshot {
+            session_id: SessionId::new(session_id),
+            status: session.status,
+            output: Vec::new(),
+            next_cursor: session.next_sequence.saturating_sub(1),
+            has_more: false,
+            truncated: false,
+            dropped_chunks: session.reader_dropped.load(Ordering::Acquire),
+        })
+    }
+
+    fn session_mut(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+    ) -> Result<&mut ManagedSession, ClaudePtyError> {
+        let session = self
+            .sessions
+            .get_mut(session_id)
+            .ok_or(ClaudePtyError::StaleHandle)?;
+        if session.owner_device_id != owner_device_id {
+            return Err(ClaudePtyError::Forbidden);
+        }
+        Ok(session)
+    }
+
+    fn prune_closed(&mut self) {
+        self.sessions
+            .retain(|_, session| session.status != ClaudePtyStatus::Closed);
+    }
+
+    #[cfg(test)]
+    fn test_runtime(program: &str, arguments: &[&str]) -> Self {
+        Self::new_with_program(
+            NodeOwnerContext::fixed(),
+            PathBuf::from(program),
+            arguments
+                .iter()
+                .map(|argument| (*argument).to_owned())
+                .collect(),
+        )
+    }
+
+    #[cfg(test)]
+    fn new_with_program(owner: NodeOwnerContext, program: PathBuf, arguments: Vec<String>) -> Self {
+        Self {
+            owner: NodeOwnerContext {
+                home: owner.home,
+                claude_path: program,
+            },
+            arguments,
+            sessions: HashMap::new(),
+            next_id: 1,
+        }
+    }
+}
+
+impl ManagedSession {
+    fn pump(&mut self) {
+        loop {
+            match self.reader_rx.try_recv() {
+                Ok(ReaderEvent::Output(bytes)) => self.append_output(bytes),
+                Ok(ReaderEvent::Exit) => self.terminal_seen = true,
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+        if self.status == ClaudePtyStatus::Closed {
+            return;
+        }
+        if self.terminal_seen
+            || self
+                .child
+                .as_mut()
+                .and_then(|child| child.try_wait().ok().flatten())
+                .is_some()
+        {
+            self.status = ClaudePtyStatus::Exited;
+        } else if self.status == ClaudePtyStatus::Starting {
+            self.status = ClaudePtyStatus::Running;
+        }
+    }
+
+    fn append_output(&mut self, bytes: Vec<u8>) {
+        if bytes.is_empty() {
+            return;
+        }
+        let bytes_len = bytes.len();
+        let text = String::from_utf8_lossy(&bytes).into_owned();
+        let chunk = ScrollbackChunk {
+            sequence: self.next_sequence,
+            text,
+            bytes: bytes_len,
+        };
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.output_bytes = self.output_bytes.saturating_add(chunk.bytes);
+        self.output.push_back(chunk);
+        while self.output_bytes > PTY_SCROLLBACK_BYTES {
+            let Some(removed) = self.output.pop_front() else {
+                break;
+            };
+            self.output_bytes = self.output_bytes.saturating_sub(removed.bytes);
+        }
+    }
+
+    fn close(&mut self) {
+        if self.status == ClaudePtyStatus::Closed {
+            return;
+        }
+        self.reader_stop.store(true, Ordering::Release);
+        self.writer.take();
+        if let Some(child) = self.child.as_mut() {
+            terminate_child(child, self.process_group);
+        }
+        self.child.take();
+        self.master.take();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        self.status = ClaudePtyStatus::Closed;
+    }
+}
+
+impl Drop for ManagedSession {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+fn default_size() -> PtySize {
+    PtySize {
+        rows: 36,
+        cols: 120,
+        pixel_width: 0,
+        pixel_height: 0,
+    }
+}
+
+fn spawn_reader(
+    mut reader: Box<dyn Read + Send>,
+    sender: mpsc::SyncSender<ReaderEvent>,
+    stop: Arc<AtomicBool>,
+    dropped: Arc<AtomicU64>,
+) -> Result<JoinHandle<()>, ClaudePtyError> {
+    thread::Builder::new()
+        .name("relay-claude-pty-reader".into())
+        .spawn(move || {
+            let mut buffer = vec![0_u8; PTY_READ_BYTES];
+            loop {
+                if stop.load(Ordering::Acquire) {
+                    break;
+                }
+                match reader.read(&mut buffer) {
+                    Ok(0) => {
+                        let _ = sender.try_send(ReaderEvent::Exit);
+                        break;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => {
+                        let _ = sender.try_send(ReaderEvent::Exit);
+                        break;
+                    }
+                    Ok(length) => {
+                        match sender.try_send(ReaderEvent::Output(buffer[..length].to_vec())) {
+                            Ok(()) => {}
+                            Err(TrySendError::Full(_)) => {
+                                dropped.fetch_add(1, Ordering::AcqRel);
+                            }
+                            Err(TrySendError::Disconnected(_)) => break,
+                        }
+                    }
+                }
+            }
+        })
+        .map_err(|_| ClaudePtyError::Transport)
+}
+
+fn session_process_group(process_id: u32) -> Option<i32> {
+    #[cfg(unix)]
+    {
+        let process_id = i32::try_from(process_id).ok()?;
+        // portable-pty creates the child as a new session leader. Require its
+        // process group to match the leader PID before ever signalling a group.
+        let process_group = getpgid(Some(Pid::from_raw(process_id))).ok()?.as_raw();
+        (process_group == process_id).then_some(process_group)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = process_id;
+        None
+    }
+}
+
+fn terminate_child(child: &mut Box<dyn Child + Send + Sync>, process_group: Option<i32>) {
+    #[cfg(unix)]
+    if let Some(process_group) = process_group {
+        // Terminate both the session leader and its PTY descendants. The
+        // immediate SIGKILL prevents a child that ignores SIGTERM from being
+        // orphaned after Relay closes the only retained handle.
+        let process_group = Pid::from_raw(process_group);
+        let _ = killpg(process_group, Signal::SIGTERM);
+        let _ = killpg(process_group, Signal::SIGKILL);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn owner_context_is_explicit_and_not_process_home() {
+        let context = NodeOwnerContext::fixed();
+        assert_eq!(context.home(), Path::new(NODE_OWNER_HOME));
+        assert_eq!(context.claude_path(), Path::new(NODE_OWNER_CLAUDE));
+    }
+
+    #[test]
+    fn owner_context_launches_with_an_allowlisted_environment() {
+        let mut runtime = NodePtyRuntime::test_runtime("/usr/bin/env", &[]);
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let output = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if !snapshot.output.is_empty() {
+                break snapshot
+                    .output
+                    .into_iter()
+                    .flat_map(|chunk| chunk.text.lines().map(str::to_owned).collect::<Vec<_>>())
+                    .collect::<Vec<_>>();
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "test PTY did not report its launch environment"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+        let mut output = output;
+        output.sort();
+        assert_eq!(
+            output,
+            vec![
+                "COLORTERM=truecolor",
+                "HOME=/home/donovanyohan",
+                "LOGNAME=donovanyohan",
+                "PATH=/home/donovanyohan/.local/bin:/usr/local/bin:/usr/bin:/bin",
+                "SHELL=/bin/bash",
+                "TERM=xterm-256color",
+                "USER=donovanyohan",
+            ]
+        );
+        runtime.close(session.as_str(), "device-a").unwrap();
+    }
+
+    #[test]
+    fn input_and_resize_are_bounded_before_the_pty() {
+        let mut runtime = NodePtyRuntime::default();
+        assert_eq!(
+            runtime.input("missing", "device", &"x".repeat(PTY_INPUT_BYTES + 1)),
+            Err(ClaudePtyError::InvalidInput)
+        );
+        assert_eq!(
+            runtime.resize("missing", "device", 1, 1),
+            Err(ClaudePtyError::InvalidResize)
+        );
+    }
+
+    #[test]
+    fn stale_handles_fail_closed() {
+        let mut runtime = NodePtyRuntime::default();
+        assert_eq!(
+            runtime.poll("missing", "device", 0),
+            Err(ClaudePtyError::StaleHandle)
+        );
+        assert_eq!(
+            runtime.close("missing", "other"),
+            Err(ClaudePtyError::StaleHandle)
+        );
+    }
+
+    #[test]
+    fn test_program_constructor_keeps_the_production_owner_context() {
+        let runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "printf READY; cat"]);
+        assert_eq!(runtime.owner().home(), Path::new(NODE_OWNER_HOME));
+        assert_eq!(runtime.owner().claude_path(), Path::new("/bin/sh"));
+    }
+
+    #[test]
+    fn output_and_close_are_terminal_lifecycle_operations() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "printf READY; cat"]);
+        // The test fixture constructor only changes the executable; the fixed
+        // production path has no argument injection surface.
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let first = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if !snapshot.output.is_empty() {
+                break snapshot;
+            }
+            assert!(Instant::now() <= deadline, "test PTY produced no output");
+            thread::sleep(Duration::from_millis(10));
+        };
+        assert_eq!(first.status, ClaudePtyStatus::Running);
+        assert!(
+            first
+                .output
+                .iter()
+                .any(|chunk| chunk.text.contains("READY"))
+        );
+        runtime
+            .input(session.as_str(), "device-a", "ping\n")
+            .unwrap();
+        runtime
+            .resize(session.as_str(), "device-a", 100, 40)
+            .unwrap();
+        assert_eq!(
+            runtime.poll(session.as_str(), "device-b", first.next_cursor),
+            Err(ClaudePtyError::Forbidden)
+        );
+        assert_eq!(
+            runtime.close(session.as_str(), "other"),
+            Err(ClaudePtyError::Forbidden)
+        );
+        let closed = runtime.close(session.as_str(), "device-a").unwrap();
+        assert_eq!(closed.status, ClaudePtyStatus::Closed);
+        assert!(runtime.sessions[session.as_str()].child.is_none());
+    }
+
+    #[test]
+    fn startup_failure_is_typed_and_leaves_no_session_handle() {
+        let mut runtime = NodePtyRuntime::test_runtime("/definitely/not/claude", &[]);
+
+        assert_eq!(runtime.create("device-a"), Err(ClaudePtyError::Unavailable));
+        assert!(runtime.sessions.is_empty());
+    }
+
+    #[test]
+    fn interrupt_reaches_the_foreground_pty_process_group() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &[
+                "-c",
+                "trap 'printf INTERRUPTED; exit 0' INT; printf READY; while :; do sleep 1; done",
+            ],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let ready = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if snapshot
+                .output
+                .iter()
+                .any(|chunk| chunk.text.contains("READY"))
+            {
+                break snapshot;
+            }
+            assert!(Instant::now() <= deadline, "test PTY did not become ready");
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        runtime.interrupt(session.as_str(), "device-a").unwrap();
+        let interrupted = loop {
+            let snapshot = runtime
+                .poll(session.as_str(), "device-a", ready.next_cursor)
+                .unwrap();
+            if snapshot
+                .output
+                .iter()
+                .any(|chunk| chunk.text.contains("INTERRUPTED"))
+            {
+                break snapshot;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "terminal interrupt was not delivered"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+        assert_eq!(interrupted.status, ClaudePtyStatus::Exited);
+    }
+
+    #[test]
+    fn slow_consumer_delivery_is_bounded_and_recoverable_by_cursor() {
+        let mut runtime = NodePtyRuntime::test_runtime("/usr/bin/yes", &["terminal output"]);
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while runtime.sessions[session.as_str()]
+            .reader_dropped
+            .load(Ordering::Acquire)
+            == 0
+        {
+            assert!(
+                Instant::now() <= deadline,
+                "reader never observed slow-consumer pressure"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let first = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+        let delivered = first
+            .output
+            .iter()
+            .map(|chunk| chunk.text.len())
+            .sum::<usize>();
+        assert!(!first.output.is_empty());
+        assert!(delivered <= PTY_DELIVERY_BYTES);
+        assert!(
+            first.has_more,
+            "the cursor must expose retained output incrementally"
+        );
+        assert!(
+            first.dropped_chunks > 0,
+            "the reader must report bounded queue drops"
+        );
+
+        let reattached = runtime
+            .poll(session.as_str(), "device-a", first.next_cursor)
+            .unwrap();
+        assert_eq!(reattached.session_id, session);
+        assert!(reattached.next_cursor >= first.next_cursor);
+        runtime.close(session.as_str(), "device-a").unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_reaps_a_descendant_in_the_relay_owned_process_group() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &[
+                "-c",
+                "sleep 30 & child=$!; printf 'CHILD:%s\\n' \"$child\"; wait \"$child\"",
+            ],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let child_pid = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if let Some(pid) = snapshot.output.iter().find_map(|chunk| {
+                chunk
+                    .text
+                    .lines()
+                    .find_map(|line| line.trim().strip_prefix("CHILD:")?.parse::<i32>().ok())
+            }) {
+                break pid;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "test PTY did not report descendant PID"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        runtime.close(session.as_str(), "device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if kill(Pid::from_raw(child_pid), None) == Err(Errno::ESRCH) {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "Relay close left a PTY descendant alive"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -15,14 +15,23 @@ use std::sync::mpsc::{self, Receiver, TryRecvError, TrySendError};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
+use filedescriptor::FileDescriptor;
 #[cfg(all(unix, test))]
 use nix::{errno::Errno, sys::signal::kill};
 #[cfg(unix)]
 use nix::{
     sys::signal::{Signal, killpg},
-    unistd::Pid,
+    unistd::{Pid, getpgid, getsid},
 };
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+#[cfg(target_os = "linux")]
+use rustix::{
+    fd::OwnedFd,
+    process::{Pid as LinuxPid, PidfdFlags, pidfd_open},
+};
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, RawFd};
 
 use crate::contract::SessionId;
 
@@ -53,6 +62,10 @@ pub const PTY_DELIVERY_BYTES: usize = 4 * 1024;
 pub const PTY_INPUT_BYTES: usize = 8 * 1024;
 /// Input is staged before it reaches the potentially blocking PTY writer.
 pub const PTY_INPUT_QUEUE_CAP: usize = 8;
+/// Input is acknowledged only after it occupies the bounded Relay queue. A
+/// full queue returns retryable backpressure rather than retaining unbounded
+/// browser data in the hub request path.
+const PTY_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(5);
 /// One small node runtime is deliberately capped before it becomes a terminal
 /// platform or a hidden process farm.
 pub const MAX_PTY_SESSIONS: usize = 8;
@@ -113,6 +126,7 @@ pub enum ClaudePtyError {
     InvalidInput,
     InvalidResize,
     Backpressure,
+    InputLost,
     Transport,
 }
 
@@ -126,6 +140,7 @@ impl ClaudePtyError {
             Self::InvalidInput => "invalid_input",
             Self::InvalidResize => "invalid_resize",
             Self::Backpressure => "input_backpressure",
+            Self::InputLost => "input_delivery_lost",
             Self::Transport => "pty_transport",
         }
     }
@@ -169,32 +184,90 @@ struct ScrollbackChunk {
     bytes: usize,
 }
 
+struct InputRequest {
+    data: Vec<u8>,
+}
+
 struct PtyInput {
-    sender: mpsc::SyncSender<Vec<u8>>,
+    sender: mpsc::SyncSender<InputRequest>,
+    stop: Arc<AtomicBool>,
+    delivery_failed: Arc<AtomicBool>,
     worker: JoinHandle<()>,
 }
 
 impl PtyInput {
     fn enqueue(&self, data: &[u8]) -> Result<(), ClaudePtyError> {
-        match self.sender.try_send(data.to_vec()) {
+        if self.delivery_failed.load(Ordering::Acquire) {
+            return Err(ClaudePtyError::InputLost);
+        }
+        let request = InputRequest {
+            data: data.to_vec(),
+        };
+        match self.sender.try_send(request) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(_)) => Err(ClaudePtyError::Backpressure),
+            Err(TrySendError::Disconnected(_)) if self.delivery_failed.load(Ordering::Acquire) => {
+                Err(ClaudePtyError::InputLost)
+            }
             Err(TrySendError::Disconnected(_)) => Err(ClaudePtyError::Transport),
         }
     }
 
     fn finish(self) {
-        let Self { sender, worker } = self;
+        let Self {
+            sender,
+            stop,
+            worker,
+            ..
+        } = self;
+        stop.store(true, Ordering::Release);
         drop(sender);
-        let _ = worker.join();
+        // A nonblocking writer observes `stop` between every retry. Never join
+        // it on the runtime mutex path: a kernel or driver regression must not
+        // turn close/revoke into an unbounded global PTY outage.
+        if worker.is_finished() {
+            let _ = worker.join();
+        }
     }
+}
+
+/// Lifetime-safe Linux ownership for the PTY session created by portable-pty.
+/// The pidfd pins the leader identity so its process-group number cannot be
+/// reused while Relay may signal it. A nonblocking duplicate of the master FD
+/// gives the input worker a cancellable writer without consuming the reader.
+#[cfg(target_os = "linux")]
+struct PtyOwnership {
+    process_group: i32,
+    writer: FileDescriptor,
+    _leader_pidfd: OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+struct MasterFd(RawFd);
+
+#[cfg(target_os = "linux")]
+impl AsRawFd for MasterFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct PtyForegroundGroup {
+    process_group: i32,
+    _leader_pidfd: OwnedFd,
+}
+
+#[cfg(not(target_os = "linux"))]
+struct PtyOwnership {
+    process_group: i32,
 }
 
 struct ManagedSession {
     owner_device_id: String,
     status: ClaudePtyStatus,
     child: Option<Box<dyn Child + Send + Sync>>,
-    process_group: Option<i32>,
+    process_group: Option<PtyOwnership>,
     master: Option<Box<dyn MasterPty + Send>>,
     input: Option<PtyInput>,
     reader: Option<JoinHandle<()>>,
@@ -296,7 +369,9 @@ impl NodePtyRuntime {
             .spawn_command(command)
             .map_err(|_| ClaudePtyError::Unavailable)?;
         drop(pair.slave);
-        let process_group = child.process_id().and_then(session_process_group);
+        let process_group = child
+            .process_id()
+            .and_then(|process_id| session_process_group(process_id, pair.master.as_ref()));
         #[cfg(unix)]
         if process_group.is_none() {
             // Do not admit a Session whose descendants could not be reaped as
@@ -309,21 +384,26 @@ impl NodePtyRuntime {
         let reader = match pair.master.try_clone_reader() {
             Ok(reader) => reader,
             Err(_) => {
-                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
+                terminate_child(
+                    &mut child,
+                    Some(pair.master.as_ref()),
+                    process_group.as_ref(),
+                );
                 return Err(ClaudePtyError::Transport);
             }
         };
-        let writer = match pair.master.take_writer() {
-            Ok(writer) => writer,
-            Err(_) => {
-                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
-                return Err(ClaudePtyError::Transport);
-            }
-        };
-        let input = match spawn_input_writer(writer) {
+        let input = match process_group
+            .as_ref()
+            .ok_or(ClaudePtyError::Transport)
+            .and_then(spawn_input_writer)
+        {
             Ok(input) => input,
             Err(error) => {
-                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
+                terminate_child(
+                    &mut child,
+                    Some(pair.master.as_ref()),
+                    process_group.as_ref(),
+                );
                 return Err(error);
             }
         };
@@ -339,7 +419,11 @@ impl NodePtyRuntime {
             Ok(reader_thread) => reader_thread,
             Err(error) => {
                 input.finish();
-                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
+                terminate_child(
+                    &mut child,
+                    Some(pair.master.as_ref()),
+                    process_group.as_ref(),
+                );
                 return Err(error);
             }
         };
@@ -618,16 +702,23 @@ impl ManagedSession {
         }
         self.reader_stop.store(true, Ordering::Release);
         let input = self.input.take();
-        if let Some(child) = self.child.as_mut() {
-            terminate_child(child, self.master.as_deref(), self.process_group);
-        }
-        self.child.take();
-        self.master.take();
+        let process_group = self.process_group.take();
         if let Some(input) = input {
             input.finish();
         }
+        if let Some(child) = self.child.as_mut() {
+            terminate_child(child, self.master.as_deref(), process_group.as_ref());
+        }
+        self.child.take();
+        self.master.take();
+        drop(process_group);
         if let Some(reader) = self.reader.take() {
-            let _ = reader.join();
+            // The reader owns a cloned master FD and can only observe EOF after
+            // every slave closes. Do not let an unexpected kernel/driver stall
+            // hold the global runtime mutex during close or owner revocation.
+            if reader.is_finished() {
+                let _ = reader.join();
+            }
         }
         self.pump();
         self.flush_pending_output();
@@ -717,6 +808,9 @@ fn spawn_reader(
                         break;
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(PTY_INPUT_POLL_INTERVAL);
+                    }
                     Err(_) => {
                         let _ = sender.try_send(ReaderEvent::Exit);
                         break;
@@ -736,37 +830,141 @@ fn spawn_reader(
         .map_err(|_| ClaudePtyError::Transport)
 }
 
-fn spawn_input_writer(mut writer: Box<dyn Write + Send>) -> Result<PtyInput, ClaudePtyError> {
-    let (sender, receiver) = mpsc::sync_channel::<Vec<u8>>(PTY_INPUT_QUEUE_CAP);
-    let worker = thread::Builder::new()
-        .name("relay-claude-pty-writer".into())
-        .spawn(move || {
-            while let Ok(data) = receiver.recv() {
-                if writer
-                    .write_all(&data)
-                    .and_then(|()| writer.flush())
-                    .is_err()
-                {
-                    break;
+fn spawn_input_writer(ownership: &PtyOwnership) -> Result<PtyInput, ClaudePtyError> {
+    #[cfg(target_os = "linux")]
+    {
+        let mut writer = ownership
+            .writer
+            .try_clone()
+            .map_err(|_| ClaudePtyError::Transport)?;
+        let (sender, receiver) = mpsc::sync_channel::<InputRequest>(PTY_INPUT_QUEUE_CAP);
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let delivery_failed = Arc::new(AtomicBool::new(false));
+        let worker_delivery_failed = Arc::clone(&delivery_failed);
+        let worker = thread::Builder::new()
+            .name("relay-claude-pty-writer".into())
+            .spawn(move || {
+                while let Ok(request) = receiver.recv() {
+                    if deliver_input(&mut writer, request.data, &worker_stop).is_err() {
+                        if !worker_stop.load(Ordering::Acquire) {
+                            worker_delivery_failed.store(true, Ordering::Release);
+                        }
+                        break;
+                    }
+                    if worker_stop.load(Ordering::Acquire) {
+                        break;
+                    }
                 }
-            }
+            })
+            .map_err(|_| ClaudePtyError::Transport)?;
+        Ok(PtyInput {
+            sender,
+            stop,
+            delivery_failed,
+            worker,
         })
-        .map_err(|_| ClaudePtyError::Transport)?;
-    Ok(PtyInput { sender, worker })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = ownership;
+        Err(ClaudePtyError::Transport)
+    }
 }
 
-fn session_process_group(process_id: u32) -> Option<i32> {
-    #[cfg(unix)]
-    {
-        // portable-pty establishes a new session before exec, so the child PID
-        // is its process-group ID even if the leader exits before Relay closes
-        // the Session. Close verifies the PTY's foreground group before
-        // signalling it, preventing stale numeric PID reuse from escaping.
-        i32::try_from(process_id).ok()
+#[cfg(target_os = "linux")]
+fn deliver_input(
+    writer: &mut FileDescriptor,
+    data: Vec<u8>,
+    stop: &AtomicBool,
+) -> Result<(), ClaudePtyError> {
+    let mut written = 0;
+    loop {
+        if stop.load(Ordering::Acquire) {
+            return Err(ClaudePtyError::Transport);
+        }
+        match writer.write(&data[written..]) {
+            Ok(0) => return Err(delivery_error(written)),
+            Ok(count) => {
+                written = written.saturating_add(count);
+                if written == data.len() {
+                    return Ok(());
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(PTY_INPUT_POLL_INTERVAL);
+            }
+            Err(_) => return Err(delivery_error(written)),
+        }
     }
-    #[cfg(not(unix))]
+}
+
+fn delivery_error(written: usize) -> ClaudePtyError {
+    if written == 0 {
+        ClaudePtyError::Transport
+    } else {
+        ClaudePtyError::InputLost
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl PtyOwnership {
+    fn capture_foreground(
+        &self,
+        master: Option<&(dyn MasterPty + Send)>,
+    ) -> Option<PtyForegroundGroup> {
+        let process_group = master?.process_group_leader()?;
+        if process_group == self.process_group {
+            return None;
+        }
+        let leader = LinuxPid::from_raw(process_group)?;
+        let leader_pidfd = pidfd_open(leader, PidfdFlags::empty()).ok()?;
+        (master?.process_group_leader() == Some(process_group)).then_some(PtyForegroundGroup {
+            process_group,
+            _leader_pidfd: leader_pidfd,
+        })
+    }
+
+    fn signal_groups(&self, foreground: Option<&PtyForegroundGroup>, signal: Signal) {
+        // A pidfd pins the original session leader's identity for this whole
+        // object lifetime. Therefore its process-group number cannot turn into
+        // an unrelated target after leader exit. Capture the live foreground
+        // group before signalling the leader, pin it with its own pidfd, and
+        // reuse that pinned identity for the TERM→KILL sequence.
+        if let Some(foreground) = foreground {
+            let _ = killpg(Pid::from_raw(foreground.process_group), signal);
+        }
+        let _ = killpg(Pid::from_raw(self.process_group), signal);
+    }
+}
+
+fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Option<PtyOwnership> {
+    #[cfg(target_os = "linux")]
     {
-        let _ = process_id;
+        let process_id = i32::try_from(process_id).ok()?;
+        let leader = LinuxPid::from_raw(process_id)?;
+        // The direct child remains waitable until this runtime reaps it, so
+        // opening this pidfd cannot race an already-reused leader PID.
+        let leader_pidfd = pidfd_open(leader, PidfdFlags::empty()).ok()?;
+        // Clone the actual master descriptor—not its /proc symlink target,
+        // which would allocate an unrelated PTY. FileDescriptor provides the
+        // safe dup/FIONBIO wrapper, so no raw-FD ownership conversion escapes
+        // into Relay.
+        let mut writer = FileDescriptor::dup(&MasterFd(master.as_raw_fd()?)).ok()?;
+        writer.set_non_blocking(true).ok()?;
+        let leader_pid = Pid::from_raw(process_id);
+        let process_group = getpgid(Some(leader_pid)).ok()?.as_raw();
+        let session_id = getsid(Some(leader_pid)).ok()?.as_raw();
+        (process_group == process_id && session_id == process_id).then_some(PtyOwnership {
+            process_group,
+            writer,
+            _leader_pidfd: leader_pidfd,
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (process_id, master);
         None
     }
 }
@@ -774,20 +972,14 @@ fn session_process_group(process_id: u32) -> Option<i32> {
 fn terminate_child(
     child: &mut Box<dyn Child + Send + Sync>,
     master: Option<&(dyn MasterPty + Send)>,
-    process_group: Option<i32>,
+    ownership: Option<&PtyOwnership>,
 ) {
-    #[cfg(unix)]
-    if let Some(process_group) = process_group.filter(|process_group| {
-        master.and_then(|master| master.process_group_leader()) == Some(*process_group)
-    }) {
-        // Terminate both the session leader and its PTY descendants. Give a
-        // cooperative TUI a bounded chance to handle SIGTERM before the final
-        // group kill guarantees Relay does not orphan descendants. Checking
-        // the PTY-local foreground group avoids signalling a reused numeric ID.
-        let process_group = Pid::from_raw(process_group);
-        let _ = killpg(process_group, Signal::SIGTERM);
+    #[cfg(target_os = "linux")]
+    if let Some(ownership) = ownership {
+        let foreground = ownership.capture_foreground(master);
+        ownership.signal_groups(foreground.as_ref(), Signal::SIGTERM);
         thread::sleep(PTY_TERMINATION_GRACE);
-        let _ = killpg(process_group, Signal::SIGKILL);
+        ownership.signal_groups(foreground.as_ref(), Signal::SIGKILL);
     }
     let _ = child.kill();
     let _ = child.wait();
@@ -1204,6 +1396,95 @@ mod tests {
             );
             thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_reaps_a_descendant_after_it_takes_the_pty_foreground_group() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &[
+                "-c",
+                "set -m; sh -c 'trap \"\" HUP TERM; while :; do sleep 1; done' & child=$!; printf 'CHILD:%s\\n' \"$child\"; fg %1",
+            ],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let child_pid = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if let Some(pid) = snapshot.output.iter().find_map(|chunk| {
+                chunk
+                    .text
+                    .lines()
+                    .find_map(|line| line.trim().strip_prefix("CHILD:")?.parse::<i32>().ok())
+            }) {
+                break pid;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "test PTY did not report the foreground descendant PID"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        let original_group = runtime.sessions[session.as_str()]
+            .process_group
+            .as_ref()
+            .expect("Unix test session records its leader process group")
+            .process_group;
+        let foreground_group = runtime.sessions[session.as_str()]
+            .master
+            .as_deref()
+            .and_then(MasterPty::process_group_leader)
+            .expect("PTY reports the foreground process group");
+        assert_ne!(
+            foreground_group, original_group,
+            "fixture must hand the terminal to the descendant group before close"
+        );
+        assert_eq!(
+            foreground_group,
+            getpgid(Some(Pid::from_raw(child_pid)))
+                .expect("foreground descendant remains inspectable")
+                .as_raw(),
+            "fixture foreground group must belong to the reported descendant"
+        );
+
+        let (closed_tx, closed_rx) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let started = Instant::now();
+            let result = runtime.close(session.as_str(), "device-a");
+            let _ = closed_tx.send((result, started.elapsed()));
+        });
+
+        let closed = match closed_rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(closed) => closed,
+            Err(_) => {
+                // Keep the red test self-cleaning on the broken implementation:
+                // its foreground-group check skips the descendant and leaves
+                // close waiting for the reader forever.
+                let _ = killpg(Pid::from_raw(child_pid), Signal::SIGKILL);
+                closed_rx
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("cleanup signal must release the blocked close")
+            }
+        };
+        assert!(closed.0.is_ok());
+        assert!(
+            closed.1 < Duration::from_millis(500),
+            "close must reap a foreground-group descendant without external cleanup"
+        );
+        let reap_deadline = Instant::now() + Duration::from_secs(2);
+        let child_reaped = loop {
+            if kill(Pid::from_raw(child_pid), None) == Err(Errno::ESRCH) {
+                break true;
+            }
+            if Instant::now() > reap_deadline {
+                let _ = killpg(Pid::from_raw(child_pid), Signal::SIGKILL);
+                break false;
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+        assert!(child_reaped, "close left the foreground descendant alive");
     }
 
     #[test]

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -27,6 +27,7 @@ use nix::{
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 #[cfg(target_os = "linux")]
 use rustix::{
+    event::{PollFd, PollFlags, Timespec, poll},
     fd::OwnedFd,
     process::{Pid as LinuxPid, PidfdFlags, pidfd_open},
 };
@@ -231,15 +232,17 @@ impl PtyInput {
     }
 }
 
-/// Lifetime-safe Linux ownership for the PTY session created by portable-pty.
-/// The pidfd pins the leader identity so its process-group number cannot be
-/// reused while Relay may signal it. A nonblocking duplicate of the master FD
-/// gives the input worker a cancellable writer without consuming the reader.
+/// Linux ownership for the PTY session created by portable-pty.
+///
+/// The direct child remains waitable until `ManagedSession::close` has
+/// terminated its group, so its PID continues to reserve the original
+/// process-group identity for the entire period Relay may call `killpg`. A
+/// nonblocking duplicate of the master FD gives the input worker a cancellable
+/// writer without consuming the reader.
 #[cfg(target_os = "linux")]
 struct PtyOwnership {
     process_group: i32,
     writer: FileDescriptor,
-    _leader_pidfd: OwnedFd,
 }
 
 #[cfg(target_os = "linux")]
@@ -255,7 +258,15 @@ impl AsRawFd for MasterFd {
 #[cfg(target_os = "linux")]
 struct PtyForegroundGroup {
     process_group: i32,
-    _leader_pidfd: OwnedFd,
+    leader_pidfd: OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+impl PtyForegroundGroup {
+    fn is_live(&self) -> bool {
+        let mut fds = [PollFd::new(&self.leader_pidfd, PollFlags::IN)];
+        poll(&mut fds, Some(&Timespec::default())).is_ok_and(|ready| ready == 0)
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -654,13 +665,11 @@ impl ManagedSession {
         if self.status == ClaudePtyStatus::Closed {
             return;
         }
-        if self.terminal_seen
-            || self
-                .child
-                .as_mut()
-                .and_then(|child| child.try_wait().ok().flatten())
-                .is_some()
-        {
+        // Do not call `Child::try_wait` here. It reaps the direct PTY leader
+        // and releases its numeric process-group identity before explicit
+        // close/revoke has finished signalling that group. Reader EOF is the
+        // non-reaping terminal observation that is safe to surface to clients.
+        if self.terminal_seen {
             self.status = ClaudePtyStatus::Exited;
         } else if self.status == ClaudePtyStatus::Starting {
             self.status = ClaudePtyStatus::Running;
@@ -922,17 +931,27 @@ impl PtyOwnership {
         let leader_pidfd = pidfd_open(leader, PidfdFlags::empty()).ok()?;
         (master?.process_group_leader() == Some(process_group)).then_some(PtyForegroundGroup {
             process_group,
-            _leader_pidfd: leader_pidfd,
+            leader_pidfd,
         })
     }
 
-    fn signal_groups(&self, foreground: Option<&PtyForegroundGroup>, signal: Signal) {
-        // A pidfd pins the original session leader's identity for this whole
-        // object lifetime. Therefore its process-group number cannot turn into
-        // an unrelated target after leader exit. Capture the live foreground
-        // group before signalling the leader, pin it with its own pidfd, and
-        // reuse that pinned identity for the TERM→KILL sequence.
-        if let Some(foreground) = foreground {
+    fn signal_groups(
+        &self,
+        master: Option<&(dyn MasterPty + Send)>,
+        foreground: Option<&PtyForegroundGroup>,
+        signal: Signal,
+    ) {
+        // The direct child remains waitable until close finishes, keeping the
+        // original Relay-owned group identifier reserved throughout. A
+        // foreground leader can exit independently, so do not signal its
+        // cached numeric group after its pidfd reports exit unless the PTY
+        // still resolves that exact group as foreground.
+        if let Some(foreground) = foreground.filter(|foreground| {
+            foreground.is_live()
+                || master
+                    .and_then(MasterPty::process_group_leader)
+                    .is_some_and(|current| current == foreground.process_group)
+        }) {
             let _ = killpg(Pid::from_raw(foreground.process_group), signal);
         }
         let _ = killpg(Pid::from_raw(self.process_group), signal);
@@ -943,10 +962,6 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
     #[cfg(target_os = "linux")]
     {
         let process_id = i32::try_from(process_id).ok()?;
-        let leader = LinuxPid::from_raw(process_id)?;
-        // The direct child remains waitable until this runtime reaps it, so
-        // opening this pidfd cannot race an already-reused leader PID.
-        let leader_pidfd = pidfd_open(leader, PidfdFlags::empty()).ok()?;
         // Clone the actual master descriptor—not its /proc symlink target,
         // which would allocate an unrelated PTY. FileDescriptor provides the
         // safe dup/FIONBIO wrapper, so no raw-FD ownership conversion escapes
@@ -959,7 +974,6 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
         (process_group == process_id && session_id == process_id).then_some(PtyOwnership {
             process_group,
             writer,
-            _leader_pidfd: leader_pidfd,
         })
     }
     #[cfg(not(target_os = "linux"))]
@@ -977,9 +991,9 @@ fn terminate_child(
     #[cfg(target_os = "linux")]
     if let Some(ownership) = ownership {
         let foreground = ownership.capture_foreground(master);
-        ownership.signal_groups(foreground.as_ref(), Signal::SIGTERM);
+        ownership.signal_groups(master, foreground.as_ref(), Signal::SIGTERM);
         thread::sleep(PTY_TERMINATION_GRACE);
-        ownership.signal_groups(foreground.as_ref(), Signal::SIGKILL);
+        ownership.signal_groups(master, foreground.as_ref(), Signal::SIGKILL);
     }
     let _ = child.kill();
     let _ = child.wait();
@@ -1371,18 +1385,6 @@ mod tests {
             );
             thread::sleep(Duration::from_millis(10));
         };
-        loop {
-            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
-            if snapshot.status == ClaudePtyStatus::Exited {
-                break;
-            }
-            assert!(
-                Instant::now() <= deadline,
-                "leader did not exit while its PTY descendant remained alive"
-            );
-            thread::sleep(Duration::from_millis(10));
-        }
-
         thread::sleep(Duration::from_millis(50));
         runtime.close(session.as_str(), "device-a").unwrap();
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -1396,6 +1398,72 @@ mod tests {
             );
             thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn leader_exit_does_not_release_the_original_process_group_before_close() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &[
+                "-c",
+                "sh -c 'trap \"\" HUP TERM; while :; do sleep 1; done' & child=$!; printf 'CHILD:%s\\n' \"$child\"; exit 0",
+            ],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let leader_pid = runtime.sessions[session.as_str()]
+            .child
+            .as_ref()
+            .and_then(|child| child.process_id())
+            .and_then(|pid| i32::try_from(pid).ok())
+            .expect("test PTY exposes its direct leader PID");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let child_pid = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if let Some(pid) = snapshot.output.iter().find_map(|chunk| {
+                chunk
+                    .text
+                    .lines()
+                    .find_map(|line| line.trim().strip_prefix("CHILD:")?.parse::<i32>().ok())
+            }) {
+                break pid;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "test PTY did not report descendant PID"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        // The direct shell exits after reporting the child. The reader may
+        // report terminal EOF, but that status probe must not reap the shell
+        // and release its process-group ID before close can safely signal it.
+        thread::sleep(Duration::from_millis(50));
+        let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+        assert_eq!(snapshot.status, ClaudePtyStatus::Exited);
+        assert_eq!(
+            kill(Pid::from_raw(leader_pid), None),
+            Ok(()),
+            "direct PTY leader must remain waitable until explicit close"
+        );
+
+        runtime.close(session.as_str(), "device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if kill(Pid::from_raw(child_pid), None) == Err(Errno::ESRCH) {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "close left a descendant in the original PTY group alive"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(
+            kill(Pid::from_raw(leader_pid), None),
+            Err(Errno::ESRCH),
+            "close must reap the retained direct PTY leader"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError, TrySendError};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[cfg(all(unix, test))]
 use nix::{errno::Errno, sys::signal::kill};
@@ -243,7 +243,7 @@ impl NodePtyRuntime {
         if owner_device_id.is_empty() || owner_device_id.len() > 64 {
             return Err(ClaudePtyError::Forbidden);
         }
-        self.prune_closed();
+        self.prune_finished_sessions();
         if self.sessions.len() >= MAX_PTY_SESSIONS {
             return Err(ClaudePtyError::Capacity);
         }
@@ -462,9 +462,33 @@ impl NodePtyRuntime {
         Ok(session)
     }
 
-    fn prune_closed(&mut self) {
-        self.sessions
-            .retain(|_, session| session.status != ClaudePtyStatus::Closed);
+    /// Tear down terminal records that have already reached a terminal state
+    /// before they can consume another live-session slot. Keeping an exited
+    /// record until the next create lets a browser observe the terminal result,
+    /// while the next create deterministically releases its PTY resources.
+    fn prune_finished_sessions(&mut self) {
+        self.sessions.retain(|_, session| {
+            session.pump();
+            !matches!(
+                session.status,
+                ClaudePtyStatus::Closed | ClaudePtyStatus::Exited
+            )
+        });
+    }
+
+    /// Reap every PTY bound to a browser-device identity after that browser
+    /// session is revoked. The opaque browser session token never crosses the
+    /// auth boundary; this runtime only receives its already-authenticated
+    /// device identity.
+    pub fn close_owner_sessions(&mut self, owner_device_id: &str) {
+        self.sessions.retain(|_, session| {
+            if session.owner_device_id == owner_device_id {
+                session.close();
+                false
+            } else {
+                true
+            }
+        });
     }
 
     #[cfg(test)]
@@ -692,13 +716,7 @@ fn terminate_child(child: &mut Box<dyn Child + Send + Sync>, process_group: Opti
         // group kill guarantees Relay does not orphan descendants.
         let process_group = Pid::from_raw(process_group);
         let _ = killpg(process_group, Signal::SIGTERM);
-        let deadline = Instant::now() + PTY_TERMINATION_GRACE;
-        while Instant::now() < deadline {
-            if child.try_wait().ok().flatten().is_some() {
-                return;
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
+        thread::sleep(PTY_TERMINATION_GRACE);
         let _ = killpg(process_group, Signal::SIGKILL);
     }
     let _ = child.kill();
@@ -965,6 +983,44 @@ mod tests {
         runtime.close(session.as_str(), "device-a").unwrap();
     }
 
+    #[test]
+    fn naturally_exited_sessions_do_not_exhaust_live_capacity() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "exit 0"]);
+
+        for _ in 0..(MAX_PTY_SESSIONS * 2) {
+            let session = runtime.create("device-a").unwrap();
+            let deadline = Instant::now() + Duration::from_secs(2);
+            loop {
+                let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+                if snapshot.status == ClaudePtyStatus::Exited {
+                    break;
+                }
+                assert!(
+                    Instant::now() <= deadline,
+                    "short-lived PTY did not report terminal exit"
+                );
+                thread::sleep(Duration::from_millis(10));
+            }
+        }
+
+        let replacement = runtime.create("device-a").unwrap();
+        assert_eq!(runtime.sessions.len(), 1);
+        runtime.close(replacement.as_str(), "device-a").unwrap();
+    }
+
+    #[test]
+    fn revoking_an_owner_reaps_only_that_owners_pty_sessions() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "printf READY; cat"]);
+        let revoked = runtime.create("device-revoked").unwrap();
+        let retained = runtime.create("device-retained").unwrap();
+
+        runtime.close_owner_sessions("device-revoked");
+
+        assert!(!runtime.sessions.contains_key(revoked.as_str()));
+        assert!(runtime.sessions.contains_key(retained.as_str()));
+        runtime.close(retained.as_str(), "device-retained").unwrap();
+    }
+
     #[cfg(unix)]
     #[test]
     fn close_reaps_a_descendant_in_the_relay_owned_process_group() {
@@ -972,7 +1028,7 @@ mod tests {
             "/bin/sh",
             &[
                 "-c",
-                "sleep 30 & child=$!; printf 'CHILD:%s\\n' \"$child\"; wait \"$child\"",
+                "sh -c 'trap \"\" TERM; while :; do sleep 1; done' & child=$!; printf 'CHILD:%s\\n' \"$child\"; wait \"$child\"",
             ],
         );
         let session = runtime.create("device-a").unwrap();

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -75,6 +75,7 @@ const MAX_ROWS: u16 = 300;
 const MIN_COLS: u16 = 20;
 const MAX_COLS: u16 = 500;
 const PTY_TERMINATION_GRACE: Duration = Duration::from_millis(250);
+const PTY_REAPER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeOwnerContext {
@@ -266,6 +267,10 @@ impl PtyForegroundGroup {
         let mut fds = [PollFd::new(&self.leader_pidfd, PollFlags::IN)];
         poll(&mut fds, Some(&Timespec::default())).is_ok_and(|ready| ready == 0)
     }
+
+    fn is_signalable(&self) -> bool {
+        self.is_live()
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -389,17 +394,13 @@ impl NodePtyRuntime {
             // a Relay-owned group. portable-pty supplies this on Unix; a
             // missing identity is a fail-closed transport setup failure.
             let _ = child.kill();
-            let _ = child.wait();
+            reap_child(child);
             return Err(ClaudePtyError::Transport);
         }
         let reader = match pair.master.try_clone_reader() {
             Ok(reader) => reader,
             Err(_) => {
-                terminate_child(
-                    &mut child,
-                    Some(pair.master.as_ref()),
-                    process_group.as_ref(),
-                );
+                terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
                 return Err(ClaudePtyError::Transport);
             }
         };
@@ -410,11 +411,7 @@ impl NodePtyRuntime {
         {
             Ok(input) => input,
             Err(error) => {
-                terminate_child(
-                    &mut child,
-                    Some(pair.master.as_ref()),
-                    process_group.as_ref(),
-                );
+                terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
                 return Err(error);
             }
         };
@@ -432,11 +429,7 @@ impl NodePtyRuntime {
             Ok(reader_thread) => reader_thread,
             Err(error) => {
                 input.finish();
-                terminate_child(
-                    &mut child,
-                    Some(pair.master.as_ref()),
-                    process_group.as_ref(),
-                );
+                terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
                 return Err(error);
             }
         };
@@ -715,10 +708,9 @@ impl ManagedSession {
         if let Some(input) = input {
             input.finish();
         }
-        if let Some(child) = self.child.as_mut() {
+        if let Some(child) = self.child.take() {
             terminate_child(child, self.master.as_deref(), process_group.as_ref());
         }
-        self.child.take();
         self.master.take();
         drop(process_group);
         if let Some(reader) = self.reader.take() {
@@ -936,23 +928,12 @@ impl PtyOwnership {
         })
     }
 
-    fn signal_groups(
-        &self,
-        master: Option<&(dyn MasterPty + Send)>,
-        foreground: Option<&PtyForegroundGroup>,
-        signal: Signal,
-    ) {
+    fn signal_groups(&self, foreground: Option<&PtyForegroundGroup>, signal: Signal) {
         // The direct child remains waitable until close finishes, keeping the
-        // original Relay-owned group identifier reserved throughout. A
-        // foreground leader can exit independently, so do not signal its
-        // cached numeric group after its pidfd reports exit unless the PTY
-        // still resolves that exact group as foreground.
-        if let Some(foreground) = foreground.filter(|foreground| {
-            foreground.is_live()
-                || master
-                    .and_then(MasterPty::process_group_leader)
-                    .is_some_and(|current| current == foreground.process_group)
-        }) {
+        // original Relay-owned group identifier reserved throughout. Never
+        // re-authorize a foreground group by its numeric PGID after its pidfd
+        // reports leader exit: that number can be stale or reused.
+        if let Some(foreground) = foreground.filter(|foreground| foreground.is_signalable()) {
             let _ = killpg(Pid::from_raw(foreground.process_group), signal);
         }
         let _ = killpg(Pid::from_raw(self.process_group), signal);
@@ -985,25 +966,89 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
 }
 
 fn terminate_child(
-    child: &mut Box<dyn Child + Send + Sync>,
+    mut child: Box<dyn Child + Send + Sync>,
     master: Option<&(dyn MasterPty + Send)>,
     ownership: Option<&PtyOwnership>,
 ) {
     #[cfg(target_os = "linux")]
     if let Some(ownership) = ownership {
         let foreground = ownership.capture_foreground(master);
-        ownership.signal_groups(master, foreground.as_ref(), Signal::SIGTERM);
+        ownership.signal_groups(foreground.as_ref(), Signal::SIGTERM);
         thread::sleep(PTY_TERMINATION_GRACE);
-        ownership.signal_groups(master, foreground.as_ref(), Signal::SIGKILL);
+        ownership.signal_groups(foreground.as_ref(), Signal::SIGKILL);
     }
     let _ = child.kill();
-    let _ = child.wait();
+    reap_child(child);
+}
+
+fn reap_child(mut child: Box<dyn Child + Send + Sync>) {
+    let _ = thread::Builder::new()
+        .name("relay-claude-pty-reaper".into())
+        .spawn(move || {
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) | Err(_) => thread::sleep(PTY_REAPER_POLL_INTERVAL),
+                }
+            }
+        });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use portable_pty::{ChildKiller, ExitStatus};
     use std::time::{Duration, Instant};
+
+    #[derive(Debug)]
+    struct BlockingChild {
+        release: Arc<AtomicBool>,
+        poll_started: Arc<AtomicBool>,
+        reaped: Arc<AtomicBool>,
+    }
+
+    #[derive(Debug)]
+    struct NoopChildKiller;
+
+    impl ChildKiller for NoopChildKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(Self)
+        }
+    }
+
+    impl ChildKiller for BlockingChild {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(NoopChildKiller)
+        }
+    }
+
+    impl Child for BlockingChild {
+        fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+            self.poll_started.store(true, Ordering::Release);
+            if self.release.load(Ordering::Acquire) {
+                self.reaped.store(true, Ordering::Release);
+                Ok(Some(ExitStatus::with_exit_code(0)))
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn wait(&mut self) -> std::io::Result<ExitStatus> {
+            panic!("the reaper must poll try_wait instead of blocking on wait")
+        }
+
+        fn process_id(&self) -> Option<u32> {
+            None
+        }
+    }
 
     #[test]
     fn owner_context_is_explicit_and_not_process_home() {
@@ -1644,5 +1689,61 @@ mod tests {
             "a blocked PTY writer must not wedge owner-session reaping"
         );
         assert!(!runtime.sessions.contains_key(session.as_str()));
+    }
+
+    #[test]
+    fn reaper_polls_a_blocked_child_without_waiting() {
+        let release = Arc::new(AtomicBool::new(false));
+        let poll_started = Arc::new(AtomicBool::new(false));
+        let reaped = Arc::new(AtomicBool::new(false));
+        let child = Box::new(BlockingChild {
+            release: Arc::clone(&release),
+            poll_started: Arc::clone(&poll_started),
+            reaped: Arc::clone(&reaped),
+        });
+
+        let started = Instant::now();
+        reap_child(child);
+        assert!(
+            started.elapsed() < Duration::from_millis(50),
+            "the caller must not wait for a blocked child reap"
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !poll_started.load(Ordering::Acquire) {
+            assert!(
+                Instant::now() <= deadline,
+                "the detached reaper never started child.try_wait"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        release.store(true, Ordering::Release);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !reaped.load(Ordering::Acquire) {
+            assert!(
+                Instant::now() <= deadline,
+                "the detached reaper never observed child termination"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dead_foreground_leader_is_not_signalable_from_numeric_group_identity() {
+        use std::os::unix::net::UnixStream;
+
+        let (mut writer, reader) = UnixStream::pair().unwrap();
+        writer.write_all(&[1]).unwrap();
+        let foreground = PtyForegroundGroup {
+            process_group: 1,
+            leader_pidfd: reader.into(),
+        };
+
+        assert!(
+            !foreground.is_signalable(),
+            "a readable pidfd must not authorize a fallback numeric killpg"
+        );
     }
 }

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -9,9 +9,9 @@
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, TrySendError};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -101,6 +101,7 @@ pub enum ClaudePtyStatus {
     Starting,
     Running,
     Exited,
+    Closing,
     Closed,
 }
 
@@ -110,6 +111,7 @@ impl ClaudePtyStatus {
             Self::Starting => "starting",
             Self::Running => "running",
             Self::Exited => "exited",
+            Self::Closing => "closing",
             Self::Closed => "closed",
         }
     }
@@ -126,6 +128,7 @@ pub enum ClaudePtyError {
     Backpressure,
     InputLost,
     Transport,
+    TeardownFailed,
 }
 
 impl ClaudePtyError {
@@ -140,6 +143,7 @@ impl ClaudePtyError {
             Self::Backpressure => "input_backpressure",
             Self::InputLost => "input_delivery_lost",
             Self::Transport => "pty_transport",
+            Self::TeardownFailed => "pty_teardown_failed",
         }
     }
 }
@@ -186,10 +190,10 @@ struct InputRequest {
 }
 
 struct PtyInput {
-    sender: mpsc::SyncSender<InputRequest>,
+    sender: Option<mpsc::SyncSender<InputRequest>>,
     stop: Arc<AtomicBool>,
     delivery_failed: Arc<AtomicBool>,
-    worker: JoinHandle<()>,
+    worker: Option<JoinHandle<()>>,
 }
 
 impl PtyInput {
@@ -200,7 +204,8 @@ impl PtyInput {
         let request = InputRequest {
             data: data.to_vec(),
         };
-        match self.sender.try_send(request) {
+        let sender = self.sender.as_ref().ok_or(ClaudePtyError::StaleHandle)?;
+        match sender.try_send(request) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(_)) => Err(ClaudePtyError::Backpressure),
             Err(TrySendError::Disconnected(_)) if self.delivery_failed.load(Ordering::Acquire) => {
@@ -210,28 +215,30 @@ impl PtyInput {
         }
     }
 
-    fn finish(self) {
-        let Self {
-            sender,
-            stop,
-            worker,
-            ..
-        } = self;
-        stop.store(true, Ordering::Release);
-        drop(sender);
-        // A nonblocking writer observes `stop` between every retry. Never join
-        // it on the runtime mutex path: a kernel or driver regression must not
-        // turn close/revoke into an unbounded global PTY outage.
-        if worker.is_finished() {
+    fn request_stop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.sender.take();
+    }
+
+    fn join_if_finished(&mut self) -> bool {
+        self.request_stop();
+        let Some(worker) = self.worker.as_ref() else {
+            return true;
+        };
+        if !worker.is_finished() {
+            return false;
+        }
+        if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
+        true
     }
 }
 
 /// Linux ownership for the PTY session created by portable-pty.
 ///
-/// The direct child remains waitable until `ManagedSession::close` has
-/// terminated its group, so its PID continues to reserve the original
+/// The direct child remains waitable until the teardown state machine has
+/// terminated its group and verified reap, so its PID reserves the original
 /// process-group identity for the entire period Relay may call `killpg`. A
 /// nonblocking duplicate of the master FD gives the input worker a cancellable
 /// writer without consuming the reader.
@@ -241,6 +248,8 @@ struct PtyOwnership {
     writer: FileDescriptor,
     #[cfg(test)]
     foreground_override: Option<ForegroundIdentity>,
+    #[cfg(test)]
+    signal_error: Option<Signal>,
 }
 
 #[cfg(target_os = "linux")]
@@ -284,38 +293,103 @@ struct ManagedSession {
     pending_utf8: Vec<u8>,
     terminal_seen: bool,
     foreign_foreground_seen: bool,
+    child_reaped: bool,
 }
 
-/// A session removed from the runtime mutex before its bounded termination
-/// grace begins. The hub finishes this outside the runtime lock so one slow
-/// close cannot serialize unrelated terminal control requests.
-pub struct PtyTermination {
-    session_id: SessionId,
-    child: Option<Box<dyn Child + Send + Sync>>,
-    process_group: Option<PtyOwnership>,
-    master: Option<Box<dyn MasterPty + Send>>,
-    reader: Option<JoinHandle<()>>,
+const PTY_CLOSE_ATTEMPTS: usize = 3;
+const MAX_CLOSED_PTY_SESSIONS: usize = MAX_PTY_SESSIONS * 4;
+const PTY_CLOSE_BACKOFF: [Duration; PTY_CLOSE_ATTEMPTS] = [
+    Duration::ZERO,
+    Duration::from_millis(50),
+    Duration::from_millis(250),
+];
+
+#[derive(Clone, Copy)]
+enum CloseCause {
+    Explicit = 1,
+    OwnerInvalidated = 2,
+    Prune = 4,
+    Startup = 8,
+    Shutdown = 16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyTeardownFailure {
+    Ownership,
+    TermSignal,
+    KillSignal,
+    ReapDeadline,
+    ReapAttemptsExhausted,
+    TryWait,
+    ResourceHandlesPending,
+    LeaseMismatch,
+}
+
+type SharedSession = Arc<Mutex<ManagedSession>>;
+
+struct ClosingSession {
+    session: SharedSession,
+    generation: u64,
+    attempts: usize,
+    causes: u8,
+    not_before: Instant,
+    last_failure: Option<PtyTeardownFailure>,
+}
+
+struct SignallingSession {
+    session: SharedSession,
+    owner_device_id: String,
+    generation: u64,
+    attempt: usize,
+    lease_id: u64,
+    causes: u8,
+}
+
+struct ClosedSession {
+    owner_device_id: String,
     next_cursor: u64,
     dropped_chunks: u64,
+    order: u64,
 }
 
-/// A create operation separates lock-bound runtime bookkeeping from any
-/// bounded PTY teardown that the caller must finish after releasing the lock.
+struct TerminalFailure {
+    closing: ClosingSession,
+}
+
+/// An exclusive, runtime-owned teardown lease. The keyed lifecycle record
+/// remains in `signalling` until this lease is returned, so no failed operation
+/// can make its child, original group identity, or PTY descriptors disappear.
+pub struct PtyTermination {
+    session_id: SessionId,
+    owner_device_id: String,
+    generation: u64,
+    attempt: usize,
+    lease_id: u64,
+    causes: u8,
+    session: SharedSession,
+}
+
+pub struct PtyTerminationOutcome {
+    result: PtyTerminationResult,
+}
+
+enum PtyTerminationResult {
+    Closed(PtyTermination),
+    Retry {
+        termination: PtyTermination,
+        failure: PtyTeardownFailure,
+    },
+}
+
+/// A create result contains only lock-bound launch bookkeeping. Callers must
+/// drive due teardown leases after releasing the runtime mutex.
 pub struct PtyCreate {
     result: Result<SessionId, ClaudePtyError>,
-    terminations: Vec<PtyTermination>,
 }
 
 impl PtyCreate {
-    fn failure(error: ClaudePtyError, terminations: Vec<PtyTermination>) -> Self {
-        Self {
-            result: Err(error),
-            terminations,
-        }
-    }
-
-    pub fn into_parts(self) -> (Result<SessionId, ClaudePtyError>, Vec<PtyTermination>) {
-        (self.result, self.terminations)
+    pub fn into_result(self) -> Result<SessionId, ClaudePtyError> {
+        self.result
     }
 }
 
@@ -327,7 +401,6 @@ pub enum OwnerSessionCloseDisposition {
 }
 
 pub struct OwnerSessionClosures {
-    pub terminations: Vec<PtyTermination>,
     pub disposition: OwnerSessionCloseDisposition,
 }
 
@@ -343,7 +416,15 @@ pub struct NodePtyRuntime {
     /// no browser/API request can influence this field.
     arguments: Vec<String>,
     sessions: HashMap<String, ManagedSession>,
+    closing: HashMap<String, ClosingSession>,
+    signalling: HashMap<String, SignallingSession>,
+    closed: HashMap<String, ClosedSession>,
+    terminal_failures: HashMap<String, TerminalFailure>,
     next_id: u64,
+    next_generation: u64,
+    next_lease_id: u64,
+    next_closed_order: u64,
+    shutdown_requested: bool,
 }
 
 impl Default for NodePtyRuntime {
@@ -360,7 +441,15 @@ impl NodePtyRuntime {
             launch_directory,
             arguments: Vec::new(),
             sessions: HashMap::new(),
+            closing: HashMap::new(),
+            signalling: HashMap::new(),
+            closed: HashMap::new(),
+            terminal_failures: HashMap::new(),
             next_id: 1,
+            next_generation: 1,
+            next_lease_id: 1,
+            next_closed_order: 1,
+            shutdown_requested: false,
         }
     }
 
@@ -373,7 +462,7 @@ impl NodePtyRuntime {
     /// This is deliberately compiled only for debug builds and runs one fixed
     /// echo fixture with an explicit interrupt trap. It is not a configurable
     /// shell command surface and cannot be enabled in a release build.
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "test-fixtures"))]
     pub fn test_fixture_cat() -> Self {
         let mut runtime = Self::default();
         runtime.owner.claude_path = PathBuf::from("/bin/sh");
@@ -388,29 +477,39 @@ impl NodePtyRuntime {
     /// Start the fixed Claude Code TUI in a real PTY. No caller-controlled
     /// command, arguments, HOME, PATH, or working directory enter this path.
     pub fn create(&mut self, owner_device_id: &str) -> Result<SessionId, ClaudePtyError> {
-        let (result, terminations) = self.begin_create(owner_device_id).into_parts();
-        for termination in terminations {
-            let _ = termination.finish();
-        }
+        self.finish_due_terminations();
+        self.schedule_prune_finished_sessions();
+        self.finish_due_terminations();
+        let result = self.try_create(owner_device_id);
+        self.finish_due_terminations();
         result
     }
 
-    /// Begin fixed-PTY creation while the runtime is locked. Any automatic
-    /// pruning or partially-started PTY cleanup is returned to the caller so
-    /// TERM/KILL grace never runs under the hub's global PTY mutex.
+    /// Begin fixed-PTY creation while the runtime is locked. It only schedules
+    /// automatic cleanup; callers must claim and finish those leases after
+    /// releasing the hub mutex, then retry admission if capacity was freed.
     pub fn begin_create(&mut self, owner_device_id: &str) -> PtyCreate {
-        if owner_device_id.is_empty() || owner_device_id.len() > 64 {
-            return PtyCreate::failure(ClaudePtyError::Forbidden, Vec::new());
+        self.schedule_prune_finished_sessions();
+        PtyCreate {
+            result: self.try_create(owner_device_id),
         }
-        let mut terminations = self.begin_prune_finished_sessions();
-        if self.sessions.len() >= MAX_PTY_SESSIONS {
-            return PtyCreate::failure(ClaudePtyError::Capacity, terminations);
+    }
+
+    fn try_create(&mut self, owner_device_id: &str) -> Result<SessionId, ClaudePtyError> {
+        if self.shutdown_requested {
+            return Err(ClaudePtyError::Unavailable);
+        }
+        if owner_device_id.is_empty() || owner_device_id.len() > 64 {
+            return Err(ClaudePtyError::Forbidden);
+        }
+        if self.capacity_consumed() >= MAX_PTY_SESSIONS {
+            return Err(ClaudePtyError::Capacity);
         }
 
         let pty_system = native_pty_system();
         let pair = match pty_system.openpty(default_size()) {
             Ok(pair) => pair,
-            Err(_) => return PtyCreate::failure(ClaudePtyError::Transport, terminations),
+            Err(_) => return Err(ClaudePtyError::Transport),
         };
         let mut command = CommandBuilder::new(self.owner.claude_path());
         command.env_clear();
@@ -426,36 +525,41 @@ impl NodePtyRuntime {
         command.env("TERM", "xterm-256color");
         command.env("COLORTERM", "truecolor");
 
-        let mut child = match pair.slave.spawn_command(command) {
+        let child = match pair.slave.spawn_command(command) {
             Ok(child) => child,
-            Err(_) => return PtyCreate::failure(ClaudePtyError::Unavailable, terminations),
+            Err(_) => return Err(ClaudePtyError::Unavailable),
         };
         drop(pair.slave);
+        let id = format!("claude-pty-{}", self.next_id);
+        self.next_id = self.next_id.saturating_add(1);
+        let session_id = SessionId::new(id.clone());
         let process_group = child
             .process_id()
             .and_then(|process_id| session_process_group(process_id, pair.master.as_ref()));
         #[cfg(unix)]
         if process_group.is_none() {
-            // Do not admit a Session whose descendants could not be reaped as
-            // a Relay-owned group. portable-pty supplies this on Unix; a
-            // missing identity is a fail-closed transport setup failure.
-            let _ = child.kill();
-            reap_child(child);
-            return PtyCreate::failure(ClaudePtyError::Transport, terminations);
+            self.register_startup_failure(
+                session_id,
+                owner_device_id,
+                child,
+                None,
+                pair.master,
+                None,
+            );
+            return Err(ClaudePtyError::Transport);
         }
-        let id = format!("claude-pty-{}", self.next_id);
-        self.next_id = self.next_id.saturating_add(1);
-        let session_id = SessionId::new(id.clone());
         let reader = match pair.master.try_clone_reader() {
             Ok(reader) => reader,
             Err(_) => {
-                terminations.push(PtyTermination::startup_failure(
+                self.register_startup_failure(
                     session_id,
+                    owner_device_id,
                     child,
                     process_group,
                     pair.master,
-                ));
-                return PtyCreate::failure(ClaudePtyError::Transport, terminations);
+                    None,
+                );
+                return Err(ClaudePtyError::Transport);
             }
         };
         let input = match process_group
@@ -465,13 +569,15 @@ impl NodePtyRuntime {
         {
             Ok(input) => input,
             Err(error) => {
-                terminations.push(PtyTermination::startup_failure(
+                self.register_startup_failure(
                     session_id,
+                    owner_device_id,
                     child,
                     process_group,
                     pair.master,
-                ));
-                return PtyCreate::failure(error, terminations);
+                    None,
+                );
+                return Err(error);
             }
         };
         let (reader_tx, reader_rx) = mpsc::sync_channel(PTY_INBOUND_CAP);
@@ -487,14 +593,15 @@ impl NodePtyRuntime {
         ) {
             Ok(reader_thread) => reader_thread,
             Err(error) => {
-                input.finish();
-                terminations.push(PtyTermination::startup_failure(
+                self.register_startup_failure(
                     session_id,
+                    owner_device_id,
                     child,
                     process_group,
                     pair.master,
-                ));
-                return PtyCreate::failure(error, terminations);
+                    Some(input),
+                );
+                return Err(error);
             }
         };
 
@@ -518,12 +625,10 @@ impl NodePtyRuntime {
                 pending_utf8: Vec::new(),
                 terminal_seen: false,
                 foreign_foreground_seen: false,
+                child_reaped: false,
             },
         );
-        PtyCreate {
-            result: Ok(session_id),
-            terminations,
-        }
+        Ok(session_id)
     }
 
     /// Return an incremental, loss-aware output snapshot. Disconnection merely
@@ -534,42 +639,38 @@ impl NodePtyRuntime {
         owner_device_id: &str,
         cursor: u64,
     ) -> Result<TerminalSnapshot, ClaudePtyError> {
-        let session = self.session_mut(session_id, owner_device_id)?;
-        session.pump();
-        let first_sequence = session
-            .output
-            .front()
-            .map_or(session.next_sequence, |chunk| chunk.sequence);
-        let truncated = cursor.saturating_add(1) < first_sequence;
-        let mut output = Vec::new();
-        let mut output_bytes: usize = 0;
-        let mut next_cursor = cursor;
-        let mut has_more = false;
-        for chunk in session
-            .output
-            .iter()
-            .filter(|chunk| chunk.sequence > cursor)
-        {
-            if !output.is_empty() && output_bytes.saturating_add(chunk.bytes) > PTY_DELIVERY_BYTES {
-                has_more = true;
-                break;
+        if let Some(session) = self.sessions.get_mut(session_id) {
+            if session.owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
             }
-            output_bytes = output_bytes.saturating_add(chunk.bytes);
-            next_cursor = chunk.sequence;
-            output.push(TerminalOutput {
-                sequence: chunk.sequence,
-                text: chunk.text.clone(),
-            });
+            session.pump();
+            return Ok(session_snapshot(session, session_id, cursor));
         }
-        Ok(TerminalSnapshot {
-            session_id: SessionId::new(session_id),
-            status: session.status,
-            output,
-            next_cursor,
-            has_more,
-            truncated,
-            dropped_chunks: session.reader_dropped.load(Ordering::Acquire),
-        })
+        if let Some(closing) = self.closing.get(session_id) {
+            let session = lock_shared_session(&closing.session);
+            return closing_snapshot(session_id, owner_device_id, &session.owner_device_id);
+        }
+        if let Some(signalling) = self.signalling.get(session_id) {
+            return closing_snapshot(session_id, owner_device_id, &signalling.owner_device_id);
+        }
+        if let Some(closed) = self.closed.get(session_id) {
+            if closed.owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            return Ok(terminal_snapshot(
+                session_id,
+                ClaudePtyStatus::Closed,
+                closed.next_cursor,
+                closed.dropped_chunks,
+            ));
+        }
+        if let Some(failure) = self.terminal_failures.get(session_id) {
+            if lock_shared_session(&failure.closing.session).owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            return Err(ClaudePtyError::TeardownFailed);
+        }
+        Err(ClaudePtyError::StaleHandle)
     }
 
     pub fn input(
@@ -581,7 +682,7 @@ impl NodePtyRuntime {
         if data.is_empty() || data.len() > PTY_INPUT_BYTES || data.contains('\0') {
             return Err(ClaudePtyError::InvalidInput);
         }
-        let session = self.session_mut(session_id, owner_device_id)?;
+        let session = self.active_session_mut(session_id, owner_device_id)?;
         session.pump();
         if session.status == ClaudePtyStatus::Closed || session.status == ClaudePtyStatus::Exited {
             return Err(ClaudePtyError::StaleHandle);
@@ -603,7 +704,7 @@ impl NodePtyRuntime {
         if !(MIN_COLS..=MAX_COLS).contains(&cols) || !(MIN_ROWS..=MAX_ROWS).contains(&rows) {
             return Err(ClaudePtyError::InvalidResize);
         }
-        let session = self.session_mut(session_id, owner_device_id)?;
+        let session = self.active_session_mut(session_id, owner_device_id)?;
         session.pump();
         let master = session.master.as_mut().ok_or(ClaudePtyError::StaleHandle)?;
         master
@@ -625,42 +726,29 @@ impl NodePtyRuntime {
         self.input(session_id, owner_device_id, "\u{3}")
     }
 
-    /// Explicit close owns child termination/reaping. Layout close must call
-    /// detach instead; this is intentionally a distinct endpoint.
+    /// Direct runtime convenience for unit tests and the node probe. Hub code
+    /// requests the transition under its mutex, then drives leases outside it.
     pub fn close(
         &mut self,
         session_id: &str,
         owner_device_id: &str,
     ) -> Result<TerminalSnapshot, ClaudePtyError> {
-        self.begin_close(session_id, owner_device_id)?.finish()
+        self.request_close(session_id, owner_device_id)?;
+        self.finish_due_terminations();
+        self.poll(session_id, owner_device_id, 0)
     }
 
-    /// Remove a Session under the runtime lock, then let the caller finish its
-    /// bounded TERM/KILL teardown without serializing other terminal controls.
-    pub fn begin_close(
+    /// Enter Closing without foreground probing or resource consumption. The
+    /// later lease either reports Closed after reap or comes back retryable.
+    pub fn request_close(
         &mut self,
         session_id: &str,
         owner_device_id: &str,
-    ) -> Result<PtyTermination, ClaudePtyError> {
-        let session = self
-            .sessions
-            .get_mut(session_id)
-            .ok_or(ClaudePtyError::StaleHandle)?;
-        if session.owner_device_id != owner_device_id {
-            return Err(ClaudePtyError::Forbidden);
-        }
-        session.pump();
-        if !session.foreground_is_owned() {
-            return Err(ClaudePtyError::Transport);
-        }
-        let session = self
-            .sessions
-            .remove(session_id)
-            .expect("checked session remains present until this mutable operation");
-        Ok(session.into_termination(session_id))
+    ) -> Result<(), ClaudePtyError> {
+        self.schedule_close(session_id, owner_device_id, CloseCause::Explicit)
     }
 
-    fn session_mut(
+    fn active_session_mut(
         &mut self,
         session_id: &str,
         owner_device_id: &str,
@@ -675,81 +763,526 @@ impl NodePtyRuntime {
         Ok(session)
     }
 
-    /// Tear down terminal records that have already reached a terminal state
-    /// before they can consume another live-session slot. Keeping an exited
-    /// record until the next create lets a browser observe the terminal result,
-    /// while the next create deterministically releases its PTY resources.
-    #[cfg(test)]
-    fn prune_finished_sessions(&mut self) {
-        for termination in self.begin_prune_finished_sessions() {
-            let _ = termination.finish();
+    fn schedule_close(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+        cause: CloseCause,
+    ) -> Result<(), ClaudePtyError> {
+        if let Some(session) = self.sessions.get_mut(session_id) {
+            if session.owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            session.pump();
+        } else if let Some(closing) = self.closing.get_mut(session_id) {
+            if lock_shared_session(&closing.session).owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            closing.causes |= cause as u8;
+            return Ok(());
+        } else if let Some(signalling) = self.signalling.get_mut(session_id) {
+            if signalling.owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            signalling.causes |= cause as u8;
+            return Ok(());
+        } else if let Some(closed) = self.closed.get(session_id) {
+            return (closed.owner_device_id == owner_device_id)
+                .then_some(())
+                .ok_or(ClaudePtyError::Forbidden);
+        } else if let Some(failure) = self.terminal_failures.get_mut(session_id) {
+            if lock_shared_session(&failure.closing.session).owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            failure.closing.causes |= cause as u8;
+            return Err(ClaudePtyError::TeardownFailed);
+        } else {
+            return Err(ClaudePtyError::StaleHandle);
         }
+
+        let session = self
+            .sessions
+            .remove(session_id)
+            .expect("the active record checked above remains present");
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.saturating_add(1);
+        self.closing.insert(
+            session_id.to_owned(),
+            ClosingSession {
+                session: Arc::new(Mutex::new(session)),
+                generation,
+                attempts: 0,
+                causes: cause as u8,
+                not_before: Instant::now(),
+                last_failure: None,
+            },
+        );
+        Ok(())
     }
 
-    fn begin_prune_finished_sessions(&mut self) -> Vec<PtyTermination> {
+    fn schedule_prune_finished_sessions(&mut self) {
         let session_ids = self
             .sessions
             .iter_mut()
             .filter_map(|(session_id, session)| {
                 session.pump();
-                (session.foreground_is_owned()
-                    && matches!(
-                        session.status,
-                        ClaudePtyStatus::Closed | ClaudePtyStatus::Exited
-                    ))
-                .then(|| session_id.clone())
+                (session.status == ClaudePtyStatus::Exited).then(|| session_id.clone())
             })
             .collect::<Vec<_>>();
-        session_ids
-            .into_iter()
-            .filter_map(|session_id| {
-                self.sessions
-                    .remove(&session_id)
-                    .map(|session| session.into_termination(&session_id))
-            })
-            .collect()
+        for session_id in session_ids {
+            let owner = self.sessions[&session_id].owner_device_id.clone();
+            let _ = self.schedule_close(&session_id, &owner, CloseCause::Prune);
+        }
     }
 
-    /// Reap every PTY bound to a browser-device identity after that browser
-    /// session is revoked. The opaque browser session token never crosses the
-    /// auth boundary; this runtime only receives its already-authenticated
-    /// device identity.
+    #[cfg(test)]
+    fn prune_finished_sessions(&mut self) {
+        self.schedule_prune_finished_sessions();
+        self.finish_due_terminations();
+    }
+
+    /// Schedule every record owned by an invalidated browser device. Auth is
+    /// acknowledged only when `owner_close_disposition` reaches Complete.
     pub fn begin_owner_session_closes(&mut self, owner_device_id: &str) -> OwnerSessionClosures {
-        let session_ids = self
+        let mut session_ids = self
             .sessions
             .iter()
             .filter(|(_, session)| session.owner_device_id == owner_device_id)
             .map(|(session_id, _)| session_id.clone())
             .collect::<Vec<_>>();
-        let mut disposition = OwnerSessionCloseDisposition::Complete;
-        let terminations = session_ids
-            .into_iter()
-            .filter_map(|session_id| {
-                let session = self
-                    .sessions
-                    .get_mut(&session_id)
-                    .expect("collected session remains present until this mutable operation");
-                session.pump();
-                if !session.foreground_is_owned() {
-                    eprintln!("relay Claude PTY teardown refused an unowned foreground group");
-                    disposition = OwnerSessionCloseDisposition::Retry;
-                    return None;
-                }
-                self.sessions
-                    .remove(&session_id)
-                    .map(|session| session.into_termination(&session_id))
-            })
-            .collect();
+        session_ids.extend(
+            self.closing
+                .iter()
+                .filter(|(_, closing)| {
+                    lock_shared_session(&closing.session).owner_device_id == owner_device_id
+                })
+                .map(|(session_id, _)| session_id.clone()),
+        );
+        session_ids.extend(
+            self.signalling
+                .iter()
+                .filter(|(_, signalling)| signalling.owner_device_id == owner_device_id)
+                .map(|(session_id, _)| session_id.clone()),
+        );
+        session_ids.extend(
+            self.terminal_failures
+                .iter()
+                .filter(|(_, failure)| {
+                    lock_shared_session(&failure.closing.session).owner_device_id == owner_device_id
+                })
+                .map(|(session_id, _)| session_id.clone()),
+        );
+        session_ids.sort();
+        session_ids.dedup();
+        for session_id in session_ids {
+            let _ = self.schedule_close(&session_id, owner_device_id, CloseCause::OwnerInvalidated);
+        }
         OwnerSessionClosures {
-            terminations,
-            disposition,
+            disposition: self.owner_close_disposition(owner_device_id),
         }
     }
 
     pub fn close_owner_sessions(&mut self, owner_device_id: &str) {
-        let closures = self.begin_owner_session_closes(owner_device_id);
-        for termination in closures.terminations {
-            let _ = termination.finish();
+        self.begin_owner_session_closes(owner_device_id);
+        self.finish_due_terminations();
+    }
+
+    /// Claim every due close attempt while locked. The returned leases are the
+    /// only values permitted to sleep, signal, join, or poll children.
+    pub fn claim_due_terminations(&mut self) -> Vec<PtyTermination> {
+        let now = Instant::now();
+        let abandoned = self
+            .signalling
+            .iter()
+            .filter(|(_, signalling)| Arc::strong_count(&signalling.session) == 1)
+            .map(|(session_id, _)| session_id.clone())
+            .collect::<Vec<_>>();
+        for session_id in abandoned {
+            let signalling = self
+                .signalling
+                .remove(&session_id)
+                .expect("abandoned lease sentinel remains present");
+            let closing = ClosingSession {
+                session: signalling.session,
+                generation: signalling.generation,
+                attempts: signalling.attempt,
+                causes: signalling.causes,
+                not_before: now + PTY_CLOSE_BACKOFF[signalling.attempt.min(PTY_CLOSE_ATTEMPTS - 1)],
+                last_failure: Some(PtyTeardownFailure::LeaseMismatch),
+            };
+            if signalling.attempt >= PTY_CLOSE_ATTEMPTS {
+                self.terminal_failures
+                    .insert(session_id, TerminalFailure { closing });
+            } else {
+                self.closing.insert(session_id, closing);
+            }
+        }
+        let session_ids = self
+            .closing
+            .iter()
+            .filter(|(_, closing)| closing.not_before <= now)
+            .map(|(session_id, _)| session_id.clone())
+            .collect::<Vec<_>>();
+        let mut terminations = Vec::with_capacity(session_ids.len());
+        for session_id in session_ids {
+            let closing = self
+                .closing
+                .remove(&session_id)
+                .expect("a due closing record remains present until leased");
+            let lease_id = self.next_lease_id;
+            self.next_lease_id = self.next_lease_id.saturating_add(1);
+            let attempt = closing.attempts.saturating_add(1);
+            let owner_device_id = lock_shared_session(&closing.session)
+                .owner_device_id
+                .clone();
+            self.signalling.insert(
+                session_id.clone(),
+                SignallingSession {
+                    session: Arc::clone(&closing.session),
+                    owner_device_id: owner_device_id.clone(),
+                    generation: closing.generation,
+                    attempt,
+                    lease_id,
+                    causes: closing.causes,
+                },
+            );
+            terminations.push(PtyTermination {
+                session_id: SessionId::new(session_id),
+                owner_device_id,
+                generation: closing.generation,
+                attempt,
+                lease_id,
+                causes: closing.causes,
+                session: Arc::clone(&closing.session),
+            });
+        }
+        terminations
+    }
+
+    /// Return a completed lease to its original keyed lifecycle record. A
+    /// retry never changes generation or ownership and never drops the bundle.
+    pub fn complete_termination(&mut self, outcome: PtyTerminationOutcome) {
+        let (termination, failure) = match outcome.result {
+            PtyTerminationResult::Closed(termination) => (termination, None),
+            PtyTerminationResult::Retry {
+                termination,
+                failure,
+            } => (termination, Some(failure)),
+        };
+        let claimed_session_id = termination.session_id.as_str().to_owned();
+        let sentinel_session_id = self
+            .signalling
+            .iter()
+            .find(|(_, signalling)| Arc::ptr_eq(&signalling.session, &termination.session))
+            .map(|(session_id, _)| session_id.clone());
+        let valid = sentinel_session_id
+            .as_ref()
+            .filter(|session_id| **session_id == claimed_session_id)
+            .and_then(|session_id| self.signalling.get(session_id))
+            .is_some_and(|signalling| {
+                signalling.generation == termination.generation
+                    && signalling.attempt == termination.attempt
+                    && signalling.lease_id == termination.lease_id
+                    && signalling.owner_device_id == termination.owner_device_id
+            });
+        if !valid {
+            eprintln!("relay Claude PTY teardown completion lease mismatch");
+            let quarantine_session_id = sentinel_session_id.unwrap_or(claimed_session_id);
+            let signalling = self.signalling.remove(&quarantine_session_id);
+            let session = signalling
+                .as_ref()
+                .map(|record| Arc::clone(&record.session))
+                .unwrap_or_else(|| Arc::clone(&termination.session));
+            let causes = signalling
+                .as_ref()
+                .map_or(termination.causes, |record| record.causes);
+            let generation = signalling
+                .as_ref()
+                .map_or(termination.generation, |record| record.generation);
+            let attempts = signalling
+                .as_ref()
+                .map_or(termination.attempt, |record| record.attempt);
+            self.terminal_failures.insert(
+                quarantine_session_id,
+                TerminalFailure {
+                    closing: ClosingSession {
+                        session,
+                        generation,
+                        attempts,
+                        causes,
+                        not_before: Instant::now(),
+                        last_failure: Some(PtyTeardownFailure::LeaseMismatch),
+                    },
+                },
+            );
+            return;
+        }
+
+        let signalling = self
+            .signalling
+            .remove(&claimed_session_id)
+            .expect("validated signalling record remains present");
+        if let Some(failure) = failure {
+            let closing = ClosingSession {
+                session: signalling.session,
+                generation: termination.generation,
+                attempts: termination.attempt,
+                causes: signalling.causes,
+                not_before: Instant::now()
+                    + PTY_CLOSE_BACKOFF[termination.attempt.min(PTY_CLOSE_ATTEMPTS - 1)],
+                last_failure: Some(failure),
+            };
+            if termination.attempt >= PTY_CLOSE_ATTEMPTS {
+                self.terminal_failures
+                    .insert(claimed_session_id, TerminalFailure { closing });
+            } else {
+                self.closing.insert(claimed_session_id, closing);
+            }
+            return;
+        }
+
+        let (next_cursor, dropped_chunks) = {
+            let mut session = lock_shared_session(&signalling.session);
+            session.release_after_reap()
+        };
+        self.insert_closed(
+            claimed_session_id,
+            ClosedSession {
+                owner_device_id: termination.owner_device_id,
+                next_cursor,
+                dropped_chunks,
+                order: 0,
+            },
+        );
+    }
+
+    /// Test/node convenience that executes a bounded batch outside any caller
+    /// mutex. Hub code claims and completes through separate lock acquisitions.
+    pub fn finish_due_terminations(&mut self) {
+        let terminations = self.claim_due_terminations();
+        for termination in terminations {
+            self.complete_termination(termination.finish());
+        }
+    }
+
+    pub fn owner_close_disposition(&self, owner_device_id: &str) -> OwnerSessionCloseDisposition {
+        let pending = self
+            .sessions
+            .values()
+            .any(|session| session.owner_device_id == owner_device_id)
+            || self.closing.values().any(|closing| {
+                lock_shared_session(&closing.session).owner_device_id == owner_device_id
+            })
+            || self
+                .signalling
+                .values()
+                .any(|signalling| signalling.owner_device_id == owner_device_id)
+            || self.terminal_failures.values().any(|failure| {
+                lock_shared_session(&failure.closing.session).owner_device_id == owner_device_id
+            });
+        if pending {
+            OwnerSessionCloseDisposition::Retry
+        } else {
+            OwnerSessionCloseDisposition::Complete
+        }
+    }
+
+    fn capacity_consumed(&self) -> usize {
+        self.sessions.len()
+            + self.closing.len()
+            + self.signalling.len()
+            + self.terminal_failures.len()
+    }
+
+    fn insert_closed(&mut self, session_id: String, mut closed: ClosedSession) {
+        closed.order = self.next_closed_order;
+        self.next_closed_order = self.next_closed_order.saturating_add(1);
+        self.closed.insert(session_id, closed);
+        while self.closed.len() > MAX_CLOSED_PTY_SESSIONS {
+            let Some(oldest) = self
+                .closed
+                .iter()
+                .min_by_key(|(_, record)| record.order)
+                .map(|(session_id, _)| session_id.clone())
+            else {
+                break;
+            };
+            self.closed.remove(&oldest);
+        }
+    }
+
+    pub fn begin_shutdown(&mut self) -> OwnerSessionCloseDisposition {
+        self.shutdown_requested = true;
+        let session_ids = self.sessions.keys().cloned().collect::<Vec<_>>();
+        for session_id in session_ids {
+            let owner = self.sessions[&session_id].owner_device_id.clone();
+            let _ = self.schedule_close(&session_id, &owner, CloseCause::Shutdown);
+        }
+        for closing in self.closing.values_mut() {
+            closing.causes |= CloseCause::Shutdown as u8;
+        }
+        for signalling in self.signalling.values_mut() {
+            signalling.causes |= CloseCause::Shutdown as u8;
+        }
+        for failure in self.terminal_failures.values_mut() {
+            failure.closing.causes |= CloseCause::Shutdown as u8;
+        }
+        self.shutdown_disposition()
+    }
+
+    pub fn shutdown_disposition(&self) -> OwnerSessionCloseDisposition {
+        if self.sessions.is_empty()
+            && self.closing.is_empty()
+            && self.signalling.is_empty()
+            && self.terminal_failures.is_empty()
+        {
+            OwnerSessionCloseDisposition::Complete
+        } else {
+            OwnerSessionCloseDisposition::Retry
+        }
+    }
+
+    pub fn has_terminal_failures(&self) -> bool {
+        !self.terminal_failures.is_empty()
+    }
+
+    pub fn has_pending_terminations(&self) -> bool {
+        !self.closing.is_empty() || !self.signalling.is_empty()
+    }
+
+    pub fn teardown_failure(
+        &self,
+        session_id: &str,
+        owner_device_id: &str,
+    ) -> Result<Option<(PtyTeardownFailure, usize)>, ClaudePtyError> {
+        if let Some(closing) = self.closing.get(session_id) {
+            if lock_shared_session(&closing.session).owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            return Ok(closing
+                .last_failure
+                .map(|failure| (failure, closing.attempts)));
+        }
+        if let Some(failure) = self.terminal_failures.get(session_id) {
+            if lock_shared_session(&failure.closing.session).owner_device_id != owner_device_id {
+                return Err(ClaudePtyError::Forbidden);
+            }
+            return Ok(failure
+                .closing
+                .last_failure
+                .map(|reason| (reason, failure.closing.attempts)));
+        }
+        Ok(None)
+    }
+
+    fn register_startup_failure(
+        &mut self,
+        session_id: SessionId,
+        owner_device_id: &str,
+        child: Box<dyn Child + Send + Sync>,
+        process_group: Option<PtyOwnership>,
+        master: Box<dyn MasterPty + Send>,
+        input: Option<PtyInput>,
+    ) {
+        let (_, reader_rx) = mpsc::sync_channel(1);
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.saturating_add(1);
+        self.closing.insert(
+            session_id.as_str().to_owned(),
+            ClosingSession {
+                session: Arc::new(Mutex::new(ManagedSession {
+                    owner_device_id: owner_device_id.to_owned(),
+                    status: ClaudePtyStatus::Starting,
+                    child: Some(child),
+                    process_group,
+                    master: Some(master),
+                    input,
+                    reader: None,
+                    reader_rx,
+                    reader_stop: Arc::new(AtomicBool::new(false)),
+                    reader_terminal: Arc::new(AtomicBool::new(false)),
+                    reader_dropped: Arc::new(AtomicU64::new(0)),
+                    output: VecDeque::new(),
+                    output_bytes: 0,
+                    next_sequence: 1,
+                    pending_utf8: Vec::new(),
+                    terminal_seen: false,
+                    foreign_foreground_seen: false,
+                    child_reaped: false,
+                })),
+                generation,
+                attempts: 0,
+                causes: CloseCause::Startup as u8,
+                not_before: Instant::now(),
+                last_failure: None,
+            },
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[cfg(test)]
+    fn set_test_foreground_identity(&mut self, session_id: &str, identity: ForegroundIdentity) {
+        if let Some(session) = self.sessions.get_mut(session_id) {
+            session
+                .process_group
+                .as_mut()
+                .expect("test session retains its original process group")
+                .foreground_override = Some(identity);
+            return;
+        }
+        lock_shared_session(
+            &self
+                .closing
+                .get(session_id)
+                .expect("test session remains in Closing")
+                .session,
+        )
+        .process_group
+        .as_mut()
+        .expect("test session retains its original process group")
+        .foreground_override = Some(identity);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[cfg(test)]
+    fn set_test_signal_error(&mut self, session_id: &str, signal: Option<Signal>) {
+        let shared = self
+            .closing
+            .get(session_id)
+            .map(|closing| Arc::clone(&closing.session))
+            .or_else(|| {
+                self.signalling
+                    .get(session_id)
+                    .map(|signalling| Arc::clone(&signalling.session))
+            })
+            .expect("test session remains in teardown");
+        lock_shared_session(&shared)
+            .process_group
+            .as_mut()
+            .expect("test session retains its original process group")
+            .signal_error = signal;
+    }
+
+    #[cfg(test)]
+    fn replace_test_closing_child(
+        &mut self,
+        session_id: &str,
+        child: Box<dyn Child + Send + Sync>,
+    ) {
+        lock_shared_session(
+            &self
+                .closing
+                .get(session_id)
+                .expect("test session has entered Closing before injecting reap behavior")
+                .session,
+        )
+        .child = Some(child);
+    }
+
+    #[cfg(test)]
+    fn force_due_terminations_for_test(&mut self) {
+        for closing in self.closing.values_mut() {
+            closing.not_before = Instant::now();
         }
     }
 
@@ -832,11 +1365,13 @@ impl ManagedSession {
     fn observe_foreground_group(&mut self) {
         #[cfg(target_os = "linux")]
         {
-            if self
-                .process_group
-                .as_ref()
-                .is_some_and(|ownership| !ownership.foreground_is_owned())
-            {
+            if self.process_group.as_ref().is_some_and(|ownership| {
+                matches!(
+                    ownership.foreground_identity(),
+                    ForegroundIdentity::ProcessGroup(process_group)
+                        if process_group != ownership.process_group
+                )
+            }) {
                 self.foreign_foreground_seen = true;
             }
         }
@@ -857,122 +1392,203 @@ impl ManagedSession {
         }
     }
 
-    fn into_termination(mut self, session_id: &str) -> PtyTermination {
+    fn prepare_for_teardown(&mut self) {
         self.reader_stop.store(true, Ordering::Release);
-        if let Some(input) = self.input.take() {
-            input.finish();
+        if let Some(input) = self.input.as_mut() {
+            input.request_stop();
         }
-        let termination = PtyTermination {
-            session_id: SessionId::new(session_id),
-            child: self.child.take(),
-            process_group: self.process_group.take(),
-            master: self.master.take(),
-            reader: self.reader.take(),
-            next_cursor: self.next_sequence.saturating_sub(1),
-            dropped_chunks: self.reader_dropped.load(Ordering::Acquire),
-        };
-        self.status = ClaudePtyStatus::Closed;
-        termination
     }
 
-    fn close(&mut self) {
-        if self.status == ClaudePtyStatus::Closed {
-            return;
+    fn finish_resource_handles(&mut self) -> bool {
+        self.prepare_for_teardown();
+        if self
+            .input
+            .as_mut()
+            .is_some_and(|input| input.join_if_finished())
+        {
+            self.input.take();
         }
-        self.reader_stop.store(true, Ordering::Release);
-        let input = self.input.take();
-        if !self.foreground_is_owned() {
-            eprintln!("relay Claude PTY teardown refused an unowned foreground group");
-            if let Some(input) = input {
-                input.finish();
+        if self.reader.as_ref().is_some_and(JoinHandle::is_finished) {
+            if let Some(reader) = self.reader.take() {
+                let _ = reader.join();
             }
-            return;
         }
-        let process_group = self.process_group.take();
-        if let Some(input) = input {
-            input.finish();
+        self.input.is_none() && self.reader.is_none()
+    }
+
+    fn release_after_reap(&mut self) -> (u64, u64) {
+        debug_assert!(self.child_reaped);
+        debug_assert!(self.input.is_none());
+        debug_assert!(self.reader.is_none());
+        self.child.take();
+        self.master.take();
+        self.process_group.take();
+        self.pump();
+        self.flush_pending_output();
+        self.status = ClaudePtyStatus::Closed;
+        (
+            self.next_sequence.saturating_sub(1),
+            self.reader_dropped.load(Ordering::Acquire),
+        )
+    }
+}
+
+#[cfg(test)]
+impl Drop for ManagedSession {
+    fn drop(&mut self) {
+        // Test fixtures must not leave live PTY children behind for later
+        // process-group cases. Production has no destructor teardown path:
+        // every outcome must return through the explicit state machine.
+        self.reader_stop.store(true, Ordering::Release);
+        if let Some(input) = self.input.as_mut() {
+            input.request_stop();
         }
-        if let Some(child) = self.child.take() {
-            let _ = terminate_child(child, process_group.as_ref());
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            reap_child(child);
         }
         self.master.take();
-        drop(process_group);
+        self.process_group.take();
         if let Some(reader) = self.reader.take() {
-            // The reader owns a cloned master FD and can only observe EOF after
-            // every slave closes. Do not let an unexpected kernel/driver stall
-            // hold the global runtime mutex during close or owner revocation.
             if reader.is_finished() {
                 let _ = reader.join();
             }
         }
-        self.pump();
-        self.flush_pending_output();
-        self.status = ClaudePtyStatus::Closed;
-    }
-}
-
-impl Drop for ManagedSession {
-    fn drop(&mut self) {
-        self.close();
     }
 }
 
 impl PtyTermination {
-    fn startup_failure(
-        session_id: SessionId,
-        child: Box<dyn Child + Send + Sync>,
-        process_group: Option<PtyOwnership>,
-        master: Box<dyn MasterPty + Send>,
-    ) -> Self {
-        Self {
-            session_id,
-            child: Some(child),
-            process_group,
-            master: Some(master),
-            reader: None,
-            next_cursor: 0,
-            dropped_chunks: 0,
-        }
-    }
-
-    /// Finish the bounded teardown after the caller has released the runtime
-    /// mutex. A terminal signalling failure is returned rather than pretending
-    /// that an unverified foreground descendant was reaped.
-    pub fn finish(mut self) -> Result<TerminalSnapshot, ClaudePtyError> {
-        self.finish_inner()?;
-        Ok(TerminalSnapshot {
-            session_id: self.session_id.clone(),
-            status: ClaudePtyStatus::Closed,
-            output: Vec::new(),
-            next_cursor: self.next_cursor,
-            has_more: false,
-            truncated: false,
-            dropped_chunks: self.dropped_chunks,
-        })
-    }
-
-    fn finish_inner(&mut self) -> Result<(), ClaudePtyError> {
-        let result = match self.child.take() {
-            Some(child) => terminate_child(child, self.process_group.as_ref()),
-            None => Ok(()),
-        };
-        self.master.take();
-        self.process_group.take();
-        if let Some(reader) = self.reader.take() {
-            // The reader owns a cloned master FD. It may still be blocked in a
-            // driver read, so joining remains opportunistic outside the mutex.
-            if reader.is_finished() {
-                let _ = reader.join();
+    /// Finish one bounded, outside-lock lease. All failure paths return `self`
+    /// with its complete original resource bundle still attached.
+    pub fn finish(self) -> PtyTerminationOutcome {
+        let failure = {
+            let mut session = lock_shared_session(&self.session);
+            session.prepare_for_teardown();
+            if !session.child_reaped {
+                let result = if session.process_group.is_none()
+                    && self.causes & CloseCause::Startup as u8 != 0
+                {
+                    terminate_startup_child(&mut session)
+                } else if !session.foreground_is_owned() {
+                    Err(PtyTeardownFailure::Ownership)
+                } else {
+                    let ManagedSession {
+                        child,
+                        process_group,
+                        ..
+                    } = &mut *session;
+                    match (child.as_deref_mut(), process_group.as_ref()) {
+                        (Some(child), Some(ownership)) => terminate_child(child, ownership),
+                        _ => Err(PtyTeardownFailure::Ownership),
+                    }
+                };
+                if let Err(failure) = result {
+                    Some(failure)
+                } else {
+                    session.child_reaped = true;
+                    None
+                }
+            } else {
+                None
             }
+        };
+        if let Some(failure) = failure {
+            return PtyTerminationOutcome {
+                result: PtyTerminationResult::Retry {
+                    termination: self,
+                    failure,
+                },
+            };
         }
-        result
+        let handles_finished = lock_shared_session(&self.session).finish_resource_handles();
+        if !handles_finished {
+            return PtyTerminationOutcome {
+                result: PtyTerminationResult::Retry {
+                    termination: self,
+                    failure: PtyTeardownFailure::ResourceHandlesPending,
+                },
+            };
+        }
+        PtyTerminationOutcome {
+            result: PtyTerminationResult::Closed(self),
+        }
     }
 }
 
-impl Drop for PtyTermination {
-    fn drop(&mut self) {
-        let _ = self.finish_inner();
+fn lock_shared_session(session: &SharedSession) -> std::sync::MutexGuard<'_, ManagedSession> {
+    session
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn session_snapshot(session: &ManagedSession, session_id: &str, cursor: u64) -> TerminalSnapshot {
+    let first_sequence = session
+        .output
+        .front()
+        .map_or(session.next_sequence, |chunk| chunk.sequence);
+    let truncated = cursor.saturating_add(1) < first_sequence;
+    let mut output = Vec::new();
+    let mut output_bytes: usize = 0;
+    let mut next_cursor = cursor;
+    let mut has_more = false;
+    for chunk in session
+        .output
+        .iter()
+        .filter(|chunk| chunk.sequence > cursor)
+    {
+        if !output.is_empty() && output_bytes.saturating_add(chunk.bytes) > PTY_DELIVERY_BYTES {
+            has_more = true;
+            break;
+        }
+        output_bytes = output_bytes.saturating_add(chunk.bytes);
+        next_cursor = chunk.sequence;
+        output.push(TerminalOutput {
+            sequence: chunk.sequence,
+            text: chunk.text.clone(),
+        });
     }
+    TerminalSnapshot {
+        session_id: SessionId::new(session_id),
+        status: session.status,
+        output,
+        next_cursor,
+        has_more,
+        truncated,
+        dropped_chunks: session.reader_dropped.load(Ordering::Acquire),
+    }
+}
+
+fn terminal_snapshot(
+    session_id: &str,
+    status: ClaudePtyStatus,
+    next_cursor: u64,
+    dropped_chunks: u64,
+) -> TerminalSnapshot {
+    TerminalSnapshot {
+        session_id: SessionId::new(session_id),
+        status,
+        output: Vec::new(),
+        next_cursor,
+        has_more: false,
+        truncated: false,
+        dropped_chunks,
+    }
+}
+
+fn closing_snapshot(
+    session_id: &str,
+    owner_device_id: &str,
+    record_owner_device_id: &str,
+) -> Result<TerminalSnapshot, ClaudePtyError> {
+    if record_owner_device_id != owner_device_id {
+        return Err(ClaudePtyError::Forbidden);
+    }
+    Ok(terminal_snapshot(
+        session_id,
+        ClaudePtyStatus::Closing,
+        0,
+        0,
+    ))
 }
 
 fn default_size() -> PtySize {
@@ -1103,10 +1719,10 @@ fn spawn_input_writer(ownership: &PtyOwnership) -> Result<PtyInput, ClaudePtyErr
             })
             .map_err(|_| ClaudePtyError::Transport)?;
         Ok(PtyInput {
-            sender,
+            sender: Some(sender),
             stop,
             delivery_failed,
-            worker,
+            worker: Some(worker),
         })
     }
     #[cfg(not(target_os = "linux"))]
@@ -1167,33 +1783,48 @@ fn foreground_identity(writer: &FileDescriptor) -> ForegroundIdentity {
 
 #[cfg(target_os = "linux")]
 impl PtyOwnership {
-    fn foreground_is_owned(&self) -> bool {
+    fn foreground_identity(&self) -> ForegroundIdentity {
         #[cfg(test)]
-        let identity = self
-            .foreground_override
-            .unwrap_or_else(|| foreground_identity(&self.writer));
+        {
+            self.foreground_override
+                .unwrap_or_else(|| foreground_identity(&self.writer))
+        }
         #[cfg(not(test))]
-        let identity = foreground_identity(&self.writer);
-        match identity {
+        {
+            foreground_identity(&self.writer)
+        }
+    }
+
+    fn foreground_is_owned(&self) -> bool {
+        match self.foreground_identity() {
             ForegroundIdentity::NoForegroundGroup => true,
             ForegroundIdentity::ProcessGroup(process_group) => process_group == self.process_group,
             ForegroundIdentity::Unavailable => false,
         }
     }
 
-    fn signal_groups(&self, signal: Signal) -> Result<(), ClaudePtyError> {
+    fn signal_groups(&self, signal: Signal) -> Result<(), PtyTeardownFailure> {
         // Relay holds a lifetime-safe identity only for the original group: its
         // direct leader remains unreaped until teardown finishes. A PTY
         // foreground group can outlive its leader, so never convert the numeric
         // `tcgetpgrp` result into `killpg`. Refuse the close instead of risking
         // an unrelated/reused group or claiming to have reaped an unowned one.
         if !self.foreground_is_owned() {
-            return Err(ClaudePtyError::Transport);
+            return Err(PtyTeardownFailure::Ownership);
         }
         // The direct child remains unreaped until this teardown completes, so
         // this numeric group identifier remains Relay-owned and identity-safe.
-        let _ = killpg(Pid::from_raw(self.process_group), signal);
-        Ok(())
+        #[cfg(test)]
+        if self.signal_error == Some(signal) {
+            return Err(match signal {
+                Signal::SIGTERM => PtyTeardownFailure::TermSignal,
+                _ => PtyTeardownFailure::KillSignal,
+            });
+        }
+        killpg(Pid::from_raw(self.process_group), signal).map_err(|_| match signal {
+            Signal::SIGTERM => PtyTeardownFailure::TermSignal,
+            _ => PtyTeardownFailure::KillSignal,
+        })
     }
 }
 
@@ -1215,6 +1846,8 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
             writer,
             #[cfg(test)]
             foreground_override: None,
+            #[cfg(test)]
+            signal_error: None,
         })
     }
     #[cfg(not(target_os = "linux"))]
@@ -1225,23 +1858,48 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
 }
 
 fn terminate_child(
-    mut child: Box<dyn Child + Send + Sync>,
-    ownership: Option<&PtyOwnership>,
-) -> Result<(), ClaudePtyError> {
-    let result = {
-        #[cfg(target_os = "linux")]
-        {
-            if let Some(ownership) = ownership {
-                ownership.signal_groups(Signal::SIGTERM)?;
-                thread::sleep(PTY_TERMINATION_GRACE);
-                ownership.signal_groups(Signal::SIGKILL)?;
-            }
-            Ok(())
-        }
-    };
-    let _ = child.kill();
-    reap_child(child);
-    result
+    child: &mut dyn Child,
+    ownership: &PtyOwnership,
+) -> Result<(), PtyTeardownFailure> {
+    #[cfg(target_os = "linux")]
+    {
+        // Both checks are fail-closed and target only the original verified
+        // Relay-owned group. There is deliberately no numeric foreground or
+        // direct-child fallback once that identity becomes unavailable.
+        ownership.signal_groups(Signal::SIGTERM)?;
+        thread::sleep(PTY_TERMINATION_GRACE);
+        ownership.signal_groups(Signal::SIGKILL)?;
+    }
+    match reap_child_until(
+        child,
+        Instant::now() + PTY_REAPER_DEADLINE,
+        PTY_REAPER_MAX_ATTEMPTS,
+        PTY_REAPER_POLL_INTERVAL,
+    ) {
+        ReapDisposition::Reaped => Ok(()),
+        ReapDisposition::Deadline => Err(PtyTeardownFailure::ReapDeadline),
+        ReapDisposition::AttemptsExhausted => Err(PtyTeardownFailure::ReapAttemptsExhausted),
+        ReapDisposition::TryWaitError => Err(PtyTeardownFailure::TryWait),
+    }
+}
+
+fn terminate_startup_child(session: &mut ManagedSession) -> Result<(), PtyTeardownFailure> {
+    let child = session
+        .child
+        .as_deref_mut()
+        .ok_or(PtyTeardownFailure::Ownership)?;
+    child.kill().map_err(|_| PtyTeardownFailure::KillSignal)?;
+    match reap_child_until(
+        child,
+        Instant::now() + PTY_REAPER_DEADLINE,
+        PTY_REAPER_MAX_ATTEMPTS,
+        PTY_REAPER_POLL_INTERVAL,
+    ) {
+        ReapDisposition::Reaped => Ok(()),
+        ReapDisposition::Deadline => Err(PtyTeardownFailure::ReapDeadline),
+        ReapDisposition::AttemptsExhausted => Err(PtyTeardownFailure::ReapAttemptsExhausted),
+        ReapDisposition::TryWaitError => Err(PtyTeardownFailure::TryWait),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1252,6 +1910,7 @@ enum ReapDisposition {
     TryWaitError,
 }
 
+#[cfg(test)]
 fn reap_child(mut child: Box<dyn Child + Send + Sync>) {
     let _ = thread::Builder::new()
         .name("relay-claude-pty-reaper".into())
@@ -1529,16 +2188,495 @@ mod tests {
         let session = runtime.create("device-a").unwrap();
 
         let started = Instant::now();
-        let termination = runtime.begin_close(session.as_str(), "device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
         assert!(
             started.elapsed() < Duration::from_millis(50),
-            "the runtime lock path must remove the Session before TERM grace"
+            "the runtime lock path must transition the Session before TERM grace"
         );
         assert!(!runtime.sessions.contains_key(session.as_str()));
+        assert!(runtime.closing.contains_key(session.as_str()));
+        runtime.finish_due_terminations();
         assert_eq!(
-            termination.finish().unwrap().status,
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
             ClaudePtyStatus::Closed
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn post_lease_unavailable_foreground_retains_the_bundle_for_retry() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &["-c", "trap '' TERM; while :; do sleep 1; done"],
+        );
+        let session = runtime.create("device-a").unwrap();
+
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        runtime.set_test_foreground_identity(session.as_str(), ForegroundIdentity::Unavailable);
+        runtime.finish_due_terminations();
+
+        {
+            let closing = &runtime.closing[session.as_str()];
+            let bundle = lock_shared_session(&closing.session);
+            assert!(bundle.child.is_some(), "retry retains the direct child");
+            assert!(
+                bundle.process_group.is_some(),
+                "retry retains original PGID identity"
+            );
+            assert!(bundle.master.is_some(), "retry retains the PTY master");
+            assert!(bundle.reader.is_some(), "retry retains the reader handle");
+            assert!(bundle.input.is_some(), "retry retains stopped writer state");
+            assert!(
+                bundle
+                    .input
+                    .as_ref()
+                    .is_some_and(|input| input.worker.is_some()),
+                "retry retains the writer join handle"
+            );
+        }
+
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closing,
+            "an outside-lock ownership failure must leave a truthful retryable record"
+        );
+        assert_eq!(
+            runtime.input(session.as_str(), "device-a", "ignored\n"),
+            Err(ClaudePtyError::StaleHandle),
+            "closing disables controls without releasing the owned bundle"
+        );
+
+        runtime
+            .set_test_foreground_identity(session.as_str(), ForegroundIdentity::NoForegroundGroup);
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed,
+            "a later verified attempt must reap the original retained child"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn signal_failure_is_typed_and_retains_the_exact_bundle() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        runtime.set_test_signal_error(session.as_str(), Some(Signal::SIGTERM));
+
+        runtime.finish_due_terminations();
+
+        assert_eq!(
+            runtime
+                .teardown_failure(session.as_str(), "device-a")
+                .unwrap(),
+            Some((PtyTeardownFailure::TermSignal, 1))
+        );
+        let closing = &runtime.closing[session.as_str()];
+        let bundle = lock_shared_session(&closing.session);
+        assert!(bundle.child.is_some());
+        assert!(bundle.process_group.is_some());
+        assert!(bundle.master.is_some());
+        assert!(bundle.reader.is_some());
+        assert!(
+            bundle
+                .input
+                .as_ref()
+                .is_some_and(|input| input.worker.is_some())
+        );
+        drop(bundle);
+
+        runtime.set_test_signal_error(session.as_str(), None);
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed
+        );
+    }
+
+    #[test]
+    fn dropped_lease_is_recovered_without_losing_or_duplicating_capacity() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        let generation = runtime.closing[session.as_str()].generation;
+        let lease = runtime.claim_due_terminations().pop().unwrap();
+        assert_eq!(
+            Arc::strong_count(&runtime.signalling[session.as_str()].session),
+            2
+        );
+
+        drop(lease);
+        assert!(runtime.claim_due_terminations().is_empty());
+
+        assert!(runtime.signalling.is_empty());
+        let closing = &runtime.closing[session.as_str()];
+        assert_eq!(closing.generation, generation);
+        assert_eq!(closing.attempts, 1);
+        assert_eq!(
+            closing.last_failure,
+            Some(PtyTeardownFailure::LeaseMismatch)
+        );
+        assert_eq!(Arc::strong_count(&closing.session), 1);
+        assert_eq!(runtime.capacity_consumed(), 1);
+    }
+
+    #[test]
+    fn mismatched_completion_quarantines_the_original_keyed_record_once() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        let mut lease = runtime.claim_due_terminations().pop().unwrap();
+        let original_generation = lease.generation;
+        let original_attempt = lease.attempt;
+        lease.generation = lease.generation.saturating_add(99);
+
+        runtime.complete_termination(PtyTerminationOutcome {
+            result: PtyTerminationResult::Retry {
+                termination: lease,
+                failure: PtyTeardownFailure::Ownership,
+            },
+        });
+
+        assert!(runtime.signalling.is_empty());
+        assert_eq!(runtime.capacity_consumed(), 1);
+        let failure = &runtime.terminal_failures[session.as_str()].closing;
+        assert_eq!(failure.generation, original_generation);
+        assert_eq!(failure.attempts, original_attempt);
+        assert_eq!(
+            failure.last_failure,
+            Some(PtyTeardownFailure::LeaseMismatch)
+        );
+
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-b").unwrap();
+        runtime.request_close(session.as_str(), "device-b").unwrap();
+        let mut lease = runtime.claim_due_terminations().pop().unwrap();
+        lease.session_id = SessionId::new("wrong-key");
+        runtime.complete_termination(PtyTerminationOutcome {
+            result: PtyTerminationResult::Retry {
+                termination: lease,
+                failure: PtyTeardownFailure::Ownership,
+            },
+        });
+        assert!(runtime.signalling.is_empty());
+        assert_eq!(runtime.capacity_consumed(), 1);
+        assert!(runtime.terminal_failures.contains_key(session.as_str()));
+        assert!(!runtime.terminal_failures.contains_key("wrong-key"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn close_causes_coalesce_without_resetting_attempt_or_backoff() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        runtime.set_test_foreground_identity(session.as_str(), ForegroundIdentity::Unavailable);
+        let lease = runtime.claim_due_terminations().pop().unwrap();
+        runtime.begin_owner_session_closes("device-a");
+        assert_ne!(
+            runtime.signalling[session.as_str()].causes & CloseCause::OwnerInvalidated as u8,
+            0,
+            "an invalidation coalesces while the exclusive lease is outside the mutex"
+        );
+        runtime.complete_termination(lease.finish());
+        let first_not_before = runtime.closing[session.as_str()].not_before;
+        assert!(first_not_before >= Instant::now());
+
+        runtime.begin_owner_session_closes("device-a");
+        let closing = &runtime.closing[session.as_str()];
+        assert_eq!(closing.attempts, 1);
+        assert_ne!(closing.causes & CloseCause::Explicit as u8, 0);
+        assert_ne!(closing.causes & CloseCause::OwnerInvalidated as u8, 0);
+
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+        let closing = &runtime.closing[session.as_str()];
+        assert_eq!(closing.attempts, 2);
+        assert!(closing.not_before >= Instant::now() + Duration::from_millis(200));
+    }
+
+    #[test]
+    fn shutdown_latches_admission_and_closed_truth_is_bounded() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        assert_eq!(
+            runtime.begin_shutdown(),
+            OwnerSessionCloseDisposition::Retry
+        );
+        assert_eq!(
+            runtime.begin_create("device-a").into_result(),
+            Err(ClaudePtyError::Unavailable)
+        );
+        runtime.finish_due_terminations();
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed
+        );
+        assert_eq!(
+            runtime.shutdown_disposition(),
+            OwnerSessionCloseDisposition::Complete
+        );
+
+        for index in 0..=MAX_CLOSED_PTY_SESSIONS {
+            runtime.insert_closed(
+                format!("closed-{index}"),
+                ClosedSession {
+                    owner_device_id: "device-a".into(),
+                    next_cursor: 0,
+                    dropped_chunks: 0,
+                    order: 0,
+                },
+            );
+        }
+        assert_eq!(runtime.closed.len(), MAX_CLOSED_PTY_SESSIONS);
+        assert!(!runtime.closed.contains_key("closed-0"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn persistent_reap_errors_exhaust_retries_without_freeing_capacity() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        let attempts = Arc::new(AtomicU64::new(0));
+
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        runtime
+            .set_test_foreground_identity(session.as_str(), ForegroundIdentity::NoForegroundGroup);
+        runtime.replace_test_closing_child(
+            session.as_str(),
+            Box::new(ErrorChild {
+                attempts: Arc::clone(&attempts),
+            }),
+        );
+        for _ in 0..PTY_CLOSE_ATTEMPTS {
+            runtime.force_due_terminations_for_test();
+            runtime.finish_due_terminations();
+        }
+
+        assert_eq!(attempts.load(Ordering::Acquire), PTY_CLOSE_ATTEMPTS as u64);
+        assert!(runtime.terminal_failures.contains_key(session.as_str()));
+        assert_eq!(runtime.capacity_consumed(), 1);
+        assert_eq!(
+            runtime.poll(session.as_str(), "device-a", 0),
+            Err(ClaudePtyError::TeardownFailed),
+            "retry exhaustion must not lie with a Closed result"
+        );
+        assert_eq!(
+            runtime.owner_close_disposition("device-a"),
+            OwnerSessionCloseDisposition::Retry,
+            "terminal teardown failure must prevent auth invalidation acknowledgement"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn reap_deadline_remains_retryable_with_child_and_identity_retained() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        runtime
+            .set_test_foreground_identity(session.as_str(), ForegroundIdentity::NoForegroundGroup);
+        runtime.replace_test_closing_child(
+            session.as_str(),
+            Box::new(BlockingChild {
+                release: Arc::new(AtomicBool::new(false)),
+                poll_started: Arc::new(AtomicBool::new(false)),
+                reaped: Arc::new(AtomicBool::new(false)),
+            }),
+        );
+
+        runtime.finish_due_terminations();
+
+        let failure = runtime
+            .teardown_failure(session.as_str(), "device-a")
+            .unwrap()
+            .expect("bounded reap reports a retry reason");
+        assert!(matches!(
+            failure.0,
+            PtyTeardownFailure::ReapDeadline | PtyTeardownFailure::ReapAttemptsExhausted
+        ));
+        let bundle = lock_shared_session(&runtime.closing[session.as_str()].session);
+        assert!(bundle.child.is_some());
+        assert!(bundle.process_group.is_some());
+        assert!(!bundle.child_reaped);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn reaped_child_waits_for_reader_without_re_signalling() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        runtime.request_close(session.as_str(), "device-a").unwrap();
+        {
+            let shared = Arc::clone(&runtime.closing[session.as_str()].session);
+            let mut bundle = lock_shared_session(&shared);
+            bundle.reader.take();
+            bundle.reader = Some(thread::spawn(|| thread::sleep(Duration::from_millis(500))));
+        }
+
+        runtime.finish_due_terminations();
+        {
+            let closing = &runtime.closing[session.as_str()];
+            assert_eq!(
+                closing.last_failure,
+                Some(PtyTeardownFailure::ResourceHandlesPending)
+            );
+            assert!(lock_shared_session(&closing.session).child_reaped);
+        }
+        runtime.set_test_signal_error(session.as_str(), Some(Signal::SIGTERM));
+        thread::sleep(Duration::from_millis(300));
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn failed_prune_consumes_full_capacity_until_retry_succeeds() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let sessions = (0..MAX_PTY_SESSIONS)
+            .map(|_| runtime.create("device-a").unwrap())
+            .collect::<Vec<_>>();
+        let exited = sessions[0].as_str();
+        runtime.sessions.get_mut(exited).unwrap().status = ClaudePtyStatus::Exited;
+        runtime.set_test_foreground_identity(exited, ForegroundIdentity::Unavailable);
+
+        assert_eq!(
+            runtime.begin_create("device-a").into_result(),
+            Err(ClaudePtyError::Capacity)
+        );
+        runtime.finish_due_terminations();
+        assert_eq!(runtime.capacity_consumed(), MAX_PTY_SESSIONS);
+        assert_eq!(
+            runtime.begin_create("device-a").into_result(),
+            Err(ClaudePtyError::Capacity),
+            "failed prune must not open an admission slot"
+        );
+
+        runtime.set_test_foreground_identity(exited, ForegroundIdentity::NoForegroundGroup);
+        for _ in 0..2 {
+            runtime.force_due_terminations_for_test();
+            runtime.finish_due_terminations();
+        }
+        assert!(runtime.begin_create("device-a").into_result().is_ok());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn partial_startup_bundle_uses_the_same_retryable_owner() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        let mut managed = runtime.sessions.remove(session.as_str()).unwrap();
+        managed.reader_stop.store(true, Ordering::Release);
+        managed.reader.take();
+        runtime.register_startup_failure(
+            session.clone(),
+            "device-a",
+            managed.child.take().unwrap(),
+            managed.process_group.take(),
+            managed.master.take().unwrap(),
+            managed.input.take(),
+        );
+        runtime.set_test_signal_error(session.as_str(), Some(Signal::SIGTERM));
+
+        runtime.finish_due_terminations();
+
+        assert!(
+            runtime.sessions.is_empty(),
+            "partial startup exposes no active handle"
+        );
+        assert_eq!(runtime.capacity_consumed(), 1);
+        assert_eq!(
+            runtime
+                .teardown_failure(session.as_str(), "device-a")
+                .unwrap(),
+            Some((PtyTeardownFailure::TermSignal, 1))
+        );
+        let bundle = lock_shared_session(&runtime.closing[session.as_str()].session);
+        assert!(bundle.child.is_some());
+        assert!(bundle.master.is_some());
+        assert!(bundle.process_group.is_some());
+        drop(bundle);
+
+        runtime.set_test_signal_error(session.as_str(), None);
+        for _ in 0..2 {
+            runtime.force_due_terminations_for_test();
+            runtime.finish_due_terminations();
+        }
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed
+        );
+        assert_eq!(runtime.capacity_consumed(), 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn startup_without_a_process_group_kills_and_reaps_the_direct_child() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "exec sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        let mut managed = runtime.sessions.remove(session.as_str()).unwrap();
+        managed.reader_stop.store(true, Ordering::Release);
+        managed.reader.take();
+        managed.process_group.take();
+        runtime.register_startup_failure(
+            session.clone(),
+            "device-a",
+            managed.child.take().unwrap(),
+            None,
+            managed.master.take().unwrap(),
+            managed.input.take(),
+        );
+
+        for _ in 0..PTY_CLOSE_ATTEMPTS {
+            runtime.force_due_terminations_for_test();
+            runtime.finish_due_terminations();
+            if runtime.closed.contains_key(session.as_str()) {
+                break;
+            }
+        }
+
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed
+        );
+        assert_eq!(runtime.capacity_consumed(), 0);
+        assert!(!runtime.has_terminal_failures());
     }
 
     #[test]
@@ -1548,16 +2686,14 @@ mod tests {
         runtime.sessions.get_mut(exited.as_str()).unwrap().status = ClaudePtyStatus::Exited;
 
         let started = Instant::now();
-        let (result, terminations) = runtime.begin_create("device-a").into_parts();
+        let result = runtime.begin_create("device-a").into_result();
         assert!(
             started.elapsed() < Duration::from_millis(50),
             "automatic pruning must detach TERM/KILL grace before the caller releases its runtime mutex"
         );
 
         let replacement = result.unwrap();
-        for termination in terminations {
-            termination.finish().unwrap();
-        }
+        runtime.finish_due_terminations();
 
         runtime.close(replacement.as_str(), "device-a").unwrap();
     }
@@ -1585,22 +2721,24 @@ mod tests {
             .foreground_override = Some(ForegroundIdentity::Unavailable);
 
         assert_eq!(
-            runtime.close(session.as_str(), "device-a"),
-            Err(ClaudePtyError::Transport),
-            "missing foreground identity must refuse teardown instead of issuing killpg"
+            runtime.close(session.as_str(), "device-a").unwrap().status,
+            ClaudePtyStatus::Closing,
+            "missing foreground identity must leave the child retryable instead of issuing killpg"
         );
-        assert!(runtime.sessions.contains_key(session.as_str()));
+        assert!(runtime.closing.contains_key(session.as_str()));
 
         let _ = killpg(Pid::from_raw(process_group), Signal::SIGKILL);
-        if let Some(child) = runtime
-            .sessions
-            .get_mut(session.as_str())
-            .unwrap()
-            .child
-            .take()
-        {
-            reap_child(child);
-        }
+        runtime
+            .set_test_foreground_identity(session.as_str(), ForegroundIdentity::NoForegroundGroup);
+        runtime.force_due_terminations_for_test();
+        runtime.finish_due_terminations();
+        assert_eq!(
+            runtime
+                .poll(session.as_str(), "device-a", 0)
+                .unwrap()
+                .status,
+            ClaudePtyStatus::Closed
+        );
     }
 
     #[test]
@@ -2023,16 +3161,15 @@ mod tests {
         assert!(runtime.sessions[session.as_str()].foreign_foreground_seen);
         let closures = runtime.begin_owner_session_closes("device-a");
         assert_eq!(closures.disposition, OwnerSessionCloseDisposition::Retry);
-        assert!(closures.terminations.is_empty());
-        assert!(runtime.sessions.contains_key(session.as_str()));
+        assert!(runtime.closing.contains_key(session.as_str()));
         assert_eq!(
-            runtime.close(session.as_str(), "device-a"),
-            Err(ClaudePtyError::Transport)
+            runtime.close(session.as_str(), "device-a").unwrap().status,
+            ClaudePtyStatus::Closing
         );
-        assert!(runtime.sessions.contains_key(session.as_str()));
+        assert!(runtime.closing.contains_key(session.as_str()));
         runtime.prune_finished_sessions();
         assert!(
-            runtime.sessions.contains_key(session.as_str()),
+            runtime.closing.contains_key(session.as_str()),
             "automatic cleanup must preserve an unsafe terminal record instead of dropping it"
         );
 

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, TrySendError};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[cfg(target_os = "linux")]
 use filedescriptor::FileDescriptor;
@@ -25,12 +25,6 @@ use nix::{
     unistd::{Pid, getpgid, getsid},
 };
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
-#[cfg(target_os = "linux")]
-use rustix::{
-    event::{PollFd, PollFlags, Timespec, poll},
-    fd::OwnedFd,
-    process::{Pid as LinuxPid, PidfdFlags, pidfd_open},
-};
 #[cfg(target_os = "linux")]
 use std::os::fd::{AsRawFd, RawFd};
 
@@ -76,6 +70,8 @@ const MIN_COLS: u16 = 20;
 const MAX_COLS: u16 = 500;
 const PTY_TERMINATION_GRACE: Duration = Duration::from_millis(250);
 const PTY_REAPER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const PTY_REAPER_DEADLINE: Duration = Duration::from_secs(1);
+const PTY_REAPER_MAX_ATTEMPTS: usize = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeOwnerContext {
@@ -255,24 +251,6 @@ impl AsRawFd for MasterFd {
     }
 }
 
-#[cfg(target_os = "linux")]
-struct PtyForegroundGroup {
-    process_group: i32,
-    leader_pidfd: OwnedFd,
-}
-
-#[cfg(target_os = "linux")]
-impl PtyForegroundGroup {
-    fn is_live(&self) -> bool {
-        let mut fds = [PollFd::new(&self.leader_pidfd, PollFlags::IN)];
-        poll(&mut fds, Some(&Timespec::default())).is_ok_and(|ready| ready == 0)
-    }
-
-    fn is_signalable(&self) -> bool {
-        self.is_live()
-    }
-}
-
 #[cfg(not(target_os = "linux"))]
 struct PtyOwnership {
     process_group: i32,
@@ -295,6 +273,20 @@ struct ManagedSession {
     next_sequence: u64,
     pending_utf8: Vec<u8>,
     terminal_seen: bool,
+    foreign_foreground_seen: bool,
+}
+
+/// A session removed from the runtime mutex before its bounded termination
+/// grace begins. The hub finishes this outside the runtime lock so one slow
+/// close cannot serialize unrelated terminal control requests.
+pub struct PtyTermination {
+    session_id: SessionId,
+    child: Option<Box<dyn Child + Send + Sync>>,
+    process_group: Option<PtyOwnership>,
+    master: Option<Box<dyn MasterPty + Send>>,
+    reader: Option<JoinHandle<()>>,
+    next_cursor: u64,
+    dropped_chunks: u64,
 }
 
 /// The node-local source of truth for Relay-owned Claude PTY Session handles.
@@ -400,7 +392,7 @@ impl NodePtyRuntime {
         let reader = match pair.master.try_clone_reader() {
             Ok(reader) => reader,
             Err(_) => {
-                terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
+                let _ = terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
                 return Err(ClaudePtyError::Transport);
             }
         };
@@ -411,7 +403,7 @@ impl NodePtyRuntime {
         {
             Ok(input) => input,
             Err(error) => {
-                terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
+                let _ = terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
                 return Err(error);
             }
         };
@@ -429,7 +421,7 @@ impl NodePtyRuntime {
             Ok(reader_thread) => reader_thread,
             Err(error) => {
                 input.finish();
-                terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
+                let _ = terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
                 return Err(error);
             }
         };
@@ -455,6 +447,7 @@ impl NodePtyRuntime {
                 next_sequence: 1,
                 pending_utf8: Vec::new(),
                 terminal_seen: false,
+                foreign_foreground_seen: false,
             },
         );
         Ok(SessionId::new(id))
@@ -566,17 +559,32 @@ impl NodePtyRuntime {
         session_id: &str,
         owner_device_id: &str,
     ) -> Result<TerminalSnapshot, ClaudePtyError> {
-        let session = self.session_mut(session_id, owner_device_id)?;
-        session.close();
-        Ok(TerminalSnapshot {
-            session_id: SessionId::new(session_id),
-            status: session.status,
-            output: Vec::new(),
-            next_cursor: session.next_sequence.saturating_sub(1),
-            has_more: false,
-            truncated: false,
-            dropped_chunks: session.reader_dropped.load(Ordering::Acquire),
-        })
+        self.begin_close(session_id, owner_device_id)?.finish()
+    }
+
+    /// Remove a Session under the runtime lock, then let the caller finish its
+    /// bounded TERM/KILL teardown without serializing other terminal controls.
+    pub fn begin_close(
+        &mut self,
+        session_id: &str,
+        owner_device_id: &str,
+    ) -> Result<PtyTermination, ClaudePtyError> {
+        let session = self
+            .sessions
+            .get_mut(session_id)
+            .ok_or(ClaudePtyError::StaleHandle)?;
+        if session.owner_device_id != owner_device_id {
+            return Err(ClaudePtyError::Forbidden);
+        }
+        session.pump();
+        if !session.foreground_is_owned() {
+            return Err(ClaudePtyError::Transport);
+        }
+        let session = self
+            .sessions
+            .remove(session_id)
+            .expect("checked session remains present until this mutable operation");
+        Ok(session.into_termination(session_id))
     }
 
     fn session_mut(
@@ -601,10 +609,11 @@ impl NodePtyRuntime {
     fn prune_finished_sessions(&mut self) {
         self.sessions.retain(|_, session| {
             session.pump();
-            !matches!(
-                session.status,
-                ClaudePtyStatus::Closed | ClaudePtyStatus::Exited
-            )
+            !session.foreground_is_owned()
+                || !matches!(
+                    session.status,
+                    ClaudePtyStatus::Closed | ClaudePtyStatus::Exited
+                )
         });
     }
 
@@ -612,15 +621,36 @@ impl NodePtyRuntime {
     /// session is revoked. The opaque browser session token never crosses the
     /// auth boundary; this runtime only receives its already-authenticated
     /// device identity.
+    pub fn begin_owner_session_closes(&mut self, owner_device_id: &str) -> Vec<PtyTermination> {
+        let session_ids = self
+            .sessions
+            .iter()
+            .filter(|(_, session)| session.owner_device_id == owner_device_id)
+            .map(|(session_id, _)| session_id.clone())
+            .collect::<Vec<_>>();
+        session_ids
+            .into_iter()
+            .filter_map(|session_id| {
+                let session = self
+                    .sessions
+                    .get_mut(&session_id)
+                    .expect("collected session remains present until this mutable operation");
+                session.pump();
+                if !session.foreground_is_owned() {
+                    eprintln!("relay Claude PTY teardown refused an unowned foreground group");
+                    return None;
+                }
+                self.sessions
+                    .remove(&session_id)
+                    .map(|session| session.into_termination(&session_id))
+            })
+            .collect()
+    }
+
     pub fn close_owner_sessions(&mut self, owner_device_id: &str) {
-        self.sessions.retain(|_, session| {
-            if session.owner_device_id == owner_device_id {
-                session.close();
-                false
-            } else {
-                true
-            }
-        });
+        for termination in self.begin_owner_session_closes(owner_device_id) {
+            let _ = termination.finish();
+        }
     }
 
     #[cfg(test)]
@@ -648,6 +678,7 @@ impl NodePtyRuntime {
 
 impl ManagedSession {
     fn pump(&mut self) {
+        self.observe_foreground_group();
         while let Ok(ReaderEvent::Output(bytes)) = self.reader_rx.try_recv() {
             self.append_output(bytes);
         }
@@ -698,18 +729,71 @@ impl ManagedSession {
         }
     }
 
+    fn observe_foreground_group(&mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            if self
+                .process_group
+                .as_ref()
+                .is_some_and(|ownership| !ownership.foreground_is_owned(self.master.as_deref()))
+            {
+                self.foreign_foreground_seen = true;
+            }
+        }
+    }
+
+    fn foreground_is_owned(&self) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            !self.foreign_foreground_seen
+                && self
+                    .process_group
+                    .as_ref()
+                    .is_none_or(|ownership| ownership.foreground_is_owned(self.master.as_deref()))
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            true
+        }
+    }
+
+    fn into_termination(mut self, session_id: &str) -> PtyTermination {
+        self.reader_stop.store(true, Ordering::Release);
+        if let Some(input) = self.input.take() {
+            input.finish();
+        }
+        let termination = PtyTermination {
+            session_id: SessionId::new(session_id),
+            child: self.child.take(),
+            process_group: self.process_group.take(),
+            master: self.master.take(),
+            reader: self.reader.take(),
+            next_cursor: self.next_sequence.saturating_sub(1),
+            dropped_chunks: self.reader_dropped.load(Ordering::Acquire),
+        };
+        self.status = ClaudePtyStatus::Closed;
+        termination
+    }
+
     fn close(&mut self) {
         if self.status == ClaudePtyStatus::Closed {
             return;
         }
         self.reader_stop.store(true, Ordering::Release);
         let input = self.input.take();
+        if !self.foreground_is_owned() {
+            eprintln!("relay Claude PTY teardown refused an unowned foreground group");
+            if let Some(input) = input {
+                input.finish();
+            }
+            return;
+        }
         let process_group = self.process_group.take();
         if let Some(input) = input {
             input.finish();
         }
         if let Some(child) = self.child.take() {
-            terminate_child(child, self.master.as_deref(), process_group.as_ref());
+            let _ = terminate_child(child, self.master.as_deref(), process_group.as_ref());
         }
         self.master.take();
         drop(process_group);
@@ -730,6 +814,49 @@ impl ManagedSession {
 impl Drop for ManagedSession {
     fn drop(&mut self) {
         self.close();
+    }
+}
+
+impl PtyTermination {
+    /// Finish the bounded teardown after the caller has released the runtime
+    /// mutex. A terminal signalling failure is returned rather than pretending
+    /// that an unverified foreground descendant was reaped.
+    pub fn finish(mut self) -> Result<TerminalSnapshot, ClaudePtyError> {
+        self.finish_inner()?;
+        Ok(TerminalSnapshot {
+            session_id: self.session_id.clone(),
+            status: ClaudePtyStatus::Closed,
+            output: Vec::new(),
+            next_cursor: self.next_cursor,
+            has_more: false,
+            truncated: false,
+            dropped_chunks: self.dropped_chunks,
+        })
+    }
+
+    fn finish_inner(&mut self) -> Result<(), ClaudePtyError> {
+        let result = match self.child.take() {
+            Some(child) => {
+                terminate_child(child, self.master.as_deref(), self.process_group.as_ref())
+            }
+            None => Ok(()),
+        };
+        self.master.take();
+        self.process_group.take();
+        if let Some(reader) = self.reader.take() {
+            // The reader owns a cloned master FD. It may still be blocked in a
+            // driver read, so joining remains opportunistic outside the mutex.
+            if reader.is_finished() {
+                let _ = reader.join();
+            }
+        }
+        result
+    }
+}
+
+impl Drop for PtyTermination {
+    fn drop(&mut self) {
+        let _ = self.finish_inner();
     }
 }
 
@@ -912,31 +1039,29 @@ fn delivery_error(written: usize) -> ClaudePtyError {
 
 #[cfg(target_os = "linux")]
 impl PtyOwnership {
-    fn capture_foreground(
-        &self,
-        master: Option<&(dyn MasterPty + Send)>,
-    ) -> Option<PtyForegroundGroup> {
-        let process_group = master?.process_group_leader()?;
-        if process_group == self.process_group {
-            return None;
-        }
-        let leader = LinuxPid::from_raw(process_group)?;
-        let leader_pidfd = pidfd_open(leader, PidfdFlags::empty()).ok()?;
-        (master?.process_group_leader() == Some(process_group)).then_some(PtyForegroundGroup {
-            process_group,
-            leader_pidfd,
-        })
+    fn foreground_is_owned(&self, master: Option<&(dyn MasterPty + Send)>) -> bool {
+        master
+            .and_then(MasterPty::process_group_leader)
+            .is_none_or(|foreground| foreground == self.process_group)
     }
 
-    fn signal_groups(&self, foreground: Option<&PtyForegroundGroup>, signal: Signal) {
-        // The direct child remains waitable until close finishes, keeping the
-        // original Relay-owned group identifier reserved throughout. Never
-        // re-authorize a foreground group by its numeric PGID after its pidfd
-        // reports leader exit: that number can be stale or reused.
-        if let Some(foreground) = foreground.filter(|foreground| foreground.is_signalable()) {
-            let _ = killpg(Pid::from_raw(foreground.process_group), signal);
+    fn signal_groups(
+        &self,
+        master: Option<&(dyn MasterPty + Send)>,
+        signal: Signal,
+    ) -> Result<(), ClaudePtyError> {
+        // Relay holds a lifetime-safe identity only for the original group: its
+        // direct leader remains unreaped until teardown finishes. A PTY
+        // foreground group can outlive its leader, so never convert the numeric
+        // `tcgetpgrp` result into `killpg`. Refuse the close instead of risking
+        // an unrelated/reused group or claiming to have reaped an unowned one.
+        if !self.foreground_is_owned(master) {
+            return Err(ClaudePtyError::Transport);
         }
+        // The direct child remains unreaped until this teardown completes, so
+        // this numeric group identifier remains Relay-owned and identity-safe.
         let _ = killpg(Pid::from_raw(self.process_group), signal);
+        Ok(())
     }
 }
 
@@ -969,29 +1094,66 @@ fn terminate_child(
     mut child: Box<dyn Child + Send + Sync>,
     master: Option<&(dyn MasterPty + Send)>,
     ownership: Option<&PtyOwnership>,
-) {
-    #[cfg(target_os = "linux")]
-    if let Some(ownership) = ownership {
-        let foreground = ownership.capture_foreground(master);
-        ownership.signal_groups(foreground.as_ref(), Signal::SIGTERM);
-        thread::sleep(PTY_TERMINATION_GRACE);
-        ownership.signal_groups(foreground.as_ref(), Signal::SIGKILL);
-    }
+) -> Result<(), ClaudePtyError> {
+    let result = {
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(ownership) = ownership {
+                ownership.signal_groups(master, Signal::SIGTERM)?;
+                thread::sleep(PTY_TERMINATION_GRACE);
+                ownership.signal_groups(master, Signal::SIGKILL)?;
+            }
+            Ok(())
+        }
+    };
     let _ = child.kill();
     reap_child(child);
+    result
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReapDisposition {
+    Reaped,
+    Deadline,
+    AttemptsExhausted,
+    TryWaitError,
 }
 
 fn reap_child(mut child: Box<dyn Child + Send + Sync>) {
     let _ = thread::Builder::new()
         .name("relay-claude-pty-reaper".into())
         .spawn(move || {
-            loop {
-                match child.try_wait() {
-                    Ok(Some(_)) => break,
-                    Ok(None) | Err(_) => thread::sleep(PTY_REAPER_POLL_INTERVAL),
-                }
+            let disposition = reap_child_until(
+                child.as_mut(),
+                Instant::now() + PTY_REAPER_DEADLINE,
+                PTY_REAPER_MAX_ATTEMPTS,
+                PTY_REAPER_POLL_INTERVAL,
+            );
+            if disposition != ReapDisposition::Reaped {
+                eprintln!("relay Claude PTY reaper stopped: {disposition:?}");
             }
         });
+}
+
+fn reap_child_until(
+    child: &mut dyn Child,
+    deadline: Instant,
+    max_attempts: usize,
+    poll_interval: Duration,
+) -> ReapDisposition {
+    if max_attempts == 0 {
+        return ReapDisposition::AttemptsExhausted;
+    }
+    for attempt in 1..=max_attempts {
+        match child.try_wait() {
+            Ok(Some(_)) => return ReapDisposition::Reaped,
+            Err(_) => return ReapDisposition::TryWaitError,
+            Ok(None) if Instant::now() >= deadline => return ReapDisposition::Deadline,
+            Ok(None) if attempt == max_attempts => return ReapDisposition::AttemptsExhausted,
+            Ok(None) => thread::sleep(poll_interval),
+        }
+    }
+    ReapDisposition::AttemptsExhausted
 }
 
 #[cfg(test)]
@@ -1005,6 +1167,11 @@ mod tests {
         release: Arc<AtomicBool>,
         poll_started: Arc<AtomicBool>,
         reaped: Arc<AtomicBool>,
+    }
+
+    #[derive(Debug)]
+    struct ErrorChild {
+        attempts: Arc<AtomicU64>,
     }
 
     #[derive(Debug)]
@@ -1030,6 +1197,16 @@ mod tests {
         }
     }
 
+    impl ChildKiller for ErrorChild {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(NoopChildKiller)
+        }
+    }
+
     impl Child for BlockingChild {
         fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
             self.poll_started.store(true, Ordering::Release);
@@ -1043,6 +1220,21 @@ mod tests {
 
         fn wait(&mut self) -> std::io::Result<ExitStatus> {
             panic!("the reaper must poll try_wait instead of blocking on wait")
+        }
+
+        fn process_id(&self) -> Option<u32> {
+            None
+        }
+    }
+
+    impl Child for ErrorChild {
+        fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+            self.attempts.fetch_add(1, Ordering::AcqRel);
+            Err(std::io::Error::other("persistent wait failure"))
+        }
+
+        fn wait(&mut self) -> std::io::Result<ExitStatus> {
+            panic!("the reaper must never fall back to blocking wait")
         }
 
         fn process_id(&self) -> Option<u32> {
@@ -1195,7 +1387,25 @@ mod tests {
         );
         let closed = runtime.close(session.as_str(), "device-a").unwrap();
         assert_eq!(closed.status, ClaudePtyStatus::Closed);
-        assert!(runtime.sessions[session.as_str()].child.is_none());
+        assert!(!runtime.sessions.contains_key(session.as_str()));
+    }
+
+    #[test]
+    fn begin_close_detaches_the_term_grace_from_the_runtime_mutex_path() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+
+        let started = Instant::now();
+        let termination = runtime.begin_close(session.as_str(), "device-a").unwrap();
+        assert!(
+            started.elapsed() < Duration::from_millis(50),
+            "the runtime lock path must remove the Session before TERM grace"
+        );
+        assert!(!runtime.sessions.contains_key(session.as_str()));
+        assert_eq!(
+            termination.finish().unwrap().status,
+            ClaudePtyStatus::Closed
+        );
     }
 
     #[test]
@@ -1561,12 +1771,12 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn close_reaps_a_descendant_after_it_takes_the_pty_foreground_group() {
+    fn close_fails_closed_for_an_unowned_foreground_group_without_pidfd_fallback() {
         let mut runtime = NodePtyRuntime::test_runtime(
             "/bin/sh",
             &[
                 "-c",
-                "set -m; sh -c 'trap \"\" HUP TERM; while :; do sleep 1; done' & child=$!; printf 'CHILD:%s\\n' \"$child\"; fg %1",
+                "set -m; sh -c \"sh -c 'trap \\\"\\\" HUP TERM; while :; do sleep 1; done' & child=\\$!; printf 'CHILD:%s\\n' \\\"\\$child\\\"; sleep 0.2; exit 0\" & fg %1",
             ],
         );
         let session = runtime.create("device-a").unwrap();
@@ -1610,42 +1820,28 @@ mod tests {
             "fixture foreground group must belong to the reported descendant"
         );
 
-        let (closed_tx, closed_rx) = mpsc::sync_channel(1);
-        thread::spawn(move || {
-            let started = Instant::now();
-            let result = runtime.close(session.as_str(), "device-a");
-            let _ = closed_tx.send((result, started.elapsed()));
-        });
-
-        let closed = match closed_rx.recv_timeout(Duration::from_millis(500)) {
-            Ok(closed) => closed,
-            Err(_) => {
-                // Keep the red test self-cleaning on the broken implementation:
-                // its foreground-group check skips the descendant and leaves
-                // close waiting for the reader forever.
-                let _ = killpg(Pid::from_raw(child_pid), Signal::SIGKILL);
-                closed_rx
-                    .recv_timeout(Duration::from_secs(2))
-                    .expect("cleanup signal must release the blocked close")
-            }
-        };
-        assert!(closed.0.is_ok());
-        assert!(
-            closed.1 < Duration::from_millis(500),
-            "close must reap a foreground-group descendant without external cleanup"
+        // The foreground group leader exits while its TERM-ignoring descendant
+        // remains alive. The prior pidfd/poll approach could become readable
+        // here and silently skip KILL. Relay remembers that it observed an
+        // unowned foreground group, so it never authorizes a numeric fallback.
+        thread::sleep(Duration::from_millis(300));
+        assert!(runtime.sessions[session.as_str()].foreign_foreground_seen);
+        assert!(runtime.begin_owner_session_closes("device-a").is_empty());
+        assert!(runtime.sessions.contains_key(session.as_str()));
+        assert_eq!(
+            runtime.close(session.as_str(), "device-a"),
+            Err(ClaudePtyError::Transport)
         );
-        let reap_deadline = Instant::now() + Duration::from_secs(2);
-        let child_reaped = loop {
-            if kill(Pid::from_raw(child_pid), None) == Err(Errno::ESRCH) {
-                break true;
-            }
-            if Instant::now() > reap_deadline {
-                let _ = killpg(Pid::from_raw(child_pid), Signal::SIGKILL);
-                break false;
-            }
-            thread::sleep(Duration::from_millis(10));
-        };
-        assert!(child_reaped, "close left the foreground descendant alive");
+        assert!(runtime.sessions.contains_key(session.as_str()));
+        runtime.prune_finished_sessions();
+        assert!(
+            runtime.sessions.contains_key(session.as_str()),
+            "automatic cleanup must preserve an unsafe terminal record instead of dropping it"
+        );
+
+        // The test fixture owns this child PID and cleans it up explicitly; a
+        // production close deliberately has no equivalent unsafe numeric path.
+        let _ = killpg(Pid::from_raw(child_pid), Signal::SIGKILL);
     }
 
     #[test]
@@ -1739,21 +1935,49 @@ mod tests {
         }
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
-    fn dead_foreground_leader_is_not_signalable_from_numeric_group_identity() {
-        use std::os::unix::net::UnixStream;
-
-        let (mut writer, reader) = UnixStream::pair().unwrap();
-        writer.write_all(&[1]).unwrap();
-        let foreground = PtyForegroundGroup {
-            process_group: 1,
-            leader_pidfd: reader.into(),
+    fn reaper_stops_after_a_persistent_try_wait_error() {
+        let attempts = Arc::new(AtomicU64::new(0));
+        let mut child = ErrorChild {
+            attempts: Arc::clone(&attempts),
         };
 
-        assert!(
-            !foreground.is_signalable(),
-            "a readable pidfd must not authorize a fallback numeric killpg"
+        assert_eq!(
+            reap_child_until(
+                &mut child,
+                Instant::now() + Duration::from_secs(1),
+                4,
+                Duration::ZERO,
+            ),
+            ReapDisposition::TryWaitError
+        );
+        assert_eq!(
+            attempts.load(Ordering::Acquire),
+            1,
+            "a persistent wait error must not leak an unbounded reaper loop"
+        );
+    }
+
+    #[test]
+    fn reaper_reports_attempt_and_deadline_dispositions() {
+        let mut child = BlockingChild {
+            release: Arc::new(AtomicBool::new(false)),
+            poll_started: Arc::new(AtomicBool::new(false)),
+            reaped: Arc::new(AtomicBool::new(false)),
+        };
+
+        assert_eq!(
+            reap_child_until(
+                &mut child,
+                Instant::now() + Duration::from_secs(1),
+                2,
+                Duration::ZERO,
+            ),
+            ReapDisposition::AttemptsExhausted
+        );
+        assert_eq!(
+            reap_child_until(&mut child, Instant::now(), 4, Duration::ZERO),
+            ReapDisposition::Deadline
         );
     }
 }

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -20,7 +20,7 @@ use nix::{errno::Errno, sys::signal::kill};
 #[cfg(unix)]
 use nix::{
     sys::signal::{Signal, killpg},
-    unistd::{Pid, getpgid},
+    unistd::Pid,
 };
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
@@ -51,6 +51,8 @@ pub const PTY_SCROLLBACK_BYTES: usize = 256 * 1024;
 pub const PTY_DELIVERY_BYTES: usize = 4 * 1024;
 /// Input is a keystroke payload, not an unbounded upload channel.
 pub const PTY_INPUT_BYTES: usize = 8 * 1024;
+/// Input is staged before it reaches the potentially blocking PTY writer.
+pub const PTY_INPUT_QUEUE_CAP: usize = 8;
 /// One small node runtime is deliberately capped before it becomes a terminal
 /// platform or a hidden process farm.
 pub const MAX_PTY_SESSIONS: usize = 8;
@@ -110,6 +112,7 @@ pub enum ClaudePtyError {
     Forbidden,
     InvalidInput,
     InvalidResize,
+    Backpressure,
     Transport,
 }
 
@@ -122,6 +125,7 @@ impl ClaudePtyError {
             Self::Forbidden => "session_forbidden",
             Self::InvalidInput => "invalid_input",
             Self::InvalidResize => "invalid_resize",
+            Self::Backpressure => "input_backpressure",
             Self::Transport => "pty_transport",
         }
     }
@@ -165,13 +169,34 @@ struct ScrollbackChunk {
     bytes: usize,
 }
 
+struct PtyInput {
+    sender: mpsc::SyncSender<Vec<u8>>,
+    worker: JoinHandle<()>,
+}
+
+impl PtyInput {
+    fn enqueue(&self, data: &[u8]) -> Result<(), ClaudePtyError> {
+        match self.sender.try_send(data.to_vec()) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(ClaudePtyError::Backpressure),
+            Err(TrySendError::Disconnected(_)) => Err(ClaudePtyError::Transport),
+        }
+    }
+
+    fn finish(self) {
+        let Self { sender, worker } = self;
+        drop(sender);
+        let _ = worker.join();
+    }
+}
+
 struct ManagedSession {
     owner_device_id: String,
     status: ClaudePtyStatus,
     child: Option<Box<dyn Child + Send + Sync>>,
     process_group: Option<i32>,
     master: Option<Box<dyn MasterPty + Send>>,
-    writer: Option<Box<dyn Write + Send>>,
+    input: Option<PtyInput>,
     reader: Option<JoinHandle<()>>,
     reader_rx: Receiver<ReaderEvent>,
     reader_stop: Arc<AtomicBool>,
@@ -272,18 +297,34 @@ impl NodePtyRuntime {
             .map_err(|_| ClaudePtyError::Unavailable)?;
         drop(pair.slave);
         let process_group = child.process_id().and_then(session_process_group);
+        #[cfg(unix)]
+        if process_group.is_none() {
+            // Do not admit a Session whose descendants could not be reaped as
+            // a Relay-owned group. portable-pty supplies this on Unix; a
+            // missing identity is a fail-closed transport setup failure.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(ClaudePtyError::Transport);
+        }
         let reader = match pair.master.try_clone_reader() {
             Ok(reader) => reader,
             Err(_) => {
-                terminate_child(&mut child, process_group);
+                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
                 return Err(ClaudePtyError::Transport);
             }
         };
         let writer = match pair.master.take_writer() {
             Ok(writer) => writer,
             Err(_) => {
-                terminate_child(&mut child, process_group);
+                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
                 return Err(ClaudePtyError::Transport);
+            }
+        };
+        let input = match spawn_input_writer(writer) {
+            Ok(input) => input,
+            Err(error) => {
+                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
+                return Err(error);
             }
         };
         let (reader_tx, reader_rx) = mpsc::sync_channel(PTY_INBOUND_CAP);
@@ -297,8 +338,8 @@ impl NodePtyRuntime {
         ) {
             Ok(reader_thread) => reader_thread,
             Err(error) => {
-                drop(writer);
-                terminate_child(&mut child, process_group);
+                input.finish();
+                terminate_child(&mut child, Some(pair.master.as_ref()), process_group);
                 return Err(error);
             }
         };
@@ -313,7 +354,7 @@ impl NodePtyRuntime {
                 child: Some(child),
                 process_group,
                 master: Some(pair.master),
-                writer: Some(writer),
+                input: Some(input),
                 reader: Some(reader_thread),
                 reader_rx,
                 reader_stop,
@@ -388,11 +429,11 @@ impl NodePtyRuntime {
         if session.status == ClaudePtyStatus::Closed || session.status == ClaudePtyStatus::Exited {
             return Err(ClaudePtyError::StaleHandle);
         }
-        let writer = session.writer.as_mut().ok_or(ClaudePtyError::StaleHandle)?;
-        writer
-            .write_all(data.as_bytes())
-            .and_then(|()| writer.flush())
-            .map_err(|_| ClaudePtyError::Transport)
+        session
+            .input
+            .as_ref()
+            .ok_or(ClaudePtyError::StaleHandle)?
+            .enqueue(data.as_bytes())
     }
 
     pub fn resize(
@@ -576,12 +617,15 @@ impl ManagedSession {
             return;
         }
         self.reader_stop.store(true, Ordering::Release);
-        self.writer.take();
+        let input = self.input.take();
         if let Some(child) = self.child.as_mut() {
-            terminate_child(child, self.process_group);
+            terminate_child(child, self.master.as_deref(), self.process_group);
         }
         self.child.take();
         self.master.take();
+        if let Some(input) = input {
+            input.finish();
+        }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }
@@ -692,14 +736,33 @@ fn spawn_reader(
         .map_err(|_| ClaudePtyError::Transport)
 }
 
+fn spawn_input_writer(mut writer: Box<dyn Write + Send>) -> Result<PtyInput, ClaudePtyError> {
+    let (sender, receiver) = mpsc::sync_channel::<Vec<u8>>(PTY_INPUT_QUEUE_CAP);
+    let worker = thread::Builder::new()
+        .name("relay-claude-pty-writer".into())
+        .spawn(move || {
+            while let Ok(data) = receiver.recv() {
+                if writer
+                    .write_all(&data)
+                    .and_then(|()| writer.flush())
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        })
+        .map_err(|_| ClaudePtyError::Transport)?;
+    Ok(PtyInput { sender, worker })
+}
+
 fn session_process_group(process_id: u32) -> Option<i32> {
     #[cfg(unix)]
     {
-        let process_id = i32::try_from(process_id).ok()?;
-        // portable-pty creates the child as a new session leader. Require its
-        // process group to match the leader PID before ever signalling a group.
-        let process_group = getpgid(Some(Pid::from_raw(process_id))).ok()?.as_raw();
-        (process_group == process_id).then_some(process_group)
+        // portable-pty establishes a new session before exec, so the child PID
+        // is its process-group ID even if the leader exits before Relay closes
+        // the Session. Close verifies the PTY's foreground group before
+        // signalling it, preventing stale numeric PID reuse from escaping.
+        i32::try_from(process_id).ok()
     }
     #[cfg(not(unix))]
     {
@@ -708,12 +771,19 @@ fn session_process_group(process_id: u32) -> Option<i32> {
     }
 }
 
-fn terminate_child(child: &mut Box<dyn Child + Send + Sync>, process_group: Option<i32>) {
+fn terminate_child(
+    child: &mut Box<dyn Child + Send + Sync>,
+    master: Option<&(dyn MasterPty + Send)>,
+    process_group: Option<i32>,
+) {
     #[cfg(unix)]
-    if let Some(process_group) = process_group {
+    if let Some(process_group) = process_group.filter(|process_group| {
+        master.and_then(|master| master.process_group_leader()) == Some(*process_group)
+    }) {
         // Terminate both the session leader and its PTY descendants. Give a
         // cooperative TUI a bounded chance to handle SIGTERM before the final
-        // group kill guarantees Relay does not orphan descendants.
+        // group kill guarantees Relay does not orphan descendants. Checking
+        // the PTY-local foreground group avoids signalling a reused numeric ID.
         let process_group = Pid::from_raw(process_group);
         let _ = killpg(process_group, Signal::SIGTERM);
         thread::sleep(PTY_TERMINATION_GRACE);
@@ -843,6 +913,23 @@ mod tests {
         runtime
             .input(session.as_str(), "device-a", "ping\n")
             .unwrap();
+        loop {
+            let snapshot = runtime
+                .poll(session.as_str(), "device-a", first.next_cursor)
+                .unwrap();
+            if snapshot
+                .output
+                .iter()
+                .any(|chunk| chunk.text.contains("ping"))
+            {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "accepted terminal input did not reach the PTY"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
         runtime
             .resize(session.as_str(), "device-a", 100, 40)
             .unwrap();
@@ -1062,5 +1149,113 @@ mod tests {
             );
             thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delayed_close_after_leader_exit_reaps_the_remaining_pty_group() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &[
+                "-c",
+                "sh -c 'trap \"\" TERM; while :; do sleep 1; done' & child=$!; printf 'CHILD:%s\\n' \"$child\"; exit 0",
+            ],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let child_pid = loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if let Some(pid) = snapshot.output.iter().find_map(|chunk| {
+                chunk
+                    .text
+                    .lines()
+                    .find_map(|line| line.trim().strip_prefix("CHILD:")?.parse::<i32>().ok())
+            }) {
+                break pid;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "test PTY did not report descendant PID"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
+        loop {
+            let snapshot = runtime.poll(session.as_str(), "device-a", 0).unwrap();
+            if snapshot.status == ClaudePtyStatus::Exited {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "leader did not exit while its PTY descendant remained alive"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        thread::sleep(Duration::from_millis(50));
+        runtime.close(session.as_str(), "device-a").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if kill(Pid::from_raw(child_pid), None) == Err(Errno::ESRCH) {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "delayed Relay close left a descendant or blocked PTY reader alive"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn non_reader_input_backpressure_does_not_wedge_close() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-a").unwrap();
+        let input = "x".repeat(PTY_INPUT_BYTES);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if runtime.input(session.as_str(), "device-a", &input)
+                == Err(ClaudePtyError::Backpressure)
+            {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "non-reading PTY never applied bounded input backpressure"
+            );
+        }
+
+        let started = Instant::now();
+        runtime.close(session.as_str(), "device-a").unwrap();
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "a blocked PTY writer must not wedge terminal close"
+        );
+    }
+
+    #[test]
+    fn non_reader_input_backpressure_does_not_wedge_owner_revoke() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let session = runtime.create("device-revoked").unwrap();
+        let input = "x".repeat(PTY_INPUT_BYTES);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if runtime.input(session.as_str(), "device-revoked", &input)
+                == Err(ClaudePtyError::Backpressure)
+            {
+                break;
+            }
+            assert!(
+                Instant::now() <= deadline,
+                "non-reading PTY never applied bounded input backpressure"
+            );
+        }
+
+        let started = Instant::now();
+        runtime.close_owner_sessions("device-revoked");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "a blocked PTY writer must not wedge owner-session reaping"
+        );
+        assert!(!runtime.sessions.contains_key(session.as_str()));
     }
 }

--- a/crates/relay-session/src/claude_pty.rs
+++ b/crates/relay-session/src/claude_pty.rs
@@ -22,7 +22,7 @@ use nix::{errno::Errno, sys::signal::kill};
 #[cfg(unix)]
 use nix::{
     sys::signal::{Signal, killpg},
-    unistd::{Pid, getpgid, getsid},
+    unistd::{Pid, getpgid, getsid, tcgetpgrp},
 };
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 #[cfg(target_os = "linux")]
@@ -239,6 +239,8 @@ impl PtyInput {
 struct PtyOwnership {
     process_group: i32,
     writer: FileDescriptor,
+    #[cfg(test)]
+    foreground_override: Option<ForegroundIdentity>,
 }
 
 #[cfg(target_os = "linux")]
@@ -249,6 +251,14 @@ impl AsRawFd for MasterFd {
     fn as_raw_fd(&self) -> RawFd {
         self.0
     }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+enum ForegroundIdentity {
+    NoForegroundGroup,
+    ProcessGroup(i32),
+    Unavailable,
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -287,6 +297,38 @@ pub struct PtyTermination {
     reader: Option<JoinHandle<()>>,
     next_cursor: u64,
     dropped_chunks: u64,
+}
+
+/// A create operation separates lock-bound runtime bookkeeping from any
+/// bounded PTY teardown that the caller must finish after releasing the lock.
+pub struct PtyCreate {
+    result: Result<SessionId, ClaudePtyError>,
+    terminations: Vec<PtyTermination>,
+}
+
+impl PtyCreate {
+    fn failure(error: ClaudePtyError, terminations: Vec<PtyTermination>) -> Self {
+        Self {
+            result: Err(error),
+            terminations,
+        }
+    }
+
+    pub fn into_parts(self) -> (Result<SessionId, ClaudePtyError>, Vec<PtyTermination>) {
+        (self.result, self.terminations)
+    }
+}
+
+/// The outcome of selecting PTYs for owner invalidation cleanup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnerSessionCloseDisposition {
+    Complete,
+    Retry,
+}
+
+pub struct OwnerSessionClosures {
+    pub terminations: Vec<PtyTermination>,
+    pub disposition: OwnerSessionCloseDisposition,
 }
 
 /// The node-local source of truth for Relay-owned Claude PTY Session handles.
@@ -346,18 +388,30 @@ impl NodePtyRuntime {
     /// Start the fixed Claude Code TUI in a real PTY. No caller-controlled
     /// command, arguments, HOME, PATH, or working directory enter this path.
     pub fn create(&mut self, owner_device_id: &str) -> Result<SessionId, ClaudePtyError> {
-        if owner_device_id.is_empty() || owner_device_id.len() > 64 {
-            return Err(ClaudePtyError::Forbidden);
+        let (result, terminations) = self.begin_create(owner_device_id).into_parts();
+        for termination in terminations {
+            let _ = termination.finish();
         }
-        self.prune_finished_sessions();
+        result
+    }
+
+    /// Begin fixed-PTY creation while the runtime is locked. Any automatic
+    /// pruning or partially-started PTY cleanup is returned to the caller so
+    /// TERM/KILL grace never runs under the hub's global PTY mutex.
+    pub fn begin_create(&mut self, owner_device_id: &str) -> PtyCreate {
+        if owner_device_id.is_empty() || owner_device_id.len() > 64 {
+            return PtyCreate::failure(ClaudePtyError::Forbidden, Vec::new());
+        }
+        let mut terminations = self.begin_prune_finished_sessions();
         if self.sessions.len() >= MAX_PTY_SESSIONS {
-            return Err(ClaudePtyError::Capacity);
+            return PtyCreate::failure(ClaudePtyError::Capacity, terminations);
         }
 
         let pty_system = native_pty_system();
-        let pair = pty_system
-            .openpty(default_size())
-            .map_err(|_| ClaudePtyError::Transport)?;
+        let pair = match pty_system.openpty(default_size()) {
+            Ok(pair) => pair,
+            Err(_) => return PtyCreate::failure(ClaudePtyError::Transport, terminations),
+        };
         let mut command = CommandBuilder::new(self.owner.claude_path());
         command.env_clear();
         for argument in &self.arguments {
@@ -372,10 +426,10 @@ impl NodePtyRuntime {
         command.env("TERM", "xterm-256color");
         command.env("COLORTERM", "truecolor");
 
-        let mut child = pair
-            .slave
-            .spawn_command(command)
-            .map_err(|_| ClaudePtyError::Unavailable)?;
+        let mut child = match pair.slave.spawn_command(command) {
+            Ok(child) => child,
+            Err(_) => return PtyCreate::failure(ClaudePtyError::Unavailable, terminations),
+        };
         drop(pair.slave);
         let process_group = child
             .process_id()
@@ -387,13 +441,21 @@ impl NodePtyRuntime {
             // missing identity is a fail-closed transport setup failure.
             let _ = child.kill();
             reap_child(child);
-            return Err(ClaudePtyError::Transport);
+            return PtyCreate::failure(ClaudePtyError::Transport, terminations);
         }
+        let id = format!("claude-pty-{}", self.next_id);
+        self.next_id = self.next_id.saturating_add(1);
+        let session_id = SessionId::new(id.clone());
         let reader = match pair.master.try_clone_reader() {
             Ok(reader) => reader,
             Err(_) => {
-                let _ = terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
-                return Err(ClaudePtyError::Transport);
+                terminations.push(PtyTermination::startup_failure(
+                    session_id,
+                    child,
+                    process_group,
+                    pair.master,
+                ));
+                return PtyCreate::failure(ClaudePtyError::Transport, terminations);
             }
         };
         let input = match process_group
@@ -403,8 +465,13 @@ impl NodePtyRuntime {
         {
             Ok(input) => input,
             Err(error) => {
-                let _ = terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
-                return Err(error);
+                terminations.push(PtyTermination::startup_failure(
+                    session_id,
+                    child,
+                    process_group,
+                    pair.master,
+                ));
+                return PtyCreate::failure(error, terminations);
             }
         };
         let (reader_tx, reader_rx) = mpsc::sync_channel(PTY_INBOUND_CAP);
@@ -421,15 +488,18 @@ impl NodePtyRuntime {
             Ok(reader_thread) => reader_thread,
             Err(error) => {
                 input.finish();
-                let _ = terminate_child(child, Some(pair.master.as_ref()), process_group.as_ref());
-                return Err(error);
+                terminations.push(PtyTermination::startup_failure(
+                    session_id,
+                    child,
+                    process_group,
+                    pair.master,
+                ));
+                return PtyCreate::failure(error, terminations);
             }
         };
 
-        let id = format!("claude-pty-{}", self.next_id);
-        self.next_id = self.next_id.saturating_add(1);
         self.sessions.insert(
-            id.clone(),
+            id,
             ManagedSession {
                 owner_device_id: owner_device_id.to_owned(),
                 status: ClaudePtyStatus::Starting,
@@ -450,7 +520,10 @@ impl NodePtyRuntime {
                 foreign_foreground_seen: false,
             },
         );
-        Ok(SessionId::new(id))
+        PtyCreate {
+            result: Ok(session_id),
+            terminations,
+        }
     }
 
     /// Return an incremental, loss-aware output snapshot. Disconnection merely
@@ -606,29 +679,50 @@ impl NodePtyRuntime {
     /// before they can consume another live-session slot. Keeping an exited
     /// record until the next create lets a browser observe the terminal result,
     /// while the next create deterministically releases its PTY resources.
+    #[cfg(test)]
     fn prune_finished_sessions(&mut self) {
-        self.sessions.retain(|_, session| {
-            session.pump();
-            !session.foreground_is_owned()
-                || !matches!(
-                    session.status,
-                    ClaudePtyStatus::Closed | ClaudePtyStatus::Exited
-                )
-        });
+        for termination in self.begin_prune_finished_sessions() {
+            let _ = termination.finish();
+        }
+    }
+
+    fn begin_prune_finished_sessions(&mut self) -> Vec<PtyTermination> {
+        let session_ids = self
+            .sessions
+            .iter_mut()
+            .filter_map(|(session_id, session)| {
+                session.pump();
+                (session.foreground_is_owned()
+                    && matches!(
+                        session.status,
+                        ClaudePtyStatus::Closed | ClaudePtyStatus::Exited
+                    ))
+                .then(|| session_id.clone())
+            })
+            .collect::<Vec<_>>();
+        session_ids
+            .into_iter()
+            .filter_map(|session_id| {
+                self.sessions
+                    .remove(&session_id)
+                    .map(|session| session.into_termination(&session_id))
+            })
+            .collect()
     }
 
     /// Reap every PTY bound to a browser-device identity after that browser
     /// session is revoked. The opaque browser session token never crosses the
     /// auth boundary; this runtime only receives its already-authenticated
     /// device identity.
-    pub fn begin_owner_session_closes(&mut self, owner_device_id: &str) -> Vec<PtyTermination> {
+    pub fn begin_owner_session_closes(&mut self, owner_device_id: &str) -> OwnerSessionClosures {
         let session_ids = self
             .sessions
             .iter()
             .filter(|(_, session)| session.owner_device_id == owner_device_id)
             .map(|(session_id, _)| session_id.clone())
             .collect::<Vec<_>>();
-        session_ids
+        let mut disposition = OwnerSessionCloseDisposition::Complete;
+        let terminations = session_ids
             .into_iter()
             .filter_map(|session_id| {
                 let session = self
@@ -638,17 +732,23 @@ impl NodePtyRuntime {
                 session.pump();
                 if !session.foreground_is_owned() {
                     eprintln!("relay Claude PTY teardown refused an unowned foreground group");
+                    disposition = OwnerSessionCloseDisposition::Retry;
                     return None;
                 }
                 self.sessions
                     .remove(&session_id)
                     .map(|session| session.into_termination(&session_id))
             })
-            .collect()
+            .collect();
+        OwnerSessionClosures {
+            terminations,
+            disposition,
+        }
     }
 
     pub fn close_owner_sessions(&mut self, owner_device_id: &str) {
-        for termination in self.begin_owner_session_closes(owner_device_id) {
+        let closures = self.begin_owner_session_closes(owner_device_id);
+        for termination in closures.terminations {
             let _ = termination.finish();
         }
     }
@@ -735,7 +835,7 @@ impl ManagedSession {
             if self
                 .process_group
                 .as_ref()
-                .is_some_and(|ownership| !ownership.foreground_is_owned(self.master.as_deref()))
+                .is_some_and(|ownership| !ownership.foreground_is_owned())
             {
                 self.foreign_foreground_seen = true;
             }
@@ -749,7 +849,7 @@ impl ManagedSession {
                 && self
                     .process_group
                     .as_ref()
-                    .is_none_or(|ownership| ownership.foreground_is_owned(self.master.as_deref()))
+                    .is_some_and(PtyOwnership::foreground_is_owned)
         }
         #[cfg(not(target_os = "linux"))]
         {
@@ -793,7 +893,7 @@ impl ManagedSession {
             input.finish();
         }
         if let Some(child) = self.child.take() {
-            let _ = terminate_child(child, self.master.as_deref(), process_group.as_ref());
+            let _ = terminate_child(child, process_group.as_ref());
         }
         self.master.take();
         drop(process_group);
@@ -818,6 +918,23 @@ impl Drop for ManagedSession {
 }
 
 impl PtyTermination {
+    fn startup_failure(
+        session_id: SessionId,
+        child: Box<dyn Child + Send + Sync>,
+        process_group: Option<PtyOwnership>,
+        master: Box<dyn MasterPty + Send>,
+    ) -> Self {
+        Self {
+            session_id,
+            child: Some(child),
+            process_group,
+            master: Some(master),
+            reader: None,
+            next_cursor: 0,
+            dropped_chunks: 0,
+        }
+    }
+
     /// Finish the bounded teardown after the caller has released the runtime
     /// mutex. A terminal signalling failure is returned rather than pretending
     /// that an unverified foreground descendant was reaped.
@@ -836,9 +953,7 @@ impl PtyTermination {
 
     fn finish_inner(&mut self) -> Result<(), ClaudePtyError> {
         let result = match self.child.take() {
-            Some(child) => {
-                terminate_child(child, self.master.as_deref(), self.process_group.as_ref())
-            }
+            Some(child) => terminate_child(child, self.process_group.as_ref()),
             None => Ok(()),
         };
         self.master.take();
@@ -1038,24 +1153,41 @@ fn delivery_error(written: usize) -> ClaudePtyError {
 }
 
 #[cfg(target_os = "linux")]
+fn foreground_identity(writer: &FileDescriptor) -> ForegroundIdentity {
+    match tcgetpgrp(writer) {
+        Ok(process_group) if process_group.as_raw() > 0 => {
+            ForegroundIdentity::ProcessGroup(process_group.as_raw())
+        }
+        // `tcgetpgrp` successfully reported no foreground group. This is not
+        // an unavailable identity and cannot smuggle in a foreign numeric PGID.
+        Ok(_) => ForegroundIdentity::NoForegroundGroup,
+        Err(_) => ForegroundIdentity::Unavailable,
+    }
+}
+
+#[cfg(target_os = "linux")]
 impl PtyOwnership {
-    fn foreground_is_owned(&self, master: Option<&(dyn MasterPty + Send)>) -> bool {
-        master
-            .and_then(MasterPty::process_group_leader)
-            .is_none_or(|foreground| foreground == self.process_group)
+    fn foreground_is_owned(&self) -> bool {
+        #[cfg(test)]
+        let identity = self
+            .foreground_override
+            .unwrap_or_else(|| foreground_identity(&self.writer));
+        #[cfg(not(test))]
+        let identity = foreground_identity(&self.writer);
+        match identity {
+            ForegroundIdentity::NoForegroundGroup => true,
+            ForegroundIdentity::ProcessGroup(process_group) => process_group == self.process_group,
+            ForegroundIdentity::Unavailable => false,
+        }
     }
 
-    fn signal_groups(
-        &self,
-        master: Option<&(dyn MasterPty + Send)>,
-        signal: Signal,
-    ) -> Result<(), ClaudePtyError> {
+    fn signal_groups(&self, signal: Signal) -> Result<(), ClaudePtyError> {
         // Relay holds a lifetime-safe identity only for the original group: its
         // direct leader remains unreaped until teardown finishes. A PTY
         // foreground group can outlive its leader, so never convert the numeric
         // `tcgetpgrp` result into `killpg`. Refuse the close instead of risking
         // an unrelated/reused group or claiming to have reaped an unowned one.
-        if !self.foreground_is_owned(master) {
+        if !self.foreground_is_owned() {
             return Err(ClaudePtyError::Transport);
         }
         // The direct child remains unreaped until this teardown completes, so
@@ -1081,6 +1213,8 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
         (process_group == process_id && session_id == process_id).then_some(PtyOwnership {
             process_group,
             writer,
+            #[cfg(test)]
+            foreground_override: None,
         })
     }
     #[cfg(not(target_os = "linux"))]
@@ -1092,16 +1226,15 @@ fn session_process_group(process_id: u32, master: &(dyn MasterPty + Send)) -> Op
 
 fn terminate_child(
     mut child: Box<dyn Child + Send + Sync>,
-    master: Option<&(dyn MasterPty + Send)>,
     ownership: Option<&PtyOwnership>,
 ) -> Result<(), ClaudePtyError> {
     let result = {
         #[cfg(target_os = "linux")]
         {
             if let Some(ownership) = ownership {
-                ownership.signal_groups(master, Signal::SIGTERM)?;
+                ownership.signal_groups(Signal::SIGTERM)?;
                 thread::sleep(PTY_TERMINATION_GRACE);
-                ownership.signal_groups(master, Signal::SIGKILL)?;
+                ownership.signal_groups(Signal::SIGKILL)?;
             }
             Ok(())
         }
@@ -1406,6 +1539,68 @@ mod tests {
             termination.finish().unwrap().status,
             ClaudePtyStatus::Closed
         );
+    }
+
+    #[test]
+    fn automatic_pruning_does_not_wait_through_term_grace_before_create_returns() {
+        let mut runtime = NodePtyRuntime::test_runtime("/bin/sh", &["-c", "sleep 30"]);
+        let exited = runtime.create("device-a").unwrap();
+        runtime.sessions.get_mut(exited.as_str()).unwrap().status = ClaudePtyStatus::Exited;
+
+        let started = Instant::now();
+        let (result, terminations) = runtime.begin_create("device-a").into_parts();
+        assert!(
+            started.elapsed() < Duration::from_millis(50),
+            "automatic pruning must detach TERM/KILL grace before the caller releases its runtime mutex"
+        );
+
+        let replacement = result.unwrap();
+        for termination in terminations {
+            termination.finish().unwrap();
+        }
+
+        runtime.close(replacement.as_str(), "device-a").unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unavailable_foreground_identity_fails_closed_before_numeric_group_signalling() {
+        let mut runtime = NodePtyRuntime::test_runtime(
+            "/bin/sh",
+            &["-c", "trap '' TERM; while :; do sleep 1; done"],
+        );
+        let session = runtime.create("device-a").unwrap();
+        let process_group = runtime.sessions[session.as_str()]
+            .process_group
+            .as_ref()
+            .expect("Linux test session records a process group")
+            .process_group;
+        runtime
+            .sessions
+            .get_mut(session.as_str())
+            .unwrap()
+            .process_group
+            .as_mut()
+            .unwrap()
+            .foreground_override = Some(ForegroundIdentity::Unavailable);
+
+        assert_eq!(
+            runtime.close(session.as_str(), "device-a"),
+            Err(ClaudePtyError::Transport),
+            "missing foreground identity must refuse teardown instead of issuing killpg"
+        );
+        assert!(runtime.sessions.contains_key(session.as_str()));
+
+        let _ = killpg(Pid::from_raw(process_group), Signal::SIGKILL);
+        if let Some(child) = runtime
+            .sessions
+            .get_mut(session.as_str())
+            .unwrap()
+            .child
+            .take()
+        {
+            reap_child(child);
+        }
     }
 
     #[test]
@@ -1826,7 +2021,9 @@ mod tests {
         // unowned foreground group, so it never authorizes a numeric fallback.
         thread::sleep(Duration::from_millis(300));
         assert!(runtime.sessions[session.as_str()].foreign_foreground_seen);
-        assert!(runtime.begin_owner_session_closes("device-a").is_empty());
+        let closures = runtime.begin_owner_session_closes("device-a");
+        assert_eq!(closures.disposition, OwnerSessionCloseDisposition::Retry);
+        assert!(closures.terminations.is_empty());
         assert!(runtime.sessions.contains_key(session.as_str()));
         assert_eq!(
             runtime.close(session.as_str(), "device-a"),

--- a/crates/relay-session/src/lib.rs
+++ b/crates/relay-session/src/lib.rs
@@ -1,5 +1,4 @@
-//! `relay-session`: a minimal, one-node **supervised Codex app-server session
-//! adapter** (Relay issue #1140).
+//! `relay-session`: minimal, one-node supervised Session adapters.
 //!
 //! ## What this crate is
 //!
@@ -16,6 +15,8 @@
 //!   prompt / cancel / close lifecycle, with monotonic arrival sequencing,
 //!   bounded queues, backpressure/lag signals, and typed degraded/failed states
 //!   with bounded recovery.
+//! - [`claude_pty`] — the fixed node-owner Claude Code PTY runtime with bounded
+//!   output, opaque handles, resize/interrupt control, and explicit close.
 //!
 //! ## What this crate is not
 //!
@@ -24,6 +25,7 @@
 //! persist raw provider transcripts. Diagnostic previews are bounded and
 //! redacted.
 
+pub mod claude_pty;
 pub mod codex;
 pub mod contract;
 pub mod jsonl;

--- a/docs/PRODUCT_CONTEXT.md
+++ b/docs/PRODUCT_CONTEXT.md
@@ -20,13 +20,14 @@ Later issues may introduce these terms only with explicit ownership and storage 
 - The PWA shell renders liveness plus passkey enrollment, sign-in, typed unsupported/denied/recovery, and trusted-browser revoke controls.
 - The hub validates WebAuthn at one configured HTTPS origin, issues revocable browser sessions for protected hub actions, and denies browser sessions at the node boundary.
 - `relay-node codex-stdio-probe` owns a one-node, local `codex app-server --stdio` Session seam. Its explicit exercise mode creates, resumes, prompts, and cancels native Codex threads through bounded JSONL; it exposes neither a network transport nor raw provider transcripts.
+- The #1151 Claude terminal slice owns one bounded, local PTY per opaque Session. It launches only the fixed Claude Code executable in the explicit node-owner home, binds controls to an authenticated browser-device identity, and retains bounded output/scrollback. Browser layout storage retains only the opaque Session reference; explicit terminal routes own input, resize, interrupt, and close.
 
 ## Authority and data path
 
 The passkey client path is limited to server-side passkey ceremonies and browser-session revocation at the configured origin. Credentials, ceremonies, and session/device records are bounded in-memory state; no browser session becomes node authority.
 
-The node owns the child-process identity and lifecycle for the Codex stdio seam. The adapter bounds and redacts event previews and does not persist raw provider transcripts, credentials, approval grants, or thread data. The PWA's Workspace layout is presentation-only: split, move, tab, hide, close, reopen, and recovery mutations never launch, duplicate, input to, or end a Session. Node liveness is checked afresh through `/health`; an unavailable or unknown state disables live-session affordances without historical/local fallback.
+The node owns the child-process identity and lifecycle for the Codex stdio seam and the fixed Claude PTY seam. Neither adapter persists raw provider transcripts, credentials, approval grants, or thread data. The PWA's Workspace layout is presentation-only: split, move, tab, hide, close, reopen, and recovery mutations never launch, duplicate, input to, or end a Session. The separate authenticated Claude terminal route resolves the opaque browser-device identity server-side and is the sole control path. Node liveness is checked afresh through `/health`; an unavailable or unknown state disables live-session affordances without historical/local fallback.
 
 ## Deferred scope
 
-PTY/RMUX, Hermes, other provider adapters, mailbox, files, Session-control API wiring, browser-control grants, node credential rotation, cross-node behavior, approval-grant persistence, and legacy API compatibility remain deferred.
+RMUX, Hermes, other provider adapters, mailbox, files, generic Session-control APIs, browser-control grants, node credential rotation, cross-node behavior, approval-grant persistence, and legacy API compatibility remain deferred.

--- a/docs/adrs/ADR-0003-workspace-layout-is-presentation-only.md
+++ b/docs/adrs/ADR-0003-workspace-layout-is-presentation-only.md
@@ -15,4 +15,4 @@ Malformed, unsupported-version, invalid/cap-exceeding, and overlong saved trees 
 
 ## Consequences
 
-The PWA can prove stable Session identity before and after layout changes without creating a Session API, terminal implementation, file browser, cross-node Workspace, provider adapter, or browser-control surface. A later accepted Session-control issue must add its own Node-bound authority contract; it must not reuse the layout persistence path as a capability channel.
+The PWA can prove stable Session identity before and after layout changes without making layout persistence a capability channel. #1151 later adds a separate, authenticated node-bound Claude PTY control route; it resolves the opaque Session reference server-side and keeps input, resize, interrupt, and explicit close outside this layout model. File browser, cross-node Workspace, generic provider adapters, and browser-control surfaces remain outside this ADR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,18 @@
     "": {
       "name": "relay-factory",
       "version": "0.1.0",
+      "dependencies": {
+        "@xterm/xterm": "^5.5.0"
+      },
       "engines": {
         "node": ">=22.22.3 <23"
       }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "smoke": "node scripts/smoke.mjs",
     "auth:smoke": "node scripts/auth-smoke.mjs",
     "auth:browser": "node scripts/passkey-browser-smoke.mjs"
+  },
+  "dependencies": {
+    "@xterm/xterm": "^5.5.0"
   }
 }

--- a/scripts/build-web.mjs
+++ b/scripts/build-web.mjs
@@ -6,9 +6,12 @@ const output = "web/dist";
 
 await rm(output, { force: true, recursive: true });
 await mkdir(output, { recursive: true });
+await mkdir(`${output}/vendor`, { recursive: true });
 await Promise.all([
   cp(source, output, { recursive: true }),
   cp(publicAssets, output, { recursive: true }),
+  cp("node_modules/@xterm/xterm/lib/xterm.js", `${output}/vendor/xterm.js`),
+  cp("node_modules/@xterm/xterm/css/xterm.css", `${output}/vendor/xterm.css`),
 ]);
 
 console.log(`built PWA shell in ${output}`);

--- a/scripts/cdp-endpoint.mjs
+++ b/scripts/cdp-endpoint.mjs
@@ -1,3 +1,12 @@
 export function devToolsEndpointFromOutput(output) {
   return output.match(/(?:^|\r?\n)DevTools listening on (ws:\/\/[^\r\n]+)\r?\n/)?.[1];
 }
+
+export function devToolsEndpointFromActivePort(contents) {
+  const [portText, path] = contents.split(/\r?\n/, 3);
+  const port = Number(portText);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535 || !path?.startsWith("/devtools/browser/")) {
+    return undefined;
+  }
+  return `ws://127.0.0.1:${port}${path}`;
+}

--- a/scripts/lint-web.mjs
+++ b/scripts/lint-web.mjs
@@ -18,7 +18,7 @@ const errors = [];
 if (!page.includes("manifest.webmanifest") || !page.includes("data-workspace-shell")) {
   errors.push("PWA shell must render the versioned Workspace presentation surface");
 }
-if (!app.includes('const HEALTH_URL = "http://127.0.0.1:8787/health"')) {
+if (!app.includes('const HEALTH_URL = "/health"')) {
   errors.push("PWA shell must use the documented liveness boundary");
 }
 if (!app.includes('const STORAGE_KEY = "relay-factory/workspace-layout/v1"')) {
@@ -32,6 +32,12 @@ if (/fetch|localStorage|document\.cookie|WebSocket|sendInput|terminate|ProcessTr
 }
 if (!app.includes("__Host-relay_csrf") || !app.includes("navigator.credentials")) {
   errors.push("PWA shell must invoke the passkey boundary with CSRF protection");
+}
+if (!page.includes("vendor/xterm.css") || !page.includes('id="open-claude"') || !page.includes('id="interrupt-session"')) {
+  errors.push("PWA shell must expose the browser-visible Claude terminal controls");
+}
+if (!page.includes('src="./vendor/xterm.js"') || !app.includes("new window.Terminal") || !app.includes("/node/claude/sessions")) {
+  errors.push("PWA shell must render and control the bounded Relay-owned Claude PTY");
 }
 if (/WebSocket|Authorization/.test(app)) {
   errors.push("PWA shell must not acquire ambient transport or bearer authority");

--- a/scripts/lint-web.mjs
+++ b/scripts/lint-web.mjs
@@ -5,6 +5,7 @@ const requiredFiles = [
   "web/src/main.js",
   "web/src/workspace-layout.js",
   "web/src/auth.js",
+  "web/src/terminal-recovery.js",
   "web/public/manifest.webmanifest",
 ];
 
@@ -12,7 +13,7 @@ for (const file of requiredFiles) {
   await access(file, constants.R_OK);
 }
 
-const [page, app, layout, auth, manifest] = await Promise.all(requiredFiles.map((file) => readFile(file, "utf8")));
+const [page, app, layout, auth, terminalRecovery, manifest] = await Promise.all(requiredFiles.map((file) => readFile(file, "utf8")));
 const errors = [];
 
 if (!page.includes("manifest.webmanifest") || !page.includes("data-workspace-shell")) {
@@ -44,6 +45,9 @@ if (/WebSocket|Authorization/.test(app)) {
 }
 if (!auth.includes("recovery_required") || !auth.includes("passkey_denied")) {
   errors.push("PWA auth adapter must expose typed recovery and denied states");
+}
+if (!terminalRecovery.includes("input_delivery_lost") || !terminalRecovery.includes("network_uncertain")) {
+  errors.push("PWA terminal recovery adapter must expose typed delivery-loss and uncertain-network states");
 }
 if (!manifest.includes('"display": "standalone"')) {
   errors.push("PWA manifest must declare standalone display");

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -257,6 +257,32 @@ try {
     async () => await evaluate(sessionId, "document.querySelector('.pane[data-selected=\"true\"] .terminal-input-recovery')?.hidden === true"),
     "saved terminal input retry after a layout render",
   );
+  await evaluate(
+    sessionId,
+    `window.relayOriginalInFlightInputFetch = window.fetch; window.relayInFlightInputStarted = false; window.fetch = async (input, init) => { const url = new URL(typeof input === 'string' ? input : input.url, window.location.href); const method = init?.method ?? (typeof input === 'string' ? 'GET' : input.method); if (!window.relayInFlightInputStarted && method === 'POST' && url.pathname.endsWith('/input')) { window.relayInFlightInputStarted = true; await new Promise(() => {}); } return window.relayOriginalInFlightInputFetch(input, init); };`,
+  );
+  await evaluate(sessionId, "document.querySelector('.xterm-helper-textarea').focus()");
+  await browser.command("Input.insertText", { text: "in-flight-across-layout-render\\n" }, sessionId);
+  await waitFor(
+    async () => await evaluate(sessionId, "window.relayInFlightInputStarted"),
+    "in-flight terminal input request",
+  );
+  const inFlightRecoveryAfterLayout = await evaluate(
+    sessionId,
+    `(() => {
+      document.querySelector('[data-action="split"]').click();
+      const recovery = document.querySelector('.pane[data-selected="true"] .terminal-input-recovery');
+      return {
+        visible: Boolean(recovery && !recovery.hidden),
+        message: recovery?.textContent,
+        controls: [...recovery?.querySelectorAll('button') ?? []].map((button) => button.textContent),
+      };
+    })()`,
+  );
+  assert.equal(inFlightRecoveryAfterLayout.visible, true, "a layout render must preserve in-flight terminal input for an explicit operator decision");
+  assert.match(inFlightRecoveryAfterLayout.message, /delivery was in progress/i);
+  assert.deepEqual(inFlightRecoveryAfterLayout.controls, ["Retry saved input", "Discard saved input"]);
+  await evaluate(sessionId, "document.querySelector('.pane[data-selected=\"true\"] .terminal-input-recovery button:nth-of-type(2)').click(); window.fetch = window.relayOriginalInFlightInputFetch; delete window.relayOriginalInFlightInputFetch; delete window.relayInFlightInputStarted");
   await evaluate(sessionId, "document.querySelector('.xterm-helper-textarea').focus()");
   await browser.command("Input.insertText", { text: "browser-keyboard\n" }, sessionId);
   const terminalOperations = await evaluate(
@@ -283,9 +309,9 @@ try {
     terminalOperations.poll.output.some((chunk) => chunk.text.includes("browser-keyboard")),
     "keyboard input through xterm must reach the Relay-owned PTY and return as terminal output",
   );
-  assert.deepEqual(
-    terminalOperations.mirrored,
-    [terminal.sessionId, terminal.sessionId],
+  assert.ok(
+    terminalOperations.mirrored.length >= 2
+      && terminalOperations.mirrored.every((sessionId) => sessionId === terminal.sessionId),
     "split panes must retain one Session identity while the browser detaches and reattaches its terminal view",
   );
   await evaluate(sessionId, "document.querySelector('#interrupt-session').click()");

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -185,6 +185,19 @@ try {
   assert.equal(terminal.hasTerminal, true, "the workbench must render an interactive xterm surface");
   assert.match(terminal.sessionId, /^claude-pty-\d+$/, "the browser receives only an opaque Relay Session ID");
   assert.ok(terminal.csrf, "the browser keeps a CSRF token distinct from the HttpOnly session cookie");
+  await evaluate(
+    sessionId,
+    `window.relayOriginalTerminalFetch = window.fetch; window.relayTerminalPollFailed = false; window.fetch = async (input, init) => { const url = new URL(typeof input === 'string' ? input : input.url, window.location.href); const method = init?.method ?? (typeof input === 'string' ? 'GET' : input.method); if (!window.relayTerminalPollFailed && method === 'GET' && url.pathname.startsWith('/node/claude/sessions/')) { window.relayTerminalPollFailed = true; throw new TypeError('transient terminal poll failure'); } return window.relayOriginalTerminalFetch(input, init); };`,
+  );
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent"))?.startsWith("Terminal unavailable:"),
+    "transient terminal polling failure",
+  );
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent"))?.includes("Relay-owned terminal · running"),
+    "terminal polling recovery",
+  );
+  await evaluate(sessionId, "window.fetch = window.relayOriginalTerminalFetch; delete window.relayOriginalTerminalFetch; delete window.relayTerminalPollFailed");
   await evaluate(sessionId, "document.querySelector('.xterm-helper-textarea').focus()");
   await browser.command("Input.insertText", { text: "browser-keyboard\n" }, sessionId);
   const terminalOperations = await evaluate(
@@ -198,7 +211,7 @@ try {
       const resize = await post('/resize', { cols: 92, rows: 28 });
       let poll = { output: [] };
       for (let attempt = 0; attempt < 25; attempt += 1) {
-        poll = await fetch('/node/claude/sessions/' + sessionId + '?cursor=0', { credentials: 'same-origin' }).then((response) => response.json());
+        poll = await fetch('/node/claude/sessions/' + sessionId + '?trace=browser-smoke&cursor=0', { credentials: 'same-origin' }).then((response) => response.json());
         if (poll.output.some((chunk) => chunk.text.includes('browser-keyboard'))) break;
         await new Promise((resolve) => setTimeout(resolve, 20));
       }

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -173,11 +173,25 @@ try {
     "a valueless unrelated Cookie segment must not invalidate a valid browser session",
   );
 
-  await evaluate(sessionId, "document.querySelector('#open-claude').click()");
+  await evaluate(
+    sessionId,
+    `window.relayOriginalTerminalCreateFetch = window.fetch; window.relayTerminalCreateRequests = 0; window.fetch = async (input, init) => { const url = new URL(typeof input === 'string' ? input : input.url, window.location.href); const method = init?.method ?? (typeof input === 'string' ? 'GET' : input.method); if (method === 'POST' && url.pathname === '/node/claude/sessions') { window.relayTerminalCreateRequests += 1; await new Promise((resolve) => setTimeout(resolve, 25)); } return window.relayOriginalTerminalCreateFetch(input, init); }; const open = document.querySelector('#open-claude'); open.click(); open.click();`,
+  );
   await waitFor(async () => {
     const status = await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent");
     return status?.includes("Relay-owned terminal · running");
   }, "Relay-owned Claude terminal render");
+  assert.equal(
+    await evaluate(sessionId, "window.relayTerminalCreateRequests"),
+    1,
+    "double-clicked terminal creation must serialize to one Relay-owned PTY",
+  );
+  assert.equal(
+    await evaluate(sessionId, "document.querySelector('#open-claude').disabled"),
+    true,
+    "a live terminal cannot overwrite its only opaque Session reference",
+  );
+  await evaluate(sessionId, "window.fetch = window.relayOriginalTerminalCreateFetch; delete window.relayOriginalTerminalCreateFetch; delete window.relayTerminalCreateRequests");
   const terminal = await evaluate(
     sessionId,
     `(() => {
@@ -246,6 +260,16 @@ try {
   await waitFor(
     async () => (await evaluate(sessionId, "document.querySelector('[data-layout-notice]')?.textContent"))?.includes("closed and reaped"),
     "explicit Relay close state",
+  );
+  assert.equal(
+    await evaluate(sessionId, "document.querySelector('#open-claude').disabled"),
+    false,
+    "explicit close must permit replacing the terminal Session reference",
+  );
+  await evaluate(sessionId, "document.querySelector('#open-claude').click()");
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('.pane[data-selected=\"true\"] .terminal-status')?.textContent"))?.includes("Relay-owned terminal · running"),
+    "replacement terminal before browser-session revocation",
   );
   assert.deepEqual(await evaluate(sessionId, "window.relayPageErrors"), [], "the terminal flow must not raise page errors");
 

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -8,7 +8,10 @@ import { access, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, resolve, sep } from "node:path";
 
-import { devToolsEndpointFromOutput } from "./cdp-endpoint.mjs";
+import {
+  devToolsEndpointFromActivePort,
+  devToolsEndpointFromOutput,
+} from "./cdp-endpoint.mjs";
 
 
 const chromium = "/usr/bin/chromium";
@@ -20,6 +23,7 @@ const vendorFiles = new Map([
   ["/vendor/xterm.css", resolve("node_modules/@xterm/xterm/css/xterm.css")],
 ]);
 const scratch = await mkdtemp(`${tmpdir()}/relay-passkey-browser-`);
+const chromeProfile = resolve(scratch, "chrome-profile");
 const recoveryHash = createHash("sha256").update(recoveryCode).digest("hex");
 const httpsPort = await reservePort();
 const origin = `https://relay.test:${httpsPort}`;
@@ -80,13 +84,13 @@ try {
       "--no-sandbox",
       "--disable-gpu",
       "--remote-debugging-port=0",
-      `--user-data-dir=${scratch}/chrome-profile`,
+      `--user-data-dir=${chromeProfile}`,
       "--ignore-certificate-errors",
       "--host-resolver-rules=MAP relay.test 127.0.0.1",
     ],
     { stdio: ["ignore", "pipe", "pipe"] },
   );
-  browser = await connectBrowser(chromiumProcess, captureProcessOutput(chromiumProcess));
+  browser = await connectBrowser(chromiumProcess, captureProcessOutput(chromiumProcess), chromeProfile);
   const { targetId } = await browser.command("Target.createTarget", { url: "about:blank" });
   const { sessionId } = await browser.command("Target.attachToTarget", { targetId, flatten: true });
   await browser.command("Page.enable", {}, sessionId);
@@ -478,10 +482,10 @@ function captureProcessOutput(process_) {
   return () => output;
 }
 
-async function connectBrowser(process_, output) {
+async function connectBrowser(process_, output, profile) {
   const debuggerUrl = await waitFor(
-    () => {
-      const endpoint = devToolsEndpointFromOutput(output());
+    async () => {
+      const endpoint = (await devToolsEndpointFromProfile(profile)) ?? devToolsEndpointFromOutput(output());
       if (endpoint) return endpoint;
       if (process_.exitCode !== null || process_.signalCode !== null) {
         throw new Error(`Chromium exited before exposing a DevTools endpoint: ${processOutputSummary(process_, output())}`);
@@ -496,6 +500,14 @@ async function connectBrowser(process_, output) {
     throw new Error(`could not connect to Chromium DevTools at ${debuggerUrl}: ${processOutputSummary(process_, output())}`, {
       cause: error,
     });
+  }
+}
+
+async function devToolsEndpointFromProfile(profile) {
+  try {
+    return devToolsEndpointFromActivePort(await readFile(resolve(profile, "DevToolsActivePort"), "utf8"));
+  } catch {
+    return undefined;
   }
 }
 

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -15,6 +15,10 @@ const chromium = "/usr/bin/chromium";
 const recoveryCode = "browser-virtual-authenticator-recovery";
 const root = resolve("web/src");
 const publicRoot = resolve("web/public");
+const vendorFiles = new Map([
+  ["/vendor/xterm.js", resolve("node_modules/@xterm/xterm/lib/xterm.js")],
+  ["/vendor/xterm.css", resolve("node_modules/@xterm/xterm/css/xterm.css")],
+]);
 const scratch = await mkdtemp(`${tmpdir()}/relay-passkey-browser-`);
 const recoveryHash = createHash("sha256").update(recoveryCode).digest("hex");
 const httpsPort = await reservePort();
@@ -103,6 +107,10 @@ try {
   );
   await browser.command("Page.navigate", { url: `${origin}/` }, sessionId);
   await waitFor(async () => (await evaluate(sessionId, "document.readyState")) === "complete");
+  await evaluate(
+    sessionId,
+    "window.relayPageErrors = []; addEventListener('error', (event) => window.relayPageErrors.push(event.message)); addEventListener('unhandledrejection', (event) => window.relayPageErrors.push(String(event.reason)));",
+  );
 
   await evaluate(
     sessionId,
@@ -143,6 +151,10 @@ try {
 
   await evaluate(sessionId, "document.querySelector('#sign-in').click()");
   await waitFor(async () => (await evaluate(sessionId, "document.querySelector('#auth-status').textContent"))?.includes("Passkey verified"));
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('#open-claude').disabled")) === false,
+    "authenticated Claude terminal affordance",
+  );
   assert.equal(
     await evaluate(sessionId, "fetch('/protected/hub', { credentials: 'same-origin' }).then((response) => response.status)"),
     200,
@@ -156,6 +168,69 @@ try {
     200,
     "a valueless unrelated Cookie segment must not invalidate a valid browser session",
   );
+
+  await evaluate(sessionId, "document.querySelector('#open-claude').click()");
+  await waitFor(async () => {
+    const status = await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent");
+    return status?.includes("Relay-owned terminal · running");
+  }, "Relay-owned Claude terminal render");
+  const terminal = await evaluate(
+    sessionId,
+    `(() => {
+      const sessionId = document.querySelector('.session-card code')?.textContent;
+      const csrf = document.cookie.split('; ').find((cookie) => cookie.startsWith('__Host-relay_csrf='))?.slice('__Host-relay_csrf='.length);
+      return { hasTerminal: Boolean(document.querySelector('.terminal-host .xterm')), sessionId, csrf };
+    })()`,
+  );
+  assert.equal(terminal.hasTerminal, true, "the workbench must render an interactive xterm surface");
+  assert.match(terminal.sessionId, /^claude-pty-\d+$/, "the browser receives only an opaque Relay Session ID");
+  assert.ok(terminal.csrf, "the browser keeps a CSRF token distinct from the HttpOnly session cookie");
+  await evaluate(sessionId, "document.querySelector('.xterm-helper-textarea').focus()");
+  await browser.command("Input.insertText", { text: "browser-keyboard\n" }, sessionId);
+  const terminalOperations = await evaluate(
+    sessionId,
+    `(async () => {
+      const sessionId = document.querySelector('.session-card code').textContent;
+      const csrf = document.cookie.split('; ').find((cookie) => cookie.startsWith('__Host-relay_csrf='))?.slice('__Host-relay_csrf='.length);
+      const post = (suffix, body) => fetch('/node/claude/sessions/' + sessionId + suffix, {
+        method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json', 'X-Relay-CSRF': csrf }, body: JSON.stringify(body),
+      }).then((response) => response.status);
+      const resize = await post('/resize', { cols: 92, rows: 28 });
+      let poll = { output: [] };
+      for (let attempt = 0; attempt < 25; attempt += 1) {
+        poll = await fetch('/node/claude/sessions/' + sessionId + '?cursor=0', { credentials: 'same-origin' }).then((response) => response.json());
+        if (poll.output.some((chunk) => chunk.text.includes('browser-keyboard'))) break;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      document.querySelector('[data-action="split"]').click();
+      const mirrored = [...document.querySelectorAll('.session-card code')].map((node) => node.textContent);
+      return { resize, poll, mirrored };
+    })()`,
+  );
+  assert.equal(terminalOperations.resize, 200, "the visible terminal must resize through the authenticated node boundary");
+  assert.ok(
+    terminalOperations.poll.output.some((chunk) => chunk.text.includes("browser-keyboard")),
+    "keyboard input through xterm must reach the Relay-owned PTY and return as terminal output",
+  );
+  assert.deepEqual(
+    terminalOperations.mirrored,
+    [terminal.sessionId, terminal.sessionId],
+    "split panes must retain one Session identity while the browser detaches and reattaches its terminal view",
+  );
+  await evaluate(sessionId, "document.querySelector('#interrupt-session').click()");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const interruptStatus = await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent");
+  assert.doesNotMatch(
+    interruptStatus,
+    /rejected|unavailable/i,
+    "browser interrupt must be accepted without turning Ctrl-C into implicit terminal close",
+  );
+  await evaluate(sessionId, "document.querySelector('#end-session').click()");
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('[data-layout-notice]')?.textContent"))?.includes("closed and reaped"),
+    "explicit Relay close state",
+  );
+  assert.deepEqual(await evaluate(sessionId, "window.relayPageErrors"), [], "the terminal flow must not raise page errors");
 
   const revokeStatuses = await evaluate(
     sessionId,
@@ -216,6 +291,8 @@ function startHub() {
       origin,
       "--recovery-code-hash",
       recoveryHash,
+      "--test-claude-fixture",
+      "cat",
     ],
     { stdio: ["ignore", "pipe", "pipe"] },
   );
@@ -300,7 +377,7 @@ async function startProxy(hubPort) {
   const [key, cert] = await Promise.all([readFile(`${scratch}/key.pem`), readFile(`${scratch}/cert.pem`)]);
   const server = createHttpsServer({ key, cert }, (request, response) => {
     const path = new URL(request.url ?? "/", origin).pathname;
-    if (path.startsWith("/auth/") || path.startsWith("/protected/")) {
+    if (path === "/health" || path.startsWith("/auth/") || path.startsWith("/node/") || path.startsWith("/protected/")) {
       const upstream = httpRequest(
         {
           host: "127.0.0.1",
@@ -326,6 +403,20 @@ async function startProxy(hubPort) {
 }
 
 async function serveStatic(path, response) {
+  const vendor = vendorFiles.get(path);
+  if (vendor) {
+    try {
+      const content = await readFile(vendor);
+      response.writeHead(200, {
+        "Cache-Control": "no-store",
+        "Content-Type": contentType(extname(vendor)),
+      });
+      response.end(content);
+    } catch {
+      response.writeHead(404).end();
+    }
+    return;
+  }
   const relative = path === "/" ? "index.html" : path.slice(1);
   const base = relative === "manifest.webmanifest" ? publicRoot : root;
   const file = resolve(base, relative);

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -381,23 +381,9 @@ try {
     403,
     "a browser session must never become node authority",
   );
-  const pendingOwnerCleanupLine = "relay Claude PTY owner cleanup remains pending for retry";
-  const pendingOwnerCleanupCount = () => hubAddress.output().split(`${pendingOwnerCleanupLine}\n`).length - 1;
-  assert.equal(
-    await evaluate(sessionId, "fetch('/health').then((response) => response.status)"),
-    200,
-    "the request-driven teardown scheduler must remain available after revocation",
-  );
-  const pendingOwnerCleanupAfterProbe = pendingOwnerCleanupCount();
-  assert.equal(await evaluate(sessionId, "fetch('/health').then((response) => response.status)"), 200);
-  assert.equal(
-    pendingOwnerCleanupCount(),
-    pendingOwnerCleanupAfterProbe,
-    "owner cleanup must converge instead of logging an unbounded request-driven retry loop",
-  );
   assert.match(
     hubAddress.output(),
-    /^relay-hub liveness listening on 127\.0\.0\.1:\d+\n(?:relay Claude PTY owner cleanup remains pending for retry\n)*$/,
+    /^relay-hub liveness listening on 127\.0\.0\.1:\d+\n$/,
     "the real WebAuthn enrollment, assertion, session, and revoke path must not append credential or session material to hub logs",
   );
 

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -216,6 +216,47 @@ try {
     "terminal polling recovery",
   );
   await evaluate(sessionId, "window.fetch = window.relayOriginalTerminalFetch; delete window.relayOriginalTerminalFetch; delete window.relayTerminalPollFailed");
+  await evaluate(
+    sessionId,
+    `window.relayOriginalTerminalInputFetch = window.fetch; window.relayTerminalInputFailed = false; window.fetch = async (input, init) => { const url = new URL(typeof input === 'string' ? input : input.url, window.location.href); const method = init?.method ?? (typeof input === 'string' ? 'GET' : input.method); if (!window.relayTerminalInputFailed && method === 'POST' && url.pathname.endsWith('/input')) { window.relayTerminalInputFailed = true; throw new TypeError('uncertain terminal input delivery'); } return window.relayOriginalTerminalInputFetch(input, init); };`,
+  );
+  await evaluate(sessionId, "document.querySelector('.xterm-helper-textarea').focus()");
+  await browser.command("Input.insertText", { text: "saved-across-layout-render\n" }, sessionId);
+  await waitFor(
+    async () => await evaluate(sessionId, `(() => {
+      const recovery = document.querySelector('.terminal-input-recovery');
+      return recovery && !recovery.hidden && recovery.textContent.includes('input is saved');
+    })()`),
+    "saved uncertain terminal input",
+  );
+  await evaluate(sessionId, "window.fetch = window.relayOriginalTerminalInputFetch; delete window.relayOriginalTerminalInputFetch; delete window.relayTerminalInputFailed");
+  const recoveryAfterLayout = await evaluate(
+    sessionId,
+    `(() => {
+      document.querySelector('[data-action="split"]').click();
+      const recovery = document.querySelector('.pane[data-selected="true"] .terminal-input-recovery');
+      return {
+        visible: Boolean(recovery && !recovery.hidden),
+        message: recovery?.textContent,
+        controls: [...recovery?.querySelectorAll('button') ?? []].map((button) => button.textContent),
+      };
+    })()`,
+  );
+  assert.equal(recoveryAfterLayout.visible, true, "a layout render must preserve paused uncertain terminal input");
+  assert.match(recoveryAfterLayout.message, /input is saved/i);
+  assert.deepEqual(recoveryAfterLayout.controls, ["Retry saved input", "Discard saved input"]);
+  const retryStatus = await evaluate(
+    sessionId,
+    `(() => {
+      document.querySelector('.pane[data-selected="true"] .terminal-input-recovery button').click();
+      return document.querySelector('.pane[data-selected="true"] .terminal-status')?.textContent;
+    })()`,
+  );
+  assert.match(retryStatus, /Retrying saved terminal input/);
+  await waitFor(
+    async () => await evaluate(sessionId, "document.querySelector('.pane[data-selected=\"true\"] .terminal-input-recovery')?.hidden === true"),
+    "saved terminal input retry after a layout render",
+  );
   await evaluate(sessionId, "document.querySelector('.xterm-helper-textarea').focus()");
   await browser.command("Input.insertText", { text: "browser-keyboard\n" }, sessionId);
   const terminalOperations = await evaluate(
@@ -233,7 +274,6 @@ try {
         if (poll.output.some((chunk) => chunk.text.includes('browser-keyboard'))) break;
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
-      document.querySelector('[data-action="split"]').click();
       const mirrored = [...document.querySelectorAll('.session-card code')].map((node) => node.textContent);
       return { resize, poll, mirrored };
     })()`,

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -72,6 +72,14 @@ if (spawnSync(chromium, ["--version"], { encoding: "utf8" }).status !== 0) {
   process.exit(0);
 }
 
+for (const [path, file] of vendorFiles) {
+  try {
+    await access(file);
+  } catch (error) {
+    throw new Error(`passkey browser matrix requires ${path}; run npm ci`, { cause: error });
+  }
+}
+
 try {
   await createCertificate();
   hub = startHub();
@@ -111,6 +119,11 @@ try {
   );
   await browser.command("Page.navigate", { url: `${origin}/` }, sessionId);
   await waitFor(async () => (await evaluate(sessionId, "document.readyState")) === "complete");
+  assert.equal(
+    await evaluate(sessionId, "typeof window.Terminal"),
+    "function",
+    "the xterm browser fixture must expose a Terminal constructor",
+  );
   await evaluate(
     sessionId,
     "window.relayPageErrors = []; addEventListener('error', (event) => window.relayPageErrors.push(event.message)); addEventListener('unhandledrejection', (event) => window.relayPageErrors.push(String(event.reason)));",
@@ -368,9 +381,23 @@ try {
     403,
     "a browser session must never become node authority",
   );
+  const pendingOwnerCleanupLine = "relay Claude PTY owner cleanup remains pending for retry";
+  const pendingOwnerCleanupCount = () => hubAddress.output().split(`${pendingOwnerCleanupLine}\n`).length - 1;
+  assert.equal(
+    await evaluate(sessionId, "fetch('/health').then((response) => response.status)"),
+    200,
+    "the request-driven teardown scheduler must remain available after revocation",
+  );
+  const pendingOwnerCleanupAfterProbe = pendingOwnerCleanupCount();
+  assert.equal(await evaluate(sessionId, "fetch('/health').then((response) => response.status)"), 200);
+  assert.equal(
+    pendingOwnerCleanupCount(),
+    pendingOwnerCleanupAfterProbe,
+    "owner cleanup must converge instead of logging an unbounded request-driven retry loop",
+  );
   assert.match(
     hubAddress.output(),
-    /^relay-hub liveness listening on 127\.0\.0\.1:\d+\n$/,
+    /^relay-hub liveness listening on 127\.0\.0\.1:\d+\n(?:relay Claude PTY owner cleanup remains pending for retry\n)*$/,
     "the real WebAuthn enrollment, assertion, session, and revoke path must not append credential or session material to hub logs",
   );
 

--- a/scripts/serve-web.mjs
+++ b/scripts/serve-web.mjs
@@ -1,17 +1,33 @@
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
-import { createServer } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import { extname, resolve, sep } from "node:path";
 
 const root = resolve("web/dist");
 const mimeTypes = new Map([
   [".html", "text/html; charset=utf-8"],
   [".js", "text/javascript; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
   [".webmanifest", "application/manifest+json"],
 ]);
 
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  if (["/health", "/auth/", "/node/", "/protected/"].some((prefix) => url.pathname === prefix || url.pathname.startsWith(prefix))) {
+    const upstream = httpRequest({
+      host: "127.0.0.1",
+      port: 8787,
+      method: request.method,
+      path: `${url.pathname}${url.search}`,
+      headers: { ...request.headers, host: "127.0.0.1:8787" },
+    }, (upstreamResponse) => {
+      response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+      upstreamResponse.pipe(response);
+    });
+    upstream.on("error", () => response.writeHead(502).end());
+    request.pipe(upstream);
+    return;
+  }
   const relativePath = url.pathname === "/" ? "index.html" : url.pathname.slice(1);
   const file = resolve(root, relativePath);
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#111827" />
     <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./vendor/xterm.css" />
     <title>Relay workspace</title>
     <style>
       :root {
@@ -166,6 +167,16 @@
       }
 
       .session-note { color: #c5d1ed; font-size: 0.85rem; margin: 0; }
+      .terminal-status { color: #aab8d8; font-size: 0.78rem; margin: 0; }
+      .terminal-host {
+        background: #050914;
+        border: 1px solid #43537b;
+        border-radius: 0.45rem;
+        min-height: 18rem;
+        overflow: hidden;
+        padding: 0.35rem;
+      }
+      .terminal-host .xterm { height: 100%; }
       .identity-list { color: #c5d1ed; font-size: 0.85rem; margin: 1rem 0 0; }
       .authority { border-top: 1px solid #273553; margin-top: 1rem; padding-top: 1rem; }
       .authority p { color: #c5d1ed; font-size: 0.85rem; margin-bottom: 0.65rem; }
@@ -263,6 +274,7 @@
           </div>
 
           <div class="toolbar" role="toolbar" aria-label="Layout controls">
+            <button type="button" id="open-claude" disabled>Open Claude terminal</button>
             <button type="button" data-action="new-tab">New Session tab</button>
             <button type="button" data-action="split">Split pane</button>
             <button type="button" data-action="move">Move pane</button>
@@ -274,13 +286,15 @@
           <div class="layout" data-layout aria-label="Workspace layout"></div>
 
           <section class="authority" aria-label="Session authority boundary">
-            <p>Pane and tab changes only alter local presentation references. Session input and end actions require a separate Node/runtime authority and are not exposed by this layout slice.</p>
-            <button type="button" id="end-session" disabled aria-describedby="session-authority-note">End Session (Node authority required)</button>
+            <p>Pane and tab changes only alter local presentation references. A signed-in operator may open one Relay-owned Claude PTY; closing a pane detaches presentation while explicit close reaps the owned process.</p>
+            <button type="button" id="interrupt-session" disabled>Interrupt Claude terminal</button>
+            <button type="button" id="end-session" disabled aria-describedby="session-authority-note">Close Claude terminal</button>
             <p id="session-authority-note" class="session-note" data-session-authority></p>
           </section>
         </section>
       </div>
     </main>
+    <script src="./vendor/xterm.js"></script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -168,6 +168,18 @@
 
       .session-note { color: #c5d1ed; font-size: 0.85rem; margin: 0; }
       .terminal-status { color: #aab8d8; font-size: 0.78rem; margin: 0; }
+      .terminal-input-recovery {
+        align-items: center;
+        border: 1px solid #ffb6ce;
+        color: #ffd0dd;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        padding: 0.65rem;
+      }
+      .terminal-input-recovery[hidden] { display: none; }
+      .terminal-input-recovery p { flex: 1 1 18rem; }
+      .terminal-input-recovery button { min-height: 2.15rem; }
       .terminal-host {
         background: #050914;
         border: 1px solid #43537b;

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -5,6 +5,7 @@ import {
   presentationForAuthError,
 } from "./auth.js";
 import { createTerminalInputQueue } from "./terminal-input.js";
+import { terminalErrorPresentation, terminalInputRecovery } from "./terminal-recovery.js";
 import {
   MAX_PANE_COUNT,
   MAX_TAB_COUNT,
@@ -280,14 +281,34 @@ function renderLayoutNode(node) {
   );
   if (activeTab.content.sessionId.startsWith("claude-pty-")) {
     const status = textElement("p", "Attaching Relay-owned Claude terminal…", "terminal-status");
+    status.setAttribute("aria-live", "polite");
     const host = document.createElement("div");
     host.className = "terminal-host";
+    const inputRecovery = document.createElement("div");
+    inputRecovery.className = "terminal-input-recovery";
+    inputRecovery.hidden = true;
+    const inputRecoveryMessage = textElement("p", "", "terminal-status");
+    const retryInput = document.createElement("button");
+    retryInput.type = "button";
+    retryInput.textContent = "Retry saved input";
+    const discardInput = document.createElement("button");
+    discardInput.type = "button";
+    discardInput.textContent = "Discard saved input";
+    inputRecovery.append(inputRecoveryMessage, retryInput, discardInput);
     session.append(
       status,
       host,
+      inputRecovery,
       textElement("p", "Pane moves and close detach this browser view; only the explicit terminal close reaps the node-owned process.", "session-note"),
     );
-    if (node.id === state.selectedPaneId) mountTerminal(activeTab.content.sessionId, host, status);
+    if (node.id === state.selectedPaneId) {
+      mountTerminal(activeTab.content.sessionId, host, status, {
+        root: inputRecovery,
+        message: inputRecoveryMessage,
+        retry: retryInput,
+        discard: discardInput,
+      });
+    }
   } else {
     session.append(textElement(
       "p",
@@ -354,7 +375,7 @@ async function closeClaudeTerminal() {
   }
 }
 
-function mountTerminal(sessionId, host, status) {
+function mountTerminal(sessionId, host, status, inputRecovery) {
   const terminal = new window.Terminal({
     cols: 120,
     rows: 36,
@@ -377,6 +398,7 @@ function mountTerminal(sessionId, host, status) {
     resizeObserver: null,
     inputSubscription: null,
     inputQueue: null,
+    inputRecovery,
     cols: 0,
     rows: 0,
   };
@@ -389,8 +411,26 @@ function mountTerminal(sessionId, host, status) {
       body: JSON.stringify({ data }),
     }),
     onError: (error) => {
-      if (terminalRuntime === runtime) runtime.status.textContent = `Input rejected: ${terminalErrorMessage(error)}`;
+      if (terminalRuntime !== runtime) return;
+      const presentation = terminalInputRecovery(error);
+      const inputPaused = runtime.inputQueue?.isPaused();
+      runtime.status.textContent = `${inputPaused ? "Input paused" : "Input not queued"}: ${presentation.message}`;
+      if (inputPaused) {
+        showTerminalInputRecovery(runtime, presentation.message);
+      } else {
+        hideTerminalInputRecovery(runtime);
+      }
     },
+  });
+  inputRecovery.retry.addEventListener("click", () => {
+    if (!runtime.inputQueue?.resume()) return;
+    hideTerminalInputRecovery(runtime);
+    runtime.status.textContent = "Retrying saved terminal input. Inspect terminal output for possible duplicate delivery.";
+  });
+  inputRecovery.discard.addEventListener("click", () => {
+    if (!runtime.inputQueue?.discard()) return;
+    hideTerminalInputRecovery(runtime);
+    runtime.status.textContent = "Saved terminal input was discarded.";
   });
   runtime.inputSubscription = terminal.onData((data) => runtime.inputQueue.enqueue(data));
   if (typeof ResizeObserver === "function") {
@@ -416,6 +456,16 @@ function disposeTerminal() {
   terminalRuntime.inputQueue?.dispose();
   terminalRuntime.terminal.dispose();
   terminalRuntime = null;
+}
+
+function showTerminalInputRecovery(runtime, message) {
+  runtime.inputRecovery.message.textContent = message;
+  runtime.inputRecovery.root.hidden = false;
+}
+
+function hideTerminalInputRecovery(runtime) {
+  runtime.inputRecovery.message.textContent = "";
+  runtime.inputRecovery.root.hidden = true;
 }
 
 async function pollTerminal(runtime) {
@@ -477,12 +527,7 @@ async function resizeTerminal(runtime) {
 }
 
 function terminalErrorMessage(error) {
-  const code = error?.code;
-  if (code === "stale_session") return "This Session belongs to a prior node runtime. Open a new terminal explicitly.";
-  if (code === "claude_unavailable") return "Claude Code could not start in the node-owner context.";
-  if (code === "input_backpressure") return "Terminal input is temporarily backlogged. Wait for Relay to catch up.";
-  if (code === "input_delivery_lost") return "Relay could not finish a queued input batch. Re-enter the command; it was not retried automatically.";
-  return presentationForAuthError(error).message;
+  return terminalErrorPresentation(error).message;
 }
 
 function sessionAuthorityMessage() {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -54,6 +54,7 @@ let terminalRuntime = null;
 const retainedTerminalInput = new Map();
 let claudeCreateInFlight = false;
 const resolvedClaudeSessionIds = new Set();
+const MAX_RESOLVED_CLAUDE_SESSION_IDS = MAX_TAB_COUNT;
 let state = loadLayout();
 let transientNotice = null;
 
@@ -366,7 +367,7 @@ async function closeClaudeTerminal() {
       headers: { "X-Relay-CSRF": csrfToken() },
       body: "{}",
     });
-    resolvedClaudeSessionIds.add(active.content.sessionId);
+    rememberResolvedClaudeSession(active.content.sessionId);
     disposeTerminal();
     transientNotice = { kind: "warning", title: "Claude terminal", message: "The Relay-owned process was closed and reaped. This tab keeps the closed Session reference for an honest reattach state." };
     render();
@@ -498,7 +499,7 @@ async function pollTerminal(runtime) {
     runtime.cursor = snapshot.nextCursor;
     runtime.status.textContent = `Relay-owned terminal · ${snapshot.status} · dropped chunks ${snapshot.droppedChunks}`;
     if (["closed", "exited"].includes(snapshot.status)) {
-      resolvedClaudeSessionIds.add(runtime.sessionId);
+      rememberResolvedClaudeSession(runtime.sessionId);
       openClaude.disabled = !canOpenClaudeTerminal();
       sessionAuthority.textContent = sessionAuthorityMessage();
       return;
@@ -516,6 +517,14 @@ async function pollTerminal(runtime) {
 
 function shouldRetryTerminalPoll(error) {
   return !error?.code || error.code === "pty_transport";
+}
+
+function rememberResolvedClaudeSession(sessionId) {
+  resolvedClaudeSessionIds.delete(sessionId);
+  resolvedClaudeSessionIds.add(sessionId);
+  while (resolvedClaudeSessionIds.size > MAX_RESOLVED_CLAUDE_SESSION_IDS) {
+    resolvedClaudeSessionIds.delete(resolvedClaudeSessionIds.values().next().value);
+  }
 }
 
 function canOpenClaudeTerminal() {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -481,6 +481,7 @@ function terminalErrorMessage(error) {
   if (code === "stale_session") return "This Session belongs to a prior node runtime. Open a new terminal explicitly.";
   if (code === "claude_unavailable") return "Claude Code could not start in the node-owner context.";
   if (code === "input_backpressure") return "Terminal input is temporarily backlogged. Wait for Relay to catch up.";
+  if (code === "input_delivery_lost") return "Relay could not finish a queued input batch. Re-enter the command; it was not retried automatically.";
   return presentationForAuthError(error).message;
 }
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -50,6 +50,8 @@ const sessionStatus = document.querySelector("#session-status");
 const trustedDevices = document.querySelector("#trusted-devices");
 let currentDeviceId = null;
 let terminalRuntime = null;
+let claudeCreateInFlight = false;
+const resolvedClaudeSessionIds = new Set();
 let state = loadLayout();
 let transientNotice = null;
 
@@ -168,7 +170,7 @@ function render() {
   }
 
   const activeClaudeSession = activeTab?.content.sessionId.startsWith("claude-pty-");
-  openClaude.disabled = state.nodeAvailability !== "available" || !currentDeviceId;
+  openClaude.disabled = !canOpenClaudeTerminal();
   interruptSession.disabled = !activeClaudeSession || !currentDeviceId;
   endSession.disabled = !activeClaudeSession || !currentDeviceId;
   sessionAuthority.textContent = sessionAuthorityMessage();
@@ -299,7 +301,9 @@ function renderLayoutNode(node) {
 }
 
 async function openClaudeTerminal() {
-  if (openClaude.disabled) return;
+  if (!canOpenClaudeTerminal()) return;
+  claudeCreateInFlight = true;
+  openClaude.disabled = true;
   try {
     const snapshot = await request("/node/claude/sessions", {
       method: "POST",
@@ -308,9 +312,10 @@ async function openClaudeTerminal() {
     });
     state = attachSessionToSelectedTab(state, snapshot.sessionId, "Claude terminal");
     persistLayout();
-    render();
   } catch (error) {
     transientNotice = { kind: "error", title: "Claude terminal", message: terminalErrorMessage(error) };
+  } finally {
+    claudeCreateInFlight = false;
     render();
   }
 }
@@ -339,6 +344,7 @@ async function closeClaudeTerminal() {
       headers: { "X-Relay-CSRF": csrfToken() },
       body: "{}",
     });
+    resolvedClaudeSessionIds.add(active.content.sessionId);
     disposeTerminal();
     transientNotice = { kind: "warning", title: "Claude terminal", message: "The Relay-owned process was closed and reaped. This tab keeps the closed Session reference for an honest reattach state." };
     render();
@@ -420,7 +426,12 @@ async function pollTerminal(runtime) {
     for (const chunk of snapshot.output) runtime.terminal.write(chunk.text);
     runtime.cursor = snapshot.nextCursor;
     runtime.status.textContent = `Relay-owned terminal · ${snapshot.status} · dropped chunks ${snapshot.droppedChunks}`;
-    if (["closed", "exited"].includes(snapshot.status)) return;
+    if (["closed", "exited"].includes(snapshot.status)) {
+      resolvedClaudeSessionIds.add(runtime.sessionId);
+      openClaude.disabled = !canOpenClaudeTerminal();
+      sessionAuthority.textContent = sessionAuthorityMessage();
+      return;
+    }
     runtime.timer = window.setTimeout(() => void pollTerminal(runtime), snapshot.hasMore ? 0 : 100);
   } catch (error) {
     if (terminalRuntime === runtime) {
@@ -434,6 +445,16 @@ async function pollTerminal(runtime) {
 
 function shouldRetryTerminalPoll(error) {
   return !error?.code || error.code === "pty_transport";
+}
+
+function canOpenClaudeTerminal() {
+  if (claudeCreateInFlight || state.nodeAvailability !== "available" || !currentDeviceId) return false;
+  const pane = selectedPane(state);
+  const active = pane.tabs.find((tab) => tab.id === pane.activeTabId);
+  const sessionId = active?.content.sessionId;
+  if (!sessionId?.startsWith("claude-pty-")) return true;
+  if (resolvedClaudeSessionIds.has(sessionId)) return true;
+  return sessionIds(state).filter((candidate) => candidate === sessionId).length > 1;
 }
 
 async function resizeTerminal(runtime) {
@@ -472,6 +493,17 @@ function sessionAuthorityMessage() {
   }
   if (!currentDeviceId) {
     return "Sign in with a passkey before requesting a Relay-owned Claude terminal. Browser authority gates the node runtime; it never exposes a process handle.";
+  }
+  if (claudeCreateInFlight) {
+    return "Relay is creating one node-owned PTY Session. Wait for that request to settle before opening another terminal.";
+  }
+  const pane = selectedPane(state);
+  const active = pane.tabs.find((tab) => tab.id === pane.activeTabId);
+  if (active?.content.sessionId.startsWith("claude-pty-") && !resolvedClaudeSessionIds.has(active.content.sessionId)) {
+    if (sessionIds(state).filter((candidate) => candidate === active.content.sessionId).length > 1) {
+      return "This tab mirrors a live Relay-owned terminal. Opening here preserves the existing Session reference in another tab.";
+    }
+    return "This tab already owns a live Relay terminal. End it explicitly or open a new tab before replacing this Session reference.";
   }
   return "The node is available. Open a Claude terminal to create one authenticated, node-owned PTY Session; layout changes remain presentation-only.";
 }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4,6 +4,7 @@ import {
   isPasskeySupported,
   presentationForAuthError,
 } from "./auth.js";
+import { createTerminalInputQueue } from "./terminal-input.js";
 import {
   MAX_PANE_COUNT,
   MAX_TAB_COUNT,
@@ -369,11 +370,23 @@ function mountTerminal(sessionId, host, status) {
     resizeTimer: null,
     resizeObserver: null,
     inputSubscription: null,
+    inputQueue: null,
     cols: 0,
     rows: 0,
   };
   terminalRuntime = runtime;
-  runtime.inputSubscription = terminal.onData((data) => void sendTerminalInput(runtime, data));
+  runtime.inputQueue = createTerminalInputQueue({
+    isActive: () => terminalRuntime === runtime,
+    send: (data) => request(`/node/claude/sessions/${runtime.sessionId}/input`, {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: JSON.stringify({ data }),
+    }),
+    onError: (error) => {
+      if (terminalRuntime === runtime) runtime.status.textContent = `Input rejected: ${terminalErrorMessage(error)}`;
+    },
+  });
+  runtime.inputSubscription = terminal.onData((data) => runtime.inputQueue.enqueue(data));
   if (typeof ResizeObserver === "function") {
     runtime.resizeObserver = new ResizeObserver(() => {
       if (runtime.resizeTimer !== null) return;
@@ -394,6 +407,7 @@ function disposeTerminal() {
   clearTimeout(terminalRuntime.resizeTimer);
   terminalRuntime.resizeObserver?.disconnect();
   terminalRuntime.inputSubscription?.dispose();
+  terminalRuntime.inputQueue?.dispose();
   terminalRuntime.terminal.dispose();
   terminalRuntime = null;
 }
@@ -409,21 +423,17 @@ async function pollTerminal(runtime) {
     if (["closed", "exited"].includes(snapshot.status)) return;
     runtime.timer = window.setTimeout(() => void pollTerminal(runtime), snapshot.hasMore ? 0 : 100);
   } catch (error) {
-    if (terminalRuntime === runtime) runtime.status.textContent = `Terminal unavailable: ${terminalErrorMessage(error)}`;
+    if (terminalRuntime === runtime) {
+      runtime.status.textContent = `Terminal unavailable: ${terminalErrorMessage(error)}`;
+      if (shouldRetryTerminalPoll(error)) {
+        runtime.timer = window.setTimeout(() => void pollTerminal(runtime), 1_000);
+      }
+    }
   }
 }
 
-async function sendTerminalInput(runtime, data) {
-  if (terminalRuntime !== runtime || !data) return;
-  try {
-    await request(`/node/claude/sessions/${runtime.sessionId}/input`, {
-      method: "POST",
-      headers: { "X-Relay-CSRF": csrfToken() },
-      body: JSON.stringify({ data }),
-    });
-  } catch (error) {
-    if (terminalRuntime === runtime) runtime.status.textContent = `Input rejected: ${terminalErrorMessage(error)}`;
-  }
+function shouldRetryTerminalPoll(error) {
+  return !error?.code || error.code === "pty_transport";
 }
 
 async function resizeTerminal(runtime) {
@@ -449,6 +459,7 @@ function terminalErrorMessage(error) {
   const code = error?.code;
   if (code === "stale_session") return "This Session belongs to a prior node runtime. Open a new terminal explicitly.";
   if (code === "claude_unavailable") return "Claude Code could not start in the node-owner context.";
+  if (code === "input_backpressure") return "Terminal input is temporarily backlogged. Wait for Relay to catch up.";
   return presentationForAuthError(error).message;
 }
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -51,6 +51,7 @@ const sessionStatus = document.querySelector("#session-status");
 const trustedDevices = document.querySelector("#trusted-devices");
 let currentDeviceId = null;
 let terminalRuntime = null;
+const retainedTerminalInput = new Map();
 let claudeCreateInFlight = false;
 const resolvedClaudeSessionIds = new Set();
 let state = loadLayout();
@@ -158,7 +159,7 @@ function render() {
   renderNodeStatus();
   renderNotice();
   renderSessionIdentity();
-  disposeTerminal();
+  disposeTerminal({ preservePausedInput: true });
   renderLayout(state.layout, layoutRoot);
 
   for (const button of document.querySelectorAll("[data-action]")) {
@@ -376,6 +377,8 @@ async function closeClaudeTerminal() {
 }
 
 function mountTerminal(sessionId, host, status, inputRecovery) {
+  const retainedInput = retainedTerminalInput.get(sessionId);
+  retainedTerminalInput.delete(sessionId);
   const terminal = new window.Terminal({
     cols: 120,
     rows: 36,
@@ -399,6 +402,7 @@ function mountTerminal(sessionId, host, status, inputRecovery) {
     inputSubscription: null,
     inputQueue: null,
     inputRecovery,
+    inputRecoveryMessage: "",
     cols: 0,
     rows: 0,
   };
@@ -421,7 +425,12 @@ function mountTerminal(sessionId, host, status, inputRecovery) {
         hideTerminalInputRecovery(runtime);
       }
     },
+    initialPausedInput: retainedInput?.pending,
   });
+  if (retainedInput) {
+    runtime.status.textContent = `Input paused: ${retainedInput.message}`;
+    showTerminalInputRecovery(runtime, retainedInput.message);
+  }
   inputRecovery.retry.addEventListener("click", () => {
     if (!runtime.inputQueue?.resume()) return;
     hideTerminalInputRecovery(runtime);
@@ -447,8 +456,15 @@ function mountTerminal(sessionId, host, status, inputRecovery) {
   void pollTerminal(runtime);
 }
 
-function disposeTerminal() {
+function disposeTerminal({ preservePausedInput = false } = {}) {
   if (!terminalRuntime) return;
+  const { sessionId, inputQueue, inputRecoveryMessage } = terminalRuntime;
+  const pausedInput = preservePausedInput ? inputQueue?.pausedInput() : null;
+  if (pausedInput && sessionIds(state).includes(sessionId)) {
+    retainedTerminalInput.set(sessionId, { pending: pausedInput, message: inputRecoveryMessage });
+  } else {
+    retainedTerminalInput.delete(sessionId);
+  }
   clearTimeout(terminalRuntime.timer);
   clearTimeout(terminalRuntime.resizeTimer);
   terminalRuntime.resizeObserver?.disconnect();
@@ -459,11 +475,13 @@ function disposeTerminal() {
 }
 
 function showTerminalInputRecovery(runtime, message) {
+  runtime.inputRecoveryMessage = message;
   runtime.inputRecovery.message.textContent = message;
   runtime.inputRecovery.root.hidden = false;
 }
 
 function hideTerminalInputRecovery(runtime) {
+  runtime.inputRecoveryMessage = "";
   runtime.inputRecovery.message.textContent = "";
   runtime.inputRecovery.root.hidden = true;
 }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -21,9 +21,10 @@ import {
   setNodeAvailability,
   splitSelectedPane,
   toggleSelectedTabStrip,
+  attachSessionToSelectedTab,
 } from "./workspace-layout.js";
 
-const HEALTH_URL = "http://127.0.0.1:8787/health";
+const HEALTH_URL = "/health";
 const STORAGE_KEY = "relay-factory/workspace-layout/v1";
 const nodeStatus = document.querySelector("#status");
 const workspaceName = document.querySelector("[data-workspace-name]");
@@ -41,9 +42,13 @@ const enrollPasskey = document.querySelector("#enroll-passkey");
 const signIn = document.querySelector("#sign-in");
 const refreshSessions = document.querySelector("#refresh-sessions");
 const revokeCurrent = document.querySelector("#revoke-current");
+const openClaude = document.querySelector("#open-claude");
+const interruptSession = document.querySelector("#interrupt-session");
+const endSession = document.querySelector("#end-session");
 const sessionStatus = document.querySelector("#session-status");
 const trustedDevices = document.querySelector("#trusted-devices");
 let currentDeviceId = null;
+let terminalRuntime = null;
 let state = loadLayout();
 let transientNotice = null;
 
@@ -63,6 +68,10 @@ layoutRoot.addEventListener("click", (event) => {
     apply(() => ({ ...state, selectedPaneId: pane.dataset.selectPane }));
   }
 });
+
+openClaude.addEventListener("click", () => void openClaudeTerminal());
+interruptSession.addEventListener("click", () => void interruptClaudeTerminal());
+endSession.addEventListener("click", () => void closeClaudeTerminal());
 
 function loadLayout() {
   try {
@@ -134,6 +143,7 @@ async function refreshNodeAvailability() {
 function render() {
   const metrics = layoutMetrics(state);
   const activePane = selectedPane(state);
+  const activeTab = activePane.tabs.find((tab) => tab.id === activePane.activeTabId);
 
   workspaceName.textContent = state.workspace.name;
   nodeBinding.textContent = `${state.workspace.node.label} · ${state.workspace.node.id}`;
@@ -144,6 +154,7 @@ function render() {
   renderNodeStatus();
   renderNotice();
   renderSessionIdentity();
+  disposeTerminal();
   renderLayout(state.layout, layoutRoot);
 
   for (const button of document.querySelectorAll("[data-action]")) {
@@ -155,6 +166,10 @@ function render() {
       (action === "close" && metrics.paneCount === 1 && activePane.tabs.length === 1);
   }
 
+  const activeClaudeSession = activeTab?.content.sessionId.startsWith("claude-pty-");
+  openClaude.disabled = state.nodeAvailability !== "available" || !currentDeviceId;
+  interruptSession.disabled = !activeClaudeSession || !currentDeviceId;
+  endSession.disabled = !activeClaudeSession || !currentDeviceId;
   sessionAuthority.textContent = sessionAuthorityMessage();
 }
 
@@ -259,15 +274,182 @@ function renderLayoutNode(node) {
   session.append(
     textElement("p", "Session reference", "meta-label"),
     textElement("code", activeTab.content.sessionId),
-    textElement(
+  );
+  if (activeTab.content.sessionId.startsWith("claude-pty-")) {
+    const status = textElement("p", "Attaching Relay-owned Claude terminal…", "terminal-status");
+    const host = document.createElement("div");
+    host.className = "terminal-host";
+    session.append(
+      status,
+      host,
+      textElement("p", "Pane moves and close detach this browser view; only the explicit terminal close reaps the node-owned process.", "session-note"),
+    );
+    if (node.id === state.selectedPaneId) mountTerminal(activeTab.content.sessionId, host, status);
+  } else {
+    session.append(textElement(
       "p",
       "This tab references the same opaque Session ID. Layout actions do not start, duplicate, input to, or end it.",
       "session-note",
-    ),
-  );
+    ));
+  }
   pane.append(session);
 
   return pane;
+}
+
+async function openClaudeTerminal() {
+  if (openClaude.disabled) return;
+  try {
+    const snapshot = await request("/node/claude/sessions", {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: "{}",
+    });
+    state = attachSessionToSelectedTab(state, snapshot.sessionId, "Claude terminal");
+    persistLayout();
+    render();
+  } catch (error) {
+    transientNotice = { kind: "error", title: "Claude terminal", message: terminalErrorMessage(error) };
+    render();
+  }
+}
+
+async function interruptClaudeTerminal() {
+  const active = selectedPane(state).tabs.find((tab) => tab.id === selectedPane(state).activeTabId);
+  if (!active?.content.sessionId.startsWith("claude-pty-")) return;
+  try {
+    await request(`/node/claude/sessions/${active.content.sessionId}/interrupt`, {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: "{}",
+    });
+  } catch (error) {
+    transientNotice = { kind: "error", title: "Claude terminal", message: terminalErrorMessage(error) };
+    render();
+  }
+}
+
+async function closeClaudeTerminal() {
+  const active = selectedPane(state).tabs.find((tab) => tab.id === selectedPane(state).activeTabId);
+  if (!active?.content.sessionId.startsWith("claude-pty-")) return;
+  try {
+    await request(`/node/claude/sessions/${active.content.sessionId}/close`, {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: "{}",
+    });
+    disposeTerminal();
+    transientNotice = { kind: "warning", title: "Claude terminal", message: "The Relay-owned process was closed and reaped. This tab keeps the closed Session reference for an honest reattach state." };
+    render();
+  } catch (error) {
+    transientNotice = { kind: "error", title: "Claude terminal", message: terminalErrorMessage(error) };
+    render();
+  }
+}
+
+function mountTerminal(sessionId, host, status) {
+  const terminal = new window.Terminal({
+    cols: 120,
+    rows: 36,
+    cursorBlink: true,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+    fontSize: 13,
+    scrollback: 2_000,
+    theme: { background: "#050914", foreground: "#edf2ff", cursor: "#82aaff" },
+  });
+  terminal.open(host);
+  terminal.focus();
+  const runtime = {
+    sessionId,
+    terminal,
+    status,
+    host,
+    cursor: 0,
+    timer: null,
+    resizeTimer: null,
+    resizeObserver: null,
+    inputSubscription: null,
+    cols: 0,
+    rows: 0,
+  };
+  terminalRuntime = runtime;
+  runtime.inputSubscription = terminal.onData((data) => void sendTerminalInput(runtime, data));
+  if (typeof ResizeObserver === "function") {
+    runtime.resizeObserver = new ResizeObserver(() => {
+      if (runtime.resizeTimer !== null) return;
+      runtime.resizeTimer = window.setTimeout(() => {
+        runtime.resizeTimer = null;
+        void resizeTerminal(runtime);
+      }, 50);
+    });
+    runtime.resizeObserver.observe(host);
+  }
+  void resizeTerminal(runtime);
+  void pollTerminal(runtime);
+}
+
+function disposeTerminal() {
+  if (!terminalRuntime) return;
+  clearTimeout(terminalRuntime.timer);
+  clearTimeout(terminalRuntime.resizeTimer);
+  terminalRuntime.resizeObserver?.disconnect();
+  terminalRuntime.inputSubscription?.dispose();
+  terminalRuntime.terminal.dispose();
+  terminalRuntime = null;
+}
+
+async function pollTerminal(runtime) {
+  try {
+    const snapshot = await request(`/node/claude/sessions/${runtime.sessionId}?cursor=${runtime.cursor}`);
+    if (terminalRuntime !== runtime) return;
+    if (snapshot.truncated) runtime.terminal.writeln("\r\n[Relay: earlier terminal output was truncated]\r\n");
+    for (const chunk of snapshot.output) runtime.terminal.write(chunk.text);
+    runtime.cursor = snapshot.nextCursor;
+    runtime.status.textContent = `Relay-owned terminal · ${snapshot.status} · dropped chunks ${snapshot.droppedChunks}`;
+    if (["closed", "exited"].includes(snapshot.status)) return;
+    runtime.timer = window.setTimeout(() => void pollTerminal(runtime), snapshot.hasMore ? 0 : 100);
+  } catch (error) {
+    if (terminalRuntime === runtime) runtime.status.textContent = `Terminal unavailable: ${terminalErrorMessage(error)}`;
+  }
+}
+
+async function sendTerminalInput(runtime, data) {
+  if (terminalRuntime !== runtime || !data) return;
+  try {
+    await request(`/node/claude/sessions/${runtime.sessionId}/input`, {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: JSON.stringify({ data }),
+    });
+  } catch (error) {
+    if (terminalRuntime === runtime) runtime.status.textContent = `Input rejected: ${terminalErrorMessage(error)}`;
+  }
+}
+
+async function resizeTerminal(runtime) {
+  if (terminalRuntime !== runtime) return;
+  const cols = Math.max(20, Math.min(500, Math.floor(runtime.host.clientWidth / 8.2) || 120));
+  const rows = Math.max(4, Math.min(300, Math.floor(runtime.host.clientHeight / 16) || 36));
+  if (runtime.cols === cols && runtime.rows === rows) return;
+  runtime.cols = cols;
+  runtime.rows = rows;
+  runtime.terminal.resize(cols, rows);
+  try {
+    await request(`/node/claude/sessions/${runtime.sessionId}/resize`, {
+      method: "POST",
+      headers: { "X-Relay-CSRF": csrfToken() },
+      body: JSON.stringify({ cols, rows }),
+    });
+  } catch (error) {
+    if (terminalRuntime === runtime) runtime.status.textContent = `Resize rejected: ${terminalErrorMessage(error)}`;
+  }
+}
+
+function terminalErrorMessage(error) {
+  const code = error?.code;
+  if (code === "stale_session") return "This Session belongs to a prior node runtime. Open a new terminal explicitly.";
+  if (code === "claude_unavailable") return "Claude Code could not start in the node-owner context.";
+  return presentationForAuthError(error).message;
 }
 
 function sessionAuthorityMessage() {
@@ -277,7 +459,10 @@ function sessionAuthorityMessage() {
   if (state.nodeAvailability === "unknown") {
     return "Node status is unknown: live Session actions stay disabled until the one-node liveness check completes.";
   }
-  return "The one-node liveness check passed. This presentation surface still has no Session control endpoint.";
+  if (!currentDeviceId) {
+    return "Sign in with a passkey before requesting a Relay-owned Claude terminal. Browser authority gates the node runtime; it never exposes a process handle.";
+  }
+  return "The node is available. Open a Claude terminal to create one authenticated, node-owned PTY Session; layout changes remain presentation-only.";
 }
 
 function textElement(tag, text, className) {
@@ -357,11 +542,14 @@ async function refreshTrustedDevices() {
     sessionStatus.textContent = currentDeviceId
       ? `${response.sessions.length} trusted browser session(s).`
       : "No active browser session.";
+    render();
   } catch (error) {
+    currentDeviceId = null;
     const presentation = presentationForAuthError(error);
     sessionStatus.textContent = presentation.code === "unsupported" ? "No active browser session." : presentation.message;
     revokeCurrent.disabled = true;
     trustedDevices.replaceChildren();
+    render();
   }
 }
 
@@ -399,6 +587,7 @@ async function revokeSession(deviceId) {
       revokeCurrent.disabled = true;
       trustedDevices.replaceChildren();
       sessionStatus.textContent = "This browser session was revoked. Protected hub calls now fail closed.";
+      render();
     } else {
       await refreshTrustedDevices();
     }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -459,9 +459,12 @@ function mountTerminal(sessionId, host, status, inputRecovery) {
 function disposeTerminal({ preservePausedInput = false } = {}) {
   if (!terminalRuntime) return;
   const { sessionId, inputQueue, inputRecoveryMessage } = terminalRuntime;
-  const pausedInput = preservePausedInput ? inputQueue?.pausedInput() : null;
-  if (pausedInput && sessionIds(state).includes(sessionId)) {
-    retainedTerminalInput.set(sessionId, { pending: pausedInput, message: inputRecoveryMessage });
+  const recoverableInput = preservePausedInput ? inputQueue?.recoverableInput() : null;
+  if (recoverableInput && sessionIds(state).includes(sessionId)) {
+    retainedTerminalInput.set(sessionId, {
+      pending: recoverableInput,
+      message: inputRecoveryMessage || "Terminal delivery was in progress when this view changed. Relay may already have received the saved input; inspect terminal output before retrying.",
+    });
   } else {
     retainedTerminalInput.delete(sessionId);
   }

--- a/web/src/terminal-input.js
+++ b/web/src/terminal-input.js
@@ -29,12 +29,14 @@ export function createTerminalInputQueue({
   onError,
   maxBytes = MAX_TERMINAL_INPUT_BYTES,
   maxPendingBytes = MAX_TERMINAL_PENDING_BYTES,
+  initialPausedInput = "",
 }) {
-  let pending = "";
-  let pendingBytes = 0;
+  const restoredInput = typeof initialPausedInput === "string" ? initialPausedInput : "";
+  let pending = restoredInput;
+  let pendingBytes = encoder.encode(restoredInput).byteLength;
   let sending = false;
   let disposed = false;
-  let paused = false;
+  let paused = Boolean(restoredInput);
   let retryTimer = null;
 
   async function flush() {
@@ -93,6 +95,9 @@ export function createTerminalInputQueue({
     },
     isPaused() {
       return paused;
+    },
+    pausedInput() {
+      return paused && pending ? pending : null;
     },
     dispose() {
       disposed = true;

--- a/web/src/terminal-input.js
+++ b/web/src/terminal-input.js
@@ -34,6 +34,7 @@ export function createTerminalInputQueue({
   const restoredInput = typeof initialPausedInput === "string" ? initialPausedInput : "";
   let pending = restoredInput;
   let pendingBytes = encoder.encode(restoredInput).byteLength;
+  let inFlight = "";
   let sending = false;
   let disposed = false;
   let paused = Boolean(restoredInput);
@@ -43,10 +44,11 @@ export function createTerminalInputQueue({
     if (disposed || paused || sending || !isActive() || !pending) return;
     const [data, remaining] = takeTerminalInputBatch(pending, maxBytes);
     pending = remaining;
+    inFlight = data;
     sending = true;
     try {
       await send(data);
-      pendingBytes -= encoder.encode(data).byteLength;
+      if (!disposed && isActive()) pendingBytes -= encoder.encode(data).byteLength;
     } catch (error) {
       if (!disposed && isActive() && error?.code === "input_backpressure") {
         pending = data + pending;
@@ -63,6 +65,7 @@ export function createTerminalInputQueue({
         onError(error);
       }
     } finally {
+      inFlight = "";
       sending = false;
       if (!disposed && !paused && isActive() && pending && retryTimer === null) void flush();
     }
@@ -98,6 +101,9 @@ export function createTerminalInputQueue({
     },
     pausedInput() {
       return paused && pending ? pending : null;
+    },
+    recoverableInput() {
+      return inFlight + pending || null;
     },
     dispose() {
       disposed = true;

--- a/web/src/terminal-input.js
+++ b/web/src/terminal-input.js
@@ -34,20 +34,30 @@ export function createTerminalInputQueue({
   let pendingBytes = 0;
   let sending = false;
   let disposed = false;
+  let retryTimer = null;
 
   async function flush() {
     if (disposed || sending || !isActive() || !pending) return;
     const [data, remaining] = takeTerminalInputBatch(pending, maxBytes);
     pending = remaining;
-    pendingBytes -= encoder.encode(data).byteLength;
     sending = true;
     try {
       await send(data);
+      pendingBytes -= encoder.encode(data).byteLength;
     } catch (error) {
-      if (!disposed && isActive()) onError(error);
+      if (!disposed && isActive() && error?.code === "input_backpressure") {
+        pending = data + pending;
+        retryTimer = setTimeout(() => {
+          retryTimer = null;
+          void flush();
+        }, 50);
+      } else if (!disposed && isActive()) {
+        pendingBytes -= encoder.encode(data).byteLength;
+        onError(error);
+      }
     } finally {
       sending = false;
-      if (!disposed && isActive() && pending) void flush();
+      if (!disposed && isActive() && pending && retryTimer === null) void flush();
     }
   }
 
@@ -65,6 +75,8 @@ export function createTerminalInputQueue({
     },
     dispose() {
       disposed = true;
+      clearTimeout(retryTimer);
+      retryTimer = null;
       pending = "";
       pendingBytes = 0;
     },

--- a/web/src/terminal-input.js
+++ b/web/src/terminal-input.js
@@ -34,10 +34,11 @@ export function createTerminalInputQueue({
   let pendingBytes = 0;
   let sending = false;
   let disposed = false;
+  let paused = false;
   let retryTimer = null;
 
   async function flush() {
-    if (disposed || sending || !isActive() || !pending) return;
+    if (disposed || paused || sending || !isActive() || !pending) return;
     const [data, remaining] = takeTerminalInputBatch(pending, maxBytes);
     pending = remaining;
     sending = true;
@@ -52,12 +53,16 @@ export function createTerminalInputQueue({
           void flush();
         }, 50);
       } else if (!disposed && isActive()) {
-        pendingBytes -= encoder.encode(data).byteLength;
+        // A rejected request is safe to retry, while a failed network request
+        // may already have reached Relay. Preserve both cases for an explicit
+        // operator decision instead of silently dropping typed terminal input.
+        pending = data + pending;
+        paused = true;
         onError(error);
       }
     } finally {
       sending = false;
-      if (!disposed && isActive() && pending && retryTimer === null) void flush();
+      if (!disposed && !paused && isActive() && pending && retryTimer === null) void flush();
     }
   }
 
@@ -66,15 +71,32 @@ export function createTerminalInputQueue({
       if (disposed || !isActive() || !data) return;
       const dataBytes = encoder.encode(data).byteLength;
       if (pendingBytes + dataBytes > maxPendingBytes) {
-        onError({ code: "input_backpressure" });
+        onError({ code: "input_backpressure", delivery: "not_queued" });
         return;
       }
       pending += data;
       pendingBytes += dataBytes;
       void flush();
     },
+    resume() {
+      if (disposed || !paused || !isActive()) return false;
+      paused = false;
+      void flush();
+      return true;
+    },
+    discard() {
+      if (disposed || !paused) return false;
+      paused = false;
+      pending = "";
+      pendingBytes = 0;
+      return true;
+    },
+    isPaused() {
+      return paused;
+    },
     dispose() {
       disposed = true;
+      paused = false;
       clearTimeout(retryTimer);
       retryTimer = null;
       pending = "";

--- a/web/src/terminal-input.js
+++ b/web/src/terminal-input.js
@@ -1,0 +1,72 @@
+export const MAX_TERMINAL_INPUT_BYTES = 8 * 1024;
+export const MAX_TERMINAL_PENDING_BYTES = 4 * MAX_TERMINAL_INPUT_BYTES;
+
+const encoder = new TextEncoder();
+
+export function takeTerminalInputBatch(data, maxBytes = MAX_TERMINAL_INPUT_BYTES) {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new RangeError("maxBytes must be a positive integer");
+  }
+  if (!data) return ["", ""];
+
+  let end = 0;
+  let bytes = 0;
+  for (const character of data) {
+    const characterBytes = encoder.encode(character).byteLength;
+    if (bytes + characterBytes > maxBytes) {
+      if (bytes === 0) throw new RangeError("maxBytes must fit one UTF-8 code point");
+      break;
+    }
+    bytes += characterBytes;
+    end += character.length;
+  }
+  return [data.slice(0, end), data.slice(end)];
+}
+
+export function createTerminalInputQueue({
+  isActive,
+  send,
+  onError,
+  maxBytes = MAX_TERMINAL_INPUT_BYTES,
+  maxPendingBytes = MAX_TERMINAL_PENDING_BYTES,
+}) {
+  let pending = "";
+  let pendingBytes = 0;
+  let sending = false;
+  let disposed = false;
+
+  async function flush() {
+    if (disposed || sending || !isActive() || !pending) return;
+    const [data, remaining] = takeTerminalInputBatch(pending, maxBytes);
+    pending = remaining;
+    pendingBytes -= encoder.encode(data).byteLength;
+    sending = true;
+    try {
+      await send(data);
+    } catch (error) {
+      if (!disposed && isActive()) onError(error);
+    } finally {
+      sending = false;
+      if (!disposed && isActive() && pending) void flush();
+    }
+  }
+
+  return {
+    enqueue(data) {
+      if (disposed || !isActive() || !data) return;
+      const dataBytes = encoder.encode(data).byteLength;
+      if (pendingBytes + dataBytes > maxPendingBytes) {
+        onError({ code: "input_backpressure" });
+        return;
+      }
+      pending += data;
+      pendingBytes += dataBytes;
+      void flush();
+    },
+    dispose() {
+      disposed = true;
+      pending = "";
+      pendingBytes = 0;
+    },
+  };
+}

--- a/web/src/terminal-recovery.js
+++ b/web/src/terminal-recovery.js
@@ -1,0 +1,85 @@
+import { presentationForAuthError } from "./auth.js";
+
+function errorCode(error) {
+  return typeof error?.code === "string" ? error.code : undefined;
+}
+
+function isNetworkTypeError(error) {
+  return error instanceof TypeError || error?.name === "TypeError";
+}
+
+export function terminalErrorPresentation(error) {
+  const code = errorCode(error);
+  switch (code) {
+    case "stale_session":
+      return {
+        code,
+        message: "This terminal belongs to a prior node runtime. Open a new terminal explicitly.",
+      };
+    case "claude_unavailable":
+      return {
+        code,
+        message: "Claude Code could not start in the node-owner context.",
+      };
+    case "session_capacity":
+      return {
+        code,
+        message: "Relay has reached its terminal-session capacity. Close an unused terminal, then try again.",
+      };
+    case "input_backpressure":
+      return {
+        code,
+        message: "Terminal input is temporarily backlogged. Relay will retry after its queue has capacity.",
+      };
+    case "input_delivery_lost":
+      return {
+        code,
+        message: "Relay could not finish a previously queued input batch. Inspect the terminal before re-entering the command.",
+      };
+    case "pty_transport":
+      return {
+        code,
+        message: "Relay's terminal transport is unavailable. Keep this terminal open while it recovers, then retry the action.",
+      };
+    default:
+      if (isNetworkTypeError(error)) {
+        return {
+          code: "network_uncertain",
+          message: "Network delivery to the Relay terminal is uncertain. Keep this terminal open and inspect it before retrying the action.",
+        };
+      }
+      return presentationForAuthError(error);
+  }
+}
+
+export function terminalInputRecovery(error) {
+  const presentation = terminalErrorPresentation(error);
+  if (error?.delivery === "not_queued") {
+    return {
+      ...presentation,
+      message: "Relay's bounded browser input queue is full. This input was not queued; wait for it to drain, then re-enter it.",
+    };
+  }
+  switch (presentation.code) {
+    case "input_delivery_lost":
+      return {
+        ...presentation,
+        message: "Relay reported that a previously queued input batch could not finish. Its terminal effect is uncertain; inspect the terminal before retrying the saved input.",
+      };
+    case "pty_transport":
+      return {
+        ...presentation,
+        message: "Relay did not admit this input because the terminal transport is unavailable. The input is saved; wait for recovery, then retry it.",
+      };
+    case "network_uncertain":
+      return {
+        ...presentation,
+        message: "Network delivery of this input is uncertain. Relay may already have received it; the input is saved, so inspect the terminal before retrying to avoid duplication.",
+      };
+    default:
+      return {
+        ...presentation,
+        message: `${presentation.message} The input is saved until you retry it or discard it.`,
+      };
+  }
+}

--- a/web/src/terminal-recovery.js
+++ b/web/src/terminal-recovery.js
@@ -11,6 +11,21 @@ function isNetworkTypeError(error) {
 export function terminalErrorPresentation(error) {
   const code = errorCode(error);
   switch (code) {
+    case "session_missing":
+      return {
+        code,
+        message: "Your Relay browser session is no longer active. Sign in again before opening or controlling a terminal.",
+      };
+    case "csrf_denied":
+      return {
+        code,
+        message: "Relay rejected this terminal control request because its browser-session proof is stale. Refresh your sign-in before retrying.",
+      };
+    case "session_forbidden":
+      return {
+        code,
+        message: "This terminal belongs to a different Relay browser device. Open a new terminal from this device instead.",
+      };
     case "stale_session":
       return {
         code,
@@ -25,6 +40,16 @@ export function terminalErrorPresentation(error) {
       return {
         code,
         message: "Relay has reached its terminal-session capacity. Close an unused terminal, then try again.",
+      };
+    case "invalid_resize":
+      return {
+        code,
+        message: "Relay rejected this terminal size. Keep the terminal open, resize the view, then retry the action.",
+      };
+    case "invalid_input":
+      return {
+        code,
+        message: "Relay rejected this terminal input before delivery. Adjust the input and re-enter it explicitly.",
       };
     case "input_backpressure":
       return {

--- a/web/src/workspace-layout.js
+++ b/web/src/workspace-layout.js
@@ -63,6 +63,19 @@ export function addSessionTab(state) {
   }), pane.id);
 }
 
+// Session lifecycle remains outside this presentation model. The caller has
+// already created or reattached a node-owned opaque Session and only records
+// that reference on the currently selected tab.
+export function attachSessionToSelectedTab(state, sessionId, title = "Claude terminal") {
+  assertText(sessionId, "Session reference", MAX_SESSION_REFERENCE_LENGTH);
+  assertText(title, "tab title");
+  const pane = selectedPane(state);
+  const tabs = pane.tabs.map((tab) => (
+    tab.id === pane.activeTabId ? { ...tab, title, content: { kind: "session", sessionId } } : tab
+  ));
+  return withLayout(state, replacePane(state.layout, pane.id, { ...pane, tabs }), pane.id);
+}
+
 export function selectTab(state, paneId, tabId) {
   const pane = findPane(state.layout, paneId);
   if (!pane || !pane.tabs.some((tab) => tab.id === tabId)) {

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -35,6 +35,8 @@ test("the PWA shell combines passkey controls with a presentation-only Workspace
   assert.match(page, /src="\.\/vendor\/xterm\.js"/);
   assert.match(app, /new window\.Terminal/);
   assert.match(app, /\/node\/claude\/sessions/);
+  assert.match(app, /function canOpenClaudeTerminal/);
+  assert.match(app, /claudeCreateInFlight/);
   assert.match(app, /snapshot\.hasMore \? 0 : 100/);
   assert.match(auth, /recovery_required/);
   assert.doesNotMatch(app, /WebSocket|Authorization/);

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -18,7 +18,7 @@ test("the PWA shell combines passkey controls with a presentation-only Workspace
   assert.match(page, /id="sign-in"/);
   assert.match(page, /id="trusted-devices"/);
   assert.match(page, /Node credentials remain separate/);
-  assert.match(app, /http:\/\/127\.0\.0\.1:8787\/health/);
+  assert.match(app, /const HEALTH_URL = "\/health"/);
   assert.match(app, /workspace-layout\.js/);
   assert.match(app, /localStorage/);
   assert.match(app, /fetch\(HEALTH_URL\)/);
@@ -32,6 +32,10 @@ test("the PWA shell combines passkey controls with a presentation-only Workspace
   assert.match(app, /function renderTrustedDevices/);
   assert.match(app, /function revokeSession/);
   assert.match(app, /navigator\.credentials\[operation\]/);
+  assert.match(page, /src="\.\/vendor\/xterm\.js"/);
+  assert.match(app, /new window\.Terminal/);
+  assert.match(app, /\/node\/claude\/sessions/);
+  assert.match(app, /snapshot\.hasMore \? 0 : 100/);
   assert.match(auth, /recovery_required/);
   assert.doesNotMatch(app, /WebSocket|Authorization/);
   assert.doesNotMatch(layout, /fetch|localStorage|document\.cookie|WebSocket|terminate|sendInput/);

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -38,6 +38,8 @@ test("the PWA shell combines passkey controls with a presentation-only Workspace
   assert.match(app, /\/node\/claude\/sessions/);
   assert.match(app, /function canOpenClaudeTerminal/);
   assert.match(app, /claudeCreateInFlight/);
+  assert.match(app, /MAX_RESOLVED_CLAUDE_SESSION_IDS = MAX_TAB_COUNT/);
+  assert.match(app, /function rememberResolvedClaudeSession/);
   assert.match(app, /terminalInputRecovery/);
   assert.match(app, /Retry saved input/);
   assert.match(app, /Discard saved input/);

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -5,11 +5,12 @@ import test from "node:test";
 const source = new URL("../src/", import.meta.url);
 
 test("the PWA shell combines passkey controls with a presentation-only Workspace layout", async () => {
-  const [page, app, layout, auth] = await Promise.all([
+  const [page, app, layout, auth, terminalRecovery] = await Promise.all([
     readFile(new URL("index.html", source), "utf8"),
     readFile(new URL("main.js", source), "utf8"),
     readFile(new URL("workspace-layout.js", source), "utf8"),
     readFile(new URL("auth.js", source), "utf8"),
+    readFile(new URL("terminal-recovery.js", source), "utf8"),
   ]);
 
   assert.match(page, /manifest\.webmanifest/);
@@ -37,6 +38,13 @@ test("the PWA shell combines passkey controls with a presentation-only Workspace
   assert.match(app, /\/node\/claude\/sessions/);
   assert.match(app, /function canOpenClaudeTerminal/);
   assert.match(app, /claudeCreateInFlight/);
+  assert.match(app, /terminalInputRecovery/);
+  assert.match(app, /Retry saved input/);
+  assert.match(app, /Discard saved input/);
+  assert.match(page, /terminal-input-recovery/);
+  assert.match(terminalRecovery, /session_capacity/);
+  assert.match(terminalRecovery, /pty_transport/);
+  assert.match(terminalRecovery, /network_uncertain/);
   assert.match(app, /snapshot\.hasMore \? 0 : 100/);
   assert.match(auth, /recovery_required/);
   assert.doesNotMatch(app, /WebSocket|Authorization/);

--- a/web/test/cdp-endpoint.test.mjs
+++ b/web/test/cdp-endpoint.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { devToolsEndpointFromOutput } from "../../scripts/cdp-endpoint.mjs";
+import {
+  devToolsEndpointFromActivePort,
+  devToolsEndpointFromOutput,
+} from "../../scripts/cdp-endpoint.mjs";
 
 test("waits for the complete DevTools endpoint line before returning it", () => {
   const endpoint = "ws://127.0.0.1:9222/devtools/browser/01234567-89ab-cdef-0123-456789abcdef";
@@ -19,4 +22,13 @@ test("waits for the complete DevTools endpoint line before returning it", () => 
 
   output += chunks.at(-1);
   assert.equal(devToolsEndpointFromOutput(output), endpoint);
+});
+
+test("uses Chrome's profile-owned DevToolsActivePort endpoint when stdout is unavailable", () => {
+  assert.equal(
+    devToolsEndpointFromActivePort("46785\n/devtools/browser/01234567-89ab-cdef-0123-456789abcdef\n"),
+    "ws://127.0.0.1:46785/devtools/browser/01234567-89ab-cdef-0123-456789abcdef",
+  );
+  assert.equal(devToolsEndpointFromActivePort("46785\n"), undefined);
+  assert.equal(devToolsEndpointFromActivePort("not-a-port\n/devtools/browser/id\n"), undefined);
 });

--- a/web/test/terminal-input.test.mjs
+++ b/web/test/terminal-input.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAX_TERMINAL_INPUT_BYTES,
+  MAX_TERMINAL_PENDING_BYTES,
+  createTerminalInputQueue,
+  takeTerminalInputBatch,
+} from "../src/terminal-input.js";
+
+async function eventually(predicate) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  assert.fail("queued work did not settle");
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolve_) => {
+    resolve = resolve_;
+  });
+  return { promise, resolve };
+}
+
+test("terminal input batches on UTF-8 boundaries", () => {
+  const [first, remaining] = takeTerminalInputBatch("ab😀cd", 6);
+  assert.equal(first, "ab😀");
+  assert.equal(remaining, "cd");
+  assert.equal(new TextEncoder().encode(first).byteLength, 6);
+  assert.throws(() => takeTerminalInputBatch("input", 0), RangeError);
+  assert.throws(() => takeTerminalInputBatch("😀", 3), RangeError);
+  assert.equal(MAX_TERMINAL_INPUT_BYTES, 8 * 1024);
+  assert.equal(MAX_TERMINAL_PENDING_BYTES, 32 * 1024);
+});
+
+test("terminal input sends one in-flight request and preserves queue ordering", async () => {
+  const first = deferred();
+  const sent = [];
+  let calls = 0;
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      calls += 1;
+      if (calls === 1) await first.promise;
+    },
+    onError: assert.fail,
+  });
+
+  queue.enqueue("first");
+  await eventually(() => sent.length === 1);
+  queue.enqueue("-second");
+  queue.enqueue("-third");
+  assert.deepEqual(sent, ["first"]);
+
+  first.resolve();
+  await eventually(() => sent.length === 2);
+  assert.deepEqual(sent, ["first", "-second-third"]);
+});
+
+test("terminal input clears pending work when the terminal closes", async () => {
+  const first = deferred();
+  const sent = [];
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      await first.promise;
+    },
+    onError: assert.fail,
+  });
+
+  queue.enqueue("first");
+  await eventually(() => sent.length === 1);
+  queue.enqueue("second");
+  queue.dispose();
+  first.resolve();
+  await Promise.resolve();
+  assert.deepEqual(sent, ["first"]);
+});
+
+test("terminal input stops when a newer runtime replaces the terminal", async () => {
+  const first = deferred();
+  const sent = [];
+  let active = true;
+  const queue = createTerminalInputQueue({
+    isActive: () => active,
+    send: async (data) => {
+      sent.push(data);
+      await first.promise;
+    },
+    onError: assert.fail,
+  });
+
+  queue.enqueue("first");
+  await eventually(() => sent.length === 1);
+  queue.enqueue("second");
+  active = false;
+  first.resolve();
+  await Promise.resolve();
+  assert.deepEqual(sent, ["first"]);
+});
+
+test("terminal input reports a failed batch and continues with later input", async () => {
+  const sent = [];
+  const errors = [];
+  let failFirst = true;
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      if (failFirst) {
+        failFirst = false;
+        throw { code: "pty_transport" };
+      }
+    },
+    onError: (error) => errors.push(error),
+  });
+
+  queue.enqueue("first");
+  await eventually(() => errors.length === 1);
+  queue.enqueue("second");
+  await eventually(() => sent.length === 2);
+  assert.deepEqual(sent, ["first", "second"]);
+  assert.deepEqual(errors, [{ code: "pty_transport" }]);
+});
+
+test("terminal input bounds queued bytes without reordering accepted input", async () => {
+  const first = deferred();
+  const sent = [];
+  const errors = [];
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    maxPendingBytes: 4,
+    send: async (data) => {
+      sent.push(data);
+      if (data === "one") await first.promise;
+    },
+    onError: (error) => errors.push(error),
+  });
+
+  queue.enqueue("one");
+  await eventually(() => sent.length === 1);
+  queue.enqueue("abc");
+  queue.enqueue("de");
+  assert.deepEqual(errors, [{ code: "input_backpressure" }]);
+
+  first.resolve();
+  await eventually(() => sent.length === 2);
+  assert.deepEqual(sent, ["one", "abc"]);
+});

--- a/web/test/terminal-input.test.mjs
+++ b/web/test/terminal-input.test.mjs
@@ -144,10 +144,31 @@ test("terminal input bounds queued bytes without reordering accepted input", asy
   queue.enqueue("one");
   await eventually(() => sent.length === 1);
   queue.enqueue("abc");
-  queue.enqueue("de");
   assert.deepEqual(errors, [{ code: "input_backpressure" }]);
 
   first.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  queue.enqueue("de");
   await eventually(() => sent.length === 2);
-  assert.deepEqual(sent, ["one", "abc"]);
+  assert.deepEqual(sent, ["one", "de"]);
+});
+
+test("terminal input retains an unaccepted server-backpressure batch", async () => {
+  const sent = [];
+  const errors = [];
+  let attempts = 0;
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      attempts += 1;
+      if (attempts === 1) throw { code: "input_backpressure" };
+    },
+    onError: (error) => errors.push(error),
+  });
+
+  queue.enqueue("first");
+  await new Promise((resolve) => setTimeout(resolve, 75));
+  assert.deepEqual(sent, ["first", "first"]);
+  assert.deepEqual(errors, []);
 });

--- a/web/test/terminal-input.test.mjs
+++ b/web/test/terminal-input.test.mjs
@@ -127,6 +127,24 @@ test("terminal input reports a failed batch and continues with later input", asy
   assert.deepEqual(errors, [{ code: "pty_transport" }]);
 });
 
+test("terminal input exposes delivery loss without retrying the batch", async () => {
+  const sent = [];
+  const errors = [];
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      throw { code: "input_delivery_lost" };
+    },
+    onError: (error) => errors.push(error),
+  });
+
+  queue.enqueue("first");
+  await eventually(() => errors.length === 1);
+  assert.deepEqual(sent, ["first"]);
+  assert.deepEqual(errors, [{ code: "input_delivery_lost" }]);
+});
+
 test("terminal input bounds queued bytes without reordering accepted input", async () => {
   const first = deferred();
   const sent = [];

--- a/web/test/terminal-input.test.mjs
+++ b/web/test/terminal-input.test.mjs
@@ -103,7 +103,7 @@ test("terminal input stops when a newer runtime replaces the terminal", async ()
   assert.deepEqual(sent, ["first"]);
 });
 
-test("terminal input reports a failed batch and continues with later input", async () => {
+test("terminal input preserves a transport-rejected batch until explicit retry", async () => {
   const sent = [];
   const errors = [];
   let failFirst = true;
@@ -122,19 +122,27 @@ test("terminal input reports a failed batch and continues with later input", asy
   queue.enqueue("first");
   await eventually(() => errors.length === 1);
   queue.enqueue("second");
+  await Promise.resolve();
+  assert.equal(queue.isPaused(), true);
+  assert.deepEqual(sent, ["first"]);
+  assert.equal(queue.resume(), true);
   await eventually(() => sent.length === 2);
-  assert.deepEqual(sent, ["first", "second"]);
+  assert.deepEqual(sent, ["first", "firstsecond"]);
   assert.deepEqual(errors, [{ code: "pty_transport" }]);
 });
 
-test("terminal input exposes delivery loss without retrying the batch", async () => {
+test("terminal input exposes delivery loss and saves the batch for explicit retry", async () => {
   const sent = [];
   const errors = [];
+  let failFirst = true;
   const queue = createTerminalInputQueue({
     isActive: () => true,
     send: async (data) => {
       sent.push(data);
-      throw { code: "input_delivery_lost" };
+      if (failFirst) {
+        failFirst = false;
+        throw { code: "input_delivery_lost" };
+      }
     },
     onError: (error) => errors.push(error),
   });
@@ -143,6 +151,37 @@ test("terminal input exposes delivery loss without retrying the batch", async ()
   await eventually(() => errors.length === 1);
   assert.deepEqual(sent, ["first"]);
   assert.deepEqual(errors, [{ code: "input_delivery_lost" }]);
+  assert.equal(queue.isPaused(), true);
+  assert.equal(queue.resume(), true);
+  await eventually(() => sent.length === 2);
+  assert.deepEqual(sent, ["first", "first"]);
+});
+
+test("terminal input preserves a network-uncertain batch without automatic replay", async () => {
+  const sent = [];
+  const errors = [];
+  let failFirst = true;
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      if (failFirst) {
+        failFirst = false;
+        throw new TypeError("Failed to fetch");
+      }
+    },
+    onError: (error) => errors.push(error),
+  });
+
+  queue.enqueue("first");
+  await eventually(() => errors.length === 1);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(queue.isPaused(), true);
+  assert.deepEqual(sent, ["first"]);
+  assert.ok(errors[0] instanceof TypeError);
+  assert.equal(queue.resume(), true);
+  await eventually(() => sent.length === 2);
+  assert.deepEqual(sent, ["first", "first"]);
 });
 
 test("terminal input bounds queued bytes without reordering accepted input", async () => {
@@ -162,7 +201,7 @@ test("terminal input bounds queued bytes without reordering accepted input", asy
   queue.enqueue("one");
   await eventually(() => sent.length === 1);
   queue.enqueue("abc");
-  assert.deepEqual(errors, [{ code: "input_backpressure" }]);
+  assert.deepEqual(errors, [{ code: "input_backpressure", delivery: "not_queued" }]);
 
   first.resolve();
   await new Promise((resolve) => setImmediate(resolve));

--- a/web/test/terminal-input.test.mjs
+++ b/web/test/terminal-input.test.mjs
@@ -60,6 +60,27 @@ test("terminal input sends one in-flight request and preserves queue ordering", 
   assert.deepEqual(sent, ["first", "-second-third"]);
 });
 
+test("terminal input exposes an in-flight batch for a render snapshot", async () => {
+  const first = deferred();
+  const sent = [];
+  const queue = createTerminalInputQueue({
+    isActive: () => true,
+    send: async (data) => {
+      sent.push(data);
+      await first.promise;
+    },
+    onError: assert.fail,
+  });
+
+  queue.enqueue("first");
+  await eventually(() => sent.length === 1);
+  queue.enqueue("second");
+
+  assert.equal(queue.recoverableInput(), "firstsecond");
+  queue.dispose();
+  first.resolve();
+});
+
 test("terminal input clears pending work when the terminal closes", async () => {
   const first = deferred();
   const sent = [];

--- a/web/test/terminal-recovery.test.mjs
+++ b/web/test/terminal-recovery.test.mjs
@@ -7,6 +7,11 @@ test("terminal transport and capacity errors stay out of passkey presentation", 
   for (const [code, expected] of [
     ["pty_transport", "terminal transport"],
     ["session_capacity", "terminal-session capacity"],
+    ["session_missing", "browser session"],
+    ["csrf_denied", "terminal control request"],
+    ["session_forbidden", "different Relay browser device"],
+    ["invalid_resize", "terminal size"],
+    ["invalid_input", "terminal input"],
   ]) {
     const presentation = terminalErrorPresentation({ code });
     assert.equal(presentation.code, code);

--- a/web/test/terminal-recovery.test.mjs
+++ b/web/test/terminal-recovery.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { terminalErrorPresentation, terminalInputRecovery } from "../src/terminal-recovery.js";
+
+test("terminal transport and capacity errors stay out of passkey presentation", () => {
+  for (const [code, expected] of [
+    ["pty_transport", "terminal transport"],
+    ["session_capacity", "terminal-session capacity"],
+  ]) {
+    const presentation = terminalErrorPresentation({ code });
+    assert.equal(presentation.code, code);
+    assert.match(presentation.message, new RegExp(expected, "i"));
+    assert.doesNotMatch(presentation.message, /passkey|ceremony/i);
+  }
+});
+
+test("network TypeError renders terminal recovery rather than passkey ceremony copy", () => {
+  const presentation = terminalErrorPresentation(new TypeError("Failed to fetch"));
+
+  assert.equal(presentation.code, "network_uncertain");
+  assert.match(presentation.message, /terminal/i);
+  assert.match(presentation.message, /uncertain/i);
+  assert.doesNotMatch(presentation.message, /passkey|ceremony/i);
+});
+
+test("lost input delivery tells the operator to inspect before retrying saved input", () => {
+  const presentation = terminalInputRecovery({ code: "input_delivery_lost" });
+
+  assert.equal(presentation.code, "input_delivery_lost");
+  assert.match(presentation.message, /previously queued input batch/i);
+  assert.match(presentation.message, /inspect the terminal/i);
+  assert.match(presentation.message, /saved input/i);
+});
+
+test("local queue admission failure marks input as not queued", () => {
+  const presentation = terminalInputRecovery({ code: "input_backpressure", delivery: "not_queued" });
+
+  assert.match(presentation.message, /not queued/i);
+  assert.match(presentation.message, /re-enter/i);
+});


### PR DESCRIPTION
## Goal

Replace the frozen PR #1152 teardown design with one retryable Relay-owned lifecycle for the bounded one-node Claude PTY.

Supersedes frozen draft PR #1152.

Refs #1151.
Refs #1136.

## Root cause

The frozen design removed the active record before fallible outside-lock foreground verification, signalling, and reaping. A failure after removal could consume the only child/process-group/resource bundle and leave no truthful retry path.

## What changed

- Models `Active -> Closing/Retryable -> Signalling/Reaping -> Closed`; three failed attempts (immediate, 50 ms, 250 ms) enter capacity-consuming `TerminalFailure`.
- Keeps the direct child, original verified process-group identity, PTY descriptors, reader/writer state, owner identity, generation, attempt, and failure truth in one shared retained bundle.
- Validates keyed lease identity before releasing resources; dropped or mismatched leases are recovered or quarantined without duplicate capacity.
- Propagates ownership, TERM, KILL, reap deadline, `try_wait`, and handle-drain failures as retryable outcomes.
- Stops input and joins reader/writer work outside the PTY mutex; a reaped child is never re-signalled through a reusable PGID.
- Adds autonomous hub retry scheduling, invalidated-owner acknowledgement only after verified `Closed`, create/revoke admission serialization, and bounded hub/node shutdown drains.
- Returns HTTP 202 while an explicit close is still `closing`; terminal teardown failure is a typed 503.
- Keeps browser-smoke diagnostics durable and verifies owner cleanup convergence.

`Closed` means the retained direct child was reaped and Relay's owned resource handles were released. It does not claim session-wide job-control containment; #1153 remains separate.

## Finite ledger coverage

- leader exit/original identity: `leader_exit_does_not_release_the_original_process_group_before_close`
- post-lease unavailable foreground + exact bundle: `post_lease_unavailable_foreground_retains_the_bundle_for_retry`
- foreign foreground/no numeric fallback: `close_fails_closed_for_an_unowned_foreground_group_without_pidfd_fallback`
- TERM-ignoring descendant: `close_reaps_a_descendant_in_the_relay_owned_process_group`
- signal/reap/try_wait/exhaustion: `signal_failure_is_typed_and_retains_the_exact_bundle`, `reap_deadline_remains_retryable_with_child_and_identity_retained`, `persistent_reap_errors_exhaust_retries_without_freeing_capacity`
- dropped/mismatched lease: `dropped_lease_is_recovered_without_losing_or_duplicating_capacity`, `mismatched_completion_quarantines_the_original_keyed_record_once`
- TTL/revoke/oldest invalidation: auth invalidation-source test plus hub acknowledgement and owner-close tests
- prune/capacity: `failed_prune_consumes_full_capacity_until_retry_succeeds`
- partial startup: `partial_startup_bundle_uses_the_same_retryable_owner`, `startup_without_a_process_group_reaps_the_direct_child`
- mutex progress: `begin_close_detaches_the_term_grace_from_the_runtime_mutex_path`, `teardown_lease_allows_unrelated_admission_progress`
- truthful closing/failure/closed/retry-success and shutdown: hub close/retry tests, `shutdown_latches_admission_and_closed_truth_is_bounded`, and node probe drain test

## Exact-head evidence

Head: `8e13de41abb5e4be0902c21b15631cb15b619963`

- `sh scripts/cargo.sh fmt --all -- --check` — exit 0
- `sh scripts/cargo.sh check --workspace --all-targets --locked` — exit 0
- `sh scripts/cargo.sh test -p relay-session --lib --locked` — exit 0, 77 passed
- `sh scripts/cargo.sh test -p relay-hub --locked` — exit 0, 11 passed
- `npm test` — exit 0, including auth HTTP and Chromium virtual-authenticator browser smoke
- `npm run lint` — exit 0
- `npm run build` — exit 0
- `npm run bench` — exit 0
- `git diff --check` — exit 0

Fresh simplify review removed one obsolete request-driven retry probe from the browser smoke after the hub moved to autonomous retry. The PTY implementation was unchanged. At the new exact head, focused browser smoke and the real node-owner Claude probe passed, then `npm test`, `npm run lint`, `npm run build`, and `npm run bench` all exited 0 again.

