### PR TITLE
feat(chat): channel thread panel + reply affordances

### DIFF
--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -20,6 +20,7 @@ const IMAGE_ATTACH_TOOLTIP =
 interface ChannelComposerProps {
   channelId: string;
   channelTitle: string;
+  placeholder?: string;
   /** Idempotent send: the SAME clientMessageId is reused across manual retries. */
   onSend: (text: string, clientMessageId: string) => Promise<void>;
   postPending: boolean;
@@ -34,6 +35,7 @@ interface ChannelComposerProps {
 export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   channelId,
   channelTitle,
+  placeholder,
   onSend,
   postPending,
   storeDown,
@@ -290,7 +292,10 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         <textarea
           ref={textareaRef}
           className="ch-composer__ta"
-          placeholder={`message #${channelTitle}…  ·  @ to mention · shift+enter for newline`}
+          placeholder={
+            placeholder ??
+            `message #${channelTitle}…  ·  @ to mention · shift+enter for newline`
+          }
           value={draft}
           rows={1}
           enterKeyHint="send"

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import type {
   ChannelMessage,
+  ChannelMessageId,
   ChannelSenderRef,
 } from '../../../../shared/channel-chat-protocol.js';
 import { AgentBadge } from '../AgentBadge.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import {
+  displayedReplyCount,
+  type DerivedReplyCount,
+} from '../../lib/chat/channel-timeline-layout.js';
 import { ChannelMessageRow } from './ChannelMessageRow.js';
 
 /** Compact wall-clock time, lowercase (DESIGN.md casing law), e.g. `3:42pm`. */
-function formatGroupTime(iso: string): string {
+export function formatGroupTime(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return '';
   let hours = date.getHours();
@@ -23,12 +28,18 @@ interface ChannelMessageGroupProps {
   sender: ChannelSenderRef;
   messages: ChannelMessage[];
   channelId: string;
+  replyCounts?: Map<ChannelMessageId, DerivedReplyCount>;
+  replyGrowth?: Map<ChannelMessageId, number>;
+  onOpenThread?: (rootId: ChannelMessageId) => void;
 }
 
 export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   sender,
   messages,
   channelId,
+  replyCounts,
+  replyGrowth,
+  onOpenThread,
 }) => {
   const identity = resolveSenderIdentity(sender);
   const first = messages[0];
@@ -58,13 +69,25 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
         </div>
       ) : null}
       <div className="ch-group__messages">
-        {messages.map((message) => (
-          <ChannelMessageRow
-            key={message.id}
-            message={message}
-            channelId={channelId}
-          />
-        ))}
+        {messages.map((message) => {
+          const derived = replyCounts?.get(message.id);
+          return (
+            <ChannelMessageRow
+              key={message.id}
+              message={message}
+              channelId={channelId}
+              replyCount={displayedReplyCount(
+                message,
+                derived,
+                replyGrowth?.get(message.id) ?? 0
+              )}
+              {...(derived?.lastReplyAt
+                ? { lastReplyHint: formatGroupTime(derived.lastReplyAt) }
+                : {})}
+              {...(onOpenThread ? { onOpenThread } : {})}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../../../shared/channel-chat-protocol.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { respondChannelApproval } from '../../lib/api.js';
@@ -24,12 +27,18 @@ interface ChannelMessageRowProps {
   message: ChannelMessage;
   channelId: string;
   variant?: 'default' | 'system';
+  replyCount?: number;
+  lastReplyHint?: string;
+  onOpenThread?: (rootId: ChannelMessageId) => void;
 }
 
 export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   message,
   channelId,
   variant = 'default',
+  replyCount = 0,
+  lastReplyHint,
+  onOpenThread,
 }) => {
   const streaming = message.status === 'streaming';
   const blinking = useIdleBlink(message.body.text, streaming);
@@ -116,11 +125,6 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       style={streamStyle}
       data-channel-message-seq={message.seq}
     >
-      {message.parentMessageId ? (
-        <div className="ch-msg__reply" aria-hidden="true">
-          ↳ reply
-        </div>
-      ) : null}
       {message.body.format === 'markdown' ? (
         <div className="ch-msg__body-wrap">
           {body}
@@ -148,6 +152,21 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
         <span className="ch-msg__tag ch-msg__tag--truncated">
           truncated · 256kb limit
         </span>
+      ) : null}
+      {message.threadId === null && replyCount > 0 && onOpenThread ? (
+        <button
+          type="button"
+          className="ch-msg__thread-chip"
+          onClick={() => onOpenThread(message.id)}
+          aria-label={`${replyCount} repl${replyCount === 1 ? 'y' : 'ies'} — open thread`}
+        >
+          <span className="ch-msg__thread-chip__count">
+            {replyCount} repl{replyCount === 1 ? 'y' : 'ies'}
+          </span>
+          {lastReplyHint ? (
+            <span className="ch-msg__thread-chip__hint">{lastReplyHint}</span>
+          ) : null}
+        </button>
       ) : null}
     </div>
   );

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -28,6 +28,7 @@ interface ChannelThreadPanelProps {
   archived: boolean;
   onRestore: () => void;
   restorePending: boolean;
+  fullSnapshotRevision: number;
 }
 
 export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
@@ -42,6 +43,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
   archived,
   onRestore,
   restorePending,
+  fullSnapshotRevision,
 }) => {
   const {
     root,
@@ -51,16 +53,22 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
     loadOlder,
     loading,
     error,
+    rootFloorRevision,
   } = useChannelThread(channelId, rootId, liveMessages);
 
   const replyActivity = useMemo(
     () => deriveReplyCounts(root ? [root, ...replies] : replies),
     [root, replies]
   );
-  const liveReplyGrowth = useLiveReplyGrowth(
-    liveMessages,
-    `${channelId}:${rootId}`
-  );
+  const liveReplyGrowth = useLiveReplyGrowth(liveMessages, {
+    scopeKey: `${channelId}:${rootId}`,
+    fullSnapshotRevision,
+    ...(root
+      ? {
+          authoritativeRoots: [{ message: root, revision: rootFloorRevision }],
+        }
+      : {}),
+  });
   const replyCount = root
     ? displayedReplyCount(
         root,
@@ -87,7 +95,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
       className="ch-thread"
       aria-label="channel thread"
       onKeyDown={(event) => {
-        if (event.key !== 'Escape') return;
+        if (event.key !== 'Escape' || event.defaultPrevented) return;
         event.preventDefault();
         onClose();
       }}

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -1,0 +1,219 @@
+import React, { useMemo } from 'react';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../../../shared/channel-chat-protocol.js';
+import { useChannelThread } from '../../hooks/useChannelThread.js';
+import {
+  buildTimelineNodes,
+  deriveReplyCounts,
+  displayedReplyCount,
+  formatDayLabel,
+} from '../../lib/chat/channel-timeline-layout.js';
+import { ChannelComposer } from './ChannelComposer.js';
+import { ChannelMessageGroup } from './ChannelMessageGroup.js';
+import { ChannelMessageRow } from './ChannelMessageRow.js';
+import { useFollowingScroll } from './useFollowingScroll.js';
+import { useLiveReplyGrowth } from './useLiveReplyGrowth.js';
+
+interface ChannelThreadPanelProps {
+  channelId: string;
+  channelTitle: string;
+  rootId: ChannelMessageId;
+  liveMessages: ChannelMessage[];
+  onClose: () => void;
+  onSend: (text: string, clientMessageId: string) => Promise<void>;
+  postPending: boolean;
+  storeDown: boolean;
+  archived: boolean;
+  onRestore: () => void;
+  restorePending: boolean;
+}
+
+export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
+  channelId,
+  channelTitle,
+  rootId,
+  liveMessages,
+  onClose,
+  onSend,
+  postPending,
+  storeDown,
+  archived,
+  onRestore,
+  restorePending,
+}) => {
+  const {
+    root,
+    replies,
+    hasMoreOlder,
+    loadingOlder,
+    loadOlder,
+    loading,
+    error,
+  } = useChannelThread(channelId, rootId, liveMessages);
+
+  const replyActivity = useMemo(
+    () => deriveReplyCounts(root ? [root, ...replies] : replies),
+    [root, replies]
+  );
+  const liveReplyGrowth = useLiveReplyGrowth(
+    liveMessages,
+    `${channelId}:${rootId}`
+  );
+  const replyCount = root
+    ? displayedReplyCount(
+        root,
+        replyActivity.get(root.id),
+        liveReplyGrowth.get(root.id) ?? 0
+      )
+    : replies.length;
+  const nodes = useMemo(() => buildTimelineNodes(replies, null), [replies]);
+  const {
+    containerRef,
+    contentRef,
+    handleScroll,
+    scrollToBottom,
+    newMessageCount,
+  } = useFollowingScroll({
+    messages: replies,
+    hasMoreOlder,
+    loadingOlder,
+    loadOlder,
+  });
+
+  return (
+    <section
+      className="ch-thread"
+      aria-label="channel thread"
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape') return;
+        event.preventDefault();
+        onClose();
+      }}
+    >
+      <header className="ch-thread__header">
+        <span className="ch-thread__title">thread</span>
+        <span className="ch-thread__count">
+          · {replyCount} repl{replyCount === 1 ? 'y' : 'ies'}
+        </span>
+        <button
+          type="button"
+          className="ch-thread__close"
+          onClick={onClose}
+          aria-label="close thread"
+        >
+          <span className="ch-thread__close-desktop" aria-hidden="true">
+            ×
+          </span>
+          <span className="ch-thread__close-mobile" aria-hidden="true">
+            ‹ back
+          </span>
+        </button>
+      </header>
+
+      <div className="ch-thread__root">
+        {root ? (
+          <ChannelMessageGroup
+            sender={root.sender}
+            messages={[root]}
+            channelId={channelId}
+          />
+        ) : loading ? (
+          <div className="ch-thread__state">loading thread…</div>
+        ) : (
+          <div className="ch-thread__state" role="alert">
+            {error ? 'thread unavailable' : 'thread root unavailable'}
+          </div>
+        )}
+        <div className="ch-thread__root-divider" role="separator">
+          <span>
+            {replyCount} repl{replyCount === 1 ? 'y' : 'ies'}
+          </span>
+        </div>
+      </div>
+
+      <div className="ch-thread__scroll-shell">
+        <div
+          ref={containerRef}
+          className="ch-thread__scroll"
+          role="log"
+          aria-live="polite"
+          aria-label="thread replies"
+          onScroll={handleScroll}
+        >
+          {!hasMoreOlder && replies.length > 0 ? (
+            <div className="ch-top-marker">beginning of thread</div>
+          ) : loadingOlder ? (
+            <div className="ch-loading-older">loading older replies…</div>
+          ) : null}
+          {error && replies.length > 0 ? (
+            <div className="ch-thread__state" role="status">
+              older replies unavailable — scroll to retry
+            </div>
+          ) : null}
+          <div ref={contentRef} className="ch-thread__content">
+            {nodes.map((node, index) => {
+              if (node.kind === 'day-divider') {
+                return (
+                  <div
+                    key={`thread-day-${node.date}-${index}`}
+                    className="ch-day-divider"
+                    role="separator"
+                  >
+                    <span className="ch-day-divider__label">
+                      {formatDayLabel(node.date)}
+                    </span>
+                  </div>
+                );
+              }
+              if (node.kind === 'system') {
+                return (
+                  <ChannelMessageRow
+                    key={node.message.id}
+                    message={node.message}
+                    channelId={channelId}
+                    variant="system"
+                  />
+                );
+              }
+              if (node.kind === 'unread-line') return null;
+              const firstId = node.messages[0]?.id ?? `thread-group-${index}`;
+              return (
+                <ChannelMessageGroup
+                  key={firstId}
+                  sender={node.sender}
+                  messages={node.messages}
+                  channelId={channelId}
+                />
+              );
+            })}
+          </div>
+        </div>
+        {newMessageCount > 0 ? (
+          <button
+            type="button"
+            className="ch-new-messages"
+            onClick={scrollToBottom}
+          >
+            {newMessageCount} new message{newMessageCount === 1 ? '' : 's'}
+          </button>
+        ) : null}
+      </div>
+
+      <ChannelComposer
+        channelId={channelId}
+        channelTitle={channelTitle}
+        placeholder="reply in thread…  ·  @ to mention · shift+enter for newline"
+        onSend={onSend}
+        postPending={postPending}
+        storeDown={storeDown}
+        archived={archived}
+        onRestore={onRestore}
+        restorePending={restorePending}
+      />
+    </section>
+  );
+};
+
+export default ChannelThreadPanel;

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -1,59 +1,23 @@
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+import React, { useEffect, useMemo, useState } from 'react';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../../../shared/channel-chat-protocol.js';
 import {
   buildTimelineNodes,
+  deriveReplyCounts,
   formatDayLabel,
+  selectTopLevel,
 } from '../../lib/chat/channel-timeline-layout.js';
-import { isNearBottom } from './scrollNearBottom.js';
 import { ChannelMessageGroup } from './ChannelMessageGroup.js';
 import { ChannelMessageRow } from './ChannelMessageRow.js';
+import { useFollowingScroll } from './useFollowingScroll.js';
+import { useLiveReplyGrowth } from './useLiveReplyGrowth.js';
 
-const LOAD_OLDER_SCROLL_THRESHOLD_PX = 80;
 const RESYNC_BUTTON_DELAY_MS = 5_000;
 
