### PR TITLE
feat(workbench): make chat session-native

### DIFF
--- a/apps/relay-hub/src/workbench.rs
+++ b/apps/relay-hub/src/workbench.rs
@@ -576,17 +576,6 @@ impl Workbench {
             live,
         };
         self.next_session_id += 1;
-        push_session_event(
-            &mut session,
-            ChatRole::System,
-            ChatCategory::Status,
-            match resume {
-                Some(_) => "session.resumed",
-                None => "session.started",
-            },
-            "Provider session connected.",
-            None,
-        );
         pump_session(&mut session);
         Ok(session)
     }
@@ -826,9 +815,73 @@ fn push_provider_event(
     next_sequence: &mut u64,
     mut event: RichChatEvent,
 ) {
+    // Session status already carries routine lifecycle/progress state. Keeping
+    // those events in the transcript produces a wall of provider plumbing
+    // rather than useful conversation. Approval prompts, errors, and tool
+    // activity use distinct categories and remain visible.
+    if event.role == ChatRole::System
+        && event.category == ChatCategory::Status
+        && event.signal.is_none()
+        && is_routine_status_label(&event.label)
+    {
+        return;
+    }
+
+    if event.role == ChatRole::Assistant && event.category == ChatCategory::Message {
+        if event.label == "assistant.message.delta" {
+            if let Some(previous) = events.back_mut().filter(|previous| {
+                previous.role == ChatRole::Assistant
+                    && previous.category == ChatCategory::Message
+                    && previous.label == "assistant.message.delta"
+            }) {
+                previous.text =
+                    redact_and_bound_display(&format!("{}{}", previous.text, event.text));
+                return;
+            }
+        } else if event.label == "assistant.message"
+            && let Some(previous) = events.back_mut().filter(|previous| {
+                previous.role == ChatRole::Assistant
+                    && previous.category == ChatCategory::Message
+                    && previous.label == "assistant.message.delta"
+            })
+        {
+            // The completion is an authoritative cumulative snapshot, not an
+            // additional chat message. Replace the assembled deltas in place.
+            previous.label = event.label;
+            previous.text = event.text;
+            previous.signal = event.signal;
+            return;
+        }
+    }
+
     event.sequence = *next_sequence;
     *next_sequence += 1;
     push_event(events, event);
+}
+
+fn is_routine_status_label(label: &str) -> bool {
+    matches!(
+        label,
+        "gateway_ready"
+            | "account.rate_limits"
+            | "item.completed"
+            | "item.started"
+            | "mcp.startup_status"
+            | "message_complete"
+            | "message_delta"
+            | "message_started"
+            | "reasoning"
+            | "remote_control.status"
+            | "session.started"
+            | "session.resumed"
+            | "session.status"
+            | "session.token_usage"
+            | "session_info"
+            | "session_title"
+            | "status_update"
+            | "turn.completed"
+            | "turn.started"
+    )
 }
 
 fn push_pressure_if_new(
@@ -926,6 +979,239 @@ mod tests {
         assert_eq!(first["sessions"][0]["events"][0]["text"], "shared history");
         assert_eq!(first["selectedWorkspaceId"], Value::Null);
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn provider_event_boundary_coalesces_deltas_and_replaces_them_with_final_snapshot() {
+        let mut events = VecDeque::new();
+        let mut next_sequence = 1;
+        for text in ["Hel", "lo", " ", "world"] {
+            push_provider_event(
+                &mut events,
+                &mut next_sequence,
+                RichChatEvent::new(
+                    0,
+                    ChatRole::Assistant,
+                    ChatCategory::Message,
+                    "assistant.message.delta",
+                    text,
+                    None,
+                ),
+            );
+        }
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::Assistant,
+                ChatCategory::Message,
+                "assistant.message",
+                "Hello world",
+                None,
+            ),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].label, "assistant.message");
+        assert_eq!(events[0].text, "Hello world");
+        assert_eq!(next_sequence, 2);
+
+        let mut completion_only = VecDeque::new();
+        let mut completion_sequence = 1;
+        push_provider_event(
+            &mut completion_only,
+            &mut completion_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::Assistant,
+                ChatCategory::Message,
+                "assistant.message",
+                "A non-streamed answer",
+                None,
+            ),
+        );
+        assert_eq!(completion_only.len(), 1);
+        assert_eq!(completion_only[0].text, "A non-streamed answer");
+    }
+
+    #[test]
+    fn shared_provider_event_boundary_re_redacts_secrets_split_across_deltas() {
+        for (chunks, expected) in [
+            (["Bear", "er private-token"], "Bearer [redacted]"),
+            (["sk", "-private-token"], "sk-[redacted]"),
+        ] {
+            let mut events = VecDeque::new();
+            let mut next_sequence = 1;
+            for chunk in chunks {
+                push_provider_event(
+                    &mut events,
+                    &mut next_sequence,
+                    RichChatEvent::new(
+                        0,
+                        ChatRole::Assistant,
+                        ChatCategory::Message,
+                        "assistant.message.delta",
+                        redact_and_bound_display(chunk),
+                        None,
+                    ),
+                );
+            }
+
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].text, expected);
+            assert!(!events[0].text.contains("private-token"));
+        }
+    }
+
+    #[test]
+    fn repeated_delta_redaction_keeps_existing_marker_stable() {
+        let mut events = VecDeque::new();
+        let mut next_sequence = 1;
+        for (chunk, expected) in [
+            ("sk-SECRET", "sk-[redacted]"),
+            (" after", "sk-[redacted] after"),
+            (" more", "sk-[redacted] after more"),
+        ] {
+            push_provider_event(
+                &mut events,
+                &mut next_sequence,
+                RichChatEvent::new(
+                    0,
+                    ChatRole::Assistant,
+                    ChatCategory::Message,
+                    "assistant.message.delta",
+                    redact_and_bound_display(chunk),
+                    None,
+                ),
+            );
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].text, expected);
+            assert!(!events[0].text.contains("…[truncated]"));
+        }
+        assert_eq!(next_sequence, 2);
+    }
+
+    #[test]
+    fn provider_event_boundary_drops_routine_status_but_keeps_actionable_activity() {
+        let mut events = VecDeque::new();
+        let mut next_sequence = 1;
+        for label in [
+            "account.rate_limits",
+            "session.started",
+            "remote_control.status",
+            "mcp.startup_status",
+            "session.status",
+            "session.token_usage",
+            "turn.started",
+        ] {
+            push_provider_event(
+                &mut events,
+                &mut next_sequence,
+                RichChatEvent::new(
+                    0,
+                    ChatRole::System,
+                    ChatCategory::Status,
+                    label,
+                    "routine provider activity",
+                    None,
+                ),
+            );
+        }
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Status,
+                "approval.request",
+                "Approval required",
+                None,
+            ),
+        );
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Error,
+                "session.status",
+                "Provider session reported a system error",
+                Some(ChatSignal::Degraded),
+            ),
+        );
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Error,
+                "unsupported_event",
+                "Provider reported unsupported event.",
+                Some(ChatSignal::Degraded),
+            ),
+        );
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Error,
+                "mcp.startup_status",
+                "MCP server failed to start: authentication failed",
+                Some(ChatSignal::Degraded),
+            ),
+        );
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Status,
+                "clarification_request",
+                "Clarification required",
+                None,
+            ),
+        );
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Error,
+                "provider.error",
+                "Provider failed",
+                Some(ChatSignal::Degraded),
+            ),
+        );
+        push_provider_event(
+            &mut events,
+            &mut next_sequence,
+            RichChatEvent::new(
+                0,
+                ChatRole::System,
+                ChatCategory::Tool,
+                "tool.started",
+                "tool search",
+                None,
+            ),
+        );
+
+        assert_eq!(events.len(), 7);
+        assert_eq!(events[0].label, "approval.request");
+        assert_eq!(events[1].label, "session.status");
+        assert_eq!(events[1].category, ChatCategory::Error);
+        assert_eq!(events[2].label, "unsupported_event");
+        assert_eq!(events[3].label, "mcp.startup_status");
+        assert_eq!(events[3].category, ChatCategory::Error);
+        assert_eq!(events[4].label, "clarification_request");
+        assert_eq!(events[5].category, ChatCategory::Error);
+        assert_eq!(events[6].category, ChatCategory::Tool);
     }
 
     #[test]

