### PR TITLE
feat(channels): @-mention routing — roster, spawn-on-first-mention, streamed replies

### DIFF
--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -109,8 +109,36 @@ agent mail, and every adapter are untouched):
   the verbs are wired into the CLI-gateway capability map. `channels.history`
   responses are byte-bounded (~4MB); on overflow they return `hasMore: true` and a
   `nextCursor` (`afterSeq`/`beforeSeq`) so the client fetches the remainder in pages.
-- **Slice-4 seam** `server/channel-agent-bridge.ts`: `AgentPatchV2` → channel
-  lifecycle translation, shipped and contract-tested but unwired until #1167.
+- **Adapter→channel bridge** `server/channel-agent-bridge.ts`: `AgentPatchV2` →
+  channel lifecycle translation. Now wired by #1167; `agent-turn-completed-v2`
+  finalizes the row with the turn's real status (`interrupted`/`failed`, not always
+  `complete`), and an optional `onAssistantMessageFinalized` hook fires on cleanly
+  completed rows to drive agent-to-agent mentions.
+- **@-mention routing (#1167)** `server/channel-agent-binder.ts`: one module owns
+  the loop — subscribe `hub.onMessagePosted` → resolve mentions (`providerId` only)
+  → single-flight ensure a `(channel, framework)` web session (spawn | reuse |
+  rebind) → wire the bridge → build a context packet (`server/channel-context-packet.ts`,
+  pure) → `adapter.sendMessage`. Browser posts and CLI-gateway-actor posts route
+  identically. Spawns default to **yolo/permission-bypass** (MVP constant
+  `CHANNEL_BINDING_YOLO_DEFAULT`) so routing never wedges on an approval; the
+  approval-render path stays wired. Per-binding FIFO turn queue (cap 8), a per-turn
+  watchdog that pauses on `waitingOn` (never force-drains a human approval), a
+  single-node cross-node guard, deterministic `turnId = chturn-<messageId>-<framework>`
+  (retry reuses it), an at-least-once delivery cursor
+  (`binding.providerSession.lastDeliveredSeq`, advanced only on send acceptance),
+  and a per-channel **consecutive-agent-turn brake** (`MAX_CONSECUTIVE_AGENT_TURNS=4`,
+  reset on any human/gateway post) bounding agent-to-agent fan-out.
+  - **Context packet** (`buildMentionContextPacket`): header addressing the agent
+    - up to 20 recent rows after the cursor and before the trigger (own rows
+      skipped, `[…earlier messages omitted]` when capped, 2 000-char/row + 24 KB caps)
+    - a footer restating the trigger. A reused session with no interim rows collapses
+      to header + footer only.
+  - **Verbs** `server/channel-chat-router.ts`: `GET /channels/:id/roster`
+    (`channels.roster`, `context:read`) — per-request framework availability +
+    live binding status; `POST /channels/:id/agents/:agentId/interrupt`
+    (`channels.interrupt`) and `POST .../approvals` (`channels.respond-approval`),
+    both `context:write`. Status transitions ride `/ws/events` as
+    `channel-agent-status`.
 
 **Privacy note:** channel message bodies are stored **raw**, with no redaction
 pipeline (unlike the `work_context_messages` sanitizer,
@@ -129,17 +157,17 @@ prompts only, no burn. Proof matrix:
 
 ## Ladder (epic #1163)
 
-| Slice | Scope                                                                      |
-| ----- | -------------------------------------------------------------------------- |
-| #1164 | Debt clear — retire v1 chat surface / kill-list items below.               |
-| #1165 | Channel core — channel = conversation model over the substrate.            |
-| #1166 | Channel UI + DM-as-channel.                                                |
-| #1167 | `@`-mentions — route mention → `(channel, agent)` session, spawn-on-first. |
-| #1168 | Claude subprocess adapter (native stream-json, warm pool, `--resume`).     |
-| #1169 | Multi-agent live proof + Codex revive.                                     |
-| #1170 | Threads (`parent_message_id` / `thread_id`).                               |
-| #1171 | Mobile cockpit (mission control).                                          |
-| #1172 | Tauri desktop suite (backlog).                                             |
+| Slice | Scope                                                                                                                                                                             |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #1164 | Debt clear — retire v1 chat surface / kill-list items below.                                                                                                                      |
+| #1165 | Channel core — channel = conversation model over the substrate.                                                                                                                   |
+| #1166 | Channel UI + DM-as-channel.                                                                                                                                                       |
+| #1167 | `@`-mentions — route mention → `(channel, agent)` session, spawn-on-first. **SHIPPED** — roster autocomplete, spawn-on-first-mention, streamed replies, interrupt/approval verbs. |
+| #1168 | Claude subprocess adapter (native stream-json, warm pool, `--resume`).                                                                                                            |
+| #1169 | Multi-agent live proof + Codex revive.                                                                                                                                            |
+| #1170 | Threads (`parent_message_id` / `thread_id`).                                                                                                                                      |
+| #1171 | Mobile cockpit (mission control).                                                                                                                                                 |
+| #1172 | Tauri desktop suite (backlog).                                                                                                                                                    |
 
 ## Kill list (PLANNED removal)
 

--- a/frontend/src/components/chat/ChannelComposer.css
+++ b/frontend/src/components/chat/ChannelComposer.css
@@ -18,6 +18,14 @@
   font-size: var(--font-size-xs);
 }
 
+/* Positioning context for the floating @mention palette (absolute, anchored to
+   the top of the textarea via `bottom: calc(100% + 8px)`). */
+.ch-composer__mention-anchor {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
 .ch-composer__ta {
   flex: 1;
   width: 100%;

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -1,6 +1,16 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import './ChannelComposer.css';
+import { useQuery } from '@tanstack/react-query';
 import { createBrowserId } from '../../lib/browserId.js';
+import { fetchChannelRoster } from '../../lib/api.js';
+import { detectTrigger } from './slashTrigger.js';
+import { MentionPalette, filterRoster } from './MentionPalette.js';
 
 const LINE_BREAK_INPUT_TYPES = new Set(['insertLineBreak', 'insertParagraph']);
 const LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS = 500;
@@ -8,6 +18,7 @@ const IMAGE_ATTACH_TOOLTIP =
   'image attachments are coming in a future update — the channel API does not accept them yet';
 
 interface ChannelComposerProps {
+  channelId: string;
   channelTitle: string;
   /** Idempotent send: the SAME clientMessageId is reused across manual retries. */
   onSend: (text: string, clientMessageId: string) => Promise<void>;
@@ -21,6 +32,7 @@ interface ChannelComposerProps {
 }
 
 export const ChannelComposer: React.FC<ChannelComposerProps> = ({
+  channelId,
   channelTitle,
   onSend,
   postPending,
@@ -36,6 +48,32 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   const clientIdRef = useRef<string | null>(null);
   const sendingRef = useRef(false);
   const [draft, setDraft] = useState('');
+  const [caret, setCaret] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [paletteDismissed, setPaletteDismissed] = useState(false);
+
+  // @mention trigger (#1167). Broader boundary than slash (`(@x`, `hey,@x` are
+  // mentions) — see slashTrigger.detectTrigger. Roster is fetched lazily on the
+  // first @ per channel and cached 30s; TanStack dedupes with the header query.
+  const trigger = detectTrigger(draft, caret, ['@']);
+  const rosterQuery = useQuery({
+    queryKey: ['channel-roster', channelId],
+    queryFn: () => fetchChannelRoster(channelId),
+    staleTime: 30_000,
+    enabled: trigger !== null,
+    retry: false,
+  });
+  // Memoize on the query string + roster data (stable primitives) so palette
+  // navigation callbacks don't churn on every keystroke that leaves both intact.
+  const triggerQuery = trigger?.query ?? null;
+  const rosterData = rosterQuery.data;
+  const entries = useMemo(
+    () =>
+      triggerQuery === null ? [] : filterRoster(rosterData ?? [], triggerQuery),
+    [triggerQuery, rosterData]
+  );
+  const paletteVisible =
+    trigger !== null && !paletteDismissed && entries.length > 0;
 
   const resize = useCallback(() => {
     const el = textareaRef.current;
@@ -50,6 +88,18 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     resize();
   }, [draft, resize]);
 
+  // Reset palette selection + reopen it whenever the draft changes (typing after
+  // an Escape dismissal re-surfaces the palette).
+  useEffect(() => {
+    setActiveIndex(0);
+    setPaletteDismissed(false);
+  }, [draft]);
+
+  const updateCaret = useCallback(() => {
+    const el = textareaRef.current;
+    if (el) setCaret(el.selectionStart ?? 0);
+  }, []);
+
   const submit = useCallback(() => {
     const content = draft.trim();
     if (!content || sendingRef.current) return;
@@ -62,6 +112,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         // draft and idempotency key so the next message is a fresh attempt.
         clientIdRef.current = null;
         setDraft('');
+        setCaret(0);
       })
       .catch(() => {
         // Keep the draft AND the same clientMessageId so a retry (press enter
@@ -72,10 +123,63 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       });
   }, [draft, onSend]);
 
+  // Splice the selected AVAILABLE agent into the draft as plain `@<id> ` text
+  // (no rich pill), replacing the active trigger span.
+  const applyMention = useCallback(() => {
+    if (!trigger) return;
+    const entry = entries[activeIndex];
+    if (!entry || !entry.available) return;
+    const replacement = `@${entry.id} `;
+    const newDraft =
+      draft.slice(0, trigger.span[0]) +
+      replacement +
+      draft.slice(trigger.span[1]);
+    const newCaret = trigger.span[0] + replacement.length;
+    setDraft(newDraft);
+    setCaret(newCaret);
+    setActiveIndex(0);
+    setPaletteDismissed(false);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (el) {
+        el.selectionStart = newCaret;
+        el.selectionEnd = newCaret;
+        el.focus();
+      }
+    });
+  }, [trigger, entries, activeIndex, draft]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       const nativeEvent = e.nativeEvent as KeyboardEvent;
       if (e.key === 'Enter' && nativeEvent.isComposing) return;
+
+      if (paletteVisible) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setActiveIndex((i) => Math.min(i + 1, entries.length - 1));
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setActiveIndex((i) => Math.max(i - 1, 0));
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setPaletteDismissed(true);
+          return;
+        }
+        if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
+          e.preventDefault();
+          const entry = entries[activeIndex];
+          if (entry && entry.available) applyMention();
+          // Unavailable/none → no-op: swallow the key so Enter neither sends
+          // nor inserts and Tab does not move focus out of the composer.
+          return;
+        }
+      }
+
       if (e.key === 'Enter' && e.shiftKey) {
         skipNextLineBreakUntilRef.current =
           performance.now() + LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS;
@@ -87,12 +191,12 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         submit();
       }
     },
-    [submit]
+    [paletteVisible, entries, activeIndex, applyMention, submit]
   );
 
   // Mobile IME parity: some IMEs only report a beforeinput line-break intent for
-  // the send key, no reliable keydown. Treat it as send before it mutates the
-  // controlled draft. Copied from Composer.tsx (LINE_BREAK_INPUT_TYPES handling).
+  // the send key, no reliable keydown. Treat it as send (or, with the palette
+  // open, a mention pick) before it mutates the controlled draft.
   const handleBeforeInput = useCallback(
     (inputEvent: InputEvent) => {
       if (!LINE_BREAK_INPUT_TYPES.has(inputEvent.inputType)) return;
@@ -106,9 +210,14 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       }
       skipNextLineBreakUntilRef.current = 0;
       inputEvent.preventDefault();
+      if (paletteVisible) {
+        const entry = entries[activeIndex];
+        if (entry && entry.available) applyMention();
+        return;
+      }
       submit();
     },
-    [submit]
+    [paletteVisible, entries, activeIndex, applyMention, submit]
   );
 
   useEffect(() => {
@@ -172,21 +281,34 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           channel store unavailable — retry shortly
         </div>
       ) : null}
-      <textarea
-        ref={textareaRef}
-        className="ch-composer__ta"
-        placeholder={`message #${channelTitle}…  ·  shift+enter for newline`}
-        value={draft}
-        rows={1}
-        enterKeyHint="send"
-        aria-label="message input"
-        data-pending={postPending ? 'true' : 'false'}
-        onChange={(event) => setDraft(event.currentTarget.value)}
-        onKeyDown={handleKeyDown}
-        onPaste={swallowImagePaste}
-        onDrop={swallowImageDrop}
-        onDragOver={(e) => e.preventDefault()}
-      />
+      <div className="ch-composer__mention-anchor">
+        <MentionPalette
+          entries={entries}
+          activeIndex={activeIndex}
+          visible={paletteVisible}
+        />
+        <textarea
+          ref={textareaRef}
+          className="ch-composer__ta"
+          placeholder={`message #${channelTitle}…  ·  @ to mention · shift+enter for newline`}
+          value={draft}
+          rows={1}
+          enterKeyHint="send"
+          aria-label="message input"
+          data-pending={postPending ? 'true' : 'false'}
+          onChange={(event) => {
+            setDraft(event.currentTarget.value);
+            setCaret(event.currentTarget.selectionStart ?? 0);
+          }}
+          onKeyDown={handleKeyDown}
+          onKeyUp={updateCaret}
+          onClick={updateCaret}
+          onSelect={updateCaret}
+          onPaste={swallowImagePaste}
+          onDrop={swallowImageDrop}
+          onDragOver={(e) => e.preventDefault()}
+        />
+      </div>
       <div className="ch-composer__bar">
         <button
           type="button"
@@ -198,7 +320,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           +img
         </button>
         <span className="ch-composer__hint">
-          <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline
+          <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline <kbd>@</kbd>mention
         </span>
       </div>
     </div>

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -22,11 +22,13 @@ function formatGroupTime(iso: string): string {
 interface ChannelMessageGroupProps {
   sender: ChannelSenderRef;
   messages: ChannelMessage[];
+  channelId: string;
 }
 
 export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   sender,
   messages,
+  channelId,
 }) => {
   const identity = resolveSenderIdentity(sender);
   const first = messages[0];
@@ -57,7 +59,11 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
       ) : null}
       <div className="ch-group__messages">
         {messages.map((message) => (
-          <ChannelMessageRow key={message.id} message={message} />
+          <ChannelMessageRow
+            key={message.id}
+            message={message}
+            channelId={channelId}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { respondChannelApproval } from '../../lib/api.js';
 
 /** DESIGN.md motion effect 4: solid while text is actively arriving, blinks
  * after 530ms of no change. Returns true when the cursor should blink. */
@@ -21,20 +22,59 @@ function useIdleBlink(signal: string, active: boolean): boolean {
 
 interface ChannelMessageRowProps {
   message: ChannelMessage;
+  channelId: string;
   variant?: 'default' | 'system';
 }
 
 export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   message,
+  channelId,
   variant = 'default',
 }) => {
   const streaming = message.status === 'streaming';
   const blinking = useIdleBlink(message.body.text, streaming);
 
   if (variant === 'system' || message.kind === 'system') {
+    // System rows carry actionable payloads in `meta` (#1167). An approval
+    // request renders approve/deny controls that call the per-agent approvals
+    // endpoint; errors are swallowed (the row heals when the agent re-emits).
+    const approvalRequestId = message.meta?.approvalRequestId;
+    const hasApproval = typeof approvalRequestId === 'string';
     return (
       <div className="ch-system-msg" role="note">
         <span className="ch-system-msg__label">{message.body.text}</span>
+        {hasApproval ? (
+          <span className="ch-system-msg__actions">
+            <button
+              type="button"
+              className="ch-system-msg__btn ch-system-msg__btn--approve"
+              onClick={() =>
+                void respondChannelApproval(
+                  channelId,
+                  String(message.meta?.agentId),
+                  String(message.meta?.approvalRequestId),
+                  { kind: 'accept', scope: 'once' }
+                ).catch(() => {})
+              }
+            >
+              approve
+            </button>
+            <button
+              type="button"
+              className="ch-system-msg__btn ch-system-msg__btn--deny"
+              onClick={() =>
+                void respondChannelApproval(
+                  channelId,
+                  String(message.meta?.agentId),
+                  String(message.meta?.approvalRequestId),
+                  { kind: 'decline' }
+                ).catch(() => {})
+              }
+            >
+              deny
+            </button>
+          </span>
+        ) : null}
       </div>
     );
   }

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -21,6 +21,7 @@ const RESYNC_BUTTON_DELAY_MS = 5_000;
 interface ChannelTimelineProps {
   messages: ChannelMessage[];
   lastReadSeq: number | null;
+  channelId: string;
   channelTitle: string;
   hasMoreOlder: boolean;
   loadingOlder: boolean;
@@ -32,6 +33,7 @@ interface ChannelTimelineProps {
 export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   messages,
   lastReadSeq,
+  channelId,
   channelTitle,
   hasMoreOlder,
   loadingOlder,
@@ -210,6 +212,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
               <ChannelMessageRow
                 key={node.message.id}
                 message={node.message}
+                channelId={channelId}
                 variant="system"
               />
             );
@@ -220,6 +223,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
               key={firstId}
               sender={node.sender}
               messages={node.messages}
+              channelId={channelId}
             />
           );
         })}

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -51,6 +51,89 @@
   margin-left: auto;
 }
 
+/* agent presence chips (#1167) — one per bound/active agent, glyph + status dot
+   + optional interrupt button. Status color: grey idle, pulsing amber busy,
+   green streaming. Only DESIGN.md tokens. */
+.ch-header__agents {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ch-agent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
+.ch-agent-chip__glyph {
+  display: inline-flex;
+  align-items: center;
+  width: 12px;
+  height: 12px;
+}
+
+.ch-agent-chip__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.ch-agent-chip--streaming .ch-agent-chip__dot {
+  background: var(--status-success);
+}
+
+.ch-agent-chip--thinking .ch-agent-chip__dot,
+.ch-agent-chip--spawning .ch-agent-chip__dot,
+.ch-agent-chip--waiting .ch-agent-chip__dot {
+  background: var(--status-warning);
+  animation: ch-agent-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes ch-agent-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+.ch-agent-chip__name {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12ch;
+}
+
+.ch-agent-chip__stop {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 2px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.6rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ch-agent-chip__stop:hover {
+  color: var(--status-error, var(--accent));
+}
+
 .ch-conn-dot {
   display: inline-block;
   width: 8px;
@@ -166,6 +249,34 @@
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   text-align: center;
+}
+
+/* approval controls on an actionable system row (#1167) */
+.ch-system-msg__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ch-system-msg__btn {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.ch-system-msg__btn--approve:hover {
+  border-color: var(--status-success);
+  color: var(--status-success);
+}
+
+.ch-system-msg__btn--deny:hover {
+  border-color: var(--status-error, var(--accent));
+  color: var(--status-error, var(--accent));
 }
 
 /* message group — one sender header + tightly-stacked bodies */

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -11,7 +11,10 @@ import { useChannelChatSocket } from '../../hooks/useChannelChatSocket.js';
 import {
   fetchWorkspaceTopic,
   restoreWorkspaceTopic,
+  fetchChannelRoster,
+  interruptChannelAgent,
   HttpError,
+  type ChannelAgentStatus,
 } from '../../lib/api.js';
 import { isDmChannel } from '../../lib/dm-channels.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
@@ -19,6 +22,10 @@ import {
   channelLastReadKey,
   useChannelActivityStore,
 } from '../../lib/stores/channel-activity.js';
+import {
+  channelAgentStatusKey,
+  useChannelAgentStatusStore,
+} from '../../lib/stores/channel-agent-status.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { AgentBadge } from '../AgentBadge.js';
 import { ChannelTimeline } from './ChannelTimeline.js';
@@ -138,6 +145,72 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     [post]
   );
 
+  // Agent presence chips (#1167). One chip per agent that is bound (roster
+  // binding) OR currently non-idle in the live status store, with a `streaming`
+  // fallback derived from the timeline reducer so the header degrades gracefully
+  // if the events socket lags.
+  const rosterChipsQuery = useQuery({
+    queryKey: ['channel-roster', channelId],
+    queryFn: () => fetchChannelRoster(channelId),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const statusMap = useChannelAgentStatusStore((s) => s.statusByChannelAgent);
+  const streamingProviderIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const message of reducer.messages) {
+      if (message.status !== 'streaming' || message.sender.kind !== 'agent')
+        continue;
+      const providerId =
+        message.sender.providerId ?? message.sender.id.replace(/^agent:/, '');
+      if (providerId) ids.add(providerId);
+    }
+    return ids;
+  }, [reducer.messages]);
+
+  const agentChips = useMemo(() => {
+    const roster = rosterChipsQuery.data ?? [];
+    const rosterById = new Map(roster.map((entry) => [entry.id, entry]));
+    const agentIds = new Set<string>();
+    for (const entry of roster) {
+      if (entry.binding != null) agentIds.add(entry.id);
+    }
+    const prefix = `${channelId} `;
+    for (const [key, status] of Object.entries(statusMap)) {
+      if (key.startsWith(prefix) && status !== 'idle') {
+        agentIds.add(key.slice(prefix.length));
+      }
+    }
+    for (const providerId of streamingProviderIds) agentIds.add(providerId);
+
+    return [...agentIds].map((agentId) => {
+      const entry = rosterById.get(agentId);
+      let status: ChannelAgentStatus =
+        statusMap[channelAgentStatusKey(channelId, agentId)] ??
+        entry?.binding?.status ??
+        'idle';
+      // Reducer-derived streaming beats a stale idle/missing socket status.
+      if (status === 'idle' && streamingProviderIds.has(agentId))
+        status = 'streaming';
+      const identity = resolveSenderIdentity({
+        kind: 'agent',
+        id: `agent:${agentId}`,
+        providerId: agentId,
+        ...(entry?.displayName ? { displayName: entry.displayName } : {}),
+      });
+      return { agentId, status, identity };
+    });
+  }, [rosterChipsQuery.data, statusMap, streamingProviderIds, channelId]);
+
+  const handleInterruptAgent = useCallback(
+    (agentId: string) => {
+      // 404 (no live binding) / 409 (NO_ACTIVE_TURN) both mean "already idle" —
+      // swallow so a race between the click and the agent finishing is silent.
+      void interruptChannelAgent(channelId, agentId).catch(() => {});
+    },
+    [channelId]
+  );
+
   const channelNotFound =
     notFound ||
     (topicQuery.error instanceof HttpError && topicQuery.error.status === 404);
@@ -188,6 +261,48 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             {channel.members.length === 1 ? '' : 's'}
           </span>
         ) : null}
+        {agentChips.length > 0 ? (
+          <span className="ch-header__agents" aria-label="active agents">
+            {agentChips.map((chip) => {
+              const canInterrupt =
+                chip.status === 'streaming' ||
+                chip.status === 'thinking' ||
+                chip.status === 'waiting';
+              return (
+                <span
+                  key={chip.agentId}
+                  className={`ch-agent-chip ch-agent-chip--${chip.status}`}
+                  title={`${chip.identity.label} · ${chip.status}`}
+                >
+                  {chip.identity.glyph ? (
+                    <span
+                      className="ch-agent-chip__glyph"
+                      style={{ color: chip.identity.colorVar }}
+                      aria-hidden="true"
+                    >
+                      <AgentBadge agent={chip.identity.glyph} />
+                    </span>
+                  ) : null}
+                  <span className="ch-agent-chip__dot" aria-hidden="true" />
+                  <span className="ch-agent-chip__name">
+                    {chip.identity.label}
+                  </span>
+                  {canInterrupt ? (
+                    <button
+                      type="button"
+                      className="ch-agent-chip__stop"
+                      aria-label={`interrupt ${chip.identity.label}`}
+                      title="interrupt"
+                      onClick={() => handleInterruptAgent(chip.agentId)}
+                    >
+                      ■
+                    </button>
+                  ) : null}
+                </span>
+              );
+            })}
+          </span>
+        ) : null}
         <span className="ch-header__spacer" />
         {disconnected ? (
           // Reconnect gave up (server outage/deploy > backoff budget). Surface a
@@ -227,6 +342,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         <ChannelTimeline
           messages={reducer.messages}
           lastReadSeq={lastReadSeq}
+          channelId={channelId}
           channelTitle={title}
           hasMoreOlder={hasMoreOlder}
           loadingOlder={loadingOlder}
@@ -241,6 +357,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       )}
 
       <ChannelComposer
