### PR TITLE
fix(hub): harden health and session restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "agent-browser": "node dist/scripts/agent-browser-cli.js",
     "test": "vitest run",
     "test:smoke:multi-node": "vitest run test/hub-cross-node-pty.test.ts test/multi-node-smoke.test.ts",
+    "diagnose:channel-memory": "npm run build:server && node --expose-gc dist/scripts/channel-memory-load.js",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",

--- a/scripts/channel-memory-load.ts
+++ b/scripts/channel-memory-load.ts
@@ -1,0 +1,158 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { bindSessionToChannel } from '../server/channel-agent-bridge.js';
+import type { ChannelBridgeRetentionSnapshot } from '../server/channel-agent-bridge.js';
+import { createChannelHub, type ChannelSocket } from '../server/channel-hub.js';
+import { createChannelMessageStore } from '../server/channel-message-store.js';
+import {
+  formatHealthMemoryLine,
+  readHealthMemorySnapshot,
+} from '../server/health.js';
+import { createLogger } from '../server/logger.js';
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import type { ChannelEventV1 } from '../shared/channel-chat-protocol.js';
+
+const logger = createLogger('health');
+const channelId = 'topic:memory-load';
+
+function parseTurns(): number {
+  const raw = process.argv[2] ?? process.env.RELAY_CHANNEL_LOAD_TURNS ?? '100';
+  const turns = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(turns) || turns < 1 || turns > 10_000) {
+    throw new Error('turn count must be an integer between 1 and 10000');
+  }
+  return turns;
+}
+
+class SinkSocket implements ChannelSocket {
+  readyState = 1;
+  bufferedAmount = 0;
+  eventCount = 0;
+  wireBytes = 0;
+  private readonly handlers = new Map<string, () => void>();
+
+  send(data: string): void {
+    // Parse to exercise the actual wire shape without retaining event payloads.
+    JSON.parse(data) as ChannelEventV1;
+    this.eventCount++;
+    this.wireBytes += Buffer.byteLength(data, 'utf8');
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.handlers.get('close')?.();
+  }
+
+  on(event: 'close' | 'error', handler: () => void): void {
+    this.handlers.set(event, handler);
+  }
+}
+
+function heapSlope(samples: number[]): number {
+  if (samples.length < 2) return 0;
+  const meanX = (samples.length - 1) / 2;
+  const meanY = samples.reduce((sum, value) => sum + value, 0) / samples.length;
+  let numerator = 0;
+  let denominator = 0;
+  for (let index = 0; index < samples.length; index++) {
+    const dx = index - meanX;
+    numerator += dx * (samples[index]! - meanY);
+    denominator += dx * dx;
+  }
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+async function main(): Promise<void> {
+  const turns = parseTurns();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-channel-load-'));
+  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  const hub = createChannelHub({ store, channelExists: () => true });
+  const adapter = new MockProtocolAdapterV2({ connectMs: 0, stepMs: 0 });
+  let socket = new SinkSocket();
+  let retention: ChannelBridgeRetentionSnapshot = {
+    openStreams: 0,
+    assistantItemIds: 0,
+    turnsWithRows: 0,
+    retainedTextBytes: 0,
+  };
+  let durableTranscriptBytes = 0;
+  const heapSamples: number[] = [];
+
+  try {
+    await adapter.connect({
+      cwd: dir,
+      port: 0,
+      sessionId: 'memory-load-mock',
+      hookToken: 'diagnostic-only',
+      configDir: dir,
+    });
+    const unbind = bindSessionToChannel({
+      channelId,
+      agentFramework: 'mock',
+      adapter,
+      store,
+      hub,
+      onRetentionSnapshot: (snapshot) => {
+        retention = snapshot;
+      },
+      onAssistantMessageFinalized: (message) => {
+        durableTranscriptBytes += Buffer.byteLength(message.body.text, 'utf8');
+      },
+    });
+    hub.handleConnection(socket, { channelId, sinceSeq: null });
+
+    for (let turn = 1; turn <= turns; turn++) {
+      const trigger = store.appendComplete({
+        channelId,
+        sender: { kind: 'human', id: 'human:load-harness' },
+        text: `mock streaming turn ${turn}`,
+      });
+      durableTranscriptBytes += Buffer.byteLength(trigger.body.text, 'utf8');
+      hub.broadcastCreated(trigger);
+      await adapter.sendMessage({
+        turnId: `load-turn-${turn}`,
+        content: trigger.body.text,
+      });
+
+      // Periodically reconnect from the previous cursor to exercise durable
+      // SQLite catch-up without retaining an application-level event ring.
+      if (turn % 10 === 0 && turn < turns) {
+        const sinceSeq = Math.max(0, store.latestSeq(channelId) - 4);
+        socket.close();
+        socket = new SinkSocket();
+        hub.handleConnection(socket, { channelId, sinceSeq });
+      }
+
+      global.gc?.();
+      const snapshot = readHealthMemorySnapshot();
+      heapSamples.push(snapshot.heapUsed);
+      logger.info(
+        `load turn=${turn} ${formatHealthMemoryLine(snapshot)} ` +
+          `bridgeRetainedBytes=${retention.retainedTextBytes} ` +
+          `durableTranscriptBytes=${durableTranscriptBytes}`
+      );
+    }
+
+    const slope = heapSlope(heapSamples);
+    logger.info(
+      `load complete turns=${turns} heapGrowthPerTurn=${Math.round(slope)} ` +
+        `bridgeOpenStreams=${retention.openStreams} ` +
+        `bridgeItemIds=${retention.assistantItemIds} ` +
+        `bridgeTurns=${retention.turnsWithRows} ` +
+        `bridgeRetainedBytes=${retention.retainedTextBytes} ` +
+        `durableTranscriptBytes=${durableTranscriptBytes} ` +
+        `socketEvents=${socket.eventCount} socketWireBytes=${socket.wireBytes}`
+    );
+    unbind();
+  } finally {
+    socket.close();
+    await adapter.disconnect();
+    hub.close();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -103,7 +103,8 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
       'POST /webhooks/manage/backfill',
     ],
     acceptedLanes: ['browser-session'],
-    middleware: 'requireAuth via createWebhookManagerRouter mounted at /webhooks/manage',
+    middleware:
+      'requireAuth via createWebhookManagerRouter mounted at /webhooks/manage',
     notes:
       'Webhook management is a browser/operator surface mounted with requireAuth; it is distinct from the secret-protected webhook receiver.',
   },
@@ -200,6 +201,7 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
     surface: 'public local setup and callbacks',
     routes: [
       '/health',
+      '/healthz',
       '/auth/status',
       'POST /auth/setup',
       'POST /auth',
@@ -208,7 +210,8 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
       '/static frontend assets',
     ],
     acceptedLanes: ['public-local-only'],
-    middleware: 'public setup/login, localhost hook callback, webhook secret, or static file serving',
+    middleware:
+      'public setup/login, localhost hook callback, webhook secret, or static file serving',
     notes:
       'Setup/login/readiness/local hook/static surfaces intentionally sit outside browser-session auth and must not expose private session, repo, node, or credential state; the webhook receiver relies on GitHub signature validation and is separate from authenticated /webhooks/manage routes.',
   },

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -28,8 +28,11 @@ const logger = createLogger('channel-agent-bridge');
 /** debounce partial-text flush to disk (same shape as relay-state-db throttled scheduler). */
 const FLUSH_DEBOUNCE_MS = 500;
 const FLUSH_MAX_WAIT_MS = 2000;