-interface ViewportAnchor {
-  seq: number;
-  offsetTop: number;
-  earliestSeqBefore: number | undefined;
-}
-
-function scrollMetrics(container: HTMLDivElement) {
-  return {
-    scrollHeight: container.scrollHeight,
-    scrollTop: container.scrollTop,
-    clientHeight: container.clientHeight,
-  };
-}
-
-function captureViewportAnchor(
-  container: HTMLDivElement
-): ViewportAnchor | null {
-  const containerTop = container.getBoundingClientRect().top;
-  const rows = container.querySelectorAll<HTMLElement>(
-    '[data-channel-message-seq]'
-  );
-  for (const row of rows) {
-    const rect = row.getBoundingClientRect();
-    if (rect.bottom < containerTop) continue;
-    const seq = Number(row.dataset.channelMessageSeq);
-    if (!Number.isFinite(seq)) continue;
-    return {
-      seq,
-      offsetTop: rect.top - containerTop,
-      earliestSeqBefore: undefined,
-    };
-  }
-  return null;
-}
-
 interface ChannelTimelineProps {
+  /** Full reducer lane, including thread replies for live reply-count derivation. */
   messages: ChannelMessage[];
   lastReadSeq: number | null;
   channelId: string;
@@ -64,6 +28,7 @@ interface ChannelTimelineProps {
   fullSnapshotRevision: number;
   needsCatchup: boolean;
   onResync: () => void;
+  onOpenThread?: (rootId: ChannelMessageId) => void;
 }
 
 export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
@@ -77,243 +42,38 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   fullSnapshotRevision,
   needsCatchup,
   onResync,
+  onOpenThread,
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const anchorRef = useRef<ViewportAnchor | null>(null);
-  const readerAnchorRef = useRef<ViewportAnchor | null>(null);
-  const shouldFollowRef = useRef(true);
-  const initializedRef = useRef(false);
-  const previousLatestSeqRef = useRef(0);
-  const previousFullSnapshotRevisionRef = useRef(fullSnapshotRevision);
-  const lastScrollTopRef = useRef(0);
-  // Bumped on every loadOlder() settlement (success-with-prepend, empty page,
-  // reached-beginning page, OR a swallowed fetch error) so the anchor is always
-  // released even when earliestSeq never changes (#1178).
-  const [loadSettleTick, setLoadSettleTick] = useState(0);
   const [showResyncButton, setShowResyncButton] = useState(false);
-  const [newMessageCount, setNewMessageCount] = useState(0);
 
+  // Replies stay in the reducer for gap/catch-up correctness. Every piece of
+  // main-lane geometry consumes this render-only projection so hidden reply seqs
+  // cannot trigger a pill, move an anchor, or create an inline timeline row.
+  const topLevelMessages = useMemo(() => selectTopLevel(messages), [messages]);
+  const replyCounts = useMemo(() => deriveReplyCounts(messages), [messages]);
+  const replyGrowth = useLiveReplyGrowth(messages, channelId);
   const nodes = useMemo(
-    () => buildTimelineNodes(messages, lastReadSeq),
-    [messages, lastReadSeq]
+    () => buildTimelineNodes(topLevelMessages, lastReadSeq),
+    [topLevelMessages, lastReadSeq]
   );
 
-  const earliestSeq = messages[0]?.seq;
-  const latestSeq = messages[messages.length - 1]?.seq ?? 0;
+  const {
+    containerRef,
+    contentRef,
+    handleScroll,
+    scrollToBottom,
+    newMessageCount,
+  } = useFollowingScroll({
+    messages: topLevelMessages,
+    hasMoreOlder,
+    loadingOlder,
+    loadOlder,
+    fullSnapshotRevision,
+  });
+
+  const earliestSeq = topLevelMessages[0]?.seq;
   const reachedBeginning = !hasMoreOlder && earliestSeq === 1;
 
-  const scrollToBottom = useCallback((): void => {
-    const container = containerRef.current;
-    if (!container) return;
-    container.scrollTop = container.scrollHeight;
-    lastScrollTopRef.current = container.scrollTop;
-    shouldFollowRef.current = true;
-    setNewMessageCount(0);
-  }, []);
-
-  // A full snapshot replaces the whole rendered window. The reader anchor is
-  // cached by scroll/resize handling before this commit; a layout-effect
-  // cleanup on a function component is too late because child DOM mutations
-  // have already landed. Restore the cached row after the replacement, then
-  // refresh it from the resulting viewport. If the row fell outside the new
-  // window, the unread divider is the deterministic semantic fallback.
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    const anchor = readerAnchorRef.current;
-    // An authoritative replacement supersedes an in-flight history prepend,
-    // whether the reader is following or browsing history.
-    anchorRef.current = null;
-    if (container && anchor && !shouldFollowRef.current) {
-      const row = container.querySelector<HTMLElement>(
-        `[data-channel-message-seq="${anchor.seq}"]`
-      );
-      const target =
-        row ??
-        container.querySelector<HTMLElement>('[data-channel-unread-divider]');
-      if (target) {
-        const offsetTop =
-          target.getBoundingClientRect().top -
-          container.getBoundingClientRect().top;
-        container.scrollTop +=
-          row === target ? offsetTop - anchor.offsetTop : offsetTop;
-        lastScrollTopRef.current = container.scrollTop;
-      }
-    }
-    readerAnchorRef.current =
-      container && !shouldFollowRef.current
-        ? captureViewportAnchor(container)
-        : null;
-  }, [fullSnapshotRevision]);
-
-  // Capture follow intent independently of post-mutation geometry. Rechecking
-  // `isNearBottom` only after a large append can turn a previously-bottomed
-  // viewport into a false negative and strand it above the new row.
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    if (!initializedRef.current) {
-      initializedRef.current = true;
-      previousLatestSeqRef.current = latestSeq;
-      scrollToBottom();
-      return;
-    }
-
-    const previousLatestSeq = previousLatestSeqRef.current;
-    if (fullSnapshotRevision !== previousFullSnapshotRevisionRef.current) {
-      previousFullSnapshotRevisionRef.current = fullSnapshotRevision;
-      previousLatestSeqRef.current = latestSeq;
-      setNewMessageCount(0);
-      if (shouldFollowRef.current) scrollToBottom();
-      return;
-    }
-    if (latestSeq < previousLatestSeq) {
-      // An authoritative full snapshot can legitimately reset seq after a
-      // channel is recreated under the same id. Reset the append baseline but
-      // preserve the reader's follow choice across the resync.
-      previousLatestSeqRef.current = latestSeq;
-      setNewMessageCount(0);
-      if (shouldFollowRef.current && !anchorRef.current) scrollToBottom();
-      return;
-    }
-    if (latestSeq > previousLatestSeq) {
-      let appendedCount = 0;
-      for (let index = messages.length - 1; index >= 0; index -= 1) {
-        if (messages[index]!.seq <= previousLatestSeq) break;
-        appendedCount += 1;
-      }
-      const latestMessage = messages[messages.length - 1];
-      const isOwnMessage =
-        latestMessage !== undefined &&
-        latestMessage.seq > previousLatestSeq &&
-        latestMessage.sender.kind === 'human';
-      if (isOwnMessage) {
-        // Slack parity: sending while reading history returns to the present.
-        // Cancel a pending prepend so its eventual settlement cannot pull the
-        // viewport away from the just-posted message.
-        anchorRef.current = null;
-        readerAnchorRef.current = null;
-        scrollToBottom();
-      } else if (shouldFollowRef.current && !anchorRef.current) {
-        scrollToBottom();
-      } else if (appendedCount > 0) {
-        setNewMessageCount((count) => count + appendedCount);
-      }
-    }
-    previousLatestSeqRef.current = latestSeq;
-  }, [fullSnapshotRevision, latestSeq, messages, scrollToBottom]);
-
-  // Streaming text, responsive layout, viewport rotation, and virtual-keyboard
-  // changes all surface as content/container resizes. Preserve bottom anchoring
-  // only when the user's last real scroll position opted into follow mode.
-  useEffect(() => {
-    const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
-
-    const preserveFollow = (): void => {
-      if (anchorRef.current) return;
-      if (!shouldFollowRef.current) {
-        readerAnchorRef.current = captureViewportAnchor(container);
-        return;
-      }
-      scrollToBottom();
-    };
-
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(preserveFollow);
-    observer.observe(content);
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [scrollToBottom]);
-
-  // Anchor lifecycle: set before loadOlder(), consumed on the next settlement.
-  // Restore scrollTop ONLY when a prepend actually landed (earliestSeq dropped)
-  // so the viewport never jumps; but ALWAYS release the anchor afterward. If it
-  // is not released on the no-prepend paths (empty page, oldest page already
-  // reaching seq 1, or a swallowed fetch error), auto-follow (line ~73) and all
-  // further older-history loads (handleScroll's `!anchorRef.current` gate) stay
-  // permanently locked until a channel switch (#1178).
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    const anchor = anchorRef.current;
-    if (!container || !anchor) return;
-    if (earliestSeq !== anchor.earliestSeqBefore) {
-      const row = container.querySelector<HTMLElement>(
-        `[data-channel-message-seq="${anchor.seq}"]`
-      );
-      if (row) {
-        const offsetTop =
-          row.getBoundingClientRect().top -
-          container.getBoundingClientRect().top;
-        container.scrollTop += offsetTop - anchor.offsetTop;
-        lastScrollTopRef.current = container.scrollTop;
-      }
-    }
-    anchorRef.current = null;
-  }, [earliestSeq, loadSettleTick]);
-
-  const handleScroll = useCallback(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    const metrics = scrollMetrics(container);
-    const scrollTopChanged =
-      Math.abs(metrics.scrollTop - lastScrollTopRef.current) > 1;
-    const pendingAnchor = anchorRef.current;
-    if (pendingAnchor && loadingOlder && scrollTopChanged) {
-      const refreshed = captureViewportAnchor(container);
-      if (refreshed) {
-        anchorRef.current = {
-          ...refreshed,
-          earliestSeqBefore: pendingAnchor.earliestSeqBefore,
-        };
-      }
-    }
-
-    const maxScrollTop = Math.max(
-      0,
-      metrics.scrollHeight - metrics.clientHeight
-    );
-    const movingUp = metrics.scrollTop < lastScrollTopRef.current - 1;
-    const atBottom =
-      maxScrollTop === 0 || maxScrollTop - metrics.scrollTop <= 1;
-    const follow = atBottom || (!movingUp && isNearBottom(metrics));
-    shouldFollowRef.current = follow;
-    lastScrollTopRef.current = metrics.scrollTop;
-    if (follow) {
-      readerAnchorRef.current = null;
-      setNewMessageCount(0);
-    } else {
-      readerAnchorRef.current = captureViewportAnchor(container);
-    }
-    if (
-      container.scrollTop < LOAD_OLDER_SCROLL_THRESHOLD_PX &&
-      hasMoreOlder &&
-      !loadingOlder &&
-      messages.length > 0 &&
-      !anchorRef.current
-    ) {
-      const fallbackSeq = earliestSeq;
-      if (fallbackSeq === undefined) return;
-      const anchor = captureViewportAnchor(container);
-      anchorRef.current = anchor
-        ? { ...anchor, earliestSeqBefore: earliestSeq }
-        : {
-            seq: fallbackSeq,
-            offsetTop: 0,
-            earliestSeqBefore: fallbackSeq,
-          };
-      // The hook swallows its own fetch errors (loadOlder resolves even on a
-      // transient failure), but guard against any future reject too so the
-      // settle tick — and thus the anchor release — always runs (#1178).
-      void loadOlder()
-        .catch(() => {})
-        .finally(() => setLoadSettleTick((tick) => tick + 1));
-    }
-  }, [hasMoreOlder, loadingOlder, loadOlder, messages.length, earliestSeq]);
-
-  // Surface a manual "resync now" button only if catch-up is still stuck after
-  // a grace period (the hook auto-reconnects in the common case).
   useEffect(() => {
     if (!needsCatchup) {
       setShowResyncButton(false);
@@ -400,6 +160,9 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 sender={node.sender}
                 messages={node.messages}
                 channelId={channelId}
+                replyCounts={replyCounts}
+                replyGrowth={replyGrowth}
+                {...(onOpenThread ? { onOpenThread } : {})}
               />
             );
           })}

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -28,6 +28,8 @@ interface ChannelTimelineProps {
   fullSnapshotRevision: number;
   needsCatchup: boolean;
   onResync: () => void;
+  replyOnlyBackfillPaused?: boolean;
+  onContinueHistory?: () => void;
   onOpenThread?: (rootId: ChannelMessageId) => void;
 }
 
@@ -42,6 +44,8 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   fullSnapshotRevision,
   needsCatchup,
   onResync,
+  replyOnlyBackfillPaused = false,
+  onContinueHistory,
   onOpenThread,
 }) => {
   const [showResyncButton, setShowResyncButton] = useState(false);
@@ -51,7 +55,10 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   // cannot trigger a pill, move an anchor, or create an inline timeline row.
   const topLevelMessages = useMemo(() => selectTopLevel(messages), [messages]);
   const replyCounts = useMemo(() => deriveReplyCounts(messages), [messages]);
-  const replyGrowth = useLiveReplyGrowth(messages, channelId);
+  const replyGrowth = useLiveReplyGrowth(messages, {
+    scopeKey: channelId,
+    fullSnapshotRevision,
+  });
   const nodes = useMemo(
     () => buildTimelineNodes(topLevelMessages, lastReadSeq),
     [topLevelMessages, lastReadSeq]
@@ -108,6 +115,18 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 resync now
               </button>
             ) : null}
+          </div>
+        ) : null}
+        {replyOnlyBackfillPaused && onContinueHistory ? (
+          <div className="ch-history-paused" role="status">
+            <span>older channel history is available</span>
+            <button
+              type="button"
+              className="ch-history-continue"
+              onClick={onContinueHistory}
+            >
+              load older channel history
+            </button>
           </div>
         ) : null}
         {reachedBeginning ? (

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -6,10 +6,25 @@
 .ch-view {
   display: flex;
   flex-direction: column;
+  position: relative;
   min-height: 0;
   height: 100%;
   background: var(--bg);
   color: var(--text);
+}
+
+.ch-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.ch-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
 }
 
 /* header — title + kind/DM glyph + member/partner label + connection dot */
@@ -454,12 +469,168 @@
   color: var(--text-muted);
 }
 
-/* inline reply breadcrumb (#1170 owns the real thread UI; slice 3 is inline) */
-.ch-msg__reply {
+/* Thread entry point: outline-only informational navigation, matching the
+   compact agent-chip vocabulary and DESIGN.md's square control law. */
+.ch-msg__thread-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  align-self: flex-start;
+  margin-top: var(--space-xs, 4px);
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--status-info);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-msg--user .ch-msg__thread-chip {
+  align-self: flex-end;
+}
+
+.ch-msg__thread-chip:hover {
+  background: color-mix(in srgb, var(--status-info) 10%, transparent);
+  border-color: var(--status-info);
+}
+
+.ch-msg__thread-chip__count {
+  color: var(--status-info);
+  font-weight: 700;
+}
+
+.ch-msg__thread-chip__hint {
   color: var(--text-muted);
-  opacity: 0.7;
-  margin-bottom: 2px;
+  opacity: 0.6;
+}
+
+/* Thread panel is structural on desktop: pure-black attached column, not a
+   floating surface. It owns its history backfill but projects live rows from
+   the channel reducer/socket. */
+.ch-thread {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  flex-shrink: 0;
+  min-height: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.ch-thread__header {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 4px;
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  text-transform: lowercase;
+}
+
+.ch-thread__title {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.ch-thread__count {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.ch-thread__close {
+  min-width: 28px;
+  min-height: 28px;
+  margin-left: auto;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-thread__close:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+}
+
+.ch-thread__close-mobile {
+  display: none;
+}
+
+.ch-thread__root {
+  flex-shrink: 0;
+  padding: 16px 24px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.ch-thread__root-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 4px 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.ch-thread__root-divider::before,
+.ch-thread__root-divider::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--border);
+}
+
+.ch-thread__root-divider > span {
+  white-space: nowrap;
+}
+
+.ch-thread__scroll-shell {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
+.ch-thread__scroll {
+  height: 100%;
+  overflow-y: auto;
+  overflow-anchor: none;
+  padding: 16px 24px;
+}
+
+.ch-thread__scroll::-webkit-scrollbar {
+  width: 4px;
+}
+
+.ch-thread__scroll::-webkit-scrollbar-thumb {
+  background: var(--border);
+}
+
+.ch-thread__content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.ch-thread__state {
+  padding: 8px 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-align: center;
+  text-transform: lowercase;
 }
 
 /* empty / unavailable / paging chrome */
@@ -553,5 +724,38 @@
 
   .ch-msg--user .ch-msg__body {
     max-width: 92%;
+  }
+
+  .ch-thread {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    width: auto;
+    border-left: 0;
+    background: var(--bg);
+  }
+
+  .ch-thread__header {
+    padding: 8px 10px;
+  }
+
+  .ch-thread__close {
+    order: -1;
+    margin-right: 4px;
+    margin-left: 0;
+  }
+
+  .ch-thread__close-desktop {
+    display: none;
+  }
+
+  .ch-thread__close-mobile {
+    display: inline;
+  }
+
+  .ch-thread__root,
+  .ch-thread__scroll {
+    padding-right: 10px;
+    padding-left: 10px;
   }
 }

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -676,6 +676,36 @@
   text-transform: lowercase;
 }
 
+.ch-history-paused {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.ch-history-continue {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-history-continue:hover {
+  border-color: var(--status-info);
+  color: var(--status-info);
+  background: color-mix(in srgb, var(--status-info) 10%, transparent);
+}
+
 /* catch-up banner — mirrors .tl-resume-banner, sticky at top of scroll area */
 .ch-catchup-banner {
   position: sticky;

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -36,6 +36,7 @@ import { ChannelThreadPanel } from './ChannelThreadPanel.js';
 const READ_WRITE_VISIBLE_GRACE_MS = 10_000;
 const AUTO_BACKFILL_MAX_ATTEMPTS = 3;
 const AUTO_BACKFILL_RETRY_BASE_MS = 200;
+const AUTO_BACKFILL_MAX_CURSOR_PAGES = 4;
 
 interface ChannelViewProps {
   channelId: string;
@@ -170,31 +171,57 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const hasTopLevelMessages = reducer.messages.some(
     (message) => message.threadId === null
   );
+  const earliestSeq = reducer.messages[0]?.seq;
+  const [replyOnlyBackfillPaused, setReplyOnlyBackfillPaused] = useState(false);
+  const [backfillContinuation, setBackfillContinuation] = useState(0);
   const autoBackfillRef = useRef<{
+    channelId: string;
     cursorKey: string | null;
+    cursorPages: number;
     attempts: number;
     retryTimer: ReturnType<typeof setTimeout> | null;
-  }>({ cursorKey: null, attempts: 0, retryTimer: null });
+  }>({
+    channelId,
+    cursorKey: null,
+    cursorPages: 0,
+    attempts: 0,
+    retryTimer: null,
+  });
   useEffect(() => {
     const state = autoBackfillRef.current;
     const clearRetry = (): void => {
       if (state.retryTimer !== null) clearTimeout(state.retryTimer);
       state.retryTimer = null;
     };
+    if (state.channelId !== channelId) {
+      clearRetry();
+      state.channelId = channelId;
+      state.cursorKey = null;
+      state.cursorPages = 0;
+      state.attempts = 0;
+      setReplyOnlyBackfillPaused(false);
+    }
     if (hasTopLevelMessages || !hasMoreOlder) {
       clearRetry();
       state.cursorKey = null;
+      state.cursorPages = 0;
       state.attempts = 0;
+      setReplyOnlyBackfillPaused(false);
       return;
     }
     if (loadingOlder) return;
-    const earliestSeq = reducer.messages[0]?.seq;
     if (earliestSeq === undefined) return;
     const cursorKey = `${channelId}:${earliestSeq}`;
     if (state.cursorKey !== cursorKey) {
       clearRetry();
+      if (state.cursorPages >= AUTO_BACKFILL_MAX_CURSOR_PAGES) {
+        setReplyOnlyBackfillPaused(true);
+        return;
+      }
       state.cursorKey = cursorKey;
+      state.cursorPages += 1;
       state.attempts = 0;
+      setReplyOnlyBackfillPaused(false);
     }
     if (
       state.retryTimer !== null ||
@@ -215,13 +242,25 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       void loadOlder();
     }, delay);
   }, [
+    backfillContinuation,
     channelId,
+    earliestSeq,
     hasMoreOlder,
     hasTopLevelMessages,
     loadOlder,
     loadingOlder,
-    reducer.messages,
   ]);
+
+  const continueReplyOnlyBackfill = useCallback(() => {
+    const state = autoBackfillRef.current;
+    if (state.retryTimer !== null) clearTimeout(state.retryTimer);
+    state.retryTimer = null;
+    state.cursorKey = null;
+    state.cursorPages = 0;
+    state.attempts = 0;
+    setReplyOnlyBackfillPaused(false);
+    setBackfillContinuation((value) => value + 1);
+  }, []);
 
   useEffect(
     () => () => {
@@ -471,6 +510,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               fullSnapshotRevision={fullSnapshotRevision}
               needsCatchup={reducer.needsCatchup}
               onResync={resync}
+              replyOnlyBackfillPaused={replyOnlyBackfillPaused}
+              onContinueHistory={continueReplyOnlyBackfill}
               onOpenThread={setActiveThreadRootId}
             />
           ) : (
@@ -505,6 +546,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             archived={archived}
             onRestore={handleRestore}
             restorePending={restorePending}
+            fullSnapshotRevision={fullSnapshotRevision}
           />
         ) : null}
       </div>

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -31,8 +31,11 @@ import { useUiStore } from '../../lib/stores/ui.js';
 import { AgentBadge } from '../AgentBadge.js';
 import { ChannelTimeline } from './ChannelTimeline.js';
 import { ChannelComposer } from './ChannelComposer.js';
+import { ChannelThreadPanel } from './ChannelThreadPanel.js';
 
 const READ_WRITE_VISIBLE_GRACE_MS = 10_000;
+const AUTO_BACKFILL_MAX_ATTEMPTS = 3;
+const AUTO_BACKFILL_RETRY_BASE_MS = 200;
 
 interface ChannelViewProps {
   channelId: string;
@@ -56,6 +59,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   } = useChannelChatSocket(channelId);
   const queryClient = useQueryClient();
   const setActiveChannelId = useUiStore((s) => s.setActiveChannelId);
+  const activeThreadRootId = useUiStore((s) => s.activeThreadRootId);
+  const setActiveThreadRootId = useUiStore((s) => s.setActiveThreadRootId);
+
+  useEffect(() => {
+    setActiveThreadRootId(null);
+  }, [channelId, setActiveThreadRootId]);
 
   // Self-derive DM-ness: ChannelSummaryView does not expose routingDefaults, so
   // fetch the topic (cached) and run the pure id derivation. Cheaper than
@@ -145,6 +154,81 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       await post(text, { clientMessageId });
     },
     [post]
+  );
+
+  const handleThreadSend = useCallback(
+    async (text: string, clientMessageId: string) => {
+      if (activeThreadRootId === null) return;
+      await post(text, {
+        clientMessageId,
+        threadId: activeThreadRootId,
+      });
+    },
+    [activeThreadRootId, post]
+  );
+
+  const hasTopLevelMessages = reducer.messages.some(
+    (message) => message.threadId === null
+  );
+  const autoBackfillRef = useRef<{
+    cursorKey: string | null;
+    attempts: number;
+    retryTimer: ReturnType<typeof setTimeout> | null;
+  }>({ cursorKey: null, attempts: 0, retryTimer: null });
+  useEffect(() => {
+    const state = autoBackfillRef.current;
+    const clearRetry = (): void => {
+      if (state.retryTimer !== null) clearTimeout(state.retryTimer);
+      state.retryTimer = null;
+    };
+    if (hasTopLevelMessages || !hasMoreOlder) {
+      clearRetry();
+      state.cursorKey = null;
+      state.attempts = 0;
+      return;
+    }
+    if (loadingOlder) return;
+    const earliestSeq = reducer.messages[0]?.seq;
+    if (earliestSeq === undefined) return;
+    const cursorKey = `${channelId}:${earliestSeq}`;
+    if (state.cursorKey !== cursorKey) {
+      clearRetry();
+      state.cursorKey = cursorKey;
+      state.attempts = 0;
+    }
+    if (
+      state.retryTimer !== null ||
+      state.attempts >= AUTO_BACKFILL_MAX_ATTEMPTS
+    ) {
+      return;
+    }
+    if (state.attempts === 0) {
+      state.attempts = 1;
+      void loadOlder();
+      return;
+    }
+    const delay = AUTO_BACKFILL_RETRY_BASE_MS * 2 ** (state.attempts - 1);
+    state.retryTimer = setTimeout(() => {
+      if (state.cursorKey !== cursorKey) return;
+      state.retryTimer = null;
+      state.attempts += 1;
+      void loadOlder();
+    }, delay);
+  }, [
+    channelId,
+    hasMoreOlder,
+    hasTopLevelMessages,
+    loadOlder,
+    loadingOlder,
+    reducer.messages,
+  ]);
+
+  useEffect(
+    () => () => {
+      const timer = autoBackfillRef.current.retryTimer;
+      if (timer !== null) clearTimeout(timer);
+    },
+    []
   );
 
   // Agent presence chips (#1167). One chip per agent that is bound (roster
@@ -272,7 +356,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     );
   }
 
