### PR TITLE
feat(channels): thread-scoped context packets

### DIFF
--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -596,12 +596,28 @@ export function createChannelAgentBinder(
       typeof row?.providerSession['lastDeliveredSeq'] === 'number'
         ? (row.providerSession['lastDeliveredSeq'] as number)
         : 0;
-    const rows = store
-      .history(binding.channelId, {
+    let rows: ChannelMessage[];
+    if (trigger.threadId !== null) {
+      rows = store.threadHistory(binding.channelId, trigger.threadId, {
         beforeSeq: trigger.seq,
         limit: PACKET_FETCH_WINDOW,
-      })
-      .filter((r) => r.seq < trigger.seq);
+      });
+      // A bounded newest-first page may omit the load-bearing root. Reinsert it
+      // through the existing point-read lane; the builder preserves it through
+      // row and byte trimming.
+      const root = store.getMessage(trigger.threadId);
+      if (root) rows.push(root);
+      rows = [...new Map(rows.map((message) => [message.id, message])).values()]
+        .filter((message) => message.seq < trigger.seq)
+        .sort((a, b) => a.seq - b.seq);
+    } else {
+      rows = store
+        .history(binding.channelId, {
+          beforeSeq: trigger.seq,
+          limit: PACKET_FETCH_WINDOW,
+        })
+        .filter((r) => r.seq < trigger.seq);
+    }
     return buildMentionContextPacket({
       channelTitle: title,
       framework: binding.framework,
@@ -671,12 +687,16 @@ export function createChannelAgentBinder(
         // only — no adapter dedupes on it today.
         clientMessageId: `${trigger.id}:${binding.framework}`,
       })
-      .then(() => advanceCursor(binding, trigger.seq))
+      .then(() => advanceCursor(binding, trigger))
       .catch((err) => handleSendFailure(binding, trigger, turnId, err));
   }
 
-  function advanceCursor(binding: LiveBinding, triggerSeq: number): void {
+  function advanceCursor(binding: LiveBinding, trigger: ChannelMessage): void {
     if (closed) return; // never write to a closing store from an in-flight send
+    // Thread packets deliberately ignore the channel-global cursor. Advancing it
+    // here would make a later top-level mention skip intervening channel rows.
+    if (trigger.threadId !== null) return;
+    const triggerSeq = trigger.seq;
     // Cursor advances only on send acceptance (§4): a failed send re-offers the
     // rows next mention (at-least-once). Never lower the cursor.
     try {

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -2,8 +2,7 @@ import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
 
 // Pure context-packet builder for @-mention routing (#1167, slice 4). No I/O:
 // store rows in, prompt string out — fully unit-testable. The binder fetches the
-// eligible rows (`store.history(channelId, { afterSeq: lastDeliveredSeq })`
-// filtered to `seq < trigger.seq`) and hands them here; this module owns ONLY the
+// eligible channel or thread rows and hands them here; this module owns ONLY the
 // deterministic string shape (§4 of the spec). It never touches the network, the
 // store, or the adapter, so the golden test pins the exact bytes an agent sees.
 
@@ -16,6 +15,8 @@ export const PACKET_MAX_BYTES = 24 * 1024;
 
 const OMITTED_MARKER = '[…earlier messages omitted]';
 const ROW_TRUNCATED_SUFFIX = '…[truncated]';
+const THREAD_SCOPE_MARKER =
+  '[Thread scope — only this thread is shown; its root message is always included]';
 
 export interface BuildMentionContextPacketInput {
   /** Human-facing channel title (topic display title), rendered as `#<title>`. */
@@ -23,10 +24,11 @@ export interface BuildMentionContextPacketInput {
   /** Framework id the packet is addressed to (`you are @<framework>`). */
   framework: string;
   /**
-   * Eligible prior rows, oldest-first: every row with
-   * `lastDeliveredSeq < seq < trigger.seq`. The agent's own prior rows are
-   * skipped HERE (they already live in the reused provider conversation), so the
-   * binder may pass the raw window untrimmed.
+   * Eligible prior rows, oldest-first. For a channel trigger this is every row
+   * with `lastDeliveredSeq < seq < trigger.seq`. For a threaded trigger this is
+   * the thread root plus prior replies; the channel delivery cursor is ignored.
+   * The agent's own prior rows are skipped HERE (they already live in the reused
+   * provider conversation), except that a thread root is always retained.
    */
   rows: ChannelMessage[];
   /** The mention row itself — always rendered in the footer, never dropped. */
@@ -101,6 +103,7 @@ export function buildMentionContextPacket(
   input: BuildMentionContextPacketInput
 ): string {
   const header = `[Relay channel #${input.channelTitle} — you are @${input.framework}, one participant in a multi-party chat]`;
+  const threadRootId = input.trigger.threadId;
 
   // Eligible = rows strictly after the delivery cursor and strictly before the
   // trigger, minus the agent's OWN prior rows (already in its reused provider
@@ -108,20 +111,35 @@ export function buildMentionContextPacket(
   // session with no interim rows therefore yields an empty window → header +
   // footer only; a first-ever mention (cursor 0) yields the full orientation
   // window.
-  const eligible = input.rows.filter(
-    (row) =>
-      row.seq > input.lastDeliveredSeq &&
-      row.seq < input.trigger.seq &&
-      !(
-        row.sender.kind === 'agent' && row.sender.providerId === input.framework
-      )
-  );
+  const isOwnAgentRow = (row: ChannelMessage): boolean =>
+    row.sender.kind === 'agent' && row.sender.providerId === input.framework;
+  const eligible = input.rows.filter((row) => {
+    if (row.seq >= input.trigger.seq) return false;
+    if (threadRootId !== null) {
+      const isRoot = row.id === threadRootId;
+      if (!isRoot && row.threadId !== threadRootId) return false;
+      return isRoot || !isOwnAgentRow(row);
+    }
+    return row.seq > input.lastDeliveredSeq && !isOwnAgentRow(row);
+  });
 
-  let contextRows = eligible;
+  let contextRows: ChannelMessage[];
   let omittedEarlier = false;
-  if (contextRows.length > PACKET_MAX_ROWS) {
-    omittedEarlier = true;
-    contextRows = contextRows.slice(contextRows.length - PACKET_MAX_ROWS);
+  if (threadRootId !== null) {
+    const root = eligible.find((row) => row.id === threadRootId);
+    if (!root) {
+      throw new Error(`thread context root missing: ${threadRootId}`);
+    }
+    const replies = eligible.filter((row) => row.id !== threadRootId);
+    const replyLimit = Math.max(0, PACKET_MAX_ROWS - 1);
+    if (replies.length > replyLimit) omittedEarlier = true;
+    contextRows = [root, ...replies.slice(-replyLimit)];
+  } else {
+    contextRows = eligible;
+    if (contextRows.length > PACKET_MAX_ROWS) {
+      omittedEarlier = true;
+      contextRows = contextRows.slice(contextRows.length - PACKET_MAX_ROWS);
+    }
   }
 
   const triggerLabel = triggerAttribution(input.trigger);
@@ -136,26 +154,33 @@ export function buildMentionContextPacket(
   ].join('\n');
 
   const assemble = (rows: ChannelMessage[], omitted: boolean): string => {
+    const scopeLines = threadRootId !== null ? [THREAD_SCOPE_MARKER] : [];
     if (rows.length === 0) {
-      return `${header}\n\n${footer}`;
+      return [header, ...scopeLines, '', footer].join('\n');
     }
     const contextBlock = [
+      ...scopeLines,
       'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
-      ...(omitted ? [OMITTED_MARKER] : []),
-      ...rows.map(renderRow),
+      ...(threadRootId !== null && omitted
+        ? [renderRow(rows[0]!), OMITTED_MARKER, ...rows.slice(1).map(renderRow)]
+        : [...(omitted ? [OMITTED_MARKER] : []), ...rows.map(renderRow)]),
     ].join('\n');
     return `${header}\n${contextBlock}\n\n${footer}`;
   };
 
-  // Whole-packet byte budget: drop oldest context rows until under (never the
-  // trigger/footer). A single over-budget footer is still delivered — losing the
-  // mention is worse than a slightly oversized packet.
+  // Whole-packet byte budget: drop oldest context rows until under. Thread mode
+  // never drops its load-bearing root; the trigger/footer is never dropped in
+  // either mode. A root/footer-only packet may exceed the budget — losing either
+  // is worse than a slightly oversized packet.
   let packet = assemble(contextRows, omittedEarlier);
   while (
-    contextRows.length > 0 &&
+    contextRows.length > (threadRootId !== null ? 1 : 0) &&
     Buffer.byteLength(packet, 'utf8') > PACKET_MAX_BYTES
   ) {
-    contextRows = contextRows.slice(1);
+    contextRows =
+      threadRootId !== null
+        ? [contextRows[0]!, ...contextRows.slice(2)]
+        : contextRows.slice(1);
     omittedEarlier = true;
     packet = assemble(contextRows, omittedEarlier);
   }

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1776,8 +1776,8 @@ describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () 
       targets: MOCK_TARGETS,
       knownProviderIds: ['mock'],
     });
-    // Throw once from the packet-fetch history call (the one with `beforeSeq`);
-    // the row helpers (no beforeSeq) pass through so waitFor stays usable.
+    // Throw once from the top-level packet-fetch history call (the one with
+    // `beforeSeq`); row helpers without beforeSeq continue to work.
     const realHistory = store.history.bind(store);
     let thrown = false;
     (store as unknown as { history: ChannelMessageStore['history'] }).history =
@@ -1788,6 +1788,44 @@ describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () 
         }
         return realHistory(id, filter);
       }) as ChannelMessageStore['history'];
+
+    post(store, binder, '@mock one', ['mock']);
+    await waitFor(() =>
+      systemRows(store).some((m) =>
+        m.body.text.includes('could not build the message context')
+      )
+    );
+    post(store, binder, '@mock two', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(sessions.spawns()).toBe(1);
+    expect(agentReplies(store, 'mock')).toHaveLength(1);
+  });
+
+  it('a store.threadHistory throw does not wedge the binding; the next mention routes', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    // Throw once from the threaded packet-fetch lane. The next top-level turn
+    // uses ordinary history and proves the queue did not wedge.
+    const realThreadHistory = store.threadHistory.bind(store);
+    let thrown = false;
+    (
+      store as unknown as {
+        threadHistory: ChannelMessageStore['threadHistory'];
+      }
+    ).threadHistory = ((
+      id: string,
+      rootMessageId: string,
+      filter?: Parameters<ChannelMessageStore['threadHistory']>[2]
+    ) => {
+      if (!thrown) {
+        thrown = true;
+        throw new Error('db boom');
+      }
+      return realThreadHistory(id, rootMessageId, filter);
+    }) as ChannelMessageStore['threadHistory'];
 
     const root = store.appendComplete({
       channelId: CH,

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -143,6 +143,72 @@ describe('buildMentionContextPacket', () => {
     );
   });
 
+  it('keeps an own-agent root but excludes same-framework reply rows', () => {
+    const root = { ...msg(1, CLAUDE, 'claude-authored root'), id: 'chm:root' };
+    const ownReply = inThread(
+      msg(2, CLAUDE, 'already retained by provider context'),
+      root.id,
+      root.id
+    );
+    const humanReply = inThread(
+      msg(3, OPERATOR, 'new human detail'),
+      root.id,
+      ownReply.id
+    );
+    const trigger = inThread(
+      msg(4, OPERATOR, '@claude continue'),
+      root.id,
+      humanReply.id
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [root, ownReply, humanReply],
+      trigger,
+      lastDeliveredSeq: 999,
+    });
+    expect(packet).toBe(
+      [
+        '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '[Thread scope — only this thread is shown; its root message is always included]',
+        'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+        'claude [agent]: claude-authored root',
+        'operator: new human detail',
+        '',
+        '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
+        '@claude continue',
+      ].join('\n')
+    );
+  });
+
+  it('excludes a reply row belonging to a different thread', () => {
+    const root = { ...msg(1, OPERATOR, 'target root'), id: 'chm:root' };
+    const targetReply = inThread(
+      msg(2, OPERATOR, 'target detail'),
+      root.id,
+      root.id
+    );
+    const otherReply = inThread(
+      msg(3, OPERATOR, 'different-thread detail'),
+      'chm:other-root',
+      'chm:other-root'
+    );
+    const trigger = inThread(
+      msg(4, OPERATOR, '@claude answer target'),
+      root.id,
+      targetReply.id
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [root, targetReply, otherReply],
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(packet).toContain('operator: target detail');
+    expect(packet).not.toContain('different-thread detail');
+  });
+
   it('keeps an own-agent root despite a high cursor and retains only newest replies', () => {
     const root = { ...msg(1, CLAUDE, 'load-bearing root'), id: 'chm:root' };
     const rows = [root];

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -52,6 +52,18 @@ function msg(
   };
 }
 
+function inThread(
+  message: ChannelMessage,
+  rootMessageId: string,
+  parentMessageId: string
+): ChannelMessage {
+  return {
+    ...message,
+    threadId: rootMessageId,
+    parentMessageId,
+  };
+}
+
 describe('buildMentionContextPacket', () => {
   it('renders the exact golden packet (own rows skipped, sender labels, footer)', () => {
     const rows = [
@@ -84,6 +96,126 @@ describe('buildMentionContextPacket', () => {
         '@claude please fix the flaky channel-hub test',
       ].join('\n')
     );
+  });
+
+  it('renders an exact thread-scoped packet and excludes unrelated channel rows', () => {
+    const root = msg(1, OPERATOR, 'root question');
+    const reply = inThread(msg(2, HERMES, 'thread detail'), root.id, root.id);
+    const system = inThread(
+      msg(3, SYSTEM, 'thread system notice', 'system'),
+      root.id,
+      reply.id
+    );
+    const streaming = {
+      ...inThread(
+        msg(4, OPERATOR, 'thread row still streaming'),
+        root.id,
+        system.id
+      ),
+      status: 'streaming' as const,
+    };
+    const unrelated = msg(5, OPERATOR, 'unrelated top-level update');
+    const trigger = inThread(
+      msg(6, OPERATOR, '@claude answer this thread'),
+      root.id,
+      streaming.id
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [root, reply, system, streaming, unrelated],
+      trigger,
+      lastDeliveredSeq: 999,
+    });
+    expect(packet).toBe(
+      [
+        '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '[Thread scope — only this thread is shown; its root message is always included]',
+        'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+        'operator: root question',
+        'hermes [agent]: thread detail',
+        '[system]: thread system notice',
+        'operator: thread row still streaming',
+        '',
+        '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
+        '@claude answer this thread',
+      ].join('\n')
+    );
+  });
+
+  it('keeps an own-agent root despite a high cursor and retains only newest replies', () => {
+    const root = { ...msg(1, CLAUDE, 'load-bearing root'), id: 'chm:root' };
+    const rows = [root];
+    for (let seq = 2; seq <= 25; seq++) {
+      rows.push(
+        inThread(msg(seq, OPERATOR, `thread line ${seq}`), root.id, root.id)
+      );
+    }
+    const trigger = inThread(
+      msg(26, OPERATOR, '@claude continue'),
+      root.id,
+      rows.at(-1)!.id
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 999,
+    });
+    expect(packet).toContain('claude [agent]: load-bearing root');
+    expect(packet).toContain('[…earlier messages omitted]');
+    expect(packet).not.toContain('operator: thread line 6\n');
+    expect(packet).toContain('operator: thread line 7');
+    expect(packet).toContain('operator: thread line 25');
+    expect(packet.indexOf('claude [agent]: load-bearing root')).toBeLessThan(
+      packet.indexOf('[…earlier messages omitted]')
+    );
+    expect(packet.indexOf('[…earlier messages omitted]')).toBeLessThan(
+      packet.indexOf('operator: thread line 7')
+    );
+    const contextLines = packet
+      .split('\n')
+      .filter(
+        (line) =>
+          line.startsWith('operator: thread line') ||
+          line === 'claude [agent]: load-bearing root'
+      );
+    expect(contextLines).toHaveLength(PACKET_MAX_ROWS);
+  });
+
+  it('drops oldest thread replies to meet the byte cap but never drops the root', () => {
+    const root = { ...msg(1, OPERATOR, 'load-bearing root'), id: 'chm:root' };
+    const rows = [root];
+    for (let seq = 2; seq <= 20; seq++) {
+      rows.push(
+        inThread(
+          msg(seq, OPERATOR, `${seq}:` + 'z'.repeat(1900)),
+          root.id,
+          root.id
+        )
+      );
+    }
+    const trigger = inThread(
+      msg(21, OPERATOR, '@claude continue'),
+      root.id,
+      rows.at(-1)!.id
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(Buffer.byteLength(packet, 'utf8')).toBeLessThanOrEqual(
+      PACKET_MAX_BYTES
+    );
+    expect(packet).toContain('operator: load-bearing root');
+    expect(packet).toContain('[…earlier messages omitted]');
+    expect(packet).not.toContain('operator: 2:');
+    expect(packet).toContain('operator: 20:');
+    expect(packet).toContain('@claude continue');
   });
 
   it('tags an AGENT-authored trigger in the footer (attribution, not impersonation)', () => {

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -447,6 +447,52 @@ describe('mention routing — end-to-end via the router', () => {
     expect(agentReply(h.store, h.channelId)[1]!.threadId).toBeNull();
   });
 
+  it('a long thread packet reinserts its root and keeps the newest replies', async () => {
+    const h = await harness(
+      (agentType) => new RecordingAdapter(agentType, 'long thread ack')
+    );
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const root = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'load-bearing long-thread root' },
+    });
+    for (let i = 1; i <= 65; i++) {
+      await req({
+        port: h.port,
+        method: 'POST',
+        url,
+        body: {
+          text: `long-thread reply ${i}`,
+          threadId: root.body.message.id,
+        },
+      });
+    }
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: {
+        text: '@mock summarize the long thread',
+        threadId: root.body.message.id,
+      },
+    });
+
+    await waitFor(() => h.adapters().length === 1);
+    const adapter = h.adapters()[0] as RecordingAdapter;
+    await waitFor(() => adapter.contents.length === 1);
+    const packet = adapter.contents[0]!;
+    expect(packet).toContain('Operator: load-bearing long-thread root');
+    expect(packet).toContain('Operator: long-thread reply 47');
+    expect(packet).toContain('Operator: long-thread reply 65');
+    expect(packet).not.toContain('Operator: long-thread reply 46\n');
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    expect(agentReply(h.store, h.channelId)[0]).toMatchObject({
+      threadId: root.body.message.id,
+    });
+  });
+
   it("the next turn's packet includes interim human rows but not the agent's own reply", async () => {
     const h = await harness(
       (agentType) => new RecordingAdapter(agentType, 'ack')

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -380,14 +380,28 @@ describe('mention routing — end-to-end via the router', () => {
     expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe('agent:mock');
   });
 
-  it('a mock agent reply to a threaded mention stays in that thread', async () => {
-    const h = await harness();
+  it('a threaded mention receives only thread context and replies in that thread', async () => {
+    const h = await harness(
+      (agentType) => new RecordingAdapter(agentType, 'thread ack')
+    );
     const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
     const root = await req<{ message: ChannelMessage }>({
       port: h.port,
       method: 'POST',
       url,
       body: { text: 'root discussion' },
+    });
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'unrelated top-level update' },
+    });
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'prior thread detail', threadId: root.body.message.id },
     });
     const trigger = await req<{ message: ChannelMessage }>({
       port: h.port,
@@ -399,10 +413,38 @@ describe('mention routing — end-to-end via the router', () => {
     expect(trigger.body.message.threadId).toBe(root.body.message.id);
 
     await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    const adapter = h.adapters()[0] as RecordingAdapter;
+    expect(adapter.contents).toHaveLength(1);
+    expect(adapter.contents[0]).toContain(
+      '[Thread scope — only this thread is shown; its root message is always included]'
+    );
+    expect(adapter.contents[0]).toContain('root discussion');
+    expect(adapter.contents[0]).toContain('prior thread detail');
+    expect(adapter.contents[0]).not.toContain('unrelated top-level update');
     const reply = agentReply(h.store, h.channelId)[0]!;
     expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.body.text).toBe('thread ack');
     expect(reply.threadId).toBe(root.body.message.id);
     expect(reply.parentMessageId).toBe(trigger.body.message.id);
+
+    // Thread delivery must not advance the channel-global cursor. Otherwise a
+    // later top-level mention would silently skip intervening channel rows.
+    expect(
+      h.store.getBinding(h.channelId, 'mock')?.providerSession[
+        'lastDeliveredSeq'
+      ]
+    ).toBeUndefined();
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock now answer at top level' },
+    });
+    await waitFor(() => adapter.contents.length === 2);
+    expect(adapter.contents[1]).toContain('unrelated top-level update');
+    expect(adapter.contents[1]).not.toContain('[Thread scope —');
+    await waitFor(() => agentReply(h.store, h.channelId).length === 2);
+    expect(agentReply(h.store, h.channelId)[1]!.threadId).toBeNull();
   });
 
   it("the next turn's packet includes interim human rows but not the agent's own reply", async () => {


### PR DESCRIPTION
## Summary

- build threaded mention packets from indexed thread history instead of the channel timeline
- keep the root message plus the newest rows under the existing row and byte caps
- mark thread-scoped packets explicitly while preserving channel packet output unchanged
- prove packet scope and same-thread reply inheritance through the mock-agent path

## Contract notes

- Thread packets do not apply or advance the global channel delivery cursor. Applying that cursor would drop load-bearing thread context and advancing it would skip channel rows that were never delivered.
- Retry behavior remains unchanged: the binder builds active content once per turn and redelivers the identical packet.
- Status and system row handling follows the existing channel packet policy.
- The implementation reuses the store thread-history lane; it adds no SQL shape.

## Verification

- focused packet, binder, and mention e2e: 3 files, 63 tests passed
- channel and gateway suites: 13 files, 175 tests passed
- push-hook changed suites: 7 files, 128 tests passed
- npm run check: passed with 0 errors (247 existing warnings)
- git diff --check: passed
- adversarial review and focused changed-hunk re-review: no remaining P0-P3 findings

Refs #1170