### PR TITLE
feat(chat): slack-style timeline scroll model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
 
       - run: npm run build
         if: steps.changes.outputs.e2e_required == 'true'
+        env:
+          RELAY_IDE_E2E_FIXTURES: '1'
 
       - name: Verify hosted Chrome
         if: steps.changes.outputs.e2e_required == 'true'

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -41,7 +41,11 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
     const approvalRequestId = message.meta?.approvalRequestId;
     const hasApproval = typeof approvalRequestId === 'string';
     return (
-      <div className="ch-system-msg" role="note">
+      <div
+        className="ch-system-msg"
+        role="note"
+        data-channel-message-seq={message.seq}
+      >
         <span className="ch-system-msg__label">{message.body.text}</span>
         {hasApproval ? (
           <span className="ch-system-msg__actions">
@@ -107,7 +111,11 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
     );
 
   return (
-    <div className={rowClasses} style={streamStyle}>
+    <div
+      className={rowClasses}
+      style={streamStyle}
+      data-channel-message-seq={message.seq}
+    >
       {message.parentMessageId ? (
         <div className="ch-msg__reply" aria-hidden="true">
           ↳ reply

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -18,6 +18,41 @@ import { ChannelMessageRow } from './ChannelMessageRow.js';
 const LOAD_OLDER_SCROLL_THRESHOLD_PX = 80;
 const RESYNC_BUTTON_DELAY_MS = 5_000;
 
+interface ViewportAnchor {
+  seq: number;
+  offsetTop: number;
+  earliestSeqBefore: number | undefined;
+}
+
+function scrollMetrics(container: HTMLDivElement) {
+  return {
+    scrollHeight: container.scrollHeight,
+    scrollTop: container.scrollTop,
+    clientHeight: container.clientHeight,
+  };
+}
+
+function captureViewportAnchor(
+  container: HTMLDivElement
+): ViewportAnchor | null {
+  const containerTop = container.getBoundingClientRect().top;
+  const rows = container.querySelectorAll<HTMLElement>(
+    '[data-channel-message-seq]'
+  );
+  for (const row of rows) {
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom < containerTop) continue;
+    const seq = Number(row.dataset.channelMessageSeq);
+    if (!Number.isFinite(seq)) continue;
+    return {
+      seq,
+      offsetTop: rect.top - containerTop,
+      earliestSeqBefore: undefined,
+    };
+  }
+  return null;
+}
+
 interface ChannelTimelineProps {
   messages: ChannelMessage[];
   lastReadSeq: number | null;
@@ -43,17 +78,16 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const anchorRef = useRef<{
-    heightBefore: number;
-    topBefore: number;
-    earliestSeqBefore: number | undefined;
-  } | null>(null);
+  const anchorRef = useRef<ViewportAnchor | null>(null);
+  const shouldFollowRef = useRef(true);
+  const initializedRef = useRef(false);
+  const previousLatestSeqRef = useRef(0);
   // Bumped on every loadOlder() settlement (success-with-prepend, empty page,
   // reached-beginning page, OR a swallowed fetch error) so the anchor is always
   // released even when earliestSeq never changes (#1178).
   const [loadSettleTick, setLoadSettleTick] = useState(0);
   const [showResyncButton, setShowResyncButton] = useState(false);
+  const [newMessageCount, setNewMessageCount] = useState(0);
 
   const nodes = useMemo(
     () => buildTimelineNodes(messages, lastReadSeq),
@@ -61,40 +95,72 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   );
 
   const earliestSeq = messages[0]?.seq;
+  const latestSeq = messages[messages.length - 1]?.seq ?? 0;
   const reachedBeginning = !hasMoreOlder && earliestSeq === 1;
 
-  // Follow-bottom signal: grows on new rows AND on streaming text growth.
-  const followSignal = useMemo(() => {
-    const last = messages[messages.length - 1];
-    return `${messages.length}:${last ? last.body.text.length : 0}`;
-  }, [messages]);
+  const scrollToBottom = useCallback((): void => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.scrollTop = container.scrollHeight;
+    shouldFollowRef.current = true;
+    setNewMessageCount(0);
+  }, []);
 
-  // Auto-follow the bottom when already near it (never yanks a user reading
-  // history). Reuses the ChatView ResizeObserver pattern verbatim.
+  // Capture follow intent independently of post-mutation geometry. Rechecking
+  // `isNearBottom` only after a large append can turn a previously-bottomed
+  // viewport into a false negative and strand it above the new row.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      previousLatestSeqRef.current = latestSeq;
+      scrollToBottom();
+      return;
+    }
+
+    const previousLatestSeq = previousLatestSeqRef.current;
+    if (latestSeq < previousLatestSeq) {
+      // An authoritative full snapshot can legitimately reset seq after a
+      // channel is recreated under the same id. Reset the append baseline but
+      // preserve the reader's follow choice across the resync.
+      previousLatestSeqRef.current = latestSeq;
+      setNewMessageCount(0);
+      if (shouldFollowRef.current && !anchorRef.current) scrollToBottom();
+      return;
+    }
+    if (latestSeq > previousLatestSeq) {
+      const appendedCount = messages.filter(
+        (message) => message.seq > previousLatestSeq
+      ).length;
+      if (shouldFollowRef.current && !anchorRef.current) {
+        scrollToBottom();
+      } else if (appendedCount > 0) {
+        setNewMessageCount((count) => count + appendedCount);
+      }
+    }
+    previousLatestSeqRef.current = latestSeq;
+  }, [latestSeq, messages, scrollToBottom]);
+
+  // Streaming text, responsive layout, viewport rotation, and virtual-keyboard
+  // changes all surface as content/container resizes. Preserve bottom anchoring
+  // only when the user's last real scroll position opted into follow mode.
   useEffect(() => {
     const container = containerRef.current;
     const content = contentRef.current;
     if (!container || !content) return;
 
-    const followIfNearBottom = (): void => {
-      if (anchorRef.current) return; // an older-history restore is pending
-      if (
-        isNearBottom({
-          scrollHeight: container.scrollHeight,
-          scrollTop: container.scrollTop,
-          clientHeight: container.clientHeight,
-        })
-      ) {
-        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-      }
+    const preserveFollow = (): void => {
+      if (anchorRef.current || !shouldFollowRef.current) return;
+      scrollToBottom();
     };
 
-    followIfNearBottom();
     if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(followIfNearBottom);
+    const observer = new ResizeObserver(preserveFollow);
     observer.observe(content);
+    observer.observe(container);
     return () => observer.disconnect();
-  }, [followSignal]);
+  }, [scrollToBottom]);
 
   // Anchor lifecycle: set before loadOlder(), consumed on the next settlement.
   // Restore scrollTop ONLY when a prepend actually landed (earliestSeq dropped)
