### PR TITLE
feat(chat): normalize agent detail cards

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,6 +46,15 @@
 - **Merged:** `--status-merged: #a78bfa` — merged PRs, completed state
 - **Info:** `--status-info: #60a5fa` — informational, review actions
 
+### Diff Line Tints
+
+- **Added line:** `--diff-added-bg: color-mix(in srgb, var(--status-success) 9%, transparent)` — restrained green tint behind added lines only
+- **Removed line:** `--diff-removed-bg: color-mix(in srgb, var(--status-error) 9%, transparent)` — restrained red tint behind removed lines only
+
+These tokens are dark-only backgrounds for diff-shaped content. Keep the text
+palette unchanged; the tint communicates line polarity without introducing a
+separate rainbow syntax theme.
+
 ### Repo / Project Identity Colors
 
 12 colors for hash-derived repo/project badge backgrounds. Each bound repo Project gets a deterministic color based on its name; free/non-git and unbound remote tabs do not inherit a repo badge just because their `cwd` looks repo-shaped.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,6 +8,10 @@
   --text-muted: #888888;
   --border: #333333;
 
+  /* Diff-shaped agent detail rows — subtle dark-only line tints. */
+  --diff-added-bg: color-mix(in srgb, var(--status-success) 9%, transparent);
+  --diff-removed-bg: color-mix(in srgb, var(--status-error) 9%, transparent);
+
   /* Status colors */
   --status-success: #4ade80;
   --status-error: #f87171;