-  const hasMessages = reducer.messages.length > 0;
+  const hasHistory =
+    reducer.messages.length > 0 || hasMoreOlder || loadingOlder;
 
   return (
     <div className="ch-view" role="main" aria-label="channel">
@@ -372,35 +457,57 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         />
       </div>
 
-      {hasMessages ? (
-        <ChannelTimeline
-          messages={reducer.messages}
-          lastReadSeq={lastReadSeq}
-          channelId={channelId}
-          channelTitle={title}
-          hasMoreOlder={hasMoreOlder}
-          loadingOlder={loadingOlder}
-          loadOlder={loadOlder}
-          fullSnapshotRevision={fullSnapshotRevision}
-          needsCatchup={reducer.needsCatchup}
-          onResync={resync}
-        />
-      ) : (
-        <div className="ch-empty">
-          <span>{emptyCopy}</span>
-        </div>
-      )}
+      <div className="ch-body">
+        <div className="ch-main">
+          {hasHistory ? (
+            <ChannelTimeline
+              messages={reducer.messages}
+              lastReadSeq={lastReadSeq}
+              channelId={channelId}
+              channelTitle={title}
+              hasMoreOlder={hasMoreOlder}
+              loadingOlder={loadingOlder}
+              loadOlder={loadOlder}
+              fullSnapshotRevision={fullSnapshotRevision}
+              needsCatchup={reducer.needsCatchup}
+              onResync={resync}
+              onOpenThread={setActiveThreadRootId}
+            />
+          ) : (
+            <div className="ch-empty">
+              <span>{emptyCopy}</span>
+            </div>
+          )}
 
-      <ChannelComposer
-        channelId={channelId}
-        channelTitle={title}
-        onSend={handleSend}
-        postPending={postPending}
-        storeDown={storeDown}
-        archived={archived}
-        onRestore={handleRestore}
-        restorePending={restorePending}
-      />
+          <ChannelComposer
+            channelId={channelId}
+            channelTitle={title}
+            onSend={handleSend}
+            postPending={postPending}
+            storeDown={storeDown}
+            archived={archived}
+            onRestore={handleRestore}
+            restorePending={restorePending}
+          />
+        </div>
+
+        {activeThreadRootId !== null ? (
+          <ChannelThreadPanel
+            key={activeThreadRootId}
+            channelId={channelId}
+            channelTitle={title}
+            rootId={activeThreadRootId}
+            liveMessages={reducer.messages}
+            onClose={() => setActiveThreadRootId(null)}
+            onSend={handleThreadSend}
+            postPending={postPending}
+            storeDown={storeDown}
+            archived={archived}
+            onRestore={handleRestore}
+            restorePending={restorePending}
+          />
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/chat/useFollowingScroll.ts
+++ b/frontend/src/components/chat/useFollowingScroll.ts
@@ -186,6 +186,19 @@ export function useFollowingScroll({
     const preserveFollow = (): void => {
       if (anchorRef.current) return;
       if (!shouldFollowRef.current) {
+        const anchor = readerAnchorRef.current;
+        if (anchor) {
+          const row = container.querySelector<HTMLElement>(
+            `[data-channel-message-seq="${anchor.seq}"]`
+          );
+          if (row) {
+            const offsetTop =
+              row.getBoundingClientRect().top -
+              container.getBoundingClientRect().top;
+            container.scrollTop += offsetTop - anchor.offsetTop;
+            lastScrollTopRef.current = container.scrollTop;
+          }
+        }
         readerAnchorRef.current = captureViewportAnchor(container);
         return;
       }

--- a/frontend/src/components/chat/useFollowingScroll.ts
+++ b/frontend/src/components/chat/useFollowingScroll.ts
@@ -1,0 +1,284 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+import { isNearBottom } from './scrollNearBottom.js';
+
+const LOAD_OLDER_SCROLL_THRESHOLD_PX = 80;
+
+interface ViewportAnchor {
+  seq: number;
+  offsetTop: number;
+  earliestSeqBefore: number | undefined;
+}
+
+interface ScrollMetrics {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}
+
+function scrollMetrics(container: HTMLDivElement): ScrollMetrics {
+  return {
+    scrollHeight: container.scrollHeight,
+    scrollTop: container.scrollTop,
+    clientHeight: container.clientHeight,
+  };
+}
+
+function captureViewportAnchor(
+  container: HTMLDivElement
+): ViewportAnchor | null {
+  const containerTop = container.getBoundingClientRect().top;
+  const rows = container.querySelectorAll<HTMLElement>(
+    '[data-channel-message-seq]'
+  );
+  for (const row of rows) {
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom < containerTop) continue;
+    const seq = Number(row.dataset.channelMessageSeq);
+    if (!Number.isFinite(seq)) continue;
+    return {
+      seq,
+      offsetTop: rect.top - containerTop,
+      earliestSeqBefore: undefined,
+    };
+  }
+  return null;
+}
+
+interface UseFollowingScrollOptions {
+  messages: ChannelMessage[];
+  hasMoreOlder: boolean;
+  loadingOlder: boolean;
+  loadOlder: () => Promise<void>;
+  /** Increment only when an authoritative snapshot replaces the visible window. */
+  fullSnapshotRevision?: number;
+}
+
+interface FollowingScrollState {
+  containerRef: RefObject<HTMLDivElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
+  handleScroll: () => void;
+  scrollToBottom: () => void;
+  newMessageCount: number;
+}
+
+/**
+ * Shared Slack-style follow/anchor model for the channel lane and thread panel.
+ * The message list is the rendered projection, not the reducer's full seq lane.
+ */
+export function useFollowingScroll({
+  messages,
+  hasMoreOlder,
+  loadingOlder,
+  loadOlder,
+  fullSnapshotRevision = 0,
+}: UseFollowingScrollOptions): FollowingScrollState {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<ViewportAnchor | null>(null);
+  const readerAnchorRef = useRef<ViewportAnchor | null>(null);
+  const shouldFollowRef = useRef(true);
+  const initializedRef = useRef(false);
+  const previousLatestSeqRef = useRef(0);
+  const previousFullSnapshotRevisionRef = useRef(fullSnapshotRevision);
+  const lastScrollTopRef = useRef(0);
+  const [loadSettleTick, setLoadSettleTick] = useState(0);
+  const [newMessageCount, setNewMessageCount] = useState(0);
+
+  const earliestSeq = messages[0]?.seq;
+  const latestSeq = messages[messages.length - 1]?.seq ?? 0;
+
+  const scrollToBottom = useCallback((): void => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.scrollTop = container.scrollHeight;
+    lastScrollTopRef.current = container.scrollTop;
+    shouldFollowRef.current = true;
+    setNewMessageCount(0);
+  }, []);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const anchor = readerAnchorRef.current;
+    anchorRef.current = null;
+    if (container && anchor && !shouldFollowRef.current) {
+      const row = container.querySelector<HTMLElement>(
+        `[data-channel-message-seq="${anchor.seq}"]`
+      );
+      const target =
+        row ??
+        container.querySelector<HTMLElement>('[data-channel-unread-divider]');
+      if (target) {
+        const offsetTop =
+          target.getBoundingClientRect().top -
+          container.getBoundingClientRect().top;
+        container.scrollTop +=
+          row === target ? offsetTop - anchor.offsetTop : offsetTop;
+        lastScrollTopRef.current = container.scrollTop;
+      }
+    }
+    readerAnchorRef.current =
+      container && !shouldFollowRef.current
+        ? captureViewportAnchor(container)
+        : null;
+  }, [fullSnapshotRevision]);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      previousLatestSeqRef.current = latestSeq;
+      scrollToBottom();
+      return;
+    }
+
+    const previousLatestSeq = previousLatestSeqRef.current;
+    if (fullSnapshotRevision !== previousFullSnapshotRevisionRef.current) {
+      previousFullSnapshotRevisionRef.current = fullSnapshotRevision;
+      previousLatestSeqRef.current = latestSeq;
+      setNewMessageCount(0);
+      if (shouldFollowRef.current) scrollToBottom();
+      return;
+    }
+    if (latestSeq < previousLatestSeq) {
+      previousLatestSeqRef.current = latestSeq;
+      setNewMessageCount(0);
+      if (shouldFollowRef.current && !anchorRef.current) scrollToBottom();
+      return;
+    }
+    if (latestSeq > previousLatestSeq) {
+      let appendedCount = 0;
+      for (let index = messages.length - 1; index >= 0; index -= 1) {
+        if (messages[index]!.seq <= previousLatestSeq) break;
+        appendedCount += 1;
+      }
+      const latestMessage = messages[messages.length - 1];
+      const isOwnMessage =
+        latestMessage !== undefined &&
+        latestMessage.seq > previousLatestSeq &&
+        latestMessage.sender.kind === 'human';
+      if (isOwnMessage) {
+        anchorRef.current = null;
+        readerAnchorRef.current = null;
+        scrollToBottom();
+      } else if (shouldFollowRef.current && !anchorRef.current) {
+        scrollToBottom();
+      } else if (appendedCount > 0) {
+        setNewMessageCount((count) => count + appendedCount);
+      }
+    }
+    previousLatestSeqRef.current = latestSeq;
+  }, [fullSnapshotRevision, latestSeq, messages, scrollToBottom]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const preserveFollow = (): void => {
+      if (anchorRef.current) return;
+      if (!shouldFollowRef.current) {
+        readerAnchorRef.current = captureViewportAnchor(container);
+        return;
+      }
+      scrollToBottom();
+    };
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(preserveFollow);
+    observer.observe(content);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [scrollToBottom]);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const anchor = anchorRef.current;
+    if (!container || !anchor) return;
+    if (earliestSeq !== anchor.earliestSeqBefore) {
+      const row = container.querySelector<HTMLElement>(
+        `[data-channel-message-seq="${anchor.seq}"]`
+      );
+      if (row) {
+        const offsetTop =
+          row.getBoundingClientRect().top -
+          container.getBoundingClientRect().top;
+        container.scrollTop += offsetTop - anchor.offsetTop;
+        lastScrollTopRef.current = container.scrollTop;
+      }
+    }
+    anchorRef.current = null;
+  }, [earliestSeq, loadSettleTick]);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const metrics = scrollMetrics(container);
+    const scrollTopChanged =
+      Math.abs(metrics.scrollTop - lastScrollTopRef.current) > 1;
+    const pendingAnchor = anchorRef.current;
+    if (pendingAnchor && loadingOlder && scrollTopChanged) {
+      const refreshed = captureViewportAnchor(container);
+      if (refreshed) {
+        anchorRef.current = {
+          ...refreshed,
+          earliestSeqBefore: pendingAnchor.earliestSeqBefore,
+        };
+      }
+    }
+
+    const maxScrollTop = Math.max(
+      0,
+      metrics.scrollHeight - metrics.clientHeight
+    );
+    const movingUp = metrics.scrollTop < lastScrollTopRef.current - 1;
+    const atBottom =
+      maxScrollTop === 0 || maxScrollTop - metrics.scrollTop <= 1;
+    const follow = atBottom || (!movingUp && isNearBottom(metrics));
+    shouldFollowRef.current = follow;
+    lastScrollTopRef.current = metrics.scrollTop;
+    if (follow) {
+      readerAnchorRef.current = null;
+      setNewMessageCount(0);
+    } else {
+      readerAnchorRef.current = captureViewportAnchor(container);
+    }
+    if (
+      container.scrollTop < LOAD_OLDER_SCROLL_THRESHOLD_PX &&
+      hasMoreOlder &&
+      !loadingOlder &&
+      messages.length > 0 &&
+      !anchorRef.current
+    ) {
+      const fallbackSeq = earliestSeq;
+      if (fallbackSeq === undefined) return;
+      const anchor = captureViewportAnchor(container);
+      anchorRef.current = anchor
+        ? { ...anchor, earliestSeqBefore: earliestSeq }
+        : {
+            seq: fallbackSeq,
+            offsetTop: 0,
+            earliestSeqBefore: fallbackSeq,
+          };
+      void loadOlder()
+        .catch(() => {})
+        .finally(() => setLoadSettleTick((tick) => tick + 1));
+    }
+  }, [hasMoreOlder, loadingOlder, loadOlder, messages.length, earliestSeq]);
+
+  return {
+    containerRef,
+    contentRef,
+    handleScroll,
+    scrollToBottom,
+    newMessageCount,
+  };
+}

--- a/frontend/src/components/chat/useLiveReplyGrowth.ts
+++ b/frontend/src/components/chat/useLiveReplyGrowth.ts
@@ -4,21 +4,43 @@ import type {
   ChannelMessageId,
 } from '../../../../shared/channel-chat-protocol.js';
 
+interface AuthoritativeRoot {
+  message: ChannelMessage;
+  revision: number;
+}
+
 interface ReplyGrowthTracker {
-  resetKey: string;
+  scopeKey: string;
+  fullSnapshotRevision: number;
   seenReplyIds: Set<ChannelMessageId>;
   latestSeq: number;
   rootFloors: Map<ChannelMessageId, number>;
+  authoritativeRootRevisions: Map<ChannelMessageId, number>;
+}
+
+interface UseLiveReplyGrowthOptions {
+  scopeKey: string;
+  fullSnapshotRevision: number;
+  authoritativeRoots?: AuthoritativeRoot[];
 }
 
 const EMPTY_GROWTH = new Map<ChannelMessageId, number>();
 
