### PR TITLE
fix: keep passkey recovery visible

### DIFF
--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -72,7 +72,7 @@ export function passkeyCapability(environment) {
     return {
       supported: false,
       code: "passkey_browser_unsupported",
-      message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+      message: "Passkeys are unavailable here. Copy the URL and open Relay directly in Safari or Chrome.",
     };
   }
   return {
@@ -137,7 +137,7 @@ export function presentationForAuthError(error) {
     case "passkey_browser_unsupported":
       return {
         code,
-        message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+        message: "Passkeys are unavailable here. Copy the URL and open Relay directly in Safari or Chrome.",
       };
     case "authenticator_unavailable":
       return {

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -62,7 +62,7 @@ test("the PWA shell is an authenticated CWD workbench, not a layout harness", as
   assert.match(app, /setup\.textContent = "Set up this browser"/);
   assert.match(app, /authenticate\.textContent = "Sign in with passkey"/);
   assert.match(app, /copyUrl\.textContent = "Copy URL"/);
-  assert.match(auth, /outside Discord or another in-app browser/);
+  assert.match(auth, /Passkeys are unavailable here/);
   assert.match(app, /onboarding\.dataset\.secureOrigin/);
   assert.match(app, /onboarding\.dataset\.passkeyApi/);
   assert.match(app, /enroll\(recoveryCode\)/);

--- a/web/test/auth.test.mjs
+++ b/web/test/auth.test.mjs
@@ -66,7 +66,7 @@ test("classifies browser capability, ceremony failures, and recovery without aut
   assert.deepEqual(passkeyCapability({ isSecureContext: true, navigator: { credentials: {} } }), {
     supported: false,
     code: "passkey_browser_unsupported",
-    message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+    message: "Passkeys are unavailable here. Copy the URL and open Relay directly in Safari or Chrome.",
   });
   assert.deepEqual(presentationForAuthError({ name: "NotAllowedError" }), {
     code: "passkey_denied",
@@ -74,7 +74,7 @@ test("classifies browser capability, ceremony failures, and recovery without aut
   });
   assert.deepEqual(presentationForAuthError({ name: "NotSupportedError" }), {
     code: "passkey_browser_unsupported",
-    message: "This browser context cannot use passkeys. Open the secure Relay URL in Safari or Chrome outside Discord or another in-app browser.",
+    message: "Passkeys are unavailable here. Copy the URL and open Relay directly in Safari or Chrome.",
   });
   assert.deepEqual(presentationForAuthError({ name: "SecurityError" }), {
     code: "passkey_security_error",


### PR DESCRIPTION
## Summary
- shorten the unsupported-WebAuthn recovery sentence so first-device onboarding stays within the compact preview viewport
- retain the Copy URL action and direct Safari/Chrome guidance
- keep enrollment and sign-in disabled when the passkey API is absent

Relates #1151.

## Verification
- focused auth/app-shell tests
- `npm run auth:browser`
- `npm run lint`
- `npm run build`
- `git diff --check`
- deployed unsupported-WebAuthn injection identified the overflow this patch addresses