### PR TITLE
feat(channels): channel timeline UI + DM-as-channel

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,6 +15,31 @@
   --status-merged: #a78bfa;
   --status-info: #60a5fa;
 
+  /* Repo / Project identity colors — DESIGN.md "Repo / Project Identity
+     Colors" palette, materialized as CSS custom properties (previously only
+     documented + inlined in lib/colors.ts). Hash-derived badge backgrounds and
+     the sender-identity tokens below reference these. */
+  --color-red: #d97757;
+  --color-green: #4ade80;
+  --color-blue: #60a5fa;
+  --color-purple: #a78bfa;
+  --color-pink: #f472b6;
+  --color-orange: #fb923c;
+  --color-teal: #34d399;
+  --color-coral: #f87171;
+  --color-yellow: #fbbf24;
+  --color-sky: #38bdf8;
+  --color-lime: #a3e635;
+  --color-indigo: #818cf8;
+
+  /* Sender identity — channel timeline (#1166). Reuses existing DESIGN.md
+     tokens; no new hex values. */
+  --sender-claude: var(--accent); /* terracotta — Relay's own accent */
+  --sender-codex: var(--color-teal); /* distinct green from --status-success */
+  --sender-hermes: var(--color-sky);
+  --sender-opencode: var(--color-indigo);
+  --sender-system: var(--text-muted);
+
   /* Typography */
   --font-mono:
     'SF Mono', 'Cascadia Code', 'JetBrains Mono', 'Fira Code', 'Consolas',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -184,6 +184,8 @@ function useTerminalDerivedState() {
   const forceOrgCockpit = useUiStore((s) => s.forceOrgCockpit);
   const topicComposerOpen = useUiStore((s) => s.topicComposerOpen);
   const setTopicComposerOpen = useUiStore((s) => s.setTopicComposerOpen);
+  const activeChannelId = useUiStore((s) => s.activeChannelId);
+  const setActiveChannelId = useUiStore((s) => s.setActiveChannelId);
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
@@ -256,6 +258,7 @@ function useTerminalDerivedState() {
         activeRepoPath,
         forceOrgCockpit,
         topicComposerOpen,
+        hasActiveChannel: activeChannelId !== null,
         activeSessionMode: activeSession?.mode,
       }),
     [
@@ -264,6 +267,7 @@ function useTerminalDerivedState() {
       activeRepoPath,
       forceOrgCockpit,
       topicComposerOpen,
+      activeChannelId,
       activeSession?.mode,
     ]
   );