+function rootsIn(messages: ChannelMessage[]): ChannelMessage[] {
+  return messages.filter((message) => message.threadId === null);
+}
+
 function seedTracker(
-  resetKey: string,
-  messages: ChannelMessage[]
+  messages: ChannelMessage[],
+  options: UseLiveReplyGrowthOptions
 ): ReplyGrowthTracker {
+  const roots = [
+    ...rootsIn(messages),
+    ...(options.authoritativeRoots ?? []).map((entry) => entry.message),
+  ];
   return {
-    resetKey,
+    scopeKey: options.scopeKey,
+    fullSnapshotRevision: options.fullSnapshotRevision,
     seenReplyIds: new Set(
       messages
         .filter((message) => message.threadId !== null)
@@ -26,21 +48,26 @@ function seedTracker(
     ),
     latestSeq: messages[messages.length - 1]?.seq ?? 0,
     rootFloors: new Map(
-      messages
-        .filter((message) => message.threadId === null)
-        .map((message) => [message.id, message.replyCount ?? 0])
+      roots.map((message) => [message.id, message.replyCount ?? 0])
+    ),
+    authoritativeRootRevisions: new Map(
+      (options.authoritativeRoots ?? []).map((entry) => [
+        entry.message.id,
+        entry.revision,
+      ])
     ),
   };
 }
 
 /**
- * Count reply IDs first observed beyond the reducer's previous high-water seq.
- * Initial-window and older-history rows seed/dedupe the tracker; only genuinely
- * appended WS/catch-up rows grow a persisted replyCount floor.
+ * Track only reply IDs observed live after a root floor is known. Roots present
+ * in a new full snapshot rebase and absorb that batch's replies; unseen replies
+ * for tracked roots absent from the truncated snapshot remain growth. A REST
+ * root revision is equally authoritative and rebases at merge time.
  */
 export function useLiveReplyGrowth(
   messages: ChannelMessage[],
-  resetKey: string
+  options: UseLiveReplyGrowthOptions
 ): Map<ChannelMessageId, number> {
   const trackerRef = useRef<ReplyGrowthTracker | null>(null);
   const [growth, setGrowth] = useState<Map<ChannelMessageId, number>>(
@@ -49,22 +76,57 @@ export function useLiveReplyGrowth(
 
   useEffect(() => {
     const tracker = trackerRef.current;
-    if (tracker === null || tracker.resetKey !== resetKey) {
-      trackerRef.current = seedTracker(resetKey, messages);
+    if (tracker === null || tracker.scopeKey !== options.scopeKey) {
+      trackerRef.current = seedTracker(messages, options);
       setGrowth((current) => (current.size === 0 ? current : new Map()));
       return;
     }
 
+    const snapshotChanged =
+      tracker.fullSnapshotRevision !== options.fullSnapshotRevision;
+    const snapshotRoots = rootsIn(messages);
+    const authoritativeRoots = options.authoritativeRoots ?? [];
+    const authoritativeRootIds = new Set(
+      authoritativeRoots.map((entry) => entry.message.id)
+    );
     const rebasedRoots = new Set<ChannelMessageId>();
-    for (const message of messages) {
-      if (message.threadId !== null) continue;
-      const nextFloor = message.replyCount ?? 0;
-      const previousFloor = tracker.rootFloors.get(message.id);
-      tracker.rootFloors.set(message.id, nextFloor);
-      // A refetch that advances the authoritative floor has absorbed prior live
-      // growth. A truncated snapshot with the root absent cannot rebase it.
-      if (previousFloor !== undefined && previousFloor !== nextFloor) {
-        rebasedRoots.add(message.id);
+
+    if (snapshotChanged) {
+      tracker.fullSnapshotRevision = options.fullSnapshotRevision;
+      for (const root of snapshotRoots) {
+        tracker.rootFloors.set(root.id, root.replyCount ?? 0);
+        rebasedRoots.add(root.id);
+      }
+    }
+
+    // First floor observation and changed floors both rebase. This also covers
+    // a root found by ordinary channel-history backfill after a truncated view.
+    for (const root of snapshotRoots) {
+      // The panel's merged REST root can carry a newer floor than the stale live
+      // root. Let that authoritative entry win once instead of oscillating the
+      // tracker down and up on every render.
+      if (authoritativeRootIds.has(root.id)) continue;
+      const floor = root.replyCount ?? 0;
+      const previous = tracker.rootFloors.get(root.id);
+      if (previous === undefined || previous !== floor) {
+        tracker.rootFloors.set(root.id, floor);
+        rebasedRoots.add(root.id);
+      }
+    }
+
+    for (const entry of authoritativeRoots) {
+      const root = entry.message;
+      const floor = root.replyCount ?? 0;
+      const previousFloor = tracker.rootFloors.get(root.id);
+      const previousRevision = tracker.authoritativeRootRevisions.get(root.id);
+      tracker.rootFloors.set(root.id, floor);
+      tracker.authoritativeRootRevisions.set(root.id, entry.revision);
+      if (
+        previousFloor === undefined ||
+        previousFloor !== floor ||
+        previousRevision !== entry.revision
+      ) {
+        rebasedRoots.add(root.id);
       }
     }
 
@@ -77,34 +139,65 @@ export function useLiveReplyGrowth(
         continue;
       }
       tracker.seenReplyIds.add(message.id);
-      if (message.seq <= previousLatestSeq) continue;
+      if (
+        message.seq <= previousLatestSeq ||
+        !tracker.rootFloors.has(message.threadId) ||
+        rebasedRoots.has(message.threadId)
+      ) {
+        continue;
+      }
       increments.set(
         message.threadId,
         (increments.get(message.threadId) ?? 0) + 1
       );
     }
     tracker.latestSeq = latestSeq;
+
     if (increments.size === 0 && rebasedRoots.size === 0) return;
     setGrowth((current) => {
       const next = new Map(current);
-      for (const rootId of rebasedRoots) next.delete(rootId);
+      let changed = false;
+      for (const rootId of rebasedRoots) {
+        changed = next.delete(rootId) || changed;
+      }
       for (const [rootId, increment] of increments) {
         next.set(rootId, (next.get(rootId) ?? 0) + increment);
+        changed = true;
       }
-      return next;
+      return changed ? next : current;
     });
-  }, [messages, resetKey]);
+  }, [messages, options]);
 
-  const activeTracker = trackerRef.current;
-  if (activeTracker?.resetKey !== resetKey) return EMPTY_GROWTH;
-  const pendingRebases = messages
-    .filter((message) => message.threadId === null)
-    .filter((message) => {
-      const floor = activeTracker.rootFloors.get(message.id);
-      return floor !== undefined && floor !== (message.replyCount ?? 0);
-    });
-  if (pendingRebases.length === 0) return growth;
+  const tracker = trackerRef.current;
+  if (tracker?.scopeKey !== options.scopeKey) return EMPTY_GROWTH;
+
+  // Hide stale growth during the render that schedules an authoritative rebase;
+  // the effect commits the same deletion immediately afterward.
+  const pendingRebases = new Set<ChannelMessageId>();
+  const authoritativeRootIds = new Set(
+    (options.authoritativeRoots ?? []).map((entry) => entry.message.id)
+  );
+  if (tracker.fullSnapshotRevision !== options.fullSnapshotRevision) {
+    for (const root of rootsIn(messages)) pendingRebases.add(root.id);
+  }
+  for (const root of rootsIn(messages)) {
+    if (authoritativeRootIds.has(root.id)) continue;
+    const floor = tracker.rootFloors.get(root.id);
+    if (floor === undefined || floor !== (root.replyCount ?? 0)) {
+      pendingRebases.add(root.id);
+    }
+  }
+  for (const entry of options.authoritativeRoots ?? []) {
+    const root = entry.message;
+    if (
+      tracker.rootFloors.get(root.id) !== (root.replyCount ?? 0) ||
+      tracker.authoritativeRootRevisions.get(root.id) !== entry.revision
+    ) {
+      pendingRebases.add(root.id);
+    }
+  }
+  if (pendingRebases.size === 0) return growth;
   const effective = new Map(growth);
-  for (const root of pendingRebases) effective.delete(root.id);
+  for (const rootId of pendingRebases) effective.delete(rootId);
   return effective;
 }

--- a/frontend/src/components/chat/useLiveReplyGrowth.ts
+++ b/frontend/src/components/chat/useLiveReplyGrowth.ts
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../../../shared/channel-chat-protocol.js';
+
+interface ReplyGrowthTracker {
+  resetKey: string;
+  seenReplyIds: Set<ChannelMessageId>;
+  latestSeq: number;
+  rootFloors: Map<ChannelMessageId, number>;
+}
+
+const EMPTY_GROWTH = new Map<ChannelMessageId, number>();
+
+function seedTracker(
+  resetKey: string,
+  messages: ChannelMessage[]
+): ReplyGrowthTracker {
+  return {
+    resetKey,
+    seenReplyIds: new Set(
+      messages
+        .filter((message) => message.threadId !== null)
+        .map((message) => message.id)
+    ),
+    latestSeq: messages[messages.length - 1]?.seq ?? 0,
+    rootFloors: new Map(
+      messages
+        .filter((message) => message.threadId === null)
+        .map((message) => [message.id, message.replyCount ?? 0])
+    ),
+  };
+}
+
+/**
+ * Count reply IDs first observed beyond the reducer's previous high-water seq.
+ * Initial-window and older-history rows seed/dedupe the tracker; only genuinely
+ * appended WS/catch-up rows grow a persisted replyCount floor.
+ */
+export function useLiveReplyGrowth(
+  messages: ChannelMessage[],
+  resetKey: string
+): Map<ChannelMessageId, number> {
+  const trackerRef = useRef<ReplyGrowthTracker | null>(null);
+  const [growth, setGrowth] = useState<Map<ChannelMessageId, number>>(
+    () => new Map()
+  );
+
+  useEffect(() => {
+    const tracker = trackerRef.current;
+    if (tracker === null || tracker.resetKey !== resetKey) {
+      trackerRef.current = seedTracker(resetKey, messages);
+      setGrowth((current) => (current.size === 0 ? current : new Map()));
+      return;
+    }
+
+    const rebasedRoots = new Set<ChannelMessageId>();
+    for (const message of messages) {
+      if (message.threadId !== null) continue;
+      const nextFloor = message.replyCount ?? 0;
+      const previousFloor = tracker.rootFloors.get(message.id);
+      tracker.rootFloors.set(message.id, nextFloor);
+      // A refetch that advances the authoritative floor has absorbed prior live
+      // growth. A truncated snapshot with the root absent cannot rebase it.
+      if (previousFloor !== undefined && previousFloor !== nextFloor) {
+        rebasedRoots.add(message.id);
+      }
+    }
+
+    const previousLatestSeq = tracker.latestSeq;
+    const increments = new Map<ChannelMessageId, number>();
+    let latestSeq = previousLatestSeq;
+    for (const message of messages) {
+      latestSeq = Math.max(latestSeq, message.seq);
+      if (message.threadId === null || tracker.seenReplyIds.has(message.id)) {
+        continue;
+      }
+      tracker.seenReplyIds.add(message.id);
+      if (message.seq <= previousLatestSeq) continue;
+      increments.set(
+        message.threadId,
+        (increments.get(message.threadId) ?? 0) + 1
+      );
+    }
+    tracker.latestSeq = latestSeq;
+    if (increments.size === 0 && rebasedRoots.size === 0) return;
+    setGrowth((current) => {
+      const next = new Map(current);
+      for (const rootId of rebasedRoots) next.delete(rootId);
+      for (const [rootId, increment] of increments) {
+        next.set(rootId, (next.get(rootId) ?? 0) + increment);
+      }
+      return next;
+    });
+  }, [messages, resetKey]);
+
+  const activeTracker = trackerRef.current;
+  if (activeTracker?.resetKey !== resetKey) return EMPTY_GROWTH;
+  const pendingRebases = messages
+    .filter((message) => message.threadId === null)
+    .filter((message) => {
+      const floor = activeTracker.rootFloors.get(message.id);
+      return floor !== undefined && floor !== (message.replyCount ?? 0);
+    });
+  if (pendingRebases.length === 0) return growth;
+  const effective = new Map(growth);
+  for (const root of pendingRebases) effective.delete(root.id);
+  return effective;
+}

--- a/frontend/src/hooks/useChannelChatSocket.ts
+++ b/frontend/src/hooks/useChannelChatSocket.ts
@@ -66,7 +66,7 @@ export interface UseChannelChatSocketState {
   fullSnapshotRevision: number;
   post: (
     text: string,
-    opts?: { clientMessageId?: string }
+    opts?: { clientMessageId?: string; threadId?: string }
   ) => Promise<ChannelMessage>;
   postPending: boolean;
   postError: HttpError | null;
@@ -403,7 +403,7 @@ export function useChannelChatSocket(
   const post = useCallback(
     async (
       text: string,
-      opts?: { clientMessageId?: string }
+      opts?: { clientMessageId?: string; threadId?: string }
     ): Promise<ChannelMessage> => {
       const cid = channelIdRef.current;
       if (!cid) throw new Error('no active channel');
@@ -414,7 +414,11 @@ export function useChannelChatSocket(
         // No optimistic insert — the server's channel-message-created-v1
         // broadcast (received over this same open socket) is the sole source of
         // truth for the row appearing, matching the reducer's idempotent replay.
-        return await postChannelMessage(cid, { text, clientMessageId });
+        return await postChannelMessage(cid, {
+          text,
+          clientMessageId,
+          ...(opts?.threadId !== undefined ? { threadId: opts.threadId } : {}),
+        });
       } catch (err) {
         if (err instanceof HttpError) setPostError(err);
         throw err;

--- a/frontend/src/hooks/useChannelThread.ts
+++ b/frontend/src/hooks/useChannelThread.ts
@@ -15,6 +15,8 @@ export interface UseChannelThreadState {
   loadOlder: () => Promise<void>;
   loading: boolean;
   error: Error | null;
+  /** Advances whenever a REST page supplies the authoritative root row. */
+  rootFloorRevision: number;
 }
 
 function asError(error: unknown): Error {
@@ -27,6 +29,32 @@ function cursorFromPage(
 ): number | null {
   const earliestReply = messages.find((message) => message.id !== rootId);
   return earliestReply?.seq ?? null;
+}
+
+function mergeThreadPage(
+  current: Map<ChannelMessageId, ChannelMessage>,
+  pageMessages: ChannelMessage[],
+  rootId: ChannelMessageId
+): Map<ChannelMessageId, ChannelMessage> {
+  const next = new Map(current);
+  for (const message of pageMessages) {
+    const retained = next.get(message.id);
+    if (retained === undefined) {
+      next.set(message.id, message);
+      continue;
+    }
+    if (message.id === rootId) {
+      next.set(rootId, {
+        ...message,
+        ...retained,
+        // REST carries the refreshed authoritative floor; the retained row may
+        // carry newer live presentation fields.
+        replyCount: Math.max(message.replyCount ?? 0, retained.replyCount ?? 0),
+      });
+    }
+    // Reply collisions retain the live row (it may still be streaming).
+  }
+  return next;
 }
 
 /**
@@ -46,12 +74,16 @@ export function useChannelThread(
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [rootFloorRevision, setRootFloorRevision] = useState(0);
 
   const requestKeyRef = useRef('');
   const backfillRef = useRef(backfill);
   const cursorRef = useRef<number | null>(null);
   const hasMoreOlderRef = useRef(false);
   const loadingOlderRef = useRef(false);
+  const lastFoldedLiveRowsRef = useRef<Map<ChannelMessageId, ChannelMessage>>(
+    new Map()
+  );
 
   backfillRef.current = backfill;
   hasMoreOlderRef.current = hasMoreOlder;
@@ -62,10 +94,12 @@ export function useChannelThread(
     cursorRef.current = null;
     hasMoreOlderRef.current = false;
     loadingOlderRef.current = false;
+    lastFoldedLiveRowsRef.current.clear();
     setBackfill(new Map());
     setHasMoreOlder(false);
     setLoadingOlder(false);
     setError(null);
+    setRootFloorRevision(0);
 
     if (rootId === null) {
       setLoading(false);
@@ -78,15 +112,16 @@ export function useChannelThread(
     })
       .then((page) => {
         if (requestKeyRef.current !== requestKey) return;
-        // Preserve a root captured from the live reducer when a newest-first
-        // page does not reach it (long threads can omit the root until the
-        // pagination walk reaches the oldest page).
-        const retainedRoot = backfillRef.current.get(rootId);
-        const next = new Map<ChannelMessageId, ChannelMessage>();
-        for (const message of page.messages) next.set(message.id, message);
-        if (retainedRoot !== undefined) next.set(rootId, retainedRoot);
+        const next = mergeThreadPage(
+          backfillRef.current,
+          page.messages,
+          rootId
+        );
         backfillRef.current = next;
         setBackfill(next);
+        if (page.messages.some((message) => message.id === rootId)) {
+          setRootFloorRevision((revision) => revision + 1);
+        }
         cursorRef.current =
           page.nextCursor?.beforeSeq ?? cursorFromPage(page.messages, rootId);
         const more =
@@ -103,20 +138,32 @@ export function useChannelThread(
       });
   }, [channelId, rootId]);
 
-  // The volatile reducer tail can later replace its whole window. Once we have
-  // seen the root live, retain it in the hook-owned map so the pinned panel root
-  // never disappears merely because channel history moved past it.
+  // Fold every live thread row into hook-owned state. A later authoritative
+  // reducer replacement must not erase rows already observed by an open panel.
   useEffect(() => {
     if (rootId === null) return;
-    const liveRoot = liveMessages.find((message) => message.id === rootId);
-    if (
-      liveRoot === undefined ||
-      backfillRef.current.get(rootId) === liveRoot
-    ) {
-      return;
+    let next: Map<ChannelMessageId, ChannelMessage> | null = null;
+    for (const message of liveMessages) {
+      if (message.id !== rootId && message.threadId !== rootId) continue;
+      if (lastFoldedLiveRowsRef.current.get(message.id) === message) continue;
+      lastFoldedLiveRowsRef.current.set(message.id, message);
+      next ??= new Map(backfillRef.current);
+      const retained = next.get(message.id);
+      next.set(
+        message.id,
+        message.id === rootId && retained
+          ? {
+              ...retained,
+              ...message,
+              replyCount: Math.max(
+                retained.replyCount ?? 0,
+                message.replyCount ?? 0
+              ),
+            }
+          : message
+      );
     }
-    const next = new Map(backfillRef.current);
-    next.set(rootId, liveRoot);
+    if (next === null) return;
     backfillRef.current = next;
     setBackfill(next);
   }, [liveMessages, rootId]);
@@ -125,9 +172,21 @@ export function useChannelThread(
     const rows = new Map(backfill);
     if (rootId !== null) {
       for (const message of liveMessages) {
-        if (message.id === rootId || message.threadId === rootId) {
-          rows.set(message.id, message);
-        }
+        if (message.id !== rootId && message.threadId !== rootId) continue;
+        const retained = rows.get(message.id);
+        rows.set(
+          message.id,
+          message.id === rootId && retained
+            ? {
+                ...retained,
+                ...message,
+                replyCount: Math.max(
+                  retained.replyCount ?? 0,
+                  message.replyCount ?? 0
+                ),
+              }
+            : message
+        );
       }
     }
     return rows;
@@ -165,10 +224,12 @@ export function useChannelThread(
         limit: THREAD_HISTORY_PAGE_LIMIT,
       });
       if (requestKeyRef.current !== requestKey) return;
-      const next = new Map(backfillRef.current);
-      for (const message of page.messages) next.set(message.id, message);
+      const next = mergeThreadPage(backfillRef.current, page.messages, rootId);
       backfillRef.current = next;
       setBackfill(next);
+      if (page.messages.some((message) => message.id === rootId)) {
+        setRootFloorRevision((revision) => revision + 1);
+      }
       cursorRef.current =
         page.nextCursor?.beforeSeq ?? cursorFromPage(page.messages, rootId);
       const more =
@@ -193,5 +254,6 @@ export function useChannelThread(
     loadOlder,
     loading,
     error,
+    rootFloorRevision,
   };
 }

--- a/frontend/src/hooks/useChannelThread.ts
+++ b/frontend/src/hooks/useChannelThread.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../../shared/channel-chat-protocol.js';
+import { fetchChannelThreadHistory } from '../lib/api.js';
+
+const THREAD_HISTORY_PAGE_LIMIT = 50;
+
+export interface UseChannelThreadState {
+  root: ChannelMessage | null;
+  replies: ChannelMessage[];
+  hasMoreOlder: boolean;
+  loadingOlder: boolean;
+  loadOlder: () => Promise<void>;
+  loading: boolean;
+  error: Error | null;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function cursorFromPage(
+  messages: ChannelMessage[],
+  rootId: ChannelMessageId
+): number | null {
+  const earliestReply = messages.find((message) => message.id !== rootId);
+  return earliestReply?.seq ?? null;
+}
+
+/**
+ * REST backfill overlaid by the channel reducer's live rows. There is no thread
+ * socket: live rows win id collisions so streaming updates remain immediate,
+ * while fetched rows (especially the root) survive reducer-window replacement.
+ */
+export function useChannelThread(
+  channelId: string,
+  rootId: ChannelMessageId | null,
+  liveMessages: ChannelMessage[]
+): UseChannelThreadState {
+  const [backfill, setBackfill] = useState<
+    Map<ChannelMessageId, ChannelMessage>
+  >(() => new Map());
+  const [hasMoreOlder, setHasMoreOlder] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const requestKeyRef = useRef('');
+  const backfillRef = useRef(backfill);
+  const cursorRef = useRef<number | null>(null);
+  const hasMoreOlderRef = useRef(false);
+  const loadingOlderRef = useRef(false);
+
+  backfillRef.current = backfill;
+  hasMoreOlderRef.current = hasMoreOlder;
+
+  useEffect(() => {
+    const requestKey = rootId === null ? '' : `${channelId}\u0000${rootId}`;
+    requestKeyRef.current = requestKey;
+    cursorRef.current = null;
+    hasMoreOlderRef.current = false;
+    loadingOlderRef.current = false;
+    setBackfill(new Map());
+    setHasMoreOlder(false);
+    setLoadingOlder(false);
+    setError(null);
+
+    if (rootId === null) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    void fetchChannelThreadHistory(channelId, rootId, {
+      limit: THREAD_HISTORY_PAGE_LIMIT,
+    })
+      .then((page) => {
+        if (requestKeyRef.current !== requestKey) return;
+        // Preserve a root captured from the live reducer when a newest-first
+        // page does not reach it (long threads can omit the root until the
+        // pagination walk reaches the oldest page).
+        const retainedRoot = backfillRef.current.get(rootId);
+        const next = new Map<ChannelMessageId, ChannelMessage>();
+        for (const message of page.messages) next.set(message.id, message);
+        if (retainedRoot !== undefined) next.set(rootId, retainedRoot);
+        backfillRef.current = next;
+        setBackfill(next);
+        cursorRef.current =
+          page.nextCursor?.beforeSeq ?? cursorFromPage(page.messages, rootId);
+        const more =
+          page.hasMore || page.messages.length >= THREAD_HISTORY_PAGE_LIMIT;
+        hasMoreOlderRef.current = more;
+        setHasMoreOlder(more);
+      })
+      .catch((caught: unknown) => {
+        if (requestKeyRef.current !== requestKey) return;
+        setError(asError(caught));
+      })
+      .finally(() => {
+        if (requestKeyRef.current === requestKey) setLoading(false);
+      });
+  }, [channelId, rootId]);
+
+  // The volatile reducer tail can later replace its whole window. Once we have
+  // seen the root live, retain it in the hook-owned map so the pinned panel root
+  // never disappears merely because channel history moved past it.
+  useEffect(() => {
+    if (rootId === null) return;
+    const liveRoot = liveMessages.find((message) => message.id === rootId);
+    if (
+      liveRoot === undefined ||
+      backfillRef.current.get(rootId) === liveRoot
+    ) {
+      return;
+    }
+    const next = new Map(backfillRef.current);
+    next.set(rootId, liveRoot);
+    backfillRef.current = next;
+    setBackfill(next);
+  }, [liveMessages, rootId]);
+
+  const merged = useMemo(() => {
+    const rows = new Map(backfill);
+    if (rootId !== null) {
+      for (const message of liveMessages) {
+        if (message.id === rootId || message.threadId === rootId) {
+          rows.set(message.id, message);
+        }
+      }
+    }
+    return rows;
+  }, [backfill, liveMessages, rootId]);
+
+  const root = rootId === null ? null : (merged.get(rootId) ?? null);
+  const replies = useMemo(
+    () =>
+      rootId === null
+        ? []
+        : [...merged.values()]
+            .filter((message) => message.threadId === rootId)
+            .sort((a, b) => a.seq - b.seq),
+    [merged, rootId]
+  );
+
+  const loadOlder = useCallback(async (): Promise<void> => {
+    if (
+      rootId === null ||
+      loadingOlderRef.current ||
+      !hasMoreOlderRef.current
+    ) {
+      return;
+    }
+    const requestKey = `${channelId}\u0000${rootId}`;
+    const beforeSeq = cursorRef.current;
+    if (beforeSeq === null) return;
+
+    loadingOlderRef.current = true;
+    setLoadingOlder(true);
+    setError(null);
+    try {
+      const page = await fetchChannelThreadHistory(channelId, rootId, {
+        beforeSeq,
+        limit: THREAD_HISTORY_PAGE_LIMIT,
+      });
+      if (requestKeyRef.current !== requestKey) return;
+      const next = new Map(backfillRef.current);
+      for (const message of page.messages) next.set(message.id, message);
+      backfillRef.current = next;
+      setBackfill(next);
+      cursorRef.current =
+        page.nextCursor?.beforeSeq ?? cursorFromPage(page.messages, rootId);
+      const more =
+        page.hasMore || page.messages.length >= THREAD_HISTORY_PAGE_LIMIT;
+      hasMoreOlderRef.current = more;
+      setHasMoreOlder(more);
+    } catch (caught: unknown) {
+      if (requestKeyRef.current === requestKey) setError(asError(caught));
+    } finally {
+      if (requestKeyRef.current === requestKey) {
+        loadingOlderRef.current = false;
+        setLoadingOlder(false);
+      }
+    }
+  }, [channelId, rootId]);
+
+  return {
+    root,
+    replies,
+    hasMoreOlder,
+    loadingOlder,
+    loadOlder,
+    loading,
+    error,
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,7 +40,10 @@ import type {
   WorkspaceTopicListResponse,
   WorkspaceTopicSearchResponse,
 } from '../../../shared/workspace-topics.js';
-import type { ChannelMessage } from '../../../shared/channel-chat-protocol.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../../shared/channel-chat-protocol.js';
 import type {
   WorkflowRunProjection,
   WorkflowRunState,
@@ -1786,11 +1789,46 @@ export async function fetchChannelHistory(
   };
 }
 
+/**
+ * Fetch one root-inclusive thread page. This intentionally uses the dedicated
+ * thread-history route rather than the unrelated `threadId` filter on channel
+ * history: the server validates the root and preserves its cursor semantics.
+ */
+export async function fetchChannelThreadHistory(
+  channelId: string,
+  rootMessageId: ChannelMessageId,
+  filter: {
+    beforeSeq?: number;
+    afterSeq?: number;
+    limit?: number;
+  } = {}
+): Promise<ChannelHistoryPage> {
+  const params = new URLSearchParams();
+  if (filter.beforeSeq !== undefined)
+    params.set('beforeSeq', String(filter.beforeSeq));
+  if (filter.afterSeq !== undefined)
+    params.set('afterSeq', String(filter.afterSeq));
+  if (filter.limit !== undefined) params.set('limit', String(filter.limit));
+  const query = params.toString();
+  const data = await json<ChannelHistoryPage>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/threads/${encodeURIComponent(rootMessageId)}${query ? `?${query}` : ''}`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    )
+  );
+  return {
+    messages: Array.isArray(data.messages) ? data.messages : [],
+    hasMore: Boolean(data.hasMore),
+    ...(data.nextCursor ? { nextCursor: data.nextCursor } : {}),
+  };
+}
+
 export async function postChannelMessage(
   channelId: string,
   input: {
     text: string;
     format?: 'markdown' | 'text';
+    threadId?: string;
     parentMessageId?: string;
     clientMessageId: string;
   }

--- a/frontend/src/lib/chat/channel-timeline-layout.ts
+++ b/frontend/src/lib/chat/channel-timeline-layout.ts
@@ -10,11 +10,62 @@
 // running group exceeds GROUP_WINDOW_MS.
 import type {
   ChannelMessage,
+  ChannelMessageId,
   ChannelSenderRef,
 } from '../../../../shared/channel-chat-protocol.js';
 
 /** Slack-standard grouping window: same-sender messages within 5 minutes group. */
 export const GROUP_WINDOW_MS = 5 * 60 * 1000;
+
+/** Main-lane projection. Replies remain in reducer state for gap accounting. */
+export function selectTopLevel(messages: ChannelMessage[]): ChannelMessage[] {
+  return messages.filter((message) => message.threadId === null);
+}
+
+export interface DerivedReplyCount {
+  /** Number of reply rows currently loaded in the reducer/backfill projection. */
+  count: number;
+  /** Newest loaded reply timestamp, if it parses later than earlier replies. */
+  lastReplyAt?: string;
+}
+
+/** Derive live reply activity from loaded child rows without mutating roots. */
+export function deriveReplyCounts(
+  messages: ChannelMessage[]
+): Map<ChannelMessageId, DerivedReplyCount> {
+  const counts = new Map<ChannelMessageId, DerivedReplyCount>();
+  for (const message of messages) {
+    if (message.threadId === null) continue;
+    const current = counts.get(message.threadId);
+    const count = (current?.count ?? 0) + 1;
+    let lastReplyAt = current?.lastReplyAt;
+    if (
+      lastReplyAt === undefined ||
+      timestampOrder(message.createdAt) > timestampOrder(lastReplyAt)
+    ) {
+      lastReplyAt = message.createdAt;
+    }
+    counts.set(message.threadId, {
+      count,
+      ...(lastReplyAt !== undefined ? { lastReplyAt } : {}),
+    });
+  }
+  return counts;
+}
+
+/** Persisted count is a floor because older replies may not be loaded. */
+export function displayedReplyCount(
+  root: ChannelMessage,
+  loaded: DerivedReplyCount | undefined,
+  liveGrowth = 0
+): number {
+  return Math.max((root.replyCount ?? 0) + liveGrowth, loaded?.count ?? 0);
+}
+
+function timestampOrder(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+}
 
 export type TimelineNode =
   | { kind: 'day-divider'; date: string /* YYYY-MM-DD local */ }

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { ChannelMessageId } from '../../../../shared/channel-chat-protocol.js';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 const SIDEBAR_WIDTH_KEY = 'claude-remote-sidebar-width';
@@ -579,6 +580,8 @@ export interface UiState {
    * never persisted (a fresh reload lands on the chat home, not a stale channel).
    */
   activeChannelId: string | null;
+  /** #1170: currently open channel thread. Session-transient; never persisted. */
+  activeThreadRootId: ChannelMessageId | null;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
   /**
@@ -627,6 +630,7 @@ export interface UiState {
   setForceOrgCockpit: (v: boolean) => void;
   setTopicComposerOpen: (v: boolean) => void;
   setActiveChannelId: (v: string | null) => void;
+  setActiveThreadRootId: (v: ChannelMessageId | null) => void;
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
@@ -666,6 +670,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   forceOrgCockpit: false,
   topicComposerOpen: false,
   activeChannelId: null,
+  activeThreadRootId: null,
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
@@ -1089,7 +1094,9 @@ export const useUiStore = create<UiState>()((set, get) => ({
   setOrgDashboardTab: (tab) => set({ orgDashboardTab: tab }),
   setForceOrgCockpit: (v) => set({ forceOrgCockpit: v }),
   setTopicComposerOpen: (v) => set({ topicComposerOpen: v }),
-  setActiveChannelId: (v) => set({ activeChannelId: v }),
+  setActiveChannelId: (v) =>
+    set({ activeChannelId: v, activeThreadRootId: null }),
+  setActiveThreadRootId: (v) => set({ activeThreadRootId: v }),
   setActiveModal: (v) => set({ activeModal: v }),
 
   saveRightSidebarWidth: () =>

--- a/frontend/src/test-channel-thread.css
+++ b/frontend/src/test-channel-thread.css
@@ -1,0 +1,19 @@
+html,
+body,
+#app,
+.ch-thread-fixture {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  margin: 0;
+}
+
+.ch-thread-fixture {
+  display: flex;
+  background: var(--bg);
+}
+
+.ch-thread-fixture > .ch-view {
+  flex: 1;
+  min-width: 0;
+}

--- a/frontend/src/test-channel-thread.tsx
+++ b/frontend/src/test-channel-thread.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ChannelMessageId } from '../../shared/channel-chat-protocol.js';
+import './App.css';
+import './test-channel-thread.css';
+import { ChannelView } from './components/chat/ChannelView.js';
+import { useUiStore } from './lib/stores/ui.js';
+
+const channelId = new URLSearchParams(window.location.search).get('channelId');
+const initialThreadRootId = new URLSearchParams(window.location.search).get(
+  'threadRootId'
+) as ChannelMessageId | null;
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, staleTime: 0 },
+  },
+});
+
+function Fixture(): React.ReactElement {
+  useEffect(() => {
+    useUiStore.getState().setActiveThreadRootId(initialThreadRootId);
+    return () => useUiStore.getState().setActiveThreadRootId(null);
+  }, []);
+  if (!channelId) return <div role="alert">missing channelId</div>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="ch-thread-fixture">
+        <ChannelView channelId={channelId} />
+      </div>
+    </QueryClientProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(<Fixture />);

--- a/frontend/test-channel-thread.html
+++ b/frontend/test-channel-thread.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Channel thread test page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-channel-thread.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -52,6 +52,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-channel-timeline.html'
   );
+  buildInputs['test-channel-thread'] = resolve(
+    import.meta.dirname,
+    'test-channel-thread.html'
+  );
 }
 
 export default defineConfig({

--- a/test/channel-thread-e2e.test.ts
+++ b/test/channel-thread-e2e.test.ts
@@ -1,0 +1,227 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createChannelAgentBinder,
+  type BinderSessions,
+  type MentionTarget,
+} from '../server/channel-agent-binder.js';
+import { createChannelChatRouter } from '../server/channel-chat-router.js';
+import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
+import {
+  createChannelMessageStore,
+  type ChannelMessageStore,
+} from '../server/channel-message-store.js';
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import type { ProtocolAdapterV2 } from '../server/protocol-adapter-v2.js';
+import type { Session, WebSession } from '../server/types.js';
+import {
+  createWorkspaceTopicStore,
+  type WorkspaceTopicStore,
+} from '../server/workspace-topics.js';
+import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+const TARGETS: MentionTarget[] = [
+  {
+    id: 'mock',
+    displayName: 'Mock',
+    kind: 'framework',
+    available: true,
+    reason: null,
+  },
+];
+
+interface Harness {
+  port: number;
+  store: ChannelMessageStore;
+  topicStore: WorkspaceTopicStore;
+  hub: ChannelHub;
+  channelId: string;
+}
+
+function mockSessions(): BinderSessions {
+  const sessions = new Map<string, WebSession>();
+  return {
+    async createWeb(params) {
+      const id = `session-${sessions.size + 1}`;
+      const adapter: ProtocolAdapterV2 = new MockProtocolAdapterV2({
+        connectMs: 1,
+        stepMs: 1,
+      });
+      await adapter.connect({
+        cwd: params.cwd,
+        port: 0,
+        sessionId: id,
+        hookToken: 'thread-e2e',
+        configDir: params.configDir,
+      });
+      const session = {
+        id,
+        mode: 'web',
+        agent: params.agentType,
+        adapterV2: adapter,
+        cwd: params.cwd,
+      } as unknown as WebSession;
+      sessions.set(id, session);
+      return { session };
+    },
+    get(id) {
+      return sessions.get(id) as unknown as Session | undefined;
+    },
+    onSessionEnd() {
+      return () => {};
+    },
+  };
+}
+
+async function createHarness(): Promise<Harness> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-thread-e2e-'));
+  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const topicStore = createWorkspaceTopicStore({
+    dbPath: path.join(dir, 'topics.db'),
+    now: () => '2026-07-18T00:00:00.000Z',
+  });
+  cleanup.push(() => topicStore.close());
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  cleanup.push(() => store.close());
+  const hub = createChannelHub({
+    store,
+    channelExists: (id) => Boolean(topicStore.get(id)),
+  });
+  cleanup.push(() => hub.close());
+  const topic = topicStore.create({
+    workspaceId: 'ws-thread-e2e',
+    title: 'Thread round trip',
+  });
+
+  const binder = createChannelAgentBinder({
+    store,
+    hub,
+    topicStore,
+    sessions: mockSessions(),
+    knownProviderIds: ['mock'],
+    mentionTargets: async () => TARGETS,
+    port: 0,
+    configDir: dir,
+  });
+  cleanup.push(() => binder.close());
+  hub.onMessagePosted((message, mentions) =>
+    binder.handleMessagePosted(message, mentions)
+  );
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createChannelChatRouter({
+      store,
+      hub,
+      topicStore,
+      binder,
+      knownProviderIds: ['mock'],
+    })
+  );
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  cleanup.push(() => server.close());
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no address');
+  return {
+    port: address.port,
+    store,
+    topicStore,
+    hub,
+    channelId: topic.id,
+  };
+}
+
+async function post(
+  harness: Harness,
+  body: { text: string; threadId?: string }
+): Promise<{ status: number; message: ChannelMessage }> {
+  const response = await fetch(
+    `http://127.0.0.1:${harness.port}/channels/${encodeURIComponent(harness.channelId)}/messages`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  const data = (await response.json()) as { message: ChannelMessage };
+  return { status: response.status, message: data.message };
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 4_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('waitFor timed out');
+}
+
+describe('channel thread mention round trip', () => {
+  it('persists the human trigger and mock reply in one thread with a live root count', async () => {
+    const harness = await createHarness();
+    const root = await post(harness, { text: 'root needing an agent answer' });
+    expect(root.status).toBe(201);
+
+    const trigger = await post(harness, {
+      text: '@mock answer inside this thread',
+      threadId: root.message.id,
+    });
+    expect(trigger.status).toBe(201);
+    expect(trigger.message).toMatchObject({
+      threadId: root.message.id,
+      parentMessageId: root.message.id,
+    });
+
+    await waitFor(() =>
+      harness.store
+        .history(harness.channelId, { limit: 20 })
+        .some(
+          (message) =>
+            message.sender.id === 'agent:mock' && message.status === 'complete'
+        )
+    );
+    const agentReply = harness.store
+      .history(harness.channelId, { limit: 20 })
+      .find(
+        (message) =>
+          message.sender.id === 'agent:mock' && message.status === 'complete'
+      );
+    expect(agentReply).toMatchObject({
+      body: { text: 'Mock v2 response complete.' },
+      threadId: root.message.id,
+      // `parentMessageId` is the immediate human trigger; `threadId` is the
+      // canonical root used by the UI projection and history endpoint.
+      parentMessageId: trigger.message.id,
+    });
+
+    const thread = harness.store.threadHistory(
+      harness.channelId,
+      root.message.id,
+      { limit: 20 }
+    );
+    expect(thread.map((message) => message.id)).toEqual([
+      root.message.id,
+      trigger.message.id,
+      agentReply!.id,
+    ]);
+    expect(harness.store.getMessage(root.message.id)?.replyCount).toBe(2);
+  });
+});

--- a/test/components/channel-live-reply-count.test.ts
+++ b/test/components/channel-live-reply-count.test.ts
@@ -130,4 +130,49 @@ describe('live reply count above a persisted floor', () => {
       '111 replies'
     );
   });
+
+  it('does not invent growth before the first tracked root floor', async () => {
+    const outOfWindow = row('chm:out-of-window', 10, rootId);
+    await render([outOfWindow]);
+    await render([outOfWindow, row('chm:still-no-floor', 11, rootId)]);
+    expect(host.querySelector('.ch-msg__thread-chip')).toBeNull();
+
+    await render([
+      row(rootId, 1, null, 10),
+      outOfWindow,
+      row('chm:still-no-floor', 11, rootId),
+    ]);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '10 replies'
+    );
+  });
+
+  it('treats root plus replies in one full snapshot as one authoritative batch', async () => {
+    const initialRoot = row(rootId, 1, null, 1);
+    const replyA = row('chm:snapshot-a', 2, rootId);
+    const replyB = row('chm:snapshot-b', 3, rootId);
+    await render([initialRoot, replyA], 1);
+
+    // The refreshed floor already contains replyB. Re-counting that same-batch
+    // row as growth reproduces the historical 3-vs-2 overcount.
+    await render([row(rootId, 1, null, 2), replyA, replyB], 2);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '2 replies'
+    );
+  });
+
+  it('counts unseen full-snapshot replies when their tracked root is absent', async () => {
+    const root = row(rootId, 1, null, 10);
+    const reply10 = row('chm:snapshot-existing', 10, rootId);
+    const reply11 = row('chm:snapshot-unseen', 11, rootId);
+    await render([root, reply10], 1);
+
+    // A truncated replacement has no fresh floor for this root, so its unseen
+    // reply remains live growth rather than being swallowed as authoritative.
+    await render([reply10, reply11], 2);
+    await render([root, reply10, reply11], 2);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '11 replies'
+    );
+  });
 });

--- a/test/components/channel-live-reply-count.test.ts
+++ b/test/components/channel-live-reply-count.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const rootId = 'chm:floor-root' as ChannelMessageId;
+
+function row(
+  id: string,
+  seq: number,
+  threadId: ChannelMessageId | null,
+  replyCount?: number
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: id as ChannelMessageId,
+    channelId: 'topic:reply-floor',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+    body: { text: id, format: 'text' },
+    threadId,
+    parentMessageId: threadId,
+    ...(replyCount !== undefined ? { replyCount } : {}),
+    createdAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+    updatedAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+  };
+}
+
+let host: HTMLDivElement;
+let reactRoot: Root;
+
+async function render(
+  messages: ChannelMessage[],
+  fullSnapshotRevision = 1
+): Promise<void> {
+  await act(async () => {
+    reactRoot.render(
+      React.createElement(ChannelTimeline, {
+        messages,
+        lastReadSeq: null,
+        channelId: 'topic:reply-floor',
+        channelTitle: 'reply-floor',
+        hasMoreOlder: false,
+        loadingOlder: false,
+        loadOlder: async () => {},
+        fullSnapshotRevision,
+        needsCatchup: false,
+        onResync: () => {},
+        onOpenThread: () => {},
+      })
+    );
+    await Promise.resolve();
+  });
+}
+
+describe('live reply count above a persisted floor', () => {
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    reactRoot = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => reactRoot.unmount());
+    host.remove();
+  });
+
+  it('adds a newly observed live child when the loaded subset is below the floor', async () => {
+    const initial = [
+      row(rootId, 1, null, 100),
+      row('chm:loaded-98', 98, rootId),
+      row('chm:loaded-99', 99, rootId),
+      row('chm:loaded-100', 100, rootId),
+    ];
+    await render(initial);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '100 replies'
+    );
+
+    await render([...initial, row('chm:live-101', 101, rootId)]);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '101 replies'
+    );
+  });
+
+  it('preserves growth through an absent-root truncated snapshot until the root refetch rebases it', async () => {
+    const initial = [
+      row(rootId, 1, null, 110),
+      row('chm:loaded-110', 110, rootId),
+    ];
+    const liveReply = row('chm:live-111', 111, rootId);
+    await render(initial);
+    await render([...initial, liveReply]);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '111 replies'
+    );
+
+    // A 100-row authoritative replacement can contain only replies. Growth is
+    // still load-bearing because there is no refreshed root floor to absorb it.
+    await render([row('chm:loaded-110', 110, rootId), liveReply], 2);
+    expect(host.querySelector('.ch-msg__thread-chip')).toBeNull();
+    await render([...initial, liveReply], 2);
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '111 replies'
+    );
+
+    // Once a refetch carries the advanced authoritative floor, growth rebases
+    // instead of double-counting it.
+    await render(
+      [
+        row(rootId, 1, null, 111),
+        row('chm:loaded-110', 110, rootId),
+        liveReply,
+      ],
+      2
+    );
+    expect(host.querySelector('.ch-msg__thread-chip')?.textContent).toContain(
+      '111 replies'
+    );
+  });
+});

