### PR TITLE
fix(codex): reasoning content and terminal status on thought cards

### DIFF
--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -460,7 +460,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   private providerExtensionSeq = 0;
   private readonly itemMap = new Map<string, string>(); // nativeItemId → relayItemId
   private readonly openAgentMessageNativeIds = new Set<string>();
-  private readonly openReasoningNativeIds = new Set<string>();
+  private readonly openReasoningByRelayId = new Map<string, string>();
   private deferredTurnCompletion: DeferredTurnCompletion | null = null;
   private readonly toolArgumentsByNativeId = new Map<
     string,
@@ -679,7 +679,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.activeStartedAt = startedAt;
     this.completedActiveTurn = false;
     this.openAgentMessageNativeIds.clear();
-    this.openReasoningNativeIds.clear();
+    this.openReasoningByRelayId.clear();
     this.clearDeferredTurnCompletion();
 
     this.emitPatch({
@@ -778,7 +778,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     // on an always-on channel binding.
     this.itemMap.clear();
     this.openAgentMessageNativeIds.clear();
-    this.openReasoningNativeIds.clear();
+    this.openReasoningByRelayId.clear();
     this.toolArgumentsByNativeId.clear();
     this.tokenUsageBuffer.clear();
     this.reasoningSummaryBuffers.clear();
@@ -825,7 +825,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   ): boolean {
     if (
       this.openAgentMessageNativeIds.size === 0 &&
-      this.openReasoningNativeIds.size === 0
+      this.openReasoningByRelayId.size === 0
     ) {
       return false;
     }
@@ -847,7 +847,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   private completeDeferredTurnIfReady(): void {
     if (
       this.openAgentMessageNativeIds.size > 0 ||
-      this.openReasoningNativeIds.size > 0 ||
+      this.openReasoningByRelayId.size > 0 ||
       !this.deferredTurnCompletion
     ) {
       return;
@@ -867,9 +867,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           ? 'failed'
           : 'cancelled';
 
-    for (const nativeId of this.openReasoningNativeIds) {
-      const relayId = this.itemMap.get(nativeId);
-      if (!relayId) continue;
+    for (const [relayId, nativeId] of this.openReasoningByRelayId) {
       const summary = this.reasoningSummaryBuffers.get(relayId) ?? '';
       const detail = this.reasoningDetailBuffers.get(relayId) ?? '';
       this.emitPatch({
@@ -891,7 +889,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       this.reasoningSummaryBuffers.delete(relayId);
       this.reasoningDetailBuffers.delete(relayId);
     }
-    this.openReasoningNativeIds.clear();
+    this.openReasoningByRelayId.clear();
   }
 
   private drainQueue(): void {
@@ -963,7 +961,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       if (this._status === 'connected') {
         const turnId = this.activeTurnId;
         if (turnId !== null && !this.completedActiveTurn) {
-          this.completeActiveTurn('interrupted');
+          const flushedDeferredCompletion = this.flushDeferredTurnCompletion();
+          if (!flushedDeferredCompletion) {
+            this.completeActiveTurn('interrupted');
+          }
         }
         this._status = 'disconnected';
         this.client = null;
@@ -1016,7 +1017,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.slashCommandsLoaded = false;
     this.itemMap.clear();
     this.openAgentMessageNativeIds.clear();
-    this.openReasoningNativeIds.clear();
+    this.openReasoningByRelayId.clear();
     this.clearDeferredTurnCompletion();
     this.toolArgumentsByNativeId.clear();
     this.tokenUsageBuffer.clear();
@@ -1361,7 +1362,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       case 'reasoning': {
         const relayId = `reasoning-${this.activeTurnId}-${nativeId}`;
         this.itemMap.set(nativeId, relayId);
-        if (nativeId) this.openReasoningNativeIds.add(nativeId);
+        this.openReasoningByRelayId.set(relayId, nativeId);
         this.emitPatch({
           type: 'agent-item-started-v2',
           sessionId: this.config.sessionId,
@@ -1616,7 +1617,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         break;
 
       case 'reasoning': {
-        if (!this.openReasoningNativeIds.has(nativeId)) break;
+        if (!this.openReasoningByRelayId.has(relayId)) break;
         // Current Codex app-server ships `summary` / `content` as string[];
         // older versions used `{ type, text }[]`. Flatten either shape and
         // fall back to streamed buffers when completion omits them.
@@ -1644,7 +1645,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             ...(nativeId ? { providerItemId: nativeId } : {}),
           },
         });
-        this.openReasoningNativeIds.delete(nativeId);
+        this.openReasoningByRelayId.delete(relayId);
         this.completeDeferredTurnIfReady();
         break;
       }

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -230,15 +230,19 @@ function diffCounts(diff: string): { additions: number; deletions: number } {
 }
 
 /**
- * Flatten codex's reasoning array shapes into a single string. Both
- * `summary: Vec<ReasoningItemReasoningSummary>` and
- * `content: Vec<ReasoningItemContent>` use `{ type, text }` entries.
+ * Flatten Codex's reasoning arrays into a single string. Current app-server
+ * emits `string[]`; older versions used `{ type, text }[]` entries.
  */
 function flattenReasoningTextEntries(value: unknown): string {
   if (!Array.isArray(value)) return '';
   return value
-    .filter(isRecord)
-    .map((entry) => stringField(entry['text']))
+    .map((entry) =>
+      typeof entry === 'string'
+        ? entry
+        : isRecord(entry)
+          ? stringField(entry['text'])
+          : ''
+    )
     .filter((text) => text.length > 0)
     .join('\n\n');
 }
@@ -456,6 +460,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   private providerExtensionSeq = 0;
   private readonly itemMap = new Map<string, string>(); // nativeItemId → relayItemId
   private readonly openAgentMessageNativeIds = new Set<string>();
+  private readonly openReasoningNativeIds = new Set<string>();
   private deferredTurnCompletion: DeferredTurnCompletion | null = null;
   private readonly toolArgumentsByNativeId = new Map<
     string,
@@ -674,6 +679,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.activeStartedAt = startedAt;
     this.completedActiveTurn = false;
     this.openAgentMessageNativeIds.clear();
+    this.openReasoningNativeIds.clear();
     this.clearDeferredTurnCompletion();
 
     this.emitPatch({
@@ -746,6 +752,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.completedActiveTurn = true;
     const turnId = this.activeTurnId;
     const completedAt = nowIso();
+    this.terminalizeOpenReasoningItems(status, completedAt);
     // Prefer native durationMs if provided, else compute from startedAt
     const durationMs =
       nativeDurationMs ??
@@ -771,6 +778,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     // on an always-on channel binding.
     this.itemMap.clear();
     this.openAgentMessageNativeIds.clear();
+    this.openReasoningNativeIds.clear();
     this.toolArgumentsByNativeId.clear();
     this.tokenUsageBuffer.clear();
     this.reasoningSummaryBuffers.clear();
@@ -815,7 +823,12 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     error?: string,
     nativeDurationMs?: number
   ): boolean {
-    if (this.openAgentMessageNativeIds.size === 0) return false;
+    if (
+      this.openAgentMessageNativeIds.size === 0 &&
+      this.openReasoningNativeIds.size === 0
+    ) {
+      return false;
+    }
     this.clearDeferredTurnCompletion();
     const timer = setTimeout(() => {
       if (this.flushDeferredTurnCompletion()) this.drainQueue();
@@ -834,11 +847,51 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   private completeDeferredTurnIfReady(): void {
     if (
       this.openAgentMessageNativeIds.size > 0 ||
+      this.openReasoningNativeIds.size > 0 ||
       !this.deferredTurnCompletion
     ) {
       return;
     }
     if (this.flushDeferredTurnCompletion()) this.drainQueue();
+  }
+
+  private terminalizeOpenReasoningItems(
+    turnStatus: 'completed' | 'interrupted' | 'failed',
+    completedAt: string
+  ): void {
+    if (!this.config || this.activeTurnId === null) return;
+    const status =
+      turnStatus === 'completed'
+        ? 'completed'
+        : turnStatus === 'failed'
+          ? 'failed'
+          : 'cancelled';
+
+    for (const nativeId of this.openReasoningNativeIds) {
+      const relayId = this.itemMap.get(nativeId);
+      if (!relayId) continue;
+      const summary = this.reasoningSummaryBuffers.get(relayId) ?? '';
+      const detail = this.reasoningDetailBuffers.get(relayId) ?? '';
+      this.emitPatch({
+        type: 'agent-item-updated-v2',
+        sessionId: this.config.sessionId,
+        timestamp: completedAt,
+        turnId: this.activeTurnId,
+        item: {
+          type: 'reasoning',
+          id: relayId,
+          summary,
+          ...(detail ? { detail } : {}),
+          visibility: 'summary',
+          status,
+          completedAt,
+          ...(nativeId ? { providerItemId: nativeId } : {}),
+        },
+      });
+      this.reasoningSummaryBuffers.delete(relayId);
+      this.reasoningDetailBuffers.delete(relayId);
+    }
+    this.openReasoningNativeIds.clear();
   }
 
   private drainQueue(): void {
@@ -934,8 +987,17 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
     // A provider-completed turn waiting only on the terminal-item grace still
     // owns its authoritative usage/boundary. Publish it before client.stop()
-    // can emit close and before teardown clears the deferred record.
-    this.flushDeferredTurnCompletion();
+    // can emit close and before teardown clears the deferred record. Otherwise
+    // an explicitly disconnected active turn is interrupted here so open
+    // reasoning cards become terminal before their identity/buffers are lost.
+    const flushedDeferredCompletion = this.flushDeferredTurnCompletion();
+    if (
+      !flushedDeferredCompletion &&
+      this.activeTurnId !== null &&
+      !this.completedActiveTurn
+    ) {
+      this.completeActiveTurn('interrupted');
+    }
 
     if (this.client) {
       try {
@@ -954,6 +1016,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.slashCommandsLoaded = false;
     this.itemMap.clear();
     this.openAgentMessageNativeIds.clear();
+    this.openReasoningNativeIds.clear();
     this.clearDeferredTurnCompletion();
     this.toolArgumentsByNativeId.clear();
     this.tokenUsageBuffer.clear();
@@ -1298,6 +1361,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       case 'reasoning': {
         const relayId = `reasoning-${this.activeTurnId}-${nativeId}`;
         this.itemMap.set(nativeId, relayId);
+        if (nativeId) this.openReasoningNativeIds.add(nativeId);
         this.emitPatch({
           type: 'agent-item-started-v2',
           sessionId: this.config.sessionId,
@@ -1552,10 +1616,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         break;
 
       case 'reasoning': {
-        // Codex ships ReasoningItem with `summary: Vec<ReasoningItemReasoningSummary>`
-        // and optional `content: Vec<ReasoningItemContent>`. Each entry has a
-        // `text` field. Flatten to plain strings; fall back to streamed buffers
-        // when the completion payload omits them.
+        if (!this.openReasoningNativeIds.has(nativeId)) break;
+        // Current Codex app-server ships `summary` / `content` as string[];
+        // older versions used `{ type, text }[]`. Flatten either shape and
+        // fall back to streamed buffers when completion omits them.
         const summaryFromPayload = flattenReasoningTextEntries(item['summary']);
         const detailFromPayload = flattenReasoningTextEntries(item['content']);
         const summary =
@@ -1577,8 +1641,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             visibility: 'summary',
             status: 'completed',
             completedAt,
+            ...(nativeId ? { providerItemId: nativeId } : {}),
           },
         });
+        this.openReasoningNativeIds.delete(nativeId);
+        this.completeDeferredTurnIfReady();
         break;
       }
 

--- a/test/fixtures/agent-detail/codex.ts
+++ b/test/fixtures/agent-detail/codex.ts
@@ -20,11 +20,32 @@ const fixture = {
   nativeEvents: [
     {
       method: 'item/started',
-      params: { item: { type: 'reasoning', id: 'reason_synthetic_codex' } },
+      params: {
+        threadId: 'thread_synthetic_codex',
+        turnId: 'turn_synthetic_codex',
+        startedAtMs: 1_000,
+        item: {
+          type: 'reasoning',
+          id: 'reason_synthetic_codex',
+          summary: [],
+          content: [],
+        },
+      },
+    },
+    {
+      method: 'item/reasoning/summaryPartAdded',
+      params: {
+        threadId: 'thread_synthetic_codex',
+        turnId: 'turn_synthetic_codex',
+        itemId: 'reason_synthetic_codex',
+        summaryIndex: 0,
+      },
     },
     {
       method: 'item/reasoning/summaryTextDelta',
       params: {
+        threadId: 'thread_synthetic_codex',
+        turnId: 'turn_synthetic_codex',
         itemId: 'reason_synthetic_codex',
         delta: thoughtContent,
         summaryIndex: 0,
@@ -33,10 +54,14 @@ const fixture = {
     {
       method: 'item/completed',
       params: {
+        threadId: 'thread_synthetic_codex',
+        turnId: 'turn_synthetic_codex',
+        completedAtMs: 2_000,
         item: {
           type: 'reasoning',
           id: 'reason_synthetic_codex',
-          summary: [{ type: 'summary_text', text: thoughtContent }],
+          summary: [thoughtContent],
+          content: [],
         },
       },
     },

--- a/test/manual/codex-live-proof.mjs
+++ b/test/manual/codex-live-proof.mjs
@@ -13,6 +13,10 @@
  *
  * Usage (from the worktree root, after `npm run build:server`):
  *   RELAY_CODEX_LIVE_PROOF=1 node test/manual/codex-live-proof.mjs
+ *
+ * Capture one reasoning-enabled turn for a hand-sanitized structural fixture:
+ *   RELAY_CODEX_LIVE_PROOF=1 RELAY_CODEX_REASONING_CAPTURE=1 \
+ *     node test/manual/codex-live-proof.mjs
  */
 import { spawn as nodeSpawn } from 'node:child_process';
 import * as os from 'node:os';
@@ -39,7 +43,11 @@ const { CodexNativeProtocolAdapter } = await import(
   )
 );
 
-const PROMPT = 'Reply with exactly "ok" and nothing else.';
+const reasoningCapture = process.env.RELAY_CODEX_REASONING_CAPTURE === '1';
+const reasoningEffort = process.env.RELAY_CODEX_REASONING_EFFORT || 'low';
+const PROMPT = reasoningCapture
+  ? 'Compute the sum of the squares from 1 through 40, factor the result into primes, and reply with exactly the prime factorization.'
+  : 'Reply with exactly "ok" and nothing else.';
 const rawChunks = [];
 
 // Wrap the real spawn so we can tee stdout for a permanent (uncommitted)
@@ -80,9 +88,24 @@ const config = {
   sessionId: 'codex-live-proof',
   hookToken: 'live-proof',
   configDir: os.tmpdir(),
-  // DI: the adapter forwards `extra.spawn` to the app-server client so we can
-  // tee the raw transcript. No operator args are injected.
-  extra: { spawn: teeSpawn },
+  // DI: the adapter forwards these capture-only settings to the app-server
+  // client. They never alter Relay's production Codex defaults.
+  extra: {
+    spawn: teeSpawn,
+    ...(reasoningCapture
+      ? {
+          args: [
+            'app-server',
+            '--listen',
+            'stdio://',
+            '-c',
+            'model_reasoning_summary="detailed"',
+            '-c',
+            `model_reasoning_effort="${reasoningEffort}"`,
+          ],
+        }
+      : {}),
+  },
 };
 
 const TIMEOUT_MS = 120_000;
@@ -128,6 +151,21 @@ try {
   }
 
   const tail = patches.slice(-10).map((p) => {
+    if (p.type === 'agent-item-delta-v2' && reasoningCapture) {
+      const deltaShape = Object.entries(p.delta)
+        .map(([field, value]) => {
+          const type = typeof value;
+          const length =
+            typeof value === 'string'
+              ? Buffer.byteLength(value, 'utf8')
+              : Array.isArray(value)
+                ? value.length
+                : null;
+          return `${field}:${type}:length=${length ?? 'n/a'}`;
+        })
+        .join(',');
+      return `${p.type}(${deltaShape})`;
+    }
     if (p.type === 'agent-item-delta-v2')
       return `${p.type}(${JSON.stringify(p.delta)})`;
     if (p.type === 'agent-turn-completed-v2')
@@ -145,7 +183,7 @@ try {
   // leak private account/environment data.
   const rawPath = path.join(
     os.tmpdir(),
-    `relay-codex-live-proof-${process.pid}.jsonl`
+    `relay-codex-${reasoningCapture ? 'reasoning-' : ''}live-proof-${process.pid}.jsonl`
   );
   fs.writeFileSync(rawPath, Buffer.concat(rawChunks));
 
@@ -156,8 +194,13 @@ try {
           completion.type === 'agent-turn-completed-v2' &&
           completion.status === 'completed',
         completionStatus: completion.status ?? completion.type,
-        assistantText,
-        threadId,
+        ...(reasoningCapture
+          ? {
+              assistantTextPresent: assistantText.length > 0,
+              threadIdPresent:
+                typeof threadId === 'string' && threadId.length > 0,
+            }
+          : { assistantText, threadId }),
         ttftMs,
         totalMs,
         patchCount: patches.length,

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -627,6 +627,81 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
     }
   });
 
+  it('flushes a deferred provider completion before handling client close', async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, client, patches } = await setupAndSend(
+        'turn-terminal-close'
+      );
+      client.feedNotification('item/started', {
+        item: { type: 'reasoning', id: 'reasoning-held-open' },
+      });
+      client.feedNotification('item/reasoning/summaryTextDelta', {
+        itemId: 'reasoning-held-open',
+        delta: 'provider-completed reasoning',
+        summaryIndex: 0,
+      });
+      client.feedNotification('thread/tokenUsageUpdated', {
+        threadId: 'thread-1',
+        turnId: 'native-turn-close',
+        tokenUsage: {
+          last: { inputTokens: 34, outputTokens: 13, totalTokens: 47 },
+        },
+      });
+      client.feedNotification('turn/completed', {
+        threadId: 'thread-1',
+        turn: {
+          id: 'native-turn-close',
+          status: 'completed',
+          durationMs: 4321,
+        },
+      });
+      expect(
+        patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+      ).toHaveLength(0);
+
+      client.emit('close', 0);
+
+      expect(
+        patches.filter(
+          (patch) =>
+            patch.type === 'agent-item-updated-v2' &&
+            patch.item.type === 'reasoning' &&
+            patch.item.status === 'completed'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          item: expect.objectContaining({
+            summary: 'provider-completed reasoning',
+            status: 'completed',
+          }),
+        }),
+      ]);
+      expect(
+        patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+      ).toEqual([
+        expect.objectContaining({
+          turnId: 'turn-terminal-close',
+          status: 'completed',
+          durationMs: 4321,
+          usage: expect.objectContaining({
+            inputTokens: 34,
+            outputTokens: 13,
+            totalTokens: 47,
+          }),
+        }),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(CODEX_TERMINAL_ITEM_GRACE_MS);
+      expect(
+        patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+      ).toHaveLength(1);
+      await adapter.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('persists an empty start as missing-terminal when the Codex grace expires', async () => {
     vi.useFakeTimers();
     const dir = fs.mkdtempSync(
@@ -851,6 +926,84 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
       )
     ).toHaveLength(1);
     await adapter.disconnect();
+  });
+
+  it('reasoning: id-less item/completed terminalizes streamed content', async () => {
+    const { adapter, client, patches } = await setupAndSend(
+      'turn-reasoning-idless-completed'
+    );
+    client.feedNotification('item/started', {
+      item: { type: 'reasoning' },
+    });
+    client.feedNotification('item/reasoning/summaryTextDelta', {
+      delta: 'id-less summary',
+      summaryIndex: 0,
+    });
+    client.feedNotification('item/reasoning/textDelta', {
+      delta: 'id-less detail',
+      contentIndex: 0,
+    });
+    client.feedNotification('item/completed', {
+      item: { type: 'reasoning' },
+    });
+
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-item-updated-v2' &&
+          patch.item.type === 'reasoning' &&
+          patch.item.status === 'completed'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        item: expect.objectContaining({
+          id: 'reasoning-turn-reasoning-idless-completed-',
+          summary: 'id-less summary',
+          detail: 'id-less detail',
+          status: 'completed',
+        }),
+      }),
+    ]);
+    await adapter.disconnect();
+  });
+
+  it('reasoning: turn completion terminalizes an id-less open item', async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, client, patches } = await setupAndSend(
+        'turn-reasoning-idless-fallback'
+      );
+      client.feedNotification('item/started', {
+        item: { type: 'reasoning' },
+      });
+      client.feedNotification('item/reasoning/summaryTextDelta', {
+        delta: 'id-less buffered summary',
+        summaryIndex: 0,
+      });
+      client.feedNotification('turn/completed', {
+        turn: { id: 'native-turn-1', status: 'completed' },
+      });
+
+      expect(
+        patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+      ).toBe(false);
+      await vi.advanceTimersByTimeAsync(CODEX_TERMINAL_ITEM_GRACE_MS);
+
+      expect(reducePatches(patches).turns[0]?.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'reasoning-turn-reasoning-idless-fallback-',
+            type: 'reasoning',
+            summary: 'id-less buffered summary',
+            status: 'completed',
+            card: expect.objectContaining({ status: 'completed' }),
+          }),
+        ])
+      );
+      await adapter.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('reasoning: item/completed without summary falls back to streamed buffer', async () => {

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -737,7 +737,7 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
     await adapter.disconnect();
   });
 
-  it('reasoning: item/completed with structured summary array preserves text', async () => {
+  it('reasoning: legacy object arrays preserve summary and detail text', async () => {
     const { adapter, client, patches } = await setupAndSend('turn-r2');
 
     client.feedNotification('item/started', {
@@ -748,7 +748,7 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
       delta: 'partial summary text',
       summaryIndex: 0,
     });
-    // Authoritative codex ReasoningItem shape: summary is Vec<{type, text}>
+    // Older app-server versions used Vec<{type, text}> for both fields.
     client.feedNotification('item/completed', {
       item: {
         type: 'reasoning',
@@ -756,6 +756,10 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
         summary: [
           { type: 'summary_text', text: 'final summary part one' },
           { type: 'summary_text', text: 'final summary part two' },
+        ],
+        content: [
+          { type: 'reasoning_text', text: 'detail part one' },
+          { type: 'reasoning_text', text: 'detail part two' },
         ],
       },
     });
@@ -775,8 +779,77 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
       expect(completed.item.summary).toBe(
         'final summary part one\n\nfinal summary part two'
       );
+      expect(completed.item.detail).toBe('detail part one\n\ndetail part two');
     }
 
+    await adapter.disconnect();
+  });
+
+  it('reasoning: current string arrays preserve summary and detail text', async () => {
+    const { adapter, client, patches } = await setupAndSend('turn-r-strings');
+
+    client.feedNotification('item/started', {
+      item: {
+        type: 'reasoning',
+        id: 'reason-strings',
+        summary: [],
+        content: [],
+      },
+    });
+    client.feedNotification('item/completed', {
+      item: {
+        type: 'reasoning',
+        id: 'reason-strings',
+        summary: ['summary part one', 'summary part two'],
+        content: ['detail part one', 'detail part two'],
+      },
+    });
+
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-item-updated-v2' &&
+          patch.item.type === 'reasoning' &&
+          patch.item.status === 'completed'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        item: expect.objectContaining({
+          summary: 'summary part one\n\nsummary part two',
+          detail: 'detail part one\n\ndetail part two',
+        }),
+      }),
+    ]);
+
+    await adapter.disconnect();
+  });
+
+  it('reasoning: duplicate item/completed emits one terminal update', async () => {
+    const { adapter, client, patches } = await setupAndSend(
+      'turn-r-duplicate-completion'
+    );
+    client.feedNotification('item/started', {
+      item: { type: 'reasoning', id: 'reason-duplicate' },
+    });
+    const completion = {
+      item: {
+        type: 'reasoning',
+        id: 'reason-duplicate',
+        summary: ['terminal summary'],
+        content: [],
+      },
+    };
+    client.feedNotification('item/completed', completion);
+    client.feedNotification('item/completed', completion);
+
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-item-updated-v2' &&
+          patch.item.type === 'reasoning' &&
+          patch.item.status === 'completed'
+      )
+    ).toHaveLength(1);
     await adapter.disconnect();
   });
 
@@ -813,6 +886,131 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
 
     await adapter.disconnect();
   });
+
+  it('reasoning: turn completion terminalizes an item missing item/completed', async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, client, patches } = await setupAndSend(
+        'turn-reasoning-fallback'
+      );
+      client.feedNotification('item/started', {
+        item: { type: 'reasoning', id: 'reason-fallback' },
+      });
+      client.feedNotification('item/reasoning/summaryTextDelta', {
+        itemId: 'reason-fallback',
+        delta: 'buffered summary',
+        summaryIndex: 0,
+      });
+      client.feedNotification('item/reasoning/textDelta', {
+        itemId: 'reason-fallback',
+        delta: 'buffered detail',
+        contentIndex: 0,
+      });
+      client.feedNotification('turn/completed', {
+        turn: { id: 'native-turn-1', status: 'completed' },
+      });
+
+      expect(
+        patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+      ).toBe(false);
+      await vi.advanceTimersByTimeAsync(CODEX_TERMINAL_ITEM_GRACE_MS);
+
+      const session = reducePatches(patches);
+      expect(session.turns[0]).toMatchObject({ status: 'completed' });
+      expect(session.turns[0]?.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'reasoning',
+            summary: 'buffered summary',
+            detail: 'buffered detail',
+            status: 'completed',
+            card: expect.objectContaining({
+              kind: 'thought',
+              content: 'buffered detail',
+              status: 'completed',
+            }),
+          }),
+        ])
+      );
+      await adapter.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reasoning: disconnect terminalizes an active item and turn exactly once', async () => {
+    const { adapter, client, patches } = await setupAndSend(
+      'turn-reasoning-disconnect'
+    );
+    client.feedNotification('item/started', {
+      item: { type: 'reasoning', id: 'reason-disconnect' },
+    });
+    client.feedNotification('item/reasoning/summaryTextDelta', {
+      itemId: 'reason-disconnect',
+      delta: 'summary before disconnect',
+      summaryIndex: 0,
+    });
+
+    await adapter.disconnect();
+
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-item-updated-v2' &&
+          patch.item.type === 'reasoning' &&
+          patch.item.status === 'cancelled'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        item: expect.objectContaining({
+          summary: 'summary before disconnect',
+          status: 'cancelled',
+        }),
+      }),
+    ]);
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-turn-completed-v2' &&
+          patch.turnId === 'turn-reasoning-disconnect' &&
+          patch.status === 'interrupted'
+      )
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    ['failed', 'failed'],
+    ['interrupted', 'cancelled'],
+  ] as const)(
+    'reasoning: %s turn terminalizes open reasoning as %s',
+    async (turnStatus, itemStatus) => {
+      const { adapter, client, patches } = await setupAndSend(
+        `turn-reasoning-${turnStatus}`
+      );
+      client.feedNotification('item/started', {
+        item: { type: 'reasoning', id: `reason-${turnStatus}` },
+      });
+      client.feedNotification('item/reasoning/summaryTextDelta', {
+        itemId: `reason-${turnStatus}`,
+        delta: `${turnStatus} summary`,
+        summaryIndex: 0,
+      });
+      client.feedNotification('turn/completed', {
+        turn: { id: 'native-turn-1', status: turnStatus },
+      });
+
+      expect(reducePatches(patches).turns[0]?.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'reasoning',
+            status: itemStatus,
+            card: expect.objectContaining({ status: itemStatus }),
+          }),
+        ])
+      );
+      await adapter.disconnect();
+    }
+  );
 
   it('commandExecution: output delta then complete', async () => {
     const { adapter, client, patches } = await setupAndSend('turn-cmd');
@@ -995,12 +1193,31 @@ describe('CodexNativeProtocolAdapter — notifications', () => {
       client.feedNotification(event.method, event.params);
     }
 
-    let session = emptyAgentSessionV2({
-      id: 'session-1',
-      provider: 'codex',
-      cwd: '/workspace/example',
-    });
-    for (const patch of patches) session = applyAgentPatchV2(session, patch);
+    const reasoningDeltaIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'agent-item-delta-v2' &&
+        patch.delta.summary === codexDetailFixture.assertions.thoughtContent
+    );
+    expect(reasoningDeltaIndex).toBeGreaterThanOrEqual(0);
+    const streamingSession = reducePatches(
+      patches.slice(0, reasoningDeltaIndex + 1)
+    );
+    expect(streamingSession.turns[0]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'reasoning',
+          summary: codexDetailFixture.assertions.thoughtContent,
+          status: 'running',
+          card: expect.objectContaining({
+            kind: 'thought',
+            content: codexDetailFixture.assertions.thoughtContent,
+            status: 'running',
+          }),
+        }),
+      ])
+    );
+
+    const session = reducePatches(patches);
     const cards = session.turns
       .flatMap((turn) => turn.items)
       .flatMap((item) =>
@@ -1916,6 +2133,14 @@ describe('CodexNativeProtocolAdapter — queue', () => {
           id: `item-${turn}`,
           type: 'agentMessage',
           text: 'terminal output',
+        },
+      });
+      client.feedNotification('item/completed', {
+        item: {
+          id: `reasoning-${turn}`,
+          type: 'reasoning',
+          summary: ['thinking'],
+          content: ['detail'],
         },
       });
       client.feedNotification('turn/completed', {


### PR DESCRIPTION
## Summary

- stream Codex reasoning summaries and details into the existing thought card in place
- accept the current app-server `string[]` completion payload while retaining compatibility with legacy `{ type, text }[]` entries
- include open reasoning items in the existing deferred terminal barrier so completion, failure, interruption, and explicit disconnect cannot leave a card pending
- make reasoning completion idempotent and keep raw live-capture bytes out of committed fixtures and public proof output

## Root cause and boundary

The #1207 channel-row teardown path intentionally mirrors only assistant-message rows; reasoning cards live in the Codex adapter/web-session item path. Its adjacent deferred-completion barrier tracked open assistant messages but not reasoning items, so turn-end cleanup could clear reasoning identity and buffers without a terminal item update.

Separately, the #1201 fixture modeled completed reasoning as arrays of `{ type, text }` objects. Current Codex app-server emits arrays of strings, so the completion flattener produced empty text and could replace streamed content with an empty terminal item.

## Sanitized live-shape capture

One reasoning-enabled Codex 0.144.1 turn was captured through the real app-server adapter. Raw stdout remained in an uncommitted temp file. The checked-in fixture is a hand-sanitized structural replay with synthetic ids, timestamps, paths, prompt text, and output.

| Boundary | #1201 fixture | Captured live shape |
| --- | --- | --- |
| `item/started` | reasoning id only | reasoning id plus empty `summary: []` and `content: []` |
| stream order | `summaryTextDelta` | `summaryPartAdded` then `summaryTextDelta` |
| `item/completed` | `summary: Array<{type,text}>` | `summary: string[]`, `content: string[]` |

The capture did not emit a detail delta; current `content: string[]`, legacy structured detail, and streamed `textDelta` are each pinned independently.

## Terminal contract

Open reasoning identities now participate in the same Codex terminal grace barrier as assistant messages. A native `item/completed` emits one completed in-place update. If that boundary is absent, turn completion resolves buffered reasoning before cleanup; failed and interrupted turns map to failed and cancelled card states. Explicit disconnect follows the same interrupted path, and duplicate completion envelopes are ignored after the first terminal transition.

## Evidence

- focused adapter/protocol/component suites: 103/103 passed
- delta-emission mutation: replay failed with `reasoningDeltaIndex = -1`, then passed after restoration
- pre-push changed suites: 508 passed, 9 skipped
- `npm run check`: green, 0 errors (250 existing warnings)
- `npm run build`: green
- Playwright smoke, Chromium, one worker, isolated runtime: 43/43 passed
- `git diff --check`: clean
- adversarial review plus focused re-review: 4 findings fixed; no residual P0-P2

Refs #1206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Codex reasoning content across supported payload formats.
  * Ensured reasoning items are finalized correctly when turns complete, are interrupted, or the connection closes.
  * Improved completion timing so final turn updates are emitted only after reasoning content is settled.
  * Prevented duplicate reasoning completion updates and preserved streamed reasoning text more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->