+        channelId={channelId}
         channelTitle={title}
         onSend={handleSend}
         postPending={postPending}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../lib/stores/channel-activity.js';
 import {
   channelAgentStatusKey,
+  resolveEffectiveAgentStatus,
   useChannelAgentStatusStore,
 } from '../../lib/stores/channel-agent-status.js';
 import { useUiStore } from '../../lib/stores/ui.js';
@@ -156,6 +157,20 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     retry: false,
   });
   const statusMap = useChannelAgentStatusStore((s) => s.statusByChannelAgent);
+  const statusUpdatedAtMap = useChannelAgentStatusStore(
+    (s) => s.updatedAtByChannelAgent
+  );
+
+  // On channel switch, drop this channel's per-agent socket statuses so the
+  // freshly-fetched roster is authoritative on open; live transitions repopulate
+  // as they arrive. Without this the previously dead `clearChannel` reconciliation
+  // never ran and a stale busy chip could survive a channel round-trip (#1167).
+  useEffect(() => {
+    const { clearChannel } = useChannelAgentStatusStore.getState();
+    clearChannel(channelId);
+    return () => clearChannel(channelId);
+  }, [channelId]);
+
   const streamingProviderIds = useMemo(() => {
     const ids = new Set<string>();
     for (const message of reducer.messages) {
@@ -168,39 +183,57 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     return ids;
   }, [reducer.messages]);
 
+  const rosterUpdatedAt = rosterChipsQuery.dataUpdatedAt;
   const agentChips = useMemo(() => {
     const roster = rosterChipsQuery.data ?? [];
     const rosterById = new Map(roster.map((entry) => [entry.id, entry]));
-    const agentIds = new Set<string>();
+    const candidateIds = new Set<string>();
     for (const entry of roster) {
-      if (entry.binding != null) agentIds.add(entry.id);
+      if (entry.binding != null) candidateIds.add(entry.id);
     }
     const prefix = `${channelId} `;
-    for (const [key, status] of Object.entries(statusMap)) {
-      if (key.startsWith(prefix) && status !== 'idle') {
-        agentIds.add(key.slice(prefix.length));
-      }
+    for (const key of Object.keys(statusMap)) {
+      if (key.startsWith(prefix)) candidateIds.add(key.slice(prefix.length));
     }
-    for (const providerId of streamingProviderIds) agentIds.add(providerId);
+    for (const providerId of streamingProviderIds) candidateIds.add(providerId);
 
-    return [...agentIds].map((agentId) => {
+    const chips: Array<{
+      agentId: string;
+      status: ChannelAgentStatus;
+      identity: ReturnType<typeof resolveSenderIdentity>;
+    }> = [];
+    for (const agentId of candidateIds) {
       const entry = rosterById.get(agentId);
-      let status: ChannelAgentStatus =
-        statusMap[channelAgentStatusKey(channelId, agentId)] ??
-        entry?.binding?.status ??
-        'idle';
-      // Reducer-derived streaming beats a stale idle/missing socket status.
-      if (status === 'idle' && streamingProviderIds.has(agentId))
-        status = 'streaming';
+      const key = channelAgentStatusKey(channelId, agentId);
+      const streaming = streamingProviderIds.has(agentId);
+      const status = resolveEffectiveAgentStatus({
+        socketStatus: statusMap[key],
+        socketUpdatedAt: statusUpdatedAtMap[key],
+        rosterStatus: entry?.binding?.status,
+        rosterUpdatedAt,
+        streaming,
+      });
+      // Show a chip for a bound agent (even when idle) or one that is currently
+      // active/streaming — but drop an unbound agent whose only signal is a stale
+      // socket status the roster has since superseded to idle.
+      if (entry?.binding == null && status === 'idle' && !streaming) continue;
       const identity = resolveSenderIdentity({
         kind: 'agent',
         id: `agent:${agentId}`,
         providerId: agentId,
         ...(entry?.displayName ? { displayName: entry.displayName } : {}),
       });
-      return { agentId, status, identity };
-    });
-  }, [rosterChipsQuery.data, statusMap, streamingProviderIds, channelId]);
+      chips.push({ agentId, status, identity });
+    }
+    return chips;
+  }, [
+    rosterChipsQuery.data,
+    rosterUpdatedAt,
+    statusMap,
+    statusUpdatedAtMap,
+    streamingProviderIds,
+    channelId,
+  ]);
 
   const handleInterruptAgent = useCallback(
     (agentId: string) => {

--- a/frontend/src/components/chat/MentionPalette.css
+++ b/frontend/src/components/chat/MentionPalette.css
@@ -1,0 +1,87 @@
+/* @mention palette (#1167). Structural + visual sibling of `.slash*`
+   (Composer.css): same absolute float above the composer, same surface/border
+   tokens, same active-row `>` marker. Only DESIGN.md tokens — no new colors. */
+
+.mention-palette {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(100% + 8px);
+  z-index: 10;
+  max-height: 260px;
+  overflow: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.mention-palette__row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 16px minmax(0, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px 6px 18px;
+  color: var(--text-muted);
+  min-width: 0;
+}
+
+.mention-palette__row:not(.mention-palette__row--unavailable):hover,
+.mention-palette__row--active:not(.mention-palette__row--unavailable) {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.mention-palette__row--active:not(.mention-palette__row--unavailable)::before {
+  content: '>';
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  line-height: 1;
+  color: var(--accent);
+}
+
+/* Unavailable rows stay visible but read as inert (greyed, no highlight). */
+.mention-palette__row--unavailable {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.mention-palette__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.mention-palette__name {
+  color: var(--text);
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: lowercase;
+  min-width: 0;
+}
+
+.mention-palette__id {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.mention-palette__reason {
+  grid-column: 1 / -1;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/chat/MentionPalette.tsx
+++ b/frontend/src/components/chat/MentionPalette.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import './MentionPalette.css';
+import type { RosterEntry } from '../../lib/api.js';
+import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { AgentBadge } from '../AgentBadge.js';
+
+/**
+ * Prefix-filter the channel roster by `id`/`displayName` (case-insensitive).
+ * Unavailable entries are intentionally KEPT — they render greyed and
+ * non-selectable so the operator can see who is in the channel but currently
+ * unroutable (and why, via the `reason` tooltip). Empty query returns all rows.
+ */
+export function filterRoster(
+  roster: RosterEntry[],
+  query: string
+): RosterEntry[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) return roster;
+  return roster.filter(
+    (entry) =>
+      entry.id.toLowerCase().startsWith(q) ||
+      entry.displayName.toLowerCase().startsWith(q)
+  );
+}
+
+interface MentionPaletteProps {
+  entries: RosterEntry[];
+  activeIndex: number;
+  visible: boolean;
+}
+
+/**
+ * Presentational `@mention` palette. Keyboard navigation lives in the parent
+ * (ChannelComposer), mirroring SlashPalette. Selecting an available row inserts
+ * plain `@<id> ` text — no rich pill. Unavailable rows are greyed, carry
+ * `aria-disabled` + the `reason` as their `title`, and are never selectable.
+ */
+export const MentionPalette: React.FC<MentionPaletteProps> = ({
+  entries,
+  activeIndex,
+  visible,
+}) => {
+  return (
+    <div
+      className="mention-palette"
+      role="listbox"
+      aria-label="agents"
+      style={{ display: visible ? undefined : 'none' }}
+    >
+      {entries.map((entry, index) => {
+        const identity = resolveSenderIdentity({
+          kind: 'agent',
+          id: `agent:${entry.id}`,
+          providerId: entry.id,
+          displayName: entry.displayName,
+        });
+        const active = index === activeIndex;
+        const unavailable = !entry.available;
+        const rowClass = [
+          'mention-palette__row',
+          active ? 'mention-palette__row--active' : null,
+          unavailable ? 'mention-palette__row--unavailable' : null,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return (
+          <div
+            key={entry.id}
+            className={rowClass}
+            role="option"
+            aria-selected={active}
+            {...(unavailable ? { 'aria-disabled': true } : {})}
+            {...(unavailable && entry.reason ? { title: entry.reason } : {})}
+          >
+            <span
+              className="mention-palette__glyph"
+              style={unavailable ? undefined : { color: identity.colorVar }}
+              aria-hidden="true"
+            >
+              {identity.glyph ? <AgentBadge agent={identity.glyph} /> : '@'}
+            </span>
+            <span
+              className="mention-palette__name"
+              style={unavailable ? undefined : { color: identity.colorVar }}
+            >
+              {entry.displayName}
+            </span>
+            <span className="mention-palette__id">@{entry.id}</span>
+            {unavailable && entry.reason ? (
+              <span className="mention-palette__reason">{entry.reason}</span>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MentionPalette;

--- a/frontend/src/components/chat/slashTrigger.ts
+++ b/frontend/src/components/chat/slashTrigger.ts
@@ -1,4 +1,12 @@
-/** Result of detecting an active slash/dollar trigger at the caret position. */
+/** Result of detecting an active composer trigger (`/`, `$`, `@`, …) at the caret. */
+export type Trigger = {
+  prefix: string;
+  query: string;
+  span: [number, number];
+  isLeading: boolean;
+};
+
+/** Back-compat shape for the slash/dollar composer trigger. */
 export type SlashTrigger = {
   prefix: '/' | '$';
   query: string;
@@ -7,61 +15,79 @@ export type SlashTrigger = {
 };
 
 /**
- * Detect whether the caret is positioned inside an active slash command trigger.
- *
- * Algorithm (§4.1):
- * 1. Walk back from caret-1 looking for '/' or '$' where ALL chars between that
- *    index and caret are non-whitespace.
- * 2. Stop walking when whitespace or string-start is hit before finding a trigger → null.
- * 3. When candidate found at pos, validate the boundary at pos-1:
- *    - pos === 0           → valid, isLeading = true
- *    - text[pos-1] === '\n'  → valid, isLeading = true
- *    - text[pos-1] is other whitespace → valid, isLeading = false
- *    - else                → invalid, null
- * 4. Return { prefix, query, span: [pos, caret], isLeading }
+ * Characters that, when they immediately precede a trigger, mean the trigger is
+ * "inside a word" and therefore NOT active. This is the exact complement of the
+ * server mention parser's boundary class (`shared/channel-chat-protocol.ts`
+ * `parseMentions`, pattern `/(^|[^A-Za-z0-9_.])@.../`): a mention is valid when
+ * the preceding char is start-of-text OR does NOT match `[A-Za-z0-9_.]`. Sharing
+ * the same predicate keeps the `@` palette trigger in parity with what the
+ * server will actually route (so `(@claude` and `hey,@claude` trigger, while
+ * mid-word `foo@claude` and email `a.b@claude` do not).
  */
-export function detectSlashTrigger(text: string, caret: number): SlashTrigger | null {
-  // Walk backwards from caret-1
+const WORD_BOUNDARY_CHAR = /[A-Za-z0-9_.]/;
+
+/**
+ * Detect whether the caret is positioned inside an active trigger for any of the
+ * supplied prefix characters.
+ *
+ * Algorithm:
+ * 1. Walk back from caret-1 looking for one of `chars` where ALL chars between
+ *    that index and the caret are non-whitespace.
+ * 2. Stop walking when whitespace or string-start is hit before finding a
+ *    trigger → null (the query part can never contain whitespace).
+ * 3. When a candidate is found at `pos`, validate the preceding boundary:
+ *    - `pos === 0`                              → valid, isLeading = true
+ *    - `text[pos-1]` does not match `[A-Za-z0-9_.]` → valid
+ *        - isLeading = true only when `text[pos-1] === '\n'`
+ *    - `text[pos-1]` matches `[A-Za-z0-9_.]`    → invalid (mid-word), null
+ * 4. Return `{ prefix, query, span: [pos, caret], isLeading }`.
+ *
+ * The boundary rule is intentionally broader than "leading whitespace only":
+ * `/` and `$` (which are only meaningful when leading) are unaffected because
+ * consumers re-check `isLeading`, while `@` matches the server mention boundary.
+ */
+export function detectTrigger(
+  text: string,
+  caret: number,
+  chars: readonly string[]
+): Trigger | null {
   for (let i = caret - 1; i >= 0; i--) {
     const ch: string = text.charAt(i);
 
-    if (ch === '/' || ch === '$') {
-      // Found a trigger candidate at i. Validate boundary.
-      if (i === 0) {
-        return {
-          prefix: ch,
-          query: text.slice(i + 1, caret),
-          span: [i, caret],
-          isLeading: true,
-        };
+    if (chars.includes(ch)) {
+      // Found a trigger candidate at i. Validate the preceding boundary.
+      const prev: string | undefined = i === 0 ? undefined : text.charAt(i - 1);
+      if (prev !== undefined && WORD_BOUNDARY_CHAR.test(prev)) {
+        // A word char immediately precedes the trigger (mid-word `foo@x`,
+        // email `a.b@x`, path segment `a/b`) → not an active trigger.
+        return null;
       }
-      const prev: string = text.charAt(i - 1);
-      if (prev === '\n') {
-        return {
-          prefix: ch,
-          query: text.slice(i + 1, caret),
-          span: [i, caret],
-          isLeading: true,
-        };
-      }
-      if (prev === ' ' || prev === '\t' || prev === '\r') {
-        return {
-          prefix: ch,
-          query: text.slice(i + 1, caret),
-          span: [i, caret],
-          isLeading: false,
-        };
-      }
-      // Non-whitespace precedes trigger → invalid
-      return null;
+      return {
+        prefix: ch,
+        query: text.slice(i + 1, caret),
+        span: [i, caret],
+        isLeading: prev === undefined || prev === '\n',
+      };
     }
 
-    // If we hit whitespace before finding a trigger char, stop.
+    // Whitespace before finding a trigger char closes the token → null.
     if (/\s/.test(ch)) {
       return null;
     }
   }
 
-  // Walked all the way to start without finding trigger or whitespace
+  // Walked all the way to start without finding a trigger or whitespace.
   return null;
+}
+
+/**
+ * Detect a slash/dollar command trigger. Thin wrapper over `detectTrigger` that
+ * narrows the prefix back to `'/' | '$'` for the three existing composer
+ * consumers. The cast is sound because only those two chars are passed.
+ */
+export function detectSlashTrigger(
+  text: string,
+  caret: number
+): SlashTrigger | null {
+  return detectTrigger(text, caret, ['/', '$']) as SlashTrigger | null;
 }

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -9,6 +9,7 @@ import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useChannelActivityStore } from '../lib/stores/channel-activity.js';
+import { useChannelAgentStatusStore } from '../lib/stores/channel-agent-status.js';
 import type { AccountTelemetry, SessionTelemetry } from '../lib/types.js';
 import type { SessionEventScope } from '../../../shared/node-boundary.js';
 import type {
@@ -413,6 +414,11 @@ export function useEventSocket({
         useChannelActivityStore
           .getState()
           .recordActivity(msg.channelId, msg.latestSeq);
+      },
+      'channel-agent-status': (msg) => {
+        useChannelAgentStatusStore
+          .getState()
+          .recordStatus(msg.channelId, msg.agentId, msg.status, msg.sessionId);
       },
       'browser-tab-opened': (msg) => {
         useUiStore.getState().openHtmlTab(msg.filePath, msg.token);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1808,6 +1808,96 @@ export async function postChannelMessage(
   return data.message;
 }
 
+// ── Channel agent roster + control (#1167, slice 4) ─────────────────────────
+// The roster lists the frameworks that can be @-mentioned in a channel, with
+// their live binding/status. Interrupt + approval are per-agent control writes.
+
+/** Live agent status within a channel (framework-id keyed). */
+export type ChannelAgentStatus =
+  | 'spawning'
+  | 'thinking'
+  | 'streaming'
+  | 'waiting'
+  | 'idle';
+
+/** One row of the channel @-mention roster (GET /channels/:id/roster). */
+export interface RosterEntry {
+  /** Framework id (e.g. `claude`, `codex`, `mock`) — what a mention resolves to. */
+  id: string;
+  displayName: string;
+  kind: 'framework';
+  /** False when the framework cannot currently be routed to (see `reason`). */
+  available: boolean;
+  reason: string | null;
+  /** Present when a live session is bound to this agent in the channel. */
+  binding: { sessionId: string; status: ChannelAgentStatus } | null;
+}
+
+export async function fetchChannelRoster(
+  channelId: string
+): Promise<RosterEntry[]> {
+  const data = await json<{ roster: RosterEntry[] }>(
+    await fetch(`/channels/${encodeURIComponent(channelId)}/roster`, {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  return Array.isArray(data.roster) ? data.roster : [];
+}
+
+/**
+ * Interrupt the given agent's active turn in a channel. Lets `HttpError`
+ * propagate: callers ignore 404 (no live binding) / 409 (NO_ACTIVE_TURN, agent
+ * idle) since both mean "nothing to interrupt".
+ */
+export async function interruptChannelAgent(
+  channelId: string,
+  agentId: string
+): Promise<void> {
+  await json<{ ok: true }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/agents/${encodeURIComponent(
+        agentId
+      )}/interrupt`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({}),
+      }
+    )
+  );
+}
+
+/**
+ * Respond to a channel agent's pending approval request. `decision` is an
+ * `AgentApprovalDecisionV2` (accept/decline/cancel) — kept `unknown` here so the
+ * caller owns the exact shape.
+ */
+export async function respondChannelApproval(
+  channelId: string,
+  agentId: string,
+  requestId: string,
+  decision: unknown
+): Promise<void> {
+  await json<{ ok: true }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/agents/${encodeURIComponent(
+        agentId
+      )}/approvals`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ requestId, decision }),
+      }
+    )
+  );
+}
+
 export interface WorkContextCreateBody {
   title?: string;
   source?: string;

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -1,0 +1,79 @@
+// Per-channel, per-agent live status cache (#1167). Fed by the `/ws/events`
+// `channel-agent-status` broadcast, which carries `{ channelId, agentId, status,
+// sessionId }`. The channel header renders a presence chip (glyph + colored dot,
+// with an interrupt affordance while the agent is busy) from this store merged
+// with the channel roster query. Structure mirrors `channel-activity.ts`.
+import { create } from 'zustand';
+import type { ChannelAgentStatus } from '../api.js';
+
+/** Composite key for the status/session maps: `"<channelId> <agentId>"`. */
+export function channelAgentStatusKey(
+  channelId: string,
+  agentId: string
+): string {
+  return `${channelId} ${agentId}`;
+}
+
+interface ChannelAgentStatusState {
+  /** Latest status per `${channelId} ${agentId}`. */
+  statusByChannelAgent: Record<string, ChannelAgentStatus>;
+  /** Backing session id per `${channelId} ${agentId}` (null when unbound). */
+  sessionByChannelAgent: Record<string, string | null>;
+  /** Record a live status transition for an agent in a channel. */
+  recordStatus: (
+    channelId: string,
+    agentId: string,
+    status: ChannelAgentStatus,
+    sessionId: string | null
+  ) => void;
+  /** Drop every agent status/session entry for a channel. */
+  clearChannel: (channelId: string) => void;
+}
+
+export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
+  (set) => ({
+    statusByChannelAgent: {},
+    sessionByChannelAgent: {},
+    recordStatus: (channelId, agentId, status, sessionId) =>
+      set((state) => {
+        const key = channelAgentStatusKey(channelId, agentId);
+        if (
+          state.statusByChannelAgent[key] === status &&
+          state.sessionByChannelAgent[key] === sessionId
+        ) {
+          return state;
+        }
+        return {
+          statusByChannelAgent: {
+            ...state.statusByChannelAgent,
+            [key]: status,
+          },
+          sessionByChannelAgent: {
+            ...state.sessionByChannelAgent,
+            [key]: sessionId,
+          },
+        };
+      }),
+    clearChannel: (channelId) =>
+      set((state) => {
+        const prefix = `${channelId} `;
+        const status: Record<string, ChannelAgentStatus> = {};
+        const session: Record<string, string | null> = {};
+        let changed = false;
+        for (const [key, value] of Object.entries(state.statusByChannelAgent)) {
+          if (key.startsWith(prefix)) changed = true;
+          else status[key] = value;
+        }
+        for (const [key, value] of Object.entries(
+          state.sessionByChannelAgent
+        )) {
+          if (!key.startsWith(prefix)) session[key] = value;
+        }
+        if (!changed) return state;
+        return {
+          statusByChannelAgent: status,
+          sessionByChannelAgent: session,
+        };
+      }),
+  })
+);

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -19,6 +19,13 @@ interface ChannelAgentStatusState {
   statusByChannelAgent: Record<string, ChannelAgentStatus>;
   /** Backing session id per `${channelId} ${agentId}` (null when unbound). */
   sessionByChannelAgent: Record<string, string | null>;
+  /**
+   * Wall-clock time (ms) of the last live transition per `${channelId}
+   * ${agentId}`. Compared against the roster query's `dataUpdatedAt` so a fresh
+   * roster snapshot can win over a stale socket status the client never saw go
+   * idle (reconnect / tab-sleep dropped the terminal transition — #1167).
+   */
+  updatedAtByChannelAgent: Record<string, number>;
   /** Record a live status transition for an agent in a channel. */
   recordStatus: (
     channelId: string,
@@ -30,10 +37,15 @@ interface ChannelAgentStatusState {
   clearChannel: (channelId: string) => void;
 }
 
+/** Injectable clock (overridable in tests). */
+const nowMs = (): number =>
+  typeof Date.now === 'function' ? Date.now() : new Date().getTime();
+
 export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
   (set) => ({
     statusByChannelAgent: {},
     sessionByChannelAgent: {},
+    updatedAtByChannelAgent: {},
     recordStatus: (channelId, agentId, status, sessionId) =>
       set((state) => {
         const key = channelAgentStatusKey(channelId, agentId);
@@ -52,6 +64,10 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
             ...state.sessionByChannelAgent,
             [key]: sessionId,
           },
+          updatedAtByChannelAgent: {
+            ...state.updatedAtByChannelAgent,
+            [key]: nowMs(),
+          },
         };
       }),
     clearChannel: (channelId) =>
@@ -59,6 +75,7 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
         const prefix = `${channelId} `;
         const status: Record<string, ChannelAgentStatus> = {};
         const session: Record<string, string | null> = {};
+        const updatedAt: Record<string, number> = {};
         let changed = false;
         for (const [key, value] of Object.entries(state.statusByChannelAgent)) {
           if (key.startsWith(prefix)) changed = true;
@@ -69,11 +86,51 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
         )) {
           if (!key.startsWith(prefix)) session[key] = value;
         }
+        for (const [key, value] of Object.entries(
+          state.updatedAtByChannelAgent
+        )) {
+          if (!key.startsWith(prefix)) updatedAt[key] = value;
+        }
         if (!changed) return state;
         return {
           statusByChannelAgent: status,
           sessionByChannelAgent: session,
+          updatedAtByChannelAgent: updatedAt,
         };
       }),
   })
 );
+
+/**
+ * Reconcile a live socket status with a freshly-fetched roster snapshot. The
+ * socket carries transition-only events (no replay on `/ws/events` reconnect),
+ * so a missed terminal 'idle' would otherwise pin the header chip at
+ * thinking/streaming/waiting forever. Resolution:
+ *   • socket wins ONLY when its last transition is at least as new as the roster
+ *     snapshot (a genuine live update the roster hasn't observed yet);
+ *   • otherwise the roster snapshot is authoritative (fixes the stuck-busy case);
+ *   • reducer-derived streaming still upgrades a resolved idle (graceful degrade
+ *     when the events socket lags), never downgrades.
+ */
+export function resolveEffectiveAgentStatus(input: {
+  socketStatus: ChannelAgentStatus | undefined;
+  socketUpdatedAt: number | undefined;
+  rosterStatus: ChannelAgentStatus | undefined;
+  rosterUpdatedAt: number;
+  streaming: boolean;
+}): ChannelAgentStatus {
+  const { socketStatus, socketUpdatedAt, rosterStatus, rosterUpdatedAt } =
+    input;
+  let status: ChannelAgentStatus;
+  if (
+    socketStatus !== undefined &&
+    socketUpdatedAt !== undefined &&
+    socketUpdatedAt >= rosterUpdatedAt
+  ) {
+    status = socketStatus;
+  } else {
+    status = rosterStatus ?? 'idle';
+  }
+  if (status === 'idle' && input.streaming) status = 'streaming';
+  return status;
+}

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -125,6 +125,13 @@ export type EventMessage =
     }
   | { type: 'server-restarting'; reason?: string }
   | { type: 'channel-activity'; channelId: string; latestSeq: number }
+  | {
+      type: 'channel-agent-status';
+      channelId: string;
+      agentId: string;
+      status: 'spawning' | 'thinking' | 'streaming' | 'waiting' | 'idle';
+      sessionId: string | null;
+    }
   | ({
       type: 'session-durability-changed';
       sessionId: string;

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -193,6 +193,19 @@ export class ChannelAgentNoActiveTurnError extends Error {
   }
 }
 
+/**
+ * Thrown from an in-flight `doEnsureBinding` continuation that resumes AFTER
+ * `close()`. It aborts the spawn/attach/store-write path so shutdown never
+ * re-populates the cleared maps, arms a fresh watchdog, or writes to a closing
+ * store. Callers swallow it silently (no system row) — it is a shutdown signal.
+ */
+class BinderClosedError extends Error {
+  constructor() {
+    super('channel agent binder is closed');
+    this.name = 'BinderClosedError';
+  }
+}
+
 const SYSTEM_SENDER = { kind: 'system', id: 'system' } as const;
 
 function bindingKey(channelId: string, framework: string): string {
@@ -396,6 +409,7 @@ export function createChannelAgentBinder(
     channelId: string,
     framework: string
   ): Promise<LiveBinding> {
+    if (closed) throw new BinderClosedError();
     const key = bindingKey(channelId, framework);
     const displayName = displayNameFor(channelId, framework);
 
@@ -452,6 +466,9 @@ export function createChannelAgentBinder(
         `@${framework} failed to start: ${errText(err)}`
       );
     }
+    // close() may have raced the spawn await: abort before we attach a bridge,
+    // arm listeners, or write to a closing store (Amendment: shutdown contract).
+    if (closed) throw new BinderClosedError();
     const binding = attachSession(
       channelId,
       framework,
@@ -532,10 +549,27 @@ export function createChannelAgentBinder(
     const adapter = binding.adapter;
     if (!adapter) return;
     const turnId = `chturn-${trigger.id}-${binding.framework}`;
+    // Build the packet BEFORE mutating any binding state: buildPacket does
+    // synchronous SQLite work (getBinding/history) that can throw. If it did so
+    // AFTER activeTurnId was set (and before the watchdog armed), the binding
+    // wedged 'turn-active' forever with no in-flight turn — the queue filled and
+    // every later mention dropped. On a throw we surface a row and keep draining.
+    let content: string;
+    try {
+      content = buildPacket(binding, trigger);
+    } catch (err) {
+      logger.warn('channel binder packet build failed:', err);
+      postSystemRow(
+        binding.channelId,
+        `@${binding.framework} could not build the message context: ${errText(err)}`
+      );
+      pump(binding); // activeTurnId is still null — keep the queue draining
+      return;
+    }
     binding.activeTurnId = turnId;
     binding.sawStream = false;
     binding.waitingOn = null;
-    binding.activeContent = buildPacket(binding, trigger);
+    binding.activeContent = content;
     setStatus(binding, 'thinking');
     armWatchdog(binding);
     deliver(binding, adapter, turnId, trigger);
@@ -561,6 +595,7 @@ export function createChannelAgentBinder(
   }
 
   function advanceCursor(binding: LiveBinding, triggerSeq: number): void {
+    if (closed) return; // never write to a closing store from an in-flight send
     // Cursor advances only on send acceptance (§4): a failed send re-offers the
     // rows next mention (at-least-once). Never lower the cursor.
     try {
@@ -587,6 +622,7 @@ export function createChannelAgentBinder(
     turnId: string,
     err: unknown
   ): Promise<void> {
+    if (closed) return; // shutdown in progress — no rows, no re-delivery
     // A rejected sendMessage means the turn was NEVER accepted (Amendment 3), so
     // a single retry-after-rebind is safe — covers dead legacy-bridge transports.
     if (!binding.retriedTurns.has(turnId)) {
@@ -596,15 +632,20 @@ export function createChannelAgentBinder(
           binding.channelId,
           binding.framework
         );
+        if (closed) return;
         if (rebound.adapter && rebound.activeTurnId === turnId) {
+          // Same binding still owns this turn — redeliver identical content.
           deliver(rebound, rebound.adapter, turnId, trigger);
           return;
         }
         if (rebound.adapter) {
-          rebound.activeTurnId = turnId;
-          rebound.activeContent = binding.activeContent;
-          armWatchdog(rebound);
-          deliver(rebound, rebound.adapter, turnId, trigger);
+          // The binding was rebound to a fresh/different session (e.g. after the
+          // failed send tore the session down). A NEWER turn may already be
+          // active on it — never clobber it. Re-enqueue (cap-respecting): pump
+          // delivers when the binding is free, and sendTurn re-establishes the
+          // status/sawStream/watchdog for the retried turn instead of the
+          // fallback overwriting an in-flight turn's lifecycle tracking.
+          enqueueTurn(rebound, trigger);
           return;
         }
       } catch {
@@ -735,6 +776,7 @@ export function createChannelAgentBinder(
     void (async () => {
       try {
         const target = await resolveTarget(framework);
+        if (closed) return; // close() raced the availability probe
         if (!target) return; // not a known framework — ignore silently
         if (!target.available) {
           postUnavailableRow(
@@ -748,6 +790,7 @@ export function createChannelAgentBinder(
         try {
           binding = await ensureBinding(trigger.channelId, framework);
         } catch (err) {
+          if (err instanceof BinderClosedError) return; // shutdown — silent
           if (err instanceof ChannelBindingError) {
             if (err.unavailable) {
               postUnavailableRow(
@@ -762,8 +805,10 @@ export function createChannelAgentBinder(
           }
           throw err;
         }
+        if (closed) return; // never enqueue/spawn a turn after close()
         enqueueTurn(binding, trigger);
       } catch (err) {
+        if (closed || err instanceof BinderClosedError) return;
         logger.warn('channel binder route failed:', err);
       }
     })();
@@ -787,32 +832,19 @@ export function createChannelAgentBinder(
     return out;
   }
 
-  function handleMessagePosted(
-    message: ChannelMessage,
-    mentions: ChannelMention[]
-  ): void {
-    if (closed) return;
-    if (message.kind !== 'message') return; // system rows never route (§1)
-    // Both browser-human and CLI-gateway-actor posts arrive here (postToChannel
-    // fires onMessagePosted for both). Treat every externally-injected post as a
-    // human turn for the loop brake: it resets the consecutive-agent counter and
-    // routes identically — the dogfood requirement (@claude via gateway ==
-    // browser). Only bound-session replies (handleAssistantFinalized) count.
-    consecutiveAgentTurns.set(message.channelId, 0);
-    for (const framework of eligibleFrameworks(message, mentions)) {
-      routeOne(message, framework);
-    }
-  }
-
-  function handleAssistantFinalized(message: ChannelMessage): void {
-    if (closed) return;
-    const mentions = parseMentions(message.body.text, deps.knownProviderIds);
-    const frameworks = eligibleFrameworks(message, mentions);
+  /**
+   * Route an AGENT-authored turn's mentions under the consecutive-agent brake
+   * (Amendment 5): each routed mention counts toward MAX_CONSECUTIVE_AGENT_TURNS
+   * and the chain pauses (with a system row) once the cap is reached. Shared by
+   * bound-session replies AND gateway-agent posts so neither can escape the
+   * token-spend guard between human turns.
+   */
+  function routeWithBrake(message: ChannelMessage, frameworks: string[]): void {
     for (const framework of frameworks) {
       const count = consecutiveAgentTurns.get(message.channelId) ?? 0;
       if (count >= MAX_CONSECUTIVE_AGENT_TURNS) {
-        // Consecutive-agent-turn brake (Amendment 5): bounds total agent-token
-        // spend between human turns. Reset happens on the next human/gateway post.
+        // Bounds total agent-token spend between human turns. Reset happens on
+        // the next human (browser / gateway-human) post.
         postSystemRow(
           message.channelId,
           `Mention chain paused — ${count} agent turns without a human.`
@@ -822,6 +854,41 @@ export function createChannelAgentBinder(
       consecutiveAgentTurns.set(message.channelId, count + 1);
       routeOne(message, framework);
     }
+  }
+
+  function handleMessagePosted(
+    message: ChannelMessage,
+    mentions: ChannelMention[]
+  ): void {
+    if (closed) return;
+    if (message.kind !== 'message') return; // system rows never route (§1)
+    // Both browser-human and CLI-gateway-actor posts arrive here (postToChannel
+    // fires onMessagePosted for both). Routing is IDENTICAL for both (locked
+    // decision: @claude via gateway == browser). The loop brake, however, keys
+    // off the server-derived sender kind — never the transport:
+    //   • human sender (browser cookie lane, or a gateway actor that maps to a
+    //     human operator) → resets the consecutive-agent counter, routes freely.
+    //   • agent sender (deriveSender kind 'agent', incl. CLI-gateway actor posts
+    //     — the shipped agent-mail loop) → an agent-authored turn: it INCREMENTS
+    //     the counter and is subject to the cap, exactly like a bound reply.
+    // Without this a bound agent posting via `relay-ide v1 channels.post` would
+    // both bypass the increment AND reset the brake, defeating the sole
+    // token-spend guard between human turns (#1167 P1).
+    const frameworks = eligibleFrameworks(message, mentions);
+    if (message.sender.kind === 'agent') {
+      routeWithBrake(message, frameworks);
+      return;
+    }
+    consecutiveAgentTurns.set(message.channelId, 0);
+    for (const framework of frameworks) {
+      routeOne(message, framework);
+    }
+  }
+
+  function handleAssistantFinalized(message: ChannelMessage): void {
+    if (closed) return;
+    const mentions = parseMentions(message.body.text, deps.knownProviderIds);
+    routeWithBrake(message, eligibleFrameworks(message, mentions));
   }
 
   // ── session death ───────────────────────────────────────────────────────────

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -1,0 +1,937 @@
+import os from 'node:os';
+
+import { createLogger } from './logger.js';
+import { bindSessionToChannel } from './channel-agent-bridge.js';
+import {
+  buildMentionContextPacket,
+  PACKET_MAX_ROWS,
+} from './channel-context-packet.js';
+import {
+  CHANNEL_HISTORY_MAX_LIMIT,
+  type ChannelBinding,
+  type ChannelMessageStore,
+} from './channel-message-store.js';
+import type { ChannelHub } from './channel-hub.js';
+import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
+import type { CreateWebParams } from './web-session-handler.js';
+import type { Session, WebSession } from './types.js';
+import type { WorkspaceTopicStore } from './workspace-topics.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import {
+  parseMentions,
+  type ChannelMention,
+  type ChannelMessage,
+} from '../shared/channel-chat-protocol.js';
+import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
+
+// @-mention routing binder (#1167, slice 4). One module owns the whole loop:
+// subscribe to hub.onMessagePosted → resolve mentions → ensure a (channel,
+// framework) web session (single-flight spawn | reuse | rebind) → wire the
+// slice-2 bridge → build a context packet → deliver the turn. Single-node only.
+//
+// It never touches the wire protocol and requires ZERO adapter changes: the
+// bridge remains the sole text mirror; the binder registers its OWN onPatch
+// listener (multi-handler) watching only turn lifecycle / live-state / approval
+// items so it can drive the queue, status, watchdog, and approval rows.
+
+const logger = createLogger('channel-agent-binder');
+
+// ── MVP policy knobs (single obvious constants — flip post-MVP) ───────────────
+
+/**
+ * MVP: channel-bound agents spawn in yolo / permission-bypass mode so mention
+ * routing never wedges on an approval prompt (user decision, #1167). Flip to
+ * `false` post-MVP to restore each framework's default permission prompts — the
+ * approval-render path (§7) stays wired and lights up automatically if an
+ * approval ever arrives.
+ */
+export const CHANNEL_BINDING_YOLO_DEFAULT = true;
+/** Permission mode that maps to yolo for the web adapters (claude → --dangerously-skip-permissions). */
+const YOLO_PERMISSION_MODE = 'bypassPermissions';
+
+/** Per-binding FIFO turn queue cap; overflow → system row, message dropped. */
+const QUEUE_CAP = 8;
+/** Force-drain a genuinely-stuck turn after this long (paused while waitingOn != null). */
+const DEFAULT_WATCHDOG_MS = 5 * 60 * 1000;
+/** Consecutive agent-authored routed turns allowed between human/gateway posts. */
+export const MAX_CONSECUTIVE_AGENT_TURNS = 4;
+/** Dedupe identical unavailable/cross-node system rows per (channel, agent). */
+const UNAVAILABLE_ROW_TTL_MS = 5 * 60 * 1000;
+/** How long a resolved framework-availability list is reused before re-probing. */
+const TARGETS_TTL_MS = 5 * 1000;
+/** Newest rows fetched before the trigger to build a packet (packet caps to N). */
+const PACKET_FETCH_WINDOW = Math.min(
+  PACKET_MAX_ROWS * 3,
+  CHANNEL_HISTORY_MAX_LIMIT
+);
+
+// ── public types ─────────────────────────────────────────────────────────────
+
+export type ChannelAgentStatus =
+  | 'spawning'
+  | 'thinking'
+  | 'streaming'
+  | 'waiting'
+  | 'idle';
+
+/** A routable framework the binder resolves mentions against. */
+export interface MentionTarget {
+  id: string;
+  displayName: string;
+  kind: 'framework';
+  available: boolean;
+  reason: string | null;
+}
+
+export interface ChannelAgentRosterEntry {
+  id: string;
+  displayName: string;
+  kind: 'framework';
+  available: boolean;
+  reason: string | null;
+  binding: { sessionId: string; status: ChannelAgentStatus } | null;
+}
+
+export type ChannelAgentStatusBroadcaster = (
+  type: string,
+  data: Record<string, unknown>
+) => void;
+
+/** Minimal session surface the binder needs (real `sessions` module satisfies it). */
+export interface BinderSessions {
+  createWeb(params: CreateWebParams): Promise<{ session: WebSession }>;
+  get(id: string): Session | undefined;
+  onSessionEnd(
+    cb: (sessionId: string, cwd: string, branchName?: string) => void
+  ): () => void;
+}
+
+export interface ChannelAgentBinderDeps {
+  store: ChannelMessageStore;
+  hub: ChannelHub;
+  topicStore: WorkspaceTopicStore | null;
+  sessions: BinderSessions;
+  /** Resolve the current routable frameworks (builtin/configured + mock in tests). */
+  mentionTargets: () => Promise<MentionTarget[]>;
+  /** Provider ids used to resolve agent-to-agent mentions (adapter registry keys). */
+  knownProviderIds: readonly string[];
+  port: number;
+  configDir: string;
+  localNodeId?: string;
+  watchdogMs?: number;
+  yolo?: boolean;
+  now?: () => number;
+}
+
+export interface ChannelAgentBinder {
+  handleMessagePosted(
+    message: ChannelMessage,
+    mentions: ChannelMention[]
+  ): void;
+  ensureBinding(channelId: string, framework: string): Promise<LiveBinding>;
+  interrupt(channelId: string, agentId: string): Promise<void>;
+  respondToApproval(
+    channelId: string,
+    agentId: string,
+    requestId: string,
+    decision: AgentApprovalDecisionV2
+  ): Promise<void>;
+  rosterForChannel(channelId: string): Promise<ChannelAgentRosterEntry[]>;
+  setStatusBroadcaster(broadcaster: ChannelAgentStatusBroadcaster): void;
+  close(): void;
+}
+
+// ── internal live state ──────────────────────────────────────────────────────
+
+interface QueuedTurn {
+  trigger: ChannelMessage;
+}
+
+export interface LiveBinding {
+  channelId: string;
+  framework: string;
+  displayName: string;
+  sessionId: string | null;
+  adapter: ProtocolAdapterV2 | null;
+  unbind: (() => void) | null;
+  patchUnlisten: (() => void) | null;
+  status: ChannelAgentStatus;
+  activeTurnId: string | null;
+  /** Context packet for the active turn (kept so a retry re-sends identical content). */
+  activeContent: string | null;
+  sawStream: boolean;
+  waitingOn: string | null;
+  queue: QueuedTurn[];
+  watchdog: NodeJS.Timeout | null;
+  retriedTurns: Set<string>;
+  announcedApprovals: Set<string>;
+}
+
+export class ChannelBindingError extends Error {
+  constructor(
+    message: string,
+    /** Ready-to-post system-row text, rate-limited when `unavailable`. */
+    readonly systemMessage: string,
+    readonly unavailable = false
+  ) {
+    super(message);
+    this.name = 'ChannelBindingError';
+  }
+}
+
+export class ChannelAgentNotFoundError extends Error {
+  constructor(message = 'no live binding for agent') {
+    super(message);
+    this.name = 'ChannelAgentNotFoundError';
+  }
+}
+
+export class ChannelAgentNoActiveTurnError extends Error {
+  constructor(message = 'agent has no active turn') {
+    super(message);
+    this.name = 'ChannelAgentNoActiveTurnError';
+  }
+}
+
+const SYSTEM_SENDER = { kind: 'system', id: 'system' } as const;
+
+function bindingKey(channelId: string, framework: string): string {
+  return `${channelId}\u0000${framework}`;
+}
+
+export function createChannelAgentBinder(
+  deps: ChannelAgentBinderDeps
+): ChannelAgentBinder {
+  const { store, hub, topicStore } = deps;
+  const localNodeId = deps.localNodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const watchdogMs = deps.watchdogMs ?? DEFAULT_WATCHDOG_MS;
+  const yolo = deps.yolo ?? CHANNEL_BINDING_YOLO_DEFAULT;
+  const now = deps.now ?? (() => Date.now());
+
+  const live = new Map<string, LiveBinding>();
+  const inflight = new Map<string, Promise<LiveBinding>>();
+  const consecutiveAgentTurns = new Map<string, number>();
+  const unavailableRowAt = new Map<string, number>();
+  let statusBroadcaster: ChannelAgentStatusBroadcaster | null = null;
+  let targetsCache: { at: number; value: MentionTarget[] } | null = null;
+  let closed = false;
+
+  const unsubSessionEnd = deps.sessions.onSessionEnd((sessionId) =>
+    handleSessionEnd(sessionId)
+  );
+
+  // ── system-row helpers ──────────────────────────────────────────────────────
+
+  function postSystemRow(
+    channelId: string,
+    text: string,
+    meta?: Record<string, unknown>
+  ): void {
+    try {
+      const message = store.appendComplete({
+        channelId,
+        kind: 'system',
+        sender: { ...SYSTEM_SENDER },
+        text,
+        ...(meta ? { meta } : {}),
+      });
+      hub.broadcastCreated(message);
+    } catch (err) {
+      logger.warn('channel binder system row failed:', err);
+    }
+  }
+
+  function postUnavailableRow(
+    channelId: string,
+    framework: string,
+    text: string
+  ): void {
+    const key = `${bindingKey(channelId, framework)}\u0000${text}`;
+    const last = unavailableRowAt.get(key);
+    if (last !== undefined && now() - last < UNAVAILABLE_ROW_TTL_MS) return;
+    unavailableRowAt.set(key, now());
+    postSystemRow(channelId, text);
+  }
+
+  // ── availability targets ────────────────────────────────────────────────────
+
+  async function getTargets(): Promise<MentionTarget[]> {
+    if (targetsCache && now() - targetsCache.at < TARGETS_TTL_MS) {
+      return targetsCache.value;
+    }
+    const value = await deps.mentionTargets();
+    targetsCache = { at: now(), value };
+    return value;
+  }
+
+  async function resolveTarget(
+    framework: string
+  ): Promise<MentionTarget | undefined> {
+    const targets = await getTargets();
+    return targets.find((target) => target.id === framework);
+  }
+
+  // ── status ──────────────────────────────────────────────────────────────────
+
+  function setStatus(binding: LiveBinding, status: ChannelAgentStatus): void {
+    if (binding.status === status) return;
+    binding.status = status;
+    statusBroadcaster?.('channel-agent-status', {
+      channelId: binding.channelId,
+      agentId: binding.framework,
+      status,
+      sessionId: binding.sessionId ?? null,
+    });
+  }
+
+  // ── watchdog ────────────────────────────────────────────────────────────────
+
+  function armWatchdog(binding: LiveBinding): void {
+    disarmWatchdog(binding);
+    binding.watchdog = setTimeout(() => {
+      binding.watchdog = null;
+      // Never force-drain a turn parked on a human approval (§3 / Amendment 2):
+      // that would abandon the approval and release a concurrent send.
+      if (binding.activeTurnId === null || binding.waitingOn !== null) return;
+      logger.warn('channel binder watchdog force-drained a stuck turn', {
+        channelId: binding.channelId,
+        framework: binding.framework,
+        turnId: binding.activeTurnId,
+      });
+      finishTurn(binding);
+    }, watchdogMs);
+    binding.watchdog.unref?.();
+  }
+
+  function disarmWatchdog(binding: LiveBinding): void {
+    if (binding.watchdog) {
+      clearTimeout(binding.watchdog);
+      binding.watchdog = null;
+    }
+  }
+
+  // ── binding lifecycle ───────────────────────────────────────────────────────
+
+  function newLiveBinding(
+    channelId: string,
+    framework: string,
+    displayName: string
+  ): LiveBinding {
+    return {
+      channelId,
+      framework,
+      displayName,
+      sessionId: null,
+      adapter: null,
+      unbind: null,
+      patchUnlisten: null,
+      status: 'idle',
+      activeTurnId: null,
+      activeContent: null,
+      sawStream: false,
+      waitingOn: null,
+      queue: [],
+      watchdog: null,
+      retriedTurns: new Set(),
+      announcedApprovals: new Set(),
+    };
+  }
+
+  function attachSession(
+    channelId: string,
+    framework: string,
+    displayName: string,
+    session: { id: string; adapterV2: ProtocolAdapterV2 }
+  ): LiveBinding {
+    const key = bindingKey(channelId, framework);
+    const existing = live.get(key);
+    // Tear down any prior wiring before re-binding a fresh adapter.
+    existing?.unbind?.();
+    existing?.patchUnlisten?.();
+    const binding =
+      existing ?? newLiveBinding(channelId, framework, displayName);
+    binding.displayName = displayName;
+    binding.sessionId = session.id;
+    binding.adapter = session.adapterV2;
+    binding.unbind = bindSessionToChannel({
+      channelId,
+      agentFramework: framework,
+      adapter: session.adapterV2,
+      store,
+      hub,
+      displayName,
+      onAssistantMessageFinalized: (message) =>
+        handleAssistantFinalized(message),
+    });
+    binding.patchUnlisten = session.adapterV2.onPatch((patch) =>
+      handleBindingPatch(binding, patch)
+    );
+    live.set(key, binding);
+    return binding;
+  }
+
+  function healthySession(
+    sessionId: string | null,
+    framework: string
+  ): (Session & { adapterV2: ProtocolAdapterV2 }) | null {
+    if (!sessionId) return null;
+    const session = deps.sessions.get(sessionId);
+    if (
+      session &&
+      session.mode === 'web' &&
+      session.agent === framework &&
+      session.adapterV2
+    ) {
+      return session as Session & { adapterV2: ProtocolAdapterV2 };
+    }
+    return null;
+  }
+
+  function displayNameFor(channelId: string, framework: string): string {
+    const topic = topicStore?.get(channelId);
+    return `#${topic?.display.title ?? channelId} · ${framework}`;
+  }
+
+  async function doEnsureBinding(
+    channelId: string,
+    framework: string
+  ): Promise<LiveBinding> {
+    const key = bindingKey(channelId, framework);
+    const displayName = displayNameFor(channelId, framework);
+
+    // 2. Reuse a live entry whose session is still healthy.
+    const existing = live.get(key);
+    if (existing?.adapter && existing.sessionId) {
+      const session = healthySession(existing.sessionId, framework);
+      if (session && session.adapterV2 === existing.adapter) return existing;
+    }
+
+    // 3. Rebind a restored session that survived a live reconnect / restart.
+    const row = store.getBinding(channelId, framework);
+    const restored = healthySession(row?.sessionId ?? null, framework);
+    if (restored) {
+      return attachSession(channelId, framework, displayName, restored);
+    }
+
+    // 3.5 Cross-node guard (Amendment 1): a remote-node topic must fail visibly,
+    // never spawn a local stand-in.
+    const topic = topicStore?.get(channelId);
+    const nodeId = topic?.routingDefaults.nodeId;
+    if (nodeId && nodeId !== localNodeId) {
+      throw new ChannelBindingError(
+        `topic ${channelId} routes to remote node ${nodeId}`,
+        'Agents on other nodes are not yet supported in channels.',
+        true
+      );
+    }
+
+    // 4. Spawn a fresh local web session.
+    const routing = topic?.routingDefaults ?? {};
+    const cwd =
+      routing.cwd ?? routing.worktreePath ?? routing.repoPath ?? os.homedir();
+    const provisional =
+      existing ?? newLiveBinding(channelId, framework, displayName);
+    live.set(key, provisional);
+    setStatus(provisional, 'spawning');
+    let created: { session: WebSession };
+    try {
+      created = await deps.sessions.createWeb({
+        agentType: framework,
+        cwd,
+        displayName,
+        port: deps.port,
+        configDir: deps.configDir,
+        ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
+        ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
+        ...(yolo ? { permissionMode: YOLO_PERMISSION_MODE } : {}),
+      });
+    } catch (err) {
+      setStatus(provisional, 'idle');
+      throw new ChannelBindingError(
+        `spawn failed for @${framework}: ${errText(err)}`,
+        `@${framework} failed to start: ${errText(err)}`
+      );
+    }
+    const binding = attachSession(
+      channelId,
+      framework,
+      displayName,
+      created.session
+    );
+    store.upsertBinding({
+      channelId,
+      agentFramework: framework,
+      sessionId: created.session.id,
+    });
+    setStatus(binding, 'idle');
+    return binding;
+  }
+
+  function ensureBinding(
+    channelId: string,
+    framework: string
+  ): Promise<LiveBinding> {
+    const key = bindingKey(channelId, framework);
+    const pending = inflight.get(key);
+    if (pending) return pending;
+    // Store the promise BEFORE any await so two concurrent mentions of the same
+    // framework in one channel single-flight to exactly one spawn.
+    const promise = doEnsureBinding(channelId, framework).finally(() => {
+      inflight.delete(key);
+    });
+    inflight.set(key, promise);
+    return promise;
+  }
+
+  // ── turn queue + delivery ───────────────────────────────────────────────────
+
+  function enqueueTurn(binding: LiveBinding, trigger: ChannelMessage): void {
+    if (binding.queue.length >= QUEUE_CAP) {
+      postSystemRow(
+        binding.channelId,
+        `@${binding.framework} has ${QUEUE_CAP} turns queued — message dropped`
+      );
+      return;
+    }
+    binding.queue.push({ trigger });
+    pump(binding);
+  }
+
+  function pump(binding: LiveBinding): void {
+    if (binding.activeTurnId !== null) return;
+    if (!binding.adapter) return;
+    const next = binding.queue.shift();
+    if (!next) return;
+    sendTurn(binding, next.trigger);
+  }
+
+  function buildPacket(binding: LiveBinding, trigger: ChannelMessage): string {
+    const topic = topicStore?.get(binding.channelId);
+    const title = topic?.display.title ?? binding.channelId;
+    const row = store.getBinding(binding.channelId, binding.framework);
+    const lastDeliveredSeq =
+      typeof row?.providerSession['lastDeliveredSeq'] === 'number'
+        ? (row.providerSession['lastDeliveredSeq'] as number)
+        : 0;
+    const rows = store
+      .history(binding.channelId, {
+        beforeSeq: trigger.seq,
+        limit: PACKET_FETCH_WINDOW,
+      })
+      .filter((r) => r.seq < trigger.seq);
+    return buildMentionContextPacket({
+      channelTitle: title,
+      framework: binding.framework,
+      rows,
+      trigger,
+      lastDeliveredSeq,
+    });
+  }
+
+  function sendTurn(binding: LiveBinding, trigger: ChannelMessage): void {
+    const adapter = binding.adapter;
+    if (!adapter) return;
+    const turnId = `chturn-${trigger.id}-${binding.framework}`;
+    binding.activeTurnId = turnId;
+    binding.sawStream = false;
+    binding.waitingOn = null;
+    binding.activeContent = buildPacket(binding, trigger);
+    setStatus(binding, 'thinking');
+    armWatchdog(binding);
+    deliver(binding, adapter, turnId, trigger);
+  }
+
+  function deliver(
+    binding: LiveBinding,
+    adapter: ProtocolAdapterV2,
+    turnId: string,
+    trigger: ChannelMessage
+  ): void {
+    adapter
+      .sendMessage({
+        turnId,
+        content: binding.activeContent ?? '',
+        // Deterministic per routed (message, framework) turn (Amendment 3): a
+        // retry reuses the same turn identity. `clientMessageId` is forward-compat
+        // only — no adapter dedupes on it today.
+        clientMessageId: `${trigger.id}:${binding.framework}`,
+      })
+      .then(() => advanceCursor(binding, trigger.seq))
+      .catch((err) => handleSendFailure(binding, trigger, turnId, err));
+  }
+
+  function advanceCursor(binding: LiveBinding, triggerSeq: number): void {
+    // Cursor advances only on send acceptance (§4): a failed send re-offers the
+    // rows next mention (at-least-once). Never lower the cursor.
+    try {
+      const row = store.getBinding(binding.channelId, binding.framework);
+      const prev = row?.providerSession ?? {};
+      const current =
+        typeof prev['lastDeliveredSeq'] === 'number'
+          ? (prev['lastDeliveredSeq'] as number)
+          : 0;
+      if (triggerSeq <= current) return;
+      store.upsertBinding({
+        channelId: binding.channelId,
+        agentFramework: binding.framework,
+        providerSession: { ...prev, lastDeliveredSeq: triggerSeq },
+      });
+    } catch (err) {
+      logger.warn('channel binder cursor advance failed:', err);
+    }
+  }
+
+  async function handleSendFailure(
+    binding: LiveBinding,
+    trigger: ChannelMessage,
+    turnId: string,
+    err: unknown
+  ): Promise<void> {
+    // A rejected sendMessage means the turn was NEVER accepted (Amendment 3), so
+    // a single retry-after-rebind is safe — covers dead legacy-bridge transports.
+    if (!binding.retriedTurns.has(turnId)) {
+      binding.retriedTurns.add(turnId);
+      try {
+        const rebound = await ensureBinding(
+          binding.channelId,
+          binding.framework
+        );
+        if (rebound.adapter && rebound.activeTurnId === turnId) {
+          deliver(rebound, rebound.adapter, turnId, trigger);
+          return;
+        }
+        if (rebound.adapter) {
+          rebound.activeTurnId = turnId;
+          rebound.activeContent = binding.activeContent;
+          armWatchdog(rebound);
+          deliver(rebound, rebound.adapter, turnId, trigger);
+          return;
+        }
+      } catch {
+        // fall through to the error row
+      }
+    }
+    postSystemRow(
+      binding.channelId,
+      `@${binding.framework} could not receive the message: ${errText(err)}`
+    );
+    finishTurn(binding);
+  }
+
+  function finishTurn(binding: LiveBinding): void {
+    if (binding.activeTurnId === null) return;
+    binding.activeTurnId = null;
+    binding.activeContent = null;
+    binding.waitingOn = null;
+    binding.sawStream = false;
+    disarmWatchdog(binding);
+    setStatus(binding, 'idle');
+    pump(binding);
+  }
+
+  // ── binder-owned patch listener ─────────────────────────────────────────────
+
+  function markStreaming(binding: LiveBinding): void {
+    binding.sawStream = true;
+    if (binding.waitingOn === null) setStatus(binding, 'streaming');
+  }
+
+  function handleBindingPatch(
+    binding: LiveBinding,
+    patch: import('../shared/agent-chat-protocol-v2.js').AgentPatchV2
+  ): void {
+    switch (patch.type) {
+      case 'agent-item-started-v2':
+        if (patch.item.type === 'approval') {
+          handleApprovalStarted(binding, patch.item);
+        } else if (
+          patch.turnId === binding.activeTurnId &&
+          patch.item.type === 'assistantMessage'
+        ) {
+          markStreaming(binding);
+        }
+        break;
+      case 'agent-item-delta-v2':
+        if (
+          patch.turnId === binding.activeTurnId &&
+          typeof patch.delta.text === 'string'
+        ) {
+          markStreaming(binding);
+        }
+        break;
+      case 'agent-item-updated-v2':
+        if (patch.item.type === 'approval' && patch.item.decision) {
+          handleApprovalResolved(binding, patch.item);
+        }
+        break;
+      case 'agent-live-state-updated-v2':
+        if (patch.live.waitingOn !== undefined) {
+          updateWaiting(binding, patch.live.waitingOn);
+        }
+        break;
+      case 'agent-turn-completed-v2':
+        if (patch.turnId === binding.activeTurnId) finishTurn(binding);
+        break;
+      case 'agent-error-v2':
+        if ((patch.turnId ?? binding.activeTurnId) === binding.activeTurnId) {
+          // Only surface a system row when NO assistant row opened — otherwise the
+          // bridge's `failed` finalize is the visible artifact (§7, no duplicate).
+          if (!binding.sawStream) {
+            postSystemRow(
+              binding.channelId,
+              `@${binding.framework} errored: ${patch.message}`
+            );
+          }
+          finishTurn(binding);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  function updateWaiting(binding: LiveBinding, waitingOn: string | null): void {
+    binding.waitingOn = waitingOn;
+    if (binding.activeTurnId === null) return;
+    if (waitingOn !== null) {
+      setStatus(binding, 'waiting');
+      disarmWatchdog(binding);
+    } else {
+      setStatus(binding, binding.sawStream ? 'streaming' : 'thinking');
+      armWatchdog(binding);
+    }
+  }
+
+  function handleApprovalStarted(
+    binding: LiveBinding,
+    item: import('../shared/agent-chat-protocol-v2.js').AgentApprovalItemV2
+  ): void {
+    if (binding.announcedApprovals.has(item.requestId)) return;
+    binding.announcedApprovals.add(item.requestId);
+    postSystemRow(
+      binding.channelId,
+      `@${binding.framework} requests approval: ${item.description} (${item.target})`,
+      {
+        approvalRequestId: item.requestId,
+        agentId: binding.framework,
+        sessionId: binding.sessionId,
+      }
+    );
+  }
+
+  function handleApprovalResolved(
+    binding: LiveBinding,
+    item: import('../shared/agent-chat-protocol-v2.js').AgentApprovalItemV2
+  ): void {
+    if (!binding.announcedApprovals.has(item.requestId)) return;
+    binding.announcedApprovals.delete(item.requestId);
+    const kind = item.decision?.kind ?? 'resolved';
+    postSystemRow(binding.channelId, `@${binding.framework} approval ${kind}`);
+  }
+
+  // ── routing ─────────────────────────────────────────────────────────────────
+
+  function routeOne(trigger: ChannelMessage, framework: string): void {
+    void (async () => {
+      try {
+        const target = await resolveTarget(framework);
+        if (!target) return; // not a known framework — ignore silently
+        if (!target.available) {
+          postUnavailableRow(
+            trigger.channelId,
+            framework,
+            `@${framework} is not available in channels yet — ${target.reason ?? 'web sessions unavailable.'}`
+          );
+          return;
+        }
+        let binding: LiveBinding;
+        try {
+          binding = await ensureBinding(trigger.channelId, framework);
+        } catch (err) {
+          if (err instanceof ChannelBindingError) {
+            if (err.unavailable) {
+              postUnavailableRow(
+                trigger.channelId,
+                framework,
+                err.systemMessage
+              );
+            } else {
+              postSystemRow(trigger.channelId, err.systemMessage);
+            }
+            return;
+          }
+          throw err;
+        }
+        enqueueTurn(binding, trigger);
+      } catch (err) {
+        logger.warn('channel binder route failed:', err);
+      }
+    })();
+  }
+
+  /** Eligible (providerId-resolved, non-self) mentions in routing order. */
+  function eligibleFrameworks(
+    message: ChannelMessage,
+    mentions: ChannelMention[]
+  ): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const mention of mentions) {
+      const framework = mention.providerId;
+      if (!framework) continue; // unknown @name never routes (§1)
+      if (framework === message.sender.providerId) continue; // self-mention
+      if (seen.has(framework)) continue;
+      seen.add(framework);
+      out.push(framework);
+    }
+    return out;
+  }
+
+  function handleMessagePosted(
+    message: ChannelMessage,
+    mentions: ChannelMention[]
+  ): void {
+    if (closed) return;
+    if (message.kind !== 'message') return; // system rows never route (§1)
+    // Both browser-human and CLI-gateway-actor posts arrive here (postToChannel
+    // fires onMessagePosted for both). Treat every externally-injected post as a
+    // human turn for the loop brake: it resets the consecutive-agent counter and
+    // routes identically — the dogfood requirement (@claude via gateway ==
+    // browser). Only bound-session replies (handleAssistantFinalized) count.
+    consecutiveAgentTurns.set(message.channelId, 0);
+    for (const framework of eligibleFrameworks(message, mentions)) {
+      routeOne(message, framework);
+    }
+  }
+
+  function handleAssistantFinalized(message: ChannelMessage): void {
+    if (closed) return;
+    const mentions = parseMentions(message.body.text, deps.knownProviderIds);
+    const frameworks = eligibleFrameworks(message, mentions);
+    for (const framework of frameworks) {
+      const count = consecutiveAgentTurns.get(message.channelId) ?? 0;
+      if (count >= MAX_CONSECUTIVE_AGENT_TURNS) {
+        // Consecutive-agent-turn brake (Amendment 5): bounds total agent-token
+        // spend between human turns. Reset happens on the next human/gateway post.
+        postSystemRow(
+          message.channelId,
+          `Mention chain paused — ${count} agent turns without a human.`
+        );
+        break;
+      }
+      consecutiveAgentTurns.set(message.channelId, count + 1);
+      routeOne(message, framework);
+    }
+  }
+
+  // ── session death ───────────────────────────────────────────────────────────
+
+  function handleSessionEnd(sessionId: string): void {
+    for (const [key, binding] of live) {
+      if (binding.sessionId !== sessionId) continue;
+      binding.unbind?.(); // bridge finalizes any open stream 'interrupted'
+      binding.patchUnlisten?.();
+      disarmWatchdog(binding);
+      for (const queued of binding.queue) {
+        postSystemRow(
+          binding.channelId,
+          `@${binding.framework} session ended before delivering a queued message.`
+        );
+        void queued;
+      }
+      binding.queue = [];
+      binding.adapter = null;
+      binding.unbind = null;
+      binding.patchUnlisten = null;
+      binding.activeTurnId = null;
+      binding.activeContent = null;
+      binding.waitingOn = null;
+      binding.announcedApprovals.clear();
+      setStatus(binding, 'idle');
+      live.delete(key);
+      try {
+        store.upsertBinding({
+          channelId: binding.channelId,
+          agentFramework: binding.framework,
+          sessionId: null,
+        });
+      } catch (err) {
+        logger.warn('channel binder unbind persist failed:', err);
+      }
+    }
+  }
+
+  // ── control verbs ───────────────────────────────────────────────────────────
+
+  async function interrupt(channelId: string, agentId: string): Promise<void> {
+    const binding = live.get(bindingKey(channelId, agentId));
+    if (!binding || !binding.adapter) throw new ChannelAgentNotFoundError();
+    if (binding.activeTurnId === null)
+      throw new ChannelAgentNoActiveTurnError();
+    await binding.adapter.interrupt({ turnId: binding.activeTurnId });
+  }
+
+  async function respondToApproval(
+    channelId: string,
+    agentId: string,
+    requestId: string,
+    decision: AgentApprovalDecisionV2
+  ): Promise<void> {
+    const binding = live.get(bindingKey(channelId, agentId));
+    if (!binding || !binding.adapter) throw new ChannelAgentNotFoundError();
+    await binding.adapter.respondToApproval({ requestId, decision });
+  }
+
+  async function rosterForChannel(
+    channelId: string
+  ): Promise<ChannelAgentRosterEntry[]> {
+    const targets = await getTargets();
+    return targets.map((target) => {
+      const binding = live.get(bindingKey(channelId, target.id));
+      const row = store.getBinding(channelId, target.id);
+      const sessionId = binding?.sessionId ?? row?.sessionId ?? null;
+      return {
+        id: target.id,
+        displayName: target.displayName,
+        kind: 'framework',
+        available: target.available,
+        reason: target.reason,
+        binding: sessionId
+          ? { sessionId, status: binding?.status ?? 'idle' }
+          : null,
+      };
+    });
+  }
+
+  return {
+    handleMessagePosted,
+    ensureBinding,
+    interrupt,
+    respondToApproval,
+    rosterForChannel,
+    setStatusBroadcaster(broadcaster) {
+      statusBroadcaster = broadcaster;
+    },
+    close() {
+      closed = true;
+      unsubSessionEnd();
+      for (const binding of live.values()) {
+        disarmWatchdog(binding);
+        binding.unbind?.();
+        binding.patchUnlisten?.();
+      }
+      live.clear();
+      inflight.clear();
+      consecutiveAgentTurns.clear();
+      unavailableRowAt.clear();
+      targetsCache = null;
+    },
+  };
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Keep referenced binding shape exported for callers/tests without widening deps.
+export type { ChannelBinding };

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -5,6 +5,7 @@ import type { ChannelHub } from './channel-hub.js';
 import type { ChannelMessageStore } from './channel-message-store.js';
 import {
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
+  type ChannelMessage,
   type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 
@@ -46,6 +47,14 @@ export interface BindSessionToChannelInput {
   store: ChannelMessageStore;
   hub: ChannelHub;
   displayName?: string;
+  /**
+   * Invoked in `finalize()` after `completeStreamBroadcast` for `status ===
+   * 'complete'` rows ONLY (#1167 §8). Bridge-authored replies bypass
+   * `postToChannel`, so `onMessagePosted` never fires for them — this is the sole
+   * hook that lets a spawned channel agent's reply trigger another agent
+   * (agent-to-agent mentions). Interrupted/failed rows never fire it.
+   */
+  onAssistantMessageFinalized?: (message: ChannelMessage) => void;
 }
 
 /**
@@ -166,11 +175,20 @@ export function bindSessionToChannel(
     } catch (err) {
       logger.warn('channel bridge member upsert failed:', err);
     }
+    // #1167 §8: only a cleanly-completed assistant reply may trigger downstream
+    // agent-to-agent mentions. Interrupted/failed rows never fan out.
+    if (status === 'complete' && input.onAssistantMessageFinalized) {
+      try {
+        input.onAssistantMessageFinalized(message);
+      } catch (err) {
+        logger.warn('channel bridge onAssistantMessageFinalized failed:', err);
+      }
+    }
   }
 
   function finalizeTurn(
     turnId: string | undefined,
-    status: 'complete' | 'failed'
+    status: 'complete' | 'interrupted' | 'failed'
   ): void {
     for (const stream of streams.values()) {
       if (stream.closed) continue;
@@ -214,7 +232,16 @@ export function bindSessionToChannel(
         break;
       }
       case 'agent-turn-completed-v2': {
-        finalizeTurn(patch.turnId, 'complete');
+        // #1167 §5: honor the turn's terminal status instead of hard-coding
+        // 'complete' so an interrupted/failed turn produces an honestly-labeled
+        // row (drives the interrupt affordance + error surfacing).
+        const status =
+          patch.status === 'interrupted'
+            ? 'interrupted'
+            : patch.status === 'failed'
+              ? 'failed'
+              : 'complete';
+        finalizeTurn(patch.turnId, status);
         break;
       }
       case 'agent-error-v2': {

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -13,8 +13,14 @@ import {
   type ChannelMessageStore,
 } from './channel-message-store.js';
 import type { ChannelHub } from './channel-hub.js';
+import {
+  ChannelAgentNoActiveTurnError,
+  ChannelAgentNotFoundError,
+  type ChannelAgentBinder,
+} from './channel-agent-binder.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
 import type { WorkspaceTopic } from '../shared/workspace-topics.js';
+import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import {
   parseMentions,
   type ChannelBodyFormat,
@@ -75,6 +81,8 @@ export interface ChannelChatRouterDeps {
   store: ChannelMessageStore | null;
   hub: ChannelHub;
   topicStore: WorkspaceTopicStore | null;
+  /** @-mention routing binder (#1167); roster/interrupt/approval routes 503 without it. */
+  binder?: ChannelAgentBinder | null;
   /** framework ids for @-mention resolution (v2 adapter registry + topic default). */
   knownProviderIds?: readonly string[];
   /** byte budget for one history response body (defaults to 4MB). */
@@ -217,6 +225,23 @@ function topicStoreOr503(
   return null;
 }
 
+function binderOr503(
+  res: Response,
+  binder: ChannelAgentBinder | null | undefined
+): ChannelAgentBinder | null {
+  if (binder) return binder;
+  sendGatewayError(
+    res,
+    'SERVER_UNAVAILABLE',
+    'channel agent binder unavailable',
+    true,
+    {
+      reasonCode: 'CHANNEL_BINDER_UNAVAILABLE',
+    }
+  );
+  return null;
+}
+
 /**
  * Server-derived sender attribution from the authenticated lane — NEVER from the
  * request body ([MF]: attribution is the core product promise). Browser cookie
@@ -347,6 +372,29 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   const getAuth = deps.requireReadActorAuth?.('channels.get') ?? auth;
   const historyAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
   const postAuth = deps.requireWriteActorAuth?.('channels.post') ?? auth;
+  const rosterAuth = deps.requireReadActorAuth?.('channels.roster') ?? auth;
+  const interruptAuth =
+    deps.requireWriteActorAuth?.('channels.interrupt') ?? auth;
+  const approvalAuth =
+    deps.requireWriteActorAuth?.('channels.respond-approval') ?? auth;
+
+  /** Persisted, non-derived channel guard shared by the #1167 agent routes. */
+  function requirePersistedChannel(
+    req: Request,
+    res: Response
+  ): WorkspaceTopic | null {
+    const topicStore = topicStoreOr503(res, deps.topicStore);
+    if (!topicStore) return null;
+    const id = req.params['id'] ?? '';
+    const topic = topicStore.get(id);
+    if (!topic || topic.source !== 'persisted') {
+      sendGatewayError(res, 'NOT_FOUND', 'channel not found', false, {
+        channelId: id,
+      });
+      return null;
+    }
+    return topic;
+  }
 
   router.get('/channels', listAuth, (req, res) => {
     if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
@@ -410,8 +458,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     if (threadId) filter.threadId = threadId;
     try {
       const all = store.history(id, filter);
-      const direction =
-        filter.afterSeq !== undefined ? 'forward' : 'backward';
+      const direction = filter.afterSeq !== undefined ? 'forward' : 'backward';
       const budgeted = budgetHistoryRows(
         all,
         direction,
@@ -525,6 +572,122 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       mapStoreError(res, error);
     }
   });
+
+  // #1167 §2: per-request agent roster (framework availability + live binding
+  // status). Derived per request — no persistent handle registry.
+  router.get('/channels/:id/roster', rosterAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    if (!storeOr503(res, deps.store)) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    const binder = binderOr503(res, deps.binder);
+    if (!binder) return;
+    binder
+      .rosterForChannel(topic.id)
+      .then((roster) => res.json({ roster }))
+      .catch((error) => mapStoreError(res, error));
+  });
+
+  // #1167 §7: interrupt the agent's active turn.
+  router.post(
+    '/channels/:id/agents/:agentId/interrupt',
+    interruptAuth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+      const topic = requirePersistedChannel(req, res);
+      if (!topic) return;
+      const binder = binderOr503(res, deps.binder);
+      if (!binder) return;
+      const agentId = req.params['agentId'] ?? '';
+      binder
+        .interrupt(topic.id, agentId)
+        .then(() => res.json({ ok: true }))
+        .catch((error) => {
+          if (error instanceof ChannelAgentNotFoundError) {
+            sendGatewayError(res, 'NOT_FOUND', 'no live agent binding', false, {
+              channelId: topic.id,
+              agentId,
+              reasonCode: 'CHANNEL_AGENT_NOT_BOUND',
+            });
+            return;
+          }
+          if (error instanceof ChannelAgentNoActiveTurnError) {
+            sendGatewayError(
+              res,
+              'SESSION_CONFLICT',
+              'agent has no active turn to interrupt',
+              false,
+              { channelId: topic.id, agentId, reasonCode: 'NO_ACTIVE_TURN' }
+            );
+            return;
+          }
+          mapStoreError(res, error);
+        });
+    }
+  );
+
+  // #1167 §7: respond to an in-channel approval request.
+  router.post(
+    '/channels/:id/agents/:agentId/approvals',
+    approvalAuth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+      const topic = requirePersistedChannel(req, res);
+      if (!topic) return;
+      const binder = binderOr503(res, deps.binder);
+      if (!binder) return;
+      const agentId = req.params['agentId'] ?? '';
+      const body = bodyRecord(req);
+      const requestId = body['requestId'];
+      if (typeof requestId !== 'string' || requestId.length === 0) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'requestId is required',
+          false,
+          {
+            field: 'requestId',
+          }
+        );
+        return;
+      }
+      const decision = body['decision'];
+      if (
+        !isRecord(decision) ||
+        (decision['kind'] !== 'accept' &&
+          decision['kind'] !== 'decline' &&
+          decision['kind'] !== 'cancel')
+      ) {
+        sendGatewayError(
+          res,
+          'INVALID_ARGUMENT',
+          'decision.kind must be accept|decline|cancel',
+          false,
+          { field: 'decision' }
+        );
+        return;
+      }
+      binder
+        .respondToApproval(
+          topic.id,
+          agentId,
+          requestId,
+          decision as unknown as AgentApprovalDecisionV2
+        )
+        .then(() => res.json({ ok: true }))
+        .catch((error) => {
+          if (error instanceof ChannelAgentNotFoundError) {
+            sendGatewayError(res, 'NOT_FOUND', 'no live agent binding', false, {
+              channelId: topic.id,
+              agentId,
+              reasonCode: 'CHANNEL_AGENT_NOT_BOUND',
+            });
+            return;
+          }
+          mapStoreError(res, error);
+        });
+    }
+  );
 
   return router;
 }

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -1,0 +1,145 @@
+import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+
+// Pure context-packet builder for @-mention routing (#1167, slice 4). No I/O:
+// store rows in, prompt string out — fully unit-testable. The binder fetches the
+// eligible rows (`store.history(channelId, { afterSeq: lastDeliveredSeq })`
+// filtered to `seq < trigger.seq`) and hands them here; this module owns ONLY the
+// deterministic string shape (§4 of the spec). It never touches the network, the
+// store, or the adapter, so the golden test pins the exact bytes an agent sees.
+
+/** Newest N context rows retained; older eligible rows collapse to one marker. */
+export const PACKET_MAX_ROWS = 20;
+/** Per-row body cap before the ellipsis marker (token frugality). */
+export const PACKET_ROW_MAX_CHARS = 2000;
+/** Whole-packet byte budget — oldest context rows drop until under (never the trigger). */
+export const PACKET_MAX_BYTES = 24 * 1024;
+
+const OMITTED_MARKER = '[…earlier messages omitted]';
+const ROW_TRUNCATED_SUFFIX = '…[truncated]';
+
+export interface BuildMentionContextPacketInput {
+  /** Human-facing channel title (topic display title), rendered as `#<title>`. */
+  channelTitle: string;
+  /** Framework id the packet is addressed to (`you are @<framework>`). */
+  framework: string;
+  /**
+   * Eligible prior rows, oldest-first: every row with
+   * `lastDeliveredSeq < seq < trigger.seq`. The agent's own prior rows are
+   * skipped HERE (they already live in the reused provider conversation), so the
+   * binder may pass the raw window untrimmed.
+   */
+  rows: ChannelMessage[];
+  /** The mention row itself — always rendered in the footer, never dropped. */
+  trigger: ChannelMessage;
+  /** Cursor: 0 for a first-ever mention (cold session → full orientation window). */
+  lastDeliveredSeq: number;
+}
+
+function senderLabel(message: ChannelMessage): string {
+  return message.sender.displayName ?? message.sender.id;
+}
+
+/** Render one row as `label: text`, agent-tagged, with multi-line bodies indented. */
+function renderRow(message: ChannelMessage): string {
+  const truncated =
+    message.body.text.length > PACKET_ROW_MAX_CHARS
+      ? message.body.text.slice(0, PACKET_ROW_MAX_CHARS) + ROW_TRUNCATED_SUFFIX
+      : message.body.text;
+  const lines = truncated.split('\n');
+  const first = lines[0] ?? '';
+  const rest = lines.slice(1);
+  const indentRest = (body: string): string =>
+    rest.length > 0
+      ? body + '\n' + rest.map((l) => `    ${l}`).join('\n')
+      : body;
+
+  if (message.kind === 'system' || message.sender.kind === 'system') {
+    return indentRest(`[system]: ${first}`);
+  }
+  const label = senderLabel(message);
+  if (message.sender.kind === 'agent') {
+    return indentRest(`${label} [agent]: ${first}`);
+  }
+  return indentRest(`${label}: ${first}`);
+}
+
+/**
+ * Build the deterministic context packet delivered as the agent's turn content.
+ *
+ * Shape (§4):
+ *   [Relay channel #<title> — you are @<framework>, one participant in a multi-party chat]
+ *   Recent messages, oldest first. Lines are "sender: text"; ...        (only with context)
+ *   […earlier messages omitted]                                          (only when >N eligible)
+ *   <sender>: <text>
+ *   ...
+ *                                                                        (blank line)
+ *   [<trigger sender> mentioned you — reply to this message; your reply is posted to the channel]
+ *   <trigger text>
+ *
+ * A reused session with no interim rows collapses to header + footer only — the
+ * provider already holds the conversation, so re-sending it wastes tokens.
+ */
+export function buildMentionContextPacket(
+  input: BuildMentionContextPacketInput
+): string {
+  const header = `[Relay channel #${input.channelTitle} — you are @${input.framework}, one participant in a multi-party chat]`;
+
+  // Eligible = rows strictly after the delivery cursor and strictly before the
+  // trigger, minus the agent's OWN prior rows (already in its reused provider
+  // conversation — re-sending wastes tokens and confuses attribution). A reused
+  // session with no interim rows therefore yields an empty window → header +
+  // footer only; a first-ever mention (cursor 0) yields the full orientation
+  // window.
+  const eligible = input.rows.filter(
+    (row) =>
+      row.seq > input.lastDeliveredSeq &&
+      row.seq < input.trigger.seq &&
+      !(
+        row.sender.kind === 'agent' && row.sender.providerId === input.framework
+      )
+  );
+
+  let contextRows = eligible;
+  let omittedEarlier = false;
+  if (contextRows.length > PACKET_MAX_ROWS) {
+    omittedEarlier = true;
+    contextRows = contextRows.slice(contextRows.length - PACKET_MAX_ROWS);
+  }
+
+  const triggerLabel = senderLabel(input.trigger);
+  const triggerText =
+    input.trigger.body.text.length > PACKET_ROW_MAX_CHARS
+      ? input.trigger.body.text.slice(0, PACKET_ROW_MAX_CHARS) +
+        ROW_TRUNCATED_SUFFIX
+      : input.trigger.body.text;
+  const footer = [
+    `[${triggerLabel} mentioned you — reply to this message; your reply is posted to the channel]`,
+    triggerText,
+  ].join('\n');
+
+  const assemble = (rows: ChannelMessage[], omitted: boolean): string => {
+    if (rows.length === 0) {
+      return `${header}\n\n${footer}`;
+    }
+    const contextBlock = [
+      'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+      ...(omitted ? [OMITTED_MARKER] : []),
+      ...rows.map(renderRow),
+    ].join('\n');
+    return `${header}\n${contextBlock}\n\n${footer}`;
+  };
+
+  // Whole-packet byte budget: drop oldest context rows until under (never the
+  // trigger/footer). A single over-budget footer is still delivered — losing the
+  // mention is worse than a slightly oversized packet.
+  let packet = assemble(contextRows, omittedEarlier);
+  while (
+    contextRows.length > 0 &&
+    Buffer.byteLength(packet, 'utf8') > PACKET_MAX_BYTES
+  ) {
+    contextRows = contextRows.slice(1);
+    omittedEarlier = true;
+    packet = assemble(contextRows, omittedEarlier);
+  }
+  return packet;
+}

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -39,6 +39,24 @@ function senderLabel(message: ChannelMessage): string {
   return message.sender.displayName ?? message.sender.id;
 }
 
+/**
+ * Trigger-footer attribution: unambiguously marks whether the mention was
+ * authored by a human or another agent (and which one). A bare display name is
+ * forgeable/ambiguous — a human named "claude" reads identically to the claude
+ * agent — so the receiving agent cannot tell a human mention from an
+ * agent-authored one without this tag (§4/§5 attribution promise, #1167 P2).
+ */
+function triggerAttribution(message: ChannelMessage): string {
+  const label = senderLabel(message);
+  if (message.sender.kind === 'agent') {
+    return `${label} [agent:${message.sender.providerId ?? message.sender.id}]`;
+  }
+  if (message.sender.kind === 'system') {
+    return `${label} [system]`;
+  }
+  return `${label} [human]`;
+}
+
 /** Render one row as `label: text`, agent-tagged, with multi-line bodies indented. */
 function renderRow(message: ChannelMessage): string {
   const truncated =
@@ -106,7 +124,7 @@ export function buildMentionContextPacket(
     contextRows = contextRows.slice(contextRows.length - PACKET_MAX_ROWS);
   }
 
-  const triggerLabel = senderLabel(input.trigger);
+  const triggerLabel = triggerAttribution(input.trigger);
   const triggerText =
     input.trigger.body.text.length > PACKET_ROW_MAX_CHARS
       ? input.trigger.body.text.slice(0, PACKET_ROW_MAX_CHARS) +

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -341,6 +341,13 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
   if (meta?.mentions && Array.isArray(meta.mentions)) {
     message.mentions = meta.mentions;
   }
+  // Surface app-level meta (e.g. #1167 approval payloads) while keeping the
+  // internal routing keys off the wire — providerId rides `sender.providerId`,
+  // mentions/truncated have dedicated fields above.
+  if (meta) {
+    const { providerId: _pid, mentions: _m, truncated: _t, ...rest } = meta;
+    if (Object.keys(rest).length > 0) message.meta = rest;
+  }
   if (row.source_session_id) {
     message.source = {
       sessionId: row.source_session_id,

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -71,6 +71,7 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'channels.list',
   'channels.get',
   'channels.history',
+  'channels.roster',
   'context.get',
   'context.list',
   'inbox.list',
@@ -108,6 +109,8 @@ export const CLI_GATEWAY_ACTOR_WRITE_COMMANDS = [
   'workspace-topics.archive',
   'workspace-topics.restore',
   'channels.post',
+  'channels.interrupt',
+  'channels.respond-approval',
 ] as const;
 export type CliGatewayActorWriteCommand =
   (typeof CLI_GATEWAY_ACTOR_WRITE_COMMANDS)[number];
@@ -343,10 +346,16 @@ export function cliGatewayActorCommandCapabilities(
   if (
     command === 'channels.list' ||
     command === 'channels.get' ||
-    command === 'channels.history'
+    command === 'channels.history' ||
+    command === 'channels.roster'
   )
     return ['context:read'];
-  if (command === 'channels.post') return ['context:write'];
+  if (
+    command === 'channels.post' ||
+    command === 'channels.interrupt' ||
+    command === 'channels.respond-approval'
+  )
+    return ['context:write'];
   if (
     command === 'workflow-runs.list' ||
     command === 'workflow-runs.get' ||

--- a/server/index.ts
+++ b/server/index.ts
@@ -144,6 +144,7 @@ import {
   getFrameworkAvailability,
   getFrameworkClientInfoWithRuntime,
   getFrameworkWebAvailability,
+  listConfiguredFrameworks,
 } from './frameworks.js';
 import {
   createOpenAiCompatibleCommandCenterIntentProvider,
@@ -233,6 +234,11 @@ import {
 } from './channel-message-store.js';
 import { createChannelHub, type ChannelHub } from './channel-hub.js';
 import { createChannelChatRouter } from './channel-chat-router.js';
+import {
+  createChannelAgentBinder,
+  type ChannelAgentBinder,
+  type MentionTarget,
+} from './channel-agent-binder.js';
 import { v2Adapters } from './protocol-adapters/index.js';
 import {
   initWorkContextArtifactStore,
@@ -1715,6 +1721,36 @@ function initChannelMessageStoreBestEffort(
   }
 }
 
+/**
+ * Routable framework targets for @-mention routing (#1167): builtin/configured
+ * frameworks gated on `supportsWebSessions` + web availability, plus `mock` when
+ * `RELAY_MOCK_AGENT=1` (dev/tests). Unavailable frameworks are INCLUDED with
+ * `available:false` so the palette can render them greyed with the reason.
+ */
+async function channelMentionTargets(config: Config): Promise<MentionTarget[]> {
+  const targets: MentionTarget[] = [];
+  for (const framework of listConfiguredFrameworks(config.frameworks)) {
+    const web = await getFrameworkWebAvailability(framework);
+    targets.push({
+      id: framework.id,
+      displayName: framework.displayName,
+      kind: 'framework',
+      available: web.available,
+      reason: web.available ? null : (web.reason ?? null),
+    });
+  }
+  if (process.env['RELAY_MOCK_AGENT'] === '1') {
+    targets.push({
+      id: 'mock',
+      displayName: 'Mock Agent',
+      kind: 'framework',
+      available: true,
+      reason: null,
+    });
+  }
+  return targets;
+}
+
 async function ensureStartupTerminalBackendAvailable(
   _startupConfig: Config
 ): Promise<void> {}
@@ -2016,6 +2052,31 @@ async function main(): Promise<void> {
     store: channelMessageStore,
     channelExists: (channelId) => Boolean(workspaceTopicStore?.get(channelId)),
   });
+  // @-mention routing binder (#1167): spawns/reuses (channel, framework) web
+  // sessions on mention and streams replies back through the slice-2 bridge.
+  // Null when the channel store failed to init (routes degrade to 503).
+  const channelAgentBinder: ChannelAgentBinder | null = channelMessageStore
+    ? createChannelAgentBinder({
+        store: channelMessageStore,
+        hub: channelHub,
+        topicStore: workspaceTopicStore,
+        sessions: {
+          createWeb: sessions.createWeb,
+          get: sessions.get,
+          onSessionEnd: sessions.onSessionEnd,
+        },
+        knownProviderIds: Object.keys(v2Adapters),
+        mentionTargets: () => channelMentionTargets(getConfig()),
+        port: startupConfig.port,
+        configDir,
+        localNodeId: DEFAULT_LOCAL_NODE_ID,
+      })
+    : null;
+  if (channelAgentBinder) {
+    channelHub.onMessagePosted((message, mentions) =>
+      channelAgentBinder.handleMessagePosted(message, mentions)
+    );
+  }
   const cliGatewayEventBus = createCliGatewayEventBus();
 
   try {
@@ -2725,6 +2786,7 @@ async function main(): Promise<void> {
       store: channelMessageStore,
       hub: channelHub,
       topicStore: workspaceTopicStore,
+      binder: channelAgentBinder,
       knownProviderIds: Object.keys(v2Adapters),
       requireAuth: requireCliGatewayAuth,
       requireReadActorAuth: requireCliGatewayAuthForActorCommand,
@@ -3199,6 +3261,9 @@ async function main(): Promise<void> {
     { strictDeny: process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1' },
     channelHub
   );
+  // Coarse per-agent status rides the existing /ws/events lane (#1167 §6),
+  // mirroring the sidebar-badge broadcaster pattern.
+  channelAgentBinder?.setStatusBroadcaster(broadcastEvent);
 
   const browserScopedToken = generateScopedToken();
   process.env['RELAY_IDE_BROWSER'] = '1';
@@ -5833,6 +5898,7 @@ async function main(): Promise<void> {
         workspaceTopicStore?.close();
         prOverseerStore?.close();
         workContextMessageStore?.close();
+        channelAgentBinder?.close();
         channelHub.close();
         channelMessageStore?.close();
         closeInterventionLog();
@@ -5919,6 +5985,7 @@ async function main(): Promise<void> {
     workspaceTopicStore?.close();
     prOverseerStore?.close();
     workContextMessageStore?.close();
+    channelAgentBinder?.close();
     channelHub.close();
     channelMessageStore?.close();
     closeInterventionLog();

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -66,6 +66,13 @@ export interface ChannelMessage {
   parentMessageId: ChannelMessageId | null;
   mentions?: ChannelMention[];
   source?: ChannelMessageSource;
+  /**
+   * Opaque row metadata surfaced to clients (#1167). System rows carry actionable
+   * payloads here — e.g. an approval request `{ approvalRequestId, agentId,
+   * sessionId }` the timeline renders approve/deny controls for. Additive and
+   * optional: rows without meta are unaffected.
+   */
+  meta?: Record<string, unknown>;
   truncated?: boolean;
   clientMessageId?: string;
   createdAt: string;

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1,0 +1,677 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import {
+  BaseProtocolAdapterV2,
+  type AdapterConfig,
+  type AdapterStatus,
+  type AgentInterruptInputV2,
+  type AgentSendMessageInputV2,
+  type ProtocolAdapterV2,
+} from '../server/protocol-adapter-v2.js';
+import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
+import {
+  createChannelAgentBinder,
+  MAX_CONSECUTIVE_AGENT_TURNS,
+  type BinderSessions,
+  type ChannelAgentBinder,
+  type MentionTarget,
+} from '../server/channel-agent-binder.js';
+import type { Session, WebSession } from '../server/types.js';
+import type { WorkspaceTopicStore } from '../server/workspace-topics.js';
+import {
+  parseMentions,
+  type ChannelMessage,
+  type ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+const cleanup: Array<() => void> = [];
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+const CH = 'topic:test';
+const OPERATOR: ChannelSenderRef = {
+  kind: 'human',
+  id: 'human:operator',
+  displayName: 'operator',
+};
+
+function makeStore(): { store: ChannelMessageStore; hub: ChannelHub } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-binder-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => store.close());
+  const hub = createChannelHub({ store, channelExists: () => true });
+  cleanup.push(() => hub.close());
+  return { store, hub };
+}
+
+async function waitFor(
+  cond: () => boolean,
+  ms = 4000,
+  step = 5
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, step));
+  }
+  throw new Error('waitFor timed out');
+}
+
+function rows(store: ChannelMessageStore): ChannelMessage[] {
+  return store.history(CH, { limit: 200 });
+}
+function agentReplies(store: ChannelMessageStore, providerId?: string) {
+  return rows(store).filter(
+    (m) =>
+      m.sender.kind === 'agent' &&
+      m.status === 'complete' &&
+      (!providerId || m.sender.providerId === providerId)
+  );
+}
+function systemRows(store: ChannelMessageStore) {
+  return rows(store).filter((m) => m.kind === 'system');
+}
+
+function post(
+  store: ChannelMessageStore,
+  binder: ChannelAgentBinder,
+  text: string,
+  knownIds: string[],
+  sender: ChannelSenderRef = OPERATOR
+): ChannelMessage {
+  const mentions = parseMentions(text, knownIds);
+  const message = store.appendComplete({
+    channelId: CH,
+    sender,
+    text,
+    ...(mentions.length ? { mentions } : {}),
+  });
+  binder.handleMessagePosted(message, message.mentions ?? []);
+  return message;
+}
+
+// ── scripted adapter (deterministic, no timers) ──────────────────────────────
+
+type ScriptMode =
+  | { mode: 'stall' }
+  | { mode: 'reply'; text: string }
+  | { mode: 'reject-once-then-reply'; text: string };
+
+class ScriptedAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    queue: false,
+    interrupt: true,
+    approvals: true,
+    streaming: true,
+  };
+  readonly sendCalls: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'scripted';
+  private rejected = false;
+
+  constructor(
+    readonly agentType: string,
+    private readonly script: ScriptMode
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(_input: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    if (this.script.mode === 'reject-once-then-reply' && !this.rejected) {
+      this.rejected = true;
+      throw new Error('transport down');
+    }
+    if (this.script.mode === 'stall') return; // resolve, never complete
+    this.runReply(input.turnId, this.script.text);
+  }
+
+  private runReply(turnId: string, text: string): void {
+    const itemId = `assistant-${turnId}`;
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turn: {
+        id: turnId,
+        status: 'running',
+        inputMessageId: `u-${turnId}`,
+        items: [],
+        startedAt: 't',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: { type: 'assistantMessage', id: itemId, text: '' },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      itemId,
+      delta: { text },
+    });
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: {
+        type: 'assistantMessage',
+        id: itemId,
+        text,
+        status: 'completed',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status: 'completed',
+    });
+  }
+}
+
+// ── sessions harness ─────────────────────────────────────────────────────────
+
+interface SessionsHarness {
+  sessions: BinderSessions;
+  spawns: () => number;
+  firstSessionId: () => string;
+  adapterFor: (sessionId: string) => ProtocolAdapterV2;
+  fireEnd: (sessionId: string) => void;
+}
+
+function makeSessions(
+  build: (agentType: string) => ProtocolAdapterV2,
+  opts: { throwOnCreate?: boolean } = {}
+): SessionsHarness {
+  const created = new Map<string, { session: WebSession }>();
+  const order: string[] = [];
+  const endCbs: Array<(id: string, cwd: string, br?: string) => void> = [];
+  let spawns = 0;
+  const sessions: BinderSessions = {
+    async createWeb(params) {
+      spawns++;
+      if (opts.throwOnCreate) throw new Error('boom: spawn failed');
+      const id = `sess-${spawns}-${params.agentType}`;
+      const adapter = build(params.agentType);
+      await adapter.connect({
+        cwd: params.cwd,
+        port: 0,
+        sessionId: id,
+        hookToken: 't',
+        configDir: params.configDir,
+      });
+      const session = {
+        id,
+        mode: 'web',
+        agent: params.agentType,
+        adapterV2: adapter,
+        cwd: params.cwd,
+      } as unknown as WebSession;
+      created.set(id, { session });
+      order.push(id);
+      return { session };
+    },
+    get(id) {
+      return created.get(id)?.session as unknown as Session | undefined;
+    },
+    onSessionEnd(cb) {
+      endCbs.push(cb);
+      return () => {
+        const i = endCbs.indexOf(cb);
+        if (i >= 0) endCbs.splice(i, 1);
+      };
+    },
+  };
+  return {
+    sessions,
+    spawns: () => spawns,
+    firstSessionId: () => order[0]!,
+    adapterFor: (id) => created.get(id)!.session.adapterV2,
+    fireEnd: (id) => {
+      created.delete(id);
+      for (const cb of [...endCbs]) cb(id, '/tmp');
+    },
+  };
+}
+
+const MOCK_TARGETS: MentionTarget[] = [
+  {
+    id: 'mock',
+    displayName: 'Mock',
+    kind: 'framework',
+    available: true,
+    reason: null,
+  },
+];
+
+function makeBinder(cfg: {
+  build: (agentType: string) => ProtocolAdapterV2;
+  targets: MentionTarget[];
+  knownProviderIds: string[];
+  topicStore?: WorkspaceTopicStore | null;
+  watchdogMs?: number;
+  throwOnCreate?: boolean;
+}): {
+  binder: ChannelAgentBinder;
+  store: ChannelMessageStore;
+  hub: ChannelHub;
+  sessions: SessionsHarness;
+} {
+  const { store, hub } = makeStore();
+  const sessions = makeSessions(cfg.build, {
+    ...(cfg.throwOnCreate ? { throwOnCreate: true } : {}),
+  });
+  const binder = createChannelAgentBinder({
+    store,
+    hub,
+    topicStore: cfg.topicStore ?? null,
+    sessions: sessions.sessions,
+    knownProviderIds: cfg.knownProviderIds,
+    mentionTargets: async () => cfg.targets,
+    port: 0,
+    configDir: '/tmp',
+    ...(cfg.watchdogMs !== undefined ? { watchdogMs: cfg.watchdogMs } : {}),
+  });
+  cleanup.push(() => binder.close());
+  return { binder, store, hub, sessions };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('channel-agent-binder — lifecycle', () => {
+  it('first mention spawns exactly one session and streams the reply as agent:mock', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    post(store, binder, '@mock hello', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(sessions.spawns()).toBe(1);
+    const reply = agentReplies(store, 'mock')[0]!;
+    expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.body.text).toBe('Mock v2 response complete.');
+  });
+
+  it('two concurrent mentions single-flight to exactly one spawn', async () => {
+    const { binder, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 5, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const [b1, b2] = await Promise.all([
+      binder.ensureBinding(CH, 'mock'),
+      binder.ensureBinding(CH, 'mock'),
+    ]);
+    expect(sessions.spawns()).toBe(1);
+    expect(b1).toBe(b2);
+  });
+
+  it('a second sequential mention reuses the live session (no respawn)', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    post(store, binder, '@mock one', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    post(store, binder, '@mock two', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(sessions.spawns()).toBe(1);
+  });
+
+  it('a mention while streaming queues and drains after the active turn', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 30 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    post(store, binder, '@mock a', ['mock']);
+    post(store, binder, '@mock b', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 2, 6000);
+    expect(sessions.spawns()).toBe(1);
+  });
+
+  it('queue overflow past the cap drops the message with a system row', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new ScriptedAdapter('stall', { mode: 'stall' }),
+      targets: [
+        {
+          id: 'stall',
+          displayName: 'Stall',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['stall'],
+    });
+    for (let i = 0; i < 10; i++) post(store, binder, `@stall ${i}`, ['stall']);
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('turns queued'))
+    );
+    const dropped = systemRows(store).filter((m) =>
+      m.body.text.includes('message dropped')
+    );
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]!.body.text).toContain('has 8 turns queued');
+  });
+
+  it('session death unbinds, nulls the row session id, and respawns on next mention', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    post(store, binder, '@mock one', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    const sid = sessions.firstSessionId();
+    sessions.fireEnd(sid);
+    expect(store.getBinding(CH, 'mock')?.sessionId).toBeNull();
+    post(store, binder, '@mock two', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(sessions.spawns()).toBe(2);
+  });
+
+  it('spawn failure posts a system row and leaves no stuck single-flight', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2(),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      throwOnCreate: true,
+    });
+    post(store, binder, '@mock one', ['mock']);
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('failed to start'))
+    );
+    post(store, binder, '@mock two', ['mock']);
+    await waitFor(() => sessions.spawns() === 2); // single-flight cleared, retried
+    expect(
+      systemRows(store).filter((m) => m.body.text.includes('failed to start'))
+    ).toHaveLength(2);
+  });
+});
+
+describe('channel-agent-binder — delivery + idempotency', () => {
+  it('uses a deterministic turnId and a retry reuses the same turn identity', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () =>
+        new ScriptedAdapter('x', {
+          mode: 'reject-once-then-reply',
+          text: 'ok',
+        }),
+      targets: [
+        {
+          id: 'x',
+          displayName: 'X',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['x'],
+    });
+    const trigger = post(store, binder, '@x go', ['x']);
+    await waitFor(() => agentReplies(store, 'x').length === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ScriptedAdapter;
+    expect(adapter.sendCalls).toHaveLength(2); // rejected once, then retried
+    const expected = `chturn-${trigger.id}-x`;
+    expect(adapter.sendCalls[0]).toBe(expected);
+    expect(adapter.sendCalls[1]).toBe(expected); // retry reuses the SAME turnId
+    expect(sessions.spawns()).toBe(1);
+  });
+
+  it('advances the delivery cursor only after a send is accepted', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = post(store, binder, '@mock hello', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    await waitFor(
+      () =>
+        store.getBinding(CH, 'mock')?.providerSession['lastDeliveredSeq'] ===
+        trigger.seq
+    );
+    expect(
+      store.getBinding(CH, 'mock')?.providerSession['lastDeliveredSeq']
+    ).toBe(trigger.seq);
+  });
+});
+
+describe('channel-agent-binder — agent-to-agent brake', () => {
+  it('caps consecutive agent turns and a human post resets the brake', async () => {
+    const build = (agentType: string) =>
+      new ScriptedAdapter(agentType, {
+        mode: 'reply',
+        text: agentType === 'a' ? 'ping @b' : 'ping @a',
+      });
+    const { binder, store } = makeBinder({
+      build,
+      targets: [
+        {
+          id: 'a',
+          displayName: 'A',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+        {
+          id: 'b',
+          displayName: 'B',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['a', 'b'],
+    });
+    post(store, binder, '@a go', ['a', 'b']);
+    await waitFor(() =>
+      systemRows(store).some((m) =>
+        m.body.text.includes('Mention chain paused')
+      )
+    );
+    const pausedRows = systemRows(store).filter((m) =>
+      m.body.text.includes('Mention chain paused')
+    );
+    expect(pausedRows).toHaveLength(1);
+    // Human-initiated a reply is not counted; the brake bounds the autonomous
+    // fan-out at MAX_CONSECUTIVE_AGENT_TURNS agent turns.
+    const beforeReset = agentReplies(store).length;
+    expect(beforeReset).toBeLessThanOrEqual(MAX_CONSECUTIVE_AGENT_TURNS + 1);
+
+    // A fresh human post resets the counter → the chain resumes.
+    post(store, binder, '@a again', ['a', 'b']);
+    await waitFor(() => agentReplies(store).length > beforeReset, 6000);
+    expect(agentReplies(store).length).toBeGreaterThan(beforeReset);
+  });
+});
+
+describe('channel-agent-binder — roster + availability', () => {
+  it('reports availability, reasons, and live binding status', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        ...MOCK_TARGETS,
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          kind: 'framework',
+          available: false,
+          reason:
+            'Codex web sessions do not yet stream chat responses (see issue #301).',
+        },
+      ],
+      knownProviderIds: ['mock', 'codex'],
+    });
+    let roster = await binder.rosterForChannel(CH);
+    const codex = roster.find((r) => r.id === 'codex')!;
+    expect(codex.available).toBe(false);
+    expect(codex.reason).toContain('#301');
+    expect(roster.find((r) => r.id === 'mock')!.binding).toBeNull();
+
+    post(store, binder, '@mock hi', ['mock', 'codex']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    roster = await binder.rosterForChannel(CH);
+    expect(roster.find((r) => r.id === 'mock')!.binding).not.toBeNull();
+    expect(roster.find((r) => r.id === 'mock')!.binding?.status).toBe('idle');
+  });
+
+  it('an unavailable framework posts a de-advertise row, rate-limited', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2(),
+      targets: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          kind: 'framework',
+          available: false,
+          reason:
+            'Codex web sessions do not yet stream chat responses (see issue #301).',
+        },
+      ],
+      knownProviderIds: ['codex'],
+    });
+    post(store, binder, '@codex fix it', ['codex']);
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('#301'))
+    );
+    post(store, binder, '@codex fix it again', ['codex']);
+    // brief settle
+    await new Promise((r) => setTimeout(r, 40));
+    expect(
+      systemRows(store).filter((m) => m.body.text.includes('not available'))
+    ).toHaveLength(1); // rate-limited: only one identical row
+    expect(sessions.spawns()).toBe(0);
+  });
+});
+
+describe('channel-agent-binder — watchdog + cross-node + interrupt', () => {
+  it('force-drains a stuck turn once the watchdog fires', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new ScriptedAdapter('stall', { mode: 'stall' }),
+      targets: [
+        {
+          id: 'stall',
+          displayName: 'Stall',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['stall'],
+      watchdogMs: 25,
+    });
+    post(store, binder, '@stall a', ['stall']);
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ScriptedAdapter;
+    await waitFor(() => adapter.sendCalls.length === 1);
+    // Watchdog (25ms) force-drains the stuck turn → the next mention delivers.
+    await new Promise((r) => setTimeout(r, 60));
+    post(store, binder, '@stall b', ['stall']);
+    await waitFor(() => adapter.sendCalls.length === 2, 4000);
+    expect(adapter.sendCalls).toHaveLength(2);
+  });
+
+  it('cross-node topics fail visibly and never spawn a local stand-in', async () => {
+    const topicStore = {
+      get: () => ({
+        id: CH,
+        source: 'persisted',
+        display: { title: 'general' },
+        routingDefaults: { nodeId: 'remote-node' },
+      }),
+    } as unknown as WorkspaceTopicStore;
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2(),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      topicStore,
+    });
+    post(store, binder, '@mock go', ['mock']);
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('other nodes'))
+    );
+    expect(sessions.spawns()).toBe(0);
+  });
+
+  it('interrupt finalizes the partial row as interrupted (bridge status-map fix)', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 60 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    post(store, binder, '@mock slow please', ['mock']);
+    await waitFor(() =>
+      rows(store).some(
+        (m) => m.sender.providerId === 'mock' && m.status === 'streaming'
+      )
+    );
+    await binder.interrupt(CH, 'mock');
+    await waitFor(() =>
+      rows(store).some(
+        (m) => m.sender.providerId === 'mock' && m.status === 'interrupted'
+      )
+    );
+    expect(
+      rows(store).some(
+        (m) => m.sender.providerId === 'mock' && m.status === 'interrupted'
+      )
+    ).toBe(true);
+  });
+
+  it('interrupt throws NO_ACTIVE_TURN when idle and NOT_FOUND when unbound', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    await expect(binder.interrupt(CH, 'mock')).rejects.toThrow(); // not bound
+    post(store, binder, '@mock hi', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    await expect(binder.interrupt(CH, 'mock')).rejects.toThrow(); // idle
+  });
+});

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -9,6 +9,7 @@ import {
   BaseProtocolAdapterV2,
   type AdapterConfig,
   type AdapterStatus,
+  type AgentApprovalResponseInputV2,
   type AgentInterruptInputV2,
   type AgentSendMessageInputV2,
   type ProtocolAdapterV2,
@@ -20,6 +21,7 @@ import {
 } from '../server/channel-message-store.js';
 import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
 import {
+  CHANNEL_BINDING_YOLO_DEFAULT,
   createChannelAgentBinder,
   MAX_CONSECUTIVE_AGENT_TURNS,
   type BinderSessions,
@@ -27,6 +29,8 @@ import {
   type MentionTarget,
 } from '../server/channel-agent-binder.js';
 import type { Session, WebSession } from '../server/types.js';
+import type { CreateWebParams } from '../server/web-session-handler.js';
+import { createWebSession } from '../server/web-session-handler.js';
 import type { WorkspaceTopicStore } from '../server/workspace-topics.js';
 import {
   parseMentions,
@@ -44,6 +48,13 @@ const OPERATOR: ChannelSenderRef = {
   kind: 'human',
   id: 'human:operator',
   displayName: 'operator',
+};
+/** A CLI-gateway actor post (deriveSender kind 'agent') — subject to the brake. */
+const AGENT_SENDER: ChannelSenderRef = {
+  kind: 'agent',
+  id: 'agent:orchestrator',
+  providerId: 'orchestrator',
+  displayName: 'orchestrator',
 };
 
 function makeStore(): { store: ChannelMessageStore; hub: ChannelHub } {
@@ -206,6 +217,256 @@ class ScriptedAdapter extends BaseProtocolAdapterV2 {
   }
 }
 
+// ── approval-driving adapter (waitingOn handshake, no timers) ─────────────────
+// Emits an approval item + `waitingOn:'approval'` on send, parks the turn, and
+// resolves it only on respondToApproval / interrupt. Records send/respond/
+// interrupt calls so the brake, watchdog-pause, and round-trip can be asserted.
+class ApprovalAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    approvals: true,
+    interrupt: true,
+    streaming: true,
+    queue: false,
+  };
+  readonly sendCalls: string[] = [];
+  readonly respondCalls: AgentApprovalResponseInputV2[] = [];
+  readonly interruptCalls: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'appr';
+  private activeTurn: string | null = null;
+  private pendingApprovalId: string | null = null;
+
+  constructor(readonly agentType: string) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    this.activeTurn = input.turnId;
+    const approvalId = `appr-${input.turnId}`;
+    this.pendingApprovalId = approvalId;
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `u-${input.turnId}`,
+        items: [],
+        startedAt: 't',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      item: {
+        type: 'approval',
+        id: approvalId,
+        requestId: approvalId,
+        kind: 'command',
+        description: 'Run mock command',
+        target: 'npm test',
+        status: 'pending',
+        startedAt: 't',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: { waitingOn: 'approval' },
+    });
+  }
+
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    this.interruptCalls.push(input.turnId ?? this.activeTurn ?? '');
+    const turnId = this.activeTurn;
+    if (turnId === null) return;
+    this.activeTurn = null;
+    this.pendingApprovalId = null;
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status: 'interrupted',
+    });
+  }
+
+  async respondToApproval(input: AgentApprovalResponseInputV2): Promise<void> {
+    this.respondCalls.push(input);
+    if (input.requestId !== this.pendingApprovalId) return;
+    const turnId = this.activeTurn;
+    if (turnId === null) return;
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: {
+        type: 'approval',
+        id: input.requestId,
+        requestId: input.requestId,
+        kind: 'command',
+        description: 'Run mock command',
+        target: 'npm test',
+        status: 'completed',
+        decision: input.decision,
+      },
+    });
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: { waitingOn: null },
+    });
+    const itemId = `a-${turnId}`;
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: { type: 'assistantMessage', id: itemId, text: '' },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      itemId,
+      delta: { text: 'approved and done' },
+    });
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: {
+        type: 'assistantMessage',
+        id: itemId,
+        text: 'approved and done',
+        status: 'completed',
+      },
+    });
+    this.activeTurn = null;
+    this.pendingApprovalId = null;
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status: 'completed',
+    });
+  }
+}
+
+// ── deferred-send adapter (send acceptance resolved/rejected on command) ──────
+// sendMessage returns a promise the test resolves (accept) or rejects (transport
+// failure) explicitly, so the send-failure/rebind interleaving is deterministic.
+class DeferredAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    streaming: true,
+    interrupt: true,
+    queue: false,
+  };
+  readonly sendCalls: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'deferred';
+  private readonly pending = new Map<
+    string,
+    { resolve: () => void; reject: (err: unknown) => void }
+  >();
+
+  constructor(readonly agentType: string) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+
+  sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    return new Promise<void>((resolve, reject) => {
+      this.pending.set(input.turnId, { resolve, reject });
+    });
+  }
+
+  rejectSend(turnId: string): void {
+    const d = this.pending.get(turnId);
+    this.pending.delete(turnId);
+    d?.reject(new Error('transport down'));
+  }
+
+  /** Accept the send AND stream a completing reply for the turn. */
+  completeReply(turnId: string, text: string): void {
+    const d = this.pending.get(turnId);
+    this.pending.delete(turnId);
+    d?.resolve();
+    const itemId = `a-${turnId}`;
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: { type: 'assistantMessage', id: itemId, text: '' },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      itemId,
+      delta: { text },
+    });
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: { type: 'assistantMessage', id: itemId, text, status: 'completed' },
+    });
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status: 'completed',
+    });
+  }
+}
+
 // ── sessions harness ─────────────────────────────────────────────────────────
 
 interface SessionsHarness {
@@ -214,20 +475,26 @@ interface SessionsHarness {
   firstSessionId: () => string;
   adapterFor: (sessionId: string) => ProtocolAdapterV2;
   fireEnd: (sessionId: string) => void;
+  lastCreateParams: () => CreateWebParams | undefined;
 }
 
 function makeSessions(
   build: (agentType: string) => ProtocolAdapterV2,
-  opts: { throwOnCreate?: boolean } = {}
+  opts: { throwOnCreate?: boolean; gate?: Promise<void> } = {}
 ): SessionsHarness {
   const created = new Map<string, { session: WebSession }>();
   const order: string[] = [];
   const endCbs: Array<(id: string, cwd: string, br?: string) => void> = [];
   let spawns = 0;
+  let lastParams: CreateWebParams | undefined;
   const sessions: BinderSessions = {
     async createWeb(params) {
       spawns++;
+      lastParams = params;
       if (opts.throwOnCreate) throw new Error('boom: spawn failed');
+      // Optional gate: park the spawn so a test can drive a close()/reorder race
+      // between createWeb being invoked and its continuation resuming.
+      if (opts.gate) await opts.gate;
       const id = `sess-${spawns}-${params.agentType}`;
       const adapter = build(params.agentType);
       await adapter.connect({
@@ -268,6 +535,7 @@ function makeSessions(
       created.delete(id);
       for (const cb of [...endCbs]) cb(id, '/tmp');
     },
+    lastCreateParams: () => lastParams,
   };
 }
 
@@ -288,6 +556,8 @@ function makeBinder(cfg: {
   topicStore?: WorkspaceTopicStore | null;
   watchdogMs?: number;
   throwOnCreate?: boolean;
+  yolo?: boolean;
+  gate?: Promise<void>;
 }): {
   binder: ChannelAgentBinder;
   store: ChannelMessageStore;
@@ -297,6 +567,7 @@ function makeBinder(cfg: {
   const { store, hub } = makeStore();
   const sessions = makeSessions(cfg.build, {
     ...(cfg.throwOnCreate ? { throwOnCreate: true } : {}),
+    ...(cfg.gate ? { gate: cfg.gate } : {}),
   });
   const binder = createChannelAgentBinder({
     store,
@@ -308,6 +579,7 @@ function makeBinder(cfg: {
     port: 0,
     configDir: '/tmp',
     ...(cfg.watchdogMs !== undefined ? { watchdogMs: cfg.watchdogMs } : {}),
+    ...(cfg.yolo !== undefined ? { yolo: cfg.yolo } : {}),
   });
   cleanup.push(() => binder.close());
   return { binder, store, hub, sessions };
@@ -673,5 +945,337 @@ describe('channel-agent-binder — watchdog + cross-node + interrupt', () => {
     post(store, binder, '@mock hi', ['mock']);
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     await expect(binder.interrupt(CH, 'mock')).rejects.toThrow(); // idle
+  });
+});
+
+// ── #1180 review findings ─────────────────────────────────────────────────────
+
+describe('channel-agent-binder — gateway agent-sender loop brake (P1 #1180)', () => {
+  it('agent-sender posts count toward the cap and pause; a human post resets', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    // MAX+1 gateway agent-sender posts: MAX route, the last one pauses. The mock
+    // reply carries no @mention, so ONLY the gateway posts move the counter.
+    for (let i = 0; i < MAX_CONSECUTIVE_AGENT_TURNS + 1; i++) {
+      post(store, binder, `@mock ${i}`, ['mock'], AGENT_SENDER);
+    }
+    await waitFor(() =>
+      systemRows(store).some((m) =>
+        m.body.text.includes('Mention chain paused')
+      )
+    );
+    await waitFor(
+      () => agentReplies(store, 'mock').length === MAX_CONSECUTIVE_AGENT_TURNS
+    );
+    await new Promise((r) => setTimeout(r, 40)); // settle: no capped turn slips
+    expect(agentReplies(store, 'mock')).toHaveLength(
+      MAX_CONSECUTIVE_AGENT_TURNS
+    );
+    expect(
+      systemRows(store).filter((m) =>
+        m.body.text.includes('Mention chain paused')
+      )
+    ).toHaveLength(1);
+
+    // A fresh HUMAN post resets the brake → the chain resumes.
+    const before = agentReplies(store, 'mock').length;
+    post(store, binder, '@mock human', ['mock'], OPERATOR);
+    await waitFor(() => agentReplies(store, 'mock').length === before + 1);
+    expect(agentReplies(store, 'mock').length).toBe(before + 1);
+  });
+
+  it('a mixed human/agent chain only brakes on consecutive agent turns', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    // Two agent posts (counter 1,2), then a human post resets, then two more
+    // agent posts (counter 1,2) — never reaches the cap, so no pause row.
+    post(store, binder, '@mock a1', ['mock'], AGENT_SENDER);
+    post(store, binder, '@mock a2', ['mock'], AGENT_SENDER);
+    post(store, binder, '@mock h1', ['mock'], OPERATOR);
+    post(store, binder, '@mock a3', ['mock'], AGENT_SENDER);
+    post(store, binder, '@mock a4', ['mock'], AGENT_SENDER);
+    await waitFor(() => agentReplies(store, 'mock').length === 5);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(agentReplies(store, 'mock')).toHaveLength(5);
+    expect(
+      systemRows(store).filter((m) =>
+        m.body.text.includes('Mention chain paused')
+      )
+    ).toHaveLength(0);
+  });
+});
+
+describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () => {
+  it('a store.history throw does not wedge the binding; the next mention routes', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    // Throw once from the packet-fetch history call (the one with `beforeSeq`);
+    // the row helpers (no beforeSeq) pass through so waitFor stays usable.
+    const realHistory = store.history.bind(store);
+    let thrown = false;
+    (store as unknown as { history: ChannelMessageStore['history'] }).history =
+      ((id: string, filter?: Parameters<ChannelMessageStore['history']>[1]) => {
+        if (!thrown && filter && 'beforeSeq' in filter) {
+          thrown = true;
+          throw new Error('db boom');
+        }
+        return realHistory(id, filter);
+      }) as ChannelMessageStore['history'];
+
+    post(store, binder, '@mock one', ['mock']);
+    await waitFor(() =>
+      systemRows(store).some((m) =>
+        m.body.text.includes('could not build the message context')
+      )
+    );
+    // Binding recovered (not stuck turn-active): the next mention delivers.
+    post(store, binder, '@mock two', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(sessions.spawns()).toBe(1); // reused, not respawned/wedged
+    expect(agentReplies(store, 'mock')).toHaveLength(1);
+  });
+});
+
+describe('channel-agent-binder — send-failure rebind clobber guard (P2 #1180)', () => {
+  it('re-enqueues the failed turn instead of clobbering a newer active turn', async () => {
+    const built: DeferredAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (t) => {
+        const a = new DeferredAdapter(t);
+        built.push(a);
+        return a;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    // M1 → session 1, turn T1 delivered, send parked (pending).
+    const m1 = post(store, binder, '@mock one', ['mock']);
+    await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
+    const a1 = built[0]!;
+    const t1 = `chturn-${m1.id}-mock`;
+    expect(a1.sendCalls).toEqual([t1]);
+    const sid1 = sessions.firstSessionId();
+
+    // Session dies → binder clears the live entry (activeTurnId reset, row null).
+    sessions.fireEnd(sid1);
+
+    // M2 → fresh session 2, turn T2 delivered, send parked.
+    const m2 = post(store, binder, '@mock two', ['mock']);
+    await waitFor(() => built.length === 2 && built[1]!.sendCalls.length === 1);
+    const a2 = built[1]!;
+    const t2 = `chturn-${m2.id}-mock`;
+    expect(a2.sendCalls).toEqual([t2]);
+
+    // Reject T1's original send: handleSendFailure rebinds → binding with T2
+    // active. The failed turn must NOT clobber T2 with a concurrent send.
+    a1.rejectSend(t1);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(a2.sendCalls).toEqual([t2]); // T1 re-enqueued, not redelivered
+
+    // T2 completes → the re-enqueued T1 drains to the SAME (live) session.
+    a2.completeReply(t2, 'reply two');
+    await waitFor(() => a2.sendCalls.length === 2, 4000);
+    expect(a2.sendCalls[1]).toBe(t1);
+    a2.completeReply(t1, 'reply one');
+    await waitFor(() => agentReplies(store, 'mock').length === 2, 4000);
+  });
+});
+
+describe('channel-agent-binder — close() gates in-flight spawns (P2 #1180)', () => {
+  it('close() racing an in-flight ensureBinding leaves no binding and no store write', async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      gate,
+    });
+    const pending = binder.ensureBinding(CH, 'mock');
+    await waitFor(() => sessions.spawns() === 1); // createWeb parked at the gate
+    binder.close();
+    releaseGate(); // spawn resolves AFTER close
+    await expect(pending).rejects.toThrow(); // BinderClosedError — no attach
+    expect(store.getBinding(CH, 'mock')?.sessionId ?? null).toBeNull();
+    expect(systemRows(store)).toHaveLength(0); // no post-close store writes
+  });
+});
+
+describe('channel-agent-binder — YOLO spawn permission mode (locked decision #1167)', () => {
+  it('binder spawns pass permissionMode bypassPermissions when the yolo default is on', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      // yolo omitted → defaults to CHANNEL_BINDING_YOLO_DEFAULT.
+    });
+    post(store, binder, '@mock hi', ['mock']);
+    await waitFor(() => sessions.spawns() === 1);
+    expect(CHANNEL_BINDING_YOLO_DEFAULT).toBe(true);
+    expect(sessions.lastCreateParams()?.permissionMode).toBe(
+      'bypassPermissions'
+    );
+  });
+
+  it('binder spawns omit permissionMode when yolo is disabled (framework default)', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      yolo: false,
+    });
+    post(store, binder, '@mock hi', ['mock']);
+    await waitFor(() => sessions.spawns() === 1);
+    expect(sessions.lastCreateParams()).toBeDefined();
+    expect(sessions.lastCreateParams()!.permissionMode).toBeUndefined();
+  });
+
+  it('the shared createWebSession path does NOT default permissionMode (no yolo leak)', async () => {
+    const map = new Map<string, Session>();
+    const { session } = await createWebSession(
+      {
+        agentType: 'mock',
+        cwd: '/tmp',
+        displayName: 'normal',
+        port: 0,
+        configDir: '/tmp',
+      },
+      map,
+      () => {},
+      { skipInitialPersist: true }
+    );
+    expect(session.agentSessionV2.config.permissionMode).toBeUndefined();
+  });
+
+  it('the shared createWebSession path plumbs bypassPermissions through when passed', async () => {
+    const map = new Map<string, Session>();
+    const { session } = await createWebSession(
+      {
+        agentType: 'mock',
+        cwd: '/tmp',
+        displayName: 'yolo',
+        port: 0,
+        configDir: '/tmp',
+        permissionMode: 'bypassPermissions',
+      },
+      map,
+      () => {},
+      { skipInitialPersist: true }
+    );
+    expect(session.agentSessionV2.config.permissionMode).toBe(
+      'bypassPermissions'
+    );
+  });
+});
+
+describe('channel-agent-binder — approval round-trip + watchdog pause (Amendment 2 #1180)', () => {
+  it('approval item posts a meta-tagged system row; the respond verb maps the decision and resolves', async () => {
+    const built: ApprovalAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (t) => {
+        const a = new ApprovalAdapter(t);
+        built.push(a);
+        return a;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = post(store, binder, '@mock please approve', ['mock']);
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('requests approval'))
+    );
+    const turnId = `chturn-${trigger.id}-mock`;
+    const requestId = `appr-${turnId}`;
+    const approvalRow = systemRows(store).find((m) =>
+      m.body.text.includes('requests approval')
+    )!;
+    expect(approvalRow.meta).toMatchObject({
+      approvalRequestId: requestId,
+      agentId: 'mock',
+    });
+    expect(approvalRow.meta?.['sessionId']).toBe(sessions.firstSessionId());
+
+    const a = built[0]!;
+    await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
+    // Adapter received the mapped decision.
+    expect(a.respondCalls).toHaveLength(1);
+    expect(a.respondCalls[0]).toMatchObject({
+      requestId,
+      decision: { kind: 'accept' },
+    });
+    // Row updated (resolved-approval system row) + the streamed reply.
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('approval accept'))
+    );
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(agentReplies(store, 'mock')[0]!.body.text).toBe('approved and done');
+  });
+
+  it('the watchdog is PAUSED while waitingOn is set (turn not force-drained) and resumes on approval', async () => {
+    const built: ApprovalAdapter[] = [];
+    const { binder, store } = makeBinder({
+      build: (t) => {
+        const a = new ApprovalAdapter(t);
+        built.push(a);
+        return a;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      watchdogMs: 25,
+    });
+    const t1msg = post(store, binder, '@mock approve one', ['mock']);
+    await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
+    const a = built[0]!;
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('requests approval'))
+    );
+    post(store, binder, '@mock two', ['mock']); // queues behind the parked turn
+    // Well past the 25ms watchdog: a fired watchdog would finishTurn → pump → T2.
+    await new Promise((r) => setTimeout(r, 90));
+    expect(a.sendCalls).toHaveLength(1); // PAUSED: T2 not pumped
+
+    const requestId = `appr-chturn-${t1msg.id}-mock`;
+    await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
+    await waitFor(() => a.sendCalls.length === 2, 4000); // resumes → T2 drains
+    expect(a.sendCalls).toHaveLength(2);
+  });
+
+  it('an approval that never resolves is still recoverable via interrupt', async () => {
+    const built: ApprovalAdapter[] = [];
+    const { binder, store } = makeBinder({
+      build: (t) => {
+        const a = new ApprovalAdapter(t);
+        built.push(a);
+        return a;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      watchdogMs: 10_000, // watchdog never fires in-window: recovery is via interrupt
+    });
+    post(store, binder, '@mock approve stuck', ['mock']);
+    await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
+    const a = built[0]!;
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('requests approval'))
+    );
+    post(store, binder, '@mock next', ['mock']); // queues behind the stuck turn
+    await new Promise((r) => setTimeout(r, 30));
+    expect(a.sendCalls).toHaveLength(1);
+
+    await binder.interrupt(CH, 'mock'); // operator recovery
+    await waitFor(() => a.sendCalls.length === 2, 4000); // parked turn drained
+    expect(a.interruptCalls).toHaveLength(1);
+    expect(a.sendCalls).toHaveLength(2);
   });
 });

