### PR TITLE
feat(codex): revive codex web sessions for channel mentions

### DIFF
--- a/server/frameworks.ts
+++ b/server/frameworks.ts
@@ -131,11 +131,9 @@ export async function getFrameworkClientInfoWithRuntime(
 
 // Reasons surfaced when a framework's `supportsWebSessions` capability is
 // false. Keep entries here keyed by framework id; the fallback below covers
-// any framework that simply doesn't declare web support yet.
-const WEB_DEADVERTISE_REASONS: Record<string, string> = {
-  codex:
-    'Codex web sessions do not yet stream chat responses (see issue #301). Use the tui (PTY) mode instead.',
-};
+// any framework that simply doesn't declare web support yet. Codex's #301
+// entry was removed when #1169 re-advertised the native app-server adapter.
+const WEB_DEADVERTISE_REASONS: Record<string, string> = {};
 
 export async function getFrameworkWebAvailability(
   framework: AgentFramework

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -29,26 +29,22 @@ const logger = createLogger('codex-native-adapter');
 
 // ── Web-session capability status ──────────────────────────────────────────
 //
-// The Codex framework is currently advertised with `supportsWebSessions: false`
-// in `server/types.ts`. The adapter maps lifecycle events (turn started/ended,
-// tool calls, command execution, file changes) and reasoning deltas, but the
-// browser chat surface never receives assistant text as `chat:text-delta`
-// events, so a user typing a prompt sees no response in web mode.
+// Codex web sessions are advertised (`supportsWebSessions: true` in
+// `server/types.ts`) as of #1169 (closes #301). This adapter drives the native
+// `codex app-server` JSON-RPC transport (server/codex-app-server-client.ts) and
+// maps assistant text end-to-end into the V2 chat protocol:
+//   - `item/started` (agentMessage) → `agent-item-started-v2` (assistantMessage)
+//   - `item/agentMessage/delta`     → `agent-item-delta-v2` `{ delta: { text } }`
+//   - `item/completed` (agentMessage) → `agent-item-updated-v2` (final text)
+//   - `turn/completed`              → `agent-turn-completed-v2`
+// alongside reasoning deltas, tool/command/file-change items, and approvals.
 //
-// Issue: https://github.com/donovan-yohan/relay-ide/issues/301
-//
-// To re-advertise web sessions, both criteria must be met:
-//   1. Assistant text streaming is mapped end-to-end:
-//      `item/agentMessage/delta` → `chat:text-delta` (with matching
-//      `chat:text-start` / `chat:text-end` lifecycle events) so the UI can
-//      render incremental assistant output the same way it does for Claude.
-//   2. An e2e round-trip test (test/protocol-adapters/codex-*.test.ts or
-//      test/web-session-*.test.ts) asserts: prompt submitted → text-delta
-//      stream observed → completion patch emitted.
-//
-// The adapter is intentionally retained — only the capability advertisement
-// is flipped — so future work can pick up from here instead of re-deriving
-// the JSON-RPC plumbing.
+// The round-trip (prompt submitted → text-delta stream → completion patch) is
+// covered by the fake-app-server unit suite in
+// test/server/protocol-adapters/codex-native-adapter.test.ts (no real codex
+// invocations), and was validated once against the real logged-in `codex` CLI
+// via test/manual/codex-live-proof.mjs. The old `chat:text-delta` gap belonged
+// to the retired hook-based `codex-adapter.ts`, not this native adapter.
 
 // ── Capability set ─────────────────────────────────────────────────────────
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -144,13 +144,16 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: false,
       supportsAttachedRuntime: false,
-      // De-advertised pending full web-session implementation. See issue #301:
-      // the Codex protocol adapter maps lifecycle/tool events but does not
-      // stream assistant text deltas as `chat:text-delta`, so the web mode
-      // appeared installed but produced no chat output. Flip back to true
-      // only after (1) assistant text streaming is mapped end-to-end and
-      // (2) an e2e round-trip test covers prompt → text-delta → completion.
-      supportsWebSessions: false,
+      // Web sessions run the native `codex app-server` JSON-RPC adapter
+      // (server/protocol-adapters/codex-native-adapter.ts +
+      // server/codex-app-server-client.ts). Re-advertised by #1169 (closes
+      // #301): the adapter maps assistant text end-to-end
+      // (`item/agentMessage/delta` → `agent-item-delta-v2`, plus item
+      // started/completed and `turn/completed`), the fake-app-server unit suite
+      // asserts the prompt → text-delta → completion round-trip, and one live
+      // hello-world proof drove the built adapter through a real thread. The
+      // old `chat:text-delta` gap belonged to the retired hook-based adapter.
+      supportsWebSessions: true,
     },
   },
   opencode: {

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -16,8 +16,9 @@ import type { AggregatedRepoInventoryResponse } from '../shared/repo-inventory.j
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 
 function framework(id: string, installed = true): FrameworkInfo {
-  // Mirrors BUILTIN_FRAMEWORKS in server/types.ts. Claude web sessions are
-  // de-advertised pending end-to-end verification (issue #300).
+  // Mirrors BUILTIN_FRAMEWORKS in server/types.ts. Codex web sessions are
+  // advertised as of #1169 (closes #301). Claude stays absent here so this
+  // frontend guard keeps exercising the "only tui" branch for one provider.
   return {
     id,
     displayName: id,
@@ -27,10 +28,7 @@ function framework(id: string, installed = true): FrameworkInfo {
       supportsYolo: true,
       supportsHooks: true,
       supportsTelemetry: false,
-      // Claude + Codex are both intentionally absent — their web-session
-      // capabilities are de-advertised pending full implementations
-      // (issues #300 and #301).
-      supportsWebSessions: ['opencode', 'hermes'].includes(id),
+      supportsWebSessions: ['opencode', 'hermes', 'codex'].includes(id),
     },
     eventSource: 'hooks',
     availability: installed
@@ -192,11 +190,12 @@ describe('CustomizeSessionDialog session mode options', () => {
     ]);
   });
 
-  // Regression guard for issue #301: Codex's web mode is intentionally
-  // de-advertised until assistant text streaming is implemented.
-  it('shows only tui for codex (web mode de-advertised, see #301)', () => {
+  // #1169 (closes #301): Codex web sessions are advertised, so the session-mode
+  // dropdown now surfaces both tui and web when codex is selected.
+  it('shows tui and web for codex (web mode advertised, #1169 closes #301)', () => {
     expect(getSessionModeOptions([framework('codex')], 'codex')).toEqual([
       { value: 'pty', label: 'tui' },
+      { value: 'web', label: 'web' },
     ]);
   });
 
@@ -219,9 +218,9 @@ describe('CustomizeSessionDialog session mode options', () => {
     expect(defaultSessionModeForAgent([framework('codex')], 'codex')).toBe(
       'pty'
     );
-    expect(defaultSessionModeForAgent([framework('opencode')], 'opencode')).toBe(
-      'pty'
-    );
+    expect(
+      defaultSessionModeForAgent([framework('opencode')], 'opencode')
+    ).toBe('pty');
   });
 
   it('disables web mode when an installed agent runtime is unavailable', () => {

--- a/test/framework-types.test.ts
+++ b/test/framework-types.test.ts
@@ -59,11 +59,10 @@ test('codex framework has correct values', () => {
   expect(codex.capabilities.supportsContinue).toBe(true);
   expect(codex.capabilities.supportsYolo).toBe(true);
   expect(codex.capabilities.supportsTelemetry).toBe(false);
-  // Regression guard for issue #301: Codex web sessions don't yet stream
-  // assistant text deltas, so the capability is intentionally de-advertised.
-  // Flip back to true only after the streaming gap is closed AND an e2e
-  // round-trip test asserts prompt → chat:text-delta → completion.
-  expect(codex.capabilities.supportsWebSessions).toBe(false);
+  // #1169 (closes #301): Codex web sessions are advertised. The native
+  // `codex app-server` adapter maps assistant text end-to-end and the
+  // fake-app-server suite asserts prompt → text-delta → completion.
+  expect(codex.capabilities.supportsWebSessions).toBe(true);
 });
 
 test('opencode framework has correct values', () => {

--- a/test/manual/codex-live-proof.mjs
+++ b/test/manual/codex-live-proof.mjs
@@ -1,0 +1,190 @@
+/* eslint-disable no-console -- console output is the entire point of this manual proof script */
+/**
+ * Manual, token-frugal live proof for the native Codex `app-server` adapter
+ * (#1169, closes #301). NOT part of the automated suite — it spawns the REAL
+ * `codex app-server` (this machine must be logged in) and spends real tokens.
+ *
+ * It drives the built `CodexNativeProtocolAdapter` directly through exactly ONE
+ * hello-world round-trip and prints the emitted patch tail, the captured codex
+ * thread id (the resumable provider-session id), the reconstructed assistant
+ * text, and wall-clock TTFT. It tees the raw app-server stdout (JSON-RPC lines)
+ * to an UNCOMMITTED temp file for local evidence only — a real transcript leaks
+ * account/environment data and must never be committed.
+ *
+ * Usage (from the worktree root, after `npm run build:server`):
+ *   RELAY_CODEX_LIVE_PROOF=1 node test/manual/codex-live-proof.mjs
+ */
+import { spawn as nodeSpawn } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+if (process.env.RELAY_CODEX_LIVE_PROOF !== '1') {
+  console.error(
+    'Refusing to run: set RELAY_CODEX_LIVE_PROOF=1 to spend real tokens.'
+  );
+  process.exit(2);
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const worktreeRoot = path.resolve(__dirname, '..', '..');
+const { CodexNativeProtocolAdapter } = await import(
+  path.join(
+    worktreeRoot,
+    'dist',
+    'server',
+    'protocol-adapters',
+    'codex-native-adapter.js'
+  )
+);
+
+const PROMPT = 'Reply with exactly "ok" and nothing else.';
+const rawChunks = [];
+
+// Wrap the real spawn so we can tee stdout for a permanent (uncommitted)
+// evidence transcript without disturbing the adapter's own reader.
+const teeSpawn = (command, args, options) => {
+  const child = nodeSpawn(command, args, options);
+  child.stdout?.on('data', (chunk) => rawChunks.push(Buffer.from(chunk)));
+  return child;
+};
+
+const adapter = new CodexNativeProtocolAdapter();
+const patches = [];
+let threadId = null;
+let firstTokenAt = null;
+let sentAt;
+
+adapter.onPatch((patch) => {
+  patches.push(patch);
+  const ps =
+    (patch.type === 'agent-session-snapshot-v2' &&
+      patch.session?.providerSession?.threadId) ||
+    (patch.type === 'agent-session-updated-v2' &&
+      patch.providerSession?.threadId);
+  if (ps) threadId = ps;
+  if (
+    firstTokenAt === null &&
+    (patch.type === 'agent-item-delta-v2' ||
+      (patch.type === 'agent-item-started-v2' &&
+        patch.item?.type === 'assistantMessage'))
+  ) {
+    firstTokenAt = Date.now();
+  }
+});
+
+const config = {
+  cwd: os.tmpdir(),
+  port: 0,
+  sessionId: 'codex-live-proof',
+  hookToken: 'live-proof',
+  configDir: os.tmpdir(),
+  // DI: the adapter forwards `extra.spawn` to the app-server client so we can
+  // tee the raw transcript. No operator args are injected.
+  extra: { spawn: teeSpawn },
+};
+
+const TIMEOUT_MS = 120_000;
+
+function waitForCompletion() {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const iv = setInterval(() => {
+      const done = patches.find((p) => p.type === 'agent-turn-completed-v2');
+      if (done) {
+        clearInterval(iv);
+        resolve(done);
+      }
+      if (Date.now() - started > TIMEOUT_MS) {
+        clearInterval(iv);
+        reject(new Error(`timed out after ${TIMEOUT_MS}ms`));
+      }
+    }, 50);
+  });
+}
+
+let exitCode = 0;
+try {
+  await adapter.connect(config);
+  sentAt = Date.now();
+  await adapter.sendMessage({ turnId: 'live-1', content: PROMPT });
+  const completion = await waitForCompletion();
+
+  const ttftMs = firstTokenAt ? firstTokenAt - sentAt : null;
+  const totalMs = Date.now() - sentAt;
+
+  let assistantText = '';
+  for (const p of patches) {
+    if (
+      (p.type === 'agent-item-updated-v2' ||
+        p.type === 'agent-item-started-v2') &&
+      p.item?.type === 'assistantMessage' &&
+      typeof p.item.text === 'string' &&
+      p.item.text
+    ) {
+      assistantText = p.item.text;
+    }
+  }
+
+  const tail = patches.slice(-10).map((p) => {
+    if (p.type === 'agent-item-delta-v2')
+      return `${p.type}(${JSON.stringify(p.delta)})`;
+    if (p.type === 'agent-turn-completed-v2')
+      return `${p.type}(status=${p.status})`;
+    if (
+      p.type === 'agent-item-updated-v2' ||
+      p.type === 'agent-item-started-v2'
+    )
+      return `${p.type}(${p.item?.type})`;
+    return p.type;
+  });
+
+  // Save the raw transcript for LOCAL evidence only, to an uncommitted temp
+  // file. NEVER write it into test/fixtures/ — a real app-server transcript can
+  // leak private account/environment data.
+  const rawPath = path.join(
+    os.tmpdir(),
+    `relay-codex-live-proof-${process.pid}.jsonl`
+  );
+  fs.writeFileSync(rawPath, Buffer.concat(rawChunks));
+
+  console.log(
+    JSON.stringify(
+      {
+        ok:
+          completion.type === 'agent-turn-completed-v2' &&
+          completion.status === 'completed',
+        completionStatus: completion.status ?? completion.type,
+        assistantText,
+        threadId,
+        ttftMs,
+        totalMs,
+        patchCount: patches.length,
+        patchTail: tail,
+        rawTranscript: rawPath,
+        usage: completion.usage ?? null,
+      },
+      null,
+      2
+    )
+  );
+  if (
+    completion.type !== 'agent-turn-completed-v2' ||
+    completion.status !== 'completed'
+  ) {
+    exitCode = 1;
+  }
+} catch (err) {
+  exitCode = 1;
+  console.error('LIVE PROOF FAILED:', err?.stack ?? err);
+  console.error(
+    'patch tail:',
+    patches.slice(-8).map((p) => p.type)
+  );
+  const errPatch = patches.find((p) => p.type === 'agent-error-v2');
+  if (errPatch) console.error('adapter error:', errPatch.message);
+} finally {
+  await adapter.disconnect().catch(() => {});
+  setTimeout(() => process.exit(exitCode), 100).unref();
+}

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -5,6 +5,7 @@ import type { CodexClientFactory } from '../../../server/protocol-adapters/codex
 import type { AdapterConfig } from '../../../server/protocol-adapter-v2.js';
 import type {
   CodexAppServerClient,
+  CodexAppServerClientOptions,
   CodexNotification,
   CodexServerRequest,
 } from '../../../server/codex-app-server-client.js';
@@ -1799,5 +1800,166 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     );
 
     await adapter.disconnect();
+  });
+});
+
+// ── Spawn hygiene (claudeArgs-leak class) ─────────────────────────────────────
+
+describe('CodexNativeProtocolAdapter — spawn hygiene', () => {
+  /**
+   * Regression guard for the claudeArgs-leak bug class (#1169 / codex memory):
+   * operator flags such as claude's `--model` / `--effort` must never reach the
+   * `codex app-server` spawn. The adapter only forwards `command` / `args` /
+   * `spawn` from `config.extra`; when `extra` is absent it forwards nothing, so
+   * the client falls back to its default `codex app-server --listen stdio://`.
+   */
+  it('forwards nothing to the client when config.extra is absent (no operator-arg leak)', async () => {
+    const capturedOpts: CodexAppServerClientOptions[] = [];
+    const stub = new StubCodexClient();
+    stub.serverResponses.set('thread/start', { thread: { id: 'thread-1' } });
+    const factory: CodexClientFactory = (opts) => {
+      capturedOpts.push(opts);
+      return stub as unknown as CodexAppServerClient;
+    };
+    const adapter = new CodexNativeProtocolAdapter(factory);
+
+    await adapter.connect(config); // config has no `extra`
+
+    expect(capturedOpts).toHaveLength(1);
+    const opts = capturedOpts[0]!;
+    // No command/args override → client uses its default codex app-server spawn.
+    expect(opts.command).toBeUndefined();
+    expect(opts.args).toBeUndefined();
+    expect(opts.spawn).toBeUndefined();
+    // cwd still flows through from the adapter config.
+    expect(opts.cwd).toBe(config.cwd);
+
+    await adapter.disconnect();
+  });
+
+  it('forwards only command/args/spawn from config.extra and ignores unrelated keys', async () => {
+    const capturedOpts: CodexAppServerClientOptions[] = [];
+    const stub = new StubCodexClient();
+    stub.serverResponses.set('thread/start', { thread: { id: 'thread-1' } });
+    const factory: CodexClientFactory = (opts) => {
+      capturedOpts.push(opts);
+      return stub as unknown as CodexAppServerClient;
+    };
+    const injectedSpawn = () => {
+      throw new Error('spawn should not be invoked by the stub factory');
+    };
+    const adapter = new CodexNativeProtocolAdapter(factory);
+
+    await adapter.connect({
+      ...config,
+      extra: {
+        command: 'codex',
+        args: ['app-server', '--listen', 'stdio://'],
+        spawn: injectedSpawn,
+        // Unrelated keys (e.g. a leaked claudeArgs bag) must be dropped.
+        claudeArgs: ['--model', 'o4-mini', '--effort', 'high'],
+        model: 'gpt-4',
+      },
+    });
+
+    expect(capturedOpts).toHaveLength(1);
+    const opts = capturedOpts[0]!;
+    expect(opts.command).toBe('codex');
+    expect(opts.args).toEqual(['app-server', '--listen', 'stdio://']);
+    expect(opts.spawn).toBe(injectedSpawn);
+    // The stray claudeArgs/model keys never become client options.
+    expect(opts).not.toHaveProperty('claudeArgs');
+    expect((opts as Record<string, unknown>)['model']).toBeUndefined();
+
+    await adapter.disconnect();
+  });
+});
+
+// ── Independent concurrent sessions (second-session regression) ───────────────
+
+describe('CodexNativeProtocolAdapter — independent concurrent sessions', () => {
+  /**
+   * Regression guard for the historical "codex 2nd session stuck initializing"
+   * concern (which lived in the PTY path, not here): two native adapters each
+   * own an independent client + turn lifecycle and must run concurrently
+   * without cross-interference or shared state. A real-transport version of
+   * this (two concurrent `codex app-server` handshakes) was verified manually.
+   */
+  it('two adapters run turns concurrently without cross-interference', async () => {
+    const fa = makeStubFactory();
+    fa.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thA' },
+    });
+    const fb = makeStubFactory();
+    fb.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thB' },
+    });
+
+    const a = new CodexNativeProtocolAdapter(fa);
+    const b = new CodexNativeProtocolAdapter(fb);
+    const pa = collectPatches(a);
+    const pb = collectPatches(b);
+
+    await Promise.all([
+      a.connect({ ...config, sessionId: 'A' }),
+      b.connect({ ...config, sessionId: 'B' }),
+    ]);
+    const ca = fa.lastClient;
+    const cb = fb.lastClient;
+
+    await Promise.all([
+      a.sendMessage({ turnId: 'ta', content: 'hi-A' }),
+      b.sendMessage({ turnId: 'tb', content: 'hi-B' }),
+    ]);
+
+    ca.feedNotification('turn/started', { turn: { id: 'na' } });
+    cb.feedNotification('turn/started', { turn: { id: 'nb' } });
+    ca.feedNotification('item/started', {
+      item: { type: 'agentMessage', id: 'ia' },
+    });
+    ca.feedNotification('item/agentMessage/delta', {
+      itemId: 'ia',
+      delta: 'A-reply',
+    });
+    cb.feedNotification('item/started', {
+      item: { type: 'agentMessage', id: 'ib' },
+    });
+    cb.feedNotification('item/agentMessage/delta', {
+      itemId: 'ib',
+      delta: 'B-reply',
+    });
+    ca.feedNotification('turn/completed', {
+      turn: { id: 'na', status: 'completed' },
+    });
+    cb.feedNotification('turn/completed', {
+      turn: { id: 'nb', status: 'completed' },
+    });
+
+    // Each adapter only sees its own text; no cross-leak between sessions.
+    const aDeltas = pa
+      .filter((p) => p.type === 'agent-item-delta-v2')
+      .map((p) => (p.type === 'agent-item-delta-v2' ? p.delta : null));
+    expect(aDeltas).toContainEqual({ text: 'A-reply' });
+    expect(JSON.stringify(pa)).not.toContain('B-reply');
+    expect(JSON.stringify(pb)).not.toContain('A-reply');
+
+    // Patches carry the right session id.
+    expect(pa.every((p) => p.sessionId === 'A')).toBe(true);
+    expect(pb.every((p) => p.sessionId === 'B')).toBe(true);
+
+    // Both turns complete independently.
+    expect(
+      pa.some(
+        (p) => p.type === 'agent-turn-completed-v2' && p.status === 'completed'
+      )
+    ).toBe(true);
+    expect(
+      pb.some(
+        (p) => p.type === 'agent-turn-completed-v2' && p.status === 'completed'
+      )
+    ).toBe(true);
+
+    await a.disconnect();
+    await b.disconnect();
   });
 });


