### PR TITLE
feat(channels): add backend thread support

### DIFF
--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -157,8 +157,8 @@ export interface LiveBinding {
   patchUnlisten: (() => void) | null;
   status: ChannelAgentStatus;
   activeTurnId: string | null;
-  /** Immediate parent for the active turn's streamed reply. */
-  activeParentMessageId: string | null;
+  /** Immediate thread parent keyed by routed turn; retained past binder idle. */
+  parentMessageIdByTurn: Map<string, string | null>;
   /** Context packet for the active turn (kept so a retry re-sends identical content). */
   activeContent: string | null;
   sawStream: boolean;
@@ -240,7 +240,10 @@ export function createChannelAgentBinder(
   function postSystemRow(
     channelId: string,
     text: string,
-    meta?: Record<string, unknown>
+    options: {
+      meta?: Record<string, unknown>;
+      parentMessageId?: string | undefined;
+    } = {}
   ): void {
     try {
       const message = store.appendComplete({
@@ -248,7 +251,10 @@ export function createChannelAgentBinder(
         kind: 'system',
         sender: { ...SYSTEM_SENDER },
         text,
-        ...(meta ? { meta } : {}),
+        ...(options.meta ? { meta: options.meta } : {}),
+        ...(options.parentMessageId
+          ? { parentMessageId: options.parentMessageId }
+          : {}),
       });
       hub.broadcastCreated(message);
     } catch (err) {
@@ -259,13 +265,47 @@ export function createChannelAgentBinder(
   function postUnavailableRow(
     channelId: string,
     framework: string,
-    text: string
+    text: string,
+    parentMessageId?: string
   ): void {
-    const key = `${bindingKey(channelId, framework)}\u0000${text}`;
+    const key = `${bindingKey(channelId, framework)}\u0000${text}\u0000${parentMessageId ?? ''}`;
     const last = unavailableRowAt.get(key);
     if (last !== undefined && now() - last < UNAVAILABLE_ROW_TTL_MS) return;
     unavailableRowAt.set(key, now());
-    postSystemRow(channelId, text);
+    postSystemRow(channelId, text, { parentMessageId });
+  }
+
+  function parentForTrigger(trigger: ChannelMessage): string | undefined {
+    return trigger.threadId !== null ? trigger.id : undefined;
+  }
+
+  function parentKeyForTurn(
+    binding: LiveBinding,
+    turnId: string
+  ): string | undefined {
+    if (binding.parentMessageIdByTurn.has(turnId)) return turnId;
+    // Hermes can label a late output item `turn-0` after clearing its current
+    // turn. Use the retained parent only when there is exactly one possible
+    // routed turn; ambiguity must fail closed rather than borrow a wrong thread.
+    if (turnId === 'turn-0' && binding.parentMessageIdByTurn.size === 1) {
+      return binding.parentMessageIdByTurn.keys().next().value;
+    }
+    return undefined;
+  }
+
+  function parentForTurn(
+    binding: LiveBinding,
+    turnId: string
+  ): string | undefined {
+    const key = parentKeyForTurn(binding, turnId);
+    return key === undefined
+      ? undefined
+      : (binding.parentMessageIdByTurn.get(key) ?? undefined);
+  }
+
+  function releaseTurnParent(binding: LiveBinding, turnId: string): void {
+    const key = parentKeyForTurn(binding, turnId);
+    if (key !== undefined) binding.parentMessageIdByTurn.delete(key);
   }
 
   // ── availability targets ────────────────────────────────────────────────────
@@ -342,7 +382,7 @@ export function createChannelAgentBinder(
       patchUnlisten: null,
       status: 'idle',
       activeTurnId: null,
-      activeParentMessageId: null,
+      parentMessageIdByTurn: new Map(),
       activeContent: null,
       sawStream: false,
       waitingOn: null,
@@ -364,6 +404,7 @@ export function createChannelAgentBinder(
     // Tear down any prior wiring before re-binding a fresh adapter.
     existing?.unbind?.();
     existing?.patchUnlisten?.();
+    existing?.parentMessageIdByTurn.clear();
     const binding =
       existing ?? newLiveBinding(channelId, framework, displayName);
     binding.displayName = displayName;
@@ -376,10 +417,7 @@ export function createChannelAgentBinder(
       store,
       hub,
       displayName,
-      parentMessageIdForTurn: (turnId) =>
-        binding.activeTurnId === turnId
-          ? (binding.activeParentMessageId ?? undefined)
-          : undefined,
+      parentMessageIdForTurn: (turnId) => parentForTurn(binding, turnId),
       onAssistantMessageFinalized: (message) =>
         handleAssistantFinalized(message),
     });
@@ -513,7 +551,8 @@ export function createChannelAgentBinder(
     if (binding.queue.length >= QUEUE_CAP) {
       postSystemRow(
         binding.channelId,
-        `@${binding.framework} has ${QUEUE_CAP} turns queued — message dropped`
+        `@${binding.framework} has ${QUEUE_CAP} turns queued — message dropped`,
+        { parentMessageId: parentForTrigger(trigger) }
       );
       return;
     }
@@ -568,14 +607,17 @@ export function createChannelAgentBinder(
       logger.warn('channel binder packet build failed:', err);
       postSystemRow(
         binding.channelId,
-        `@${binding.framework} could not build the message context: ${errText(err)}`
+        `@${binding.framework} could not build the message context: ${errText(err)}`,
+        { parentMessageId: parentForTrigger(trigger) }
       );
       pump(binding); // activeTurnId is still null — keep the queue draining
       return;
     }
     binding.activeTurnId = turnId;
-    binding.activeParentMessageId =
-      trigger.threadId !== null ? trigger.id : null;
+    binding.parentMessageIdByTurn.set(
+      turnId,
+      parentForTrigger(trigger) ?? null
+    );
     binding.sawStream = false;
     binding.waitingOn = null;
     binding.activeContent = content;
@@ -663,15 +705,16 @@ export function createChannelAgentBinder(
     }
     postSystemRow(
       binding.channelId,
-      `@${binding.framework} could not receive the message: ${errText(err)}`
+      `@${binding.framework} could not receive the message: ${errText(err)}`,
+      { parentMessageId: parentForTrigger(trigger) }
     );
+    releaseTurnParent(binding, turnId);
     finishTurn(binding);
   }
 
   function finishTurn(binding: LiveBinding): void {
     if (binding.activeTurnId === null) return;
     binding.activeTurnId = null;
-    binding.activeParentMessageId = null;
     binding.activeContent = null;
     binding.waitingOn = null;
     binding.sawStream = false;
@@ -747,20 +790,42 @@ export function createChannelAgentBinder(
           updateWaiting(binding, patch.live.waitingOn);
         }
         break;
-      case 'agent-turn-completed-v2':
-        if (patch.turnId === binding.activeTurnId) finishTurn(binding);
+      case 'agent-turn-completed-v2': {
+        // The bridge listener runs first, so any terminally-opened row has
+        // already resolved its parent. Prune before finishTurn pumps a queued
+        // turn, so a Hermes fallback cannot become ambiguous with its successor.
+        const completedParentKey = parentKeyForTurn(binding, patch.turnId);
+        releaseTurnParent(binding, patch.turnId);
+        if (completedParentKey === binding.activeTurnId) finishTurn(binding);
         break;
+      }
       case 'agent-error-v2':
-        if ((patch.turnId ?? binding.activeTurnId) === binding.activeTurnId) {
-          // Only surface a system row when NO assistant row opened — otherwise the
-          // bridge's `failed` finalize is the visible artifact (§7, no duplicate).
-          if (!binding.sawStream) {
-            postSystemRow(
-              binding.channelId,
-              `@${binding.framework} errored: ${patch.message}`
-            );
+        {
+          const terminalTurnId = patch.turnId ?? binding.activeTurnId;
+          const terminalParentKey =
+            terminalTurnId === null
+              ? undefined
+              : parentKeyForTurn(binding, terminalTurnId);
+          if (terminalParentKey === binding.activeTurnId) {
+            // Only surface a system row when NO assistant row opened — otherwise the
+            // bridge's `failed` finalize is the visible artifact (§7, no duplicate).
+            if (!binding.sawStream) {
+              postSystemRow(
+                binding.channelId,
+                `@${binding.framework} errored: ${patch.message}`,
+                {
+                  parentMessageId:
+                    binding.activeTurnId === null
+                      ? undefined
+                      : parentForTurn(binding, binding.activeTurnId),
+                }
+              );
+            }
           }
-          finishTurn(binding);
+          if (terminalTurnId !== null) {
+            releaseTurnParent(binding, terminalTurnId);
+          }
+          if (terminalParentKey === binding.activeTurnId) finishTurn(binding);
         }
         break;
       default:
@@ -790,9 +855,15 @@ export function createChannelAgentBinder(
       binding.channelId,
       `@${binding.framework} requests approval: ${item.description} (${item.target})`,
       {
-        approvalRequestId: item.requestId,
-        agentId: binding.framework,
-        sessionId: binding.sessionId,
+        parentMessageId:
+          binding.activeTurnId === null
+            ? undefined
+            : parentForTurn(binding, binding.activeTurnId),
+        meta: {
+          approvalRequestId: item.requestId,
+          agentId: binding.framework,
+          sessionId: binding.sessionId,
+        },
       }
     );
   }
@@ -804,7 +875,12 @@ export function createChannelAgentBinder(
     if (!binding.announcedApprovals.has(item.requestId)) return;
     binding.announcedApprovals.delete(item.requestId);
     const kind = item.decision?.kind ?? 'resolved';
-    postSystemRow(binding.channelId, `@${binding.framework} approval ${kind}`);
+    postSystemRow(binding.channelId, `@${binding.framework} approval ${kind}`, {
+      parentMessageId:
+        binding.activeTurnId === null
+          ? undefined
+          : parentForTurn(binding, binding.activeTurnId),
+    });
   }
 
   // ── routing ─────────────────────────────────────────────────────────────────
@@ -819,7 +895,8 @@ export function createChannelAgentBinder(
           postUnavailableRow(
             trigger.channelId,
             framework,
-            `@${framework} is not available in channels yet — ${target.reason ?? 'web sessions unavailable.'}`
+            `@${framework} is not available in channels yet — ${target.reason ?? 'web sessions unavailable.'}`,
+            parentForTrigger(trigger)
           );
           return;
         }
@@ -833,10 +910,13 @@ export function createChannelAgentBinder(
               postUnavailableRow(
                 trigger.channelId,
                 framework,
-                err.systemMessage
+                err.systemMessage,
+                parentForTrigger(trigger)
               );
             } else {
-              postSystemRow(trigger.channelId, err.systemMessage);
+              postSystemRow(trigger.channelId, err.systemMessage, {
+                parentMessageId: parentForTrigger(trigger),
+              });
             }
             return;
           }
@@ -884,7 +964,8 @@ export function createChannelAgentBinder(
         // the next human (browser / gateway-human) post.
         postSystemRow(
           message.channelId,
-          `Mention chain paused — ${count} agent turns without a human.`
+          `Mention chain paused — ${count} agent turns without a human.`,
+          { parentMessageId: parentForTrigger(message) }
         );
         break;
       }
@@ -939,16 +1020,16 @@ export function createChannelAgentBinder(
       for (const queued of binding.queue) {
         postSystemRow(
           binding.channelId,
-          `@${binding.framework} session ended before delivering a queued message.`
+          `@${binding.framework} session ended before delivering a queued message.`,
+          { parentMessageId: parentForTrigger(queued.trigger) }
         );
-        void queued;
       }
       binding.queue = [];
       binding.adapter = null;
       binding.unbind = null;
       binding.patchUnlisten = null;
       binding.activeTurnId = null;
-      binding.activeParentMessageId = null;
+      binding.parentMessageIdByTurn.clear();
       binding.activeContent = null;
       binding.waitingOn = null;
       binding.announcedApprovals.clear();
@@ -1024,6 +1105,7 @@ export function createChannelAgentBinder(
         disarmWatchdog(binding);
         binding.unbind?.();
         binding.patchUnlisten?.();
+        binding.parentMessageIdByTurn.clear();
       }
       live.clear();
       inflight.clear();

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -157,6 +157,8 @@ export interface LiveBinding {
   patchUnlisten: (() => void) | null;
   status: ChannelAgentStatus;
   activeTurnId: string | null;
+  /** Immediate parent for the active turn's streamed reply. */
+  activeParentMessageId: string | null;
   /** Context packet for the active turn (kept so a retry re-sends identical content). */
   activeContent: string | null;
   sawStream: boolean;
@@ -340,6 +342,7 @@ export function createChannelAgentBinder(
       patchUnlisten: null,
       status: 'idle',
       activeTurnId: null,
+      activeParentMessageId: null,
       activeContent: null,
       sawStream: false,
       waitingOn: null,
@@ -373,6 +376,10 @@ export function createChannelAgentBinder(
       store,
       hub,
       displayName,
+      parentMessageIdForTurn: (turnId) =>
+        binding.activeTurnId === turnId
+          ? (binding.activeParentMessageId ?? undefined)
+          : undefined,
       onAssistantMessageFinalized: (message) =>
         handleAssistantFinalized(message),
     });
@@ -567,6 +574,8 @@ export function createChannelAgentBinder(
       return;
     }
     binding.activeTurnId = turnId;
+    binding.activeParentMessageId =
+      trigger.threadId !== null ? trigger.id : null;
     binding.sawStream = false;
     binding.waitingOn = null;
     binding.activeContent = content;
@@ -662,6 +671,7 @@ export function createChannelAgentBinder(
   function finishTurn(binding: LiveBinding): void {
     if (binding.activeTurnId === null) return;
     binding.activeTurnId = null;
+    binding.activeParentMessageId = null;
     binding.activeContent = null;
     binding.waitingOn = null;
     binding.sawStream = false;
@@ -938,6 +948,7 @@ export function createChannelAgentBinder(
       binding.unbind = null;
       binding.patchUnlisten = null;
       binding.activeTurnId = null;
+      binding.activeParentMessageId = null;
       binding.activeContent = null;
       binding.waitingOn = null;
       binding.announcedApprovals.clear();

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -159,6 +159,8 @@ export interface LiveBinding {
   activeTurnId: string | null;
   /** Immediate thread parent keyed by routed turn; retained past binder idle. */
   parentMessageIdByTurn: Map<string, string | null>;
+  /** Anonymous turn-0 cannot be associated safely after retained generations overlap. */
+  turnZeroFallbackUnsafe: boolean;
   /** Context packet for the active turn (kept so a retry re-sends identical content). */
   activeContent: string | null;
   sawStream: boolean;
@@ -287,7 +289,12 @@ export function createChannelAgentBinder(
     // Hermes can label a late output item `turn-0` after clearing its current
     // turn. Use the retained parent only when there is exactly one possible
     // routed turn; ambiguity must fail closed rather than borrow a wrong thread.
-    if (turnId === 'turn-0' && binding.parentMessageIdByTurn.size === 1) {
+    if (
+      turnId === 'turn-0' &&
+      binding.activeTurnId === null &&
+      !binding.turnZeroFallbackUnsafe &&
+      binding.parentMessageIdByTurn.size === 1
+    ) {
       return binding.parentMessageIdByTurn.keys().next().value;
     }
     return undefined;
@@ -383,6 +390,7 @@ export function createChannelAgentBinder(
       status: 'idle',
       activeTurnId: null,
       parentMessageIdByTurn: new Map(),
+      turnZeroFallbackUnsafe: false,
       activeContent: null,
       sawStream: false,
       waitingOn: null,
@@ -404,7 +412,19 @@ export function createChannelAgentBinder(
     // Tear down any prior wiring before re-binding a fresh adapter.
     existing?.unbind?.();
     existing?.patchUnlisten?.();
-    existing?.parentMessageIdByTurn.clear();
+    if (existing) {
+      // A rejected send can discover a dead transport, attach a replacement
+      // session, then redeliver the SAME active turn. Preserve that turn's
+      // parent across the rebind; discard only idle/older retained entries.
+      for (const turnId of existing.parentMessageIdByTurn.keys()) {
+        if (turnId !== existing.activeTurnId) {
+          existing.parentMessageIdByTurn.delete(turnId);
+        }
+      }
+      // Removing the old adapter listeners establishes a hard boundary for
+      // anonymous provider turn ids while retaining an exact active retry.
+      existing.turnZeroFallbackUnsafe = false;
+    }
     const binding =
       existing ?? newLiveBinding(channelId, framework, displayName);
     binding.displayName = displayName;
@@ -613,6 +633,16 @@ export function createChannelAgentBinder(
       pump(binding); // activeTurnId is still null — keep the queue draining
       return;
     }
+    // Retained parents exist solely for output that opens shortly after a bare
+    // idle finalized its turn. Once a successor starts, the old association is
+    // no longer safe for a turn-0 fallback and must not accumulate forever.
+    if (binding.parentMessageIdByTurn.size > 0) {
+      // A successor started while its predecessor was retained after bare idle.
+      // Future anonymous turn-0 patches cannot be assigned to either generation
+      // safely; exact turn ids continue to work.
+      binding.turnZeroFallbackUnsafe = true;
+    }
+    binding.parentMessageIdByTurn.clear();
     binding.activeTurnId = turnId;
     binding.parentMessageIdByTurn.set(
       turnId,
@@ -794,19 +824,49 @@ export function createChannelAgentBinder(
         // The bridge listener runs first, so any terminally-opened row has
         // already resolved its parent. Prune before finishTurn pumps a queued
         // turn, so a Hermes fallback cannot become ambiguous with its successor.
+        const completedByExactTurnId = binding.parentMessageIdByTurn.has(
+          patch.turnId
+        );
         const completedParentKey = parentKeyForTurn(binding, patch.turnId);
         releaseTurnParent(binding, patch.turnId);
-        if (completedParentKey === binding.activeTurnId) finishTurn(binding);
+        if (completedByExactTurnId) {
+          // An exact terminal establishes which retained generation ended, so
+          // a later isolated turn may safely use the anonymous fallback again.
+          binding.turnZeroFallbackUnsafe = false;
+        }
+        if (
+          patch.turnId === binding.activeTurnId ||
+          completedParentKey === binding.activeTurnId
+        ) {
+          finishTurn(binding);
+        }
         break;
       }
       case 'agent-error-v2':
         {
+          const activeTurnId = binding.activeTurnId;
+          if (activeTurnId !== null && patch.turnId === undefined) {
+            // Legacy chat:error dispatches its paired turn-0 completion only
+            // after this handler returns. The queued successor can bare-idle
+            // synchronously while finishTurn pumps it, so mark the anonymous
+            // namespace unsafe before that successor starts.
+            binding.turnZeroFallbackUnsafe = true;
+          }
           const terminalTurnId = patch.turnId ?? binding.activeTurnId;
+          const terminalByExactTurnId =
+            patch.turnId !== undefined &&
+            binding.parentMessageIdByTurn.has(patch.turnId);
           const terminalParentKey =
             terminalTurnId === null
               ? undefined
               : parentKeyForTurn(binding, terminalTurnId);
-          if (terminalParentKey === binding.activeTurnId) {
+          const targetsActiveTurn =
+            activeTurnId !== null &&
+            (patch.turnId === activeTurnId ||
+              terminalParentKey === activeTurnId);
+          const targetsIdleBinding =
+            activeTurnId === null && patch.turnId === undefined;
+          if (targetsActiveTurn || targetsIdleBinding) {
             // Only surface a system row when NO assistant row opened — otherwise the
             // bridge's `failed` finalize is the visible artifact (§7, no duplicate).
             if (!binding.sawStream) {
@@ -815,9 +875,9 @@ export function createChannelAgentBinder(
                 `@${binding.framework} errored: ${patch.message}`,
                 {
                   parentMessageId:
-                    binding.activeTurnId === null
+                    activeTurnId === null
                       ? undefined
-                      : parentForTurn(binding, binding.activeTurnId),
+                      : parentForTurn(binding, activeTurnId),
                 }
               );
             }
@@ -825,7 +885,12 @@ export function createChannelAgentBinder(
           if (terminalTurnId !== null) {
             releaseTurnParent(binding, terminalTurnId);
           }
-          if (terminalParentKey === binding.activeTurnId) finishTurn(binding);
+          if (terminalByExactTurnId) {
+            binding.turnZeroFallbackUnsafe = false;
+          }
+          if (targetsActiveTurn) {
+            finishTurn(binding);
+          }
         }
         break;
       default:

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -47,6 +47,8 @@ export interface BindSessionToChannelInput {
   store: ChannelMessageStore;
   hub: ChannelHub;
   displayName?: string;
+  /** Resolve the immediate parent for a routed turn, if it began in a thread. */
+  parentMessageIdForTurn?: (turnId: string) => string | undefined;
   /**
    * Invoked in `finalize()` after `completeStreamBroadcast` for `status ===
    * 'complete'` rows ONLY (#1167 §8). Bridge-authored replies bypass
@@ -93,11 +95,13 @@ export function bindSessionToChannel(
     const existing = streams.get(itemId);
     if (existing) return existing;
     turnsWithRows.add(turnId);
+    const parentMessageId = input.parentMessageIdForTurn?.(turnId);
     const message = store.beginStream({
       channelId,
       sender,
       source: { sessionId, turnId, itemId },
       ...(initialText ? { text: initialText } : {}),
+      ...(parentMessageId ? { parentMessageId } : {}),
     });
     const stream: BridgeStream = {
       messageId: message.id,

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -522,9 +522,11 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       const rootMessageId = req.params['rootMessageId'] ?? '';
       const filter: ChannelHistoryFilter = {};
       const beforeSeq = parseSeqQuery(req.query['beforeSeq']);
-      if (beforeSeq !== undefined) filter.beforeSeq = beforeSeq;
       const afterSeq = parseSeqQuery(req.query['afterSeq']);
+      // Match the established history precedence: when both cursors are
+      // supplied, afterSeq selects forward pagination and beforeSeq is ignored.
       if (afterSeq !== undefined) filter.afterSeq = afterSeq;
+      else if (beforeSeq !== undefined) filter.beforeSeq = beforeSeq;
       const limit = parseHistoryLimit(req.query['limit']);
       // One extra row makes row-limit pagination observable without a COUNT.
       filter.limit = limit + 1;
@@ -603,11 +605,18 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     // Public thread writes identify the message being replied to as `threadId`.
     // The store derives the canonical root and persists this supplied id as the
     // immediate parent; callers cannot forge a root id.
+    const suppliedThreadId = body['threadId'];
     const threadId =
-      typeof body['threadId'] === 'string' && body['threadId'].length > 0
-        ? body['threadId']
+      typeof suppliedThreadId === 'string' && suppliedThreadId.length > 0
+        ? suppliedThreadId
         : undefined;
-    if ('threadId' in body && threadId === undefined) {
+    // JSON null is the protocol's explicit no-thread value and is equivalent
+    // to omitting the field. Empty strings and other non-strings are malformed.
+    if (
+      'threadId' in body &&
+      suppliedThreadId !== null &&
+      threadId === undefined
+    ) {
       sendGatewayError(
         res,
         'INVALID_ARGUMENT',

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -8,6 +8,8 @@ import {
   type CliGatewayActorWriteCommand,
 } from './cli-gateway-actor-auth.js';
 import {
+  CHANNEL_HISTORY_DEFAULT_LIMIT,
+  CHANNEL_HISTORY_MAX_LIMIT,
   ChannelMessageStoreError,
   type ChannelHistoryFilter,
   type ChannelMessageStore,
@@ -75,6 +77,32 @@ function budgetHistoryRows(
       ? { afterSeq: kept[kept.length - 1]!.seq }
       : { beforeSeq: kept[0]!.seq };
   return { rows: kept, hasMore: true, nextCursor };
+}
+
+/** Apply a public row limit plus the existing byte budget to a lookahead page. */
+function budgetHistoryPage(
+  messages: ChannelMessage[],
+  direction: 'forward' | 'backward',
+  limit: number,
+  maxBytes: number
+): {
+  rows: ChannelMessage[];
+  hasMore: boolean;
+  nextCursor?: Record<string, number>;
+} {
+  const rowTruncated = messages.length > limit;
+  const rowPage = rowTruncated
+    ? direction === 'forward'
+      ? messages.slice(0, limit)
+      : messages.slice(messages.length - limit)
+    : messages;
+  const budgeted = budgetHistoryRows(rowPage, direction, maxBytes);
+  if (budgeted.hasMore || !rowTruncated) return budgeted;
+  const nextCursor =
+    direction === 'forward'
+      ? { afterSeq: budgeted.rows[budgeted.rows.length - 1]!.seq }
+      : { beforeSeq: budgeted.rows[0]!.seq };
+  return { ...budgeted, hasMore: true, nextCursor };
 }
 
 export interface ChannelChatRouterDeps {
@@ -304,6 +332,12 @@ function parseSeqQuery(value: unknown): number | undefined {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
+function parseHistoryLimit(value: unknown): number {
+  const parsed = parseSeqQuery(value);
+  if (parsed === undefined) return CHANNEL_HISTORY_DEFAULT_LIMIT;
+  return Math.max(1, Math.min(CHANNEL_HISTORY_MAX_LIMIT, parsed));
+}
+
 function channelSummaryView(
   store: ChannelMessageStore,
   topic: WorkspaceTopic
@@ -371,6 +405,8 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   const listAuth = deps.requireReadActorAuth?.('channels.list') ?? auth;
   const getAuth = deps.requireReadActorAuth?.('channels.get') ?? auth;
   const historyAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
+  const threadHistoryAuth =
+    deps.requireReadActorAuth?.('channels.threads.history') ?? auth;
   const postAuth = deps.requireWriteActorAuth?.('channels.post') ?? auth;
   const rosterAuth = deps.requireReadActorAuth?.('channels.roster') ?? auth;
   const interruptAuth =
@@ -475,6 +511,45 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     }
   });
 
+  router.get(
+    '/channels/:id/threads/:rootMessageId',
+    threadHistoryAuth,
+    (req, res) => {
+      if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+      const store = storeOr503(res, deps.store);
+      if (!store) return;
+      const id = req.params['id'] ?? '';
+      const rootMessageId = req.params['rootMessageId'] ?? '';
+      const filter: ChannelHistoryFilter = {};
+      const beforeSeq = parseSeqQuery(req.query['beforeSeq']);
+      if (beforeSeq !== undefined) filter.beforeSeq = beforeSeq;
+      const afterSeq = parseSeqQuery(req.query['afterSeq']);
+      if (afterSeq !== undefined) filter.afterSeq = afterSeq;
+      const limit = parseHistoryLimit(req.query['limit']);
+      // One extra row makes row-limit pagination observable without a COUNT.
+      filter.limit = limit + 1;
+      try {
+        const all = store.threadHistory(id, rootMessageId, filter);
+        const direction =
+          filter.afterSeq !== undefined ? 'forward' : 'backward';
+        const budgeted = budgetHistoryPage(
+          all,
+          direction,
+          limit,
+          deps.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES
+        );
+        res.json({
+          messages: budgeted.rows,
+          ...(budgeted.hasMore
+            ? { hasMore: true, nextCursor: budgeted.nextCursor }
+            : {}),
+        });
+      } catch (error) {
+        mapStoreError(res, error);
+      }
+    }
+  );
+
   router.post('/channels/:id/messages', postAuth, (req, res) => {
     if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
     const store = storeOr503(res, deps.store);
@@ -525,10 +600,43 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       body['format'] === 'text' || body['format'] === 'markdown'
         ? (body['format'] as ChannelBodyFormat)
         : undefined;
-    const parentMessageId =
+    // Public thread writes identify the message being replied to as `threadId`.
+    // The store derives the canonical root and persists this supplied id as the
+    // immediate parent; callers cannot forge a root id.
+    const threadId =
+      typeof body['threadId'] === 'string' && body['threadId'].length > 0
+        ? body['threadId']
+        : undefined;
+    if ('threadId' in body && threadId === undefined) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'threadId must be a non-empty message id',
+        false,
+        { field: 'threadId' }
+      );
+      return;
+    }
+    const legacyParentMessageId =
       typeof body['parentMessageId'] === 'string'
         ? body['parentMessageId']
         : undefined;
+    const resolvedLegacyParentMessageId = legacyParentMessageId || undefined;
+    if (
+      threadId !== undefined &&
+      resolvedLegacyParentMessageId !== undefined &&
+      threadId !== resolvedLegacyParentMessageId
+    ) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'threadId and parentMessageId must identify the same message',
+        false,
+        { fields: ['threadId', 'parentMessageId'] }
+      );
+      return;
+    }
+    const parentMessageId = threadId ?? resolvedLegacyParentMessageId;
     const clientMessageId =
       typeof body['clientMessageId'] === 'string'
         ? body['clientMessageId']

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -114,6 +114,7 @@ interface ChannelMessageRow {
   created_at: string;
   updated_at: string;
   completed_at: string | null;
+  reply_count?: number;
 }
 
 interface MemberRow {
@@ -230,6 +231,12 @@ export interface ChannelMessageStore {
     clientMessageId: string
   ): ChannelMessage | null;
   history(channelId: string, filter?: ChannelHistoryFilter): ChannelMessage[];
+  /** Root-inclusive history for one canonical thread. */
+  threadHistory(
+    channelId: string,
+    rootMessageId: string,
+    filter?: ChannelHistoryFilter
+  ): ChannelMessage[];
   /**
    * Rows a reconnecting client may still hold as stale `streaming` copies:
    * agent-origin rows (source triple set) at or below the reconnect cursor, in
@@ -288,11 +295,14 @@ function assertBodySize(text: string): void {
   }
 }
 
-function cleanLimit(limit: unknown): number {
+function cleanLimit(
+  limit: unknown,
+  maxLimit = CHANNEL_HISTORY_MAX_LIMIT
+): number {
   if (typeof limit !== 'number' || !Number.isFinite(limit)) {
     return CHANNEL_HISTORY_DEFAULT_LIMIT;
   }
-  return Math.max(1, Math.min(CHANNEL_HISTORY_MAX_LIMIT, Math.floor(limit)));
+  return Math.max(1, Math.min(maxLimit, Math.floor(limit)));
 }
 
 function parseMeta(raw: string | null): ChannelMessageMeta | undefined {
@@ -338,6 +348,7 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+  if (row.reply_count !== undefined) message.replyCount = row.reply_count;
   if (meta?.mentions && Array.isArray(meta.mentions)) {
     message.mentions = meta.mentions;
   }
@@ -673,32 +684,109 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
 
     history(channelId, filter = {}) {
       const limit = cleanLimit(filter.limit);
-      const clauses = ['channel_id = @channelId'];
+      const clauses = ['m.channel_id = @channelId'];
       const params: Record<string, unknown> = { channelId, limit };
       if (filter.threadId) {
-        clauses.push('thread_id = @threadId');
+        clauses.push('m.thread_id = @threadId');
         params['threadId'] = filter.threadId;
       }
       if (typeof filter.afterSeq === 'number') {
-        clauses.push('seq > @afterSeq');
+        clauses.push('m.seq > @afterSeq');
         params['afterSeq'] = filter.afterSeq;
         const rows = db
           .prepare(
-            `SELECT * FROM channel_messages WHERE ${clauses.join(' AND ')}
-             ORDER BY seq ASC LIMIT @limit`
+            `SELECT m.*,
+                    (SELECT COUNT(*) FROM channel_messages replies
+                     WHERE replies.thread_id = m.id) AS reply_count
+             FROM channel_messages m WHERE ${clauses.join(' AND ')}
+             ORDER BY m.seq ASC LIMIT @limit`
           )
           .all(params) as ChannelMessageRow[];
         return rows.map(rowToMessage);
       }
       if (typeof filter.beforeSeq === 'number') {
-        clauses.push('seq < @beforeSeq');
+        clauses.push('m.seq < @beforeSeq');
         params['beforeSeq'] = filter.beforeSeq;
       }
       // Default + beforeSeq: newest `limit` rows, returned seq-ascending.
       const rows = db
         .prepare(
-          `SELECT * FROM channel_messages WHERE ${clauses.join(' AND ')}
-           ORDER BY seq DESC LIMIT @limit`
+          `SELECT m.*,
+                  (SELECT COUNT(*) FROM channel_messages replies
+                   WHERE replies.thread_id = m.id) AS reply_count
+           FROM channel_messages m WHERE ${clauses.join(' AND ')}
+           ORDER BY m.seq DESC LIMIT @limit`
+        )
+        .all(params) as ChannelMessageRow[];
+      return rows.reverse().map(rowToMessage);
+    },
+
+    threadHistory(channelId, rootMessageId, filter = {}) {
+      const root = selectById.get(rootMessageId) as
+        | ChannelMessageRow
+        | undefined;
+      if (!root) {
+        throw new ChannelMessageStoreError(
+          404,
+          'thread_root_not_found',
+          'thread root message not found',
+          { rootMessageId }
+        );
+      }
+      if (root.channel_id !== channelId) {
+        throw new ChannelMessageStoreError(
+          409,
+          'thread_root_channel_mismatch',
+          'thread root message belongs to another channel',
+          { rootMessageId, rootChannelId: root.channel_id, channelId }
+        );
+      }
+      if (root.thread_id !== null) {
+        throw new ChannelMessageStoreError(
+          400,
+          'thread_root_required',
+          'rootMessageId must identify a thread root',
+          { rootMessageId, canonicalRootMessageId: root.thread_id }
+        );
+      }
+
+      // Router pagination asks for one lookahead row, hence MAX + 1 here while
+      // the public page size remains capped at CHANNEL_HISTORY_MAX_LIMIT.
+      const limit = cleanLimit(filter.limit, CHANNEL_HISTORY_MAX_LIMIT + 1);
+      const clauses = [
+        'm.channel_id = @channelId',
+        '(m.id = @rootMessageId OR m.thread_id = @rootMessageId)',
+      ];
+      const params: Record<string, unknown> = {
+        channelId,
+        rootMessageId,
+        limit,
+      };
+      if (typeof filter.afterSeq === 'number') {
+        clauses.push('m.seq > @afterSeq');
+        params['afterSeq'] = filter.afterSeq;
+        const rows = db
+          .prepare(
+            `SELECT m.*,
+                    (SELECT COUNT(*) FROM channel_messages replies
+                     WHERE replies.thread_id = m.id) AS reply_count
+             FROM channel_messages m WHERE ${clauses.join(' AND ')}
+             ORDER BY m.seq ASC LIMIT @limit`
+          )
+          .all(params) as ChannelMessageRow[];
+        return rows.map(rowToMessage);
+      }
+      if (typeof filter.beforeSeq === 'number') {
+        clauses.push('m.seq < @beforeSeq');
+        params['beforeSeq'] = filter.beforeSeq;
+      }
+      const rows = db
+        .prepare(
+          `SELECT m.*,
+                  (SELECT COUNT(*) FROM channel_messages replies
+                   WHERE replies.thread_id = m.id) AS reply_count
+           FROM channel_messages m WHERE ${clauses.join(' AND ')}
+           ORDER BY m.seq DESC LIMIT @limit`
         )
         .all(params) as ChannelMessageRow[];
       return rows.reverse().map(rowToMessage);

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -36,6 +36,35 @@ export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
 const CHANNEL_SUMMARY_PREVIEW_MAX_CHARS = 200;
 
+export type ChannelThreadHistoryQueryMode = 'default' | 'after' | 'before';
+
+/** Production query builder exported so query-plan tests exercise exact SQL. */
+export function buildChannelThreadHistorySql(
+  mode: ChannelThreadHistoryQueryMode
+): string {
+  const seqClause =
+    mode === 'after'
+      ? 'AND seq > @afterSeq'
+      : mode === 'before'
+        ? 'AND seq < @beforeSeq'
+        : '';
+  const order = mode === 'after' ? 'ASC' : 'DESC';
+  return `SELECT m.*,
+                  (SELECT COUNT(*) FROM channel_messages replies
+                   WHERE replies.thread_id = m.id) AS reply_count
+           FROM (
+             SELECT root.* FROM channel_messages root
+              WHERE root.id = @rootMessageId
+                AND root.channel_id = @channelId ${seqClause}
+             UNION ALL
+             SELECT thread_reply.*
+               FROM channel_messages thread_reply INDEXED BY idx_chm_thread
+              WHERE thread_reply.thread_id = @rootMessageId
+                AND thread_reply.channel_id = @channelId ${seqClause}
+           ) m
+           ORDER BY m.seq ${order} LIMIT @limit`;
+}
+
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS channel_messages (
   id                TEXT PRIMARY KEY,
@@ -767,39 +796,22 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         rootMessageId,
         limit,
       };
-      let seqClause = '';
-      let order = 'DESC';
+      let queryMode: ChannelThreadHistoryQueryMode = 'default';
       if (typeof filter.afterSeq === 'number') {
         params['afterSeq'] = filter.afterSeq;
-        seqClause = 'AND seq > @afterSeq';
-        order = 'ASC';
+        queryMode = 'after';
       } else if (typeof filter.beforeSeq === 'number') {
         params['beforeSeq'] = filter.beforeSeq;
-        seqClause = 'AND seq < @beforeSeq';
+        queryMode = 'before';
       }
 
       // Keep the root-inclusive contract without an OR predicate. The root is
       // a single primary-key probe and replies are an idx_chm_thread range;
       // thread reads therefore scale with thread size, not channel size.
       const rows = db
-        .prepare(
-          `SELECT m.*,
-                  (SELECT COUNT(*) FROM channel_messages replies
-                   WHERE replies.thread_id = m.id) AS reply_count
-           FROM (
-             SELECT root.* FROM channel_messages root
-              WHERE root.id = @rootMessageId
-                AND root.channel_id = @channelId ${seqClause}
-             UNION ALL
-             SELECT thread_reply.*
-               FROM channel_messages thread_reply INDEXED BY idx_chm_thread
-              WHERE thread_reply.thread_id = @rootMessageId
-                AND thread_reply.channel_id = @channelId ${seqClause}
-           ) m
-           ORDER BY m.seq ${order} LIMIT @limit`
-        )
+        .prepare(buildChannelThreadHistorySql(queryMode))
         .all(params) as ChannelMessageRow[];
-      if (order === 'DESC') rows.reverse();
+      if (queryMode !== 'after') rows.reverse();
       return rows.map(rowToMessage);
     },
 

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -425,7 +425,16 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
     throw error;
   }
 
-  const selectById = db.prepare('SELECT * FROM channel_messages WHERE id = ?');
+  // Point reads can be emitted directly on the WS lane (stream finalization and
+  // catch-up replacement), so they must carry the same derived replyCount as a
+  // timeline history row. Otherwise a replace-by-id reducer can erase a count
+  // that was already visible to the client.
+  const selectById = db.prepare(
+    `SELECT m.*,
+            (SELECT COUNT(*) FROM channel_messages replies
+             WHERE replies.thread_id = m.id) AS reply_count
+     FROM channel_messages m WHERE m.id = ?`
+  );
   const selectBySource = db.prepare(
     `SELECT * FROM channel_messages
      WHERE source_session_id IS @sessionId
@@ -753,53 +762,58 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       // Router pagination asks for one lookahead row, hence MAX + 1 here while
       // the public page size remains capped at CHANNEL_HISTORY_MAX_LIMIT.
       const limit = cleanLimit(filter.limit, CHANNEL_HISTORY_MAX_LIMIT + 1);
-      const clauses = [
-        'm.channel_id = @channelId',
-        '(m.id = @rootMessageId OR m.thread_id = @rootMessageId)',
-      ];
       const params: Record<string, unknown> = {
         channelId,
         rootMessageId,
         limit,
       };
+      let seqClause = '';
+      let order = 'DESC';
       if (typeof filter.afterSeq === 'number') {
-        clauses.push('m.seq > @afterSeq');
         params['afterSeq'] = filter.afterSeq;
-        const rows = db
-          .prepare(
-            `SELECT m.*,
-                    (SELECT COUNT(*) FROM channel_messages replies
-                     WHERE replies.thread_id = m.id) AS reply_count
-             FROM channel_messages m WHERE ${clauses.join(' AND ')}
-             ORDER BY m.seq ASC LIMIT @limit`
-          )
-          .all(params) as ChannelMessageRow[];
-        return rows.map(rowToMessage);
-      }
-      if (typeof filter.beforeSeq === 'number') {
-        clauses.push('m.seq < @beforeSeq');
+        seqClause = 'AND seq > @afterSeq';
+        order = 'ASC';
+      } else if (typeof filter.beforeSeq === 'number') {
         params['beforeSeq'] = filter.beforeSeq;
+        seqClause = 'AND seq < @beforeSeq';
       }
+
+      // Keep the root-inclusive contract without an OR predicate. The root is
+      // a single primary-key probe and replies are an idx_chm_thread range;
+      // thread reads therefore scale with thread size, not channel size.
       const rows = db
         .prepare(
           `SELECT m.*,
                   (SELECT COUNT(*) FROM channel_messages replies
                    WHERE replies.thread_id = m.id) AS reply_count
-           FROM channel_messages m WHERE ${clauses.join(' AND ')}
-           ORDER BY m.seq DESC LIMIT @limit`
+           FROM (
+             SELECT root.* FROM channel_messages root
+              WHERE root.id = @rootMessageId
+                AND root.channel_id = @channelId ${seqClause}
+             UNION ALL
+             SELECT thread_reply.*
+               FROM channel_messages thread_reply INDEXED BY idx_chm_thread
+              WHERE thread_reply.thread_id = @rootMessageId
+                AND thread_reply.channel_id = @channelId ${seqClause}
+           ) m
+           ORDER BY m.seq ${order} LIMIT @limit`
         )
         .all(params) as ChannelMessageRow[];
-      return rows.reverse().map(rowToMessage);
+      if (order === 'DESC') rows.reverse();
+      return rows.map(rowToMessage);
     },
 
     listResyncRows(channelId, uptoSeq, limit) {
       const bounded = Math.max(1, Math.min(1000, Math.floor(limit)));
       const rows = db
         .prepare(
-          `SELECT * FROM channel_messages
-           WHERE channel_id = @channelId AND seq <= @uptoSeq
-             AND source_session_id IS NOT NULL
-           ORDER BY seq DESC LIMIT @limit`
+          `SELECT m.*,
+                  (SELECT COUNT(*) FROM channel_messages replies
+                   WHERE replies.thread_id = m.id) AS reply_count
+             FROM channel_messages m
+            WHERE m.channel_id = @channelId AND m.seq <= @uptoSeq
+              AND m.source_session_id IS NOT NULL
+            ORDER BY m.seq DESC LIMIT @limit`
         )
         .all({ channelId, uptoSeq, limit: bounded }) as ChannelMessageRow[];
       return rows.reverse().map(rowToMessage);

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -71,6 +71,7 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'channels.list',
   'channels.get',
   'channels.history',
+  'channels.threads.history',
   'channels.roster',
   'context.get',
   'context.list',
@@ -347,6 +348,7 @@ export function cliGatewayActorCommandCapabilities(
     command === 'channels.list' ||
     command === 'channels.get' ||
     command === 'channels.history' ||
+    command === 'channels.threads.history' ||
     command === 'channels.roster'
   )
     return ['context:read'];

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -64,6 +64,8 @@ export interface ChannelMessage {
   body: { text: string; format: ChannelBodyFormat };
   threadId: ChannelMessageId | null;
   parentMessageId: ChannelMessageId | null;
+  /** Number of replies whose canonical thread root is this message. */
+  replyCount?: number;
   mentions?: ChannelMention[];
   source?: ChannelMessageSource;
   /**
@@ -199,6 +201,13 @@ export function isChannelMessage(value: unknown): value is ChannelMessage {
   if (
     value.parentMessageId !== null &&
     typeof value.parentMessageId !== 'string'
+  )
+    return false;
+  if (
+    value.replyCount !== undefined &&
+    (typeof value.replyCount !== 'number' ||
+      !Number.isSafeInteger(value.replyCount) ||
+      value.replyCount < 0)
   )
     return false;
   if (

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -557,6 +557,101 @@ class IdleWithoutTurnCompletedAdapter extends BaseProtocolAdapterV2 {
   }
 }
 
+// Bare-idle harness with explicit late/error terminals. It keeps lifecycle
+// ordering deterministic for retained-parent pruning and legacy error-pair
+// regressions without relying on timers.
+class ManualBareIdleAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'attached' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    interrupt: true,
+    streaming: true,
+  };
+  readonly sendCalls: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'manual-idle';
+  private itemNumber = 0;
+  private idleOneSend = false;
+
+  constructor(
+    readonly agentType: string,
+    private readonly autoIdle = true
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(_i: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    if (this.autoIdle || this.idleOneSend) {
+      this.idleOneSend = false;
+      this.emitPatch({
+        type: 'agent-live-state-updated-v2',
+        sessionId: this.sid,
+        timestamp: 't',
+        live: { status: 'idle', activeTurnId: null },
+      });
+    }
+  }
+
+  idleNextSend(): void {
+    this.idleOneSend = true;
+  }
+
+  emitLate(turnId: string, text = 'late reply'): void {
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: {
+        type: 'assistantMessage',
+        id: `manual-late-${++this.itemNumber}`,
+        text,
+        status: 'completed',
+      },
+    });
+  }
+
+  emitCompleted(turnId: string): void {
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status: 'completed',
+    });
+  }
+
+  emitError(message: string): void {
+    this.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      message,
+    });
+  }
+
+  emitLegacyErrorPair(message: string): void {
+    this.emitError(message);
+    this.emitCompleted('turn-0');
+  }
+}
+
 // Emits bare idle before its first assistant row. This reproduces late-opening
 // output after binder finishTurn, including Hermes' `turn-0` fallback label.
 class LateOpeningReplyAdapter extends BaseProtocolAdapterV2 {
@@ -632,6 +727,7 @@ interface SessionsHarness {
   firstSessionId: () => string;
   adapterFor: (sessionId: string) => ProtocolAdapterV2;
   fireEnd: (sessionId: string) => void;
+  forgetWithoutEnd: (sessionId: string) => void;
   lastCreateParams: () => CreateWebParams | undefined;
 }
 
@@ -691,6 +787,9 @@ function makeSessions(
     fireEnd: (id) => {
       created.delete(id);
       for (const cb of [...endCbs]) cb(id, '/tmp');
+    },
+    forgetWithoutEnd: (id) => {
+      created.delete(id);
     },
     lastCreateParams: () => lastParams,
   };
@@ -864,6 +963,187 @@ describe('channel-agent-binder — lifecycle', () => {
     }
   });
 
+  it('bounds retained parents across many bare-idle turns', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    for (let i = 0; i < 20; i++) {
+      post(store, binder, `@mock idle ${i}`, ['mock']);
+    }
+    await waitFor(() => {
+      if (sessions.spawns() !== 1) return false;
+      return (
+        (
+          sessions.adapterFor(
+            sessions.firstSessionId()
+          ) as ManualBareIdleAdapter
+        ).sendCalls.length === 20
+      );
+    });
+    const binding = await binder.ensureBinding(CH, 'mock');
+    expect(binding.activeTurnId).toBeNull();
+    expect(binding.parentMessageIdByTurn.size).toBeLessThanOrEqual(1);
+  });
+
+  it('prunes predecessors so an exact late successor recovers from fallback poisoning', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const rootOne = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root one',
+    });
+    const rootTwo = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root two',
+    });
+    const rootThree = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root three',
+    });
+    post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
+    const triggerTwo = post(
+      store,
+      binder,
+      '@mock two',
+      ['mock'],
+      OPERATOR,
+      rootTwo.id
+    );
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ManualBareIdleAdapter;
+    await waitFor(() => adapter.sendCalls.length === 2);
+    adapter.emitLate(adapter.sendCalls[1]!);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(agentReplies(store, 'mock')[0]).toMatchObject({
+      threadId: rootTwo.id,
+      parentMessageId: triggerTwo.id,
+    });
+    // Exact terminal evidence identifies and releases B, clearing the overlap
+    // ambiguity. A later isolated C may safely use a genuine turn-0 fallback.
+    adapter.emitCompleted(adapter.sendCalls[1]!);
+    const triggerThree = post(
+      store,
+      binder,
+      '@mock three',
+      ['mock'],
+      OPERATOR,
+      rootThree.id
+    );
+    await waitFor(() => adapter.sendCalls.length === 3);
+    adapter.emitLate('turn-0', 'valid fallback');
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(agentReplies(store, 'mock')[1]).toMatchObject({
+      threadId: rootThree.id,
+      parentMessageId: triggerThree.id,
+    });
+  });
+
+  it('never resurrects a stale turn-0 against a newer retained successor', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const rootOne = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root one',
+    });
+    const rootTwo = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root two',
+    });
+    post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
+    post(store, binder, '@mock two', ['mock'], OPERATOR, rootTwo.id);
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ManualBareIdleAdapter;
+    await waitFor(() => adapter.sendCalls.length === 2);
+    // Both turns have bare-idled; this anonymous row may belong to the older
+    // generation and therefore must not borrow the newer turn's parent.
+    adapter.emitLate('turn-0', 'stale reply');
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(agentReplies(store, 'mock')[0]).toMatchObject({
+      threadId: null,
+      parentMessageId: null,
+    });
+  });
+
+  it('does not let a legacy error pair finish a freshly pumped successor', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType, false),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    post(store, binder, '@mock first', ['mock']);
+    const successor = post(
+      store,
+      binder,
+      '@mock successor',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ManualBareIdleAdapter;
+    await waitFor(() => adapter.sendCalls.length === 1);
+    // Patch 1 of the pair pumps U; model U synchronously bare-idling before
+    // patch 2 (turn-0 completed) is dispatched.
+    adapter.idleNextSend();
+    adapter.emitLegacyErrorPair('legacy failure');
+    await waitFor(() => adapter.sendCalls.length === 2);
+    const binding = await binder.ensureBinding(CH, 'mock');
+    expect(binding.activeTurnId).toBeNull();
+    expect(binding.parentMessageIdByTurn.has(adapter.sendCalls[1]!)).toBe(true);
+    adapter.emitLate(adapter.sendCalls[1]!, 'successor late reply');
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(agentReplies(store, 'mock')[0]).toMatchObject({
+      threadId: root.id,
+      parentMessageId: successor.id,
+    });
+    adapter.emitCompleted(adapter.sendCalls[1]!);
+    expect(binding.parentMessageIdByTurn.size).toBe(0);
+  });
+
+  it('surfaces an agent error received while the binding is idle', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new ManualBareIdleAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    post(store, binder, '@mock idle', ['mock']);
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ManualBareIdleAdapter;
+    await waitFor(() => adapter.sendCalls.length === 1);
+    adapter.emitError('idle failure');
+    await waitFor(() =>
+      systemRows(store).some((row) =>
+        row.body.text.includes('@mock errored: idle failure')
+      )
+    );
+  });
+
   it('two concurrent mentions single-flight to exactly one spawn', async () => {
     const { binder, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 5, stepMs: 1 }),
@@ -1029,6 +1309,57 @@ describe('channel-agent-binder — lifecycle', () => {
 });
 
 describe('channel-agent-binder — delivery + idempotency', () => {
+  it('preserves an active threaded turn across transport rebind and finishes promptly', async () => {
+    let spawnNumber = 0;
+    let firstAdapter: DeferredAdapter | null = null;
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => {
+        spawnNumber++;
+        if (spawnNumber === 1) {
+          firstAdapter = new DeferredAdapter(agentType);
+          return firstAdapter;
+        }
+        return new ScriptedAdapter(agentType, {
+          mode: 'reply',
+          text: 'rebound reply',
+        });
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const trigger = post(
+      store,
+      binder,
+      '@mock retry',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(
+      () => firstAdapter !== null && firstAdapter.sendCalls.length === 1
+    );
+    const turnId = firstAdapter!.sendCalls[0]!;
+    // Model a dead transport discovered by send rejection before the normal
+    // session-end callback has removed the live binding.
+    sessions.forgetWithoutEnd(sessions.firstSessionId());
+    firstAdapter!.rejectSend(turnId);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    const reply = agentReplies(store, 'mock')[0]!;
+    expect(reply).toMatchObject({
+      threadId: root.id,
+      parentMessageId: trigger.id,
+    });
+    expect(sessions.spawns()).toBe(2);
+    const rebound = await binder.ensureBinding(CH, 'mock');
+    expect(rebound.activeTurnId).toBeNull();
+    expect(rebound.status).toBe('idle');
+  });
+
   it('threads a terminal send-failure row to its triggering reply', async () => {
     const { binder, store } = makeBinder({
       build: () => new ScriptedAdapter('x', { mode: 'reject' }),

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -100,7 +100,8 @@ function post(
   binder: ChannelAgentBinder,
   text: string,
   knownIds: string[],
-  sender: ChannelSenderRef = OPERATOR
+  sender: ChannelSenderRef = OPERATOR,
+  parentMessageId?: string
 ): ChannelMessage {
   const mentions = parseMentions(text, knownIds);
   const message = store.appendComplete({
@@ -108,6 +109,7 @@ function post(
     sender,
     text,
     ...(mentions.length ? { mentions } : {}),
+    ...(parentMessageId ? { parentMessageId } : {}),
   });
   binder.handleMessagePosted(message, message.mentions ?? []);
   return message;
@@ -118,6 +120,7 @@ function post(
 type ScriptMode =
   | { mode: 'stall' }
   | { mode: 'reply'; text: string }
+  | { mode: 'reject' }
   | { mode: 'reject-once-then-reply'; text: string };
 
 class ScriptedAdapter extends BaseProtocolAdapterV2 {
@@ -162,6 +165,7 @@ class ScriptedAdapter extends BaseProtocolAdapterV2 {
       this.rejected = true;
       throw new Error('transport down');
     }
+    if (this.script.mode === 'reject') throw new Error('transport down');
     if (this.script.mode === 'stall') return; // resolve, never complete
     this.runReply(input.turnId, this.script.text);
   }
@@ -553,6 +557,73 @@ class IdleWithoutTurnCompletedAdapter extends BaseProtocolAdapterV2 {
   }
 }
 
+// Emits bare idle before its first assistant row. This reproduces late-opening
+// output after binder finishTurn, including Hermes' `turn-0` fallback label.
+class LateOpeningReplyAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'attached' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    interrupt: true,
+    streaming: true,
+  };
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'late';
+  private outputNumber = 0;
+
+  constructor(
+    readonly agentType: string,
+    private readonly fallbackTurnId: boolean
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(_i: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    const outputNumber = ++this.outputNumber;
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: { status: 'idle', activeTurnId: null },
+    });
+    const turnId = this.fallbackTurnId ? 'turn-0' : input.turnId;
+    setTimeout(() => {
+      this.emitPatch({
+        type: 'agent-item-updated-v2',
+        sessionId: this.sid,
+        timestamp: 't',
+        turnId,
+        item: {
+          type: 'assistantMessage',
+          id: `late-${turnId}-${outputNumber}`,
+          text: 'late reply',
+          status: 'completed',
+        },
+      });
+      this.emitPatch({
+        type: 'agent-turn-completed-v2',
+        sessionId: this.sid,
+        timestamp: 't',
+        turnId,
+        status: 'completed',
+      });
+    }, 5).unref?.();
+  }
+}
+
 // ── sessions harness ─────────────────────────────────────────────────────────
 
 interface SessionsHarness {
@@ -686,6 +757,111 @@ describe('channel-agent-binder — lifecycle', () => {
     const reply = agentReplies(store, 'mock')[0]!;
     expect(reply.sender.id).toBe('agent:mock');
     expect(reply.body.text).toBe('Mock v2 response complete.');
+    expect(reply.threadId).toBeNull();
+    expect(reply.parentMessageId).toBeNull();
+  });
+
+  it.each([
+    ['the routed turn id', false],
+    ['the unambiguous Hermes turn-0 fallback', true],
+  ])(
+    'retains the exact thread parent for a late-opening row using %s',
+    async (_label, fallbackTurnId) => {
+      const { binder, store } = makeBinder({
+        build: (agentType) =>
+          new LateOpeningReplyAdapter(agentType, fallbackTurnId),
+        targets: MOCK_TARGETS,
+        knownProviderIds: ['mock'],
+      });
+      const root = store.appendComplete({
+        channelId: CH,
+        sender: OPERATOR,
+        text: 'root',
+      });
+      const trigger = post(
+        store,
+        binder,
+        '@mock threaded',
+        ['mock'],
+        OPERATOR,
+        root.id
+      );
+      await waitFor(() => agentReplies(store, 'mock').length === 1);
+      const reply = agentReplies(store, 'mock')[0]!;
+      expect(trigger.threadId).toBe(root.id);
+      expect(reply.threadId).toBe(root.id);
+      expect(reply.parentMessageId).toBe(trigger.id);
+    }
+  );
+
+  it('releases each Hermes fallback association before the next threaded turn', async () => {
+    const { binder, store } = makeBinder({
+      build: (agentType) => new LateOpeningReplyAdapter(agentType, true),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const rootOne = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root one',
+    });
+    const rootTwo = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root two',
+    });
+    const triggerOne = post(
+      store,
+      binder,
+      '@mock one',
+      ['mock'],
+      OPERATOR,
+      rootOne.id
+    );
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    const triggerTwo = post(
+      store,
+      binder,
+      '@mock two',
+      ['mock'],
+      OPERATOR,
+      rootTwo.id
+    );
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    const replies = agentReplies(store, 'mock');
+    expect(replies[0]).toMatchObject({
+      threadId: rootOne.id,
+      parentMessageId: triggerOne.id,
+    });
+    expect(replies[1]).toMatchObject({
+      threadId: rootTwo.id,
+      parentMessageId: triggerTwo.id,
+    });
+  });
+
+  it('fails closed when a turn-0 fallback could belong to multiple turns', async () => {
+    const { binder, store } = makeBinder({
+      build: (agentType) => new LateOpeningReplyAdapter(agentType, true),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const rootOne = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root one',
+    });
+    const rootTwo = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root two',
+    });
+    post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
+    post(store, binder, '@mock two', ['mock'], OPERATOR, rootTwo.id);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    for (const reply of agentReplies(store, 'mock')) {
+      expect(reply.threadId).toBeNull();
+      expect(reply.parentMessageId).toBeNull();
+    }
   });
 
   it('two concurrent mentions single-flight to exactly one spawn', async () => {
@@ -741,7 +917,17 @@ describe('channel-agent-binder — lifecycle', () => {
       ],
       knownProviderIds: ['stall'],
     });
-    for (let i = 0; i < 10; i++) post(store, binder, `@stall ${i}`, ['stall']);
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const triggers: ChannelMessage[] = [];
+    for (let i = 0; i < 10; i++) {
+      triggers.push(
+        post(store, binder, `@stall ${i}`, ['stall'], OPERATOR, root.id)
+      );
+    }
     await waitFor(() =>
       systemRows(store).some((m) => m.body.text.includes('turns queued'))
     );
@@ -750,6 +936,8 @@ describe('channel-agent-binder — lifecycle', () => {
     );
     expect(dropped).toHaveLength(1);
     expect(dropped[0]!.body.text).toContain('has 8 turns queued');
+    expect(dropped[0]!.threadId).toBe(root.id);
+    expect(dropped[0]!.parentMessageId).toBe(triggers.at(-1)!.id);
   });
 
   it('session death unbinds, nulls the row session id, and respawns on next mention', async () => {
@@ -768,6 +956,42 @@ describe('channel-agent-binder — lifecycle', () => {
     expect(sessions.spawns()).toBe(2);
   });
 
+  it('threads session-ended rows for queued trigger messages', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new DeferredAdapter(agentType),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    post(store, binder, '@mock active', ['mock'], OPERATOR, root.id);
+    const queued = post(
+      store,
+      binder,
+      '@mock queued',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as DeferredAdapter;
+    await waitFor(() => adapter.sendCalls.length === 1);
+    sessions.fireEnd(sessions.firstSessionId());
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('session ended'))
+    );
+    const ended = systemRows(store).find((m) =>
+      m.body.text.includes('session ended')
+    )!;
+    expect(ended.threadId).toBe(root.id);
+    expect(ended.parentMessageId).toBe(queued.id);
+  });
+
   it('spawn failure posts a system row and leaves no stuck single-flight', async () => {
     const { binder, store, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2(),
@@ -775,19 +999,66 @@ describe('channel-agent-binder — lifecycle', () => {
       knownProviderIds: ['mock'],
       throwOnCreate: true,
     });
-    post(store, binder, '@mock one', ['mock']);
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const first = post(store, binder, '@mock one', ['mock'], OPERATOR, root.id);
     await waitFor(() =>
       systemRows(store).some((m) => m.body.text.includes('failed to start'))
     );
-    post(store, binder, '@mock two', ['mock']);
+    const second = post(
+      store,
+      binder,
+      '@mock two',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
     await waitFor(() => sessions.spawns() === 2); // single-flight cleared, retried
-    expect(
-      systemRows(store).filter((m) => m.body.text.includes('failed to start'))
-    ).toHaveLength(2);
+    const failures = systemRows(store).filter((m) =>
+      m.body.text.includes('failed to start')
+    );
+    expect(failures).toHaveLength(2);
+    expect(failures.map((m) => m.parentMessageId)).toEqual([
+      first.id,
+      second.id,
+    ]);
   });
 });
 
 describe('channel-agent-binder — delivery + idempotency', () => {
+  it('threads a terminal send-failure row to its triggering reply', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new ScriptedAdapter('x', { mode: 'reject' }),
+      targets: [
+        {
+          id: 'x',
+          displayName: 'X',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['x'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const trigger = post(store, binder, '@x go', ['x'], OPERATOR, root.id);
+    await waitFor(() =>
+      systemRows(store).some((m) => m.body.text.includes('could not receive'))
+    );
+    const failure = systemRows(store).find((m) =>
+      m.body.text.includes('could not receive')
+    )!;
+    expect(failure.threadId).toBe(root.id);
+    expect(failure.parentMessageId).toBe(trigger.id);
+  });
+
   it('uses a deterministic turnId and a retry reuses the same turn identity', async () => {
     const { binder, store, sessions } = makeBinder({
       build: () =>
@@ -864,7 +1135,12 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
       ],
       knownProviderIds: ['a', 'b'],
     });
-    post(store, binder, '@a go', ['a', 'b']);
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    post(store, binder, '@a go', ['a', 'b'], OPERATOR, root.id);
     await waitFor(() =>
       systemRows(store).some((m) =>
         m.body.text.includes('Mention chain paused')
@@ -874,6 +1150,8 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
       m.body.text.includes('Mention chain paused')
     );
     expect(pausedRows).toHaveLength(1);
+    expect(pausedRows[0]!.threadId).toBe(root.id);
+    expect(pausedRows[0]!.parentMessageId).not.toBeNull();
     // Human-initiated a reply is not counted; the brake bounds the autonomous
     // fan-out at MAX_CONSECUTIVE_AGENT_TURNS agent turns.
     const beforeReset = agentReplies(store).length;
@@ -961,16 +1239,49 @@ describe('channel-agent-binder — roster + availability', () => {
       ],
       knownProviderIds: ['codex'],
     });
-    post(store, binder, '@codex fix it', ['codex']);
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const trigger = post(
+      store,
+      binder,
+      '@codex fix it',
+      ['codex'],
+      OPERATOR,
+      root.id
+    );
     await waitFor(() =>
       systemRows(store).some((m) => m.body.text.includes('#301'))
     );
-    post(store, binder, '@codex fix it again', ['codex']);
+    const secondTrigger = post(
+      store,
+      binder,
+      '@codex fix it again',
+      ['codex'],
+      OPERATOR,
+      root.id
+    );
     // brief settle
     await new Promise((r) => setTimeout(r, 40));
     expect(
       systemRows(store).filter((m) => m.body.text.includes('not available'))
-    ).toHaveLength(1); // rate-limited: only one identical row
+    ).toHaveLength(2); // distinct trigger parents must not suppress each other
+    const unavailable = systemRows(store).find(
+      (m) =>
+        m.body.text.includes('not available') &&
+        m.parentMessageId === trigger.id
+    )!;
+    expect(unavailable.threadId).toBe(root.id);
+    expect(unavailable.parentMessageId).toBe(trigger.id);
+    expect(
+      systemRows(store).some(
+        (m) =>
+          m.body.text.includes('not available') &&
+          m.parentMessageId === secondTrigger.id
+      )
+    ).toBe(true);
     expect(sessions.spawns()).toBe(0);
   });
 });
@@ -1147,12 +1458,29 @@ describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () 
         return realHistory(id, filter);
       }) as ChannelMessageStore['history'];
 
-    post(store, binder, '@mock one', ['mock']);
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const failedTrigger = post(
+      store,
+      binder,
+      '@mock one',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
     await waitFor(() =>
       systemRows(store).some((m) =>
         m.body.text.includes('could not build the message context')
       )
     );
+    const failure = systemRows(store).find((m) =>
+      m.body.text.includes('could not build the message context')
+    )!;
+    expect(failure.threadId).toBe(root.id);
+    expect(failure.parentMessageId).toBe(failedTrigger.id);
     // Binding recovered (not stuck turn-active): the next mention delivers.
     post(store, binder, '@mock two', ['mock']);
     await waitFor(() => agentReplies(store, 'mock').length === 1);
@@ -1307,7 +1635,19 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
       targets: MOCK_TARGETS,
       knownProviderIds: ['mock'],
     });
-    const trigger = post(store, binder, '@mock please approve', ['mock']);
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const trigger = post(
+      store,
+      binder,
+      '@mock please approve',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
     await waitFor(() =>
       systemRows(store).some((m) => m.body.text.includes('requests approval'))
     );
@@ -1321,6 +1661,8 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
       agentId: 'mock',
     });
     expect(approvalRow.meta?.['sessionId']).toBe(sessions.firstSessionId());
+    expect(approvalRow.threadId).toBe(root.id);
+    expect(approvalRow.parentMessageId).toBe(trigger.id);
 
     const a = built[0]!;
     await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
@@ -1334,6 +1676,11 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     await waitFor(() =>
       systemRows(store).some((m) => m.body.text.includes('approval accept'))
     );
+    const resolvedRow = systemRows(store).find((m) =>
+      m.body.text.includes('approval accept')
+    )!;
+    expect(resolvedRow.threadId).toBe(root.id);
+    expect(resolvedRow.parentMessageId).toBe(trigger.id);
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     expect(agentReplies(store, 'mock')[0]!.body.text).toBe('approved and done');
   });

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -378,6 +378,31 @@ describe('mention routing — end-to-end via the router', () => {
     expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe('agent:mock');
   });
 
+  it('a mock agent reply to a threaded mention stays in that thread', async () => {
+    const h = await harness();
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'root discussion' },
+    });
+    const trigger = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock answer in thread', threadId: root.body.message.id },
+    });
+    expect(trigger.status).toBe(201);
+    expect(trigger.body.message.threadId).toBe(root.body.message.id);
+
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    const reply = agentReply(h.store, h.channelId)[0]!;
+    expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.threadId).toBe(root.body.message.id);
+    expect(reply.parentMessageId).toBe(trigger.body.message.id);
+  });
+
   it("the next turn's packet includes interim human rows but not the agent's own reply", async () => {
     const h = await harness(
       (agentType) => new RecordingAdapter(agentType, 'ack')

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -352,6 +352,8 @@ describe('mention routing — end-to-end via the router', () => {
     const reply = agentReply(h.store, h.channelId)[0]!;
     expect(reply.sender.id).toBe('agent:mock');
     expect(reply.body.text).toBe('Mock v2 response complete.');
+    expect(reply.threadId).toBeNull();
+    expect(reply.parentMessageId).toBeNull();
     // cursor advanced to the trigger seq
     expect(
       h.store.getBinding(h.channelId, 'mock')?.providerSession[

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -217,7 +217,7 @@ describe('channel-message-store posts, threads, idempotency', () => {
     expect(s.history('topic:c')).toHaveLength(1);
   });
 
-  it('inherits thread_id from parent and rejects a cross-channel parent', () => {
+  it('inherits thread_id from parent and validates parent identity/channel', () => {
     const s = store();
     const root = s.appendComplete({
       channelId: 'topic:c',
@@ -239,14 +239,44 @@ describe('channel-message-store posts, threads, idempotency', () => {
       parentMessageId: reply.id,
     });
     expect(nested.threadId).toBe(root.id);
-    expect(() =>
+    try {
       s.appendComplete({
         channelId: 'topic:other',
         sender: HUMAN,
         text: 'x',
         parentMessageId: root.id,
-      })
-    ).toThrow(ChannelMessageStoreError);
+      });
+      throw new Error('expected cross-channel parent rejection');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChannelMessageStoreError);
+      expect((error as ChannelMessageStoreError).status).toBe(409);
+      expect((error as ChannelMessageStoreError).code).toBe(
+        'parent_channel_mismatch'
+      );
+    }
+    try {
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: HUMAN,
+        text: 'x',
+        parentMessageId: 'chm:missing',
+      });
+      throw new Error('expected missing parent rejection');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChannelMessageStoreError);
+      expect((error as ChannelMessageStoreError).status).toBe(404);
+      expect((error as ChannelMessageStoreError).code).toBe(
+        'parent_message_not_found'
+      );
+    }
+
+    const history = s.history('topic:c');
+    expect(history.find((message) => message.id === root.id)?.replyCount).toBe(
+      2
+    );
+    expect(
+      s.threadHistory('topic:c', root.id).map((message) => message.id)
+    ).toEqual([root.id, reply.id, nested.id]);
   });
 
   it('rejects a body over the 256KB cap', () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -6,6 +6,7 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  buildChannelThreadHistorySql,
   createChannelMessageStore,
   ChannelMessageStoreError,
   type ChannelMessageStore,
@@ -348,27 +349,10 @@ describe('channel-message-store posts, threads, idempotency', () => {
 
     const raw = new Database(p, { readonly: true });
     cleanup.push(() => raw.close());
-    // Keep this SQL structurally identical to threadHistory's forward query so
-    // the regression test proves the defining invariant behind the UNION: one
-    // root-id lookup plus a range over idx_chm_thread, never a channel walk.
+    // EXPLAIN the exact production query: one root-id lookup plus a range over
+    // idx_chm_thread, never a hand-copied approximation or channel walk.
     const plan = raw
-      .prepare(
-        `EXPLAIN QUERY PLAN
-         SELECT m.*,
-                (SELECT COUNT(*) FROM channel_messages replies
-                 WHERE replies.thread_id = m.id) AS reply_count
-           FROM (
-             SELECT root.* FROM channel_messages root
-              WHERE root.id = @rootMessageId
-                AND root.channel_id = @channelId AND seq > @afterSeq
-             UNION ALL
-             SELECT thread_reply.*
-               FROM channel_messages thread_reply INDEXED BY idx_chm_thread
-              WHERE thread_reply.thread_id = @rootMessageId
-                AND thread_reply.channel_id = @channelId AND seq > @afterSeq
-           ) m
-          ORDER BY m.seq ASC LIMIT @limit`
-      )
+      .prepare(`EXPLAIN QUERY PLAN ${buildChannelThreadHistorySql('after')}`)
       .all({
         rootMessageId: root.id,
         channelId: 'topic:c',

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -195,6 +195,58 @@ describe('channel-message-store streaming lifecycle', () => {
     // A cursor below the agent row excludes it.
     expect(s.listResyncRows('topic:c', 1, 500)).toHaveLength(0);
   });
+
+  it('keeps replyCount on point reads, finalization rows, and resync replacements', () => {
+    const s = store();
+    const root = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: {
+        sessionId: 'root-session',
+        turnId: 'root-turn',
+        itemId: 'root',
+      },
+    });
+    s.finalizeStream(root.id, { text: 'root', status: 'complete' });
+    const statuses = ['complete', 'failed', 'interrupted'] as const;
+    for (const [index, status] of statuses.entries()) {
+      const reply = s.beginStream({
+        channelId: 'topic:c',
+        sender: AGENT,
+        source: {
+          sessionId: `reply-session-${index}`,
+          turnId: `reply-turn-${index}`,
+          itemId: `reply-${index}`,
+        },
+        parentMessageId: root.id,
+      });
+      s.finalizeStream(reply.id, { text: status, status });
+    }
+    const streaming = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: {
+        sessionId: 'reply-session-stream',
+        turnId: 'reply-turn-stream',
+        itemId: 'reply-stream',
+      },
+      parentMessageId: root.id,
+    });
+    expect(streaming.status).toBe('streaming');
+
+    // replyCount intentionally includes every persisted reply status: a thread
+    // badge counts rows, not only cleanly completed agent output.
+    expect(s.getMessage(root.id)?.replyCount).toBe(4);
+    expect(
+      s.finalizeStream(root.id, { text: 'ignored', status: 'failed' })
+        ?.replyCount
+    ).toBe(4);
+    expect(
+      s
+        .listResyncRows('topic:c', Number.MAX_SAFE_INTEGER, 500)
+        .find((message) => message.id === root.id)?.replyCount
+    ).toBe(4);
+  });
 });
 
 describe('channel-message-store posts, threads, idempotency', () => {
@@ -277,6 +329,59 @@ describe('channel-message-store posts, threads, idempotency', () => {
     expect(
       s.threadHistory('topic:c', root.id).map((message) => message.id)
     ).toEqual([root.id, reply.id, nested.id]);
+  });
+
+  it('plans thread history as a root PK probe plus thread-index range', () => {
+    const p = dbPath();
+    const s = store(p);
+    const root = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'root',
+    });
+    s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'reply',
+      parentMessageId: root.id,
+    });
+
+    const raw = new Database(p, { readonly: true });
+    cleanup.push(() => raw.close());
+    // Keep this SQL structurally identical to threadHistory's forward query so
+    // the regression test proves the defining invariant behind the UNION: one
+    // root-id lookup plus a range over idx_chm_thread, never a channel walk.
+    const plan = raw
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT m.*,
+                (SELECT COUNT(*) FROM channel_messages replies
+                 WHERE replies.thread_id = m.id) AS reply_count
+           FROM (
+             SELECT root.* FROM channel_messages root
+              WHERE root.id = @rootMessageId
+                AND root.channel_id = @channelId AND seq > @afterSeq
+             UNION ALL
+             SELECT thread_reply.*
+               FROM channel_messages thread_reply INDEXED BY idx_chm_thread
+              WHERE thread_reply.thread_id = @rootMessageId
+                AND thread_reply.channel_id = @channelId AND seq > @afterSeq
+           ) m
+          ORDER BY m.seq ASC LIMIT @limit`
+      )
+      .all({
+        rootMessageId: root.id,
+        channelId: 'topic:c',
+        afterSeq: 0,
+        limit: 51,
+      }) as Array<{ detail: string }>;
+    const details = plan.map((row) => row.detail).join('\n');
+    expect(details).toMatch(/SEARCH root USING INDEX .*\(id=\?\)/);
+    expect(details).toMatch(
+      /SEARCH thread_reply USING INDEX idx_chm_thread \(thread_id=\? AND seq>\?\)/
+    );
+    expect(details).not.toContain('idx_chm_channel_seq');
+    expect(details).not.toMatch(/SCAN (?:root|thread_reply)/);
   });
 
   it('rejects a body over the 256KB cap', () => {

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -318,11 +318,203 @@ describe('channel routes — read / write contract', () => {
   });
 });
 
+describe('channel routes — threads', () => {
+  it('writes nested replies, pages root-inclusive history, and reports replyCount', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: { id: string; seq: number } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    let parentId = root.body.message.id;
+    for (let i = 1; i <= 4; i++) {
+      const reply = await req<{
+        message: {
+          id: string;
+          seq: number;
+          threadId: string;
+          parentMessageId: string;
+        };
+      }>({
+        port: h.port,
+        method: 'POST',
+        url: messageUrl,
+        body: { text: `reply ${i}`, threadId: parentId },
+      });
+      expect(reply.status).toBe(201);
+      expect(reply.body.message.threadId).toBe(root.body.message.id);
+      expect(reply.body.message.parentMessageId).toBe(parentId);
+      parentId = reply.body.message.id;
+    }
+
+    const timeline = await req<{
+      messages: Array<{ id: string; replyCount?: number }>;
+    }>({ port: h.port, method: 'GET', url: messageUrl });
+    expect(
+      timeline.body.messages.find(
+        (message) => message.id === root.body.message.id
+      )?.replyCount
+    ).toBe(4);
+
+    const threadUrl = `/channels/${encodeURIComponent(h.channelId)}/threads/${encodeURIComponent(root.body.message.id)}`;
+    const page1 = await req<{
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { afterSeq?: number };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?afterSeq=0&limit=2`,
+    });
+    expect(page1.status).toBe(200);
+    expect(page1.body.messages.map((message) => message.seq)).toEqual([1, 2]);
+    expect(page1.body.hasMore).toBe(true);
+    expect(page1.body.nextCursor).toEqual({ afterSeq: 2 });
+
+    const page2 = await req<{
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { afterSeq?: number };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?afterSeq=${page1.body.nextCursor!.afterSeq}&limit=2`,
+    });
+    expect(page2.body.messages.map((message) => message.seq)).toEqual([3, 4]);
+    expect(page2.body.hasMore).toBe(true);
+    expect(page2.body.nextCursor).toEqual({ afterSeq: 4 });
+  });
+
+  it('returns 404 for an unknown parent and 409 for a cross-channel parent', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const missing = await req({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'reply', threadId: 'chm:missing' },
+    });
+    expect(missing.status).toBe(404);
+
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    const other = h.topicStore.create({ workspaceId: 'ws', title: 'Other' });
+    const mismatch = await req({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(other.id)}/messages`,
+      body: { text: 'cross channel', threadId: root.body.message.id },
+    });
+    expect(mismatch.status).toBe(409);
+
+    const invalid = await req({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'invalid', threadId: '' },
+    });
+    expect(invalid.status).toBe(400);
+  });
+
+  it('preserves parentMessageId writes and rejects conflicting dual fields', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const firstRoot = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'first root' },
+    });
+    const secondRoot = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'second root' },
+    });
+
+    const legacy = await req<{
+      message: { threadId: string; parentMessageId: string };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: {
+        text: 'legacy reply',
+        parentMessageId: firstRoot.body.message.id,
+      },
+    });
+    expect(legacy.status).toBe(201);
+    expect(legacy.body.message.threadId).toBe(firstRoot.body.message.id);
+    expect(legacy.body.message.parentMessageId).toBe(firstRoot.body.message.id);
+
+    const legacyEmpty = await req<{
+      message: { threadId: string | null; parentMessageId: string | null };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'legacy empty is root', parentMessageId: '' },
+    });
+    expect(legacyEmpty.status).toBe(201);
+    expect(legacyEmpty.body.message.threadId).toBeNull();
+    expect(legacyEmpty.body.message.parentMessageId).toBeNull();
+
+    const conflict = await req({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: {
+        text: 'ambiguous reply',
+        threadId: firstRoot.body.message.id,
+        parentMessageId: secondRoot.body.message.id,
+      },
+    });
+    expect(conflict.status).toBe(400);
+  });
+
+  it('broadcasts a threaded reply on the normal channel created-event lane', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    const sock = fakeSocket();
+    h.hub.handleConnection(sock, { channelId: h.channelId, sinceSeq: null });
+    await req({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'threaded', threadId: root.body.message.id },
+    });
+    const created = sock.sent.find(
+      (event) =>
+        event.type === 'channel-message-created-v1' &&
+        event.message.body.text === 'threaded'
+    );
+    expect(created?.type).toBe('channel-message-created-v1');
+    if (created?.type === 'channel-message-created-v1') {
+      expect(created.message.threadId).toBe(root.body.message.id);
+    }
+  });
+});
+
 describe('channel routes — gateway capability mapping', () => {
   it('registers channels verbs in the actor command sets', () => {
     expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.list');
     expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.get');
     expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain('channels.history');
+    expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toContain(
+      'channels.threads.history'
+    );
     expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toContain('channels.post');
   });
 
@@ -336,6 +528,9 @@ describe('channel routes — gateway capability mapping', () => {
     expect(cliGatewayActorCommandCapabilities('channels.history')).toEqual([
       'context:read',
     ]);
+    expect(
+      cliGatewayActorCommandCapabilities('channels.threads.history')
+    ).toEqual(['context:read']);
     expect(cliGatewayActorCommandCapabilities('channels.post')).toEqual([
       'context:write',
     ]);

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -385,6 +385,19 @@ describe('channel routes — threads', () => {
     expect(page2.body.messages.map((message) => message.seq)).toEqual([3, 4]);
     expect(page2.body.hasMore).toBe(true);
     expect(page2.body.nextCursor).toEqual({ afterSeq: 4 });
+
+    const terminal = await req<{
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { afterSeq?: number };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?afterSeq=4&limit=2`,
+    });
+    expect(terminal.body.messages.map((message) => message.seq)).toEqual([5]);
+    expect(terminal.body).not.toHaveProperty('hasMore');
+    expect(terminal.body).not.toHaveProperty('nextCursor');
   });
 
   it('returns 404 for an unknown parent and 409 for a cross-channel parent', async () => {
@@ -420,6 +433,82 @@ describe('channel routes — threads', () => {
       body: { text: 'invalid', threadId: '' },
     });
     expect(invalid.status).toBe(400);
+
+    const numeric = await req({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'invalid numeric id', threadId: 42 },
+    });
+    expect(numeric.status).toBe(400);
+  });
+
+  it('returns the exact 404/409/400 thread-history root contract', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const missing = await req<{
+      error: { code: string; details: { reasonCode: string } };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/threads/chm%3Amissing`,
+    });
+    expect(missing).toMatchObject({
+      status: 404,
+      body: {
+        error: {
+          code: 'NOT_FOUND',
+          details: { reasonCode: 'THREAD_ROOT_NOT_FOUND' },
+        },
+      },
+    });
+
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    const reply = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'reply', threadId: root.body.message.id },
+    });
+    const other = h.topicStore.create({ workspaceId: 'ws', title: 'Other' });
+    const mismatch = await req<{
+      error: { code: string; details: { reasonCode: string } };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(other.id)}/threads/${encodeURIComponent(root.body.message.id)}`,
+    });
+    expect(mismatch).toMatchObject({
+      status: 409,
+      body: {
+        error: {
+          code: 'SESSION_CONFLICT',
+          details: { reasonCode: 'THREAD_ROOT_CHANNEL_MISMATCH' },
+        },
+      },
+    });
+
+    const nonRoot = await req<{
+      error: { code: string; details: { reasonCode: string } };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/threads/${encodeURIComponent(reply.body.message.id)}`,
+    });
+    expect(nonRoot).toMatchObject({
+      status: 400,
+      body: {
+        error: {
+          code: 'INVALID_ARGUMENT',
+          details: { reasonCode: 'THREAD_ROOT_REQUIRED' },
+        },
+      },
+    });
   });
 
   it('preserves parentMessageId writes and rejects conflicting dual fields', async () => {
@@ -476,6 +565,241 @@ describe('channel routes — threads', () => {
       },
     });
     expect(conflict.status).toBe(400);
+  });
+
+  it('treats null thread aliases as absent and accepts equal dual ids', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root', threadId: null, parentMessageId: null },
+    });
+    expect(root.status).toBe(201);
+
+    const threadNull = await req<{
+      message: { threadId: string; parentMessageId: string };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: {
+        text: 'legacy id wins',
+        threadId: null,
+        parentMessageId: root.body.message.id,
+      },
+    });
+    expect(threadNull.status).toBe(201);
+    expect(threadNull.body.message.parentMessageId).toBe(root.body.message.id);
+
+    const parentNull = await req<{
+      message: { threadId: string; parentMessageId: string };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: {
+        text: 'public id wins',
+        threadId: root.body.message.id,
+        parentMessageId: null,
+      },
+    });
+    expect(parentNull.status).toBe(201);
+    expect(parentNull.body.message.parentMessageId).toBe(root.body.message.id);
+
+    const equal = await req({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: {
+        text: 'equal ids',
+        threadId: root.body.message.id,
+        parentMessageId: root.body.message.id,
+      },
+    });
+    expect(equal.status).toBe(201);
+  });
+
+  it('walks backward pages, gives afterSeq precedence, and omits terminal cursors', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    for (let i = 1; i <= 5; i++) {
+      await req({
+        port: h.port,
+        method: 'POST',
+        url: messageUrl,
+        body: { text: `reply ${i}`, threadId: root.body.message.id },
+      });
+    }
+    const threadUrl = `/channels/${encodeURIComponent(h.channelId)}/threads/${encodeURIComponent(root.body.message.id)}`;
+    const newest = await req<{
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { beforeSeq?: number };
+    }>({ port: h.port, method: 'GET', url: `${threadUrl}?limit=2` });
+    expect(newest.body.messages.map((m) => m.seq)).toEqual([5, 6]);
+    expect(newest.body.nextCursor).toEqual({ beforeSeq: 5 });
+
+    const middle = await req<{
+      messages: Array<{ seq: number }>;
+      nextCursor?: { beforeSeq?: number };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?beforeSeq=${newest.body.nextCursor!.beforeSeq}&limit=2`,
+    });
+    expect(middle.body.messages.map((m) => m.seq)).toEqual([3, 4]);
+    expect(middle.body.nextCursor).toEqual({ beforeSeq: 3 });
+
+    const oldest = await req<{
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { beforeSeq?: number };
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?beforeSeq=3&limit=2`,
+    });
+    expect(oldest.body.messages.map((m) => m.seq)).toEqual([1, 2]);
+    expect(oldest.body).not.toHaveProperty('hasMore');
+    expect(oldest.body).not.toHaveProperty('nextCursor');
+
+    const afterWins = await req<{ messages: Array<{ seq: number }> }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?beforeSeq=2&afterSeq=4&limit=10`,
+    });
+    expect(afterWins.body.messages.map((m) => m.seq)).toEqual([5, 6]);
+  });
+
+  it('clamps thread limits and preserves the legacy timeline thread filter', async () => {
+    const h = await harness();
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    for (let i = 1; i <= 204; i++) {
+      h.store.appendComplete({
+        channelId: h.channelId,
+        sender: { kind: 'human', id: 'human:operator' },
+        text: `reply ${i}`,
+        parentMessageId: root.body.message.id,
+      });
+    }
+    const threadUrl = `/channels/${encodeURIComponent(h.channelId)}/threads/${encodeURIComponent(root.body.message.id)}`;
+    const zero = await req<{ messages: unknown[] }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?afterSeq=0&limit=0`,
+    });
+    expect(zero.body.messages).toHaveLength(1);
+    const huge = await req<{ messages: unknown[] }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?afterSeq=0&limit=999`,
+    });
+    expect(huge.body.messages).toHaveLength(200);
+    const junk = await req<{ messages: unknown[] }>({
+      port: h.port,
+      method: 'GET',
+      url: `${threadUrl}?afterSeq=0&limit=junk`,
+    });
+    expect(junk.body.messages).toHaveLength(50);
+
+    const legacy = await req<{
+      messages: Array<{ threadId: string | null }>;
+    }>({
+      port: h.port,
+      method: 'GET',
+      url: `${messageUrl}?threadId=${encodeURIComponent(root.body.message.id)}&limit=200`,
+    });
+    expect(legacy.body.messages).toHaveLength(200);
+    expect(
+      legacy.body.messages.every((m) => m.threadId === root.body.message.id)
+    ).toBe(true);
+  });
+
+  it('byte-budgets forward and backward thread pages with usable cursors', async () => {
+    const h = await harness({ historyMaxBytes: 2600 });
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messageUrl,
+      body: { text: 'root' },
+    });
+    for (let i = 1; i <= 8; i++) {
+      h.store.appendComplete({
+        channelId: h.channelId,
+        sender: { kind: 'human', id: 'human:operator' },
+        text: `${i}:${'x'.repeat(900)}`,
+        parentMessageId: root.body.message.id,
+      });
+    }
+    const threadUrl = `/channels/${encodeURIComponent(h.channelId)}/threads/${encodeURIComponent(root.body.message.id)}`;
+    type ThreadPage = {
+      messages: Array<{ seq: number }>;
+      hasMore?: boolean;
+      nextCursor?: { afterSeq?: number; beforeSeq?: number };
+    };
+    const expected = Array.from({ length: 9 }, (_, index) => index + 1);
+
+    const forwardSeqs: number[] = [];
+    let afterSeq = 0;
+    for (let pageNumber = 0; pageNumber < 20; pageNumber++) {
+      const page = await req<ThreadPage>({
+        port: h.port,
+        method: 'GET',
+        url: `${threadUrl}?afterSeq=${afterSeq}&limit=200`,
+      });
+      const seqs = page.body.messages.map((message) => message.seq);
+      expect(seqs.length).toBeGreaterThan(0);
+      forwardSeqs.push(...seqs);
+      if (!page.body.hasMore) {
+        expect(page.body).not.toHaveProperty('hasMore');
+        expect(page.body).not.toHaveProperty('nextCursor');
+        break;
+      }
+      expect(page.body.nextCursor?.afterSeq).toBe(seqs.at(-1));
+      afterSeq = page.body.nextCursor!.afterSeq!;
+    }
+    expect(forwardSeqs).toEqual(expected);
+    expect(new Set(forwardSeqs).size).toBe(expected.length);
+
+    const backwardSeqs: number[] = [];
+    let beforeSeq: number | undefined;
+    for (let pageNumber = 0; pageNumber < 20; pageNumber++) {
+      const page = await req<ThreadPage>({
+        port: h.port,
+        method: 'GET',
+        url:
+          beforeSeq === undefined
+            ? `${threadUrl}?limit=200`
+            : `${threadUrl}?beforeSeq=${beforeSeq}&limit=200`,
+      });
+      const seqs = page.body.messages.map((message) => message.seq);
+      expect(seqs.length).toBeGreaterThan(0);
+      backwardSeqs.unshift(...seqs);
+      if (!page.body.hasMore) {
+        expect(page.body).not.toHaveProperty('hasMore');
+        expect(page.body).not.toHaveProperty('nextCursor');
+        break;
+      }
+      expect(page.body.nextCursor?.beforeSeq).toBe(seqs[0]);
+      beforeSeq = page.body.nextCursor!.beforeSeq!;
+    }
+    expect(backwardSeqs).toEqual(expected);
+    expect(new Set(backwardSeqs).size).toBe(expected.length);
   });
 
   it('broadcasts a threaded reply on the normal channel created-event lane', async () => {

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -352,6 +352,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'channels.list',
     'channels.get',
     'channels.history',
+    'channels.threads.history',
     'channels.roster',
     'context.get',
     'context.list',


### PR DESCRIPTION
## Summary

- add threaded channel writes through public `threadId` while preserving the existing `parentMessageId` alias
- add root-inclusive, cursor-paginated thread history with `hasMore` / `nextCursor`
- preserve `replyCount` on history, point reads, finalization broadcasts, and WS resync replacements
- use a root PK probe plus the existing `idx_chm_thread` range index for thread history, with the plan test consuming the exact production SQL builder
- retain exact per-turn thread parents for late-opening agent rows and thread trigger-derived system rows
- preserve active thread parents across transport rebind retries and bound anonymous `turn-0` retention
- fail closed when unresolved anonymous turn generations overlap, then re-arm only after exact terminal evidence or hard reattach
- register `channels.threads.history` as a `context:read` gateway command

Part of #1170. Epic: #1163.

## Contract decisions

- Unknown parent/root remains `404`.
- Cross-channel or mismatched parent/root remains `409 SESSION_CONFLICT`. This preserves the existing store/router convention and supersedes the original brief request for `400`.
- JSON `threadId: null` is equivalent to omission and creates a root post. Empty strings and other non-string `threadId` values return `400`.
- `parentMessageId` remains a permissive compatibility alias. Equal IDs are accepted; conflicting non-empty `threadId` and `parentMessageId` values return `400`.
- When both `afterSeq` and `beforeSeq` are supplied, `afterSeq` wins and `beforeSeq` is ignored. This is a pinned precedence rule, not a `400` error.
- Thread history includes the root followed by replies. Main timeline filtering remains a later client slice.
- `replyCount` is computed at read time and counts every persisted reply status, including streaming, complete, failed, and interrupted rows. The existing thread index avoids counter drift and a schema migration.

## Non-goal

Agent context packets remain channel-scoped in this bounded backend slice. Agent replies inherit the triggering thread; thread-scoped packet construction remains follow-up work.

## Verification

Head: `24e2b2f90c328c871553bdc18306ee0114fe902b`

- exact-head focused lifecycle/store run: 2 files, 60 tests passed
- all channel and gateway suites: 13 files, 171 tests passed
- pre-push changed-test gate: 13 files, 166 tests passed
- `npm run check`: exit 0; 247 existing warnings, 0 errors
- `git diff --check`: passed
- focused adversarial review and changed-hunk re-review: no remaining P0/P1/P2 findings

All commands used Node 24 via `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added threaded message replies with consistent parent-message association, including agent responses and system notifications.
  * Added thread history retrieval with cursor-based pagination and response size limits.
  * Added reply counts to channel messages.
  * Added validation and compatibility handling for thread identifiers.
  * Added access-controlled CLI support for reading thread history.

* **Bug Fixes**
  * Improved thread context preservation across retries, reconnects, failures, approvals, and session shutdowns.
  * Prevented incorrect cross-thread message associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->