### PR TITLE
feat(channels): channel conversation core — durable store, multi-sender protocol, WS fan-out

### DIFF
--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -25,7 +25,7 @@ here).
 The old model was **session = conversation** (one chat bound to one agent
 process). The pivot inverts it:
 
-- **Channel = conversation.** Agents are *participants* in a channel, not the
+- **Channel = conversation.** Agents are _participants_ in a channel, not the
   channel itself.
 - **DM = a 2-member channel** (one human, one agent). No separate DM primitive.
 - **@-mention routes** a message into an adapter session bound to
@@ -39,15 +39,15 @@ process). The pivot inverts it:
 The substrate below already exists in code; the channel-chat product is new
 wiring over it. Verified 2026-07-17 against source:
 
-| Concept          | Primitive (SHIPPED)                                                    | Notes                                                                                                    |
-| ---------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Workspace        | `ia_workspaces` (`server/ia-store.ts`, epic #1021)                     | Rail entries: `status`, `pinned`, `color`, `icon`, `default_repo_path`, `default_node_id`.               |
-| Channel          | `workspace_topics` (`server/workspace-topics.ts`)                     | Record carries `routingDefaults`, `promptDefaults`, and channel `kind` = repo/product-area/journal/ops/research/topic. |
-| Message store    | `work_context_messages` (`server/work-context-messages.ts`)          | Columns include `thread_id`, `parent_message_id`, `sender_kind`/`sender_id`, `audience_json`, `visibility`. |
-| Mention targets  | Agent roster (`shared/agent-roster.ts`, #952/#953)                    | `RosterEntry.provider` = framework id (`claude`/`codex`/`hermes`); derived per live session.              |
-| Agent transport  | `ProtocolAdapterV2` (`server/protocol-adapter-v2.ts`, `protocol-adapters/index.ts`) | v2 registry: `mock`, `claude`, `codex` (native), `opencode`/`hermes` via legacy bridge.                  |
+| Concept         | Primitive (SHIPPED)                                                                 | Notes                                                                                                                                                                                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Workspace       | `ia_workspaces` (`server/ia-store.ts`, epic #1021)                                  | Rail entries: `status`, `pinned`, `color`, `icon`, `default_repo_path`, `default_node_id`.                                                                                                                                                                 |
+| Channel         | `workspace_topics` (`server/workspace-topics.ts`)                                   | Record carries `routingDefaults`, `promptDefaults`, and channel `kind` = repo/product-area/journal/ops/research/topic. Channel identity = topic id.                                                                                                        |
+| Message store   | `channel_messages` (`server/channel-message-store.ts`, #1165 SHIPPED)               | New durable `channel-chat.db`: per-channel gap-free `seq`, streaming lifecycle, `sender_kind`/`sender_id`, `thread_id`/`parent_message_id`, `source_*` bridge provenance. `work_context_messages` is agent-mail (#945), a deliberately separate substrate. |
+| Mention targets | Agent roster (`shared/agent-roster.ts`, #952/#953)                                  | `RosterEntry.provider` = framework id (`claude`/`codex`/`hermes`); derived per live session.                                                                                                                                                               |
+| Agent transport | `ProtocolAdapterV2` (`server/protocol-adapter-v2.ts`, `protocol-adapters/index.ts`) | v2 registry: `mock`, `claude`, `codex` (native), `opencode`/`hermes` via legacy bridge.                                                                                                                                                                    |
 
-**Verification nuance:** the roster is *derived from live sessions* and keyed by
+**Verification nuance:** the roster is _derived from live sessions_ and keyed by
 `sessionId` + `provider`, not a persistent per-agent handle registry. So
 `@claude` resolves to a framework/provider id, and spawn-on-first-mention must
 bind `(channel, agent-framework)` and create the session — it cannot assume a
@@ -74,6 +74,40 @@ This replaces the current `ClaudeProtocolAdapter` (`claude-adapter.ts`), which
 drives Claude through the Anthropic Agent SDK (`@anthropic-ai/claude-agent-sdk`
 `query()`) and is de-advertised for web sessions under #300.
 
+## Slice 2 — Channel core (SHIPPED, #1165)
+
+The conversation substrate is live and fully additive (`web_sessions`, `/ws/:sessionId`,
+agent mail, and every adapter are untouched):
+
+- **Durable store** `server/channel-message-store.ts` (`channel-chat.db`): atomic
+  single-statement `seq` allocation with a `UNIQUE(channel_id, seq)` backstop,
+  streaming rows (begin → debounced partial-text flush → finalize in place),
+  boot sweep of stale `streaming` → `interrupted` (+ system message), orphan GC
+  against the topic store, source-triple and `clientMessageId` idempotency, 256KB
+  per-message cap. **Unread arithmetic must count by seq range; catch-up is always
+  DB-backed** (the durable seq log is the replay buffer — there is no event ring).
+- **Wire protocol** `shared/channel-chat-protocol.ts`: `ChannelEventV1` (snapshot /
+  created / delta / completed / resync-required), a runtime validator, a pure
+  self-diagnosing reducer (gap → `needsCatchup`, `deltaIndex` + quarantine per
+  message), and `parseMentions`. **`AgentPatchV2` is not extended** — a server-side
+  bridge translates instead, so no adapter changes.
+- **Fan-out** `server/channel-hub.ts` + `GET /ws/channels/:channelId?sinceSeq=N`:
+  server→client only, register-before-snapshot connect with snapshot/live dedupe,
+  50ms delta coalescing, per-socket backpressure (suppress deltas → resync → 4409),
+  and coarse `channel-activity` sidebar badges on `/ws/events`.
+- **Verbs** `server/channel-chat-router.ts`: `channels.list/get/history/post`
+  (REST-only writes, one internal `postToChannel`). **Sender is server-derived from
+  the auth lane, never the request body**; derived/archived topics are rejected;
+  the verbs are wired into the CLI-gateway capability map.
+- **Slice-4 seam** `server/channel-agent-bridge.ts`: `AgentPatchV2` → channel
+  lifecycle translation, shipped and contract-tested but unwired until #1167.
+
+**Privacy note:** channel message bodies are stored **raw**, with no redaction
+pipeline (unlike the `work_context_messages` sanitizer,
+`shared/work-context-message.ts`). This is consistent with `agent_session_v2_json`
+today, but is a standing privacy posture decision to revisit before any
+`visibility:'shared'` / multi-user channel.
+
 ## Live proof gate (PLANNED)
 
 Token-frugal testing against **real** Claude / Codex accounts — hello-world
@@ -85,17 +119,17 @@ prompts only, no burn. Proof matrix:
 
 ## Ladder (epic #1163)
 
-| Slice   | Scope                                                                 |
-| ------- | --------------------------------------------------------------------- |
-| #1164   | Debt clear — retire v1 chat surface / kill-list items below.          |
-| #1165   | Channel core — channel = conversation model over the substrate.       |
-| #1166   | Channel UI + DM-as-channel.                                           |
-| #1167   | `@`-mentions — route mention → `(channel, agent)` session, spawn-on-first. |
-| #1168   | Claude subprocess adapter (native stream-json, warm pool, `--resume`).|
-| #1169   | Multi-agent live proof + Codex revive.                                |
-| #1170   | Threads (`parent_message_id` / `thread_id`).                          |
-| #1171   | Mobile cockpit (mission control).                                     |
-| #1172   | Tauri desktop suite (backlog).                                        |
+| Slice | Scope                                                                      |
+| ----- | -------------------------------------------------------------------------- |
+| #1164 | Debt clear — retire v1 chat surface / kill-list items below.               |
+| #1165 | Channel core — channel = conversation model over the substrate.            |
+| #1166 | Channel UI + DM-as-channel.                                                |
+| #1167 | `@`-mentions — route mention → `(channel, agent)` session, spawn-on-first. |
+| #1168 | Claude subprocess adapter (native stream-json, warm pool, `--resume`).     |
+| #1169 | Multi-agent live proof + Codex revive.                                     |
+| #1170 | Threads (`parent_message_id` / `thread_id`).                               |
+| #1171 | Mobile cockpit (mission control).                                          |
+| #1172 | Tauri desktop suite (backlog).                                             |
 
 ## Kill list (PLANNED removal)
 

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -94,11 +94,18 @@ agent mail, and every adapter are untouched):
 - **Fan-out** `server/channel-hub.ts` + `GET /ws/channels/:channelId?sinceSeq=N`:
   server→client only, register-before-snapshot connect with snapshot/live dedupe,
   50ms delta coalescing, per-socket backpressure (suppress deltas → resync → 4409),
-  and coarse `channel-activity` sidebar badges on `/ws/events`.
+  and coarse `channel-activity` sidebar badges on `/ws/events`. Connect flushes
+  pending accumulator text before the snapshot (so a mid-stream connector never
+  double-renders); catch-up also re-sends any streaming row that finalized while
+  the client was disconnected; a cursor ahead of the server head forces a full
+  snapshot (client reset); snapshot/catch-up assembly is byte-bounded (~4MB →
+  `truncated`, client pages the rest via `channels.history`).
 - **Verbs** `server/channel-chat-router.ts`: `channels.list/get/history/post`
   (REST-only writes, one internal `postToChannel`). **Sender is server-derived from
   the auth lane, never the request body**; derived/archived topics are rejected;
-  the verbs are wired into the CLI-gateway capability map.
+  the verbs are wired into the CLI-gateway capability map. `channels.history`
+  responses are byte-bounded (~4MB); on overflow they return `hasMore: true` and a
+  `nextCursor` (`afterSeq`/`beforeSeq`) so the client fetches the remainder in pages.
 - **Slice-4 seam** `server/channel-agent-bridge.ts`: `AgentPatchV2` → channel
   lifecycle translation, shipped and contract-tested but unwired until #1167.
 

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -58,6 +58,11 @@ export function bindSessionToChannel(
 ): () => void {
   const { channelId, agentFramework, adapter, store, hub } = input;
   const streams = new Map<string, BridgeStream>();
+  // Item ids started as `assistantMessage`. Only these may open/mirror a channel
+  // stream. Plan/reasoning/tool items also carry `delta.text` on real adapters
+  // (e.g. the codex-native plan item `plan-<turnId>`), and §6.3 mirrors ONLY
+  // assistantMessage text — so a delta for any other item type is dropped.
+  const assistantItemIds = new Set<string>();
 
   const sender: ChannelSenderRef = {
     kind: 'agent',
@@ -178,6 +183,7 @@ export function bindSessionToChannel(
     switch (patch.type) {
       case 'agent-item-started-v2': {
         if (patch.item.type === 'assistantMessage') {
+          assistantItemIds.add(patch.item.id);
           openStream(
             patch.turnId,
             patch.item.id,
@@ -189,10 +195,15 @@ export function bindSessionToChannel(
       }
       case 'agent-item-delta-v2': {
         if (typeof patch.delta.text !== 'string') break;
-        // Lazy-open when an adapter emits text deltas without a started event.
-        const stream =
-          streams.get(patch.itemId) ??
-          openStream(patch.turnId, patch.itemId, patch.sessionId, '');
+        let stream = streams.get(patch.itemId);
+        if (!stream) {
+          // Lazy-open ONLY for an item started as an assistantMessage — never for
+          // plan/reasoning/tool items (whose text is not mirrored, §6.3) nor for
+          // an item whose type we have not seen. Mirroring a plan-item delta here
+          // would persist plan text as an agent-authored channel message.
+          if (!assistantItemIds.has(patch.itemId)) break;
+          stream = openStream(patch.turnId, patch.itemId, patch.sessionId, '');
+        }
         appendDelta(stream, patch.delta.text);
         break;
       }

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -1,0 +1,228 @@
+import { createLogger } from './logger.js';
+import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
+import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
+import type { ChannelHub } from './channel-hub.js';
+import type { ChannelMessageStore } from './channel-message-store.js';
+import {
+  CHANNEL_MESSAGE_BODY_MAX_BYTES,
+  type ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+const logger = createLogger('channel-agent-bridge');
+
+// Adapter→channel bridge (#1165, unwired seam for slice 4 / #1167). Consumes ONLY
+// the `ProtocolAdapterV2` onPatch contract and translates the multi-item agent
+// stream into channel message lifecycle rows. Because it assumes no SDK shape,
+// hermes/opencode (via LegacyProtocolAdapterV2Bridge) and #1168's stream-json
+// Claude subprocess adapter plug in with ZERO bridge changes.
+//
+// Translation table (§6.3):
+//   agent-item-started-v2 (assistantMessage) / first text delta → beginStream + created(streaming)
+//   agent-item-delta-v2 (text)                                   → coalesced delta + debounced updateStreamText
+//   agent-item-updated-v2 (final assistantMessage) / turn-completed → finalize('complete') + completed
+//   agent-error-v2                                               → finalize('failed') + completed
+//   bound session dies/disposed mid-stream (unbind)             → finalize('interrupted') + completed
+//   non-text items / live-state                                 → NOT mirrored (mechanics stay in agentSessionV2)
+
+/** debounce partial-text flush to disk (same shape as relay-state-db throttled scheduler). */
+const FLUSH_DEBOUNCE_MS = 500;
+const FLUSH_MAX_WAIT_MS = 2000;
+
+interface BridgeStream {
+  messageId: string;
+  turnId: string;
+  itemId: string;
+  text: string;
+  byteLength: number;
+  closed: boolean;
+  flushTimer: NodeJS.Timeout | null;
+  firstScheduledAt: number | null;
+}
+
+export interface BindSessionToChannelInput {
+  channelId: string;
+  agentFramework: string;
+  adapter: ProtocolAdapterV2;
+  store: ChannelMessageStore;
+  hub: ChannelHub;
+  displayName?: string;
+}
+
+/**
+ * Bind a live adapter session's patch stream to a channel. Returns an unbind
+ * function; calling it unsubscribes the patch listener and finalizes any still-
+ * open stream as `interrupted` (session death mid-stream leaves no stuck ghost).
+ */
+export function bindSessionToChannel(
+  input: BindSessionToChannelInput
+): () => void {
+  const { channelId, agentFramework, adapter, store, hub } = input;
+  const streams = new Map<string, BridgeStream>();
+
+  const sender: ChannelSenderRef = {
+    kind: 'agent',
+    id: `agent:${agentFramework}`,
+    providerId: agentFramework,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+  };
+
+  function openStream(
+    turnId: string,
+    itemId: string,
+    sessionId: string,
+    initialText: string
+  ): BridgeStream {
+    const existing = streams.get(itemId);
+    if (existing) return existing;
+    const message = store.beginStream({
+      channelId,
+      sender,
+      source: { sessionId, turnId, itemId },
+      ...(initialText ? { text: initialText } : {}),
+    });
+    const stream: BridgeStream = {
+      messageId: message.id,
+      turnId,
+      itemId,
+      text: message.body.text,
+      byteLength: Buffer.byteLength(message.body.text, 'utf8'),
+      closed: message.status !== 'streaming',
+      flushTimer: null,
+      firstScheduledAt: null,
+    };
+    streams.set(itemId, stream);
+    hub.beginStreamBroadcast(message);
+    return stream;
+  }
+
+  function scheduleFlush(stream: BridgeStream): void {
+    const now = Date.now();
+    if (stream.firstScheduledAt === null) stream.firstScheduledAt = now;
+    if (stream.flushTimer) clearTimeout(stream.flushTimer);
+    const elapsed = now - stream.firstScheduledAt;
+    const delay = Math.min(
+      FLUSH_DEBOUNCE_MS,
+      Math.max(0, FLUSH_MAX_WAIT_MS - elapsed)
+    );
+    stream.flushTimer = setTimeout(() => {
+      stream.flushTimer = null;
+      stream.firstScheduledAt = null;
+      if (stream.closed) return;
+      try {
+        store.updateStreamText(stream.messageId, stream.text);
+      } catch (err) {
+        logger.warn('channel bridge flush failed:', err);
+      }
+    }, delay);
+    stream.flushTimer.unref?.();
+  }
+
+  function appendDelta(stream: BridgeStream, text: string): void {
+    if (stream.closed || text.length === 0) return;
+    const addBytes = Buffer.byteLength(text, 'utf8');
+    if (stream.byteLength + addBytes > CHANNEL_MESSAGE_BODY_MAX_BYTES) {
+      // 256KB accumulator cap: force-finalize truncated, drop remaining deltas.
+      finalize(stream, 'complete', stream.text, true);
+      return;
+    }
+    stream.text += text;
+    stream.byteLength += addBytes;
+    hub.pushDelta(stream.messageId, text);
+    scheduleFlush(stream);
+  }
+
+  function finalize(
+    stream: BridgeStream,
+    status: 'complete' | 'interrupted' | 'failed',
+    text: string,
+    truncated = false
+  ): void {
+    if (stream.closed) return;
+    stream.closed = true;
+    if (stream.flushTimer) {
+      clearTimeout(stream.flushTimer);
+      stream.flushTimer = null;
+    }
+    let message;
+    try {
+      message = store.finalizeStream(stream.messageId, {
+        text,
+        status,
+        ...(truncated ? { truncated: true } : {}),
+      });
+    } catch (err) {
+      logger.warn('channel bridge finalize failed:', err);
+      return;
+    }
+    if (!message) return;
+    hub.completeStreamBroadcast(message);
+    try {
+      store.upsertMember({ channelId, kind: 'agent', id: sender.id });
+    } catch (err) {
+      logger.warn('channel bridge member upsert failed:', err);
+    }
+  }
+
+  function finalizeTurn(
+    turnId: string | undefined,
+    status: 'complete' | 'failed'
+  ): void {
+    for (const stream of streams.values()) {
+      if (stream.closed) continue;
+      if (turnId !== undefined && stream.turnId !== turnId) continue;
+      finalize(stream, status, stream.text);
+    }
+  }
+
+  function handlePatch(patch: AgentPatchV2): void {
+    switch (patch.type) {
+      case 'agent-item-started-v2': {
+        if (patch.item.type === 'assistantMessage') {
+          openStream(
+            patch.turnId,
+            patch.item.id,
+            patch.sessionId,
+            patch.item.text ?? ''
+          );
+        }
+        break;
+      }
+      case 'agent-item-delta-v2': {
+        if (typeof patch.delta.text !== 'string') break;
+        // Lazy-open when an adapter emits text deltas without a started event.
+        const stream =
+          streams.get(patch.itemId) ??
+          openStream(patch.turnId, patch.itemId, patch.sessionId, '');
+        appendDelta(stream, patch.delta.text);
+        break;
+      }
+      case 'agent-item-updated-v2': {
+        if (patch.item.type !== 'assistantMessage') break;
+        const stream = streams.get(patch.item.id);
+        if (stream) finalize(stream, 'complete', patch.item.text);
+        break;
+      }
+      case 'agent-turn-completed-v2': {
+        finalizeTurn(patch.turnId, 'complete');
+        break;
+      }
+      case 'agent-error-v2': {
+        finalizeTurn(patch.turnId, 'failed');
+        break;
+      }
+      default:
+        // Non-text items (commandExecution/fileChange/approvals/reasoning),
+        // agent-live-state-updated-v2, session snapshots — not mirrored.
+        break;
+    }
+  }
+
+  const unlisten = adapter.onPatch(handlePatch);
+
+  return () => {
+    unlisten();
+    for (const stream of streams.values()) {
+      if (!stream.closed) finalize(stream, 'interrupted', stream.text);
+    }
+  };
+}

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -27,12 +27,58 @@ const CONTEXT_WRITE = 'context:write';
 
 const DEFAULT_KNOWN_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
 
+/**
+ * Byte budget for one REST history response. Rows are row-bounded (max 200) but
+ * each body is capped at 256KB, so an unbudgeted page could reach ~51MB. We stop
+ * at the budget and return a `nextCursor` so the client fetches the rest in pages.
+ */
+const DEFAULT_HISTORY_MAX_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Trim a history page to the byte budget. `forward` (afterSeq) keeps the
+ * oldest-first rows and continues via `afterSeq`; `backward` (default/beforeSeq)
+ * keeps the newest rows and continues via `beforeSeq`. Always keeps ≥1 row.
+ */
+function budgetHistoryRows(
+  messages: ChannelMessage[],
+  direction: 'forward' | 'backward',
+  maxBytes: number
+): {
+  rows: ChannelMessage[];
+  hasMore: boolean;
+  nextCursor?: Record<string, number>;
+} {
+  if (messages.length === 0) return { rows: [], hasMore: false };
+  const order = direction === 'backward' ? [...messages].reverse() : messages;
+  const kept: ChannelMessage[] = [];
+  let bytes = 0;
+  let truncated = false;
+  for (const message of order) {
+    const size = Buffer.byteLength(JSON.stringify(message), 'utf8') + 1;
+    if (kept.length > 0 && bytes + size > maxBytes) {
+      truncated = true;
+      break;
+    }
+    bytes += size;
+    kept.push(message);
+  }
+  if (direction === 'backward') kept.reverse();
+  if (!truncated) return { rows: kept, hasMore: false };
+  const nextCursor =
+    direction === 'forward'
+      ? { afterSeq: kept[kept.length - 1]!.seq }
+      : { beforeSeq: kept[0]!.seq };
+  return { rows: kept, hasMore: true, nextCursor };
+}
+
 export interface ChannelChatRouterDeps {
   store: ChannelMessageStore | null;
   hub: ChannelHub;
   topicStore: WorkspaceTopicStore | null;
   /** framework ids for @-mention resolution (v2 adapter registry + topic default). */
   knownProviderIds?: readonly string[];
+  /** byte budget for one history response body (defaults to 4MB). */
+  historyMaxBytes?: number;
   requireAuth?: RequestHandler;
   requireReadActorAuth?: (
     command: CliGatewayActorReadCommand,
@@ -363,7 +409,20 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         : undefined;
     if (threadId) filter.threadId = threadId;
     try {
-      res.json({ messages: store.history(id, filter) });
+      const all = store.history(id, filter);
+      const direction =
+        filter.afterSeq !== undefined ? 'forward' : 'backward';
+      const budgeted = budgetHistoryRows(
+        all,
+        direction,
+        deps.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES
+      );
+      res.json({
+        messages: budgeted.rows,
+        ...(budgeted.hasMore
+          ? { hasMore: true, nextCursor: budgeted.nextCursor }
+          : {}),
+      });
     } catch (error) {
       mapStoreError(res, error);
     }

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -1,0 +1,471 @@
+import { Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+
+import type { RelayCliGatewayErrorCode } from '../shared/cli-gateway-contract.js';
+import {
+  authenticatedCliGatewayActorCredential,
+  type CliGatewayActorReadCommand,
+  type CliGatewayActorWriteCommand,
+} from './cli-gateway-actor-auth.js';
+import {
+  ChannelMessageStoreError,
+  type ChannelHistoryFilter,
+  type ChannelMessageStore,
+} from './channel-message-store.js';
+import type { ChannelHub } from './channel-hub.js';
+import type { WorkspaceTopicStore } from './workspace-topics.js';
+import type { WorkspaceTopic } from '../shared/workspace-topics.js';
+import {
+  parseMentions,
+  type ChannelBodyFormat,
+  type ChannelMessage,
+  type ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+const CONTEXT_READ = 'context:read';
+const CONTEXT_WRITE = 'context:write';
+
+const DEFAULT_KNOWN_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
+
+export interface ChannelChatRouterDeps {
+  store: ChannelMessageStore | null;
+  hub: ChannelHub;
+  topicStore: WorkspaceTopicStore | null;
+  /** framework ids for @-mention resolution (v2 adapter registry + topic default). */
+  knownProviderIds?: readonly string[];
+  requireAuth?: RequestHandler;
+  requireReadActorAuth?: (
+    command: CliGatewayActorReadCommand,
+    options?: {
+      scopeForRequest?: (
+        req: Request
+      ) => { workContextIds?: string[] } | undefined;
+    }
+  ) => RequestHandler;
+  requireWriteActorAuth?: (
+    command: CliGatewayActorWriteCommand,
+    options?: {
+      scopeForRequest?: (
+        req: Request
+      ) => { workContextIds?: string[] } | undefined;
+    }
+  ) => RequestHandler;
+}
+
+interface GatewayErrorBody {
+  error: {
+    code: RelayCliGatewayErrorCode;
+    message: string;
+    retryable: boolean;
+    details?: Record<string, unknown>;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function bodyRecord(req: Request): Record<string, unknown> {
+  return isRecord(req.body) ? req.body : {};
+}
+
+function parseCapabilityHeader(value: string | undefined): Set<string> {
+  if (!value) return new Set();
+  return new Set(
+    value
+      .split(/[\s,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+}
+
+function statusForCode(code: RelayCliGatewayErrorCode): number {
+  switch (code) {
+    case 'UNAUTHORIZED':
+      return 401;
+    case 'FORBIDDEN':
+      return 403;
+    case 'NOT_FOUND':
+      return 404;
+    case 'SESSION_CONFLICT':
+      return 409;
+    case 'SERVER_UNAVAILABLE':
+      return 503;
+    case 'INTERNAL':
+      return 500;
+    default:
+      return 400;
+  }
+}
+
+function sendGatewayError(
+  res: Response,
+  code: RelayCliGatewayErrorCode,
+  message: string,
+  retryable = false,
+  details?: Record<string, unknown>,
+  statusOverride?: number
+): void {
+  const body: GatewayErrorBody = {
+    error: { code, message, retryable, ...(details ? { details } : {}) },
+  };
+  res.status(statusOverride ?? statusForCode(code)).json(body);
+}
+
+function denyMissingCapability(
+  req: Request,
+  res: Response,
+  required: readonly string[]
+): boolean {
+  const provided = parseCapabilityHeader(req.header('x-relay-capabilities'));
+  const actorCredential = authenticatedCliGatewayActorCredential(req);
+  for (const capability of actorCredential?.capabilities ?? []) {
+    provided.add(capability);
+  }
+  const missing = required.filter((capability) => !provided.has(capability));
+  if (missing.length === 0) return false;
+  sendGatewayError(
+    res,
+    'FORBIDDEN',
+    `missing required capability: ${missing[0]}`,
+    false,
+    {
+      capability: missing[0],
+      missingCapabilities: missing,
+    }
+  );
+  return true;
+}
+
+function storeOr503(
+  res: Response,
+  store: ChannelMessageStore | null
+): ChannelMessageStore | null {
+  if (store) return store;
+  sendGatewayError(
+    res,
+    'SERVER_UNAVAILABLE',
+    'channel store unavailable',
+    true,
+    {
+      reasonCode: 'CHANNEL_STORE_UNAVAILABLE',
+    }
+  );
+  return null;
+}
+
+function topicStoreOr503(
+  res: Response,
+  topicStore: WorkspaceTopicStore | null
+): WorkspaceTopicStore | null {
+  if (topicStore) return topicStore;
+  sendGatewayError(
+    res,
+    'SERVER_UNAVAILABLE',
+    'workspace topic store unavailable',
+    true,
+    {
+      reasonCode: 'WORKSPACE_TOPICS_UNAVAILABLE',
+    }
+  );
+  return null;
+}
+
+/**
+ * Server-derived sender attribution from the authenticated lane — NEVER from the
+ * request body ([MF]: attribution is the core product promise). Browser cookie
+ * session → human operator; CLI-gateway actor credential → agent:<actor id>.
+ */
+function deriveSender(req: Request): ChannelSenderRef {
+  const credential = authenticatedCliGatewayActorCredential(req);
+  if (credential) {
+    return {
+      kind: 'agent',
+      id: `agent:${credential.actor.id}`,
+      providerId: credential.actor.id,
+      ...(credential.actor.displayName
+        ? { displayName: credential.actor.displayName }
+        : {}),
+    };
+  }
+  return { kind: 'human', id: 'human:operator', displayName: 'Operator' };
+}
+
+function mapStoreError(res: Response, error: unknown): void {
+  if (error instanceof ChannelMessageStoreError) {
+    if (error.status === 413) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        error.message,
+        false,
+        { reasonCode: error.code.toUpperCase(), ...(error.details ?? {}) },
+        413
+      );
+      return;
+    }
+    const code: RelayCliGatewayErrorCode =
+      error.status === 404
+        ? 'NOT_FOUND'
+        : error.status === 409
+          ? 'SESSION_CONFLICT'
+          : error.status >= 500
+            ? 'INTERNAL'
+            : 'INVALID_ARGUMENT';
+    sendGatewayError(res, code, error.message, false, {
+      reasonCode: error.code.toUpperCase(),
+      ...(error.details ?? {}),
+    });
+    return;
+  }
+  sendGatewayError(
+    res,
+    'INTERNAL',
+    error instanceof Error ? error.message : String(error),
+    false
+  );
+}
+
+function parseSeqQuery(value: unknown): number | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw !== 'string' || !raw.trim()) return undefined;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function channelSummaryView(
+  store: ChannelMessageStore,
+  topic: WorkspaceTopic
+): Record<string, unknown> {
+  const summary = store.getChannelSummary(topic.id);
+  return {
+    id: topic.id,
+    title: topic.display.title,
+    ...(topic.display.kind ? { kind: topic.display.kind } : {}),
+    visibility: topic.visibility,
+    archived: topic.status === 'archived',
+    latestSeq: summary?.latestSeq ?? 0,
+    messageCount: summary?.messageCount ?? 0,
+    lastMessage: summary?.lastMessage ?? null,
+    members: store.listMembers(topic.id),
+  };
+}
+
+/**
+ * The ONLY channel write path. Persist → auto-enroll the sender as a member →
+ * broadcast `channel-message-created-v1` (which also emits the sidebar badge and
+ * fires the `onMessagePosted` hook #1167 subscribes to).
+ */
+function postToChannel(
+  store: ChannelMessageStore,
+  hub: ChannelHub,
+  input: {
+    channelId: string;
+    sender: ChannelSenderRef;
+    text: string;
+    format?: ChannelBodyFormat;
+    parentMessageId?: string;
+    clientMessageId?: string;
+    mentions: ReturnType<typeof parseMentions>;
+  }
+): ChannelMessage {
+  const message = store.appendComplete({
+    channelId: input.channelId,
+    sender: input.sender,
+    text: input.text,
+    ...(input.format ? { format: input.format } : {}),
+    ...(input.parentMessageId
+      ? { parentMessageId: input.parentMessageId }
+      : {}),
+    ...(input.clientMessageId
+      ? { clientMessageId: input.clientMessageId }
+      : {}),
+    ...(input.mentions.length ? { mentions: input.mentions } : {}),
+  });
+  store.upsertMember({
+    channelId: input.channelId,
+    kind: input.sender.kind === 'agent' ? 'agent' : 'human',
+    id: input.sender.id,
+  });
+  hub.broadcastCreated(message, input.mentions);
+  return message;
+}
+
+export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
+  const router = Router();
+  const passthrough: RequestHandler = (_req, _res, next) => next();
+  const auth = deps.requireAuth ?? passthrough;
+  const knownProviderIds = deps.knownProviderIds ?? DEFAULT_KNOWN_PROVIDER_IDS;
+
+  const listAuth = deps.requireReadActorAuth?.('channels.list') ?? auth;
+  const getAuth = deps.requireReadActorAuth?.('channels.get') ?? auth;
+  const historyAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
+  const postAuth = deps.requireWriteActorAuth?.('channels.post') ?? auth;
+
+  router.get('/channels', listAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topicStore = topicStoreOr503(res, deps.topicStore);
+    if (!topicStore) return;
+    try {
+      const summaries = new Set(
+        store.listChannelSummaries().map((summary) => summary.channelId)
+      );
+      const topics = topicStore.list({ includeArchived: true });
+      const channels = topics
+        .filter(
+          (topic) => topic.status !== 'archived' || summaries.has(topic.id)
+        )
+        .map((topic) => channelSummaryView(store, topic));
+      res.json({ channels });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  router.get('/channels/:id', getAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topicStore = topicStoreOr503(res, deps.topicStore);
+    if (!topicStore) return;
+    const id = req.params['id'] ?? '';
+    const topic = topicStore.get(id);
+    if (!topic || topic.source !== 'persisted') {
+      sendGatewayError(res, 'NOT_FOUND', 'channel not found', false, {
+        channelId: id,
+      });
+      return;
+    }
+    try {
+      res.json({ channel: channelSummaryView(store, topic) });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  router.get('/channels/:id/messages', historyAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const id = req.params['id'] ?? '';
+    const filter: ChannelHistoryFilter = {};
+    const beforeSeq = parseSeqQuery(req.query['beforeSeq']);
+    if (beforeSeq !== undefined) filter.beforeSeq = beforeSeq;
+    const afterSeq = parseSeqQuery(req.query['afterSeq']);
+    if (afterSeq !== undefined) filter.afterSeq = afterSeq;
+    const limit = parseSeqQuery(req.query['limit']);
+    if (limit !== undefined) filter.limit = limit;
+    const threadId =
+      typeof req.query['threadId'] === 'string'
+        ? req.query['threadId']
+        : undefined;
+    if (threadId) filter.threadId = threadId;
+    try {
+      res.json({ messages: store.history(id, filter) });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  router.post('/channels/:id/messages', postAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topicStore = topicStoreOr503(res, deps.topicStore);
+    if (!topicStore) return;
+    const id = req.params['id'] ?? '';
+    const body = bodyRecord(req);
+
+    // [MF] Reject a client-supplied sender field outright — attribution is
+    // ALWAYS server-derived from the auth lane, never forgeable from the body.
+    if ('sender' in body) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'sender is server-derived and must not be supplied in the request body',
+        false,
+        { field: 'sender', reasonCode: 'CHANNEL_SENDER_NOT_ALLOWED' }
+      );
+      return;
+    }
+
+    // [MF] Topic must be a persisted, non-archived channel (derived topics from
+    // deriveWorkspaceTopicsFromWorkContexts are rejected).
+    const topic = topicStore.get(id);
+    if (!topic || topic.source !== 'persisted') {
+      sendGatewayError(res, 'NOT_FOUND', 'channel not found', false, {
+        channelId: id,
+      });
+      return;
+    }
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+
+    const text = body['text'];
+    if (typeof text !== 'string' || text.length === 0) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'text is required', false, {
+        field: 'text',
+      });
+      return;
+    }
+    const format =
+      body['format'] === 'text' || body['format'] === 'markdown'
+        ? (body['format'] as ChannelBodyFormat)
+        : undefined;
+    const parentMessageId =
+      typeof body['parentMessageId'] === 'string'
+        ? body['parentMessageId']
+        : undefined;
+    const clientMessageId =
+      typeof body['clientMessageId'] === 'string'
+        ? body['clientMessageId']
+        : undefined;
+
+    const sender = deriveSender(req);
+
+    // clientMessageId idempotency: return the existing row without re-broadcast.
+    if (clientMessageId) {
+      const existing = store.findByClientMessage(
+        id,
+        sender.id,
+        clientMessageId
+      );
+      if (existing) {
+        res.status(200).json({ message: existing });
+        return;
+      }
+    }
+
+    const providerIds = [
+      ...knownProviderIds,
+      ...(topic.routingDefaults.providerId
+        ? [topic.routingDefaults.providerId]
+        : []),
+    ];
+    const mentions = parseMentions(text, providerIds);
+
+    try {
+      const message = postToChannel(store, deps.hub, {
+        channelId: id,
+        sender,
+        text,
+        ...(format ? { format } : {}),
+        ...(parentMessageId ? { parentMessageId } : {}),
+        ...(clientMessageId ? { clientMessageId } : {}),
+        mentions,
+      });
+      res.status(201).json({ message });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  return router;
+}

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -34,6 +34,14 @@ const HARD_LIMIT_BYTES = 4 * 1024 * 1024; // close 4409 above this
 const SNAPSHOT_FULL_LIMIT = 100;
 /** catch-up beyond this gap falls back to a full snapshot. */
 const CATCHUP_MAX_ROWS = 500;
+/**
+ * Byte budget for a single WS snapshot / catch-up assembly. Rows are row-bounded
+ * (SNAPSHOT_FULL_LIMIT / CATCHUP_MAX_ROWS) but each body is capped at 256KB, so a
+ * transcript-heavy channel could otherwise serialize tens of MB into one
+ * `ws.send`. We stop accumulating past this budget and flag `truncated` so the
+ * client paginates the remainder via `channels.history`.
+ */
+const DEFAULT_SNAPSHOT_MAX_BYTES = 4 * 1024 * 1024;
 
 /**
  * Minimal socket surface the hub needs. The real `ws` WebSocket satisfies it;
@@ -88,6 +96,8 @@ export interface ChannelHubOptions {
   channelExists?: (channelId: string) => boolean;
   coalesceMs?: number;
   badgeBroadcaster?: ChannelBadgeBroadcaster;
+  /** byte budget for one snapshot/catch-up assembly (defaults to 4MB). */
+  snapshotMaxBytes?: number;
 }
 
 export interface ChannelHub {
@@ -110,6 +120,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
   const store = options.store;
   const coalesceMs = options.coalesceMs ?? DEFAULT_COALESCE_MS;
   const channelExists = options.channelExists ?? (() => true);
+  const snapshotMaxBytes = options.snapshotMaxBytes ?? DEFAULT_SNAPSHOT_MAX_BYTES;
   let badgeBroadcaster = options.badgeBroadcaster ?? null;
 
   const subscribers = new Map<string, Set<Subscriber>>();
@@ -219,6 +230,35 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     });
   }
 
+  /**
+   * Assemble rows under the byte budget. `keepEnd` chooses which side to keep
+   * when the candidate set overflows: `'tail'` keeps the newest rows (full
+   * snapshot — older rows scroll back), `'head'` keeps the oldest-first rows
+   * (catch-up — forward pagination fills the remainder). Always keeps ≥1 row
+   * (a single row is ≤256KB < 4MB), returning `truncated` when it stopped early.
+   */
+  function assembleWithBudget(
+    candidate: ChannelMessage[],
+    keepEnd: 'head' | 'tail'
+  ): { rows: ChannelMessage[]; truncated: boolean } {
+    if (candidate.length === 0) return { rows: [], truncated: false };
+    const order = keepEnd === 'tail' ? [...candidate].reverse() : candidate;
+    const kept: ChannelMessage[] = [];
+    let bytes = 0;
+    let truncated = false;
+    for (const row of order) {
+      const size = Buffer.byteLength(JSON.stringify(row), 'utf8') + 1;
+      if (kept.length > 0 && bytes + size > snapshotMaxBytes) {
+        truncated = true;
+        break;
+      }
+      bytes += size;
+      kept.push(row);
+    }
+    if (keepEnd === 'tail') kept.reverse();
+    return { rows: kept, truncated };
+  }
+
   function buildSnapshot(
     channelId: string,
     sinceSeq: number | null
@@ -228,30 +268,66 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       ? store.listMembers(channelId)
       : [];
     let mode: 'full' | 'catchup';
-    let rows: ChannelMessage[];
-    let truncated = false;
+    let assembled: { rows: ChannelMessage[]; truncated: boolean };
+    // The head advertised to the client. Normally the true channel head; capped
+    // to the last row actually delivered when a catch-up is byte-truncated, so
+    // the reducer's `lastSeq` never skips undelivered rows.
+    let snapshotLatestSeq = latestSeq;
 
-    if (sinceSeq === null || latestSeq - sinceSeq > CATCHUP_MAX_ROWS) {
+    // A cursor ahead of the server head (rollback / topic recreated under the
+    // same deterministic slug) must reset the client, not silently drop every
+    // future message — force a full snapshot so `lastSeq` is pulled back to head.
+    const staleAhead = sinceSeq !== null && sinceSeq > latestSeq;
+
+    if (
+      sinceSeq === null ||
+      staleAhead ||
+      latestSeq - sinceSeq > CATCHUP_MAX_ROWS
+    ) {
       mode = 'full';
-      rows = store
+      const fullRows = store
         ? store.history(channelId, { limit: SNAPSHOT_FULL_LIMIT })
         : [];
-      truncated = rows.length > 0 && (rows[0]?.seq ?? 1) > 1;
+      assembled = assembleWithBudget(fullRows, 'tail');
+      if (!assembled.truncated) {
+        assembled.truncated =
+          assembled.rows.length > 0 && (assembled.rows[0]?.seq ?? 1) > 1;
+      }
     } else {
       mode = 'catchup';
-      rows = [];
+      // Reconnect catch-up must also refresh rows at or below the cursor whose
+      // status changed while the client was disconnected — specifically a stream
+      // that finalized (streaming → complete/interrupted/failed) without adding a
+      // new seq. `history({ afterSeq })` alone never resends those, leaving a
+      // permanently stuck streaming row. Agent-origin rows are the only ones that
+      // mutate in place, so re-send their CURRENT state; the reducer replaces the
+      // stale copy by id. This heals every reconnect path (incl. backpressure
+      // resync and post-restart, since it is a pure DB read).
+      const resync = store
+        ? store.listResyncRows(channelId, sinceSeq, CATCHUP_MAX_ROWS)
+        : [];
+      const fresh: ChannelMessage[] = [];
       let cursor = sinceSeq;
-      while (store && rows.length < CATCHUP_MAX_ROWS) {
+      while (store && fresh.length < CATCHUP_MAX_ROWS) {
         const page = store.history(channelId, { afterSeq: cursor, limit: 200 });
         if (page.length === 0) break;
-        rows.push(...page);
+        fresh.push(...page);
         cursor = page[page.length - 1]!.seq;
         if (page.length < 200) break;
       }
+      assembled = assembleWithBudget([...resync, ...fresh], 'head');
+      if (assembled.truncated && assembled.rows.length > 0) {
+        snapshotLatestSeq = assembled.rows[assembled.rows.length - 1]!.seq;
+      }
     }
+
+    const rows = assembled.rows;
 
     // Overlay the hub's in-memory accumulated text onto streaming rows — it is
     // authoritative over the DB flush lag — and record each open stream's index.
+    // Any pending (accumulated-but-unemitted) delta text was flushed before this
+    // read (see flushPendingForChannel), so `acc.deltaIndex` is the exact index
+    // whose text is already reflected in `acc.text`.
     const inFlight: ChannelInFlightRef[] = [];
     const messages = rows.map((message) => {
       const acc = accumulators.get(message.id);
@@ -269,9 +345,9 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       mode,
       messages,
       members,
-      latestSeq,
+      latestSeq: snapshotLatestSeq,
       inFlight,
-      truncated,
+      truncated: assembled.truncated,
     };
   }
 
@@ -291,6 +367,29 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       deltaIndex: acc.deltaIndex,
       delta: { text },
     });
+  }
+
+  /**
+   * Flush any pending (accumulated-but-unemitted) delta text for a channel's
+   * streaming rows synchronously, before a connecting socket reads its snapshot.
+   *
+   * Without this, `buildSnapshot` would overlay `acc.text` (which includes the
+   * unflushed `pendingText`) while recording only the last EMITTED `deltaIndex`;
+   * the subsequent coalesce flush would then re-deliver that same text as
+   * `deltaIndex + 1` and the reducer would append it a SECOND time (duplicated
+   * render). Flushing here — while the new socket is already registered and still
+   * buffering — routes the flush delta through the connect-time queue where the
+   * deltaIndex dedupe drops it, so the snapshot and the live stream agree exactly.
+   */
+  function flushPendingForChannel(channelId: string): void {
+    for (const acc of accumulators.values()) {
+      if (acc.channelId !== channelId || acc.pendingText.length === 0) continue;
+      if (acc.coalesceTimer) {
+        clearTimeout(acc.coalesceTimer);
+        acc.coalesceTimer = null;
+      }
+      flushAccumulator(acc.messageId);
+    }
   }
 
   return {
@@ -316,6 +415,11 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       // race; better-sqlite3 reads are synchronous, so the queue + dedupe below
       // is defense in depth.
       addSubscriber(channelId, sub);
+
+      // Flush any pending accumulator text BEFORE reading the snapshot so the
+      // snapshot's recorded deltaIndex matches the overlaid text exactly; the
+      // flush delta queues on this buffering socket and is deduped below.
+      flushPendingForChannel(channelId);
 
       const snapshot = buildSnapshot(channelId, sinceSeq);
       if (snapshot.type === 'channel-snapshot-v1') {

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -1,0 +1,446 @@
+import { createLogger } from './logger.js';
+import type { ChannelMessageStore } from './channel-message-store.js';
+import {
+  type ChannelEventV1,
+  type ChannelInFlightRef,
+  type ChannelMemberRef,
+  type ChannelMention,
+  type ChannelMessage,
+  type ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+const logger = createLogger('channel-hub');
+
+// Per-channel fan-out hub (#1165). Owns the live subscriber sets, per-message
+// in-flight accumulators, delta coalescing, the connect-time snapshot/live
+// dedupe, backpressure watermarks, the `onMessagePosted` hook, and the coarse
+// `channel-activity` sidebar badge emit. There is NO in-memory event ring:
+// committed catch-up always reads SQLite (the durable seq log is the buffer).
+
+/** WebSocket.OPEN — kept local so fake sockets in tests need no ws import. */
+const WS_OPEN = 1;
+
+/** app close code: unknown/missing channel (precedent TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE 4404). */
+export const CHANNEL_WS_NOT_FOUND_CLOSE_CODE = 4404;
+/** app close code: sustained backpressure overflow; client reconnects with sinceSeq. */
+export const CHANNEL_WS_BACKPRESSURE_CLOSE_CODE = 4409;
+
+/** flush one coalesced delta per tick, bounding event rate regardless of token rate. */
+const DEFAULT_COALESCE_MS = 50;
+const WATERMARK_HIGH_BYTES = 1024 * 1024; // suppress deltas above this
+const WATERMARK_LOW_BYTES = 256 * 1024; // resume + resync below this
+const HARD_LIMIT_BYTES = 4 * 1024 * 1024; // close 4409 above this
+/** full snapshot window (last N messages). */
+const SNAPSHOT_FULL_LIMIT = 100;
+/** catch-up beyond this gap falls back to a full snapshot. */
+const CATCHUP_MAX_ROWS = 500;
+
+/**
+ * Minimal socket surface the hub needs. The real `ws` WebSocket satisfies it;
+ * tests inject fakes with a settable `bufferedAmount` to exercise backpressure.
+ */
+export interface ChannelSocket {
+  readonly readyState: number;
+  readonly bufferedAmount?: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  on(event: 'close' | 'error', handler: () => void): void;
+}
+
+interface Subscriber {
+  ws: ChannelSocket;
+  channelId: string;
+  /** live events queue here until the connect-time snapshot has been sent. */
+  buffering: boolean;
+  queue: ChannelEventV1[];
+  snapshotLatestSeq: number;
+  snapshotInFlight: Map<string, number>;
+  /** suppressing deltas after a high-watermark breach until the buffer drains. */
+  lagging: boolean;
+}
+
+interface Accumulator {
+  channelId: string;
+  messageId: string;
+  sender: ChannelSenderRef;
+  /** authoritative in-memory text (>= last DB flush). */
+  text: string;
+  /** text not yet emitted as a coalesced delta. */
+  pendingText: string;
+  /** last emitted deltaIndex (−1 before the first flush). */
+  deltaIndex: number;
+  coalesceTimer: NodeJS.Timeout | null;
+}
+
+export type ChannelMessagePostedHandler = (
+  message: ChannelMessage,
+  mentions: ChannelMention[]
+) => void;
+
+export type ChannelBadgeBroadcaster = (
+  type: string,
+  data: Record<string, unknown>
+) => void;
+
+export interface ChannelHubOptions {
+  store: ChannelMessageStore | null;
+  /** channel existence check (topic-store backed in prod). Defaults to always-true. */
+  channelExists?: (channelId: string) => boolean;
+  coalesceMs?: number;
+  badgeBroadcaster?: ChannelBadgeBroadcaster;
+}
+
+export interface ChannelHub {
+  handleConnection(
+    ws: ChannelSocket,
+    input: { channelId: string; sinceSeq: number | null }
+  ): void;
+  broadcastCreated(message: ChannelMessage, mentions?: ChannelMention[]): void;
+  beginStreamBroadcast(message: ChannelMessage): void;
+  pushDelta(messageId: string, text: string): void;
+  completeStreamBroadcast(message: ChannelMessage): void;
+  onMessagePosted(handler: ChannelMessagePostedHandler): () => void;
+  setBadgeBroadcaster(broadcaster: ChannelBadgeBroadcaster): void;
+  channelExists(channelId: string): boolean;
+  subscriberCount(channelId: string): number;
+  close(): void;
+}
+
+export function createChannelHub(options: ChannelHubOptions): ChannelHub {
+  const store = options.store;
+  const coalesceMs = options.coalesceMs ?? DEFAULT_COALESCE_MS;
+  const channelExists = options.channelExists ?? (() => true);
+  let badgeBroadcaster = options.badgeBroadcaster ?? null;
+
+  const subscribers = new Map<string, Set<Subscriber>>();
+  const accumulators = new Map<string, Accumulator>();
+  const postedHandlers = new Set<ChannelMessagePostedHandler>();
+
+  function nowIso(): string {
+    return new Date().toISOString();
+  }
+
+  function bufferedAmount(ws: ChannelSocket): number {
+    return typeof ws.bufferedAmount === 'number' ? ws.bufferedAmount : 0;
+  }
+
+  function rawSend(ws: ChannelSocket, event: ChannelEventV1): void {
+    if (ws.readyState !== WS_OPEN) return;
+    try {
+      ws.send(JSON.stringify(event));
+    } catch (err) {
+      logger.warn('channel-hub send failed:', err);
+    }
+  }
+
+  function addSubscriber(channelId: string, sub: Subscriber): void {
+    let set = subscribers.get(channelId);
+    if (!set) {
+      set = new Set();
+      subscribers.set(channelId, set);
+    }
+    set.add(sub);
+  }
+
+  function removeSubscriber(channelId: string, sub: Subscriber): void {
+    const set = subscribers.get(channelId);
+    if (!set) return;
+    set.delete(sub);
+    if (set.size === 0) subscribers.delete(channelId);
+  }
+
+  function latestSeqFor(channelId: string): number {
+    return store ? store.latestSeq(channelId) : 0;
+  }
+
+  function resyncEvent(channelId: string): ChannelEventV1 {
+    return {
+      type: 'channel-resync-required-v1',
+      channelId,
+      timestamp: nowIso(),
+      latestSeq: latestSeqFor(channelId),
+    };
+  }
+
+  /**
+   * Deliver one event to one live subscriber with backpressure discipline:
+   *  - `bufferedAmount > 4MB` → close 4409 (durable log is re-fetchable by seq).
+   *  - `bufferedAmount > 1MB` → mark lagging; suppress DELTA events only.
+   *  - durable events (`created`/`completed`/`snapshot`/`resync`) are ALWAYS sent.
+   *  - draining below 256KB clears lagging and emits `channel-resync-required-v1`.
+   */
+  function deliver(sub: Subscriber, event: ChannelEventV1): void {
+    const ws = sub.ws;
+    if (ws.readyState !== WS_OPEN) return;
+    const buffered = bufferedAmount(ws);
+    if (buffered > HARD_LIMIT_BYTES) {
+      closeSubscriber(sub, CHANNEL_WS_BACKPRESSURE_CLOSE_CODE);
+      return;
+    }
+    if (sub.lagging && buffered < WATERMARK_LOW_BYTES) {
+      sub.lagging = false;
+      rawSend(ws, resyncEvent(sub.channelId));
+    }
+    if (event.type === 'channel-message-delta-v1') {
+      if (sub.lagging) return; // suppress deltas while lagging
+      if (buffered > WATERMARK_HIGH_BYTES) {
+        sub.lagging = true;
+        return;
+      }
+    }
+    rawSend(ws, event);
+  }
+
+  function closeSubscriber(sub: Subscriber, code: number): void {
+    removeSubscriber(sub.channelId, sub);
+    try {
+      sub.ws.close(code);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function broadcast(channelId: string, event: ChannelEventV1): void {
+    const set = subscribers.get(channelId);
+    if (!set) return;
+    for (const sub of [...set]) {
+      if (sub.buffering) {
+        sub.queue.push(event);
+        continue;
+      }
+      deliver(sub, event);
+    }
+  }
+
+  function emitBadge(channelId: string): void {
+    badgeBroadcaster?.('channel-activity', {
+      channelId,
+      latestSeq: latestSeqFor(channelId),
+    });
+  }
+
+  function buildSnapshot(
+    channelId: string,
+    sinceSeq: number | null
+  ): ChannelEventV1 {
+    const latestSeq = latestSeqFor(channelId);
+    const members: ChannelMemberRef[] = store
+      ? store.listMembers(channelId)
+      : [];
+    let mode: 'full' | 'catchup';
+    let rows: ChannelMessage[];
+    let truncated = false;
+
+    if (sinceSeq === null || latestSeq - sinceSeq > CATCHUP_MAX_ROWS) {
+      mode = 'full';
+      rows = store
+        ? store.history(channelId, { limit: SNAPSHOT_FULL_LIMIT })
+        : [];
+      truncated = rows.length > 0 && (rows[0]?.seq ?? 1) > 1;
+    } else {
+      mode = 'catchup';
+      rows = [];
+      let cursor = sinceSeq;
+      while (store && rows.length < CATCHUP_MAX_ROWS) {
+        const page = store.history(channelId, { afterSeq: cursor, limit: 200 });
+        if (page.length === 0) break;
+        rows.push(...page);
+        cursor = page[page.length - 1]!.seq;
+        if (page.length < 200) break;
+      }
+    }
+
+    // Overlay the hub's in-memory accumulated text onto streaming rows — it is
+    // authoritative over the DB flush lag — and record each open stream's index.
+    const inFlight: ChannelInFlightRef[] = [];
+    const messages = rows.map((message) => {
+      const acc = accumulators.get(message.id);
+      if (acc && message.status === 'streaming') {
+        inFlight.push({ messageId: message.id, deltaIndex: acc.deltaIndex });
+        return { ...message, body: { ...message.body, text: acc.text } };
+      }
+      return message;
+    });
+
+    return {
+      type: 'channel-snapshot-v1',
+      channelId,
+      timestamp: nowIso(),
+      mode,
+      messages,
+      members,
+      latestSeq,
+      inFlight,
+      truncated,
+    };
+  }
+
+  function flushAccumulator(messageId: string): void {
+    const acc = accumulators.get(messageId);
+    if (!acc) return;
+    acc.coalesceTimer = null;
+    if (acc.pendingText.length === 0) return;
+    acc.deltaIndex += 1;
+    const text = acc.pendingText;
+    acc.pendingText = '';
+    broadcast(acc.channelId, {
+      type: 'channel-message-delta-v1',
+      channelId: acc.channelId,
+      timestamp: nowIso(),
+      messageId: acc.messageId as ChannelMessage['id'],
+      deltaIndex: acc.deltaIndex,
+      delta: { text },
+    });
+  }
+
+  return {
+    handleConnection(ws, { channelId, sinceSeq }) {
+      if (!store || !channelExists(channelId)) {
+        try {
+          ws.close(CHANNEL_WS_NOT_FOUND_CLOSE_CODE);
+        } catch {
+          /* ignore */
+        }
+        return;
+      }
+      const sub: Subscriber = {
+        ws,
+        channelId,
+        buffering: true,
+        queue: [],
+        snapshotLatestSeq: 0,
+        snapshotInFlight: new Map(),
+        lagging: false,
+      };
+      // Register FIRST so live events during snapshot build queue rather than
+      // race; better-sqlite3 reads are synchronous, so the queue + dedupe below
+      // is defense in depth.
+      addSubscriber(channelId, sub);
+
+      const snapshot = buildSnapshot(channelId, sinceSeq);
+      if (snapshot.type === 'channel-snapshot-v1') {
+        sub.snapshotLatestSeq = snapshot.latestSeq;
+        for (const ref of snapshot.inFlight) {
+          sub.snapshotInFlight.set(ref.messageId, ref.deltaIndex);
+        }
+      }
+      deliver(sub, snapshot);
+
+      // Flush queued live events with dedupe: drop committed events with
+      // seq <= snapshot endSeq; drop deltas with deltaIndex <= the snapshot's
+      // recorded index for that message (dedupe stream events by messageId +
+      // deltaIndex, NOT seq); always forward completed (idempotent replace-by-id).
+      const queued = sub.queue;
+      sub.queue = [];
+      sub.buffering = false;
+      for (const event of queued) {
+        if (
+          event.type === 'channel-message-created-v1' &&
+          event.message.seq <= sub.snapshotLatestSeq
+        ) {
+          continue;
+        }
+        if (event.type === 'channel-message-delta-v1') {
+          const recorded = sub.snapshotInFlight.get(event.messageId);
+          if (recorded !== undefined && event.deltaIndex <= recorded) continue;
+        }
+        deliver(sub, event);
+      }
+
+      ws.on('close', () => removeSubscriber(channelId, sub));
+      ws.on('error', () => removeSubscriber(channelId, sub));
+    },
+
+    broadcastCreated(message, mentions) {
+      broadcast(message.channelId, {
+        type: 'channel-message-created-v1',
+        channelId: message.channelId,
+        timestamp: nowIso(),
+        message,
+      });
+      emitBadge(message.channelId);
+      const resolved = mentions ?? message.mentions ?? [];
+      for (const handler of [...postedHandlers]) {
+        try {
+          handler(message, resolved);
+        } catch (err) {
+          logger.warn('onMessagePosted handler error:', err);
+        }
+      }
+    },
+
+    beginStreamBroadcast(message) {
+      accumulators.set(message.id, {
+        channelId: message.channelId,
+        messageId: message.id,
+        sender: message.sender,
+        text: message.body.text,
+        pendingText: '',
+        deltaIndex: -1,
+        coalesceTimer: null,
+      });
+      broadcast(message.channelId, {
+        type: 'channel-message-created-v1',
+        channelId: message.channelId,
+        timestamp: nowIso(),
+        message,
+      });
+      emitBadge(message.channelId);
+    },
+
+    pushDelta(messageId, text) {
+      const acc = accumulators.get(messageId);
+      if (!acc || text.length === 0) return;
+      acc.text += text;
+      acc.pendingText += text;
+      if (!acc.coalesceTimer) {
+        acc.coalesceTimer = setTimeout(
+          () => flushAccumulator(messageId),
+          coalesceMs
+        );
+        acc.coalesceTimer.unref?.();
+      }
+    },
+
+    completeStreamBroadcast(message) {
+      const acc = accumulators.get(message.id);
+      if (acc?.coalesceTimer) clearTimeout(acc.coalesceTimer);
+      accumulators.delete(message.id);
+      broadcast(message.channelId, {
+        type: 'channel-message-completed-v1',
+        channelId: message.channelId,
+        timestamp: nowIso(),
+        message,
+      });
+      emitBadge(message.channelId);
+    },
+
+    onMessagePosted(handler) {
+      postedHandlers.add(handler);
+      return () => {
+        postedHandlers.delete(handler);
+      };
+    },
+
+    setBadgeBroadcaster(broadcaster) {
+      badgeBroadcaster = broadcaster;
+    },
+
+    channelExists(channelId) {
+      return channelExists(channelId);
+    },
+
+    subscriberCount(channelId) {
+      return subscribers.get(channelId)?.size ?? 0;
+    },
+
+    close() {
+      for (const acc of accumulators.values()) {
+        if (acc.coalesceTimer) clearTimeout(acc.coalesceTimer);
+      }
+      accumulators.clear();
+      subscribers.clear();
+      postedHandlers.clear();
+    },
+  };
+}

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -230,6 +230,19 @@ export interface ChannelMessageStore {
     clientMessageId: string
   ): ChannelMessage | null;
   history(channelId: string, filter?: ChannelHistoryFilter): ChannelMessage[];
+  /**
+   * Rows a reconnecting client may still hold as stale `streaming` copies:
+   * agent-origin rows (source triple set) at or below the reconnect cursor, in
+   * their CURRENT state, nearest the cursor first. Only agent streams mutate in
+   * place (streaming → complete/interrupted/failed without a new seq), so this is
+   * the exact set catch-up must re-send to heal a stream that finalized while the
+   * client was disconnected. Bounded by `limit`.
+   */
+  listResyncRows(
+    channelId: string,
+    uptoSeq: number,
+    limit: number
+  ): ChannelMessage[];
   latestSeq(channelId: string): number;
   listChannelSummaries(): ChannelSummary[];
   getChannelSummary(channelId: string): ChannelSummary | null;
@@ -681,6 +694,19 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
            ORDER BY seq DESC LIMIT @limit`
         )
         .all(params) as ChannelMessageRow[];
+      return rows.reverse().map(rowToMessage);
+    },
+
+    listResyncRows(channelId, uptoSeq, limit) {
+      const bounded = Math.max(1, Math.min(1000, Math.floor(limit)));
+      const rows = db
+        .prepare(
+          `SELECT * FROM channel_messages
+           WHERE channel_id = @channelId AND seq <= @uptoSeq
+             AND source_session_id IS NOT NULL
+           ORDER BY seq DESC LIMIT @limit`
+        )
+        .all({ channelId, uptoSeq, limit: bounded }) as ChannelMessageRow[];
       return rows.reverse().map(rowToMessage);
     },
 

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -1,0 +1,931 @@
+import * as crypto from 'node:crypto';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import {
+  CHANNEL_CHAT_PROTOCOL_VERSION,
+  CHANNEL_MESSAGE_BODY_MAX_BYTES,
+  type ChannelBodyFormat,
+  type ChannelMemberRef,
+  type ChannelMention,
+  type ChannelMessage,
+  type ChannelMessageId,
+  type ChannelMessageKind,
+  type ChannelMessageStatus,
+  type ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+// Durable channel conversation store (#1165). Owns `channel-chat.db` in the
+// config dir with its own `schema_version` runner (same pattern as
+// work-context-messages.ts / ia-store.ts). `work_context_messages` is NOT
+// evolved — it is agent-mail (#945) with audience/redaction semantics and
+// random-UUID tiebreak ordering; wrong substrate for a seq-ordered chat log.
+//
+// Store invariants (documented here so future features do not regress them):
+//  * Any unread arithmetic must COUNT by seq range — never assume contiguity
+//    survives future features.
+//  * Catch-up is ALWAYS DB-backed (the durable seq log is the replay buffer);
+//    there is no in-memory event ring.
+//  * Edits/deletes are out of scope for slice 2 and must NEVER be implemented as
+//    row deletion — that would break gap-free seq. Future mutation lands as new
+//    events over retained rows.
+
+const SCHEMA_VERSION = 1;
+export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
+export const CHANNEL_HISTORY_MAX_LIMIT = 200;
+const CHANNEL_SUMMARY_PREVIEW_MAX_CHARS = 200;
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS channel_messages (
+  id                TEXT PRIMARY KEY,
+  channel_id        TEXT NOT NULL,
+  seq               INTEGER NOT NULL,
+  kind              TEXT NOT NULL DEFAULT 'message'
+                      CHECK (kind IN ('message','system')),
+  status            TEXT NOT NULL DEFAULT 'complete'
+                      CHECK (status IN ('streaming','complete','interrupted','failed')),
+  sender_kind       TEXT NOT NULL CHECK (sender_kind IN ('human','agent','system')),
+  sender_id         TEXT NOT NULL,
+  sender_display    TEXT,
+  thread_id         TEXT,
+  parent_message_id TEXT,
+  body_text         TEXT NOT NULL DEFAULT '',
+  body_format       TEXT NOT NULL DEFAULT 'markdown',
+  meta_json         TEXT,
+  source_session_id TEXT,
+  source_turn_id    TEXT,
+  source_item_id    TEXT,
+  client_message_id TEXT,
+  created_at        TEXT NOT NULL,
+  updated_at        TEXT NOT NULL,
+  completed_at      TEXT,
+  UNIQUE (channel_id, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_chm_channel_seq
+  ON channel_messages(channel_id, seq);
+CREATE INDEX IF NOT EXISTS idx_chm_thread
+  ON channel_messages(thread_id, seq) WHERE thread_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chm_source_dedupe
+  ON channel_messages(source_session_id, source_turn_id, source_item_id)
+  WHERE source_session_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chm_client_dedupe
+  ON channel_messages(channel_id, sender_id, client_message_id)
+  WHERE client_message_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS channel_members (
+  channel_id    TEXT NOT NULL,
+  member_kind   TEXT NOT NULL CHECK (member_kind IN ('human','agent')),
+  member_id     TEXT NOT NULL,
+  joined_at     TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  PRIMARY KEY (channel_id, member_kind, member_id)
+);
+
+CREATE TABLE IF NOT EXISTS channel_agent_bindings (
+  channel_id            TEXT NOT NULL,
+  agent_framework       TEXT NOT NULL,
+  session_id            TEXT,
+  provider_session_json TEXT NOT NULL DEFAULT '{}',
+  created_at            TEXT NOT NULL,
+  updated_at            TEXT NOT NULL,
+  PRIMARY KEY (channel_id, agent_framework)
+);
+`;
+
+interface ChannelMessageRow {
+  id: string;
+  channel_id: string;
+  seq: number;
+  kind: string;
+  status: string;
+  sender_kind: string;
+  sender_id: string;
+  sender_display: string | null;
+  thread_id: string | null;
+  parent_message_id: string | null;
+  body_text: string;
+  body_format: string;
+  meta_json: string | null;
+  source_session_id: string | null;
+  source_turn_id: string | null;
+  source_item_id: string | null;
+  client_message_id: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+interface MemberRow {
+  channel_id: string;
+  member_kind: string;
+  member_id: string;
+  joined_at: string;
+  metadata_json: string;
+}
+
+interface BindingRow {
+  channel_id: string;
+  agent_framework: string;
+  session_id: string | null;
+  provider_session_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChannelMessageMeta {
+  mentions?: ChannelMention[];
+  truncated?: boolean;
+  [key: string]: unknown;
+}
+
+export interface AppendCompleteInput {
+  channelId: string;
+  kind?: ChannelMessageKind;
+  sender: ChannelSenderRef;
+  text: string;
+  format?: ChannelBodyFormat;
+  parentMessageId?: string;
+  clientMessageId?: string;
+  mentions?: ChannelMention[];
+  meta?: ChannelMessageMeta;
+}
+
+export interface BeginStreamInput {
+  channelId: string;
+  sender: ChannelSenderRef;
+  source: { sessionId: string; turnId?: string; itemId?: string };
+  text?: string;
+  parentMessageId?: string;
+  mentions?: ChannelMention[];
+}
+
+export interface FinalizeStreamInput {
+  text: string;
+  status: Extract<ChannelMessageStatus, 'complete' | 'interrupted' | 'failed'>;
+  truncated?: boolean;
+}
+
+export interface ChannelSummary {
+  channelId: string;
+  latestSeq: number;
+  messageCount: number;
+  lastMessage: {
+    id: ChannelMessageId;
+    seq: number;
+    preview: string;
+    senderId: string;
+    senderKind: ChannelSenderKindLoose;
+    status: ChannelMessageStatus;
+    createdAt: string;
+  } | null;
+}
+
+type ChannelSenderKindLoose = ChannelSenderRef['kind'];
+
+export interface ChannelHistoryFilter {
+  beforeSeq?: number;
+  afterSeq?: number;
+  limit?: number;
+  threadId?: string;
+}
+
+export interface ChannelBinding {
+  channelId: string;
+  agentFramework: string;
+  sessionId: string | null;
+  providerSession: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StaleStreamSweepResult {
+  channelId: string;
+  interruptedIds: ChannelMessageId[];
+  systemMessage: ChannelMessage;
+}
+
+export class ChannelMessageStoreError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'ChannelMessageStoreError';
+  }
+}
+
+export interface ChannelMessageStore {
+  close(): void;
+  appendComplete(input: AppendCompleteInput): ChannelMessage;
+  beginStream(input: BeginStreamInput): ChannelMessage;
+  updateStreamText(id: string, text: string): ChannelMessage | null;
+  finalizeStream(id: string, input: FinalizeStreamInput): ChannelMessage | null;
+  getMessage(id: string): ChannelMessage | null;
+  findByClientMessage(
+    channelId: string,
+    senderId: string,
+    clientMessageId: string
+  ): ChannelMessage | null;
+  history(channelId: string, filter?: ChannelHistoryFilter): ChannelMessage[];
+  latestSeq(channelId: string): number;
+  listChannelSummaries(): ChannelSummary[];
+  getChannelSummary(channelId: string): ChannelSummary | null;
+  upsertMember(input: {
+    channelId: string;
+    kind: 'human' | 'agent';
+    id: string;
+    metadata?: Record<string, unknown>;
+  }): ChannelMemberRef;
+  listMembers(channelId: string): ChannelMemberRef[];
+  findDmChannel(memberIdA: string, memberIdB: string): string | null;
+  getBinding(channelId: string, agentFramework: string): ChannelBinding | null;
+  upsertBinding(input: {
+    channelId: string;
+    agentFramework: string;
+    sessionId?: string | null;
+    providerSession?: Record<string, unknown>;
+  }): ChannelBinding;
+  sweepStaleStreaming(): StaleStreamSweepResult[];
+  sweepOrphans(persistedTopicIds: Set<string>): {
+    channelsDeleted: string[];
+    messagesDeleted: number;
+  };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function createMessageId(): ChannelMessageId {
+  return `chm:${crypto.randomUUID()}`;
+}
+
+function assertBodySize(text: string): void {
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes > CHANNEL_MESSAGE_BODY_MAX_BYTES) {
+    throw new ChannelMessageStoreError(
+      413,
+      'channel_message_body_too_large',
+      'channel message body exceeds 256KB cap',
+      { bytes, maxBytes: CHANNEL_MESSAGE_BODY_MAX_BYTES }
+    );
+  }
+}
+
+function cleanLimit(limit: unknown): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit)) {
+    return CHANNEL_HISTORY_DEFAULT_LIMIT;
+  }
+  return Math.max(1, Math.min(CHANNEL_HISTORY_MAX_LIMIT, Math.floor(limit)));
+}
+
+function parseMeta(raw: string | null): ChannelMessageMeta | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object'
+      ? (parsed as ChannelMessageMeta)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rowToMessage(row: ChannelMessageRow): ChannelMessage {
+  const meta = parseMeta(row.meta_json);
+  const sender: ChannelSenderRef = {
+    kind: row.sender_kind as ChannelSenderRef['kind'],
+    id: row.sender_id,
+    ...(row.sender_display ? { displayName: row.sender_display } : {}),
+  };
+  const providerId =
+    typeof meta?.['providerId'] === 'string'
+      ? (meta['providerId'] as string)
+      : undefined;
+  if (providerId) sender.providerId = providerId;
+  if (row.source_session_id) sender.sessionId = row.source_session_id;
+
+  const message: ChannelMessage = {
+    schemaVersion: CHANNEL_CHAT_PROTOCOL_VERSION,
+    id: row.id as ChannelMessageId,
+    channelId: row.channel_id,
+    seq: row.seq,
+    kind: row.kind as ChannelMessageKind,
+    status: row.status as ChannelMessageStatus,
+    sender,
+    body: {
+      text: row.body_text,
+      format: (row.body_format as ChannelBodyFormat) ?? 'markdown',
+    },
+    threadId: (row.thread_id as ChannelMessageId | null) ?? null,
+    parentMessageId: (row.parent_message_id as ChannelMessageId | null) ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+  if (meta?.mentions && Array.isArray(meta.mentions)) {
+    message.mentions = meta.mentions;
+  }
+  if (row.source_session_id) {
+    message.source = {
+      sessionId: row.source_session_id,
+      ...(row.source_turn_id ? { turnId: row.source_turn_id } : {}),
+      ...(row.source_item_id ? { itemId: row.source_item_id } : {}),
+    };
+  }
+  if (meta?.truncated === true) message.truncated = true;
+  if (row.client_message_id) message.clientMessageId = row.client_message_id;
+  if (row.completed_at) message.completedAt = row.completed_at;
+  return message;
+}
+
+function buildMeta(input: {
+  mentions?: ChannelMention[];
+  truncated?: boolean;
+  providerId?: string;
+  extra?: ChannelMessageMeta;
+}): string | null {
+  const meta: ChannelMessageMeta = { ...(input.extra ?? {}) };
+  if (input.mentions && input.mentions.length > 0)
+    meta.mentions = input.mentions;
+  if (input.truncated) meta.truncated = true;
+  if (input.providerId) meta['providerId'] = input.providerId;
+  return Object.keys(meta).length > 0 ? JSON.stringify(meta) : null;
+}
+
+function runMigrations(db: Database.Database): void {
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
+  );
+  const row = db.prepare('SELECT version FROM schema_version LIMIT 1').get() as
+    | { version: number }
+    | undefined;
+  if (!row) db.prepare('INSERT INTO schema_version (version) VALUES (0)').run();
+  const current = row?.version ?? 0;
+  if (current > SCHEMA_VERSION) {
+    throw new Error(
+      `channel-chat.db schema ${current} is newer than supported ${SCHEMA_VERSION}`
+    );
+  }
+  if (current < 1) {
+    db.transaction(() => {
+      db.exec(SCHEMA_SQL);
+      db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION);
+    })();
+  }
+}
+
+export function initChannelMessageStore(
+  configDir: string
+): ChannelMessageStore {
+  return createChannelMessageStore(path.join(configDir, 'channel-chat.db'));
+}
+
+export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
+  const db = new Database(dbPath);
+  try {
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    runMigrations(db);
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+
+  const selectById = db.prepare('SELECT * FROM channel_messages WHERE id = ?');
+  const selectBySource = db.prepare(
+    `SELECT * FROM channel_messages
+     WHERE source_session_id IS @sessionId
+       AND source_turn_id IS @turnId
+       AND source_item_id IS @itemId`
+  );
+  const selectByClientId = db.prepare(
+    `SELECT * FROM channel_messages
+     WHERE channel_id = @channelId AND sender_id = @senderId
+       AND client_message_id = @clientMessageId`
+  );
+
+  // Single atomic INSERT: seq is allocated inside the same statement via
+  // SELECT COALESCE(MAX(seq),0)+1. SQLite takes the write lock for the whole
+  // statement (incl. the subquery), so concurrent inserts serialize correctly;
+  // UNIQUE(channel_id, seq) is the loud backstop for any residual race
+  // (dev/prod config-dir overlap) — a constraint failure, never a silent reorder.
+  const insertMessage = db.prepare(
+    `INSERT INTO channel_messages (
+       id, channel_id, seq, kind, status, sender_kind, sender_id, sender_display,
+       thread_id, parent_message_id, body_text, body_format, meta_json,
+       source_session_id, source_turn_id, source_item_id, client_message_id,
+       created_at, updated_at, completed_at
+     ) VALUES (
+       @id, @channelId,
+       (SELECT COALESCE(MAX(seq), 0) + 1 FROM channel_messages WHERE channel_id = @channelId),
+       @kind, @status, @senderKind, @senderId, @senderDisplay,
+       @threadId, @parentMessageId, @bodyText, @bodyFormat, @metaJson,
+       @sourceSessionId, @sourceTurnId, @sourceItemId, @clientMessageId,
+       @createdAt, @updatedAt, @completedAt
+     )`
+  );
+
+  function insertRow(params: Record<string, unknown>): ChannelMessageRow {
+    try {
+      insertMessage.run(params);
+    } catch (error) {
+      if (String(error).includes('UNIQUE constraint failed')) {
+        throw new ChannelMessageStoreError(
+          409,
+          'channel_message_seq_conflict',
+          'channel message seq/uniqueness conflict',
+          { id: params['id'] }
+        );
+      }
+      throw error;
+    }
+    return selectById.get(params['id']) as ChannelMessageRow;
+  }
+
+  function resolveThread(
+    channelId: string,
+    parentMessageId: string | undefined
+  ): string | null {
+    if (!parentMessageId) return null;
+    const parent = selectById.get(parentMessageId) as
+      | ChannelMessageRow
+      | undefined;
+    if (!parent) {
+      throw new ChannelMessageStoreError(
+        404,
+        'parent_message_not_found',
+        'parent message not found',
+        { parentMessageId }
+      );
+    }
+    if (parent.channel_id !== channelId) {
+      throw new ChannelMessageStoreError(
+        409,
+        'parent_channel_mismatch',
+        'parent message belongs to another channel',
+        { parentMessageId, parentChannelId: parent.channel_id, channelId }
+      );
+    }
+    return parent.thread_id ?? parent.id;
+  }
+
+  const upsertMemberStmt = db.prepare(
+    `INSERT INTO channel_members (channel_id, member_kind, member_id, joined_at, metadata_json)
+     VALUES (@channelId, @memberKind, @memberId, @joinedAt, @metadataJson)
+     ON CONFLICT(channel_id, member_kind, member_id) DO UPDATE SET
+       metadata_json = excluded.metadata_json`
+  );
+  const listMembersStmt = db.prepare(
+    'SELECT * FROM channel_members WHERE channel_id = ? ORDER BY joined_at ASC, member_id ASC'
+  );
+
+  function memberRowToRef(row: MemberRow): ChannelMemberRef {
+    return {
+      kind: row.member_kind as 'human' | 'agent',
+      id: row.member_id,
+      joinedAt: row.joined_at,
+    };
+  }
+
+  function getMessageById(id: string): ChannelMessage | null {
+    const row = selectById.get(id) as ChannelMessageRow | undefined;
+    return row ? rowToMessage(row) : null;
+  }
+
+  function appendCompleteImpl(input: AppendCompleteInput): ChannelMessage {
+    assertBodySize(input.text);
+    if (input.clientMessageId) {
+      const existing = selectByClientId.get({
+        channelId: input.channelId,
+        senderId: input.sender.id,
+        clientMessageId: input.clientMessageId,
+      }) as ChannelMessageRow | undefined;
+      if (existing) return rowToMessage(existing);
+    }
+    const threadId = resolveThread(input.channelId, input.parentMessageId);
+    const now = nowIso();
+    const id = createMessageId();
+    const row = insertRow({
+      id,
+      channelId: input.channelId,
+      kind: input.kind ?? 'message',
+      status: 'complete',
+      senderKind: input.sender.kind,
+      senderId: input.sender.id,
+      senderDisplay: input.sender.displayName ?? null,
+      threadId,
+      parentMessageId: input.parentMessageId ?? null,
+      bodyText: input.text,
+      bodyFormat: input.format ?? 'markdown',
+      metaJson: buildMeta({
+        ...(input.mentions ? { mentions: input.mentions } : {}),
+        ...(input.sender.providerId
+          ? { providerId: input.sender.providerId }
+          : {}),
+        ...(input.meta ? { extra: input.meta } : {}),
+      }),
+      sourceSessionId: null,
+      sourceTurnId: null,
+      sourceItemId: null,
+      clientMessageId: input.clientMessageId ?? null,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: now,
+    });
+    return rowToMessage(row);
+  }
+
+  function getBindingImpl(
+    channelId: string,
+    agentFramework: string
+  ): ChannelBinding | null {
+    const row = db
+      .prepare(
+        'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND agent_framework = ?'
+      )
+      .get(channelId, agentFramework) as BindingRow | undefined;
+    return row ? bindingRowToRecord(row) : null;
+  }
+
+  return {
+    close() {
+      db.close();
+    },
+
+    appendComplete(input) {
+      return appendCompleteImpl(input);
+    },
+
+    beginStream(input) {
+      // Idempotent: single-process synchronous check-then-insert is race-free;
+      // idx_chm_source_dedupe is the loud backstop for any cross-process retry.
+      const existing = selectBySource.get({
+        sessionId: input.source.sessionId,
+        turnId: input.source.turnId ?? null,
+        itemId: input.source.itemId ?? null,
+      }) as ChannelMessageRow | undefined;
+      if (existing) return rowToMessage(existing);
+
+      const initialText = input.text ?? '';
+      assertBodySize(initialText);
+      const threadId = resolveThread(input.channelId, input.parentMessageId);
+      const now = nowIso();
+      const id = createMessageId();
+      const row = insertRow({
+        id,
+        channelId: input.channelId,
+        kind: 'message',
+        status: 'streaming',
+        senderKind: input.sender.kind,
+        senderId: input.sender.id,
+        senderDisplay: input.sender.displayName ?? null,
+        threadId,
+        parentMessageId: input.parentMessageId ?? null,
+        bodyText: initialText,
+        bodyFormat: 'markdown',
+        metaJson: buildMeta({
+          ...(input.mentions ? { mentions: input.mentions } : {}),
+          ...(input.sender.providerId
+            ? { providerId: input.sender.providerId }
+            : {}),
+        }),
+        sourceSessionId: input.source.sessionId,
+        sourceTurnId: input.source.turnId ?? null,
+        sourceItemId: input.source.itemId ?? null,
+        clientMessageId: null,
+        createdAt: now,
+        updatedAt: now,
+        completedAt: null,
+      });
+      return rowToMessage(row);
+    },
+
+    updateStreamText(id, text) {
+      assertBodySize(text);
+      const row = selectById.get(id) as ChannelMessageRow | undefined;
+      if (!row) return null;
+      db.prepare(
+        'UPDATE channel_messages SET body_text = @text, updated_at = @now WHERE id = @id'
+      ).run({ id, text, now: nowIso() });
+      return getMessageById(id);
+    },
+
+    finalizeStream(id, input) {
+      const row = selectById.get(id) as ChannelMessageRow | undefined;
+      if (!row) return null;
+      // Idempotent replay: finalizing an already-final row is a no-op.
+      if (row.status !== 'streaming') return rowToMessage(row);
+      assertBodySize(input.text);
+      const now = nowIso();
+      const meta = parseMeta(row.meta_json) ?? {};
+      if (input.truncated) meta.truncated = true;
+      db.prepare(
+        `UPDATE channel_messages
+         SET body_text = @text, status = @status, meta_json = @metaJson,
+             updated_at = @now, completed_at = @now
+         WHERE id = @id`
+      ).run({
+        id,
+        text: input.text,
+        status: input.status,
+        metaJson:
+          Object.keys(meta).length > 0 ? JSON.stringify(meta) : row.meta_json,
+        now,
+      });
+      return getMessageById(id);
+    },
+
+    getMessage(id) {
+      return getMessageById(id);
+    },
+
+    findByClientMessage(channelId, senderId, clientMessageId) {
+      const row = selectByClientId.get({
+        channelId,
+        senderId,
+        clientMessageId,
+      }) as ChannelMessageRow | undefined;
+      return row ? rowToMessage(row) : null;
+    },
+
+    history(channelId, filter = {}) {
+      const limit = cleanLimit(filter.limit);
+      const clauses = ['channel_id = @channelId'];
+      const params: Record<string, unknown> = { channelId, limit };
+      if (filter.threadId) {
+        clauses.push('thread_id = @threadId');
+        params['threadId'] = filter.threadId;
+      }
+      if (typeof filter.afterSeq === 'number') {
+        clauses.push('seq > @afterSeq');
+        params['afterSeq'] = filter.afterSeq;
+        const rows = db
+          .prepare(
+            `SELECT * FROM channel_messages WHERE ${clauses.join(' AND ')}
+             ORDER BY seq ASC LIMIT @limit`
+          )
+          .all(params) as ChannelMessageRow[];
+        return rows.map(rowToMessage);
+      }
+      if (typeof filter.beforeSeq === 'number') {
+        clauses.push('seq < @beforeSeq');
+        params['beforeSeq'] = filter.beforeSeq;
+      }
+      // Default + beforeSeq: newest `limit` rows, returned seq-ascending.
+      const rows = db
+        .prepare(
+          `SELECT * FROM channel_messages WHERE ${clauses.join(' AND ')}
+           ORDER BY seq DESC LIMIT @limit`
+        )
+        .all(params) as ChannelMessageRow[];
+      return rows.reverse().map(rowToMessage);
+    },
+
+    latestSeq(channelId) {
+      const row = db
+        .prepare(
+          'SELECT COALESCE(MAX(seq), 0) AS latest FROM channel_messages WHERE channel_id = ?'
+        )
+        .get(channelId) as { latest: number };
+      return row.latest;
+    },
+
+    listChannelSummaries() {
+      const rows = db
+        .prepare(
+          `SELECT last.* FROM (
+             SELECT channel_id, MAX(seq) AS max_seq, COUNT(*) AS cnt
+             FROM channel_messages GROUP BY channel_id
+           ) agg
+           JOIN channel_messages last
+             ON last.channel_id = agg.channel_id AND last.seq = agg.max_seq
+           ORDER BY last.updated_at DESC`
+        )
+        .all() as Array<ChannelMessageRow & { cnt?: number }>;
+      // Second pass for counts keyed by channel (kept explicit for clarity).
+      const counts = new Map<string, number>();
+      for (const c of db
+        .prepare(
+          'SELECT channel_id, COUNT(*) AS cnt FROM channel_messages GROUP BY channel_id'
+        )
+        .all() as Array<{ channel_id: string; cnt: number }>) {
+        counts.set(c.channel_id, c.cnt);
+      }
+      return rows.map((row) =>
+        summaryFromLastRow(row, counts.get(row.channel_id) ?? 0)
+      );
+    },
+
+    getChannelSummary(channelId) {
+      const last = db
+        .prepare(
+          `SELECT * FROM channel_messages WHERE channel_id = ?
+           ORDER BY seq DESC LIMIT 1`
+        )
+        .get(channelId) as ChannelMessageRow | undefined;
+      const count = (
+        db
+          .prepare(
+            'SELECT COUNT(*) AS cnt FROM channel_messages WHERE channel_id = ?'
+          )
+          .get(channelId) as { cnt: number }
+      ).cnt;
+      if (!last) {
+        return { channelId, latestSeq: 0, messageCount: 0, lastMessage: null };
+      }
+      return summaryFromLastRow(last, count);
+    },
+
+    upsertMember(input) {
+      const joinedAt = nowIso();
+      const existing = (
+        listMembersStmt.all(input.channelId) as MemberRow[]
+      ).find(
+        (row) => row.member_kind === input.kind && row.member_id === input.id
+      );
+      upsertMemberStmt.run({
+        channelId: input.channelId,
+        memberKind: input.kind,
+        memberId: input.id,
+        joinedAt: existing?.joined_at ?? joinedAt,
+        metadataJson: JSON.stringify(input.metadata ?? {}),
+      });
+      return {
+        kind: input.kind,
+        id: input.id,
+        joinedAt: existing?.joined_at ?? joinedAt,
+      };
+    },
+
+    listMembers(channelId) {
+      return (listMembersStmt.all(channelId) as MemberRow[]).map(
+        memberRowToRef
+      );
+    },
+
+    findDmChannel(memberIdA, memberIdB) {
+      const row = db
+        .prepare(
+          `SELECT channel_id FROM channel_members
+           GROUP BY channel_id
+           HAVING COUNT(*) = 2
+             AND SUM(CASE WHEN member_id = @a THEN 1 ELSE 0 END) = 1
+             AND SUM(CASE WHEN member_id = @b THEN 1 ELSE 0 END) = 1
+           LIMIT 1`
+        )
+        .get({ a: memberIdA, b: memberIdB }) as
+        | { channel_id: string }
+        | undefined;
+      return row?.channel_id ?? null;
+    },
+
+    getBinding(channelId, agentFramework) {
+      return getBindingImpl(channelId, agentFramework);
+    },
+
+    upsertBinding(input) {
+      const now = nowIso();
+      const existing = db
+        .prepare(
+          'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND agent_framework = ?'
+        )
+        .get(input.channelId, input.agentFramework) as BindingRow | undefined;
+      const providerSessionJson = JSON.stringify(
+        input.providerSession ??
+          (existing ? JSON.parse(existing.provider_session_json) : {})
+      );
+      db.prepare(
+        `INSERT INTO channel_agent_bindings
+           (channel_id, agent_framework, session_id, provider_session_json, created_at, updated_at)
+         VALUES (@channelId, @agentFramework, @sessionId, @providerSessionJson, @createdAt, @updatedAt)
+         ON CONFLICT(channel_id, agent_framework) DO UPDATE SET
+           session_id = excluded.session_id,
+           provider_session_json = excluded.provider_session_json,
+           updated_at = excluded.updated_at`
+      ).run({
+        channelId: input.channelId,
+        agentFramework: input.agentFramework,
+        sessionId:
+          input.sessionId !== undefined
+            ? input.sessionId
+            : (existing?.session_id ?? null),
+        providerSessionJson,
+        createdAt: existing?.created_at ?? now,
+        updatedAt: now,
+      });
+      return getBindingImpl(input.channelId, input.agentFramework)!;
+    },
+
+    sweepStaleStreaming() {
+      const channels = db
+        .prepare(
+          "SELECT DISTINCT channel_id FROM channel_messages WHERE status = 'streaming'"
+        )
+        .all() as Array<{ channel_id: string }>;
+      const results: StaleStreamSweepResult[] = [];
+      for (const { channel_id: channelId } of channels) {
+        const stale = db
+          .prepare(
+            "SELECT id FROM channel_messages WHERE channel_id = ? AND status = 'streaming'"
+          )
+          .all(channelId) as Array<{ id: string }>;
+        const now = nowIso();
+        db.prepare(
+          `UPDATE channel_messages
+           SET status = 'interrupted', updated_at = @now, completed_at = @now
+           WHERE channel_id = @channelId AND status = 'streaming'`
+        ).run({ channelId, now });
+        const systemMessage = appendCompleteImpl({
+          channelId,
+          kind: 'system',
+          sender: { kind: 'system', id: 'system' },
+          text: 'Agent reply interrupted by restart.',
+        });
+        results.push({
+          channelId,
+          interruptedIds: stale.map((s) => s.id as ChannelMessageId),
+          systemMessage,
+        });
+      }
+      return results;
+    },
+
+    sweepOrphans(persistedTopicIds) {
+      const channelIds = new Set<string>();
+      for (const table of [
+        'channel_messages',
+        'channel_members',
+        'channel_agent_bindings',
+      ]) {
+        for (const row of db
+          .prepare(`SELECT DISTINCT channel_id FROM ${table}`)
+          .all() as Array<{ channel_id: string }>) {
+          channelIds.add(row.channel_id);
+        }
+      }
+      const orphans = [...channelIds].filter(
+        (id) => !persistedTopicIds.has(id)
+      );
+      let messagesDeleted = 0;
+      const deleteTx = db.transaction((ids: string[]) => {
+        for (const id of ids) {
+          messagesDeleted +=
+            db
+              .prepare('DELETE FROM channel_messages WHERE channel_id = ?')
+              .run(id).changes ?? 0;
+          db.prepare('DELETE FROM channel_members WHERE channel_id = ?').run(
+            id
+          );
+          db.prepare(
+            'DELETE FROM channel_agent_bindings WHERE channel_id = ?'
+          ).run(id);
+        }
+      });
+      deleteTx(orphans);
+      return { channelsDeleted: orphans, messagesDeleted };
+    },
+  };
+
+  function summaryFromLastRow(
+    row: ChannelMessageRow,
+    messageCount: number
+  ): ChannelSummary {
+    return {
+      channelId: row.channel_id,
+      latestSeq: row.seq,
+      messageCount,
+      lastMessage: {
+        id: row.id as ChannelMessageId,
+        seq: row.seq,
+        preview: row.body_text.slice(0, CHANNEL_SUMMARY_PREVIEW_MAX_CHARS),
+        senderId: row.sender_id,
+        senderKind: row.sender_kind as ChannelSenderRef['kind'],
+        status: row.status as ChannelMessageStatus,
+        createdAt: row.created_at,
+      },
+    };
+  }
+}
+
+function bindingRowToRecord(row: BindingRow): ChannelBinding {
+  let providerSession: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(row.provider_session_json) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      providerSession = parsed as Record<string, unknown>;
+    }
+  } catch {
+    providerSession = {};
+  }
+  return {
+    channelId: row.channel_id,
+    agentFramework: row.agent_framework,
+    sessionId: row.session_id,
+    providerSession,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -68,6 +68,9 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'workspace-topics.list',
   'workspace-topics.search',
   'workspace-topics.get',
+  'channels.list',
+  'channels.get',
+  'channels.history',
   'context.get',
   'context.list',
   'inbox.list',
@@ -104,6 +107,7 @@ export const CLI_GATEWAY_ACTOR_WRITE_COMMANDS = [
   'workspace-topics.update',
   'workspace-topics.archive',
   'workspace-topics.restore',
+  'channels.post',
 ] as const;
 export type CliGatewayActorWriteCommand =
   (typeof CLI_GATEWAY_ACTOR_WRITE_COMMANDS)[number];
@@ -333,6 +337,16 @@ export function cliGatewayActorCommandCapabilities(
   if (command === 'inbox.list' || command === 'inbox.get')
     return ['inbox:read'];
   if (command === 'work-context-messages.append') return ['context:write'];
+  // Channel conversation verbs (#1165): reads gate on context:read, the single
+  // post write gates on context:write. Mounting the router alone is not enough —
+  // the capability map must resolve or gateway auth fails at runtime.
+  if (
+    command === 'channels.list' ||
+    command === 'channels.get' ||
+    command === 'channels.history'
+  )
+    return ['context:read'];
+  if (command === 'channels.post') return ['context:write'];
   if (
     command === 'workflow-runs.list' ||
     command === 'workflow-runs.get' ||

--- a/server/index.ts
+++ b/server/index.ts
@@ -1995,10 +1995,13 @@ async function main(): Promise<void> {
     try {
       channelMessageStore.sweepStaleStreaming();
       if (workspaceTopicStore) {
+        // Enumerate ALL stored topic ids uncapped — NOT via `list()`, which caps
+        // at 200 while the store retains up to 500. Feeding the capped list to
+        // sweepOrphans would delete every channel whose topic ranks beyond the
+        // top-200-by-updated_at (silent, unrecoverable data loss) once >200
+        // topics exist.
         const persistedTopicIds = new Set(
-          workspaceTopicStore
-            .list({ includeArchived: true })
-            .map((topic) => topic.id)
+          workspaceTopicStore.listAllTopicIds()
         );
         channelMessageStore.sweepOrphans(persistedTopicIds);
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -228,6 +228,13 @@ import { createAgentRosterRouter } from './features/agent-roster-router.js';
 import { buildAttentionEventInput } from '../shared/agent-roster.js';
 import { createWorkContextMessageRouter } from './features/work-context-message-router.js';
 import {
+  initChannelMessageStore,
+  type ChannelMessageStore,
+} from './channel-message-store.js';
+import { createChannelHub, type ChannelHub } from './channel-hub.js';
+import { createChannelChatRouter } from './channel-chat-router.js';
+import { v2Adapters } from './protocol-adapters/index.js';
+import {
   initWorkContextArtifactStore,
   type WorkContextArtifactStore,
 } from './work-context-artifacts.js';
@@ -1694,6 +1701,20 @@ function initWorkContextMessageStoreBestEffort(
   }
 }
 
+function initChannelMessageStoreBestEffort(
+  configDir: string
+): ChannelMessageStore | null {
+  try {
+    return initChannelMessageStore(configDir);
+  } catch (err) {
+    logger.warn(
+      'Channel message store disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
 async function ensureStartupTerminalBackendAvailable(
   _startupConfig: Config
 ): Promise<void> {}
@@ -1965,6 +1986,33 @@ async function main(): Promise<void> {
   const prOverseerStore = initPrOverseerStoreBestEffort(configDir);
   const workContextMessageStore =
     initWorkContextMessageStoreBestEffort(configDir);
+  // Channel conversation core (#1165). Own SQLite (`channel-chat.db`); routes and
+  // the /ws/channels lane degrade when init fails — a failed channel store never
+  // takes down the hub or the untouched /ws/:sessionId lane. Boot order: init →
+  // sweep stale streaming → sweep orphans → hub → mount router → wire ws.
+  const channelMessageStore = initChannelMessageStoreBestEffort(configDir);
+  if (channelMessageStore) {
+    try {
+      channelMessageStore.sweepStaleStreaming();
+      if (workspaceTopicStore) {
+        const persistedTopicIds = new Set(
+          workspaceTopicStore
+            .list({ includeArchived: true })
+            .map((topic) => topic.id)
+        );
+        channelMessageStore.sweepOrphans(persistedTopicIds);
+      }
+    } catch (err) {
+      logger.warn(
+        'Channel store boot sweep failed:',
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+  const channelHub: ChannelHub = createChannelHub({
+    store: channelMessageStore,
+    channelExists: (channelId) => Boolean(workspaceTopicStore?.get(channelId)),
+  });
   const cliGatewayEventBus = createCliGatewayEventBus();
 
   try {
@@ -2666,6 +2714,20 @@ async function main(): Promise<void> {
       requireWriteActorAuth: requireCliGatewayAuthForActorCommand,
     })
   );
+  // channel conversation core (#1165): channels.* verbs over channel-chat.db.
+  // Topic CRUD stays on the workspace-topics routes above; channels are a read/
+  // write conversation surface keyed by workspace_topics id. Single write path.
+  app.use(
+    createChannelChatRouter({
+      store: channelMessageStore,
+      hub: channelHub,
+      topicStore: workspaceTopicStore,
+      knownProviderIds: Object.keys(v2Adapters),
+      requireAuth: requireCliGatewayAuth,
+      requireReadActorAuth: requireCliGatewayAuthForActorCommand,
+      requireWriteActorAuth: requireCliGatewayAuthForActorCommand,
+    })
+  );
   // #765 / ADR-019: context.* / inbox.* gateway verbs. #759 wires the router
   // to the concrete #758 `ContextPacketStore` via the integration adapter
   // (method renames, throw→result-union remap, PULL-as-delivery flip). When the
@@ -3131,7 +3193,8 @@ async function main(): Promise<void> {
     hubNodeLinks,
     sessionEnvelopeRegistry,
     securityAuditLog,
-    { strictDeny: process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1' }
+    { strictDeny: process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1' },
+    channelHub
   );
 
   const browserScopedToken = generateScopedToken();
@@ -5767,6 +5830,8 @@ async function main(): Promise<void> {
         workspaceTopicStore?.close();
         prOverseerStore?.close();
         workContextMessageStore?.close();
+        channelHub.close();
+        channelMessageStore?.close();
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
@@ -5851,6 +5916,8 @@ async function main(): Promise<void> {
     workspaceTopicStore?.close();
     prOverseerStore?.close();
     workContextMessageStore?.close();
+    channelHub.close();
+    channelMessageStore?.close();
     closeInterventionLog();
     for (const s of localRelayNode.sessions.list()) {
       try {

--- a/server/workspace-topics.ts
+++ b/server/workspace-topics.ts
@@ -96,6 +96,14 @@ export interface WorkspaceTopicStore {
   restore(id: string): WorkspaceTopic | null;
   get(id: string): WorkspaceTopic | null;
   list(filter?: WorkspaceTopicListFilter): WorkspaceTopic[];
+  /**
+   * Every stored topic id, uncapped — a direct id query, NOT the `list()` read
+   * model (which caps at WORKSPACE_TOPICS_MAX_LIST_ENTRIES=200 while the store
+   * retains up to 500). Callers that must enumerate the complete id set — e.g.
+   * the channel-store orphan GC — MUST use this, or channels whose topic ranks
+   * beyond the top-200-by-`updated_at` get their messages wrongly swept.
+   */
+  listAllTopicIds(): string[];
 }
 
 function defaultClock(): string {
@@ -261,6 +269,13 @@ export function createWorkspaceTopicStore(input: {
       return rows
         .map((row) => parseRow(row))
         .filter((topic): topic is WorkspaceTopic => Boolean(topic));
+    },
+
+    listAllTopicIds() {
+      const rows = db
+        .prepare('SELECT id FROM workspace_topics')
+        .all() as Array<{ id: string }>;
+      return rows.map((row) => row.id);
     },
   };
 }

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -54,6 +54,8 @@ import {
   policyDecisionToRelayError,
 } from './hub-policy-evaluator.js';
 import { sourceTupleFromIncomingMessage } from './node-source-diagnostics.js';
+import type { ChannelHub } from './channel-hub.js';
+import { isWorkspaceTopicId } from '../shared/workspace-topics.js';
 
 const logger = createLogger('ws');
 
@@ -574,7 +576,8 @@ function setupWebSocket(
   nodeLinks?: HubNodeLinkManager,
   sessionEnvelopes: InMemorySessionEnvelopeRegistry = sessionEnvelopeRegistry,
   auditSink?: RoutedSessionAuditSink,
-  sourceDiagnostics?: NodeLinkSourceDiagnosticsOptions
+  sourceDiagnostics?: NodeLinkSourceDiagnosticsOptions,
+  channelHub?: ChannelHub
 ): {
   wss: WebSocketServer;
   broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
@@ -658,6 +661,11 @@ function setupWebSocket(
       }
     }
   }
+
+  // Sidebar badges ride the existing /ws/events broadcast as coarse
+  // `channel-activity` notifications (never deltas — that lane has no
+  // subscription filter and would flood all tabs).
+  channelHub?.setBadgeBroadcaster(broadcastEvent);
 
   function broadcastBranchChanged(cwdPath: string, branchName: string): void {
     const matchingSessions = sessions
@@ -884,6 +892,34 @@ function setupWebSocket(
         });
         ws.on('close', cleanup);
         ws.on('error', cleanup);
+      });
+      return;
+    }
+
+    // Channel fan-out lane: /ws/channels/:channelId?sinceSeq=N (server→client
+    // only; all writes are REST). Checked before the /ws/:sessionId fallback.
+    const channelMatch = requestPath.match(/^\/ws\/channels\/([^/]+)$/);
+    if (channelMatch) {
+      let channelId: string;
+      try {
+        channelId = decodeURIComponent(channelMatch[1]!);
+      } catch {
+        socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+      if (!channelHub || !isWorkspaceTopicId(channelId)) {
+        socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+      const sinceSeq = parseReplayCursor(
+        requestUrl.searchParams.get('sinceSeq')
+      );
+      // Upgrade first, then let the hub validate channel existence and close
+      // with app code 4404 if unknown (app close codes are only valid post-upgrade).
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        channelHub.handleConnection(ws, { channelId, sinceSeq });
       });
       return;
     }

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -1,0 +1,473 @@
+// Channel conversation core wire protocol (#1165, epic #1163).
+//
+// `ChannelEventV1` is a NEW, purpose-built multi-sender envelope. It deliberately
+// does NOT extend `AgentPatchV2` (shared/agent-chat-protocol-v2.ts), whose reducer
+// is structurally single-agent (singular `live.activeTurnId`); grafting sender
+// attribution onto it would corrupt every adapter. A channel is a durable,
+// multi-party timeline: humans and agents post into one seq-ordered log. Two
+// agents streaming at once are two independent `streaming` rows with distinct ids
+// and distinct (already-assigned) seqs — cross-sender corruption is structurally
+// impossible because no reducer field is shared between senders.
+
+export const CHANNEL_CHAT_PROTOCOL_VERSION = 1 as const;
+
+/** 256KB per-message body cap, parity with WORK_CONTEXT_MESSAGE_PAYLOAD_MAX_BYTES. */
+export const CHANNEL_MESSAGE_BODY_MAX_BYTES = 256 * 1024;
+
+export type ChannelMessageId = `chm:${string}`;
+
+export type ChannelSenderKind = 'human' | 'agent' | 'system';
+export type ChannelMessageKind = 'message' | 'system';
+export type ChannelMessageStatus =
+  | 'streaming'
+  | 'complete'
+  | 'interrupted'
+  | 'failed';
+export type ChannelBodyFormat = 'markdown' | 'text';
+
+export interface ChannelSenderRef {
+  kind: ChannelSenderKind;
+  /** 'human:<actorId>' | 'agent:<frameworkId>' | 'system' */
+  id: string;
+  displayName?: string;
+  /** agent framework id (claude/codex/hermes/opencode) */
+  providerId?: string;
+  /** backing adapter session (slice 4 fills) */
+  sessionId?: string;
+}
+
+export interface ChannelMemberRef {
+  kind: 'human' | 'agent';
+  id: string;
+  joinedAt: string;
+}
+
+export interface ChannelMention {
+  raw: string;
+  providerId?: string;
+}
+
+export interface ChannelMessageSource {
+  sessionId: string;
+  turnId?: string;
+  itemId?: string;
+}
+
+export interface ChannelMessage {
+  schemaVersion: 1;
+  id: ChannelMessageId;
+  channelId: string;
+  seq: number;
+  kind: ChannelMessageKind;
+  status: ChannelMessageStatus;
+  sender: ChannelSenderRef;
+  body: { text: string; format: ChannelBodyFormat };
+  threadId: ChannelMessageId | null;
+  parentMessageId: ChannelMessageId | null;
+  mentions?: ChannelMention[];
+  source?: ChannelMessageSource;
+  truncated?: boolean;
+  clientMessageId?: string;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+}
+
+export interface ChannelInFlightRef {
+  messageId: ChannelMessageId;
+  deltaIndex: number;
+}
+
+interface ChannelEventBaseV1 {
+  channelId: string;
+  timestamp: string;
+}
+
+export interface ChannelSnapshotEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-snapshot-v1';
+  /** full: replace state; catchup: merge by seq/id */
+  mode: 'full' | 'catchup';
+  /** seq-ascending; streaming rows carry accumulated in-memory text */
+  messages: ChannelMessage[];
+  members: ChannelMemberRef[];
+  latestSeq: number;
+  inFlight: ChannelInFlightRef[];
+  /** true when a full snapshot did not reach seq 1 */
+  truncated: boolean;
+}
+
+export interface ChannelMessageCreatedEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-message-created-v1';
+  /** status 'complete' (post) or 'streaming' (stream open) */
+  message: ChannelMessage;
+}
+
+export interface ChannelMessageDeltaEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-message-delta-v1';
+  messageId: ChannelMessageId;
+  /** server-assigned 0,1,2,... per message, per coalesced flush */
+  deltaIndex: number;
+  delta: { text: string };
+}
+
+export interface ChannelMessageCompletedEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-message-completed-v1';
+  /** authoritative full row; status complete|interrupted|failed */
+  message: ChannelMessage;
+}
+
+export interface ChannelResyncRequiredEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-resync-required-v1';
+  latestSeq: number;
+}
+
+export type ChannelEventV1 =
+  | ChannelSnapshotEventV1
+  | ChannelMessageCreatedEventV1
+  | ChannelMessageDeltaEventV1
+  | ChannelMessageCompletedEventV1
+  | ChannelResyncRequiredEventV1;
+
+// ── runtime validators ──────────────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const SENDER_KINDS = new Set<string>(['human', 'agent', 'system']);
+const MESSAGE_KINDS = new Set<string>(['message', 'system']);
+const MESSAGE_STATUSES = new Set<string>([
+  'streaming',
+  'complete',
+  'interrupted',
+  'failed',
+]);
+const BODY_FORMATS = new Set<string>(['markdown', 'text']);
+
+function isSenderRef(value: unknown): value is ChannelSenderRef {
+  return (
+    isRecord(value) &&
+    typeof value.kind === 'string' &&
+    SENDER_KINDS.has(value.kind) &&
+    typeof value.id === 'string' &&
+    (value.displayName === undefined ||
+      typeof value.displayName === 'string') &&
+    (value.providerId === undefined || typeof value.providerId === 'string') &&
+    (value.sessionId === undefined || typeof value.sessionId === 'string')
+  );
+}
+
+function isMemberRef(value: unknown): value is ChannelMemberRef {
+  return (
+    isRecord(value) &&
+    (value.kind === 'human' || value.kind === 'agent') &&
+    typeof value.id === 'string' &&
+    typeof value.joinedAt === 'string'
+  );
+}
+
+export function isChannelMessage(value: unknown): value is ChannelMessage {
+  if (!isRecord(value)) return false;
+  if (value.schemaVersion !== CHANNEL_CHAT_PROTOCOL_VERSION) return false;
+  if (typeof value.id !== 'string' || !value.id.startsWith('chm:'))
+    return false;
+  if (typeof value.channelId !== 'string') return false;
+  if (typeof value.seq !== 'number' || !Number.isFinite(value.seq))
+    return false;
+  if (typeof value.kind !== 'string' || !MESSAGE_KINDS.has(value.kind))
+    return false;
+  if (typeof value.status !== 'string' || !MESSAGE_STATUSES.has(value.status))
+    return false;
+  if (!isSenderRef(value.sender)) return false;
+  if (
+    !isRecord(value.body) ||
+    typeof value.body.text !== 'string' ||
+    typeof value.body.format !== 'string' ||
+    !BODY_FORMATS.has(value.body.format)
+  ) {
+    return false;
+  }
+  if (value.threadId !== null && typeof value.threadId !== 'string')
+    return false;
+  if (
+    value.parentMessageId !== null &&
+    typeof value.parentMessageId !== 'string'
+  )
+    return false;
+  if (
+    typeof value.createdAt !== 'string' ||
+    typeof value.updatedAt !== 'string'
+  )
+    return false;
+  return true;
+}
+
+function isMessageArray(value: unknown): value is ChannelMessage[] {
+  return Array.isArray(value) && value.every(isChannelMessage);
+}
+
+function isInFlightArray(value: unknown): value is ChannelInFlightRef[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        isRecord(entry) &&
+        typeof entry.messageId === 'string' &&
+        typeof entry.deltaIndex === 'number'
+    )
+  );
+}
+
+export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
+  if (!isRecord(value)) return false;
+  if (typeof value.type !== 'string') return false;
+  if (typeof value.channelId !== 'string') return false;
+  if (typeof value.timestamp !== 'string') return false;
+  switch (value.type) {
+    case 'channel-snapshot-v1':
+      return (
+        (value.mode === 'full' || value.mode === 'catchup') &&
+        isMessageArray(value.messages) &&
+        Array.isArray(value.members) &&
+        value.members.every(isMemberRef) &&
+        typeof value.latestSeq === 'number' &&
+        isInFlightArray(value.inFlight) &&
+        typeof value.truncated === 'boolean'
+      );
+    case 'channel-message-created-v1':
+      return isChannelMessage(value.message);
+    case 'channel-message-delta-v1':
+      return (
+        typeof value.messageId === 'string' &&
+        typeof value.deltaIndex === 'number' &&
+        isRecord(value.delta) &&
+        typeof value.delta.text === 'string'
+      );
+    case 'channel-message-completed-v1':
+      return isChannelMessage(value.message);
+    case 'channel-resync-required-v1':
+      return typeof value.latestSeq === 'number';
+    default:
+      return false;
+  }
+}
+
+// ── pure reducer ────────────────────────────────────────────────────────────
+
+export interface ChannelReducerState {
+  channelId: string;
+  /** seq-ordered */
+  messages: ChannelMessage[];
+  byId: Record<string, ChannelMessage>;
+  lastSeq: number;
+  /** last applied deltaIndex per streaming message */
+  inFlightDelta: Record<string, number>;
+  /** streams that received an out-of-order delta; drop further deltas until completed heals */
+  quarantined: Record<string, true>;
+  /** self-diagnosis flag: the client re-syncs via afterSeq/sinceSeq when set */
+  needsCatchup: boolean;
+}
+
+export function initialChannelReducerState(
+  channelId: string
+): ChannelReducerState {
+  return {
+    channelId,
+    messages: [],
+    byId: {},
+    lastSeq: 0,
+    inFlightDelta: {},
+    quarantined: {},
+    needsCatchup: false,
+  };
+}
+
+function sortedInsert(
+  messages: ChannelMessage[],
+  message: ChannelMessage
+): ChannelMessage[] {
+  const next = messages.filter((existing) => existing.id !== message.id);
+  let index = next.findIndex((existing) => existing.seq > message.seq);
+  if (index === -1) index = next.length;
+  next.splice(index, 0, message);
+  return next;
+}
+
+function rebuildById(
+  messages: ChannelMessage[]
+): Record<string, ChannelMessage> {
+  const byId: Record<string, ChannelMessage> = {};
+  for (const message of messages) byId[message.id] = message;
+  return byId;
+}
+
+function inFlightFromRefs(
+  inFlight: ChannelInFlightRef[]
+): Record<string, number> {
+  const map: Record<string, number> = {};
+  for (const ref of inFlight) map[ref.messageId] = ref.deltaIndex;
+  return map;
+}
+
+/**
+ * Pure reducer for `ChannelEventV1`. It is self-diagnosing: it can never silently
+ * render a corrupted timeline. On any gap or unknown-id surprise it sets
+ * `needsCatchup` (drives the client to `channels.history?afterSeq=lastSeq` or a
+ * reconnect with `sinceSeq=lastSeq`) instead of guessing. Deterministic under
+ * replay: applying the same event stream twice yields the same state.
+ */
+export function applyChannelEventV1(
+  state: ChannelReducerState,
+  event: ChannelEventV1
+): ChannelReducerState {
+  switch (event.type) {
+    case 'channel-snapshot-v1': {
+      if (event.mode === 'full') {
+        const messages = [...event.messages].sort((a, b) => a.seq - b.seq);
+        return {
+          channelId: state.channelId,
+          messages,
+          byId: rebuildById(messages),
+          lastSeq: event.latestSeq,
+          inFlightDelta: inFlightFromRefs(event.inFlight),
+          quarantined: {},
+          needsCatchup: false,
+        };
+      }
+      // catchup: merge ascending
+      let messages = state.messages;
+      for (const message of [...event.messages].sort((a, b) => a.seq - b.seq)) {
+        if (state.byId[message.id] || message.seq > state.lastSeq) {
+          messages = sortedInsert(messages, message);
+        }
+      }
+      return {
+        ...state,
+        messages,
+        byId: rebuildById(messages),
+        lastSeq: Math.max(state.lastSeq, event.latestSeq),
+        inFlightDelta: inFlightFromRefs(event.inFlight),
+        quarantined: {},
+        needsCatchup: false,
+      };
+    }
+
+    case 'channel-message-created-v1': {
+      const message = event.message;
+      if (state.byId[message.id]) return state; // idempotent replay
+      if (message.seq <= state.lastSeq) return state; // idempotent replay
+      if (message.seq > state.lastSeq + 1) {
+        return { ...state, needsCatchup: true }; // gap — do not apply
+      }
+      const messages = sortedInsert(state.messages, message);
+      return {
+        ...state,
+        messages,
+        byId: rebuildById(messages),
+        lastSeq: message.seq,
+      };
+    }
+
+    case 'channel-message-delta-v1': {
+      const existing = state.byId[event.messageId];
+      if (!existing) return { ...state, needsCatchup: true };
+      if (existing.status !== 'streaming') return state; // late delta after finalize
+      if (state.quarantined[event.messageId]) return state; // dropped until completed heals
+      const expected = (state.inFlightDelta[event.messageId] ?? -1) + 1;
+      if (event.deltaIndex !== expected) {
+        // out-of-order — quarantine THIS message only
+        return {
+          ...state,
+          quarantined: { ...state.quarantined, [event.messageId]: true },
+        };
+      }
+      const updated: ChannelMessage = {
+        ...existing,
+        body: { ...existing.body, text: existing.body.text + event.delta.text },
+      };
+      const messages = state.messages.map((message) =>
+        message.id === updated.id ? updated : message
+      );
+      return {
+        ...state,
+        messages,
+        byId: { ...state.byId, [updated.id]: updated },
+        inFlightDelta: {
+          ...state.inFlightDelta,
+          [event.messageId]: event.deltaIndex,
+        },
+      };
+    }
+
+    case 'channel-message-completed-v1': {
+      const message = event.message;
+      if (!state.byId[message.id]) return { ...state, needsCatchup: true };
+      const messages = state.messages.map((existing) =>
+        existing.id === message.id ? message : existing
+      );
+      const inFlightDelta = { ...state.inFlightDelta };
+      delete inFlightDelta[message.id];
+      const quarantined = { ...state.quarantined };
+      delete quarantined[message.id];
+      return {
+        ...state,
+        messages,
+        byId: { ...state.byId, [message.id]: message },
+        inFlightDelta,
+        quarantined,
+      };
+    }
+
+    case 'channel-resync-required-v1':
+      return { ...state, needsCatchup: true };
+
+    default:
+      return state;
+  }
+}
+
+// ── mention parser (stored, not routed in slice 2) ──────────────────────────
+
+/**
+ * Extract `@mention` tokens from message text, skipping code fences, inline code,
+ * and email-like `local@domain` spans. Returns both the raw token and, when the
+ * name matches a known framework provider id (case-insensitive), the resolved
+ * `providerId`. Both are persisted so alias policy (`@Claude` vs `@claude`,
+ * custom providers) can change later without a data migration. #1167 inherits
+ * this hardened tokenizer.
+ */
+export function parseMentions(
+  text: string,
+  knownProviderIds: readonly string[] = []
+): ChannelMention[] {
+  const known = new Map<string, string>();
+  for (const id of knownProviderIds) known.set(id.toLowerCase(), id);
+
+  const masked = maskCodeSpans(text);
+  const mentionPattern = /(^|[^A-Za-z0-9_.])@([A-Za-z][A-Za-z0-9_-]*)/g;
+  const seen = new Set<string>();
+  const mentions: ChannelMention[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = mentionPattern.exec(masked)) !== null) {
+    const name = match[2];
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const providerId = known.get(key);
+    mentions.push({
+      raw: `@${name}`,
+      ...(providerId ? { providerId } : {}),
+    });
+  }
+  return mentions;
+}
+
+/** Replace fenced + inline code spans with equal-length spaces so mention offsets stay aligned. */
+function maskCodeSpans(text: string): string {
+  const maskRun = (source: string, pattern: RegExp): string =>
+    source.replace(pattern, (span) => ' '.repeat(span.length));
+  let masked = maskRun(text, /```[\s\S]*?```/g);
+  masked = maskRun(masked, /`[^`]*`/g);
+  return masked;
+}

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -1,0 +1,286 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import type { AdapterConfig } from '../server/protocol-adapter-v2.js';
+import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
+import { bindSessionToChannel } from '../server/channel-agent-bridge.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+function makeStore(): { store: ChannelMessageStore; hub: ChannelHub } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-channel-bridge-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => store.close());
+  const hub = createChannelHub({ store, channelExists: () => true });
+  cleanup.push(() => hub.close());
+  return { store, hub };
+}
+
+function config(sessionId: string): AdapterConfig {
+  return {
+    cwd: '/tmp',
+    port: 0,
+    sessionId,
+    hookToken: 'tok',
+    configDir: '/tmp',
+  };
+}
+
+function assistantStarted(
+  sessionId: string,
+  turnId: string,
+  itemId: string
+): AgentPatchV2 {
+  return {
+    type: 'agent-item-started-v2',
+    sessionId,
+    timestamp: 't',
+    turnId,
+    item: { type: 'assistantMessage', id: itemId, text: '' },
+  };
+}
+function textDelta(
+  sessionId: string,
+  turnId: string,
+  itemId: string,
+  text: string
+): AgentPatchV2 {
+  return {
+    type: 'agent-item-delta-v2',
+    sessionId,
+    timestamp: 't',
+    turnId,
+    itemId,
+    delta: { text },
+  };
+}
+function assistantUpdated(
+  sessionId: string,
+  turnId: string,
+  itemId: string,
+  text: string
+): AgentPatchV2 {
+  return {
+    type: 'agent-item-updated-v2',
+    sessionId,
+    timestamp: 't',
+    turnId,
+    item: { type: 'assistantMessage', id: itemId, text },
+  };
+}
+
+describe('channel-agent-bridge lifecycle', () => {
+  it('mirrors a full assistant turn as an attributed complete row', async () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 });
+    await adapter.connect(config('sess-1'));
+    const unbind = bindSessionToChannel({
+      channelId: 'topic:test',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+    });
+    cleanup.push(unbind);
+
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'hello' });
+
+    const messages = store.history('topic:test');
+    expect(messages).toHaveLength(1);
+    const message = messages[0]!;
+    expect(message.status).toBe('complete');
+    expect(message.sender).toMatchObject({
+      kind: 'agent',
+      id: 'agent:claude',
+      providerId: 'claude',
+    });
+    expect(message.body.text).toBe('Mock v2 response complete.');
+    expect(message.source).toMatchObject({
+      sessionId: 'sess-1',
+      turnId: 'turn-1',
+      itemId: 'assistant-turn-1',
+    });
+    expect(
+      store.listMembers('topic:test').some((m) => m.id === 'agent:claude')
+    ).toBe(true);
+  });
+
+  it('keeps two concurrent bound sessions from cross-contaminating in one channel', async () => {
+    const { store, hub } = makeStore();
+    const a1 = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 });
+    const a2 = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 });
+    await a1.connect(config('s1'));
+    await a2.connect(config('s2'));
+    cleanup.push(
+      bindSessionToChannel({
+        channelId: 'topic:c',
+        agentFramework: 'claude',
+        adapter: a1,
+        store,
+        hub,
+      })
+    );
+    cleanup.push(
+      bindSessionToChannel({
+        channelId: 'topic:c',
+        agentFramework: 'codex',
+        adapter: a2,
+        store,
+        hub,
+      })
+    );
+
+    await Promise.all([
+      a1.sendMessage({ turnId: 't1', content: 'hi' }),
+      a2.sendMessage({ turnId: 't2', content: 'hi' }),
+    ]);
+
+    const messages = store.history('topic:c');
+    expect(messages).toHaveLength(2);
+    const claude = messages.find((m) => m.sender.id === 'agent:claude');
+    const codex = messages.find((m) => m.sender.id === 'agent:codex');
+    expect(claude?.body.text).toBe('Mock v2 response complete.');
+    expect(codex?.body.text).toBe('Mock v2 response complete.');
+    expect(claude?.source?.sessionId).toBe('s1');
+    expect(codex?.source?.sessionId).toBe('s2');
+  });
+
+  it('finalizes as failed on agent-error-v2 keeping the partial text', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:e',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1'));
+    adapter.broadcastPatch(textDelta('s', 'turn', 'a1', 'partial'));
+    adapter.broadcastPatch({
+      type: 'agent-error-v2',
+      sessionId: 's',
+      timestamp: 't',
+      message: 'boom',
+      turnId: 'turn',
+    });
+
+    const messages = store.history('topic:e');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      status: 'failed',
+      body: { text: 'partial' },
+    });
+  });
+
+  it('finalizes an open stream as interrupted when the session is unbound mid-stream', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    const unbind = bindSessionToChannel({
+      channelId: 'topic:d',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1'));
+    adapter.broadcastPatch(textDelta('s', 'turn', 'a1', 'hi'));
+    unbind();
+
+    const messages = store.history('topic:d');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      status: 'interrupted',
+      body: { text: 'hi' },
+    });
+  });
+
+  it('does not double-commit on re-emitted patches (source triple dedupe)', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:r',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1'));
+    adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1')); // re-emit
+    adapter.broadcastPatch(assistantUpdated('s', 'turn', 'a1', 'full'));
+    adapter.broadcastPatch(assistantUpdated('s', 'turn', 'a1', 'full-again')); // stream closed
+
+    const messages = store.history('topic:r');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      status: 'complete',
+      body: { text: 'full' },
+    });
+  });
+
+  it('does not mirror non-text items', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:n',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch({
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: { type: 'commandExecution', id: 'c1', command: 'ls', output: '' },
+    });
+    adapter.broadcastPatch({
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: { type: 'reasoning', id: 'r1', summary: 'thinking' },
+    });
+    expect(store.history('topic:n')).toHaveLength(0);
+  });
+
+  it('force-finalizes truncated when the in-flight text exceeds the 256KB cap', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:cap',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1'));
+    adapter.broadcastPatch(textDelta('s', 'turn', 'a1', 'start '));
+    adapter.broadcastPatch(
+      textDelta('s', 'turn', 'a1', 'x'.repeat(256 * 1024))
+    ); // breach
+
+    const messages = store.history('topic:cap');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      status: 'complete',
+      truncated: true,
+      body: { text: 'start ' },
+    });
+  });
+});

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -232,6 +232,32 @@ describe('channel-agent-bridge lifecycle', () => {
     });
   });
 
+  it('does not mirror plan-item (or unknown-item) text deltas', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:plan',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+    });
+    // A plan item is started as a non-assistantMessage, then streams text deltas
+    // (real codex-native adapters emit plan updates this way on `plan-<turnId>`).
+    adapter.broadcastPatch({
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: { type: 'plan', id: 'plan-turn', text: '' },
+    });
+    adapter.broadcastPatch(textDelta('s', 'turn', 'plan-turn', 'Step 1: do it'));
+    // A delta for an itemId never started at all is likewise dropped.
+    adapter.broadcastPatch(textDelta('s', 'turn', 'ghost-item', 'stray text'));
+
+    expect(store.history('topic:plan')).toHaveLength(0);
+  });
+
   it('does not mirror non-text items', () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2();

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyChannelEventV1,
+  initialChannelReducerState,
+  isChannelEventV1,
+  parseMentions,
+  type ChannelEventV1,
+  type ChannelMessage,
+  type ChannelMessageId,
+  type ChannelReducerState,
+} from '../shared/channel-chat-protocol.js';
+
+const CHANNEL = 'topic:general';
+
+function message(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: 'chm:1' as ChannelMessageId,
+    channelId: CHANNEL,
+    seq: 1,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: 'hi', format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-18T00:00:00.000Z',
+    updatedAt: '2026-07-18T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function created(m: ChannelMessage): ChannelEventV1 {
+  return {
+    type: 'channel-message-created-v1',
+    channelId: CHANNEL,
+    timestamp: 't',
+    message: m,
+  };
+}
+function delta(
+  messageId: string,
+  deltaIndex: number,
+  text: string
+): ChannelEventV1 {
+  return {
+    type: 'channel-message-delta-v1',
+    channelId: CHANNEL,
+    timestamp: 't',
+    messageId: messageId as ChannelMessageId,
+    deltaIndex,
+    delta: { text },
+  };
+}
+function completed(m: ChannelMessage): ChannelEventV1 {
+  return {
+    type: 'channel-message-completed-v1',
+    channelId: CHANNEL,
+    timestamp: 't',
+    message: m,
+  };
+}
+
+function reduce(
+  state: ChannelReducerState,
+  events: ChannelEventV1[]
+): ChannelReducerState {
+  return events.reduce(applyChannelEventV1, state);
+}
+
+describe('isChannelEventV1 validator matrix', () => {
+  it('accepts each event variant', () => {
+    const snapshot: ChannelEventV1 = {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'full',
+      messages: [message()],
+      members: [{ kind: 'human', id: 'human:operator', joinedAt: 't' }],
+      latestSeq: 1,
+      inFlight: [],
+      truncated: false,
+    };
+    expect(isChannelEventV1(snapshot)).toBe(true);
+    expect(isChannelEventV1(created(message()))).toBe(true);
+    expect(isChannelEventV1(delta('chm:1', 0, 'x'))).toBe(true);
+    expect(isChannelEventV1(completed(message()))).toBe(true);
+    expect(
+      isChannelEventV1({
+        type: 'channel-resync-required-v1',
+        channelId: CHANNEL,
+        timestamp: 't',
+        latestSeq: 3,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects malformed / unknown events', () => {
+    expect(isChannelEventV1(null)).toBe(false);
+    expect(
+      isChannelEventV1({ type: 'nope', channelId: CHANNEL, timestamp: 't' })
+    ).toBe(false);
+    expect(
+      isChannelEventV1({
+        type: 'channel-message-delta-v1',
+        channelId: CHANNEL,
+        timestamp: 't',
+        messageId: 'chm:1',
+        deltaIndex: 'x',
+        delta: { text: 'y' },
+      })
+    ).toBe(false);
+    expect(
+      isChannelEventV1(
+        created({ ...message(), sender: { kind: 'ghost' } as never })
+      )
+    ).toBe(false);
+    expect(
+      isChannelEventV1(created({ ...message(), body: { text: 1 } as never }))
+    ).toBe(false);
+  });
+});
+
+describe('applyChannelEventV1 reducer', () => {
+  it('appends in-order created events and bumps lastSeq', () => {
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+      created(message({ id: 'chm:2' as ChannelMessageId, seq: 2 })),
+    ]);
+    expect(state.lastSeq).toBe(2);
+    expect(state.messages.map((m) => m.seq)).toEqual([1, 2]);
+    expect(state.needsCatchup).toBe(false);
+  });
+
+  it('drops a duplicate created as a no-op', () => {
+    const first = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+    ]);
+    const again = applyChannelEventV1(
+      first,
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 }))
+    );
+    expect(again.messages).toHaveLength(1);
+    expect(again.lastSeq).toBe(1);
+  });
+
+  it('sets needsCatchup on a seq gap without partial apply', () => {
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+      created(message({ id: 'chm:3' as ChannelMessageId, seq: 3 })),
+    ]);
+    expect(state.needsCatchup).toBe(true);
+    expect(state.messages.map((m) => m.seq)).toEqual([1]); // seq 3 NOT applied
+    expect(state.lastSeq).toBe(1);
+  });
+
+  it('interleaves two concurrent streams with no cross-contamination', () => {
+    const a = message({
+      id: 'chm:a' as ChannelMessageId,
+      seq: 1,
+      status: 'streaming',
+      body: { text: '', format: 'markdown' },
+    });
+    const b = message({
+      id: 'chm:b' as ChannelMessageId,
+      seq: 2,
+      status: 'streaming',
+      body: { text: '', format: 'markdown' },
+    });
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(a),
+      created(b),
+      delta('chm:a', 0, 'a1'),
+      delta('chm:b', 0, 'b1'),
+      delta('chm:a', 1, 'a2'),
+      delta('chm:b', 1, 'b2'),
+    ]);
+    expect(state.byId['chm:a']?.body.text).toBe('a1a2');
+    expect(state.byId['chm:b']?.body.text).toBe('b1b2');
+  });
+
+  it('quarantines only the out-of-order stream and heals it on completed', () => {
+    const a = message({
+      id: 'chm:a' as ChannelMessageId,
+      seq: 1,
+      status: 'streaming',
+      body: { text: '', format: 'markdown' },
+    });
+    const b = message({
+      id: 'chm:b' as ChannelMessageId,
+      seq: 2,
+      status: 'streaming',
+      body: { text: '', format: 'markdown' },
+    });
+    let state = reduce(initialChannelReducerState(CHANNEL), [
+      created(a),
+      created(b),
+      delta('chm:a', 0, 'a0'),
+      delta('chm:a', 2, 'a-skip'), // out of order → quarantine A only
+      delta('chm:a', 1, 'a-dropped'), // dropped while quarantined
+      delta('chm:b', 0, 'b0'), // B unaffected
+    ]);
+    expect(state.quarantined['chm:a']).toBe(true);
+    expect(state.byId['chm:a']?.body.text).toBe('a0'); // frozen after quarantine
+    expect(state.byId['chm:b']?.body.text).toBe('b0');
+    // completed heals A with the authoritative full body and clears quarantine
+    state = applyChannelEventV1(
+      state,
+      completed(
+        message({
+          id: 'chm:a' as ChannelMessageId,
+          seq: 1,
+          status: 'complete',
+          body: { text: 'a-full', format: 'markdown' },
+        })
+      )
+    );
+    expect(state.quarantined['chm:a']).toBeUndefined();
+    expect(state.byId['chm:a']?.body.text).toBe('a-full');
+    expect(state.inFlightDelta['chm:a']).toBeUndefined();
+  });
+
+  it('drops a delta for an unknown id by requesting catchup', () => {
+    const state = applyChannelEventV1(
+      initialChannelReducerState(CHANNEL),
+      delta('chm:missing', 0, 'x')
+    );
+    expect(state.needsCatchup).toBe(true);
+  });
+
+  it('full snapshot replaces, catchup merges', () => {
+    const full: ChannelEventV1 = {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'full',
+      messages: [
+        message({ id: 'chm:1' as ChannelMessageId, seq: 1 }),
+        message({ id: 'chm:2' as ChannelMessageId, seq: 2 }),
+      ],
+      members: [],
+      latestSeq: 2,
+      inFlight: [],
+      truncated: true,
+    };
+    let state = applyChannelEventV1(initialChannelReducerState(CHANNEL), full);
+    expect(state.messages).toHaveLength(2);
+    expect(state.lastSeq).toBe(2);
+
+    const catchup: ChannelEventV1 = {
+      type: 'channel-snapshot-v1',
+      channelId: CHANNEL,
+      timestamp: 't',
+      mode: 'catchup',
+      messages: [message({ id: 'chm:3' as ChannelMessageId, seq: 3 })],
+      members: [],
+      latestSeq: 3,
+      inFlight: [],
+      truncated: false,
+    };
+    state = applyChannelEventV1(state, catchup);
+    expect(state.messages.map((m) => m.seq)).toEqual([1, 2, 3]);
+    expect(state.lastSeq).toBe(3);
+  });
+
+  it('is deterministic under replay', () => {
+    const events: ChannelEventV1[] = [
+      created(
+        message({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          status: 'streaming',
+          body: { text: '', format: 'markdown' },
+        })
+      ),
+      delta('chm:1', 0, 'foo'),
+      delta('chm:1', 1, 'bar'),
+      completed(
+        message({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          status: 'complete',
+          body: { text: 'foobar', format: 'markdown' },
+        })
+      ),
+    ];
+    const a = reduce(initialChannelReducerState(CHANNEL), events);
+    const b = reduce(initialChannelReducerState(CHANNEL), events);
+    expect(a).toEqual(b);
+    expect(a.byId['chm:1']?.body.text).toBe('foobar');
+  });
+});
+
+describe('parseMentions', () => {
+  const known = ['claude', 'codex', 'hermes'];
+
+  it('resolves known providers case-insensitively and keeps the raw token', () => {
+    expect(parseMentions('hey @Claude look', known)).toEqual([
+      { raw: '@Claude', providerId: 'claude' },
+    ]);
+  });
+
+  it('keeps unknown mentions without a providerId', () => {
+    expect(parseMentions('ping @bob', known)).toEqual([{ raw: '@bob' }]);
+  });
+
+  it('ignores mentions inside fenced and inline code', () => {
+    expect(parseMentions('```\n@claude\n```', known)).toEqual([]);
+    expect(parseMentions('run `@codex now`', known)).toEqual([]);
+  });
+
+  it('ignores emails and a bare @', () => {
+    expect(parseMentions('mail foo@bar.com please', known)).toEqual([]);
+    expect(parseMentions('meet @ noon', known)).toEqual([]);
+  });
+
+  it('dedupes repeated mentions', () => {
+    expect(parseMentions('@claude @claude @Claude', known)).toEqual([
+      { raw: '@claude', providerId: 'claude' },
+    ]);
+  });
+});

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -13,9 +13,11 @@ import {
   type ChannelHub,
   type ChannelSocket,
 } from '../server/channel-hub.js';
-import type {
-  ChannelEventV1,
-  ChannelSenderRef,
+import {
+  applyChannelEventV1,
+  initialChannelReducerState,
+  type ChannelEventV1,
+  type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 
 const cleanup: Array<() => void> = [];
@@ -209,6 +211,156 @@ describe('channel-hub fan-out', () => {
       .filter((e) => e.type === 'channel-message-delta-v1')
       .map((d) => (d.type === 'channel-message-delta-v1' ? d.deltaIndex : -1));
     expect(deltas).toEqual([1]); // idx 0 was in the snapshot, never re-sent live
+  });
+});
+
+describe('channel-hub snapshot correctness', () => {
+  it('does not duplicate pending accumulator text for a subscriber that connects mid-coalesce window', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 50 });
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess' },
+    });
+    hub.beginStreamBroadcast(streaming);
+
+    // idx 0 flushed with no subscribers connected.
+    hub.pushDelta(streaming.id, 'Hello ');
+    vi.advanceTimersByTime(50);
+
+    // Second delta is PENDING (timer armed, not yet fired) when the subscriber
+    // connects — this is the coalesce window the finding exploits.
+    hub.pushDelta(streaming.id, 'world');
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+
+    let applied = 0;
+    let state = initialChannelReducerState('topic:c');
+    const drain = (): void => {
+      while (applied < sock.sent.length) {
+        state = applyChannelEventV1(state, sock.sent[applied++]!);
+      }
+    };
+    drain(); // snapshot (the queued flush delta is deduped away at connect)
+
+    // Fire the pending window. Without the fix a duplicate 'world' delta lands
+    // here and the reducer appends it a second time.
+    vi.advanceTimersByTime(50);
+    drain();
+
+    const row = state.byId[streaming.id];
+    expect(row?.body.text).toBe('Hello world'); // exact, not 'Hello worldworld'
+    expect(state.needsCatchup).toBe(false);
+    expect(state.quarantined[streaming.id]).toBeUndefined();
+  });
+
+  it('heals a stream that finalized while the client was disconnected on reconnect', () => {
+    const s = store();
+    const hub = hubWith(s);
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess', turnId: 't1', itemId: 'a1' },
+      text: 'partial',
+    });
+    hub.beginStreamBroadcast(streaming);
+
+    // Client sees the streaming row, then disconnects.
+    const first = fakeSocket();
+    hub.handleConnection(first, { channelId: 'topic:c', sinceSeq: null });
+    let state = initialChannelReducerState('topic:c');
+    for (const e of first.sent) state = applyChannelEventV1(state, e);
+    expect(state.byId[streaming.id]?.status).toBe('streaming');
+    first.emit('close');
+
+    // Stream finalizes WHILE the client is gone (no new seq allocated).
+    const finalMsg = s.finalizeStream(streaming.id, {
+      text: 'final answer',
+      status: 'complete',
+    });
+    hub.completeStreamBroadcast(finalMsg!);
+
+    // Reconnect with the stale cursor (== latestSeq → catch-up, gap 0).
+    const reconnect = fakeSocket();
+    hub.handleConnection(reconnect, {
+      channelId: 'topic:c',
+      sinceSeq: state.lastSeq,
+    });
+    for (const e of reconnect.sent) state = applyChannelEventV1(state, e);
+
+    const row = state.byId[streaming.id];
+    expect(row?.status).toBe('complete'); // no permanently stuck streaming row
+    expect(row?.body.text).toBe('final answer');
+    expect(state.needsCatchup).toBe(false);
+  });
+
+  it('forces a full snapshot (client reset) when the cursor is ahead of the server head', () => {
+    const s = store();
+    for (let i = 1; i <= 3; i++) {
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: `m${i}` });
+    }
+    const hub = hubWith(s);
+
+    // Simulate a client that synced far ahead (seq 999) before a rollback shrank
+    // the server head back to 3.
+    let state = initialChannelReducerState('topic:c');
+    state = applyChannelEventV1(state, {
+      type: 'channel-snapshot-v1',
+      channelId: 'topic:c',
+      timestamp: 't',
+      mode: 'full',
+      messages: [],
+      members: [],
+      latestSeq: 999,
+      inFlight: [],
+      truncated: false,
+    });
+    expect(state.lastSeq).toBe(999);
+
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: 999 });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(snap.mode).toBe('full'); // reset, not a silent empty catch-up
+    expect(snap.latestSeq).toBe(3);
+
+    // Reducer resets to head; a subsequent message is no longer dropped as replay.
+    state = applyChannelEventV1(state, snap);
+    expect(state.lastSeq).toBe(3);
+    const m4 = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'm4',
+    });
+    hub.broadcastCreated(m4);
+    for (const e of sock.sent.slice(1)) state = applyChannelEventV1(state, e);
+    expect(state.byId[m4.id]).toBeDefined();
+    expect(state.lastSeq).toBe(4);
+  });
+
+  it('byte-budgets a full snapshot and flags truncated', () => {
+    const s = store();
+    const body = 'x'.repeat(2000);
+    for (let i = 0; i < 20; i++) {
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: body });
+    }
+    // ~8KB budget → only a few of the 2KB+ rows fit.
+    const hub = hubWith(s, { snapshotMaxBytes: 8 * 1000 });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(snap.truncated).toBe(true);
+    expect(snap.messages.length).toBeGreaterThan(0);
+    expect(snap.messages.length).toBeLessThan(20); // stopped before all rows
+    const bytes = Buffer.byteLength(JSON.stringify(snap.messages), 'utf8');
+    expect(bytes).toBeLessThanOrEqual(8 * 1000 + 2500);
+    // Full snapshot keeps the newest rows (tail).
+    expect(snap.messages[snap.messages.length - 1]?.seq).toBe(20);
   });
 });
 

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -1,0 +1,321 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import {
+  createChannelHub,
+  type ChannelHub,
+  type ChannelSocket,
+} from '../server/channel-hub.js';
+import type {
+  ChannelEventV1,
+  ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+const HUMAN: ChannelSenderRef = { kind: 'human', id: 'human:operator' };
+const AGENT: ChannelSenderRef = {
+  kind: 'agent',
+  id: 'agent:claude',
+  providerId: 'claude',
+};
+
+function store(): ChannelMessageStore {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-channel-hub-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const s = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => s.close());
+  return s;
+}
+
+interface FakeSocket extends ChannelSocket {
+  bufferedAmount: number;
+  readyState: number;
+  sent: ChannelEventV1[];
+  closed: number | null;
+  emit(event: 'close' | 'error'): void;
+}
+
+function fakeSocket(): FakeSocket {
+  const handlers: Partial<Record<'close' | 'error', () => void>> = {};
+  return {
+    readyState: 1,
+    bufferedAmount: 0,
+    sent: [],
+    closed: null,
+    send(data: string) {
+      this.sent.push(JSON.parse(data) as ChannelEventV1);
+    },
+    close(code?: number) {
+      this.closed = code ?? 1000;
+      this.readyState = 3;
+    },
+    on(event, handler) {
+      handlers[event] = handler;
+    },
+    emit(event) {
+      handlers[event]?.();
+    },
+  };
+}
+
+function hubWith(
+  s: ChannelMessageStore,
+  opts: Partial<Parameters<typeof createChannelHub>[0]> = {}
+): ChannelHub {
+  const hub = createChannelHub({
+    store: s,
+    channelExists: () => true,
+    ...opts,
+  });
+  cleanup.push(() => hub.close());
+  return hub;
+}
+
+describe('channel-hub fan-out', () => {
+  it('delivers a committed post to every subscriber', () => {
+    const s = store();
+    const hub = hubWith(s);
+    const a = fakeSocket();
+    const b = fakeSocket();
+    hub.handleConnection(a, { channelId: 'topic:c', sinceSeq: null });
+    hub.handleConnection(b, { channelId: 'topic:c', sinceSeq: null });
+    expect(a.sent[0]?.type).toBe('channel-snapshot-v1');
+
+    const msg = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'hi',
+    });
+    hub.broadcastCreated(msg);
+    for (const sock of [a, b]) {
+      expect(
+        sock.sent.some((e) => e.type === 'channel-message-created-v1')
+      ).toBe(true);
+    }
+  });
+
+  it('serves (sinceSeq, head] then live with seq continuity across the boundary', () => {
+    const s = store();
+    for (let i = 1; i <= 3; i++) {
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: `m${i}` });
+    }
+    const hub = hubWith(s);
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: 1 });
+    const snap = sock.sent[0];
+    expect(snap?.type).toBe('channel-snapshot-v1');
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(snap.mode).toBe('catchup');
+    expect(snap.messages.map((m) => m.seq)).toEqual([2, 3]);
+
+    const m4 = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'm4',
+    });
+    hub.broadcastCreated(m4);
+    const created = sock.sent.find(
+      (e) => e.type === 'channel-message-created-v1'
+    );
+    if (created?.type !== 'channel-message-created-v1')
+      throw new Error('expected created');
+    expect(created.message.seq).toBe(4); // no dup, no gap after snapshot head (3)
+  });
+
+  it('falls back to a full snapshot when the catch-up gap exceeds 500 rows', () => {
+    const s = store();
+    for (let i = 0; i < 510; i++) {
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: `m${i}` });
+    }
+    const hub = hubWith(s);
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: 1 });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(snap.mode).toBe('full');
+    expect(snap.messages).toHaveLength(100);
+  });
+
+  it('coalesces a burst of deltas into one event per tick with incrementing deltaIndex', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 50 });
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess' },
+    });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+    hub.beginStreamBroadcast(streaming);
+
+    hub.pushDelta(streaming.id, 'a');
+    hub.pushDelta(streaming.id, 'b');
+    vi.advanceTimersByTime(50);
+    let deltas = sock.sent.filter((e) => e.type === 'channel-message-delta-v1');
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({ deltaIndex: 0, delta: { text: 'ab' } });
+
+    hub.pushDelta(streaming.id, 'c');
+    vi.advanceTimersByTime(50);
+    deltas = sock.sent.filter((e) => e.type === 'channel-message-delta-v1');
+    expect(
+      deltas.map((d) =>
+        d.type === 'channel-message-delta-v1' ? d.deltaIndex : -1
+      )
+    ).toEqual([0, 1]);
+  });
+
+  it('dedupes stream deltas by messageId + deltaIndex across the snapshot boundary', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 10 });
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess' },
+    });
+    hub.beginStreamBroadcast(streaming);
+    hub.pushDelta(streaming.id, 'hello');
+    vi.advanceTimersByTime(10); // flush idx 0 (no subscribers yet)
+
+    const late = fakeSocket();
+    hub.handleConnection(late, { channelId: 'topic:c', sinceSeq: null });
+    const snap = late.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+    expect(snap.inFlight).toEqual([{ messageId: streaming.id, deltaIndex: 0 }]);
+    const overlaid = snap.messages.find((m) => m.id === streaming.id);
+    expect(overlaid?.body.text).toBe('hello'); // in-memory text overlaid on DB lag
+
+    hub.pushDelta(streaming.id, ' world');
+    vi.advanceTimersByTime(10); // flush idx 1
+    const deltas = late.sent
+      .filter((e) => e.type === 'channel-message-delta-v1')
+      .map((d) => (d.type === 'channel-message-delta-v1' ? d.deltaIndex : -1));
+    expect(deltas).toEqual([1]); // idx 0 was in the snapshot, never re-sent live
+  });
+});
+
+describe('channel-hub backpressure', () => {
+  it('suppresses deltas over the watermark, keeps durable events, resyncs on drain, and recovers', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 5 });
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess' },
+    });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+    hub.beginStreamBroadcast(streaming);
+    sock.sent.length = 0;
+
+    // Over the 1MB high watermark → deltas suppressed.
+    sock.bufferedAmount = 2 * 1024 * 1024;
+    hub.pushDelta(streaming.id, 'x');
+    vi.advanceTimersByTime(5);
+    expect(
+      sock.sent.filter((e) => e.type === 'channel-message-delta-v1')
+    ).toHaveLength(0);
+
+    // Durable events are always delivered even while lagging.
+    hub.broadcastCreated(
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'durable' })
+    );
+    expect(sock.sent.some((e) => e.type === 'channel-message-created-v1')).toBe(
+      true
+    );
+
+    // Drain below 256KB → the next deliver emits a resync.
+    sock.bufferedAmount = 100 * 1024;
+    hub.broadcastCreated(
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: HUMAN,
+        text: 'durable2',
+      })
+    );
+    expect(sock.sent.some((e) => e.type === 'channel-resync-required-v1')).toBe(
+      true
+    );
+
+    // Recovered: subsequent deltas are delivered again.
+    hub.pushDelta(streaming.id, 'y');
+    vi.advanceTimersByTime(5);
+    expect(sock.sent.some((e) => e.type === 'channel-message-delta-v1')).toBe(
+      true
+    );
+  });
+
+  it('closes the socket with 4409 on sustained overflow', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 5 });
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess' },
+    });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+    hub.beginStreamBroadcast(streaming);
+
+    sock.bufferedAmount = 5 * 1024 * 1024;
+    hub.pushDelta(streaming.id, 'z');
+    vi.advanceTimersByTime(5);
+    expect(sock.closed).toBe(4409);
+    expect(hub.subscriberCount('topic:c')).toBe(0);
+  });
+});
+
+describe('channel-hub connection lifecycle', () => {
+  it('closes unknown channels with 4404', () => {
+    const s = store();
+    const hub = hubWith(s, { channelExists: () => false });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:missing', sinceSeq: null });
+    expect(sock.closed).toBe(4404);
+  });
+
+  it('removes a subscriber on disconnect', () => {
+    const s = store();
+    const hub = hubWith(s);
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+    expect(hub.subscriberCount('topic:c')).toBe(1);
+    sock.emit('close');
+    expect(hub.subscriberCount('topic:c')).toBe(0);
+  });
+
+  it('emits a channel-activity badge on committed posts', () => {
+    const s = store();
+    const badges: Array<{ type: string; data: Record<string, unknown> }> = [];
+    const hub = hubWith(s, {
+      badgeBroadcaster: (type, data) => badges.push({ type, data }),
+    });
+    hub.broadcastCreated(
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'hi' })
+    );
+    expect(badges).toContainEqual({
+      type: 'channel-activity',
+      data: { channelId: 'topic:c', latestSeq: 1 },
+    });
+  });
+});

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -169,6 +169,32 @@ describe('channel-message-store streaming lifecycle', () => {
     expect(final?.truncated).toBe(true);
     expect(s.getMessage(begun.id)?.truncated).toBe(true);
   });
+
+  it('listResyncRows returns agent-origin rows at/below the cursor in current state', () => {
+    const s = store();
+    s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'human' }); // seq 1, no source
+    const stream = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'x', turnId: 't', itemId: 'i' },
+    }); // seq 2, agent-origin
+    s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'later' }); // seq 3
+
+    // Only the agent stream row is a resync candidate (human posts never go stale).
+    const before = s.listResyncRows('topic:c', 3, 500);
+    expect(before.map((m) => m.seq)).toEqual([2]);
+    expect(before[0]?.status).toBe('streaming');
+
+    // After it finalizes, the SAME query returns its final state — this is what
+    // lets reconnect catch-up heal a stream that finalized while disconnected.
+    s.finalizeStream(stream.id, { text: 'done', status: 'complete' });
+    const after = s.listResyncRows('topic:c', 3, 500);
+    expect(after[0]?.status).toBe('complete');
+    expect(after[0]?.body.text).toBe('done');
+
+    // A cursor below the agent row excludes it.
+    expect(s.listResyncRows('topic:c', 1, 500)).toHaveLength(0);
+  });
 });
 
 describe('channel-message-store posts, threads, idempotency', () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -1,0 +1,337 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createChannelMessageStore,
+  ChannelMessageStoreError,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import type { ChannelSenderRef } from '../shared/channel-chat-protocol.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+function dbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-channel-store-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return path.join(dir, 'channel-chat.db');
+}
+
+function store(pathOverride?: string): ChannelMessageStore {
+  const s = createChannelMessageStore(pathOverride ?? dbPath());
+  cleanup.push(() => s.close());
+  return s;
+}
+
+const HUMAN: ChannelSenderRef = { kind: 'human', id: 'human:operator' };
+const AGENT: ChannelSenderRef = {
+  kind: 'agent',
+  id: 'agent:claude',
+  providerId: 'claude',
+};
+
+describe('channel-message-store seq allocation', () => {
+  it('assigns strictly monotonic, gap-free seq per channel across interleaved channels', () => {
+    const s = store();
+    const seqA: number[] = [];
+    const seqB: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      seqA.push(
+        s.appendComplete({ channelId: 'topic:a', sender: HUMAN, text: `a${i}` })
+          .seq
+      );
+      seqB.push(
+        s.appendComplete({ channelId: 'topic:b', sender: HUMAN, text: `b${i}` })
+          .seq
+      );
+    }
+    expect(seqA).toEqual([1, 2, 3, 4, 5]);
+    expect(seqB).toEqual([1, 2, 3, 4, 5]);
+    expect(s.latestSeq('topic:a')).toBe(5);
+  });
+
+  it('allocates gap-free seq across two store handles on one db file and surfaces UNIQUE loudly', () => {
+    const p = dbPath();
+    const a = store(p);
+    const b = store(p);
+    const seqs: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      seqs.push(
+        a.appendComplete({
+          channelId: 'topic:shared',
+          sender: HUMAN,
+          text: `a${i}`,
+        }).seq
+      );
+      seqs.push(
+        b.appendComplete({
+          channelId: 'topic:shared',
+          sender: HUMAN,
+          text: `b${i}`,
+        }).seq
+      );
+    }
+    const sorted = [...seqs].sort((x, y) => x - y);
+    expect(sorted).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]); // gap-free, unique
+    expect(new Set(seqs).size).toBe(12);
+
+    // The UNIQUE(channel_id, seq) backstop turns any residual race into a loud
+    // constraint failure rather than a silent reorder.
+    const raw = new Database(p);
+    cleanup.push(() => raw.close());
+    expect(() =>
+      raw
+        .prepare(
+          `INSERT INTO channel_messages
+             (id, channel_id, seq, kind, status, sender_kind, sender_id, body_text, body_format, created_at, updated_at)
+           VALUES (?, 'topic:shared', 1, 'message', 'complete', 'human', 'human:operator', 'dup', 'markdown', 't', 't')`
+        )
+        .run('chm:dup')
+    ).toThrow(/UNIQUE/);
+  });
+});
+
+describe('channel-message-store streaming lifecycle', () => {
+  it('keeps id/seq stable through begin → flush → finalize', () => {
+    const s = store();
+    const begun = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess-1', turnId: 't1', itemId: 'a1' },
+    });
+    expect(begun.status).toBe('streaming');
+    const flushed = s.updateStreamText(begun.id, 'partial text');
+    expect(flushed?.id).toBe(begun.id);
+    expect(flushed?.seq).toBe(begun.seq);
+    expect(flushed?.body.text).toBe('partial text');
+    const final = s.finalizeStream(begun.id, {
+      text: 'final text',
+      status: 'complete',
+    });
+    expect(final?.id).toBe(begun.id);
+    expect(final?.seq).toBe(begun.seq);
+    expect(final?.status).toBe('complete');
+    expect(final?.body.text).toBe('final text');
+    expect(final?.completedAt).toBeTruthy();
+  });
+
+  it('finalizing an already-final row is an idempotent no-op', () => {
+    const s = store();
+    const begun = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess-1', turnId: 't1', itemId: 'a1' },
+    });
+    s.finalizeStream(begun.id, { text: 'done', status: 'complete' });
+    const replay = s.finalizeStream(begun.id, {
+      text: 'OVERWRITE',
+      status: 'failed',
+    });
+    expect(replay?.status).toBe('complete');
+    expect(replay?.body.text).toBe('done');
+  });
+
+  it('dedupes beginStream by source triple (one row)', () => {
+    const s = store();
+    const one = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess-1', turnId: 't1', itemId: 'a1' },
+    });
+    const two = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess-1', turnId: 't1', itemId: 'a1' },
+    });
+    expect(two.id).toBe(one.id);
+    expect(s.history('topic:c')).toHaveLength(1);
+  });
+
+  it('persists a truncation marker on force-finalize', () => {
+    const s = store();
+    const begun = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess-1' },
+    });
+    const final = s.finalizeStream(begun.id, {
+      text: 'capped',
+      status: 'complete',
+      truncated: true,
+    });
+    expect(final?.truncated).toBe(true);
+    expect(s.getMessage(begun.id)?.truncated).toBe(true);
+  });
+});
+
+describe('channel-message-store posts, threads, idempotency', () => {
+  it('returns the original row for a repeated clientMessageId', () => {
+    const s = store();
+    const first = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'hello',
+      clientMessageId: 'client-1',
+    });
+    const second = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'hello again',
+      clientMessageId: 'client-1',
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.body.text).toBe('hello');
+    expect(s.history('topic:c')).toHaveLength(1);
+  });
+
+  it('inherits thread_id from parent and rejects a cross-channel parent', () => {
+    const s = store();
+    const root = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'root',
+    });
+    expect(root.threadId).toBeNull();
+    const reply = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'reply',
+      parentMessageId: root.id,
+    });
+    expect(reply.threadId).toBe(root.id);
+    const nested = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'nested',
+      parentMessageId: reply.id,
+    });
+    expect(nested.threadId).toBe(root.id);
+    expect(() =>
+      s.appendComplete({
+        channelId: 'topic:other',
+        sender: HUMAN,
+        text: 'x',
+        parentMessageId: root.id,
+      })
+    ).toThrow(ChannelMessageStoreError);
+  });
+
+  it('rejects a body over the 256KB cap', () => {
+    const s = store();
+    const big = 'x'.repeat(256 * 1024 + 1);
+    expect(() =>
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: big })
+    ).toThrow(/256KB|too large/i);
+  });
+
+  it('paginates history via beforeSeq/afterSeq/limit', () => {
+    const s = store();
+    for (let i = 1; i <= 10; i++) {
+      s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: `m${i}` });
+    }
+    const newest = s.history('topic:c', { limit: 3 });
+    expect(newest.map((m) => m.seq)).toEqual([8, 9, 10]);
+    const older = s.history('topic:c', { beforeSeq: 8, limit: 3 });
+    expect(older.map((m) => m.seq)).toEqual([5, 6, 7]);
+    const after = s.history('topic:c', { afterSeq: 7, limit: 10 });
+    expect(after.map((m) => m.seq)).toEqual([8, 9, 10]);
+  });
+
+  it('summarizes channels with latestSeq, count and preview', () => {
+    const s = store();
+    s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'first' });
+    s.appendComplete({ channelId: 'topic:c', sender: AGENT, text: 'second' });
+    const summaries = s.listChannelSummaries();
+    const c = summaries.find((x) => x.channelId === 'topic:c');
+    expect(c?.latestSeq).toBe(2);
+    expect(c?.messageCount).toBe(2);
+    expect(c?.lastMessage?.preview).toBe('second');
+  });
+});
+
+describe('channel-message-store members and bindings', () => {
+  it('upserts and lists members and finds a DM channel', () => {
+    const s = store();
+    s.upsertMember({
+      channelId: 'topic:dm',
+      kind: 'human',
+      id: 'human:operator',
+    });
+    s.upsertMember({
+      channelId: 'topic:dm',
+      kind: 'agent',
+      id: 'agent:claude',
+    });
+    s.upsertMember({
+      channelId: 'topic:dm',
+      kind: 'agent',
+      id: 'agent:claude',
+    }); // idempotent
+    expect(s.listMembers('topic:dm')).toHaveLength(2);
+    expect(s.findDmChannel('human:operator', 'agent:claude')).toBe('topic:dm');
+    expect(s.findDmChannel('human:operator', 'agent:codex')).toBeNull();
+  });
+
+  it('stores and reads agent bindings (slice-4 landing pad)', () => {
+    const s = store();
+    const created = s.upsertBinding({
+      channelId: 'topic:c',
+      agentFramework: 'claude',
+      providerSession: { claudeSessionId: 'abc' },
+    });
+    expect(created.sessionId).toBeNull();
+    const updated = s.upsertBinding({
+      channelId: 'topic:c',
+      agentFramework: 'claude',
+      sessionId: 'sess-9',
+    });
+    expect(updated.sessionId).toBe('sess-9');
+    expect(updated.providerSession).toEqual({ claudeSessionId: 'abc' });
+  });
+});
+
+describe('channel-message-store boot sweeps', () => {
+  it('flips stale streaming rows to interrupted and appends a system message', () => {
+    const s = store();
+    const stuck = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'sess-1' },
+    });
+    const results = s.sweepStaleStreaming();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.interruptedIds).toContain(stuck.id);
+    expect(s.getMessage(stuck.id)?.status).toBe('interrupted');
+    const system = s.getMessage(results[0]!.systemMessage.id);
+    expect(system?.kind).toBe('system');
+    expect(system?.sender.kind).toBe('system');
+  });
+
+  it('sweeps orphaned rows for channel ids not in the persisted topic set', () => {
+    const s = store();
+    s.appendComplete({ channelId: 'topic:live', sender: HUMAN, text: 'keep' });
+    s.appendComplete({
+      channelId: 'topic:gone',
+      sender: HUMAN,
+      text: 'orphan',
+    });
+    s.upsertMember({
+      channelId: 'topic:gone',
+      kind: 'human',
+      id: 'human:operator',
+    });
+    const result = s.sweepOrphans(new Set(['topic:live']));
+    expect(result.channelsDeleted).toEqual(['topic:gone']);
+    expect(result.messagesDeleted).toBe(1);
+    expect(s.history('topic:gone')).toHaveLength(0);
+    expect(s.history('topic:live')).toHaveLength(1);
+    expect(s.listMembers('topic:gone')).toHaveLength(0);
+  });
+});

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -50,7 +50,7 @@ interface Harness {
 }
 
 async function harness(
-  options: { withStore?: boolean } = {}
+  options: { withStore?: boolean; historyMaxBytes?: number } = {}
 ): Promise<Harness> {
   const dir = tmpDir();
   const topicStore = createWorkspaceTopicStore({
@@ -86,6 +86,9 @@ async function harness(
       store: options.withStore === false ? null : store,
       hub,
       topicStore,
+      ...(options.historyMaxBytes !== undefined
+        ? { historyMaxBytes: options.historyMaxBytes }
+        : {}),
     })
   );
   const server = http.createServer(app);
@@ -261,6 +264,32 @@ describe('channel routes — read / write contract', () => {
       url: `${url}?afterSeq=3&limit=10`,
     });
     expect(page.body.messages.map((m) => m.seq)).toEqual([4, 5]);
+  });
+
+  it('byte-budgets a history response and returns a continuation cursor', async () => {
+    const h = await harness({ historyMaxBytes: 4000 });
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const body = 'y'.repeat(1000);
+    for (let i = 0; i < 12; i++) {
+      await req({ port: h.port, method: 'POST', url, body: { text: body } });
+    }
+    // Forward pagination (afterSeq): keeps oldest-first, continues via afterSeq.
+    const page = await req<{
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { afterSeq?: number };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${url}?afterSeq=0&limit=200`,
+    });
+    expect(page.body.hasMore).toBe(true);
+    expect(page.body.messages.length).toBeGreaterThan(0);
+    expect(page.body.messages.length).toBeLessThan(12); // stopped before the full page
+    const lastSeq = page.body.messages[page.body.messages.length - 1]!.seq;
+    expect(page.body.nextCursor?.afterSeq).toBe(lastSeq);
+    const bytes = Buffer.byteLength(JSON.stringify(page.body.messages), 'utf8');
+    expect(bytes).toBeLessThanOrEqual(4000 + 1200);
   });
 
   it('echoes a posted message to a live channel subscriber (REST → WS round-trip)', async () => {

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -1,0 +1,314 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  attachAuthenticatedCliGatewayActorCredential,
+  cliGatewayActorCommandCapabilities,
+  CLI_GATEWAY_ACTOR_READ_COMMANDS,
+  CLI_GATEWAY_ACTOR_WRITE_COMMANDS,
+} from '../server/cli-gateway-actor-auth.js';
+import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import {
+  createChannelHub,
+  type ChannelHub,
+  type ChannelSocket,
+} from '../server/channel-hub.js';
+import { createChannelChatRouter } from '../server/channel-chat-router.js';
+import {
+  createWorkspaceTopicStore,
+  type WorkspaceTopicStore,
+} from '../server/workspace-topics.js';
+import type { ChannelEventV1 } from '../shared/channel-chat-protocol.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-channel-routes-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+interface Harness {
+  port: number;
+  store: ChannelMessageStore;
+  topicStore: WorkspaceTopicStore;
+  hub: ChannelHub;
+  channelId: string;
+}
+
+async function harness(
+  options: { withStore?: boolean } = {}
+): Promise<Harness> {
+  const dir = tmpDir();
+  const topicStore = createWorkspaceTopicStore({
+    dbPath: path.join(dir, 'topics.db'),
+    now: () => '2026-07-18T00:00:00.000Z',
+  });
+  cleanup.push(() => topicStore.close());
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => store.close());
+  const hub = createChannelHub({
+    store,
+    channelExists: (id) => Boolean(topicStore.get(id)),
+  });
+  cleanup.push(() => hub.close());
+  const topic = topicStore.create({ workspaceId: 'ws', title: 'General' });
+
+  const app = express();
+  app.use(express.json());
+  // Simulate the CLI-gateway actor lane: attach a credential when the test asks.
+  app.use((req, _res, next) => {
+    const actorId = req.header('x-test-actor-id');
+    if (actorId) {
+      attachAuthenticatedCliGatewayActorCredential(req, {
+        id: 'cred-1',
+        actor: { type: 'agent', id: actorId, displayName: 'Claude Bot' },
+        capabilities: ['context:read', 'context:write'],
+      } as unknown as ScopedActorCredentialRecord);
+    }
+    next();
+  });
+  app.use(
+    createChannelChatRouter({
+      store: options.withStore === false ? null : store,
+      hub,
+      topicStore,
+    })
+  );
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  cleanup.push(() => server.close());
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no address');
+  return { port: address.port, store, topicStore, hub, channelId: topic.id };
+}
+
+async function req<T>(input: {
+  port: number;
+  method: 'GET' | 'POST';
+  url: string;
+  body?: unknown;
+  capabilities?: string;
+  headers?: Record<string, string>;
+}): Promise<{ status: number; body: T }> {
+  const res = await fetch(`http://127.0.0.1:${input.port}${input.url}`, {
+    method: input.method,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-relay-capabilities':
+        input.capabilities ??
+        (input.method === 'GET' ? 'context:read' : 'context:write'),
+      ...(input.headers ?? {}),
+    },
+    ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+  });
+  return { status: res.status, body: (await res.json()) as T };
+}
+
+function fakeSocket(): ChannelSocket & { sent: ChannelEventV1[] } {
+  return {
+    readyState: 1,
+    bufferedAmount: 0,
+    sent: [],
+    send(data: string) {
+      this.sent.push(JSON.parse(data) as ChannelEventV1);
+    },
+    close() {},
+    on() {},
+  };
+}
+
+describe('channel routes — attribution', () => {
+  it('rejects a client-supplied sender field with 400', async () => {
+    const h = await harness();
+    const res = await req<{ error: { reasonCode?: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'hi', sender: { kind: 'agent', id: 'agent:evil' } },
+    });
+    expect(res.status).toBe(400);
+    expect(h.store.history(h.channelId)).toHaveLength(0); // nothing persisted
+  });
+
+  it('derives a human sender from the browser cookie lane', async () => {
+    const h = await harness();
+    const res = await req<{
+      message: { sender: { kind: string; id: string } };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'hello from operator' },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.message.sender).toMatchObject({
+      kind: 'human',
+      id: 'human:operator',
+    });
+  });
+
+  it('derives an agent sender from the CLI-gateway actor lane', async () => {
+    const h = await harness();
+    const res = await req<{
+      message: { sender: { kind: string; id: string } };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'hello from claude' },
+      headers: { 'x-test-actor-id': 'claude' },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.message.sender).toMatchObject({
+      kind: 'agent',
+      id: 'agent:claude',
+    });
+  });
+});
+
+describe('channel routes — topic validation', () => {
+  it('rejects a post to an unknown / derived topic with 404', async () => {
+    const h = await harness();
+    const res = await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent('topic:ghost')}/messages`,
+      body: { text: 'hi' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a post to an archived topic with 409', async () => {
+    const h = await harness();
+    h.topicStore.archive(h.channelId);
+    const res = await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'hi' },
+    });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('channel routes — read / write contract', () => {
+  it('lists a persisted topic as a channel with summary fields', async () => {
+    const h = await harness();
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'first message' },
+    });
+    const res = await req<{ channels: Array<Record<string, unknown>> }>({
+      port: h.port,
+      method: 'GET',
+      url: '/channels',
+    });
+    expect(res.status).toBe(200);
+    const channel = res.body.channels.find((c) => c['id'] === h.channelId);
+    expect(channel).toMatchObject({
+      latestSeq: 1,
+      messageCount: 1,
+      archived: false,
+    });
+  });
+
+  it('is idempotent under a repeated clientMessageId', async () => {
+    const h = await harness();
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const first = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'once', clientMessageId: 'c-1' },
+    });
+    expect(first.status).toBe(201);
+    const second = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'twice', clientMessageId: 'c-1' },
+    });
+    expect(second.status).toBe(200);
+    expect(second.body.message.id).toBe(first.body.message.id);
+    expect(h.store.history(h.channelId)).toHaveLength(1);
+  });
+
+  it('paginates history with limit and afterSeq', async () => {
+    const h = await harness();
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    for (let i = 0; i < 5; i++) {
+      await req({ port: h.port, method: 'POST', url, body: { text: `m${i}` } });
+    }
+    const page = await req<{ messages: Array<{ seq: number }> }>({
+      port: h.port,
+      method: 'GET',
+      url: `${url}?afterSeq=3&limit=10`,
+    });
+    expect(page.body.messages.map((m) => m.seq)).toEqual([4, 5]);
+  });
+
+  it('echoes a posted message to a live channel subscriber (REST → WS round-trip)', async () => {
+    const h = await harness();
+    const sock = fakeSocket();
+    h.hub.handleConnection(sock, { channelId: h.channelId, sinceSeq: null });
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'broadcast me' },
+    });
+    const created = sock.sent.find(
+      (e) => e.type === 'channel-message-created-v1'
+    );
+    expect(created).toBeDefined();
+    if (created?.type === 'channel-message-created-v1') {
+      expect(created.message.body.text).toBe('broadcast me');
+    }
+  });
+
+  it('returns 503 when the channel store failed to initialize', async () => {
+    const h = await harness({ withStore: false });
+    const res = await req({ port: h.port, method: 'GET', url: '/channels' });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('channel routes — gateway capability mapping', () => {
+  it('registers channels verbs in the actor command sets', () => {
+    expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.list');
+    expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.get');
+    expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.history');
+    expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toContain('channels.post');
+  });
+
+  it('maps channels verbs to context read/write capability bits', () => {
+    expect(cliGatewayActorCommandCapabilities('channels.list')).toEqual([
+      'context:read',
+    ]);
+    expect(cliGatewayActorCommandCapabilities('channels.get')).toEqual([
+      'context:read',
+    ]);
+    expect(cliGatewayActorCommandCapabilities('channels.history')).toEqual([
+      'context:read',
+    ]);
+    expect(cliGatewayActorCommandCapabilities('channels.post')).toEqual([
+      'context:write',
+    ]);
+  });
+});

--- a/test/channel-topic-orphan-sweep.test.ts
+++ b/test/channel-topic-orphan-sweep.test.ts
@@ -1,0 +1,63 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createChannelMessageStore } from '../server/channel-message-store.js';
+import { createWorkspaceTopicStore } from '../server/workspace-topics.js';
+import { WORKSPACE_TOPICS_MAX_LIST_ENTRIES } from '../shared/workspace-topics.js';
+import type { ChannelSenderRef } from '../shared/channel-chat-protocol.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+const HUMAN: ChannelSenderRef = { kind: 'human', id: 'human:operator' };
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-orphan-sweep-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+describe('channel orphan sweep vs. capped topic list', () => {
+  it('keeps channel messages for topics that rank beyond the 200-row list() cap', () => {
+    const dir = tmpDir();
+    // Monotonic clock so `updated_at DESC` ordering is deterministic — the
+    // oldest-created topics fall out of the top-200 list() window.
+    let tick = 0;
+    const topicStore = createWorkspaceTopicStore({
+      dbPath: path.join(dir, 'workspace-topics.db'),
+      now: () => new Date(1_700_000_000_000 + tick++ * 1000).toISOString(),
+    });
+    cleanup.push(() => topicStore.close());
+    const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+    cleanup.push(() => store.close());
+
+    const total = WORKSPACE_TOPICS_MAX_LIST_ENTRIES + 5; // 205, under the 500 store cap
+    const ids: string[] = [];
+    for (let i = 0; i < total; i++) {
+      ids.push(topicStore.create({ workspaceId: 'ws', title: `T${i}` }).id);
+    }
+
+    // list() silently caps at 200; listAllTopicIds() returns the full 205.
+    const capped = topicStore.list({ includeArchived: true });
+    expect(capped).toHaveLength(WORKSPACE_TOPICS_MAX_LIST_ENTRIES);
+    expect(topicStore.listAllTopicIds()).toHaveLength(total);
+
+    // The oldest-created topic is a live, persisted channel — but absent from the
+    // capped window. Post a channel message to it.
+    const cappedIds = new Set(capped.map((t) => t.id));
+    const evicted = ids[0]!;
+    expect(cappedIds.has(evicted)).toBe(false); // the buggy path would sweep it
+    store.appendComplete({ channelId: evicted, sender: HUMAN, text: 'keep me' });
+
+    // The FIXED boot sweep enumerates all ids uncapped, so the message survives.
+    const result = store.sweepOrphans(new Set(topicStore.listAllTopicIds()));
+    expect(result.channelsDeleted).not.toContain(evicted);
+    expect(store.history(evicted)).toHaveLength(1);
+  });
+});

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -349,6 +349,9 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'workspace-topics.list',
     'workspace-topics.search',
     'workspace-topics.get',
+    'channels.list',
+    'channels.get',
+    'channels.history',
     'context.get',
     'context.list',
     'inbox.list',
@@ -563,6 +566,7 @@ test('classifies explicitly scoped CLI gateway actor write routes into the actor
     'workspace-topics.update',
     'workspace-topics.archive',
     'workspace-topics.restore',
+    'channels.post',
   ]);
 
   for (const command of CLI_GATEWAY_ACTOR_WRITE_COMMANDS) {

--- a/test/server-shutdown-contract.test.ts
+++ b/test/server-shutdown-contract.test.ts
@@ -31,7 +31,7 @@ describe('server shutdown store closing contract', () => {
     expect(gracefulShutdownSource).toContain('agentPresenceStore?.close();');
     expect(gracefulShutdownSource).toContain('workspaceSurfaceStore?.close();');
     expect(gracefulShutdownSource).toMatch(
-      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+closeInterventionLog\(\);/
+      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+closeInterventionLog\(\);/
     );
   });
 

--- a/test/ws-channels-upgrade.test.ts
+++ b/test/ws-channels-upgrade.test.ts
@@ -1,0 +1,107 @@
+import { EventEmitter, once } from 'node:events';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+
+import { setupWebSocket } from '../server/ws.js';
+import { createLocalRelayNode } from '../server/local-node.js';
+import { createChannelMessageStore } from '../server/channel-message-store.js';
+import { createChannelHub } from '../server/channel-hub.js';
+import type { WorktreeWatcher } from '../server/watcher.js';
+
+// Exercises the REAL ws.ts upgrade handler for /ws/channels/:channelId — the
+// auth-before-upgrade gate, the 4404 close for unknown channels, and the
+// snapshot-on-connect happy path — rather than driving the hub with fake sockets.
+
+const cleanupFns: Array<() => void> = [];
+const KNOWN_CHANNEL = 'topic:known';
+const TOKEN = 'valid-cookie-token';
+
+afterEach(() => {
+  for (const cleanup of cleanupFns.splice(0)) cleanup();
+});
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('server did not listen on a tcp port');
+  }
+  return address.port;
+}
+
+function makeServer(): { server: http.Server } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ws-channels-'));
+  cleanupFns.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanupFns.push(() => store.close());
+  const hub = createChannelHub({
+    store,
+    channelExists: (id) => id === KNOWN_CHANNEL,
+  });
+  cleanupFns.push(() => hub.close());
+
+  const server = http.createServer();
+  const watcher = new EventEmitter();
+  const { wss } = setupWebSocket(
+    server,
+    new Set<string>([TOKEN]),
+    watcher as unknown as WorktreeWatcher,
+    undefined,
+    true,
+    createLocalRelayNode({ nodeId: 'node-a', environmentId: 'env-a' }),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    hub
+  );
+  cleanupFns.push(() => wss.close());
+  cleanupFns.push(() => server.close());
+  return { server };
+}
+
+function connect(port: number, channelId: string, cookie?: string): WebSocket {
+  const client = new WebSocket(
+    `ws://127.0.0.1:${port}/ws/channels/${encodeURIComponent(channelId)}`,
+    cookie ? { headers: { Cookie: cookie } } : {}
+  );
+  client.on('error', () => {});
+  cleanupFns.push(() => client.close());
+  return client;
+}
+
+describe('/ws/channels upgrade auth', () => {
+  it('rejects an unauthenticated upgrade with 401 (no upgrade)', async () => {
+    const { server } = makeServer();
+    const port = await listen(server);
+    const client = connect(port, KNOWN_CHANNEL, 'token=not-the-token');
+    const [, res] = (await once(client, 'unexpected-response')) as [
+      http.ClientRequest,
+      http.IncomingMessage,
+    ];
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('closes an authenticated upgrade to an unknown channel with app code 4404', async () => {
+    const { server } = makeServer();
+    const port = await listen(server);
+    const client = connect(port, 'topic:ghost', `token=${TOKEN}`);
+    const [code] = (await once(client, 'close')) as [number];
+    expect(code).toBe(4404);
+  });
+
+  it('delivers a snapshot on an authenticated upgrade to a valid channel', async () => {
+    const { server } = makeServer();
+    const port = await listen(server);
+    const client = connect(port, KNOWN_CHANNEL, `token=${TOKEN}`);
+    const [raw] = (await once(client, 'message')) as [Buffer];
+    const event = JSON.parse(raw.toString()) as { type: string };
+    expect(event.type).toBe('channel-snapshot-v1');
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of epic #1163 (Slack-style workspace chat). Ships the **channel = conversation** substrate: a durable multi-sender store, a purpose-built wire protocol, per-channel WS fan-out, REST/gateway verbs, and the slice-4 adapter bridge seam. **Fully additive** — `web_sessions`, `/ws/:sessionId`, agent mail, and every adapter are untouched.

Implements the judge-panel design spec (posted on #1165). All judge must-fixes (`[MF]`) are applied.

### What landed
- **`shared/channel-chat-protocol.ts`** — `ChannelEventV1` envelope (snapshot / created / delta / completed / resync-required), runtime validator, and a **self-diagnosing pure reducer** (gap → `needsCatchup`, per-message `deltaIndex` + quarantine, no cross-sender shared state). `AgentPatchV2` is **not** extended. Plus `parseMentions` (code-fence / inline-code / email safe).
- **`server/channel-message-store.ts`** — `channel-chat.db` (schema v1) with **atomic single-statement `seq` allocation** + `UNIQUE(channel_id, seq)` loud backstop, streaming lifecycle (begin → debounced flush → finalize in place), **boot sweep** of stale `streaming` → `interrupted` (+ system message), **orphan GC** against the topic store, source-triple + `clientMessageId` idempotency, 256KB cap, members, and slice-4 `channel_agent_bindings`.
- **`server/channel-hub.ts`** — per-channel fan-out: register-before-snapshot connect with **snapshot/live dedupe** (drop `seq ≤ endSeq`; drop `deltaIndex ≤` recorded per messageId), 50ms delta coalescing, **backpressure watermarks** (suppress deltas → `channel-resync-required-v1` → 4409 close), and coarse `channel-activity` sidebar badges on `/ws/events`. No event ring — catch-up is always DB-backed.
- **`server/channel-chat-router.ts`** — `channels.list/get/history/post`. **REST-only writes** via one internal `postToChannel`. **Sender is server-derived from the auth lane, never the body** (spoofed `sender` → 400); derived/archived topics rejected; `clientMessageId` idempotent.
- **`server/channel-agent-bridge.ts`** — `AgentPatchV2` → channel lifecycle translation (assistant text only; tools/commands stay in `agentSessionV2`), debounced flush, 256KB cap, interrupted-on-death. Shipped and contract-tested, **unwired** until #1167.
- **`server/cli-gateway-actor-auth.ts`** — `channels.*` added to the read/write command sets **and** the capability map (`context:read` / `context:write`).
- **`server/ws.ts` / `server/index.ts`** — `GET /ws/channels/:channelId?sinceSeq=N` lane, best-effort store init with **503 degradation**, boot sweeps, badge wiring, close hooks.
- **`docs/CHANNEL_CHAT.md`** — slice-2 status flipped to SHIPPED + explicit raw-body **privacy note**.

## Verification

`npm run check` — green (exit 0).

New + affected suites (81 tests):
```
npx vitest run test/channel-*.test.ts test/cli-gateway-actor-auth.test.ts test/server-shutdown-contract.test.ts
PASS (81) FAIL (0)
```

Covers: atomic seq under two store handles on one db file (+ UNIQUE surfaces loudly), source-triple + client-post idempotent finalize, boot sweep, orphan GC, 256KB truncation; reducer multi-sender interleave + snapshot/live dedupe + gap→catchup; hub connect continuity, coalescing, and backpressure overflow → resync → recovery; routes spoofed-sender rejected, derived/archived rejected, gateway capability map; bridge concurrent sessions, error→failed, death→interrupted, re-emit dedupe, non-text not mirrored, 256KB force-finalize.

Full `npm test`: all failures are pre-existing flakes that pass in isolation — `branch-watcher [needs:git-init]` (worktree GIT_DIR), `server-startup` / `work-context-messages` template discovery under parallel load (pass-in-isolation rule per docs/QUALITY.md; my changes touch neither).

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)