--- a/crates/relay-hermes-session/src/lib.rs
+++ b/crates/relay-hermes-session/src/lib.rs
@@ -683,7 +683,7 @@ impl HermesSessionAdapter {
                 )
             }
             "message.delta" => match assistant_message_text(payload) {
-                Some(text) => (EventKind::Status, "assistant_message", text),
+                Some(text) => (EventKind::Status, "assistant.message.delta", text),
                 None => (
                     EventKind::Status,
                     "message_delta",
@@ -693,7 +693,7 @@ impl HermesSessionAdapter {
             "message.complete" => {
                 self.status = SessionStatus::Idle;
                 match assistant_message_text(payload) {
-                    Some(text) => (EventKind::Status, "assistant_message", text),
+                    Some(text) => (EventKind::Status, "assistant.message", text),
                     None => (
                         EventKind::Status,
                         "message_complete",
@@ -966,7 +966,7 @@ fn assistant_message_text(payload: Option<&serde_json::Map<String, Value>>) -> O
 }
 
 fn hermes_rich_event(sequence: u64, kind: EventKind, label: &str, preview: &str) -> RichChatEvent {
-    if label == "assistant_message" {
+    if label.starts_with("assistant.message") {
         return RichChatEvent::new(
             sequence,
             ChatRole::Assistant,

--- a/crates/relay-session/src/codex.rs
+++ b/crates/relay-session/src/codex.rs
@@ -120,10 +120,28 @@ pub const EVENT_LEDGER: &[LedgerEntry] = &[
         observed: false,
     },
     LedgerEntry {
+        method: "thread/status/changed",
+        kind: EventKind::Lifecycle,
+        label: "session.status",
+        observed: true,
+    },
+    LedgerEntry {
+        method: "thread/tokenUsage/updated",
+        kind: EventKind::Progress,
+        label: "session.token_usage",
+        observed: true,
+    },
+    LedgerEntry {
         method: "mcpServer/startupStatus/updated",
         kind: EventKind::Diagnostic,
         label: "mcp.startup_status",
         observed: false,
+    },
+    LedgerEntry {
+        method: "account/rateLimits/updated",
+        kind: EventKind::Progress,
+        label: "account.rate_limits",
+        observed: true,
     },
     LedgerEntry {
         method: "turn/started",
@@ -140,7 +158,7 @@ pub const EVENT_LEDGER: &[LedgerEntry] = &[
     LedgerEntry {
         method: "item/agentMessage/delta",
         kind: EventKind::Progress,
-        label: "assistant.message",
+        label: "assistant.message.delta",
         observed: false,
     },
     LedgerEntry {
@@ -327,6 +345,31 @@ mod tests {
             .find(|e| e.method == "turn/started")
             .unwrap();
         assert!(!turn.observed);
+    }
+
+    #[test]
+    fn observed_current_turn_plumbing_maps_to_neutral_events() {
+        for (method, kind, label) in [
+            (
+                "thread/status/changed",
+                EventKind::Lifecycle,
+                "session.status",
+            ),
+            (
+                "thread/tokenUsage/updated",
+                EventKind::Progress,
+                "session.token_usage",
+            ),
+            (
+                "account/rateLimits/updated",
+                EventKind::Progress,
+                "account.rate_limits",
+            ),
+        ] {
+            let frame =
+                scan_line(format!(r#"{{"method":"{method}","params":{{}}}}"#).as_bytes()).unwrap();
+            assert_eq!(map_frame(&frame), Mapped::Event { kind, label });
+        }
     }
 
     #[test]

--- a/crates/relay-session/src/jsonl.rs
+++ b/crates/relay-session/src/jsonl.rs
@@ -48,6 +48,10 @@ pub struct Frame {
     /// Displayable assistant text extracted only from known agent-message
     /// notification shapes before the parsed provider payload is dropped.
     pub display_text: Option<String>,
+    /// Whether a known diagnostic notification reports a failure that must not
+    /// be compacted as routine provider status. Only the boolean and bounded
+    /// redacted [`Frame::preview`] cross the framing boundary.
+    pub diagnostic_failure: bool,
     /// Safe display text or generic diagnostic metadata; never a raw frame.
     pub preview: String,
 }
@@ -172,7 +176,16 @@ pub fn scan_line(line: &[u8]) -> Result<Frame, ScanError> {
     } else {
         None
     };
-    let preview = safe_preview(&class, display_text.as_deref());
+    let diagnostic_preview = if matches!(class, FrameClass::Notification) {
+        extract_known_notification_failure(method.as_deref(), params)
+    } else {
+        None
+    };
+    let diagnostic_failure = diagnostic_preview.is_some();
+    let preview = safe_preview(
+        &class,
+        display_text.as_deref().or(diagnostic_preview.as_deref()),
+    );
 
     Ok(Frame {
         class,
@@ -183,6 +196,7 @@ pub fn scan_line(line: &[u8]) -> Result<Frame, ScanError> {
         has_params,
         event_turn_id,
         display_text,
+        diagnostic_failure,
         preview,
     })
 }
@@ -215,6 +229,50 @@ fn extract_agent_message(method: Option<&str>, params: Option<&Value>) -> Option
     Some(redact_and_bound_display(text))
 }
 
+fn extract_known_notification_failure(
+    method: Option<&str>,
+    params: Option<&Value>,
+) -> Option<String> {
+    match method? {
+        "mcpServer/startupStatus/updated" => extract_mcp_startup_failure(params),
+        "thread/status/changed" => extract_thread_status_failure(params),
+        _ => None,
+    }
+}
+
+fn extract_mcp_startup_failure(params: Option<&Value>) -> Option<String> {
+    let params = params?.as_object()?;
+    let status = params.get("status").and_then(Value::as_str);
+    let error = params
+        .get("error")
+        .and_then(Value::as_str)
+        .filter(|error| !error.is_empty());
+    if status != Some("failed") && error.is_none() {
+        return None;
+    }
+
+    let text = if let Some(error) = error {
+        format!("MCP server failed to start: {error}")
+    } else if params.get("failureReason").and_then(Value::as_str)
+        == Some("reauthenticationRequired")
+    {
+        "MCP server failed to start: reauthentication required".to_owned()
+    } else {
+        "MCP server failed to start".to_owned()
+    };
+    Some(redact_and_bound_preview(&text))
+}
+
+fn extract_thread_status_failure(params: Option<&Value>) -> Option<String> {
+    let status = params?
+        .as_object()?
+        .get("status")?
+        .as_object()?
+        .get("type")?
+        .as_str()?;
+    (status == "systemError").then(|| "Provider session reported a system error".to_owned())
+}
+
 pub fn redact_and_bound_display(text: &str) -> String {
     let mut text = redact_secrets(text);
     if text.len() > crate::contract::MAX_CHAT_TEXT_BYTES {
@@ -241,14 +299,19 @@ fn nested_result_id(result: Option<&Value>, outer: &str) -> Option<String> {
 
 /// Redact obvious secrets, then bound the string to [`MAX_PREVIEW_BYTES`].
 pub fn redacted_preview(line: &[u8]) -> String {
-    let mut text = redact_secrets(&String::from_utf8_lossy(line));
+    redact_and_bound_preview(&String::from_utf8_lossy(line))
+}
+
+fn redact_and_bound_preview(text: &str) -> String {
+    const TRUNCATED: &str = "…[truncated]";
+    let mut text = redact_secrets(text);
     if text.len() > MAX_PREVIEW_BYTES {
-        let mut end = MAX_PREVIEW_BYTES;
+        let mut end = MAX_PREVIEW_BYTES.saturating_sub(TRUNCATED.len());
         while end > 0 && !text.is_char_boundary(end) {
             end -= 1;
         }
         text.truncate(end);
-        text.push_str("…[truncated]");
+        text.push_str(TRUNCATED);
     }
     text
 }
@@ -387,6 +450,7 @@ fn decode_ascii_unicode_escape(bytes: &[u8]) -> Option<u8> {
 }
 
 fn append_redacted_tokens(input: &str, mut i: usize, end: usize, output: &mut String) {
+    const REDACTED_MARKER: &[u8] = b"[redacted]";
     let bytes = input.as_bytes();
     while i < end {
         if starts_with_ci(&bytes[i..end], b"bearer ") {
@@ -400,6 +464,9 @@ fn append_redacted_tokens(input: &str, mut i: usize, end: usize, output: &mut St
         if starts_with_ci(&bytes[i..end], b"sk-") && is_token_boundary(bytes, i) {
             output.push_str("sk-[redacted]");
             i += 3;
+            if bytes[i..end].starts_with(REDACTED_MARKER) {
+                i += REDACTED_MARKER.len();
+            }
             while i < end && (bytes[i].is_ascii_alphanumeric() || matches!(bytes[i], b'-' | b'_')) {
                 i += 1;
             }
@@ -481,6 +548,78 @@ mod tests {
         )
         .unwrap();
         assert!(reasoning.display_text.is_none());
+    }
+
+    #[test]
+    fn extracts_only_bounded_redacted_mcp_startup_failures() {
+        for status in ["starting", "ready"] {
+            let line = serde_json::to_vec(&serde_json::json!({
+                "method": "mcpServer/startupStatus/updated",
+                "params": {"name": "private-name", "status": status, "error": null},
+            }))
+            .unwrap();
+            let frame = scan_line(&line).unwrap();
+            assert!(!frame.diagnostic_failure);
+            assert_eq!(frame.preview, "provider event");
+        }
+
+        let failed = scan_line(
+            br#"{"method":"mcpServer/startupStatus/updated","params":{"name":"private-name","status":"failed","error":"Bearer private-token"}}"#,
+        )
+        .unwrap();
+        assert!(failed.diagnostic_failure);
+        assert_eq!(
+            failed.preview,
+            "MCP server failed to start: Bearer [redacted]"
+        );
+        assert!(!failed.preview.contains("private-token"));
+        assert!(!failed.preview.contains("private-name"));
+
+        let long_line = serde_json::to_vec(&serde_json::json!({
+            "method": "mcpServer/startupStatus/updated",
+            "params": {
+                "name": "private-name",
+                "status": "failed",
+                "error": format!("sk-SECRET {}", "x".repeat(MAX_PREVIEW_BYTES * 2)),
+            },
+        }))
+        .unwrap();
+        let long_failure = scan_line(&long_line).unwrap();
+        assert!(long_failure.diagnostic_failure);
+        assert!(long_failure.preview.len() <= MAX_PREVIEW_BYTES);
+        assert!(long_failure.preview.contains("sk-[redacted]"));
+        assert!(!long_failure.preview.contains("SECRET"));
+
+        let reauth = scan_line(
+            br#"{"method":"mcpServer/startupStatus/updated","params":{"name":"private-name","status":"failed","error":null,"failureReason":"reauthenticationRequired"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            reauth.preview,
+            "MCP server failed to start: reauthentication required"
+        );
+    }
+
+    #[test]
+    fn extracts_only_thread_system_error_state() {
+        for status in ["notLoaded", "idle", "active"] {
+            let line = serde_json::to_vec(&serde_json::json!({
+                "method": "thread/status/changed",
+                "params": {"threadId": "private-id", "status": {"type": status}},
+            }))
+            .unwrap();
+            let frame = scan_line(&line).unwrap();
+            assert!(!frame.diagnostic_failure);
+            assert_eq!(frame.preview, "provider event");
+        }
+
+        let failed = scan_line(
+            br#"{"method":"thread/status/changed","params":{"threadId":"private-id","status":{"type":"systemError"}}}"#,
+        )
+        .unwrap();
+        assert!(failed.diagnostic_failure);
+        assert_eq!(failed.preview, "Provider session reported a system error");
+        assert!(!failed.preview.contains("private-id"));
     }
     use std::time::{Duration, Instant};
 
@@ -627,6 +766,24 @@ mod tests {
     }
 
     #[test]
+    fn exact_redaction_markers_are_idempotent() {
+        for input in [
+            "sk-[redacted]",
+            "Bearer [redacted]",
+            "prefix [redacted] suffix",
+            r#"{"access_token":"[redacted]"}"#,
+        ] {
+            let once = redact_secrets(input);
+            assert_eq!(redact_secrets(&once), once, "input: {input}");
+        }
+
+        assert_eq!(
+            redact_secrets("sk-[redacted]SECRET after"),
+            "sk-[redacted] after"
+        );
+    }
+
+    #[test]
     fn frame_preview_never_retains_raw_payloads_or_reasoning() {
         let frame = scan_line(
             br#"{"method":"auth","params":{"accessToken":"mask-me-a","refreshToken":"mask-me-b","idToken":"mask-me-c","client\u0053ecret":"mask-me-\u0064"}}"#,
@@ -650,7 +807,7 @@ mod tests {
         line.extend(std::iter::repeat_n(b'z', MAX_PREVIEW_BYTES * 4));
         line.extend_from_slice(b"\"}");
         let preview = redacted_preview(&line);
-        assert!(preview.len() <= MAX_PREVIEW_BYTES + "…[truncated]".len());
+        assert!(preview.len() <= MAX_PREVIEW_BYTES);
         assert!(preview.ends_with("…[truncated]"));
     }
 }

--- a/crates/relay-session/src/supervisor.rs
+++ b/crates/relay-session/src/supervisor.rs
@@ -978,17 +978,50 @@ impl<T: Transport> Supervisor<T> {
 
 fn codex_rich_event(sequence: u64, kind: EventKind, label: &str, frame: &Frame) -> RichChatEvent {
     if let Some(text) = frame.display_text.as_deref() {
+        // Delta notifications are incremental chunks while an agent-message
+        // item completion is the authoritative cumulative snapshot. Preserve
+        // that distinction at the neutral boundary so consumers can coalesce
+        // a streamed answer without displaying the completed text twice.
+        let message_label = if label == "assistant.message.delta" {
+            label
+        } else {
+            "assistant.message"
+        };
         return RichChatEvent::new(
             sequence,
             ChatRole::Assistant,
             ChatCategory::Message,
-            "assistant.message",
+            message_label,
             text,
             None,
         );
     }
+    if frame.diagnostic_failure {
+        return RichChatEvent::new(
+            sequence,
+            ChatRole::System,
+            ChatCategory::Error,
+            label,
+            frame.preview.clone(),
+            Some(ChatSignal::Degraded),
+        );
+    }
     let (category, text, signal) = match kind {
-        EventKind::Diagnostic | EventKind::Unsupported => (
+        EventKind::Unsupported => (
+            ChatCategory::Error,
+            format!("Provider reported {}.", label.replace('_', " ")),
+            Some(ChatSignal::Degraded),
+        ),
+        EventKind::Diagnostic
+            if matches!(label, "remote_control.status" | "mcp.startup_status") =>
+        {
+            (
+                ChatCategory::Status,
+                format!("{}.", label.replace(['.', '_'], " ")),
+                None,
+            )
+        }
+        EventKind::Diagnostic => (
             ChatCategory::Error,
             format!("Provider reported {}.", label.replace('_', " ")),
             Some(ChatSignal::Degraded),
@@ -1227,8 +1260,92 @@ mod tests {
         let event = supervisor.next_event().unwrap();
         assert_eq!(event.rich.role, ChatRole::Assistant);
         assert_eq!(event.rich.category, ChatCategory::Message);
+        assert_eq!(event.rich.label, "assistant.message");
         assert_eq!(event.rich.text, "answer Bearer [redacted]");
         assert!(!event.rich.text.contains("private-token"));
+    }
+
+    #[test]
+    fn streamed_agent_message_distinguishes_deltas_from_completed_snapshot() {
+        let lines = [
+            r#"{"method":"item/agentMessage/delta","params":{"delta":"Hel"}}"#,
+            r#"{"method":"item/agentMessage/delta","params":{"delta":"lo"}}"#,
+            r#"{"method":"item/completed","params":{"item":{"type":"agentMessage","text":"Hello"}}}"#,
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines(lines));
+        supervisor.pump();
+        let assistant = std::iter::from_fn(|| supervisor.next_event())
+            .filter(|event| event.rich.role == ChatRole::Assistant)
+            .map(|event| (event.rich.label, event.rich.text))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            assistant,
+            vec![
+                ("assistant.message.delta".to_owned(), "Hel".to_owned()),
+                ("assistant.message.delta".to_owned(), "lo".to_owned()),
+                ("assistant.message".to_owned(), "Hello".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mcp_startup_failure_is_visible_while_ready_status_stays_routine() {
+        let lines = [
+            r#"{"method":"mcpServer/startupStatus/updated","params":{"name":"safe","status":"ready","error":null}}"#,
+            r#"{"method":"mcpServer/startupStatus/updated","params":{"name":"safe","status":"failed","error":"Bearer private-token"}}"#,
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines(lines));
+        supervisor.pump();
+        let events = std::iter::from_fn(|| supervisor.next_event())
+            .filter(|event| event.rich.label == "mcp.startup_status")
+            .map(|event| event.rich)
+            .collect::<Vec<_>>();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].category, ChatCategory::Status);
+        assert_eq!(events[0].signal, None);
+        assert_eq!(events[1].category, ChatCategory::Error);
+        assert_eq!(events[1].signal, Some(ChatSignal::Degraded));
+        assert_eq!(
+            events[1].text,
+            "MCP server failed to start: Bearer [redacted]"
+        );
+        assert!(!events[1].text.contains("private-token"));
+    }
+
+    #[test]
+    fn observed_turn_plumbing_is_supported_and_thread_system_error_stays_visible() {
+        let lines = [
+            r#"{"method":"thread/status/changed","params":{"threadId":"private","status":{"type":"active","activeFlags":[]}}}"#,
+            r#"{"method":"thread/tokenUsage/updated","params":{}}"#,
+            r#"{"method":"account/rateLimits/updated","params":{}}"#,
+            r#"{"method":"thread/status/changed","params":{"threadId":"private","status":{"type":"systemError"}}}"#,
+        ];
+        let mut supervisor = Supervisor::new(ScriptedTransport::from_lines(lines));
+        supervisor.pump();
+        let events = std::iter::from_fn(|| supervisor.next_event())
+            .filter(|event| {
+                matches!(
+                    event.rich.label.as_str(),
+                    "session.status" | "session.token_usage" | "account.rate_limits"
+                )
+            })
+            .map(|event| event.rich)
+            .collect::<Vec<_>>();
+
+        assert_eq!(supervisor.signals().unsupported, 0);
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].category, ChatCategory::Status);
+        assert_eq!(events[1].label, "session.token_usage");
+        assert_eq!(events[1].category, ChatCategory::Status);
+        assert_eq!(events[2].label, "account.rate_limits");
+        assert_eq!(events[2].category, ChatCategory::Status);
+        assert_eq!(events[3].label, "session.status");
+        assert_eq!(events[3].category, ChatCategory::Error);
+        assert_eq!(events[3].signal, Some(ChatSignal::Degraded));
+        assert_eq!(events[3].text, "Provider session reported a system error");
+        assert!(!events[3].text.contains("private"));
     }
 
     #[test]
@@ -1244,6 +1361,11 @@ mod tests {
         assert_eq!(supervisor.signals().malformed, 1);
         assert_eq!(supervisor.signals().over_limit, 1);
         assert_eq!(supervisor.signals().unsupported, 1);
+        let unsupported = std::iter::from_fn(|| supervisor.next_event())
+            .find(|event| event.rich.label == "unsupported_event")
+            .expect("unknown provider notification remains visible");
+        assert_eq!(unsupported.rich.category, ChatCategory::Error);
+        assert_eq!(unsupported.rich.signal, Some(ChatSignal::Degraded));
     }
 
     #[test]

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -969,15 +969,34 @@ async function exerciseLiveWorkbench(sessionId, { expectedWorkspaceCount, worksp
   assert.deepEqual(composerState, { composerCount: 1, inputDisabled: false, sendDisabled: true, sendType: "submit", sameForm: true });
   await evaluate(
     sessionId,
-    `(() => { const form = document.querySelector("[data-chat-composer]"); const input = form.querySelector("textarea"); const send = form.querySelector("[type=submit]"); window.relaySubmitObserved = false; form.addEventListener("submit", () => { window.relaySubmitObserved = true; }, { once: true }); input.value = "Reply with one word: relay"; input.dispatchEvent(new Event("input", { bubbles: true })); send.click(); })()`,
+    `(() => { const form = document.querySelector("[data-chat-composer]"); const input = form.querySelector("textarea"); window.relaySubmitObserved = false; form.addEventListener("submit", () => { window.relaySubmitObserved = true; }, { once: true }); input.value = "Reply with one word: relay"; input.dispatchEvent(new Event("input", { bubbles: true })); input.focus(); input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })); })()`,
   );
-  assert.equal(await evaluate(sessionId, "window.relaySubmitObserved"), true, "Send must submit the active chat tab composer");
+  assert.equal(await evaluate(sessionId, "window.relaySubmitObserved"), true, "Enter must submit the active chat tab composer");
+  assert.deepEqual(
+    await evaluate(sessionId, "(() => { const form = document.querySelector('[data-chat-composer]'); return { value: form.querySelector('textarea').value, sendDisabled: form.querySelector('[type=submit]').disabled }; })()"),
+    { value: "", sendDisabled: true },
+    "successful keyboard-first submission must clear the active draft immediately",
+  );
+  await waitFor(
+    async () => evaluate(sessionId, "document.activeElement === document.querySelector('[data-chat-composer] textarea')"),
+    "composer focus restoration after its optimistic render microtask",
+  );
+  await evaluate(sessionId, "window.relayComposerBeforeRefresh = document.querySelector('[data-chat-composer] textarea')");
   await waitFor(
     async () => (await evaluate(sessionId, "document.querySelectorAll('.chat-event--user').length")) === 1,
     async () => ({
       dom: await evaluate(sessionId, "({ disabled: document.querySelector('[data-chat-composer] textarea')?.disabled, error: document.querySelector('#workbench-error').textContent, errorCode: document.querySelector('#workbench-error').dataset.code, timeline: document.querySelector('.chat-timeline')?.innerText, state: document.querySelector('#session-status').dataset.state })"),
       runtimeEvents: browser.events.filter((event) => event.method === "Runtime.exceptionThrown"),
     }),
+  );
+  await waitFor(
+    async () => evaluate(sessionId, "document.querySelector('[data-chat-composer] textarea') !== window.relayComposerBeforeRefresh"),
+    "an actual composer node replacement during the scheduled Session refresh",
+  );
+  assert.deepEqual(
+    await evaluate(sessionId, "(() => { const input = document.querySelector('[data-chat-composer] textarea'); return { value: input?.value, focused: document.activeElement === input }; })()"),
+    { value: "", focused: true },
+    "the cleared draft and focus must survive the actual composer node replacement",
   );
   await waitFor(
     async () => evaluate(sessionId, `fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => snapshot.sessions.find((session) => session.id === ${JSON.stringify(liveSessionId)})?.events?.some((event) => event.role === 'assistant' && event.kind === 'message' && event.label === 'assistant.message' && event.text.toLowerCase().includes('relay')))`),
@@ -1057,7 +1076,7 @@ async function exerciseLiveWorkbench(sessionId, { expectedWorkspaceCount, worksp
   );
   const presentation = await evaluate(
     sessionId,
-    `(() => { const pane = document.querySelector('.workbench-pane'); const body = pane?.querySelector('.pane-body--chat'); return { paneCount: document.querySelectorAll('.workbench-pane').length, terminalSurfaceCount: document.querySelectorAll('.terminal-surface').length, composerCount: document.querySelectorAll('[data-chat-composer]').length, composerInsideChatPane: Boolean(pane?.matches('.workbench-pane--chat') && pane.querySelector(':scope > [data-chat-composer]')), userMessages: document.querySelectorAll('.chat-event--user').length, assistantMessages: [...document.querySelectorAll('.chat-event--assistant p')].map((message) => message.textContent), genericEvents: document.querySelectorAll('.chat-event--error, .chat-event--tool, .chat-event--status').length, nearBottom: body ? body.scrollHeight - body.clientHeight - body.scrollTop <= 80 : false, state: document.querySelector('#session-status').dataset.state }; })()`,
+    `(() => { const pane = document.querySelector('.workbench-pane'); const body = pane?.querySelector('.pane-body--chat'); return { paneCount: document.querySelectorAll('.workbench-pane').length, terminalSurfaceCount: document.querySelectorAll('.terminal-surface').length, composerCount: document.querySelectorAll('[data-chat-composer]').length, composerValue: document.querySelector('[data-chat-composer] textarea')?.value, composerInsideChatPane: Boolean(pane?.matches('.workbench-pane--chat') && pane.querySelector(':scope > [data-chat-composer]')), userMessages: document.querySelectorAll('.chat-event--user').length, userArticleNames: [...document.querySelectorAll('.chat-event--user')].map((message) => message.getAttribute('aria-label')), assistantMessages: [...document.querySelectorAll('.chat-event--assistant p')].map((message) => message.textContent), assistantArticleNames: [...document.querySelectorAll('.chat-event--assistant')].map((message) => message.getAttribute('aria-label')), visibleRoleLabels: document.querySelectorAll('.chat-event--user .chat-event__role, .chat-event--assistant .chat-event__role').length, messageCopyActions: document.querySelectorAll('.chat-event--message .chat-event__copy[aria-label="Copy message"]').length, genericEvents: document.querySelectorAll('.chat-event--error, .chat-event--tool, .chat-event--status').length, nearBottom: body ? body.scrollHeight - body.clientHeight - body.scrollTop <= 80 : false, state: document.querySelector('#session-status').dataset.state }; })()`,
   );
   assert.deepEqual(
     presentation,
@@ -1065,14 +1084,38 @@ async function exerciseLiveWorkbench(sessionId, { expectedWorkspaceCount, worksp
       paneCount: 1,
       terminalSurfaceCount: 0,
       composerCount: 1,
+      composerValue: "",
       composerInsideChatPane: true,
       userMessages: 1,
+      userArticleNames: ["Your message"],
       assistantMessages: ["relay"],
+      assistantArticleNames: ["Assistant message"],
+      visibleRoleLabels: 0,
+      messageCopyActions: 2,
       genericEvents: 0,
       nearBottom: true,
       state: "idle",
     },
     "the final live chat view must be normalized, current, quiet, and composer-owned",
+  );
+  const focusedCopyKey = await evaluate(
+    sessionId,
+    "(() => { const button = document.querySelector('.chat-event--assistant .chat-event__copy'); button.focus(); const key = button.dataset.chatCopyKey; button.click(); return key; })()",
+  );
+  await waitFor(
+    async () => evaluate(sessionId, `Boolean(document.querySelector('[data-chat-copy-key="${focusedCopyKey}"]')?.dataset.copyState)`),
+    "keyboard copy feedback",
+  );
+  const copyFeedback = await evaluate(
+    sessionId,
+    `(() => { const button = document.querySelector('[data-chat-copy-key="${focusedCopyKey}"]'); return { state: button.dataset.copyState, status: button.parentElement.querySelector('.chat-event__copy-status').textContent }; })()`,
+  );
+  assert.ok(["copied", "unavailable"].includes(copyFeedback.state), `copy state: ${JSON.stringify(copyFeedback)}`);
+  assert.ok(copyFeedback.status.length > 0, "copy must expose an accessible status without changing chat content");
+  await evaluate(sessionId, "window.relayCopyBeforeResize = document.activeElement; window.dispatchEvent(new Event('resize'))");
+  await waitFor(
+    async () => evaluate(sessionId, `(() => { const button = document.querySelector('[data-chat-copy-key="${focusedCopyKey}"]'); const status = button?.parentElement.querySelector('.chat-event__copy-status'); return button !== window.relayCopyBeforeResize && document.activeElement === button && button?.dataset.copyState === ${JSON.stringify(copyFeedback.state)} && status?.textContent === ${JSON.stringify(copyFeedback.status)}; })()`),
+    "copy node replacement with focus and feedback restoration after a pane rerender",
   );
   if (process.env.RELAY_WORKBENCH_SCREENSHOT_PATH) {
     const screenshot = await browser.command("Page.captureScreenshot", { format: "png" }, sessionId);

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -861,10 +861,9 @@ async function exerciseVisibleClaudeWorkbench(sessionId) {
   );
   const actions = await evaluate(sessionId, "window.relayClaudeRequests");
   assert.ok(actions.some((action) => action.path.endsWith("/resize")), "visible xterm must resize the shared PTY from its pane bounds");
-  assert.ok(actions.some((action) => action.path.endsWith("/input")), "visible xterm input must use the shared PTY API");
-  const beforeRefreshOutput = await evaluate(sessionId, "document.querySelector('.terminal-host .xterm-rows').textContent");
-  const beforeRefreshEchoes = beforeRefreshOutput.split("browser-ui").length - 1;
-  assert.ok(beforeRefreshEchoes >= 1, "visible xterm must render real fixture output before refresh");
+  const inputAction = actions.find((action) => action.path.endsWith("/input"));
+  assert.ok(inputAction, "visible xterm input must use the shared PTY API");
+  const terminalSessionPath = inputAction.path.slice(0, -"/input".length);
   await evaluate(sessionId, "document.querySelector('#interrupt-session').click()");
   await waitFor(
     async () => (await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent"))?.includes("exited"),
@@ -874,14 +873,32 @@ async function exerciseVisibleClaudeWorkbench(sessionId) {
     (await evaluate(sessionId, "window.relayClaudeRequests")).some((action) => action.path.endsWith("/interrupt")),
     "visible interrupt must target the selected Claude Session",
   );
+  const authoritativeOutput = await drainTerminalOutput(sessionId, terminalSessionPath);
+  const expectedEchoes = markerCount(authoritativeOutput.text, "browser-ui");
+  assert.ok(expectedEchoes > 0, "the exited PTY snapshot must retain real fixture output before refresh");
+  await waitForVisibleTerminalMarkerCount(sessionId, {
+    authoritativeOutput,
+    expected: expectedEchoes,
+    label: "before refresh",
+    marker: "browser-ui",
+  });
 
   await browser.command("Page.reload", { ignoreCache: true }, sessionId);
   await waitFor(async () => (await evaluate(sessionId, "document.readyState")) === "complete");
-  await waitFor(async () => Boolean(await evaluate(sessionId, "document.querySelector('.terminal-host .xterm-rows')?.textContent.includes('browser-ui')")));
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('.terminal-status')?.textContent ?? ''")).includes("exited"),
+    async () => evaluate(sessionId, "({ status: document.querySelector('.terminal-status')?.textContent, rows: document.querySelector('.terminal-host .xterm-rows')?.textContent })"),
+  );
+  await waitForVisibleTerminalMarkerCount(sessionId, {
+    authoritativeOutput,
+    expected: expectedEchoes,
+    label: "after refresh",
+    marker: "browser-ui",
+  });
   const restoredOutput = await evaluate(sessionId, "document.querySelector('.terminal-host .xterm-rows').textContent");
   assert.equal(
-    restoredOutput.split("browser-ui").length - 1,
-    beforeRefreshEchoes,
+    markerCount(restoredOutput, "browser-ui"),
+    expectedEchoes,
     "refresh restoration must not duplicate terminal output",
   );
   assert.match(
@@ -1223,6 +1240,113 @@ async function evaluate(sessionId, expression) {
   );
   if (response.exceptionDetails) throw new Error(response.exceptionDetails.text);
   return response.result.value;
+}
+
+async function drainTerminalOutput(sessionId, terminalSessionPath) {
+  return evaluate(
+    sessionId,
+    `(async () => {
+      let cursor = 0;
+      let pages = 0;
+      let status = "unknown";
+      let text = "";
+      while (pages < 128) {
+        const response = await fetch(${JSON.stringify(terminalSessionPath)} + "?cursor=" + cursor, { credentials: "same-origin" });
+        if (!response.ok) throw new Error("terminal snapshot failed with HTTP " + response.status);
+        const snapshot = await response.json();
+        if (snapshot.truncated) throw new Error("terminal snapshot was truncated before authoritative comparison");
+        for (const chunk of snapshot.output) {
+          if (chunk.sequence > cursor) text += chunk.text;
+        }
+        const previousCursor = cursor;
+        cursor = snapshot.nextCursor;
+        status = snapshot.status;
+        pages += 1;
+        if (!snapshot.hasMore) return { cursor, pages, status, text };
+        if (cursor <= previousCursor) throw new Error("terminal snapshot pagination did not advance");
+      }
+      throw new Error("terminal snapshot pagination exceeded 128 pages");
+    })()`,
+  );
+}
+
+function markerCount(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+async function waitForVisibleTerminalMarkerCount(sessionId, {
+  authoritativeOutput,
+  expected,
+  label,
+  marker,
+}) {
+  let latest;
+  await waitFor(
+    async () => {
+      latest = await terminalMarkerRenderState(sessionId, marker, expected);
+      if (latest.count > expected) {
+        throw new Error(`${label}: visible terminal output exceeded the authoritative marker count: ${JSON.stringify({
+          authoritativeOutput,
+          expected,
+          visible: latest,
+        })}`);
+      }
+      return latest.ready;
+    },
+    async () => ({ authoritativeOutput, expected, label, visible: latest }),
+  );
+}
+
+async function terminalMarkerRenderState(sessionId, marker, expected) {
+  return evaluate(
+    sessionId,
+    `(async () => {
+      const marker = ${JSON.stringify(marker)};
+      const expected = ${JSON.stringify(expected)};
+      const rows = document.querySelector(".terminal-host .xterm-rows");
+      const status = () => document.querySelector(".terminal-status")?.textContent ?? "";
+      const count = () => (rows?.textContent ?? "").split(marker).length - 1;
+      if (!rows || count() !== expected) {
+        return { count: count(), frames: 0, mutations: 0, ready: false, rows: rows?.textContent ?? "", status: status() };
+      }
+
+      let frames = 0;
+      let mutationVersion = 0;
+      let observedMutationVersion = 0;
+      let quietFrames = 0;
+      const observer = new MutationObserver(() => { mutationVersion += 1; });
+      observer.observe(rows, { characterData: true, childList: true, subtree: true });
+      return new Promise((resolve_) => {
+        const finish = (ready) => {
+          observer.disconnect();
+          resolve_({ count: count(), frames, mutations: mutationVersion, ready, rows: rows.textContent ?? "", status: status() });
+        };
+        const inspectFrame = () => {
+          frames += 1;
+          const visibleCount = count();
+          if (visibleCount > expected || visibleCount < expected) {
+            finish(false);
+            return;
+          }
+          if (mutationVersion === observedMutationVersion) quietFrames += 1;
+          else {
+            observedMutationVersion = mutationVersion;
+            quietFrames = 0;
+          }
+          if (quietFrames >= 3) {
+            finish(true);
+            return;
+          }
+          if (frames >= 12) {
+            finish(false);
+            return;
+          }
+          requestAnimationFrame(inspectFrame);
+        };
+        requestAnimationFrame(inspectFrame);
+      });
+    })()`,
+  );
 }
 
 async function workbenchLayoutGeometry(sessionId) {

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -4,7 +4,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { createServer as createHttpServer, request as httpRequest } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, resolve, sep } from "node:path";
 
@@ -12,6 +12,7 @@ import {
   devToolsEndpointFromActivePort,
   devToolsEndpointFromOutput,
 } from "./cdp-endpoint.mjs";
+import { removeTreeWithRetry } from "./remove-tree-retry.mjs";
 
 
 const chromium = "/usr/bin/chromium";
@@ -29,6 +30,8 @@ let hub;
 let proxy;
 let chromiumProcess;
 let browser;
+let matrixError;
+let cleanupError;
 
 class Cdp {
   static async connect(url) {
@@ -64,8 +67,16 @@ class Cdp {
     return new Promise((resolve_, reject) => this.pending.set(id, { resolve: resolve_, reject }));
   }
 
-  close() {
-    this.socket.close();
+  async close() {
+    if (this.socket.readyState === WebSocket.CLOSED) return;
+    await new Promise((resolve_) => {
+      const timeout = setTimeout(resolve_, 1_000);
+      this.socket.addEventListener("close", () => {
+        clearTimeout(timeout);
+        resolve_();
+      }, { once: true });
+      this.socket.close();
+    });
   }
 }
 
@@ -105,14 +116,14 @@ try {
   assert.deepEqual(
     await evaluate(
       sessionId,
-      "({ title: document.querySelector('#auth-onboarding-title')?.textContent, setup: document.querySelector('#auth-onboarding-enroll')?.textContent, signIn: document.querySelector('#auth-onboarding-sign-in')?.textContent, recoveryType: document.querySelector('#auth-onboarding-recovery')?.type, composerHidden: document.querySelector('.composer').hidden, onboardingFits: document.querySelector('#pane-root').scrollHeight <= document.querySelector('#pane-root').clientHeight })",
+      "({ title: document.querySelector('#auth-onboarding-title')?.textContent, setup: document.querySelector('#auth-onboarding-enroll')?.textContent, signIn: document.querySelector('#auth-onboarding-sign-in')?.textContent, recoveryType: document.querySelector('#auth-onboarding-recovery')?.type, composerCount: document.querySelectorAll('[data-chat-composer]').length, onboardingFits: document.querySelector('#pane-root').scrollHeight <= document.querySelector('#pane-root').clientHeight })",
     ),
     {
       title: "Set up Relay owner",
       setup: "Set up Relay owner",
       signIn: "Sign in with passkey",
       recoveryType: "password",
-      composerHidden: true,
+      composerCount: 0,
       onboardingFits: true,
     },
     "an unclaimed Relay must get code-free owner setup and explicit sign-in controls",
@@ -168,7 +179,15 @@ try {
 
   await evaluate(sessionId, "document.querySelector('#auth-onboarding-sign-in').click()");
   await waitFor(async () => (await evaluate(sessionId, "document.querySelector('#auth-status').textContent"))?.includes("Browser access verified"));
-  assert.equal(await evaluate(sessionId, "document.querySelector('.composer').hidden"), false, "authenticated workbench must restore the Session composer");
+  await waitFor(
+    async () => evaluate(sessionId, "!document.querySelector('#auth-onboarding') && Boolean(document.querySelector('.session-launcher'))"),
+    "the authenticated workbench shell",
+  );
+  assert.deepEqual(
+    await evaluate(sessionId, "({ onboardingPresent: Boolean(document.querySelector('#auth-onboarding')), launcherPresent: Boolean(document.querySelector('.session-launcher')), composerCount: document.querySelectorAll('[data-chat-composer]').length })"),
+    { onboardingPresent: false, launcherPresent: true, composerCount: 0 },
+    "authenticated workbench must expose Session launch controls without a universal composer",
+  );
   await browser.command("Log.enable", {}, sessionId);
   assert.equal(
     await evaluate(sessionId, "fetch('/protected/hub', { credentials: 'same-origin' }).then((response) => response.status)"),
@@ -202,8 +221,8 @@ try {
   await browser.command("Page.reload", { ignoreCache: true }, sessionId);
   await waitFor(async () => (await evaluate(sessionId, "document.readyState")) === "complete");
   await waitFor(
-    async () => await evaluate(sessionId, "typeof window.Terminal === 'function' && !document.querySelector('.composer').hidden"),
-    async () => evaluate(sessionId, "({ terminal: typeof window.Terminal, composerHidden: document.querySelector('.composer').hidden, auth: document.querySelector('#auth-status').textContent })"),
+    async () => await evaluate(sessionId, "typeof window.Terminal === 'function' && !document.querySelector('#auth-onboarding')"),
+    async () => evaluate(sessionId, "({ terminal: typeof window.Terminal, onboardingPresent: Boolean(document.querySelector('#auth-onboarding')), composerCount: document.querySelectorAll('[data-chat-composer]').length, auth: document.querySelector('#auth-status').textContent })"),
   );
 
   const workspaceId = await addProjectThroughPicker(sessionId, process.cwd());
@@ -288,13 +307,18 @@ try {
 
   if (process.env.RELAY_WORKBENCH_LIVE === "1") {
     const liveEventOffset = browser.events.length;
-    await exerciseLiveWorkbench(sessionId);
+    const liveEvidence = await exerciseLiveWorkbench(sessionId, {
+      expectedWorkspaceCount: 2,
+      workspaceCwd: process.cwd(),
+      workspaceId,
+    });
     const pageErrors = browser.events.slice(liveEventOffset).filter((event) => (
       event.method === "Runtime.exceptionThrown"
       || (event.method === "Runtime.consoleAPICalled" && event.params.type === "error")
       || (event.method === "Log.entryAdded" && event.params.entry.level === "error")
     ));
     assert.deepEqual(pageErrors, [], "the live workbench path must not emit page or console errors");
+    console.log(`live Codex workbench evidence: ${JSON.stringify({ ...liveEvidence, pageErrors: pageErrors.length })}`);
   }
 
   await exerciseCrossBrowserTerminal(secondSessionId, sessionId, workspaceId, "browser-a-operated");
@@ -436,20 +460,62 @@ try {
     "non-private exposure must deny first-owner options without a fallback",
   );
   console.log("passkey browser matrix passed with Chromium CDP virtual authenticator");
+} catch (error) {
+  matrixError = error;
 } finally {
-  browser?.close();
-  proxy?.close();
-  const exits = [];
-  if (hub?.exitCode === null) {
-    exits.push(once(hub, "exit"));
-    hub.kill("SIGTERM");
+  const cleanupFailures = [];
+  for (const cleanup of [
+    () => browser?.close(),
+    () => stopChildProcess(chromiumProcess, "Chromium"),
+    () => Promise.all([stopChildProcess(hub, "Relay hub"), closeServer(proxy)]),
+    () => removeTreeWithRetry(scratch),
+  ]) {
+    try {
+      await cleanup();
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
   }
-  if (chromiumProcess?.exitCode === null) {
-    exits.push(once(chromiumProcess, "exit"));
-    chromiumProcess.kill("SIGTERM");
-  }
-  await Promise.all(exits);
-  await rm(scratch, { recursive: true, force: true });
+  if (cleanupFailures.length === 1) cleanupError = cleanupFailures[0];
+  else if (cleanupFailures.length > 1) cleanupError = new AggregateError(cleanupFailures, "Browser matrix cleanup failed");
+}
+
+if (matrixError) {
+  if (cleanupError) console.error(`browser matrix cleanup also failed: ${cleanupError.stack ?? cleanupError}`);
+  throw matrixError;
+}
+if (cleanupError) throw cleanupError;
+
+async function stopChildProcess(process_, label) {
+  if (!process_ || process_.exitCode !== null || process_.signalCode !== null) return;
+  const gracefulExit = waitForChildExit(process_, 2_000);
+  process_.kill("SIGTERM");
+  if (await gracefulExit) return;
+  const forcedExit = waitForChildExit(process_, 2_000);
+  process_.kill("SIGKILL");
+  if (await forcedExit) return;
+  throw new Error(`${label} did not exit after SIGTERM and SIGKILL`);
+}
+
+function waitForChildExit(process_, timeoutMs) {
+  if (process_.exitCode !== null || process_.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve_) => {
+    const onExit = () => finish(true);
+    const timeout = setTimeout(() => finish(false), timeoutMs);
+    const finish = (exited) => {
+      clearTimeout(timeout);
+      process_.removeListener("exit", onExit);
+      resolve_(exited);
+    };
+    process_.once("exit", onExit);
+  });
+}
+
+function closeServer(server) {
+  if (!server?.listening) return Promise.resolve();
+  return new Promise((resolve_, reject) => {
+    server.close((error) => error ? reject(error) : resolve_());
+  });
 }
 
 function startHub(port = 0, exposure = "private") {
@@ -701,12 +767,12 @@ async function recoverExpiredProjectBrowse(sessionId, cwd) {
   );
   const lockedState = await evaluate(
     sessionId,
-    "({ pickerHidden: document.querySelector('#workspace-add').hidden, accessOpen: document.querySelector('.auth-compact').open, onboardingTitle: document.querySelector('#auth-onboarding-title')?.textContent, composerHidden: document.querySelector('.composer').hidden, focused: document.activeElement?.id, state: document.querySelector('#session-status').dataset.state, auth: document.querySelector('#auth-status').textContent })",
+    "({ pickerHidden: document.querySelector('#workspace-add').hidden, accessOpen: document.querySelector('.auth-compact').open, onboardingTitle: document.querySelector('#auth-onboarding-title')?.textContent, composerCount: document.querySelectorAll('[data-chat-composer]').length, focused: document.activeElement?.id, state: document.querySelector('#session-status').dataset.state, auth: document.querySelector('#auth-status').textContent })",
   );
   const { auth, ...lockedUi } = lockedState;
   assert.deepEqual(
     lockedUi,
-    { pickerHidden: true, accessOpen: true, onboardingTitle: "Sign in to continue adding this Project", composerHidden: true, focused: "auth-onboarding-sign-in", state: "unknown" },
+    { pickerHidden: true, accessOpen: true, onboardingTitle: "Sign in to continue adding this Project", composerCount: 0, focused: "auth-onboarding-sign-in", state: "unknown" },
     "expired Project browse must lock the workbench and expose focused passkey recovery",
   );
   assert.match(auth, /Sign in again to continue adding this Project\./);
@@ -798,12 +864,38 @@ async function exerciseVisibleClaudeWorkbench(sessionId) {
   );
 }
 
-async function exerciseLiveWorkbench(sessionId) {
-  await waitFor(async () => (await evaluate(sessionId, "document.querySelectorAll('#workspace-list button').length")) === 1);
+async function exerciseLiveWorkbench(sessionId, { expectedWorkspaceCount, workspaceCwd, workspaceId }) {
+  await waitFor(
+    async () => evaluate(
+      sessionId,
+      `document.querySelectorAll('#workspace-list button').length >= ${expectedWorkspaceCount} && [...document.querySelectorAll('#workspace-list button')].some((button) => button.querySelector('.sidebar-item__meta')?.textContent === ${JSON.stringify(workspaceCwd)})`,
+    ),
+    `the original Project among ${expectedWorkspaceCount} catalog entries`,
+  );
+  await evaluate(
+    sessionId,
+    `[...document.querySelectorAll('#workspace-list button')].find((button) => button.querySelector('.sidebar-item__meta')?.textContent === ${JSON.stringify(workspaceCwd)}).click()`,
+  );
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('#workspace-list [aria-current=\"page\"] .sidebar-item__meta')?.textContent")) === workspaceCwd,
+    "the original Project selection",
+  );
+  assert.equal(
+    await evaluate(
+      sessionId,
+      `fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => snapshot.workspaces.find((workspace) => workspace.cwd === ${JSON.stringify(workspaceCwd)})?.id)`,
+    ),
+    workspaceId,
+    "live Codex QA must target the intended original Project",
+  );
   assert.equal(
     await evaluate(sessionId, "document.querySelector('[data-provider=\"hermes\"]').disabled"),
     true,
     "an unavailable Hermes adapter must remain visibly unavailable instead of presenting a fake conversation",
+  );
+  const previousSessionIds = await evaluate(
+    sessionId,
+    "fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => snapshot.sessions.map((session) => session.id))",
   );
   const previousSessionCount = await evaluate(sessionId, "document.querySelectorAll('#session-list .sidebar-item').length");
   await evaluate(sessionId, "document.querySelector('[data-provider=\"codex\"]').click()");
@@ -811,26 +903,32 @@ async function exerciseLiveWorkbench(sessionId) {
     async () => (await evaluate(sessionId, "document.querySelectorAll('#session-list .sidebar-item').length")) >= previousSessionCount + 1,
     async () => evaluate(sessionId, "({ error: document.querySelector('#workbench-error').textContent, errorCode: document.querySelector('#workbench-error').dataset.code, state: document.querySelector('#session-status').dataset.state })"),
   );
+  const liveSessionId = await evaluate(
+    sessionId,
+    `fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => snapshot.sessions.find((session) => session.provider === 'codex' && session.workspaceId === ${JSON.stringify(workspaceId)} && !${JSON.stringify(previousSessionIds)}.includes(session.id))?.id)`,
+  );
+  assert.ok(liveSessionId, "live Codex QA must identify the newly created Session in the intended Project");
   const composerState = await evaluate(
     sessionId,
-    "({ inputDisabled: document.querySelector('#message-input').disabled, sendDisabled: document.querySelector('#send-message').disabled, sendType: document.querySelector('#send-message').type, formId: document.querySelector('#send-message').form?.id })",
+    "(() => { const form = document.querySelector('[data-chat-composer]'); const input = form?.querySelector('textarea'); const send = form?.querySelector('[type=submit]'); return { composerCount: document.querySelectorAll('[data-chat-composer]').length, inputDisabled: input?.disabled, sendDisabled: send?.disabled, sendType: send?.type, sameForm: input?.form === send?.form }; })()",
   );
-  assert.deepEqual(composerState, { inputDisabled: false, sendDisabled: false, sendType: "submit", formId: "composer" });
+  assert.deepEqual(composerState, { composerCount: 1, inputDisabled: false, sendDisabled: true, sendType: "submit", sameForm: true });
   await evaluate(
     sessionId,
-    `window.relaySubmitObserved = false; document.querySelector("#composer").addEventListener("submit", () => { window.relaySubmitObserved = true; }, { once: true }); document.querySelector("#message-input").value = "Reply with one word: relay"; document.querySelector("#send-message").click();`,
+    `(() => { const form = document.querySelector("[data-chat-composer]"); const input = form.querySelector("textarea"); const send = form.querySelector("[type=submit]"); window.relaySubmitObserved = false; form.addEventListener("submit", () => { window.relaySubmitObserved = true; }, { once: true }); input.value = "Reply with one word: relay"; input.dispatchEvent(new Event("input", { bubbles: true })); send.click(); })()`,
   );
-  assert.equal(await evaluate(sessionId, "window.relaySubmitObserved"), true, "Send must submit the shared composer");
+  assert.equal(await evaluate(sessionId, "window.relaySubmitObserved"), true, "Send must submit the active chat tab composer");
   await waitFor(
     async () => (await evaluate(sessionId, "document.querySelectorAll('.chat-event--user').length")) === 1,
     async () => ({
-      dom: await evaluate(sessionId, "({ disabled: document.querySelector('#message-input').disabled, error: document.querySelector('#workbench-error').textContent, errorCode: document.querySelector('#workbench-error').dataset.code, timeline: document.querySelector('.chat-timeline')?.innerText, state: document.querySelector('#session-status').dataset.state })"),
+      dom: await evaluate(sessionId, "({ disabled: document.querySelector('[data-chat-composer] textarea')?.disabled, error: document.querySelector('#workbench-error').textContent, errorCode: document.querySelector('#workbench-error').dataset.code, timeline: document.querySelector('.chat-timeline')?.innerText, state: document.querySelector('#session-status').dataset.state })"),
       runtimeEvents: browser.events.filter((event) => event.method === "Runtime.exceptionThrown"),
     }),
   );
   await waitFor(
-    async () => evaluate(sessionId, "[...document.querySelectorAll('.chat-event code')].some((label) => label.textContent === 'turn.started')"),
-    async () => evaluate(sessionId, "({ error: document.querySelector('#workbench-error').textContent, errorCode: document.querySelector('#workbench-error').dataset.code, state: document.querySelector('#session-status').dataset.state, timeline: document.querySelector('.chat-timeline')?.innerText })"),
+    async () => evaluate(sessionId, `fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => snapshot.sessions.find((session) => session.id === ${JSON.stringify(liveSessionId)})?.events?.some((event) => event.role === 'assistant' && event.kind === 'message' && event.label === 'assistant.message' && event.text.toLowerCase().includes('relay')))`),
+    async () => evaluate(sessionId, `fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => { const session = snapshot.sessions.find((candidate) => candidate.id === ${JSON.stringify(liveSessionId)}); return { status: session?.status, events: session?.events?.map((event) => ({ role: event.role, kind: event.kind, label: event.label, text: event.text })) }; })`),
+    45_000,
   );
   const previousTabCount = await evaluate(sessionId, "document.querySelectorAll('.session-tab').length");
   await evaluate(sessionId, "document.querySelector('[data-layout-action=\"new-tab\"]').click()");
@@ -872,10 +970,6 @@ async function exerciseLiveWorkbench(sessionId) {
     "(() => { const split = document.querySelector('.workspace-split'); return { innerWidth: window.innerWidth, scrollWidth: document.documentElement.scrollWidth, shellWidth: document.querySelector('.workbench-shell').getBoundingClientRect().width, splitWidth: split.getBoundingClientRect().width, mainWidth: document.querySelector('.main-panel').getBoundingClientRect().width, paneRootWidth: document.querySelector('.pane-root').getBoundingClientRect().width, columns: getComputedStyle(split).gridTemplateColumns, inlineColumns: split.style.gridTemplateColumns, paneWidths: [...document.querySelectorAll('.workbench-pane')].map((pane) => pane.getBoundingClientRect().width), tabScrollWidths: [...document.querySelectorAll('.tab-strip')].map((tabs) => tabs.scrollWidth) }; })()",
   );
   assert.equal(viewport.scrollWidth > viewport.innerWidth, false, `split workbench overflow: ${JSON.stringify(viewport)}`);
-  if (process.env.RELAY_WORKBENCH_SCREENSHOT_PATH) {
-    const screenshot = await browser.command("Page.captureScreenshot", { format: "png" }, sessionId);
-    await writeFile(process.env.RELAY_WORKBENCH_SCREENSHOT_PATH, Buffer.from(screenshot.data, "base64"));
-  }
   await browser.command("Page.reload", { ignoreCache: true }, sessionId);
   await waitFor(async () => (await evaluate(sessionId, "document.readyState")) === "complete");
   await waitFor(async () => (await evaluate(sessionId, "document.querySelectorAll('#session-list .sidebar-item').length")) >= 1);
@@ -886,10 +980,51 @@ async function exerciseLiveWorkbench(sessionId) {
     sessionId,
     "({ workspaceCount: document.querySelectorAll('#workspace-list button').length, userEvents: document.querySelectorAll('.chat-event--user').length, panes: document.querySelectorAll('.workbench-pane').length, sessionState: document.querySelector('#session-status').dataset.state })",
   );
-  assert.equal(restored.workspaceCount, 1, "browser refresh must restore the selected CWD Workspace");
+  assert.equal(restored.workspaceCount, expectedWorkspaceCount, "browser refresh must retain the complete Project catalog");
   assert.ok(restored.userEvents >= 1, "submitted user text must remain in the restored shared timeline");
   assert.equal(restored.panes, 2, "browser refresh must restore the direct-manipulation layout");
   assert.notEqual(restored.sessionState, "unknown", "restored session must report an honest provider state");
+  const evidence = await evaluate(
+    sessionId,
+    `fetch('/api/workbench', { credentials: 'same-origin' }).then((response) => response.json()).then((snapshot) => { const session = snapshot.sessions.find((candidate) => candidate.id === ${JSON.stringify(liveSessionId)}); return { workspaceId: session?.workspaceId, sessionId: session?.id, status: session?.status, eventLabels: session?.events?.map((event) => event.label), assistantMessages: session?.events?.filter((event) => event.role === 'assistant' && event.kind === 'message').map((event) => event.text) }; })`,
+  );
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const paneCount = await evaluate(sessionId, "document.querySelectorAll('.workbench-pane').length");
+    if (paneCount <= 1) break;
+    await evaluate(sessionId, "document.querySelector('[data-layout-action=\"close-pane\"]').click()");
+  }
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelectorAll('.workbench-pane').length")) === 1,
+    "live QA presentation cleanup to one pane",
+  );
+  await waitFor(
+    async () => (await evaluate(sessionId, "document.querySelector('#session-status').dataset.state")) === "idle",
+    "the completed live Codex Session to render idle",
+  );
+  const presentation = await evaluate(
+    sessionId,
+    `(() => { const pane = document.querySelector('.workbench-pane'); const body = pane?.querySelector('.pane-body--chat'); return { paneCount: document.querySelectorAll('.workbench-pane').length, terminalSurfaceCount: document.querySelectorAll('.terminal-surface').length, composerCount: document.querySelectorAll('[data-chat-composer]').length, composerInsideChatPane: Boolean(pane?.matches('.workbench-pane--chat') && pane.querySelector(':scope > [data-chat-composer]')), userMessages: document.querySelectorAll('.chat-event--user').length, assistantMessages: [...document.querySelectorAll('.chat-event--assistant p')].map((message) => message.textContent), genericEvents: document.querySelectorAll('.chat-event--error, .chat-event--tool, .chat-event--status').length, nearBottom: body ? body.scrollHeight - body.clientHeight - body.scrollTop <= 80 : false, state: document.querySelector('#session-status').dataset.state }; })()`,
+  );
+  assert.deepEqual(
+    presentation,
+    {
+      paneCount: 1,
+      terminalSurfaceCount: 0,
+      composerCount: 1,
+      composerInsideChatPane: true,
+      userMessages: 1,
+      assistantMessages: ["relay"],
+      genericEvents: 0,
+      nearBottom: true,
+      state: "idle",
+    },
+    "the final live chat view must be normalized, current, quiet, and composer-owned",
+  );
+  if (process.env.RELAY_WORKBENCH_SCREENSHOT_PATH) {
+    const screenshot = await browser.command("Page.captureScreenshot", { format: "png" }, sessionId);
+    await writeFile(process.env.RELAY_WORKBENCH_SCREENSHOT_PATH, Buffer.from(screenshot.data, "base64"));
+  }
+  return { ...evidence, presentation };
 }
 
 async function createCertificate() {

--- a/scripts/passkey-browser-smoke.mjs
+++ b/scripts/passkey-browser-smoke.mjs
@@ -32,6 +32,7 @@ let chromiumProcess;
 let browser;
 let matrixError;
 let cleanupError;
+let layoutGeometryEvidence;
 
 class Cdp {
   static async connect(url) {
@@ -188,6 +189,34 @@ try {
     { onboardingPresent: false, launcherPresent: true, composerCount: 0 },
     "authenticated workbench must expose Session launch controls without a universal composer",
   );
+  const initialClosedGeometry = await workbenchLayoutGeometry(sessionId);
+  assertWorkbenchLayoutGeometry(initialClosedGeometry, "authenticated shell with Settings closed");
+  await evaluate(sessionId, "document.querySelector('.auth-compact').open = true");
+  const initialOpenGeometry = await workbenchLayoutGeometry(sessionId);
+  assertWorkbenchLayoutGeometry(initialOpenGeometry, "authenticated shell with Settings open");
+  assertSettingsPopupGeometry(initialOpenGeometry, "authenticated shell with Settings open");
+  await evaluate(sessionId, "document.querySelector('.auth-compact').open = false");
+  const initialReclosedGeometry = await workbenchLayoutGeometry(sessionId);
+  assertWorkbenchLayoutGeometry(initialReclosedGeometry, "authenticated shell after Settings closes");
+  assert.deepEqual(
+    {
+      left: initialOpenGeometry.settingsLeftInset,
+      bottom: initialOpenGeometry.settingsBottomInset,
+      paneBottomGap: initialOpenGeometry.paneBottomGap,
+    },
+    {
+      left: initialClosedGeometry.settingsLeftInset,
+      bottom: initialClosedGeometry.settingsBottomInset,
+      paneBottomGap: initialClosedGeometry.paneBottomGap,
+    },
+    "opening Settings must not move its bottom-left anchor or the pane row",
+  );
+  assert.deepEqual(
+    initialReclosedGeometry,
+    initialClosedGeometry,
+    "closing Settings must restore identical workbench geometry",
+  );
+  layoutGeometryEvidence = { initialClosedGeometry, initialOpenGeometry, initialReclosedGeometry };
   await browser.command("Log.enable", {}, sessionId);
   assert.equal(
     await evaluate(sessionId, "fetch('/protected/hub', { credentials: 'same-origin' }).then((response) => response.status)"),
@@ -226,6 +255,13 @@ try {
   );
 
   const workspaceId = await addProjectThroughPicker(sessionId, process.cwd());
+  const workspaceGeometry = await workbenchLayoutGeometry(sessionId);
+  assertWorkbenchLayoutGeometry(workspaceGeometry, "selected Project after a workbench render");
+  assert.ok(
+    Math.abs(workspaceGeometry.paneHeight - initialClosedGeometry.paneHeight) <= 1,
+    `a render-triggering Project selection must preserve pane height: ${JSON.stringify({ initialClosedGeometry, workspaceGeometry })}`,
+  );
+  layoutGeometryEvidence.workspaceGeometry = workspaceGeometry;
   await enrollAndSignIn(secondSessionId);
   await waitFor(async () => (await evaluate(secondSessionId, "document.querySelectorAll('#workspace-list button').length")) === 1);
   assert.equal(
@@ -459,6 +495,7 @@ try {
     { status: 403, body: { error: { code: "claim_exposure_denied" } } },
     "non-private exposure must deny first-owner options without a fallback",
   );
+  console.log(`workbench layout geometry passed: ${JSON.stringify(layoutGeometryEvidence)}`);
   console.log("passkey browser matrix passed with Chromium CDP virtual authenticator");
 } catch (error) {
   matrixError = error;
@@ -1186,6 +1223,76 @@ async function evaluate(sessionId, expression) {
   );
   if (response.exceptionDetails) throw new Error(response.exceptionDetails.text);
   return response.result.value;
+}
+
+async function workbenchLayoutGeometry(sessionId) {
+  return evaluate(
+    sessionId,
+    `(() => {
+      const main = document.querySelector('.main-panel').getBoundingClientRect();
+      const panes = document.querySelector('#pane-root').getBoundingClientRect();
+      const sidebar = document.querySelector('.sidebar');
+      const sidebarBounds = sidebar.getBoundingClientRect();
+      const sidebarStyle = getComputedStyle(sidebar);
+      const settings = document.querySelector('.auth-compact');
+      const summary = settings.querySelector('summary').getBoundingClientRect();
+      const popup = settings.querySelector('.auth-compact__body').getBoundingClientRect();
+      const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
+      const round = (value) => Math.round(value * 100) / 100;
+      return {
+        errorDisplay: getComputedStyle(document.querySelector('#workbench-error')).display,
+        pickerHidden: document.querySelector('#workspace-add').hidden,
+        settingsOpen: settings.open,
+        paneBottomGap: round(main.bottom - panes.bottom),
+        paneHeight: round(panes.height),
+        settingsLeftInset: round(summary.left - sidebarBounds.left),
+        settingsBottomInset: round(sidebarBounds.bottom - summary.bottom),
+        sidebarPaddingLeft: round(parseFloat(sidebarStyle.paddingLeft)),
+        sidebarPaddingBottom: round(parseFloat(sidebarStyle.paddingBottom)),
+        settingsPopup: settings.open ? {
+          leftOffset: round(popup.left - summary.left),
+          gapAboveSummary: round(summary.top - popup.bottom),
+          expectedGap: round(rootFontSize * 0.35),
+          viewportLeftInset: round(popup.left),
+          viewportTopInset: round(popup.top),
+          viewportRightInset: round(window.innerWidth - popup.right),
+          viewportBottomInset: round(window.innerHeight - popup.bottom),
+        } : null,
+      };
+    })()`,
+  );
+}
+
+function assertWorkbenchLayoutGeometry(geometry, label) {
+  assert.equal(geometry.errorDisplay, "none", `${label}: the empty error banner must remain hidden`);
+  assert.equal(geometry.pickerHidden, true, `${label}: the optional Project picker must remain hidden`);
+  assert.ok(Math.abs(geometry.paneBottomGap) <= 1, `${label}: pane root must fill the main panel: ${JSON.stringify(geometry)}`);
+  assert.ok(
+    Math.abs(geometry.settingsLeftInset - geometry.sidebarPaddingLeft) <= 1,
+    `${label}: Settings must retain the sidebar left inset: ${JSON.stringify(geometry)}`,
+  );
+  assert.ok(
+    Math.abs(geometry.settingsBottomInset - geometry.sidebarPaddingBottom) <= 1,
+    `${label}: Settings must retain the sidebar bottom inset: ${JSON.stringify(geometry)}`,
+  );
+}
+
+function assertSettingsPopupGeometry(geometry, label) {
+  const popup = geometry.settingsPopup;
+  assert.ok(popup, `${label}: Settings popup geometry must be observable`);
+  assert.ok(Math.abs(popup.leftOffset) <= 1, `${label}: popup must align with the Settings summary: ${JSON.stringify(geometry)}`);
+  assert.ok(
+    Math.abs(popup.gapAboveSummary - popup.expectedGap) <= 1,
+    `${label}: popup gap must equal 0.35rem: ${JSON.stringify(geometry)}`,
+  );
+  for (const [edge, inset] of Object.entries({
+    left: popup.viewportLeftInset,
+    top: popup.viewportTopInset,
+    right: popup.viewportRightInset,
+    bottom: popup.viewportBottomInset,
+  })) {
+    assert.ok(inset >= -1, `${label}: popup ${edge} edge must stay inside the viewport: ${JSON.stringify(geometry)}`);
+  }
 }
 
 async function waitFor(predicate, timeoutDescription = "browser matrix state", timeoutMs = 15_000) {

--- a/scripts/remove-tree-retry.mjs
+++ b/scripts/remove-tree-retry.mjs
@@ -1,0 +1,22 @@
+import { rm } from "node:fs/promises";
+
+const TRANSIENT_REMOVE_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
+
+export async function removeTreeWithRetry(
+  path,
+  {
+    maxAttempts = 6,
+    remove = (target) => rm(target, { recursive: true, force: true }),
+    wait = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+  } = {},
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await remove(path);
+      return;
+    } catch (error) {
+      if (!TRANSIENT_REMOVE_CODES.has(error?.code) || attempt === maxAttempts) throw error;
+      await wait(Math.min(25 * (2 ** (attempt - 1)), 200));
+    }
+  }
+}

--- a/web/src/chat.js
+++ b/web/src/chat.js
@@ -7,13 +7,33 @@ const PRESENTATIONS = {
 };
 
 const REFRESHABLE_SESSION_STATUSES = new Set(["starting", "working", "degraded"]);
+const ROUTINE_STATUS_LABELS = new Set([
+  "gateway_ready",
+  "item.completed",
+  "item.started",
+  "mcp.startup_status",
+  "message_complete",
+  "message_delta",
+  "message_started",
+  "reasoning",
+  "remote_control.status",
+  "session.started",
+  "session.resumed",
+  "session_info",
+  "session_title",
+  "status_update",
+  "turn.completed",
+  "turn.started",
+]);
 
 export function sessionMayHaveMoreEvents(session) {
   return REFRESHABLE_SESSION_STATUSES.has(session?.status);
 }
 
 export function eventPresentation(event) {
-  const presentation = PRESENTATIONS[event?.role] ?? PRESENTATIONS.status;
+  const presentation = event?.role === "assistant" || event?.role === "user"
+    ? PRESENTATIONS[event.role]
+    : PRESENTATIONS[event?.kind] ?? PRESENTATIONS[event?.role] ?? PRESENTATIONS.status;
   return {
     tone: presentation.tone,
     roleLabel: presentation.label,
@@ -22,18 +42,45 @@ export function eventPresentation(event) {
   };
 }
 
+export function normalizeChatEvents(events) {
+  const normalized = [];
+  for (const source of Array.isArray(events) ? events : []) {
+    if (!source || typeof source !== "object" || isRoutineStatus(source)) continue;
+    const event = { ...source };
+    if (event.role === "assistant" && event.kind === "message" && typeof event.text === "string") {
+      const previous = normalized.at(-1);
+      if (previous?.role === "assistant" && previous.kind === "message") {
+        if (event.label === "assistant.message.delta" && previous.label === "assistant.message.delta") {
+          previous.text += event.text;
+          continue;
+        }
+        if (event.label === "assistant.message" && previous.label === "assistant.message.delta") {
+          previous.label = event.label;
+          previous.text = event.text;
+          previous.sequence = event.sequence ?? previous.sequence;
+          continue;
+        }
+        if (event.label === previous.label && event.text === previous.text) continue;
+      }
+    }
+    normalized.push(event);
+  }
+  return normalized;
+}
+
 export function renderChatTimeline(container, session) {
   container.replaceChildren();
   if (!session) {
     container.append(emptyState("Choose a conversation or start one from this Workspace."));
     return;
   }
-  if (!Array.isArray(session.events) || session.events.length === 0) {
+  const events = normalizeChatEvents(session.events);
+  if (events.length === 0) {
     container.append(emptyState("Connected. Send the first message when you are ready."));
     return;
   }
 
-  for (const event of session.events) {
+  for (const event of events) {
     const presentation = eventPresentation(event);
     const item = document.createElement("article");
     item.className = `chat-event chat-event--${presentation.tone}`;
@@ -43,13 +90,19 @@ export function renderChatTimeline(container, session) {
     role.textContent = presentation.roleLabel;
     const kind = document.createElement("code");
     kind.textContent = presentation.eventLabel;
-    heading.append(role, kind);
+    heading.append(role);
+    if (!["assistant", "user"].includes(presentation.tone)) heading.append(kind);
     const text = document.createElement("p");
     text.textContent = presentation.text;
     item.append(heading, text);
     container.append(item);
   }
-  container.scrollTop = container.scrollHeight;
+}
+
+function isRoutineStatus(event) {
+  if (!ROUTINE_STATUS_LABELS.has(event.label)) return false;
+  if (event.role === "assistant" || event.role === "user") return false;
+  return event.signal == null && event.kind !== "error" && event.kind !== "tool";
 }
 
 function emptyState(text) {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -131,12 +131,16 @@
       .chat-timeline { align-content: start; display: grid; gap: 0.25rem; margin: 0 auto; max-width: 50rem; min-height: 100%; width: 100%; }
       .chat-event { display: grid; gap: 0.35rem; max-width: 100%; padding: 0.8rem 0; }
       .chat-event header { align-items: center; display: flex; gap: 0.55rem; }
-      .chat-event__role { color: #e2d8d1; font-size: 0.72rem; font-weight: 700; }
       .chat-event code { color: #776f69; font-size: 0.68rem; }
       .chat-event p { color: #d3cbc5; line-height: 1.55; margin: 0; overflow-wrap: anywhere; white-space: pre-wrap; }
-      .chat-event--user { background: #100c0a; border: 1px solid #30231e; justify-self: end; margin: 0.45rem 0; max-width: min(88%, 42rem); padding: 0.65rem 0.75rem; }
-      .chat-event--user header { justify-content: flex-end; }
-      .chat-event--assistant { justify-self: stretch; }
+      .chat-event--message { position: relative; }
+      .chat-event--user { background: #100c0a; border: 1px solid #30231e; justify-self: end; margin: 0.45rem 0; max-width: min(88%, 42rem); padding: 0.65rem 2.8rem 0.65rem 0.75rem; }
+      .chat-event--assistant { justify-self: stretch; padding-right: 2.4rem; }
+      .chat-event__copy { background: #000; border: 1px solid #302b28; color: #8d847d; height: 1.8rem; min-height: 1.8rem; opacity: 0; padding: 0.3rem; pointer-events: none; position: absolute; right: 0.25rem; top: 0.45rem; width: 1.8rem; }
+      .chat-event__copy svg { fill: none; height: 0.9rem; stroke: currentColor; stroke-linecap: square; stroke-linejoin: miter; stroke-width: 1.5; width: 0.9rem; }
+      .chat-event--message:hover .chat-event__copy, .chat-event--message:focus-within .chat-event__copy, .chat-event__copy:focus-visible { opacity: 1; pointer-events: auto; }
+      .chat-event__copy[data-copy-state="copied"] { color: #9ca78b; }
+      .chat-event__copy[data-copy-state="unavailable"] { color: #df8a69; }
       .chat-event--tool, .chat-event--status { border-left: 1px solid #3a332e; margin: 0.25rem 0; padding: 0.45rem 0.75rem; }
       .chat-event--tool p, .chat-event--status p { color: #9f958e; font-size: 0.76rem; line-height: 1.4; }
       .chat-event--error { border-left: 2px solid #df8a69; padding-left: 0.75rem; }
@@ -160,6 +164,12 @@
       @media (max-width: 64rem) {
         .pane-divider { cursor: row-resize; min-height: 0.5rem; min-width: 0; }
         .pane-divider::after { inset: 0.18rem 0.6rem; }
+      }
+
+      @media (hover: none), (pointer: coarse) {
+        .chat-event--user { padding-right: 3.6rem; }
+        .chat-event--assistant { padding-right: 3.25rem; }
+        .chat-event__copy { height: 2.75rem; min-height: 2.75rem; opacity: 1; pointer-events: auto; width: 2.75rem; }
       }
 
       @media (max-width: 48rem) {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -31,12 +31,12 @@
       code { color: #b8aaa1; font: inherit; }
 
       .workbench-shell { display: grid; grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr); height: 100dvh; min-height: 0; }
-      .sidebar { border-right: 1px solid #302b28; display: grid; grid-template-rows: auto auto auto minmax(0, 1fr) auto; min-height: 0; min-width: 0; padding: 0.75rem; }
-      .brand { align-items: center; border-bottom: 1px solid #302b28; display: flex; justify-content: space-between; padding: 0 0 0.75rem; }
+      .sidebar { border-right: 1px solid #302b28; display: grid; grid-template-areas: "brand" "picker" "projects" "recent" "settings"; grid-template-rows: auto auto auto minmax(0, 1fr) auto; min-height: 0; min-width: 0; padding: 0.75rem; }
+      .brand { align-items: center; border-bottom: 1px solid #302b28; display: flex; grid-area: brand; justify-content: space-between; padding: 0 0 0.75rem; }
       .brand__mark, .section-label { color: #d97855; font-size: 0.73rem; font-weight: 700; letter-spacing: 0.12em; margin: 0; text-transform: lowercase; }
       .icon-button { flex: 0 0 2.25rem; padding: 0.35rem; width: 2.25rem; }
       .icon-button svg { fill: none; height: 1.1rem; stroke: currentColor; stroke-linecap: square; stroke-linejoin: miter; stroke-width: 1.6; width: 1.1rem; }
-      .workspace-add { border-bottom: 1px solid #302b28; display: grid; gap: 0.55rem; padding: 0.75rem 0; }
+      .workspace-add { border-bottom: 1px solid #302b28; display: grid; gap: 0.55rem; grid-area: picker; padding: 0.75rem 0; }
       .workspace-add[hidden] { display: none; }
       .directory-browser { display: grid; gap: 0.45rem; min-height: 0; }
       .directory-path { color: #9b918a; font-size: 0.72rem; margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -44,8 +44,8 @@
       .workspace-add__actions { display: flex; gap: 0.45rem; }
       .workspace-list, .session-list { display: grid; gap: 0.18rem; list-style: none; margin: 0; padding: 0; }
       .workspace-list { margin: 0.65rem 0 0; }
-      .workspace-section { padding-top: 0.8rem; }
-      .session-section { min-height: 0; overflow: auto; padding-top: 1rem; }
+      .workspace-section { grid-area: projects; padding-top: 0.8rem; }
+      .session-section { grid-area: recent; min-height: 0; overflow: auto; padding-top: 1rem; }
       .session-list { margin-top: 0.65rem; }
       .sidebar-item { align-items: center; background: transparent; border: 0; color: #b8b0aa; display: flex; gap: 0.55rem; justify-content: flex-start; min-width: 0; text-align: left; width: 100%; }
       .sidebar-item[aria-current="page"] { background: #19120f; color: #f2e8e1; box-shadow: inset 2px 0 #d97855; }
@@ -55,12 +55,12 @@
       .sidebar-empty { color: #716a64; font-size: 0.78rem; line-height: 1.5; margin: 0.65rem 0 0; }
       .session-row { align-items: stretch; display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: 0.18rem; }
       .session-row__action { min-height: 2rem; opacity: 0.82; width: 2rem; }
-      .auth-compact { border-top: 1px solid #302b28; color: #8d847d; font-size: 0.74rem; padding-top: 0.5rem; position: relative; }
+      .auth-compact { --settings-top-padding: 0.5rem; border-top: 1px solid #302b28; color: #8d847d; font-size: 0.74rem; grid-area: settings; padding-top: var(--settings-top-padding); position: relative; }
       .auth-compact summary { align-items: center; color: #8d847d; cursor: pointer; display: inline-flex; gap: 0.45rem; list-style: none; min-height: 2.25rem; padding: 0.35rem; }
       .auth-compact summary::-webkit-details-marker { display: none; }
       .auth-compact summary:hover { color: #e0e0e0; }
       .auth-compact summary svg { fill: none; height: 1rem; stroke: currentColor; stroke-linecap: square; stroke-linejoin: miter; stroke-width: 1.5; width: 1rem; }
-      .auth-compact__body { background: #0a0a0a; border: 1px solid #302b28; bottom: calc(100% + 0.35rem); display: grid; gap: 0.5rem; left: 0; max-height: min(70dvh, 34rem); overflow: auto; padding: 0.75rem; position: absolute; width: min(24rem, calc(100vw - 1.5rem)); z-index: 20; }
+      .auth-compact__body { background: #0a0a0a; border: 1px solid #302b28; bottom: calc(100% - var(--settings-top-padding) + 0.35rem); display: grid; gap: 0.5rem; left: 0; max-height: min(70dvh, 34rem); overflow: auto; padding: 0.75rem; position: absolute; width: min(24rem, calc(100vw - 1.5rem)); z-index: 20; }
       .auth-compact__body label { font-size: 0.72rem; }
       .auth-onboarding { background: #090807; border: 1px solid #302b28; display: grid; gap: 0.55rem; margin: 0 auto; max-width: 32rem; padding: 1rem; position: relative; }
       .auth-onboarding h2 { font-size: 1rem; margin: 0; padding-right: 4.75rem; }
@@ -77,8 +77,8 @@
       .security-audit { margin: 0; max-height: 6rem; overflow: auto; padding-left: 1rem; }
       .security-audit li { margin-bottom: 0.2rem; }
 
-      .main-panel { display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto auto minmax(0, 1fr); min-height: 0; min-width: 0; }
-      .session-header { align-items: center; border-bottom: 1px solid #302b28; display: flex; gap: 0.8rem; justify-content: space-between; min-height: 3.85rem; padding: 0.75rem 1rem; }
+      .main-panel { display: grid; grid-template-areas: "header" "notice" "panes"; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto auto minmax(0, 1fr); min-height: 0; min-width: 0; }
+      .session-header { align-items: center; border-bottom: 1px solid #302b28; display: flex; gap: 0.8rem; grid-area: header; justify-content: space-between; min-height: 3.85rem; padding: 0.75rem 1rem; }
       .session-header__title { min-width: 0; }
       .session-header h1 { font-size: 0.95rem; font-weight: 600; margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
       .session-header p { color: #877e77; font-size: 0.72rem; margin: 0.25rem 0 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -96,7 +96,7 @@
       .session-state[data-state="error"], .session-state[data-state="degraded"] { color: #df8a69; }
       .session-state[data-state="idle"] { color: #9ca78b; }
 
-      .pane-root { background: #000; min-height: 0; min-width: 0; overflow: hidden; }
+      .pane-root { background: #000; grid-area: panes; min-height: 0; min-width: 0; overflow: hidden; }
       .pane-root--onboarding { overflow: auto; padding: 0.75rem; }
       .pane-root > .workbench-pane, .pane-root > .workspace-split { height: 100%; min-height: 0; }
       .workspace-split { display: grid; max-width: 100%; min-width: 0; width: 100%; }
@@ -153,7 +153,7 @@
       .provider-picker__label { color: #827971; font-size: 0.72rem; margin-right: 0.1rem; }
       .provider-button { color: #b8b0aa; font-size: 0.75rem; min-height: 2rem; }
       .provider-button[data-provider="hermes"] { border-color: #4c3a34; }
-      .workspace-error { border-bottom: 1px solid #5a3025; color: #df8a69; font-size: 0.76rem; margin: 0; padding: 0.45rem 1rem; }
+      .workspace-error { border-bottom: 1px solid #5a3025; color: #df8a69; font-size: 0.76rem; grid-area: notice; margin: 0; padding: 0.45rem 1rem; }
       .workspace-error:empty { display: none; }
       .sr-only { height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; clip: rect(0, 0, 0, 0); white-space: nowrap; }
 
@@ -165,7 +165,7 @@
       @media (max-width: 48rem) {
         html, body { height: auto; overflow: auto; }
         .workbench-shell { grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr); height: auto; min-height: 100dvh; }
-        .sidebar { border-bottom: 1px solid #302b28; border-right: 0; grid-template-rows: auto auto auto auto; }
+        .sidebar { border-bottom: 1px solid #302b28; border-right: 0; grid-template-areas: "brand" "picker" "projects" "recent" "settings"; grid-template-rows: repeat(5, auto); }
         .session-section { max-height: 8.5rem; padding-top: 0.75rem; }
         .workspace-list, .session-list { display: flex; overflow-x: auto; }
         .sidebar-item { flex: 0 0 auto; max-width: 14rem; }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -22,7 +22,7 @@
       body { margin: 0; min-width: 320px; background: #000; }
       button, input, textarea { color: inherit; font: inherit; }
       button, input, textarea { border: 1px solid #302b28; border-radius: 0; background: #0b0a09; }
-      button { align-items: center; cursor: pointer; display: inline-flex; justify-content: center; min-height: 2.25rem; padding: 0.45rem 0.65rem; }
+      button { align-items: center; background: transparent; cursor: pointer; display: inline-flex; justify-content: center; min-height: 2.25rem; padding: 0.45rem 0.65rem; }
       button:hover:not(:disabled) { background: #181411; border-color: #7d4836; }
       button:focus-visible, input:focus-visible, textarea:focus-visible, [role="separator"]:focus-visible { outline: 2px solid #d97855; outline-offset: 2px; }
       button:disabled { color: #746d67; cursor: not-allowed; }
@@ -33,7 +33,7 @@
       .workbench-shell { display: grid; grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr); height: 100dvh; min-height: 0; }
       .sidebar { border-right: 1px solid #302b28; display: grid; grid-template-rows: auto auto auto minmax(0, 1fr) auto; min-height: 0; min-width: 0; padding: 0.75rem; }
       .brand { align-items: center; border-bottom: 1px solid #302b28; display: flex; justify-content: space-between; padding: 0 0 0.75rem; }
-      .brand__mark, .section-label { color: #d97855; font-size: 0.73rem; font-weight: 700; letter-spacing: 0.12em; margin: 0; text-transform: uppercase; }
+      .brand__mark, .section-label { color: #d97855; font-size: 0.73rem; font-weight: 700; letter-spacing: 0.12em; margin: 0; text-transform: lowercase; }
       .icon-button { flex: 0 0 2.25rem; padding: 0.35rem; width: 2.25rem; }
       .icon-button svg { fill: none; height: 1.1rem; stroke: currentColor; stroke-linecap: square; stroke-linejoin: miter; stroke-width: 1.6; width: 1.1rem; }
       .workspace-add { border-bottom: 1px solid #302b28; display: grid; gap: 0.55rem; padding: 0.75rem 0; }
@@ -55,9 +55,12 @@
       .sidebar-empty { color: #716a64; font-size: 0.78rem; line-height: 1.5; margin: 0.65rem 0 0; }
       .session-row { align-items: stretch; display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: 0.18rem; }
       .session-row__action { min-height: 2rem; opacity: 0.82; width: 2rem; }
-      .auth-compact { border-top: 1px solid #302b28; color: #8d847d; font-size: 0.74rem; padding-top: 0.75rem; }
-      .auth-compact summary { color: #b8b0aa; cursor: pointer; }
-      .auth-compact__body { display: grid; gap: 0.5rem; margin-top: 0.7rem; }
+      .auth-compact { border-top: 1px solid #302b28; color: #8d847d; font-size: 0.74rem; padding-top: 0.5rem; position: relative; }
+      .auth-compact summary { align-items: center; color: #8d847d; cursor: pointer; display: inline-flex; gap: 0.45rem; list-style: none; min-height: 2.25rem; padding: 0.35rem; }
+      .auth-compact summary::-webkit-details-marker { display: none; }
+      .auth-compact summary:hover { color: #e0e0e0; }
+      .auth-compact summary svg { fill: none; height: 1rem; stroke: currentColor; stroke-linecap: square; stroke-linejoin: miter; stroke-width: 1.5; width: 1rem; }
+      .auth-compact__body { background: #0a0a0a; border: 1px solid #302b28; bottom: calc(100% + 0.35rem); display: grid; gap: 0.5rem; left: 0; max-height: min(70dvh, 34rem); overflow: auto; padding: 0.75rem; position: absolute; width: min(24rem, calc(100vw - 1.5rem)); z-index: 20; }
       .auth-compact__body label { font-size: 0.72rem; }
       .auth-onboarding { background: #090807; border: 1px solid #302b28; display: grid; gap: 0.55rem; margin: 0 auto; max-width: 32rem; padding: 1rem; position: relative; }
       .auth-onboarding h2 { font-size: 1rem; margin: 0; padding-right: 4.75rem; }
@@ -74,30 +77,48 @@
       .security-audit { margin: 0; max-height: 6rem; overflow: auto; padding-left: 1rem; }
       .security-audit li { margin-bottom: 0.2rem; }
 
-      .main-panel { display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr) auto; min-height: 0; min-width: 0; }
+      .main-panel { display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto auto minmax(0, 1fr); min-height: 0; min-width: 0; }
       .session-header { align-items: center; border-bottom: 1px solid #302b28; display: flex; gap: 0.8rem; justify-content: space-between; min-height: 3.85rem; padding: 0.75rem 1rem; }
       .session-header__title { min-width: 0; }
       .session-header h1 { font-size: 0.95rem; font-weight: 600; margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
       .session-header p { color: #877e77; font-size: 0.72rem; margin: 0.25rem 0 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
       .session-actions, .layout-toolbar { align-items: center; display: flex; gap: 0.35rem; }
       .layout-toolbar { border-right: 1px solid #302b28; padding-right: 0.55rem; }
-      .session-state { color: #d97855; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; }
+      .session-launcher { position: relative; }
+      .session-launcher > summary { align-items: center; border: 1px solid #302b28; cursor: pointer; display: inline-flex; height: 2.25rem; justify-content: center; list-style: none; width: 2.25rem; }
+      .session-launcher > summary::-webkit-details-marker { display: none; }
+      .session-launcher > summary:hover { background: #181411; border-color: #7d4836; }
+      .session-launcher > summary svg { fill: none; height: 1.1rem; stroke: currentColor; stroke-linecap: square; stroke-width: 1.6; width: 1.1rem; }
+      .session-launcher[open] > summary { border-color: #d97855; color: #d97855; }
+      .session-launcher .provider-picker { background: #0a0a0a; border: 1px solid #302b28; display: grid; min-width: 10rem; padding: 0.35rem; position: absolute; right: 0; top: calc(100% + 0.35rem); z-index: 30; }
+      .session-launcher .provider-button { justify-content: flex-start; width: 100%; }
+      .session-state { color: #d97855; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: lowercase; }
       .session-state[data-state="error"], .session-state[data-state="degraded"] { color: #df8a69; }
       .session-state[data-state="idle"] { color: #9ca78b; }
 
-      .pane-root { background: #050403; min-height: 0; min-width: 0; overflow: hidden; padding: clamp(0.75rem, 2vw, 1.5rem); }
+      .pane-root { background: #000; min-height: 0; min-width: 0; overflow: hidden; }
       .pane-root--onboarding { overflow: auto; padding: 0.75rem; }
       .pane-root > .workbench-pane, .pane-root > .workspace-split { height: 100%; min-height: 0; }
       .workspace-split { display: grid; max-width: 100%; min-width: 0; width: 100%; }
-      .workbench-pane { background: #090807; border: 1px solid #302b28; display: grid; grid-template-rows: auto minmax(0, 1fr); min-height: 0; min-width: 0; overflow: hidden; }
-      .workbench-pane--selected { border-color: #4b3026; }
-      .tab-strip { align-items: stretch; background: #0b0a09; border-bottom: 1px solid #302b28; display: flex; gap: 0.2rem; min-height: 2.55rem; min-width: 0; overflow-x: auto; padding: 0.22rem; }
+      .workbench-pane { background: #000; display: grid; grid-template-rows: auto minmax(0, 1fr); min-height: 0; min-width: 0; overflow: hidden; position: relative; }
+      .workbench-pane--chat { grid-template-rows: auto minmax(0, 1fr) auto; }
+      .workbench-pane--selected { box-shadow: inset 0 1px #33241e; }
+      .tab-strip { align-items: stretch; background: #000; border-bottom: 1px solid #24211f; display: flex; gap: 0.2rem; min-height: 2.55rem; min-width: 0; overflow-x: auto; padding: 0 0.45rem; scrollbar-width: thin; }
       .session-tab { background: transparent; border: 0; color: #8d847d; flex: 0 0 auto; font-size: 0.72rem; min-height: 2rem; max-width: 12rem; overflow: hidden; padding: 0.35rem 0.55rem; text-overflow: ellipsis; white-space: nowrap; }
       .session-tab[data-active="true"] { background: #19120f; color: #f2e8e1; box-shadow: inset 0 -2px #d97855; }
+      .tab-drop-zone { bottom: 2.55rem; opacity: 0; pointer-events: none; position: absolute; top: 2.55rem; transition: opacity 120ms ease-out; width: clamp(2.25rem, 12%, 5rem); z-index: 12; }
+      .tab-drop-zone--before { left: 0; }
+      .tab-drop-zone--after { right: 0; }
+      .workbench-pane[data-tab-drag-active="true"] .tab-drop-zone { opacity: 1; pointer-events: auto; }
+      .tab-drop-zone[data-drag-over="true"] { background: color-mix(in srgb, #d97855 10%, transparent); border: 1px solid #d97855; }
       .pane-divider { background: #171310; cursor: col-resize; min-width: 0.5rem; position: relative; }
       .pane-divider:hover { background: #593526; }
       .pane-divider::after { background: #52433b; content: ""; inset: 0.6rem 0.18rem; position: absolute; }
-      .pane-body { min-height: 0; min-width: 0; overflow: auto; padding: clamp(0.8rem, 2vw, 1.5rem); }
+      .pane-body { min-height: 0; min-width: 0; overflow: auto; padding: clamp(0.75rem, 2vw, 1.25rem); scrollbar-color: #3a332e transparent; scrollbar-width: thin; }
+      .pane-body::-webkit-scrollbar { height: 0.45rem; width: 0.45rem; }
+      .pane-body::-webkit-scrollbar-track { background: transparent; }
+      .pane-body::-webkit-scrollbar-thumb { background: #3a332e; border: 1px solid #000; }
+      .pane-body::-webkit-scrollbar-thumb:hover { background: #5a4c44; }
       .pane-body--terminal { overflow: hidden; padding: 0.45rem; }
       .terminal-surface { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; height: 100%; min-height: 0; }
       .terminal-status { color: #8d847d; font-size: 0.72rem; margin: 0; padding: 0.15rem 0.25rem 0.5rem; }
@@ -107,28 +128,34 @@
       .terminal-recovery[hidden] { display: none; }
       .terminal-recovery p { color: #df8a69; flex: 1 1 18rem; font-size: 0.72rem; margin: 0; }
       .terminal-recovery button { min-height: 2rem; }
-      .chat-timeline { display: grid; gap: 0.8rem; margin: 0 auto; max-width: 54rem; min-height: 100%; }
-      .chat-event { border-left: 2px solid #3a332e; display: grid; gap: 0.35rem; padding: 0.4rem 0 0.4rem 0.75rem; }
+      .chat-timeline { align-content: start; display: grid; gap: 0.25rem; margin: 0 auto; max-width: 50rem; min-height: 100%; width: 100%; }
+      .chat-event { display: grid; gap: 0.35rem; max-width: 100%; padding: 0.8rem 0; }
       .chat-event header { align-items: center; display: flex; gap: 0.55rem; }
-      .chat-event__role { color: #e2d8d1; font-size: 0.74rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
-      .chat-event code { color: #887f78; font-size: 0.72rem; }
-      .chat-event p { color: #c6bdb7; line-height: 1.5; margin: 0; overflow-wrap: anywhere; white-space: pre-wrap; }
-      .chat-event--user { border-left-color: #d97855; }
-      .chat-event--assistant { border-left-color: #9ca78b; }
-      .chat-event--tool { border-left-color: #bb987a; }
-      .chat-event--error { border-left-color: #df8a69; }
+      .chat-event__role { color: #e2d8d1; font-size: 0.72rem; font-weight: 700; }
+      .chat-event code { color: #776f69; font-size: 0.68rem; }
+      .chat-event p { color: #d3cbc5; line-height: 1.55; margin: 0; overflow-wrap: anywhere; white-space: pre-wrap; }
+      .chat-event--user { background: #100c0a; border: 1px solid #30231e; justify-self: end; margin: 0.45rem 0; max-width: min(88%, 42rem); padding: 0.65rem 0.75rem; }
+      .chat-event--user header { justify-content: flex-end; }
+      .chat-event--assistant { justify-self: stretch; }
+      .chat-event--tool, .chat-event--status { border-left: 1px solid #3a332e; margin: 0.25rem 0; padding: 0.45rem 0.75rem; }
+      .chat-event--tool p, .chat-event--status p { color: #9f958e; font-size: 0.76rem; line-height: 1.4; }
+      .chat-event--error { border-left: 2px solid #df8a69; padding-left: 0.75rem; }
       .chat-empty { color: #776f69; line-height: 1.6; margin: 0; padding: 1.5rem 0; }
       .workspace-canvas-empty { margin: 0 auto; max-width: 54rem; }
-      .composer { border-top: 1px solid #302b28; padding: 0.75rem 1rem 1rem; }
-      .composer__inner { display: grid; gap: 0.55rem; margin: 0 auto; max-width: 54rem; }
-      .composer__row { align-items: end; display: flex; gap: 0.55rem; }
-      .composer__row[hidden] { display: none; }
-      .composer__row textarea { flex: 1; }
+      .chat-composer { border-top: 1px solid #24211f; padding: 0.6rem clamp(0.75rem, 2vw, 1.25rem) 0.75rem; }
+      .chat-composer__inner { border: 1px solid #3a332e; display: grid; grid-template-columns: minmax(0, 1fr) auto; margin: 0 auto; max-width: 50rem; }
+      .chat-composer__inner:focus-within { border-color: #d97855; }
+      .chat-composer textarea { background: transparent; border: 0; line-height: 1.45; max-height: 10rem; min-height: 3rem; overflow-y: auto; padding: 0.7rem 0.75rem; resize: none; }
+      .chat-composer textarea:focus-visible { outline: 0; }
+      .chat-composer__send { align-self: end; background: transparent; border: 0; border-left: 1px solid #302b28; color: #d97855; height: 2.5rem; min-height: 2.5rem; padding: 0.45rem; width: 2.5rem; }
+      .chat-composer__send svg { fill: none; height: 1rem; stroke: currentColor; stroke-linecap: square; stroke-linejoin: miter; stroke-width: 1.6; width: 1rem; }
       .provider-picker { align-items: center; display: flex; flex-wrap: wrap; gap: 0.5rem; }
       .provider-picker__label { color: #827971; font-size: 0.72rem; margin-right: 0.1rem; }
       .provider-button { color: #b8b0aa; font-size: 0.75rem; min-height: 2rem; }
       .provider-button[data-provider="hermes"] { border-color: #4c3a34; }
-      .workspace-error { color: #df8a69; font-size: 0.76rem; margin: 0; min-height: 1.1rem; }
+      .workspace-error { border-bottom: 1px solid #5a3025; color: #df8a69; font-size: 0.76rem; margin: 0; padding: 0.45rem 1rem; }
+      .workspace-error:empty { display: none; }
+      .sr-only { height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; clip: rect(0, 0, 0, 0); white-space: nowrap; }
 
       @media (max-width: 64rem) {
         .pane-divider { cursor: row-resize; min-height: 0.5rem; min-width: 0; }
@@ -145,9 +172,11 @@
         .session-header { align-items: flex-start; }
         .session-actions { gap: 0.25rem; }
         .layout-toolbar { gap: 0.2rem; padding-right: 0.35rem; }
-        .pane-root { min-height: 22rem; padding: 0.6rem; }
+        .pane-root { min-height: 22rem; }
         .workspace-split { min-width: 0; }
         .pane-root { overflow: auto; }
+        .chat-event--user { max-width: 94%; }
+        .chat-composer { padding-bottom: max(0.75rem, env(safe-area-inset-bottom)); }
       }
     </style>
   </head>
@@ -186,15 +215,18 @@
           <p id="session-empty" class="sidebar-empty">No Sessions in this Project.</p>
         </section>
 
-        <button id="sign-out" type="button" hidden>Sign out this browser</button>
         <details class="auth-compact">
-          <summary>Browser access</summary>
+          <summary aria-label="Settings">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7zM19 12l2-1-2-3-2 .5-1.5-1L15 5h-6L8.5 7.5l-1.5 1L5 8l-2 3 2 1v2l-2 1 2 3 2-.5 1.5 1L9 21h6l.5-2.5 1.5-1 2 .5 2-3-2-1z" /></svg>
+            <span>settings</span>
+          </summary>
           <div class="auth-compact__body">
             <p id="auth-status" aria-live="polite">Checking passkey support…</p>
             <label for="recovery-code">Lost passkey access? Recovery code for replacement enrollment</label>
             <input id="recovery-code" type="password" autocomplete="off" />
             <button id="enroll-passkey" type="button">Enroll replacement passkey</button>
             <button id="sign-in" type="button">Sign in with passkey</button>
+            <button id="sign-out" type="button" hidden>Sign out this browser</button>
             <section id="security-management" hidden aria-label="Browser and passkey security">
               <p class="section-label">Trusted browsers</p>
               <div id="trusted-browsers" class="security-list"></div>
@@ -214,6 +246,16 @@
             <p id="session-subtitle">Choose a Workspace to continue.</p>
           </div>
           <div class="session-actions">
+            <details class="session-launcher">
+              <summary aria-label="Start session" title="Start session">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+              </summary>
+              <div class="provider-picker" aria-label="Start a Session">
+                <button class="provider-button" type="button" data-provider="claude">Claude Code</button>
+                <button class="provider-button" type="button" data-provider="hermes">Hermes</button>
+                <button class="provider-button" type="button" data-provider="codex">Codex</button>
+              </div>
+            </details>
             <div class="layout-toolbar" aria-label="Workspace layout">
               <button class="icon-button" type="button" data-layout-action="new-tab" aria-label="New tab" title="New tab (Ctrl+T)" disabled>
                 <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 6h14v12H5zM12 9v6M9 12h6" /></svg>
@@ -238,25 +280,23 @@
           </div>
         </header>
 
-        <div id="pane-root" class="pane-root" aria-label="Conversation panes"></div>
+        <p id="workbench-error" class="workspace-error" aria-live="polite"></p>
 
-        <footer class="composer" hidden>
-          <form id="composer" class="composer__inner">
-            <p id="workbench-error" class="workspace-error" aria-live="polite"></p>
-            <div class="provider-picker" aria-label="Start a Session">
-              <span class="provider-picker__label">Start</span>
-              <button class="provider-button" type="button" data-provider="claude">Claude Code</button>
-              <button class="provider-button" type="button" data-provider="hermes">Hermes</button>
-              <button class="provider-button" type="button" data-provider="codex">Codex</button>
-            </div>
-            <div class="composer__row">
-              <textarea id="message-input" name="message" placeholder="Message the selected session" aria-label="Message" disabled></textarea>
-              <button id="send-message" type="submit" disabled>Send</button>
-            </div>
-          </form>
-        </footer>
+        <div id="pane-root" class="pane-root" aria-label="Conversation panes"></div>
       </section>
     </main>
+    <template id="chat-composer-template">
+      <form class="chat-composer" data-chat-composer>
+        <div class="chat-composer__inner">
+          <label class="sr-only" data-composer-label>Message</label>
+          <textarea name="message" rows="1" placeholder="Message this session" aria-describedby="composer-keyboard-hint"></textarea>
+          <button class="chat-composer__send" type="submit" aria-label="Send message" title="Send message">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" /></svg>
+          </button>
+        </div>
+        <span id="composer-keyboard-hint" class="sr-only">Enter sends. Shift Enter adds a new line.</span>
+      </form>
+    </template>
     <script src="./vendor/xterm.js"></script>
     <script type="module" src="./main.js"></script>
   </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -116,6 +116,7 @@ let pendingDirectoryBrowse = null;
 const terminalRuntimes = new Map();
 const retainedTerminalInput = new Map();
 const chatDrafts = new Map();
+const pendingChatSubmissions = new Set();
 const chatScrollStates = new Map();
 const chatAnnouncementFingerprints = new Map();
 const terminalsPendingRemoval = new Set();
@@ -489,6 +490,7 @@ function sidebarButton(label, meta) {
 
 function renderPaneRoot(workspace) {
   const focusedComposer = captureComposerFocus(paneRoot);
+  const chatCopyState = captureChatCopyState(paneRoot);
   if (focusedComposer) chatDrafts.set(focusedComposer.tabId, focusedComposer.value);
   captureChatScrollStates();
   disposeTerminals({ preservePausedInput: true });
@@ -507,6 +509,7 @@ function renderPaneRoot(workspace) {
   }
   paneRoot.append(renderLayoutNode(activeLayout.layout));
   restoreComposerFocus(paneRoot, focusedComposer);
+  restoreChatCopyState(paneRoot, chatCopyState);
 }
 
 function renderLayoutNode(node) {
@@ -554,6 +557,7 @@ function renderLayoutNode(node) {
   timeline.setAttribute("aria-live", "off");
   timeline.setAttribute("aria-atomic", "false");
   renderChatTimeline(timeline, session);
+  decorateChatMessages(timeline, scrollKey);
   body.append(timeline);
   trackChatScroll(body, scrollKey);
   pane.append(body);
@@ -611,6 +615,73 @@ function renderChatAnnouncement(tabId, session) {
   return live;
 }
 
+function decorateChatMessages(timeline, tabId) {
+  for (const [messageIndex, item] of [...timeline.querySelectorAll(".chat-event--user, .chat-event--assistant")].entries()) {
+    const text = item.querySelector("p");
+    if (!text) continue;
+    item.classList.add("chat-event--message");
+    item.setAttribute("aria-label", item.classList.contains("chat-event--user") ? "Your message" : "Assistant message");
+    item.querySelector("header")?.remove();
+    const status = document.createElement("span");
+    status.className = "sr-only chat-event__copy-status";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    const copy = iconButton("Copy message", "Copy message", "M8 8h10v10H8zM6 16H4V4h12v2");
+    copy.classList.add("chat-event__copy");
+    copy.dataset.chatCopyKey = `${tabId}:${messageIndex}`;
+    copy.addEventListener("click", () => void copyChatMessage(copy, status, text.textContent ?? ""));
+    item.append(copy, status);
+  }
+}
+
+function captureChatCopyState(root) {
+  const focused = root.ownerDocument?.activeElement;
+  const feedback = new Map();
+  for (const button of root.querySelectorAll("[data-chat-copy-key]")) {
+    const status = button.parentElement?.querySelector(".chat-event__copy-status");
+    if (button.dataset.copyState || status?.textContent) {
+      feedback.set(button.dataset.chatCopyKey, {
+        copyState: button.dataset.copyState ?? "",
+        status: status?.textContent ?? "",
+      });
+    }
+  }
+  return {
+    feedback,
+    focusedKey: focused?.matches?.("[data-chat-copy-key]") ? focused.dataset.chatCopyKey : null,
+  };
+}
+
+function restoreChatCopyState(root, state) {
+  if (!state) return;
+  for (const button of root.querySelectorAll("[data-chat-copy-key]")) {
+    const feedback = state.feedback.get(button.dataset.chatCopyKey);
+    if (feedback) {
+      if (feedback.copyState) button.dataset.copyState = feedback.copyState;
+      const status = button.parentElement?.querySelector(".chat-event__copy-status");
+      if (status) status.textContent = feedback.status;
+    }
+  }
+  if (!state.focusedKey) return;
+  queueMicrotask(() => {
+    const button = [...root.querySelectorAll("[data-chat-copy-key]")]
+      .find((candidate) => candidate.dataset.chatCopyKey === state.focusedKey);
+    if (button?.isConnected) button.focus({ preventScroll: true });
+  });
+}
+
+async function copyChatMessage(button, status, text) {
+  try {
+    if (typeof navigator.clipboard?.writeText !== "function") throw new Error("clipboard unavailable");
+    await navigator.clipboard.writeText(text);
+    button.dataset.copyState = "copied";
+    status.textContent = "Message copied.";
+  } catch {
+    button.dataset.copyState = "unavailable";
+    status.textContent = "Copy unavailable. The conversation is unchanged.";
+  }
+}
+
 function renderChatComposer(paneId, tabId, session) {
   const fragment = chatComposerTemplate.content.cloneNode(true);
   const form = fragment.querySelector("[data-chat-composer]");
@@ -630,11 +701,11 @@ function renderChatComposer(paneId, tabId, session) {
   hint.id = hintId;
   const disabled = ["closed", "exited"].includes(session.status);
   textarea.disabled = disabled;
-  send.disabled = disabled || textarea.value.trim().length === 0;
+  updateChatComposerSendState(tabId, textarea, send, disabled);
   resizeComposerTextarea(textarea);
   textarea.addEventListener("input", () => {
     chatDrafts.set(tabId, textarea.value);
-    send.disabled = textarea.value.trim().length === 0;
+    updateChatComposerSendState(tabId, textarea, send, disabled);
     resizeComposerTextarea(textarea);
   });
   textarea.addEventListener("keydown", (event) => {
@@ -645,10 +716,38 @@ function renderChatComposer(paneId, tabId, session) {
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     const text = textarea.value.trim();
-    if (!text) return;
+    if (!text || pendingChatSubmissions.has(tabId)) return;
+    pendingChatSubmissions.add(tabId);
+    clearSubmittedChatDraft(tabId, textarea, send);
     void submitMessage(session, text, tabId);
   });
   return form;
+}
+
+function updateChatComposerSendState(tabId, textarea, send, disabled = false) {
+  send.disabled = disabled || pendingChatSubmissions.has(tabId) || textarea.value.trim().length === 0;
+}
+
+function clearSubmittedChatDraft(tabId, textarea, send) {
+  chatDrafts.delete(tabId);
+  textarea.value = "";
+  send.disabled = true;
+  resizeComposerTextarea(textarea);
+}
+
+function recoverChatDraft(tabId, failedText) {
+  const currentText = chatDrafts.get(tabId) ?? "";
+  const recoveredText = currentText
+    ? `${failedText}\n${currentText}`
+    : failedText;
+  chatDrafts.set(tabId, recoveredText);
+  const textarea = [...paneRoot.querySelectorAll("[data-chat-composer] textarea")]
+    .find((candidate) => candidate.closest("[data-chat-composer]")?.dataset.tabId === tabId);
+  if (!textarea) return;
+  textarea.value = recoveredText;
+  const send = textarea.closest("[data-chat-composer]")?.querySelector("button[type='submit']");
+  if (send) updateChatComposerSendState(tabId, textarea, send);
+  resizeComposerTextarea(textarea);
 }
 
 function resizeComposerTextarea(textarea) {
@@ -1519,12 +1618,13 @@ async function submitMessage(session, text, draftKey) {
       body: JSON.stringify({ sessionId: session.id, text }),
     }));
   } catch (error) {
-    chatDrafts.set(draftKey, text);
+    recoverChatDraft(draftKey, text);
     showError(error);
     await refreshWorkbench({ restore: false });
-    return;
+  } finally {
+    pendingChatSubmissions.delete(draftKey);
+    render();
   }
-  render();
 }
 
 async function interrupt() {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4,7 +4,12 @@ import {
   passkeyCapability,
   presentationForAuthError,
 } from "./auth.js";
-import { renderChatTimeline, sessionMayHaveMoreEvents } from "./chat.js";
+import {
+  eventPresentation,
+  normalizeChatEvents,
+  renderChatTimeline,
+  sessionMayHaveMoreEvents,
+} from "./chat.js";
 import {
   claudeMetadata,
   mergeRecentClaudeSessions,
@@ -20,6 +25,7 @@ import {
   addSessionTab,
   closeSelectedPane,
   createWorkspaceLayout,
+  detachTabToNewPane,
   moveSelectedPane,
   moveTab,
   openSessionTab,
@@ -35,6 +41,8 @@ import {
 const WORKBENCH_URL = "/api/workbench";
 const STORAGE_KEY = "relay-factory/workbench/v1";
 const LAYOUT_STORAGE_KEY = "relay-factory/workbench-layouts/v1";
+const MAX_DISMISSED_CLAUDE_SESSIONS = 64;
+const MAX_PROVIDER_SESSION_ID_LENGTH = 128;
 const PROVIDER_LABELS = new Map([
   ["claude", "Claude Code"],
   ["codex", "Codex"],
@@ -69,10 +77,7 @@ const sessionStatus = document.querySelector("#session-status");
 const interruptSession = document.querySelector("#interrupt-session");
 const closeTerminal = document.querySelector("#close-terminal");
 const paneRoot = document.querySelector("#pane-root");
-const composer = document.querySelector("#composer");
-const composerShell = composer.closest(".composer");
-const messageInput = document.querySelector("#message-input");
-const sendMessage = document.querySelector("#send-message");
+const chatComposerTemplate = document.querySelector("#chat-composer-template");
 const workbenchError = document.querySelector("#workbench-error");
 const authStatus = document.querySelector("#auth-status");
 const recoveryCode = document.querySelector("#recovery-code");
@@ -87,8 +92,10 @@ const securityAudit = document.querySelector("#security-audit");
 
 let workbench = { providers: { claude: false, codex: false, hermes: false }, sessions: [], workspaces: [] };
 let saved = loadSavedState();
+const dismissedClaudeSessionIds = new Set(saved.dismissedClaudeSessionIds);
 let savedLayouts = loadSavedLayouts();
-let recentClaudeSessions = restoreRecentClaudeSessions(JSON.stringify(saved.claudeSessions ?? []));
+let recentClaudeSessions = restoreRecentClaudeSessions(JSON.stringify(saved.claudeSessions ?? []))
+  .filter((session) => !dismissedClaudeSessionIds.has(session.providerSessionId));
 let mayHaveSession = saved.mayHaveSession === true;
 let selectedWorkspaceCwd = saved.selectedWorkspaceCwd ?? null;
 let selectedSessionId = saved.selectedSessionId ?? null;
@@ -108,6 +115,10 @@ let directorySnapshot = null;
 let pendingDirectoryBrowse = null;
 const terminalRuntimes = new Map();
 const retainedTerminalInput = new Map();
+const chatDrafts = new Map();
+const chatScrollStates = new Map();
+const chatAnnouncementFingerprints = new Map();
+const terminalsPendingRemoval = new Set();
 
 document.querySelector("#show-workspace-add").addEventListener("click", () => {
   workspaceAdd.hidden = false;
@@ -119,12 +130,8 @@ document.querySelector("#cancel-workspace-add").addEventListener("click", () => 
 });
 directoryUp.addEventListener("click", () => void browseDirectory(directorySnapshot?.parent ?? undefined));
 selectDirectory.addEventListener("click", () => void addWorkspace(directorySnapshot?.path));
-composer.addEventListener("submit", (event) => {
-  event.preventDefault();
-  void submitMessage();
-});
 interruptSession.addEventListener("click", () => void interrupt());
-closeTerminal.addEventListener("click", () => void closeClaudeTerminal(activeSession()));
+closeTerminal.addEventListener("click", () => void closeOrRemoveClaudeTerminal(activeSession()));
 for (const button of document.querySelectorAll("[data-provider]")) {
   button.addEventListener("click", () => void startSession(button.dataset.provider));
 }
@@ -167,8 +174,16 @@ function selectedWorkspace() {
 function sessionsForSelectedWorkspace() {
   const workspace = selectedWorkspace();
   if (!workspace) return [];
-  const live = workbench.sessions.filter((session) => session.workspaceId === workspace.id);
-  return mergeRecentClaudeSessions(live, recentClaudeSessions, workspace);
+  const live = workbench.sessions.filter((session) => (
+    session.workspaceId === workspace.id
+    && !isDismissedClaudeSession(session)
+  ));
+  return mergeRecentClaudeSessions(live, recentClaudeSessions, workspace)
+    .filter((session) => !isDismissedClaudeSession(session));
+}
+
+function isDismissedClaudeSession(session, dismissed = dismissedClaudeSessionIds) {
+  return session?.provider === "claude" && dismissed.has(session.providerSessionId);
 }
 
 function activeSession() {
@@ -237,7 +252,6 @@ function render() {
   recoveryCode.hidden = firstClaim;
   recoveryCode.previousElementSibling.hidden = firstClaim;
   enrollPasskey.textContent = firstClaim ? "Set up Relay owner" : "Enroll replacement passkey";
-  composerShell.hidden = !authorized;
   paneRoot.classList.toggle("pane-root--onboarding", !authorized);
   renderPaneRoot(workspace);
 
@@ -260,14 +274,16 @@ function render() {
     setSessionState(session.status, session.status);
   }
 
-  messageInput.parentElement.hidden = terminalSelected;
-  messageInput.disabled = !session || terminalSelected;
-  sendMessage.disabled = !session || terminalSelected;
   interruptSession.disabled = !session || (terminalSelected
     ? !["starting", "running"].includes(session.status)
     : !["working", "idle"].includes(session.status));
   closeTerminal.hidden = !terminalSelected;
-  closeTerminal.disabled = !terminalSelected || ["closing", "closed"].includes(session?.status);
+  closeTerminal.disabled = !terminalSelected || session?.status === "closing";
+  const terminalCloseLabel = ["closed", "exited"].includes(session?.status)
+    ? "Remove closed terminal"
+    : "Close terminal process";
+  closeTerminal.setAttribute("aria-label", terminalCloseLabel);
+  closeTerminal.title = terminalCloseLabel;
   for (const button of document.querySelectorAll("[data-provider]")) {
     button.disabled = !workspace || !authorized || !workbench.providers[button.dataset.provider];
   }
@@ -442,11 +458,14 @@ function sessionRow(session) {
   resume.disabled = resumingSessionIds.has(session.id);
   resume.hidden = session.provider === "claude";
   resume.addEventListener("click", () => void resumeSession(session));
-  const closeLabel = session.provider === "claude" ? "Close terminal process" : "Close Session";
+  const closedTerminal = session.provider === "claude" && ["closed", "exited"].includes(session.status);
+  const closeLabel = session.provider === "claude"
+    ? closedTerminal ? "Remove closed terminal" : "Close terminal process"
+    : "Close Session";
   const close = iconButton(closeLabel, closeLabel, "M7 7l10 10M17 7 7 17");
   close.classList.add("session-row__action");
-  close.disabled = session.provider === "claude" && ["closing", "closed"].includes(session.status);
-  close.addEventListener("click", () => void (session.provider === "claude" ? closeClaudeTerminal(session) : closeSession(session)));
+  close.disabled = session.provider === "claude" && session.status === "closing";
+  close.addEventListener("click", () => void (session.provider === "claude" ? closeOrRemoveClaudeTerminal(session) : closeSession(session)));
   row.append(button, resume, close);
   return row;
 }
@@ -469,6 +488,9 @@ function sidebarButton(label, meta) {
 }
 
 function renderPaneRoot(workspace) {
+  const focusedComposer = captureComposerFocus(paneRoot);
+  if (focusedComposer) chatDrafts.set(focusedComposer.tabId, focusedComposer.value);
+  captureChatScrollStates();
   disposeTerminals({ preservePausedInput: true });
   paneRoot.replaceChildren();
   if (!authorized) {
@@ -484,6 +506,7 @@ function renderPaneRoot(workspace) {
     return;
   }
   paneRoot.append(renderLayoutNode(activeLayout.layout));
+  restoreComposerFocus(paneRoot, focusedComposer);
 }
 
 function renderLayoutNode(node) {
@@ -515,18 +538,168 @@ function renderLayoutNode(node) {
   const body = document.createElement("div");
   body.className = "pane-body";
   if (sessionSurface(session) === "terminal") {
+    pane.classList.add("workbench-pane--terminal");
     body.classList.add("pane-body--terminal");
     body.append(renderTerminalSurface(node.id, session));
-    pane.append(body);
+    pane.append(body, ...tabDetachDropZones(node.id));
     return pane;
   }
+  pane.classList.add("workbench-pane--chat");
+  body.classList.add("pane-body--chat");
+  const scrollKey = active?.id ?? node.id;
+  body.dataset.chatScrollKey = scrollKey;
   const timeline = document.createElement("div");
   timeline.className = "chat-timeline";
-  timeline.setAttribute("aria-live", "polite");
+  timeline.setAttribute("role", "log");
+  timeline.setAttribute("aria-live", "off");
+  timeline.setAttribute("aria-atomic", "false");
   renderChatTimeline(timeline, session);
   body.append(timeline);
+  trackChatScroll(body, scrollKey);
   pane.append(body);
+  if (session && active) pane.append(renderChatAnnouncement(active.id, session));
+  if (session && active) pane.append(renderChatComposer(node.id, active.id, session));
+  pane.append(...tabDetachDropZones(node.id));
   return pane;
+}
+
+function captureComposerFocus(root) {
+  const active = root.ownerDocument?.activeElement;
+  if (!active || !root.contains(active) || !active.matches("[data-chat-composer] textarea")) return null;
+  const form = active.closest("[data-chat-composer]");
+  if (!form?.dataset.tabId) return null;
+  return {
+    tabId: form.dataset.tabId,
+    value: active.value,
+    selectionStart: active.selectionStart,
+    selectionEnd: active.selectionEnd,
+    selectionDirection: active.selectionDirection,
+  };
+}
+
+function restoreComposerFocus(root, state) {
+  if (!state) return;
+  queueMicrotask(() => {
+    const textarea = [...root.querySelectorAll("[data-chat-composer] textarea")]
+      .find((candidate) => candidate.closest("[data-chat-composer]")?.dataset.tabId === state.tabId);
+    if (!textarea || textarea.disabled || !textarea.isConnected) return;
+    textarea.focus({ preventScroll: true });
+    const start = Math.min(state.selectionStart ?? textarea.value.length, textarea.value.length);
+    const end = Math.min(state.selectionEnd ?? start, textarea.value.length);
+    textarea.setSelectionRange(start, end, state.selectionDirection ?? "none");
+  });
+}
+
+function renderChatAnnouncement(tabId, session) {
+  const live = document.createElement("div");
+  live.className = "sr-only";
+  live.setAttribute("role", "status");
+  live.setAttribute("aria-live", "polite");
+  live.setAttribute("aria-atomic", "false");
+  const event = normalizeChatEvents(session.events).at(-1);
+  if (!event) return live;
+  const presentation = eventPresentation(event);
+  const fingerprint = `${presentation.tone}\u0000${presentation.eventLabel}\u0000${presentation.text}`;
+  const previous = chatAnnouncementFingerprints.get(tabId);
+  chatAnnouncementFingerprints.set(tabId, fingerprint);
+  const isStreamDelta = presentation.eventLabel.endsWith(".delta");
+  if (previous && previous !== fingerprint && presentation.tone !== "user" && !isStreamDelta) {
+    queueMicrotask(() => {
+      if (live.isConnected) live.textContent = `${presentation.roleLabel}: ${presentation.text}`;
+    });
+  }
+  return live;
+}
+
+function renderChatComposer(paneId, tabId, session) {
+  const fragment = chatComposerTemplate.content.cloneNode(true);
+  const form = fragment.querySelector("[data-chat-composer]");
+  const label = fragment.querySelector("[data-composer-label]");
+  const textarea = fragment.querySelector("textarea");
+  const send = fragment.querySelector("button[type='submit']");
+  const hint = fragment.querySelector(".sr-only:last-child");
+  const fieldId = `message-${paneId}-${tabId}`.replace(/[^a-zA-Z0-9_-]/g, "-");
+  const hintId = `${fieldId}-hint`;
+  form.dataset.paneId = paneId;
+  form.dataset.tabId = tabId;
+  label.htmlFor = fieldId;
+  label.textContent = `Message ${sessionTabTitle(session)}`;
+  textarea.id = fieldId;
+  textarea.setAttribute("aria-describedby", hintId);
+  textarea.value = chatDrafts.get(tabId) ?? "";
+  hint.id = hintId;
+  const disabled = ["closed", "exited"].includes(session.status);
+  textarea.disabled = disabled;
+  send.disabled = disabled || textarea.value.trim().length === 0;
+  resizeComposerTextarea(textarea);
+  textarea.addEventListener("input", () => {
+    chatDrafts.set(tabId, textarea.value);
+    send.disabled = textarea.value.trim().length === 0;
+    resizeComposerTextarea(textarea);
+  });
+  textarea.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing || event.keyCode === 229) return;
+    event.preventDefault();
+    form.requestSubmit(send);
+  });
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const text = textarea.value.trim();
+    if (!text) return;
+    void submitMessage(session, text, tabId);
+  });
+  return form;
+}
+
+function resizeComposerTextarea(textarea) {
+  textarea.style.height = "auto";
+  textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+}
+
+function captureChatScrollStates() {
+  for (const body of paneRoot.querySelectorAll("[data-chat-scroll-key]")) {
+    const distanceFromBottom = body.scrollHeight - body.clientHeight - body.scrollTop;
+    chatScrollStates.set(body.dataset.chatScrollKey, {
+      nearBottom: distanceFromBottom <= 80,
+      scrollTop: body.scrollTop,
+    });
+  }
+}
+
+function trackChatScroll(body, scrollKey) {
+  const restore = () => {
+    if (!body.isConnected) return;
+    const state = chatScrollStates.get(scrollKey);
+    if (!state || state.nearBottom) body.scrollTop = body.scrollHeight;
+    else body.scrollTop = state.scrollTop;
+  };
+  queueMicrotask(restore);
+  body.addEventListener("scroll", () => {
+    const distanceFromBottom = body.scrollHeight - body.clientHeight - body.scrollTop;
+    chatScrollStates.set(scrollKey, {
+      nearBottom: distanceFromBottom <= 80,
+      scrollTop: body.scrollTop,
+    });
+  }, { passive: true });
+}
+
+function tabDetachDropZones(paneId) {
+  return ["before", "after"].map((placement) => {
+    const zone = document.createElement("div");
+    zone.className = `tab-drop-zone tab-drop-zone--${placement}`;
+    zone.dataset.placement = placement;
+    zone.setAttribute("aria-hidden", "true");
+    zone.addEventListener("dragover", (event) => {
+      if (draggedTab?.paneId !== paneId) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "move";
+      zone.dataset.dragOver = "true";
+    });
+    zone.addEventListener("dragleave", () => { delete zone.dataset.dragOver; });
+    zone.addEventListener("drop", (event) => handleTabDetach(event, placement));
+    return zone;
+  });
 }
 
 function renderTerminalSurface(paneId, session) {
@@ -706,6 +879,12 @@ async function pollTerminal(runtime) {
     runtime.polled = true;
     runtime.interactive = ["starting", "running"].includes(snapshot.status);
     runtime.status.textContent = `Claude Code · ${snapshot.status}`;
+    if (["closed", "exited"].includes(snapshot.status) && terminalsPendingRemoval.has(runtime.sessionId)) {
+      const closedSession = sessionsForSelectedWorkspace()
+        .find((candidate) => candidate.providerSessionId === runtime.sessionId);
+      if (closedSession) removeClaudeSessionPresentation(closedSession);
+      return;
+    }
     if (updateClaudeSessionStatus(runtime.sessionId, snapshot.status)) {
       render();
       return;
@@ -777,10 +956,16 @@ function renderTab(pane, tab, index) {
     draggedTab = { paneId: pane.id, tabId: tab.id };
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("text/plain", tab.id);
+    for (const candidate of paneRoot.querySelectorAll("[data-pane-id]")) {
+      if (candidate.dataset.paneId === pane.id) candidate.dataset.tabDragActive = "true";
+    }
   });
   button.addEventListener("dragover", (event) => event.preventDefault());
   button.addEventListener("drop", (event) => handleTabDrop(event, pane.id, index));
-  button.addEventListener("dragend", () => { draggedTab = null; });
+  button.addEventListener("dragend", () => {
+    clearTabDragState();
+    draggedTab = null;
+  });
   return button;
 }
 
@@ -870,7 +1055,37 @@ function handleTabDrop(event, targetPaneId, targetIndex) {
   } catch (error) {
     showLayoutError(error);
   } finally {
+    clearTabDragState();
     draggedTab = null;
+  }
+}
+
+function handleTabDetach(event, placement) {
+  event.preventDefault();
+  event.stopPropagation();
+  if (!draggedTab) return;
+  try {
+    activeLayout = detachTabToNewPane(activeLayout, {
+      sourcePaneId: draggedTab.paneId,
+      tabId: draggedTab.tabId,
+      placement,
+    });
+    selectedSessionId = activeSession()?.id ?? selectedSessionId;
+    render();
+  } catch (error) {
+    showLayoutError(error);
+  } finally {
+    clearTabDragState();
+    draggedTab = null;
+  }
+}
+
+function clearTabDragState() {
+  for (const pane of paneRoot.querySelectorAll("[data-tab-drag-active]")) {
+    delete pane.dataset.tabDragActive;
+  }
+  for (const zone of paneRoot.querySelectorAll("[data-drag-over]")) {
+    delete zone.dataset.dragOver;
   }
 }
 
@@ -1182,6 +1397,7 @@ async function startSession(provider) {
         body: JSON.stringify({ workspaceId: workspace.id, provider }),
       });
     const session = provider === "claude" ? created.workbenchSession : created;
+    if (session.provider === "claude") dismissedClaudeSessionIds.delete(session.providerSessionId);
     workbench.sessions = [session, ...workbench.sessions];
     if (!activeLayout) activeLayout = createLayout(workspace, session.id);
     else activeLayout = openSessionTab(activeLayout, session.id, sessionTabTitle(session));
@@ -1245,25 +1461,53 @@ async function closeClaudeTerminal(session) {
   if (session?.provider !== "claude") return;
   clearError();
   beginWorkbenchMutation();
+  terminalsPendingRemoval.add(session.providerSessionId);
   try {
     const snapshot = await request(`/node/claude/sessions/${session.providerSessionId}/close`, {
       method: "POST",
       body: "{}",
     });
+    if (["closed", "exited"].includes(snapshot.status)) {
+      removeClaudeSessionPresentation(session);
+      return;
+    }
     updateClaudeSessionStatus(session.providerSessionId, snapshot.status);
   } catch (error) {
+    terminalsPendingRemoval.delete(session.providerSessionId);
     showError(error);
   }
   render();
 }
 
-async function submitMessage() {
-  const session = activeSession();
-  const text = messageInput.value.trim();
+async function closeOrRemoveClaudeTerminal(session) {
+  if (!session || session.provider !== "claude") return;
+  if (["closed", "exited"].includes(session.status)) {
+    removeClaudeSessionPresentation(session);
+    return;
+  }
+  await closeClaudeTerminal(session);
+}
+
+function removeClaudeSessionPresentation(session) {
+  rememberDismissedClaudeSession(session.providerSessionId);
+  terminalsPendingRemoval.delete(session.providerSessionId);
+  activeLayout = activeLayout ? removeSessionFromLayout(activeLayout, session.id) : null;
+  workbench.sessions = workbench.sessions.filter((candidate) => candidate.id !== session.id);
+  recentClaudeSessions = recentClaudeSessions.filter((candidate) => candidate.providerSessionId !== session.providerSessionId);
+  const nextSession = sessionsForSelectedWorkspace()[0] ?? null;
+  selectedSessionId = nextSession?.id ?? null;
+  if (!activeLayout && nextSession) {
+    activeLayout = createLayout(selectedWorkspace(), nextSession.id);
+    activeLayoutWorkspaceCwd = selectedWorkspaceCwd;
+  }
+  render();
+}
+
+async function submitMessage(session, text, draftKey) {
   if (!session || !text) return;
   clearError();
   beginWorkbenchMutation();
-  messageInput.value = "";
+  chatDrafts.delete(draftKey);
   replaceSession({
     ...session,
     events: [...(session.events ?? []), { role: "user", kind: "message", label: "message.sent", text }],
@@ -1275,6 +1519,7 @@ async function submitMessage() {
       body: JSON.stringify({ sessionId: session.id, text }),
     }));
   } catch (error) {
+    chatDrafts.set(draftKey, text);
     showError(error);
     await refreshWorkbench({ restore: false });
     return;
@@ -1369,26 +1614,67 @@ function clearError() {
 }
 
 function loadSavedState() {
+  return savedStateFromStorage(window.localStorage.getItem(STORAGE_KEY));
+}
+
+function savedStateFromStorage(serialized) {
   try {
-    const state = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "null");
-    if ([1, 2].includes(state?.version) && Array.isArray(state.workspaces)) return state;
+    const state = JSON.parse(serialized ?? "null");
+    if ([1, 2].includes(state?.version) && Array.isArray(state.workspaces)) {
+      return {
+        ...state,
+        dismissedClaudeSessionIds: normalizeDismissedClaudeSessionIds(state.dismissedClaudeSessionIds),
+      };
+    }
   } catch {
     // Browser storage is convenience-only; live workbench state remains hub-owned.
   }
-  return { version: 2, mayHaveSession: false, selectedSessionId: null, selectedWorkspaceCwd: null, workspaces: [], claudeSessions: [] };
+  return {
+    version: 2,
+    mayHaveSession: false,
+    selectedSessionId: null,
+    selectedWorkspaceCwd: null,
+    workspaces: [],
+    claudeSessions: [],
+    dismissedClaudeSessionIds: [],
+  };
+}
+
+function normalizeDismissedClaudeSessionIds(value) {
+  const normalized = [];
+  for (const candidate of Array.isArray(value) ? value : []) {
+    if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > MAX_PROVIDER_SESSION_ID_LENGTH) continue;
+    const duplicate = normalized.indexOf(candidate);
+    if (duplicate >= 0) normalized.splice(duplicate, 1);
+    normalized.push(candidate);
+    if (normalized.length > MAX_DISMISSED_CLAUDE_SESSIONS) normalized.shift();
+  }
+  return normalized;
+}
+
+function rememberDismissedClaudeSession(providerSessionId) {
+  const normalized = normalizeDismissedClaudeSessionIds([
+    ...dismissedClaudeSessionIds,
+    providerSessionId,
+  ]);
+  dismissedClaudeSessionIds.clear();
+  for (const candidate of normalized) dismissedClaudeSessionIds.add(candidate);
 }
 
 function persistState() {
   if (!authorized || !hasWorkbenchSnapshot) return;
   const liveClaude = workbench.sessions.flatMap((session) => {
-    if (session.provider !== "claude") return [];
+    if (session.provider !== "claude" || isDismissedClaudeSession(session)) return [];
     const workspace = workbench.workspaces.find((candidate) => candidate.id === session.workspaceId);
     const metadata = claudeMetadata({ ...session, title: "Claude Code" }, workspace?.cwd);
     return metadata ? [metadata] : [];
   });
   recentClaudeSessions = restoreRecentClaudeSessions(serializeRecentClaudeSessions([
     ...liveClaude,
-    ...recentClaudeSessions.filter((recent) => !liveClaude.some((live) => live.providerSessionId === recent.providerSessionId)),
+    ...recentClaudeSessions.filter((recent) => (
+      !dismissedClaudeSessionIds.has(recent.providerSessionId)
+      && !liveClaude.some((live) => live.providerSessionId === recent.providerSessionId)
+    )),
   ]));
   saved = {
     version: 2,
@@ -1397,6 +1683,7 @@ function persistState() {
     selectedWorkspaceCwd,
     workspaces: workbench.workspaces.map((workspace) => ({ cwd: workspace.cwd, name: workspace.name })),
     claudeSessions: recentClaudeSessions,
+    dismissedClaudeSessionIds: normalizeDismissedClaudeSessionIds([...dismissedClaudeSessionIds]),
   };
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));

--- a/web/src/workspace-layout.js
+++ b/web/src/workspace-layout.js
@@ -213,6 +213,76 @@ export function moveTab(state, sourcePaneId, tabId, targetPaneId, targetIndex) {
   }), target.id);
 }
 
+export function detachTabToNewPane(state, {
+  sourcePaneId,
+  tabId,
+  placement = "after",
+} = {}) {
+  if (!["before", "after"].includes(placement)) {
+    throw new TypeError("Detached tab placement must be before or after its source pane.");
+  }
+
+  const metrics = layoutMetrics(state);
+  if (metrics.paneCount >= MAX_PANE_COUNT) {
+    throw new LayoutLimitError("pane-cap", `This Workspace is limited to ${MAX_PANE_COUNT} panes.`);
+  }
+
+  const source = findPane(state.layout, sourcePaneId);
+  if (!source) throw new TypeError("Detached tab references a missing pane.");
+  const sourceIndex = source.tabs.findIndex((tab) => tab.id === tabId);
+  if (sourceIndex < 0) throw new TypeError("Detached tab references a missing tab.");
+  if (source.tabs.length === 1 && metrics.tabCount >= MAX_TAB_COUNT) {
+    throw new LayoutLimitError("tab-cap", `This Workspace is limited to ${MAX_TAB_COUNT} tabs.`);
+  }
+  if (paneDepth(state.layout, source.id) >= MAX_LAYOUT_DEPTH) {
+    throw new LayoutLimitError("depth-cap", `This Workspace is limited to ${MAX_LAYOUT_DEPTH} layout splits.`);
+  }
+
+  const sourceTab = source.tabs[sourceIndex];
+  const mirrorsOnlyTab = source.tabs.length === 1;
+  const detachedTab = mirrorsOnlyTab
+    ? {
+        ...clone(sourceTab),
+        id: nextId(state.layout, "tab"),
+        title: `${sourceTab.title} mirror`,
+      }
+    : sourceTab;
+  const sourceTabs = mirrorsOnlyTab
+    ? source.tabs
+    : source.tabs.filter((candidate) => candidate.id !== tabId);
+  const remainingSource = mirrorsOnlyTab
+    ? clone(source)
+    : {
+        ...source,
+        activeTabId: source.activeTabId === tabId
+          ? sourceTabs[Math.min(sourceIndex, sourceTabs.length - 1)].id
+          : source.activeTabId,
+        tabs: sourceTabs,
+      };
+  const detachedPane = {
+    kind: "tabs",
+    id: nextId(state.layout, "pane"),
+    showTabStrip: true,
+    activeTabId: detachedTab.id,
+    tabs: [detachedTab],
+  };
+  const children = placement === "before"
+    ? { first: detachedPane, second: remainingSource }
+    : { first: remainingSource, second: detachedPane };
+  const split = {
+    kind: "split",
+    id: nextId(state.layout, "split"),
+    direction: "row",
+    ratio: 0.5,
+    ...children,
+  };
+  return withLayout(
+    state,
+    replacePane(state.layout, source.id, split),
+    detachedPane.id,
+  );
+}
+
 export function setSplitRatio(state, splitId, ratio) {
   if (typeof ratio !== "number" || !Number.isFinite(ratio)) {
     throw new TypeError("Split ratio is invalid.");

--- a/web/test/app-shell.test.mjs
+++ b/web/test/app-shell.test.mjs
@@ -71,7 +71,8 @@ test("the PWA shell is an authenticated CWD workbench, not a layout harness", as
   assert.match(app, /onboarding\.dataset\.secureOrigin/);
   assert.match(app, /onboarding\.dataset\.passkeyApi/);
   assert.match(app, /enroll\(recoveryCode\)/);
-  assert.match(app, /composerShell\.hidden = !authorized/);
+  assert.match(page, /id="chat-composer-template"/);
+  assert.match(app, /pane\.append\(renderChatComposer\(node\.id, active\.id, session\)\)/);
   assert.match(app, /paneRoot\.classList\.toggle\("pane-root--onboarding", !authorized\)/);
   assert.doesNotMatch(app, /WebSocket|Authorization/);
   assert.doesNotMatch(app, /showDirectoryPicker|webkitdirectory/);

--- a/web/test/chat-shell.test.mjs
+++ b/web/test/chat-shell.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = new URL("../src/", import.meta.url);
+
+test("each chat tab owns an integrated keyboard-first composer", async () => {
+  const [page, app] = await Promise.all([
+    readFile(new URL("index.html", source), "utf8"),
+    readFile(new URL("main.js", source), "utf8"),
+  ]);
+
+  assert.match(page, /<template id="chat-composer-template">/);
+  assert.match(page, /class="chat-composer__send"[^>]*type="submit"[^>]*aria-label="Send message"/);
+  assert.match(page, /Enter sends\. Shift Enter adds a new line\./);
+  assert.doesNotMatch(page, /<footer class="composer"|id="message-input"|id="send-message"/);
+  assert.match(app, /if \(session && active\) pane\.append\(renderChatComposer\(node\.id, active\.id, session\)\)/);
+  assert.match(app, /if \(sessionSurface\(session\) === "terminal"\) \{[\s\S]*?return pane;[\s\S]*?renderChatComposer/);
+  assert.match(app, /event\.key !== "Enter" \|\| event\.shiftKey \|\| event\.isComposing/);
+  assert.match(app, /event\.preventDefault\(\);\s*form\.requestSubmit\(send\);/);
+  assert.match(app, /const chatDrafts = new Map\(\)/);
+});
+
+test("chat refresh follows only readers already near the bottom", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+
+  assert.match(app, /captureChatScrollStates\(\);\s*disposeTerminals/);
+  assert.match(app, /nearBottom: distanceFromBottom <= 80/);
+  assert.match(app, /if \(!state \|\| state\.nearBottom\) body\.scrollTop = body\.scrollHeight;\s*else body\.scrollTop = state\.scrollTop;/);
+  assert.doesNotMatch(app, /body\.scrollTop = 0/);
+});
+
+test("refresh restores the focused composer value and text selection without scrolling", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+  const helpers = app.slice(
+    app.indexOf("function captureComposerFocus"),
+    app.indexOf("function renderChatAnnouncement"),
+  );
+  assert.ok(helpers.includes("function restoreComposerFocus"));
+  const queued = [];
+  const { captureComposerFocus, restoreComposerFocus } = Function(
+    "queueMicrotask",
+    `"use strict"; ${helpers}; return { captureComposerFocus, restoreComposerFocus };`,
+  )((callback) => queued.push(callback));
+
+  const form = { dataset: { tabId: "tab-2" } };
+  const original = {
+    closest: () => form,
+    matches: (selector) => selector === "[data-chat-composer] textarea",
+    selectionDirection: "backward",
+    selectionEnd: 12,
+    selectionStart: 4,
+    value: "keep this draft",
+  };
+  const root = {
+    contains: (candidate) => candidate === original,
+    ownerDocument: { activeElement: original },
+  };
+  const state = captureComposerFocus(root);
+  assert.deepEqual(state, {
+    tabId: "tab-2",
+    value: "keep this draft",
+    selectionStart: 4,
+    selectionEnd: 12,
+    selectionDirection: "backward",
+  });
+
+  let focusOptions;
+  let selection;
+  const replacement = {
+    closest: () => form,
+    disabled: false,
+    focus: (options) => { focusOptions = options; },
+    isConnected: true,
+    setSelectionRange: (...range) => { selection = range; },
+    value: state.value,
+  };
+  restoreComposerFocus({ querySelectorAll: () => [replacement] }, state);
+  assert.equal(queued.length, 1);
+  queued.shift()();
+  assert.deepEqual(focusOptions, { preventScroll: true });
+  assert.deepEqual(selection, [4, 12, "backward"]);
+  assert.match(app, /timeline\.setAttribute\("aria-live", "off"\)/);
+  assert.match(app, /live\.setAttribute\("aria-atomic", "false"\)/);
+});
+
+test("tab edges detach through the layout model and closed terminals leave no shadow pane", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+
+  assert.match(app, /detachTabToNewPane\(activeLayout, \{\s*sourcePaneId: draggedTab\.paneId,\s*tabId: draggedTab\.tabId,\s*placement,/);
+  assert.match(app, /tabDetachDropZones\(node\.id\)/);
+  assert.match(app, /activeLayout = activeLayout \? removeSessionFromLayout\(activeLayout, session\.id\) : null;/);
+  assert.match(app, /recentClaudeSessions = recentClaudeSessions\.filter/);
+  assert.match(app, /"Remove closed terminal"/);
+});
+
+test("account sign-out is nested behind compact settings", async () => {
+  const page = await readFile(new URL("index.html", source), "utf8");
+  const settings = page.match(/<details class="auth-compact">[\s\S]*?<\/details>/)?.[0];
+
+  assert.ok(settings, "compact settings menu must exist");
+  assert.match(settings, /<summary aria-label="Settings">/);
+  assert.match(settings, /id="sign-out"/);
+  assert.doesNotMatch(page.replace(settings, ""), /id="sign-out"/);
+});
+
+test("closed Claude tombstones survive reload, stay bounded, and filter only matching terminals", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+  const savedStateSource = app.slice(
+    app.indexOf("function savedStateFromStorage"),
+    app.indexOf("function normalizeDismissedClaudeSessionIds"),
+  );
+  const normalizeSource = app.slice(
+    app.indexOf("function normalizeDismissedClaudeSessionIds"),
+    app.indexOf("function rememberDismissedClaudeSession"),
+  );
+  const filterSource = app.slice(
+    app.indexOf("function isDismissedClaudeSession"),
+    app.indexOf("function activeSession"),
+  );
+  const { savedStateFromStorage, isDismissedClaudeSession } = Function(
+    "MAX_DISMISSED_CLAUDE_SESSIONS",
+    "MAX_PROVIDER_SESSION_ID_LENGTH",
+    `"use strict"; ${normalizeSource}; ${savedStateSource}; ${filterSource}; return { savedStateFromStorage, isDismissedClaudeSession };`,
+  )(64, 128);
+
+  const ids = Array.from({ length: 70 }, (_, index) => `pty-${index}`);
+  const reloaded = savedStateFromStorage(JSON.stringify({
+    version: 2,
+    workspaces: [],
+    dismissedClaudeSessionIds: [...ids, { output: "terminal secret" }, "", "pty-10"],
+  }));
+  assert.equal(reloaded.dismissedClaudeSessionIds.length, 64);
+  assert.equal(reloaded.dismissedClaudeSessionIds[0], "pty-6");
+  assert.equal(reloaded.dismissedClaudeSessionIds.at(-1), "pty-10");
+  assert.equal(JSON.stringify(reloaded).includes("terminal secret"), false);
+
+  const dismissed = new Set(reloaded.dismissedClaudeSessionIds);
+  assert.equal(isDismissedClaudeSession({ provider: "claude", providerSessionId: "pty-10" }, dismissed), true);
+  assert.equal(isDismissedClaudeSession({ provider: "claude", providerSessionId: "pty-1" }, dismissed), false);
+  assert.equal(isDismissedClaudeSession({ provider: "codex", providerSessionId: "pty-10" }, dismissed), false);
+  assert.match(app, /dismissedClaudeSessionIds: normalizeDismissedClaudeSessionIds\(\[\.\.\.dismissedClaudeSessionIds\]\)/);
+  assert.match(app, /const dismissedClaudeSessionIds = new Set\(saved\.dismissedClaudeSessionIds\)/);
+  assert.match(app, /restoreRecentClaudeSessions[\s\S]*?\.filter\(\(session\) => !dismissedClaudeSessionIds\.has\(session\.providerSessionId\)\)/);
+});
+
+test("browser auth smoke targets per-tab composers instead of the removed universal footer", async () => {
+  const smoke = await readFile(new URL("../../scripts/passkey-browser-smoke.mjs", import.meta.url), "utf8");
+
+  assert.match(smoke, /querySelectorAll\('\[data-chat-composer\]'\)\.length/);
+  assert.match(smoke, /document\.querySelector\("\[data-chat-composer\]"\)/);
+  assert.doesNotMatch(smoke, /querySelector\('\.composer'\)|#message-input|#send-message|#composer/);
+  const liveExercise = smoke.slice(
+    smoke.indexOf("async function exerciseLiveWorkbench"),
+    smoke.indexOf("async function createCertificate"),
+  );
+  assert.match(liveExercise, /expectedWorkspaceCount, workspaceCwd, workspaceId/);
+  assert.match(liveExercise, /workspace-list button'\)\.length >= \$\{expectedWorkspaceCount\}/);
+  assert.match(liveExercise, /live Codex QA must target the intended original Project/);
+  assert.match(liveExercise, /event\.label === 'assistant\.message'/);
+  assert.match(liveExercise, /live QA presentation cleanup to one pane/);
+  assert.doesNotMatch(liveExercise, /workspace-list button'\)\.length"\)\) === 1/);
+  assert.doesNotMatch(liveExercise, /event\.label === 'turn\.started'/);
+});

--- a/web/test/chat-shell.test.mjs
+++ b/web/test/chat-shell.test.mjs
@@ -104,6 +104,27 @@ test("account sign-out is nested behind compact settings", async () => {
   assert.doesNotMatch(page.replace(settings, ""), /id="sign-out"/);
 });
 
+test("hidden optional controls cannot displace pane content or bottom-left settings", async () => {
+  const page = await readFile(new URL("index.html", source), "utf8");
+
+  assert.match(page, /\.main-panel \{[^}]*grid-template-areas: "header" "notice" "panes";/);
+  assert.match(page, /\.session-header \{[^}]*grid-area: header;/);
+  assert.match(page, /\.workspace-error \{[^}]*grid-area: notice;/);
+  assert.match(page, /\.pane-root \{[^}]*grid-area: panes;/);
+  assert.match(page, /\.workspace-error:empty \{ display: none; \}/);
+
+  assert.match(page, /\.sidebar \{[^}]*grid-template-areas: "brand" "picker" "projects" "recent" "settings";/);
+  assert.match(page, /\.brand \{[^}]*grid-area: brand;/);
+  assert.match(page, /\.workspace-add \{[^}]*grid-area: picker;/);
+  assert.match(page, /\.workspace-section \{[^}]*grid-area: projects;/);
+  assert.match(page, /\.session-section \{[^}]*grid-area: recent;/);
+  assert.match(page, /\.auth-compact \{[^}]*grid-area: settings;/);
+  assert.match(
+    page,
+    /@media \(max-width: 48rem\) \{[\s\S]*?\.sidebar \{[^}]*grid-template-areas: "brand" "picker" "projects" "recent" "settings";[^}]*grid-template-rows: repeat\(5, auto\);/,
+  );
+});
+
 test("closed Claude tombstones survive reload, stay bounded, and filter only matching terminals", async () => {
   const app = await readFile(new URL("main.js", source), "utf8");
   const savedStateSource = app.slice(

--- a/web/test/chat-shell.test.mjs
+++ b/web/test/chat-shell.test.mjs
@@ -21,6 +21,204 @@ test("each chat tab owns an integrated keyboard-first composer", async () => {
   assert.match(app, /const chatDrafts = new Map\(\)/);
 });
 
+test("per-tab submission clears, locks duplicate sends, and recovers before newer typing", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+  const helpers = app.slice(
+    app.indexOf("function updateChatComposerSendState"),
+    app.indexOf("function captureChatScrollStates"),
+  );
+  const chatDrafts = new Map([["tab-1", "hello"]]);
+  const pendingChatSubmissions = new Set();
+  const send = { disabled: false };
+  const form = { dataset: { tabId: "tab-1" }, querySelector: () => send };
+  const textarea = {
+    closest: () => form,
+    scrollHeight: 64,
+    style: {},
+    value: "hello",
+  };
+  const { clearSubmittedChatDraft, recoverChatDraft, updateChatComposerSendState } = Function(
+    "chatDrafts",
+    "pendingChatSubmissions",
+    "paneRoot",
+    `"use strict"; ${helpers}; return { clearSubmittedChatDraft, recoverChatDraft, updateChatComposerSendState };`,
+  )(chatDrafts, pendingChatSubmissions, { querySelectorAll: () => [textarea] });
+
+  pendingChatSubmissions.add("tab-1");
+  clearSubmittedChatDraft("tab-1", textarea, send);
+  assert.equal(textarea.value, "");
+  assert.equal(send.disabled, true);
+  assert.equal(chatDrafts.has("tab-1"), false);
+  assert.equal(textarea.style.height, "64px");
+  assert.equal(textarea.disabled, undefined, "a pending request must not disable newer typing");
+
+  textarea.value = "new text typed while sending";
+  chatDrafts.set("tab-1", "new text typed while sending");
+  updateChatComposerSendState("tab-1", textarea, send);
+  assert.equal(send.disabled, true, "a pending tab must block a second send");
+  recoverChatDraft("tab-1", "hello");
+  assert.equal(textarea.value, "hello\nnew text typed while sending");
+  assert.equal(chatDrafts.get("tab-1"), textarea.value);
+  assert.equal(send.disabled, true, "failure recovery stays locked until the request settles");
+  pendingChatSubmissions.delete("tab-1");
+  updateChatComposerSendState("tab-1", textarea, send);
+  assert.equal(send.disabled, false, "a settled request unlocks the recovered draft");
+
+  textarea.value = "hello";
+  chatDrafts.set("tab-1", "hello");
+  pendingChatSubmissions.add("tab-1");
+  recoverChatDraft("tab-1", "hello");
+  assert.equal(
+    textarea.value,
+    "hello\nhello",
+    "identical non-empty text is still independent newer typing and must not be deduplicated",
+  );
+  pendingChatSubmissions.delete("tab-1");
+  assert.match(app, /const pendingChatSubmissions = new Set\(\)/);
+  assert.match(app, /if \(!text \|\| pendingChatSubmissions\.has\(tabId\)\) return;/);
+  assert.match(app, /clearSubmittedChatDraft\(tabId, textarea, send\);\s*void submitMessage/);
+  assert.match(app, /catch \(error\) \{\s*recoverChatDraft\(draftKey, text\);/);
+  assert.match(app, /finally \{\s*pendingChatSubmissions\.delete\(draftKey\);\s*render\(\);/);
+});
+
+test("pending submission unlocks after both request success and ordered failure recovery", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+  const submitSource = app.slice(
+    app.indexOf("async function submitMessage"),
+    app.indexOf("async function interrupt"),
+  );
+  const session = { id: "session-1", events: [], provider: "codex" };
+
+  async function exercise(request) {
+    const pending = new Set(["tab-1"]);
+    const order = [];
+    const submitMessage = Function(
+      "chatDrafts",
+      "pendingChatSubmissions",
+      "clearError",
+      "beginWorkbenchMutation",
+      "replaceSession",
+      "render",
+      "request",
+      "recoverChatDraft",
+      "showError",
+      "refreshWorkbench",
+      `"use strict"; ${submitSource}; return submitMessage;`,
+    )(
+      new Map(),
+      pending,
+      () => order.push("clear"),
+      () => order.push("begin"),
+      () => order.push("replace"),
+      () => order.push(`render:${pending.has("tab-1") ? "pending" : "settled"}`),
+      request,
+      () => order.push("recover"),
+      () => order.push("error"),
+      async () => order.push("refresh"),
+    );
+    await submitMessage(session, "hello", "tab-1");
+    return { order, pending };
+  }
+
+  const success = await exercise(async () => ({ ...session, events: [{ role: "user" }] }));
+  assert.equal(success.pending.has("tab-1"), false);
+  assert.deepEqual(success.order, ["clear", "begin", "replace", "render:pending", "replace", "render:settled"]);
+
+  const failure = await exercise(async () => { throw new Error("offline"); });
+  assert.equal(failure.pending.has("tab-1"), false);
+  assert.deepEqual(
+    failure.order,
+    ["clear", "begin", "replace", "render:pending", "recover", "error", "refresh", "render:settled"],
+    "failed text must recover before the pending lock is released",
+  );
+});
+
+test("message rows omit visible role labels and expose resilient copy actions", async () => {
+  const [page, app] = await Promise.all([
+    readFile(new URL("index.html", source), "utf8"),
+    readFile(new URL("main.js", source), "utf8"),
+  ]);
+  const copySource = app.slice(
+    app.indexOf("async function copyChatMessage"),
+    app.indexOf("function renderChatComposer"),
+  );
+  const copied = [];
+  const copyChatMessage = Function(
+    "navigator",
+    `"use strict"; ${copySource}; return copyChatMessage;`,
+  )({ clipboard: { writeText: async (text) => copied.push(text) } });
+  const button = { dataset: {} };
+  const status = { textContent: "" };
+  await copyChatMessage(button, status, "answer text");
+  assert.deepEqual(copied, ["answer text"]);
+  assert.equal(button.dataset.copyState, "copied");
+  assert.equal(status.textContent, "Message copied.");
+
+  const failedCopy = Function(
+    "navigator",
+    `"use strict"; ${copySource}; return copyChatMessage;`,
+  )({ clipboard: { writeText: async () => { throw new Error("denied"); } } });
+  await failedCopy(button, status, "preserved answer");
+  assert.equal(button.dataset.copyState, "unavailable");
+  assert.match(status.textContent, /conversation is unchanged/);
+
+  assert.match(app, /item\.querySelector\("header"\)\?\.remove\(\)/);
+  assert.match(app, /item\.setAttribute\("aria-label", item\.classList\.contains\("chat-event--user"\) \? "Your message" : "Assistant message"\)/);
+  assert.match(app, /iconButton\("Copy message", "Copy message",/);
+  assert.match(app, /copy\.dataset\.chatCopyKey = `\$\{tabId\}:\$\{messageIndex\}`/);
+  assert.match(app, /status\.setAttribute\("aria-live", "polite"\)/);
+  assert.match(page, /\.chat-event--message:hover \.chat-event__copy/);
+  assert.match(page, /@media \(hover: none\), \(pointer: coarse\) \{[\s\S]*?\.chat-event__copy \{[^}]*min-height: 2\.75rem;[^}]*opacity: 1;[^}]*pointer-events: auto;[^}]*width: 2\.75rem;/);
+  assert.doesNotMatch(page, /chat-event--thinking/);
+  assert.doesNotMatch(page, /\.chat-event__role/);
+});
+
+test("copy focus and feedback survive a pane replacement by stable message key", async () => {
+  const app = await readFile(new URL("main.js", source), "utf8");
+  const helpers = app.slice(
+    app.indexOf("function captureChatCopyState"),
+    app.indexOf("async function copyChatMessage"),
+  );
+  const originalStatus = { textContent: "Message copied." };
+  const original = {
+    dataset: { chatCopyKey: "tab-2:1", copyState: "copied" },
+    matches: (selector) => selector === "[data-chat-copy-key]",
+    parentElement: { querySelector: () => originalStatus },
+  };
+  const sourceRoot = {
+    ownerDocument: { activeElement: original },
+    querySelectorAll: () => [original],
+  };
+  const queued = [];
+  const { captureChatCopyState, restoreChatCopyState } = Function(
+    "queueMicrotask",
+    `"use strict"; ${helpers}; return { captureChatCopyState, restoreChatCopyState };`,
+  )((callback) => queued.push(callback));
+  const state = captureChatCopyState(sourceRoot);
+  assert.equal(state.focusedKey, "tab-2:1");
+  assert.deepEqual(state.feedback.get("tab-2:1"), {
+    copyState: "copied",
+    status: "Message copied.",
+  });
+
+  const replacementStatus = { textContent: "" };
+  let focusOptions;
+  const replacement = {
+    dataset: { chatCopyKey: "tab-2:1" },
+    focus: (options) => { focusOptions = options; },
+    isConnected: true,
+    parentElement: { querySelector: () => replacementStatus },
+  };
+  restoreChatCopyState({ querySelectorAll: () => [replacement] }, state);
+  assert.equal(replacement.dataset.copyState, "copied");
+  assert.equal(replacementStatus.textContent, "Message copied.");
+  assert.equal(queued.length, 1);
+  queued.shift()();
+  assert.deepEqual(focusOptions, { preventScroll: true });
+  assert.match(app, /const chatCopyState = captureChatCopyState\(paneRoot\)/);
+  assert.match(app, /restoreChatCopyState\(paneRoot, chatCopyState\)/);
+});
+
 test("chat refresh follows only readers already near the bottom", async () => {
   const app = await readFile(new URL("main.js", source), "utf8");
 

--- a/web/test/chat.test.mjs
+++ b/web/test/chat.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { eventPresentation, sessionMayHaveMoreEvents } from "../src/chat.js";
+import { eventPresentation, normalizeChatEvents, sessionMayHaveMoreEvents } from "../src/chat.js";
 
 test("one shared chat timeline gives provider-neutral event roles stable, honest presentations", () => {
   assert.deepEqual(eventPresentation({ role: "user", label: "message.sent", text: "hello" }), {
@@ -24,6 +24,42 @@ test("one shared chat timeline gives provider-neutral event roles stable, honest
   });
   assert.equal(eventPresentation({ role: "unknown" }).roleLabel, "Status");
   assert.equal(eventPresentation({ role: "unknown" }).eventLabel, "session.update");
+  assert.equal(eventPresentation({ role: "system", kind: "error" }).tone, "error");
+});
+
+test("assistant deltas coalesce and a cumulative completion replaces the streamed text", () => {
+  const events = normalizeChatEvents([
+    { role: "assistant", kind: "message", label: "assistant.message.delta", text: "Hel", sequence: 1 },
+    { role: "assistant", kind: "message", label: "assistant.message.delta", text: "lo", sequence: 2 },
+    { role: "assistant", kind: "message", label: "assistant.message.delta", text: " ", sequence: 3 },
+    { role: "assistant", kind: "message", label: "assistant.message.delta", text: "world", sequence: 4 },
+    { role: "assistant", kind: "message", label: "assistant.message", text: "Hello world", sequence: 5 },
+  ]);
+
+  assert.deepEqual(events, [
+    { role: "assistant", kind: "message", label: "assistant.message", text: "Hello world", sequence: 5 },
+  ]);
+});
+
+test("routine provider status is hidden while errors, approvals, and tools remain", () => {
+  const events = normalizeChatEvents([
+    { role: "system", kind: "status", label: "session.started", text: "Provider connected" },
+    { role: "system", kind: "status", label: "remote_control.status", text: "remote control status" },
+    { role: "system", kind: "status", label: "turn.started", text: "turn started" },
+    { role: "system", kind: "status", label: "approval.request", text: "Approval required" },
+    { role: "system", kind: "error", label: "provider.error", text: "Provider failed", signal: "degraded" },
+    { role: "system", kind: "tool", label: "tool.started", text: "tool search" },
+  ]);
+
+  assert.deepEqual(events.map(({ label }) => label), ["approval.request", "provider.error", "tool.started"]);
+});
+
+test("a non-streamed completed assistant message is never dropped", () => {
+  assert.deepEqual(normalizeChatEvents([
+    { role: "assistant", kind: "message", label: "assistant.message", text: "Complete answer" },
+  ]), [
+    { role: "assistant", kind: "message", label: "assistant.message", text: "Complete answer" },
+  ]);
 });
 
 test("nonterminal degraded sessions keep polling for later provider events", () => {

--- a/web/test/remove-tree-retry.test.mjs
+++ b/web/test/remove-tree-retry.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { removeTreeWithRetry } from "../../scripts/remove-tree-retry.mjs";
+
+test("temporary tree cleanup retries only bounded transient filesystem failures", async () => {
+  const delays = [];
+  let attempts = 0;
+  await removeTreeWithRetry("/tmp/browser-profile", {
+    maxAttempts: 4,
+    remove: async () => {
+      attempts += 1;
+      if (attempts < 3) throw Object.assign(new Error("profile busy"), { code: "ENOTEMPTY" });
+    },
+    wait: async (delayMs) => { delays.push(delayMs); },
+  });
+  assert.equal(attempts, 3);
+  assert.deepEqual(delays, [25, 50]);
+
+  attempts = 0;
+  await assert.rejects(
+    removeTreeWithRetry("/tmp/browser-profile", {
+      remove: async () => {
+        attempts += 1;
+        throw Object.assign(new Error("access denied"), { code: "EACCES" });
+      },
+      wait: async () => {},
+    }),
+    { code: "EACCES" },
+  );
+  assert.equal(attempts, 1);
+});
+
+test("temporary tree cleanup surfaces the last error after its retry budget", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    removeTreeWithRetry("/tmp/browser-profile", {
+      maxAttempts: 3,
+      remove: async () => {
+        attempts += 1;
+        throw Object.assign(new Error(`busy ${attempts}`), { code: "EBUSY" });
+      },
+      wait: async () => {},
+    }),
+    (error) => error.code === "EBUSY" && error.message === "busy 3",
+  );
+  assert.equal(attempts, 3);
+});

--- a/web/test/workspace-layout.test.mjs
+++ b/web/test/workspace-layout.test.mjs
@@ -14,6 +14,8 @@ import {
   canUseLiveSessionActions,
   closeSelectedPane,
   createWorkspaceLayout,
+  detachTabToNewPane,
+  layoutMetrics,
   moveTab,
   moveSelectedPane,
   openSessionTab,
@@ -180,6 +182,105 @@ test("opening, dragging, and resizing Session tabs remains a bounded presentatio
   );
 });
 
+test("detaching a tab creates a selected sibling split without cloning Session references", () => {
+  let state = createWorkspaceLayout({ sessionId: "session-opaque-20" });
+  state = openSessionTab(state, "session-opaque-21", "Codex session");
+  state = openSessionTab(state, "session-opaque-22", "Hermes session");
+  const sourcePaneId = state.layout.id;
+  const detachedTabId = state.layout.tabs[1].id;
+  const sourceActiveTabId = state.layout.tabs[2].id;
+
+  state = detachTabToNewPane(state, {
+    sourcePaneId,
+    tabId: detachedTabId,
+    placement: "before",
+  });
+
+  assert.equal(state.layout.kind, "split");
+  assert.equal(state.layout.first.id, state.selectedPaneId);
+  assert.equal(state.layout.first.tabs[0].id, detachedTabId);
+  assert.equal(state.layout.first.tabs[0].content.sessionId, "session-opaque-21");
+  assert.equal(state.layout.second.id, sourcePaneId);
+  assert.equal(state.layout.second.activeTabId, sourceActiveTabId);
+  assert.deepEqual(sessionIds(state), ["session-opaque-21", "session-opaque-20", "session-opaque-22"]);
+  assert.deepEqual(layoutMetrics(state), { paneCount: 2, tabCount: 3, maxDepth: 1 });
+});
+
+test("detaching a sole tab mirrors its Session reference into a selected sibling pane", () => {
+  const singleTab = createWorkspaceLayout({ sessionId: "session-opaque-22" });
+  const sourceTab = singleTab.layout.tabs[0];
+  const detached = detachTabToNewPane(singleTab, {
+    sourcePaneId: singleTab.layout.id,
+    tabId: sourceTab.id,
+  });
+
+  assert.equal(detached.layout.kind, "split");
+  assert.equal(detached.layout.first.tabs[0].id, sourceTab.id);
+  assert.equal(detached.layout.second.id, detached.selectedPaneId);
+  assert.notEqual(detached.layout.second.tabs[0].id, sourceTab.id);
+  assert.equal(detached.layout.second.tabs[0].title, `${sourceTab.title} mirror`);
+  assert.deepEqual(sessionIds(detached), ["session-opaque-22", "session-opaque-22"]);
+  assert.deepEqual(layoutMetrics(detached), { paneCount: 2, tabCount: 2, maxDepth: 1 });
+});
+
+test("detaching a tab enforces placement, pane-count, and tab-count invariants", () => {
+  const singleTab = createWorkspaceLayout({ sessionId: "session-opaque-23" });
+  assert.throws(
+    () => detachTabToNewPane(singleTab, {
+      sourcePaneId: singleTab.layout.id,
+      tabId: singleTab.layout.tabs[0].id,
+      placement: "sideways",
+    }),
+    /placement must be before or after/,
+  );
+
+  let capped = singleTab;
+  capped = detachTabToNewPane(capped, {
+    sourcePaneId: capped.layout.id,
+    tabId: capped.layout.tabs[0].id,
+  });
+  capped = detachTabToNewPane(capped, {
+    sourcePaneId: capped.selectedPaneId,
+    tabId: activeSessionTab(capped).tab.id,
+  });
+  capped = detachTabToNewPane(capped, {
+    sourcePaneId: capped.selectedPaneId,
+    tabId: activeSessionTab(capped).tab.id,
+  });
+  assert.throws(
+    () => detachTabToNewPane(capped, {
+      sourcePaneId: capped.selectedPaneId,
+      tabId: activeSessionTab(capped).tab.id,
+    }),
+    (error) => error instanceof LayoutLimitError && error.code === "pane-cap",
+  );
+
+  let tabCapped = createWorkspaceLayout({ sessionId: "session-opaque-tab-cap" });
+  for (let count = 1; count < 4; count += 1) tabCapped = addSessionTab(tabCapped);
+  const rootPaneId = tabCapped.layout.id;
+  tabCapped = detachTabToNewPane(tabCapped, {
+    sourcePaneId: rootPaneId,
+    tabId: activeSessionTab(tabCapped).tab.id,
+  });
+  const firstMirrorPaneId = tabCapped.selectedPaneId;
+  tabCapped = selectTab(tabCapped, rootPaneId, tabCapped.layout.first.activeTabId);
+  tabCapped = addSessionTab(tabCapped);
+  tabCapped = detachTabToNewPane(tabCapped, {
+    sourcePaneId: rootPaneId,
+    tabId: activeSessionTab(tabCapped).tab.id,
+  });
+  tabCapped = selectTab(tabCapped, rootPaneId, tabCapped.layout.first.first.activeTabId);
+  tabCapped = addSessionTab(tabCapped);
+  assert.equal(layoutMetrics(tabCapped).tabCount, MAX_TAB_COUNT);
+  assert.throws(
+    () => detachTabToNewPane(tabCapped, {
+      sourcePaneId: firstMirrorPaneId,
+      tabId: tabCapped.layout.second.tabs[0].id,
+    }),
+    (error) => error instanceof LayoutLimitError && error.code === "tab-cap",
+  );
+});
+
 test("attaching an already-owned Session replaces only the selected opaque layout reference", () => {
   const initial = createWorkspaceLayout({ sessionId: "session-opaque-14" });
   const attached = attachSessionToSelectedTab(initial, "session-opaque-15", "Attached session");
@@ -199,4 +300,13 @@ test("closing a provider Session removes only its presentation references", () =
   assert.deepEqual(sessionIds(state), ["session-opaque-12"]);
   assert.equal(state.layout.kind, "tabs");
   assert.equal(activeSessionTab(state).tab.content.sessionId, "session-opaque-12");
+});
+
+test("closing the final provider Session removes its last tab and pane instead of retaining a shadow layout", () => {
+  let state = createWorkspaceLayout({ sessionId: "session-opaque-final" });
+  state = splitSelectedPane(state);
+
+  const removed = removeSessionFromLayout(state, "session-opaque-final");
+
+  assert.equal(removed, null);
 });


### PR DESCRIPTION
## Summary

- coalesce Codex token deltas into one assistant turn and replace them with the authoritative final snapshot
- compact routine provider lifecycle, token-usage, and rate-limit notifications while preserving real errors, approvals, tools, and unknown protocol events
- move the composer into each chat pane with Enter/Ctrl/Cmd send, Shift+Enter newline, per-tab drafts, autosizing, and integrated send affordance
- render user and assistant turns as a real conversation with stable near-bottom scrolling and restrained scrollbars
- clear submitted drafts before optimistic rerenders, serialize sends per tab, and recover failed text ahead of any newer typing
- remove visible user/assistant labels while preserving accessible ownership and adding hover, keyboard, and touch copy actions
- support edge-drag tab splitting, remove final-session ghost panes, and move sign-out behind compact settings
- harden Chromium smoke cleanup and cover the new shell, streaming, layout, and lifecycle behavior

## Root cause

Codex incremental deltas and cumulative completion snapshots were both appended as independent transcript rows. The web shell also owned one global composer and rebuilt the active pane on every refresh, which reset focus, selection, and scroll state. An optimistic send deleted the saved draft but rerendering captured the still-populated focused textarea back into storage. Layout removal and tab splitting did not model the final-session and sole-tab cases.

## Verification

- exact commit: `bd864cc6bb7498e4fb353da51b966143c19fc229`
- tested Git tree: `a0ecb2a88dabf833e0514d677c19e29b08778916`
- `npm run lint`
- `npm test` — 170 Rust tests and 57 web tests; factory, passkey HTTP, and Chromium browser smokes passed
- `npm run build`
- live Codex app-server turn: assistant returned exactly `relay`; transcript labels were only `message.sent` and `assistant.message`; session remained idle/non-degraded; zero page errors
- live chat UX proof: composer cleared immediately and remained empty after actual node replacement; visible role labels `0`; accessible article names retained; two copy actions present; copy focus and feedback survived a pane rerender
- layout regression proof: pane bottom gap remained `0px` and pane height remained `431.41px` across Settings open/close and a render-triggering Project selection; Settings stayed `12px` from the sidebar left/bottom edges
- terminal replay smoke derives its expected marker count from the authoritative PTY snapshot and requires render quiescence, removing a CI timing race without weakening duplicate detection
- adversarial review plus focused re-review completed with no unresolved P0/P1 findings

## Deployment

- live URL: `https://dev.fish-rattlesnake.ts.net:1151`
- immutable artifact: `/home/donovanyohan/.local/share/relay-1151-preview/bd864cc6bb7498e4fb353da51b966143c19fc229`
- web, hub, and Hermes dashboard services active with zero restarts; listeners confirmed on `4173`, `8787`, and `19120`
- local and tailnet `/health` return healthy; `/source-sha.txt` returns exact `bd864cc6bb7498e4fb353da51b966143c19fc229`
- protected `/api/workspaces` remains `401` locally and over tailnet
- live local/tail `index.html` and `main.js` hashes match the immutable artifact; Tailscale routing remained unchanged
- rollback snapshot: `/home/donovanyohan/.local/share/relay-1151-preview/rollback-bd864cc6-precutover`