--- a/test/channel-agent-status-reconcile.test.ts
+++ b/test/channel-agent-status-reconcile.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  channelAgentStatusKey,
+  resolveEffectiveAgentStatus,
+  useChannelAgentStatusStore,
+} from '../frontend/src/lib/stores/channel-agent-status.js';
+
+// #1180 P2: stale busy agent-status reconciliation. The socket carries
+// transition-only events (no replay on reconnect), so a missed terminal 'idle'
+// would pin the header chip busy forever. `resolveEffectiveAgentStatus` lets a
+// fresh roster snapshot win over a stale socket status, keyed on timestamps.
+
+describe('resolveEffectiveAgentStatus', () => {
+  it('roster wins when its snapshot is newer than the last socket transition', () => {
+    // The stuck-busy case: socket streamed at t=100, roster fetched idle at t=200.
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'streaming',
+        socketUpdatedAt: 100,
+        rosterStatus: 'idle',
+        rosterUpdatedAt: 200,
+        streaming: false,
+      })
+    ).toBe('idle');
+  });
+
+  it('socket wins when its transition is newer than the roster snapshot', () => {
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'streaming',
+        socketUpdatedAt: 300,
+        rosterStatus: 'idle',
+        rosterUpdatedAt: 200,
+        streaming: false,
+      })
+    ).toBe('streaming');
+  });
+
+  it('a socket transition exactly at the roster snapshot time still wins (>=)', () => {
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'thinking',
+        socketUpdatedAt: 200,
+        rosterStatus: 'idle',
+        rosterUpdatedAt: 200,
+        streaming: false,
+      })
+    ).toBe('thinking');
+  });
+
+  it('falls back to the roster status when there is no socket entry', () => {
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: undefined,
+        socketUpdatedAt: undefined,
+        rosterStatus: 'waiting',
+        rosterUpdatedAt: 200,
+        streaming: false,
+      })
+    ).toBe('waiting');
+  });
+
+  it('resolves to idle when neither socket nor roster reports a status', () => {
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: undefined,
+        socketUpdatedAt: undefined,
+        rosterStatus: undefined,
+        rosterUpdatedAt: 200,
+        streaming: false,
+      })
+    ).toBe('idle');
+  });
+
+  it('reducer-derived streaming upgrades a resolved idle but never downgrades a live status', () => {
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'idle',
+        socketUpdatedAt: 300,
+        rosterStatus: 'idle',
+        rosterUpdatedAt: 200,
+        streaming: true,
+      })
+    ).toBe('streaming');
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'streaming',
+        socketUpdatedAt: 300,
+        rosterStatus: 'idle',
+        rosterUpdatedAt: 200,
+        streaming: false,
+      })
+    ).toBe('streaming');
+  });
+});
+
+describe('useChannelAgentStatusStore — timestamped reconciliation state', () => {
+  beforeEach(() => {
+    useChannelAgentStatusStore.setState({
+      statusByChannelAgent: {},
+      sessionByChannelAgent: {},
+      updatedAtByChannelAgent: {},
+    });
+  });
+
+  it('recordStatus stamps an updatedAt timestamp alongside the status', () => {
+    const before = Date.now();
+    useChannelAgentStatusStore
+      .getState()
+      .recordStatus('c1', 'mock', 'streaming', 's1');
+    const key = channelAgentStatusKey('c1', 'mock');
+    const state = useChannelAgentStatusStore.getState();
+    expect(state.statusByChannelAgent[key]).toBe('streaming');
+    expect(state.updatedAtByChannelAgent[key]).toBeGreaterThanOrEqual(before);
+  });
+
+  it('clearChannel drops status, session, AND updatedAt for that channel only', () => {
+    const s = useChannelAgentStatusStore.getState();
+    s.recordStatus('c1', 'mock', 'streaming', 's1');
+    s.recordStatus('c2', 'mock', 'thinking', 's2');
+    useChannelAgentStatusStore.getState().clearChannel('c1');
+    const state = useChannelAgentStatusStore.getState();
+    const c1 = channelAgentStatusKey('c1', 'mock');
+    const c2 = channelAgentStatusKey('c2', 'mock');
+    expect(state.statusByChannelAgent[c1]).toBeUndefined();
+    expect(state.sessionByChannelAgent[c1]).toBeUndefined();
+    expect(state.updatedAtByChannelAgent[c1]).toBeUndefined();
+    // The other channel is untouched.
+    expect(state.statusByChannelAgent[c2]).toBe('thinking');
+    expect(state.updatedAtByChannelAgent[c2]).toBeGreaterThan(0);
+  });
+});

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMentionContextPacket,
+  PACKET_MAX_ROWS,
+  PACKET_ROW_MAX_CHARS,
+  PACKET_MAX_BYTES,
+} from '../server/channel-context-packet.js';
+import type {
+  ChannelMessage,
+  ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
+
+const OPERATOR: ChannelSenderRef = {
+  kind: 'human',
+  id: 'human:operator',
+  displayName: 'operator',
+};
+const HERMES: ChannelSenderRef = {
+  kind: 'agent',
+  id: 'agent:hermes',
+  providerId: 'hermes',
+  displayName: 'hermes',
+};
+const SYSTEM: ChannelSenderRef = { kind: 'system', id: 'system' };
+const CLAUDE: ChannelSenderRef = {
+  kind: 'agent',
+  id: 'agent:claude',
+  providerId: 'claude',
+  displayName: 'claude',
+};
+
+function msg(
+  seq: number,
+  sender: ChannelSenderRef,
+  text: string,
+  kind: 'message' | 'system' = 'message'
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:row-${seq}`,
+    channelId: 'general',
+    seq,
+    kind,
+    status: 'complete',
+    sender,
+    body: { text, format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: 't',
+    updatedAt: 't',
+  };
+}
+
+describe('buildMentionContextPacket', () => {
+  it('renders the exact golden packet (own rows skipped, sender labels, footer)', () => {
+    const rows = [
+      msg(1, OPERATOR, 'hey team, the build is red'),
+      msg(2, HERMES, 'bisecting now'),
+      msg(3, SYSTEM, 'codex is not available in channels yet', 'system'),
+      msg(4, CLAUDE, 'i already looked at this'), // OWN row — must be skipped
+    ];
+    const trigger = msg(
+      5,
+      OPERATOR,
+      '@claude please fix the flaky channel-hub test'
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(packet).toBe(
+      [
+        '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+        'operator: hey team, the build is red',
+        'hermes [agent]: bisecting now',
+        '[system]: codex is not available in channels yet',
+        '',
+        '[operator mentioned you — reply to this message; your reply is posted to the channel]',
+        '@claude please fix the flaky channel-hub test',
+      ].join('\n')
+    );
+  });
+
+  it('caps to the newest N rows and prepends the omitted marker', () => {
+    const rows: ChannelMessage[] = [];
+    for (let seq = 1; seq <= 25; seq++)
+      rows.push(msg(seq, OPERATOR, `line ${seq}`));
+    const trigger = msg(26, OPERATOR, '@claude look');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'c',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(packet).toContain('[…earlier messages omitted]');
+    // Newest 20 kept: rows 6..25 present, rows 1..5 omitted.
+    expect(packet).toContain('operator: line 6');
+    expect(packet).toContain('operator: line 25');
+    expect(packet).not.toContain('operator: line 5\n');
+    const contextLines = packet
+      .split('\n')
+      .filter((l) => l.startsWith('operator: line'));
+    expect(contextLines).toHaveLength(PACKET_MAX_ROWS);
+  });
+
+  it('truncates an over-long row body with the ellipsis marker', () => {
+    const big = 'x'.repeat(PACKET_ROW_MAX_CHARS + 500);
+    const rows = [msg(1, OPERATOR, big)];
+    const trigger = msg(2, OPERATOR, '@claude go');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'c',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(packet).toContain('…[truncated]');
+    expect(packet).not.toContain('x'.repeat(PACKET_ROW_MAX_CHARS + 1));
+  });
+
+  it('drops oldest context rows to stay under the whole-packet byte budget', () => {
+    const rows: ChannelMessage[] = [];
+    // Each row ~1.9KB; 20 rows ~38KB > 24KB budget → oldest drop.
+    for (let seq = 1; seq <= 20; seq++) {
+      rows.push(msg(seq, OPERATOR, `${seq}:` + 'y'.repeat(1900)));
+    }
+    const trigger = msg(21, OPERATOR, '@claude go');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'c',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(Buffer.byteLength(packet, 'utf8')).toBeLessThanOrEqual(
+      PACKET_MAX_BYTES
+    );
+    // The trigger/footer always survives.
+    expect(packet).toContain('@claude go');
+  });
+
+  it('honors the delivery cursor: only rows after lastDeliveredSeq', () => {
+    const rows = [
+      msg(1, OPERATOR, 'old one'),
+      msg(2, OPERATOR, 'old two'),
+      msg(3, OPERATOR, 'interim three'),
+    ];
+    const trigger = msg(4, OPERATOR, '@claude go');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'c',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 2,
+    });
+    expect(packet).not.toContain('old one');
+    expect(packet).not.toContain('old two');
+    expect(packet).toContain('operator: interim three');
+  });
+
+  it('reused session with no interim rows → header + footer only', () => {
+    const trigger = msg(10, OPERATOR, '@claude go');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [],
+      trigger,
+      lastDeliveredSeq: 9,
+    });
+    expect(packet).toBe(
+      [
+        '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '',
+        '[operator mentioned you — reply to this message; your reply is posted to the channel]',
+        '@claude go',
+      ].join('\n')
+    );
+    expect(packet).not.toContain('Recent messages');
+  });
+
+  it('indents multi-line row bodies under the sender line', () => {
+    const rows = [msg(1, OPERATOR, 'first line\nsecond line')];
+    const trigger = msg(2, OPERATOR, '@claude go');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'c',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(packet).toContain('operator: first line\n    second line');
+  });
+});

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -80,10 +80,40 @@ describe('buildMentionContextPacket', () => {
         'hermes [agent]: bisecting now',
         '[system]: codex is not available in channels yet',
         '',
-        '[operator mentioned you — reply to this message; your reply is posted to the channel]',
+        '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
         '@claude please fix the flaky channel-hub test',
       ].join('\n')
     );
+  });
+
+  it('tags an AGENT-authored trigger in the footer (attribution, not impersonation)', () => {
+    const trigger = msg(5, HERMES, '@claude take a look at my bisect');
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [],
+      trigger,
+      lastDeliveredSeq: 4,
+    });
+    expect(packet).toBe(
+      [
+        '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '',
+        '[hermes [agent:hermes] mentioned you — reply to this message; your reply is posted to the channel]',
+        '@claude take a look at my bisect',
+      ].join('\n')
+    );
+    // A human mention is unambiguously distinguishable from the agent one above.
+    const humanTrigger = msg(6, OPERATOR, '@claude and you look too');
+    const humanPacket = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [],
+      trigger: humanTrigger,
+      lastDeliveredSeq: 5,
+    });
+    expect(humanPacket).toContain('[operator [human] mentioned you —');
+    expect(humanPacket).not.toContain('[agent:');
   });
 
   it('caps to the newest N rows and prepends the omitted marker', () => {
@@ -177,7 +207,7 @@ describe('buildMentionContextPacket', () => {
       [
         '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
         '',
-        '[operator mentioned you — reply to this message; your reply is posted to the channel]',
+        '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
         '@claude go',
       ].join('\n')
     );

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -4,15 +4,28 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import express from 'express';
+import type { RequestHandler } from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   attachAuthenticatedCliGatewayActorCredential,
+  bearerActorToken,
+  classifyCliGatewayCredentialLane,
   cliGatewayActorCommandCapabilities,
+  cliGatewayActorFailure,
+  createCliGatewayActorRegistry,
+  isCliGatewayActorTokenRequest,
+  issueCliGatewayActorCredential,
+  sendCliGatewayActorFailure,
+  validateCliGatewayActorCredential,
   CLI_GATEWAY_ACTOR_READ_COMMANDS,
   CLI_GATEWAY_ACTOR_WRITE_COMMANDS,
+  type CliGatewayActorCommand,
 } from '../server/cli-gateway-actor-auth.js';
-import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+import type {
+  ScopedActorCredentialRecord,
+  ScopedActorCredentialRegistry,
+} from '../shared/scoped-actor-credentials.js';
 import {
   createChannelMessageStore,
   type ChannelMessageStore,
@@ -164,9 +177,57 @@ function makeSessions(
   };
 }
 
+/**
+ * The REAL scoped-actor auth composition (bearer token → lane classify →
+ * validate → attach), mirroring `requireCliGatewayActorAuth` in server/index.ts.
+ * No fabricated credential: the router only sees a credential the registry
+ * actually minted and validated.
+ */
+function realActorAuthDeps(registry: ScopedActorCredentialRegistry): {
+  requireReadActorAuth: (command: CliGatewayActorCommand) => RequestHandler;
+  requireWriteActorAuth: (command: CliGatewayActorCommand) => RequestHandler;
+} {
+  const make =
+    (expectedCommand: CliGatewayActorCommand): RequestHandler =>
+    (req, res, next) => {
+      if (!isCliGatewayActorTokenRequest(req)) {
+        res.status(401).json({ error: { code: 'UNAUTHORIZED' } });
+        return;
+      }
+      const lane = classifyCliGatewayCredentialLane(req, expectedCommand);
+      if (lane !== 'scoped-actor-credential') {
+        sendCliGatewayActorFailure(res, cliGatewayActorFailure({ lane }));
+        return;
+      }
+      const validation = validateCliGatewayActorCredential(registry, {
+        token: bearerActorToken(req),
+        capabilities: cliGatewayActorCommandCapabilities(expectedCommand),
+      });
+      if ('reason' in validation) {
+        sendCliGatewayActorFailure(
+          res,
+          cliGatewayActorFailure({
+            reason: validation.reason,
+            ...(validation.deniedBits
+              ? { deniedBits: validation.deniedBits }
+              : {}),
+          })
+        );
+        return;
+      }
+      attachAuthenticatedCliGatewayActorCredential(req, validation.credential);
+      next();
+    };
+  return {
+    requireReadActorAuth: (command) => make(command),
+    requireWriteActorAuth: (command) => make(command),
+  };
+}
+
 async function harness(
   build: (agentType: string) => ProtocolAdapterV2 = () =>
-    new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 })
+    new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+  opts: { actorRegistry?: ScopedActorCredentialRegistry } = {}
 ): Promise<Harness> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-mention-e2e-'));
   cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -200,17 +261,20 @@ async function harness(
 
   const app = express();
   app.use(express.json());
-  app.use((req, _res, next) => {
-    const actorId = req.header('x-test-actor-id');
-    if (actorId) {
-      attachAuthenticatedCliGatewayActorCredential(req, {
-        id: 'cred-1',
-        actor: { type: 'agent', id: actorId, displayName: actorId },
-        capabilities: ['context:read', 'context:write'],
-      } as unknown as ScopedActorCredentialRecord);
-    }
-    next();
-  });
+  if (!opts.actorRegistry) {
+    // Fabricated-credential fast path used by the routing-parity tests.
+    app.use((req, _res, next) => {
+      const actorId = req.header('x-test-actor-id');
+      if (actorId) {
+        attachAuthenticatedCliGatewayActorCredential(req, {
+          id: 'cred-1',
+          actor: { type: 'agent', id: actorId, displayName: actorId },
+          capabilities: ['context:read', 'context:write'],
+        } as unknown as ScopedActorCredentialRecord);
+      }
+      next();
+    });
+  }
   app.use(
     createChannelChatRouter({
       store,
@@ -218,6 +282,7 @@ async function harness(
       topicStore,
       binder,
       knownProviderIds: ['mock', 'claude', 'codex', 'opencode', 'hermes'],
+      ...(opts.actorRegistry ? realActorAuthDeps(opts.actorRegistry) : {}),
     })
   );
   const server = http.createServer(app);
@@ -385,6 +450,88 @@ describe('mention routing — end-to-end via the router', () => {
     });
     expect(res.status).toBe(409);
     expect(res.body.error.details?.reasonCode).toBe('NO_ACTIVE_TURN');
+  });
+});
+
+describe('mention routing — real scoped-actor auth composition (P2 #1180)', () => {
+  it('a real minted actor token authenticates, routes @mock, and is braked as an agent sender', async () => {
+    // Mint a REAL credential in the registry the auth middleware validates
+    // against — no fabricated record, the full bearer→validate→attach path runs.
+    const registry = createCliGatewayActorRegistry();
+    // Mirrors the shipped mail-loop credential: session:read stamps the read
+    // task-ref (giving a non-empty scope), context:write authorizes channels.post.
+    const issued = issueCliGatewayActorCredential(registry, {
+      actor: { type: 'agent', id: 'orchestrator', displayName: 'orchestrator' },
+      capabilities: ['session:read', 'context:read', 'context:write'],
+    });
+    const h = await harness(undefined, { actorRegistry: registry });
+    const actorHeaders = {
+      authorization: `Bearer ${issued.token}`,
+      'x-relay-cli-actor-token': 'v1',
+      'x-relay-cli-command': 'channels.post',
+    };
+    const postOnce = (text: string) =>
+      req<{ message: ChannelMessage }>({
+        port: h.port,
+        method: 'POST',
+        url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+        body: { text },
+        headers: actorHeaders,
+      });
+
+    // First post: server-derived agent attribution from the validated credential.
+    const first = await postOnce('@mock brief 0');
+    expect(first.status).toBe(201);
+    expect(first.body.message.sender).toMatchObject({
+      kind: 'agent',
+      id: 'agent:orchestrator',
+    });
+    // Routing works through the real auth lane.
+    await waitFor(() => agentReply(h.store, h.channelId).length >= 1);
+    expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe('agent:mock');
+
+    // Brake accounting: further agent-sender posts count toward the cap. Posting
+    // past MAX trips the pause row — a browser (human) sender never would, proving
+    // the actor post is accounted as an agent turn end-to-end.
+    for (let i = 1; i <= 4; i++) {
+      const res = await postOnce(`@mock brief ${i}`);
+      expect(res.status).toBe(201);
+    }
+    await waitFor(() =>
+      h.store
+        .history(h.channelId, { limit: 200 })
+        .some(
+          (m) =>
+            m.kind === 'system' && m.body.text.includes('Mention chain paused')
+        )
+    );
+    const paused = h.store
+      .history(h.channelId, { limit: 200 })
+      .filter(
+        (m) =>
+          m.kind === 'system' && m.body.text.includes('Mention chain paused')
+      );
+    expect(paused).toHaveLength(1);
+  });
+
+  it('rejects a bogus bearer token (no fabricated credential accepted)', async () => {
+    const registry = createCliGatewayActorRegistry();
+    const h = await harness(undefined, { actorRegistry: registry });
+    const res = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock hello' },
+      headers: {
+        authorization: 'Bearer relay-sac-v1.not-a-real-token',
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'channels.post',
+      },
+    });
+    expect(res.status).toBeGreaterThanOrEqual(401);
+    expect(res.status).toBeLessThan(404);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(agentReply(h.store, h.channelId)).toHaveLength(0); // never routed
   });
 });
 

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -1,0 +1,408 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  attachAuthenticatedCliGatewayActorCredential,
+  cliGatewayActorCommandCapabilities,
+  CLI_GATEWAY_ACTOR_READ_COMMANDS,
+  CLI_GATEWAY_ACTOR_WRITE_COMMANDS,
+} from '../server/cli-gateway-actor-auth.js';
+import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
+import { createChannelChatRouter } from '../server/channel-chat-router.js';
+import {
+  createChannelAgentBinder,
+  type BinderSessions,
+  type MentionTarget,
+} from '../server/channel-agent-binder.js';
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import {
+  BaseProtocolAdapterV2,
+  type AdapterConfig,
+  type AdapterStatus,
+  type AgentSendMessageInputV2,
+  type ProtocolAdapterV2,
+} from '../server/protocol-adapter-v2.js';
+import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  createWorkspaceTopicStore,
+  type WorkspaceTopicStore,
+} from '../server/workspace-topics.js';
+import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+import type { Session, WebSession } from '../server/types.js';
+
+const cleanup: Array<() => void> = [];
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+const TARGETS: MentionTarget[] = [
+  {
+    id: 'mock',
+    displayName: 'Mock',
+    kind: 'framework',
+    available: true,
+    reason: null,
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex',
+    kind: 'framework',
+    available: false,
+    reason:
+      'Codex web sessions do not yet stream chat responses (see issue #301).',
+  },
+];
+
+/** Adapter that records the content it receives and replies with a fixed line. */
+class RecordingAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = { text: true, streaming: true };
+  readonly contents: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'rec';
+  constructor(
+    readonly agentType: string,
+    private readonly reply: string
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.contents.push(input.content);
+    const itemId = `a-${input.turnId}`;
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      item: { type: 'assistantMessage', id: itemId, text: '' },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      itemId,
+      delta: { text: this.reply },
+    });
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      status: 'completed',
+    });
+  }
+}
+
+interface Harness {
+  port: number;
+  store: ChannelMessageStore;
+  hub: ChannelHub;
+  channelId: string;
+  adapters: () => ProtocolAdapterV2[];
+}
+
+function makeSessions(
+  build: (agentType: string) => ProtocolAdapterV2,
+  adapters: ProtocolAdapterV2[]
+): BinderSessions {
+  const created = new Map<string, WebSession>();
+  let n = 0;
+  return {
+    async createWeb(params) {
+      const id = `sess-${++n}-${params.agentType}`;
+      const adapter = build(params.agentType);
+      adapters.push(adapter);
+      await adapter.connect({
+        cwd: params.cwd,
+        port: 0,
+        sessionId: id,
+        hookToken: 't',
+        configDir: params.configDir,
+      });
+      const session = {
+        id,
+        mode: 'web',
+        agent: params.agentType,
+        adapterV2: adapter,
+        cwd: params.cwd,
+      } as unknown as WebSession;
+      created.set(id, session);
+      return { session };
+    },
+    get(id) {
+      return created.get(id) as unknown as Session | undefined;
+    },
+    onSessionEnd() {
+      return () => {};
+    },
+  };
+}
+
+async function harness(
+  build: (agentType: string) => ProtocolAdapterV2 = () =>
+    new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 })
+): Promise<Harness> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-mention-e2e-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const topicStore: WorkspaceTopicStore = createWorkspaceTopicStore({
+    dbPath: path.join(dir, 'topics.db'),
+    now: () => '2026-07-18T00:00:00.000Z',
+  });
+  cleanup.push(() => topicStore.close());
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => store.close());
+  const hub = createChannelHub({
+    store,
+    channelExists: (id) => Boolean(topicStore.get(id)),
+  });
+  cleanup.push(() => hub.close());
+  const topic = topicStore.create({ workspaceId: 'ws', title: 'General' });
+
+  const adapters: ProtocolAdapterV2[] = [];
+  const binder = createChannelAgentBinder({
+    store,
+    hub,
+    topicStore,
+    sessions: makeSessions(build, adapters),
+    knownProviderIds: ['mock', 'claude', 'codex', 'opencode', 'hermes'],
+    mentionTargets: async () => TARGETS,
+    port: 0,
+    configDir: dir,
+  });
+  cleanup.push(() => binder.close());
+  hub.onMessagePosted((m, mentions) => binder.handleMessagePosted(m, mentions));
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    const actorId = req.header('x-test-actor-id');
+    if (actorId) {
+      attachAuthenticatedCliGatewayActorCredential(req, {
+        id: 'cred-1',
+        actor: { type: 'agent', id: actorId, displayName: actorId },
+        capabilities: ['context:read', 'context:write'],
+      } as unknown as ScopedActorCredentialRecord);
+    }
+    next();
+  });
+  app.use(
+    createChannelChatRouter({
+      store,
+      hub,
+      topicStore,
+      binder,
+      knownProviderIds: ['mock', 'claude', 'codex', 'opencode', 'hermes'],
+    })
+  );
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  cleanup.push(() => server.close());
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no address');
+  return {
+    port: address.port,
+    store,
+    hub,
+    channelId: topic.id,
+    adapters: () => adapters,
+  };
+}
+
+async function req<T>(input: {
+  port: number;
+  method: 'GET' | 'POST';
+  url: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): Promise<{ status: number; body: T }> {
+  const res = await fetch(`http://127.0.0.1:${input.port}${input.url}`, {
+    method: input.method,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-relay-capabilities':
+        input.method === 'GET' ? 'context:read' : 'context:write',
+      ...(input.headers ?? {}),
+    },
+    ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+  });
+  return { status: res.status, body: (await res.json()) as T };
+}
+
+async function waitFor(cond: () => boolean, ms = 4000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error('waitFor timed out');
+}
+
+function agentReply(store: ChannelMessageStore, channelId: string) {
+  return store
+    .history(channelId, { limit: 200 })
+    .filter(
+      (m: ChannelMessage) =>
+        m.sender.id === 'agent:mock' && m.status === 'complete'
+    );
+}
+
+describe('mention routing — end-to-end via the router', () => {
+  it('a browser @mock post spawns a mock web session and streams the reply back', async () => {
+    const h = await harness();
+    const res = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock hello there' },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.message.sender.kind).toBe('human');
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    const reply = agentReply(h.store, h.channelId)[0]!;
+    expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.body.text).toBe('Mock v2 response complete.');
+    // cursor advanced to the trigger seq
+    expect(
+      h.store.getBinding(h.channelId, 'mock')?.providerSession[
+        'lastDeliveredSeq'
+      ]
+    ).toBe(res.body.message.seq);
+  });
+
+  it('a CLI-gateway-actor @mock post routes identically to a browser post', async () => {
+    const h = await harness();
+    const res = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock brief from the orchestrator' },
+      headers: { 'x-test-actor-id': 'orchestrator' },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.message.sender).toMatchObject({
+      kind: 'agent',
+      id: 'agent:orchestrator',
+    });
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe('agent:mock');
+  });
+
+  it("the next turn's packet includes interim human rows but not the agent's own reply", async () => {
+    const h = await harness(
+      (agentType) => new RecordingAdapter(agentType, 'ack')
+    );
+    // turn 1
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock first' },
+    });
+    await waitFor(
+      () => (h.adapters()[0] as RecordingAdapter).contents.length === 1
+    );
+    // an interim human message with no mention
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: 'meanwhile the CI went green' },
+    });
+    // turn 2
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock second' },
+    });
+    await waitFor(
+      () => (h.adapters()[0] as RecordingAdapter).contents.length === 2
+    );
+    const packet2 = (h.adapters()[0] as RecordingAdapter).contents[1]!;
+    expect(packet2).toContain('meanwhile the CI went green');
+    expect(packet2).not.toContain('ack'); // agent's own prior reply is skipped
+    expect(packet2).toContain('@mock second');
+  });
+
+  it('the roster verb reports availability + reasons', async () => {
+    const h = await harness();
+    const res = await req<{
+      roster: Array<{ id: string; available: boolean; reason: string | null }>;
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/roster`,
+    });
+    expect(res.status).toBe(200);
+    const mock = res.body.roster.find((r) => r.id === 'mock')!;
+    expect(mock.available).toBe(true);
+    const codex = res.body.roster.find((r) => r.id === 'codex')!;
+    expect(codex.available).toBe(false);
+    expect(codex.reason).toContain('#301');
+  });
+
+  it('interrupt returns 409 NO_ACTIVE_TURN when the agent is idle', async () => {
+    const h = await harness();
+    // bind mock first
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock hi' },
+    });
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    const res = await req<{ error: { details?: { reasonCode?: string } } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/agents/mock/interrupt`,
+      body: {},
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error.details?.reasonCode).toBe('NO_ACTIVE_TURN');
+  });
+});
+
+describe('mention routing — gateway command/capability mapping', () => {
+  it('registers the new verbs with the correct capability bits', () => {
+    expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.roster');
+    expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toContain('channels.interrupt');
+    expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toContain(
+      'channels.respond-approval'
+    );
+    expect(cliGatewayActorCommandCapabilities('channels.roster')).toEqual([
+      'context:read',
+    ]);
+    expect(cliGatewayActorCommandCapabilities('channels.interrupt')).toEqual([
+      'context:write',
+    ]);
+    expect(
+      cliGatewayActorCommandCapabilities('channels.respond-approval')
+    ).toEqual(['context:write']);
+  });
+});

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -352,6 +352,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'channels.list',
     'channels.get',
     'channels.history',