--- a/frontend/src/components/DiffViewer.tsx
+++ b/frontend/src/components/DiffViewer.tsx
@@ -342,6 +342,7 @@ function useDiffTokenizer(
     if (
       cached &&
       cached.source === sourceKey &&
+      cached.language === lang &&
       cached.highlightOutput !== null
     ) {
       const tokenLines = cached.highlightOutput as ThemedToken[][];
@@ -365,7 +366,10 @@ function useDiffTokenizer(
     tokenizeCode(subsetSource, lang)
       .then((tokenLines) => {
         if (gen !== genRef.current) return;
-        setHighlightOutput(cacheKey, tokenLines);
+        setHighlightOutput(cacheKey, tokenLines, {
+          source: subsetSource,
+          language: lang,
+        });
         const highlighted = rawLines.map((line, i) => ({
           ...line,
           tokens: tokenLines[i] ?? null,

--- a/frontend/src/components/chat/AgentDetailCard.css
+++ b/frontend/src/components/chat/AgentDetailCard.css
@@ -1,0 +1,129 @@
+.ch-agent-card {
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.ch-agent-card__toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  min-width: 0;
+  min-height: 32px;
+  padding: var(--space-xs) var(--space-sm);
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ch-agent-card__toggle:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.ch-agent-card__toggle:disabled {
+  cursor: default;
+}
+
+.ch-agent-card__chevron,
+.ch-agent-card__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.ch-agent-card__chevron {
+  transition: transform 120ms ease-out;
+}
+
+.ch-agent-card__chevron--open {
+  transform: rotate(90deg);
+}
+
+.ch-agent-card__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ch-agent-card__size,
+.ch-agent-card__status {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.ch-agent-card__size {
+  margin-left: auto;
+}
+
+.ch-agent-card__status--running {
+  color: var(--status-warning);
+}
+
+.ch-agent-card__status--completed {
+  color: var(--status-success);
+}
+
+.ch-agent-card__status--failed {
+  color: var(--status-error);
+}
+
+.ch-agent-card__status--cancelled,
+.ch-agent-card__status--pending {
+  color: var(--text-muted);
+}
+
+.ch-agent-card__body {
+  max-height: 320px;
+  overflow: auto;
+  border-top: 1px solid var(--border);
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.ch-agent-card__code {
+  margin: 0;
+  padding: var(--space-sm);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+  tab-size: 2;
+}
+
+.ch-agent-card__code code,
+.ch-agent-card__line {
+  display: block;
+  min-width: max-content;
+}
+
+.ch-agent-card__line {
+  padding: 0 var(--space-xs);
+}
+
+.ch-agent-card__line--added {
+  background: var(--diff-added-bg);
+}
+
+.ch-agent-card__line--removed {
+  background: var(--diff-removed-bg);
+}
+
+@media (max-width: 767px) {
+  .ch-agent-card__size {
+    display: none;
+  }
+
+  .ch-agent-card__body {
+    max-height: 240px;
+  }
+}

--- a/frontend/src/components/chat/AgentDetailCard.css
+++ b/frontend/src/components/chat/AgentDetailCard.css
@@ -100,6 +100,13 @@
   tab-size: 2;
 }
 
+.ch-agent-card__truncated {
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px dashed var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
 .ch-agent-card__code code,
 .ch-agent-card__line {
   display: block;
@@ -119,10 +126,6 @@
 }
 
 @media (max-width: 767px) {
-  .ch-agent-card__size {
-    display: none;
-  }
-
   .ch-agent-card__body {
     max-height: 240px;
   }

--- a/frontend/src/components/chat/AgentDetailCard.tsx
+++ b/frontend/src/components/chat/AgentDetailCard.tsx
@@ -15,7 +15,12 @@ interface AgentDetailCardProps {
   card: AgentDetailCardV2;
   /** Stable outer item id; isolates syntax-highlight cache entries. */
   itemId: string;
+  onUserToggle?: (itemId: string) => void;
 }
+
+export const AGENT_DETAIL_RENDER_MAX_CHARS = 64 * 1024;
+export const AGENT_DETAIL_RENDER_MAX_LINES = 1_000;
+export const AGENT_DETAIL_HIGHLIGHT_MAX_CHARS = 24 * 1024;
 
 function CardIcon({ kind }: Pick<AgentDetailCardV2, 'kind'>) {
   const props = { size: 14, strokeWidth: 1.5, 'aria-hidden': true } as const;
@@ -57,6 +62,10 @@ function byteLabel(bytes: number): string {
   return `${mib < 10 ? mib.toFixed(1) : Math.round(mib)}mb`;
 }
 
+function charLabel(characters: number): string {
+  return `${characters} char${characters === 1 ? '' : 's'}`;
+}
+
 function contentSize(card: AgentDetailCardV2): string | null {
   if (card.kind === 'diff') {
     const additions = card.additions ?? 0;
@@ -64,10 +73,23 @@ function contentSize(card: AgentDetailCardV2): string | null {
     return `+${additions} -${deletions}`;
   }
   const content = card.content ?? '';
-  const bytes = card.sizeBytes ?? new TextEncoder().encode(content).byteLength;
-  if (bytes === 0) return null;
-  const lines = content.split('\n').length;
-  return `${lines} line${lines === 1 ? '' : 's'} · ${byteLabel(bytes)}`;
+  const magnitude = card.sizeBytes ?? content.length;
+  if (magnitude === 0) return null;
+  const magnitudeLabel =
+    card.sizeBytes === undefined
+      ? charLabel(content.length)
+      : byteLabel(card.sizeBytes);
+  if (
+    card.status === 'running' ||
+    content.length > AGENT_DETAIL_RENDER_MAX_CHARS
+  ) {
+    return magnitudeLabel;
+  }
+  let lines = 1;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content.charCodeAt(index) === 10) lines += 1;
+  }
+  return `${lines} line${lines === 1 ? '' : 's'} · ${magnitudeLabel}`;
 }
 
 function lineClass(kind: AgentDetailCardV2['kind'], line: string): string {
@@ -88,38 +110,87 @@ interface CardContentProps {
   itemId: string;
 }
 
+interface BoundedCardContent {
+  content: string;
+  truncated: 'start' | 'end' | null;
+}
+
+function boundCardContent(card: AgentDetailCardV2): BoundedCardContent {
+  const source = card.content ?? '';
+  const keepTail = card.kind === 'output' || card.kind === 'tool_call';
+  const charBounded =
+    source.length <= AGENT_DETAIL_RENDER_MAX_CHARS
+      ? source
+      : keepTail
+        ? source.slice(-AGENT_DETAIL_RENDER_MAX_CHARS)
+        : source.slice(0, AGENT_DETAIL_RENDER_MAX_CHARS);
+  const lines = charBounded.split('\n');
+  const lineTruncated = lines.length > AGENT_DETAIL_RENDER_MAX_LINES;
+  const visibleLines = lineTruncated
+    ? keepTail
+      ? lines.slice(-AGENT_DETAIL_RENDER_MAX_LINES)
+      : lines.slice(0, AGENT_DETAIL_RENDER_MAX_LINES)
+    : lines;
+  return {
+    content: visibleLines.join('\n'),
+    truncated:
+      source.length > AGENT_DETAIL_RENDER_MAX_CHARS
+        ? keepTail
+          ? 'start'
+          : 'end'
+        : lineTruncated
+          ? keepTail
+            ? 'start'
+            : 'end'
+          : null,
+  };
+}
+
 function CardContent({ card, itemId }: CardContentProps) {
-  const content = card.content ?? '';
+  const bounded = useMemo(() => boundCardContent(card), [card]);
+  const content = bounded.content;
   const language = card.kind === 'diff' ? 'diff' : card.language;
   const cacheKey = `agent-detail:${itemId}:${language ?? 'text'}`;
+  const highlightContent =
+    language &&
+    card.status !== 'running' &&
+    content.length <= AGENT_DETAIL_HIGHLIGHT_MAX_CHARS
+      ? content
+      : '';
   const { tokens } = useShikiHighlight(
     cacheKey,
-    language ? content : '',
+    highlightContent,
     language ?? 'text'
   );
   const rawLines = useMemo(() => content.split('\n'), [content]);
 
   return (
-    <pre className="ch-agent-card__code">
-      <code>
-        {rawLines.map((line, lineIndex) => (
-          <span
-            className={lineClass(card.kind, line)}
-            key={`${lineIndex}:${line}`}
-          >
-            {tokens?.[lineIndex]?.map((token, tokenIndex) => (
-              <span
-                key={tokenIndex}
-                style={{ color: token.color ?? 'var(--text)' }}
-              >
-                {token.content}
-              </span>
-            )) ?? line}
-            {'\n'}
-          </span>
-        ))}
-      </code>
-    </pre>
+    <>
+      {bounded.truncated ? (
+        <div className="ch-agent-card__truncated" role="note">
+          {bounded.truncated === 'start'
+            ? 'showing latest bounded output'
+            : 'showing first bounded output'}
+        </div>
+      ) : null}
+      <pre className="ch-agent-card__code">
+        <code>
+          {rawLines.map((line, lineIndex) => (
+            <span className={lineClass(card.kind, line)} key={lineIndex}>
+              {tokens?.[lineIndex]?.map((token, tokenIndex) => (
+                <span
+                  key={tokenIndex}
+                  style={{ color: token.color ?? 'var(--text)' }}
+                >
+                  {token.content}
+                </span>
+              )) ?? line}
+              {'\n'}
+            </span>
+          ))}
+        </code>
+      </pre>
+    </>
   );
 }
 
@@ -130,6 +201,7 @@ function CardContent({ card, itemId }: CardContentProps) {
 export const AgentDetailCard: React.FC<AgentDetailCardProps> = ({
   card,
   itemId,
+  onUserToggle,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const hasContent = Boolean(card.content);
@@ -148,7 +220,10 @@ export const AgentDetailCard: React.FC<AgentDetailCardProps> = ({
         className="ch-agent-card__toggle"
         aria-expanded={expanded}
         disabled={!hasContent}
-        onClick={() => setExpanded((value) => !value)}
+        onClick={() => {
+          onUserToggle?.(itemId);
+          setExpanded((value) => !value);
+        }}
       >
         <ChevronRight
           className={`ch-agent-card__chevron${expanded ? ' ch-agent-card__chevron--open' : ''}`}

--- a/frontend/src/components/chat/AgentDetailCard.tsx
+++ b/frontend/src/components/chat/AgentDetailCard.tsx
@@ -1,0 +1,177 @@
+import React, { useMemo, useState } from 'react';
+import {
+  ChevronRight,
+  CircleDot,
+  FileDiff,
+  MessageSquare,
+  Terminal,
+  Wrench,
+} from 'lucide-react';
+import type { AgentDetailCardV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+import { useShikiHighlight } from '../../hooks/useShikiHighlight.js';
+import './AgentDetailCard.css';
+
+interface AgentDetailCardProps {
+  card: AgentDetailCardV2;
+  /** Stable outer item id; isolates syntax-highlight cache entries. */
+  itemId: string;
+}
+
+function CardIcon({ kind }: Pick<AgentDetailCardV2, 'kind'>) {
+  const props = { size: 14, strokeWidth: 1.5, 'aria-hidden': true } as const;
+  switch (kind) {
+    case 'message':
+      return <MessageSquare {...props} />;
+    case 'thought':
+      return <CircleDot {...props} />;
+    case 'tool_call':
+      return <Wrench {...props} />;
+    case 'output':
+      return <Terminal {...props} />;
+    case 'diff':
+      return <FileDiff {...props} />;
+  }
+}
+
+function statusClass(status: AgentDetailCardV2['status']): string {
+  switch (status) {
+    case 'running':
+      return 'ch-agent-card__status--running';
+    case 'completed':
+      return 'ch-agent-card__status--completed';
+    case 'failed':
+      return 'ch-agent-card__status--failed';
+    case 'cancelled':
+      return 'ch-agent-card__status--cancelled';
+    case 'pending':
+    default:
+      return 'ch-agent-card__status--pending';
+  }
+}
+
+function byteLabel(bytes: number): string {
+  if (bytes < 1024) return `${bytes}b`;
+  const kib = bytes / 1024;
+  if (kib < 1024) return `${kib < 10 ? kib.toFixed(1) : Math.round(kib)}kb`;
+  const mib = kib / 1024;
+  return `${mib < 10 ? mib.toFixed(1) : Math.round(mib)}mb`;
+}
+
+function contentSize(card: AgentDetailCardV2): string | null {
+  if (card.kind === 'diff') {
+    const additions = card.additions ?? 0;
+    const deletions = card.deletions ?? 0;
+    return `+${additions} -${deletions}`;
+  }
+  const content = card.content ?? '';
+  const bytes = card.sizeBytes ?? new TextEncoder().encode(content).byteLength;
+  if (bytes === 0) return null;
+  const lines = content.split('\n').length;
+  return `${lines} line${lines === 1 ? '' : 's'} · ${byteLabel(bytes)}`;
+}
+
+function lineClass(kind: AgentDetailCardV2['kind'], line: string): string {
+  if (kind !== 'diff' || line.startsWith('+++') || line.startsWith('---')) {
+    return 'ch-agent-card__line';
+  }
+  if (line.startsWith('+')) {
+    return 'ch-agent-card__line ch-agent-card__line--added';
+  }
+  if (line.startsWith('-')) {
+    return 'ch-agent-card__line ch-agent-card__line--removed';
+  }
+  return 'ch-agent-card__line';
+}
+
+interface CardContentProps {
+  card: AgentDetailCardV2;
+  itemId: string;
+}
+
+function CardContent({ card, itemId }: CardContentProps) {
+  const content = card.content ?? '';
+  const language = card.kind === 'diff' ? 'diff' : card.language;
+  const cacheKey = `agent-detail:${itemId}:${language ?? 'text'}`;
+  const { tokens } = useShikiHighlight(
+    cacheKey,
+    language ? content : '',
+    language ?? 'text'
+  );
+  const rawLines = useMemo(() => content.split('\n'), [content]);
+
+  return (
+    <pre className="ch-agent-card__code">
+      <code>
+        {rawLines.map((line, lineIndex) => (
+          <span
+            className={lineClass(card.kind, line)}
+            key={`${lineIndex}:${line}`}
+          >
+            {tokens?.[lineIndex]?.map((token, tokenIndex) => (
+              <span
+                key={tokenIndex}
+                style={{ color: token.color ?? 'var(--text)' }}
+              >
+                {token.content}
+              </span>
+            )) ?? line}
+            {'\n'}
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}
+
+/**
+ * Framework-agnostic ACP-style detail card. The adapter owns normalization;
+ * this component only consumes the durable typed card contract.
+ */
+export const AgentDetailCard: React.FC<AgentDetailCardProps> = ({
+  card,
+  itemId,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const hasContent = Boolean(card.content);
+  const size = contentSize(card);
+  const title = card.path ?? card.title;
+
+  return (
+    <div
+      className="ch-agent-card"
+      data-agent-card-kind={card.kind}
+      role="article"
+      aria-label={`${card.kind.replace('_', ' ')} ${title}`}
+    >
+      <button
+        type="button"
+        className="ch-agent-card__toggle"
+        aria-expanded={expanded}
+        disabled={!hasContent}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <ChevronRight
+          className={`ch-agent-card__chevron${expanded ? ' ch-agent-card__chevron--open' : ''}`}
+          size={14}
+          strokeWidth={1.5}
+          aria-hidden="true"
+        />
+        <span className="ch-agent-card__icon">
+          <CardIcon kind={card.kind} />
+        </span>
+        <span className="ch-agent-card__title">{title}</span>
+        {size ? <span className="ch-agent-card__size">{size}</span> : null}
+        <span className={`ch-agent-card__status ${statusClass(card.status)}`}>
+          {card.status}
+        </span>
+      </button>
+      {expanded && hasContent ? (
+        <div className="ch-agent-card__body">
+          <CardContent card={card} itemId={itemId} />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default AgentDetailCard;

--- a/frontend/src/components/chat/ChatView.css
+++ b/frontend/src/components/chat/ChatView.css
@@ -1,10 +1,30 @@
 .chat-view {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
   height: 100%;
   background: var(--bg);
   color: var(--text);
+}
+
+.tl-jump-latest {
+  position: absolute;
+  left: 50%;
+  bottom: 68px;
+  z-index: 2;
+  transform: translateX(-50%);
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid var(--status-info);
+  background: var(--bg);
+  color: var(--status-info);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+
+.tl-jump-latest:hover {
+  background: color-mix(in srgb, var(--status-info) 10%, var(--bg));
 }
 
 /* timeline — matches chat.html lines 120-129 verbatim */

--- a/frontend/src/components/chat/ChatView.css
+++ b/frontend/src/components/chat/ChatView.css
@@ -367,6 +367,10 @@
 }
 
 /* reasoning block — relay-specific, not in chat.html */
+.turn__item {
+  min-width: 0;
+}
+
 .reasoning {
   border-left: 1px solid var(--border);
   padding-left: 10px;

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import './ChatView.css';
 import { useAgentChatSocket } from '../../hooks/useAgentChatSocket.js';
 import { createBrowserId } from '../../lib/browserId.js';
@@ -36,6 +42,121 @@ interface ChatViewProps {
   sessionId: string | null;
 }
 
+interface ReaderAnchor {
+  itemId: string;
+  offsetTop: number;
+}
+
+function captureReaderAnchor(container: HTMLDivElement): ReaderAnchor | null {
+  const containerTop = container.getBoundingClientRect().top;
+  const items = container.querySelectorAll<HTMLElement>('[data-agent-item-id]');
+  for (const item of items) {
+    const rect = item.getBoundingClientRect();
+    if (rect.bottom < containerTop) continue;
+    const itemId = item.dataset.agentItemId;
+    if (!itemId) continue;
+    return { itemId, offsetTop: rect.top - containerTop };
+  }
+  return null;
+}
+
+function findAnchoredItem(
+  container: HTMLDivElement,
+  itemId: string
+): HTMLElement | null {
+  for (const item of container.querySelectorAll<HTMLElement>(
+    '[data-agent-item-id]'
+  )) {
+    if (item.dataset.agentItemId === itemId) return item;
+  }
+  return null;
+}
+
+/**
+ * Exact production scroll model for an agent-detail timeline. Exported so the
+ * static evidence harness can exercise follow intent and anchor restoration
+ * without opening a real adapter WebSocket.
+ */
+interface UseAgentTimelineScrollOptions {
+  timelineId: string | null;
+  itemCount: number;
+}
+
+export function useAgentTimelineScroll({
+  timelineId,
+  itemCount,
+}: UseAgentTimelineScrollOptions) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const shouldFollowRef = useRef(true);
+  const readerAnchorRef = useRef<ReaderAnchor | null>(null);
+  const previousTimelineIdRef = useRef(timelineId);
+
+  // Session identity is part of the scroll state. Equal item counts across two
+  // sessions must not preserve the old reader anchor/follow intent and open the
+  // next conversation halfway up its history.
+  useLayoutEffect(() => {
+    if (previousTimelineIdRef.current === timelineId) return;
+    previousTimelineIdRef.current = timelineId;
+    shouldFollowRef.current = true;
+    readerAnchorRef.current = null;
+    const container = containerRef.current;
+    if (container) container.scrollTop = container.scrollHeight;
+    bottomRef.current?.scrollIntoView({ behavior: 'auto' });
+  }, [timelineId]);
+
+  const handleTimelineScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    shouldFollowRef.current = isNearBottom({
+      scrollHeight: container.scrollHeight,
+      scrollTop: container.scrollTop,
+      clientHeight: container.clientHeight,
+    });
+    readerAnchorRef.current = shouldFollowRef.current
+      ? null
+      : captureReaderAnchor(container);
+  }, []);
+
+  // #1197 scroll invariant, reused for agent-detail rows: follow intent is
+  // sticky while at the bottom; a reader who scrolled up keeps the same first
+  // visible item at the same offset when streaming or card expansion reflows
+  // content above it.
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const preserveViewport = () => {
+      if (shouldFollowRef.current) {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+        return;
+      }
+      const anchor = readerAnchorRef.current;
+      if (anchor) {
+        const item = findAnchoredItem(container, anchor.itemId);
+        if (item) {
+          const offsetTop =
+            item.getBoundingClientRect().top -
+            container.getBoundingClientRect().top;
+          container.scrollTop += offsetTop - anchor.offsetTop;
+        }
+      }
+      readerAnchorRef.current = captureReaderAnchor(container);
+    };
+
+    preserveViewport();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(preserveViewport);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [itemCount, timelineId]);
+
+  return { bottomRef, containerRef, contentRef, handleTimelineScroll };
+}
+
 export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
   const {
     session,
@@ -47,9 +168,6 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
     continueHere,
     pushClientError,
   } = useAgentChatSocket(sessionId);
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
   const [eventVerbosity, setEventVerbosity] =
     React.useState<EventVerbosity>('normal');
 
@@ -59,36 +177,8 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
     [session]
   );
 
-  // Auto-follow the bottom of the timeline as new items arrive AND as a
-  // single streaming item (e.g. an assistantMessage growing via deltas)
-  // grows the content height without changing itemCount. A ResizeObserver on
-  // the content wrapper catches both cases; scrolling only happens if the
-  // user was already near the bottom, so scrolling up to read history is
-  // never interrupted.
-  useEffect(() => {
-    const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
-
-    const followIfNearBottom = () => {
-      if (
-        isNearBottom({
-          scrollHeight: container.scrollHeight,
-          scrollTop: container.scrollTop,
-          clientHeight: container.clientHeight,
-        })
-      ) {
-        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-      }
-    };
-
-    followIfNearBottom();
-
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(followIfNearBottom);
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, [itemCount]);
+  const { bottomRef, containerRef, contentRef, handleTimelineScroll } =
+    useAgentTimelineScroll({ timelineId: sessionId, itemCount });
 
   const isActive = useMemo(
     () =>
@@ -182,6 +272,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
         role="log"
         aria-live="polite"
         aria-label="message timeline"
+        onScroll={handleTimelineScroll}
       >
         {(canResume || resumeFailed) && (
           <div className="tl-resume-banner">

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -14,7 +14,10 @@ import {
   type ComposerSendAttachment,
 } from './Composer.js';
 import { QueueChips } from './QueueChips.js';
-import { isNearBottom } from './scrollNearBottom.js';
+import {
+  deriveFollowIntent,
+  readTimelineScrollMetrics,
+} from './followingScrollPrimitives.js';
 import { Turn, type EventVerbosity } from './Turn.js';
 import type { AgentSlashCommandV2 } from '../../../../shared/agent-chat-protocol-v2.js';
 
@@ -50,26 +53,36 @@ interface ReaderAnchor {
 function captureReaderAnchor(container: HTMLDivElement): ReaderAnchor | null {
   const containerTop = container.getBoundingClientRect().top;
   const items = container.querySelectorAll<HTMLElement>('[data-agent-item-id]');
-  for (const item of items) {
-    const rect = item.getBoundingClientRect();
-    if (rect.bottom < containerTop) continue;
-    const itemId = item.dataset.agentItemId;
-    if (!itemId) continue;
-    return { itemId, offsetTop: rect.top - containerTop };
+  let low = 0;
+  let high = items.length - 1;
+  let firstVisible = -1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const rect = items[middle]!.getBoundingClientRect();
+    if (rect.bottom >= containerTop) {
+      firstVisible = middle;
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
   }
-  return null;
+  if (firstVisible < 0) return null;
+  const item = items[firstVisible]!;
+  const itemId = item.dataset.agentItemId;
+  if (!itemId) return null;
+  return {
+    itemId,
+    offsetTop: item.getBoundingClientRect().top - containerTop,
+  };
 }
 
 function findAnchoredItem(
   container: HTMLDivElement,
   itemId: string
 ): HTMLElement | null {
-  for (const item of container.querySelectorAll<HTMLElement>(
-    '[data-agent-item-id]'
-  )) {
-    if (item.dataset.agentItemId === itemId) return item;
-  }
-  return null;
+  return container.querySelector<HTMLElement>(
+    `[data-agent-item-id="${CSS.escape(itemId)}"]`
+  );
 }
 
 /**
@@ -82,16 +95,49 @@ interface UseAgentTimelineScrollOptions {
   itemCount: number;
 }
 
+interface AgentTimelineScrollState {
+  bottomRef: React.RefObject<HTMLDivElement | null>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  handleTimelineScroll: () => void;
+  prepareUserReflow: (itemId: string) => void;
+  scrollToBottom: () => void;
+  showJumpToLatest: boolean;
+}
+
 export function useAgentTimelineScroll({
   timelineId,
   itemCount,
-}: UseAgentTimelineScrollOptions) {
+}: UseAgentTimelineScrollOptions): AgentTimelineScrollState {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const shouldFollowRef = useRef(true);
   const readerAnchorRef = useRef<ReaderAnchor | null>(null);
+  const userReflowAnchorRef = useRef<ReaderAnchor | null>(null);
   const previousTimelineIdRef = useRef(timelineId);
+  const lastScrollTopRef = useRef(0);
+  const programmaticFollowUntilRef = useRef(0);
+  const [showJumpToLatest, setShowJumpToLatest] = React.useState(false);
+
+  const scrollToBottom = useCallback((): void => {
+    const container = containerRef.current;
+    if (!container) return;
+    const previousScrollTop = container.scrollTop;
+    shouldFollowRef.current = true;
+    readerAnchorRef.current = null;
+    userReflowAnchorRef.current = null;
+    setShowJumpToLatest(false);
+    // Direct assignment matches #1197 and avoids smooth-scroll frames that can
+    // masquerade as reader input. The guard remains for any browser-emitted
+    // intermediate/programmatic frames.
+    programmaticFollowUntilRef.current = performance.now() + 500;
+    container.scrollTop = container.scrollHeight;
+    // Keep the pre-scroll baseline until the browser reports the scroll. This
+    // makes every downward intermediate frame programmatic while a genuine
+    // upward gesture still disengages follow immediately.
+    lastScrollTopRef.current = previousScrollTop;
+  }, []);
 
   // Session identity is part of the scroll state. Equal item counts across two
   // sessions must not preserve the old reader anchor/follow intent and open the
@@ -101,22 +147,59 @@ export function useAgentTimelineScroll({
     previousTimelineIdRef.current = timelineId;
     shouldFollowRef.current = true;
     readerAnchorRef.current = null;
-    const container = containerRef.current;
-    if (container) container.scrollTop = container.scrollHeight;
-    bottomRef.current?.scrollIntoView({ behavior: 'auto' });
-  }, [timelineId]);
+    userReflowAnchorRef.current = null;
+    programmaticFollowUntilRef.current = 0;
+    scrollToBottom();
+  }, [timelineId, scrollToBottom]);
 
   const handleTimelineScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
-    shouldFollowRef.current = isNearBottom({
-      scrollHeight: container.scrollHeight,
-      scrollTop: container.scrollTop,
-      clientHeight: container.clientHeight,
-    });
-    readerAnchorRef.current = shouldFollowRef.current
-      ? null
-      : captureReaderAnchor(container);
+    const metrics = readTimelineScrollMetrics(container);
+    const intent = deriveFollowIntent(metrics, lastScrollTopRef.current);
+    const inProgrammaticFollow =
+      performance.now() <= programmaticFollowUntilRef.current &&
+      !intent.movingUp;
+    if (inProgrammaticFollow) {
+      shouldFollowRef.current = true;
+      readerAnchorRef.current = null;
+      if (intent.atBottom) programmaticFollowUntilRef.current = 0;
+    } else {
+      programmaticFollowUntilRef.current = 0;
+      shouldFollowRef.current = intent.follow;
+      readerAnchorRef.current = intent.follow
+        ? null
+        : captureReaderAnchor(container);
+      setShowJumpToLatest(!intent.follow);
+    }
+    lastScrollTopRef.current = metrics.scrollTop;
+  }, []);
+
+  const prepareUserReflow = useCallback((itemId: string): void => {
+    const container = containerRef.current;
+    if (!container) return;
+    const item = findAnchoredItem(container, itemId);
+    if (!item) return;
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    const toggledCardIsVisible =
+      itemRect.bottom >= containerRect.top &&
+      itemRect.top <= containerRect.bottom;
+    const toggledCardAnchor = {
+      itemId,
+      offsetTop: itemRect.top - containerRect.top,
+    };
+    // A visible card header is the user's focal point. If the card is above
+    // or below the viewport (for example, a programmatic fixture click), keep
+    // the current first-visible row fixed instead of jumping to the card.
+    const anchor = toggledCardIsVisible
+      ? toggledCardAnchor
+      : (captureReaderAnchor(container) ?? toggledCardAnchor);
+    userReflowAnchorRef.current = anchor;
+    readerAnchorRef.current = anchor;
+    shouldFollowRef.current = false;
+    programmaticFollowUntilRef.current = 0;
+    setShowJumpToLatest(true);
   }, []);
 
   // #1197 scroll invariant, reused for agent-detail rows: follow intent is
@@ -129,8 +212,22 @@ export function useAgentTimelineScroll({
     if (!container || !content) return;
 
     const preserveViewport = () => {
+      const userAnchor = userReflowAnchorRef.current;
+      if (userAnchor) {
+        userReflowAnchorRef.current = null;
+        const item = findAnchoredItem(container, userAnchor.itemId);
+        if (item) {
+          const offsetTop =
+            item.getBoundingClientRect().top -
+            container.getBoundingClientRect().top;
+          container.scrollTop += offsetTop - userAnchor.offsetTop;
+          lastScrollTopRef.current = container.scrollTop;
+        }
+        readerAnchorRef.current = captureReaderAnchor(container);
+        return;
+      }
       if (shouldFollowRef.current) {
-        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+        scrollToBottom();
         return;
       }
       const anchor = readerAnchorRef.current;
@@ -141,6 +238,7 @@ export function useAgentTimelineScroll({
             item.getBoundingClientRect().top -
             container.getBoundingClientRect().top;
           container.scrollTop += offsetTop - anchor.offsetTop;
+          lastScrollTopRef.current = container.scrollTop;
         }
       }
       readerAnchorRef.current = captureReaderAnchor(container);
@@ -152,9 +250,17 @@ export function useAgentTimelineScroll({
     const observer = new ResizeObserver(preserveViewport);
     observer.observe(content);
     return () => observer.disconnect();
-  }, [itemCount, timelineId]);
+  }, [itemCount, timelineId, scrollToBottom]);
 
-  return { bottomRef, containerRef, contentRef, handleTimelineScroll };
+  return {
+    bottomRef,
+    containerRef,
+    contentRef,
+    handleTimelineScroll,
+    prepareUserReflow,
+    scrollToBottom,
+    showJumpToLatest,
+  };
 }
 
 export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
@@ -177,8 +283,15 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
     [session]
   );
 
-  const { bottomRef, containerRef, contentRef, handleTimelineScroll } =
-    useAgentTimelineScroll({ timelineId: sessionId, itemCount });
+  const {
+    bottomRef,
+    containerRef,
+    contentRef,
+    handleTimelineScroll,
+    prepareUserReflow,
+    scrollToBottom,
+    showJumpToLatest,
+  } = useAgentTimelineScroll({ timelineId: sessionId, itemCount });
 
   const isActive = useMemo(
     () =>
@@ -327,6 +440,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
                 onApprove={approve}
                 onAnswer={answer}
                 slashCommands={mergedSlashCommands}
+                onDetailCardToggle={prepareUserReflow}
               />
             ))}
             <QueueChips session={session} />
@@ -334,6 +448,15 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
         )}
         <div ref={bottomRef} />
       </div>
+      {showJumpToLatest ? (
+        <button
+          type="button"
+          className="tl-jump-latest"
+          onClick={scrollToBottom}
+        >
+          jump to latest
+        </button>
+      ) : null}
       <Composer
         onSend={handleSend}
         onInterrupt={handleInterrupt}

--- a/frontend/src/components/chat/Turn.tsx
+++ b/frontend/src/components/chat/Turn.tsx
@@ -6,9 +6,10 @@ import type {
   AgentSlashCommandV2,
   AgentTurnV2,
 } from '../../../../shared/agent-chat-protocol-v2.js';
+import { agentDetailCardForItem } from '../../../../shared/agent-chat-protocol-v2.js';
+import { AgentDetailCard } from './AgentDetailCard.js';
 import { ApprovalCard } from './ApprovalCard.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
-import { FileChangeRow } from './FileChangeRow.js';
 import {
   CompactionCard,
   HookPromptCard,
@@ -18,7 +19,6 @@ import {
 } from './MediaCard.js';
 import { PlanCard } from './PlanCard.js';
 import { QuestionCard } from './QuestionCard.js';
-import { ToolCard } from './ToolCard.js';
 import { TurnFooter } from './TurnFooter.js';
 import { TurnHeader } from './TurnHeader.js';
 import { renderProviderExtension } from './extensions/registry.js';
@@ -87,17 +87,6 @@ function renderUserMessage(
   );
 }
 
-const REASONING_LABEL_MAX_LEN = 80;
-
-/** Single-line, truncated label for the reasoning <summary>; falls back to 'thinking'. */
-function reasoningLabel(summary: string | undefined): string {
-  if (!summary) return 'thinking';
-  const singleLine = summary.replace(/\s+/g, ' ').trim();
-  if (!singleLine) return 'thinking';
-  if (singleLine.length <= REASONING_LABEL_MAX_LEN) return singleLine;
-  return `${singleLine.slice(0, REASONING_LABEL_MAX_LEN - 1).trimEnd()}…`;
-}
-
 function renderItem(
   item: AgentItemV2,
   eventVerbosity: EventVerbosity,
@@ -107,6 +96,14 @@ function renderItem(
 ): React.ReactNode {
   if (!shouldRenderItem(item, eventVerbosity)) return null;
 
+  // Persisted sessions predating #1198 may not carry `card` yet. Project their
+  // provider-neutral item type at render time, while live adapter patches
+  // arrive with this same card already attached and updated in place.
+  const detailCard = item.card ?? agentDetailCardForItem(item);
+  if (detailCard && detailCard.kind !== 'message') {
+    return <AgentDetailCard card={detailCard} itemId={item.id} />;
+  }
+
   switch (item.type) {
     case 'userMessage':
       return renderUserMessage(item.text, commandIndex);
@@ -115,18 +112,13 @@ function renderItem(
         <AssistantMarkdown text={item.text} keyPrefix={item.id} />
       ) : null;
     case 'reasoning':
-      return (
-        <details className="reasoning" open={item.visibility === 'full'}>
-          <summary>{reasoningLabel(item.summary)}</summary>
-          <pre className="tl-text">{item.detail ?? item.summary}</pre>
-        </details>
-      );
+      return null;
     case 'commandExecution':
     case 'dynamicToolCall':
     case 'mcpToolCall':
-      return <ToolCard item={item} />;
+      return null;
     case 'fileChange':
-      return <FileChangeRow item={item} />;
+      return null;
     case 'approval':
       return <ApprovalCard item={item} onApprove={onApprove} />;
     case 'providerExtension':
@@ -203,11 +195,27 @@ export const Turn: React.FC<TurnProps> = ({
   return (
     <div className="turn" role="group" aria-label={`turn ${index + 1}`}>
       <TurnHeader turn={turn} />
-      {turn.items.map((item) => (
-        <React.Fragment key={item.id}>
-          {renderItem(item, eventVerbosity, onApprove, onAnswer, commandIndex)}
-        </React.Fragment>
-      ))}
+      {turn.items.map((item) => {
+        const rendered = renderItem(
+          item,
+          eventVerbosity,
+          onApprove,
+          onAnswer,
+          commandIndex
+        );
+        if (rendered == null || typeof rendered === 'boolean') {
+          return null;
+        }
+        return (
+          <div
+            className="turn__item"
+            data-agent-item-id={item.id}
+            key={item.id}
+          >
+            {rendered}
+          </div>
+        );
+      })}
       {turn.error && (
         <div className="tl-error">
           <span>error</span>

--- a/frontend/src/components/chat/Turn.tsx
+++ b/frontend/src/components/chat/Turn.tsx
@@ -35,6 +35,7 @@ interface TurnProps {
   onAnswer: (requestId: string, answers: Record<string, string[]>) => void;
   /** Slash command catalog for skill token highlighting in user messages. */
   slashCommands?: AgentSlashCommandV2[];
+  onDetailCardToggle?: (itemId: string) => void;
 }
 
 const EVENT_VERBOSITY_RANK: Record<EventVerbosity, number> = {
@@ -92,7 +93,8 @@ function renderItem(
   eventVerbosity: EventVerbosity,
   onApprove: (requestId: string, decision: AgentApprovalDecisionV2) => void,
   onAnswer: (requestId: string, answers: Record<string, string[]>) => void,
-  commandIndex: Set<string>
+  commandIndex: Set<string>,
+  onDetailCardToggle?: (itemId: string) => void
 ): React.ReactNode {
   if (!shouldRenderItem(item, eventVerbosity)) return null;
 
@@ -101,7 +103,13 @@ function renderItem(
   // arrive with this same card already attached and updated in place.
   const detailCard = item.card ?? agentDetailCardForItem(item);
   if (detailCard && detailCard.kind !== 'message') {
-    return <AgentDetailCard card={detailCard} itemId={item.id} />;
+    return (
+      <AgentDetailCard
+        card={detailCard}
+        itemId={item.id}
+        {...(onDetailCardToggle ? { onUserToggle: onDetailCardToggle } : {})}
+      />
+    );
   }
 
   switch (item.type) {
@@ -187,6 +195,7 @@ export const Turn: React.FC<TurnProps> = ({
   onApprove,
   onAnswer,
   slashCommands,
+  onDetailCardToggle,
 }) => {
   const commandIndex = slashCommands
     ? buildCommandIndex(slashCommands)
@@ -201,7 +210,8 @@ export const Turn: React.FC<TurnProps> = ({
           eventVerbosity,
           onApprove,
           onAnswer,
-          commandIndex
+          commandIndex,
+          onDetailCardToggle
         );
         if (rendered == null || typeof rendered === 'boolean') {
           return null;

--- a/frontend/src/components/chat/followingScrollPrimitives.ts
+++ b/frontend/src/components/chat/followingScrollPrimitives.ts
@@ -1,0 +1,35 @@
+import { isNearBottom } from './scrollNearBottom.js';
+
+export interface TimelineScrollMetrics {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}
+
+export function readTimelineScrollMetrics(
+  container: HTMLDivElement
+): TimelineScrollMetrics {
+  return {
+    scrollHeight: container.scrollHeight,
+    scrollTop: container.scrollTop,
+    clientHeight: container.clientHeight,
+  };
+}
+
+/**
+ * #1197 follow-intent guard shared by channel and agent timelines. Moving up
+ * always disengages follow; moving down re-engages only near the bottom.
+ */
+export function deriveFollowIntent(
+  metrics: TimelineScrollMetrics,
+  lastScrollTop: number
+): { atBottom: boolean; movingUp: boolean; follow: boolean } {
+  const maxScrollTop = Math.max(0, metrics.scrollHeight - metrics.clientHeight);
+  const movingUp = metrics.scrollTop < lastScrollTop - 1;
+  const atBottom = maxScrollTop === 0 || maxScrollTop - metrics.scrollTop <= 1;
+  return {
+    atBottom,
+    movingUp,
+    follow: atBottom || (!movingUp && isNearBottom(metrics)),
+  };
+}

--- a/frontend/src/components/chat/useFollowingScroll.ts
+++ b/frontend/src/components/chat/useFollowingScroll.ts
@@ -7,7 +7,10 @@ import {
   type RefObject,
 } from 'react';
 import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
-import { isNearBottom } from './scrollNearBottom.js';
+import {
+  deriveFollowIntent,
+  readTimelineScrollMetrics,
+} from './followingScrollPrimitives.js';
 
 const LOAD_OLDER_SCROLL_THRESHOLD_PX = 80;
 
@@ -15,20 +18,6 @@ interface ViewportAnchor {
   seq: number;
   offsetTop: number;
   earliestSeqBefore: number | undefined;
-}
-
-interface ScrollMetrics {
-  scrollHeight: number;
-  scrollTop: number;
-  clientHeight: number;
-}
-
-function scrollMetrics(container: HTMLDivElement): ScrollMetrics {
-  return {
-    scrollHeight: container.scrollHeight,
-    scrollTop: container.scrollTop,
-    clientHeight: container.clientHeight,
-  };
 }
 
 function captureViewportAnchor(
@@ -234,7 +223,7 @@ export function useFollowingScroll({
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
-    const metrics = scrollMetrics(container);
+    const metrics = readTimelineScrollMetrics(container);
     const scrollTopChanged =
       Math.abs(metrics.scrollTop - lastScrollTopRef.current) > 1;
     const pendingAnchor = anchorRef.current;
@@ -248,14 +237,7 @@ export function useFollowingScroll({
       }
     }
 
-    const maxScrollTop = Math.max(
-      0,
-      metrics.scrollHeight - metrics.clientHeight
-    );
-    const movingUp = metrics.scrollTop < lastScrollTopRef.current - 1;
-    const atBottom =
-      maxScrollTop === 0 || maxScrollTop - metrics.scrollTop <= 1;
-    const follow = atBottom || (!movingUp && isNearBottom(metrics));
+    const { follow } = deriveFollowIntent(metrics, lastScrollTopRef.current);
     shouldFollowRef.current = follow;
     lastScrollTopRef.current = metrics.scrollTop;
     if (follow) {

--- a/frontend/src/hooks/useShikiHighlight.ts
+++ b/frontend/src/hooks/useShikiHighlight.ts
@@ -41,8 +41,8 @@ export function useShikiHighlight(
 
   // Track the current tokenization generation to discard stale results.
   const genRef = useRef(0);
-  // Track the (key, source) pair we last kicked tokenization off for, plus
-  // whether that pass has settled. This is the loop guard: registering an
+  // Track the (key, source, language) input we last kicked tokenization off
+  // for, plus whether that pass has settled. This is the loop guard: registering an
   // entry mutates the store, which re-runs the highlight effect (its dep array
   // includes `entry`). Without this ref the effect would call
   // `setEntry(... null)` again on that re-run — producing a fresh entry object
@@ -55,6 +55,7 @@ export function useShikiHighlight(
   const kickedRef = useRef<{
     key: string;
     source: string;
+    language: string;
     settled: boolean;
   } | null>(null);
 
@@ -67,7 +68,7 @@ export function useShikiHighlight(
 
   // Kick off highlighting when:
   //   (a) the entry doesn't exist yet, or
-  //   (b) the source changed, or
+  //   (b) the source or language changed, or
   //   (c) highlight output was evicted by GC (entry exists, source matches,
   //       but highlightOutput went null after previously being populated).
   useEffect(() => {
@@ -75,20 +76,29 @@ export function useShikiHighlight(
 
     const currentOutput = entry?.highlightOutput ?? null;
     const currentSource = entry?.source;
+    const currentLanguage = entry?.language;
 
-    // Already highlighted and source matches — nothing to do.
-    if (currentOutput !== null && currentSource === code) return;
+    // Already highlighted and the complete input matches — nothing to do.
+    if (
+      currentOutput !== null &&
+      currentSource === code &&
+      currentLanguage === language
+    ) {
+      return;
+    }
 
-    // A tokenization pass is already in-flight for this exact (key, source)
-    // and has not settled yet; the null output just means it has not resolved.
+    // A tokenization pass is already in-flight for this exact input and has
+    // not settled yet; the null output just means it has not resolved.
     // Re-registering here would loop — wait for it to call setHighlightOutput.
     const kicked = kickedRef.current;
     const inFlight =
       kicked !== null &&
       kicked.key === key &&
       kicked.source === code &&
+      kicked.language === language &&
       !kicked.settled &&
-      currentSource === code;
+      currentSource === code &&
+      currentLanguage === language;
     if (inFlight) return;
 
     // Register the entry immediately with null output so the GC store has
@@ -96,14 +106,14 @@ export function useShikiHighlight(
     setEntry(key, code, language, null);
 
     const gen = ++genRef.current;
-    const kick = { key, source: code, settled: false };
+    const kick = { key, source: code, language, settled: false };
     kickedRef.current = kick;
 
     tokenizeCode(code, language)
       .then((tokens) => {
         kick.settled = true;
         if (gen !== genRef.current) return; // stale
-        setHighlightOutput(key, tokens);
+        setHighlightOutput(key, tokens, { source: code, language });
       })
       .catch(() => {
         // Tokenization failure is non-fatal — plain text stays visible.
@@ -111,14 +121,23 @@ export function useShikiHighlight(
       });
   }, [key, code, language, entry, setEntry, setHighlightOutput]);
 
+  // Never pair token text from a previous source/language with current raw
+  // lines. A source update renders current plain text immediately until its
+  // own tokenization generation settles.
+  const entryMatchesInput =
+    entry?.source === code && entry?.language === language;
   const tokens =
-    entry?.highlightOutput !== null && entry?.highlightOutput !== undefined
+    entryMatchesInput &&
+    entry?.highlightOutput !== null &&
+    entry?.highlightOutput !== undefined
       ? (entry.highlightOutput as ThemedToken[][])
       : null;
 
   const highlighting =
-    entry === undefined ||
-    (entry.source === code && entry.highlightOutput === null);
+    code.length > 0 &&
+    (!entryMatchesInput ||
+      entry === undefined ||
+      entry.highlightOutput === null);
 
   return { tokens, highlighting };
 }

--- a/frontend/src/lib/shiki-lazy-chunk-gate.ts
+++ b/frontend/src/lib/shiki-lazy-chunk-gate.ts
@@ -1,0 +1,74 @@
+function isShikiRuntimeModule(moduleId: string): boolean {
+  const normalized = moduleId.replaceAll('\\', '/');
+  return (
+    normalized.includes('/node_modules/shiki/') ||
+    normalized.includes('/node_modules/@shikijs/')
+  );
+}
+
+export interface ShikiChunkGraphNode {
+  fileName: string;
+  isEntry: boolean;
+  imports: readonly string[];
+  dynamicImports: readonly string[];
+  moduleIds: readonly string[];
+}
+
+/**
+ * Return a build-gate failure when Shiki is absent, statically reachable from
+ * an entry, or emitted outside every entry's dynamic-import graph.
+ */
+export function shikiLazyChunkViolation(
+  chunks: readonly ShikiChunkGraphNode[]
+): string | null {
+  const byFileName = new Map(chunks.map((chunk) => [chunk.fileName, chunk]));
+  const staticReachable = new Set<string>();
+  const dynamicReachable = new Set<string>();
+  const queue = chunks
+    .filter((chunk) => chunk.isEntry)
+    .map((chunk) => ({ fileName: chunk.fileName, crossedDynamicEdge: false }));
+
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+    const current = queue[queueIndex]!;
+    const reached = current.crossedDynamicEdge
+      ? dynamicReachable
+      : staticReachable;
+    if (reached.has(current.fileName)) continue;
+    reached.add(current.fileName);
+
+    const chunk = byFileName.get(current.fileName);
+    if (!chunk) continue;
+    for (const imported of chunk.imports) {
+      queue.push({
+        fileName: imported,
+        crossedDynamicEdge: current.crossedDynamicEdge,
+      });
+    }
+    for (const imported of chunk.dynamicImports) {
+      queue.push({ fileName: imported, crossedDynamicEdge: true });
+    }
+  }
+
+  const shikiChunks = chunks.filter((chunk) =>
+    chunk.moduleIds.some(isShikiRuntimeModule)
+  );
+  if (shikiChunks.length === 0) {
+    return 'Shiki lazy chunk missing from frontend build';
+  }
+
+  const eagerShikiChunk = shikiChunks.find((chunk) =>
+    staticReachable.has(chunk.fileName)
+  );
+  if (eagerShikiChunk) {
+    const moduleId = eagerShikiChunk.moduleIds.find(isShikiRuntimeModule);
+    return `Shiki must remain lazy; entry static graph includes ${moduleId ?? eagerShikiChunk.fileName}`;
+  }
+
+  const unreachableShikiChunk = shikiChunks.find(
+    (chunk) => !dynamicReachable.has(chunk.fileName)
+  );
+  if (unreachableShikiChunk) {
+    return `Shiki chunk ${unreachableShikiChunk.fileName} is not reachable through a dynamic import from an entry`;
+  }
+  return null;
+}

--- a/frontend/src/lib/shiki.ts
+++ b/frontend/src/lib/shiki.ts
@@ -1,9 +1,4 @@
-import {
-  createHighlighter,
-  type Highlighter,
-  type BundledLanguage,
-} from 'shiki';
-import type { ThemedToken } from 'shiki';
+import type { BundledLanguage, Highlighter, ThemedToken } from 'shiki';
 import { createLogger } from './logger.js';
 
 export type { ThemedToken };
@@ -58,13 +53,20 @@ let highlighterPromise: Promise<Highlighter> | null = null;
 
 export function getHighlighter(): Promise<Highlighter> {
   if (!highlighterPromise) {
-    highlighterPromise = createHighlighter({
-      themes: [tuiTheme],
-      langs: PRELOAD_LANGS,
-    }).catch((err) => {
-      highlighterPromise = null; // allow retry on next call
-      throw err;
-    });
+    // Keep Shiki and its grammars out of the initial UI chunk. Agent detail
+    // cards mount highlighted content only after expansion, so the first code
+    // block pays this cost on demand and every later block reuses the singleton.
+    highlighterPromise = import('shiki')
+      .then(({ createHighlighter }) =>
+        createHighlighter({
+          themes: [tuiTheme],
+          langs: PRELOAD_LANGS,
+        })
+      )
+      .catch((err) => {
+        highlighterPromise = null; // allow retry on next call
+        throw err;
+      });
   }
   return highlighterPromise;
 }
@@ -105,7 +107,10 @@ export async function tokenizeCode(
     try {
       await highlighter.loadLanguage(resolvedLang);
     } catch (err: unknown) {
-      logger.warn(`Failed to load "${resolvedLang}", falling back to javascript`, err);
+      logger.warn(
+        `Failed to load "${resolvedLang}", falling back to javascript`,
+        err
+      );
       resolvedLang = 'javascript';
     }
   }

--- a/frontend/src/lib/stores/shiki-gc.ts
+++ b/frontend/src/lib/stores/shiki-gc.ts
@@ -47,6 +47,11 @@ export interface TabHighlightEntry {
   lastViewedAt: number;
 }
 
+export interface HighlightInputIdentity {
+  source: string;
+  language: string;
+}
+
 interface ShikiGcState {
   /** Per-key highlight entries. */
   entries: Map<string, TabHighlightEntry>;
@@ -64,8 +69,12 @@ interface ShikiGcState {
     language: string,
     highlightOutput: unknown | null
   ) => void;
-  /** Update highlight output only (after async re-highlighting). */
-  setHighlightOutput: (key: string, highlightOutput: unknown | null) => void;
+  /** Update output; expectedInput makes async writers compare-and-set. */
+  setHighlightOutput: (
+    key: string,
+    highlightOutput: unknown | null,
+    expectedInput?: HighlightInputIdentity
+  ) => void;
   /** Record that a tab is being viewed now (refreshes lastViewedAt). */
   touchTab: (key: string) => void;
   /** Remove a tab entry entirely (tab closed). */
@@ -103,10 +112,17 @@ export const useShikiGcStore = create<ShikiGcState>((set, get) => ({
     });
   },
 
-  setHighlightOutput: (key, highlightOutput) => {
+  setHighlightOutput: (key, highlightOutput, expectedInput) => {
     set((state) => {
       const entry = state.entries.get(key);
       if (!entry) return state;
+      if (
+        expectedInput &&
+        (entry.source !== expectedInput.source ||
+          entry.language !== expectedInput.language)
+      ) {
+        return state;
+      }
       const next = new Map(state.entries);
       next.set(key, { ...entry, highlightOutput });
       return { entries: next };

--- a/frontend/src/test-agent-detail-rows.css
+++ b/frontend/src/test-agent-detail-rows.css
@@ -1,0 +1,43 @@
+.agent-detail-fixture {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  min-height: 0;
+  background: var(--bg);
+}
+
+.agent-detail-fixture__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  flex: none;
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.agent-detail-fixture__switches {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.agent-detail-fixture__switches button {
+  padding: 1px var(--space-xs);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+}
+
+.agent-detail-fixture__switches button:disabled {
+  color: var(--accent);
+}
+
+.agent-detail-fixture .tl {
+  min-height: 0;
+}

--- a/frontend/src/test-agent-detail-rows.tsx
+++ b/frontend/src/test-agent-detail-rows.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import type {
+  AgentAssistantMessageItemV2,
+  AgentProviderV2,
+  AgentSessionV2,
+} from '../../shared/agent-chat-protocol-v2.js';
+import claudeFixture from '../../test/fixtures/agent-detail/claude.js';
+import codexFixture from '../../test/fixtures/agent-detail/codex.js';
+import hermesFixture from '../../test/fixtures/agent-detail/hermes.js';
+import './App.css';
+import './components/chat/ChatView.css';
+import './test-agent-detail-rows.css';
+import { useAgentTimelineScroll } from './components/chat/ChatView.js';
+import { Turn } from './components/chat/Turn.js';
+
+const fixtures = {
+  claude: claudeFixture,
+  codex: codexFixture,
+  hermes: hermesFixture,
+} as const;
+
+type FixtureProvider = keyof typeof fixtures;
+
+function providerFromQuery(): FixtureProvider {
+  const raw = new URLSearchParams(window.location.search).get('provider');
+  return raw === 'claude' || raw === 'codex' || raw === 'hermes'
+    ? raw
+    : 'claude';
+}
+
+function anchorItems(provider: AgentProviderV2): AgentAssistantMessageItemV2[] {
+  return Array.from({ length: 48 }, (_, index) => ({
+    id: `${provider}-anchor-${String(index + 1).padStart(2, '0')}`,
+    type: 'assistantMessage',
+    status: 'completed',
+    text: `synthetic anchor row ${String(index + 1).padStart(2, '0')}`,
+  }));
+}
+
+function withAnchorRows(session: AgentSessionV2): AgentSessionV2 {
+  const turn = session.turns[0];
+  if (!turn) return session;
+  return {
+    ...session,
+    turns: [
+      {
+        ...turn,
+        items: [...turn.items, ...anchorItems(session.provider)],
+      },
+    ],
+  };
+}
+
+function Fixture(): React.ReactElement {
+  const [provider, setProvider] = useState(providerFromQuery);
+  const session = useMemo(
+    () => withAnchorRows(fixtures[provider].session),
+    [provider]
+  );
+  const turn = session.turns[0]!;
+  const itemCount = turn.items.length;
+  const { containerRef, contentRef, bottomRef, handleTimelineScroll } =
+    useAgentTimelineScroll({ timelineId: session.id, itemCount });
+
+  return (
+    <main className="agent-detail-fixture" data-fixture-provider={provider}>
+      <div className="agent-detail-fixture__label">
+        <span>{provider} · hand-sanitized structural replay</span>
+        <span className="agent-detail-fixture__switches">
+          {(Object.keys(fixtures) as FixtureProvider[]).map((candidate) => (
+            <button
+              type="button"
+              key={candidate}
+              disabled={candidate === provider}
+              onClick={() => setProvider(candidate)}
+            >
+              show {candidate} fixture
+            </button>
+          ))}
+        </span>
+      </div>
+      <div
+        ref={containerRef}
+        className="tl"
+        role="log"
+        aria-label="agent detail timeline"
+        onScroll={handleTimelineScroll}
+      >
+        <div ref={contentRef} className="tl-content">
+          <Turn
+            turn={turn}
+            index={0}
+            session={session}
+            onApprove={() => {}}
+            onAnswer={() => {}}
+          />
+        </div>
+        <div ref={bottomRef} />
+      </div>
+    </main>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(<Fixture />);

--- a/frontend/src/test-agent-detail-rows.tsx
+++ b/frontend/src/test-agent-detail-rows.tsx
@@ -21,12 +21,20 @@ const fixtures = {
 } as const;
 
 type FixtureProvider = keyof typeof fixtures;
+type FixtureLayout = 'default' | 'card-near-bottom';
 
 function providerFromQuery(): FixtureProvider {
   const raw = new URLSearchParams(window.location.search).get('provider');
   return raw === 'claude' || raw === 'codex' || raw === 'hermes'
     ? raw
     : 'claude';
+}
+
+function layoutFromQuery(): FixtureLayout {
+  return new URLSearchParams(window.location.search).get('layout') ===
+    'card-near-bottom'
+    ? 'card-near-bottom'
+    : 'default';
 }
 
 function anchorItems(provider: AgentProviderV2): AgentAssistantMessageItemV2[] {
@@ -38,15 +46,23 @@ function anchorItems(provider: AgentProviderV2): AgentAssistantMessageItemV2[] {
   }));
 }
 
-function withAnchorRows(session: AgentSessionV2): AgentSessionV2 {
+function withAnchorRows(
+  session: AgentSessionV2,
+  layout: FixtureLayout
+): AgentSessionV2 {
   const turn = session.turns[0];
   if (!turn) return session;
+  const anchors = anchorItems(session.provider);
+  const items =
+    layout === 'card-near-bottom'
+      ? [...anchors.slice(0, 44), ...turn.items, ...anchors.slice(44)]
+      : [...turn.items, ...anchors];
   return {
     ...session,
     turns: [
       {
         ...turn,
-        items: [...turn.items, ...anchorItems(session.provider)],
+        items,
       },
     ],
   };
@@ -54,17 +70,29 @@ function withAnchorRows(session: AgentSessionV2): AgentSessionV2 {
 
 function Fixture(): React.ReactElement {
   const [provider, setProvider] = useState(providerFromQuery);
+  const layout = layoutFromQuery();
   const session = useMemo(
-    () => withAnchorRows(fixtures[provider].session),
-    [provider]
+    () => withAnchorRows(fixtures[provider].session, layout),
+    [layout, provider]
   );
   const turn = session.turns[0]!;
   const itemCount = turn.items.length;
-  const { containerRef, contentRef, bottomRef, handleTimelineScroll } =
-    useAgentTimelineScroll({ timelineId: session.id, itemCount });
+  const {
+    containerRef,
+    contentRef,
+    bottomRef,
+    handleTimelineScroll,
+    prepareUserReflow,
+    scrollToBottom,
+    showJumpToLatest,
+  } = useAgentTimelineScroll({ timelineId: session.id, itemCount });
 
   return (
-    <main className="agent-detail-fixture" data-fixture-provider={provider}>
+    <main
+      className="agent-detail-fixture"
+      data-fixture-provider={provider}
+      data-fixture-layout={layout}
+    >
       <div className="agent-detail-fixture__label">
         <span>{provider} · hand-sanitized structural replay</span>
         <span className="agent-detail-fixture__switches">
@@ -94,10 +122,20 @@ function Fixture(): React.ReactElement {
             session={session}
             onApprove={() => {}}
             onAnswer={() => {}}
+            onDetailCardToggle={prepareUserReflow}
           />
         </div>
         <div ref={bottomRef} />
       </div>
+      {showJumpToLatest ? (
+        <button
+          type="button"
+          className="tl-jump-latest"
+          onClick={scrollToBottom}
+        >
+          jump to latest
+        </button>
+      ) : null}
     </main>
   );
 }

--- a/frontend/test-agent-detail-rows.html
+++ b/frontend/test-agent-detail-rows.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agent detail row test page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-agent-detail-rows.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -56,6 +56,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-channel-thread.html'
   );
+  buildInputs['test-agent-detail-rows'] = resolve(
+    import.meta.dirname,
+    'test-agent-detail-rows.html'
+  );
 }
 
 export default defineConfig({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { resolve } from 'node:path';
@@ -9,6 +9,7 @@ import {
   getDevFrontendHost,
   getDevFrontendPort,
 } from './dev-server.js';
+import { shikiLazyChunkViolation } from './src/lib/shiki-lazy-chunk-gate.js';
 
 // Resolve via Node's module resolution so it works in worktrees, monorepos,
 // and any node_modules layout without hard-coded relative paths.
@@ -17,6 +18,21 @@ const xtermDir = path.dirname(
 );
 const addonWebgpu = path.resolve(xtermDir, 'addons', 'addon-webgpu');
 const includeE2eFixtures = process.env.RELAY_IDE_E2E_FIXTURES === '1';
+
+/** Build-time backpressure: syntax grammars must stay off the eager UI path. */
+export function shikiLazyChunkGate(): Plugin {
+  return {
+    name: 'relay-shiki-lazy-chunk-gate',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+      const chunks = Object.values(bundle).flatMap((output) =>
+        output.type === 'chunk' ? [output] : []
+      );
+      const violation = shikiLazyChunkViolation(chunks);
+      if (violation) this.error(violation);
+    },
+  };
+}
 
 const buildInputs: Record<string, string> = {
   main: resolve(import.meta.dirname, 'index.html'),
@@ -64,7 +80,7 @@ if (includeE2eFixtures) {
 
 export default defineConfig({
   root: import.meta.dirname,
-  plugins: [react()],
+  plugins: [react(), shikiLazyChunkGate()],
   resolve: {
     alias: {
       $lib: path.resolve(import.meta.dirname, 'src/lib'),

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -6,6 +6,7 @@ import type {
 } from './protocol-adapter.js';
 import {
   isAgentPatchV2,
+  withAgentDetailCards,
   type AgentApprovalDecisionV2,
   type AgentCapabilitySetV2,
   type AgentPatchV2,
@@ -123,7 +124,8 @@ export abstract class BaseProtocolAdapterV2 implements ProtocolAdapterV2 {
   }
 
   protected emitPatch(patch: AgentPatchV2): void {
-    if (!isAgentPatchV2(patch)) {
+    const normalizedPatch = withAgentDetailCards(patch);
+    if (!isAgentPatchV2(normalizedPatch)) {
       logger.error(`[${this.agentType}] invalid AgentPatchV2:`, patch);
       throw new Error(
         `[${this.agentType}] attempted to emit invalid AgentPatchV2`
@@ -132,7 +134,7 @@ export abstract class BaseProtocolAdapterV2 implements ProtocolAdapterV2 {
 
     for (const handler of [...this.handlers]) {
       try {
-        handler(patch);
+        handler(normalizedPatch);
       } catch (err) {
         logger.error(`[${this.agentType}] AgentPatchV2 handler error:`, err);
       }

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -427,6 +427,11 @@ function patchFromFileResult(result: Record<string, unknown>): string {
   const gitPatch = stringField(gitDiff.patch);
   if (gitPatch) return gitPatch;
 
+  // Some persistent-subprocess builds surface the unified patch directly on
+  // tool_use_result instead of nesting it under gitDiff.
+  const directPatch = stringField(result.patch);
+  if (directPatch) return directPatch;
+
   const hunks = result.structuredPatch;
   if (!Array.isArray(hunks)) return '';
   const out: string[] = [];

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -429,6 +429,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   // Item tracking
   private providerExtensionSeq = 0;
   private readonly itemMap = new Map<string, string>(); // nativeItemId → relayItemId
+  private readonly toolArgumentsByNativeId = new Map<
+    string,
+    Record<string, unknown>
+  >();
   private pendingModelOverride: string | null = null;
 
   // Reasoning streaming buffers, keyed by relayItemId. Used to preserve the
@@ -735,6 +739,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     // ids and streamed reasoning/token buffers across turns grows without bound
     // on an always-on channel binding.
     this.itemMap.clear();
+    this.toolArgumentsByNativeId.clear();
     this.tokenUsageBuffer.clear();
     this.reasoningSummaryBuffers.clear();
     this.reasoningDetailBuffers.clear();
@@ -860,6 +865,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.providerSessionId = null;
     this.slashCommandsLoaded = false;
     this.itemMap.clear();
+    this.toolArgumentsByNativeId.clear();
     this.tokenUsageBuffer.clear();
     this.reasoningSummaryBuffers.clear();
     this.reasoningDetailBuffers.clear();
@@ -1299,6 +1305,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       case 'mcpToolCall': {
         const relayId = `mcp-${nativeId}`;
         this.itemMap.set(nativeId, relayId);
+        const args = isRecord(item['arguments']) ? item['arguments'] : {};
+        this.toolArgumentsByNativeId.set(nativeId, args);
         this.emitPatch({
           type: 'agent-item-started-v2',
           sessionId: this.config.sessionId,
@@ -1310,7 +1318,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             providerItemId: nativeId,
             server: stringField(item['server']),
             tool: stringField(item['tool']),
-            arguments: isRecord(item['arguments']) ? item['arguments'] : {},
+            arguments: args,
             status: 'running',
             startedAt: nowIso(),
           },
@@ -1321,6 +1329,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       case 'dynamicToolCall': {
         const relayId = `tool-${nativeId}`;
         this.itemMap.set(nativeId, relayId);
+        const args = isRecord(item['arguments']) ? item['arguments'] : {};
+        this.toolArgumentsByNativeId.set(nativeId, args);
         this.emitPatch({
           type: 'agent-item-started-v2',
           sessionId: this.config.sessionId,
@@ -1332,7 +1342,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             providerItemId: nativeId,
             namespace: 'codex',
             tool: stringField(item['tool']),
-            arguments: isRecord(item['arguments']) ? item['arguments'] : {},
+            arguments: args,
             status: 'running',
             startedAt: nowIso(),
           },
@@ -1344,6 +1354,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         const relayId = `collab-${nativeId}`;
         this.itemMap.set(nativeId, relayId);
         const nativeTool = stringField(item['tool']);
+        const args = isRecord(item['arguments']) ? item['arguments'] : {};
+        this.toolArgumentsByNativeId.set(nativeId, args);
         this.emitPatch({
           type: 'agent-item-started-v2',
           sessionId: this.config.sessionId,
@@ -1355,7 +1367,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             providerItemId: nativeId,
             namespace: 'codex',
             tool: `collab:${nativeTool}`,
-            arguments: isRecord(item['arguments']) ? item['arguments'] : {},
+            arguments: args,
             status: 'running',
             startedAt: nowIso(),
           },
@@ -1520,6 +1532,14 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             status: kindType || 'edited',
           };
         });
+        // `item/completed` is authoritative and replaces the reducer entity.
+        // Carry the final apply-patch payload forward; otherwise the preceding
+        // patchUpdated delta is discarded and a completed diff card goes blank.
+        const patch = changes
+          .filter(isRecord)
+          .map((change) => stringField(change['diff']))
+          .filter(Boolean)
+          .join('\n');
         this.emitPatch({
           type: 'agent-item-updated-v2',
           sessionId: this.config.sessionId,
@@ -1533,6 +1553,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
               paths.length > 0
                 ? paths
                 : [{ path: 'unknown', status: 'edited' }],
+            ...(patch ? { patch } : {}),
             applyStatus,
             status: 'completed',
             completedAt,
@@ -1541,7 +1562,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         break;
       }
 
-      case 'mcpToolCall':
+      case 'mcpToolCall': {
+        const args = isRecord(item['arguments'])
+          ? item['arguments']
+          : (this.toolArgumentsByNativeId.get(nativeId) ?? {});
+        this.toolArgumentsByNativeId.delete(nativeId);
         this.emitPatch({
           type: 'agent-item-updated-v2',
           sessionId: this.config.sessionId,
@@ -1553,12 +1578,14 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             providerItemId: nativeId,
             server: stringField(item['server']),
             tool: stringField(item['tool']),
+            arguments: args,
             result: item['result'],
             status: 'completed',
             completedAt,
           },
         });
         break;
+      }
 
       case 'dynamicToolCall':
       case 'collabAgentToolCall': {
@@ -1566,6 +1593,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           itemType === 'collabAgentToolCall'
             ? `collab:${stringField(item['tool'])}`
             : stringField(item['tool']);
+        const args = isRecord(item['arguments'])
+          ? item['arguments']
+          : (this.toolArgumentsByNativeId.get(nativeId) ?? {});
+        this.toolArgumentsByNativeId.delete(nativeId);
         this.emitPatch({
           type: 'agent-item-updated-v2',
           sessionId: this.config.sessionId,
@@ -1577,6 +1608,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             providerItemId: nativeId,
             namespace: 'codex',
             tool,
+            arguments: args,
             result: item['result'],
             status: 'completed',
             completedAt,

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -219,6 +219,16 @@ function stringField(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback;
 }
 
+function diffCounts(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions += 1;
+    if (line.startsWith('-') && !line.startsWith('---')) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
 /**
  * Flatten codex's reasoning array shapes into a single string. Both
  * `summary: Vec<ReasoningItemReasoningSummary>` and
@@ -1765,7 +1775,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       timestamp: nowIso(),
       turnId: this.activeTurnId,
       itemId: relayId,
-      delta: { patch: combinedPatch },
+      mode: 'replace',
+      delta: { patch: combinedPatch, card: diffCounts(combinedPatch) },
     });
   }
 

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -456,6 +456,30 @@ function parseToolArguments(value: unknown): Record<string, unknown> {
   }
 }
 
+function isHermesFileEditTool(toolName: string): boolean {
+  return /^(?:apply[_-]?patch|edit|multi[_-]?edit|write|write[_-]?file)$/i.test(
+    toolName
+  );
+}
+
+function isUnifiedDiffOutput(output: string): boolean {
+  return (
+    /(^|\n)diff --git /.test(output) ||
+    (/(^|\n)--- (?:a\/|\/dev\/null)/.test(output) &&
+      /(^|\n)\+\+\+ (?:b\/|\/dev\/null)/.test(output))
+  );
+}
+
+function diffCounts(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+    if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+  }
+  return { additions, deletions };
+}
+
 /**
  * Concatenate the text of a Responses API `message` output-item. The item shape
  * is `{ type: 'message', role, content: [{ type: 'output_text', text }, …] }`;
@@ -1221,15 +1245,37 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     });
     const output = item['output'];
     if (output !== undefined && output !== null) {
-      this.fire({
-        type: 'chat:tool-result',
-        turnId,
-        toolCallId: callId,
-        toolName,
-        status: isIncomplete ? 'error' : 'completed',
-        output: typeof output === 'string' ? output : JSON.stringify(output),
-        durationMs: 0,
-      });
+      const outputText =
+        typeof output === 'string' ? output : JSON.stringify(output);
+      const args = parseToolArguments(rawArgs);
+      if (
+        !isIncomplete &&
+        isHermesFileEditTool(toolName) &&
+        isUnifiedDiffOutput(outputText)
+      ) {
+        const { additions, deletions } = diffCounts(outputText);
+        const pathValue = args['path'] ?? args['file_path'];
+        this.fire({
+          type: 'chat:file-change',
+          turnId,
+          toolCallId: callId,
+          path: typeof pathValue === 'string' ? pathValue : 'unknown',
+          kind: 'modified',
+          additions,
+          deletions,
+          diff: outputText,
+        });
+      } else {
+        this.fire({
+          type: 'chat:tool-result',
+          turnId,
+          toolCallId: callId,
+          toolName,
+          status: isIncomplete ? 'error' : 'completed',
+          output: outputText,
+          durationMs: 0,
+        });
+      }
     }
     this._pendingToolCalls.delete(itemId);
   }
@@ -1250,7 +1296,14 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
 
   private handleReasoningSummaryDone(event: SseEvent, turnId: string): void {
     const text = event.data['text'];
-    const content = typeof text === 'string' ? text : this._reasoningBuffer;
+    // Hermes can finish a streamed reasoning summary with `text: ""`. The
+    // completion update is authoritative in the v2 reducer, so forwarding that
+    // empty string used to replace the accumulated thought with a bodyless
+    // completed row. Preserve the streamed buffer unless done carries content.
+    const content =
+      typeof text === 'string' && text.length > 0
+        ? text
+        : this._reasoningBuffer;
     this.fire({
       type: 'chat:reasoning',
       turnId,

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -480,6 +480,44 @@ function diffCounts(diff: string): { additions: number; deletions: number } {
   return { additions, deletions };
 }
 
+type HermesDiffKind = 'added' | 'modified' | 'deleted';
+
+function diffHeaderPath(value: string | undefined): string | null {
+  if (!value) return null;
+  const token = value.split('\t', 1)[0]?.trim() ?? '';
+  if (!token || token === '/dev/null') return null;
+  const unquoted =
+    token.startsWith('"') && token.endsWith('"') ? token.slice(1, -1) : token;
+  return unquoted.replace(/^[ab]\//, '');
+}
+
+function hermesDiffTarget(
+  args: Record<string, unknown>,
+  diff: string
+): { path: string; kind: HermesDiffKind } {
+  const oldHeader = /^--- (.+)$/m.exec(diff)?.[1];
+  const newHeader = /^\+\+\+ (.+)$/m.exec(diff)?.[1];
+  const oldIsNull = oldHeader?.split('\t', 1)[0]?.trim() === '/dev/null';
+  const newIsNull = newHeader?.split('\t', 1)[0]?.trim() === '/dev/null';
+  const kind: HermesDiffKind = oldIsNull
+    ? 'added'
+    : newIsNull
+      ? 'deleted'
+      : 'modified';
+  const explicitPath = args['path'] ?? args['file_path'];
+  const headerPath =
+    kind === 'deleted'
+      ? diffHeaderPath(oldHeader)
+      : (diffHeaderPath(newHeader) ?? diffHeaderPath(oldHeader));
+  return {
+    path:
+      typeof explicitPath === 'string' && explicitPath.trim()
+        ? explicitPath
+        : (headerPath ?? 'unknown'),
+    kind,
+  };
+}
+
 /**
  * Concatenate the text of a Responses API `message` output-item. The item shape
  * is `{ type: 'message', role, content: [{ type: 'output_text', text }, …] }`;
@@ -1254,13 +1292,13 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
         isUnifiedDiffOutput(outputText)
       ) {
         const { additions, deletions } = diffCounts(outputText);
-        const pathValue = args['path'] ?? args['file_path'];
+        const target = hermesDiffTarget(args, outputText);
         this.fire({
           type: 'chat:file-change',
           turnId,
           toolCallId: callId,
-          path: typeof pathValue === 'string' ? pathValue : 'unknown',
-          kind: 'modified',
+          path: target.path,
+          kind: target.kind,
           additions,
           deletions,
           diff: outputText,

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -135,6 +135,43 @@ export interface AgentTurnV2 {
   usage?: AgentUsageV2;
 }
 
+/**
+ * Framework-neutral presentation contract for an agent detail row (#1198).
+ *
+ * Adapters still retain their richer typed item payloads, while renderers read
+ * this ACP-shaped projection exclusively. A stable item id is the durable card
+ * entity: started/updated patches mutate that one entity in place rather than
+ * appending status rows.
+ */
+export type AgentDetailCardKindV2 =
+  | 'message'
+  | 'thought'
+  | 'tool_call'
+  | 'output'
+  | 'diff';
+
+export type AgentDetailCardStatusV2 =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export interface AgentDetailCardV2 {
+  kind: AgentDetailCardKindV2;
+  title: string;
+  status: AgentDetailCardStatusV2;
+  /** Expandable body. Diff cards carry unified-diff-shaped content here. */
+  content?: string;
+  /** Optional renderer hint; never a provider/framework identifier. */
+  language?: string;
+  command?: string;
+  path?: string;
+  additions?: number;
+  deletions?: number;
+  sizeBytes?: number;
+}
+
 interface AgentItemBaseV2 {
   id: string;
   providerItemId?: string;
@@ -143,6 +180,8 @@ interface AgentItemBaseV2 {
   status?: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
   error?: string;
   metadata?: Record<string, unknown>;
+  /** Normalized renderer input; adapter boundaries populate this additively. */
+  card?: AgentDetailCardV2;
 }
 
 export interface AgentUserMessageItemV2 extends AgentItemBaseV2 {
@@ -372,6 +411,185 @@ export type AgentItemV2 =
   | AgentHookPromptItemV2
   | AgentProviderExtensionItemV2
   | AgentErrorMessageItemV2;
+
+function detailCardStatus(item: AgentItemV2): AgentDetailCardStatusV2 {
+  return item.status ?? 'pending';
+}
+
+function detailCardText(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function detailCardBytes(content: string): number {
+  return new TextEncoder().encode(content).byteLength;
+}
+
+function diffLineCounts(content: string): {
+  additions: number;
+  deletions: number;
+} {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of content.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+    if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+  }
+  return { additions, deletions };
+}
+
+function isUnifiedDiff(content: string): boolean {
+  return (
+    /(^|\n)diff --git /.test(content) ||
+    (/(^|\n)--- (?:a\/|\/dev\/null)/.test(content) &&
+      /(^|\n)\+\+\+ (?:b\/|\/dev\/null)/.test(content))
+  );
+}
+
+function toolCardContent(
+  args: Record<string, unknown> | undefined,
+  output: unknown
+): string {
+  const inputText = detailCardText(args);
+  const outputText = detailCardText(output);
+  if (inputText && outputText)
+    return `input\n${inputText}\n\noutput\n${outputText}`;
+  if (inputText) return `input\n${inputText}`;
+  if (outputText) return `output\n${outputText}`;
+  return '';
+}
+
+function detailCardTitle(content: string, fallback: string): string {
+  const title = content.replace(/\s+/g, ' ').trim();
+  if (!title) return fallback;
+  return title.length <= 80 ? title : `${title.slice(0, 79).trimEnd()}…`;
+}
+
+/**
+ * Project a provider-rich item onto the one framework-neutral detail-card
+ * shape. This is intentionally exhaustive by item type and contains no
+ * framework/provider branch.
+ */
+export function agentDetailCardForItem(
+  item: AgentItemV2
+): AgentDetailCardV2 | undefined {
+  const status = detailCardStatus(item);
+  switch (item.type) {
+    case 'assistantMessage':
+    case 'userMessage': {
+      const content = item.text;
+      return {
+        kind: 'message',
+        title: item.type === 'userMessage' ? 'message' : 'response',
+        status,
+        ...(content ? { content, sizeBytes: detailCardBytes(content) } : {}),
+      };
+    }
+    case 'reasoning': {
+      const content = item.detail || item.summary;
+      return {
+        kind: 'thought',
+        title: detailCardTitle(item.summary, 'thinking'),
+        status,
+        ...(content ? { content, sizeBytes: detailCardBytes(content) } : {}),
+      };
+    }
+    case 'commandExecution': {
+      const content = item.output;
+      return {
+        kind: 'output',
+        title: item.command || 'command',
+        status,
+        command: item.command,
+        language: 'bash',
+        ...(content ? { content, sizeBytes: detailCardBytes(content) } : {}),
+      };
+    }
+    case 'fileChange': {
+      const content = item.patch ?? '';
+      const path = item.paths[0]?.path;
+      return {
+        kind: 'diff',
+        title:
+          path ??
+          `${item.paths.length} file${item.paths.length === 1 ? '' : 's'}`,
+        status,
+        language: 'diff',
+        ...(path ? { path } : {}),
+        ...(content
+          ? {
+              content,
+              sizeBytes: detailCardBytes(content),
+              ...diffLineCounts(content),
+            }
+          : {}),
+      };
+    }
+    case 'dynamicToolCall':
+    case 'mcpToolCall': {
+      const tool = item.tool;
+      const output =
+        item.type === 'dynamicToolCall'
+          ? item.content || detailCardText(item.result)
+          : item.progress || detailCardText(item.result);
+      const content = toolCardContent(item.arguments, output);
+      const isDiff =
+        item.metadata?.contentKind === 'diff' || isUnifiedDiff(content);
+      return {
+        kind: isDiff ? 'diff' : 'tool_call',
+        title: tool || 'tool',
+        status,
+        ...(isDiff ? { language: 'diff' } : {}),
+        ...(content
+          ? {
+              content,
+              sizeBytes: detailCardBytes(content),
+              ...(isDiff ? diffLineCounts(content) : {}),
+            }
+          : {}),
+      };
+    }
+    default:
+      return undefined;
+  }
+}
+
+/** Add or refresh the normalized card without mutating the provider item. */
+export function withAgentDetailCard(item: AgentItemV2): AgentItemV2 {
+  const card = agentDetailCardForItem(item);
+  if (!card) return item;
+  return { ...item, card } as AgentItemV2;
+}
+
+function withDetailCardsInTurn(turn: AgentTurnV2): AgentTurnV2 {
+  return { ...turn, items: turn.items.map(withAgentDetailCard) };
+}
+
+/** Normalize every item-bearing patch at the adapter emission boundary. */
+export function withAgentDetailCards(patch: AgentPatchV2): AgentPatchV2 {
+  switch (patch.type) {
+    case 'agent-session-snapshot-v2':
+      return {
+        ...patch,
+        session: {
+          ...patch.session,
+          turns: patch.session.turns.map(withDetailCardsInTurn),
+        },
+      };
+    case 'agent-turn-started-v2':
+      return { ...patch, turn: withDetailCardsInTurn(patch.turn) };
+    case 'agent-item-started-v2':
+    case 'agent-item-updated-v2':
+      return { ...patch, item: withAgentDetailCard(patch.item) };
+    default:
+      return patch;
+  }
+}
 
 interface AgentPatchBaseV2 {
   type: AgentPatchV2['type'];
@@ -819,7 +1037,11 @@ function applyItemDelta(
 
   if (existing) {
     return items.map((item) =>
-      item.id === patch.itemId ? appendItemDelta(item, patch.delta) : item
+      item.id === patch.itemId
+        ? item.card
+          ? withAgentDetailCard(appendItemDelta(item, patch.delta))
+          : appendItemDelta(item, patch.delta)
+        : item
     );
   }
 
@@ -957,6 +1179,40 @@ const ITEM_VALIDATORS: Record<string, ItemValidator> = {
     (v.source === 'agent' || v.source === 'client'),
 };
 
+const DETAIL_CARD_KINDS = new Set<AgentDetailCardKindV2>([
+  'message',
+  'thought',
+  'tool_call',
+  'output',
+  'diff',
+]);
+
+const DETAIL_CARD_STATUSES = new Set<AgentDetailCardStatusV2>([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+function isDetailCard(value: unknown): value is AgentDetailCardV2 {
+  return (
+    isRecord(value) &&
+    typeof value.kind === 'string' &&
+    DETAIL_CARD_KINDS.has(value.kind as AgentDetailCardKindV2) &&
+    typeof value.title === 'string' &&
+    typeof value.status === 'string' &&
+    DETAIL_CARD_STATUSES.has(value.status as AgentDetailCardStatusV2) &&
+    (value.content === undefined || typeof value.content === 'string') &&
+    (value.language === undefined || typeof value.language === 'string') &&
+    (value.command === undefined || typeof value.command === 'string') &&
+    (value.path === undefined || typeof value.path === 'string') &&
+    (value.additions === undefined || typeof value.additions === 'number') &&
+    (value.deletions === undefined || typeof value.deletions === 'number') &&
+    (value.sizeBytes === undefined || typeof value.sizeBytes === 'number')
+  );
+}
+
 function isItem(value: unknown): value is AgentItemV2 {
   if (
     !isRecord(value) ||
@@ -966,7 +1222,11 @@ function isItem(value: unknown): value is AgentItemV2 {
     return false;
   }
   const validator = ITEM_VALIDATORS[value.type];
-  return validator ? validator(value) : false;
+  return (
+    !!validator &&
+    validator(value) &&
+    (value.card === undefined || isDetailCard(value.card))
+  );
 }
 
 function isSession(value: unknown): value is AgentSessionV2 {

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -470,6 +470,12 @@ function detailCardTitle(content: string, fallback: string): string {
   return title.length <= 80 ? title : `${title.slice(0, 79).trimEnd()}…`;
 }
 
+function isTerminalDetailStatus(status: AgentDetailCardStatusV2): boolean {
+  return (
+    status === 'completed' || status === 'failed' || status === 'cancelled'
+  );
+}
+
 /**
  * Project a provider-rich item onto the one framework-neutral detail-card
  * shape. This is intentionally exhaustive by item type and contains no
@@ -479,6 +485,7 @@ export function agentDetailCardForItem(
   item: AgentItemV2
 ): AgentDetailCardV2 | undefined {
   const status = detailCardStatus(item);
+  const includeDerivedFields = isTerminalDetailStatus(status);
   switch (item.type) {
     case 'assistantMessage':
     case 'userMessage': {
@@ -487,16 +494,32 @@ export function agentDetailCardForItem(
         kind: 'message',
         title: item.type === 'userMessage' ? 'message' : 'response',
         status,
-        ...(content ? { content, sizeBytes: detailCardBytes(content) } : {}),
+        ...(content
+          ? {
+              content,
+              ...(includeDerivedFields
+                ? { sizeBytes: detailCardBytes(content) }
+                : {}),
+            }
+          : {}),
       };
     }
     case 'reasoning': {
       const content = item.detail || item.summary;
       return {
         kind: 'thought',
-        title: detailCardTitle(item.summary, 'thinking'),
+        title: includeDerivedFields
+          ? detailCardTitle(item.summary, 'thinking')
+          : 'thinking',
         status,
-        ...(content ? { content, sizeBytes: detailCardBytes(content) } : {}),
+        ...(content
+          ? {
+              content,
+              ...(includeDerivedFields
+                ? { sizeBytes: detailCardBytes(content) }
+                : {}),
+            }
+          : {}),
       };
     }
     case 'commandExecution': {
@@ -507,7 +530,14 @@ export function agentDetailCardForItem(
         status,
         command: item.command,
         language: 'bash',
-        ...(content ? { content, sizeBytes: detailCardBytes(content) } : {}),
+        ...(content
+          ? {
+              content,
+              ...(includeDerivedFields
+                ? { sizeBytes: detailCardBytes(content) }
+                : {}),
+            }
+          : {}),
       };
     }
     case 'fileChange': {
@@ -524,8 +554,12 @@ export function agentDetailCardForItem(
         ...(content
           ? {
               content,
-              sizeBytes: detailCardBytes(content),
-              ...diffLineCounts(content),
+              ...(includeDerivedFields
+                ? {
+                    sizeBytes: detailCardBytes(content),
+                    ...diffLineCounts(content),
+                  }
+                : {}),
             }
           : {}),
       };
@@ -548,8 +582,12 @@ export function agentDetailCardForItem(
         ...(content
           ? {
               content,
-              sizeBytes: detailCardBytes(content),
-              ...(isDiff ? diffLineCounts(content) : {}),
+              ...(includeDerivedFields
+                ? {
+                    sizeBytes: detailCardBytes(content),
+                    ...(isDiff ? diffLineCounts(content) : {}),
+                  }
+                : {}),
             }
           : {}),
       };
@@ -630,6 +668,8 @@ export interface AgentItemDeltaPatchV2 extends AgentPatchBaseV2 {
   type: 'agent-item-delta-v2';
   turnId: string;
   itemId: string;
+  /** Append is the streaming default; replace is for authoritative snapshots. */
+  mode?: 'append' | 'replace';
   delta: {
     text?: string;
     output?: string;
@@ -637,6 +677,12 @@ export interface AgentItemDeltaPatchV2 extends AgentPatchBaseV2 {
     detail?: string;
     patch?: string;
     content?: string;
+    status?: AgentDetailCardStatusV2;
+    error?: string;
+    exitCode?: number | null;
+    durationMs?: number;
+    /** Cheap emitter-derived summary for live cards; terminal updates derive all fields. */
+    card?: Pick<AgentDetailCardV2, 'additions' | 'deletions'>;
   };
 }
 
@@ -832,6 +878,9 @@ export function isAgentPatchV2(value: unknown): value is AgentPatchV2 {
       return (
         typeof value.turnId === 'string' &&
         typeof value.itemId === 'string' &&
+        (value.mode === undefined ||
+          value.mode === 'append' ||
+          value.mode === 'replace') &&
         isDelta(value.delta)
       );
     case 'agent-item-updated-v2':
@@ -1037,11 +1086,7 @@ function applyItemDelta(
 
   if (existing) {
     return items.map((item) =>
-      item.id === patch.itemId
-        ? item.card
-          ? withAgentDetailCard(appendItemDelta(item, patch.delta))
-          : appendItemDelta(item, patch.delta)
-        : item
+      item.id === patch.itemId ? applyDeltaToItem(item, patch) : item
     );
   }
 
@@ -1060,6 +1105,65 @@ function applyItemDelta(
       startedAt: patch.timestamp,
     },
   ];
+}
+
+function applyDeltaToItem(
+  item: AgentItemV2,
+  patch: Extract<AgentPatchV2, { type: 'agent-item-delta-v2' }>
+): AgentItemV2 {
+  const next = appendItemDelta(item, patch.delta, patch.mode ?? 'append');
+  const card = item.card;
+  if (next.type === 'assistantMessage' || next.type === 'userMessage') {
+    return next;
+  }
+
+  const status = patch.delta.status ?? card?.status ?? detailCardStatus(next);
+  if (isTerminalDetailStatus(status)) return withAgentDetailCard(next);
+  if (!card) return next;
+
+  let content = card.content;
+  switch (next.type) {
+    case 'reasoning':
+      content = next.detail || next.summary;
+      break;
+    case 'commandExecution':
+      content = next.output;
+      break;
+    case 'fileChange':
+      content = next.patch;
+      break;
+    case 'dynamicToolCall': {
+      const fragment = patch.delta.content;
+      if (typeof fragment === 'string') {
+        const hadOutput =
+          item.type === 'dynamicToolCall' &&
+          typeof item.content === 'string' &&
+          item.content;
+        const separator = hadOutput
+          ? ''
+          : card.content
+            ? '\n\noutput\n'
+            : 'output\n';
+        content =
+          patch.mode === 'replace'
+            ? `${card.content ? `${card.content}\n\n` : ''}output\n${fragment}`
+            : `${card.content ?? ''}${separator}${fragment}`;
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return {
+    ...next,
+    card: {
+      ...card,
+      status,
+      ...(content !== undefined ? { content } : {}),
+      ...(patch.delta.card ?? {}),
+    },
+  } as AgentItemV2;
 }
 
 function completeTurn(
@@ -1089,16 +1193,26 @@ function completeTurn(
 
 function appendItemDelta(
   item: AgentItemV2,
-  delta: AgentItemDeltaPatchV2['delta']
+  delta: AgentItemDeltaPatchV2['delta'],
+  mode: 'append' | 'replace'
 ): AgentItemV2 {
   let next: AgentItemV2 = item;
 
-  next = appendStringField(next, delta, 'text');
-  next = appendStringField(next, delta, 'output');
-  next = appendStringField(next, delta, 'summary');
-  next = appendStringField(next, delta, 'detail');
-  next = appendStringField(next, delta, 'patch');
-  next = appendStringField(next, delta, 'content');
+  next = appendStringField(next, delta, 'text', mode);
+  next = appendStringField(next, delta, 'output', mode);
+  next = appendStringField(next, delta, 'summary', mode);
+  next = appendStringField(next, delta, 'detail', mode);
+  next = appendStringField(next, delta, 'patch', mode);
+  next = appendStringField(next, delta, 'content', mode);
+
+  if (delta.status !== undefined) next = { ...next, status: delta.status };
+  if (delta.error !== undefined) next = { ...next, error: delta.error };
+  if (delta.exitCode !== undefined && next.type === 'commandExecution') {
+    next = { ...next, exitCode: delta.exitCode };
+  }
+  if (delta.durationMs !== undefined && next.type === 'commandExecution') {
+    next = { ...next, durationMs: delta.durationMs };
+  }
 
   return next;
 }
@@ -1106,13 +1220,17 @@ function appendItemDelta(
 function appendStringField<K extends keyof AgentItemDeltaPatchV2['delta']>(
   item: AgentItemV2,
   delta: AgentItemDeltaPatchV2['delta'],
-  key: K
+  key: K,
+  mode: 'append' | 'replace'
 ): AgentItemV2 {
   const fragment = delta[key];
   const current = (item as unknown as Record<string, unknown>)[key];
 
   if (typeof fragment !== 'string') {
     return item;
+  }
+  if (mode === 'replace') {
+    return { ...item, [key]: fragment } as AgentItemV2;
   }
   if (current === undefined) {
     return {
@@ -1428,13 +1546,53 @@ function isPartialLiveState(value: unknown): boolean {
 }
 
 function isDelta(value: unknown): value is AgentItemDeltaPatchV2['delta'] {
-  return (
-    isRecord(value) &&
-    DELTA_STRING_FIELDS.every(
+  if (!isRecord(value)) return false;
+  if (
+    !DELTA_STRING_FIELDS.every(
       (field) =>
         !Object.hasOwn(value, field) || typeof value[field] === 'string'
-    ) &&
-    DELTA_STRING_FIELDS.some((field) => typeof value[field] === 'string')
+    )
+  ) {
+    return false;
+  }
+  if (
+    value.status !== undefined &&
+    !(
+      typeof value.status === 'string' &&
+      DETAIL_CARD_STATUSES.has(value.status as AgentDetailCardStatusV2)
+    )
+  ) {
+    return false;
+  }
+  if (value.error !== undefined && typeof value.error !== 'string')
+    return false;
+  if (
+    value.exitCode !== undefined &&
+    value.exitCode !== null &&
+    typeof value.exitCode !== 'number'
+  ) {
+    return false;
+  }
+  if (value.durationMs !== undefined && typeof value.durationMs !== 'number') {
+    return false;
+  }
+  if (
+    value.card !== undefined &&
+    (!isRecord(value.card) ||
+      (value.card.additions !== undefined &&
+        typeof value.card.additions !== 'number') ||
+      (value.card.deletions !== undefined &&
+        typeof value.card.deletions !== 'number'))
+  ) {
+    return false;
+  }
+  return (
+    DELTA_STRING_FIELDS.some((field) => typeof value[field] === 'string') ||
+    value.status !== undefined ||
+    value.error !== undefined ||
+    value.exitCode !== undefined ||
+    value.durationMs !== undefined ||
+    value.card !== undefined
   );
 }
 

--- a/shared/agent-chat-v1-compat.ts
+++ b/shared/agent-chat-v1-compat.ts
@@ -216,7 +216,6 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
 
     case 'chat:tool-result': {
       const content = event.output || event.error || '';
-      if (!content) return [];
       return [
         {
           type: 'agent-item-delta-v2',
@@ -224,9 +223,19 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
           timestamp: event.timestamp,
           turnId: event.turnId,
           itemId: toolCallItemId(event.toolCallId),
-          delta: isCommandTool(event.toolName)
-            ? { output: content }
-            : { content },
+          delta: {
+            ...(content
+              ? isCommandTool(event.toolName)
+                ? { output: content }
+                : { content }
+              : {}),
+            status: toolCallStatusToItemStatus(event.status),
+            ...(event.error ? { error: event.error } : {}),
+            ...(event.exitCode !== undefined
+              ? { exitCode: event.exitCode }
+              : {}),
+            durationMs: event.durationMs,
+          },
         },
       ];
     }
@@ -250,7 +259,6 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
               },
             ],
             ...(event.diff ? { patch: event.diff } : {}),
-            applyStatus: 'applied',
             status: 'completed',
             metadata: {
               source: event.source,

--- a/shared/agent-chat-v1-compat.ts
+++ b/shared/agent-chat-v1-compat.ts
@@ -57,6 +57,17 @@ function toolCallStatusToItemStatus(
   }
 }
 
+function isCommandTool(toolName: string): boolean {
+  return /^(?:run[_-]?command|bash|shell|exec|execute[_-]?command)$/i.test(
+    toolName
+  );
+}
+
+function commandFromToolInput(input: Record<string, unknown>): string {
+  const command = input.command ?? input.cmd;
+  return typeof command === 'string' ? command : '';
+}
+
 export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
   switch (event.type) {
     case 'chat:provider-session':
@@ -157,7 +168,30 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
         },
       ];
 
-    case 'chat:tool-call':
+    case 'chat:tool-call': {
+      const status = toolCallStatusToItemStatus(event.status);
+      if (isCommandTool(event.toolName)) {
+        return [
+          {
+            type: 'agent-item-updated-v2',
+            sessionId: event.sessionId,
+            timestamp: event.timestamp,
+            turnId: event.turnId,
+            item: {
+              type: 'commandExecution',
+              id: toolCallItemId(event.toolCallId),
+              providerItemId: event.toolCallId,
+              command: commandFromToolInput(event.input),
+              output: '',
+              status,
+              metadata: compactMetadata({
+                source: event.source,
+                description: event.description || undefined,
+              }),
+            },
+          },
+        ];
+      }
       return [
         {
           type: 'agent-item-updated-v2',
@@ -170,7 +204,7 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
             namespace: event.source,
             tool: event.toolName,
             arguments: event.input,
-            status: toolCallStatusToItemStatus(event.status),
+            status,
             metadata: compactMetadata({
               source: event.source,
               description: event.description || undefined,
@@ -178,6 +212,7 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
           },
         },
       ];
+    }
 
     case 'chat:tool-result': {
       const content = event.output || event.error || '';
@@ -189,10 +224,43 @@ export function mapChatEventToAgentPatchV2(event: ChatEvent): AgentPatchV2[] {
           timestamp: event.timestamp,
           turnId: event.turnId,
           itemId: toolCallItemId(event.toolCallId),
-          delta: { content },
+          delta: isCommandTool(event.toolName)
+            ? { output: content }
+            : { content },
         },
       ];
     }
+
+    case 'chat:file-change':
+      return [
+        {
+          type: 'agent-item-updated-v2',
+          sessionId: event.sessionId,
+          timestamp: event.timestamp,
+          turnId: event.turnId,
+          item: {
+            type: 'fileChange',
+            id: toolCallItemId(event.toolCallId),
+            providerItemId: event.toolCallId,
+            paths: [
+              {
+                path: event.path,
+                ...(event.oldPath ? { oldPath: event.oldPath } : {}),
+                status: event.kind,
+              },
+            ],
+            ...(event.diff ? { patch: event.diff } : {}),
+            applyStatus: 'applied',
+            status: 'completed',
+            metadata: {
+              source: event.source,
+              additions: event.additions,
+              deletions: event.deletions,
+              contentKind: 'diff',
+            },
+          },
+        },
+      ];
 
     case 'chat:reasoning':
       return [

--- a/test/agent-chat-protocol-v2.test.ts
+++ b/test/agent-chat-protocol-v2.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyAgentPatchV2,
+  agentDetailCardForItem,
   emptyAgentSessionV2,
   isAgentPatchV2,
+  withAgentDetailCards,
 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
 
@@ -422,5 +424,79 @@ describe('Agent Chat Protocol v2', () => {
         startedAt: timestamp,
       },
     ]);
+  });
+
+  it('keeps one normalized card entity current across output deltas', () => {
+    const withTurn = applyAgentPatchV2(makeSession(), {
+      type: 'agent-turn-started-v2',
+      sessionId: 's1',
+      timestamp,
+      turn: {
+        id: 't-card',
+        status: 'running',
+        inputMessageId: 'user-card',
+        items: [],
+        startedAt: timestamp,
+      },
+    });
+    const started = withAgentDetailCards({
+      type: 'agent-item-started-v2',
+      sessionId: 's1',
+      timestamp,
+      turnId: 't-card',
+      item: {
+        type: 'commandExecution',
+        id: 'exec-1',
+        command: 'npm test',
+        output: '',
+        status: 'running',
+      },
+    });
+    const withStart = applyAgentPatchV2(withTurn, started);
+    const withFirst = applyAgentPatchV2(withStart, {
+      type: 'agent-item-delta-v2',
+      sessionId: 's1',
+      timestamp,
+      turnId: 't-card',
+      itemId: 'exec-1',
+      delta: { output: 'one\n' },
+    });
+    const withSecond = applyAgentPatchV2(withFirst, {
+      type: 'agent-item-delta-v2',
+      sessionId: 's1',
+      timestamp,
+      turnId: 't-card',
+      itemId: 'exec-1',
+      delta: { output: 'two\n' },
+    });
+
+    expect(withSecond.turns[0]?.items).toHaveLength(1);
+    expect(withSecond.turns[0]?.items[0]).toMatchObject({
+      id: 'exec-1',
+      output: 'one\ntwo\n',
+      card: {
+        kind: 'output',
+        title: 'npm test',
+        content: 'one\ntwo\n',
+        language: 'bash',
+        status: 'running',
+      },
+    });
+  });
+
+  it('does not mis-tag plain file-tool output as a diff', () => {
+    expect(
+      agentDetailCardForItem({
+        type: 'dynamicToolCall',
+        id: 'write-1',
+        namespace: 'fixture',
+        tool: 'Write',
+        content: 'wrote 500 lines to demo.ts\n@@ -12 ms from baseline',
+        status: 'completed',
+      })
+    ).toMatchObject({
+      kind: 'tool_call',
+      content: 'output\nwrote 500 lines to demo.ts\n@@ -12 ms from baseline',
+    });
   });
 });

--- a/test/agent-chat-protocol-v2.test.ts
+++ b/test/agent-chat-protocol-v2.test.ts
@@ -482,6 +482,68 @@ describe('Agent Chat Protocol v2', () => {
         status: 'running',
       },
     });
+    expect(withSecond.turns[0]?.items[0]?.card).not.toHaveProperty('sizeBytes');
+
+    const terminal = applyAgentPatchV2(withSecond, {
+      type: 'agent-item-delta-v2',
+      sessionId: 's1',
+      timestamp,
+      turnId: 't-card',
+      itemId: 'exec-1',
+      delta: { status: 'completed', durationMs: 10 },
+    });
+    expect(terminal.turns[0]?.items[0]).toMatchObject({
+      status: 'completed',
+      durationMs: 10,
+      card: {
+        status: 'completed',
+        content: 'one\ntwo\n',
+        sizeBytes: 8,
+      },
+    });
+  });
+
+  it('does not recompute never-rendered message cards on text deltas', () => {
+    const withTurn = applyAgentPatchV2(makeSession(), {
+      type: 'agent-turn-started-v2',
+      sessionId: 's1',
+      timestamp,
+      turn: {
+        id: 't-message-card',
+        status: 'running',
+        inputMessageId: 'user-message-card',
+        items: [],
+        startedAt: timestamp,
+      },
+    });
+    const started = withAgentDetailCards({
+      type: 'agent-item-started-v2',
+      sessionId: 's1',
+      timestamp,
+      turnId: 't-message-card',
+      item: {
+        type: 'assistantMessage',
+        id: 'message-card-1',
+        text: '',
+        status: 'running',
+      },
+    });
+    const withStart = applyAgentPatchV2(withTurn, started);
+    const originalCard = withStart.turns[0]?.items[0]?.card;
+    const withDelta = applyAgentPatchV2(withStart, {
+      type: 'agent-item-delta-v2',
+      sessionId: 's1',
+      timestamp,
+      turnId: 't-message-card',
+      itemId: 'message-card-1',
+      delta: { text: 'streamed text' },
+    });
+
+    expect(withDelta.turns[0]?.items[0]).toMatchObject({
+      text: 'streamed text',
+      status: 'running',
+    });
+    expect(withDelta.turns[0]?.items[0]?.card).toBe(originalCard);
   });
 
   it('does not mis-tag plain file-tool output as a diff', () => {

--- a/test/agent-chat-v1-compat.test.ts
+++ b/test/agent-chat-v1-compat.test.ts
@@ -268,6 +268,46 @@ describe('Agent Chat v1 compatibility bridge', () => {
     expect(mapChatEventToAgentPatchV2(event)).toEqual([]);
   });
 
+  it('maps a tagged legacy file edit onto the same durable tool entity', () => {
+    const event: ChatEvent = {
+      type: 'chat:file-change',
+      sessionId: 'session-1',
+      timestamp,
+      source: 'hermes',
+      turnId: 'turn-1',
+      toolCallId: 'call-1',
+      path: 'demo.ts',
+      kind: 'modified',
+      additions: 1,
+      deletions: 1,
+      diff: '@@ -1 +1 @@\n-old\n+new\n',
+    };
+
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([
+      {
+        type: 'agent-item-updated-v2',
+        sessionId: 'session-1',
+        timestamp,
+        turnId: 'turn-1',
+        item: {
+          type: 'fileChange',
+          id: 'tool-call-1',
+          providerItemId: 'call-1',
+          paths: [{ path: 'demo.ts', status: 'modified' }],
+          patch: '@@ -1 +1 @@\n-old\n+new\n',
+          applyStatus: 'applied',
+          status: 'completed',
+          metadata: {
+            source: 'hermes',
+            additions: 1,
+            deletions: 1,
+            contentKind: 'diff',
+          },
+        },
+      },
+    ]);
+  });
+
   it('maps v1 reasoning events to a reasoning item update', () => {
     const event: ChatEvent = {
       type: 'chat:reasoning',

--- a/test/agent-chat-v1-compat.test.ts
+++ b/test/agent-chat-v1-compat.test.ts
@@ -5,10 +5,41 @@ import {
   mapAgentPatchV2ToChatEvents,
   mapChatEventToAgentPatchV2,
 } from '../shared/agent-chat-v1-compat.js';
-import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  applyAgentPatchV2,
+  emptyAgentSessionV2,
+  type AgentPatchV2,
+  type AgentSessionV2,
+} from '../shared/agent-chat-protocol-v2.js';
 import type { ChatEvent } from '../shared/chat-events.js';
 
 const timestamp = '2026-04-25T00:00:00.000Z';
+
+function reduceCompatEvents(events: ChatEvent[]): AgentSessionV2 {
+  let session = emptyAgentSessionV2({
+    id: 'session-1',
+    provider: 'opencode',
+    cwd: '/workspace/example',
+  });
+  session = applyAgentPatchV2(session, {
+    type: 'agent-turn-started-v2',
+    sessionId: 'session-1',
+    timestamp,
+    turn: {
+      id: 'turn-1',
+      status: 'running',
+      inputMessageId: 'input-1',
+      items: [],
+      startedAt: timestamp,
+    },
+  });
+  for (const event of events) {
+    for (const patch of mapChatEventToAgentPatchV2(event)) {
+      session = applyAgentPatchV2(session, patch);
+    }
+  }
+  return session;
+}
 
 describe('Agent Chat v1 compatibility bridge', () => {
   it('maps v1 text deltas to assistant message item deltas', () => {
@@ -226,7 +257,7 @@ describe('Agent Chat v1 compatibility bridge', () => {
     ]);
   });
 
-  it('maps v1 tool-result events to a content-appending item delta keyed by the same tool item id', () => {
+  it('maps v1 tool-result events to terminal content deltas keyed by the same tool item id', () => {
     const event: ChatEvent = {
       type: 'chat:tool-result',
       sessionId: 'session-1',
@@ -247,12 +278,16 @@ describe('Agent Chat v1 compatibility bridge', () => {
         timestamp,
         turnId: 'turn-1',
         itemId: 'tool-call-1',
-        delta: { content: 'file contents' },
+        delta: {
+          content: 'file contents',
+          status: 'completed',
+          durationMs: 12,
+        },
       },
     ]);
   });
 
-  it('drops tool-result events with no output or error to avoid a no-op patch', () => {
+  it('keeps a terminal tool-result update even when it has no body', () => {
     const event: ChatEvent = {
       type: 'chat:tool-result',
       sessionId: 'session-1',
@@ -265,7 +300,101 @@ describe('Agent Chat v1 compatibility bridge', () => {
       durationMs: 12,
     };
 
-    expect(mapChatEventToAgentPatchV2(event)).toEqual([]);
+    expect(mapChatEventToAgentPatchV2(event)).toEqual([
+      {
+        type: 'agent-item-delta-v2',
+        sessionId: 'session-1',
+        timestamp,
+        turnId: 'turn-1',
+        itemId: 'tool-call-1',
+        delta: { status: 'completed', durationMs: 12 },
+      },
+    ]);
+  });
+
+  it('finishes an OpenCode-shaped command result on the original stable item', () => {
+    const session = reduceCompatEvents([
+      {
+        type: 'chat:tool-call',
+        sessionId: 'session-1',
+        timestamp,
+        source: 'opencode',
+        turnId: 'turn-1',
+        toolCallId: 'bash-1',
+        toolName: 'bash',
+        description: '',
+        input: { command: 'npm test' },
+        status: 'running',
+      },
+      {
+        type: 'chat:tool-result',
+        sessionId: 'session-1',
+        timestamp,
+        source: 'opencode',
+        turnId: 'turn-1',
+        toolCallId: 'bash-1',
+        toolName: 'bash',
+        status: 'completed',
+        output: 'PASS\n',
+        exitCode: 0,
+        durationMs: 42,
+      },
+    ]);
+
+    expect(session.turns[0]?.items).toHaveLength(1);
+    expect(session.turns[0]?.items[0]).toMatchObject({
+      id: 'tool-bash-1',
+      type: 'commandExecution',
+      command: 'npm test',
+      output: 'PASS\n',
+      status: 'completed',
+      exitCode: 0,
+      durationMs: 42,
+      card: { kind: 'output', status: 'completed', content: 'PASS\n' },
+    });
+  });
+
+  it('fails an OpenCode-shaped tool result with its error on the original stable item', () => {
+    const session = reduceCompatEvents([
+      {
+        type: 'chat:tool-call',
+        sessionId: 'session-1',
+        timestamp,
+        source: 'opencode',
+        turnId: 'turn-1',
+        toolCallId: 'read-1',
+        toolName: 'read_file',
+        description: '',
+        input: { path: '/workspace/example/missing.ts' },
+        status: 'running',
+      },
+      {
+        type: 'chat:tool-result',
+        sessionId: 'session-1',
+        timestamp,
+        source: 'opencode',
+        turnId: 'turn-1',
+        toolCallId: 'read-1',
+        toolName: 'read_file',
+        status: 'error',
+        durationMs: 7,
+        error: 'synthetic missing file',
+      },
+    ]);
+
+    expect(session.turns[0]?.items).toHaveLength(1);
+    expect(session.turns[0]?.items[0]).toMatchObject({
+      id: 'tool-read-1',
+      type: 'dynamicToolCall',
+      arguments: { path: '/workspace/example/missing.ts' },
+      content: 'synthetic missing file',
+      status: 'failed',
+      error: 'synthetic missing file',
+      card: {
+        kind: 'tool_call',
+        status: 'failed',
+      },
+    });
   });
 
   it('maps a tagged legacy file edit onto the same durable tool entity', () => {
@@ -295,7 +424,6 @@ describe('Agent Chat v1 compatibility bridge', () => {
           providerItemId: 'call-1',
           paths: [{ path: 'demo.ts', status: 'modified' }],
           patch: '@@ -1 +1 @@\n-old\n+new\n',
-          applyStatus: 'applied',
           status: 'completed',
           metadata: {
             source: 'hermes',

--- a/test/components/agent-detail-card.test.ts
+++ b/test/components/agent-detail-card.test.ts
@@ -5,12 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import type { AgentDetailCardV2 } from '../../shared/agent-chat-protocol-v2.js';
 
-vi.mock('../../frontend/src/hooks/useShikiHighlight.js', () => ({
-  useShikiHighlight: () => ({ tokens: null, highlighting: false }),
+const shikiMocks = vi.hoisted(() => ({
+  useShikiHighlight: vi.fn(() => ({ tokens: null, highlighting: false })),
 }));
 
-const { AgentDetailCard } =
-  await import('../../frontend/src/components/chat/AgentDetailCard.js');
+vi.mock('../../frontend/src/hooks/useShikiHighlight.js', () => ({
+  useShikiHighlight: shikiMocks.useShikiHighlight,
+}));
+
+const {
+  AgentDetailCard,
+  AGENT_DETAIL_RENDER_MAX_CHARS,
+  AGENT_DETAIL_RENDER_MAX_LINES,
+} = await import('../../frontend/src/components/chat/AgentDetailCard.js');
 
 let host: HTMLDivElement;
 let root: Root;
@@ -33,6 +40,7 @@ async function toggle(): Promise<void> {
 
 describe('AgentDetailCard', () => {
   beforeEach(() => {
+    shikiMocks.useShikiHighlight.mockClear();
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
@@ -140,5 +148,51 @@ describe('AgentDetailCard', () => {
       'final result'
     );
     expect(host.textContent).not.toContain('first result');
+  });
+
+  it('bounds large streaming output and skips Shiki until completion', async () => {
+    const content = Array.from(
+      { length: AGENT_DETAIL_RENDER_MAX_LINES + 250 },
+      (_, index) => `${index}:${'x'.repeat(80)}`
+    ).join('\n');
+    expect(content.length).toBeGreaterThan(AGENT_DETAIL_RENDER_MAX_CHARS);
+    await render({
+      kind: 'output',
+      title: 'npm run build',
+      status: 'running',
+      content,
+      language: 'bash',
+      sizeBytes: content.length,
+    });
+
+    await toggle();
+
+    expect(
+      host.querySelectorAll('.ch-agent-card__line').length
+    ).toBeLessThanOrEqual(AGENT_DETAIL_RENDER_MAX_LINES);
+    expect(host.querySelector('.ch-agent-card__truncated')?.textContent).toBe(
+      'showing latest bounded output'
+    );
+    expect(host.textContent).toContain(
+      `${AGENT_DETAIL_RENDER_MAX_LINES + 249}:`
+    );
+    expect(shikiMocks.useShikiHighlight).toHaveBeenLastCalledWith(
+      'agent-detail:durable-item-1:bash',
+      '',
+      'bash'
+    );
+  });
+
+  it('labels fallback content length as characters, not bytes', async () => {
+    await render({
+      kind: 'output',
+      title: 'unicode output',
+      status: 'running',
+      content: '✓',
+    });
+
+    expect(host.querySelector('.ch-agent-card__size')?.textContent).toBe(
+      '1 char'
+    );
   });
 });

--- a/test/components/agent-detail-card.test.ts
+++ b/test/components/agent-detail-card.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { AgentDetailCardV2 } from '../../shared/agent-chat-protocol-v2.js';
+
+vi.mock('../../frontend/src/hooks/useShikiHighlight.js', () => ({
+  useShikiHighlight: () => ({ tokens: null, highlighting: false }),
+}));
+
+const { AgentDetailCard } =
+  await import('../../frontend/src/components/chat/AgentDetailCard.js');
+
+let host: HTMLDivElement;
+let root: Root;
+
+async function render(card: AgentDetailCardV2): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(AgentDetailCard, { card, itemId: 'durable-item-1' })
+    );
+  });
+}
+
+async function toggle(): Promise<void> {
+  const button = host.querySelector<HTMLButtonElement>(
+    '.ch-agent-card__toggle'
+  );
+  expect(button).toBeTruthy();
+  await act(async () => button?.click());
+}
+
+describe('AgentDetailCard', () => {
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('keeps a 500-line output collapsed until its summary is toggled', async () => {
+    const content = Array.from(
+      { length: 500 },
+      (_, index) => `line ${index}`
+    ).join('\n');
+    await render({
+      kind: 'output',
+      title: 'npm test -- --runInBand',
+      status: 'completed',
+      content,
+      sizeBytes: new TextEncoder().encode(content).byteLength,
+    });
+
+    const button = host.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    expect(button?.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('.ch-agent-card__body')).toBeNull();
+    expect(button?.textContent).toContain('npm test -- --runInBand');
+    expect(button?.textContent).toContain('500 lines');
+    expect(button?.textContent).toContain('completed');
+
+    await toggle();
+    expect(button?.getAttribute('aria-expanded')).toBe('true');
+    expect(host.querySelector('.ch-agent-card__body')?.textContent).toContain(
+      'line 499'
+    );
+
+    await toggle();
+    expect(host.querySelector('.ch-agent-card__body')).toBeNull();
+  });
+
+  it('expands thought content and keeps the toggle functional', async () => {
+    await render({
+      kind: 'thought',
+      title: 'inspect the reducer path',
+      status: 'running',
+      content: 'The snapshot may replace the current item.',
+    });
+
+    expect(host.querySelector('.ch-agent-card__body')).toBeNull();
+    await toggle();
+    expect(host.querySelector('.ch-agent-card__body')?.textContent).toContain(
+      'The snapshot may replace the current item.'
+    );
+  });
+
+  it('tints only added and removed diff lines and reports their counts', async () => {
+    await render({
+      kind: 'diff',
+      title: 'frontend/src/App.tsx',
+      path: 'frontend/src/App.tsx',
+      status: 'completed',
+      content: '--- a/App.tsx\n+++ b/App.tsx\n-old\n+new\n context',
+      additions: 1,
+      deletions: 1,
+    });
+
+    expect(host.querySelector('.ch-agent-card__toggle')?.textContent).toContain(
+      '+1 -1'
+    );
+    await toggle();
+
+    const added = host.querySelectorAll('.ch-agent-card__line--added');
+    const removed = host.querySelectorAll('.ch-agent-card__line--removed');
+    expect(added).toHaveLength(1);
+    expect(removed).toHaveLength(1);
+    expect(added[0]?.textContent).toContain('+new');
+    expect(removed[0]?.textContent).toContain('-old');
+  });
+
+  it('updates one expanded durable card in place as status and content change', async () => {
+    await render({
+      kind: 'tool_call',
+      title: 'search files',
+      status: 'running',
+      content: 'first result',
+    });
+    await toggle();
+
+    await render({
+      kind: 'tool_call',
+      title: 'search files',
+      status: 'completed',
+      content: 'final result',
+    });
+
+    expect(host.querySelectorAll('.ch-agent-card')).toHaveLength(1);
+    expect(
+      host
+        .querySelector('.ch-agent-card__toggle')
+        ?.getAttribute('aria-expanded')
+    ).toBe('true');
+    expect(host.querySelector('.ch-agent-card__body')?.textContent).toContain(
+      'final result'
+    );
+    expect(host.textContent).not.toContain('first result');
+  });
+});

--- a/test/components/chat-v2-rendering.test.ts
+++ b/test/components/chat-v2-rendering.test.ts
@@ -187,9 +187,9 @@ describe('chat v2 rendering against chat.html primitives', () => {
     mocks.session = null;
   });
 
-  async function renderChat() {
+  async function renderChat(sessionId = 'session-1') {
     await act(async () => {
-      root.render(React.createElement(ChatView, { sessionId: 'session-1' }));
+      root.render(React.createElement(ChatView, { sessionId }));
     });
   }
 
@@ -237,10 +237,10 @@ describe('chat v2 rendering against chat.html primitives', () => {
       '.turn-header',
       '.turn-footer',
       '.tl-text--user',
-      '.tcard',
-      '.tcard__h',
-      '.tcard__body',
-      '.fc-row',
+      '.ch-agent-card[data-agent-card-kind="output"]',
+      '.ch-agent-card[data-agent-card-kind="diff"]',
+      '.ch-agent-card[data-agent-card-kind="tool_call"]',
+      '.ch-agent-card__toggle',
       '.acard',
       '.turn-footer--running',
       '.queue',
@@ -260,6 +260,7 @@ describe('chat v2 rendering against chat.html primitives', () => {
       'frontend/src/components/chat/Composer.tsx'
     );
     expect(container.textContent).toContain('2 queued');
+    expect(container.querySelector('.ch-agent-card__body')).toBeNull();
   });
 
   it('forwards all approval decisions through the v2 socket callback', async () => {
@@ -641,7 +642,7 @@ describe('chat v2 rendering against chat.html primitives', () => {
     expect(imgLink?.textContent).toContain('a diagram');
   });
 
-  it('shows a truncated reasoning summary in <summary>, falling back to "thinking"', async () => {
+  it('shows a truncated thought card title, falling back to "thinking"', async () => {
     const longSummary =
       'Investigating the composer regression across every provider adapter and slash-command handler before proposing a fix';
     mocks.session = makeSession({
@@ -687,13 +688,91 @@ describe('chat v2 rendering against chat.html primitives', () => {
     await renderChat();
 
     const summaries = Array.from(
-      container.querySelectorAll('.reasoning summary')
+      container.querySelectorAll(
+        '.ch-agent-card[data-agent-card-kind="thought"] .ch-agent-card__title'
+      )
     ).map((el) => el.textContent);
 
     expect(summaries[0]).toBe('checking the socket reconnect path');
     expect(summaries[1]).toBe(`${longSummary.slice(0, 79)}…`);
     expect(summaries[1]?.length).toBeLessThanOrEqual(80);
     expect(summaries[2]).toBe('thinking');
+  });
+
+  it('excludes hidden provider items from the visible anchor candidates', async () => {
+    mocks.session = makeSession({
+      turns: [
+        {
+          id: 'turn-anchor-visibility',
+          status: 'completed',
+          inputMessageId: 'user-anchor-visibility',
+          startedAt: timestamp(),
+          items: [
+            {
+              id: 'hidden-provider-row',
+              type: 'providerExtension',
+              namespace: 'mock',
+              payload: { kind: 'trace-only' },
+              metadata: { eventVisibility: 'trace' },
+              status: 'completed',
+            },
+            {
+              id: 'visible-anchor-row',
+              type: 'assistantMessage',
+              text: 'visible anchor',
+              status: 'completed',
+            },
+          ],
+        },
+      ],
+    });
+
+    await renderChat();
+
+    expect(
+      container.querySelector('[data-agent-item-id="hidden-provider-row"]')
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-agent-item-id="visible-anchor-row"]')
+    ).toBeTruthy();
+  });
+
+  it('opens a new session at newest even when its item count matches a scrolled-up session', async () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+
+    try {
+      mocks.session = makeSession({ id: 'session-a' });
+      await renderChat('session-a');
+      const timeline = container.querySelector<HTMLElement>('.tl');
+      expect(timeline).toBeTruthy();
+      Object.defineProperty(timeline, 'scrollHeight', {
+        value: 1_000,
+        configurable: true,
+      });
+      Object.defineProperty(timeline, 'clientHeight', {
+        value: 300,
+        configurable: true,
+      });
+      Object.defineProperty(timeline, 'scrollTop', {
+        value: 100,
+        configurable: true,
+        writable: true,
+      });
+      await act(async () => {
+        timeline?.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      scrollSpy.mockClear();
+
+      mocks.session = makeSession({ id: 'session-b' });
+      await renderChat('session-b');
+
+      expect(timeline?.scrollTop).toBe(1_000);
+      expect(scrollSpy).toHaveBeenCalled();
+    } finally {
+      scrollSpy.mockRestore();
+    }
   });
 
   it('auto-follows the bottom as streamed content resizes the timeline, without yanking a scrolled-up reader', async () => {
@@ -737,6 +816,7 @@ describe('chat v2 rendering against chat.html primitives', () => {
       Object.defineProperty(timeline, 'scrollTop', {
         value: 650,
         configurable: true,
+        writable: true,
       });
       scrollSpy.mockClear();
       await act(async () => {
@@ -749,6 +829,10 @@ describe('chat v2 rendering against chat.html primitives', () => {
       Object.defineProperty(timeline, 'scrollTop', {
         value: 50,
         configurable: true,
+        writable: true,
+      });
+      await act(async () => {
+        timeline.dispatchEvent(new Event('scroll', { bubbles: true }));
       });
       scrollSpy.mockClear();
       await act(async () => {

--- a/test/components/chat-v2-rendering.test.ts
+++ b/test/components/chat-v2-rendering.test.ts
@@ -737,7 +737,66 @@ describe('chat v2 rendering against chat.html primitives', () => {
     ).toBeTruthy();
   });
 
-  it('opens a new session at newest even when its item count matches a scrolled-up session', async () => {
+  it('keeps an expanded card open through stable-id status and content updates', async () => {
+    const sessionWithOutput = (
+      status: 'running' | 'completed',
+      output: string
+    ): AgentSessionV2 =>
+      makeSession({
+        live: {
+          ...makeSession().live,
+          status: status === 'running' ? 'working' : 'idle',
+        },
+        turns: [
+          {
+            id: 'turn-stream-card',
+            status,
+            inputMessageId: 'user-stream-card',
+            startedAt: timestamp(),
+            items: [
+              {
+                id: 'user-stream-card',
+                type: 'userMessage',
+                text: 'run build',
+                status: 'completed',
+              },
+              {
+                id: 'stable-output-card',
+                type: 'commandExecution',
+                command: 'npm run build',
+                output,
+                status,
+              },
+            ],
+          },
+        ],
+      });
+
+    mocks.session = sessionWithOutput('running', 'building…');
+    await renderChat();
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-agent-item-id="stable-output-card"] .ch-agent-card__toggle'
+    );
+    await act(async () => toggle?.click());
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+
+    mocks.session = sessionWithOutput('completed', 'build complete');
+    await renderChat();
+
+    const updatedToggle = container.querySelector<HTMLButtonElement>(
+      '[data-agent-item-id="stable-output-card"] .ch-agent-card__toggle'
+    );
+    expect(updatedToggle).toBe(toggle);
+    expect(updatedToggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(
+      container.querySelector(
+        '[data-agent-item-id="stable-output-card"] .ch-agent-card__body'
+      )?.textContent
+    ).toContain('build complete');
+    expect(container.textContent).not.toContain('building…');
+  });
+
+  it('opens a new session at newest without a smooth transition when its item count matches', async () => {
     const scrollSpy = vi
       .spyOn(Element.prototype, 'scrollIntoView')
       .mockImplementation(() => {});
@@ -769,9 +828,116 @@ describe('chat v2 rendering against chat.html primitives', () => {
       await renderChat('session-b');
 
       expect(timeline?.scrollTop).toBe(1_000);
-      expect(scrollSpy).toHaveBeenCalled();
+      expect(scrollSpy).not.toHaveBeenCalled();
     } finally {
       scrollSpy.mockRestore();
+    }
+  });
+
+  it('preserves the first-visible reader anchor when a toggled card is above the viewport', async () => {
+    class ResizeObserverStub {
+      static instances: ResizeObserverStub[] = [];
+      callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        ResizeObserverStub.instances.push(this);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      trigger() {
+        this.callback([], this as unknown as ResizeObserver);
+      }
+    }
+    ResizeObserverStub.instances = [];
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+    const rect = (top: number, bottom: number): DOMRect =>
+      ({
+        x: 0,
+        y: top,
+        top,
+        bottom,
+        left: 0,
+        right: 600,
+        width: 600,
+        height: bottom - top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    try {
+      mocks.session = makeSession({
+        turns: [
+          {
+            id: 'turn-anchor-reflow',
+            status: 'completed',
+            inputMessageId: 'offscreen-card',
+            startedAt: timestamp(),
+            completedAt: timestamp(100),
+            items: [
+              {
+                id: 'offscreen-card',
+                type: 'commandExecution',
+                command: 'npm test',
+                output: 'expanded output',
+                status: 'completed',
+              },
+              {
+                id: 'reader-anchor',
+                type: 'assistantMessage',
+                text: 'reader focal row',
+                status: 'completed',
+              },
+            ],
+          },
+        ],
+      });
+      await renderChat();
+
+      const timeline = container.querySelector<HTMLElement>('.tl')!;
+      const offscreenCard = container.querySelector<HTMLElement>(
+        '[data-agent-item-id="offscreen-card"]'
+      )!;
+      const readerAnchor = container.querySelector<HTMLElement>(
+        '[data-agent-item-id="reader-anchor"]'
+      )!;
+      const toggle = offscreenCard.querySelector<HTMLButtonElement>(
+        '.ch-agent-card__toggle'
+      )!;
+      const observer = ResizeObserverStub.instances.at(-1);
+      expect(observer).toBeTruthy();
+
+      Object.defineProperties(timeline, {
+        scrollHeight: { value: 1_000, configurable: true },
+        clientHeight: { value: 400, configurable: true },
+        scrollTop: { value: 600, configurable: true, writable: true },
+      });
+      vi.spyOn(timeline, 'getBoundingClientRect').mockImplementation(() =>
+        rect(0, 400)
+      );
+      vi.spyOn(offscreenCard, 'getBoundingClientRect').mockImplementation(() =>
+        rect(-100, -60)
+      );
+      let readerTop = 20;
+      vi.spyOn(readerAnchor, 'getBoundingClientRect').mockImplementation(() =>
+        rect(readerTop, readerTop + 30)
+      );
+
+      await act(async () => {
+        timeline.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      timeline.scrollTop = 50;
+      await act(async () => {
+        timeline.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+
+      await act(async () => toggle.click());
+      readerTop = 340;
+      await act(async () => observer?.trigger());
+
+      expect(timeline.scrollTop).toBe(370);
+    } finally {
+      vi.unstubAllGlobals();
     }
   });
 
@@ -822,7 +988,8 @@ describe('chat v2 rendering against chat.html primitives', () => {
       await act(async () => {
         observerInstance?.trigger();
       });
-      expect(scrollSpy).toHaveBeenCalled();
+      expect(timeline.scrollTop).toBe(1_000);
+      expect(scrollSpy).not.toHaveBeenCalled();
 
       // Reader scrolled up to read history — a resize (more streamed
       // content) must not yank them back down.
@@ -839,6 +1006,40 @@ describe('chat v2 rendering against chat.html primitives', () => {
         observerInstance?.trigger();
       });
       expect(scrollSpy).not.toHaveBeenCalled();
+      expect(timeline.scrollTop).toBe(50);
+      const jump =
+        container.querySelector<HTMLButtonElement>('.tl-jump-latest');
+      expect(jump).toBeTruthy();
+      await act(async () => jump?.click());
+      expect(timeline.scrollTop).toBe(1_000);
+      expect(container.querySelector('.tl-jump-latest')).toBeNull();
+
+      // A browser may report programmatic-scroll frames after the assignment.
+      // Compare them with the old top: a downward frame far from the bottom
+      // must keep follow engaged and must not resurrect the jump affordance.
+      timeline.scrollTop = 300;
+      await act(async () => {
+        timeline.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      expect(container.querySelector('.tl-jump-latest')).toBeNull();
+
+      timeline.scrollTop = 600;
+      await act(async () => {
+        timeline.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      expect(container.querySelector('.tl-jump-latest')).toBeNull();
+      await act(async () => {
+        observerInstance?.trigger();
+      });
+      expect(timeline.scrollTop).toBe(1_000);
+
+      // Once the guarded scroll reaches bottom, a real upward gesture must
+      // disengage follow even though it remains inside the near-bottom band.
+      timeline.scrollTop = 550;
+      await act(async () => {
+        timeline.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      expect(container.querySelector('.tl-jump-latest')).toBeTruthy();
     } finally {
       scrollSpy.mockRestore();
       vi.unstubAllGlobals();

--- a/test/e2e/agent-detail-rows.spec.ts
+++ b/test/e2e/agent-detail-rows.spec.ts
@@ -7,9 +7,12 @@ const fixtures = [claudeFixture, codexFixture, hermesFixture] as const;
 
 async function openFixture(
   page: Page,
-  provider: (typeof fixtures)[number]['provider']
+  provider: (typeof fixtures)[number]['provider'],
+  layout: 'default' | 'card-near-bottom' = 'default'
 ): Promise<Locator> {
-  await page.goto(`/test-agent-detail-rows.html?provider=${provider}`);
+  await page.goto(
+    `/test-agent-detail-rows.html?provider=${provider}&layout=${layout}`
+  );
   await expect(
     page.locator(`[data-fixture-provider="${provider}"]`)
   ).toBeVisible();
@@ -208,5 +211,43 @@ test.describe('smoke agent detail timeline identity (#1198)', () => {
     await expect(
       timeline.locator('[data-agent-item-id="claude-anchor-12"]')
     ).toHaveCount(0);
+  });
+
+  test('a near-bottom card toggle stays anchored and exposes jump-to-latest', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page, 'codex', 'card-near-bottom');
+    const diff = card(timeline, 'diff');
+    const toggle = diff.locator('.ch-agent-card__toggle');
+    await expect(toggle).toBeInViewport();
+    const before = await toggle.boundingBox();
+    if (!before) throw new Error('missing card toggle geometry');
+
+    await toggle.click();
+
+    await expect(diff.locator('.ch-agent-card__body')).toBeVisible();
+    const after = await toggle.boundingBox();
+    if (!after) throw new Error('missing expanded card toggle geometry');
+    expect(after.y).toBeCloseTo(before.y, 0);
+    await expect(
+      page.getByRole('button', { name: 'jump to latest' })
+    ).toBeVisible();
+    await expect.poll(() => bottomDistance(timeline)).toBeGreaterThan(1);
+
+    await page.getByRole('button', { name: 'jump to latest' }).click();
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+
+  test('mobile keeps diff magnitude visible in the collapsed summary', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 720 });
+    const timeline = await openFixture(page, 'claude');
+    await expect(
+      card(timeline, 'diff').locator('.ch-agent-card__size')
+    ).toBeVisible();
+    await expect(
+      card(timeline, 'diff').locator('.ch-agent-card__size')
+    ).toHaveText('+250 -250');
   });
 });

--- a/test/e2e/agent-detail-rows.spec.ts
+++ b/test/e2e/agent-detail-rows.spec.ts
@@ -1,0 +1,212 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import claudeFixture from '../fixtures/agent-detail/claude.js';
+import codexFixture from '../fixtures/agent-detail/codex.js';
+import hermesFixture from '../fixtures/agent-detail/hermes.js';
+
+const fixtures = [claudeFixture, codexFixture, hermesFixture] as const;
+
+async function openFixture(
+  page: Page,
+  provider: (typeof fixtures)[number]['provider']
+): Promise<Locator> {
+  await page.goto(`/test-agent-detail-rows.html?provider=${provider}`);
+  await expect(
+    page.locator(`[data-fixture-provider="${provider}"]`)
+  ).toBeVisible();
+  const timeline = page.getByRole('log', { name: 'agent detail timeline' });
+  await expect(timeline).toBeVisible();
+  await expect(timeline.locator('.ch-agent-card')).toHaveCount(3);
+  return timeline;
+}
+
+function card(timeline: Locator, kind: 'thought' | 'output' | 'diff'): Locator {
+  return timeline.locator(`.ch-agent-card[data-agent-card-kind="${kind}"]`);
+}
+
+async function bottomDistance(timeline: Locator): Promise<number> {
+  return timeline.evaluate(
+    (element) => element.scrollHeight - element.scrollTop - element.clientHeight
+  );
+}
+
+async function firstVisibleItem(
+  timeline: Locator
+): Promise<{ itemId: string; top: number }> {
+  return timeline.evaluate((element) => {
+    const containerTop = element.getBoundingClientRect().top;
+    const item = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-agent-item-id]')
+    ).find(
+      (candidate) => candidate.getBoundingClientRect().bottom >= containerTop
+    );
+    if (!item?.dataset.agentItemId) {
+      throw new Error('missing first-visible agent item');
+    }
+    return {
+      itemId: item.dataset.agentItemId,
+      top: item.getBoundingClientRect().top - containerTop,
+    };
+  });
+}
+
+for (const fixture of fixtures) {
+  test.describe(`smoke ${fixture.provider} agent detail rows (#1198)`, () => {
+    test('thought content starts collapsed and toggles without an empty row', async ({
+      page,
+    }) => {
+      const timeline = await openFixture(page, fixture.provider);
+      const thought = card(timeline, 'thought');
+      const toggle = thought.locator('.ch-agent-card__toggle');
+
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(thought.locator('.ch-agent-card__body')).toHaveCount(0);
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      await expect(thought.locator('.ch-agent-card__body')).toContainText(
+        fixture.assertions.thoughtContent
+      );
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(thought.locator('.ch-agent-card__body')).toHaveCount(0);
+    });
+
+    test('500 changed lines stay one-line collapsed and expand inside a bounded scroller', async ({
+      page,
+    }) => {
+      const timeline = await openFixture(page, fixture.provider);
+      const diff = card(timeline, 'diff');
+      const toggle = diff.locator('.ch-agent-card__toggle');
+      const collapsedHeight = await diff.evaluate(
+        (element) => element.getBoundingClientRect().height
+      );
+
+      expect(collapsedHeight).toBeLessThanOrEqual(40);
+      await expect(toggle).toContainText('+250 -250');
+      await expect(toggle).toContainText(fixture.assertions.diffPath);
+      await toggle.click();
+
+      const body = diff.locator('.ch-agent-card__body');
+      await expect(body).toBeVisible();
+      await expect(
+        body.locator(
+          '.ch-agent-card__line--added, .ch-agent-card__line--removed'
+        )
+      ).toHaveCount(fixture.assertions.changedLineCount);
+      const geometry = await body.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          clientHeight: element.clientHeight,
+          scrollHeight: element.scrollHeight,
+          overflowY: style.overflowY,
+        };
+      });
+      expect(geometry.clientHeight).toBeLessThan(geometry.scrollHeight);
+      expect(['auto', 'scroll']).toContain(geometry.overflowY);
+
+      await body.evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+      });
+      await expect
+        .poll(() => body.evaluate((element) => element.scrollTop))
+        .toBeGreaterThan(0);
+    });
+
+    test('diff tints and lazy syntax tokens are visible after expansion', async ({
+      page,
+    }) => {
+      const timeline = await openFixture(page, fixture.provider);
+      const diff = card(timeline, 'diff');
+      await diff.locator('.ch-agent-card__toggle').click();
+
+      const added = diff.locator('.ch-agent-card__line--added').first();
+      const removed = diff.locator('.ch-agent-card__line--removed').first();
+      await expect(added).toBeVisible();
+      await expect(removed).toBeVisible();
+      const [addedTint, removedTint] = await Promise.all([
+        added.evaluate((element) => getComputedStyle(element).backgroundColor),
+        removed.evaluate(
+          (element) => getComputedStyle(element).backgroundColor
+        ),
+      ]);
+      expect(addedTint).not.toBe('rgba(0, 0, 0, 0)');
+      expect(removedTint).not.toBe('rgba(0, 0, 0, 0)');
+      expect(addedTint).not.toBe(removedTint);
+
+      const output = card(timeline, 'output');
+      await output.locator('.ch-agent-card__toggle').click();
+      await expect
+        .poll(() =>
+          output.locator('.ch-agent-card__line span[style*="color"]').count()
+        )
+        .toBeGreaterThan(0);
+    });
+
+    test('expanding a card above the reader preserves the first-visible item anchor', async ({
+      page,
+    }) => {
+      const timeline = await openFixture(page, fixture.provider);
+      const requestedAnchor = timeline.locator(
+        `[data-agent-item-id="${fixture.provider}-anchor-20"]`
+      );
+      await requestedAnchor.scrollIntoViewIfNeeded();
+      await timeline.evaluate((element) => {
+        element.dispatchEvent(new Event('scroll'));
+      });
+      await expect.poll(() => bottomDistance(timeline)).toBeGreaterThan(100);
+      const anchor = await firstVisibleItem(timeline);
+
+      // A Playwright click would scroll the off-screen card into view first,
+      // masking the production reflow behavior. Dispatch a DOM click so only
+      // the card expansion changes geometry.
+      await card(timeline, 'diff')
+        .locator('.ch-agent-card__toggle')
+        .evaluate((element) => (element as HTMLButtonElement).click());
+      await expect(
+        card(timeline, 'diff').locator('.ch-agent-card__body')
+      ).toBeAttached();
+
+      const anchoredItem = timeline.locator(
+        `[data-agent-item-id="${anchor.itemId}"]`
+      );
+      await expect
+        .poll(async () => {
+          const containerBox = await timeline.boundingBox();
+          const itemBox = await anchoredItem.boundingBox();
+          if (!containerBox || !itemBox) {
+            throw new Error('missing anchor geometry');
+          }
+          return itemBox.y - containerBox.y;
+        })
+        .toBeCloseTo(anchor.top, 0);
+      await expect.poll(() => bottomDistance(timeline)).toBeGreaterThan(100);
+    });
+  });
+}
+
+test.describe('smoke agent detail timeline identity (#1198)', () => {
+  test('switching equal-length sessions resets follow intent to the newest row', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page, 'claude');
+    await timeline
+      .locator('[data-agent-item-id="claude-anchor-12"]')
+      .scrollIntoViewIfNeeded();
+    await timeline.evaluate((element) => {
+      element.dispatchEvent(new Event('scroll'));
+    });
+    await expect.poll(() => bottomDistance(timeline)).toBeGreaterThan(100);
+
+    await page.getByRole('button', { name: 'show hermes fixture' }).click();
+    await expect(
+      page.locator('[data-fixture-provider="hermes"]')
+    ).toBeVisible();
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+    await expect(
+      timeline.locator('[data-agent-item-id="hermes-anchor-48"]')
+    ).toBeAttached();
+    await expect(
+      timeline.locator('[data-agent-item-id="claude-anchor-12"]')
+    ).toHaveCount(0);
+  });
+});

--- a/test/fixtures/agent-detail/claude.ts
+++ b/test/fixtures/agent-detail/claude.ts
@@ -86,7 +86,7 @@ const fixture = {
     outputTitle: 'node scripts/synthetic-check.mjs',
     outputContent: commandOutput,
     outputLanguage: 'bash',
-    diffItemType: 'fileChange',
+    applyStatus: 'applied',
   }),
   assertions: {
     thoughtContent,

--- a/test/fixtures/agent-detail/claude.ts
+++ b/test/fixtures/agent-detail/claude.ts
@@ -1,0 +1,98 @@
+import {
+  fixtureSanitization,
+  makeFixtureSession,
+  SANITIZED_FIXTURE_LINE_COUNT,
+  SANITIZED_FIXTURE_PATH,
+  sanitizedLargeDiff,
+  type SanitizedAgentDetailFixture,
+} from './types.js';
+
+const thoughtContent =
+  'Claude synthetic thought: inspect the adapter boundary before editing.';
+const commandOutput =
+  'export function syntheticClaudeValue(): number {\n  return 42;\n}';
+const patch = sanitizedLargeDiff();
+
+const fixture = {
+  schemaVersion: 1,
+  provider: 'claude',
+  sanitization: fixtureSanitization(),
+  nativeEvents: [
+    {
+      type: 'system',
+      subtype: 'init',
+      session_id: '00000000-0000-4000-8000-000000001198',
+    },
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg_synthetic_claude_1198',
+        content: [
+          { type: 'thinking', thinking: thoughtContent },
+          {
+            type: 'tool_use',
+            id: 'tool_synthetic_claude_command',
+            name: 'Bash',
+            input: { command: 'node scripts/synthetic-check.mjs' },
+          },
+          {
+            type: 'tool_use',
+            id: 'tool_synthetic_claude_edit',
+            name: 'Edit',
+            input: {
+              file_path: SANITIZED_FIXTURE_PATH,
+              old_string: 'synthetic old text',
+              new_string: 'synthetic new text',
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool_synthetic_claude_command',
+            content: commandOutput,
+          },
+        ],
+      },
+      tool_use_result: { stdout: commandOutput, stderr: '' },
+    },
+    {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool_synthetic_claude_edit',
+            content: patch,
+          },
+        ],
+      },
+      tool_use_result: {
+        filePath: SANITIZED_FIXTURE_PATH,
+        gitDiff: { patch },
+      },
+    },
+  ],
+  session: makeFixtureSession({
+    provider: 'claude',
+    thoughtContent,
+    outputTitle: 'node scripts/synthetic-check.mjs',
+    outputContent: commandOutput,
+    outputLanguage: 'bash',
+    diffItemType: 'fileChange',
+  }),
+  assertions: {
+    thoughtContent,
+    diffPath: SANITIZED_FIXTURE_PATH,
+    changedLineCount: SANITIZED_FIXTURE_LINE_COUNT,
+  },
+} satisfies SanitizedAgentDetailFixture;
+
+export default fixture;

--- a/test/fixtures/agent-detail/codex.ts
+++ b/test/fixtures/agent-detail/codex.ts
@@ -1,0 +1,133 @@
+import {
+  fixtureSanitization,
+  makeFixtureSession,
+  SANITIZED_FIXTURE_LINE_COUNT,
+  SANITIZED_FIXTURE_PATH,
+  sanitizedLargeDiff,
+  type SanitizedAgentDetailFixture,
+} from './types.js';
+
+const thoughtContent =
+  'Codex synthetic thought: verify the reducer contract before applying the patch.';
+const commandOutput =
+  'export const syntheticCodexValue = {\n  ready: true,\n};';
+const patch = sanitizedLargeDiff();
+
+const fixture = {
+  schemaVersion: 1,
+  provider: 'codex',
+  sanitization: fixtureSanitization(),
+  nativeEvents: [
+    {
+      method: 'item/started',
+      params: { item: { type: 'reasoning', id: 'reason_synthetic_codex' } },
+    },
+    {
+      method: 'item/reasoning/summaryTextDelta',
+      params: {
+        itemId: 'reason_synthetic_codex',
+        delta: thoughtContent,
+        summaryIndex: 0,
+      },
+    },
+    {
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'reasoning',
+          id: 'reason_synthetic_codex',
+          summary: [{ type: 'summary_text', text: thoughtContent }],
+        },
+      },
+    },
+    {
+      method: 'item/started',
+      params: {
+        item: {
+          type: 'commandExecution',
+          id: 'command_synthetic_codex',
+          command: 'node scripts/synthetic-check.mjs',
+          cwd: '/workspace/example',
+        },
+      },
+    },
+    {
+      method: 'item/commandExecution/outputDelta',
+      params: { itemId: 'command_synthetic_codex', delta: commandOutput },
+    },
+    {
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'commandExecution',
+          id: 'command_synthetic_codex',
+          command: 'node scripts/synthetic-check.mjs',
+          cwd: '/workspace/example',
+          aggregatedOutput: commandOutput,
+          exitCode: 0,
+        },
+      },
+    },
+    {
+      method: 'item/started',
+      params: {
+        item: {
+          type: 'fileChange',
+          id: 'file_synthetic_codex',
+          changes: [
+            {
+              path: SANITIZED_FIXTURE_PATH,
+              kind: { type: 'update' },
+              diff: '',
+            },
+          ],
+        },
+      },
+    },
+    {
+      method: 'item/fileChange/patchUpdated',
+      params: {
+        itemId: 'file_synthetic_codex',
+        changes: [
+          {
+            path: SANITIZED_FIXTURE_PATH,
+            kind: { type: 'update' },
+            diff: patch,
+          },
+        ],
+      },
+    },
+    {
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'fileChange',
+          id: 'file_synthetic_codex',
+          changes: [
+            {
+              path: SANITIZED_FIXTURE_PATH,
+              kind: { type: 'update' },
+              diff: patch,
+            },
+          ],
+          applyStatus: 'applied',
+        },
+      },
+    },
+  ],
+  session: makeFixtureSession({
+    provider: 'codex',
+    thoughtContent,
+    outputTitle: 'node scripts/synthetic-check.mjs',
+    outputContent: commandOutput,
+    outputLanguage: 'bash',
+    diffItemType: 'fileChange',
+  }),
+  assertions: {
+    thoughtContent,
+    diffPath: SANITIZED_FIXTURE_PATH,
+    changedLineCount: SANITIZED_FIXTURE_LINE_COUNT,
+  },
+} satisfies SanitizedAgentDetailFixture;
+
+export default fixture;

--- a/test/fixtures/agent-detail/codex.ts
+++ b/test/fixtures/agent-detail/codex.ts
@@ -121,7 +121,7 @@ const fixture = {
     outputTitle: 'node scripts/synthetic-check.mjs',
     outputContent: commandOutput,
     outputLanguage: 'bash',
-    diffItemType: 'fileChange',
+    applyStatus: 'applied',
   }),
   assertions: {
     thoughtContent,

--- a/test/fixtures/agent-detail/hermes.ts
+++ b/test/fixtures/agent-detail/hermes.ts
@@ -78,7 +78,6 @@ const fixture = {
     outputTitle: 'node scripts/synthetic-check.mjs',
     outputContent: commandOutput,
     outputLanguage: 'bash',
-    diffItemType: 'fileChange',
   }),
   assertions: {
     thoughtContent,

--- a/test/fixtures/agent-detail/hermes.ts
+++ b/test/fixtures/agent-detail/hermes.ts
@@ -1,0 +1,90 @@
+import {
+  fixtureSanitization,
+  makeFixtureSession,
+  SANITIZED_FIXTURE_LINE_COUNT,
+  SANITIZED_FIXTURE_PATH,
+  sanitizedLargeDiff,
+  type SanitizedAgentDetailFixture,
+} from './types.js';
+
+const thoughtContent =
+  'Hermes synthetic thought: inspect the tool event before returning output.';
+const commandOutput =
+  'export interface SyntheticHermesValue {\n  ready: boolean;\n}';
+const patch = sanitizedLargeDiff();
+
+const fixture = {
+  schemaVersion: 1,
+  provider: 'hermes',
+  sanitization: fixtureSanitization(),
+  nativeEvents: [
+    { type: 'response.created', response: { id: 'resp_synthetic_hermes' } },
+    {
+      type: 'response.reasoning_summary_text.delta',
+      delta: thoughtContent,
+    },
+    {
+      type: 'response.reasoning_summary_text.done',
+      text: thoughtContent,
+    },
+    {
+      type: 'response.output_item.added',
+      item: {
+        id: 'item_synthetic_hermes_command',
+        type: 'function_call',
+        call_id: 'call_synthetic_hermes_command',
+        name: 'run_command',
+        arguments: '{"command":"node scripts/synthetic-check.mjs"}',
+      },
+    },
+    {
+      type: 'response.output_item.added',
+      item: {
+        id: 'item_synthetic_hermes_patch',
+        type: 'function_call',
+        call_id: 'call_synthetic_hermes_patch',
+        name: 'apply_patch',
+        arguments: `{"path":"${SANITIZED_FIXTURE_PATH}"}`,
+      },
+    },
+    {
+      type: 'response.output_item.done',
+      item: {
+        id: 'item_synthetic_hermes_command',
+        type: 'function_call',
+        call_id: 'call_synthetic_hermes_command',
+        name: 'run_command',
+        arguments: '{"command":"node scripts/synthetic-check.mjs"}',
+        status: 'completed',
+        output: commandOutput,
+      },
+    },
+    {
+      type: 'response.output_item.done',
+      item: {
+        id: 'item_synthetic_hermes_patch',
+        type: 'function_call',
+        call_id: 'call_synthetic_hermes_patch',
+        name: 'apply_patch',
+        arguments: `{"path":"${SANITIZED_FIXTURE_PATH}"}`,
+        status: 'completed',
+        output: patch,
+      },
+    },
+  ],
+  session: makeFixtureSession({
+    provider: 'hermes',
+    thoughtContent,
+    outputTitle: 'node scripts/synthetic-check.mjs',
+    outputContent: commandOutput,
+    outputLanguage: 'bash',
+    diffItemType: 'fileChange',
+  }),
+  assertions: {
+    thoughtContent,
+    diffPath: SANITIZED_FIXTURE_PATH,
+    changedLineCount: SANITIZED_FIXTURE_LINE_COUNT,
+  },
+} satisfies SanitizedAgentDetailFixture;
+
+export default fixture;

--- a/test/fixtures/agent-detail/types.ts
+++ b/test/fixtures/agent-detail/types.ts
@@ -56,7 +56,7 @@ interface FixtureSessionInput {
   outputTitle: string;
   outputContent: string;
   outputLanguage: string;
-  diffItemType: 'fileChange' | 'dynamicToolCall';
+  applyStatus?: 'applied';
 }
 
 function bytes(value: string): number {
@@ -151,29 +151,16 @@ export function makeFixtureSession(input: FixtureSessionInput): AgentSessionV2 {
               sizeBytes: bytes(input.outputContent),
             },
           },
-          input.diffItemType === 'fileChange'
-            ? {
-                id: diffId,
-                providerItemId: `synthetic-${diffId}`,
-                type: 'fileChange',
-                status: 'completed',
-                paths: [{ path: SANITIZED_FIXTURE_PATH, status: 'update' }],
-                patch,
-                applyStatus: 'applied',
-                card: diffCard,
-              }
-            : {
-                id: diffId,
-                providerItemId: `synthetic-${diffId}`,
-                type: 'dynamicToolCall',
-                status: 'completed',
-                namespace: 'fixture',
-                tool: 'apply_patch',
-                content: patch,
-                result: { status: 'completed' },
-                metadata: { contentKind: 'diff' },
-                card: diffCard,
-              },
+          {
+            id: diffId,
+            providerItemId: `synthetic-${diffId}`,
+            type: 'fileChange',
+            status: 'completed',
+            paths: [{ path: SANITIZED_FIXTURE_PATH, status: 'update' }],
+            patch,
+            ...(input.applyStatus ? { applyStatus: input.applyStatus } : {}),
+            card: diffCard,
+          },
         ],
       },
     ],

--- a/test/fixtures/agent-detail/types.ts
+++ b/test/fixtures/agent-detail/types.ts
@@ -1,0 +1,190 @@
+import type {
+  AgentDetailCardV2,
+  AgentProviderV2,
+  AgentSessionV2,
+} from '../../../shared/agent-chat-protocol-v2.js';
+
+export const SANITIZED_FIXTURE_PATH = '/workspace/example/src/widget.ts';
+export const SANITIZED_FIXTURE_LINE_COUNT = 500;
+
+/**
+ * A deliberately synthetic 500-line edit. The surrounding provider event
+ * envelopes mirror real adapter transcripts, but every byte below was written
+ * for this public fixture: no live prompts, paths, ids, output, or account data.
+ */
+export function sanitizedLargeDiff(): string {
+  const removed = Array.from(
+    { length: SANITIZED_FIXTURE_LINE_COUNT / 2 },
+    (_, index) => `-export const oldValue${index + 1} = ${index + 1};`
+  );
+  const added = Array.from(
+    { length: SANITIZED_FIXTURE_LINE_COUNT / 2 },
+    (_, index) => `+export const newValue${index + 1} = ${index + 1};`
+  );
+  return [
+    `--- a${SANITIZED_FIXTURE_PATH}`,
+    `+++ b${SANITIZED_FIXTURE_PATH}`,
+    '@@ -1,250 +1,250 @@',
+    ...removed,
+    ...added,
+  ].join('\n');
+}
+
+export interface SanitizedAgentDetailFixture {
+  schemaVersion: 1;
+  provider: Extract<AgentProviderV2, 'claude' | 'codex' | 'hermes'>;
+  sanitization: {
+    method: 'hand-sanitized-structural-replay';
+    containsLiveTranscriptBytes: false;
+    syntheticIds: true;
+    syntheticPath: typeof SANITIZED_FIXTURE_PATH;
+  };
+  /** Structurally faithful provider envelopes consumed by adapter tests. */
+  nativeEvents: readonly Record<string, unknown>[];
+  /** Adapter-normalized state consumed directly by the renderer harness. */
+  session: AgentSessionV2;
+  assertions: {
+    thoughtContent: string;
+    diffPath: typeof SANITIZED_FIXTURE_PATH;
+    changedLineCount: typeof SANITIZED_FIXTURE_LINE_COUNT;
+  };
+}
+
+interface FixtureSessionInput {
+  provider: SanitizedAgentDetailFixture['provider'];
+  thoughtContent: string;
+  outputTitle: string;
+  outputContent: string;
+  outputLanguage: string;
+  diffItemType: 'fileChange' | 'dynamicToolCall';
+}
+
+function bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function card(input: AgentDetailCardV2): AgentDetailCardV2 {
+  return input;
+}
+
+export function makeFixtureSession(input: FixtureSessionInput): AgentSessionV2 {
+  const provider = input.provider;
+  const thoughtId = `${provider}-thought`;
+  const outputId = `${provider}-output`;
+  const diffId = `${provider}-diff`;
+  const patch = sanitizedLargeDiff();
+  const diffCard = card({
+    kind: 'diff',
+    title: SANITIZED_FIXTURE_PATH,
+    status: 'completed',
+    content: patch,
+    language: 'diff',
+    path: SANITIZED_FIXTURE_PATH,
+    additions: SANITIZED_FIXTURE_LINE_COUNT / 2,
+    deletions: SANITIZED_FIXTURE_LINE_COUNT / 2,
+    sizeBytes: bytes(patch),
+  });
+
+  return {
+    id: `fixture-${provider}`,
+    provider,
+    providerSession: { sessionId: `synthetic-${provider}-session` },
+    capabilities: {
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+    },
+    config: { cwd: '/workspace/example', model: `synthetic-${provider}-model` },
+    live: {
+      status: 'idle',
+      activeTurnId: null,
+      waitingOn: null,
+      activeRequestIds: [],
+      proposedPlanItemId: null,
+      queueLength: 0,
+      fastModeAvailable: false,
+      error: null,
+    },
+    turns: [
+      {
+        id: `turn-${provider}`,
+        providerTurnId: `synthetic-${provider}-turn`,
+        status: 'completed',
+        inputMessageId: `input-${provider}`,
+        startedAt: '2026-07-19T00:00:00.000Z',
+        completedAt: '2026-07-19T00:00:01.000Z',
+        items: [
+          {
+            id: thoughtId,
+            providerItemId: `synthetic-${thoughtId}`,
+            type: 'reasoning',
+            status: 'completed',
+            summary: input.thoughtContent,
+            detail: input.thoughtContent,
+            visibility: 'summary',
+            card: {
+              kind: 'thought',
+              title: input.thoughtContent,
+              status: 'completed',
+              content: input.thoughtContent,
+              sizeBytes: bytes(input.thoughtContent),
+            },
+          },
+          {
+            id: outputId,
+            providerItemId: `synthetic-${outputId}`,
+            type: 'commandExecution',
+            status: 'completed',
+            command: input.outputTitle,
+            cwd: '/workspace/example',
+            output: input.outputContent,
+            exitCode: 0,
+            card: {
+              kind: 'output',
+              title: input.outputTitle,
+              status: 'completed',
+              content: input.outputContent,
+              language: input.outputLanguage,
+              command: input.outputTitle,
+              sizeBytes: bytes(input.outputContent),
+            },
+          },
+          input.diffItemType === 'fileChange'
+            ? {
+                id: diffId,
+                providerItemId: `synthetic-${diffId}`,
+                type: 'fileChange',
+                status: 'completed',
+                paths: [{ path: SANITIZED_FIXTURE_PATH, status: 'update' }],
+                patch,
+                applyStatus: 'applied',
+                card: diffCard,
+              }
+            : {
+                id: diffId,
+                providerItemId: `synthetic-${diffId}`,
+                type: 'dynamicToolCall',
+                status: 'completed',
+                namespace: 'fixture',
+                tool: 'apply_patch',
+                content: patch,
+                result: { status: 'completed' },
+                metadata: { contentKind: 'diff' },
+                card: diffCard,
+              },
+        ],
+      },
+    ],
+  };
+}
+
+export function fixtureSanitization(): SanitizedAgentDetailFixture['sanitization'] {
+  return {
+    method: 'hand-sanitized-structural-replay',
+    containsLiveTranscriptBytes: false,
+    syntheticIds: true,
+    syntheticPath: SANITIZED_FIXTURE_PATH,
+  };
+}

--- a/test/frontend-vite-shiki-gate.test.ts
+++ b/test/frontend-vite-shiki-gate.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  shikiLazyChunkViolation,
+  type ShikiChunkGraphNode,
+} from '../frontend/src/lib/shiki-lazy-chunk-gate.js';
+
+const SHIKI_MODULE = '/repo/node_modules/shiki/dist/index.mjs';
+
+function chunk(
+  fileName: string,
+  overrides: Partial<ShikiChunkGraphNode> = {}
+): ShikiChunkGraphNode {
+  return {
+    fileName,
+    isEntry: false,
+    imports: [],
+    dynamicImports: [],
+    moduleIds: [`/repo/frontend/${fileName}.ts`],
+    ...overrides,
+  };
+}
+
+describe('frontend Shiki lazy-chunk build gate', () => {
+  it('rejects Shiki hidden behind transitive static imports from an entry', () => {
+    const violation = shikiLazyChunkViolation([
+      chunk('entry.js', { isEntry: true, imports: ['shared.js'] }),
+      chunk('shared.js', { imports: ['syntax.js'] }),
+      chunk('syntax.js', { moduleIds: [SHIKI_MODULE] }),
+    ]);
+
+    expect(violation).toContain('entry static graph includes');
+  });
+
+  it('accepts Shiki reached only after a dynamic-import edge', () => {
+    const violation = shikiLazyChunkViolation([
+      chunk('entry.js', {
+        isEntry: true,
+        dynamicImports: ['syntax-loader.js'],
+      }),
+      chunk('syntax-loader.js', { imports: ['syntax.js'] }),
+      chunk('syntax.js', { moduleIds: [SHIKI_MODULE] }),
+    ]);
+
+    expect(violation).toBeNull();
+  });
+
+  it('rejects an emitted Shiki chunk outside every entry dynamic graph', () => {
+    const violation = shikiLazyChunkViolation([
+      chunk('entry.js', { isEntry: true }),
+      chunk('orphan-syntax.js', { moduleIds: [SHIKI_MODULE] }),
+    ]);
+
+    expect(violation).toContain('not reachable through a dynamic import');
+  });
+});

--- a/test/hooks/useShikiHighlight.test.ts
+++ b/test/hooks/useShikiHighlight.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const shikiMocks = vi.hoisted(() => ({
+  tokenizeCode: vi.fn(async (code: string) => [
+    [{ content: code, color: '#e0e0e0' }],
+  ]),
+}));
+
+vi.mock('../../frontend/src/lib/shiki.js', () => ({
+  tokenizeCode: shikiMocks.tokenizeCode,
+}));
+
+const [{ useShikiHighlight }, { useShikiGcStore }] = await Promise.all([
+  import('../../frontend/src/hooks/useShikiHighlight.js'),
+  import('../../frontend/src/lib/stores/shiki-gc.js'),
+]);
+
+function Harness({
+  code,
+  language = 'typescript',
+}: {
+  code: string;
+  language?: string;
+}): React.ReactElement {
+  const { tokens } = useShikiHighlight('stable-code-card', code, language);
+  return React.createElement(
+    'div',
+    null,
+    tokens?.flatMap((line) => line.map((token) => token.content)).join('') ??
+      `plain:${code}`
+  );
+}
+
+describe('useShikiHighlight current-source fence', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    shikiMocks.tokenizeCode.mockClear();
+    shikiMocks.tokenizeCode.mockImplementation(async (code: string) => [
+      [{ content: code, color: '#e0e0e0' }],
+    ]);
+    useShikiGcStore.setState({ entries: new Map() });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('never renders token text cached for the previous source', async () => {
+    await act(async () => {
+      root.render(React.createElement(Harness, { code: 'old source' }));
+    });
+    expect(host.textContent).toBe('old source');
+
+    // Inspect the commit before passive effects can replace the cache entry.
+    // The new raw source must render immediately; old token bytes must not.
+    act(() => {
+      flushSync(() => {
+        root.render(React.createElement(Harness, { code: 'new source' }));
+      });
+      expect(host.textContent).toBe('plain:new source');
+    });
+
+    await act(async () => {});
+    expect(host.textContent).toBe('new source');
+
+    act(() => {
+      flushSync(() => {
+        root.render(
+          React.createElement(Harness, {
+            code: 'new source',
+            language: 'json',
+          })
+        );
+      });
+      expect(host.textContent).toBe('plain:new source');
+    });
+
+    await act(async () => {});
+    expect(host.textContent).toBe('new source');
+    expect(shikiMocks.tokenizeCode).toHaveBeenLastCalledWith(
+      'new source',
+      'json'
+    );
+  });
+
+  it('rejects an older unmounted instance resolving after a newer shared-cache writer', async () => {
+    const pending = new Map<
+      string,
+      (tokens: Array<Array<{ content: string; color: string }>>) => void
+    >();
+    shikiMocks.tokenizeCode.mockImplementation(
+      (code: string) =>
+        new Promise((resolve) => {
+          pending.set(code, (tokens) => {
+            pending.delete(code);
+            resolve(tokens);
+          });
+        })
+    );
+
+    const olderHost = document.createElement('div');
+    document.body.appendChild(olderHost);
+    const olderRoot = createRoot(olderHost);
+    let olderMounted = true;
+
+    try {
+      await act(async () => {
+        olderRoot.render(
+          React.createElement(Harness, { code: 'older source' })
+        );
+      });
+      act(() => olderRoot.unmount());
+      olderMounted = false;
+      olderHost.remove();
+      await act(async () => {
+        root.render(React.createElement(Harness, { code: 'newer source' }));
+      });
+
+      await act(async () => {
+        pending.get('newer source')?.([
+          [{ content: 'newer tokens', color: '#e0e0e0' }],
+        ]);
+        await Promise.resolve();
+      });
+      expect(host.textContent).toBe('newer tokens');
+
+      await act(async () => {
+        pending.get('older source')?.([
+          [{ content: 'stale older tokens', color: '#e0e0e0' }],
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(host.textContent).toBe('newer tokens');
+      expect(
+        useShikiGcStore.getState().entries.get('stable-code-card')
+          ?.highlightOutput
+      ).toEqual([[{ content: 'newer tokens', color: '#e0e0e0' }]]);
+      expect(pending.size).toBe(0);
+    } finally {
+      if (olderMounted) act(() => olderRoot.unmount());
+      olderHost.remove();
+      await act(async () => {
+        for (const settle of [...pending.values()]) settle([]);
+        await Promise.resolve();
+      });
+    }
+  });
+});

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -552,6 +552,80 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     await adapter.disconnect();
   });
 
+  it('maps a direct persistent-subprocess file patch into a populated diff card', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    const patches = collectPatches(adapter);
+    await adapter.connect(baseConfig());
+    await adapter.sendMessage({ turnId: 'turn-direct-patch', content: 'edit' });
+    const child = harness.latest().child;
+    await child.waitForFrames(1);
+    child.serverWrite({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-direct-patch',
+    });
+    child.serverWrite({
+      type: 'assistant',
+      message: {
+        id: 'message-direct-patch',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-direct-patch',
+            name: 'Edit',
+            input: { file_path: '/workspace/example/src/direct.ts' },
+          },
+        ],
+      },
+    });
+    const directPatch =
+      '--- a/src/direct.ts\n+++ b/src/direct.ts\n@@ -1 +1 @@\n-old\n+new\n';
+    child.serverWrite({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-direct-patch',
+            content: directPatch,
+          },
+        ],
+      },
+      tool_use_result: {
+        filePath: '/workspace/example/src/direct.ts',
+        patch: directPatch,
+      },
+    });
+    child.serverWrite(successResult());
+
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+    const file = patches.find(
+      (patch) =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'fileChange'
+    );
+    expect(file).toMatchObject({
+      item: {
+        id: 'file-tool-direct-patch',
+        patch: directPatch,
+        status: 'completed',
+        card: {
+          kind: 'diff',
+          path: '/workspace/example/src/direct.ts',
+          content: directPatch,
+          additions: 1,
+          deletions: 1,
+        },
+      },
+    });
+
+    await adapter.disconnect();
+  });
+
   it('replays the sanitized Claude detail fixture into normalized cards', async () => {
     const harness = makeHarness();
     const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../server/protocol-adapters/claude-adapter.js';
 import type { AdapterConfig } from '../../../server/protocol-adapter-v2.js';
 import type { ClaudeSpawnFn } from '../../../server/claude-stream-client.js';
+import claudeDetailFixture from '../../fixtures/agent-detail/claude.js';
 import {
   applyAgentPatchV2,
   emptyAgentSessionV2,
@@ -492,6 +493,50 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       ])
     );
 
+    const thought = patches.find(
+      (patch) =>
+        patch.type === 'agent-item-started-v2' &&
+        patch.item.type === 'reasoning'
+    );
+    expect(
+      thought?.type === 'agent-item-started-v2' && thought.item.card
+    ).toMatchObject({
+      kind: 'thought',
+      title: 'plan',
+      content: 'plan',
+      status: 'completed',
+    });
+
+    const command = patches.find(
+      (patch) =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'commandExecution'
+    );
+    expect(
+      command?.type === 'agent-item-updated-v2' && command.item.card
+    ).toMatchObject({
+      kind: 'output',
+      title: 'echo hi',
+      command: 'echo hi',
+      content: 'hi\n',
+      language: 'bash',
+      status: 'completed',
+    });
+
+    const file = patches.find(
+      (patch) =>
+        patch.type === 'agent-item-started-v2' &&
+        patch.item.type === 'fileChange'
+    );
+    expect(
+      file?.type === 'agent-item-started-v2' && file.item.card
+    ).toMatchObject({
+      kind: 'diff',
+      title: '/repo/a.ts',
+      path: '/repo/a.ts',
+      status: 'pending',
+    });
+
     const mcpUpdate = patches.find(
       (p) => p.type === 'agent-item-updated-v2' && p.item.type === 'mcpToolCall'
     );
@@ -503,6 +548,42 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       tool: 'create_issue',
       status: 'completed',
     });
+
+    await adapter.disconnect();
+  });
+
+  it('replays the sanitized Claude detail fixture into normalized cards', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    const patches = collectPatches(adapter);
+    await adapter.connect(baseConfig());
+    await adapter.sendMessage({ turnId: 'turn-fixture', content: 'fixture' });
+    const child = harness.latest().child;
+    await child.waitForFrames(1);
+
+    for (const event of claudeDetailFixture.nativeEvents) {
+      child.serverWrite(event);
+    }
+    child.serverWrite(successResult());
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const session = reduce(patches);
+    const cards = session.turns
+      .flatMap((turn) => turn.items)
+      .flatMap((item) =>
+        item.card && item.card.kind !== 'message' ? [item.card] : []
+      );
+    const expectedCards = claudeDetailFixture.session.turns
+      .flatMap((turn) => turn.items)
+      .flatMap((item) =>
+        item.card && item.card.kind !== 'message' ? [item.card] : []
+      );
+    expect(cards).toEqual(expectedCards);
+    expect(claudeDetailFixture.sanitization.containsLiveTranscriptBytes).toBe(
+      false
+    );
 
     await adapter.disconnect();
   });

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -130,6 +130,16 @@ function collectPatches(adapter: CodexNativeProtocolAdapter): AgentPatchV2[] {
   return patches;
 }
 
+function reducePatches(patches: AgentPatchV2[]) {
+  let session = emptyAgentSessionV2({
+    id: config.sessionId,
+    provider: 'codex',
+    cwd: config.cwd,
+  });
+  for (const patch of patches) session = applyAgentPatchV2(session, patch);
+  return session;
+}
+
 function retentionCounts(adapter: CodexNativeProtocolAdapter) {
   const state = adapter as unknown as {
     itemMap: Map<unknown, unknown>;
@@ -602,7 +612,7 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
     await adapter.disconnect();
   });
 
-  it('fileChange: patch delta then complete', async () => {
+  it('fileChange: cumulative patch updates replace the live body and counts', async () => {
     const { adapter, client, patches } = await setupAndSend('turn-file');
 
     // Authoritative FileUpdateChange shape: kind is tagged union { type: 'add'|'delete'|'update' }
@@ -614,16 +624,63 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
       },
     });
     // Authoritative item/fileChange/patchUpdated shape: { changes: FileUpdateChange[] }
+    const firstPatch =
+      '--- a/foo.ts\n+++ b/foo.ts\n@@ -1 +1 @@\n-old\n+intermediate\n';
     client.feedNotification('item/fileChange/patchUpdated', {
       itemId: 'fc-1',
       changes: [
         {
           path: 'foo.ts',
           kind: { type: 'update' },
-          diff: '@@ -1,1 +1,2 @@\n+new line\n',
+          diff: firstPatch,
         },
       ],
     });
+    const afterFirst = reducePatches(patches);
+    expect(afterFirst.turns[0]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'fileChange',
+          patch: firstPatch,
+          card: expect.objectContaining({
+            content: firstPatch,
+            additions: 1,
+            deletions: 1,
+          }),
+        }),
+      ])
+    );
+
+    const finalPatch =
+      '--- a/foo.ts\n+++ b/foo.ts\n@@ -1 +1,2 @@\n-old\n+final one\n+final two\n';
+    client.feedNotification('item/fileChange/patchUpdated', {
+      itemId: 'fc-1',
+      changes: [
+        {
+          path: 'foo.ts',
+          kind: { type: 'update' },
+          diff: finalPatch,
+        },
+      ],
+    });
+    const midStream = reducePatches(patches);
+    expect(midStream.turns[0]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'fileChange',
+          patch: finalPatch,
+          card: expect.objectContaining({
+            content: finalPatch,
+            additions: 2,
+            deletions: 1,
+          }),
+        }),
+      ])
+    );
+    expect(JSON.stringify(midStream.turns[0]?.items)).not.toContain(
+      'intermediate'
+    );
+
     client.feedNotification('item/completed', {
       item: {
         type: 'fileChange',
@@ -632,7 +689,7 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
           {
             path: 'foo.ts',
             kind: { type: 'update' },
-            diff: '@@ -1,1 +1,2 @@\n+new line\n',
+            diff: finalPatch,
           },
         ],
         applyStatus: 'applied',
@@ -650,23 +707,27 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
         }),
         expect.objectContaining({
           type: 'agent-item-delta-v2',
-          delta: { patch: '@@ -1,1 +1,2 @@\n+new line\n' },
+          mode: 'replace',
+          delta: {
+            patch: finalPatch,
+            card: { additions: 2, deletions: 1 },
+          },
         }),
         expect.objectContaining({
           type: 'agent-item-updated-v2',
           item: expect.objectContaining({
             applyStatus: 'applied',
-            patch: '@@ -1,1 +1,2 @@\n+new line\n',
+            patch: finalPatch,
             card: {
               kind: 'diff',
               title: 'foo.ts',
               status: 'completed',
               language: 'diff',
               path: 'foo.ts',
-              content: '@@ -1,1 +1,2 @@\n+new line\n',
-              additions: 1,
-              deletions: 0,
-              sizeBytes: 26,
+              content: finalPatch,
+              additions: 2,
+              deletions: 1,
+              sizeBytes: new TextEncoder().encode(finalPatch).byteLength,
             },
           }),
         }),

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -9,7 +9,12 @@ import type {
   CodexNotification,
   CodexServerRequest,
 } from '../../../server/codex-app-server-client.js';
-import type { AgentPatchV2 } from '../../../shared/agent-chat-protocol-v2.js';
+import {
+  applyAgentPatchV2,
+  emptyAgentSessionV2,
+  type AgentPatchV2,
+} from '../../../shared/agent-chat-protocol-v2.js';
+import codexDetailFixture from '../../fixtures/agent-detail/codex.js';
 
 vi.mock('../../../server/logger.js', () => ({
   createLogger: () => ({
@@ -649,9 +654,53 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
         }),
         expect.objectContaining({
           type: 'agent-item-updated-v2',
-          item: expect.objectContaining({ applyStatus: 'applied' }),
+          item: expect.objectContaining({
+            applyStatus: 'applied',
+            patch: '@@ -1,1 +1,2 @@\n+new line\n',
+            card: {
+              kind: 'diff',
+              title: 'foo.ts',
+              status: 'completed',
+              language: 'diff',
+              path: 'foo.ts',
+              content: '@@ -1,1 +1,2 @@\n+new line\n',
+              additions: 1,
+              deletions: 0,
+              sizeBytes: 26,
+            },
+          }),
         }),
       ])
+    );
+
+    await adapter.disconnect();
+  });
+
+  it('replays the sanitized Codex detail fixture into normalized cards', async () => {
+    const { adapter, client, patches } = await setupAndSend('turn-fixture');
+    for (const event of codexDetailFixture.nativeEvents) {
+      client.feedNotification(event.method, event.params);
+    }
+
+    let session = emptyAgentSessionV2({
+      id: 'session-1',
+      provider: 'codex',
+      cwd: '/workspace/example',
+    });
+    for (const patch of patches) session = applyAgentPatchV2(session, patch);
+    const cards = session.turns
+      .flatMap((turn) => turn.items)
+      .flatMap((item) =>
+        item.card && item.card.kind !== 'message' ? [item.card] : []
+      );
+    const expectedCards = codexDetailFixture.session.turns
+      .flatMap((turn) => turn.items)
+      .flatMap((item) =>
+        item.card && item.card.kind !== 'message' ? [item.card] : []
+      );
+    expect(cards).toEqual(expectedCards);
+    expect(codexDetailFixture.sanitization.containsLiveTranscriptBytes).toBe(
+      false
     );
 
     await adapter.disconnect();
@@ -666,7 +715,7 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
         id: 'mcp-1',
         server: 'github',
         tool: 'search',
-        arguments: {},
+        arguments: { query: 'fixture' },
       },
     });
     client.feedNotification('item/completed', {
@@ -695,6 +744,22 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
         }),
       ])
     );
+    const completed = patches.find(
+      (patch) =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'mcpToolCall'
+    );
+    expect(completed).toMatchObject({
+      item: {
+        id: 'mcp-mcp-1',
+        arguments: { query: 'fixture' },
+        card: {
+          kind: 'tool_call',
+          content: 'input\n{\n  "query": "fixture"\n}\n\noutput\n[]',
+          status: 'completed',
+        },
+      },
+    });
 
     await adapter.disconnect();
   });
@@ -707,7 +772,7 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
         type: 'dynamicToolCall',
         id: 'dyn-1',
         tool: 'myTool',
-        arguments: {},
+        arguments: { query: 'fixture' },
       },
     });
     client.feedNotification('item/completed', {
@@ -719,25 +784,42 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
       },
     });
 
-    expect(patches).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'agent-item-started-v2',
-          item: expect.objectContaining({
-            type: 'dynamicToolCall',
-            namespace: 'codex',
-            tool: 'myTool',
-          }),
-        }),
-        expect.objectContaining({
-          type: 'agent-item-updated-v2',
-          item: expect.objectContaining({
-            type: 'dynamicToolCall',
-            result: 'done',
-          }),
-        }),
-      ])
+    const lifecycle = patches.filter(
+      (patch) =>
+        (patch.type === 'agent-item-started-v2' ||
+          patch.type === 'agent-item-updated-v2') &&
+        patch.item.type === 'dynamicToolCall'
     );
+    expect(lifecycle).toHaveLength(2);
+    expect(
+      lifecycle.map((patch) =>
+        patch.type === 'agent-item-started-v2' ||
+        patch.type === 'agent-item-updated-v2'
+          ? patch.item.id
+          : null
+      )
+    ).toEqual(['tool-dyn-1', 'tool-dyn-1']);
+    expect(lifecycle[0]).toMatchObject({
+      item: {
+        arguments: { query: 'fixture' },
+        card: {
+          kind: 'tool_call',
+          content: 'input\n{\n  "query": "fixture"\n}',
+          status: 'running',
+        },
+      },
+    });
+    expect(lifecycle[1]).toMatchObject({
+      item: {
+        arguments: { query: 'fixture' },
+        result: 'done',
+        card: {
+          kind: 'tool_call',
+          content: 'input\n{\n  "query": "fixture"\n}\n\noutput\ndone',
+          status: 'completed',
+        },
+      },
+    });
 
     await adapter.disconnect();
   });

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -11,7 +11,13 @@ import {
   resolveHermesGatewaySettings,
 } from '../../../server/protocol-adapters/hermes-adapter.js';
 import type { AdapterConfig } from '../../../server/protocol-adapter.js';
+import {
+  applyAgentPatchV2,
+  emptyAgentSessionV2,
+  type AgentPatchV2,
+} from '../../../shared/agent-chat-protocol-v2.js';
 import type { ChatEvent } from '../../../shared/chat-events.js';
+import hermesDetailFixture from '../../fixtures/agent-detail/hermes.js';
 
 const ENV_KEYS = [
   'HOME',
@@ -470,6 +476,50 @@ describe('Hermes Responses SSE hardening', () => {
     });
   });
 
+  it('replays the sanitized Hermes detail fixture into normalized cards', async () => {
+    gateway = await startInlineGateway((send, res) => {
+      for (const event of hermesDetailFixture.nativeEvents) send(event);
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_synthetic_hermes', status: 'completed' },
+      });
+      res.end();
+    });
+
+    const v2 = createAdapterV2('hermes');
+    const patches: AgentPatchV2[] = [];
+    v2.onPatch((patch) => patches.push(patch));
+    try {
+      await v2.connect(configFor(gateway.endpoint, 'sess-diff'));
+      await v2.sendMessage({ turnId: 'turn-1', content: 'patch demo.ts' });
+    } finally {
+      await v2.disconnect();
+    }
+
+    let session = emptyAgentSessionV2({
+      id: 'sess-diff',
+      provider: 'hermes',
+      cwd: '/workspace/example',
+    });
+    for (const patch of patches) session = applyAgentPatchV2(session, patch);
+    const items = session.turns.flatMap((turn) => turn.items);
+    expect(
+      items.filter((item) => item.id === 'tool-call_synthetic_hermes_patch')
+    ).toHaveLength(1);
+    const cards = items.flatMap((item) =>
+      item.card && item.card.kind !== 'message' ? [item.card] : []
+    );
+    const expectedCards = hermesDetailFixture.session.turns
+      .flatMap((turn) => turn.items)
+      .flatMap((item) =>
+        item.card && item.card.kind !== 'message' ? [item.card] : []
+      );
+    expect(cards).toEqual(expectedCards);
+    expect(hermesDetailFixture.sanitization.containsLiveTranscriptBytes).toBe(
+      false
+    );
+  });
+
   it('echoes the submitted user message when the turn starts', async () => {
     gateway = await startInlineGateway((send, res) => {
       send({ type: 'response.created', response: { id: 'resp_user_echo' } });
@@ -529,7 +579,7 @@ describe('Hermes Responses SSE hardening', () => {
     expect(complete).toMatchObject({ role: 'assistant', content: 'Hello' });
   });
 
-  it('streams reasoning summary deltas and completes on done', async () => {
+  it('keeps streamed reasoning when Hermes completes with an empty done text', async () => {
     gateway = await startInlineGateway((send, res) => {
       send({ type: 'response.created', response: { id: 'resp_reason' } });
       send({
@@ -542,7 +592,9 @@ describe('Hermes Responses SSE hardening', () => {
       });
       send({
         type: 'response.reasoning_summary_text.done',
-        text: 'Thinking it through',
+        // Sanitized real gateway shape: Hermes may send an empty authoritative
+        // done field after non-empty deltas. The emitter must not blank the row.
+        text: '',
       });
       send({
         type: 'response.completed',

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -282,6 +282,49 @@ describe('Hermes Responses SSE hardening', () => {
     }
   });
 
+  async function runCompletedTool(input: {
+    toolName: string;
+    arguments: Record<string, unknown>;
+    output: string;
+  }): Promise<ChatEvent[]> {
+    gateway = await startInlineGateway((send, res) => {
+      send({ type: 'response.created', response: { id: 'resp_tool_fixture' } });
+      send({
+        type: 'response.output_item.added',
+        item: {
+          id: 'item_tool_fixture',
+          type: 'function_call',
+          call_id: 'call_tool_fixture',
+          name: input.toolName,
+          arguments: JSON.stringify(input.arguments),
+        },
+      });
+      send({
+        type: 'response.output_item.done',
+        item: {
+          id: 'item_tool_fixture',
+          type: 'function_call',
+          call_id: 'call_tool_fixture',
+          name: input.toolName,
+          arguments: JSON.stringify(input.arguments),
+          status: 'completed',
+          output: input.output,
+        },
+      });
+      send({
+        type: 'response.completed',
+        response: { id: 'resp_tool_fixture', status: 'completed' },
+      });
+      res.end();
+    });
+    adapter = new HermesProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((event) => events.push(event));
+    await adapter.connect(configFor(gateway.endpoint, 'sess-tool-fixture'));
+    await adapter.sendMessage('turn-1', 'synthetic tool fixture');
+    return events;
+  }
+
   it('maps response.error to a chat:error and fails the turn instead of hanging', async () => {
     gateway = await startInlineGateway((send, res) => {
       send({ type: 'response.created', response: { id: 'resp_err' } });
@@ -476,6 +519,90 @@ describe('Hermes Responses SSE hardening', () => {
     });
   });
 
+  it.each([
+    {
+      label: 'added',
+      diff: '--- /dev/null\n+++ b/src/created.ts\n@@ -0,0 +1 @@\n+export const created = true;\n',
+      path: 'src/created.ts',
+      kind: 'added',
+      additions: 1,
+      deletions: 0,
+    },
+    {
+      label: 'deleted',
+      diff: '--- a/src/deleted.ts\n+++ /dev/null\n@@ -1 +0,0 @@\n-export const removed = true;\n',
+      path: 'src/deleted.ts',
+      kind: 'deleted',
+      additions: 0,
+      deletions: 1,
+    },
+  ])(
+    'derives $label file path and kind from unified-diff headers when args have only patch input',
+    async ({ diff, path, kind, additions, deletions }) => {
+      const events = await runCompletedTool({
+        toolName: 'apply_patch',
+        arguments: { input: diff },
+        output: diff,
+      });
+
+      expect(
+        events.filter((event) => event.type === 'chat:file-change')
+      ).toEqual([
+        expect.objectContaining({
+          path,
+          kind,
+          additions,
+          deletions,
+          diff,
+        }),
+      ]);
+    }
+  );
+
+  it('keeps plain file-tool output as a tool result instead of promoting it to a diff', async () => {
+    const events = await runCompletedTool({
+      toolName: 'write_file',
+      arguments: { path: '/workspace/example/src/plain.ts' },
+      output: 'wrote 500 synthetic lines',
+    });
+
+    expect(events.some((event) => event.type === 'chat:file-change')).toBe(
+      false
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'chat:tool-result',
+          toolName: 'write_file',
+          output: 'wrote 500 synthetic lines',
+        }),
+      ])
+    );
+  });
+
+  it('keeps diff-shaped non-edit tool output as a tool result', async () => {
+    const diff =
+      '--- a/src/read-only.ts\n+++ b/src/read-only.ts\n@@ -1 +1 @@\n-old\n+new\n';
+    const events = await runCompletedTool({
+      toolName: 'run_command',
+      arguments: { command: 'git diff -- src/read-only.ts' },
+      output: diff,
+    });
+
+    expect(events.some((event) => event.type === 'chat:file-change')).toBe(
+      false
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'chat:tool-result',
+          toolName: 'run_command',
+          output: diff,
+        }),
+      ])
+    );
+  });
+
   it('replays the sanitized Hermes detail fixture into normalized cards', async () => {
     gateway = await startInlineGateway((send, res) => {
       for (const event of hermesDetailFixture.nativeEvents) send(event);
@@ -506,6 +633,14 @@ describe('Hermes Responses SSE hardening', () => {
     expect(
       items.filter((item) => item.id === 'tool-call_synthetic_hermes_patch')
     ).toHaveLength(1);
+    const diffItem = items.find(
+      (item) => item.id === 'tool-call_synthetic_hermes_patch'
+    );
+    expect(diffItem).not.toHaveProperty('applyStatus');
+    const fixtureDiffItem = hermesDetailFixture.session.turns
+      .flatMap((turn) => turn.items)
+      .find((item) => item.type === 'fileChange');
+    expect(fixtureDiffItem).not.toHaveProperty('applyStatus');
     const cards = items.flatMap((item) =>
       item.card && item.card.kind !== 'message' ? [item.card] : []
     );

--- a/test/shiki-gc.test.ts
+++ b/test/shiki-gc.test.ts
@@ -148,6 +148,19 @@ describe('shiki-gc store', () => {
         useShikiGcStore.getState().setHighlightOutput('nonexistent', ['tokens'])
       ).not.toThrow();
     });
+
+    it('rejects a stale async write whose expected input no longer matches', () => {
+      addEntry('tab1', 'new source', 'json', ['new-tokens'], Date.now());
+
+      useShikiGcStore.getState().setHighlightOutput('tab1', ['stale-tokens'], {
+        source: 'old source',
+        language: 'typescript',
+      });
+
+      expect(
+        useShikiGcStore.getState().entries.get('tab1')?.highlightOutput
+      ).toEqual(['new-tokens']);
+    });
   });
 
   describe('runGc — idle threshold eviction', () => {


### PR DESCRIPTION
## Summary

- normalize Claude, Codex, and Hermes activity into a provider-neutral `message | thought | tool_call | output | diff` detail-card contract at the adapter boundary
- render thought, tool, output, and diff cards collapsed by default with stable expansion, bounded scrolling, diff tint, and lazy syntax highlighting
- add sanitized structural replay fixtures and smoke coverage for all three adapters without committing live transcript bytes

## Adapter audit

| Adapter | Native input | Normalized behavior |
| --- | --- | --- |
| Claude persistent subprocess | reasoning blocks, tool use/results, command and file payloads | preserves thought text, maps tool lifecycle to one durable card, recognizes structured patch results |
| Codex app-server | reasoning, command execution, file changes, dynamic/MCP/collab tools | retains arguments and patches across completion events and updates the stable item/card in place |
| Hermes legacy bridge | reasoning deltas/done plus tool start/result events | fixes empty final thought emission, maps command events to output, and tags only genuine unified diffs |

The renderer consumes only the normalized card contract and has no framework conditionals. Existing persisted V2 items receive the same card derivation at the render boundary for backward compatibility. Channel main-lane filtering remains message-only per the #1191 contract.

## Highlighting and bundle impact

The smallest viable option is the existing Shiki dependency loaded through a singleton dynamic `import('shiki')` only after a card is expanded. Collapsed cards and ordinary chat do not load the highlighter; plain text remains the fallback while it initializes.

- exact nightly baseline, all JS: 12,508,218 bytes raw / 2,707,418 gzip
- this branch, all JS: 12,513,300 bytes raw / 2,708,245 gzip
- total delta: +5,082 bytes raw / +827 bytes gzip
- lazy Shiki chunk: 196.28 kB raw / 61.94 kB gzip
- main entry delta: -191.20 kB raw / -61.13 kB gzip

## Evidence

- adapter/protocol suites: 128 passed
- component suites: 20 passed
- pre-push changed suites: 869 passed, 9 skipped
- literal CI smoke grep: 36 passed, including 13 new three-adapter scenarios
- `npm run check`: green (0 errors; 251 existing warnings)
- production build and fixture-enabled build: green
- `git diff --check`: clean
- adversarial review plus focused re-review: no unresolved P0-P2 findings

Refs #1198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable agent detail cards for thoughts, command output, tool calls, and file changes.
  * Added diff summaries with added/removed line counts, syntax highlighting, truncation, and responsive scrolling.
  * Added a “Jump to latest” control while preserving reading position during streaming and card expansion.
* **Bug Fixes**
  * Improved display of streamed tool arguments, completed patches, and file-change details.
  * Prevented stale syntax highlighting from replacing current content.
  * Preserved reasoning text when completion events contain empty updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->