+/** Bounded dedupe tombstones for late provider replay after a row finalized. */
+export const CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX = 256;
 
 interface BridgeStream {
+  sourceKey: string;
   messageId: string;
   turnId: string;
   itemId: string;
@@ -87,6 +90,24 @@ export function bindSessionToChannel(
   // for a turn absent here produced ZERO message rows — a silent finalization
   // that gets a warn log (#1181, defect 4) rather than passing unnoticed.
   const turnsWithRows = new Set<string>();
+  const recentFinalizedItemKeys = new Set<string>();
+
+  function itemSourceKey(
+    sessionId: string,
+    turnId: string,
+    itemId: string
+  ): string {
+    return `${sessionId}\u0000${turnId}\u0000${itemId}`;
+  }
+
+  function rememberFinalizedItem(key: string): void {
+    recentFinalizedItemKeys.delete(key);
+    recentFinalizedItemKeys.add(key);
+    if (recentFinalizedItemKeys.size <= CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX)
+      return;
+    const oldest = recentFinalizedItemKeys.values().next().value;
+    if (oldest !== undefined) recentFinalizedItemKeys.delete(oldest);
+  }
 
   function reportRetention(): void {
     if (!input.onRetentionSnapshot) return;
@@ -114,9 +135,15 @@ export function bindSessionToChannel(
     itemId: string,
     sessionId: string,
     initialText: string
-  ): BridgeStream {
+  ): BridgeStream | null {
     const existing = streams.get(itemId);
     if (existing) return existing;
+    const sourceKey = itemSourceKey(sessionId, turnId, itemId);
+    if (recentFinalizedItemKeys.has(sourceKey)) {
+      assistantItemTurnIds.delete(itemId);
+      reportRetention();
+      return null;
+    }
     const parentMessageId = input.parentMessageIdForTurn?.(turnId);
     const message = store.beginStream({
       channelId,
@@ -129,19 +156,14 @@ export function bindSessionToChannel(
       // Source-triple dedupe returned an already-finalized durable row. A late
       // duplicate final is a pure no-op: never recreate the hub accumulator or
       // turn-retention state for a stream that cannot receive more deltas.
-      return {
-        messageId: message.id,
-        turnId,
-        itemId,
-        text: message.body.text,
-        byteLength: Buffer.byteLength(message.body.text, 'utf8'),
-        closed: true,
-        flushTimer: null,
-        firstScheduledAt: null,
-      };
+      rememberFinalizedItem(sourceKey);
+      assistantItemTurnIds.delete(itemId);
+      reportRetention();
+      return null;
     }
     turnsWithRows.add(turnId);
     const stream: BridgeStream = {
+      sourceKey,
       messageId: message.id,
       turnId,
       itemId,
@@ -202,6 +224,7 @@ export function bindSessionToChannel(
     if (stream.closed) {
       streams.delete(stream.itemId);
       assistantItemTurnIds.delete(stream.itemId);
+      rememberFinalizedItem(stream.sourceKey);
       reportRetention();
       return;
     }
@@ -227,6 +250,7 @@ export function bindSessionToChannel(
       reportRetention();
     }
     if (!message) return;
+    rememberFinalizedItem(stream.sourceKey);
     hub.completeStreamBroadcast(message);
     try {
       store.upsertMember({ channelId, kind: 'agent', id: sender.id });
@@ -246,8 +270,7 @@ export function bindSessionToChannel(
 
   function finalizeTurn(
     turnId: string | undefined,
-    status: 'complete' | 'interrupted' | 'failed',
-    terminal = true
+    status: 'complete' | 'interrupted' | 'failed'
   ): void {
     for (const stream of streams.values()) {
       if (stream.closed) continue;
@@ -270,7 +293,11 @@ export function bindSessionToChannel(
         turnId,
       });
     }
-    if (terminal && turnId !== undefined) {
+    if (turnId === undefined) {
+      turnsWithRows.clear();
+      assistantItemTurnIds.clear();
+      reportRetention();
+    } else {
       turnsWithRows.delete(turnId);
       for (const [itemId, itemTurnId] of assistantItemTurnIds) {
         if (itemTurnId === turnId) assistantItemTurnIds.delete(itemId);
@@ -295,7 +322,7 @@ export function bindSessionToChannel(
       }
       case 'agent-item-delta-v2': {
         if (typeof patch.delta.text !== 'string') break;
-        let stream = streams.get(patch.itemId);
+        let stream: BridgeStream | null | undefined = streams.get(patch.itemId);
         if (!stream) {
           // Lazy-open ONLY for an item started as an assistantMessage — never for
           // plan/reasoning/tool items (whose text is not mirrored, §6.3) nor for
@@ -304,12 +331,15 @@ export function bindSessionToChannel(
           if (!assistantItemTurnIds.has(patch.itemId)) break;
           stream = openStream(patch.turnId, patch.itemId, patch.sessionId, '');
         }
+        if (!stream) break;
         appendDelta(stream, patch.delta.text);
         break;
       }
       case 'agent-item-updated-v2': {
         if (patch.item.type !== 'assistantMessage') break;
-        let stream = streams.get(patch.item.id);
+        let stream: BridgeStream | null | undefined = streams.get(
+          patch.item.id
+        );
         if (!stream) {
           // A completed assistantMessage that never opened a stream — no
           // `started`, no text delta — is a non-streamed reply delivered as a
@@ -324,6 +354,7 @@ export function bindSessionToChannel(
             patch.item.text ?? ''
           );
         }
+        if (!stream) break;
         finalize(stream, 'complete', patch.item.text ?? '');
         break;
       }
@@ -341,10 +372,9 @@ export function bindSessionToChannel(
         break;
       }
       case 'agent-error-v2': {
-        // Adapters emit the authoritative turn-completed patch after the error;
-        // keep the row marker until then so that terminal patch does not produce
-        // a false "no message rows" warning.
-        finalizeTurn(patch.turnId, 'failed', false);
+        // An error is terminal for bridge-owned output even when a provider
+        // never follows it with turn/completed.
+        finalizeTurn(patch.turnId, 'failed');
         break;
       }
       default:
@@ -364,6 +394,7 @@ export function bindSessionToChannel(
     streams.clear();
     assistantItemTurnIds.clear();
     turnsWithRows.clear();
+    recentFinalizedItemKeys.clear();
     reportRetention();
   };
 }

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -57,6 +57,15 @@ export interface BindSessionToChannelInput {
    * (agent-to-agent mentions). Interrupted/failed rows never fire it.
    */
   onAssistantMessageFinalized?: (message: ChannelMessage) => void;
+  /** Optional bounded-load diagnostic seam; never affects delivery. */
+  onRetentionSnapshot?: (snapshot: ChannelBridgeRetentionSnapshot) => void;
+}
+
+export interface ChannelBridgeRetentionSnapshot {
+  openStreams: number;
+  assistantItemIds: number;
+  turnsWithRows: number;
+  retainedTextBytes: number;
 }
 
 /**
@@ -73,11 +82,25 @@ export function bindSessionToChannel(
   // stream. Plan/reasoning/tool items also carry `delta.text` on real adapters
   // (e.g. the codex-native plan item `plan-<turnId>`), and §6.3 mirrors ONLY
   // assistantMessage text — so a delta for any other item type is dropped.
-  const assistantItemIds = new Set<string>();
+  const assistantItemTurnIds = new Map<string, string>();
   // Turn ids that opened at least one channel-message stream. A `turn-completed`
   // for a turn absent here produced ZERO message rows — a silent finalization
   // that gets a warn log (#1181, defect 4) rather than passing unnoticed.
   const turnsWithRows = new Set<string>();
+
+  function reportRetention(): void {
+    if (!input.onRetentionSnapshot) return;
+    let retainedTextBytes = 0;
+    for (const stream of streams.values()) {
+      retainedTextBytes += stream.byteLength;
+    }
+    input.onRetentionSnapshot({
+      openStreams: streams.size,
+      assistantItemIds: assistantItemTurnIds.size,
+      turnsWithRows: turnsWithRows.size,
+      retainedTextBytes,
+    });
+  }
 
   const sender: ChannelSenderRef = {
     kind: 'agent',
@@ -94,7 +117,6 @@ export function bindSessionToChannel(
   ): BridgeStream {
     const existing = streams.get(itemId);
     if (existing) return existing;
-    turnsWithRows.add(turnId);
     const parentMessageId = input.parentMessageIdForTurn?.(turnId);
     const message = store.beginStream({
       channelId,
@@ -103,18 +125,35 @@ export function bindSessionToChannel(
       ...(initialText ? { text: initialText } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
+    if (message.status !== 'streaming') {
+      // Source-triple dedupe returned an already-finalized durable row. A late
+      // duplicate final is a pure no-op: never recreate the hub accumulator or
+      // turn-retention state for a stream that cannot receive more deltas.
+      return {
+        messageId: message.id,
+        turnId,
+        itemId,
+        text: message.body.text,
+        byteLength: Buffer.byteLength(message.body.text, 'utf8'),
+        closed: true,
+        flushTimer: null,
+        firstScheduledAt: null,
+      };
+    }
+    turnsWithRows.add(turnId);
     const stream: BridgeStream = {
       messageId: message.id,
       turnId,
       itemId,
       text: message.body.text,
       byteLength: Buffer.byteLength(message.body.text, 'utf8'),
-      closed: message.status !== 'streaming',
+      closed: false,
       flushTimer: null,
       firstScheduledAt: null,
     };
     streams.set(itemId, stream);
     hub.beginStreamBroadcast(message);
+    reportRetention();
     return stream;
   }
 
@@ -160,7 +199,12 @@ export function bindSessionToChannel(
     text: string,
     truncated = false
   ): void {
-    if (stream.closed) return;
+    if (stream.closed) {
+      streams.delete(stream.itemId);
+      assistantItemTurnIds.delete(stream.itemId);
+      reportRetention();
+      return;
+    }
     stream.closed = true;
     if (stream.flushTimer) {
       clearTimeout(stream.flushTimer);
@@ -175,7 +219,12 @@ export function bindSessionToChannel(
       });
     } catch (err) {
       logger.warn('channel bridge finalize failed:', err);
-      return;
+    } finally {
+      // The durable row owns completed output. Never retain full streamed text
+      // or provider item ids for the lifetime of the channel binding.
+      streams.delete(stream.itemId);
+      assistantItemTurnIds.delete(stream.itemId);
+      reportRetention();
     }
     if (!message) return;
     hub.completeStreamBroadcast(message);
@@ -197,7 +246,8 @@ export function bindSessionToChannel(
 
   function finalizeTurn(
     turnId: string | undefined,
-    status: 'complete' | 'interrupted' | 'failed'
+    status: 'complete' | 'interrupted' | 'failed',
+    terminal = true
   ): void {
     for (const stream of streams.values()) {
       if (stream.closed) continue;
@@ -220,13 +270,20 @@ export function bindSessionToChannel(
         turnId,
       });
     }
+    if (terminal && turnId !== undefined) {
+      turnsWithRows.delete(turnId);
+      for (const [itemId, itemTurnId] of assistantItemTurnIds) {
+        if (itemTurnId === turnId) assistantItemTurnIds.delete(itemId);
+      }
+      reportRetention();
+    }
   }
 
   function handlePatch(patch: AgentPatchV2): void {
     switch (patch.type) {
       case 'agent-item-started-v2': {
         if (patch.item.type === 'assistantMessage') {
-          assistantItemIds.add(patch.item.id);
+          assistantItemTurnIds.set(patch.item.id, patch.turnId);
           openStream(
             patch.turnId,
             patch.item.id,
@@ -244,7 +301,7 @@ export function bindSessionToChannel(
           // plan/reasoning/tool items (whose text is not mirrored, §6.3) nor for
           // an item whose type we have not seen. Mirroring a plan-item delta here
           // would persist plan text as an agent-authored channel message.
-          if (!assistantItemIds.has(patch.itemId)) break;
+          if (!assistantItemTurnIds.has(patch.itemId)) break;
           stream = openStream(patch.turnId, patch.itemId, patch.sessionId, '');
         }
         appendDelta(stream, patch.delta.text);
@@ -284,7 +341,10 @@ export function bindSessionToChannel(
         break;
       }
       case 'agent-error-v2': {
-        finalizeTurn(patch.turnId, 'failed');
+        // Adapters emit the authoritative turn-completed patch after the error;
+        // keep the row marker until then so that terminal patch does not produce
+        // a false "no message rows" warning.
+        finalizeTurn(patch.turnId, 'failed', false);
         break;
       }
       default:
@@ -301,5 +361,9 @@ export function bindSessionToChannel(
     for (const stream of streams.values()) {
       if (!stream.closed) finalize(stream, 'interrupted', stream.text);
     }
+    streams.clear();
+    assistantItemTurnIds.clear();
+    turnsWithRows.clear();
+    reportRetention();
   };
 }

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -42,6 +42,14 @@ const CATCHUP_MAX_ROWS = 500;
  * client paginates the remainder via `channels.history`.
  */
 const DEFAULT_SNAPSHOT_MAX_BYTES = 4 * 1024 * 1024;
+/**
+ * Defense-in-depth bounds for events produced re-entrantly while a subscriber's
+ * connect-time snapshot is being sent. In production the better-sqlite3 snapshot
+ * read is synchronous, but the queue must still have a hard ceiling: SQLite is
+ * the durable catch-up buffer, so an overflowing client can reconnect by seq.
+ */
+const DEFAULT_CONNECT_QUEUE_MAX_EVENTS = CATCHUP_MAX_ROWS;
+const DEFAULT_CONNECT_QUEUE_MAX_BYTES = DEFAULT_SNAPSHOT_MAX_BYTES;
 
 /**
  * Minimal socket surface the hub needs. The real `ws` WebSocket satisfies it;
@@ -61,6 +69,7 @@ interface Subscriber {
   /** live events queue here until the connect-time snapshot has been sent. */
   buffering: boolean;
   queue: ChannelEventV1[];
+  queueBytes: number;
   snapshotLatestSeq: number;
   snapshotInFlight: Map<string, number>;
   /** suppressing deltas after a high-watermark breach until the buffer drains. */
@@ -98,6 +107,10 @@ export interface ChannelHubOptions {
   badgeBroadcaster?: ChannelBadgeBroadcaster;
   /** byte budget for one snapshot/catch-up assembly (defaults to 4MB). */
   snapshotMaxBytes?: number;
+  /** connect-time live queue event cap (defaults to the catch-up row cap). */
+  connectQueueMaxEvents?: number;
+  /** connect-time live queue byte cap (defaults to 4MB). */
+  connectQueueMaxBytes?: number;
 }
 
 export interface ChannelHub {
@@ -120,7 +133,12 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
   const store = options.store;
   const coalesceMs = options.coalesceMs ?? DEFAULT_COALESCE_MS;
   const channelExists = options.channelExists ?? (() => true);
-  const snapshotMaxBytes = options.snapshotMaxBytes ?? DEFAULT_SNAPSHOT_MAX_BYTES;
+  const snapshotMaxBytes =
+    options.snapshotMaxBytes ?? DEFAULT_SNAPSHOT_MAX_BYTES;
+  const connectQueueMaxEvents =
+    options.connectQueueMaxEvents ?? DEFAULT_CONNECT_QUEUE_MAX_EVENTS;
+  const connectQueueMaxBytes =
+    options.connectQueueMaxBytes ?? DEFAULT_CONNECT_QUEUE_MAX_BYTES;
   let badgeBroadcaster = options.badgeBroadcaster ?? null;
 
   const subscribers = new Map<string, Set<Subscriber>>();
@@ -216,7 +234,16 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     if (!set) return;
     for (const sub of [...set]) {
       if (sub.buffering) {
+        const eventBytes = Buffer.byteLength(JSON.stringify(event), 'utf8');
+        if (
+          sub.queue.length >= connectQueueMaxEvents ||
+          sub.queueBytes + eventBytes > connectQueueMaxBytes
+        ) {
+          closeSubscriber(sub, CHANNEL_WS_BACKPRESSURE_CLOSE_CODE);
+          continue;
+        }
         sub.queue.push(event);
+        sub.queueBytes += eventBytes;
         continue;
       }
       deliver(sub, event);
@@ -407,6 +434,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         channelId,
         buffering: true,
         queue: [],
+        queueBytes: 0,
         snapshotLatestSeq: 0,
         snapshotInFlight: new Map(),
         lagging: false,
@@ -429,6 +457,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         }
       }
       deliver(sub, snapshot);
+      if (ws.readyState !== WS_OPEN) return;
 
       // Flush queued live events with dedupe: drop committed events with
       // seq <= snapshot endSeq; drop deltas with deltaIndex <= the snapshot's
@@ -436,6 +465,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       // deltaIndex, NOT seq); always forward completed (idempotent replace-by-id).
       const queued = sub.queue;
       sub.queue = [];
+      sub.queueBytes = 0;
       sub.buffering = false;
       for (const event of queued) {
         if (

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -126,6 +126,11 @@ export interface ChannelHub {
   setBadgeBroadcaster(broadcaster: ChannelBadgeBroadcaster): void;
   channelExists(channelId: string): boolean;
   subscriberCount(channelId: string): number;
+  /** Internal load-harness diagnostic; connect queues must drain back to zero. */
+  retentionSnapshot(): {
+    connectQueueEvents: number;
+    connectQueueBytes: number;
+  };
   close(): void;
 }
 
@@ -566,6 +571,18 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
 
     subscriberCount(channelId) {
       return subscribers.get(channelId)?.size ?? 0;
+    },
+
+    retentionSnapshot() {
+      let connectQueueEvents = 0;
+      let connectQueueBytes = 0;
+      for (const channelSubscribers of subscribers.values()) {
+        for (const subscriber of channelSubscribers) {
+          connectQueueEvents += subscriber.queue.length;
+          connectQueueBytes += subscriber.queueBytes;
+        }
+      }
+      return { connectQueueEvents, connectQueueBytes };
     },
 
     close() {

--- a/server/health.ts
+++ b/server/health.ts
@@ -1,0 +1,107 @@
+import { performance } from 'node:perf_hooks';
+import type { RequestHandler } from 'express';
+import { createLogger, type Logger } from './logger.js';
+
+export const DEFAULT_EVENT_LOOP_LAG_THRESHOLD_MS = 2_000;
+export const DEFAULT_EVENT_LOOP_PROBE_INTERVAL_MS = 1_000;
+export const DEFAULT_MEMORY_LOG_INTERVAL_MS = 60_000;
+
+export interface HealthMemorySnapshot {
+  rss: number;
+  heapUsed: number;
+  external: number;
+}
+
+export interface HealthMonitor {
+  handler: RequestHandler;
+  getLagMs(): number;
+  stop(): void;
+}
+
+export interface HealthMonitorOptions {
+  lagThresholdMs?: number;
+  probeIntervalMs?: number;
+  memoryLogIntervalMs?: number;
+  getLagMs?: () => number;
+  memoryUsage?: () => NodeJS.MemoryUsage;
+  monotonicNow?: () => number;
+  logger?: Logger;
+}
+
+const healthLogger = createLogger('health');
+
+export function readHealthMemorySnapshot(
+  memoryUsage: () => NodeJS.MemoryUsage = process.memoryUsage
+): HealthMemorySnapshot {
+  const { rss, heapUsed, external } = memoryUsage();
+  return { rss, heapUsed, external };
+}
+
+export function formatHealthMemoryLine(snapshot: HealthMemorySnapshot): string {
+  return `memory rss=${snapshot.rss} heapUsed=${snapshot.heapUsed} external=${snapshot.external}`;
+}
+
+export function logHealthMemorySnapshot(
+  logger: Logger = healthLogger,
+  memoryUsage: () => NodeJS.MemoryUsage = process.memoryUsage
+): HealthMemorySnapshot {
+  const snapshot = readHealthMemorySnapshot(memoryUsage);
+  logger.info(formatHealthMemoryLine(snapshot));
+  return snapshot;
+}
+
+export function createHealthMonitor(
+  options: HealthMonitorOptions = {}
+): HealthMonitor {
+  const lagThresholdMs =
+    options.lagThresholdMs ?? DEFAULT_EVENT_LOOP_LAG_THRESHOLD_MS;
+  const probeIntervalMs =
+    options.probeIntervalMs ?? DEFAULT_EVENT_LOOP_PROBE_INTERVAL_MS;
+  const memoryLogIntervalMs =
+    options.memoryLogIntervalMs ?? DEFAULT_MEMORY_LOG_INTERVAL_MS;
+  const memoryUsage = options.memoryUsage ?? process.memoryUsage;
+  const logger = options.logger ?? healthLogger;
+  const monotonicNow =
+    options.monotonicNow ?? performance.now.bind(performance);
+
+  let measuredLagMs = 0;
+  let expectedProbeAt = monotonicNow() + probeIntervalMs;
+  const probeTimer = options.getLagMs
+    ? undefined
+    : setInterval(() => {
+        const now = monotonicNow();
+        measuredLagMs = Math.max(0, now - expectedProbeAt);
+        // Rebase after every sample. A single stall remains visible for one
+        // probe interval without accumulating permanent scheduler drift.
+        expectedProbeAt = now + probeIntervalMs;
+      }, probeIntervalMs);
+  probeTimer?.unref();
+
+  const memoryTimer = setInterval(() => {
+    logHealthMemorySnapshot(logger, memoryUsage);
+  }, memoryLogIntervalMs);
+  memoryTimer.unref();
+
+  const getLagMs = (): number =>
+    Math.max(0, options.getLagMs?.() ?? measuredLagMs);
+
+  const handler: RequestHandler = (_req, res) => {
+    const lagMs = Math.round(getLagMs());
+    const { rss } = readHealthMemorySnapshot(memoryUsage);
+    const healthy = lagMs <= lagThresholdMs;
+    res.status(healthy ? 200 : 503).json({
+      status: healthy ? 'ok' : 'degraded',
+      lagMs,
+      rss,
+    });
+  };
+
+  return {
+    handler,
+    getLagMs,
+    stop() {
+      if (probeTimer) clearInterval(probeTimer);
+      clearInterval(memoryTimer);
+    },
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -5999,14 +5999,37 @@ async function main(): Promise<void> {
   // previous process hasn't released the port yet (launchd KeepAlive restarts).
   const MAX_RETRIES = 5;
   let attempt = 0;
+
+  const configuredReattachTimeoutMs = positiveIntegerEnv(
+    'RELAY_IDE_WEB_SESSION_REATTACH_TIMEOUT_MS'
+  );
+  // Integration-test-only ordering seam. Normal startup never sleeps: the
+  // hold is accepted only under NODE_ENV=test and defaults to zero. Keeping it
+  // inside the exact function handed to restoreSessionsAfterListen means the
+  // real-process regression fails if this function is moved/awaited before
+  // server.listen().
+  const testStartupRestoreHoldMs =
+    process.env['NODE_ENV'] === 'test'
+      ? (positiveIntegerEnv('RELAY_IDE_TEST_STARTUP_RESTORE_HOLD_MS') ?? 0)
+      : 0;
+  async function restoreStartupSessions(): Promise<number> {
+    if (testStartupRestoreHoldMs > 0) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, testStartupRestoreHoldMs)
+      );
+    }
+    return restoreFromDisk(
+      configDir,
+      getConfig().repos ?? [],
+      getConfig().frameworks,
+      configuredReattachTimeoutMs === undefined
+        ? undefined
+        : { webSessionReattachTimeoutMs: configuredReattachTimeoutMs }
+    );
+  }
   cancelStartupRestore = restoreSessionsAfterListen(
     server,
-    () =>
-      restoreFromDisk(
-        configDir,
-        getConfig().repos ?? [],
-        getConfig().frameworks
-      ),
+    restoreStartupSessions,
     {
       restored: (restoredCount) => {
         if (restoredCount === 0) return;
@@ -6044,6 +6067,17 @@ async function main(): Promise<void> {
     }
   });
   tryListen();
+}
+
+function positiveIntegerEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return undefined;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    logger.warn(`Ignoring ${name}: expected a positive integer number of ms.`);
+    return undefined;
+  }
+  return parsed;
 }
 
 main().catch((err) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,8 @@ import { promisify } from 'node:util';
 
 import express from 'express';
 import cookieParser from 'cookie-parser';
+import { createHealthMonitor } from './health.js';
+import { restoreSessionsAfterListen } from './startup-restore.js';
 
 import {
   loadConfig,
@@ -2129,6 +2131,8 @@ async function main(): Promise<void> {
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
   });
+  const healthMonitor = createHealthMonitor();
+  app.get('/healthz', healthMonitor.handler);
 
   function authenticatedBrowserSession(req: express.Request): boolean {
     const token = req.cookies && req.cookies.token;
@@ -4007,20 +4011,6 @@ async function main(): Promise<void> {
     });
     res.json(result);
   });
-
-  // Restore sessions from a previous update restart
-  const restoredCount = await restoreFromDisk(
-    configDir,
-    getConfig().repos ?? [],
-    getConfig().frameworks
-  );
-  if (restoredCount > 0) {
-    logger.info(`Restored ${restoredCount} session(s) from previous update.`);
-    // Start git watching for restored sessions
-    for (const session of localRelayNode.sessions.list()) {
-      gitWatcher.watch(session.cwd);
-    }
-  }
 
   startTelemetry({
     getActiveSessions: sessions.list,
@@ -5956,13 +5946,17 @@ async function main(): Promise<void> {
   const devInstance =
     process.env.RELAY_IDE_DEV_INSTANCE === '1' ||
     process.env.RELAY_IDE_SELF_HOST === '1';
+  let cancelStartupRestore = (): void => {};
   async function gracefulShutdown() {
+    cancelStartupRestore();
+    sessions.cancelBackgroundRestores();
     const restartReason = devInstance ? 'dev-restart' : 'signal-shutdown';
     broadcastEvent('server-restarting', { reason: restartReason });
     await stopPolling();
     stopEventBatching();
     stopTelemetry();
     closeAnalytics();
+    healthMonitor.stop();
     branchWatcher.close();
     refWatcher.close();
     gitWatcher.close();
@@ -6005,6 +5999,32 @@ async function main(): Promise<void> {
   // previous process hasn't released the port yet (launchd KeepAlive restarts).
   const MAX_RETRIES = 5;
   let attempt = 0;
+  cancelStartupRestore = restoreSessionsAfterListen(
+    server,
+    () =>
+      restoreFromDisk(
+        configDir,
+        getConfig().repos ?? [],
+        getConfig().frameworks
+      ),
+    {
+      restored: (restoredCount) => {
+        if (restoredCount === 0) return;
+        logger.info(
+          `Restored ${restoredCount} session(s) from previous update.`
+        );
+        for (const session of localRelayNode.sessions.list()) {
+          gitWatcher.watch(session.cwd);
+        }
+      },
+      failed: (err) => {
+        logger.error(
+          'Background session restore failed:',
+          err instanceof Error ? err.message : String(err)
+        );
+      },
+    }
+  );
   function tryListen() {
     server.listen(startupConfig.port, startupConfig.host, () => {
       const addr = server.address() as import('node:net').AddressInfo;

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -617,6 +617,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     const resolver = this.pendingApprovals.get(input.requestId);
     if (!resolver) return;
     this.pendingApprovals.delete(input.requestId);
+    this.approvalMeta.delete(input.requestId);
     resolver(input.decision);
   }
 
@@ -625,6 +626,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     const resolver = this.pendingInputRequests.get(requestId);
     if (!resolver) return;
     this.pendingInputRequests.delete(requestId);
+    this.inputRequestMeta.delete(requestId);
     resolver({ answers: input.answers });
   }
 
@@ -727,6 +729,15 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       ...(usage !== undefined ? { usage } : {}),
       ...(error !== undefined ? { error } : {}),
     });
+
+    // These maps translate provider output ids only while the current turn is
+    // live. The canonical V2 transcript owns completed items; retaining native
+    // ids and streamed reasoning/token buffers across turns grows without bound
+    // on an always-on channel binding.
+    this.itemMap.clear();
+    this.tokenUsageBuffer.clear();
+    this.reasoningSummaryBuffers.clear();
+    this.reasoningDetailBuffers.clear();
 
     this.activeTurnId = null;
     this.nativeActiveTurnId = null;

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -26,7 +26,7 @@ import { cleanupCodexHooksAdapter } from './codex-hooks-adapter.js';
 import type { CreatePtyParams } from './pty-handler.js';
 import {
   createWebSession,
-  reconnectWebSession,
+  reconnectWebSessionAdapter,
   continueHereWebSession,
   type CreateWebParams,
 } from './web-session-handler.js';
@@ -52,6 +52,7 @@ import {
 import { buildSessionEvent } from './session-attribution.js';
 import { createLogger } from './logger.js';
 import type { SessionLane } from '../shared/session-lane.js';
+import type { AdapterConfig } from './protocol-adapter.js';
 import {
   deriveSessionDurability,
   type SessionDurabilityNodeStatus,
@@ -1060,6 +1061,9 @@ function list(): SessionSummary[] {
         idle: s.idle,
         customCommand: s.customCommand,
         status: s.status,
+        ...(s.restoreState !== undefined
+          ? { restoreState: s.restoreState }
+          : {}),
         durability,
         needsBranchRename: !!s.needsBranchRename,
         agentState: s.agentState,
@@ -1987,8 +1991,20 @@ function restoreSession(
   create(createParams);
 }
 
+const DEFAULT_WEB_SESSION_REATTACH_TIMEOUT_MS = 15_000;
+const webSessionRestoreAttempts = new Map<
+  string,
+  { generation: number; adapter: WebSession['adapterV2'] }
+>();
+let webSessionRestoreShutdown = false;
+
+interface RestoreFromDiskOptions {
+  webSessionReattachTimeoutMs?: number;
+}
+
 async function restoreWebSessionFromDb(
-  row: import('./relay-state-db.js').LoadedWebSessionRow
+  row: import('./relay-state-db.js').LoadedWebSessionRow,
+  reattachTimeoutMs: number
 ): Promise<void> {
   // Restore persisted adapter runtime settings so the reconnected session
   // matches what was originally running rather than reverting to defaults.
@@ -2032,11 +2048,11 @@ async function restoreWebSessionFromDb(
   // persisted DB row with a freshly-initialized blank transcript before we
   // copy back agentSessionV2 below — a process death in that window would
   // lose the session.
-  const { session } = await createWebSession(
+  const { session, config } = await createWebSession(
     createParams,
     sessions,
     fireBackendStateIfChanged,
-    { skipInitialPersist: true }
+    { skipInitialPersist: true, deferConnect: true }
   );
 
   // Replace the freshly-created blank transcript with the persisted one.
@@ -2052,6 +2068,7 @@ async function restoreWebSessionFromDb(
   session.createdAt = new Date(row.createdAt).toISOString();
   session.lastActivity = new Date(row.lastActivity).toISOString();
   session.status = row.status === 'archived' ? 'disconnected' : row.status;
+  session.restoreState = 'restoring';
 
   // Derive runtime state from the persisted live snapshot, mirroring the
   // mapping in web-session-handler's adapter listener.
@@ -2077,14 +2094,104 @@ async function restoreWebSessionFromDb(
   // (vendor may not assign a new id, but live status flips).
   upsertWebSessionNow(session);
 
-  // If the adapter supports resume and we have a stored vendor session ID,
-  // reconnect via resumeSession so the provider continues the conversation.
-  // On failure, surface a single client-source errorMessage into the timeline
-  // and leave session disconnected — user must start a fresh session.
+  // Provider transport startup and resume are deliberately detached from the
+  // restore caller. The HTTP listener is already accepting requests when this
+  // function is invoked, and a dead provider can therefore never block auth or
+  // health request handling during boot.
+  void reattachRestoredWebSession(session, config, reattachTimeoutMs).catch(
+    (err) => {
+      if (webSessionRestoreShutdown) return;
+      logger.error(
+        `Detached reattach failed for web session ${session.id}`,
+        err
+      );
+    }
+  );
+}
+
+async function reattachRestoredWebSession(
+  session: WebSession,
+  config: AdapterConfig,
+  timeoutMs: number
+): Promise<void> {
+  if (webSessionRestoreShutdown) return;
+  const priorAttempt = webSessionRestoreAttempts.get(session.id);
+  const generation = (priorAttempt?.generation ?? 0) + 1;
+  const attemptAdapter = session.adapterV2;
+  webSessionRestoreAttempts.set(session.id, {
+    generation,
+    adapter: attemptAdapter,
+  });
+
+  const isCurrentAttempt = (): boolean =>
+    !webSessionRestoreShutdown &&
+    webSessionRestoreAttempts.get(session.id)?.generation === generation &&
+    session.adapterV2 === attemptAdapter &&
+    session.restoreState === 'restoring';
+
+  const attempt = (async () => {
+    if (!isCurrentAttempt()) return;
+    await attemptAdapter.connect(config);
+    // Timeout/failure fencing: a late transport connect must not continue into
+    // provider resume after this attempt has already been declared failed.
+    if (!isCurrentAttempt()) return;
+    await reconnectWebSessionAdapter(session, attemptAdapter);
+    // Resume may ignore disconnect and settle after its deadline. Check the
+    // generation again before allowing the adapter to remain connected.
+    if (!isCurrentAttempt()) {
+      await attemptAdapter.disconnect().catch(() => {});
+    }
+  })();
+
+  // Promise.race observes rejection, while this continuation guarantees a
+  // late successful handshake is torn down instead of becoming an orphaned
+  // live transport after the timeout path returned.
+  void attempt.then(
+    () => {
+      if (!isCurrentAttempt()) {
+        void attemptAdapter.disconnect().catch(() => {});
+      }
+    },
+    () => {}
+  );
+
+  let timeout: NodeJS.Timeout | undefined;
+  const timedOut = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(
+        new Error(`provider reattach timed out after ${String(timeoutMs)}ms`)
+      );
+    }, timeoutMs);
+    timeout.unref();
+  });
+
   try {
-    await reconnectWebSession(session);
+    await Promise.race([attempt, timedOut]);
+    if (!isCurrentAttempt()) return;
+    webSessionRestoreAttempts.delete(session.id);
+    delete session.restoreState;
+    fireBackendStateIfChanged(session);
+    upsertWebSessionNow(session);
   } catch (err) {
+    if (!isCurrentAttempt()) return;
+    webSessionRestoreAttempts.delete(session.id);
+    session.restoreState = 'reattach-failed';
+    // Best effort cancellation makes a hung provider release its transport.
+    // Do not await disconnect: failure state must become visible immediately,
+    // even when the provider's cleanup path is itself wedged.
+    void attemptAdapter.disconnect().catch(() => {});
     surfaceResumeFailure(session, err);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function cancelBackgroundRestores(): void {
+  webSessionRestoreShutdown = true;
+  const attempts = Array.from(webSessionRestoreAttempts.values());
+  webSessionRestoreAttempts.clear();
+  for (const { adapter } of attempts) {
+    void adapter.disconnect().catch(() => {});
   }
 }
 
@@ -2394,13 +2501,16 @@ async function restorePendingSessionsFromDisk(
   );
 }
 
-async function restoreWebSessionsFromDb(): Promise<number> {
+async function restoreWebSessionsFromDb(
+  reattachTimeoutMs: number
+): Promise<number> {
   let restored = 0;
   // Web sessions live in relay-state.db. No staleness wipe — DB rows persist
   // until user archives or closes the session.
   for (const row of loadAllWebSessions()) {
+    if (webSessionRestoreShutdown) break;
     try {
-      await restoreWebSessionFromDb(row);
+      await restoreWebSessionFromDb(row, reattachTimeoutMs);
       restored++;
     } catch (err) {
       logger.error(
@@ -2415,14 +2525,19 @@ async function restoreWebSessionsFromDb(): Promise<number> {
 async function restoreFromDisk(
   configDir: string,
   workspaces?: string[],
-  frameworks?: Record<string, Partial<AgentFramework>>
+  frameworks?: Record<string, Partial<AgentFramework>>,
+  options: RestoreFromDiskOptions = {}
 ): Promise<number> {
+  webSessionRestoreShutdown = false;
   const restoredPty = await restorePendingSessionsFromDisk(
     configDir,
     workspaces,
     frameworks
   );
-  const restoredWeb = await restoreWebSessionsFromDb();
+  const restoredWeb = await restoreWebSessionsFromDb(
+    options.webSessionReattachTimeoutMs ??
+      DEFAULT_WEB_SESSION_REATTACH_TIMEOUT_MS
+  );
   syncDisplayNameCounters();
   return restoredPty + restoredWeb;
 }
@@ -2567,6 +2682,12 @@ async function continueHereWeb(sessionId: string): Promise<void> {
     return;
   }
 
+  const replaceTimedOutAdapter = session.restoreState === 'reattach-failed';
+  // Manual cold recovery supersedes the failed boot-reattach fence. The
+  // continue-here flow disconnects and re-registers adapter listeners before
+  // establishing its fresh provider session.
+  delete session.restoreState;
+
   const config = {
     cwd: session.cwd,
     port: defaultPort ?? 3456,
@@ -2584,7 +2705,9 @@ async function continueHereWeb(sessionId: string): Promise<void> {
       : {}),
   };
 
-  await continueHereWebSession(session, config, fireBackendStateIfChanged);
+  await continueHereWebSession(session, config, fireBackendStateIfChanged, {
+    replaceAdapter: replaceTimedOutAdapter,
+  });
 }
 
 export {
@@ -2622,6 +2745,7 @@ export {
   nextAgentName,
   serializeAll,
   restoreFromDisk,
+  cancelBackgroundRestores,
   getSessionMeta,
   getAllSessionMeta,
   populateMetaCache,

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -27,6 +27,8 @@ import type { CreatePtyParams } from './pty-handler.js';
 import {
   createWebSession,
   reconnectWebSessionAdapter,
+  retireWebSessionAdapter,
+  setWebSessionRestoreSnapshotFence,
   continueHereWebSession,
   type CreateWebParams,
 } from './web-session-handler.js';
@@ -1153,6 +1155,7 @@ function kill(id: string): void {
   if (session.mode === 'pty') {
     void terminatePtySession(session, 'explicit-session-kill');
   } else {
+    supersedeWebSessionRestore(session);
     // Web session: disconnect adapter (tears down network connections and event handlers)
     session.adapterV2?.disconnect().catch(() => {
       // Adapter may already be disconnected — still proceed with cleanup
@@ -1994,7 +1997,11 @@ function restoreSession(
 const DEFAULT_WEB_SESSION_REATTACH_TIMEOUT_MS = 15_000;
 const webSessionRestoreAttempts = new Map<
   string,
-  { generation: number; adapter: WebSession['adapterV2'] }
+  {
+    generation: number;
+    adapter: WebSession['adapterV2'];
+    session: WebSession;
+  }
 >();
 let webSessionRestoreShutdown = false;
 
@@ -2056,7 +2063,12 @@ async function restoreWebSessionFromDb(
   );
 
   // Replace the freshly-created blank transcript with the persisted one.
-  session.agentSessionV2 = row.agentSessionV2;
+  const persistedAgentSessionV2 = structuredClone(row.agentSessionV2);
+  const persistedProviderSession =
+    persistedAgentSessionV2.providerSession === undefined
+      ? undefined
+      : { ...persistedAgentSessionV2.providerSession };
+  session.agentSessionV2 = structuredClone(persistedAgentSessionV2);
   session.customCommand = row.meta.customCommand;
   if (row.meta.needsBranchRename) {
     session.needsBranchRename = true;
@@ -2098,21 +2110,24 @@ async function restoreWebSessionFromDb(
   // restore caller. The HTTP listener is already accepting requests when this
   // function is invoked, and a dead provider can therefore never block auth or
   // health request handling during boot.
-  void reattachRestoredWebSession(session, config, reattachTimeoutMs).catch(
-    (err) => {
-      if (webSessionRestoreShutdown) return;
-      logger.error(
-        `Detached reattach failed for web session ${session.id}`,
-        err
-      );
-    }
-  );
+  void reattachRestoredWebSession(
+    session,
+    config,
+    reattachTimeoutMs,
+    persistedAgentSessionV2,
+    persistedProviderSession
+  ).catch((err) => {
+    if (webSessionRestoreShutdown) return;
+    logger.error(`Detached reattach failed for web session ${session.id}`, err);
+  });
 }
 
 async function reattachRestoredWebSession(
   session: WebSession,
   config: AdapterConfig,
-  timeoutMs: number
+  timeoutMs: number,
+  persistedAgentSessionV2: WebSession['agentSessionV2'],
+  persistedProviderSession: Record<string, string> | undefined
 ): Promise<void> {
   if (webSessionRestoreShutdown) return;
   const priorAttempt = webSessionRestoreAttempts.get(session.id);
@@ -2121,24 +2136,59 @@ async function reattachRestoredWebSession(
   webSessionRestoreAttempts.set(session.id, {
     generation,
     adapter: attemptAdapter,
+    session,
   });
+
+  const deleteOwnAttempt = (): void => {
+    const current = webSessionRestoreAttempts.get(session.id);
+    if (
+      current?.generation === generation &&
+      current.adapter === attemptAdapter &&
+      current.session === session
+    ) {
+      webSessionRestoreAttempts.delete(session.id);
+    }
+  };
 
   const isCurrentAttempt = (): boolean =>
     !webSessionRestoreShutdown &&
+    sessions.get(session.id) === session &&
     webSessionRestoreAttempts.get(session.id)?.generation === generation &&
+    webSessionRestoreAttempts.get(session.id)?.adapter === attemptAdapter &&
+    webSessionRestoreAttempts.get(session.id)?.session === session &&
     session.adapterV2 === attemptAdapter &&
     session.restoreState === 'restoring';
 
+  setWebSessionRestoreSnapshotFence(attemptAdapter, true);
   const attempt = (async () => {
-    if (!isCurrentAttempt()) return;
+    if (!isCurrentAttempt()) {
+      deleteOwnAttempt();
+      return;
+    }
     await attemptAdapter.connect(config);
     // Timeout/failure fencing: a late transport connect must not continue into
     // provider resume after this attempt has already been declared failed.
-    if (!isCurrentAttempt()) return;
+    if (!isCurrentAttempt()) {
+      deleteOwnAttempt();
+      return;
+    }
+    // Provider connect snapshots describe a blank transport wrapper, not the
+    // durable Relay transcript. Restore the captured state (including the
+    // provider resume identity) before resume chooses its vendor session id.
+    session.agentSessionV2 = structuredClone(persistedAgentSessionV2);
+    if (persistedProviderSession !== undefined) {
+      session.agentSessionV2.providerSession = {
+        ...persistedProviderSession,
+      };
+    } else {
+      delete session.agentSessionV2.providerSession;
+    }
+    upsertWebSessionNow(session);
     await reconnectWebSessionAdapter(session, attemptAdapter);
     // Resume may ignore disconnect and settle after its deadline. Check the
     // generation again before allowing the adapter to remain connected.
     if (!isCurrentAttempt()) {
+      deleteOwnAttempt();
       await attemptAdapter.disconnect().catch(() => {});
     }
   })();
@@ -2149,6 +2199,7 @@ async function reattachRestoredWebSession(
   void attempt.then(
     () => {
       if (!isCurrentAttempt()) {
+        deleteOwnAttempt();
         void attemptAdapter.disconnect().catch(() => {});
       }
     },
@@ -2167,14 +2218,20 @@ async function reattachRestoredWebSession(
 
   try {
     await Promise.race([attempt, timedOut]);
-    if (!isCurrentAttempt()) return;
-    webSessionRestoreAttempts.delete(session.id);
+    if (!isCurrentAttempt()) {
+      deleteOwnAttempt();
+      return;
+    }
+    deleteOwnAttempt();
     delete session.restoreState;
     fireBackendStateIfChanged(session);
     upsertWebSessionNow(session);
   } catch (err) {
-    if (!isCurrentAttempt()) return;
-    webSessionRestoreAttempts.delete(session.id);
+    if (!isCurrentAttempt()) {
+      deleteOwnAttempt();
+      return;
+    }
+    deleteOwnAttempt();
     session.restoreState = 'reattach-failed';
     // Best effort cancellation makes a hung provider release its transport.
     // Do not await disconnect: failure state must become visible immediately,
@@ -2182,8 +2239,23 @@ async function reattachRestoredWebSession(
     void attemptAdapter.disconnect().catch(() => {});
     surfaceResumeFailure(session, err);
   } finally {
+    setWebSessionRestoreSnapshotFence(attemptAdapter, false);
     if (timeout) clearTimeout(timeout);
   }
+}
+
+function supersedeWebSessionRestore(session: WebSession): void {
+  const attempt = webSessionRestoreAttempts.get(session.id);
+  const adapter =
+    attempt?.session === session ? attempt.adapter : session.adapterV2;
+  if (attempt?.session === session) {
+    webSessionRestoreAttempts.delete(session.id);
+  }
+  // Failure/timeout transitions remove their attempt record before the old
+  // transport necessarily settles. Retire the live adapter regardless so
+  // deleting restoreState cannot briefly reopen its patch handler.
+  retireWebSessionAdapter(adapter);
+  void adapter.disconnect().catch(() => {});
 }
 
 function cancelBackgroundRestores(): void {
@@ -2191,6 +2263,7 @@ function cancelBackgroundRestores(): void {
   const attempts = Array.from(webSessionRestoreAttempts.values());
   webSessionRestoreAttempts.clear();
   for (const { adapter } of attempts) {
+    retireWebSessionAdapter(adapter);
     void adapter.disconnect().catch(() => {});
   }
 }
@@ -2666,8 +2739,10 @@ async function continueHereWeb(sessionId: string): Promise<void> {
   // Only allow the recovery flow when the session is in a disconnected/failed
   // state. An active or waiting session should not have its adapter torn down
   // by a stale or unexpected client command.
+  const replaceRestoreAdapter = session.restoreState !== undefined;
   const liveStatus = session.agentSessionV2.live.status;
   const isDisconnected =
+    replaceRestoreAdapter ||
     liveStatus === 'disconnected' ||
     session.adapterV2.status === 'disconnected';
   if (!isDisconnected) {
@@ -2682,7 +2757,9 @@ async function continueHereWeb(sessionId: string): Promise<void> {
     return;
   }
 
-  const replaceTimedOutAdapter = session.restoreState === 'reattach-failed';
+  if (replaceRestoreAdapter) {
+    supersedeWebSessionRestore(session);
+  }
   // Manual cold recovery supersedes the failed boot-reattach fence. The
   // continue-here flow disconnects and re-registers adapter listeners before
   // establishing its fresh provider session.
@@ -2706,7 +2783,7 @@ async function continueHereWeb(sessionId: string): Promise<void> {
   };
 
   await continueHereWebSession(session, config, fireBackendStateIfChanged, {
-    replaceAdapter: replaceTimedOutAdapter,
+    replaceAdapter: replaceRestoreAdapter,
   });
 }
 

--- a/server/startup-restore.ts
+++ b/server/startup-restore.ts
@@ -1,0 +1,47 @@
+import type http from 'node:http';
+
+interface SessionRestoreResultHandlers {
+  restored(count: number): void;
+  failed(error: unknown): void;
+}
+
+/**
+ * Start serialized-session restore only after the HTTP server is listening.
+ * The restore promise is intentionally detached so provider work cannot hold
+ * the listener callback or any request path open.
+ */
+export function restoreSessionsAfterListen(
+  server: http.Server,
+  restore: () => Promise<number>,
+  handlers: SessionRestoreResultHandlers
+): () => void {
+  let active = true;
+  const fail = (error: unknown): void => {
+    if (!active) return;
+    try {
+      handlers.failed(error);
+    } catch {
+      // Startup diagnostics must never become an unhandled rejection.
+    }
+  };
+  const onListening = (): void => {
+    let restorePromise: Promise<number>;
+    try {
+      restorePromise = restore();
+    } catch (err) {
+      fail(err);
+      return;
+    }
+    void restorePromise
+      .then((count) => {
+        if (!active) return;
+        handlers.restored(count);
+      })
+      .catch(fail);
+  };
+  server.once('listening', onListening);
+  return () => {
+    active = false;
+    server.off('listening', onListening);
+  };
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -57,6 +57,7 @@ export type EventSourceType = 'hooks' | 'plugin' | 'parser' | 'timer';
 export type ContinuePolicy = 'always' | 'never';
 export type BranchLifecycleState = 'active' | 'stale' | 'merged';
 export type SessionStatus = 'active' | 'disconnected';
+export type SessionRestoreState = 'restoring' | 'reattach-failed';
 export type SessionMode = 'pty' | 'web';
 export type TerminalBackend = 'relay-pty';
 
@@ -346,6 +347,8 @@ interface BaseSession {
   idle: boolean;
   customCommand: string | null;
   status: SessionStatus;
+  /** Background provider reattach state for sessions materialized at boot. */
+  restoreState?: SessionRestoreState;
   needsBranchRename: boolean;
   agentState: AgentState;
   workspaceId?: string;
@@ -483,6 +486,8 @@ export interface SessionSummary {
   /** PTY sessions only */
   terminalBackend?: TerminalBackend;
   status: SessionStatus;
+  /** Background provider reattach state for sessions materialized at boot. */
+  restoreState?: SessionRestoreState;
   /**
    * Derived durability state (#614). Coarse `status` stays for backward
    * compatibility; consumers reasoning about reattach/process ownership

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -3,6 +3,7 @@ import type { WebSession, Session } from './types.js';
 import type { AgentType } from './types.js';
 import { createAdapterV2 } from './protocol-adapters/index.js';
 import type { AdapterConfig } from './protocol-adapter.js';
+import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
 import type {
   AgentPatchV2,
   AgentSessionBreakItemV2,
@@ -51,8 +52,8 @@ export async function createWebSession(
   params: CreateWebParams,
   sessionsMap: Map<string, Session>,
   onBackendStateChanged: (session: Session) => void,
-  options: { skipInitialPersist?: boolean } = {}
-): Promise<{ session: WebSession }> {
+  options: { skipInitialPersist?: boolean; deferConnect?: boolean } = {}
+): Promise<{ session: WebSession; config: AdapterConfig }> {
   const id = params.id ?? crypto.randomBytes(8).toString('hex');
   const adapterV2 = createAdapterV2(params.agentType);
   const activeRuntime = adapterV2;
@@ -125,6 +126,10 @@ export async function createWebSession(
   sessionsMap.set(id, session);
 
   adapterV2.onPatch((patch) => {
+    if (session.adapterV2 !== adapterV2) return;
+    // A timed-out boot reattach is authoritative. Providers that resolve or
+    // emit after cancellation must not resurrect the failed session.
+    if (session.restoreState === 'reattach-failed') return;
     handleAgentPatchV2(session, patch, onBackendStateChanged);
   });
 
@@ -141,14 +146,16 @@ export async function createWebSession(
     ...(params.extra !== undefined ? { extra: params.extra } : {}),
   };
 
-  try {
-    await adapterV2.connect(config);
-  } catch (err) {
-    // Clean up zombie: remove from map and disconnect adapter to clear handlers
-    sessionsMap.delete(id);
-    await adapterV2.disconnect().catch(() => {});
-    session.agentState = 'error';
-    throw err;
+  if (!options.deferConnect) {
+    try {
+      await adapterV2.connect(config);
+    } catch (err) {
+      // Clean up zombie: remove from map and disconnect adapter to clear handlers
+      sessionsMap.delete(id);
+      await adapterV2.disconnect().catch(() => {});
+      session.agentState = 'error';
+      throw err;
+    }
   }
 
   logger.info('web session created', { id, agentType: params.agentType });
@@ -160,7 +167,7 @@ export async function createWebSession(
     upsertWebSessionNow(session);
   }
 
-  return { session };
+  return { session, config };
 }
 
 /**
@@ -193,7 +200,13 @@ function extractProviderSessionId(
  * which performs a clean transport-level reconnect with no history.
  */
 export async function reconnectWebSession(session: WebSession): Promise<void> {
-  const adapterV2 = session.adapterV2;
+  return reconnectWebSessionAdapter(session, session.adapterV2);
+}
+
+export async function reconnectWebSessionAdapter(
+  session: WebSession,
+  adapterV2: ProtocolAdapterV2
+): Promise<void> {
   const capabilities = adapterV2.capabilities;
   const providerSession = session.agentSessionV2.providerSession;
 
@@ -230,11 +243,10 @@ export async function reconnectWebSession(session: WebSession): Promise<void> {
  * 1. Emit a synthetic `sessionBreak` divider patch BEFORE disconnecting so
  *    all currently-registered onPatch listeners (session state reducer +
  *    per-WebSocket forwarders) receive and forward it to connected clients.
- * 2. Disconnect the current adapter (clears the handler set).
+ * 2. Best-effort disconnect the current adapter.
  * 3. Clear the stored vendor session ID from the in-memory session so that
  *    a subsequent `reconnectWebSession` (or any DB read) sees no stale ID.
- * 4. Re-register the session-level state reducer/persistence handler so new
- *    patches from the fresh connection are processed correctly.
+ * 4. Replace it with a new adapter instance and register the state reducer.
  * 5. Call `adapter.connect()` with the same config but no resume argument.
  *
  * The Relay session ID (`session.id`) is never changed — all URLs and
@@ -243,9 +255,10 @@ export async function reconnectWebSession(session: WebSession): Promise<void> {
 export async function continueHereWebSession(
   session: WebSession,
   config: AdapterConfig,
-  onBackendStateChanged: (session: Session) => void
+  onBackendStateChanged: (session: Session) => void,
+  options: { replaceAdapter?: boolean } = {}
 ): Promise<boolean> {
-  const adapterV2 = session.adapterV2;
+  const staleAdapter = session.adapterV2;
 
   // Issue 6 fix: guard against accidental teardown of an active session.
   // Only proceed when the session live state is disconnected or the adapter
@@ -253,14 +266,14 @@ export async function continueHereWebSession(
   // down by a stale or unexpected client command.
   const liveStatus = session.agentSessionV2.live.status;
   const isDisconnected =
-    liveStatus === 'disconnected' || adapterV2.status === 'disconnected';
+    liveStatus === 'disconnected' || staleAdapter.status === 'disconnected';
   if (!isDisconnected) {
     logger.warn(
       'continue-here: ignoring request for non-disconnected session (skipping)',
       {
         id: session.id,
         liveStatus,
-        adapterStatus: adapterV2.status,
+        adapterStatus: staleAdapter.status,
       }
     );
     return false;
@@ -296,7 +309,7 @@ export async function continueHereWebSession(
     // Apply to session state and push to agentPatchesV2 for reconnect replay.
     applyWebSessionPatchV2(session, itemPatch);
     // Broadcast to all live onPatch listeners (session reducer + WS forwarders).
-    adapterV2.broadcastPatch(itemPatch);
+    staleAdapter.broadcastPatch(itemPatch);
   }
 
   logger.info('continue-here: disconnecting current adapter', {
@@ -304,13 +317,22 @@ export async function continueHereWebSession(
     agentType: session.adapterType,
   });
 
-  await adapterV2.disconnect().catch((err: unknown) => {
-    // Non-fatal: adapter may already be in a bad state after resume failure.
-    logger.warn('continue-here: disconnect error (continuing anyway)', {
-      id: session.id,
-      err: String(err),
+  const disconnectStaleAdapter = staleAdapter
+    .disconnect()
+    .catch((err: unknown) => {
+      // Non-fatal: adapter may already be in a bad state after resume failure.
+      logger.warn('continue-here: disconnect error (continuing anyway)', {
+        id: session.id,
+        err: String(err),
+      });
     });
-  });
+  if (options.replaceAdapter) {
+    // A timed-out provider may never finish cleanup. The replacement adapter
+    // is isolated, so stale cleanup stays detached from the fresh connection.
+    void disconnectStaleAdapter;
+  } else {
+    await disconnectStaleAdapter;
+  }
 
   // Clear vendor session ID so no stale resume ID remains in memory.
   if (session.agentSessionV2.providerSession !== undefined) {
@@ -320,12 +342,18 @@ export async function continueHereWebSession(
     };
   }
 
-  // Bug 1 fix: re-register the session-level state reducer/persistence handler.
-  // disconnect() clears all handlers registered via onPatch, including the one
-  // set up at session-create time in createWebSession. Without re-registering,
-  // patches from the fresh connect are not applied to session state and not
-  // persisted to the DB.
+  const adapterV2 = options.replaceAdapter
+    ? createAdapterV2(session.adapterType)
+    : staleAdapter;
+  if (options.replaceAdapter) {
+    session.adapterV2 = adapterV2;
+    session.runtimeOwnership = adapterV2.runtimeOwnership;
+  }
+
+  // Register the reducer on the replacement adapter. Identity fencing keeps
+  // late patches from the superseded provider from mutating this session.
   adapterV2.onPatch((patch) => {
+    if (session.adapterV2 !== adapterV2) return;
     handleAgentPatchV2(session, patch, onBackendStateChanged);
   });
 

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -24,6 +24,56 @@ import {
 import { createLocalCompatibilitySessionEnvelope } from '../shared/session-envelope.js';
 
 const logger = createLogger('web-session');
+const restoreSnapshotFencedAdapters = new WeakSet<ProtocolAdapterV2>();
+const retiredWebSessionAdapters = new WeakSet<ProtocolAdapterV2>();
+const webSessionPatchSubscribers = new WeakMap<
+  WebSession,
+  Set<(patch: AgentPatchV2) => void>
+>();
+
+export function onWebSessionPatch(
+  session: WebSession,
+  handler: (patch: AgentPatchV2) => void
+): () => void {
+  let subscribers = webSessionPatchSubscribers.get(session);
+  if (!subscribers) {
+    subscribers = new Set();
+    webSessionPatchSubscribers.set(session, subscribers);
+  }
+  subscribers.add(handler);
+  return () => {
+    subscribers?.delete(handler);
+    if (subscribers?.size === 0) webSessionPatchSubscribers.delete(session);
+  };
+}
+
+function notifyWebSessionPatchSubscribers(
+  session: WebSession,
+  patch: AgentPatchV2
+): void {
+  for (const handler of webSessionPatchSubscribers.get(session) ?? []) {
+    try {
+      handler(patch);
+    } catch (err) {
+      logger.warn('web session patch subscriber failed', err);
+    }
+  }
+}
+
+export function retireWebSessionAdapter(adapter: ProtocolAdapterV2): void {
+  retiredWebSessionAdapters.add(adapter);
+}
+
+export function setWebSessionRestoreSnapshotFence(
+  adapter: ProtocolAdapterV2,
+  fenced: boolean
+): void {
+  if (fenced) {
+    restoreSnapshotFencedAdapters.add(adapter);
+  } else {
+    restoreSnapshotFencedAdapters.delete(adapter);
+  }
+}
 
 export interface CreateWebParams {
   id?: string;
@@ -126,11 +176,20 @@ export async function createWebSession(
   sessionsMap.set(id, session);
 
   adapterV2.onPatch((patch) => {
+    if (sessionsMap.get(id) !== session) return;
     if (session.adapterV2 !== adapterV2) return;
+    if (retiredWebSessionAdapters.has(adapterV2)) return;
+    if (
+      patch.type === 'agent-session-snapshot-v2' &&
+      restoreSnapshotFencedAdapters.has(adapterV2)
+    ) {
+      return;
+    }
     // A timed-out boot reattach is authoritative. Providers that resolve or
     // emit after cancellation must not resurrect the failed session.
     if (session.restoreState === 'reattach-failed') return;
     handleAgentPatchV2(session, patch, onBackendStateChanged);
+    notifyWebSessionPatchSubscribers(session, patch);
   });
 
   const config: AdapterConfig = {
@@ -266,7 +325,9 @@ export async function continueHereWebSession(
   // down by a stale or unexpected client command.
   const liveStatus = session.agentSessionV2.live.status;
   const isDisconnected =
-    liveStatus === 'disconnected' || staleAdapter.status === 'disconnected';
+    options.replaceAdapter === true ||
+    liveStatus === 'disconnected' ||
+    staleAdapter.status === 'disconnected';
   if (!isDisconnected) {
     logger.warn(
       'continue-here: ignoring request for non-disconnected session (skipping)',
@@ -277,6 +338,14 @@ export async function continueHereWebSession(
       }
     );
     return false;
+  }
+
+  const replacementAdapter = options.replaceAdapter
+    ? createAdapterV2(session.adapterType)
+    : undefined;
+  if (replacementAdapter) {
+    session.adapterV2 = replacementAdapter;
+    session.runtimeOwnership = replacementAdapter.runtimeOwnership;
   }
 
   // Bug 2 fix: emit the synthetic sessionBreak BEFORE disconnect so that all
@@ -310,6 +379,9 @@ export async function continueHereWebSession(
     applyWebSessionPatchV2(session, itemPatch);
     // Broadcast to all live onPatch listeners (session reducer + WS forwarders).
     staleAdapter.broadcastPatch(itemPatch);
+    if (replacementAdapter) {
+      notifyWebSessionPatchSubscribers(session, itemPatch);
+    }
   }
 
   logger.info('continue-here: disconnecting current adapter', {
@@ -342,19 +414,14 @@ export async function continueHereWebSession(
     };
   }
 
-  const adapterV2 = options.replaceAdapter
-    ? createAdapterV2(session.adapterType)
-    : staleAdapter;
-  if (options.replaceAdapter) {
-    session.adapterV2 = adapterV2;
-    session.runtimeOwnership = adapterV2.runtimeOwnership;
-  }
+  const adapterV2 = replacementAdapter ?? staleAdapter;
 
   // Register the reducer on the replacement adapter. Identity fencing keeps
   // late patches from the superseded provider from mutating this session.
   adapterV2.onPatch((patch) => {
     if (session.adapterV2 !== adapterV2) return;
     handleAgentPatchV2(session, patch, onBackendStateChanged);
+    notifyWebSessionPatchSubscribers(session, patch);
   });
 
   logger.info('continue-here: connecting fresh adapter session', {

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -14,6 +14,7 @@ import { loadConfig } from './config.js';
 import { verifyCookieToken } from './auth.js';
 import { validateScopedToken } from './browser-content.js';
 import { createAgentSessionSnapshotPatch } from './web-session-v2-state.js';
+import { onWebSessionPatch } from './web-session-handler.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import {
   DEFAULT_LOCAL_NODE_ID,
@@ -1087,7 +1088,7 @@ function setupWebSocket(
       // Web session — JSON relay
       const patchReplayStart = session.agentPatchesV2.length;
       const snapshotPatch = createAgentSessionSnapshotPatch(session);
-      const unlistenV2 = session.adapterV2.onPatch((patch) => {
+      const unlistenV2 = onWebSessionPatch(session, (patch) => {
         if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(patch));
       });
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -130,7 +130,9 @@ test('isPinConfigured treats legacy disabled sentinel and unsupported hashes as 
   expect(isPinConfigured(hash)).toBe(true);
   expect(isPinConfigured('disabled')).toBe(false);
   expect(
-    isPinConfigured('$2b$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012')
+    isPinConfigured(
+      '$2b$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012'
+    )
   ).toBe(false);
   expect(isPinConfigured('')).toBe(false);
   expect(isPinConfigured(undefined)).toBe(false);
@@ -264,7 +266,8 @@ const expectedInventoryCoverage = [
   },
   {
     surface: 'browser webhook management APIs',
-    middleware: 'requireAuth via createWebhookManagerRouter mounted at /webhooks/manage',
+    middleware:
+      'requireAuth via createWebhookManagerRouter mounted at /webhooks/manage',
     acceptedLanes: ['browser-session'],
     routes: [
       'POST /webhooks/manage/setup',
@@ -361,6 +364,7 @@ const expectedInventoryCoverage = [
     acceptedLanes: ['public-local-only'],
     routes: [
       '/health',
+      '/healthz',
       '/auth/status',
       'POST /auth/setup',
       'POST /auth',
@@ -412,7 +416,8 @@ test('auth route lane inventory exactly matches asserted route coverage', () => 
 test('auth route lane inventory keeps credential classes distinct', () => {
   const routeToLanes = new Map<string, string[]>();
   for (const entry of AUTH_ROUTE_LANE_INVENTORY) {
-    for (const route of entry.routes) routeToLanes.set(route, entry.acceptedLanes);
+    for (const route of entry.routes)
+      routeToLanes.set(route, entry.acceptedLanes);
   }
 
   expect(routeToLanes.get('WS /hub/node-link')).toEqual(['node-credential']);

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
 import type { AdapterConfig } from '../server/protocol-adapter-v2.js';
@@ -13,6 +13,7 @@ import {
 } from '../server/channel-message-store.js';
 import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
 import { bindSessionToChannel } from '../server/channel-agent-bridge.js';
+import type { ChannelBridgeRetentionSnapshot } from '../server/channel-agent-bridge.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -84,6 +85,39 @@ function assistantUpdated(
 }
 
 describe('channel-agent-bridge lifecycle', () => {
+  it('releases completed stream text and item ids after every turn', async () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2({ connectMs: 0, stepMs: 0 });
+    await adapter.connect(config('sess-retention'));
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
+    const unbind = bindSessionToChannel({
+      channelId: 'topic:retention',
+      agentFramework: 'mock',
+      adapter,
+      store,
+      hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
+    });
+    cleanup.push(unbind);
+
+    for (let turn = 0; turn < 50; turn++) {
+      await adapter.sendMessage({
+        turnId: `turn-${turn}`,
+        content: `stream turn ${turn}`,
+      });
+      expect(retained).toEqual({
+        openStreams: 0,
+        assistantItemIds: 0,
+        turnsWithRows: 0,
+        retainedTextBytes: 0,
+      });
+    }
+
+    expect(store.history('topic:retention', { limit: 100 })).toHaveLength(50);
+  });
+
   it('mirrors a full assistant turn as an attributed complete row', async () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 });
@@ -209,26 +243,47 @@ describe('channel-agent-bridge lifecycle', () => {
     });
   });
 
-  it('does not double-commit on re-emitted patches (source triple dedupe)', () => {
+  it('treats a duplicate final after turn completion as a pure no-op', () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2();
+    const beginBroadcast = vi.spyOn(hub, 'beginStreamBroadcast');
+    const completeBroadcast = vi.spyOn(hub, 'completeStreamBroadcast');
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
     bindSessionToChannel({
       channelId: 'topic:r',
       agentFramework: 'claude',
       adapter,
       store,
       hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
     });
     adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1'));
     adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1')); // re-emit
     adapter.broadcastPatch(assistantUpdated('s', 'turn', 'a1', 'full'));
-    adapter.broadcastPatch(assistantUpdated('s', 'turn', 'a1', 'full-again')); // stream closed
+    adapter.broadcastPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      status: 'completed',
+    });
+    adapter.broadcastPatch(assistantUpdated('s', 'turn', 'a1', 'full-again'));
 
     const messages = store.history('topic:r');
     expect(messages).toHaveLength(1);
     expect(messages[0]).toMatchObject({
       status: 'complete',
       body: { text: 'full' },
+    });
+    expect(beginBroadcast).toHaveBeenCalledTimes(1);
+    expect(completeBroadcast).toHaveBeenCalledTimes(1);
+    expect(retained).toEqual({
+      openStreams: 0,
+      assistantItemIds: 0,
+      turnsWithRows: 0,
+      retainedTextBytes: 0,
     });
   });
 

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -12,7 +12,10 @@ import {
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
-import { bindSessionToChannel } from '../server/channel-agent-bridge.js';
+import {
+  bindSessionToChannel,
+  CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX,
+} from '../server/channel-agent-bridge.js';
 import type { ChannelBridgeRetentionSnapshot } from '../server/channel-agent-bridge.js';
 
 const cleanup: Array<() => void> = [];
@@ -81,6 +84,16 @@ function assistantUpdated(
     timestamp: 't',
     turnId,
     item: { type: 'assistantMessage', id: itemId, text },
+  };
+}
+
+function turnCompleted(sessionId: string, turnId: string): AgentPatchV2 {
+  return {
+    type: 'agent-turn-completed-v2',
+    sessionId,
+    timestamp: 't',
+    turnId,
+    status: 'completed',
   };
 }
 
@@ -196,12 +209,16 @@ describe('channel-agent-bridge lifecycle', () => {
   it('finalizes as failed on agent-error-v2 keeping the partial text', () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2();
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
     bindSessionToChannel({
       channelId: 'topic:e',
       agentFramework: 'claude',
       adapter,
       store,
       hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
     });
     adapter.broadcastPatch(assistantStarted('s', 'turn', 'a1'));
     adapter.broadcastPatch(textDelta('s', 'turn', 'a1', 'partial'));
@@ -218,6 +235,47 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(messages[0]).toMatchObject({
       status: 'failed',
       body: { text: 'partial' },
+    });
+    expect(retained).toEqual({
+      openStreams: 0,
+      assistantItemIds: 0,
+      turnsWithRows: 0,
+      retainedTextBytes: 0,
+    });
+  });
+
+  it('releases every turn when a terminal agent error has no turn id', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
+    bindSessionToChannel({
+      channelId: 'topic:error-all',
+      agentFramework: 'gemini',
+      adapter,
+      store,
+      hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
+    });
+    adapter.broadcastPatch(assistantStarted('s', 'turn-a', 'item-a'));
+    adapter.broadcastPatch(assistantStarted('s', 'turn-b', 'item-b'));
+    adapter.broadcastPatch({
+      type: 'agent-error-v2',
+      sessionId: 's',
+      timestamp: 't',
+      message: 'transport closed',
+    });
+
+    expect(store.history('topic:error-all')).toEqual([
+      expect.objectContaining({ status: 'failed' }),
+      expect.objectContaining({ status: 'failed' }),
+    ]);
+    expect(retained).toEqual({
+      openStreams: 0,
+      assistantItemIds: 0,
+      turnsWithRows: 0,
+      retainedTextBytes: 0,
     });
   });
 
@@ -279,6 +337,107 @@ describe('channel-agent-bridge lifecycle', () => {
     });
     expect(beginBroadcast).toHaveBeenCalledTimes(1);
     expect(completeBroadcast).toHaveBeenCalledTimes(1);
+    expect(retained).toEqual({
+      openStreams: 0,
+      assistantItemIds: 0,
+      turnsWithRows: 0,
+      retainedTextBytes: 0,
+    });
+  });
+
+  it('bounds Gemini-style replayed starts against a finalized durable row', () => {
+    const { store, hub } = makeStore();
+    const firstAdapter = new MockProtocolAdapterV2();
+    const unbindFirst = bindSessionToChannel({
+      channelId: 'topic:replay',
+      agentFramework: 'gemini',
+      adapter: firstAdapter,
+      store,
+      hub,
+    });
+    firstAdapter.broadcastPatch(
+      assistantUpdated('session-gemini', 'turn-replay', 'item-replay', 'done')
+    );
+    unbindFirst();
+
+    const beginStore = vi.spyOn(store, 'beginStream');
+    const beginBroadcast = vi.spyOn(hub, 'beginStreamBroadcast');
+    const replayAdapter = new MockProtocolAdapterV2();
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
+    bindSessionToChannel({
+      channelId: 'topic:replay',
+      agentFramework: 'gemini',
+      adapter: replayAdapter,
+      store,
+      hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
+    });
+
+    replayAdapter.broadcastPatch(
+      assistantStarted('session-gemini', 'turn-replay', 'item-replay')
+    );
+    replayAdapter.broadcastPatch(
+      assistantStarted('session-gemini', 'turn-replay', 'item-replay')
+    );
+
+    expect(beginStore).toHaveBeenCalledTimes(1);
+    expect(beginBroadcast).not.toHaveBeenCalled();
+    expect(store.history('topic:replay')).toHaveLength(1);
+    expect(retained).toEqual({
+      openStreams: 0,
+      assistantItemIds: 0,
+      turnsWithRows: 0,
+      retainedTextBytes: 0,
+    });
+  });
+
+  it('bounds finalized-item replay tombstones while preserving dedupe', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
+    bindSessionToChannel({
+      channelId: 'topic:tombstones',
+      agentFramework: 'gemini',
+      adapter,
+      store,
+      hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
+    });
+
+    for (
+      let index = 0;
+      index <= CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX;
+      index++
+    ) {
+      const turnId = `turn-${index}`;
+      adapter.broadcastPatch(
+        assistantUpdated('session-gemini', turnId, `item-${index}`, 'done')
+      );
+      adapter.broadcastPatch(turnCompleted('session-gemini', turnId));
+    }
+
+    const beginStore = vi.spyOn(store, 'beginStream');
+    const beginBroadcast = vi.spyOn(hub, 'beginStreamBroadcast');
+    const newest = CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX;
+    adapter.broadcastPatch(
+      assistantStarted('session-gemini', `turn-${newest}`, `item-${newest}`)
+    );
+    expect(beginStore).not.toHaveBeenCalled();
+
+    // The oldest tombstone was evicted, so one durable lookup refreshes it;
+    // subsequent replay is served by the bounded tombstone without another hit.
+    adapter.broadcastPatch(
+      assistantStarted('session-gemini', 'turn-0', 'item-0')
+    );
+    adapter.broadcastPatch(
+      assistantStarted('session-gemini', 'turn-0', 'item-0')
+    );
+    expect(beginStore).toHaveBeenCalledOnce();
+    expect(beginBroadcast).not.toHaveBeenCalled();
     expect(retained).toEqual({
       openStreams: 0,
       assistantItemIds: 0,

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -9,6 +9,7 @@ import {
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import {
+  CHANNEL_WS_BACKPRESSURE_CLOSE_CODE,
   createChannelHub,
   type ChannelHub,
   type ChannelSocket,
@@ -87,6 +88,35 @@ function hubWith(
 }
 
 describe('channel-hub fan-out', () => {
+  it('bounds the connect-time live queue and relies on durable reconnect catch-up', () => {
+    const s = store();
+    const hub = hubWith(s, { connectQueueMaxEvents: 3 });
+    const sock = fakeSocket();
+    const ordinarySend = sock.send;
+    let injected = false;
+    sock.send = function (data: string) {
+      ordinarySend.call(this, data);
+      if (injected) return;
+      injected = true;
+      // Re-entrant delivery is a defense-in-depth stand-in for live traffic at
+      // the snapshot boundary. The fourth queued event must close, not retain.
+      for (let index = 0; index < 4; index++) {
+        const message = s.appendComplete({
+          channelId: 'topic:c',
+          sender: HUMAN,
+          text: `queued-${index}`,
+        });
+        hub.broadcastCreated(message);
+      }
+    };
+
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+
+    expect(sock.closed).toBe(CHANNEL_WS_BACKPRESSURE_CLOSE_CODE);
+    expect(hub.subscriberCount('topic:c')).toBe(0);
+    expect(s.latestSeq('topic:c')).toBe(4); // reconnect can replay every row
+  });
+
   it('delivers a committed post to every subscriber', () => {
     const s = store();
     const hub = hubWith(s);

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -117,6 +117,92 @@ describe('channel-hub fan-out', () => {
     expect(s.latestSeq('topic:c')).toBe(4); // reconnect can replay every row
   });
 
+  it('closes when cumulative connect-queue bytes exceed the cap below the event cap', () => {
+    const s = store();
+    const messages = [0, 1].map((index) =>
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: HUMAN,
+        text: `${index}-${'x'.repeat(512)}`,
+      })
+    );
+    const eventBytes = messages.map((message) =>
+      Buffer.byteLength(
+        JSON.stringify({
+          type: 'channel-message-created-v1',
+          channelId: 'topic:c',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message,
+        }),
+        'utf8'
+      )
+    );
+    const hub = hubWith(s, {
+      connectQueueMaxEvents: 10,
+      connectQueueMaxBytes: eventBytes[0]! + eventBytes[1]! - 1,
+    });
+    const sock = fakeSocket();
+    const ordinarySend = sock.send;
+    let injected = false;
+    sock.send = function (data: string) {
+      ordinarySend.call(this, data);
+      if (injected) return;
+      injected = true;
+      for (const message of messages) hub.broadcastCreated(message);
+    };
+
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+
+    expect(sock.closed).toBe(CHANNEL_WS_BACKPRESSURE_CLOSE_CODE);
+    expect(hub.subscriberCount('topic:c')).toBe(0);
+  });
+
+  it('resets connect-queue byte accounting after a successful snapshot flush', () => {
+    const s = store();
+    const messages = [0, 1].map((index) =>
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: HUMAN,
+        text: `${index}-${'x'.repeat(128)}`,
+      })
+    );
+    const exactQueueBytes = messages.reduce(
+      (total, message) =>
+        total +
+        Buffer.byteLength(
+          JSON.stringify({
+            type: 'channel-message-created-v1',
+            channelId: 'topic:c',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            message,
+          }),
+          'utf8'
+        ),
+      0
+    );
+    const hub = hubWith(s, {
+      connectQueueMaxEvents: 10,
+      connectQueueMaxBytes: exactQueueBytes,
+    });
+    const sock = fakeSocket();
+    const ordinarySend = sock.send;
+    let injected = false;
+    sock.send = function (data: string) {
+      ordinarySend.call(this, data);
+      if (injected) return;
+      injected = true;
+      for (const message of messages) hub.broadcastCreated(message);
+    };
+
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+
+    expect(sock.closed).toBeNull();
+    expect(hub.retentionSnapshot()).toEqual({
+      connectQueueEvents: 0,
+      connectQueueBytes: 0,
+    });
+  });
+
   it('delivers a committed post to every subscriber', () => {
     const s = store();
     const hub = hubWith(s);

--- a/test/fixtures/hanging-codex-app-server.mjs
+++ b/test/fixtures/hanging-codex-app-server.mjs
@@ -1,0 +1,4 @@
+// Test fixture for startup restore: accept the stdio transport but never
+// answer Codex's JSON-RPC initialize request. The parent must enforce its
+// reattach deadline and terminate this process.
+process.stdin.resume();

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -21,6 +21,7 @@ afterEach(async () => {
           new Promise<void>((resolve) => server.close(() => resolve()))
       )
   );
+  vi.useRealTimers();
 });
 
 async function serveHealthz(lagMs: number): Promise<string> {
@@ -48,6 +49,72 @@ async function serveHealthz(lagMs: number): Promise<string> {
 }
 
 describe('/healthz', () => {
+  it('returns 503 from the actual monotonic interval drift probe', () => {
+    vi.useFakeTimers();
+    let monotonicMs = 0;
+    const monitor = createHealthMonitor({
+      lagThresholdMs: 50,
+      probeIntervalMs: 100,
+      memoryLogIntervalMs: 60_000,
+      monotonicNow: () => monotonicMs,
+      memoryUsage: () => ({
+        rss: 123_456,
+        heapTotal: 80_000,
+        heapUsed: 40_000,
+        external: 2_000,
+        arrayBuffers: 1_000,
+      }),
+    });
+    monitors.push(monitor);
+    monotonicMs = 175;
+    vi.advanceTimersByTime(100);
+
+    const json = vi.fn();
+    const response = {
+      status: vi.fn().mockReturnThis(),
+      json,
+    };
+    monitor.handler({} as never, response as never, vi.fn());
+
+    expect(monitor.getLagMs()).toBe(75);
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(json).toHaveBeenCalledWith({
+      status: 'degraded',
+      lagMs: 75,
+      rss: 123_456,
+    });
+  });
+
+  it('logs the memory line on the periodic interval', () => {
+    vi.useFakeTimers();
+    const info = vi.fn();
+    const monitor = createHealthMonitor({
+      getLagMs: () => 0,
+      memoryLogIntervalMs: 60_000,
+      logger: {
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info,
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      memoryUsage: () => ({
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 60,
+        external: 40,
+        arrayBuffers: 20,
+      }),
+    });
+    monitors.push(monitor);
+
+    vi.advanceTimersByTime(59_999);
+    expect(info).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(info).toHaveBeenCalledOnce();
+    expect(info).toHaveBeenCalledWith('memory rss=100 heapUsed=60 external=40');
+  });
+
   it('returns the unauthenticated health shape', async () => {
     const baseUrl = await serveHealthz(12.4);
     const response = await fetch(`${baseUrl}/healthz`);

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,0 +1,100 @@
+import http from 'node:http';
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createHealthMonitor,
+  formatHealthMemoryLine,
+  logHealthMemorySnapshot,
+  type HealthMonitor,
+} from '../server/health.js';
+
+const servers: http.Server[] = [];
+const monitors: HealthMonitor[] = [];
+
+afterEach(async () => {
+  for (const monitor of monitors.splice(0)) monitor.stop();
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve()))
+      )
+  );
+});
+
+async function serveHealthz(lagMs: number): Promise<string> {
+  const monitor = createHealthMonitor({
+    getLagMs: () => lagMs,
+    lagThresholdMs: 100,
+    memoryLogIntervalMs: 60_000,
+    memoryUsage: () => ({
+      rss: 123_456,
+      heapTotal: 80_000,
+      heapUsed: 40_000,
+      external: 2_000,
+      arrayBuffers: 1_000,
+    }),
+  });
+  monitors.push(monitor);
+  const app = express();
+  app.get('/healthz', monitor.handler);
+  const server = http.createServer(app);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no address');
+  return `http://127.0.0.1:${String(address.port)}`;
+}
+
+describe('/healthz', () => {
+  it('returns the unauthenticated health shape', async () => {
+    const baseUrl = await serveHealthz(12.4);
+    const response = await fetch(`${baseUrl}/healthz`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: 'ok',
+      lagMs: 12,
+      rss: 123_456,
+    });
+  });
+
+  it('returns 503 when the injected event-loop lag exceeds the threshold', async () => {
+    const baseUrl = await serveHealthz(101);
+    const response = await fetch(`${baseUrl}/healthz`);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: 'degraded',
+      lagMs: 101,
+      rss: 123_456,
+    });
+  });
+
+  it('formats one memory line with rss, heapUsed, and external', () => {
+    const info = vi.fn();
+    const snapshot = logHealthMemorySnapshot(
+      {
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info,
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      () => ({
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 60,
+        external: 40,
+        arrayBuffers: 20,
+      })
+    );
+
+    expect(formatHealthMemoryLine(snapshot)).toBe(
+      'memory rss=100 heapUsed=60 external=40'
+    );
+    expect(info).toHaveBeenCalledOnce();
+    expect(info).toHaveBeenCalledWith('memory rss=100 heapUsed=60 external=40');
+  });
+});

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -100,7 +100,10 @@ async function expectJsonStatus<T>(
   return body;
 }
 
-async function rawUpgradeStatus(port: number, pathName: string): Promise<number> {
+async function rawUpgradeStatus(
+  port: number,
+  pathName: string
+): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
       socket.write(
@@ -159,6 +162,14 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
 
   try {
     const port = await waitForListeningPort(child);
+
+    const health = await fetch(`http://127.0.0.1:${port}/healthz`);
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toMatchObject({
+      status: 'ok',
+      lagMs: expect.any(Number),
+      rss: expect.any(Number),
+    });
 
     // Hit GET /auth/status — should work without auth
     const res = await fetch(`http://127.0.0.1:${port}/auth/status`);
@@ -257,7 +268,9 @@ test('legacy disabled PIN sentinel allows first-run setup instead of lockout', a
 });
 
 test('NO_PIN does not bypass protected browser or CLI gateway auth paths', async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-no-pin-no-bypass-'));
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-no-pin-no-bypass-')
+  );
   const configPath = path.join(tmpDir, 'config.json');
   fs.writeFileSync(
     configPath,
@@ -305,7 +318,9 @@ test('NO_PIN does not bypass protected browser or CLI gateway auth paths', async
 });
 
 test('protected hub accepts grant-backed CLI actor credential for nodes.list without browser-cookie fallback', async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-cli-actor-protected-'));
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-cli-actor-protected-')
+  );
   const configPath = path.join(tmpDir, 'config.json');
   const pin = '246810';
   fs.writeFileSync(
@@ -400,7 +415,11 @@ test('protected hub accepts grant-backed CLI actor credential for nodes.list wit
         'x-relay-capabilities': 'session:read',
       },
     });
-    await expectJsonStatus<{ nodes: unknown[] }>(actorNodes, 200, 'actor nodes.list');
+    await expectJsonStatus<{ nodes: unknown[] }>(
+      actorNodes,
+      200,
+      'actor nodes.list'
+    );
 
     const nodeCredentialNodes = await fetch(`${base}/nodes`, {
       headers: {

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -1,10 +1,17 @@
-import { test, expect } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
 import { hashPin } from '../server/auth.js';
+import {
+  closeRelayStateDb,
+  initRelayStateDb,
+  upsertWebSessionNow,
+} from '../server/relay-state-db.js';
+import type { SessionSummary, WebSession } from '../server/types.js';
+import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
 import {
   CLI_GATEWAY_ACTOR_AUDIENCE,
   CLI_GATEWAY_READ_SCOPE_TASK_REF,
@@ -16,6 +23,11 @@ const SERVER_SCRIPT = path.resolve(
   'dist',
   'server',
   'index.js'
+);
+const HANGING_CODEX_APP_SERVER = path.resolve(
+  import.meta.dirname,
+  'fixtures',
+  'hanging-codex-app-server.mjs'
 );
 
 if (!fs.existsSync(SERVER_SCRIPT)) {
@@ -82,6 +94,100 @@ function startServer(opts: StartServerOpts): ChildProcess {
     env: { ...process.env, ...opts.env },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+}
+
+function captureOutput(child: ChildProcess): {
+  stdout(): string;
+  stderr(): string;
+} {
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  return {
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+function seedHangingCodexSession(configDir: string): void {
+  const id = 'startup-hanging-codex';
+  const now = new Date().toISOString();
+  const session = {
+    mode: 'web',
+    id,
+    type: 'agent',
+    agent: 'codex',
+    cwd: configDir,
+    displayName: 'Restored hanging Codex',
+    createdAt: now,
+    lastActivity: now,
+    idle: true,
+    customCommand: null,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+    adapterV2: {
+      disconnect: async () => {},
+    },
+    adapterType: 'codex',
+    agentSessionV2: emptyAgentSessionV2({
+      id,
+      provider: 'codex',
+      cwd: configDir,
+      capabilities: { resume: true },
+      providerSession: { threadId: 'thread-that-never-reattaches' },
+      config: {
+        providerOptions: {
+          command: process.execPath,
+          args: [HANGING_CODEX_APP_SERVER],
+        },
+      },
+    }),
+    agentPatchesV2: [],
+    protocolVersion: 2,
+    currentTurnId: null,
+    runtimeOwnership: 'spawned',
+    hookToken: 'startup-hanging-codex-hook',
+    hooksActive: true,
+  } as unknown as WebSession;
+
+  initRelayStateDb(configDir);
+  try {
+    upsertWebSessionNow(session);
+  } finally {
+    closeRelayStateDb();
+  }
+}
+
+async function waitForRestoredSession(
+  baseUrl: string,
+  cookie: string,
+  predicate: (session: SessionSummary) => boolean,
+  timeoutMs = 5_000
+): Promise<SessionSummary> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const response = await fetch(`${baseUrl}/sessions`, {
+      headers: { cookie },
+    });
+    if (response.ok) {
+      const sessions = (await response.json()) as SessionSummary[];
+      const session = sessions.find(
+        (candidate) =>
+          candidate.id === 'startup-hanging-codex' && predicate(candidate)
+      );
+      if (session) return session;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(
+    'restored hanging Codex session did not reach expected state'
+  );
 }
 
 function cookieFromSetCookie(headers: Headers): string {
@@ -176,6 +282,96 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { hasPIN: boolean };
     expect(body.hasPIN).toBe(false);
+  } finally {
+    await killAndWait(child);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('real server listens before a hanging serialized-session restore', async () => {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-listen-before-restore-')
+  );
+  const configPath = path.join(tmpDir, 'config.json');
+  const pin = '246810';
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      port: 0,
+      host: '127.0.0.1',
+      pinHash: await hashPin(pin),
+      cookieTTL: '1h',
+    })
+  );
+  seedHangingCodexSession(tmpDir);
+
+  const child = startServer({
+    env: {
+      RELAY_IDE_CONFIG: configPath,
+      RELAY_IDE_PORT: '0',
+      RELAY_IDE_WEB_SESSION_REATTACH_TIMEOUT_MS: '500',
+      RELAY_IDE_TEST_STARTUP_RESTORE_HOLD_MS: '1000',
+      NODE_ENV: 'test',
+      HOME: tmpDir,
+    },
+  });
+  const output = captureOutput(child);
+
+  try {
+    const port = await waitForListeningPort(child);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    const [health, authStatus] = await Promise.all([
+      fetch(`${baseUrl}/healthz`),
+      fetch(`${baseUrl}/auth/status`),
+    ]);
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toMatchObject({ status: 'ok' });
+    expect(authStatus.status).toBe(200);
+    await expect(authStatus.json()).resolves.toEqual({ hasPIN: true });
+    // The real startup restore function is still held. This proves both public
+    // routes answered while restore remained incomplete.
+    expect(output.stdout()).not.toContain(
+      'Restored 1 session(s) from previous update.'
+    );
+
+    const login = await fetch(`${baseUrl}/auth`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pin }),
+    });
+    expect(login.status).toBe(200);
+    const cookie = cookieFromSetCookie(login.headers);
+
+    await waitForRestoredSession(
+      baseUrl,
+      cookie,
+      (session) => session.restoreState === 'restoring'
+    );
+    const failed = await waitForRestoredSession(
+      baseUrl,
+      cookie,
+      (session) => session.restoreState === 'reattach-failed'
+    );
+    expect(failed).toMatchObject({
+      status: 'disconnected',
+      agentState: 'error',
+      restoreState: 'reattach-failed',
+    });
+
+    await vi.waitFor(() =>
+      expect(output.stdout()).toContain(
+        'Restored 1 session(s) from previous update.'
+      )
+    );
+    const listeningAt = output
+      .stdout()
+      .indexOf('relay-ide listening on 127.0.0.1:');
+    const restoredAt = output
+      .stdout()
+      .indexOf('Restored 1 session(s) from previous update.');
+    expect(listeningAt, output.stderr()).toBeGreaterThanOrEqual(0);
+    expect(restoredAt, output.stderr()).toBeGreaterThan(listeningAt);
   } finally {
     await killAndWait(child);
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -125,6 +125,25 @@ function collectPatches(adapter: CodexNativeProtocolAdapter): AgentPatchV2[] {
   return patches;
 }
 
+function retentionCounts(adapter: CodexNativeProtocolAdapter) {
+  const state = adapter as unknown as {
+    itemMap: Map<unknown, unknown>;
+    tokenUsageBuffer: Map<unknown, unknown>;
+    reasoningSummaryBuffers: Map<unknown, unknown>;
+    reasoningDetailBuffers: Map<unknown, unknown>;
+    approvalMeta: Map<unknown, unknown>;
+    inputRequestMeta: Map<unknown, unknown>;
+  };
+  return {
+    itemIds: state.itemMap.size,
+    tokenUsage: state.tokenUsageBuffer.size,
+    reasoningSummary: state.reasoningSummaryBuffers.size,
+    reasoningDetail: state.reasoningDetailBuffers.size,
+    approvalMeta: state.approvalMeta.size,
+    inputRequestMeta: state.inputRequestMeta.size,
+  };
+}
+
 function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
   return new Promise((resolve, reject) => {
     const started = Date.now();
@@ -1150,6 +1169,7 @@ describe('CodexNativeProtocolAdapter — approval flows', () => {
     const response = client.calls.find((c) => c.method === '__respond:10');
     expect(response).toBeDefined();
     expect(response?.params).toMatchObject({ decision: 'accept' });
+    expect(retentionCounts(adapter).approvalMeta).toBe(0);
 
     // Verify approval item emitted
     expect(patches).toEqual(
@@ -1442,6 +1462,7 @@ describe('CodexNativeProtocolAdapter — input requests', () => {
       contentItems: [{ id: 'q1', value: 'Alice' }],
       success: true,
     });
+    expect(retentionCounts(adapter).inputRequestMeta).toBe(0);
 
     await adapter.disconnect();
   });
@@ -1450,6 +1471,66 @@ describe('CodexNativeProtocolAdapter — input requests', () => {
 // ── Queue ─────────────────────────────────────────────────────────────────────
 
 describe('CodexNativeProtocolAdapter — queue', () => {
+  it('releases transient provider output indexes at each turn boundary', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-retention' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient!;
+
+    for (let turn = 0; turn < 25; turn++) {
+      const relayTurnId = `turn-retention-${turn}`;
+      const nativeTurnId = `native-retention-${turn}`;
+      await adapter.sendMessage({ turnId: relayTurnId, content: 'stream' });
+      client.feedNotification('turn/started', {
+        turn: { id: nativeTurnId },
+      });
+      client.feedNotification('item/started', {
+        turnId: nativeTurnId,
+        item: { id: `item-${turn}`, type: 'agentMessage' },
+      });
+      client.feedNotification('item/started', {
+        turnId: nativeTurnId,
+        item: { id: `reasoning-${turn}`, type: 'reasoning' },
+      });
+      client.feedNotification('item/reasoning/summaryTextDelta', {
+        turnId: nativeTurnId,
+        itemId: `reasoning-${turn}`,
+        delta: 'thinking',
+      });
+      client.feedNotification('item/reasoning/textDelta', {
+        turnId: nativeTurnId,
+        itemId: `reasoning-${turn}`,
+        delta: 'detail',
+      });
+      client.feedNotification('thread/tokenUsageUpdated', {
+        turnId: nativeTurnId,
+        tokenUsage: { total: { totalTokens: 10 } },
+      });
+
+      expect(retentionCounts(adapter)).toMatchObject({
+        itemIds: 2,
+        tokenUsage: 1,
+        reasoningSummary: 1,
+        reasoningDetail: 1,
+      });
+      client.feedNotification('turn/completed', {
+        threadId: 'thread-retention',
+        turn: { id: nativeTurnId, status: 'completed' },
+      });
+      expect(retentionCounts(adapter)).toMatchObject({
+        itemIds: 0,
+        tokenUsage: 0,
+        reasoningSummary: 0,
+        reasoningDetail: 0,
+      });
+    }
+
+    await adapter.disconnect();
+  });
+
   it('queues second send while turn active, drains after turn/completed', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -6,6 +6,7 @@ import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
 import type {
   AgentCapabilitySetV2,
   AgentPatchV2,
+  AgentSessionV2,
 } from '../shared/agent-chat-protocol-v2.js';
 import type { LoadedWebSessionRow } from '../server/relay-state-db.js';
 import type {
@@ -19,6 +20,7 @@ import type {
   ProtocolAdapterV2,
 } from '../server/protocol-adapter-v2.js';
 import { getSessionCategory } from '../server/session-attribution.js';
+import type { WebSession } from '../server/types.js';
 
 const capabilities: AgentCapabilitySetV2 = {
   text: true,
@@ -50,6 +52,8 @@ const resumeSession = vi.fn();
 const reconnect = vi.fn();
 const connect = vi.fn();
 const disconnect = vi.fn();
+let emitBlankSnapshotOnConnect = false;
+let emitPatchOnDisconnect: AgentPatchV2 | undefined;
 
 class RestoreFailureAdapter implements ProtocolAdapterV2 {
   readonly agentType = 'claude';
@@ -60,8 +64,22 @@ class RestoreFailureAdapter implements ProtocolAdapterV2 {
 
   async connect(config: AdapterConfig): Promise<void> {
     await connect(config);
+    if (emitBlankSnapshotOnConnect) {
+      this.emit({
+        type: 'agent-session-snapshot-v2',
+        sessionId: config.sessionId,
+        timestamp: new Date().toISOString(),
+        session: emptyAgentSessionV2({
+          id: config.sessionId,
+          provider: 'claude',
+          cwd: config.cwd,
+          capabilities,
+        }),
+      });
+    }
   }
   async disconnect(): Promise<void> {
+    if (emitPatchOnDisconnect) this.emit(emitPatchOnDisconnect);
     this.handlers.clear();
     await disconnect();
   }
@@ -124,6 +142,8 @@ describe('web session restore failure recovery', () => {
     disconnect.mockReset();
     latestAdapter = undefined;
     createdAdapters.length = 0;
+    emitBlankSnapshotOnConnect = false;
+    emitPatchOnDisconnect = undefined;
   });
 
   afterEach(async () => {
@@ -233,6 +253,90 @@ describe('web session restore failure recovery', () => {
       )
     ).toBe(true);
     expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
+  });
+
+  it('fences blank connect snapshots and resumes from the persisted transcript identity', async () => {
+    emitBlankSnapshotOnConnect = true;
+    const persisted = emptyAgentSessionV2({
+      id: 'web-restore-snapshot',
+      provider: 'claude',
+      cwd: configDir,
+      capabilities,
+      providerSession: { claudeSessionId: 'durable-provider-session' },
+    });
+    const now = new Date().toISOString();
+    persisted.turns = [
+      {
+        id: 'durable-turn',
+        status: 'completed',
+        inputMessageId: 'durable-input',
+        items: [
+          {
+            type: 'assistantMessage',
+            id: 'durable-item',
+            text: 'persisted transcript',
+            status: 'completed',
+            startedAt: now,
+            completedAt: now,
+          },
+        ],
+        startedAt: now,
+        completedAt: now,
+      },
+    ];
+    const persistedWrites: AgentSessionV2[] = [];
+    upsertWebSessionNow.mockImplementation((session: WebSession) => {
+      persistedWrites.push(structuredClone(session.agentSessionV2));
+    });
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-snapshot',
+        vendor: 'claude',
+        vendorSessionId: 'durable-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'snapshot restore',
+        workspaceId: null,
+        agentSessionV2: persisted,
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'snapshot-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+    await sessions.restoreFromDisk(configDir);
+    await vi.waitFor(() =>
+      expect(resumeSession).toHaveBeenCalledWith('durable-provider-session')
+    );
+
+    const session = sessions.get('web-restore-snapshot');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+    expect(session.agentSessionV2.providerSession).toEqual({
+      claudeSessionId: 'durable-provider-session',
+    });
+    expect(session.agentSessionV2.turns).toHaveLength(1);
+    expect(session.agentSessionV2.turns[0]?.id).toBe('durable-turn');
+    expect(persistedWrites.length).toBeGreaterThan(0);
+    expect(
+      persistedWrites.every(
+        (write) =>
+          write.turns[0]?.id === 'durable-turn' &&
+          write.providerSession?.['claudeSessionId'] ===
+            'durable-provider-session'
+      )
+    ).toBe(true);
   });
 
   it('materializes a hanging transport as restoring, then fails it at the hard deadline', async () => {
@@ -425,14 +529,40 @@ describe('web session restore failure recovery', () => {
     const session = sessions.get('web-restore-superseded');
     if (session?.mode !== 'web') throw new Error('expected web session');
     const staleAdapter = session.adapterV2;
+    const { onWebSessionPatch } =
+      await import('../server/web-session-handler.js');
+    const forwardedPatches: AgentPatchV2[] = [];
+    const unlisten = onWebSessionPatch(session, (patch) => {
+      forwardedPatches.push(patch);
+    });
 
     await vi.waitFor(() =>
       expect(session.restoreState).toBe('reattach-failed')
     );
+    const failureTurnId = session.agentSessionV2.turns[0]?.id;
+    emitPatchOnDisconnect = {
+      type: 'agent-session-snapshot-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      session: emptyAgentSessionV2({
+        id: session.id,
+        provider: 'claude',
+        cwd: configDir,
+        capabilities,
+      }),
+    };
     await sessions.continueHereWeb(session.id);
 
     expect(createdAdapters).toHaveLength(2);
     expect(session.adapterV2).not.toBe(staleAdapter);
+    expect(session.agentSessionV2.turns[0]?.id).toBe(failureTurnId);
+    expect(
+      forwardedPatches.filter(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          patch.item.type === 'sessionBreak'
+      )
+    ).toHaveLength(1);
     const freshAdapter = session.adapterV2 as RestoreFailureAdapter;
     freshAdapter.emit({
       type: 'agent-live-state-updated-v2',
@@ -447,6 +577,10 @@ describe('web session restore failure recovery', () => {
       },
     });
     expect(session.agentSessionV2.live.status).toBe('idle');
+    expect(forwardedPatches.at(-1)).toMatchObject({
+      type: 'agent-live-state-updated-v2',
+      live: { status: 'idle' },
+    });
 
     settleResume?.();
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -478,6 +612,162 @@ describe('web session restore failure recovery', () => {
     expect(session.adapterV2).toBe(freshAdapter);
     expect(session.agentSessionV2.live.status).toBe('working');
     expect(session.agentState).toBe('processing');
+    unlisten();
+  });
+
+  it('supersedes a still-restoring adapter when Continue Here runs before timeout', async () => {
+    let settleResume: (() => void) | undefined;
+    resumeSession.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          settleResume = resolve;
+        })
+    );
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-midflight',
+        vendor: 'claude',
+        vendorSessionId: 'stored-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'midflight transport',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-midflight',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-provider-session' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'midflight-restored-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+    await sessions.restoreFromDisk(configDir, undefined, undefined, {
+      webSessionReattachTimeoutMs: 1_000,
+    });
+    const session = sessions.get('web-restore-midflight');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+    await vi.waitFor(() => expect(resumeSession).toHaveBeenCalledOnce());
+    expect(session.restoreState).toBe('restoring');
+    const staleAdapter = session.adapterV2;
+
+    await sessions.continueHereWeb(session.id);
+    const freshAdapter = session.adapterV2 as RestoreFailureAdapter;
+    expect(freshAdapter).not.toBe(staleAdapter);
+    freshAdapter.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: { status: 'idle', error: null },
+    });
+    settleResume?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    staleAdapter.emit({
+      type: 'agent-session-snapshot-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      session: emptyAgentSessionV2({
+        id: session.id,
+        provider: 'claude',
+        cwd: configDir,
+        capabilities,
+      }),
+    });
+    freshAdapter.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: { status: 'working', activeTurnId: 'fresh-midflight-turn' },
+    });
+
+    expect(session.adapterV2).toBe(freshAdapter);
+    expect(session.agentSessionV2.live.status).toBe('working');
+    expect(session.agentSessionV2.live.activeTurnId).toBe(
+      'fresh-midflight-turn'
+    );
+  });
+
+  it('supersedes a killed restoring session and blocks every late persistence path', async () => {
+    let settleResume: (() => void) | undefined;
+    resumeSession.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          settleResume = resolve;
+        })
+    );
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-killed',
+        vendor: 'claude',
+        vendorSessionId: 'stored-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'killed transport',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-killed',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-provider-session' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'killed-restored-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+    await sessions.restoreFromDisk(configDir, undefined, undefined, {
+      webSessionReattachTimeoutMs: 1_000,
+    });
+    const session = sessions.get('web-restore-killed');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+    await vi.waitFor(() => expect(resumeSession).toHaveBeenCalledOnce());
+    const staleAdapter = session.adapterV2 as RestoreFailureAdapter;
+    upsertWebSessionNow.mockClear();
+
+    sessions.kill(session.id);
+    expect(deleteWebSession).toHaveBeenCalledWith(session.id);
+    expect(sessions.get(session.id)).toBeUndefined();
+    settleResume?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    staleAdapter.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: { status: 'idle', error: null },
+    });
+
+    expect(sessions.get(session.id)).toBeUndefined();
+    expect(upsertWebSessionNow).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
   });
 
   it('restores persisted free web sessions without synthesizing repo bindings', async () => {

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -48,6 +48,8 @@ const deleteWebSession = vi.fn();
 const scheduleWebSessionUpsert = vi.fn();
 const resumeSession = vi.fn();
 const reconnect = vi.fn();
+const connect = vi.fn();
+const disconnect = vi.fn();
 
 class RestoreFailureAdapter implements ProtocolAdapterV2 {
   readonly agentType = 'claude';
@@ -56,9 +58,12 @@ class RestoreFailureAdapter implements ProtocolAdapterV2 {
   readonly status: AdapterStatus = 'connected';
   private handlers = new Set<AgentPatchHandlerV2>();
 
-  async connect(_config: AdapterConfig): Promise<void> {}
+  async connect(config: AdapterConfig): Promise<void> {
+    await connect(config);
+  }
   async disconnect(): Promise<void> {
     this.handlers.clear();
+    await disconnect();
   }
   async reconnect(): Promise<void> {
     await reconnect();
@@ -79,7 +84,13 @@ class RestoreFailureAdapter implements ProtocolAdapterV2 {
   emit(patch: AgentPatchV2): void {
     for (const handler of this.handlers) handler(patch);
   }
+  broadcastPatch(patch: AgentPatchV2): void {
+    this.emit(patch);
+  }
 }
+
+let latestAdapter: RestoreFailureAdapter | undefined;
+const createdAdapters: RestoreFailureAdapter[] = [];
 
 vi.mock('../server/relay-state-db.js', () => ({
   loadAllWebSessions,
@@ -89,7 +100,11 @@ vi.mock('../server/relay-state-db.js', () => ({
 }));
 
 vi.mock('../server/protocol-adapters/index.js', () => ({
-  createAdapterV2: () => new RestoreFailureAdapter(),
+  createAdapterV2: () => {
+    latestAdapter = new RestoreFailureAdapter();
+    createdAdapters.push(latestAdapter);
+    return latestAdapter;
+  },
 }));
 
 describe('web session restore failure recovery', () => {
@@ -105,6 +120,10 @@ describe('web session restore failure recovery', () => {
     scheduleWebSessionUpsert.mockReset();
     reconnect.mockReset();
     resumeSession.mockReset();
+    connect.mockReset();
+    disconnect.mockReset();
+    latestAdapter = undefined;
+    createdAdapters.length = 0;
   });
 
   afterEach(async () => {
@@ -178,7 +197,9 @@ describe('web session restore failure recovery', () => {
     const restored = await sessions.restoreFromDisk(configDir);
 
     expect(restored).toBe(1);
-    expect(resumeSession).toHaveBeenCalledWith('stored-provider-session');
+    await vi.waitFor(() =>
+      expect(resumeSession).toHaveBeenCalledWith('stored-provider-session')
+    );
     expect(reconnect).not.toHaveBeenCalled();
 
     const session = sessions.get('web-restore-failure');
@@ -189,8 +210,11 @@ describe('web session restore failure recovery', () => {
     expect(session.needsBranchRename).toBe(true);
     expect(session.workspaceId).toBe('workspace-1');
     expect(session.additionalDirs).toEqual([path.join(configDir, 'extra')]);
-    expect(session.status).toBe('disconnected');
-    expect(session.agentState).toBe('error');
+    await vi.waitFor(() => {
+      expect(session.restoreState).toBe('reattach-failed');
+      expect(session.status).toBe('disconnected');
+      expect(session.agentState).toBe('error');
+    });
     expect(session.controlState).toMatchObject({
       controlMode: 'co-driven',
       controlFreshness: 'fresh',
@@ -209,6 +233,251 @@ describe('web session restore failure recovery', () => {
       )
     ).toBe(true);
     expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
+  });
+
+  it('materializes a hanging transport as restoring, then fails it at the hard deadline', async () => {
+    connect.mockImplementationOnce(() => new Promise<void>(() => {}));
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-hangs',
+        vendor: 'claude',
+        vendorSessionId: 'stored-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'hung transport',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-hangs',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-provider-session' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'hung-restored-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+
+    const restored = await sessions.restoreFromDisk(
+      configDir,
+      undefined,
+      undefined,
+      { webSessionReattachTimeoutMs: 20 }
+    );
+
+    expect(restored).toBe(1);
+    const session = sessions.get('web-restore-hangs');
+    expect(session?.mode).toBe('web');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+    expect(session.restoreState).toBe('restoring');
+    expect(sessions.list()).toContainEqual(
+      expect.objectContaining({
+        id: 'web-restore-hangs',
+        restoreState: 'restoring',
+      })
+    );
+    expect(resumeSession).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      expect(session.restoreState).toBe('reattach-failed');
+      expect(session.agentSessionV2.live.status).toBe('disconnected');
+      expect(disconnect).toHaveBeenCalled();
+    });
+    expect(sessions.list()).toContainEqual(
+      expect.objectContaining({
+        id: 'web-restore-hangs',
+        restoreState: 'reattach-failed',
+      })
+    );
+  });
+
+  it('keeps timeout failure authoritative when a late resume settles', async () => {
+    let settleResume: (() => void) | undefined;
+    resumeSession.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          settleResume = resolve;
+        })
+    );
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-late',
+        vendor: 'claude',
+        vendorSessionId: 'stored-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'late transport',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-late',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-provider-session' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'late-restored-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+    await sessions.restoreFromDisk(configDir, undefined, undefined, {
+      webSessionReattachTimeoutMs: 20,
+    });
+    const session = sessions.get('web-restore-late');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+
+    await vi.waitFor(() =>
+      expect(session.restoreState).toBe('reattach-failed')
+    );
+    settleResume?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    latestAdapter?.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: {
+        status: 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        error: null,
+      },
+    });
+
+    expect(session.restoreState).toBe('reattach-failed');
+    expect(session.status).toBe('disconnected');
+    expect(session.agentSessionV2.live.status).toBe('disconnected');
+    expect(disconnect.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('isolates Continue Here from a superseded restore that settles late', async () => {
+    let settleResume: (() => void) | undefined;
+    resumeSession.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          settleResume = resolve;
+        })
+    );
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-superseded',
+        vendor: 'claude',
+        vendorSessionId: 'stored-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'superseded transport',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-superseded',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-provider-session' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'superseded-restored-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+    await sessions.restoreFromDisk(configDir, undefined, undefined, {
+      webSessionReattachTimeoutMs: 20,
+    });
+    const session = sessions.get('web-restore-superseded');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+    const staleAdapter = session.adapterV2;
+
+    await vi.waitFor(() =>
+      expect(session.restoreState).toBe('reattach-failed')
+    );
+    await sessions.continueHereWeb(session.id);
+
+    expect(createdAdapters).toHaveLength(2);
+    expect(session.adapterV2).not.toBe(staleAdapter);
+    const freshAdapter = session.adapterV2 as RestoreFailureAdapter;
+    freshAdapter.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: {
+        status: 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        error: null,
+      },
+    });
+    expect(session.agentSessionV2.live.status).toBe('idle');
+
+    settleResume?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    staleAdapter.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: {
+        status: 'disconnected',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        error: 'late stale restore',
+      },
+    });
+    freshAdapter.emit({
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp: new Date().toISOString(),
+      live: {
+        status: 'working',
+        activeTurnId: 'fresh-turn',
+        waitingOn: null,
+        activeRequestIds: [],
+        error: null,
+      },
+    });
+
+    expect(session.adapterV2).toBe(freshAdapter);
+    expect(session.agentSessionV2.live.status).toBe('working');
+    expect(session.agentState).toBe('processing');
   });
 
   it('restores persisted free web sessions without synthesizing repo bindings', async () => {
@@ -250,7 +519,9 @@ describe('web session restore failure recovery', () => {
     const restored = await sessions.restoreFromDisk(configDir);
 
     expect(restored).toBe(1);
-    expect(resumeSession).toHaveBeenCalledWith('stored-free-provider-session');
+    await vi.waitFor(() =>
+      expect(resumeSession).toHaveBeenCalledWith('stored-free-provider-session')
+    );
 
     const session = sessions.get('web-restore-free');
     expect(session).toBeTruthy();
@@ -319,7 +590,9 @@ describe('web session restore failure recovery', () => {
     const restored = await sessions.restoreFromDisk(configDir);
 
     expect(restored).toBe(1);
-    expect(resumeSession).toHaveBeenCalledWith('resp_stored');
+    await vi.waitFor(() =>
+      expect(resumeSession).toHaveBeenCalledWith('resp_stored')
+    );
     expect(reconnect).not.toHaveBeenCalled();
   });
 });

--- a/test/startup-restore.test.ts
+++ b/test/startup-restore.test.ts
@@ -1,0 +1,62 @@
+import http from 'node:http';
+import express from 'express';
+import { afterEach, expect, it, vi } from 'vitest';
+import { createHealthMonitor, type HealthMonitor } from '../server/health.js';
+import { restoreSessionsAfterListen } from '../server/startup-restore.js';
+
+const servers: http.Server[] = [];
+const monitors: HealthMonitor[] = [];
+
+afterEach(async () => {
+  for (const monitor of monitors.splice(0)) monitor.stop();
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve()))
+      )
+  );
+});
+
+it('listens before a hanging background restore and keeps health/auth responsive', async () => {
+  const monitor = createHealthMonitor({
+    getLagMs: () => 0,
+    memoryLogIntervalMs: 60_000,
+  });
+  monitors.push(monitor);
+  const app = express();
+  app.get('/healthz', monitor.handler);
+  app.get('/auth/status', (_req, res) => res.json({ hasPIN: false }));
+  const server = http.createServer(app);
+  servers.push(server);
+
+  let restoreStarted = false;
+  restoreSessionsAfterListen(
+    server,
+    () => {
+      restoreStarted = true;
+      return new Promise<number>(() => {});
+    },
+    { restored: vi.fn(), failed: vi.fn() }
+  );
+  expect(restoreStarted).toBe(false);
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  await vi.waitFor(() => expect(restoreStarted).toBe(true));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no address');
+  const baseUrl = `http://127.0.0.1:${String(address.port)}`;
+
+  const [health, auth] = await Promise.all([
+    fetch(`${baseUrl}/healthz`),
+    fetch(`${baseUrl}/auth/status`),
+  ]);
+  expect(health.status).toBe(200);
+  await expect(health.json()).resolves.toMatchObject({
+    status: 'ok',
+    lagMs: 0,
+  });
+  expect(auth.status).toBe(200);
+  await expect(auth.json()).resolves.toEqual({ hasPIN: false });
+});


### PR DESCRIPTION
## Summary

- add public event-loop-aware `/healthz` and periodic `health` memory telemetry
- restore serialized web sessions only after listen, with visible lifecycle state, per-session deadlines, shutdown fencing, and isolated cold recovery
- release completed channel/adapter streaming state and bound the WS connect queue with SQLite-backed recovery
- add a 100-turn mock streaming memory diagnostic

## Root cause

Provider transport handshakes ran synchronously before the hub listened, while completed channel streams and Codex provider item indexes survived turn boundaries. That combination could wedge startup and grow heap across an always-on channel binding.

## Validation

- focused reliability suites: 119 passed
- pre-push changed suites: 907 passed, 9 skipped
- `npm run check`
- `npm run build`
- 100-turn diagnostic: 1,470 bytes/turn heap slope; zero retained bridge streams, item ids, turn ids, or text bytes
- full repository run: 5,525 passed, 9 skipped; inherited Relay env caused 3 host failures that cleared when sanitized, while 2 unchanged branch-watcher assertions remain blocked by missing filesystem-watch events on this host
- `git diff --check`

Closes #1196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/healthz` endpoint reporting service status, event-loop lag, and memory usage.
  * Server health and authentication endpoints are available while session restoration continues in the background.
  * Session listings now show when restoration is in progress or has failed.

* **Bug Fixes**
  * Improved recovery from interrupted or timed-out session reconnects.
  * Prevented duplicate messages and replayed events from reopening completed streams.
  * Added connection backpressure limits to protect clients during large event bursts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->