+    'channels.roster',
     'context.get',
     'context.list',
     'inbox.list',
@@ -567,6 +568,8 @@ test('classifies explicitly scoped CLI gateway actor write routes into the actor
     'workspace-topics.archive',
     'workspace-topics.restore',
     'channels.post',
+    'channels.interrupt',
+    'channels.respond-approval',
   ]);
 
   for (const command of CLI_GATEWAY_ACTOR_WRITE_COMMANDS) {

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -3,6 +3,7 @@
 import React, { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ChannelComposer } from '../../frontend/src/components/chat/ChannelComposer.js';
 
 (
@@ -31,17 +32,27 @@ interface RenderOpts {
 }
 
 async function renderComposer(opts: RenderOpts = {}): Promise<void> {
+  // ChannelComposer lazily fetches the @mention roster via useQuery, so it must
+  // render under a QueryClientProvider even when the palette never opens.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   await act(async () => {
     root.render(
-      React.createElement(ChannelComposer, {
-        channelTitle: 'general',
-        onSend: opts.onSend ?? (() => Promise.resolve()),
-        postPending: opts.postPending ?? false,
-        storeDown: opts.storeDown ?? false,
-        archived: opts.archived ?? false,
-        onRestore: opts.onRestore ?? (() => {}),
-        restorePending: opts.restorePending ?? false,
-      })
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(ChannelComposer, {
+          channelId: 'topic:general',
+          channelTitle: 'general',
+          onSend: opts.onSend ?? (() => Promise.resolve()),
+          postPending: opts.postPending ?? false,
+          storeDown: opts.storeDown ?? false,
+          archived: opts.archived ?? false,
+          onRestore: opts.onRestore ?? (() => {}),
+          restorePending: opts.restorePending ?? false,
+        })
+      )
     );
   });
 }