### PR DESCRIPTION
Slice of epic #1163 (#1169, Codex-revive half). Makes `@codex` work in channels the way `@claude` does: the native Codex `app-server` adapter is re-advertised for web sessions so the mention-routing loop (PR #1180) spawns and streams a real Codex reply.

## Investigation (what was actually broken)

- **Root cause:** codex carried `supportsWebSessions: false` (`server/types.ts`) plus a `#301` web-de-advertise reason (`server/frameworks.ts`). `channelMentionTargets` → `getFrameworkWebAvailability(codex)` therefore returned `available: false`, so the binder's `routeOne` refused to spawn `@codex` and posted an "unavailable" system row. That single flag was the blocker.
- **The #301 gap is already closed.** The native `codex-native-adapter.ts` (app-server JSON-RPC, `runtimeOwnership: spawned`) already maps assistant text end-to-end: `item/started`(agentMessage) → `agent-item-started-v2`, `item/agentMessage/delta` → `agent-item-delta-v2 {delta:{text}}`, `item/completed` → `agent-item-updated-v2`, `turn/completed` → `agent-turn-completed-v2`. The `chat:text-delta` gap that motivated #301 belonged to the retired hook-based `codex-adapter.ts`, not this adapter. A 71-test fake-app-server suite already asserted the prompt → text-delta → completion round-trip.
- **claudeArgs-leak class: not present in this path.** The web-session `extra` builder (`server/index.ts`) only populates `extra` for hermes; codex gets `{}`, so `CodexAppServerClient` uses its default `codex app-server --listen stdio://` spawn — no operator flags reach it. (That leak lived in the PTY `buildAgentArgs` path and was already fixed there.)
- **"2nd session stuck initializing": not present in this path.** Verified with a token-free probe: two concurrent `codex app-server` processes both complete `initialize` + `thread/start` (~280 ms each), no hang. Each adapter owns an independent client/process with no shared or static state. The historical hang was a PTY-path issue.
- **Transport validity:** codex-cli `0.144.1` supports `codex app-server --listen stdio://` (the client's default args).

## Fixes

- `server/types.ts` — codex `supportsWebSessions: true` + refreshed comment.
- `server/frameworks.ts` — drop the codex `#301` entry from `WEB_DEADVERTISE_REASONS`.
- `server/protocol-adapters/codex-native-adapter.ts` — replace the stale de-advertise header note (documents the live end-to-end mapping instead).
- `test/framework-types.test.ts` + `test/customize-session-dialog.test.ts` — update the `#301` regression guards to assert codex web is advertised (`tui + web`).

## New tests (fake app-server, zero real codex invocations)

- **Spawn hygiene (claudeArgs-leak class):** the adapter forwards only `command`/`args`/`spawn` from `config.extra` and drops any stray keys (e.g. a leaked `claudeArgs`/`model` bag); absent `extra` forwards nothing, so the client keeps its default `codex app-server` spawn.
- **Independent concurrent sessions:** two native adapters run turns concurrently with no cross-interference (per-session text/ids isolated, both complete), locking in the "no 2nd-session interference" property.

## Verification (node 24)

- `npm run check`: green (0 errors; pre-existing sonarjs warnings only).
- `test/server/protocol-adapters/codex-native-adapter.test.ts` + `test/framework-types.test.ts` + `test/customize-session-dialog.test.ts`: **108 passed** (74 in the adapter suite).
- `test/channel-agent-binder.test.ts` + `test/channel-mention-e2e.test.ts` + `test/channel-context-packet.test.ts` + `customize-session-dialog-dm-channel`: 45 passed (mention/binder fixtures are mock-driven and unaffected).

### Live proof (token-frugal — exactly one hello-world round-trip)

Real logged-in `codex` CLI `0.144.1`, driven through the built `CodexNativeProtocolAdapter` (`test/manual/codex-live-proof.mjs`, prompt: `Reply with exactly "ok" and nothing else.`):

| Field | Value |
|---|---|
| result | `completed`, `ok: true`, assistant text = `ok` |
| codex thread id | captured live (redacted here) |
| TTFT | ~3.1 s (`ttftMs: 3093`, total 3216 ms) |
| patch tail | `assistantMessage(started)` → `agent-item-delta-v2({"text":"ok"})` → `assistantMessage(updated)` → `agent-turn-completed-v2(status=completed)` → `agent-live-state-updated-v2` |

The manual proof tees its raw app-server transcript to `os.tmpdir()` only — **no transcript is committed** and no fixture was generated from a real session. Per the token-frugality cap, only this one round-trip was spent.

Refs #1169, closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex now supports web sessions, including streaming assistant responses and completion events.
  * Codex sessions now offer both TUI and web modes.
  * Added an optional live verification tool for testing Codex app-server round trips.

* **Bug Fixes**
  * Improved isolation between concurrent Codex sessions.
  * Prevented unrelated configuration options from being passed to the Codex session client.

* **Tests**
  * Added regression coverage for web-session availability, session isolation, and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->