@@ -108,8 +174,15 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     const anchor = anchorRef.current;
     if (!container || !anchor) return;
     if (earliestSeq !== anchor.earliestSeqBefore) {
-      container.scrollTop =
-        container.scrollHeight - anchor.heightBefore + anchor.topBefore;
+      const row = container.querySelector<HTMLElement>(
+        `[data-channel-message-seq="${anchor.seq}"]`
+      );
+      if (row) {
+        const offsetTop =
+          row.getBoundingClientRect().top -
+          container.getBoundingClientRect().top;
+        container.scrollTop += offsetTop - anchor.offsetTop;
+      }
     }
     anchorRef.current = null;
   }, [earliestSeq, loadSettleTick]);
@@ -117,6 +190,9 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
+    const nearBottom = isNearBottom(scrollMetrics(container));
+    shouldFollowRef.current = nearBottom;
+    if (nearBottom) setNewMessageCount(0);
     if (
       container.scrollTop < LOAD_OLDER_SCROLL_THRESHOLD_PX &&
       hasMoreOlder &&
@@ -124,11 +200,16 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
       messages.length > 0 &&
       !anchorRef.current
     ) {
-      anchorRef.current = {
-        heightBefore: container.scrollHeight,
-        topBefore: container.scrollTop,
-        earliestSeqBefore: earliestSeq,
-      };
+      const fallbackSeq = earliestSeq;
+      if (fallbackSeq === undefined) return;
+      const anchor = captureViewportAnchor(container);
+      anchorRef.current = anchor
+        ? { ...anchor, earliestSeqBefore: earliestSeq }
+        : {
+            seq: fallbackSeq,
+            offsetTop: 0,
+            earliestSeqBefore: fallbackSeq,
+          };
       // The hook swallows its own fetch errors (loadOlder resolves even on a
       // transient failure), but guard against any future reject too so the
       // settle tick — and thus the anchor release — always runs (#1178).
@@ -153,82 +234,92 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   }, [needsCatchup]);
 
   return (
-    <div
-      ref={containerRef}
-      className="ch-tl"
-      role="log"
-      aria-live="polite"
-      aria-label="channel timeline"
-      onScroll={handleScroll}
-    >
-      {needsCatchup ? (
-        <div className="ch-catchup-banner" role="status">
-          <span>chat is out of sync — reconnecting…</span>
-          {showResyncButton ? (
-            <button
-              type="button"
-              className="ch-catchup-banner__btn"
-              onClick={onResync}
-            >
-              resync now
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-      {reachedBeginning ? (
-        <div className="ch-top-marker">beginning of #{channelTitle}</div>
-      ) : loadingOlder ? (
-        <div className="ch-loading-older">loading older messages…</div>
-      ) : null}
-      <div ref={contentRef} className="ch-tl-content">
-        {nodes.map((node, index) => {
-          if (node.kind === 'day-divider') {
-            return (
-              <div
-                key={`day-${node.date}-${index}`}
-                className="ch-day-divider"
-                role="separator"
+    <div className="ch-tl-shell">
+      <div
+        ref={containerRef}
+        className="ch-tl"
+        role="log"
+        aria-live="polite"
+        aria-label="channel timeline"
+        onScroll={handleScroll}
+      >
+        {needsCatchup ? (
+          <div className="ch-catchup-banner" role="status">
+            <span>chat is out of sync — reconnecting…</span>
+            {showResyncButton ? (
+              <button
+                type="button"
+                className="ch-catchup-banner__btn"
+                onClick={onResync}
               >
-                <span className="ch-day-divider__label">
-                  {formatDayLabel(node.date)}
-                </span>
-              </div>
-            );
-          }
-          if (node.kind === 'unread-line') {
+                resync now
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+        {reachedBeginning ? (
+          <div className="ch-top-marker">beginning of #{channelTitle}</div>
+        ) : loadingOlder ? (
+          <div className="ch-loading-older">loading older messages…</div>
+        ) : null}
+        <div ref={contentRef} className="ch-tl-content">
+          {nodes.map((node, index) => {
+            if (node.kind === 'day-divider') {
+              return (
+                <div
+                  key={`day-${node.date}-${index}`}
+                  className="ch-day-divider"
+                  role="separator"
+                >
+                  <span className="ch-day-divider__label">
+                    {formatDayLabel(node.date)}
+                  </span>
+                </div>
+              );
+            }
+            if (node.kind === 'unread-line') {
+              return (
+                <div
+                  key={`unread-${index}`}
+                  className="ch-unread-line"
+                  role="separator"
+                  aria-label="new messages"
+                >
+                  <span className="ch-unread-line__label">new</span>
+                </div>
+              );
+            }
+            if (node.kind === 'system') {
+              return (
+                <ChannelMessageRow
+                  key={node.message.id}
+                  message={node.message}
+                  channelId={channelId}
+                  variant="system"
+                />
+              );
+            }
+            const firstId = node.messages[0]?.id ?? `group-${index}`;
             return (
-              <div
-                key={`unread-${index}`}
-                className="ch-unread-line"
-                role="separator"
-                aria-label="new messages"
-              >
-                <span className="ch-unread-line__label">new</span>
-              </div>
-            );
-          }
-          if (node.kind === 'system') {
-            return (
-              <ChannelMessageRow
-                key={node.message.id}
-                message={node.message}
+              <ChannelMessageGroup
+                key={firstId}
+                sender={node.sender}
+                messages={node.messages}
                 channelId={channelId}
-                variant="system"
               />
             );
-          }
-          const firstId = node.messages[0]?.id ?? `group-${index}`;
-          return (
-            <ChannelMessageGroup
-              key={firstId}
-              sender={node.sender}
-              messages={node.messages}
-              channelId={channelId}
-            />
-          );
-        })}
+          })}
+        </div>
       </div>
-      <div ref={bottomRef} />
+      {newMessageCount > 0 ? (
+        <button
+          type="button"
+          className="ch-new-messages"
+          onClick={scrollToBottom}
+        >
+          {newMessageCount} new message{newMessageCount === 1 ? '' : 's'}
+        </button>
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -61,6 +61,7 @@ interface ChannelTimelineProps {
   hasMoreOlder: boolean;
   loadingOlder: boolean;
   loadOlder: () => Promise<void>;
+  fullSnapshotRevision: number;
   needsCatchup: boolean;
   onResync: () => void;
 }
@@ -73,15 +74,19 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   hasMoreOlder,
   loadingOlder,
   loadOlder,
+  fullSnapshotRevision,
   needsCatchup,
   onResync,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const anchorRef = useRef<ViewportAnchor | null>(null);
+  const readerAnchorRef = useRef<ViewportAnchor | null>(null);
   const shouldFollowRef = useRef(true);
   const initializedRef = useRef(false);
   const previousLatestSeqRef = useRef(0);
+  const previousFullSnapshotRevisionRef = useRef(fullSnapshotRevision);
+  const lastScrollTopRef = useRef(0);
   // Bumped on every loadOlder() settlement (success-with-prepend, empty page,
   // reached-beginning page, OR a swallowed fetch error) so the anchor is always
   // released even when earliestSeq never changes (#1178).
@@ -102,9 +107,44 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     const container = containerRef.current;
     if (!container) return;
     container.scrollTop = container.scrollHeight;
+    lastScrollTopRef.current = container.scrollTop;
     shouldFollowRef.current = true;
     setNewMessageCount(0);
   }, []);
+
+  // A full snapshot replaces the whole rendered window. The reader anchor is
+  // cached by scroll/resize handling before this commit; a layout-effect
+  // cleanup on a function component is too late because child DOM mutations
+  // have already landed. Restore the cached row after the replacement, then
+  // refresh it from the resulting viewport. If the row fell outside the new
+  // window, the unread divider is the deterministic semantic fallback.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const anchor = readerAnchorRef.current;
+    // An authoritative replacement supersedes an in-flight history prepend,
+    // whether the reader is following or browsing history.
+    anchorRef.current = null;
+    if (container && anchor && !shouldFollowRef.current) {
+      const row = container.querySelector<HTMLElement>(
+        `[data-channel-message-seq="${anchor.seq}"]`
+      );
+      const target =
+        row ??
+        container.querySelector<HTMLElement>('[data-channel-unread-divider]');
+      if (target) {
+        const offsetTop =
+          target.getBoundingClientRect().top -
+          container.getBoundingClientRect().top;
+        container.scrollTop +=
+          row === target ? offsetTop - anchor.offsetTop : offsetTop;
+        lastScrollTopRef.current = container.scrollTop;
+      }
+    }
+    readerAnchorRef.current =
+      container && !shouldFollowRef.current
+        ? captureViewportAnchor(container)
+        : null;
+  }, [fullSnapshotRevision]);
 
   // Capture follow intent independently of post-mutation geometry. Rechecking
   // `isNearBottom` only after a large append can turn a previously-bottomed
@@ -120,6 +160,13 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     }
 
     const previousLatestSeq = previousLatestSeqRef.current;
+    if (fullSnapshotRevision !== previousFullSnapshotRevisionRef.current) {
+      previousFullSnapshotRevisionRef.current = fullSnapshotRevision;
+      previousLatestSeqRef.current = latestSeq;
+      setNewMessageCount(0);
+      if (shouldFollowRef.current) scrollToBottom();
+      return;
+    }
     if (latestSeq < previousLatestSeq) {
       // An authoritative full snapshot can legitimately reset seq after a
       // channel is recreated under the same id. Reset the append baseline but
@@ -130,17 +177,31 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
       return;
     }
     if (latestSeq > previousLatestSeq) {
-      const appendedCount = messages.filter(
-        (message) => message.seq > previousLatestSeq
-      ).length;
-      if (shouldFollowRef.current && !anchorRef.current) {
+      let appendedCount = 0;
+      for (let index = messages.length - 1; index >= 0; index -= 1) {
+        if (messages[index]!.seq <= previousLatestSeq) break;
+        appendedCount += 1;
+      }
+      const latestMessage = messages[messages.length - 1];
+      const isOwnMessage =
+        latestMessage !== undefined &&
+        latestMessage.seq > previousLatestSeq &&
+        latestMessage.sender.kind === 'human';
+      if (isOwnMessage) {
+        // Slack parity: sending while reading history returns to the present.
+        // Cancel a pending prepend so its eventual settlement cannot pull the
+        // viewport away from the just-posted message.
+        anchorRef.current = null;
+        readerAnchorRef.current = null;
+        scrollToBottom();
+      } else if (shouldFollowRef.current && !anchorRef.current) {
         scrollToBottom();
       } else if (appendedCount > 0) {
         setNewMessageCount((count) => count + appendedCount);
       }
     }
     previousLatestSeqRef.current = latestSeq;
-  }, [latestSeq, messages, scrollToBottom]);
+  }, [fullSnapshotRevision, latestSeq, messages, scrollToBottom]);
 
   // Streaming text, responsive layout, viewport rotation, and virtual-keyboard
   // changes all surface as content/container resizes. Preserve bottom anchoring
@@ -151,7 +212,11 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     if (!container || !content) return;
 
     const preserveFollow = (): void => {
-      if (anchorRef.current || !shouldFollowRef.current) return;
+      if (anchorRef.current) return;
+      if (!shouldFollowRef.current) {
+        readerAnchorRef.current = captureViewportAnchor(container);
+        return;
+      }
       scrollToBottom();
     };
 
@@ -182,6 +247,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
           row.getBoundingClientRect().top -
           container.getBoundingClientRect().top;
         container.scrollTop += offsetTop - anchor.offsetTop;
+        lastScrollTopRef.current = container.scrollTop;
       }
     }
     anchorRef.current = null;
@@ -190,9 +256,36 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
-    const nearBottom = isNearBottom(scrollMetrics(container));
-    shouldFollowRef.current = nearBottom;
-    if (nearBottom) setNewMessageCount(0);
+    const metrics = scrollMetrics(container);
+    const scrollTopChanged =
+      Math.abs(metrics.scrollTop - lastScrollTopRef.current) > 1;
+    const pendingAnchor = anchorRef.current;
+    if (pendingAnchor && loadingOlder && scrollTopChanged) {
+      const refreshed = captureViewportAnchor(container);
+      if (refreshed) {
+        anchorRef.current = {
+          ...refreshed,
+          earliestSeqBefore: pendingAnchor.earliestSeqBefore,
+        };
+      }
+    }
+
+    const maxScrollTop = Math.max(
+      0,
+      metrics.scrollHeight - metrics.clientHeight
+    );
+    const movingUp = metrics.scrollTop < lastScrollTopRef.current - 1;
+    const atBottom =
+      maxScrollTop === 0 || maxScrollTop - metrics.scrollTop <= 1;
+    const follow = atBottom || (!movingUp && isNearBottom(metrics));
+    shouldFollowRef.current = follow;
+    lastScrollTopRef.current = metrics.scrollTop;
+    if (follow) {
+      readerAnchorRef.current = null;
+      setNewMessageCount(0);
+    } else {
+      readerAnchorRef.current = captureViewportAnchor(container);
+    }
     if (
       container.scrollTop < LOAD_OLDER_SCROLL_THRESHOLD_PX &&
       hasMoreOlder &&
@@ -284,6 +377,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                   className="ch-unread-line"
                   role="separator"
                   aria-label="new messages"
+                  data-channel-unread-divider
                 >
                   <span className="ch-unread-line__label">new</span>
                 </div>

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -214,7 +214,7 @@
   padding: 4px 12px;
   border: 1px solid var(--status-info);
   border-radius: 0;
-  background: transparent;
+  background: var(--surface);
   color: var(--status-info);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
@@ -224,7 +224,7 @@
 }
 
 .ch-new-messages:hover {
-  background: color-mix(in srgb, var(--status-info) 10%, transparent);
+  background: color-mix(in srgb, var(--status-info) 10%, var(--surface));
 }
 
 /* day divider — mirrors .tl-session-break, centered muted label + rule */

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -168,10 +168,19 @@
   color: var(--accent);
 }
 