--- a/test/components/channel-timeline-anchor.test.ts
+++ b/test/components/channel-timeline-anchor.test.ts
@@ -39,6 +39,7 @@ async function renderTimeline(loadOlder: () => Promise<void>): Promise<void> {
       React.createElement(ChannelTimeline, {
         messages: [msg(5), msg(6)],
         lastReadSeq: null,
+        channelId: 'topic:general',
         channelTitle: 'general',
         hasMoreOlder: true,
         loadingOlder: false,

--- a/test/components/mention-palette.test.ts
+++ b/test/components/mention-palette.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  MentionPalette,
+  filterRoster,
+} from '../../frontend/src/components/chat/MentionPalette.js';
+import type { RosterEntry } from '../../frontend/src/lib/api.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roster: RosterEntry[] = [
+  {
+    id: 'claude',
+    displayName: 'Claude',
+    kind: 'framework',
+    available: true,
+    reason: null,
+    binding: null,
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex',
+    kind: 'framework',
+    available: false,
+    reason: 'no api key configured',
+    binding: null,
+  },
+  {
+    id: 'hermes',
+    displayName: 'Hermes',
+    kind: 'framework',
+    available: true,
+    reason: null,
+    binding: { sessionId: 'sess-1', status: 'thinking' },
+  },
+];
+
+describe('filterRoster', () => {
+  it('prefix-filters by id and displayName (case-insensitive)', () => {
+    expect(filterRoster(roster, 'h').map((e) => e.id)).toEqual(['hermes']);
+    expect(filterRoster(roster, 'Cod').map((e) => e.id)).toEqual(['codex']);
+  });
+
+  it('keeps unavailable entries in the filtered list', () => {
+    // 'c' matches both claude (available) and codex (unavailable) — the
+    // unavailable one is retained (rendered greyed/non-selectable, not dropped).
+    const result = filterRoster(roster, 'c');
+    expect(result.map((e) => e.id)).toEqual(['claude', 'codex']);
+    expect(result.some((e) => !e.available)).toBe(true);
+  });
+
+  it('returns the whole roster for an empty query', () => {
+    expect(filterRoster(roster, '')).toHaveLength(3);
+  });
+});
+
+describe('MentionPalette rendering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('renders one option per entry and marks unavailable rows disabled with the reason title', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MentionPalette, {
+          entries: roster,
+          activeIndex: 0,
+          visible: true,
+        })
+      );
+    });
+
+    const options = Array.from(
+      container.querySelectorAll('[role="option"]')
+    ) as HTMLElement[];
+    expect(options).toHaveLength(3);
+
+    // Available rows are selectable (no aria-disabled).
+    const claudeRow = options[0]!;
+    expect(claudeRow.getAttribute('aria-disabled')).toBeNull();
+    expect(claudeRow.textContent).toContain('Claude');
+
+    // The unavailable row is greyed, aria-disabled, and exposes its reason as a
+    // hover title.
+    const codexRow = container.querySelector(
+      '.mention-palette__row--unavailable'
+    ) as HTMLElement;
+    expect(codexRow).not.toBeNull();
+    expect(codexRow.getAttribute('aria-disabled')).toBe('true');
+    expect(codexRow.getAttribute('title')).toBe('no api key configured');
+    expect(codexRow.getAttribute('role')).toBe('option');
+  });
+
+  it('hides the listbox when not visible', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MentionPalette, {
+          entries: roster,
+          activeIndex: 0,
+          visible: false,
+        })
+      );
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    expect(listbox.style.display).toBe('none');
+  });
+});

