### PR TITLE
fix: guide passkey browser recovery

### DIFF
--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -56,12 +56,57 @@ export function credentialToJson(credential) {
   };
 }
 
+export function passkeyCapability(environment) {
+  if (!environment.isSecureContext) {
+    return {
+      supported: false,
+      code: "insecure_context",
+      message: "Passkeys require Relay's exact HTTPS address. Reopen this page using the secure URL shown below.",
+    };
+  }
+  if (
+    !environment.PublicKeyCredential
+    || !environment.navigator?.credentials?.create
+    || !environment.navigator?.credentials?.get
+  ) {
+    return {
+      supported: false,
+      code: "passkey_browser_unsupported",
+      message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+    };
+  }
+  return {
+    supported: true,
+    code: "passkey_ready",
+    message: "Sign in with an enrolled passkey to open this workbench.",
+  };
+}
+
 export function isPasskeySupported(environment) {
-  return Boolean(environment.isSecureContext && environment.navigator?.credentials?.create && environment.navigator?.credentials?.get);
+  return passkeyCapability(environment).supported;
+}
+
+function authErrorCode(error) {
+  if (error?.code) return error.code;
+  switch (error?.name) {
+    case "NotAllowedError":
+    case "AbortError":
+      return "passkey_denied";
+    case "SecurityError":
+      return "passkey_security_error";
+    case "NotSupportedError":
+      return "passkey_browser_unsupported";
+    case "ConstraintError":
+    case "InvalidStateError":
+    case "UnknownError":
+      return "authenticator_unavailable";
+    default:
+      return "passkey_failed";
+  }
 }
 
 export function presentationForAuthError(error) {
-  const code = error?.code ?? (error?.name === "NotAllowedError" ? "passkey_denied" : "unsupported");
+  const code = authErrorCode(error);
   switch (code) {
     case "passkey_denied":
       return {
@@ -74,19 +119,35 @@ export function presentationForAuthError(error) {
         message: "No enrolled passkey is available. Recovery can enroll a replacement passkey but cannot sign you in.",
       };
     case "origin_mismatch":
+    case "passkey_security_error":
       return {
         code,
-        message: "This page is not at Relay's configured secure origin, so passkey requests are blocked.",
+        message: "Relay could not verify this page as its configured secure origin. Open the exact HTTPS Relay URL in Safari or Chrome.",
       };
     case "recovery_denied":
       return {
         code,
         message: "That recovery code is invalid for this Relay deployment. Obtain the current code privately, then try again. No PIN or anonymous session was enabled.",
       };
+    case "insecure_context":
+      return {
+        code,
+        message: "Passkeys require Relay's exact HTTPS address. Reopen this page using the secure URL shown below.",
+      };
+    case "passkey_browser_unsupported":
+      return {
+        code,
+        message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+      };
+    case "authenticator_unavailable":
+      return {
+        code,
+        message: "No compatible device passkey authenticator was available. Enable device screen lock and passkey sync, then retry in Safari or Chrome.",
+      };
     default:
       return {
-        code: "unsupported",
-        message: "This browser or origin cannot run a secure passkey ceremony.",
+        code: "passkey_failed",
+        message: "Passkey setup failed in this browser. Copy the secure Relay URL below, open it in Safari or Chrome, and retry.",
       };
   }
 }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -59,14 +59,15 @@
       .auth-compact summary { color: #b8b0aa; cursor: pointer; }
       .auth-compact__body { display: grid; gap: 0.5rem; margin-top: 0.7rem; }
       .auth-compact__body label { font-size: 0.72rem; }
-      .auth-onboarding { background: #090807; border: 1px solid #302b28; display: grid; gap: 0.55rem; margin: 0 auto; max-width: 32rem; padding: 1rem; }
-      .auth-onboarding h2 { font-size: 1rem; margin: 0; }
+      .auth-onboarding { background: #090807; border: 1px solid #302b28; display: grid; gap: 0.55rem; margin: 0 auto; max-width: 32rem; padding: 1rem; position: relative; }
+      .auth-onboarding h2 { font-size: 1rem; margin: 0; padding-right: 4.75rem; }
       .auth-onboarding p { color: #9b928b; line-height: 1.5; margin: 0; }
       .auth-onboarding ol { color: #b8b0aa; display: grid; gap: 0.45rem; line-height: 1.45; margin: 0; padding-left: 1.25rem; }
       .auth-onboarding label { color: #b8b0aa; font-size: 0.75rem; }
       .auth-onboarding__actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
       .auth-onboarding__actions button { font-size: 0.88rem; }
       .auth-onboarding__status { border-top: 1px solid #302b28; padding-top: 0.5rem; }
+      .auth-onboarding__copy { font-size: 0.7rem; min-height: 1.8rem; padding: 0.25rem 0.4rem; position: absolute; right: 0.55rem; top: 0.55rem; }
       .security-list { display: grid; gap: 0.3rem; }
       .security-row { align-items: center; display: flex; gap: 0.35rem; justify-content: space-between; }
       .security-row code { color: #b8b0aa; font-size: 0.65rem; overflow: hidden; text-overflow: ellipsis; }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,7 +1,7 @@
 import {
   credentialToJson,
   decodePublicKeyOptions,
-  isPasskeySupported,
+  passkeyCapability,
   presentationForAuthError,
 } from "./auth.js";
 import { renderChatTimeline, sessionMayHaveMoreEvents } from "./chat.js";
@@ -147,12 +147,11 @@ window.addEventListener("resize", () => {
   layoutResizeTimer = window.setTimeout(() => render(), 80);
 });
 
-const passkeySupported = isPasskeySupported(window);
-if (passkeySupported) {
-  authStatus.textContent = "Sign in with an enrolled passkey to open this workbench.";
-} else {
-  const presentation = presentationForAuthError();
-  authStatus.textContent = presentation.message;
+const passkeyClient = passkeyCapability(window);
+const passkeySupported = passkeyClient.supported;
+authStatus.textContent = passkeyClient.message;
+if (!passkeySupported) {
+  authStatus.dataset.code = passkeyClient.code;
   enrollPasskey.disabled = true;
   signIn.disabled = true;
 }
@@ -946,8 +945,27 @@ function authOnboarding() {
   status.className = "auth-onboarding__status";
   status.setAttribute("aria-live", "polite");
   status.textContent = authStatus.textContent;
-  onboarding.append(title, introduction, steps, label, input, actions, status);
+  const copyUrl = document.createElement("button");
+  copyUrl.id = "auth-onboarding-copy-url";
+  copyUrl.type = "button";
+  copyUrl.textContent = "Copy URL";
+  copyUrl.className = "auth-onboarding__copy";
+  copyUrl.title = "Copy the secure Relay URL to open directly in Safari or Chrome";
+  copyUrl.addEventListener("click", () => void copySecureRelayUrl(status));
+  onboarding.dataset.secureOrigin = window.isSecureContext ? "yes" : "no";
+  onboarding.dataset.passkeyApi = passkeySupported ? "yes" : "no";
+  onboarding.append(title, introduction, steps, label, input, actions, status, copyUrl);
   return onboarding;
+}
+
+async function copySecureRelayUrl(status) {
+  const url = window.location.href;
+  try {
+    await navigator.clipboard.writeText(url);
+    status.textContent = "Secure Relay URL copied. Open it directly in Safari or Chrome, then retry passkey setup.";
+  } catch {
+    status.textContent = `Copy this URL and open it directly in Safari or Chrome: ${url}`;
+  }
 }
 
 function syncAuthOnboardingStatus() {

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -61,6 +61,10 @@ test("the PWA shell is an authenticated CWD workbench, not a layout harness", as
   assert.match(app, /onboarding\.id = "auth-onboarding"/);
   assert.match(app, /setup\.textContent = "Set up this browser"/);
   assert.match(app, /authenticate\.textContent = "Sign in with passkey"/);
+  assert.match(app, /copyUrl\.textContent = "Copy URL"/);
+  assert.match(auth, /outside Discord or another in-app browser/);
+  assert.match(app, /onboarding\.dataset\.secureOrigin/);
+  assert.match(app, /onboarding\.dataset\.passkeyApi/);
   assert.match(app, /enroll\(recoveryCode\)/);
   assert.match(app, /composerShell\.hidden = !authorized/);
   assert.match(app, /paneRoot\.classList\.toggle\("pane-root--onboarding", !authorized\)/);

--- a/web/test/auth.test.mjs
+++ b/web/test/auth.test.mjs
@@ -5,6 +5,7 @@ import {
   credentialToJson,
   decodePublicKeyOptions,
   isPasskeySupported,
+  passkeyCapability,
   presentationForAuthError,
 } from "../src/auth.js";
 
@@ -50,12 +51,38 @@ test("serializes a credential response without retaining browser secrets", () =>
   });
 });
 
-test("classifies unsupported, denied, and recovery flows without PIN fallback", () => {
-  assert.equal(isPasskeySupported({ isSecureContext: false, navigator: {} }), false);
-  assert.equal(isPasskeySupported({ isSecureContext: true, navigator: { credentials: {} } }), false);
+test("classifies browser capability, ceremony failures, and recovery without auth downgrade", () => {
+  const supported = {
+    isSecureContext: true,
+    PublicKeyCredential: class PublicKeyCredential {},
+    navigator: { credentials: { create() {}, get() {} } },
+  };
+  assert.equal(isPasskeySupported(supported), true);
+  assert.deepEqual(passkeyCapability({ isSecureContext: false, navigator: {} }), {
+    supported: false,
+    code: "insecure_context",
+    message: "Passkeys require Relay's exact HTTPS address. Reopen this page using the secure URL shown below.",
+  });
+  assert.deepEqual(passkeyCapability({ isSecureContext: true, navigator: { credentials: {} } }), {
+    supported: false,
+    code: "passkey_browser_unsupported",
+    message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+  });
   assert.deepEqual(presentationForAuthError({ name: "NotAllowedError" }), {
     code: "passkey_denied",
     message: "The passkey ceremony was cancelled or denied. No weaker sign-in method was used.",
+  });
+  assert.deepEqual(presentationForAuthError({ name: "NotSupportedError" }), {
+    code: "passkey_browser_unsupported",
+    message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+  });
+  assert.deepEqual(presentationForAuthError({ name: "SecurityError" }), {
+    code: "passkey_security_error",
+    message: "Relay could not verify this page as its configured secure origin. Open the exact HTTPS Relay URL in Safari or Chrome.",
+  });
+  assert.deepEqual(presentationForAuthError({ name: "InvalidStateError" }), {
+    code: "authenticator_unavailable",
+    message: "No compatible device passkey authenticator was available. Enable device screen lock and passkey sync, then retry in Safari or Chrome.",
   });
   assert.deepEqual(presentationForAuthError({ code: "recovery_required" }), {
     code: "recovery_required",


### PR DESCRIPTION
## Summary
- distinguish insecure origins, absent WebAuthn APIs, denied ceremonies, browser security rejection, and unavailable authenticators
- keep passkey authentication strict while guiding embedded-browser users to the exact Relay URL in Safari or Chrome
- add a compact Copy URL recovery action without regressing the onboarding viewport

Relates #1151.

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run bench`
- `git diff --check`
- Chromium CDP passkey matrix, including compact onboarding fit

## Security
No PIN, anonymous mode, insecure origin, or other weaker authentication fallback is added.