--- a/test/components/channel-thread-layout.test.ts
+++ b/test/components/channel-thread-layout.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveReplyCounts,
+  displayedReplyCount,
+  selectTopLevel,
+} from '../../frontend/src/lib/chat/channel-timeline-layout.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+function message(
+  id: string,
+  seq: number,
+  overrides: Partial<ChannelMessage> = {}
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: id as ChannelMessageId,
+    channelId: 'topic:thread-test',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: id, format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+    updatedAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+    ...overrides,
+  };
+}
+
+describe('channel thread timeline projections', () => {
+  it('filters replies only at the top-level render boundary', () => {
+    const root = message('chm:root', 1);
+    const system = message('chm:system', 2, {
+      kind: 'system',
+      sender: { kind: 'system', id: 'system' },
+    });
+    const reply = message('chm:reply', 3, {
+      threadId: root.id,
+      parentMessageId: root.id,
+    });
+    const source = [root, system, reply];
+
+    expect(selectTopLevel(source).map((row) => row.id)).toEqual([
+      root.id,
+      system.id,
+    ]);
+    expect(source).toHaveLength(3);
+  });
+
+  it('derives loaded count and newest activity per canonical root', () => {
+    const rootA = message('chm:root-a', 1);
+    const rootB = message('chm:root-b', 2);
+    const rows = [
+      rootA,
+      rootB,
+      message('chm:a-late', 5, {
+        threadId: rootA.id,
+        parentMessageId: rootA.id,
+        createdAt: '2026-07-18T12:05:00.000Z',
+      }),
+      message('chm:a-early', 3, {
+        threadId: rootA.id,
+        parentMessageId: rootA.id,
+        createdAt: '2026-07-18T12:03:00.000Z',
+      }),
+      message('chm:b', 4, {
+        threadId: rootB.id,
+        parentMessageId: rootB.id,
+        createdAt: '2026-07-18T12:04:00.000Z',
+      }),
+    ];
+
+    expect(deriveReplyCounts(rows)).toEqual(
+      new Map([
+        [rootA.id, { count: 2, lastReplyAt: '2026-07-18T12:05:00.000Z' }],
+        [rootB.id, { count: 1, lastReplyAt: '2026-07-18T12:04:00.000Z' }],
+      ])
+    );
+  });
+
+  it('uses the persisted reply count as a floor and live children as growth', () => {
+    const root = message('chm:root', 1, { replyCount: 8 });
+    expect(displayedReplyCount(root, { count: 3 })).toBe(8);
+    expect(displayedReplyCount(root, { count: 3 }, 1)).toBe(9);
+    expect(displayedReplyCount(root, { count: 9 })).toBe(9);
+    expect(displayedReplyCount(message('chm:fresh', 2), undefined)).toBe(0);
+  });
+});