--- a/test/lib/mention-trigger.test.ts
+++ b/test/lib/mention-trigger.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { detectTrigger } from '../../frontend/src/components/chat/slashTrigger.js';
+import { parseMentions } from '../../shared/channel-chat-protocol.js';
+
+// Boundary PARITY: `detectTrigger(text, caret, ['@'])` (composer-side, caret
+// anchored) must agree with `parseMentions` (server-side, whole-text) on whether
+// the `@` at the caret is a routable mention boundary. The server pattern
+// `/(^|[^A-Za-z0-9_.])@.../` treats `@` as a mention when the preceding char is
+// start-of-text OR NOT in `[A-Za-z0-9_.]` — broader than "leading whitespace".
+// Code-span masking is server-only and out of scope for detectTrigger.
+
+interface ParityCase {
+  label: string;
+  text: string;
+  caret: number;
+  /** Is the `@` at this caret a valid, routable mention boundary? */
+  valid: boolean;
+  /** The mention name (without `@`) when valid. */
+  name?: string;
+}
+
+const cases: ParityCase[] = [
+  {
+    label: 'mid-word foo@claude is NOT a mention',
+    text: 'foo@claude',
+    caret: 10,
+    valid: false,
+  },
+  {
+    label: 'email a.b@claude is NOT a mention',
+    text: 'a.b@claude',
+    caret: 10,
+    valid: false,
+  },
+  {
+    label: 'open-paren (@claude IS a mention',
+    text: '(@claude',
+    caret: 8,
+    valid: true,
+    name: 'claude',
+  },
+  {
+    label: 'space hey @claude IS a mention',
+    text: 'hey @claude',
+    caret: 11,
+    valid: true,
+    name: 'claude',
+  },
+  {
+    label: 'leading @Claude preserves casing',
+    text: '@Claude',
+    caret: 7,
+    valid: true,
+    name: 'Claude',
+  },
+  {
+    label: 'comma hey,@claude IS a mention',
+    text: 'hey,@claude',
+    caret: 11,
+    valid: true,
+    name: 'claude',
+  },
+];
+
+describe('detectTrigger @ boundary parity with parseMentions', () => {
+  for (const c of cases) {
+    it(c.label, () => {
+      const trigger = detectTrigger(c.text, c.caret, ['@']);
+      const mentions = parseMentions(c.text, ['claude']);
+      const parserSaysMention = mentions.some(
+        (m) => m.raw.toLowerCase() === `@${(c.name ?? '').toLowerCase()}`
+      );
+
+      // The two independent implementations agree on the boundary verdict.
+      expect(trigger !== null).toBe(c.valid);
+      expect(parserSaysMention).toBe(c.valid);
+      if (c.valid) {
+        expect(trigger?.prefix).toBe('@');
+        expect(trigger?.query).toBe(c.name);
+      }
+    });
+  }
+});
+
+describe('detectTrigger @ caret anchoring', () => {
+  it('extracts the partial query as the user types', () => {
+    expect(detectTrigger('@cla', 4, ['@'])).toEqual({
+      prefix: '@',
+      query: 'cla',
+      span: [0, 4],
+      isLeading: true,
+    });
+  });
+
+  it('is inactive once whitespace closes the token', () => {
+    // caret sits inside "done"; walking back hits the space before any '@'.
+    expect(detectTrigger('@claude done', 12, ['@'])).toBeNull();
+  });
+
+  it('a mid-text mention is detected but not leading', () => {
+    expect(detectTrigger('hey @cla', 8, ['@'])).toEqual({
+      prefix: '@',
+      query: 'cla',
+      span: [4, 8],
+      isLeading: false,
+    });
+  });
+});