@@ -272,13 +276,24 @@ function useTerminalDerivedState() {
   // a launch from the composer or a sidebar selection navigates to that
   // session. (The composer can open while a session is still active, so a
   // mere "session is active" check would close it immediately.)
+  // #1166: selecting/launching a session also wins over a previously open
+  // channel — clear activeChannelId so the two never render at once.
   const composerPrevSessionRef = useRef(activeSessionId);
   useEffect(() => {
     if (composerPrevSessionRef.current !== activeSessionId) {
       composerPrevSessionRef.current = activeSessionId;
       if (topicComposerOpen) setTopicComposerOpen(false);
+      if (activeSessionId !== null && activeChannelId !== null) {
+        setActiveChannelId(null);
+      }
     }
-  }, [activeSessionId, topicComposerOpen, setTopicComposerOpen]);
+  }, [
+    activeSessionId,
+    topicComposerOpen,
+    setTopicComposerOpen,
+    activeChannelId,
+    setActiveChannelId,
+  ]);
 
   return {
     activeRepoPath,

--- a/frontend/src/components/ChatHome.tsx
+++ b/frontend/src/components/ChatHome.tsx
@@ -4,6 +4,7 @@ import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import TopicComposer from './TopicComposer.js';
 import ChatView from './chat/ChatView.js';
+import ChannelView from './chat/ChannelView.js';
 import LiveSessionsPanel from './LiveSessionsPanel.js';
 import './ChatHome.css';
 
@@ -23,19 +24,12 @@ export default function ChatHome({ onSelectSession }: ChatHomeProps) {
   const sessions = useSessionsStore((s) => s.sessions);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
   const topicComposerOpen = useUiStore((s) => s.topicComposerOpen);
+  const activeChannelId = useUiStore((s) => s.activeChannelId);
   const activeSession = useMemo(
     () =>
       activeSessionId ? resolveSessionByKey(sessions, activeSessionId) : null,
     [activeSessionId, sessions]
   );
-
-  const mostRecentSession = useMemo(() => {
-    let best: (typeof sessions)[number] | undefined;
-    for (const session of sessions) {
-      if (!best || session.lastActivity > best.lastActivity) best = session;
-    }
-    return best;
-  }, [sessions]);
 
   // Live PTY agent/terminal sessions (Claude/Codex/Hermes TUIs, bare
   // terminals). Web-mode chat sessions live in the composer/ChatView flow, so
@@ -46,6 +40,16 @@ export default function ChatHome({ onSelectSession }: ChatHomeProps) {
     [sessions]
   );
 
+  // "Resume" must never resurrect the retired per-session web-chat surface, so
+  // it iterates the same web-excluded set LiveSessionsPanel shows (#1166).
+  const mostRecentSession = useMemo(() => {
+    let best: (typeof liveSessions)[number] | undefined;
+    for (const session of liveSessions) {
+      if (!best || session.lastActivity > best.lastActivity) best = session;
+    }
+    return best;
+  }, [liveSessions]);
+
   const resume = mostRecentSession
     ? {
         label: `resume "${mostRecentSession.displayName}"`,
@@ -55,7 +59,14 @@ export default function ChatHome({ onSelectSession }: ChatHomeProps) {
 
   return (
     <div className="chat-home" aria-label="chat home">
-      {activeSession?.mode === 'web' && !topicComposerOpen ? (
+      {activeChannelId ? (
+        // #1166: an open channel (DM or regular) is the primary chat surface.
+        // Keyed by id so unread-capture/last-read-write run per channel-open.
+        <ChannelView key={activeChannelId} channelId={activeChannelId} />
+      ) : activeSession?.mode === 'web' && !topicComposerOpen ? (
+        // Legacy per-session web chat: reachable only for pre-existing web-mode
+        // session rows (read-only compat). No creation path produces one after
+        // the #1166 entry-point rewires; provably unreachable from every launch.
         <ChatView sessionId={scopedSessionKey(activeSession)} />
       ) : (
         <>

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1274,6 +1274,59 @@
   padding: 0;
 }
 
+/* #1166: DM sub-section header under a workspace group. Matches the muted,
+   lowercase participants-header treatment with a top border to separate it
+   from the channel list above. */
+.topic-workspace-group__dm-header {
+  padding: 6px 10px 2px;
+  margin-top: 4px;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  text-transform: lowercase;
+  opacity: 0.7;
+}
+
+.topic-tree__list--dm {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* #1166: DM row badge — agent glyph in its sender color on a muted-variant
+   background. Override the default badge svg stroke/fill so the AgentBadge
+   currentColor glyph renders (default .topic-row__badge svg strokes with --bg). */
+.topic-row__badge--dm {
+  box-shadow: none;
+  color: var(--text);
+}
+
+.topic-row__dm-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.topic-row__badge--dm .topic-row__dm-glyph svg {
+  width: 12px;
+  height: 12px;
+  fill: currentColor;
+  stroke: none;
+}
+
+/* #1166: presence-only unread-activity dot (not a count badge). */
+.topic-row__activity-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 4px;
+  border-radius: 50%;
+  background: var(--status-info);
+  flex: 0 0 6px;
+}
+
 /* #1084: search scope toggle */
 .topic-search__scope {
   background: transparent;

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -41,6 +41,12 @@ import {
   sendSessionInput,
 } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
+import { resolveSenderIdentity } from '../lib/chat/sender-identity.js';
+import {
+  hasUnseenActivity,
+  useChannelActivityStore,
+} from '../lib/stores/channel-activity.js';
+import { AgentBadge } from './AgentBadge.js';
 import { openTopicTaskRoom } from '../lib/topic-task-room.js';
 import type { SessionSummary } from '../lib/types.js';
 import { formatRelativeTimeCompact } from '../lib/utils.js';
@@ -242,6 +248,37 @@ function topicLatestStatus(item: TopicNavItem): string {
 }
 
 function TopicBadge({ item }: { item: TopicNavItem }) {
+  // #1166: DM rows show the agent's colored glyph on a muted-variant background
+  // (the same color-mix recipe repo-identity badges use), not a generic icon.
+  if (item.isDirectMessage && item.dmProviderId) {
+    const identity = resolveSenderIdentity({
+      kind: 'agent',
+      id: `agent:${item.dmProviderId}`,
+      providerId: item.dmProviderId,
+    });
+    return (
+      <span
+        className="topic-row__badge topic-row__badge--dm"
+        style={{
+          background: `color-mix(in srgb, ${identity.colorVar} 15%, transparent)`,
+        }}
+        aria-label={`direct message with ${identity.label}`}
+        title={`direct message with ${identity.label}`}
+      >
+        {identity.glyph ? (
+          <span
+            className="topic-row__dm-glyph"
+            style={{ color: identity.colorVar }}
+            aria-hidden="true"
+          >
+            <AgentBadge agent={identity.glyph} />
+          </span>
+        ) : (
+          <TopicKindIcon kind={item.kind} />
+        )}
+      </span>
+    );
+  }
   const background = item.color ?? deriveColor(item.badgeSeed);
   const label = item.channelKind
     ? `${item.channelKind} channel`
@@ -1417,6 +1454,7 @@ function TopicRow({
   model,
   expandedIds,
   selectedId,
+  activeChannelId,
   onToggle,
   onSelect,
   onSelectSession,
@@ -1426,6 +1464,7 @@ function TopicRow({
   model: TopicNavModel;
   expandedIds: Set<string>;
   selectedId: string | null;
+  activeChannelId: string | null;
   onToggle: (id: string) => void;
   onSelect: (id: string) => void;
   onSelectSession?: ((id: string) => void) | undefined;
@@ -1433,6 +1472,16 @@ function TopicRow({
   const hasNested = item.childIds.length > 0 || item.participants.length > 0;
   const expanded = expandedIds.has(item.id);
   const selected = selectedId === item.id;
+  // Presence-only activity dot (#1166): re-render when this channel's latest-seq
+  // changes; hasUnseenActivity compares it against the client-local last-read.
+  const latestSeq = useChannelActivityStore(
+    (s) => s.latestSeqByChannel[item.id]
+  );
+  const showActivityDot = useMemo(
+    () =>
+      latestSeq !== undefined && hasUnseenActivity(item.id, activeChannelId),
+    [item.id, activeChannelId, latestSeq]
+  );
 
   const activate = () => {
     onSelect(item.id);
@@ -1480,6 +1529,13 @@ function TopicRow({
           </span>
         </button>
         <span className="topic-row__trail" aria-label={item.statusLabel}>
+          {showActivityDot ? (
+            <span
+              className="topic-row__activity-dot"
+              aria-label="unread activity"
+              title="unread activity"
+            />
+          ) : null}
           <StatusGlyph tone={item.tone} />
         </span>
       </div>
@@ -1508,6 +1564,7 @@ function TopicRow({
                     model={model}
                     expandedIds={expandedIds}
                     selectedId={selectedId}
+                    activeChannelId={activeChannelId}
                     onToggle={onToggle}
                     onSelect={onSelect}
                     onSelectSession={onSelectSession}
@@ -1842,11 +1899,55 @@ function ArchivedToggle({
 }
 
 /** The workspace-grouped chat tree: a section per workspace + an orphan lane. */
+function partitionChannelsAndDms(
+  ids: string[],
+  model: TopicNavModel
+): { channels: string[]; dms: string[] } {
+  const channels: string[] = [];
+  const dms: string[] = [];
+  for (const id of ids) {
+    (model.byId.get(id)?.isDirectMessage ? dms : channels).push(id);
+  }
+  return { channels, dms };
+}
+
+/** Regular channels then, if any, a `direct messages` sub-section (#1166). */
+function ChannelsAndDmsLists({
+  ids,
+  model,
+  renderRow,
+}: {
+  ids: string[];
+  model: TopicNavModel;
+  renderRow: (id: string) => ReactNode;
+}) {
+  const { channels, dms } = partitionChannelsAndDms(ids, model);
+  return (
+    <>
+      <ul className="topic-tree__list">
+        {channels.map((id) => renderRow(id))}
+      </ul>
+      {dms.length > 0 ? (
+        <>
+          <div className="topic-workspace-group__dm-header">
+            direct messages
+          </div>
+          <ul className="topic-tree__list topic-tree__list--dm">
+            {dms.map((id) => renderRow(id))}
+          </ul>
+        </>
+      ) : null}
+    </>
+  );
+}
+
 function GroupedTopicTree({
   grouped,
+  model,
   renderRow,
 }: {
   grouped: GroupedTopicNav;
+  model: TopicNavModel;
   renderRow: (id: string) => ReactNode;
 }) {
   return (
@@ -1865,9 +1966,11 @@ function GroupedTopicTree({
             ) : null}
             <span className="topic-workspace-group__name">{group.title}</span>
           </div>
-          <ul className="topic-tree__list">
-            {group.rootIds.map((id) => renderRow(id))}
-          </ul>
+          <ChannelsAndDmsLists
+            ids={group.rootIds}
+            model={model}
+            renderRow={renderRow}
+          />
         </section>
       ))}
       {grouped.orphanRootIds.length > 0 ? (
@@ -1880,9 +1983,11 @@ function GroupedTopicTree({
               <span className="topic-workspace-group__name">no workspace</span>
             </div>
           ) : null}
-          <ul className="topic-tree__list">
-            {grouped.orphanRootIds.map((id) => renderRow(id))}
-          </ul>
+          <ChannelsAndDmsLists
+            ids={grouped.orphanRootIds}
+            model={model}
+            renderRow={renderRow}
+          />
         </section>
       ) : null}
     </div>
@@ -1996,6 +2101,7 @@ export function TopicSidebarView({
     () => new Map(topics.map((topic) => [topic.id, topic])),
     [topics]
   );
+  const activeChannelId = useUiStore((s) => s.activeChannelId);
   const workspaceNameById = useMemo(
     () =>
       new Map(workspaces.map((workspace) => [workspace.id, workspace.name])),
@@ -2038,10 +2144,20 @@ export function TopicSidebarView({
   // and the workspace pane operate in the topic's node/repo. Only fires on an
   // explicit user selection — the initial/auto-selection sets `selectedId`
   // directly and never clobbers the active repo.
+  // #1166: for a persisted channel (anything backed by GET /channels), clicking
+  // the row also opens it in the main pane (activeChannelId) and closes the
+  // composer — "selected in sidebar" and "open in main pane" become one state
+  // for channels. Derived (non-persisted) topics never route to a channel.
   const select = useCallback(
     (id: string) => {
       setSelectedId(id);
-      applyTopicActiveContext(topicsById.get(id));
+      const topic = topicsById.get(id);
+      applyTopicActiveContext(topic);
+      if (topic?.source === 'persisted') {
+        const ui = useUiStore.getState();
+        ui.setActiveChannelId(id);
+        ui.setTopicComposerOpen(false);
+      }
     },
     [topicsById]
   );
@@ -2061,6 +2177,7 @@ export function TopicSidebarView({
         model={model}
         expandedIds={expandedIds}
         selectedId={selectedId}
+        activeChannelId={activeChannelId}
         onToggle={toggle}
         onSelect={select}
         onSelectSession={onSelectSession}
@@ -2164,7 +2281,11 @@ export function TopicSidebarView({
         canScope={activeWorkspaceId != null}
       />
       <ArchivedToggle showArchived={showArchived} onToggle={onToggleArchived} />
-      <GroupedTopicTree grouped={grouped} renderRow={renderTopicRow} />
+      <GroupedTopicTree
+        grouped={grouped}
+        model={model}
+        renderRow={renderTopicRow}
+      />
       <TopicAdvancedDetailGate
         item={selectedItem}
         show={showAdvancedDetail}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1473,14 +1473,19 @@ function TopicRow({
   const expanded = expandedIds.has(item.id);
   const selected = selectedId === item.id;
   // Presence-only activity dot (#1166): re-render when this channel's latest-seq
-  // changes; hasUnseenActivity compares it against the client-local last-read.
+  // OR its reactive last-read marker changes (#1178 — the read marker is now in
+  // the store, so reading a channel hides the dot immediately instead of leaving
+  // a stale localStorage read on screen). hasUnseenActivity compares the two.
   const latestSeq = useChannelActivityStore(
     (s) => s.latestSeqByChannel[item.id]
+  );
+  const lastReadSeq = useChannelActivityStore(
+    (s) => s.lastReadByChannel[item.id]
   );
   const showActivityDot = useMemo(
     () =>
       latestSeq !== undefined && hasUnseenActivity(item.id, activeChannelId),
-    [item.id, activeChannelId, latestSeq]
+    [item.id, activeChannelId, latestSeq, lastReadSeq]
   );
 
   const activate = () => {

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -17,8 +17,10 @@ import {
   createAgentSession,
   getCurrentSessionContext,
 } from '../lib/session-utils.js';
+import { getOrCreateDmChannel } from '../hooks/useTopicRoomCreate.js';
 import type { SummaryNodeInfo } from '../lib/workspace-summary.js';
 import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
+import { useConfigStore } from '../lib/stores/config.js';
 import { useToastStore } from '../lib/stores/toasts.js';
 import { TerminalNodePicker } from './TerminalNodePicker.js';
 import DialogShell, { type DialogShellHandle } from './dialogs/DialogShell.js';
@@ -650,7 +652,6 @@ export function WorkspaceArea({
   const layout = useWorkspaceLayoutStore((s) => s.layout);
   const activePaneId = useWorkspaceLayoutStore((s) => s.activePaneId);
   const addTab = useWorkspaceLayoutStore((s) => s.addTab);
-  const openTabBeside = useWorkspaceLayoutStore((s) => s.openTabBeside);
   const closeTab = useWorkspaceLayoutStore((s) => s.closeTab);
   const selectTab = useWorkspaceLayoutStore((s) => s.selectTab);
   const resetLayout = useWorkspaceLayoutStore((s) => s.resetLayout);
@@ -900,46 +901,42 @@ export function WorkspaceArea({
     [pendingRemoteTerminal, remoteTerminalCreating]
   );
 
-  // #1076/#1077: spawn a native Hermes chat and place it in a split pane
-  // beside the pane whose control was used, so agents can be watched together.
+  // #1166/#1178: the pane-header '+chat' button opens a Hermes DM channel, not a
+  // mode:'web' session that renders the retired ChatView. Route it through the
+  // same get-or-create DM channel flow as every other entry point (TopicComposer,
+  // CustomizeSessionDialog) so no UI path can still mint a web session. A channel
+  // is a full-surface view, so this activates ChannelView directly rather than a
+  // split pane (the old "beside" placement no longer applies).
   const spawnHermesBeside = useCallback(
     async (paneId: string) => {
-      const { currentActiveWorkspace, currentWorktreePath } =
-        getCurrentSessionContext();
+      const { currentActiveWorkspace } = getCurrentSessionContext();
       if (!currentActiveWorkspace) {
         useUiStore.getState().setActiveModal({ modal: 'env-picker' });
         return;
       }
       setActivePane(paneId);
-      const { session, error } = await createAgentSession({
-        agent: 'hermes',
-        type: 'agent',
-        mode: 'web',
-        repoPath: currentActiveWorkspace.path,
-        worktreePath: currentWorktreePath,
-        sessionLane: 'local-repo',
-      });
-      if (error && !(error instanceof ConflictError)) {
-        workspaceLogger.error('failed to create hermes chat', error);
+      try {
+        const framework = useConfigStore
+          .getState()
+          .frameworks.find((f) => f.id === 'hermes');
+        const topic = await getOrCreateDmChannel({
+          providerId: 'hermes',
+          providerDisplayName: framework?.displayName ?? 'Hermes',
+          workspaceId: useUiStore.getState().activeWorkspaceId,
+        });
+        useUiStore.getState().setActiveChannelId(topic.id);
+      } catch (error) {
+        workspaceLogger.error('failed to open hermes chat', error);
         useToastStore
           .getState()
           .showToast(
             error instanceof Error
               ? error.message
-              : 'failed to create hermes chat'
+              : 'failed to open hermes chat'
           );
-        return;
-      }
-      if (session?.id) {
-        useSessionsStore.getState().setActiveSessionId(session.id);
-        openTabBeside({
-          kind: 'session',
-          sessionId: session.id,
-          sessionType: 'agent',
-        });
       }
     },
-    [setActivePane, openTabBeside]
+    [setActivePane]
   );
 
   const renderAddControl = useCallback(

--- a/frontend/src/components/chat/ChannelComposer.css
+++ b/frontend/src/components/chat/ChannelComposer.css
@@ -1,0 +1,121 @@
+/* Channel composer (#1166). Reuses Composer.css rules (textarea, bar, hint,
+   attach) at the same type/spacing scale — no slash palette, no queue chips, no
+   context popover (turn/session concepts that don't exist on ChannelMessage). */
+
+.ch-composer {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+}
+
+.ch-composer__banner {
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--status-error);
+  color: var(--status-error);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.ch-composer__ta {
+  flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg);
+  color: var(--text);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  padding: 10px 12px;
+  resize: none;
+  outline: none;
+  line-height: 1.5;
+  overflow-y: auto;
+}
+
+.ch-composer__ta::placeholder {
+  color: var(--text-muted);
+}
+
+.ch-composer__ta:focus {
+  border-bottom-color: var(--accent);
+}
+
+/* pending POST round-trip: dim the affordance subtly, but never block typing */
+.ch-composer__ta[data-pending='true'] {
+  opacity: 0.85;
+}
+
+.ch-composer__bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.ch-composer__attach {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 2px 6px;
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.ch-composer__hint kbd {
+  border: 1px solid var(--border);
+  padding: 0 4px;
+  font-size: 0.65rem;
+  opacity: 0.7;
+  margin-right: 4px;
+}
+
+/* archived state — composer replaced by a single-row restore bar */
+.ch-composer__archived-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.ch-composer__restore {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.ch-composer__restore:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.ch-composer__restore:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (max-width: 767px) {
+  .ch-composer__ta {
+    padding: 6px 4px;
+  }
+
+  .ch-composer__bar {
+    gap: 4px;
+    padding: 3px 4px;
+  }
+}

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -1,0 +1,208 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './ChannelComposer.css';
+import { createBrowserId } from '../../lib/browserId.js';
+
+const LINE_BREAK_INPUT_TYPES = new Set(['insertLineBreak', 'insertParagraph']);
+const LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS = 500;
+const IMAGE_ATTACH_TOOLTIP =
+  'image attachments are coming in a future update — the channel API does not accept them yet';
+
+interface ChannelComposerProps {
+  channelTitle: string;
+  /** Idempotent send: the SAME clientMessageId is reused across manual retries. */
+  onSend: (text: string, clientMessageId: string) => Promise<void>;
+  postPending: boolean;
+  /** 503 CHANNEL_STORE_UNAVAILABLE — persistent inline banner, input stays live. */
+  storeDown: boolean;
+  /** 409 CHANNEL_ARCHIVED — composer replaced by a restore bar. */
+  archived: boolean;
+  onRestore: () => void;
+  restorePending: boolean;
+}
+
+export const ChannelComposer: React.FC<ChannelComposerProps> = ({
+  channelTitle,
+  onSend,
+  postPending,
+  storeDown,
+  archived,
+  onRestore,
+  restorePending,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const skipNextLineBreakUntilRef = useRef(0);
+  // Idempotency (§6.3): one clientMessageId per draft attempt, reused on retry
+  // until a send succeeds, so a flaky connection never double-posts.
+  const clientIdRef = useRef<string | null>(null);
+  const sendingRef = useRef(false);
+  const [draft, setDraft] = useState('');
+
+  const resize = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const lineHeight = parseInt(getComputedStyle(el).lineHeight, 10) || 20;
+    const maxHeight = lineHeight * 6 + 32;
+    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+  }, []);
+
+  useEffect(() => {
+    resize();
+  }, [draft, resize]);
+
+  const submit = useCallback(() => {
+    const content = draft.trim();
+    if (!content || sendingRef.current) return;
+    if (!clientIdRef.current) clientIdRef.current = createBrowserId('chm');
+    const clientMessageId = clientIdRef.current;
+    sendingRef.current = true;
+    void onSend(content, clientMessageId)
+      .then(() => {
+        // Success: the row arrives via the socket, not this promise. Reset the
+        // draft and idempotency key so the next message is a fresh attempt.
+        clientIdRef.current = null;
+        setDraft('');
+      })
+      .catch(() => {
+        // Keep the draft AND the same clientMessageId so a retry (press enter
+        // again) dedupes server-side instead of double-posting.
+      })
+      .finally(() => {
+        sendingRef.current = false;
+      });
+  }, [draft, onSend]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const nativeEvent = e.nativeEvent as KeyboardEvent;
+      if (e.key === 'Enter' && nativeEvent.isComposing) return;
+      if (e.key === 'Enter' && e.shiftKey) {
+        skipNextLineBreakUntilRef.current =
+          performance.now() + LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS;
+        return;
+      }
+      skipNextLineBreakUntilRef.current = 0;
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        submit();
+      }
+    },
+    [submit]
+  );
+
+  // Mobile IME parity: some IMEs only report a beforeinput line-break intent for
+  // the send key, no reliable keydown. Treat it as send before it mutates the
+  // controlled draft. Copied from Composer.tsx (LINE_BREAK_INPUT_TYPES handling).
+  const handleBeforeInput = useCallback(
+    (inputEvent: InputEvent) => {
+      if (!LINE_BREAK_INPUT_TYPES.has(inputEvent.inputType)) return;
+      if (inputEvent.isComposing) return;
+      if (
+        skipNextLineBreakUntilRef.current > 0 &&
+        performance.now() <= skipNextLineBreakUntilRef.current
+      ) {
+        skipNextLineBreakUntilRef.current = 0;
+        return;
+      }
+      skipNextLineBreakUntilRef.current = 0;
+      inputEvent.preventDefault();
+      submit();
+    },
+    [submit]
+  );
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.addEventListener('beforeinput', handleBeforeInput);
+    return () => textarea.removeEventListener('beforeinput', handleBeforeInput);
+  }, [handleBeforeInput]);
+
+  // Paste/drop of image files is detected and swallowed (no text paste of
+  // binary) — the attach affordance is visibly present but inert in slice 3.
+  const swallowImagePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of Array.from(items)) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          e.preventDefault();
+          return;
+        }
+      }
+    },
+    []
+  );
+
+  const swallowImageDrop = useCallback(
+    (e: React.DragEvent<HTMLTextAreaElement>) => {
+      const dropped = e.dataTransfer?.files;
+      if (
+        dropped &&
+        Array.from(dropped).some((f) => f.type.startsWith('image/'))
+      ) {
+        e.preventDefault();
+      }
+    },
+    []
+  );
+
+  if (archived) {
+    return (
+      <div className="ch-composer ch-composer--archived" role="form">
+        <div className="ch-composer__archived-bar">
+          <span>this channel is archived</span>
+          <button
+            type="button"
+            className="ch-composer__restore"
+            onClick={onRestore}
+            disabled={restorePending}
+          >
+            {restorePending ? 'restoring…' : 'restore'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ch-composer" role="form" aria-label="message composer">
+      {storeDown ? (
+        <div className="ch-composer__banner" role="alert">
+          channel store unavailable — retry shortly
+        </div>
+      ) : null}
+      <textarea
+        ref={textareaRef}
+        className="ch-composer__ta"
+        placeholder={`message #${channelTitle}…  ·  shift+enter for newline`}
+        value={draft}
+        rows={1}
+        enterKeyHint="send"
+        aria-label="message input"
+        data-pending={postPending ? 'true' : 'false'}
+        onChange={(event) => setDraft(event.currentTarget.value)}
+        onKeyDown={handleKeyDown}
+        onPaste={swallowImagePaste}
+        onDrop={swallowImageDrop}
+        onDragOver={(e) => e.preventDefault()}
+      />
+      <div className="ch-composer__bar">
+        <button
+          type="button"
+          className="ch-composer__attach"
+          aria-label="attach image"
+          title={IMAGE_ATTACH_TOOLTIP}
+          disabled
+        >
+          +img
+        </button>
+        <span className="ch-composer__hint">
+          <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ChannelComposer;

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type {
+  ChannelMessage,
+  ChannelSenderRef,
+} from '../../../../shared/channel-chat-protocol.js';
+import { AgentBadge } from '../AgentBadge.js';
+import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { ChannelMessageRow } from './ChannelMessageRow.js';
+
+/** Compact wall-clock time, lowercase (DESIGN.md casing law), e.g. `3:42pm`. */
+function formatGroupTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  let hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const meridiem = hours >= 12 ? 'pm' : 'am';
+  hours = hours % 12;
+  if (hours === 0) hours = 12;
+  return `${hours}:${minutes}${meridiem}`;
+}
+
+interface ChannelMessageGroupProps {
+  sender: ChannelSenderRef;
+  messages: ChannelMessage[];
+}
+
+export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
+  sender,
+  messages,
+}) => {
+  const identity = resolveSenderIdentity(sender);
+  const first = messages[0];
+  // Human messages carry no name chrome — they are always "you", right-aligned
+  // bubbles in a single-operator system (spec §4). Agent/system get a header.
+  const showHeader = identity.kind !== 'human';
+
+  return (
+    <div className="ch-group">
+      {showHeader && first ? (
+        <div className="ch-group__header">
+          {identity.glyph ? (
+            <span
+              className="ch-group__badge"
+              style={{ color: identity.colorVar }}
+              aria-hidden="true"
+            >
+              <AgentBadge agent={identity.glyph} />
+            </span>
+          ) : null}
+          <span className="ch-group__name" style={{ color: identity.colorVar }}>
+            {identity.label}
+          </span>
+          <span className="ch-group__time">
+            {formatGroupTime(first.createdAt)}
+          </span>
+        </div>
+      ) : null}
+      <div className="ch-group__messages">
+        {messages.map((message) => (
+          <ChannelMessageRow key={message.id} message={message} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ChannelMessageGroup;

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+import { AssistantMarkdown } from './AssistantMarkdown.js';
+import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+
+/** DESIGN.md motion effect 4: solid while text is actively arriving, blinks
+ * after 530ms of no change. Returns true when the cursor should blink. */
+function useIdleBlink(signal: string, active: boolean): boolean {
+  const [blinking, setBlinking] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setBlinking(false);
+      return;
+    }
+    setBlinking(false);
+    const timer = setTimeout(() => setBlinking(true), 530);
+    return () => clearTimeout(timer);
+  }, [signal, active]);
+  return blinking;
+}
+
+interface ChannelMessageRowProps {
+  message: ChannelMessage;
+  variant?: 'default' | 'system';
+}
+
+export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
+  message,
+  variant = 'default',
+}) => {
+  const streaming = message.status === 'streaming';
+  const blinking = useIdleBlink(message.body.text, streaming);
+
+  if (variant === 'system' || message.kind === 'system') {
+    return (
+      <div className="ch-system-msg" role="note">
+        <span className="ch-system-msg__label">{message.body.text}</span>
+      </div>
+    );
+  }
+
+  const isHuman = message.sender.kind === 'human';
+  const rowClasses = [
+    'ch-msg',
+    isHuman ? 'ch-msg--user' : null,
+    message.status === 'streaming' ? 'ch-msg--streaming' : null,
+    message.status === 'interrupted' ? 'ch-msg--interrupted' : null,
+    message.status === 'failed' ? 'ch-msg--failed' : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const streamStyle =
+    streaming && !isHuman
+      ? ({
+          borderLeftColor: resolveSenderIdentity(message.sender).colorVar,
+        } as React.CSSProperties)
+      : undefined;
+
+  const body =
+    message.body.format === 'markdown' ? (
+      <div className="ch-msg__body">
+        <AssistantMarkdown text={message.body.text} keyPrefix={message.id} />
+      </div>
+    ) : (
+      <pre className="ch-msg__text ch-msg__body">{message.body.text}</pre>
+    );
+
+  return (
+    <div className={rowClasses} style={streamStyle}>
+      {message.parentMessageId ? (
+        <div className="ch-msg__reply" aria-hidden="true">
+          ↳ reply
+        </div>
+      ) : null}
+      {message.body.format === 'markdown' ? (
+        <div className="ch-msg__body-wrap">
+          {body}
+          {streaming ? (
+            <span
+              className={`ch-msg__cursor${blinking ? ' ch-msg__cursor--blinking' : ''}`}
+              aria-hidden="true"
+            >
+              █
+            </span>
+          ) : null}
+        </div>
+      ) : (
+        body
+      )}
+      {message.status === 'interrupted' ? (
+        <span className="ch-msg__tag ch-msg__tag--interrupted">
+          interrupted
+        </span>
+      ) : null}
+      {message.status === 'failed' ? (
+        <span className="ch-msg__tag ch-msg__tag--failed">failed</span>
+      ) : null}
+      {message.truncated ? (
+        <span className="ch-msg__tag ch-msg__tag--truncated">
+          truncated · 256kb limit
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+export default ChannelMessageRow;

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -42,9 +42,15 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
-  const anchorRef = useRef<{ heightBefore: number; topBefore: number } | null>(
-    null
-  );
+  const anchorRef = useRef<{
+    heightBefore: number;
+    topBefore: number;
+    earliestSeqBefore: number | undefined;
+  } | null>(null);
+  // Bumped on every loadOlder() settlement (success-with-prepend, empty page,
+  // reached-beginning page, OR a swallowed fetch error) so the anchor is always
+  // released even when earliestSeq never changes (#1178).
+  const [loadSettleTick, setLoadSettleTick] = useState(0);
   const [showResyncButton, setShowResyncButton] = useState(false);
 
   const nodes = useMemo(
@@ -88,16 +94,23 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     return () => observer.disconnect();
   }, [followSignal]);
 
-  // Anchor preservation: after older messages prepend (earliest seq drops),
-  // restore scrollTop so the viewport never jumps.
+  // Anchor lifecycle: set before loadOlder(), consumed on the next settlement.
+  // Restore scrollTop ONLY when a prepend actually landed (earliestSeq dropped)
+  // so the viewport never jumps; but ALWAYS release the anchor afterward. If it
+  // is not released on the no-prepend paths (empty page, oldest page already
+  // reaching seq 1, or a swallowed fetch error), auto-follow (line ~73) and all
+  // further older-history loads (handleScroll's `!anchorRef.current` gate) stay
+  // permanently locked until a channel switch (#1178).
   useLayoutEffect(() => {
     const container = containerRef.current;
     const anchor = anchorRef.current;
     if (!container || !anchor) return;
-    container.scrollTop =
-      container.scrollHeight - anchor.heightBefore + anchor.topBefore;
+    if (earliestSeq !== anchor.earliestSeqBefore) {
+      container.scrollTop =
+        container.scrollHeight - anchor.heightBefore + anchor.topBefore;
+    }
     anchorRef.current = null;
-  }, [earliestSeq]);
+  }, [earliestSeq, loadSettleTick]);
 
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
@@ -112,10 +125,16 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
       anchorRef.current = {
         heightBefore: container.scrollHeight,
         topBefore: container.scrollTop,
+        earliestSeqBefore: earliestSeq,
       };
-      void loadOlder();
+      // The hook swallows its own fetch errors (loadOlder resolves even on a
+      // transient failure), but guard against any future reject too so the
+      // settle tick — and thus the anchor release — always runs (#1178).
+      void loadOlder()
+        .catch(() => {})
+        .finally(() => setLoadSettleTick((tick) => tick + 1));
     }
-  }, [hasMoreOlder, loadingOlder, loadOlder, messages.length]);
+  }, [hasMoreOlder, loadingOlder, loadOlder, messages.length, earliestSeq]);
 
   // Surface a manual "resync now" button only if catch-up is still stuck after
   // a grace period (the hook auto-reconnects in the common case).

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -1,0 +1,213 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+import {
+  buildTimelineNodes,
+  formatDayLabel,
+} from '../../lib/chat/channel-timeline-layout.js';
+import { isNearBottom } from './scrollNearBottom.js';
+import { ChannelMessageGroup } from './ChannelMessageGroup.js';
+import { ChannelMessageRow } from './ChannelMessageRow.js';
+
+const LOAD_OLDER_SCROLL_THRESHOLD_PX = 80;
+const RESYNC_BUTTON_DELAY_MS = 5_000;
+
+interface ChannelTimelineProps {
+  messages: ChannelMessage[];
+  lastReadSeq: number | null;
+  channelTitle: string;
+  hasMoreOlder: boolean;
+  loadingOlder: boolean;
+  loadOlder: () => Promise<void>;
+  needsCatchup: boolean;
+  onResync: () => void;
+}
+
+export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
+  messages,
+  lastReadSeq,
+  channelTitle,
+  hasMoreOlder,
+  loadingOlder,
+  loadOlder,
+  needsCatchup,
+  onResync,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<{ heightBefore: number; topBefore: number } | null>(
+    null
+  );
+  const [showResyncButton, setShowResyncButton] = useState(false);
+
+  const nodes = useMemo(
+    () => buildTimelineNodes(messages, lastReadSeq),
+    [messages, lastReadSeq]
+  );
+
+  const earliestSeq = messages[0]?.seq;
+  const reachedBeginning = !hasMoreOlder && earliestSeq === 1;
+
+  // Follow-bottom signal: grows on new rows AND on streaming text growth.
+  const followSignal = useMemo(() => {
+    const last = messages[messages.length - 1];
+    return `${messages.length}:${last ? last.body.text.length : 0}`;
+  }, [messages]);
+
+  // Auto-follow the bottom when already near it (never yanks a user reading
+  // history). Reuses the ChatView ResizeObserver pattern verbatim.
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const followIfNearBottom = (): void => {
+      if (anchorRef.current) return; // an older-history restore is pending
+      if (
+        isNearBottom({
+          scrollHeight: container.scrollHeight,
+          scrollTop: container.scrollTop,
+          clientHeight: container.clientHeight,
+        })
+      ) {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    };
+
+    followIfNearBottom();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(followIfNearBottom);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [followSignal]);
+
+  // Anchor preservation: after older messages prepend (earliest seq drops),
+  // restore scrollTop so the viewport never jumps.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const anchor = anchorRef.current;
+    if (!container || !anchor) return;
+    container.scrollTop =
+      container.scrollHeight - anchor.heightBefore + anchor.topBefore;
+    anchorRef.current = null;
+  }, [earliestSeq]);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (
+      container.scrollTop < LOAD_OLDER_SCROLL_THRESHOLD_PX &&
+      hasMoreOlder &&
+      !loadingOlder &&
+      messages.length > 0 &&
+      !anchorRef.current
+    ) {
+      anchorRef.current = {
+        heightBefore: container.scrollHeight,
+        topBefore: container.scrollTop,
+      };
+      void loadOlder();
+    }
+  }, [hasMoreOlder, loadingOlder, loadOlder, messages.length]);
+
+  // Surface a manual "resync now" button only if catch-up is still stuck after
+  // a grace period (the hook auto-reconnects in the common case).
+  useEffect(() => {
+    if (!needsCatchup) {
+      setShowResyncButton(false);
+      return;
+    }
+    const timer = setTimeout(
+      () => setShowResyncButton(true),
+      RESYNC_BUTTON_DELAY_MS
+    );
+    return () => clearTimeout(timer);
+  }, [needsCatchup]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="ch-tl"
+      role="log"
+      aria-live="polite"
+      aria-label="channel timeline"
+      onScroll={handleScroll}
+    >
+      {needsCatchup ? (
+        <div className="ch-catchup-banner" role="status">
+          <span>chat is out of sync — reconnecting…</span>
+          {showResyncButton ? (
+            <button
+              type="button"
+              className="ch-catchup-banner__btn"
+              onClick={onResync}
+            >
+              resync now
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      {reachedBeginning ? (
+        <div className="ch-top-marker">beginning of #{channelTitle}</div>
+      ) : loadingOlder ? (
+        <div className="ch-loading-older">loading older messages…</div>
+      ) : null}
+      <div ref={contentRef} className="ch-tl-content">
+        {nodes.map((node, index) => {
+          if (node.kind === 'day-divider') {
+            return (
+              <div
+                key={`day-${node.date}-${index}`}
+                className="ch-day-divider"
+                role="separator"
+              >
+                <span className="ch-day-divider__label">
+                  {formatDayLabel(node.date)}
+                </span>
+              </div>
+            );
+          }
+          if (node.kind === 'unread-line') {
+            return (
+              <div
+                key={`unread-${index}`}
+                className="ch-unread-line"
+                role="separator"
+                aria-label="new messages"
+              >
+                <span className="ch-unread-line__label">new</span>
+              </div>
+            );
+          }
+          if (node.kind === 'system') {
+            return (
+              <ChannelMessageRow
+                key={node.message.id}
+                message={node.message}
+                variant="system"
+              />
+            );
+          }
+          const firstId = node.messages[0]?.id ?? `group-${index}`;
+          return (
+            <ChannelMessageGroup
+              key={firstId}
+              sender={node.sender}
+              messages={node.messages}
+            />
+          );
+        })}
+      </div>
+      <div ref={bottomRef} />
+    </div>
+  );
+};
+
+export default ChannelTimeline;

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -63,6 +63,28 @@
   background: var(--status-success);
 }
 
+.ch-conn-dot--off {
+  background: var(--status-error, var(--text-muted));
+}
+
+/* manual reconnect affordance shown when reconnect backoff has given up */
+.ch-reconnect-btn {
+  margin-right: 8px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.ch-reconnect-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* timeline scroll container — mirrors .tl */
 .ch-tl {
   flex: 1;

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -1,0 +1,390 @@
+/* Channel timeline view (#1166). A near-1:1 density/type match to ChatView.css
+   so the channel surface reads as the same product — same font sizes, spacing
+   scale, and tokens — over a different (multi-sender) data model. No new spacing
+   values; all pulled from DESIGN.md's 4px scale and existing tokens. */
+
+.ch-view {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* header — title + kind/DM glyph + member/partner label + connection dot */
+.ch-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.ch-header__glyph {
+  display: inline-flex;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+}
+
+.ch-header__title {
+  color: var(--text);
+  font-weight: 700;
+  text-transform: lowercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ch-header__meta {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.ch-header__spacer {
+  margin-left: auto;
+}
+
+.ch-conn-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.ch-conn-dot--on {
+  background: var(--status-success);
+}
+
+/* timeline scroll container — mirrors .tl */
+.ch-tl {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.ch-tl::-webkit-scrollbar {
+  width: 4px;
+}
+.ch-tl::-webkit-scrollbar-thumb {
+  background: var(--border);
+}
+
+.ch-tl-content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+/* day divider — mirrors .tl-session-break, centered muted label + rule */
+.ch-day-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.ch-day-divider::before,
+.ch-day-divider::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--border);
+}
+
+.ch-day-divider__label {
+  white-space: nowrap;
+}
+
+/* unread line — 1px info rule + right-aligned "new" label */
+.ch-unread-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  color: var(--status-info);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.ch-unread-line::before {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--status-info);
+}
+
+.ch-unread-line__label {
+  white-space: nowrap;
+}
+
+/* system message — full-width centered muted, own row (never in a group) */
+.ch-system-msg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-align: center;
+}
+
+/* message group — one sender header + tightly-stacked bodies */
+.ch-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ch-group__header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+
+.ch-group__badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  width: 14px;
+  height: 14px;
+}
+
+.ch-group__name {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: lowercase;
+}
+
+.ch-group__time {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.ch-group__messages {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+/* single message row */
+.ch-msg {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border-left: 2px solid transparent;
+  padding-left: 8px;
+  margin-left: -8px;
+}
+
+.ch-msg--streaming,
+.ch-msg--interrupted,
+.ch-msg--failed {
+  border-left-width: 2px;
+  border-left-style: solid;
+}
+
+.ch-msg--interrupted {
+  border-left-color: var(--status-warning);
+}
+
+.ch-msg--failed {
+  border-left-color: var(--status-error);
+}
+
+/* message body text — matches .tl-text scale */
+.ch-msg__text {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* human message bubble — reuses .tl-text--user treatment (right-aligned) */
+.ch-msg--user .ch-msg__body {
+  color: var(--text);
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  margin: 0 0 0 auto;
+  max-width: 75%;
+  width: fit-content;
+  align-self: flex-end;
+}
+
+.ch-msg--user {
+  align-items: flex-end;
+  border-left: none;
+  padding-left: 0;
+  margin-left: 0;
+}
+
+/* streaming block cursor — DESIGN.md motion effect 4 (solid while active,
+   blinks after 530ms idle, opacity 0.7 when visible) */
+.ch-msg__cursor {
+  display: inline-block;
+  margin-left: 1px;
+  opacity: 0.7;
+}
+
+.ch-msg__cursor--blinking {
+  animation: ch-cursor-blink 1s step-end infinite;
+}
+
+@keyframes ch-cursor-blink {
+  0%,
+  50% {
+    opacity: 0.7;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* trailing status tags — interrupted / failed / truncated */
+.ch-msg__tag {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: lowercase;
+  margin-left: 6px;
+  opacity: 0.85;
+}
+
+.ch-msg__tag--interrupted {
+  color: var(--status-warning);
+}
+
+.ch-msg__tag--failed {
+  color: var(--status-error);
+}
+
+.ch-msg__tag--truncated {
+  color: var(--text-muted);
+}
+
+/* inline reply breadcrumb (#1170 owns the real thread UI; slice 3 is inline) */
+.ch-msg__reply {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  opacity: 0.7;
+  margin-bottom: 2px;
+}
+
+/* empty / unavailable / paging chrome */
+.ch-empty,
+.ch-unavailable {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+.ch-back-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.ch-back-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.ch-loading-older,
+.ch-top-marker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+/* catch-up banner — mirrors .tl-resume-banner, sticky at top of scroll area */
+.ch-catchup-banner {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.ch-catchup-banner__btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.ch-catchup-banner__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+@media (max-width: 767px) {
+  .ch-header {
+    padding: 8px 10px;
+  }
+
+  .ch-tl {
+    padding: 10px 6px;
+    gap: 12px;
+  }
+
+  .ch-tl-content {
+    gap: 12px;
+  }
+
+  .ch-msg--user .ch-msg__body {
+    max-width: 92%;
+  }
+}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -15,7 +15,10 @@ import {
 } from '../../lib/api.js';
 import { isDmChannel } from '../../lib/dm-channels.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
-import { channelLastReadKey } from '../../lib/stores/channel-activity.js';
+import {
+  channelLastReadKey,
+  useChannelActivityStore,
+} from '../../lib/stores/channel-activity.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { AgentBadge } from '../AgentBadge.js';
 import { ChannelTimeline } from './ChannelTimeline.js';
@@ -32,6 +35,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     channel,
     reducer,
     connected,
+    disconnected,
     notFound,
     hasMoreOlder,
     loadingOlder,
@@ -87,14 +91,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       typeof performance !== 'undefined' ? performance.now() : Date.now();
     const write = (): void => {
       if (lastSeqRef.current <= 0) return;
-      try {
-        localStorage.setItem(
-          channelLastReadKey(channelId),
-          String(lastSeqRef.current)
-        );
-      } catch {
-        /* localStorage unavailable */
-      }
+      // Reactive store write (not a raw localStorage set) so the sidebar's
+      // unread dot recomputes the moment this channel is read (#1178). The store
+      // mirrors the value to localStorage for cross-reload persistence.
+      useChannelActivityStore
+        .getState()
+        .markChannelRead(channelId, lastSeqRef.current);
     };
     const onVisibility = (): void => {
       if (document.hidden && now() - mountedAt > READ_WRITE_VISIBLE_GRACE_MS) {
@@ -187,10 +189,37 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
           </span>
         ) : null}
         <span className="ch-header__spacer" />
+        {disconnected ? (
+          // Reconnect gave up (server outage/deploy > backoff budget). Surface a
+          // manual affordance — NOT gated on needsCatchup, which can never flip
+          // true while the socket is dead (#1178).
+          <button
+            type="button"
+            className="ch-reconnect-btn"
+            onClick={resync}
+            title="disconnected — reconnect"
+          >
+            reconnect
+          </button>
+        ) : null}
         <span
-          className={`ch-conn-dot${connected ? ' ch-conn-dot--on' : ''}`}
-          title={connected ? 'connected' : 'reconnecting'}
-          aria-label={connected ? 'connected' : 'reconnecting'}
+          className={`ch-conn-dot${connected ? ' ch-conn-dot--on' : ''}${
+            disconnected ? ' ch-conn-dot--off' : ''
+          }`}
+          title={
+            connected
+              ? 'connected'
+              : disconnected
+                ? 'disconnected'
+                : 'reconnecting'
+          }
+          aria-label={
+            connected
+              ? 'connected'
+              : disconnected
+                ? 'disconnected'
+                : 'reconnecting'
+          }
         />
       </div>
 

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -1,0 +1,227 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import './ChannelView.css';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useChannelChatSocket } from '../../hooks/useChannelChatSocket.js';
+import {
+  fetchWorkspaceTopic,
+  restoreWorkspaceTopic,
+  HttpError,
+} from '../../lib/api.js';
+import { isDmChannel } from '../../lib/dm-channels.js';
+import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { channelLastReadKey } from '../../lib/stores/channel-activity.js';
+import { useUiStore } from '../../lib/stores/ui.js';
+import { AgentBadge } from '../AgentBadge.js';
+import { ChannelTimeline } from './ChannelTimeline.js';
+import { ChannelComposer } from './ChannelComposer.js';
+
+const READ_WRITE_VISIBLE_GRACE_MS = 10_000;
+
+interface ChannelViewProps {
+  channelId: string;
+}
+
+export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
+  const {
+    channel,
+    reducer,
+    connected,
+    notFound,
+    hasMoreOlder,
+    loadingOlder,
+    loadOlder,
+    post,
+    postPending,
+    postError,
+    resync,
+  } = useChannelChatSocket(channelId);
+  const queryClient = useQueryClient();
+  const setActiveChannelId = useUiStore((s) => s.setActiveChannelId);
+
+  // Self-derive DM-ness: ChannelSummaryView does not expose routingDefaults, so
+  // fetch the topic (cached) and run the pure id derivation. Cheaper than
+  // threading an isDm prop through every caller (spec §7.2, logged deviation).
+  const topicQuery = useQuery({
+    queryKey: ['workspace-topic', channelId],
+    queryFn: () => fetchWorkspaceTopic(channelId),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const dmProviderId = topicQuery.data ? isDmChannel(topicQuery.data) : null;
+  const isDm = dmProviderId !== null;
+  const dmIdentity = dmProviderId
+    ? resolveSenderIdentity({
+        kind: 'agent',
+        id: `agent:${dmProviderId}`,
+        providerId: dmProviderId,
+      })
+    : null;
+
+  const title = channel?.title ?? topicQuery.data?.display.title ?? channelId;
+
+  // Unread line: captured once on mount (per channelId, since ChatHome keys this
+  // component by channelId). Absent marker → null → no unread line drawn.
+  const [lastReadSeq] = useState<number | null>(() => {
+    try {
+      const raw = localStorage.getItem(channelLastReadKey(channelId));
+      return raw !== null ? Number(raw) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  // Write the last-read marker on unmount (channel closed/navigated) and on a
+  // focus-loss after a 10s-visible grace, mirroring Slack's read semantics.
+  const lastSeqRef = useRef(0);
+  lastSeqRef.current = reducer.lastSeq;
+  useEffect(() => {
+    const mountedAt =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const now = (): number =>
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const write = (): void => {
+      if (lastSeqRef.current <= 0) return;
+      try {
+        localStorage.setItem(
+          channelLastReadKey(channelId),
+          String(lastSeqRef.current)
+        );
+      } catch {
+        /* localStorage unavailable */
+      }
+    };
+    const onVisibility = (): void => {
+      if (document.hidden && now() - mountedAt > READ_WRITE_VISIBLE_GRACE_MS) {
+        write();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      write();
+    };
+  }, [channelId]);
+
+  const archived =
+    channel?.archived === true ||
+    (postError instanceof HttpError && postError.status === 409);
+  const storeDown = postError instanceof HttpError && postError.status === 503;
+
+  const [restorePending, setRestorePending] = useState(false);
+  const handleRestore = useCallback(async () => {
+    setRestorePending(true);
+    try {
+      await restoreWorkspaceTopic(channelId);
+      await queryClient.invalidateQueries({ queryKey: ['channel', channelId] });
+      await queryClient.invalidateQueries({
+        queryKey: ['workspace-topic', channelId],
+      });
+    } catch {
+      /* leave the archived bar in place; the user can retry */
+    } finally {
+      setRestorePending(false);
+    }
+  }, [channelId, queryClient]);
+
+  const handleSend = useCallback(
+    async (text: string, clientMessageId: string) => {
+      await post(text, { clientMessageId });
+    },
+    [post]
+  );
+
+  const channelNotFound =
+    notFound ||
+    (topicQuery.error instanceof HttpError && topicQuery.error.status === 404);
+
+  const emptyCopy = useMemo(() => {
+    if (isDm && dmIdentity)
+      return `no messages yet — say hi to ${dmIdentity.label}`;
+    return 'no messages yet';
+  }, [isDm, dmIdentity]);
+
+  if (channelNotFound) {
+    return (
+      <div className="ch-view" role="main" aria-label="channel">
+        <div className="ch-unavailable">
+          <span>this chat no longer exists</span>
+          <button
+            type="button"
+            className="ch-back-btn"
+            onClick={() => setActiveChannelId(null)}
+          >
+            back to chat
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const hasMessages = reducer.messages.length > 0;
+
+  return (
+    <div className="ch-view" role="main" aria-label="channel">
+      <div className="ch-header">
+        {isDm && dmIdentity?.glyph ? (
+          <span
+            className="ch-header__glyph"
+            style={{ color: dmIdentity.colorVar }}
+            aria-hidden="true"
+          >
+            <AgentBadge agent={dmIdentity.glyph} />
+          </span>
+        ) : null}
+        <span className="ch-header__title">
+          {isDm && dmIdentity ? `@${dmIdentity.label}` : `#${title}`}
+        </span>
+        {!isDm && channel ? (
+          <span className="ch-header__meta">
+            · {channel.members.length} member
+            {channel.members.length === 1 ? '' : 's'}
+          </span>
+        ) : null}
+        <span className="ch-header__spacer" />
+        <span
+          className={`ch-conn-dot${connected ? ' ch-conn-dot--on' : ''}`}
+          title={connected ? 'connected' : 'reconnecting'}
+          aria-label={connected ? 'connected' : 'reconnecting'}
+        />
+      </div>
+
+      {hasMessages ? (
+        <ChannelTimeline
+          messages={reducer.messages}
+          lastReadSeq={lastReadSeq}
+          channelTitle={title}
+          hasMoreOlder={hasMoreOlder}
+          loadingOlder={loadingOlder}
+          loadOlder={loadOlder}
+          needsCatchup={reducer.needsCatchup}
+          onResync={resync}
+        />
+      ) : (
+        <div className="ch-empty">
+          <span>{emptyCopy}</span>
+        </div>
+      )}
+
+      <ChannelComposer
+        channelTitle={title}
+        onSend={handleSend}
+        postPending={postPending}
+        storeDown={storeDown}
+        archived={archived}
+        onRestore={handleRestore}
+        restorePending={restorePending}
+      />
+    </div>
+  );
+};
+
+export default ChannelView;

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -1450,9 +1450,13 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
             providerDisplayName: framework?.displayName ?? form.selectedAgent,
             workspaceId: useUiStore.getState().activeWorkspaceId,
           });
+          // #1178: open the channel via the channel path ONLY. Do NOT feed the
+          // topic id into onSessionCreated/activeSessionId — App wires that to
+          // setActiveSessionId, and the channel↔session mutual-exclusion effect
+          // would then clear the activeChannelId we just set (flash-and-close),
+          // while persisting an unresolvable 'topic:...' active-session key.
           useUiStore.getState().setActiveChannelId(topic.id);
           shellRef.current?.close();
-          onSessionCreated?.(topic.id);
         } catch (err) {
           setError(err instanceof Error ? err.message : 'Failed to open chat');
         } finally {

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -32,9 +32,11 @@ import {
   isFrameworkAvailable,
   isFrameworkWebAvailable,
   selectLaunchAgent,
+  shouldRouteToChannel,
   type SessionLaunchMode,
   type SessionModeOption,
 } from '../../lib/session-launch-mode.js';
+import { getOrCreateDmChannel } from '../../hooks/useTopicRoomCreate.js';
 import type {
   AgentType,
   AggregatedRepoInventoryGroup,
@@ -727,7 +729,14 @@ function CustomizeSessionBody({
     ? ([{ value: 'pty', label: 'shell' }] satisfies SessionModeOption[])
     : remoteNodeSelected
       ? ([{ value: 'pty', label: 'tui' }] satisfies SessionModeOption[])
-      : getSessionModeOptions(frameworkOptions, form.selectedAgent);
+      : // #1166: a web agent launch now opens as a DM channel, not a distinct
+        // "web session" — relabel so the picker copy matches the behavior.
+        getSessionModeOptions(frameworkOptions, form.selectedAgent).map(
+          (option) =>
+            option.value === 'web' && !option.disabled
+              ? { ...option, label: 'web (opens as chat)' }
+              : option
+        );
   const selectedFramework = frameworkOptions.find(
     (framework) => framework.id === form.selectedAgent
   );
@@ -1420,6 +1429,35 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       // and require the user to pick another option (or wait for recovery).
       if (selectedOptionDegradedMessage) {
         setError(selectedOptionDegradedMessage);
+        return;
+      }
+      // #1166: an agent launch in web mode routes to a DM channel, never a
+      // mode:'web' session. (Remote nodes force pty above, so this is local +
+      // agent + web only.) Same getOrCreateDmChannel + setActiveChannelId flow
+      // as TopicComposer — this closes the last UI-driven web-session path.
+      if (
+        shouldRouteToChannel(
+          form.dialogSessionType === 'agent' ? 'agent' : 'terminal',
+          remoteNodeSelected ? 'pty' : form.sessionMode
+        )
+      ) {
+        setCreating(true);
+        setError(null);
+        try {
+          const framework = frameworks.find((f) => f.id === form.selectedAgent);
+          const topic = await getOrCreateDmChannel({
+            providerId: form.selectedAgent,
+            providerDisplayName: framework?.displayName ?? form.selectedAgent,
+            workspaceId: useUiStore.getState().activeWorkspaceId,
+          });
+          useUiStore.getState().setActiveChannelId(topic.id);
+          shellRef.current?.close();
+          onSessionCreated?.(topic.id);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Failed to open chat');
+        } finally {
+          setCreating(false);
+        }
         return;
       }
       const cwdForRemote = remoteNodeSelected

--- a/frontend/src/hooks/useChannelChatSocket.ts
+++ b/frontend/src/hooks/useChannelChatSocket.ts
@@ -1,0 +1,328 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  applyChannelEventV1,
+  initialChannelReducerState,
+  isChannelEventV1,
+  mergeHistoryPage,
+  type ChannelMessage,
+  type ChannelReducerState,
+} from '../../../shared/channel-chat-protocol.js';
+import {
+  fetchChannel,
+  fetchChannelHistory,
+  postChannelMessage,
+  HttpError,
+  type ChannelSummaryView,
+} from '../lib/api.js';
+import { createBrowserId } from '../lib/browserId.js';
+
+// app close codes emitted by the channel WS hub (server/channel-hub.ts).
+const CHANNEL_WS_NOT_FOUND_CLOSE_CODE = 4404;
+const CHANNEL_WS_BACKPRESSURE_CLOSE_CODE = 4409;
+
+const BACKOFF_STEPS = [1_000, 2_000, 4_000, 8_000];
+const BACKOFF_CAP = 10_000;
+const MAX_RECONNECT_ATTEMPTS = 30;
+const HISTORY_PAGE_LIMIT = 50;
+
+/**
+ * Read-only WebSocket + REST hook for a single channel (#1166). Mirrors
+ * `useAgentChatSocket`'s reconnect/unmountedRef/wsRef structure but is
+ * server→client-only over the socket — posting is REST (`post()`), and the
+ * channel WS hub carries no application ping/pong (it never registers an inbound
+ * `message` handler), so no pong-timeout health check is used. Recovery leans on
+ * the reducer's own `needsCatchup` self-diagnosis (reconnect with
+ * `sinceSeq=lastSeq`) plus native close detection with exponential backoff.
+ */
+export interface UseChannelChatSocketState {
+  channel: ChannelSummaryView | null;
+  reducer: ChannelReducerState;
+  connected: boolean;
+  /** True after a WS `4404` close or a `fetchChannel` 404 — channel is gone. */
+  notFound: boolean;
+  hasMoreOlder: boolean;
+  loadingOlder: boolean;
+  loadOlder: () => Promise<void>;
+  post: (
+    text: string,
+    opts?: { clientMessageId?: string }
+  ) => Promise<ChannelMessage>;
+  postPending: boolean;
+  postError: HttpError | null;
+  clearPostError: () => void;
+  /** Force a fresh reconnect with sinceSeq=lastSeq (manual "resync now"). */
+  resync: () => void;
+}
+
+export function useChannelChatSocket(
+  channelId: string | null
+): UseChannelChatSocketState {
+  const [reducer, setReducer] = useState<ChannelReducerState>(() =>
+    initialChannelReducerState(channelId ?? '')
+  );
+  const [connected, setConnected] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+  const [hasMoreOlder, setHasMoreOlder] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [postPending, setPostPending] = useState(false);
+  const [postError, setPostError] = useState<HttpError | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptRef = useRef(0);
+  const unmountedRef = useRef(false);
+  const channelIdRef = useRef(channelId);
+  const cursorRef = useRef<number | null>(null);
+  const reducerRef = useRef(reducer);
+  const hasMoreOlderRef = useRef(false);
+  const loadingOlderRef = useRef(false);
+
+  channelIdRef.current = channelId;
+  reducerRef.current = reducer;
+  hasMoreOlderRef.current = hasMoreOlder;
+
+  // A separate small fetch: the WS snapshot carries messages/members but not the
+  // topic's archived/title/kind fields. React Query 404 → surfaced as notFound.
+  const channelQuery = useQuery({
+    queryKey: ['channel', channelId],
+    queryFn: () => fetchChannel(channelId as string),
+    enabled: channelId !== null,
+    staleTime: 10_000,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (
+      channelQuery.error instanceof HttpError &&
+      channelQuery.error.status === 404
+    ) {
+      setNotFound(true);
+    }
+  }, [channelQuery.error]);
+
+  // Advance the reconnect cursor once real data exists; an empty channel keeps
+  // it null so a reconnect re-requests a full snapshot.
+  useEffect(() => {
+    if (reducer.lastSeq > 0) cursorRef.current = reducer.lastSeq;
+  }, [reducer.lastSeq]);
+
+  const connect = useCallback((cid: string) => {
+    if (unmountedRef.current) return;
+
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const cursor = cursorRef.current;
+    const query = cursor !== null ? `?sinceSeq=${cursor}` : '';
+    const ws = new WebSocket(
+      `${wsProtocol}//${location.host}/ws/channels/${encodeURIComponent(cid)}${query}`
+    );
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (unmountedRef.current || wsRef.current !== ws) return;
+      reconnectAttemptRef.current = 0;
+      setConnected(true);
+    };
+
+    ws.onmessage = (event) => {
+      if (wsRef.current !== ws) return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+      if (!isChannelEventV1(parsed)) return;
+      const channelEvent = parsed;
+      if (
+        channelEvent.type === 'channel-snapshot-v1' &&
+        channelEvent.mode === 'full'
+      ) {
+        // full-snapshot `truncated` === "older history exists before seq 1's
+        // reach"; a catchup's `truncated` is byte-budget only, so never touch
+        // older-history availability on catchup.
+        hasMoreOlderRef.current = channelEvent.truncated;
+        setHasMoreOlder(channelEvent.truncated);
+      }
+      setReducer((prev) => applyChannelEventV1(prev, channelEvent));
+    };
+
+    ws.onclose = (event) => {
+      if (unmountedRef.current || wsRef.current !== ws) return;
+      wsRef.current = null;
+      setConnected(false);
+      if (event.code === CHANNEL_WS_NOT_FOUND_CLOSE_CODE) {
+        setNotFound(true);
+        return; // channel gone — stop reconnecting
+      }
+      if (event.code === CHANNEL_WS_BACKPRESSURE_CLOSE_CODE) {
+        // expected self-healing path: reconnect immediately with the current
+        // lastSeq as sinceSeq, no backoff.
+        reconnectAttemptRef.current = 0;
+        if (channelIdRef.current) connect(channelIdRef.current);
+        return;
+      }
+      scheduleReconnect();
+    };
+
+    ws.onerror = () => {
+      // Browser WS errors are opaque; the following close handler drives recovery.
+    };
+
+    function scheduleReconnect(): void {
+      if (
+        !channelIdRef.current ||
+        reconnectAttemptRef.current >= MAX_RECONNECT_ATTEMPTS
+      ) {
+        return;
+      }
+      const attempt = reconnectAttemptRef.current;
+      reconnectAttemptRef.current += 1;
+      const delay = Math.min(
+        BACKOFF_STEPS[attempt] ?? BACKOFF_CAP,
+        BACKOFF_CAP
+      );
+      reconnectTimerRef.current = setTimeout(() => {
+        if (channelIdRef.current) connect(channelIdRef.current);
+      }, delay);
+    }
+  }, []);
+
+  const forceReconnect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setConnected(false);
+    reconnectAttemptRef.current = 0;
+    if (channelIdRef.current) connect(channelIdRef.current);
+  }, [connect]);
+
+  // Reducer self-diagnosis: on a detected gap it sets needsCatchup; recover by
+  // reconnecting with sinceSeq=lastSeq (the reducer's documented recovery path).
+  useEffect(() => {
+    if (reducer.needsCatchup) forceReconnect();
+  }, [reducer.needsCatchup, forceReconnect]);
+
+  useEffect(() => {
+    unmountedRef.current = false;
+    cursorRef.current = null;
+    hasMoreOlderRef.current = false;
+    loadingOlderRef.current = false;
+    reconnectAttemptRef.current = 0;
+    setReducer(initialChannelReducerState(channelId ?? ''));
+    setConnected(false);
+    setNotFound(false);
+    setHasMoreOlder(false);
+    setLoadingOlder(false);
+    setPostError(null);
+
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+
+    if (channelId) {
+      connect(channelId);
+    } else if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    return () => {
+      unmountedRef.current = true;
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (wsRef.current) {
+        wsRef.current.onopen = null;
+        wsRef.current.onmessage = null;
+        wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [channelId, connect]);
+
+  const loadOlder = useCallback(async () => {
+    const cid = channelIdRef.current;
+    if (!cid || loadingOlderRef.current || !hasMoreOlderRef.current) return;
+    loadingOlderRef.current = true;
+    setLoadingOlder(true);
+    try {
+      const earliest = reducerRef.current.messages[0]?.seq;
+      const page = await fetchChannelHistory(cid, {
+        ...(earliest !== undefined ? { beforeSeq: earliest } : {}),
+        limit: HISTORY_PAGE_LIMIT,
+      });
+      if (channelIdRef.current !== cid) return;
+      setReducer((prev) => mergeHistoryPage(prev, page.messages));
+      const more = page.hasMore || page.messages.length >= HISTORY_PAGE_LIMIT;
+      hasMoreOlderRef.current = more;
+      setHasMoreOlder(more);
+    } catch {
+      // Leave hasMoreOlder as-is; a later scroll retries.
+    } finally {
+      loadingOlderRef.current = false;
+      setLoadingOlder(false);
+    }
+  }, []);
+
+  const post = useCallback(
+    async (
+      text: string,
+      opts?: { clientMessageId?: string }
+    ): Promise<ChannelMessage> => {
+      const cid = channelIdRef.current;
+      if (!cid) throw new Error('no active channel');
+      const clientMessageId = opts?.clientMessageId ?? createBrowserId('chm');
+      setPostPending(true);
+      setPostError(null);
+      try {
+        // No optimistic insert — the server's channel-message-created-v1
+        // broadcast (received over this same open socket) is the sole source of
+        // truth for the row appearing, matching the reducer's idempotent replay.
+        return await postChannelMessage(cid, { text, clientMessageId });
+      } catch (err) {
+        if (err instanceof HttpError) setPostError(err);
+        throw err;
+      } finally {
+        setPostPending(false);
+      }
+    },
+    []
+  );
+
+  const clearPostError = useCallback(() => setPostError(null), []);
+
+  return {
+    channel: channelQuery.data ?? null,
+    reducer,
+    connected,
+    notFound,
+    hasMoreOlder,
+    loadingOlder,
+    loadOlder,
+    post,
+    postPending,
+    postError,
+    clearPostError,
+    resync: forceReconnect,
+  };
+}

--- a/frontend/src/hooks/useChannelChatSocket.ts
+++ b/frontend/src/hooks/useChannelChatSocket.ts
@@ -16,6 +16,7 @@ import {
   type ChannelSummaryView,
 } from '../lib/api.js';
 import { createBrowserId } from '../lib/browserId.js';
+import { useChannelActivityStore } from '../lib/stores/channel-activity.js';
 
 // app close codes emitted by the channel WS hub (server/channel-hub.ts).
 const CHANNEL_WS_NOT_FOUND_CLOSE_CODE = 4404;
@@ -25,6 +26,15 @@ const BACKOFF_STEPS = [1_000, 2_000, 4_000, 8_000];
 const BACKOFF_CAP = 10_000;
 const MAX_RECONNECT_ATTEMPTS = 30;
 const HISTORY_PAGE_LIMIT = 50;
+// Liveness (#1178): the channel socket is push-only with no app ping/pong, so a
+// half-open socket (NAT/proxy idle drop, tab sleep/wake, wifi→cellular) reports
+// OPEN forever while silently missing messages. Detect it without a server
+// change: a background probe runs every INTERVAL while the tab is visible and,
+// once the socket has been silent for THRESHOLD, does a cheap REST head-check
+// (`fetchChannel().latestSeq`) — a divergence forces a fresh reconnect. Tab
+// wake / network-online events probe immediately regardless of the threshold.
+const LIVENESS_PROBE_INTERVAL_MS = 30_000;
+const LIVENESS_IDLE_THRESHOLD_MS = 120_000;
 
 /**
  * Read-only WebSocket + REST hook for a single channel (#1166). Mirrors
@@ -33,12 +43,20 @@ const HISTORY_PAGE_LIMIT = 50;
  * channel WS hub carries no application ping/pong (it never registers an inbound
  * `message` handler), so no pong-timeout health check is used. Recovery leans on
  * the reducer's own `needsCatchup` self-diagnosis (reconnect with
- * `sinceSeq=lastSeq`) plus native close detection with exponential backoff.
+ * `sinceSeq=lastSeq`), native close detection with exponential backoff, and a
+ * visibility/online + idle REST head-check liveness probe (#1178) that catches
+ * half-dead sockets the socket layer never reports as closed.
  */
 export interface UseChannelChatSocketState {
   channel: ChannelSummaryView | null;
   reducer: ChannelReducerState;
   connected: boolean;
+  /**
+   * True once reconnect backoff has exhausted its attempt budget (server outage
+   * longer than the backoff window). The UI surfaces a manual reconnect
+   * affordance in this state — it is NOT the same as "reconnecting" (#1178).
+   */
+  disconnected: boolean;
   /** True after a WS `4404` close or a `fetchChannel` 404 — channel is gone. */
   notFound: boolean;
   hasMoreOlder: boolean;
@@ -62,6 +80,7 @@ export function useChannelChatSocket(
     initialChannelReducerState(channelId ?? '')
   );
   const [connected, setConnected] = useState(false);
+  const [disconnected, setDisconnected] = useState(false);
   const [notFound, setNotFound] = useState(false);
   const [hasMoreOlder, setHasMoreOlder] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
@@ -77,6 +96,17 @@ export function useChannelChatSocket(
   const reducerRef = useRef(reducer);
   const hasMoreOlderRef = useRef(false);
   const loadingOlderRef = useRef(false);
+  // Timestamp of the last inbound socket activity (open or message). The
+  // liveness probe treats a socket silent past LIVENESS_IDLE_THRESHOLD_MS as
+  // suspect and REST-verifies it (#1178).
+  const lastActivityRef = useRef(0);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
 
   channelIdRef.current = channelId;
   reducerRef.current = reducer;
@@ -107,106 +137,130 @@ export function useChannelChatSocket(
     if (reducer.lastSeq > 0) cursorRef.current = reducer.lastSeq;
   }, [reducer.lastSeq]);
 
-  const connect = useCallback((cid: string) => {
-    if (unmountedRef.current) return;
+  const connect = useCallback(
+    (cid: string) => {
+      if (unmountedRef.current) return;
 
-    if (wsRef.current) {
-      wsRef.current.onopen = null;
-      wsRef.current.onmessage = null;
-      wsRef.current.onclose = null;
-      wsRef.current.onerror = null;
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-
-    const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const cursor = cursorRef.current;
-    const query = cursor !== null ? `?sinceSeq=${cursor}` : '';
-    const ws = new WebSocket(
-      `${wsProtocol}//${location.host}/ws/channels/${encodeURIComponent(cid)}${query}`
-    );
-    wsRef.current = ws;
-
-    ws.onopen = () => {
-      if (unmountedRef.current || wsRef.current !== ws) return;
-      reconnectAttemptRef.current = 0;
-      setConnected(true);
-    };
-
-    ws.onmessage = (event) => {
-      if (wsRef.current !== ws) return;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(event.data as string);
-      } catch {
-        return;
+      if (wsRef.current) {
+        wsRef.current.onopen = null;
+        wsRef.current.onmessage = null;
+        wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.close();
+        wsRef.current = null;
       }
-      if (!isChannelEventV1(parsed)) return;
-      const channelEvent = parsed;
-      if (
-        channelEvent.type === 'channel-snapshot-v1' &&
-        channelEvent.mode === 'full'
-      ) {
-        // full-snapshot `truncated` === "older history exists before seq 1's
-        // reach"; a catchup's `truncated` is byte-budget only, so never touch
-        // older-history availability on catchup.
-        hasMoreOlderRef.current = channelEvent.truncated;
-        setHasMoreOlder(channelEvent.truncated);
-      }
-      setReducer((prev) => applyChannelEventV1(prev, channelEvent));
-    };
 
-    ws.onclose = (event) => {
-      if (unmountedRef.current || wsRef.current !== ws) return;
-      wsRef.current = null;
-      setConnected(false);
-      if (event.code === CHANNEL_WS_NOT_FOUND_CLOSE_CODE) {
-        setNotFound(true);
-        return; // channel gone — stop reconnecting
-      }
-      if (event.code === CHANNEL_WS_BACKPRESSURE_CLOSE_CODE) {
-        // expected self-healing path: reconnect immediately with the current
-        // lastSeq as sinceSeq, no backoff.
-        reconnectAttemptRef.current = 0;
-        if (channelIdRef.current) connect(channelIdRef.current);
-        return;
-      }
-      scheduleReconnect();
-    };
-
-    ws.onerror = () => {
-      // Browser WS errors are opaque; the following close handler drives recovery.
-    };
-
-    function scheduleReconnect(): void {
-      if (
-        !channelIdRef.current ||
-        reconnectAttemptRef.current >= MAX_RECONNECT_ATTEMPTS
-      ) {
-        return;
-      }
-      const attempt = reconnectAttemptRef.current;
-      reconnectAttemptRef.current += 1;
-      const delay = Math.min(
-        BACKOFF_STEPS[attempt] ?? BACKOFF_CAP,
-        BACKOFF_CAP
+      const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const cursor = cursorRef.current;
+      const query = cursor !== null ? `?sinceSeq=${cursor}` : '';
+      const ws = new WebSocket(
+        `${wsProtocol}//${location.host}/ws/channels/${encodeURIComponent(cid)}${query}`
       );
-      reconnectTimerRef.current = setTimeout(() => {
-        if (channelIdRef.current) connect(channelIdRef.current);
-      }, delay);
-    }
-  }, []);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (unmountedRef.current || wsRef.current !== ws) return;
+        reconnectAttemptRef.current = 0;
+        lastActivityRef.current = Date.now();
+        setConnected(true);
+        setDisconnected(false);
+      };
+
+      ws.onmessage = (event) => {
+        if (wsRef.current !== ws) return;
+        lastActivityRef.current = Date.now();
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(event.data as string);
+        } catch {
+          return;
+        }
+        if (!isChannelEventV1(parsed)) return;
+        const channelEvent = parsed;
+        if (
+          channelEvent.type === 'channel-snapshot-v1' &&
+          channelEvent.mode === 'full'
+        ) {
+          // full-snapshot `truncated` === "older history exists before seq 1's
+          // reach"; a catchup's `truncated` is byte-budget only, so never touch
+          // older-history availability on catchup.
+          hasMoreOlderRef.current = channelEvent.truncated;
+          setHasMoreOlder(channelEvent.truncated);
+          // Stale-ahead reset (#1178): a full snapshot is authoritative for the
+          // head. If the channel was recreated under the same deterministic DM id
+          // and its seq restarted low, clamp the client seq stores DOWN so the
+          // sidebar's activity guard and last-read marker don't suppress the
+          // unread dot for the new channel's whole first lifetime.
+          useChannelActivityStore
+            .getState()
+            .clampChannelStores(cid, channelEvent.latestSeq);
+        }
+        setReducer((prev) => applyChannelEventV1(prev, channelEvent));
+      };
+
+      ws.onclose = (event) => {
+        if (unmountedRef.current || wsRef.current !== ws) return;
+        wsRef.current = null;
+        setConnected(false);
+        if (event.code === CHANNEL_WS_NOT_FOUND_CLOSE_CODE) {
+          setNotFound(true);
+          return; // channel gone — stop reconnecting
+        }
+        if (event.code === CHANNEL_WS_BACKPRESSURE_CLOSE_CODE) {
+          // expected self-healing path: reconnect immediately with the current
+          // lastSeq as sinceSeq, no backoff.
+          reconnectAttemptRef.current = 0;
+          if (channelIdRef.current) connect(channelIdRef.current);
+          return;
+        }
+        scheduleReconnect();
+      };
+
+      ws.onerror = () => {
+        // Browser WS errors are opaque; the following close handler drives recovery.
+      };
+
+      function scheduleReconnect(): void {
+        if (!channelIdRef.current) return;
+        if (reconnectAttemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
+          // Give-up state (#1178): stop the backoff and surface a manual reconnect
+          // affordance. `connected` is already false; `disconnected` distinguishes
+          // "gave up" from "still retrying" so the UI stops claiming reconnecting.
+          setDisconnected(true);
+          return;
+        }
+        const attempt = reconnectAttemptRef.current;
+        reconnectAttemptRef.current += 1;
+        const delay = Math.min(
+          BACKOFF_STEPS[attempt] ?? BACKOFF_CAP,
+          BACKOFF_CAP
+        );
+        // Clear any prior pending timer before overwriting the ref so a stale
+        // timer can never fire against a newer socket (#1178).
+        clearReconnectTimer();
+        reconnectTimerRef.current = setTimeout(() => {
+          reconnectTimerRef.current = null;
+          if (channelIdRef.current) connect(channelIdRef.current);
+        }, delay);
+      }
+    },
+    [clearReconnectTimer]
+  );
 
   const forceReconnect = useCallback(() => {
+    // Cancel any pending backoff timer first — otherwise it fires later and
+    // tears down the socket we are about to (re)open (#1178).
+    clearReconnectTimer();
     if (wsRef.current) {
       wsRef.current.onclose = null;
       wsRef.current.close();
       wsRef.current = null;
     }
     setConnected(false);
+    setDisconnected(false);
     reconnectAttemptRef.current = 0;
     if (channelIdRef.current) connect(channelIdRef.current);
-  }, [connect]);
+  }, [clearReconnectTimer, connect]);
 
   // Reducer self-diagnosis: on a detected gap it sets needsCatchup; recover by
   // reconnecting with sinceSeq=lastSeq (the reducer's documented recovery path).
@@ -214,23 +268,83 @@ export function useChannelChatSocket(
     if (reducer.needsCatchup) forceReconnect();
   }, [reducer.needsCatchup, forceReconnect]);
 
+  // Liveness probe (#1178): detect half-dead sockets the socket layer never
+  // reports as closed. `force` (tab wake / network online) probes immediately;
+  // the background interval only probes an OPEN socket that has gone quiet past
+  // the idle threshold. A REST head-check whose `latestSeq` outruns what we hold
+  // proves the socket silently dropped messages → force a fresh reconnect.
+  useEffect(() => {
+    if (!channelId) return;
+
+    const probe = async (force: boolean): Promise<void> => {
+      const cid = channelIdRef.current;
+      if (!cid || unmountedRef.current) return;
+      const ws = wsRef.current;
+      const open = ws?.readyState === WebSocket.OPEN;
+      if (!open) {
+        // Socket not established. A forced signal (user returned / network back)
+        // short-circuits any pending backoff and reconnects now; the background
+        // interval leaves an in-progress backoff (or given-up state) alone.
+        if (force) forceReconnect();
+        return;
+      }
+      if (
+        !force &&
+        Date.now() - lastActivityRef.current < LIVENESS_IDLE_THRESHOLD_MS
+      ) {
+        return;
+      }
+      try {
+        const summary = await fetchChannel(cid);
+        if (channelIdRef.current !== cid || unmountedRef.current) return;
+        if (wsRef.current?.readyState !== WebSocket.OPEN) return;
+        const known = cursorRef.current ?? reducerRef.current.lastSeq;
+        if (summary.latestSeq > known) {
+          forceReconnect();
+        } else {
+          // Confirmed healthy — reset the idle clock so we don't re-probe on
+          // every interval tick while the channel is simply quiet.
+          lastActivityRef.current = Date.now();
+        }
+      } catch {
+        // head-check failed (offline/transient); the next tick retries.
+      }
+    };
+
+    const onVisible = (): void => {
+      if (document.visibilityState === 'visible') void probe(true);
+    };
+    const onOnline = (): void => void probe(true);
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('online', onOnline);
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'hidden') return;
+      void probe(false);
+    }, LIVENESS_PROBE_INTERVAL_MS);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('online', onOnline);
+      clearInterval(interval);
+    };
+  }, [channelId, forceReconnect]);
+
   useEffect(() => {
     unmountedRef.current = false;
     cursorRef.current = null;
     hasMoreOlderRef.current = false;
     loadingOlderRef.current = false;
     reconnectAttemptRef.current = 0;
+    lastActivityRef.current = 0;
     setReducer(initialChannelReducerState(channelId ?? ''));
     setConnected(false);
+    setDisconnected(false);
     setNotFound(false);
     setHasMoreOlder(false);
     setLoadingOlder(false);
     setPostError(null);
 
-    if (reconnectTimerRef.current) {
-      clearTimeout(reconnectTimerRef.current);
-      reconnectTimerRef.current = null;
-    }
+    clearReconnectTimer();
 
     if (channelId) {
       connect(channelId);
@@ -245,10 +359,7 @@ export function useChannelChatSocket(
 
     return () => {
       unmountedRef.current = true;
-      if (reconnectTimerRef.current) {
-        clearTimeout(reconnectTimerRef.current);
-        reconnectTimerRef.current = null;
-      }
+      clearReconnectTimer();
       if (wsRef.current) {
         wsRef.current.onopen = null;
         wsRef.current.onmessage = null;
@@ -258,7 +369,7 @@ export function useChannelChatSocket(
         wsRef.current = null;
       }
     };
-  }, [channelId, connect]);
+  }, [channelId, connect, clearReconnectTimer]);
 
   const loadOlder = useCallback(async () => {
     const cid = channelIdRef.current;
@@ -315,6 +426,7 @@ export function useChannelChatSocket(
     channel: channelQuery.data ?? null,
     reducer,
     connected,
+    disconnected,
     notFound,
     hasMoreOlder,
     loadingOlder,

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -8,6 +8,7 @@ import { resolveSessionByKey } from '../lib/session-keys.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
+import { useChannelActivityStore } from '../lib/stores/channel-activity.js';
 import type { AccountTelemetry, SessionTelemetry } from '../lib/types.js';
 import type { SessionEventScope } from '../../../shared/node-boundary.js';
 import type {
@@ -407,6 +408,11 @@ export function useEventSocket({
           .handleAccountTelemetryEvent(
             msg.data as AccountTelemetry | Record<string, unknown> | null
           );
+      },
+      'channel-activity': (msg) => {
+        useChannelActivityStore
+          .getState()
+          .recordActivity(msg.channelId, msg.latestSeq);
       },
       'browser-tab-opened': (msg) => {
         useUiStore.getState().openHtmlTab(msg.filePath, msg.token);

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -1,13 +1,18 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
+  WorkspaceTopic,
   WorkspaceTopicCreateInput,
   WorkspaceTopicLaunchIntent,
 } from '../../../shared/workspace-topics.js';
 import {
+  createWorkspaceTopic,
   createWorkspaceTopicRoomAndMaybeLaunch,
   fetchHubNodes,
+  fetchWorkspaceTopic,
   launchWorkspaceTopicRoom,
+  postChannelMessage,
+  HttpError,
   type WorkspaceTopicLaunchFailure,
   type WorkspaceTopicRoomCreateResult,
 } from '../lib/api.js';
@@ -21,6 +26,8 @@ import {
   TOPIC_ROOM_DRAFT_EMPTY,
   type TopicRoomDraft,
 } from '../lib/topic-create.js';
+import { dmChannelCreateInput, dmChannelTopicId } from '../lib/dm-channels.js';
+import { createBrowserId } from '../lib/browserId.js';
 import { taskRefFromDraft } from '../lib/topic-task-ref.js';
 import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
@@ -28,6 +35,29 @@ import { useUiStore } from '../lib/stores/ui.js';
 import { useToastStore } from '../lib/stores/toasts.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import type { SessionSummary } from '../lib/types.js';
+
+/**
+ * Get-or-create the deterministic per-(workspace, framework) DM channel (#1166).
+ * Does I/O (so it lives here, not in the pure `dm-channels` module): a GET, and
+ * on 404 a bare-topic create. Shared by every DM entry point (TopicComposer,
+ * CustomizeSessionDialog). Re-opening the same DM reuses the same channel id, so
+ * no duplicate DM channels are ever created.
+ */
+export async function getOrCreateDmChannel(input: {
+  providerId: string;
+  providerDisplayName: string;
+  workspaceId: string | null;
+}): Promise<WorkspaceTopic> {
+  const id = dmChannelTopicId(input.providerId, input.workspaceId);
+  try {
+    return await fetchWorkspaceTopic(id);
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) {
+      return createWorkspaceTopic(dmChannelCreateInput(input));
+    }
+    throw err;
+  }
+}
 
 /**
  * #1058: stateful draft + create/launch plumbing for codex-style topic
@@ -233,6 +263,58 @@ export function useTopicRoomCreate({
   const submit = useCallback(
     async (intent: WorkspaceTopicLaunchIntent) => {
       if (!effectiveTitle) return;
+
+      // #1166: a web-mode agent launch is now a DM channel, not a mode:'web'
+      // session. Get-or-create the deterministic DM channel, post the first
+      // message into it, and open ChannelView — never spawn a web session.
+      const willLaunchToChannel =
+        intent === 'create-and-launch' &&
+        draft.templateKind === 'agent-task' &&
+        launchMode === 'web';
+      if (willLaunchToChannel) {
+        setSubmittingIntent('create-and-launch');
+        setLaunchFailure(null);
+        try {
+          const framework = frameworks.find((f) => f.id === selectedProviderId);
+          const topic = await getOrCreateDmChannel({
+            providerId: selectedProviderId,
+            providerDisplayName: framework?.displayName ?? selectedProviderId,
+            workspaceId: activeWorkspaceId,
+          });
+          const prompt = draft.prompt.trim();
+          if (prompt) {
+            await postChannelMessage(topic.id, {
+              text: prompt,
+              clientMessageId: createBrowserId('chm'),
+            });
+          }
+          await queryClient.invalidateQueries({
+            queryKey: ['workspace-topics'],
+          });
+          const ui = useUiStore.getState();
+          ui.setActiveChannelId(topic.id);
+          ui.setTopicComposerOpen(false);
+          ui.setForceOrgCockpit(false);
+          setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+          // onLaunched closes the composer; ChatHome ignores whether the id is a
+          // session key or a channel id.
+          onLaunched?.(topic.id);
+        } catch (error) {
+          setLaunchFailure({
+            stage: 'session',
+            message: error instanceof Error ? error.message : String(error),
+            retryable: true,
+            ...(error instanceof HttpError && error.code
+              ? { code: error.code }
+              : {}),
+            ...(error instanceof HttpError ? { status: error.status } : {}),
+          });
+        } finally {
+          setSubmittingIntent(null);
+        }
+        return;
+      }
+
       const launch = buildTopicRoomLaunchBody(
         previewCreate,
         draft.templateKind,
@@ -313,12 +395,17 @@ export function useTopicRoomCreate({
       }
     },
     [
+      activeWorkspaceId,
       createdRoom,
+      draft.prompt,
       draft.templateKind,
       effectiveTitle,
       frameworks,
+      launchMode,
+      onLaunched,
       previewCreate,
       queryClient,
+      selectedProviderId,
       selectLaunchedSession,
       taskRef,
     ]

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -296,9 +296,12 @@ export function useTopicRoomCreate({
           ui.setTopicComposerOpen(false);
           ui.setForceOrgCockpit(false);
           setDraft(TOPIC_ROOM_DRAFT_EMPTY);
-          // onLaunched closes the composer; ChatHome ignores whether the id is a
-          // session key or a channel id.
-          onLaunched?.(topic.id);
+          // #1178: open the channel via the channel path ONLY. Do NOT pass the
+          // topic id to onLaunched — in the mounted app that resolves to
+          // handleSelectSession → setActiveSessionId, and the channel↔session
+          // mutual-exclusion effect would clear the activeChannelId we just set
+          // (flash-and-close) and persist a bogus 'topic:...' session key.
+          // setActiveChannelId above is sufficient to render ChannelView.
         } catch (error) {
           setLaunchFailure({
             stage: 'session',
@@ -402,7 +405,6 @@ export function useTopicRoomCreate({
       effectiveTitle,
       frameworks,
       launchMode,
-      onLaunched,
       previewCreate,
       queryClient,
       selectedProviderId,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,6 +40,7 @@ import type {
   WorkspaceTopicListResponse,
   WorkspaceTopicSearchResponse,
 } from '../../../shared/workspace-topics.js';
+import type { ChannelMessage } from '../../../shared/channel-chat-protocol.js';
 import type {
   WorkflowRunProjection,
   WorkflowRunState,
@@ -1678,6 +1679,133 @@ export async function restoreWorkspaceTopic(
     })
   );
   return data.topic;
+}
+
+/** Fetch a single workspace topic by id (GET /workspace-topics/:id). */
+export async function fetchWorkspaceTopic(id: string): Promise<WorkspaceTopic> {
+  const data = await json<{ topic: WorkspaceTopic }>(
+    await fetch(`/workspace-topics/${encodeURIComponent(id)}`, {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  return data.topic;
+}
+
+/**
+ * Create a bare workspace topic (POST /workspace-topics) with no attached
+ * WorkContext — used by the DM-as-channel flow (#1166), which needs only the
+ * topic/channel identity, not the full room + WorkContext of a session launch.
+ */
+export async function createWorkspaceTopic(
+  input: WorkspaceTopicCreateInput
+): Promise<WorkspaceTopic> {
+  const data = await json<{ topic?: WorkspaceTopic }>(
+    await fetch('/workspace-topics', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify(input),
+    })
+  );
+  if (!data.topic) throw new Error('workspace topic response missing topic');
+  return data.topic;
+}
+
+// ── Channel chat (#1166, epic #1163) ────────────────────────────────────────
+// REST client over the already-shipped channel core. Channel identity == topic
+// id. All writes go through POST /channels/:id/messages; the socket
+// (`useChannelChatSocket`) is read-only. Sender is always server-derived — never
+// send a `sender` field.
+
+export interface ChannelSummaryView {
+  id: string;
+  title: string;
+  kind?: string;
+  visibility: 'default' | 'private' | 'shared';
+  archived: boolean;
+  latestSeq: number;
+  messageCount: number;
+  lastMessage: {
+    id: string;
+    seq: number;
+    preview: string;
+    senderId: string;
+    senderKind: 'human' | 'agent' | 'system';
+    status: string;
+    createdAt: string;
+  } | null;
+  members: { kind: 'human' | 'agent'; id: string; joinedAt: string }[];
+}
+
+export async function fetchChannel(
+  channelId: string
+): Promise<ChannelSummaryView> {
+  const data = await json<{ channel: ChannelSummaryView }>(
+    await fetch(`/channels/${encodeURIComponent(channelId)}`, {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  return data.channel;
+}
+
+export interface ChannelHistoryPage {
+  messages: ChannelMessage[];
+  hasMore: boolean;
+  nextCursor?: { afterSeq?: number; beforeSeq?: number };
+}
+
+export async function fetchChannelHistory(
+  channelId: string,
+  filter: {
+    beforeSeq?: number;
+    afterSeq?: number;
+    limit?: number;
+    threadId?: string;
+  } = {}
+): Promise<ChannelHistoryPage> {
+  const params = new URLSearchParams();
+  if (filter.beforeSeq !== undefined)
+    params.set('beforeSeq', String(filter.beforeSeq));
+  if (filter.afterSeq !== undefined)
+    params.set('afterSeq', String(filter.afterSeq));
+  if (filter.limit !== undefined) params.set('limit', String(filter.limit));
+  if (filter.threadId !== undefined) params.set('threadId', filter.threadId);
+  const query = params.toString();
+  const data = await json<ChannelHistoryPage>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/messages${query ? `?${query}` : ''}`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    )
+  );
+  return {
+    messages: Array.isArray(data.messages) ? data.messages : [],
+    hasMore: Boolean(data.hasMore),
+    ...(data.nextCursor ? { nextCursor: data.nextCursor } : {}),
+  };
+}
+
+export async function postChannelMessage(
+  channelId: string,
+  input: {
+    text: string;
+    format?: 'markdown' | 'text';
+    parentMessageId?: string;
+    clientMessageId: string;
+  }
+): Promise<ChannelMessage> {
+  const data = await json<{ message: ChannelMessage }>(
+    await fetch(`/channels/${encodeURIComponent(channelId)}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify(input),
+    })
+  );
+  return data.message;
 }
 
 export interface WorkContextCreateBody {

--- a/frontend/src/lib/chat/channel-timeline-layout.ts
+++ b/frontend/src/lib/chat/channel-timeline-layout.ts
@@ -1,0 +1,153 @@
+// Pure timeline layout for the channel view (#1166). Groups consecutive
+// same-sender messages, inserts day dividers and the client-local unread line.
+// Deliberately React-free so grouping/divider logic is unit-testable without
+// mounting components (see test/components/channel-timeline-grouping.test.ts).
+//
+// Grouping rules (spec §5.1): a new group starts when the message is a system
+// message (never grouped), the sender changes, the local calendar day changes
+// (which also emits a day-divider), the first-unread boundary is crossed (which
+// also emits the unread line), or the gap since the previous message in the
+// running group exceeds GROUP_WINDOW_MS.
+import type {
+  ChannelMessage,
+  ChannelSenderRef,
+} from '../../../../shared/channel-chat-protocol.js';
+
+/** Slack-standard grouping window: same-sender messages within 5 minutes group. */
+export const GROUP_WINDOW_MS = 5 * 60 * 1000;
+
+export type TimelineNode =
+  | { kind: 'day-divider'; date: string /* YYYY-MM-DD local */ }
+  | { kind: 'group'; sender: ChannelSenderRef; messages: ChannelMessage[] }
+  | { kind: 'system'; message: ChannelMessage }
+  | { kind: 'unread-line' };
+
+function localDayKeyFromDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Local-calendar day key (YYYY-MM-DD) for an ISO timestamp. */
+export function localDayKey(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return localDayKeyFromDate(date);
+}
+
+const WEEKDAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
+const MONTHS = [
+  'jan',
+  'feb',
+  'mar',
+  'apr',
+  'may',
+  'jun',
+  'jul',
+  'aug',
+  'sep',
+  'oct',
+  'nov',
+  'dec',
+] as const;
+
+/**
+ * Day-divider label: `today` / `yesterday` when applicable, else `ddd, mmm d`.
+ * Always lowercase (DESIGN.md casing law) — never relies on locale casing.
+ */
+export function formatDayLabel(
+  dateKey: string,
+  now: Date = new Date()
+): string {
+  const todayKey = localDayKeyFromDate(now);
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  const yesterdayKey = localDayKeyFromDate(yesterday);
+  if (dateKey === todayKey) return 'today';
+  if (dateKey === yesterdayKey) return 'yesterday';
+  const parts = dateKey.split('-').map((part) => Number(part));
+  const year = parts[0] ?? 1970;
+  const month = parts[1] ?? 1;
+  const day = parts[2] ?? 1;
+  const date = new Date(year, month - 1, day);
+  return `${WEEKDAYS[date.getDay()]}, ${MONTHS[date.getMonth()]} ${date.getDate()}`;
+}
+
+interface RunningGroup {
+  sender: ChannelSenderRef;
+  messages: ChannelMessage[];
+  lastCreatedMs: number;
+}
+
+/**
+ * Build the ordered node list for a seq-ascending message array. `lastReadSeq`
+ * of `null` (never read) draws no unread line — a first-ever open shows no
+ * "everything is unread" marker.
+ */
+export function buildTimelineNodes(
+  messages: ChannelMessage[],
+  lastReadSeq: number | null
+): TimelineNode[] {
+  const nodes: TimelineNode[] = [];
+  let group: RunningGroup | null = null;
+  let prevDay: string | null = null;
+  let unreadInserted = lastReadSeq === null;
+
+  const flush = (): void => {
+    if (group) {
+      nodes.push({
+        kind: 'group',
+        sender: group.sender,
+        messages: group.messages,
+      });
+      group = null;
+    }
+  };
+
+  for (const message of messages) {
+    const day = localDayKey(message.createdAt);
+    const createdMs = Date.parse(message.createdAt);
+    const createdMsSafe = Number.isNaN(createdMs) ? 0 : createdMs;
+
+    if (day !== prevDay) {
+      flush();
+      nodes.push({ kind: 'day-divider', date: day });
+      prevDay = day;
+    }
+
+    if (!unreadInserted && lastReadSeq !== null && message.seq > lastReadSeq) {
+      flush();
+      nodes.push({ kind: 'unread-line' });
+      unreadInserted = true;
+    }
+
+    if (message.kind === 'system') {
+      flush();
+      nodes.push({ kind: 'system', message });
+      continue;
+    }
+
+    if (group) {
+      const sameSender =
+        group.sender.kind === message.sender.kind &&
+        group.sender.id === message.sender.id;
+      const withinWindow =
+        createdMsSafe - group.lastCreatedMs <= GROUP_WINDOW_MS;
+      if (!sameSender || !withinWindow) flush();
+    }
+
+    if (!group) {
+      group = {
+        sender: message.sender,
+        messages: [],
+        lastCreatedMs: createdMsSafe,
+      };
+    }
+    group.messages.push(message);
+    group.lastCreatedMs = createdMsSafe;
+  }
+
+  flush();
+  return nodes;
+}

--- a/frontend/src/lib/chat/sender-identity.ts
+++ b/frontend/src/lib/chat/sender-identity.ts
@@ -1,0 +1,73 @@
+// Sender identity visual system for the channel timeline (#1166).
+//
+// Resolves a `ChannelSenderRef` to a stable color / glyph / label. Human is
+// always "you" (right-aligned bubble, no name chrome). Known agent frameworks
+// map to fixed CSS custom properties (defined in App.css, each reusing an
+// existing DESIGN.md identity token — no invented hex values); long-tail custom
+// providers fall back to the existing hash-based `deriveColor`. Reused verbatim
+// by the future @mention pill (#1167) and sidebar presence dot — do not fork.
+import type { ChannelSenderRef } from '../../../../shared/channel-chat-protocol.js';
+import { deriveColor } from '../colors.js';
+
+export type KnownAgentGlyph = 'claude' | 'codex' | 'hermes' | 'opencode';
+
+export interface SenderIdentity {
+  /** Display label — human is always 'you'. */
+  label: string;
+  /** CSS color value: a `var(--sender-*)` custom property, or a hash-derived hex. */
+  colorVar: string;
+  /** AgentBadge glyph id, or null for human/system (no glyph). */
+  glyph: KnownAgentGlyph | null;
+  kind: 'human' | 'agent' | 'system';
+}
+
+const KNOWN_AGENT_COLOR_VAR: Record<string, string> = {
+  claude: '--sender-claude',
+  codex: '--sender-codex',
+  hermes: '--sender-hermes',
+  opencode: '--sender-opencode',
+};
+
+const KNOWN_AGENT_GLYPHS: readonly KnownAgentGlyph[] = [
+  'claude',
+  'codex',
+  'hermes',
+  'opencode',
+];
+
+function isKnownGlyph(value: string): value is KnownAgentGlyph {
+  return (KNOWN_AGENT_GLYPHS as readonly string[]).includes(value);
+}
+
+export function resolveSenderIdentity(
+  sender: ChannelSenderRef
+): SenderIdentity {
+  if (sender.kind === 'human') {
+    return {
+      label: sender.displayName ?? 'you',
+      colorVar: 'var(--text)',
+      glyph: null,
+      kind: 'human',
+    };
+  }
+  if (sender.kind === 'system') {
+    return {
+      label: 'system',
+      colorVar: 'var(--sender-system)',
+      glyph: null,
+      kind: 'system',
+    };
+  }
+  const providerId = sender.providerId ?? sender.id.replace(/^agent:/, '');
+  const knownVar = KNOWN_AGENT_COLOR_VAR[providerId];
+  const colorVar = knownVar
+    ? `var(${knownVar})`
+    : deriveColor(`sender:agent:${providerId}`);
+  const glyph = isKnownGlyph(providerId) ? providerId : null;
+  return {
+    label: sender.displayName ?? providerId,
+    colorVar,
+    glyph,
+    kind: 'agent',
+  };
+}

--- a/frontend/src/lib/dm-channels.ts
+++ b/frontend/src/lib/dm-channels.ts
@@ -5,22 +5,40 @@
 // no `WorkspaceTopicChannelKind` enum extension or server marker is required.
 //
 // See channel-ui-spec §0.2/§0.3 and §3.1.
-import { createWorkspaceTopicId } from '../../../shared/workspace-topics.js';
 import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
 import type { WorkspaceTopicCreateInput } from '../../../shared/workspace-topics.js';
 
 /** Local-workspace sentinel already used by TopicComposer when no IA workspace is active. */
 export const DM_DEFAULT_WORKSPACE_ID = 'workspace:local';
 
+// A DM id is namespaced with `~` separators. `createWorkspaceTopicId` (the same
+// function the server uses to mint a topic id from its user-chosen title) slugs
+// every id down to `[a-z0-9._-]` — it can NEVER emit a `~`, though `~` is legal
+// per the topic-id grammar (`/^topic:[A-Za-z0-9._~%-]+$/`). Building the DM id
+// directly with `~` therefore puts it in an id sub-namespace that no ordinary
+// title can collide with (a topic literally titled "dm claude" would otherwise
+// mint `topic:...-dm-claude`, the exact old DM id).
+const DM_ID_MARKER = 'dm~';
+
+/** Slug a provider/workspace segment to the title-id charset (no `~`, no `%`). */
+function slugifyDmSegment(part: string): string {
+  return part
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
 /** Deterministic per-(workspace, framework) DM channel id. Pure, no I/O. */
 export function dmChannelTopicId(
   providerId: string,
   workspaceId: string | null
 ): string {
-  return createWorkspaceTopicId(
-    `dm-${providerId}`,
-    workspaceId ?? DM_DEFAULT_WORKSPACE_ID
-  );
+  const provider = slugifyDmSegment(providerId) || 'agent';
+  const workspace =
+    slugifyDmSegment(workspaceId ?? DM_DEFAULT_WORKSPACE_ID) || 'workspace';
+  return `topic:${DM_ID_MARKER}${provider}~${workspace}`;
 }
 
 /**

--- a/frontend/src/lib/dm-channels.ts
+++ b/frontend/src/lib/dm-channels.ts
@@ -1,0 +1,55 @@
+// DM-as-channel derivation (#1166, epic #1163). A "direct message" is not a
+// distinct backend entity — it is a regular `workspace_topics` channel whose id
+// follows a deterministic per-(workspace, framework) formula. DM-ness is a pure
+// client-side derivation from the topic's id + `routingDefaults.providerId`, so
+// no `WorkspaceTopicChannelKind` enum extension or server marker is required.
+//
+// See channel-ui-spec §0.2/§0.3 and §3.1.
+import { createWorkspaceTopicId } from '../../../shared/workspace-topics.js';
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
+import type { WorkspaceTopicCreateInput } from '../../../shared/workspace-topics.js';
+
+/** Local-workspace sentinel already used by TopicComposer when no IA workspace is active. */
+export const DM_DEFAULT_WORKSPACE_ID = 'workspace:local';
+
+/** Deterministic per-(workspace, framework) DM channel id. Pure, no I/O. */
+export function dmChannelTopicId(
+  providerId: string,
+  workspaceId: string | null
+): string {
+  return createWorkspaceTopicId(
+    `dm-${providerId}`,
+    workspaceId ?? DM_DEFAULT_WORKSPACE_ID
+  );
+}
+
+/**
+ * A topic is a DM iff its id matches the deterministic formula for its OWN
+ * `routingDefaults.providerId`. Recomputes the id — no string-prefix guessing,
+ * no server-side marker needed. Returns the provider id when true, else null.
+ */
+export function isDmChannel(
+  topic: Pick<WorkspaceTopic, 'id' | 'workspaceId' | 'routingDefaults'>
+): string | null {
+  const providerId = topic.routingDefaults?.providerId;
+  if (!providerId) return null;
+  return topic.id === dmChannelTopicId(providerId, topic.workspaceId)
+    ? providerId
+    : null;
+}
+
+/** Build the POST /workspace-topics body for a new DM channel. */
+export function dmChannelCreateInput(input: {
+  providerId: string;
+  providerDisplayName: string;
+  workspaceId: string | null;
+}): WorkspaceTopicCreateInput {
+  const workspaceId = input.workspaceId ?? DM_DEFAULT_WORKSPACE_ID;
+  return {
+    id: dmChannelTopicId(input.providerId, workspaceId),
+    workspaceId,
+    title: input.providerDisplayName,
+    visibility: 'default',
+    routingDefaults: { providerId: input.providerId },
+  };
+}

--- a/frontend/src/lib/session-launch-mode.ts
+++ b/frontend/src/lib/session-launch-mode.ts
@@ -59,3 +59,17 @@ export function defaultSessionModeForAgent(
   );
   return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
 }
+
+/**
+ * #1166: an agent launch in `web` mode now routes to a DM channel
+ * (`ChannelView`) instead of spawning a `mode:'web'` session (`ChatView`).
+ * Shared by every UI creation entry point (TopicComposer, CustomizeSessionDialog)
+ * so "web session" can never be produced from a creation path. PTY/terminal
+ * launches are unaffected.
+ */
+export function shouldRouteToChannel(
+  type: 'agent' | 'terminal' | null | undefined,
+  mode: SessionLaunchMode | null | undefined
+): boolean {
+  return type === 'agent' && mode === 'web';
+}

--- a/frontend/src/lib/state/app-view-mode.ts
+++ b/frontend/src/lib/state/app-view-mode.ts
@@ -26,6 +26,13 @@ export interface ResolveAppViewModeInput {
    */
   topicComposerOpen?: boolean;
   /**
+   * #1166: a channel (persisted workspace_topic) is open in the main chat pane.
+   * Channel view is part of the chat shell and takes priority over the composer
+   * and any active session — selecting a channel row always shows the channel,
+   * never a stale composer or a leftover session surface.
+   */
+  hasActiveChannel?: boolean;
+  /**
    * Transport mode of the active session. Web-mode chat sessions stay in the
    * chat shell (`ChatView`); live PTY agent/terminal sessions surface their
    * real terminal (viewMode 'session') so the user can watch and drive the
@@ -41,9 +48,13 @@ export function resolveAppViewMode({
   activeRepoPath,
   forceOrgCockpit = false,
   topicComposerOpen = false,
+  hasActiveChannel = false,
   activeSessionMode,
 }: ResolveAppViewModeInput): AppViewMode {
   if (analyticsView !== null) return 'analytics';
+  // Channel takes priority within 'chat' mode — checked before topicComposerOpen
+  // and any active session so a channel selection always wins.
+  if (hasActiveChannel) return 'chat';
   if (topicComposerOpen) return 'chat';
   if (hasActiveSession) {
     // Explicit legacy cockpit escape hatch still wins.

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -8,6 +8,7 @@ import type { SessionSummary } from '../types.js';
 import { isAttentionState, type DisplayState } from './display-state.js';
 import { highestPriorityState } from './attention.js';
 import { scopedSessionKey, sessionKeyMatches } from '../session-keys.js';
+import { isDmChannel } from '../dm-channels.js';
 
 export type TopicNavTone = 'active' | 'attention' | 'idle' | 'empty' | 'error';
 export type TopicNavKind = 'repo' | 'folder' | 'thread';
@@ -86,6 +87,10 @@ export interface TopicNavItem {
   kindLabel: string;
   /** User-chosen Discord-style channel taxonomy (repo/product-area/…). */
   channelKind: WorkspaceTopicChannelKind | null;
+  /** #1166: true when this topic is a DM channel (deterministic-id derivation). */
+  isDirectMessage: boolean;
+  /** Provider id of the DM partner, or null for a regular channel. */
+  dmProviderId: string | null;
   icon: string | null;
   color: string | null;
   pinned: boolean;
@@ -668,6 +673,7 @@ export function buildTopicNavModel(input: {
       });
     const kind = topicKind(topic);
     const order = topic.grouping.order ?? Number.MAX_SAFE_INTEGER;
+    const dmProviderId = isDmChannel(topic);
     return {
       id: topic.id,
       workspaceId: topic.workspaceId,
@@ -678,6 +684,8 @@ export function buildTopicNavModel(input: {
       kind: kind.kind,
       kindLabel: kind.label,
       channelKind: topic.display.kind ?? null,
+      isDirectMessage: dmProviderId !== null,
+      dmProviderId,
       icon: topic.display.icon ?? null,
       color: topic.display.color ?? null,
       pinned: topic.state.pinned,

--- a/frontend/src/lib/stores/channel-activity.ts
+++ b/frontend/src/lib/stores/channel-activity.ts
@@ -7,11 +7,43 @@ import { create } from 'zustand';
 
 interface ChannelActivityState {
   latestSeqByChannel: Record<string, number>;
+  /**
+   * Reactive last-read marker per channel (#1178). Mirrors the persistent
+   * localStorage marker but lives in the store so the sidebar's unread dot
+   * recomputes the instant a channel is read — localStorage is not reactive, so
+   * a render that read it before ChannelView's unmount write would otherwise
+   * keep showing a stale dot until unrelated activity arrived.
+   */
+  lastReadByChannel: Record<string, number>;
   recordActivity: (channelId: string, latestSeq: number) => void;
+  /** Mark a channel read up to `seq` (monotonic up). Reactive + persistent. */
+  markChannelRead: (channelId: string, seq: number) => void;
+  /**
+   * Clamp both stores DOWN to an authoritative head seq (#1178). Used when a
+   * full snapshot reports a `latestSeq` below the stored marker — i.e. a DM was
+   * deleted and recreated under the same deterministic id and its seq restarted
+   * low. Without this the monotonic activity guard drops every new broadcast and
+   * the stale-high last-read marker suppresses the unread dot indefinitely.
+   */
+  clampChannelStores: (channelId: string, headSeq: number) => void;
+}
+
+/** localStorage key for a channel's client-local last-read seq marker. */
+export function channelLastReadKey(channelId: string): string {
+  return `relay-channel-last-read::${channelId}`;
+}
+
+function persistLastRead(channelId: string, seq: number): void {
+  try {
+    localStorage.setItem(channelLastReadKey(channelId), String(seq));
+  } catch {
+    /* localStorage unavailable */
+  }
 }
 
 export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
   latestSeqByChannel: {},
+  lastReadByChannel: {},
   recordActivity: (channelId, latestSeq) =>
     set((state) => {
       const current = state.latestSeqByChannel[channelId];
@@ -23,20 +55,62 @@ export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
         },
       };
     }),
+  markChannelRead: (channelId, seq) =>
+    set((state) => {
+      if (seq <= 0) return state;
+      const current = state.lastReadByChannel[channelId];
+      if (current !== undefined && current >= seq) return state;
+      persistLastRead(channelId, seq);
+      return {
+        lastReadByChannel: { ...state.lastReadByChannel, [channelId]: seq },
+      };
+    }),
+  clampChannelStores: (channelId, headSeq) =>
+    set((state) => {
+      const next: Partial<ChannelActivityState> = {};
+      const storedRead = state.lastReadByChannel[channelId];
+      const storedActivity = state.latestSeqByChannel[channelId];
+      const persistedRead = readPersistedLastRead(channelId);
+      // Lower the read marker (store + localStorage) when it sits above head.
+      if (
+        (storedRead !== undefined && storedRead > headSeq) ||
+        persistedRead > headSeq
+      ) {
+        persistLastRead(channelId, headSeq);
+        next.lastReadByChannel = {
+          ...state.lastReadByChannel,
+          [channelId]: headSeq,
+        };
+      }
+      if (storedActivity !== undefined && storedActivity > headSeq) {
+        next.latestSeqByChannel = {
+          ...state.latestSeqByChannel,
+          [channelId]: headSeq,
+        };
+      }
+      return Object.keys(next).length > 0 ? next : state;
+    }),
 }));
 
-/** localStorage key for a channel's client-local last-read seq marker. */
-export function channelLastReadKey(channelId: string): string {
-  return `relay-channel-last-read::${channelId}`;
-}
-
-function readLastReadSeq(channelId: string): number {
+function readPersistedLastRead(channelId: string): number {
   try {
     const raw = localStorage.getItem(channelLastReadKey(channelId));
     return raw ? Number(raw) : 0;
   } catch {
     return 0;
   }
+}
+
+/**
+ * Client-local last-read seq for a channel. Prefers the reactive store value
+ * (freshly written on read) and falls back to the persisted localStorage marker
+ * for channels the store has not hydrated yet (e.g. first render after reload).
+ */
+function readLastReadSeq(channelId: string): number {
+  const stored =
+    useChannelActivityStore.getState().lastReadByChannel[channelId];
+  if (stored !== undefined) return stored;
+  return readPersistedLastRead(channelId);
 }
 
 /**

--- a/frontend/src/lib/stores/channel-activity.ts
+++ b/frontend/src/lib/stores/channel-activity.ts
@@ -1,0 +1,55 @@
+// Coarse per-channel activity cache (#1166). Fed by the `/ws/events`
+// `channel-activity` broadcast, which carries only `{ channelId, latestSeq }` —
+// no per-user unread count, no sender info. The sidebar renders a presence-only
+// dot (not a count badge) when a channel has activity newer than the client's
+// local last-read marker and isn't the currently-open channel.
+import { create } from 'zustand';
+
+interface ChannelActivityState {
+  latestSeqByChannel: Record<string, number>;
+  recordActivity: (channelId: string, latestSeq: number) => void;
+}
+
+export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
+  latestSeqByChannel: {},
+  recordActivity: (channelId, latestSeq) =>
+    set((state) => {
+      const current = state.latestSeqByChannel[channelId];
+      if (current !== undefined && current >= latestSeq) return state;
+      return {
+        latestSeqByChannel: {
+          ...state.latestSeqByChannel,
+          [channelId]: latestSeq,
+        },
+      };
+    }),
+}));
+
+/** localStorage key for a channel's client-local last-read seq marker. */
+export function channelLastReadKey(channelId: string): string {
+  return `relay-channel-last-read::${channelId}`;
+}
+
+function readLastReadSeq(channelId: string): number {
+  try {
+    const raw = localStorage.getItem(channelLastReadKey(channelId));
+    return raw ? Number(raw) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * True when the channel has activity newer than the client's last-read marker
+ * AND isn't the currently-open channel. Presence-only signal for the sidebar.
+ */
+export function hasUnseenActivity(
+  channelId: string,
+  activeChannelId: string | null
+): boolean {
+  if (channelId === activeChannelId) return false;
+  const latestSeq =
+    useChannelActivityStore.getState().latestSeqByChannel[channelId];
+  if (latestSeq === undefined) return false;
+  return latestSeq > readLastReadSeq(channelId);
+}

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -571,6 +571,14 @@ export interface UiState {
    * sidebar selection). Session-transient; never persisted.
    */
   topicComposerOpen: boolean;
+  /**
+   * #1166: the id of the channel (persisted workspace_topic) currently open in
+   * the main chat pane. Takes priority over topicComposerOpen and the legacy
+   * web-mode session surface in `resolveAppViewMode`. Mutually exclusive with an
+   * active session (App.tsx clears one when the other is set). Session-transient;
+   * never persisted (a fresh reload lands on the chat home, not a stale channel).
+   */
+  activeChannelId: string | null;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
   /**
@@ -618,6 +626,7 @@ export interface UiState {
   setOrgDashboardTab: (tab: OrgDashboardTab) => void;
   setForceOrgCockpit: (v: boolean) => void;
   setTopicComposerOpen: (v: boolean) => void;
+  setActiveChannelId: (v: string | null) => void;
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
@@ -656,6 +665,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   orgDashboardTab: loadAdvancedMode() ? 'active-work' : 'prs',
   forceOrgCockpit: false,
   topicComposerOpen: false,
+  activeChannelId: null,
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
@@ -1079,6 +1089,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   setOrgDashboardTab: (tab) => set({ orgDashboardTab: tab }),
   setForceOrgCockpit: (v) => set({ forceOrgCockpit: v }),
   setTopicComposerOpen: (v) => set({ topicComposerOpen: v }),
+  setActiveChannelId: (v) => set({ activeChannelId: v }),
   setActiveModal: (v) => set({ activeModal: v }),
 
   saveRightSidebarWidth: () =>

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -124,6 +124,7 @@ export type EventMessage =
       manifest?: NodeManifest;
     }
   | { type: 'server-restarting'; reason?: string }
+  | { type: 'channel-activity'; channelId: string; latestSeq: number }
   | ({
       type: 'session-durability-changed';
       sessionId: string;

--- a/scripts/seed-channel-chat.ts
+++ b/scripts/seed-channel-chat.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+//
+// Dev-only channel seeding (#1166). Loads a ChannelMessage fixture into a given
+// channel's `channel-chat.db` so the mixed human+agent timeline (grouping,
+// sender colors, streaming/interrupted/failed/truncated/system rows, a
+// day-boundary crossing, and a reply breadcrumb) can be validated in the real
+// UI before #1167 wires any live agent posting. Refuses to run in production.
+//
+// Usage:
+//   node dist/scripts/seed-channel-chat.js \
+//     --db <path-to>/channel-chat.db \
+//     --channel topic:<id> \
+//     [--fixture test/fixtures/channel-chat/mixed-timeline.json]
+//
+// The channel must already exist as a persisted workspace topic (create it via
+// POST /workspace-topics or the DM entry point) so GET /channels/:id resolves.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createChannelMessageStore } from '../server/channel-message-store.js';
+import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+
+function getArg(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function main(): void {
+  if (process.env['NODE_ENV'] === 'production') {
+    console.error('seed-channel-chat refuses to run with NODE_ENV=production');
+    process.exit(1);
+  }
+
+  const dbPath = getArg('--db');
+  const channelId = getArg('--channel');
+  const fixturePath =
+    getArg('--fixture') ??
+    path.join('test', 'fixtures', 'channel-chat', 'mixed-timeline.json');
+
+  if (!dbPath || !channelId) {
+    console.error(
+      'usage: seed-channel-chat --db <channel-chat.db> --channel <topic:id> [--fixture <path>]'
+    );
+    process.exit(1);
+  }
+
+  const fixture = JSON.parse(
+    readFileSync(fixturePath, 'utf8')
+  ) as ChannelMessage[];
+  const store = createChannelMessageStore(dbPath);
+
+  // The store assigns fresh ids on insert, so the fixture's literal
+  // parentMessageId values are stale — remap fixture id → newly-created id.
+  const idMap = new Map<string, string>();
+  const resolveParent = (raw: string | null): string | undefined => {
+    if (!raw) return undefined;
+    return idMap.get(raw) ?? undefined;
+  };
+
+  let seeded = 0;
+  for (const message of fixture) {
+    const sender = message.sender;
+    const format = message.body.format;
+    const text = message.body.text;
+    const parentMessageId = resolveParent(message.parentMessageId);
+
+    if (message.kind === 'system') {
+      const created = store.appendComplete({
+        channelId,
+        kind: 'system',
+        sender,
+        text,
+        format,
+      });
+      idMap.set(message.id, created.id);
+      seeded += 1;
+      continue;
+    }
+
+    if (message.status === 'streaming') {
+      const created = store.beginStream({
+        channelId,
+        sender,
+        source: { sessionId: 'seed-session' },
+        text,
+        ...(parentMessageId ? { parentMessageId } : {}),
+      });
+      idMap.set(message.id, created.id);
+      seeded += 1;
+      continue;
+    }
+
+    if (message.status === 'interrupted' || message.status === 'failed') {
+      const started = store.beginStream({
+        channelId,
+        sender,
+        source: { sessionId: 'seed-session' },
+        text: '',
+        ...(parentMessageId ? { parentMessageId } : {}),
+      });
+      const finalized = store.finalizeStream(started.id, {
+        text,
+        status: message.status,
+        ...(message.truncated ? { truncated: true } : {}),
+      });
+      idMap.set(message.id, finalized?.id ?? started.id);
+      seeded += 1;
+      continue;
+    }
+
+    const created = store.appendComplete({
+      channelId,
+      sender,
+      text,
+      format,
+      ...(parentMessageId ? { parentMessageId } : {}),
+      ...(message.truncated ? { meta: { truncated: true } } : {}),
+    });
+    idMap.set(message.id, created.id);
+    seeded += 1;
+  }
+
+  console.log(`seeded ${seeded} messages into ${channelId} (${dbPath})`);
+}
+
+main();

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -426,6 +426,34 @@ export function applyChannelEventV1(
   }
 }
 
+/**
+ * Merge a page of history (`channels.history` REST response) into an existing
+ * reducer state. Pure + additive: dedupes by id via `sortedInsert` (so a
+ * re-merge of overlapping pages is idempotent), keeps `messages` seq-ascending,
+ * and never lowers `lastSeq` (older pages carry lower seqs; `lastSeq` stays the
+ * max). Used by the reverse-infinite-scroll `loadOlder()` path in
+ * `useChannelChatSocket`, which reads history via REST rather than the socket.
+ */
+export function mergeHistoryPage(
+  state: ChannelReducerState,
+  page: ChannelMessage[]
+): ChannelReducerState {
+  if (page.length === 0) return state;
+  let messages = state.messages;
+  for (const message of [...page].sort((a, b) => a.seq - b.seq)) {
+    messages = sortedInsert(messages, message);
+  }
+  const highestSeq = messages.length
+    ? messages[messages.length - 1]!.seq
+    : state.lastSeq;
+  return {
+    ...state,
+    messages,
+    byId: rebuildById(messages),
+    lastSeq: Math.max(state.lastSeq, highestSeq),
+  };
+}
+
 // ── mention parser (stored, not routed in slice 2) ──────────────────────────
 
 /**

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ChannelComposer } from '../../frontend/src/components/chat/ChannelComposer.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setNativeValue(el: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+interface RenderOpts {
+  onSend?: (text: string, clientMessageId: string) => Promise<void>;
+  postPending?: boolean;
+  storeDown?: boolean;
+  archived?: boolean;
+  onRestore?: () => void;
+  restorePending?: boolean;
+}
+
+async function renderComposer(opts: RenderOpts = {}): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(ChannelComposer, {
+        channelTitle: 'general',
+        onSend: opts.onSend ?? (() => Promise.resolve()),
+        postPending: opts.postPending ?? false,
+        storeDown: opts.storeDown ?? false,
+        archived: opts.archived ?? false,
+        onRestore: opts.onRestore ?? (() => {}),
+        restorePending: opts.restorePending ?? false,
+      })
+    );
+  });
+}
+
+async function typeAndEnter(text: string): Promise<void> {
+  const ta = container.querySelector('.ch-composer__ta') as HTMLTextAreaElement;
+  await act(async () => {
+    setNativeValue(ta, text);
+  });
+  await act(async () => {
+    ta.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function enterAgain(): Promise<void> {
+  const ta = container.querySelector('.ch-composer__ta') as HTMLTextAreaElement;
+  await act(async () => {
+    ta.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('ChannelComposer (#1178)', () => {
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('reuses the same clientMessageId on retry after a failed send, then rotates on success', async () => {
+    const ids: string[] = [];
+    let failNext = true;
+    const onSend = vi.fn(async (_text: string, clientMessageId: string) => {
+      ids.push(clientMessageId);
+      if (failNext) {
+        failNext = false;
+        throw new Error('boom');
+      }
+    });
+
+    await renderComposer({ onSend });
+
+    await typeAndEnter('hello world');
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    // Draft is preserved after the failure so the user can retry.
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    expect(ta.value).toBe('hello world');
+
+    // Retry (press Enter again) → SAME clientMessageId so the server dedupes.
+    await enterAgain();
+    expect(onSend).toHaveBeenCalledTimes(2);
+    expect(ids[0]).toBe(ids[1]);
+
+    // Success cleared the draft and rotated the idempotency key.
+    expect(ta.value).toBe('');
+    await typeAndEnter('second message');
+    expect(onSend).toHaveBeenCalledTimes(3);
+    expect(ids[2]).not.toBe(ids[0]);
+  });
+
+  it('shows the 503 store-unavailable banner while keeping the input live', async () => {
+    await renderComposer({ storeDown: true });
+    const banner = container.querySelector('.ch-composer__banner');
+    expect(banner?.textContent).toContain('unavailable');
+    // Input stays present (not replaced) so a queued draft is not lost.
+    expect(container.querySelector('.ch-composer__ta')).not.toBeNull();
+  });
+
+  it('replaces the composer with a restore bar when 409 archived', async () => {
+    const onRestore = vi.fn();
+    await renderComposer({ archived: true, onRestore });
+    expect(container.querySelector('.ch-composer--archived')).not.toBeNull();
+    // The textarea is gone in the archived state.
+    expect(container.querySelector('.ch-composer__ta')).toBeNull();
+
+    const restore = container.querySelector(
+      '.ch-composer__restore'
+    ) as HTMLButtonElement;
+    await act(async () => restore.click());
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/channel-timeline-anchor.test.ts
+++ b/test/components/channel-timeline-anchor.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function msg(seq: number): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: 'topic:general',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: `m${seq}`, format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-18T10:00:00.000Z',
+    updatedAt: '2026-07-18T10:00:00.000Z',
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderTimeline(loadOlder: () => Promise<void>): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(ChannelTimeline, {
+        messages: [msg(5), msg(6)],
+        lastReadSeq: null,
+        channelTitle: 'general',
+        hasMoreOlder: true,
+        loadingOlder: false,
+        loadOlder,
+        needsCatchup: false,
+        onResync: () => {},
+      })
+    );
+  });
+}
+
+async function scrollToTop(): Promise<void> {
+  const el = container.querySelector('.ch-tl') as HTMLDivElement;
+  // happy-dom has no layout, so scrollTop defaults to 0 (< the 80px threshold).
+  await act(async () => {
+    el.dispatchEvent(new Event('scroll'));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('ChannelTimeline anchor release (#1178)', () => {
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('releases the anchor when loadOlder settles without a prepend (no earliestSeq change)', async () => {
+    // Mirrors the hook contract: loadOlder resolves even when the page is empty
+    // or already at seq 1, so earliestSeq never changes and the [earliestSeq]
+    // layout effect never fires.
+    const loadOlder = vi.fn().mockResolvedValue(undefined);
+    await renderTimeline(loadOlder);
+
+    await scrollToTop();
+    expect(loadOlder).toHaveBeenCalledTimes(1);
+
+    // Anchor must be released on settlement, so a second scroll pages again.
+    await scrollToTop();
+    expect(loadOlder).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the anchor even when loadOlder rejects (transient fetch error)', async () => {
+    const loadOlder = vi.fn().mockRejectedValue(new Error('network'));
+    await renderTimeline(loadOlder);
+
+    await scrollToTop();
+    expect(loadOlder).toHaveBeenCalledTimes(1);
+
+    await scrollToTop();
+    expect(loadOlder).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/components/channel-timeline-grouping.test.ts
+++ b/test/components/channel-timeline-grouping.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   buildTimelineNodes,
   formatDayLabel,
@@ -12,6 +12,20 @@ import type {
 import fixtureData from '../fixtures/channel-chat/mixed-timeline.json';
 
 const fixture = fixtureData as unknown as ChannelMessage[];
+
+// Grouping/day-divider layout is LOCAL-calendar sensitive: the fixture's day
+// boundary (10:22Z on 07-17 → 09:00Z on 07-18) collapses into one local day at
+// UTC-10 or beyond, so the asserted node sequence and divider dates flip under
+// those offsets. Pin TZ=UTC for this file (restored after) so the assertions are
+// deterministic on any machine (#1178). Runtime TZ mutation is honored by V8.
+const originalTz = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = 'UTC';
+});
+afterAll(() => {
+  if (originalTz === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTz;
+});
 
 function kinds(nodes: TimelineNode[]): string[] {
   return nodes.map((node) => node.kind);
@@ -138,6 +152,36 @@ describe('buildTimelineNodes — grouping rules', () => {
       null
     );
     expect(kinds(nodes)).toEqual(['day-divider', 'group', 'group']);
+  });
+
+  it('breaks a same-sender group across a day boundary within the window (§5.1)', () => {
+    // Same sender, only 3 minutes apart (well inside GROUP_WINDOW_MS), but they
+    // straddle local midnight — the day boundary MUST still split the group and
+    // emit a fresh day divider. TZ is pinned to UTC so these instants are
+    // 07-18 and 07-19 locally.
+    const nodes = buildTimelineNodes(
+      [
+        msg({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          createdAt: '2026-07-18T23:58:00.000Z',
+        }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          createdAt: '2026-07-19T00:01:00.000Z',
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual([
+      'day-divider',
+      'group',
+      'day-divider',
+      'group',
+    ]);
+    expect(groupSeqs(nodes[1]!)).toEqual([1]);
+    expect(groupSeqs(nodes[3]!)).toEqual([2]);
   });
 
   it('returns an empty node list for no messages', () => {

--- a/test/components/channel-timeline-grouping.test.ts
+++ b/test/components/channel-timeline-grouping.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTimelineNodes,
+  formatDayLabel,
+  GROUP_WINDOW_MS,
+  type TimelineNode,
+} from '../../frontend/src/lib/chat/channel-timeline-layout.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+import fixtureData from '../fixtures/channel-chat/mixed-timeline.json';
+
+const fixture = fixtureData as unknown as ChannelMessage[];
+
+function kinds(nodes: TimelineNode[]): string[] {
+  return nodes.map((node) => node.kind);
+}
+
+function groupSeqs(node: TimelineNode): number[] {
+  return node.kind === 'group' ? node.messages.map((m) => m.seq) : [];
+}
+
+function msg(overrides: Partial<ChannelMessage>): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: 'chm:x' as ChannelMessageId,
+    channelId: 'topic:general',
+    seq: 1,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: 'x', format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-18T10:00:00.000Z',
+    updatedAt: '2026-07-18T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('buildTimelineNodes — mixed fixture', () => {
+  it('produces the exact node sequence with no unread marker (lastReadSeq null)', () => {
+    const nodes = buildTimelineNodes(fixture, null);
+    expect(kinds(nodes)).toEqual([
+      'day-divider',
+      'group', // human 1,2
+      'group', // claude 3,4 (streaming + complete, same sender within window)
+      'group', // claude 5,6 (>5min gap breaks group even though same sender)
+      'system', // 7
+      'day-divider', // day boundary
+      'group', // human 8,9
+    ]);
+    expect(groupSeqs(nodes[1]!)).toEqual([1, 2]);
+    expect(groupSeqs(nodes[2]!)).toEqual([3, 4]);
+    expect(groupSeqs(nodes[3]!)).toEqual([5, 6]);
+    expect(groupSeqs(nodes[6]!)).toEqual([8, 9]);
+    expect(nodes.some((n) => n.kind === 'unread-line')).toBe(false);
+  });
+
+  it('day dividers carry the correct local dates', () => {
+    const dividers = buildTimelineNodes(fixture, null).filter(
+      (n): n is Extract<TimelineNode, { kind: 'day-divider' }> =>
+        n.kind === 'day-divider'
+    );
+    expect(dividers.map((d) => d.date)).toEqual(['2026-07-17', '2026-07-18']);
+  });
+
+  it('never groups a system message with its neighbors', () => {
+    const nodes = buildTimelineNodes(fixture, null);
+    const system = nodes.find((n) => n.kind === 'system');
+    expect(system).toBeTruthy();
+    if (system?.kind === 'system') expect(system.message.seq).toBe(7);
+  });
+
+  it('inserts the unread line before the first message past lastReadSeq', () => {
+    const nodes = buildTimelineNodes(fixture, 4);
+    const unreadIndex = nodes.findIndex((n) => n.kind === 'unread-line');
+    expect(unreadIndex).toBeGreaterThan(-1);
+    // The node immediately after the unread line is the group starting at seq 5.
+    const next = nodes[unreadIndex + 1];
+    expect(next?.kind).toBe('group');
+    expect(groupSeqs(next!)).toEqual([5, 6]);
+    // Everything before the unread line has seq <= 4.
+    const before = nodes
+      .slice(0, unreadIndex)
+      .flatMap((n) => (n.kind === 'group' ? n.messages.map((m) => m.seq) : []));
+    expect(Math.max(...before)).toBe(4);
+  });
+});
+
+describe('buildTimelineNodes — grouping rules', () => {
+  it('breaks a group when the gap exceeds the 5-minute window', () => {
+    const base = '2026-07-18T10:00:00.000Z';
+    const later = new Date(
+      Date.parse(base) + GROUP_WINDOW_MS + 1000
+    ).toISOString();
+    const nodes = buildTimelineNodes(
+      [
+        msg({ id: 'chm:1' as ChannelMessageId, seq: 1, createdAt: base }),
+        msg({ id: 'chm:2' as ChannelMessageId, seq: 2, createdAt: later }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group', 'group']);
+  });
+
+  it('keeps same-sender messages within the window in one group', () => {
+    const nodes = buildTimelineNodes(
+      [
+        msg({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          createdAt: '2026-07-18T10:00:00.000Z',
+        }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          createdAt: '2026-07-18T10:04:00.000Z',
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group']);
+    expect(groupSeqs(nodes[1]!)).toEqual([1, 2]);
+  });
+
+  it('breaks a group when the sender changes', () => {
+    const nodes = buildTimelineNodes(
+      [
+        msg({ id: 'chm:1' as ChannelMessageId, seq: 1 }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          sender: { kind: 'agent', id: 'agent:claude', providerId: 'claude' },
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group', 'group']);
+  });
+
+  it('returns an empty node list for no messages', () => {
+    expect(buildTimelineNodes([], null)).toEqual([]);
+  });
+});
+
+describe('formatDayLabel', () => {
+  it('renders today/yesterday relative to now, lowercase', () => {
+    const now = new Date('2026-07-18T12:00:00');
+    expect(formatDayLabel('2026-07-18', now)).toBe('today');
+    expect(formatDayLabel('2026-07-17', now)).toBe('yesterday');
+  });
+
+  it('renders an absolute lowercase "ddd, mmm d" label otherwise', () => {
+    const now = new Date('2026-07-18T12:00:00');
+    // 2026-07-10 is a Friday.
+    expect(formatDayLabel('2026-07-10', now)).toBe('fri, jul 10');
+  });
+});

--- a/test/customize-session-dialog-dm-channel.test.ts
+++ b/test/customize-session-dialog-dm-channel.test.ts
@@ -1,0 +1,295 @@
+// @vitest-environment happy-dom
+
+import React, { act, createRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { FrameworkInfo } from '../frontend/src/lib/types.js';
+import type { CustomizeSessionDialogHandle } from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
+import type { AggregatedRepoInventoryResponse } from '../shared/repo-inventory.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
+
+const mocks = vi.hoisted(() => ({
+  fetchRepoInventory: vi.fn(),
+  fetchHubNodes: vi.fn(),
+  createAgentSession: vi.fn(),
+  getOrCreateDmChannel: vi.fn(),
+  setActiveChannelId: vi.fn(),
+  configState: {
+    defaultContinue: false,
+    defaultYolo: false,
+    defaultAgent: 'hermes',
+    defaultNotifications: true,
+    claudeFullscreen: true,
+    frameworks: [] as FrameworkInfo[],
+    refreshConfig: vi.fn(),
+    loadFrameworks: vi.fn(),
+  },
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    fetchRepoInventory: mocks.fetchRepoInventory,
+    fetchHubNodes: mocks.fetchHubNodes,
+  };
+});
+
+vi.mock(
+  '../frontend/src/hooks/useTopicRoomCreate.js',
+  async (importOriginal) => {
+    const actual = await importOriginal<object>();
+    return { ...actual, getOrCreateDmChannel: mocks.getOrCreateDmChannel };
+  }
+);
+
+vi.mock('../frontend/src/lib/stores/config.js', () => {
+  const useConfigStore = (
+    selector: (state: typeof mocks.configState) => unknown
+  ) => selector(mocks.configState);
+  useConfigStore.getState = () => mocks.configState;
+  return { useConfigStore };
+});
+
+vi.mock('../frontend/src/lib/stores/ui.js', () => ({
+  DEFAULT_TERMINAL_FONT_SIZE: 14,
+  useUiStore: {
+    getState: () => ({
+      terminalFontSize: 14,
+      activeWorkspaceId: null,
+      setActiveChannelId: mocks.setActiveChannelId,
+    }),
+  },
+}));
+
+vi.mock('../frontend/src/lib/session-utils.js', () => ({
+  createAgentSession: mocks.createAgentSession,
+}));
+
+vi.mock('../frontend/src/components/dialogs/DialogShell.js', async () => {
+  const ReactModule = await import('react');
+  type DialogShellHandle = { open: () => void; close: () => void };
+  interface MockDialogShellProps {
+    title: string;
+    children: ReactModule.ReactNode;
+    footer?: ReactModule.ReactNode;
+  }
+  const DialogShell = ReactModule.forwardRef<
+    DialogShellHandle,
+    MockDialogShellProps
+  >(function MockDialogShell({ title, children, footer }, ref) {
+    const [open, setOpen] = ReactModule.useState(false);
+    ReactModule.useImperativeHandle(ref, () => ({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+    }));
+    return ReactModule.createElement(
+      'div',
+      { role: 'dialog', 'aria-label': title, 'data-open': String(open) },
+      open
+        ? ReactModule.createElement(
+            ReactModule.Fragment,
+            null,
+            children,
+            footer
+          )
+        : null
+    );
+  });
+  return { default: DialogShell };
+});
+
+const { default: CustomizeSessionDialog } =
+  await import('../frontend/src/components/dialogs/CustomizeSessionDialog.js');
+
+function webFramework(id = 'hermes'): FrameworkInfo {
+  return {
+    id,
+    displayName: id === 'hermes' ? 'Hermes' : id,
+    command: id,
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: false,
+      supportsWebSessions: true,
+    },
+    eventSource: 'hooks',
+    availability: { installed: true, path: `/usr/local/bin/${id}` },
+  } as FrameworkInfo;
+}
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'local',
+    displayName: 'local mac',
+    hostname: 'local.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'local', status: 'connected' },
+    capabilities: {
+      totals: { available: 10, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        git: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      terminalBackends: { 'relay-pty': 'available' },
+      agents: { hermes: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-05-12T00:00:00.000Z',
+    pairedAt: '2026-05-12T00:00:00.000Z',
+    lastSeenAt: '2026-05-12T00:00:00.000Z',
+    credentialId: 'cred-local',
+    ...overrides,
+  } as HubNodeSummary;
+}
+
+function inventory(prefix: string): AggregatedRepoInventoryResponse {
+  return {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    reports: [],
+    groups: ['one', 'two'].map((suffix, index) => ({
+      groupId: `${prefix}-${suffix}`,
+      repoIdentity: `github.com/example/${prefix}-${suffix}`,
+      displayName: `${prefix}-${suffix}`,
+      selectedRemote: null,
+      remotes: [],
+      warnings: [],
+      identityDebug: {
+        groupedBy: 'repoIdentity',
+        repoIdentity: `github.com/example/${prefix}-${suffix}`,
+        instanceCount: 1,
+        nodeIds: ['local'],
+      },
+      instances: [
+        {
+          repoInstanceId: `local:%2Ftmp%2F${prefix}-${suffix}`,
+          nodeId: 'local',
+          localPath: `/tmp/${prefix}-${suffix}`,
+          name: `${prefix}-${suffix}`,
+          isGitRepo: true,
+          defaultBranch: 'nightly',
+          currentBranch: index === 0 ? 'nightly' : 'feature',
+          repoIdentity: `github.com/example/${prefix}-${suffix}`,
+          selectedRemote: null,
+          remotes: [],
+          repoIdentityWarnings: [],
+          worktrees: [],
+          reportedAt: '2026-05-12T00:00:00.000Z',
+        },
+      ],
+    })),
+  } as AggregatedRepoInventoryResponse;
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderAndOpen(): Promise<{
+  el: HTMLElement;
+  onSessionCreated: ReturnType<typeof vi.fn>;
+}> {
+  mocks.configState.frameworks = [webFramework('hermes')];
+  mocks.configState.defaultAgent = 'hermes';
+  mocks.configState.refreshConfig.mockResolvedValue(undefined);
+  mocks.fetchRepoInventory.mockResolvedValue(inventory('local'));
+  mocks.fetchHubNodes.mockResolvedValue([node()]);
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const ref = createRef<CustomizeSessionDialogHandle>();
+  const onSessionCreated = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  await act(async () => {
+    root!.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(CustomizeSessionDialog, { ref, onSessionCreated })
+      )
+    );
+  });
+  await act(async () => {
+    await ref.current!.open({ name: 'local-one', path: '/tmp/local-one' });
+  });
+  await flush();
+  return { el: container, onSessionCreated };
+}
+
+describe('CustomizeSessionDialog DM channel routing (#1178)', () => {
+  beforeEach(() => {
+    mocks.getOrCreateDmChannel.mockResolvedValue({
+      id: dmChannelTopicId('hermes', null),
+    });
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    container = null;
+    root = null;
+    vi.clearAllMocks();
+  });
+
+  it('opens the DM channel without routing the topic id through onSessionCreated', async () => {
+    const { el, onSessionCreated } = await renderAndOpen();
+
+    // hermes defaults to web mode; make it explicit if the mode select exists.
+    const modeSelect = el.querySelector('#cs-mode') as HTMLSelectElement | null;
+    if (modeSelect && modeSelect.value !== 'web') {
+      await act(async () => {
+        modeSelect.value = 'web';
+        modeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      await flush();
+    }
+
+    await act(async () => {
+      (
+        el.querySelector(
+          '[data-track="dialog.customize-session.create"]'
+        ) as HTMLButtonElement
+      ).click();
+    });
+    await flush();
+
+    const dmId = dmChannelTopicId('hermes', null);
+    // Routed a web agent launch to the DM channel...
+    expect(mocks.getOrCreateDmChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'hermes' })
+    );
+    // ...opened via the channel path...
+    expect(mocks.setActiveChannelId).toHaveBeenCalledWith(dmId);
+    // ...and NEVER through the session-selection callback (no flash-and-close,
+    // no bogus 'topic:...' active-session key).
+    expect(onSessionCreated).not.toHaveBeenCalled();
+    // No mode:'web' session was created either.
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
+  });
+});

--- a/test/fixtures/channel-chat/mixed-timeline.json
+++ b/test/fixtures/channel-chat/mixed-timeline.json
@@ -1,0 +1,161 @@
+[
+  {
+    "schemaVersion": 1,
+    "id": "chm:1",
+    "channelId": "topic:general",
+    "seq": 1,
+    "kind": "message",
+    "status": "complete",
+    "sender": { "kind": "human", "id": "human:operator", "displayName": "you" },
+    "body": { "text": "first human message", "format": "markdown" },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:00:00.000Z",
+    "updatedAt": "2026-07-17T10:00:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:2",
+    "channelId": "topic:general",
+    "seq": 2,
+    "kind": "message",
+    "status": "complete",
+    "sender": { "kind": "human", "id": "human:operator", "displayName": "you" },
+    "body": {
+      "text": "second human message (same group)",
+      "format": "markdown"
+    },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:01:00.000Z",
+    "updatedAt": "2026-07-17T10:01:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:3",
+    "channelId": "topic:general",
+    "seq": 3,
+    "kind": "message",
+    "status": "streaming",
+    "sender": {
+      "kind": "agent",
+      "id": "agent:claude",
+      "providerId": "claude",
+      "displayName": "claude"
+    },
+    "body": { "text": "streaming partial output", "format": "markdown" },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:02:00.000Z",
+    "updatedAt": "2026-07-17T10:02:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:4",
+    "channelId": "topic:general",
+    "seq": 4,
+    "kind": "message",
+    "status": "complete",
+    "sender": {
+      "kind": "agent",
+      "id": "agent:claude",
+      "providerId": "claude",
+      "displayName": "claude"
+    },
+    "body": {
+      "text": "completed agent message (group continuation)",
+      "format": "markdown"
+    },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:03:00.000Z",
+    "updatedAt": "2026-07-17T10:03:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:5",
+    "channelId": "topic:general",
+    "seq": 5,
+    "kind": "message",
+    "status": "interrupted",
+    "sender": {
+      "kind": "agent",
+      "id": "agent:claude",
+      "providerId": "claude",
+      "displayName": "claude"
+    },
+    "body": { "text": "this reply was interrupted", "format": "markdown" },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:20:00.000Z",
+    "updatedAt": "2026-07-17T10:20:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:6",
+    "channelId": "topic:general",
+    "seq": 6,
+    "kind": "message",
+    "status": "failed",
+    "sender": {
+      "kind": "agent",
+      "id": "agent:claude",
+      "providerId": "claude",
+      "displayName": "claude"
+    },
+    "body": { "text": "this reply failed", "format": "markdown" },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:21:00.000Z",
+    "updatedAt": "2026-07-17T10:21:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:7",
+    "channelId": "topic:general",
+    "seq": 7,
+    "kind": "system",
+    "status": "complete",
+    "sender": { "kind": "system", "id": "system" },
+    "body": {
+      "text": "stream interrupted by server restart",
+      "format": "text"
+    },
+    "threadId": null,
+    "parentMessageId": null,
+    "createdAt": "2026-07-17T10:22:00.000Z",
+    "updatedAt": "2026-07-17T10:22:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:8",
+    "channelId": "topic:general",
+    "seq": 8,
+    "kind": "message",
+    "status": "complete",
+    "sender": { "kind": "human", "id": "human:operator", "displayName": "you" },
+    "body": { "text": "a very large truncated message", "format": "markdown" },
+    "threadId": null,
+    "parentMessageId": null,
+    "truncated": true,
+    "createdAt": "2026-07-18T09:00:00.000Z",
+    "updatedAt": "2026-07-18T09:00:00.000Z"
+  },
+  {
+    "schemaVersion": 1,
+    "id": "chm:9",
+    "channelId": "topic:general",
+    "seq": 9,
+    "kind": "message",
+    "status": "complete",
+    "sender": { "kind": "human", "id": "human:operator", "displayName": "you" },
+    "body": {
+      "text": "reply referencing an earlier message",
+      "format": "markdown"
+    },
+    "threadId": "chm:4",
+    "parentMessageId": "chm:4",
+    "createdAt": "2026-07-18T09:01:00.000Z",
+    "updatedAt": "2026-07-18T09:01:00.000Z"
+  }
+]

--- a/test/hooks/useChannelChatSocket.test.ts
+++ b/test/hooks/useChannelChatSocket.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { UseChannelChatSocketState } from '../../frontend/src/hooks/useChannelChatSocket.js';
+import { useChannelActivityStore } from '../../frontend/src/lib/stores/channel-activity.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const fetchChannelMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return { ...actual, fetchChannel: fetchChannelMock as Mock };
+});
+
+import { useChannelChatSocket } from '../../frontend/src/hooks/useChannelChatSocket.js';
+
+// ── Minimal WebSocket double ─────────────────────────────────────────────────
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: ((ev: { code: number }) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  // test-driven server events
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+  message(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+  serverClose(code = 1006): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code });
+  }
+
+  // client-initiated close: the hook nulls handlers first, so no onclose fires
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+  send(): void {}
+}
+
+const CID = 'topic:test-channel';
+
+function summary(latestSeq: number) {
+  return {
+    id: CID,
+    title: 'test',
+    visibility: 'default' as const,
+    archived: false,
+    latestSeq,
+    messageCount: latestSeq,
+    lastMessage: null,
+    members: [],
+  };
+}
+
+function fullSnapshot(latestSeq: number) {
+  return {
+    type: 'channel-snapshot-v1',
+    channelId: CID,
+    timestamp: new Date().toISOString(),
+    mode: 'full',
+    messages: [],
+    members: [],
+    latestSeq,
+    inFlight: [],
+    truncated: false,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let latest: UseChannelChatSocketState;
+
+function Harness({ channelId }: { channelId: string | null }) {
+  latest = useChannelChatSocket(channelId);
+  return null;
+}
+
+async function render(channelId: string | null): Promise<void> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await act(async () => {
+    root.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(Harness, { channelId })
+      )
+    );
+  });
+}
+
+function currentSocket(): MockWebSocket {
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1]!;
+}
+
+async function openCurrent(): Promise<void> {
+  await act(async () => {
+    currentSocket().open();
+    await Promise.resolve();
+  });
+}
+
+async function sendSnapshot(latestSeq: number): Promise<void> {
+  await act(async () => {
+    currentSocket().message(fullSnapshot(latestSeq));
+    await Promise.resolve();
+  });
+}
+
+describe('useChannelChatSocket liveness + recovery (#1178)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    fetchChannelMock.mockReset();
+    fetchChannelMock.mockResolvedValue(summary(0));
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    useChannelActivityStore.setState({
+      latestSeqByChannel: {},
+      lastReadByChannel: {},
+    });
+    try {
+      localStorage.clear();
+    } catch {
+      /* ignore */
+    }
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('idle-probe forces a reconnect when a REST head-check outruns the socket', async () => {
+    await render(CID);
+    await openCurrent();
+    await sendSnapshot(5); // reducer.lastSeq → 5, cursor → 5
+    expect(latest.connected).toBe(true);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // Server advanced past what the (now half-dead) socket ever delivered.
+    fetchChannelMock.mockResolvedValue(summary(9));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(151_000);
+    });
+
+    // A fresh socket was opened to catch up.
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('idle-probe leaves a healthy-but-quiet socket alone', async () => {
+    await render(CID);
+    await openCurrent();
+    await sendSnapshot(5);
+
+    fetchChannelMock.mockResolvedValue(summary(5)); // no divergence
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200_000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('visibilitychange reconnects a socket that silently closed', async () => {
+    await render(CID);
+    await openCurrent();
+    await act(async () => {
+      currentSocket().serverClose(1006); // NAT/proxy drop → backoff pending
+      await Promise.resolve();
+    });
+    const afterClose = MockWebSocket.instances.length;
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+
+    expect(MockWebSocket.instances.length).toBe(afterClose + 1);
+  });
+
+  it('resync cancels a pending backoff timer so it cannot reopen later', async () => {
+    await render(CID);
+    await openCurrent();
+    await act(async () => {
+      currentSocket().serverClose(1006); // schedules a 1s backoff reconnect
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latest.resync();
+      await Promise.resolve();
+    });
+    const afterResync = MockWebSocket.instances.length;
+
+    // The stale backoff timer must NOT also fire and tear down the new socket.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(MockWebSocket.instances.length).toBe(afterResync);
+  });
+
+  it('surfaces disconnected after the reconnect budget is exhausted, then resync recovers', async () => {
+    await render(CID);
+    await openCurrent();
+
+    for (let i = 0; i < 40 && !latest.disconnected; i++) {
+      await act(async () => {
+        currentSocket().serverClose(1006);
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+    }
+
+    expect(latest.disconnected).toBe(true);
+    expect(latest.connected).toBe(false);
+
+    const before = MockWebSocket.instances.length;
+    await act(async () => {
+      latest.resync();
+      await Promise.resolve();
+    });
+    expect(latest.disconnected).toBe(false);
+    expect(MockWebSocket.instances.length).toBe(before + 1);
+  });
+
+  it('clamps client seq stores DOWN when a full snapshot head is below the stored marker', async () => {
+    // A DM recreated under the same deterministic id restarts seq low.
+    useChannelActivityStore.getState().recordActivity(CID, 50);
+    useChannelActivityStore.getState().markChannelRead(CID, 40);
+
+    await render(CID);
+    await openCurrent();
+    await sendSnapshot(5); // authoritative head is now 5
+
+    const state = useChannelActivityStore.getState();
+    expect(state.latestSeqByChannel[CID]).toBe(5);
+    expect(state.lastReadByChannel[CID]).toBe(5);
+  });
+});

--- a/test/lib/channel-history-merge.test.ts
+++ b/test/lib/channel-history-merge.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  initialChannelReducerState,
+  mergeHistoryPage,
+  type ChannelMessage,
+  type ChannelMessageId,
+  type ChannelReducerState,
+} from '../../shared/channel-chat-protocol.js';
+
+function msg(seq: number): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: 'topic:general',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: `m${seq}`, format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-18T00:00:00.000Z',
+    updatedAt: '2026-07-18T00:00:00.000Z',
+  };
+}
+
+function stateWith(seqs: number[], lastSeq: number): ChannelReducerState {
+  const messages = seqs.map(msg);
+  const byId: Record<string, ChannelMessage> = {};
+  for (const m of messages) byId[m.id] = m;
+  return {
+    ...initialChannelReducerState('topic:general'),
+    messages,
+    byId,
+    lastSeq,
+  };
+}
+
+describe('mergeHistoryPage', () => {
+  it('prepends older messages, keeping seq order and lastSeq unchanged', () => {
+    const state = stateWith([3, 4], 4);
+    const next = mergeHistoryPage(state, [msg(1), msg(2)]);
+    expect(next.messages.map((m) => m.seq)).toEqual([1, 2, 3, 4]);
+    expect(Object.keys(next.byId).sort()).toEqual([
+      'chm:1',
+      'chm:2',
+      'chm:3',
+      'chm:4',
+    ]);
+    expect(next.lastSeq).toBe(4);
+  });
+
+  it('is idempotent for overlapping pages (dedupes by id)', () => {
+    const state = stateWith([3, 4], 4);
+    const once = mergeHistoryPage(state, [msg(2), msg(3)]);
+    const twice = mergeHistoryPage(once, [msg(2), msg(3)]);
+    expect(twice.messages.map((m) => m.seq)).toEqual([2, 3, 4]);
+  });
+
+  it('returns the same state reference for an empty page', () => {
+    const state = stateWith([1], 1);
+    expect(mergeHistoryPage(state, [])).toBe(state);
+  });
+
+  it('raises lastSeq if the page contains a newer message than current', () => {
+    const state = stateWith([1], 1);
+    const next = mergeHistoryPage(state, [msg(5)]);
+    expect(next.lastSeq).toBe(5);
+    expect(next.messages.map((m) => m.seq)).toEqual([1, 5]);
+  });
+});

--- a/test/lib/chat/sender-identity.test.ts
+++ b/test/lib/chat/sender-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSenderIdentity } from '../../../frontend/src/lib/chat/sender-identity.js';
+
+describe('resolveSenderIdentity', () => {
+  it('renders human as "you" with no glyph and the text color', () => {
+    const id = resolveSenderIdentity({ kind: 'human', id: 'human:operator' });
+    expect(id.kind).toBe('human');
+    expect(id.label).toBe('you');
+    expect(id.glyph).toBe(null);
+    expect(id.colorVar).toBe('var(--text)');
+  });
+
+  it('honors a human displayName override', () => {
+    const id = resolveSenderIdentity({
+      kind: 'human',
+      id: 'human:op',
+      displayName: 'operator',
+    });
+    expect(id.label).toBe('operator');
+  });
+
+  it('renders system with the muted sender token and no glyph', () => {
+    const id = resolveSenderIdentity({ kind: 'system', id: 'system' });
+    expect(id.kind).toBe('system');
+    expect(id.glyph).toBe(null);
+    expect(id.colorVar).toBe('var(--sender-system)');
+  });
+
+  it.each([
+    ['claude', 'var(--sender-claude)'],
+    ['codex', 'var(--sender-codex)'],
+    ['hermes', 'var(--sender-hermes)'],
+    ['opencode', 'var(--sender-opencode)'],
+  ] as const)(
+    'maps known agent %s to its fixed color token and glyph',
+    (providerId, colorVar) => {
+      const id = resolveSenderIdentity({
+        kind: 'agent',
+        id: `agent:${providerId}`,
+        providerId,
+      });
+      expect(id.kind).toBe('agent');
+      expect(id.colorVar).toBe(colorVar);
+      expect(id.glyph).toBe(providerId);
+      expect(id.label).toBe(providerId);
+    }
+  );
+
+  it('derives providerId from the id when the field is absent', () => {
+    const id = resolveSenderIdentity({ kind: 'agent', id: 'agent:claude' });
+    expect(id.glyph).toBe('claude');
+    expect(id.colorVar).toBe('var(--sender-claude)');
+  });
+
+  it('falls back to a hash-derived color and null glyph for custom providers', () => {
+    const id = resolveSenderIdentity({
+      kind: 'agent',
+      id: 'agent:custom:acme',
+      providerId: 'custom:acme',
+      displayName: 'Acme Bot',
+    });
+    expect(id.glyph).toBe(null);
+    expect(id.label).toBe('Acme Bot');
+    // Not a sender token — a concrete hex from the hash palette.
+    expect(id.colorVar.startsWith('#')).toBe(true);
+  });
+});

--- a/test/lib/dm-channels.test.ts
+++ b/test/lib/dm-channels.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DM_DEFAULT_WORKSPACE_ID,
+  dmChannelCreateInput,
+  dmChannelTopicId,
+  isDmChannel,
+} from '../../frontend/src/lib/dm-channels.js';
+import { createWorkspaceTopicId } from '../../shared/workspace-topics.js';
+import type { WorkspaceTopic } from '../../shared/workspace-topics.js';
+
+function topic(overrides: Partial<WorkspaceTopic>): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:x',
+    workspaceId: 'workspace:local',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'x' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: {},
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: '2026-07-18T00:00:00.000Z',
+    updatedAt: '2026-07-18T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('dmChannelTopicId', () => {
+  it('is deterministic per (workspace, provider) and stable across calls', () => {
+    const a = dmChannelTopicId('claude', 'workspace:local');
+    const b = dmChannelTopicId('claude', 'workspace:local');
+    expect(a).toBe(b);
+    expect(a).toBe(createWorkspaceTopicId('dm-claude', 'workspace:local'));
+  });
+
+  it('defaults a null workspace to the local sentinel', () => {
+    expect(dmChannelTopicId('hermes', null)).toBe(
+      dmChannelTopicId('hermes', DM_DEFAULT_WORKSPACE_ID)
+    );
+  });
+
+  it('produces distinct ids per provider and per workspace', () => {
+    expect(dmChannelTopicId('claude', 'workspace:local')).not.toBe(
+      dmChannelTopicId('codex', 'workspace:local')
+    );
+    expect(dmChannelTopicId('claude', 'workspace:local')).not.toBe(
+      dmChannelTopicId('claude', 'workspace:acme')
+    );
+  });
+});
+
+describe('isDmChannel', () => {
+  it('returns the providerId when the id matches its own deterministic form', () => {
+    const workspaceId = 'workspace:local';
+    const dm = topic({
+      workspaceId,
+      id: dmChannelTopicId('claude', workspaceId),
+      routingDefaults: { providerId: 'claude' },
+    });
+    expect(isDmChannel(dm)).toBe('claude');
+  });
+
+  it('returns null for a regular channel (no provider)', () => {
+    expect(
+      isDmChannel(topic({ id: 'topic:general', routingDefaults: {} }))
+    ).toBe(null);
+  });
+
+  it('returns null when the id does not match the provider formula', () => {
+    // A topic that HAS a providerId but whose id was not minted by the DM
+    // formula (e.g. a normal repo channel that happens to route to claude).
+    const notDm = topic({
+      id: 'topic:frontend',
+      workspaceId: 'workspace:local',
+      routingDefaults: { providerId: 'claude' },
+    });
+    expect(isDmChannel(notDm)).toBe(null);
+  });
+
+  it('is workspace-sensitive: a DM id from another workspace is not a DM here', () => {
+    const other = topic({
+      workspaceId: 'workspace:local',
+      id: dmChannelTopicId('claude', 'workspace:acme'),
+      routingDefaults: { providerId: 'claude' },
+    });
+    expect(isDmChannel(other)).toBe(null);
+  });
+});
+
+describe('dmChannelCreateInput', () => {
+  it('builds a create body whose id round-trips through isDmChannel', () => {
+    const input = dmChannelCreateInput({
+      providerId: 'codex',
+      providerDisplayName: 'Codex',
+      workspaceId: 'workspace:local',
+    });
+    expect(input.id).toBe(dmChannelTopicId('codex', 'workspace:local'));
+    expect(input.routingDefaults).toEqual({ providerId: 'codex' });
+    expect(input.title).toBe('Codex');
+    expect(isDmChannel(topic({ ...input, id: input.id! }))).toBe('codex');
+  });
+
+  it('defaults workspace to the local sentinel', () => {
+    const input = dmChannelCreateInput({
+      providerId: 'hermes',
+      providerDisplayName: 'Hermes',
+      workspaceId: null,
+    });
+    expect(input.workspaceId).toBe(DM_DEFAULT_WORKSPACE_ID);
+  });
+});

--- a/test/lib/dm-channels.test.ts
+++ b/test/lib/dm-channels.test.ts
@@ -39,7 +39,23 @@ describe('dmChannelTopicId', () => {
     const a = dmChannelTopicId('claude', 'workspace:local');
     const b = dmChannelTopicId('claude', 'workspace:local');
     expect(a).toBe(b);
-    expect(a).toBe(createWorkspaceTopicId('dm-claude', 'workspace:local'));
+    // Namespaced with `~` so it lives in an id sub-namespace no title can reach.
+    expect(a).toBe('topic:dm~claude~workspace-local');
+  });
+
+  it('cannot collide with a title-derived id of an ordinary topic (#1178)', () => {
+    // The server mints ordinary topic ids from the user title via
+    // createWorkspaceTopicId. A user topic titled "dm claude" / "DM-Claude"
+    // would previously mint the exact old DM id; the `~` namespace forbids it.
+    const workspaceId = 'workspace:local';
+    for (const title of ['dm claude', 'DM-Claude', 'dm-claude', 'dm.claude']) {
+      expect(dmChannelTopicId('claude', workspaceId)).not.toBe(
+        createWorkspaceTopicId(title, workspaceId)
+      );
+    }
+    // The DM id contains a `~`; a title-derived id provably never can.
+    expect(dmChannelTopicId('claude', workspaceId)).toContain('~');
+    expect(createWorkspaceTopicId('dm claude', workspaceId)).not.toContain('~');
   });
 
   it('defaults a null workspace to the local sentinel', () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -49,6 +49,7 @@ import { useUiStore } from '../frontend/src/lib/stores/ui.js';
 import type { FrameworkInfo } from '../frontend/src/lib/types.js';
 import TopicComposer from '../frontend/src/components/TopicComposer.js';
 import ChatHome from '../frontend/src/components/ChatHome.js';
+import { scopedSessionKey } from '../frontend/src/lib/session-keys.js';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -698,6 +699,102 @@ describe('TopicComposer', () => {
     expect(createArg?.id).toBe(dmId);
     expect(createArg?.routingDefaults).toEqual({ providerId: 'hermes' });
     expect(useUiStore.getState().activeChannelId).toBe(dmId);
+  });
+
+  it('opens the DM via the channel path only — never the session-selection callback (#1178)', async () => {
+    // Regression for the flash-and-close bug: routing the topic id through
+    // onSelectSession (→ handleSelectSession → setActiveSessionId in the app)
+    // triggers the channel↔session mutual-exclusion effect, which clears the
+    // channel we just opened AND persists a bogus 'topic:...' active-session key.
+    const dmId = dmChannelTopicId('hermes', null);
+    vi.mocked(fetchWorkspaceTopic).mockResolvedValue({
+      id: dmId,
+      workspaceId: 'workspace:local',
+      routingDefaults: { providerId: 'hermes' },
+      display: { title: 'Hermes' },
+    } as never);
+    vi.mocked(postChannelMessage).mockResolvedValue({} as never);
+    const onSelectSession = vi.fn();
+    renderComposer(onSelectSession);
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const provider = container.querySelector(
+      '.topic-composer__provider-select'
+    ) as HTMLSelectElement;
+    act(() => {
+      setNativeValue(ta, 'via hermes');
+      setSelectValue(provider, 'hermes');
+    });
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    // Channel opened, and NO session key was routed/persisted.
+    expect(useUiStore.getState().activeChannelId).toBe(dmId);
+    expect(onSelectSession).not.toHaveBeenCalled();
+    expect(useSessionsStore.getState().activeSessionId).toBeNull();
+  });
+
+  it("resume never targets a mode:'web' session, even when it is the most recent (#1178)", async () => {
+    // The retired per-session web-chat surface must not be resurrected by the
+    // one-tap resume affordance — resume iterates the web-excluded live set.
+    const webSession = {
+      id: 'sess-web',
+      type: 'agent',
+      agent: 'hermes',
+      mode: 'web',
+      repoPath: '/repo/relay-ide',
+      cwd: '/repo/relay-ide',
+      displayName: 'web chat (newer)',
+      createdAt: '2026-07-10T00:00:00.000Z',
+      lastActivity: '2026-07-10T00:00:00.000Z',
+      idle: false,
+    } as const;
+    const ptySession = {
+      id: 'sess-pty',
+      type: 'agent',
+      agent: 'claude',
+      mode: 'pty',
+      repoPath: '/repo/relay-ide',
+      cwd: '/repo/relay-ide',
+      displayName: 'claude tui (older)',
+      createdAt: '2026-07-05T00:00:00.000Z',
+      lastActivity: '2026-07-05T00:00:00.000Z',
+      idle: false,
+    } as const;
+    useSessionsStore.setState({
+      sessions: [webSession, ptySession] as never,
+      activeSessionId: null,
+      refreshAll: vi.fn(async () => {}),
+    });
+    useUiStore.setState({
+      activeRepoPath: null,
+      forceOrgCockpit: false,
+      topicComposerOpen: false,
+      activeChannelId: null,
+    });
+
+    const onSelectSession = vi.fn();
+    renderChatHome(onSelectSession);
+
+    const resumeBtn = Array.from(
+      container.querySelectorAll('.topic-composer__footer button')
+    ).find((b) => b.textContent?.startsWith('resume')) as
+      | HTMLButtonElement
+      | undefined;
+    // Resume points at the older pty session, not the newer web one.
+    expect(resumeBtn?.textContent).toContain('claude tui (older)');
+    expect(resumeBtn?.textContent).not.toContain('web chat');
+
+    await act(async () => resumeBtn?.click());
+    expect(onSelectSession).toHaveBeenCalledWith(scopedSessionKey(ptySession));
+    expect(onSelectSession).not.toHaveBeenCalledWith(
+      scopedSessionKey(webSession)
+    );
   });
 
   it('keeps a launched chat in the chat shell while the sessions feed catches up', async () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -21,6 +21,10 @@ vi.mock('../frontend/src/lib/api.js', async (importOriginal) => {
     fetchHubNodes: vi.fn().mockResolvedValue([]),
     createWorkspaceTopicRoomAndMaybeLaunch: vi.fn(),
     launchWorkspaceTopicRoom: vi.fn(),
+    // #1166: DM-as-channel entry point (web-mode agent launches route here).
+    fetchWorkspaceTopic: vi.fn(),
+    createWorkspaceTopic: vi.fn(),
+    postChannelMessage: vi.fn(),
   };
 });
 
@@ -33,8 +37,12 @@ vi.mock('../frontend/src/components/chat/ChatView.js', () => ({
 
 import {
   createWorkspaceTopicRoomAndMaybeLaunch,
+  createWorkspaceTopic,
+  fetchWorkspaceTopic,
   launchWorkspaceTopicRoom,
+  postChannelMessage,
 } from '../frontend/src/lib/api.js';
+import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
 import { useConfigStore } from '../frontend/src/lib/stores/config.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
@@ -361,6 +369,7 @@ describe('TopicComposer', () => {
       activeRepoPath: null,
       forceOrgCockpit: false,
       topicComposerOpen: false,
+      activeChannelId: null,
     });
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -609,12 +618,17 @@ describe('TopicComposer', () => {
     expect(call.launch).toBeDefined();
   });
 
-  it('uses a one-off provider override without mutating settings', async () => {
-    vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
-      status: 'created',
-      topic: { id: 'topic:1' },
-      workContext: { id: 'wc:1' },
+  it('routes a one-off web-mode override to a DM channel, not a web session (#1166)', async () => {
+    // Hermes selected + web launch mode now opens the deterministic DM channel
+    // and posts the first message, instead of spawning a mode:'web' session.
+    const dmId = dmChannelTopicId('hermes', null);
+    vi.mocked(fetchWorkspaceTopic).mockResolvedValue({
+      id: dmId,
+      workspaceId: 'workspace:local',
+      routingDefaults: { providerId: 'hermes' },
+      display: { title: 'Hermes' },
     } as never);
+    vi.mocked(postChannelMessage).mockResolvedValue({} as never);
     renderComposer();
     const ta = container.querySelector(
       '.topic-composer__ta'
@@ -637,14 +651,53 @@ describe('TopicComposer', () => {
     await act(async () => {
       form.dispatchEvent(new Event('submit', { bubbles: true }));
     });
-    const call = vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
-      .calls[0]?.[0] as {
-      room: { topic: { routingDefaults?: { providerId?: string } } };
-      launch?: { mode?: string; agent?: string };
-    };
-    expect(call.room.topic.routingDefaults?.providerId).toBe('hermes');
-    expect(call.launch).toMatchObject({ mode: 'web', agent: 'hermes' });
+
+    // No web session is created.
+    expect(createWorkspaceTopicRoomAndMaybeLaunch).not.toHaveBeenCalled();
+    // The DM channel is opened and the first message posted into it.
+    expect(postChannelMessage).toHaveBeenCalledWith(
+      dmId,
+      expect.objectContaining({ text: 'ship through hermes' })
+    );
+    expect(useUiStore.getState().activeChannelId).toBe(dmId);
+    expect(useUiStore.getState().topicComposerOpen).toBe(false);
+    // Settings default is untouched by the one-off override.
     expect(useConfigStore.getState().defaultAgent).toBe('claude');
+  });
+
+  it('creates the DM channel when it does not exist yet, reusing its id (#1166)', async () => {
+    const dmId = dmChannelTopicId('hermes', null);
+    const { HttpError } = await import('../frontend/src/lib/api.js');
+    vi.mocked(fetchWorkspaceTopic).mockRejectedValue(new HttpError(404));
+    vi.mocked(createWorkspaceTopic).mockResolvedValue({
+      id: dmId,
+      workspaceId: 'workspace:local',
+      routingDefaults: { providerId: 'hermes' },
+      display: { title: 'Hermes' },
+    } as never);
+    vi.mocked(postChannelMessage).mockResolvedValue({} as never);
+    renderComposer();
+    const ta = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    const provider = container.querySelector(
+      '.topic-composer__provider-select'
+    ) as HTMLSelectElement;
+    act(() => {
+      setNativeValue(ta, 'first hermes message');
+      setSelectValue(provider, 'hermes');
+    });
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+    // Created with the SAME deterministic id fetchWorkspaceTopic looked up.
+    const createArg = vi.mocked(createWorkspaceTopic).mock.calls[0]?.[0];
+    expect(createArg?.id).toBe(dmId);
+    expect(createArg?.routingDefaults).toEqual({ providerId: 'hermes' });
+    expect(useUiStore.getState().activeChannelId).toBe(dmId);
   });
 
   it('keeps a launched chat in the chat shell while the sessions feed catches up', async () => {
@@ -792,12 +845,11 @@ describe('TopicComposer', () => {
     const ta = container.querySelector(
       '.topic-composer__ta'
     ) as HTMLTextAreaElement;
-    const provider = container.querySelector(
-      '.topic-composer__provider-select'
-    ) as HTMLSelectElement;
+    // Default provider (claude) → pty session launch, which keeps the
+    // create-and-launch retry path this test covers. (Web-mode agent launches
+    // now route to a DM channel instead — see the #1166 DM tests above.)
     act(() => {
       setNativeValue(ta, 'retry this launch');
-      setSelectValue(provider, 'hermes');
     });
     const form = container.querySelector(
       '.topic-composer__form'
@@ -817,7 +869,7 @@ describe('TopicComposer', () => {
         topic: { id: 'topic:retry' },
         workContext: { id: 'wc:retry' },
       },
-      launch: expect.objectContaining({ mode: 'web', agent: 'hermes' }),
+      launch: expect.objectContaining({ mode: 'pty', agent: 'claude' }),
     });
   });
 });


### PR DESCRIPTION
## Summary

Slice 3 of epic #1163 (Slack-style workspace chat). Adds the **channel timeline UI** and unifies **DMs as deterministic-id channels**, making the old per-session web-chat surface unreachable from every UI creation path. Frontend-only plus one additive, pure shared-lib helper — no server changes.

### What shipped
- **Channel surface**: `ChannelView` / `ChannelTimeline` / `ChannelMessageGroup` / `ChannelMessageRow` / `ChannelComposer` over a new read-only WS + REST hook `useChannelChatSocket` (mirrors `useAgentChatSocket`; reuses the shared `ChannelReducerState`/`applyChannelEventV1` verbatim). Timeline grouping, day dividers, client-local unread line, streaming block cursor, interrupted/failed/truncated tags, inline reply breadcrumb, reverse-infinite-scroll paging with anchor preservation, catch-up banner.
- **Pure libs**: `dm-channels` (deterministic per-(workspace, framework) DM id derivation), `sender-identity` (fixed color/glyph table over existing DESIGN.md identity tokens — no new hex), `channel-timeline-layout` (React-free grouping/divider/unread logic), `channel-activity` store.
- **DM entry-point rewiring** (the "web session becomes unreachable" requirement): `TopicComposer`/`useTopicRoomCreate` route web-mode agent launches to `getOrCreateDmChannel` + `setActiveChannelId`; `CustomizeSessionDialog` gets the same parity fix (web option relabeled `web (opens as chat)`); `ChatHome` renders `ChannelView` and its "resume" quick action never resurfaces a `mode:'web'` session.
- **Sidebar**: channels vs. DMs split with a `direct messages` sub-section per workspace group; DM row badge shows the agent glyph in its sender color; presence-only unread-activity dot fed by the coarse `channel-activity` event.
- **Routing**: `activeChannelId` in the ui store, `resolveAppViewMode` gives it priority within `chat` mode, and App clears it on session navigation (mutual exclusion).
- **Shared (additive, pure)**: `mergeHistoryPage()` for the paging merge.
- **Design tokens**: materialized DESIGN.md's documented Repo/Project identity `--color-*` palette in `App.css` (previously only in docs + `lib/colors.ts`) and added the `--sender-*` tokens on top.

Out-of-scope seams left named but unbuilt: #1170 threads, #1171 mobile cockpit chrome, #1167 mention autocomplete, image attachments (inert `+img`), backend `mode:'web'` removal (§8.5).

## Verification

- `npm run check` — **green** (0 errors; 243 pre-existing repo-wide sonarjs warnings only). Also enforced by the pre-commit hook on this commit.
- `npm test` — new + blast-radius suites green: **255 pass / 0 fail** across `dm-channels`, `sender-identity`, `channel-history-merge`, `channel-timeline-grouping`, `topic-composer` (updated for DM routing), `app-view-mode`, `topic-nav`, `topic-sidebar-shell`, `customize-session-dialog*`, `useEventSocket`, `ui-store`, `unread`.
- Two `topic-composer` tests that asserted the now-removed hermes→web-session behavior were updated to assert the new DM-channel routing (open channel + post first message, no `mode:'web'` session); a third was re-scoped to the still-valid pty session-launch retry path.
- Full-suite failures are all pre-existing load flakes unrelated to this change (`branch-watcher` `[needs:git-init]`, `server-startup`, `cli-gateway-*-tools`, `browser-cli`, `hermes-session-api.e2e`, `hub-node-production-wiring`, `node-device-pair-cli`, `relayctl-preturn`) — none import any file touched here, and `cli-gateway-claude-tools` passes in isolation (pass-in-isolation rule).

## Runtime proof (no agent tokens — mock/seed data only)

`npm run build` → launched the built hub on an isolated port, authenticated, then:
1. `POST /workspace-topics` created a persisted DM channel (`routingDefaults.providerId=claude`).
2. `POST /channels/:id/messages` posted a human message → `201`, server-derived `sender: { kind: human, id: human:operator }`.
3. Seeded the mixed fixture (claude agent row + system + truncated + reply) via `scripts/seed-channel-chat.ts` into `channel-chat.db`.
4. `GET /channels/:id/messages` → mixed timeline with attribution: `["human","human","human","agent:claude","system","human","human"]`.
5. `WS /ws/channels/:id` → `channel-snapshot-v1` (mode `full`, latestSeq 7, 7 messages) with the same attribution.
6. **Playwright render** of the real UI: `ChannelView` rendered with header `@claude`, a `claude` group header in terracotta `rgb(217,119,87)` (= `--sender-claude`), 5 human bubbles, the agent-origin row, a `today` day divider, the system row, the `truncated · 256kb limit` tag, and the `↳ reply` breadcrumb — plus the sidebar `direct messages` sub-section. No real agent CLI invoked. Proof data cleaned up afterward.

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated chat channels and direct-message conversations with real-time messaging.
  * Added message timelines with grouping, unread markers, history loading, streaming indicators, replies, and reconnect controls.
  * Added channel composer support, including retries, archived-channel restoration, and unavailable-state messaging.
  * Added direct-message organization, sender badges, activity indicators, and provider-specific identities.
  * Web-mode agent launches now open in chat channels instead of web sessions.

* **Bug Fixes**
  * Improved channel reconnection and synchronization when connections become stale or unavailable.

* **Tests**
  * Added coverage for channel messaging, timeline behavior, direct-message routing, identity styling, and recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->