### PR TITLE
fix(channels): hermes reply finalization, duplicate rows, presence, zero-row logging

### DIFF
--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -706,6 +706,16 @@ export function createChannelAgentBinder(
         }
         break;
       case 'agent-live-state-updated-v2':
+        // A session that reports `idle` has no active turn. Finalize ours even
+        // when a matching `agent-turn-completed-v2` never fired (or arrives
+        // after this idle live-state): hermes can emit `session-status idle`
+        // without a paired turn-completed when its turn id was already cleared,
+        // and the plain `waitingOn: null` branch below would otherwise flip the
+        // binding back to 'thinking' and wedge presence forever (#1181 defect 3).
+        if (patch.live.status === 'idle' && binding.activeTurnId !== null) {
+          finishTurn(binding);
+          break;
+        }
         if (patch.live.waitingOn !== undefined) {
           updateWaiting(binding, patch.live.waitingOn);
         }

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -706,14 +706,31 @@ export function createChannelAgentBinder(
         }
         break;
       case 'agent-live-state-updated-v2':
-        // A session that reports `idle` has no active turn. Finalize ours even
-        // when a matching `agent-turn-completed-v2` never fired (or arrives
-        // after this idle live-state): hermes can emit `session-status idle`
-        // without a paired turn-completed when its turn id was already cleared,
-        // and the plain `waitingOn: null` branch below would otherwise flip the
-        // binding back to 'thinking' and wedge presence forever (#1181 defect 3).
-        if (patch.live.status === 'idle' && binding.activeTurnId !== null) {
-          finishTurn(binding);
+        if (patch.live.status === 'idle') {
+          // A session that reports `idle` has no active turn. Finalize ours even
+          // when a matching `agent-turn-completed-v2` never fired (or arrives
+          // after this idle live-state): hermes can emit `session-status idle`
+          // without a paired turn-completed when its turn id was already
+          // cleared, and the `waitingOn` branch below would otherwise flip the
+          // binding back to 'thinking' and wedge presence forever (#1181 defect
+          // 3).
+          //
+          // BUT while an approval is outstanding (or the binding is otherwise
+          // waiting) the idle is a lie: hermes fires `session-status
+          // {status:'idle', waitingOn:'approval'}` alongside a permission
+          // prompt, and the legacy compat mapping strips the `waitingOn` for the
+          // idle case (agent-chat-v1-compat.ts), so a BARE idle arrives
+          // mid-approval. Ignore it entirely then — finalizing would abandon the
+          // approval and let `pump` dispatch a concurrent turn to the same
+          // session, and falling through to `updateWaiting(null)` would clobber
+          // the waiting state and re-arm the watchdog against the parked turn.
+          if (
+            binding.activeTurnId !== null &&
+            binding.announcedApprovals.size === 0 &&
+            binding.waitingOn === null
+          ) {
+            finishTurn(binding);
+          }
           break;
         }
         if (patch.live.waitingOn !== undefined) {

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -72,6 +72,10 @@ export function bindSessionToChannel(
   // (e.g. the codex-native plan item `plan-<turnId>`), and §6.3 mirrors ONLY
   // assistantMessage text — so a delta for any other item type is dropped.
   const assistantItemIds = new Set<string>();
+  // Turn ids that opened at least one channel-message stream. A `turn-completed`
+  // for a turn absent here produced ZERO message rows — a silent finalization
+  // that gets a warn log (#1181, defect 4) rather than passing unnoticed.
+  const turnsWithRows = new Set<string>();
 
   const sender: ChannelSenderRef = {
     kind: 'agent',
@@ -88,6 +92,7 @@ export function bindSessionToChannel(
   ): BridgeStream {
     const existing = streams.get(itemId);
     if (existing) return existing;
+    turnsWithRows.add(turnId);
     const message = store.beginStream({
       channelId,
       sender,
@@ -195,6 +200,22 @@ export function bindSessionToChannel(
       if (turnId !== undefined && stream.turnId !== turnId) continue;
       finalize(stream, status, stream.text);
     }
+    // #1181 defect 4: a cleanly-completed bound-agent turn that produced no
+    // channel message row is a silent failure (the reply never reached the
+    // channel). Log it — but never post a system row — so the gap is diagnosable
+    // instead of invisible. Interrupted/failed turns are expected to be able to
+    // finish empty, so they are not flagged.
+    if (
+      status === 'complete' &&
+      turnId !== undefined &&
+      !turnsWithRows.has(turnId)
+    ) {
+      logger.warn('channel bridge turn finalized with no message rows', {
+        channelId,
+        agentFramework,
+        turnId,
+      });
+    }
   }
 
   function handlePatch(patch: AgentPatchV2): void {
@@ -227,8 +248,22 @@ export function bindSessionToChannel(
       }
       case 'agent-item-updated-v2': {
         if (patch.item.type !== 'assistantMessage') break;
-        const stream = streams.get(patch.item.id);
-        if (stream) finalize(stream, 'complete', patch.item.text);
+        let stream = streams.get(patch.item.id);
+        if (!stream) {
+          // A completed assistantMessage that never opened a stream — no
+          // `started`, no text delta — is a non-streamed reply delivered as a
+          // single message-complete (e.g. a hermes v0.18.2 message output-item,
+          // #1181). Materialize the row directly so the reply is not silently
+          // dropped; openStream seeds it with the final text and finalize closes
+          // it in the same tick.
+          stream = openStream(
+            patch.turnId,
+            patch.item.id,
+            patch.sessionId,
+            patch.item.text ?? ''
+          );
+        }
+        finalize(stream, 'complete', patch.item.text ?? '');
         break;
       }
       case 'agent-turn-completed-v2': {

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -1481,6 +1481,28 @@ export class ClaudeProtocolAdapter
       : `${prefix}-${turnId}-${index}`;
   }
 
+  /**
+   * Echo-drop guard for `handleAssistantMessage`: has this content block already
+   * been streamed? Checks the provider-id-keyed id AND the bare `${prefix}-
+   * ${turnId}-${index}` id. The bare form matters when the streamed item's
+   * `message_start` carried no message id (`streamProviderMessageId` null): the
+   * streamed item is keyed bare while this echo carries the message's real id,
+   * so the two ids diverge and — without the bare check — the echo would open a
+   * SECOND channel row for one assistant message (bridge opens per item id;
+   * store dedupes per source-triple), the #1181 duplicate-row defect.
+   */
+  private echoAlreadyStreamed(
+    streamed: Set<string>,
+    prefix: 'msg' | 'thinking',
+    turnId: string,
+    id: string,
+    index: number
+  ): boolean {
+    if (streamed.has(id)) return true;
+    const bareId = this.streamItemId(prefix, turnId, null, index);
+    return streamed.has(bareId);
+  }
+
   private handleStreamEvent(
     turnId: string,
     message: Record<string, unknown>
@@ -1676,7 +1698,15 @@ export class ClaudeProtocolAdapter
           providerMessageId,
           itemIndex
         );
-        if (this.streamedTextItems.has(id)) {
+        if (
+          this.echoAlreadyStreamed(
+            this.streamedTextItems,
+            'msg',
+            turnId,
+            id,
+            itemIndex
+          )
+        ) {
           // Stream already emitted start/deltas/stop — echo-drop the duplicate.
           continue;
         }
@@ -1725,7 +1755,15 @@ export class ClaudeProtocolAdapter
           providerMessageId,
           itemIndex
         );
-        if (this.streamedReasoningItems.has(id)) {
+        if (
+          this.echoAlreadyStreamed(
+            this.streamedReasoningItems,
+            'thinking',
+            turnId,
+            id,
+            itemIndex
+          )
+        ) {
           continue;
         }
         this.emitPatch({

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -456,6 +456,34 @@ function parseToolArguments(value: unknown): Record<string, unknown> {
   }
 }
 
+/**
+ * Concatenate the text of a Responses API `message` output-item. The item shape
+ * is `{ type: 'message', role, content: [{ type: 'output_text', text }, …] }`;
+ * some builds inline `text` directly on the item. Non-text parts (refusals,
+ * tool references) contribute nothing. Used to recover the assistant reply that
+ * hermes v0.18.2 delivers as a message output-item rather than a streamed
+ * `output_text.done` (#1181).
+ */
+function extractResponsesMessageText(item: Record<string, unknown>): string {
+  if (typeof item['text'] === 'string') return item['text'];
+  const content = item['content'];
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const part of content) {
+    if (part && typeof part === 'object') {
+      const p = part as Record<string, unknown>;
+      const type = p['type'];
+      if (
+        (type === undefined || type === 'output_text' || type === 'text') &&
+        typeof p['text'] === 'string'
+      ) {
+        parts.push(p['text']);
+      }
+    }
+  }
+  return parts.join('');
+}
+
 const RESPONSES_METADATA_MAX_KEYS = 16;
 const RESPONSES_METADATA_KEY_MAX = 64;
 const RESPONSES_METADATA_VALUE_MAX = 512;
@@ -648,6 +676,15 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
   >();
   /** Accumulated reasoning summary text for the turn currently streaming. */
   private _reasoningBuffer = '';
+  /**
+   * True once an assistant `chat:message-complete` has been emitted for the turn
+   * currently streaming. Guards the three assistant-text delivery paths so a
+   * hermes build that streams text (`output_text.done`) never double-emits with
+   * the message output-item (`output_item.done` type `message`) or the
+   * `response.completed` `output[]` fallback that cover v0.18.2, which delivers
+   * the reply as a message output-item only (#1181).
+   */
+  private _assistantEmittedThisTurn = false;
 
   get status(): AdapterStatus {
     return this._status;
@@ -665,6 +702,7 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._initialInstructionsSent = false;
     this._pendingToolCalls.clear();
     this._reasoningBuffer = '';
+    this._assistantEmittedThisTurn = false;
 
     const settings = resolveHermesGatewaySettings(config.extra);
     this._endpoint = settings.endpoint;
@@ -689,6 +727,7 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._lastResponseId = null;
     this._pendingToolCalls.clear();
     this._reasoningBuffer = '';
+    this._assistantEmittedThisTurn = false;
     this._status = 'disconnected';
   }
 
@@ -713,6 +752,7 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._messageAbortController = new AbortController();
     this._currentTurnId = turnId;
     this._reasoningBuffer = '';
+    this._assistantEmittedThisTurn = false;
     this._pendingToolCalls.clear();
 
     this.fire({ type: 'chat:session-status', status: 'active' });
@@ -1075,6 +1115,40 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
       role: 'assistant',
       content: typeof text === 'string' ? text : '',
     });
+    // Streamed-text path is authoritative: mark the turn's assistant reply as
+    // emitted so the message output-item and response.completed fallback
+    // (#1181) do not re-emit the same reply.
+    this._assistantEmittedThisTurn = true;
+  }
+
+  /**
+   * Emit a completed assistant `chat:message-complete` from a Responses API
+   * `message` output-item. Hermes v0.18.2 delivers the reply as a message
+   * output-item (via `output_item.done` or the completed response's `output[]`)
+   * instead of streaming `output_text.done` (#1181). No-op — returning false —
+   * when an assistant reply was already emitted this turn (dedupe vs the
+   * streamed path), the item is not an assistant message, or it carries no
+   * text. Reuses the streamed path's `msg-<turnId>` id so any residual
+   * double-emit collapses at the store's source-triple dedupe.
+   */
+  private emitAssistantMessageItem(
+    item: Record<string, unknown>,
+    turnId: string
+  ): boolean {
+    if (this._assistantEmittedThisTurn) return false;
+    const role = item['role'];
+    if (typeof role === 'string' && role !== 'assistant') return false;
+    const text = extractResponsesMessageText(item);
+    if (!text) return false;
+    this._assistantEmittedThisTurn = true;
+    this.fire({
+      type: 'chat:message-complete',
+      turnId,
+      messageId: `msg-${turnId}`,
+      role: 'assistant',
+      content: text,
+    });
+    return true;
   }
 
   private handleOutputItemAdded(event: SseEvent, turnId: string): void {
@@ -1120,6 +1194,12 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
 
   private handleOutputItemDone(event: SseEvent, turnId: string): void {
     const item = event.data['item'] as Record<string, unknown> | undefined;
+    if (item?.['type'] === 'message') {
+      // v0.18.2 assistant reply shape: a completed `message` output-item. Map
+      // it to a message-complete so the reply becomes a channel row (#1181).
+      this.emitAssistantMessageItem(item, turnId);
+      return;
+    }
     if (item?.['type'] !== 'function_call') return;
     const itemId = String(item['id'] ?? '');
     const pending = this._pendingToolCalls.get(itemId);
@@ -1197,6 +1277,11 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
       });
     }
     this.emitTelemetryFromResponse(response, turnId);
+    // Fallback finalization: if neither the streamed `output_text.done` path nor
+    // a `message` output-item emitted the assistant reply this turn, recover it
+    // from the completed response's `output[]` so a hermes turn never finalizes
+    // with an invisible reply (#1181).
+    this.emitAssistantFallbackFromResponse(response, turnId);
     if (this._currentTurnId) {
       this.fire({
         type: 'chat:turn-completed',
@@ -1210,6 +1295,32 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     }
     this._pendingToolCalls.clear();
     this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  /**
+   * Emit the assistant reply from a completed response's `output[]` when no
+   * assistant message was emitted this turn (#1181). Scans for the first
+   * assistant `message` item carrying text; `emitAssistantMessageItem` sets the
+   * dedupe flag, so at most one row is produced per turn.
+   */
+  private emitAssistantFallbackFromResponse(
+    response: Record<string, unknown> | undefined,
+    turnId: string
+  ): void {
+    if (this._assistantEmittedThisTurn) return;
+    const output = response?.['output'];
+    if (!Array.isArray(output)) return;
+    for (const candidate of output) {
+      if (candidate && typeof candidate === 'object') {
+        const item = candidate as Record<string, unknown>;
+        if (
+          item['type'] === 'message' &&
+          this.emitAssistantMessageItem(item, turnId)
+        ) {
+          return;
+        }
+      }
+    }
   }
 
   private handleResponseFailed(event: SseEvent): void {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -294,6 +294,24 @@ class ApprovalAdapter extends BaseProtocolAdapterV2 {
       timestamp: 't',
       live: { waitingOn: 'approval' },
     });
+    // Real hermes shape (#1181 re-review): hermes fires
+    // `session-status {status:'idle', waitingOn:'approval'}` alongside the
+    // permission prompt, and the legacy compat mapping strips the waitingOn for
+    // the `idle` case — so the binder sees a BARE idle mid-approval. It must
+    // ignore it: never finalize (which would let pump dispatch a concurrent
+    // turn) and never clobber the waiting state / re-arm the watchdog.
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: {
+        status: 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        error: null,
+      },
+    });
   }
 
   async interrupt(input: AgentInterruptInputV2): Promise<void> {
@@ -1374,6 +1392,48 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     await binder.interrupt(CH, 'mock'); // operator recovery
     await waitFor(() => a.sendCalls.length === 2, 4000); // parked turn drained
     expect(a.interruptCalls).toHaveLength(1);
+    expect(a.sendCalls).toHaveLength(2);
+  });
+
+  it('the trailing idle live-state during an approval never finalizes the turn (#1181 re-review)', async () => {
+    const built: ApprovalAdapter[] = [];
+    const { binder, store } = makeBinder({
+      build: (t) => {
+        const a = new ApprovalAdapter(t);
+        built.push(a);
+        return a;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      watchdogMs: 25,
+    });
+    const t1 = post(store, binder, '@mock please approve', ['mock']);
+    await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
+    const a = built[0]!;
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('requests approval'))
+    );
+    // Queue a second turn behind the parked (approval-pending) turn.
+    post(store, binder, '@mock two', ['mock']);
+
+    // Well past the 25ms watchdog: the trailing bare `idle` live-state must NOT
+    // have finalized the turn (which would pump T2) nor re-armed the watchdog
+    // (which would force-drain the parked turn and pump T2). Without the guard
+    // this is where the concurrent turn leaks.
+    await new Promise((r) => setTimeout(r, 90));
+    expect(a.sendCalls).toHaveLength(1); // T2 NOT pumped — turn stayed parked
+    // Presence stayed 'waiting' — never flipped to idle/thinking mid-approval.
+    expect(
+      (await binder.rosterForChannel(CH)).find((r) => r.id === 'mock')!.binding
+        ?.status
+    ).toBe('waiting');
+
+    // Resolving the approval resumes the turn: it completes normally, then T2 drains.
+    const requestId = `appr-chturn-${t1.id}-mock`;
+    await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
+    await waitFor(() => agentReplies(store, 'mock').length === 1, 4000);
+    expect(agentReplies(store, 'mock')[0]!.body.text).toBe('approved and done');
+    await waitFor(() => a.sendCalls.length === 2, 4000); // queued turn drained
     expect(a.sendCalls).toHaveLength(2);
   });
 });

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -467,6 +467,74 @@ class DeferredAdapter extends BaseProtocolAdapterV2 {
   }
 }
 