--- a/test/server-shutdown-contract.test.ts
+++ b/test/server-shutdown-contract.test.ts
@@ -31,7 +31,7 @@ describe('server shutdown store closing contract', () => {
     expect(gracefulShutdownSource).toContain('agentPresenceStore?.close();');
     expect(gracefulShutdownSource).toContain('workspaceSurfaceStore?.close();');
     expect(gracefulShutdownSource).toMatch(
-      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+closeInterventionLog\(\);/
+      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelAgentBinder\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+closeInterventionLog\(\);/
     );
   });
 


### PR DESCRIPTION
## Summary

Slice 4 of epic #1163 — **@-mention routing**. A channel message that `@`-mentions an agent framework now spawns (or reuses) a `(channel, framework)` web session, streams the agent's reply back into the timeline, and exposes roster autocomplete + interrupt/approval controls. Browser posts and CLI-gateway-actor posts route **identically** (dogfood-ready). Single-node; no adapter or wire-protocol changes.

### Backend
- **`server/channel-agent-binder.ts`** (new) — owns the whole loop: `hub.onMessagePosted` → resolve mentions (`providerId` only) → single-flight ensure a web session (spawn | reuse | rebind) → wire the slice-2 bridge → build a pure context packet → `adapter.sendMessage`. Per-binding FIFO queue (cap 8), approval-aware watchdog, deterministic `turnId`, at-least-once delivery cursor, single-node cross-node guard, and a per-channel consecutive-agent-turn brake (cap 4, reset on any human/gateway post). Registers its own `onPatch` listener; the bridge stays the sole text mirror.
- **`server/channel-context-packet.ts`** (new) — pure, unit-testable packet builder (N / per-row / byte caps, own-row skip, delivery-cursor windows).
- **`server/channel-agent-bridge.ts`** — finalize with the turn's real status (`interrupted`/`failed`, not always `complete`) + optional `onAssistantMessageFinalized` hook driving agent-to-agent mentions.
- **`server/channel-chat-router.ts`** + **`server/cli-gateway-actor-auth.ts`** — `channels.roster` / `channels.interrupt` / `channels.respond-approval` verbs + capability map + 503 fallbacks.
- **`server/index.ts`** binder construction / `onMessagePosted` / status-broadcaster / close wiring; `ChannelMessage` gains an optional `meta` (approval payloads).