+/* Timeline shell owns floating scroll affordances without making them part of
+   the scrollable geometry. */
+.ch-tl-shell {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
 /* timeline scroll container — mirrors .tl */
 .ch-tl {
-  flex: 1;
+  height: 100%;
   overflow-y: auto;
+  overflow-anchor: none;
   padding: 18px 24px;
   display: flex;
   flex-direction: column;
@@ -191,6 +200,31 @@
   flex-direction: column;
   gap: 14px;
   min-width: 0;
+}
+
+/* Square, outline-only floating affordance per DESIGN.md. Info matches the
+   unread-divider semantics. */
+.ch-new-messages {
+  position: absolute;
+  left: 50%;
+  bottom: 8px;
+  z-index: 6;
+  transform: translateX(-50%);
+  min-height: 32px;
+  padding: 4px 12px;
+  border: 1px solid var(--status-info);
+  border-radius: 0;
+  background: transparent;
+  color: var(--status-info);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ch-new-messages:hover {
+  background: color-mix(in srgb, var(--status-info) 10%, transparent);
 }
 
 /* day divider — mirrors .tl-session-break, centered muted label + rule */

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -48,6 +48,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     hasMoreOlder,
     loadingOlder,
     loadOlder,
+    fullSnapshotRevision,
     post,
     postPending,
     postError,
@@ -380,6 +381,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
           hasMoreOlder={hasMoreOlder}
           loadingOlder={loadingOlder}
           loadOlder={loadOlder}
+          fullSnapshotRevision={fullSnapshotRevision}
           needsCatchup={reducer.needsCatchup}
           onResync={resync}
         />

--- a/frontend/src/hooks/useChannelChatSocket.ts
+++ b/frontend/src/hooks/useChannelChatSocket.ts
@@ -62,6 +62,8 @@ export interface UseChannelChatSocketState {
   hasMoreOlder: boolean;
   loadingOlder: boolean;
   loadOlder: () => Promise<void>;
+  /** Increments whenever an authoritative full snapshot replaces the window. */
+  fullSnapshotRevision: number;
   post: (
     text: string,
     opts?: { clientMessageId?: string }
@@ -84,6 +86,7 @@ export function useChannelChatSocket(
   const [notFound, setNotFound] = useState(false);
   const [hasMoreOlder, setHasMoreOlder] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [fullSnapshotRevision, setFullSnapshotRevision] = useState(0);
   const [postPending, setPostPending] = useState(false);
   const [postError, setPostError] = useState<HttpError | null>(null);
 
@@ -181,6 +184,7 @@ export function useChannelChatSocket(
           channelEvent.type === 'channel-snapshot-v1' &&
           channelEvent.mode === 'full'
         ) {
+          setFullSnapshotRevision((revision) => revision + 1);
           // full-snapshot `truncated` === "older history exists before seq 1's
           // reach"; a catchup's `truncated` is byte-budget only, so never touch
           // older-history availability on catchup.
@@ -342,6 +346,7 @@ export function useChannelChatSocket(
     setNotFound(false);
     setHasMoreOlder(false);
     setLoadingOlder(false);
+    setFullSnapshotRevision(0);
     setPostError(null);
 
     clearReconnectTimer();
@@ -431,6 +436,7 @@ export function useChannelChatSocket(
     hasMoreOlder,
     loadingOlder,
     loadOlder,
+    fullSnapshotRevision,
     post,
     postPending,
     postError,

--- a/frontend/src/test-channel-timeline.css
+++ b/frontend/src/test-channel-timeline.css
@@ -1,0 +1,32 @@
+.ch-scroll-fixture {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  min-height: 0;
+  background: var(--bg);
+}
+
+.ch-scroll-fixture__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex: none;
+  padding: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ch-scroll-fixture__controls button {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.ch-scroll-fixture__stage {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}

--- a/frontend/src/test-channel-timeline.tsx
+++ b/frontend/src/test-channel-timeline.tsx
@@ -9,7 +9,13 @@ import './components/chat/ChannelView.css';
 import './test-channel-timeline.css';
 import { ChannelTimeline } from './components/chat/ChannelTimeline.js';
 
-function message(seq: number, text = `timeline row ${seq}`): ChannelMessage {
+function message(
+  seq: number,
+  text = `timeline row ${seq}`,
+  sender: ChannelMessage['sender'] = seq % 2 === 0
+    ? { kind: 'human', id: 'human:operator' }
+    : { kind: 'agent', id: 'agent:codex', providerId: 'codex' }
+): ChannelMessage {
   const createdAt = new Date(Date.UTC(2026, 6, 18, 10, seq)).toISOString();
   return {
     schemaVersion: 1,
@@ -18,10 +24,7 @@ function message(seq: number, text = `timeline row ${seq}`): ChannelMessage {
     seq,
     kind: 'message',
     status: 'complete',
-    sender:
-      seq % 2 === 0
-        ? { kind: 'human', id: 'human:operator' }
-        : { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+    sender,
     body: { text, format: 'text' },
     threadId: null,
     parentMessageId: null,
@@ -37,6 +40,8 @@ const INITIAL_MESSAGES = Array.from({ length: 50 }, (_, index) =>
 function Fixture(): React.ReactElement {
   const [messages, setMessages] = useState(INITIAL_MESSAGES);
   const [hasMoreOlder, setHasMoreOlder] = useState(true);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [fullSnapshotRevision, setFullSnapshotRevision] = useState(0);
 
   const append = useCallback((count: number, large = false) => {
     setMessages((current) => {
@@ -52,6 +57,29 @@ function Fixture(): React.ReactElement {
         }),
       ];
     });
+  }, []);
+
+  const appendOwn = useCallback(() => {
+    setMessages((current) => {
+      const seq = (current[current.length - 1]?.seq ?? 0) + 1;
+      return [
+        ...current,
+        message(seq, 'my new message', {
+          kind: 'human',
+          id: 'human:operator',
+        }),
+      ];
+    });
+  }, []);
+
+  const replaceSnapshot = useCallback((anchorSurvives: boolean) => {
+    setMessages(
+      anchorSurvives
+        ? Array.from({ length: 530 }, (_, index) => message(index + 41))
+        : Array.from({ length: 50 }, (_, index) => message(index + 600))
+    );
+    setHasMoreOlder(false);
+    setFullSnapshotRevision((revision) => revision + 1);
   }, []);
 
   const growStream = useCallback(() => {
@@ -74,7 +102,8 @@ function Fixture(): React.ReactElement {
 
   const loadOlder = useCallback(async () => {
     if (!hasMoreOlder) return;
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    setLoadingOlder(true);
+    await new Promise((resolve) => setTimeout(resolve, 250));
     setMessages((current) => {
       const earliest = current[0]?.seq ?? 21;
       const latest = current[current.length - 1]?.seq ?? 70;
@@ -83,9 +112,18 @@ function Fixture(): React.ReactElement {
       );
       // Deliberately append a catch-up row in the same commit. A total-height
       // delta anchor would incorrectly include its height and move the reader.
-      return [...older, ...current, message(latest + 1, 'concurrent catch-up')];
+      return [
+        ...older,
+        ...current,
+        message(latest + 1, 'concurrent catch-up', {
+          kind: 'agent',
+          id: 'agent:codex',
+          providerId: 'codex',
+        }),
+      ];
     });
     setHasMoreOlder(false);
+    setLoadingOlder(false);
   }, [hasMoreOlder]);
 
   return (
@@ -100,8 +138,23 @@ function Fixture(): React.ReactElement {
         <button data-testid="append-burst" onClick={() => append(3)}>
           append burst
         </button>
+        <button data-testid="append-own" onClick={appendOwn}>
+          append own
+        </button>
         <button data-testid="grow-stream" onClick={growStream}>
           grow stream
+        </button>
+        <button
+          data-testid="snapshot-overlap"
+          onClick={() => replaceSnapshot(true)}
+        >
+          snapshot overlap
+        </button>
+        <button
+          data-testid="snapshot-gap"
+          onClick={() => replaceSnapshot(false)}
+        >
+          snapshot gap
         </button>
       </div>
       <div className="ch-scroll-fixture__stage">
@@ -111,8 +164,9 @@ function Fixture(): React.ReactElement {
           channelId="topic:scroll-fixture"
           channelTitle="scroll-fixture"
           hasMoreOlder={hasMoreOlder}
-          loadingOlder={false}
+          loadingOlder={loadingOlder}
           loadOlder={loadOlder}
+          fullSnapshotRevision={fullSnapshotRevision}
           needsCatchup={false}
           onResync={() => {}}
         />

--- a/frontend/src/test-channel-timeline.tsx
+++ b/frontend/src/test-channel-timeline.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+import './App.css';
+import './components/chat/ChannelView.css';
+import './test-channel-timeline.css';
+import { ChannelTimeline } from './components/chat/ChannelTimeline.js';
+
+function message(seq: number, text = `timeline row ${seq}`): ChannelMessage {
+  const createdAt = new Date(Date.UTC(2026, 6, 18, 10, seq)).toISOString();
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: 'topic:scroll-fixture',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender:
+      seq % 2 === 0
+        ? { kind: 'human', id: 'human:operator' }
+        : { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+    body: { text, format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+const INITIAL_MESSAGES = Array.from({ length: 50 }, (_, index) =>
+  message(index + 21)
+);
+
+function Fixture(): React.ReactElement {
+  const [messages, setMessages] = useState(INITIAL_MESSAGES);
+  const [hasMoreOlder, setHasMoreOlder] = useState(true);
+
+  const append = useCallback((count: number, large = false) => {
+    setMessages((current) => {
+      const latest = current[current.length - 1]?.seq ?? 0;
+      return [
+        ...current,
+        ...Array.from({ length: count }, (_, index) => {
+          const seq = latest + index + 1;
+          const text = large
+            ? `oversized row ${seq}\n${'large append content\n'.repeat(80)}`
+            : `incoming row ${seq}`;
+          return message(seq, text);
+        }),
+      ];
+    });
+  }, []);
+
+  const growStream = useCallback(() => {
+    setMessages((current) => {
+      const last = current[current.length - 1];
+      if (!last) return current;
+      return [
+        ...current.slice(0, -1),
+        {
+          ...last,
+          status: 'streaming',
+          body: {
+            ...last.body,
+            text: `${last.body.text}\n${'stream growth\n'.repeat(60)}`,
+          },
+        },
+      ];
+    });
+  }, []);
+
+  const loadOlder = useCallback(async () => {
+    if (!hasMoreOlder) return;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    setMessages((current) => {
+      const earliest = current[0]?.seq ?? 21;
+      const latest = current[current.length - 1]?.seq ?? 70;
+      const older = Array.from({ length: 20 }, (_, index) =>
+        message(earliest - 20 + index)
+      );
+      // Deliberately append a catch-up row in the same commit. A total-height
+      // delta anchor would incorrectly include its height and move the reader.
+      return [...older, ...current, message(latest + 1, 'concurrent catch-up')];
+    });
+    setHasMoreOlder(false);
+  }, [hasMoreOlder]);
+
+  return (
+    <div className="ch-scroll-fixture">
+      <div className="ch-scroll-fixture__controls">
+        <button data-testid="append-one" onClick={() => append(1)}>
+          append one
+        </button>
+        <button data-testid="append-large" onClick={() => append(1, true)}>
+          append large
+        </button>
+        <button data-testid="append-burst" onClick={() => append(3)}>
+          append burst
+        </button>
+        <button data-testid="grow-stream" onClick={growStream}>
+          grow stream
+        </button>
+      </div>
+      <div className="ch-scroll-fixture__stage">
+        <ChannelTimeline
+          messages={messages}
+          lastReadSeq={55}
+          channelId="topic:scroll-fixture"
+          channelTitle="scroll-fixture"
+          hasMoreOlder={hasMoreOlder}
+          loadingOlder={false}
+          loadOlder={loadOlder}
+          needsCatchup={false}
+          onResync={() => {}}
+        />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(<Fixture />);

--- a/frontend/test-channel-timeline.html
+++ b/frontend/test-channel-timeline.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Channel timeline scroll test page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-channel-timeline.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,6 +48,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-pr-row-long.html'
   );
+  buildInputs['test-channel-timeline'] = resolve(
+    import.meta.dirname,
+    'test-channel-timeline.html'
+  );
 }
 
 export default defineConfig({

--- a/test/components/channel-timeline-anchor.test.ts
+++ b/test/components/channel-timeline-anchor.test.ts
@@ -44,6 +44,7 @@ async function renderTimeline(loadOlder: () => Promise<void>): Promise<void> {
         hasMoreOlder: true,
         loadingOlder: false,
         loadOlder,
+        fullSnapshotRevision: 0,
         needsCatchup: false,
         onResync: () => {},
       })

--- a/test/components/channel-timeline-scroll.test.ts
+++ b/test/components/channel-timeline-scroll.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function message(seq: number, text = `message ${seq}`): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: 'topic:general',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text, format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+    updatedAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+  };
+}
+
+let host: HTMLDivElement;
+let root: Root;
+let timelineScrollHeight = 1_000;
+let timelineClientHeight = 300;
+let resizeCallback: ResizeObserverCallback | null = null;
+
+const originalScrollHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'scrollHeight'
+);
+const originalClientHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'clientHeight'
+);
+const OriginalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).classList.contains('ch-tl')
+        ? timelineScrollHeight
+        : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).classList.contains('ch-tl')
+        ? timelineClientHeight
+        : 0;
+    },
+  });
+  globalThis.ResizeObserver = class ResizeObserverMock {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {
+      resizeCallback = null;
+    }
+  };
+});
+
+afterAll(() => {
+  if (originalScrollHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'scrollHeight',
+      originalScrollHeight
+    );
+  }
+  if (originalClientHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'clientHeight',
+      originalClientHeight
+    );
+  }
+  globalThis.ResizeObserver = OriginalResizeObserver;
+});
+
+async function render(messages: ChannelMessage[]): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(ChannelTimeline, {
+        messages,
+        lastReadSeq: null,
+        channelId: 'topic:general',
+        channelTitle: 'general',
+        hasMoreOlder: false,
+        loadingOlder: false,
+        loadOlder: async () => {},
+        needsCatchup: false,
+        onResync: () => {},
+      })
+    );
+  });
+}
+
+function timeline(): HTMLDivElement {
+  const element = host.querySelector<HTMLDivElement>('.ch-tl');
+  if (!element) throw new Error('timeline not rendered');
+  return element;
+}
+
+async function userScroll(scrollTop: number): Promise<void> {
+  const element = timeline();
+  element.scrollTop = scrollTop;
+  await act(async () => {
+    element.dispatchEvent(new Event('scroll'));
+  });
+}
+
+describe('ChannelTimeline scroll model (#1193)', () => {
+  beforeEach(() => {
+    timelineScrollHeight = 1_000;
+    timelineClientHeight = 300;
+    resizeCallback = null;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('opens at the bottom and follows an append larger than the threshold', async () => {
+    await render([message(1), message(2)]);
+    expect(timeline().scrollTop).toBe(1_000);
+
+    await userScroll(700);
+    timelineScrollHeight = 2_000;
+    await render([message(1), message(2), message(3, 'large append')]);
+    expect(timeline().scrollTop).toBe(2_000);
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+  });
+
+  it('keeps scrollTop stable while up, counts appended rows, then jumps and clears', async () => {
+    await render([message(1), message(2)]);
+    await userScroll(200);
+
+    timelineScrollHeight = 1_300;
+    await render([message(1), message(2), message(3), message(4), message(5)]);
+    expect(timeline().scrollTop).toBe(200);
+    const jump = host.querySelector<HTMLButtonElement>('.ch-new-messages');
+    expect(jump?.textContent).toBe('3 new messages');
+
+    await act(async () => jump?.click());
+    expect(timeline().scrollTop).toBe(1_300);
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+  });
+
+  it('uses the saved follow intent for streaming and viewport resizes', async () => {
+    await render([message(1), message(2)]);
+    await userScroll(700);
+
+    timelineScrollHeight = 1_600;
+    await render([message(1), message(2, 'streamed content')]);
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(timeline().scrollTop).toBe(1_600);
+
+    await userScroll(200);
+    timelineClientHeight = 180;
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(timeline().scrollTop).toBe(200);
+  });
+
+  it('keeps a follower bottomed across an authoritative lower-seq snapshot', async () => {
+    await render([message(99), message(100)]);
+
+    timelineScrollHeight = 800;
+    await render([message(1), message(2)]);
+    expect(timeline().scrollTop).toBe(800);
+  });
+
+  it('does not hijack a reader on a lower-seq reset and counts the next append from the reset baseline', async () => {
+    await render([message(99), message(100)]);
+    await userScroll(200);
+
+    timelineScrollHeight = 800;
+    await render([message(1), message(2)]);
+    expect(timeline().scrollTop).toBe(200);
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+
+    timelineScrollHeight = 1_100;
+    await render([message(1), message(2), message(3)]);
+    expect(timeline().scrollTop).toBe(200);
+    expect(host.querySelector('.ch-new-messages')?.textContent).toBe(
+      '1 new message'
+    );
+  });
+});

--- a/test/components/channel-timeline-scroll.test.ts
+++ b/test/components/channel-timeline-scroll.test.ts
@@ -21,7 +21,11 @@ import type {
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-function message(seq: number, text = `message ${seq}`): ChannelMessage {
+function message(
+  seq: number,
+  text = `message ${seq}`,
+  own = false
+): ChannelMessage {
   return {
     schemaVersion: 1,
     id: `chm:${seq}` as ChannelMessageId,
@@ -29,7 +33,9 @@ function message(seq: number, text = `message ${seq}`): ChannelMessage {
     seq,
     kind: 'message',
     status: 'complete',
-    sender: { kind: 'human', id: 'human:operator' },
+    sender: own
+      ? { kind: 'human', id: 'human:operator' }
+      : { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
     body: { text, format: 'text' },
     threadId: null,
     parentMessageId: null,
@@ -101,17 +107,27 @@ afterAll(() => {
   globalThis.ResizeObserver = OriginalResizeObserver;
 });
 
-async function render(messages: ChannelMessage[]): Promise<void> {
+async function render(
+  messages: ChannelMessage[],
+  options: {
+    hasMoreOlder?: boolean;
+    loadingOlder?: boolean;
+    loadOlder?: () => Promise<void>;
+    fullSnapshotRevision?: number;
+    lastReadSeq?: number | null;
+  } = {}
+): Promise<void> {
   await act(async () => {
     root.render(
       React.createElement(ChannelTimeline, {
         messages,
-        lastReadSeq: null,
+        lastReadSeq: options.lastReadSeq ?? null,
         channelId: 'topic:general',
         channelTitle: 'general',
-        hasMoreOlder: false,
-        loadingOlder: false,
-        loadOlder: async () => {},
+        hasMoreOlder: options.hasMoreOlder ?? false,
+        loadingOlder: options.loadingOlder ?? false,
+        loadOlder: options.loadOlder ?? (async () => {}),
+        fullSnapshotRevision: options.fullSnapshotRevision ?? 0,
         needsCatchup: false,
         onResync: () => {},
       })
@@ -174,6 +190,17 @@ describe('ChannelTimeline scroll model (#1193)', () => {
     expect(host.querySelector('.ch-new-messages')).toBeNull();
   });
 
+  it('returns to the bottom for an own human append while scrolled up', async () => {
+    await render([message(1), message(2)]);
+    await userScroll(200);
+
+    timelineScrollHeight = 1_300;
+    await render([message(1), message(2), message(3, 'mine', true)]);
+
+    expect(timeline().scrollTop).toBe(1_300);
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+  });
+
   it('uses the saved follow intent for streaming and viewport resizes', async () => {
     await render([message(1), message(2)]);
     await userScroll(700);
@@ -187,6 +214,19 @@ describe('ChannelTimeline scroll model (#1193)', () => {
     timelineClientHeight = 180;
     await act(async () => resizeCallback?.([], {} as ResizeObserver));
     expect(timeline().scrollTop).toBe(200);
+  });
+
+  it('disengages follow when scrolling to the top of a low-overflow timeline before prepend growth', async () => {
+    timelineScrollHeight = 400;
+    timelineClientHeight = 300;
+    await render([message(3), message(4)]);
+
+    await userScroll(0);
+    timelineScrollHeight = 480;
+    await render([message(1), message(2), message(3), message(4)]);
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+
+    expect(timeline().scrollTop).toBe(0);
   });
 
   it('keeps a follower bottomed across an authoritative lower-seq snapshot', async () => {

--- a/test/e2e/channel-timeline-scroll.spec.ts
+++ b/test/e2e/channel-timeline-scroll.spec.ts
@@ -25,7 +25,25 @@ async function scrollAwayFromBottom(timeline: Locator): Promise<number> {
   });
 }
 
-test.describe('channel timeline scroll UX (#1193)', () => {
+async function firstVisibleAnchor(
+  timeline: Locator
+): Promise<{ seq: string; top: number }> {
+  return timeline.evaluate((element) => {
+    const containerTop = element.getBoundingClientRect().top;
+    const row = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-channel-message-seq]')
+    ).find(
+      (candidate) => candidate.getBoundingClientRect().bottom >= containerTop
+    );
+    if (!row) throw new Error('missing visible anchor row');
+    return {
+      seq: row.dataset.channelMessageSeq ?? '',
+      top: row.getBoundingClientRect().top - containerTop,
+    };
+  });
+}
+
+test.describe('smoke channel timeline scroll UX (#1193)', () => {
   test('opens at the newest message', async ({ page }) => {
     const timeline = await openFixture(page);
     await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
@@ -69,6 +87,38 @@ test.describe('channel timeline scroll UX (#1193)', () => {
     ).toBeVisible();
   });
 
+  test('refreshes the prepend anchor when the reader scrolls during a delayed history load', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    await timeline.evaluate((element) => {
+      element.scrollTop = 40;
+      element.dispatchEvent(new Event('scroll'));
+    });
+    await expect(timeline.locator('.ch-loading-older')).toBeVisible();
+
+    await timeline.evaluate((element) => {
+      element.scrollTop = 70;
+      element.dispatchEvent(new Event('scroll'));
+    });
+    const readerAnchor = await firstVisibleAnchor(timeline);
+
+    await expect(
+      timeline.locator('[data-channel-message-seq="1"]')
+    ).toBeAttached();
+    const restored = timeline.locator(
+      `[data-channel-message-seq="${readerAnchor.seq}"]`
+    );
+    await expect
+      .poll(async () => {
+        const container = await timeline.boundingBox();
+        const row = await restored.boundingBox();
+        if (!container || !row) throw new Error('missing anchor geometry');
+        return row.y - container.y;
+      })
+      .toBeCloseTo(readerAnchor.top, 0);
+  });
+
   test('new-message affordance jumps to present and clears', async ({
     page,
   }) => {
@@ -87,13 +137,72 @@ test.describe('channel timeline scroll UX (#1193)', () => {
       };
     });
     expect(style).toEqual({
-      backgroundColor: 'rgba(0, 0, 0, 0)',
+      backgroundColor: 'rgb(10, 10, 10)',
       borderRadius: '0px',
       borderStyle: 'solid',
     });
     await jump.click();
     await expect(jump).toBeHidden();
     await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+
+  test('posting an own message cancels a pending prepend and returns to the present', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    await timeline.evaluate((element) => {
+      element.scrollTop = 40;
+      element.dispatchEvent(new Event('scroll'));
+    });
+    await expect(timeline.locator('.ch-loading-older')).toBeVisible();
+
+    await page.getByTestId('append-own').click();
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+    await expect(page.locator('.ch-new-messages')).toHaveCount(0);
+
+    // The delayed prepend settlement must not restore the cancelled anchor.
+    await expect(
+      timeline.locator('[data-channel-message-seq="1"]')
+    ).toBeAttached();
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+    await expect(page.locator('.ch-new-messages')).toHaveCount(0);
+  });
+
+  test('full snapshots preserve a surviving row and fall back to the unread divider across a gap', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    await scrollAwayFromBottom(timeline);
+    const overlapAnchor = await firstVisibleAnchor(timeline);
+
+    await page.getByTestId('snapshot-overlap').click();
+    await expect(
+      timeline.locator(`[data-channel-message-seq="${overlapAnchor.seq}"]`)
+    ).toBeAttached();
+    await expect
+      .poll(async () => {
+        const container = await timeline.boundingBox();
+        const row = await timeline
+          .locator(`[data-channel-message-seq="${overlapAnchor.seq}"]`)
+          .boundingBox();
+        if (!container || !row) throw new Error('missing overlap geometry');
+        return row.y - container.y;
+      })
+      .toBeCloseTo(overlapAnchor.top, 0);
+    await expect(page.locator('.ch-new-messages')).toHaveCount(0);
+
+    await page.getByTestId('snapshot-gap').click();
+    const unreadDivider = timeline.locator('[data-channel-unread-divider]');
+    await expect(unreadDivider).toBeVisible();
+    await expect
+      .poll(async () => {
+        const container = await timeline.boundingBox();
+        const divider = await unreadDivider.boundingBox();
+        if (!container || !divider) throw new Error('missing divider geometry');
+        return divider.y - container.y;
+      })
+      .toBeCloseTo(0, 0);
+    await expect(page.locator('.ch-new-messages')).toHaveCount(0);
   });
 
   test('preserves the visible row across prepend plus concurrent catch-up and keeps the unread divider', async ({

--- a/test/e2e/channel-timeline-scroll.spec.ts
+++ b/test/e2e/channel-timeline-scroll.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+async function openFixture(page: Page): Promise<Locator> {
+  await page.goto('/test-channel-timeline.html');
+  const timeline = page.getByRole('log', { name: 'channel timeline' });
+  await expect(timeline).toBeVisible();
+  await expect(timeline.locator('[data-channel-message-seq]')).toHaveCount(50);
+  return timeline;
+}
+
+async function bottomDistance(timeline: Locator): Promise<number> {
+  return timeline.evaluate(
+    (element) => element.scrollHeight - element.scrollTop - element.clientHeight
+  );
+}
+
+async function scrollAwayFromBottom(timeline: Locator): Promise<number> {
+  return timeline.evaluate((element) => {
+    element.scrollTop = Math.max(
+      100,
+      element.scrollHeight - element.clientHeight - 500
+    );
+    element.dispatchEvent(new Event('scroll'));
+    return element.scrollTop;
+  });
+}
+
+test.describe('channel timeline scroll UX (#1193)', () => {
+  test('opens at the newest message', async ({ page }) => {
+    const timeline = await openFixture(page);
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+
+  test('follows oversized appends and streaming growth from the bottom', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+
+    await page.getByTestId('append-large').click();
+    await expect(timeline.locator('[data-channel-message-seq]')).toHaveCount(
+      51
+    );
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+
+    await page.getByTestId('grow-stream').click();
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+
+  test('does not hijack a reader for catch-up bursts or stream growth', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    const before = await scrollAwayFromBottom(timeline);
+
+    await page.getByTestId('append-burst').click();
+    await expect(
+      page.getByRole('button', { name: '3 new messages' })
+    ).toBeVisible();
+    await expect
+      .poll(() => timeline.evaluate((element) => element.scrollTop))
+      .toBe(before);
+
+    await page.getByTestId('grow-stream').click();
+    await expect
+      .poll(() => timeline.evaluate((element) => element.scrollTop))
+      .toBe(before);
+    await expect(
+      page.getByRole('button', { name: '3 new messages' })
+    ).toBeVisible();
+  });
+
+  test('new-message affordance jumps to present and clears', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    await scrollAwayFromBottom(timeline);
+    await page.getByTestId('append-one').click();
+
+    const jump = page.getByRole('button', { name: '1 new message' });
+    await expect(jump).toBeVisible();
+    const style = await jump.evaluate((element) => {
+      const computed = getComputedStyle(element);
+      return {
+        backgroundColor: computed.backgroundColor,
+        borderRadius: computed.borderRadius,
+        borderStyle: computed.borderStyle,
+      };
+    });
+    expect(style).toEqual({
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      borderRadius: '0px',
+      borderStyle: 'solid',
+    });
+    await jump.click();
+    await expect(jump).toBeHidden();
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+
+  test('preserves the visible row across prepend plus concurrent catch-up and keeps the unread divider', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    await expect(
+      page.getByRole('separator', { name: 'new messages' })
+    ).toHaveCount(1);
+    const dividerBeforeFirstUnread = await timeline.evaluate((element) => {
+      const divider = element.querySelector('[aria-label="new messages"]');
+      const firstUnread = element.querySelector(
+        '[data-channel-message-seq="56"]'
+      );
+      return Boolean(
+        divider &&
+        firstUnread &&
+        divider.compareDocumentPosition(firstUnread) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      );
+    });
+    expect(dividerBeforeFirstUnread).toBe(true);
+
+    const anchor = await timeline.evaluate((element) => {
+      element.scrollTop = 40;
+      const containerTop = element.getBoundingClientRect().top;
+      const row = Array.from(
+        element.querySelectorAll<HTMLElement>('[data-channel-message-seq]')
+      ).find(
+        (candidate) => candidate.getBoundingClientRect().bottom >= containerTop
+      );
+      if (!row) throw new Error('missing visible anchor row');
+      const result = {
+        seq: row.dataset.channelMessageSeq ?? '',
+        top: row.getBoundingClientRect().top - containerTop,
+      };
+      element.dispatchEvent(new Event('scroll'));
+      return result;
+    });
+
+    await expect(
+      timeline.locator('[data-channel-message-seq="1"]')
+    ).toBeAttached();
+    const restoredTop = await timeline
+      .locator(`[data-channel-message-seq="${anchor.seq}"]`)
+      .evaluate(
+        (row, timelineElement) =>
+          row.getBoundingClientRect().top -
+          (timelineElement as HTMLElement).getBoundingClientRect().top,
+        await timeline.elementHandle()
+      );
+    expect(restoredTop).toBeCloseTo(anchor.top, 0);
+    await expect(
+      page.getByRole('button', { name: '1 new message' })
+    ).toBeVisible();
+  });
+
+  test('keeps the bottom anchored across mobile viewport and keyboard-sized resizes', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const timeline = await openFixture(page);
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+
+    await page.setViewportSize({ width: 390, height: 520 });
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+});

--- a/test/hooks/useChannelChatSocket.test.ts
+++ b/test/hooks/useChannelChatSocket.test.ts
@@ -273,4 +273,16 @@ describe('useChannelChatSocket liveness + recovery (#1178)', () => {
     expect(state.latestSeqByChannel[CID]).toBe(5);
     expect(state.lastReadByChannel[CID]).toBe(5);
   });
+
+  it('increments the explicit replacement revision for every full snapshot', async () => {
+    await render(CID);
+    await openCurrent();
+    expect(latest.fullSnapshotRevision).toBe(0);
+
+    await sendSnapshot(5);
+    expect(latest.fullSnapshotRevision).toBe(1);
+
+    await sendSnapshot(8);
+    expect(latest.fullSnapshotRevision).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

- open every channel at the newest message and retain follow intent across large appends, streaming growth, responsive layout, and virtual-keyboard-sized viewport changes
- preserve reader position while scrolled up, count appended rows in a floating outline-only new-message affordance, and keep stale-head resync from hijacking the viewport
- anchor history prepends to the first visible message so simultaneous catch-up rows cannot cause a jump; preserve the existing localStorage-backed unread divider
- add a built React fixture plus Playwright coverage for all five issue behaviors, catch-up bursts, streaming growth, and mobile resize

## Implementation notes

The timeline uses existing browser primitives: scroll geometry, layout effects, and ResizeObserver. The first-visible message sequence and pixel offset are the prepend invariant; total scroll-height deltas are intentionally avoided because they conflate prepended history with concurrent appends.

The new-message control follows DESIGN.md: square corners, transparent rest state, status-info outline/text, and a tokenized hover tint.

## Evidence

Exact head: 672c49175b1995e680d762c86bd605d2787cd544

- focused ChannelTimeline Vitest: 13/13 passed
- Playwright channel timeline scroll spec: 6/6 passed
- frontend/channel blast-radius Vitest: 224/224 passed
- push changed-test hook: 29/29 passed
- npm run check: passed, 0 errors
- npm run build: passed
- git diff --check: passed

Closes #1193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced channel timeline scrolling with more reliable “follow latest” anchoring.
  * Preserved the reader’s position while loading older history, including when new messages arrive at the same time.
  * Improved the floating “new messages” button behavior to help you jump to the latest and dismiss the counter appropriately.
  * Kept scroll behavior stable during streaming updates, layout/resize changes, and snapshot-based timeline resets (avoids unnecessary jumps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->