+// ── idle-without-turn-completed adapter (#1181 defect 3) ─────────────────────
+// Emits `working` then a trailing `idle` live-state but NO agent-turn-completed-v2
+// (and no assistant item) — the shape a hermes turn produces when it signals
+// session-status idle without a paired turn-completed. Reproduces the presence
+// wedge: the binder must fall back to idle instead of flipping to 'thinking'.
+class IdleWithoutTurnCompletedAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'attached' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    interrupt: true,
+    streaming: true,
+  };
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'idle-nc';
+  constructor(readonly agentType: string) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(_i: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: { status: 'working', error: null },
+    });
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `user-${input.turnId}`,
+        items: [],
+        startedAt: 't',
+      },
+    });
+    // No assistant item, and crucially NO agent-turn-completed-v2 — only a
+    // trailing idle live-state, as a hermes turn can emit.
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: {
+        status: 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        error: null,
+      },
+    });
+  }
+}
+
 // ── sessions harness ─────────────────────────────────────────────────────────
 
 interface SessionsHarness {
@@ -828,6 +896,36 @@ describe('channel-agent-binder — roster + availability', () => {
     roster = await binder.rosterForChannel(CH);
     expect(roster.find((r) => r.id === 'mock')!.binding).not.toBeNull();
     expect(roster.find((r) => r.id === 'mock')!.binding?.status).toBe('idle');
+  });
+
+  it('clears presence to idle when a turn finalizes with an idle live-state and no turn-completed (#1181)', async () => {
+    const { binder, store } = makeBinder({
+      build: (agentType) => new IdleWithoutTurnCompletedAdapter(agentType),
+      targets: [
+        {
+          id: 'hermes',
+          displayName: 'Hermes',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['hermes'],
+    });
+    const statuses: string[] = [];
+    binder.setStatusBroadcaster((_type, data) => {
+      if (data['agentId'] === 'hermes') statuses.push(String(data['status']));
+    });
+    post(store, binder, '@hermes hi', ['hermes']);
+    // The turn must reach 'thinking' (proving it was delivered) and then settle
+    // back to 'idle' — NOT wedge on 'thinking' — even though no
+    // agent-turn-completed-v2 fired; the trailing idle live-state finalizes it.
+    await waitFor(
+      () => statuses.includes('thinking') && statuses.at(-1) === 'idle',
+      3000
+    );
+    expect(statuses).toContain('thinking');
+    expect(statuses.at(-1)).toBe('idle');
   });
 
   it('an unavailable framework posts a de-advertise row, rate-limited', async () => {

--- a/test/channel-agent-bridge-zero-row.test.ts
+++ b/test/channel-agent-bridge-zero-row.test.ts
@@ -1,0 +1,109 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// #1181 defect 4: a cleanly-completed bound-agent turn that produces zero
+// channel rows is a silent failure and must be warn-logged (log only — never a
+// system row). Mock the logger so the warn hook is assertable.
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnSpy,
+    error: vi.fn(),
+  }),
+}));
+
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
+import { bindSessionToChannel } from '../server/channel-agent-bridge.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+  warnSpy.mockClear();
+});
+
+function makeStore(): { store: ChannelMessageStore; hub: ChannelHub } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-zero-row-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => store.close());
+  const hub = createChannelHub({ store, channelExists: () => true });
+  cleanup.push(() => hub.close());
+  return { store, hub };
+}
+
+function turnCompleted(turnId: string): AgentPatchV2 {
+  return {
+    type: 'agent-turn-completed-v2',
+    sessionId: 's',
+    timestamp: 't',
+    turnId,
+    status: 'completed',
+  };
+}
+
+describe('channel-agent-bridge zero-row finalization (#1181)', () => {
+  it('warn-logs when a completed turn produced no message rows', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:zr',
+      agentFramework: 'hermes',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(turnCompleted('turn-empty'));
+
+    // No channel rows, and no system row was posted.
+    expect(store.history('topic:zr')).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'channel bridge turn finalized with no message rows',
+      expect.objectContaining({
+        channelId: 'topic:zr',
+        agentFramework: 'hermes',
+        turnId: 'turn-empty',
+      })
+    );
+  });
+
+  it('does NOT warn when the turn produced a row', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:ok',
+      agentFramework: 'hermes',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn-ok',
+      item: { type: 'assistantMessage', id: 'msg-turn-ok', text: 'ok' },
+    });
+    adapter.broadcastPatch(turnCompleted('turn-ok'));
+
+    expect(store.history('topic:ok')).toHaveLength(1);
+    expect(
+      warnSpy.mock.calls.some(
+        (call) =>
+          call[0] === 'channel bridge turn finalized with no message rows'
+      )
+    ).toBe(false);
+  });
+});

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -232,6 +232,60 @@ describe('channel-agent-bridge lifecycle', () => {
     });
   });
 