### Frontend
- `detectTrigger` generalization (+ `detectSlashTrigger` wrapper), `MentionPalette`, `@`-trigger composer integration; header agent presence chips + interrupt; approval-row buttons; `channel-agent-status` store + `/ws/events` handler; `fetchChannelRoster` / `interruptChannelAgent` / `respondChannelApproval` API helpers.

## Applied spec amendments (authoritative)
1. **Cross-node guard** — a remote-node topic fails visibly, never spawns a local stand-in.
2. **Approval-aware watchdog** — paused whenever `waitingOn != null` (never force-drains a turn parked on a human approval).
3. **Deterministic `turnId = chturn-<messageId>-<framework>`** (a retry reuses it); `clientMessageId` is inert / forward-compat only — no adapter dedupes on it.
4. **`supportsWebSessions` on nightly** — claude/opencode/hermes `true`, codex `false` (PR #1176 merged). Tests route on `mock` (+ hermes/opencode); no live `@claude` assertion.
5. **Consecutive-agent-turn brake** replaces hop-threading (cap 4, reset on any human/gateway post).

## User decisions applied
- **YOLO default** for channel bindings — spawns set permission bypass via the single constant `CHANNEL_BINDING_YOLO_DEFAULT` (flip post-MVP); the approval-render path stays wired.
- **Dogfood-ready** — a gateway-actor post with `@claude` routes exactly like a browser post (covered by the e2e).

## Verification (node 24, `RELAY_MOCK_AGENT` — zero real-agent invocations)
- `npm run check`: **green** (0 errors).
- New + affected suites **green in isolation** (136 tests): context-packet golden + caps; binder lifecycle (first-spawn, **two concurrent → one spawn**, reuse, queue+cap drop, session-death → `interrupted` + `sessionId:null` + respawn, spawn-fail no stuck single-flight, deterministic turnId + retry idempotency, consecutive-agent brake + reset, roster, watchdog force-drain, cross-node, interrupt status-map); mock **end-to-end via the router** incl. gateway-actor post path + roster verb + capability mapping; frontend trigger parity + palette.
- Full `npm test` (clean solo run): the only failing file is the pre-existing `test/branch-watcher.test.ts` (`[needs:git-init]`), confirmed identical on pristine `origin/nightly` via stash — not introduced here. Parallel-load flakiness swings failure counts across identical code; each suite passes in isolation. No channel/mention/binder/gateway suite fails.

Closes #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