--- a/test/components/channel-timeline-scroll.test.ts
+++ b/test/components/channel-timeline-scroll.test.ts
@@ -216,6 +216,32 @@ describe('ChannelTimeline scroll model (#1193)', () => {
     expect(timeline().scrollTop).toBe(200);
   });
 
+  it('restores the visible reader anchor across a non-following reflow', async () => {
+    await render([message(1), message(2)]);
+    const firstRow = host.querySelector<HTMLElement>(
+      '[data-channel-message-seq="1"]'
+    );
+    if (!firstRow) throw new Error('missing first message row');
+    let rowTop = 40;
+    firstRow.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: rowTop,
+        top: rowTop,
+        left: 0,
+        right: 100,
+        bottom: rowTop + 20,
+        width: 100,
+        height: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    await userScroll(200);
+
+    rowTop = 80;
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(timeline().scrollTop).toBe(240);
+  });
+
   it('disengages follow when scrolling to the top of a low-overflow timeline before prepend growth', async () => {
     timelineScrollHeight = 400;
     timelineClientHeight = 300;

--- a/test/e2e/channel-thread.spec.ts
+++ b/test/e2e/channel-thread.spec.ts
@@ -1,0 +1,439 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type BrowserContext,
+  type Page,
+} from '@playwright/test';
+
+const PIN = '1170-thread-ui';
+const CAPS = {
+  read: { 'x-relay-capabilities': 'context:read' },
+  write: {
+    'Content-Type': 'application/json',
+    'x-relay-capabilities': 'context:write',
+  },
+};
+
+interface PostedMessage {
+  id: string;
+  seq: number;
+  threadId: string | null;
+  body: { text: string };
+}
+
+let fixtureOrdinal = 0;
+
+async function authenticate(context: BrowserContext): Promise<void> {
+  const request = context.request;
+  const status = await request.get('/auth/status');
+  expect(status.ok()).toBe(true);
+  const { hasPIN } = (await status.json()) as { hasPIN: boolean };
+  const auth = hasPIN
+    ? await request.post('/auth', { data: { pin: PIN } })
+    : await request.post('/auth/setup', {
+        data: { pin: PIN, confirm: PIN },
+      });
+  expect(auth.ok()).toBe(true);
+}
+
+async function createChannel(context: BrowserContext): Promise<string> {
+  fixtureOrdinal += 1;
+  const id = `topic:e2e-thread-${Date.now()}-${fixtureOrdinal}`;
+  const response = await context.request.post('/workspace-topics', {
+    headers: CAPS.write,
+    data: {
+      id,
+      workspaceId: 'ws-e2e-thread',
+      title: `thread-e2e-${fixtureOrdinal}`,
+    },
+  });
+  expect(response.status()).toBe(201);
+  return id;
+}
+
+async function postMessage(
+  request: APIRequestContext,
+  channelId: string,
+  text: string,
+  threadId?: string
+): Promise<PostedMessage> {
+  const response = await request.post(
+    `/channels/${encodeURIComponent(channelId)}/messages`,
+    {
+      headers: CAPS.write,
+      data: {
+        text,
+        clientMessageId: `e2e-${Date.now()}-${Math.random()}`,
+        ...(threadId ? { threadId } : {}),
+      },
+    }
+  );
+  expect(response.status()).toBe(201);
+  const body = (await response.json()) as { message: PostedMessage };
+  return body.message;
+}
+
+async function seedThread(
+  context: BrowserContext,
+  replyCount: number
+): Promise<{ channelId: string; root: PostedMessage }> {
+  await authenticate(context);
+  const channelId = await createChannel(context);
+  const root = await postMessage(
+    context.request,
+    channelId,
+    'load-bearing thread root'
+  );
+  for (let index = 1; index <= replyCount; index += 1) {
+    await postMessage(
+      context.request,
+      channelId,
+      `seeded thread reply ${String(index).padStart(3, '0')}`,
+      root.id
+    );
+  }
+  return { channelId, root };
+}
+
+async function openChannel(
+  page: Page,
+  input: { channelId: string; threadRootId?: string }
+): Promise<void> {
+  const params = new URLSearchParams({ channelId: input.channelId });
+  if (input.threadRootId) params.set('threadRootId', input.threadRootId);
+  await page.goto(`/test-channel-thread.html?${params}`);
+  await expect(page.getByRole('main', { name: 'channel' })).toBeVisible();
+  await expect(page.getByLabel(/connected|reconnecting/)).toHaveAttribute(
+    'aria-label',
+    'connected'
+  );
+}
+
+test.describe.serial('smoke channel thread UI (#1170)', () => {
+  test('opens the panel from the reply chip with a pinned root and thread composer', async ({
+    context,
+    page,
+  }) => {
+    const { channelId } = await seedThread(context, 2);
+    await openChannel(page, { channelId });
+
+    const chip = page.getByRole('button', {
+      name: '2 replies — open thread',
+    });
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    const panel = page.locator('.ch-thread');
+    await expect(panel).toBeVisible();
+    await expect(
+      panel.locator('.ch-thread__root').getByText('load-bearing thread root')
+    ).toBeVisible();
+    await expect(
+      panel.getByRole('textbox', { name: 'message input' })
+    ).toHaveAttribute('placeholder', /reply in thread/i);
+  });
+
+  test('posts a reply into the panel, not the main lane, and increments the chip', async ({
+    context,
+    page,
+  }) => {
+    const { channelId } = await seedThread(context, 1);
+    await openChannel(page, { channelId });
+    await page.getByRole('button', { name: '1 reply — open thread' }).click();
+
+    const panel = page.locator('.ch-thread');
+    const mainTimeline = page.locator('.ch-tl');
+    const input = panel.getByRole('textbox', { name: 'message input' });
+    await input.fill('reply posted from the thread composer');
+    await input.press('Enter');
+
+    await expect(
+      panel
+        .locator('.ch-thread__scroll')
+        .getByText('reply posted from the thread composer')
+    ).toBeVisible();
+    await expect(
+      mainTimeline.getByText('reply posted from the thread composer')
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: '2 replies — open thread' })
+    ).toBeVisible();
+    await expect(panel.locator('.ch-thread__header')).toContainText(
+      '2 replies'
+    );
+  });
+
+  test('updates chip and panel header live after a second REST sender posts', async ({
+    context,
+    page,
+  }) => {
+    const { channelId, root } = await seedThread(context, 1);
+    await openChannel(page, { channelId });
+    await page.getByRole('button', { name: '1 reply — open thread' }).click();
+
+    await postMessage(
+      context.request,
+      channelId,
+      'live reply from another sender',
+      root.id
+    );
+
+    await expect(
+      page.getByRole('button', { name: '2 replies — open thread' })
+    ).toBeVisible();
+    const panel = page.locator('.ch-thread');
+    await expect(panel.locator('.ch-thread__header')).toContainText(
+      '2 replies'
+    );
+    await expect(
+      panel
+        .locator('.ch-thread__scroll')
+        .getByText('live reply from another sender')
+    ).toBeVisible();
+    await expect(
+      page.locator('.ch-tl').getByText('live reply from another sender')
+    ).toHaveCount(0);
+  });
+
+  test('walks a thread beyond one page without moving the visible reply or the pinned root', async ({
+    context,
+    page,
+  }) => {
+    const { channelId, root } = await seedThread(context, 210);
+    const olderRequests: string[] = [];
+    const channelHistoryRequests: string[] = [];
+    let failedFirstChannelBackfill = false;
+    await page.route('**/channels/**/messages?**', async (route) => {
+      const url = route.request().url();
+      if (
+        route.request().method() === 'GET' &&
+        url.includes(`/channels/${encodeURIComponent(channelId)}/messages`) &&
+        url.includes('beforeSeq=')
+      ) {
+        channelHistoryRequests.push(url);
+        if (!failedFirstChannelBackfill) {
+          failedFirstChannelBackfill = true;
+          await route.abort('failed');
+          return;
+        }
+      }
+      await route.continue();
+    });
+    page.on('request', (request) => {
+      if (
+        request.method() === 'GET' &&
+        request.url().includes(`/threads/${encodeURIComponent(root.id)}`) &&
+        request.url().includes('beforeSeq=')
+      ) {
+        olderRequests.push(request.url());
+      }
+    });
+    // Normal channel open intentionally starts on a reply-only 100-row socket
+    // snapshot. The view must retry one transient failure, then walk multiple
+    // pages non-geometrically until the root/top-level lane is reachable.
+    await openChannel(page, { channelId });
+    await expect(page.getByText('load-bearing thread root')).toBeVisible();
+    await expect
+      .poll(() => channelHistoryRequests.length)
+      .toBeGreaterThanOrEqual(3);
+    const rootChip = page.getByRole('button', {
+      name: '210 replies — open thread',
+    });
+    await expect(rootChip).toBeVisible();
+    await expect(
+      page.locator('.ch-tl').getByText(/seeded thread reply/)
+    ).toHaveCount(0);
+    await rootChip.click();
+
+    const panel = page.locator('.ch-thread');
+    const scroll = panel.locator('.ch-thread__scroll');
+    await expect(scroll).toBeVisible();
+    await expect(scroll.getByText('seeded thread reply 210')).toBeVisible();
+
+    const anchor = await scroll.evaluate((element) => {
+      element.scrollTop = 0;
+      const containerTop = element.getBoundingClientRect().top;
+      const row = Array.from(
+        element.querySelectorAll<HTMLElement>('[data-channel-message-seq]')
+      ).find(
+        (candidate) => candidate.getBoundingClientRect().bottom >= containerTop
+      );
+      if (!row) throw new Error('missing visible thread anchor row');
+      const result = {
+        seq: row.dataset.channelMessageSeq ?? '',
+        top: row.getBoundingClientRect().top - containerTop,
+      };
+      element.dispatchEvent(new Event('scroll'));
+      return result;
+    });
+    const anchorRow = scroll.locator(
+      `[data-channel-message-seq="${anchor.seq}"]`
+    );
+    await expect.poll(() => olderRequests.length).toBeGreaterThan(0);
+    await expect
+      .poll(async () => {
+        const container = await scroll.boundingBox();
+        const row = await anchorRow.boundingBox();
+        if (!container || !row)
+          throw new Error('missing thread anchor geometry');
+        return row.y - container.y;
+      })
+      .toBeCloseTo(anchor.top, 0);
+
+    // 110 replies require two backward pages beyond the newest 50 before the
+    // root-inclusive oldest page is reached.
+    await scroll.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event('scroll'));
+    });
+    await expect.poll(() => olderRequests.length).toBeGreaterThan(1);
+
+    await expect(
+      panel.locator('.ch-thread__root').getByText('load-bearing thread root')
+    ).toBeVisible();
+    const rootBox = await panel.locator('.ch-thread__root').boundingBox();
+    const scrollBox = await scroll.boundingBox();
+    expect(rootBox).not.toBeNull();
+    expect(scrollBox).not.toBeNull();
+    expect(rootBox!.y + rootBox!.height).toBeLessThanOrEqual(scrollBox!.y + 1);
+  });
+
+  test('switching roots resets the panel follow lane to the bottom with no stale pill', async ({
+    context,
+    page,
+  }) => {
+    await authenticate(context);
+    const channelId = await createChannel(context);
+    const rootA = await postMessage(
+      context.request,
+      channelId,
+      'thread switch root a'
+    );
+    for (let index = 1; index <= 70; index += 1) {
+      await postMessage(
+        context.request,
+        channelId,
+        `thread a reply ${String(index).padStart(2, '0')}`,
+        rootA.id
+      );
+    }
+    const rootB = await postMessage(
+      context.request,
+      channelId,
+      'thread switch root b'
+    );
+    await postMessage(context.request, channelId, 'thread b reply 1', rootB.id);
+    await postMessage(context.request, channelId, 'thread b reply 2', rootB.id);
+
+    await openChannel(page, { channelId });
+    await page
+      .getByRole('button', { name: '70 replies — open thread' })
+      .click();
+    const panel = page.locator('.ch-thread');
+    const scroll = panel.locator('.ch-thread__scroll');
+    await expect(scroll.getByText('thread a reply 70')).toBeVisible();
+    await scroll.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event('scroll'));
+    });
+    await expect
+      .poll(() =>
+        scroll.evaluate(
+          (element) => element.scrollHeight > element.clientHeight
+        )
+      )
+      .toBe(true);
+
+    await page.getByRole('button', { name: '2 replies — open thread' }).click();
+    await expect(panel.locator('.ch-thread__header')).toContainText(
+      '2 replies'
+    );
+    await expect(scroll.getByText('thread b reply 2')).toBeVisible();
+    await expect
+      .poll(() =>
+        scroll.evaluate(
+          (element) =>
+            element.scrollHeight - element.scrollTop - element.clientHeight
+        )
+      )
+      .toBeLessThanOrEqual(1);
+    await expect(panel.locator('.ch-new-messages')).toHaveCount(0);
+  });
+
+  test('a hidden thread reply advances its count without moving the scrolled-up main lane', async ({
+    context,
+    page,
+  }) => {
+    await authenticate(context);
+    const channelId = await createChannel(context);
+    for (let index = 1; index <= 45; index += 1) {
+      await postMessage(
+        context.request,
+        channelId,
+        `top-level history ${String(index).padStart(2, '0')}`
+      );
+    }
+    const root = await postMessage(
+      context.request,
+      channelId,
+      'hidden reply scroll root'
+    );
+    await postMessage(
+      context.request,
+      channelId,
+      'existing hidden reply',
+      root.id
+    );
+
+    await openChannel(page, { channelId });
+    const main = page.locator('.ch-tl');
+    await main.evaluate((element) => {
+      element.scrollTop = 100;
+      element.dispatchEvent(new Event('scroll'));
+    });
+    const before = await main.evaluate((element) => element.scrollTop);
+    expect(before).toBe(100);
+
+    await postMessage(context.request, channelId, 'new hidden reply', root.id);
+    await expect(
+      page.getByRole('button', { name: '2 replies — open thread' })
+    ).toHaveCount(1);
+    await expect
+      .poll(() => main.evaluate((element) => element.scrollTop))
+      .toBe(before);
+    await expect(page.locator('.ch-main .ch-new-messages')).toHaveCount(0);
+    await expect(main.getByText('new hidden reply')).toHaveCount(0);
+  });
+
+  test('uses a 380px desktop split, a mounted mobile overlay/back, and Escape close', async ({
+    context,
+    page,
+  }) => {
+    const { channelId } = await seedThread(context, 1);
+    await openChannel(page, { channelId });
+    await page.getByRole('button', { name: '1 reply — open thread' }).click();
+
+    const panel = page.locator('.ch-thread');
+    await expect
+      .poll(async () => (await panel.boundingBox())?.width ?? 0)
+      .toBeCloseTo(380, 0);
+    await expect(page.locator('.ch-main')).toBeVisible();
+
+    await page.setViewportSize({ width: 390, height: 700 });
+    const mobileBox = await panel.boundingBox();
+    expect(mobileBox).not.toBeNull();
+    expect(mobileBox!.x).toBeCloseTo(0, 0);
+    expect(mobileBox!.y).toBeCloseTo(0, 0);
+    expect(mobileBox!.width).toBeCloseTo(390, 0);
+    expect(mobileBox!.height).toBeCloseTo(700, 0);
+    await expect(panel.getByText('‹ back')).toBeVisible();
+    expect(await page.locator('.ch-main').count()).toBe(1);
+
+    const input = panel.getByRole('textbox', { name: 'message input' });
+    await input.focus();
+    await page.keyboard.press('Escape');
+    await expect(panel).toHaveCount(0);
+    await expect(page.locator('.ch-main')).toBeVisible();
+  });
+});