+  it('materializes a non-streamed complete assistantMessage as one row (#1181)', () => {
+    // A completed assistantMessage that never opened a stream (no started, no
+    // delta) — the shape a hermes v0.18.2 message output-item maps to. Without
+    // the bridge materializing it, the reply is silently dropped.
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:ns',
+      agentFramework: 'hermes',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(assistantUpdated('s', 'turn', 'msg-turn', 'ok'));
+
+    const messages = store.history('topic:ns');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      status: 'complete',
+      body: { text: 'ok' },
+    });
+    expect(messages[0]!.sender).toMatchObject({
+      kind: 'agent',
+      id: 'agent:hermes',
+    });
+  });
+
+  it('does not double-commit a non-streamed complete followed by turn-completed (#1181)', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:ns2',
+      agentFramework: 'hermes',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(assistantUpdated('s', 'turn', 'msg-turn', 'ok'));
+    adapter.broadcastPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      status: 'completed',
+    });
+
+    const messages = store.history('topic:ns2');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      status: 'complete',
+      body: { text: 'ok' },
+    });
+  });
+
   it('does not mirror plan-item (or unknown-item) text deltas', () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2();
@@ -251,7 +305,9 @@ describe('channel-agent-bridge lifecycle', () => {
       turnId: 'turn',
       item: { type: 'plan', id: 'plan-turn', text: '' },
     });
-    adapter.broadcastPatch(textDelta('s', 'turn', 'plan-turn', 'Step 1: do it'));
+    adapter.broadcastPatch(
+      textDelta('s', 'turn', 'plan-turn', 'Step 1: do it')
+    );
     // A delta for an itemId never started at all is likewise dropped.
     adapter.broadcastPatch(textDelta('s', 'turn', 'ghost-item', 'stray text'));
 

--- a/test/channel-claude-duplicate-row.test.ts
+++ b/test/channel-claude-duplicate-row.test.ts
@@ -1,0 +1,223 @@
+/**
+ * #1181 defect 2 regression: a single Claude assistant reply must persist as
+ * exactly one channel row, whether or not the streamed item id and the
+ * `assistant` echo message id diverge.
+ *
+ * Root cause: when `message_start` carries no message id,
+ * `streamProviderMessageId` is null so the streamed assistant item is keyed
+ * `msg-<turnId>-<index>` (bare), while the echo message carries its own real
+ * id and is keyed `msg-<turnId>-<realId>-<index>`. The two ids diverge, the
+ * adapter's echo-drop misses, the bridge opens a second stream, and the store's
+ * source-triple dedupe (session/turn/item) treats them as different → two rows.
+ *
+ * This replays live-shaped stream-json through the real adapter → bridge →
+ * store and asserts one row for both the matching-id and divergent-id shapes.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ChildProcess } from 'node:child_process';
+import {
+  ClaudeProtocolAdapter,
+  ClaudeProcessRegistry,
+} from '../server/protocol-adapters/claude-adapter.js';
+import type { ClaudeSpawnFn } from '../server/claude-stream-client.js';
+import type { AdapterConfig } from '../server/protocol-adapter-v2.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import { createChannelHub } from '../server/channel-hub.js';
+import { bindSessionToChannel } from '../server/channel-agent-bridge.js';
+
+interface MockChild extends EventEmitter {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+  pid: number;
+  serverWrite(obj: unknown): void;
+  waitForFrames(count: number): Promise<void>;
+}
+
+function makeMockChild(): MockChild {
+  const child = new EventEmitter() as MockChild;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.pid = Math.floor(Math.random() * 100000);
+  let frames = 0;
+  const waiters: Array<{ count: number; resolve: () => void }> = [];
+  child.stdin.on('data', (chunk: Buffer) => {
+    for (const line of chunk.toString().split('\n')) {
+      if (!line.trim()) continue;
+      frames++;
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (frames >= waiters[i]!.count) waiters.splice(i, 1)[0]!.resolve();
+      }
+    }
+  });
+  child.kill = vi.fn(() => true);
+  child.serverWrite = (obj) => child.stdout.push(JSON.stringify(obj) + '\n');
+  child.waitForFrames = (count) =>
+    new Promise((resolve) => {
+      if (frames >= count) return resolve();
+      waiters.push({ count, resolve });
+    });
+  return child;
+}
+
+function makeHarness(): { spawnFn: ClaudeSpawnFn; latest: () => MockChild } {
+  const spawns: MockChild[] = [];
+  const spawnFn: ClaudeSpawnFn = () => {
+    const child = makeMockChild();
+    spawns.push(child);
+    return child as unknown as ChildProcess;
+  };
+  return { spawnFn, latest: () => spawns[spawns.length - 1]! };
+}
+
+function baseConfig(): AdapterConfig {
+  return {
+    cwd: '/tmp/repo',
+    port: 3000,
+    sessionId: 'session-1',
+    hookToken: 'token',
+    configDir: '/tmp/config',
+  };
+}
+
+function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() - start > timeoutMs) return reject(new Error('timeout'));
+      setTimeout(tick, 2);
+    };
+    tick();
+  });
+}
+
+async function replayToRowCount(lines: unknown[]): Promise<number> {
+  const harness = makeHarness();
+  const adapter = new ClaudeProtocolAdapter(
+    harness.spawnFn,
+    new ClaudeProcessRegistry(1_000_000)
+  );
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-claude-dup-'));
+  const store: ChannelMessageStore = createChannelMessageStore(
+    path.join(dir, 'channel-chat.db')
+  );
+  const hub = createChannelHub({ store, channelExists: () => true });
+  const unbind = bindSessionToChannel({
+    channelId: 'topic:general',
+    agentFramework: 'claude',
+    adapter,
+    store,
+    hub,
+  });
+  await adapter.connect(baseConfig());
+  await adapter.sendMessage({ turnId: 'turn-replay', content: 'hello' });
+  const child = harness.latest();
+  await child.waitForFrames(1);
+  for (const line of lines) child.serverWrite(line);
+  await waitFor(() => store.history('topic:general').length >= 1);
+  await new Promise((r) => setTimeout(r, 50));
+  const rows = store
+    .history('topic:general')
+    .filter((m) => m.sender.kind === 'agent');
+  unbind();
+  hub.close();
+  store.close();
+  fs.rmSync(dir, { recursive: true, force: true });
+  return rows.length;
+}
+
+describe('claude single reply → one channel row (#1181)', () => {
+  it('persists one row for the matching-id fixture', async () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const lines = fs
+      .readFileSync(
+        path.join(here, 'fixtures', 'claude-stream', 'hello.jsonl'),
+        'utf8'
+      )
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as unknown);
+    expect(await replayToRowCount(lines)).toBe(1);
+  });
+
+  it('persists one row when message_start carries no id (divergent stream/echo ids)', async () => {
+    const sid = '00000000-0000-4000-8000-000000000001';
+    const lines: unknown[] = [
+      { type: 'system', subtype: 'init', session_id: sid, uuid: 'u-init' },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { id: '', type: 'message', role: 'assistant', content: [] },
+        },
+        session_id: sid,
+        uuid: 'u1',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text', text: '' },
+        },
+        session_id: sid,
+        uuid: 'u2',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'ok' },
+        },
+        session_id: sid,
+        uuid: 'u3',
+      },
+      {
+        // Echo carries its own real message id — diverges from the bare streamed id.
+        type: 'assistant',
+        message: {
+          id: 'msg_real_001',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+        },
+        session_id: sid,
+        uuid: 'u4',
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        session_id: sid,
+        uuid: 'u5',
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'message_stop' },
+        session_id: sid,
+        uuid: 'u6',
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'ok',
+        session_id: sid,
+        uuid: 'u7',
+      },
+    ];
+    expect(await replayToRowCount(lines)).toBe(1);
+  });
+});

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -601,3 +601,176 @@ describe('Hermes Responses SSE hardening', () => {
     });
   });
 });
+
+// #1181 defect 1: hermes replies must always finalize to exactly one assistant
+// `chat:message-complete`, whichever wire shape the reply arrives in.
+describe('Hermes assistant reply finalization (#1181)', () => {
+  let gateway: InlineGateway | undefined;
+  let adapter: HermesProtocolAdapter | undefined;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.disconnect().catch(() => {});
+      adapter = undefined;
+    }
+    if (gateway) {
+      await new Promise<void>((resolve) =>
+        gateway!.server.close(() => resolve())
+      );
+      gateway = undefined;
+    }
+  });
+
+  function assistantCompletes(events: ChatEvent[]): ChatEvent[] {
+    return events.filter(
+      (event) =>
+        event.type === 'chat:message-complete' && event.role === 'assistant'
+    );
+  }
+
+  it('maps a v0.18.2 message output-item to exactly one assistant message-complete', async () => {
+    // v0.18.2 delivers the reply as a `message` output-item via
+    // output_item.done, with NO streamed output_text.done.
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_v0182' } });
+      send({
+        type: 'response.output_item.done',
+        item: {
+          id: 'msg_out_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'ok', annotations: [] }],
+        },
+      });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_v0182', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-v0182'));
+    await adapter.sendMessage('turn-1', 'say ok');
+
+    const completes = assistantCompletes(events);
+    expect(completes).toHaveLength(1);
+    expect(completes[0]).toMatchObject({
+      role: 'assistant',
+      content: 'ok',
+      turnId: 'turn-1',
+    });
+  });
+
+  it('emits exactly one assistant message-complete on the streamed output_text.done shape', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_stream' } });
+      send({ type: 'response.output_text.delta', delta: 'o' });
+      send({ type: 'response.output_text.delta', delta: 'k' });
+      send({ type: 'response.output_text.done', text: 'ok' });
+      send({
+        type: 'response.completed',
+        response: {
+          id: 'resp_stream',
+          status: 'completed',
+          output: [
+            {
+              id: 'msg_stream_1',
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'ok' }],
+            },
+          ],
+        },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-stream'));
+    await adapter.sendMessage('turn-1', 'say ok');
+
+    const completes = assistantCompletes(events);
+    expect(completes).toHaveLength(1);
+    expect(completes[0]).toMatchObject({ content: 'ok' });
+  });
+
+  it('does not double-emit when BOTH output_text.done and the message output-item arrive', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_both' } });
+      send({ type: 'response.output_text.delta', delta: 'ok' });
+      send({ type: 'response.output_text.done', text: 'ok' });
+      send({
+        type: 'response.output_item.done',
+        item: {
+          id: 'msg_both_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'ok' }],
+        },
+      });
+      send({
+        type: 'response.completed',
+        response: {
+          id: 'resp_both',
+          status: 'completed',
+          output: [
+            {
+              id: 'msg_both_1',
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'ok' }],
+            },
+          ],
+        },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-both'));
+    await adapter.sendMessage('turn-1', 'say ok');
+
+    expect(assistantCompletes(events)).toHaveLength(1);
+  });
+
+  it('recovers the reply from response.completed output[] when no item.done/text.done arrives', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_fallback' } });
+      send({
+        type: 'response.completed',
+        response: {
+          id: 'resp_fallback',
+          status: 'completed',
+          output: [
+            {
+              id: 'msg_fallback_1',
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'ok' }],
+            },
+          ],
+        },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+
+    await adapter.connect(configFor(gateway.endpoint, 'sess-fallback'));
+    await adapter.sendMessage('turn-1', 'say ok');
+
+    const completes = assistantCompletes(events);
+    expect(completes).toHaveLength(1);
+    expect(completes[0]).toMatchObject({ content: 'ok' });
+  });
+});


### PR DESCRIPTION
Closes #1181

Four defects found by live proof rows 1b/2 of epic #1163, fixed at their root layers with regression tests and one live hermes turn against gateway v0.18.2.

## Fixes

### 1. P1 — Hermes replies never became channel rows
`server/protocol-adapters/hermes-adapter.ts` + `server/channel-agent-bridge.ts`. Hermes v0.18.2 delivers the reply as a `message` output-item (via `output_item.done` or the completed response's `output[]`), not a streamed `output_text.done`, so `handleOutputItemDone` dropped it and the turn finalized with no assistant content.
- Adapter: map message output-items to `chat:message-complete`, add a `response.completed` `output[]` fallback, and gate all three delivery paths with a per-turn `_assistantEmittedThisTurn` flag so builds that DO stream text never double-emit.
- Bridge: a completed `assistantMessage` that never opened a stream (no `started`, no delta) is now materialized into a row on `agent-item-updated-v2` instead of being dropped.

### 2. P2 — Claude single turn produced two identical rows
`server/protocol-adapters/claude-adapter.ts`. **Root cause:** when `message_start` carries no message id, `streamProviderMessageId` is null, so the streamed assistant item is keyed `msg-<turnId>-<index>` (bare) while the `assistant` echo carries its own real id and is keyed `msg-<turnId>-<realId>-<index>`. The two ids diverge → the adapter's echo-drop misses → the bridge opens a second stream → the store's source-triple dedupe (session/turn/item) persists two rows. Reproduced by replaying the sanitized fixture through adapter→bridge→store (matching-id fixture = 1 row; empty-`message_start`-id shape = 2 rows before fix). Fixed with a bare-id fallback in the echo-drop check.

### 3. P2 — Roster presence stuck on "thinking"
`server/channel-agent-binder.ts`. A hermes turn can emit `session-status idle` without a paired turn-completed; the binder's `agent-live-state-updated-v2` handler only looked at `waitingOn`, so a trailing `waitingOn: null` flipped the still-active binding back to `thinking` and wedged presence until the 5-minute watchdog. Now finalizes the active turn whenever the session reports `idle`.

### 4. P2 — Silent zero-row finalization
`server/channel-agent-bridge.ts`. A cleanly-completed bound-agent turn that produced zero channel rows now emits a warn log (log only — no system row) so the gap is diagnosable.

## Tests
- `test/server/protocol-adapters/hermes-adapter.test.ts` — v0.18.2 / streaming / both-events / fallback shapes each → exactly one message-complete.
- `test/channel-agent-bridge.test.ts` — non-streamed complete → one row; no double-commit when turn-completed follows.
- `test/channel-agent-bridge-zero-row.test.ts` — warn fires on a zero-row turn, silent when a row exists.
- `test/channel-claude-duplicate-row.test.ts` — one row for both matching-id and divergent-id claude shapes (fails with 2 rows pre-fix).
- `test/channel-agent-binder.test.ts` — idle-without-turn-completed → presence reaches `thinking` then settles at `idle` (fails pre-fix).

Each regression test was confirmed red without its fix. Full suite: only `test/branch-watcher.test.ts` fails, a pre-existing inotify-timing flake unrelated to these changes (imports only `server/watcher.js`). `npm run check` = 0 errors.

## Live evidence
Throwaway hub built from this branch on port 3460 (fresh config dir, PIN 4242), real hermes gateway v0.18.2 on :8642. Posted `@hermes Reply with exactly "ok" and nothing else.` in a hermes DM:

```
post @hermes -> 201
  poll 0: 1 rows [human:operator:complete]
  poll 2: 2 rows [human:operator:complete, agent:hermes:complete]

AGENT_ROW_FOUND sender=agent:hermes status=complete body="ok"
VERIFY_OK
```

The `agent:hermes` row now appears with body `ok`; no zero-row warn fired (a row was produced). Budget honored: exactly one hermes turn, zero claude/codex spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)