### PR TITLE
fix: require recovery before passkey setup

### DIFF
--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -112,6 +112,27 @@ try {
 
   await evaluate(
     sessionId,
+    `window.relayOriginalFetch = window.fetch; window.relayEnrollmentFetches = []; window.fetch = (...args) => { window.relayEnrollmentFetches.push(args[0]); return window.relayOriginalFetch(...args); }; document.querySelector("#auth-onboarding-enroll").click();`,
+  );
+  assert.deepEqual(
+    await evaluate(
+      sessionId,
+      `({ status: document.querySelector("#auth-onboarding-status").textContent, focused: document.activeElement?.id, fetches: window.relayEnrollmentFetches })`,
+    ),
+    {
+      status: "Enter the current deployment recovery code before setting up this browser.",
+      focused: "auth-onboarding-recovery",
+      fetches: [],
+    },
+    "empty first-device setup must require recovery before any enrollment request",
+  );
+  await evaluate(
+    sessionId,
+    `window.fetch = window.relayOriginalFetch; delete window.relayOriginalFetch; delete window.relayEnrollmentFetches;`,
+  );
+
+  await evaluate(
+    sessionId,
     `Object.defineProperty(navigator.credentials, "create", { configurable: true, value: async () => null });`,
   );
   assert.equal(

--- a/web/src/auth.js
+++ b/web/src/auth.js
@@ -118,6 +118,11 @@ export function presentationForAuthError(error) {
         code,
         message: "No enrolled passkey is available. Recovery can enroll a replacement passkey but cannot sign you in.",
       };
+    case "session_missing":
+      return {
+        code,
+        message: "Browser access is not active. Enter the deployment recovery code to set up this browser, or sign in with an existing passkey.",
+      };
     case "origin_mismatch":
     case "passkey_security_error":
       return {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -925,6 +925,7 @@ function authOnboarding() {
   input.id = "auth-onboarding-recovery";
   input.type = "password";
   input.autocomplete = "off";
+  input.required = true;
   const actions = document.createElement("div");
   actions.className = "auth-onboarding__actions";
   const setup = document.createElement("button");
@@ -1438,7 +1439,13 @@ function iconButton(label, title, path) {
 }
 
 async function enroll(recoveryInput) {
-  const recovery = recoveryInput.value;
+  const recovery = recoveryInput.value.trim();
+  if (!recovery && !authorized) {
+    authStatus.textContent = "Enter the current deployment recovery code before setting up this browser.";
+    syncAuthOnboardingStatus();
+    recoveryInput.focus();
+    return;
+  }
   recoveryInput.value = "";
   const headers = recovery ? { "X-Relay-Recovery-Code": recovery } : { "X-Relay-CSRF": csrfToken() };
   if (await runCeremony("/auth/passkeys/enroll/options", "/auth/passkeys/enroll/verify", "create", headers)) {

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -61,6 +61,9 @@ test("the PWA shell is an authenticated CWD workbench, not a layout harness", as
   assert.match(app, /onboarding\.id = "auth-onboarding"/);
   assert.match(app, /setup\.textContent = "Set up this browser"/);
   assert.match(app, /authenticate\.textContent = "Sign in with passkey"/);
+  assert.match(app, /input\.required = true/);
+  assert.match(app, /if \(!recovery && !authorized\)/);
+  assert.match(app, /Enter the current deployment recovery code before setting up this browser/);
   assert.match(app, /copyUrl\.textContent = "Copy URL"/);
   assert.match(auth, /Passkeys are unavailable here/);
   assert.match(app, /onboarding\.dataset\.secureOrigin/);

--- a/web/test/auth.test.mjs
+++ b/web/test/auth.test.mjs
@@ -88,6 +88,10 @@ test("classifies browser capability, ceremony failures, and recovery without aut
     code: "recovery_required",
     message: "No enrolled passkey is available. Recovery can enroll a replacement passkey but cannot sign you in.",
   });
+  assert.deepEqual(presentationForAuthError({ code: "session_missing" }), {
+    code: "session_missing",
+    message: "Browser access is not active. Enter the deployment recovery code to set up this browser, or sign in with an existing passkey.",
+  });
   assert.deepEqual(presentationForAuthError({ code: "recovery_denied" }), {
     code: "recovery_denied",
     message: "That recovery code is invalid for this Relay deployment. Obtain the current code privately, then try again. No PIN or anonymous session was enabled.",


### PR DESCRIPTION
## Summary
- stop first-device passkey setup before the network request when the deployment recovery code is empty
- focus the required recovery field and show direct recovery guidance instead of blaming browser capability
- map a stale `session_missing` enrollment response to actionable auth copy

Relates #1151.

## Verification
- focused auth/app-shell tests
- browser regression: empty setup click emits zero fetches, focuses recovery input, and shows the exact requirement
- `npm run auth:browser`
- `npm run lint`
- `npm run build`
- `git diff --check`