--- a/test/e2e/channel-thread.spec.ts
+++ b/test/e2e/channel-thread.spec.ts
@@ -3,6 +3,7 @@ import {
   test,
   type APIRequestContext,
   type BrowserContext,
+  type Locator,
   type Page,
 } from '@playwright/test';
 
@@ -108,6 +109,39 @@ async function openChannel(
     'aria-label',
     'connected'
   );
+}
+
+async function captureFirstVisible(
+  log: Locator
+): Promise<{ seq: string; top: number }> {
+  return log.evaluate((element) => {
+    const containerTop = element.getBoundingClientRect().top;
+    const row = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-channel-message-seq]')
+    ).find(
+      (candidate) => candidate.getBoundingClientRect().bottom >= containerTop
+    );
+    if (!row) throw new Error('missing visible message row');
+    return {
+      seq: row.dataset.channelMessageSeq ?? '',
+      top: row.getBoundingClientRect().top - containerTop,
+    };
+  });
+}
+
+async function expectAnchorStable(
+  log: Locator,
+  anchor: { seq: string; top: number }
+): Promise<void> {
+  const row = log.locator(`[data-channel-message-seq="${anchor.seq}"]`);
+  await expect
+    .poll(async () => {
+      const containerBox = await log.boundingBox();
+      const rowBox = await row.boundingBox();
+      if (!containerBox || !rowBox) throw new Error('missing anchor geometry');
+      return rowBox.y - containerBox.y;
+    })
+    .toBeCloseTo(anchor.top, 0);
 }
 
 test.describe.serial('smoke channel thread UI (#1170)', () => {
@@ -234,9 +268,11 @@ test.describe.serial('smoke channel thread UI (#1170)', () => {
     // pages non-geometrically until the root/top-level lane is reachable.
     await openChannel(page, { channelId });
     await expect(page.getByText('load-bearing thread root')).toBeVisible();
-    await expect
-      .poll(() => channelHistoryRequests.length)
-      .toBeGreaterThanOrEqual(3);
+    // One same-cursor failure + three successful distinct cursor pages reaches
+    // this 210-reply root. The failed retry does not spend another page slot.
+    await expect.poll(() => channelHistoryRequests.length).toBe(4);
+    await page.waitForTimeout(500);
+    expect(channelHistoryRequests).toHaveLength(4);
     const rootChip = page.getByRole('button', {
       name: '210 replies — open thread',
     });
@@ -281,8 +317,8 @@ test.describe.serial('smoke channel thread UI (#1170)', () => {
       })
       .toBeCloseTo(anchor.top, 0);
 
-    // 110 replies require two backward pages beyond the newest 50 before the
-    // root-inclusive oldest page is reached.
+    // The thread-history lane itself still walks backward in 50-row pages and
+    // keeps its visible row stable while prepending.
     await scroll.evaluate((element) => {
       element.scrollTop = 0;
       element.dispatchEvent(new Event('scroll'));
@@ -297,6 +333,43 @@ test.describe.serial('smoke channel thread UI (#1170)', () => {
     expect(rootBox).not.toBeNull();
     expect(scrollBox).not.toBeNull();
     expect(rootBox!.y + rootBox!.height).toBeLessThanOrEqual(scrollBox!.y + 1);
+  });
+
+  test('caps automatic channel backfill at four cursor pages and resumes only on demand', async ({
+    context,
+    page,
+  }) => {
+    const { channelId } = await seedThread(context, 310);
+    const channelHistoryRequests: string[] = [];
+    page.on('request', (request) => {
+      const url = request.url();
+      if (
+        request.method() === 'GET' &&
+        url.includes(`/channels/${encodeURIComponent(channelId)}/messages`) &&
+        url.includes('beforeSeq=')
+      ) {
+        channelHistoryRequests.push(url);
+      }
+    });
+
+    await openChannel(page, { channelId });
+    const continuation = page.getByRole('button', {
+      name: 'load older channel history',
+    });
+    await expect(continuation).toBeVisible();
+    await expect.poll(() => channelHistoryRequests.length).toBe(4);
+    await page.waitForTimeout(500);
+    expect(channelHistoryRequests).toHaveLength(4);
+    await expect(page.getByText('load-bearing thread root')).toHaveCount(0);
+
+    await continuation.click();
+    await expect(page.getByText('load-bearing thread root')).toBeVisible();
+    await expect
+      .poll(() => channelHistoryRequests.length)
+      .toBeGreaterThanOrEqual(5);
+    await expect(
+      page.getByRole('button', { name: '310 replies — open thread' })
+    ).toBeVisible();
   });
 
   test('switching roots resets the panel follow lane to the bottom with no stale pill', async ({
@@ -404,6 +477,111 @@ test.describe.serial('smoke channel thread UI (#1170)', () => {
       .toBe(before);
     await expect(page.locator('.ch-main .ch-new-messages')).toHaveCount(0);
     await expect(main.getByText('new hidden reply')).toHaveCount(0);
+  });
+
+  test('Escape dismisses an open thread mention palette before closing the panel', async ({
+    context,
+    page,
+  }) => {
+    const { channelId } = await seedThread(context, 1);
+    await openChannel(page, { channelId });
+    await page.getByRole('button', { name: '1 reply — open thread' }).click();
+
+    const panel = page.locator('.ch-thread');
+    const input = panel.getByRole('textbox', { name: 'message input' });
+    await input.fill('draft survives @');
+    const palette = panel.getByRole('listbox', { name: 'agents' });
+    await expect(palette).toBeVisible();
+
+    await input.press('Escape');
+    await expect(palette).toBeHidden();
+    await expect(panel).toBeVisible();
+    await expect(input).toHaveValue('draft survives @');
+
+    await input.press('Escape');
+    await expect(panel).toHaveCount(0);
+  });
+
+  test('keeps the main composer interactive while a thread is open', async ({
+    context,
+    page,
+  }) => {
+    const { channelId } = await seedThread(context, 1);
+    await openChannel(page, { channelId });
+    await page.getByRole('button', { name: '1 reply — open thread' }).click();
+
+    const panel = page.locator('.ch-thread');
+    const main = page.locator('.ch-main');
+    const mainInput = main.getByRole('textbox', { name: 'message input' });
+    await mainInput.fill('root-level post while thread remains open');
+    await mainInput.press('Enter');
+
+    await expect(
+      main
+        .locator('.ch-tl')
+        .getByText('root-level post while thread remains open')
+    ).toBeVisible();
+    await expect(
+      panel
+        .locator('.ch-thread__scroll')
+        .getByText('root-level post while thread remains open')
+    ).toHaveCount(0);
+    await expect(panel.locator('.ch-thread__header')).toContainText('1 reply');
+    await expect(
+      page.getByRole('button', { name: '1 reply — open thread' })
+    ).toHaveCount(1);
+  });
+
+  test('preserves the main-lane first visible row while opening and closing the desktop split', async ({
+    context,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await authenticate(context);
+    const channelId = await createChannel(context);
+    let root: PostedMessage | null = null;
+    for (let index = 1; index <= 60; index += 1) {
+      const message = await postMessage(
+        context.request,
+        channelId,
+        `desktop anchor row ${String(index).padStart(2, '0')} ${'wrapping content '.repeat(9)}`
+      );
+      if (index === 30) {
+        root = message;
+        await postMessage(
+          context.request,
+          channelId,
+          'reply that enables the desktop thread chip',
+          root.id
+        );
+      }
+    }
+    expect(root).not.toBeNull();
+
+    await openChannel(page, { channelId });
+    const mainLog = page.locator('.ch-main .ch-tl');
+    await mainLog.evaluate((element) => {
+      element.scrollTop = Math.max(
+        1,
+        element.scrollHeight - element.clientHeight - 500
+      );
+      element.dispatchEvent(new Event('scroll'));
+    });
+    const beforeOpen = await captureFirstVisible(mainLog);
+
+    const chip = page.getByRole('button', {
+      name: '1 reply — open thread',
+    });
+    await chip.evaluate((button) => (button as HTMLButtonElement).click());
+    await expect(page.locator('.ch-thread')).toBeVisible();
+    await expectAnchorStable(mainLog, beforeOpen);
+
+    const beforeClose = await captureFirstVisible(mainLog);
+    await page
+      .getByRole('button', { name: 'close thread' })
+      .evaluate((button) => (button as HTMLButtonElement).click());
+    await expect(page.locator('.ch-thread')).toHaveCount(0);
+    await expectAnchorStable(mainLog, beforeClose);
   });
 
   test('uses a 380px desktop split, a mounted mobile overlay/back, and Escape close', async ({

--- a/test/hooks/useChannelChatSocket-thread-post.test.ts
+++ b/test/hooks/useChannelChatSocket-thread-post.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { ChannelMessageId } from '../../shared/channel-chat-protocol.js';
+
+const apiMocks = vi.hoisted(() => ({
+  fetchChannel: vi.fn(),
+  postChannelMessage: vi.fn(),
+}));
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return { ...actual, ...apiMocks };
+});
+
+import {
+  useChannelChatSocket,
+  type UseChannelChatSocketState,
+} from '../../frontend/src/hooks/useChannelChatSocket.js';
+
+class MockWebSocket {
+  static OPEN = 1;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close(): void {}
+}
+
+const channelId = 'topic:thread-post';
+const rootId = 'chm:root' as ChannelMessageId;
+let container: HTMLDivElement;
+let reactRoot: Root;
+let latest: UseChannelChatSocketState;
+
+function Harness() {
+  latest = useChannelChatSocket(channelId);
+  return null;
+}
+
+describe('useChannelChatSocket thread post', () => {
+  beforeEach(() => {
+    apiMocks.fetchChannel.mockReset().mockResolvedValue({
+      id: channelId,
+      title: 'thread post',
+      visibility: 'default',
+      archived: false,
+      latestSeq: 0,
+      messageCount: 0,
+      lastMessage: null,
+      members: [],
+    });
+    apiMocks.postChannelMessage
+      .mockReset()
+      .mockResolvedValue({ id: 'chm:new' });
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => reactRoot.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('forwards threadId and clientMessageId without parentMessageId', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    await act(async () => {
+      reactRoot.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Harness)
+        )
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await latest.post('thread reply', {
+        clientMessageId: 'browser:thread-reply',
+        threadId: rootId,
+      });
+    });
+
+    expect(apiMocks.postChannelMessage).toHaveBeenCalledWith(channelId, {
+      text: 'thread reply',
+      clientMessageId: 'browser:thread-reply',
+      threadId: rootId,
+    });
+  });
+});

--- a/test/hooks/useChannelThread.test.ts
+++ b/test/hooks/useChannelThread.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+const fetchThreadMock = vi.hoisted(() => vi.fn());
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  fetchChannelThreadHistory: fetchThreadMock,
+}));
+
+import {
+  useChannelThread,
+  type UseChannelThreadState,
+} from '../../frontend/src/hooks/useChannelThread.js';
+
+const channelId = 'topic:thread-hook';
+const rootId = 'chm:root' as ChannelMessageId;
+
+function row(
+  id: string,
+  seq: number,
+  threadId: ChannelMessageId | null = null,
+  text = id
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: id as ChannelMessageId,
+    channelId,
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text, format: 'markdown' },
+    threadId,
+    parentMessageId: threadId,
+    createdAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+    updatedAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+  };
+}
+
+let container: HTMLDivElement;
+let reactRoot: Root;
+let latest: UseChannelThreadState;
+
+function Harness({
+  live,
+  activeRootId = rootId,
+}: {
+  live: ChannelMessage[];
+  activeRootId?: ChannelMessageId;
+}) {
+  latest = useChannelThread(channelId, activeRootId, live);
+  return null;
+}
+
+async function render(
+  live: ChannelMessage[],
+  activeRootId: ChannelMessageId = rootId
+): Promise<void> {
+  await act(async () => {
+    reactRoot.render(React.createElement(Harness, { live, activeRootId }));
+    await Promise.resolve();
+  });
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe('useChannelThread', () => {
+  beforeEach(() => {
+    fetchThreadMock.mockReset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => reactRoot.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('overlays live rows, scopes by root, and retains the root after live eviction', async () => {
+    const fetchedReply = row('chm:reply-2', 2, rootId, 'fetched reply');
+    fetchThreadMock.mockResolvedValueOnce({
+      // A newest-first long-thread page may not reach the root at all.
+      messages: [fetchedReply],
+      hasMore: false,
+    });
+    const liveRoot = row('chm:root', 1, null, 'live root');
+    const liveReply = row('chm:reply-3', 3, rootId, 'live reply');
+    const otherReply = row(
+      'chm:other',
+      4,
+      'chm:different-root' as ChannelMessageId
+    );
+
+    await render([liveRoot, liveReply, otherReply]);
+
+    expect(fetchThreadMock).toHaveBeenCalledWith(channelId, rootId, {
+      limit: 50,
+    });
+    expect(latest.root?.body.text).toBe('live root');
+    expect(latest.replies.map((reply) => reply.id)).toEqual([
+      fetchedReply.id,
+      liveReply.id,
+    ]);
+
+    await render([liveReply, otherReply]);
+    expect(latest.root?.body.text).toBe('live root');
+    expect(latest.replies.some((reply) => reply.id === otherReply.id)).toBe(
+      false
+    );
+  });
+
+  it('walks backward with the server cursor, dedupes, and keeps seq order', async () => {
+    const reply40 = row('chm:reply-40', 40, rootId);
+    const reply41 = row('chm:reply-41', 41, rootId);
+    fetchThreadMock
+      .mockResolvedValueOnce({
+        messages: [reply40, reply41],
+        hasMore: true,
+        nextCursor: { beforeSeq: 40 },
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          row('chm:root', 1),
+          row('chm:reply-39', 39, rootId),
+          reply40,
+        ],
+        hasMore: false,
+      });
+
+    await render([]);
+    expect(latest.hasMoreOlder).toBe(true);
+
+    await act(async () => {
+      await latest.loadOlder();
+    });
+
+    expect(fetchThreadMock).toHaveBeenNthCalledWith(2, channelId, rootId, {
+      beforeSeq: 40,
+      limit: 50,
+    });
+    expect(latest.root?.id).toBe(rootId);
+    expect(latest.replies.map((reply) => reply.seq)).toEqual([39, 40, 41]);
+    expect(latest.hasMoreOlder).toBe(false);
+  });
+
+  it('ignores every stale field when an earlier root request resolves last', async () => {
+    const rootA = 'chm:root-a' as ChannelMessageId;
+    const rootB = 'chm:root-b' as ChannelMessageId;
+    const requestA = deferred<{
+      messages: ChannelMessage[];
+      hasMore: boolean;
+      nextCursor: { beforeSeq: number };
+    }>();
+    const requestB = deferred<{
+      messages: ChannelMessage[];
+      hasMore: boolean;
+    }>();
+    fetchThreadMock
+      .mockReturnValueOnce(requestA.promise)
+      .mockReturnValueOnce(requestB.promise);
+
+    await render([], rootA);
+    expect(latest.loading).toBe(true);
+    await render([], rootB);
+
+    await act(async () => {
+      requestB.resolve({
+        messages: [row(rootB, 20, null, 'root b')],
+        hasMore: false,
+      });
+      await requestB.promise;
+      await Promise.resolve();
+    });
+    expect(latest.root?.id).toBe(rootB);
+    expect(latest.loading).toBe(false);
+    expect(latest.hasMoreOlder).toBe(false);
+
+    await act(async () => {
+      requestA.resolve({
+        messages: [
+          row(rootA, 1, null, 'stale root a'),
+          row('chm:stale-a-reply', 2, rootA),
+        ],
+        hasMore: true,
+        nextCursor: { beforeSeq: 2 },
+      });
+      await requestA.promise;
+      await Promise.resolve();
+    });
+
+    expect(latest.root?.id).toBe(rootB);
+    expect(latest.replies).toEqual([]);
+    expect(latest.loading).toBe(false);
+    expect(latest.loadingOlder).toBe(false);
+    expect(latest.hasMoreOlder).toBe(false);
+    await act(async () => latest.loadOlder());
+    expect(fetchThreadMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/hooks/useChannelThread.test.ts
+++ b/test/hooks/useChannelThread.test.ts
@@ -17,6 +17,11 @@ import {
   useChannelThread,
   type UseChannelThreadState,
 } from '../../frontend/src/hooks/useChannelThread.js';
+import { useLiveReplyGrowth } from '../../frontend/src/components/chat/useLiveReplyGrowth.js';
+import {
+  deriveReplyCounts,
+  displayedReplyCount,
+} from '../../frontend/src/lib/chat/channel-timeline-layout.js';
 
 const channelId = 'topic:thread-hook';
 const rootId = 'chm:root' as ChannelMessageId;
@@ -46,6 +51,7 @@ function row(
 let container: HTMLDivElement;
 let reactRoot: Root;
 let latest: UseChannelThreadState;
+let latestDisplayedCount = 0;
 
 function Harness({
   live,
@@ -64,6 +70,41 @@ async function render(
 ): Promise<void> {
   await act(async () => {
     reactRoot.render(React.createElement(Harness, { live, activeRootId }));
+    await Promise.resolve();
+  });
+}
+
+function GrowthHarness({ live }: { live: ChannelMessage[] }) {
+  latest = useChannelThread(channelId, rootId, live);
+  const growth = useLiveReplyGrowth(live, {
+    scopeKey: `${channelId}:${rootId}`,
+    fullSnapshotRevision: 1,
+    ...(latest.root
+      ? {
+          authoritativeRoots: [
+            {
+              message: latest.root,
+              revision: latest.rootFloorRevision,
+            },
+          ],
+        }
+      : {}),
+  });
+  const rows = latest.root ? [latest.root, ...latest.replies] : latest.replies;
+  const derived = deriveReplyCounts(rows);
+  latestDisplayedCount = latest.root
+    ? displayedReplyCount(
+        latest.root,
+        derived.get(rootId),
+        growth.get(rootId) ?? 0
+      )
+    : 0;
+  return null;
+}
+
+async function renderGrowth(live: ChannelMessage[]): Promise<void> {
+  await act(async () => {
+    reactRoot.render(React.createElement(GrowthHarness, { live }));
     await Promise.resolve();
   });
 }
@@ -124,6 +165,13 @@ describe('useChannelThread', () => {
     expect(latest.replies.some((reply) => reply.id === otherReply.id)).toBe(
       false
     );
+
+    await render([]);
+    expect(latest.root?.body.text).toBe('live root');
+    expect(latest.replies.map((reply) => reply.id)).toEqual([
+      fetchedReply.id,
+      liveReply.id,
+    ]);
   });
 
   it('walks backward with the server cursor, dedupes, and keeps seq order', async () => {
@@ -212,5 +260,32 @@ describe('useChannelThread', () => {
     expect(latest.hasMoreOlder).toBe(false);
     await act(async () => latest.loadOlder());
     expect(fetchThreadMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebases live growth when the initial REST fetch supplies its root floor', async () => {
+    const request = deferred<{
+      messages: ChannelMessage[];
+      hasMore: boolean;
+    }>();
+    fetchThreadMock.mockReturnValueOnce(request.promise);
+    const liveRoot = { ...row(rootId, 1), replyCount: 2 };
+    const reply2 = row('chm:race-reply-2', 2, rootId);
+    const reply3 = row('chm:race-reply-3', 3, rootId);
+
+    await renderGrowth([liveRoot, reply2]);
+    await renderGrowth([liveRoot, reply2, reply3]);
+    expect(latestDisplayedCount).toBe(3);
+
+    await act(async () => {
+      request.resolve({
+        messages: [{ ...liveRoot, replyCount: 3 }, reply2, reply3],
+        hasMore: false,
+      });
+      await request.promise;
+      await Promise.resolve();
+    });
+    expect(latest.root?.replyCount).toBe(3);
+    expect(latest.rootFloorRevision).toBe(1);
+    expect(latestDisplayedCount).toBe(3);
   });
 });

--- a/test/lib/channel-thread-api.test.ts
+++ b/test/lib/channel-thread-api.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchChannelThreadHistory,
+  postChannelMessage,
+} from '../../frontend/src/lib/api.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+const rootId = 'chm:root/id' as ChannelMessageId;
+
+function row(): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: rootId,
+    channelId: 'topic:eng threads',
+    seq: 1,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: 'root', format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-18T10:00:00.000Z',
+    updatedAt: '2026-07-18T10:00:00.000Z',
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('channel thread API client', () => {
+  it('uses the dedicated root-inclusive route and read capability', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          messages: [row()],
+          hasMore: true,
+          nextCursor: { beforeSeq: 40 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const page = await fetchChannelThreadHistory('topic:eng threads', rootId, {
+      beforeSeq: 41,
+      afterSeq: 42,
+      limit: 50,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/channels/topic%3Aeng%20threads/threads/chm%3Aroot%2Fid?beforeSeq=41&afterSeq=42&limit=50',
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(page).toEqual({
+      messages: [row()],
+      hasMore: true,
+      nextCursor: { beforeSeq: 40 },
+    });
+  });
+
+  it('posts threadId without inventing the legacy parent alias', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: row() }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postChannelMessage('topic:eng', {
+      text: 'reply',
+      clientMessageId: 'browser:1',
+      threadId: rootId,
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      text: 'reply',
+      clientMessageId: 'browser:1',
+      threadId: rootId,
+    });
+    expect(String(init.body)).not.toContain('parentMessageId');
+  });
+});

--- a/test/stores/channel-thread-ui-state.test.ts
+++ b/test/stores/channel-thread-ui-state.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUiStore } from '../../frontend/src/lib/stores/ui.js';
+import type { ChannelMessageId } from '../../shared/channel-chat-protocol.js';
+
+describe('channel thread transient UI state', () => {
+  beforeEach(() => {
+    useUiStore.setState({
+      activeChannelId: null,
+      activeThreadRootId: null,
+    });
+  });
+
+  it('opens a thread and clears it whenever channel selection is set', () => {
+    const rootId = 'chm:root' as ChannelMessageId;
+    useUiStore.getState().setActiveThreadRootId(rootId);
+    expect(useUiStore.getState().activeThreadRootId).toBe(rootId);
+
+    useUiStore.getState().setActiveChannelId('topic:next');
+    expect(useUiStore.getState().activeChannelId).toBe('topic:next');
+    expect(useUiStore.getState().activeThreadRootId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- add the channel thread panel with desktop split/mobile overlay, reply chips, pinned root, pagination, and a thread composer
- keep one channel socket and project reducer state at render time while REST backfill supplies older thread rows
- preserve Slack-style scroll behavior and live reply counts across truncated snapshots, hidden replies, and reconnects
- add component, hook, API, mock-adapter, and smoke Playwright coverage for the full thread workflow

## Validation

- focused thread Vitest: 7 files, 13/13 tests passed
- pre-push changed-test gate: 94 files, 770/770 tests passed
- scoped thread Playwright: 7/7 passed
- literal CI smoke command (`npx playwright test --grep "smoke"`): 19/19 passed
- `npm run check`: passed with 0 errors (247 existing warnings)
- `RELAY_IDE_E2E_FIXTURES=1 npm run build`: passed, 2,957 modules transformed
- `git diff --check`: passed
- scrubbed full `npm test`: 440/441 files passed; 5,513 tests passed and 9 skipped. The two unchanged `test/branch-watcher.test.ts` filesystem-event cases fail on this host even in isolation because watcher events do not arrive.

Refs #1170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added threaded conversations with reply counts, thread indicators, and a dedicated thread panel.
  * Users can open, browse, paginate, and reply within threads.
  * Added live reply updates, new-message indicators, and improved scroll position preservation.
  * Added channel history continuation controls when older messages are available.
  * Added customizable message composer placeholders.

* **Bug Fixes**
  * Improved thread state reset when switching channels or thread roots.
  * Prevented stale or duplicate reply counts during live updates and history refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->