### PR TITLE
Fix: render agent detail cards in channels

### DIFF
--- a/frontend/src/components/chat/AssistantMarkdown.tsx
+++ b/frontend/src/components/chat/AssistantMarkdown.tsx
@@ -15,13 +15,63 @@
 import React from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type {
+  AgentDetailCardStatusV2,
+  AgentDetailCardV2,
+} from '../../../../shared/agent-chat-protocol-v2.js';
 import { CodeBlock } from '../CodeBlock.js';
+import { AgentDetailCard } from './AgentDetailCard.js';
 
 interface MarkdownCodeNode {
-  position?: { start?: { offset?: number } };
+  position?: {
+    start?: { offset?: number; line?: number };
+    end?: { line?: number };
+  };
 }
 
-function buildComponents(keyPrefix: string): Components {
+function codeCard(
+  code: string,
+  language: string,
+  status: AgentDetailCardStatusV2
+): AgentDetailCardV2 {
+  const unifiedDiff =
+    language === 'diff' ||
+    /(^|\n)diff --git /.test(code) ||
+    (/(^|\n)--- (?:a\/|\/dev\/null)/.test(code) &&
+      /(^|\n)\+\+\+ (?:b\/|\/dev\/null)/.test(code));
+  if (unifiedDiff) {
+    let additions = 0;
+    let deletions = 0;
+    for (const line of code.split('\n')) {
+      if (line.startsWith('+') && !line.startsWith('+++')) additions += 1;
+      if (line.startsWith('-') && !line.startsWith('---')) deletions += 1;
+    }
+    return {
+      kind: 'diff',
+      title: 'diff',
+      status,
+      content: code,
+      language: 'diff',
+      additions,
+      deletions,
+      sizeBytes: new TextEncoder().encode(code).byteLength,
+    };
+  }
+  return {
+    kind: 'output',
+    title: language === 'text' ? 'output' : `${language} code`,
+    status,
+    content: code,
+    language,
+    sizeBytes: new TextEncoder().encode(code).byteLength,
+  };
+}
+
+function buildComponents(
+  keyPrefix: string,
+  codeBlockPresentation: 'plain' | 'card',
+  codeBlockStatus: AgentDetailCardStatusV2
+): Components {
   return {
     a: ({ href, children, ...rest }) => (
       <a {...rest} href={href} target="_blank" rel="noopener noreferrer">
@@ -34,6 +84,7 @@ function buildComponents(keyPrefix: string): Components {
     code: ({ className, children, node, ...rest }) => {
       const match = /language-(\S+)/.exec(className ?? '');
       const codeText = String(children).replace(/\n$/, '');
+      const position = (node as MarkdownCodeNode | undefined)?.position;
       // A fenced code block only carries a `language-*` class when a
       // language is specified after the ```. Language-less fences and
       // 4-space-indented blocks still render as block-level `<pre><code>`
@@ -42,7 +93,12 @@ function buildComponents(keyPrefix: string): Components {
       // through CodeBlock (which preserves whitespace) rather than the
       // plain inline `<code>` path (which inherits `white-space: normal`
       // from `.tl-markdown` and collapses newlines to spaces).
-      const isBlock = Boolean(match) || codeText.includes('\n');
+      const isBlock =
+        Boolean(match) ||
+        codeText.includes('\n') ||
+        (position?.start?.line !== undefined &&
+          position.end?.line !== undefined &&
+          position.end.line > position.start.line);
       if (!isBlock) {
         return (
           <code className="tl-md-code" {...rest}>
@@ -51,9 +107,15 @@ function buildComponents(keyPrefix: string): Components {
         );
       }
       const language = match?.[1] ?? 'text';
-      const offset =
-        (node as MarkdownCodeNode | undefined)?.position?.start?.offset ??
-        codeText.length;
+      const offset = position?.start?.offset ?? codeText.length;
+      if (codeBlockPresentation === 'card') {
+        return (
+          <AgentDetailCard
+            card={codeCard(codeText, language, codeBlockStatus)}
+            itemId={`${keyPrefix}:code:${offset}`}
+          />
+        );
+      }
       return (
         <div className="tl-md-pre">
           <CodeBlock
@@ -88,15 +150,20 @@ interface AssistantMarkdownProps {
   text: string;
   /** Stable id used to scope syntax-highlight cache keys for code fences in this message. */
   keyPrefix: string;
+  /** Channel rows collapse block code; legacy Turn rendering remains unchanged. */
+  codeBlockPresentation?: 'plain' | 'card';
+  codeBlockStatus?: AgentDetailCardStatusV2;
 }
 
 export const AssistantMarkdown: React.FC<AssistantMarkdownProps> = ({
   text,
   keyPrefix,
+  codeBlockPresentation = 'plain',
+  codeBlockStatus = 'completed',
 }) => {
   const components = React.useMemo(
-    () => buildComponents(keyPrefix),
-    [keyPrefix]
+    () => buildComponents(keyPrefix, codeBlockPresentation, codeBlockStatus),
+    [keyPrefix, codeBlockPresentation, codeBlockStatus]
   );
   return (
     <div className="tl-text tl-markdown">

--- a/frontend/src/components/chat/AssistantMarkdown.tsx
+++ b/frontend/src/components/chat/AssistantMarkdown.tsx
@@ -24,10 +24,22 @@ import { AgentDetailCard } from './AgentDetailCard.js';
 
 interface MarkdownCodeNode {
   position?: {
-    start?: { offset?: number; line?: number };
-    end?: { line?: number };
+    start?: { offset?: number };
   };
 }
+
+/** Reused across renders — allocating a TextEncoder per code card is wasteful. */
+const textEncoder = new TextEncoder();
+
+/**
+ * react-markdown renders block code (fenced — with or without a language — or
+ * 4-space-indented) inside a `<pre>`, but inline code spans are not wrapped.
+ * The `pre` renderer publishes this so the `code` renderer can classify block
+ * vs inline without leaning on source line positions: a CommonMark inline span
+ * may legally span source lines (its interior newline collapses to a space),
+ * which would otherwise be misread as a block card.
+ */
+const CodeBlockContext = React.createContext(false);
 
 function codeCard(
   code: string,
@@ -54,7 +66,7 @@ function codeCard(
       language: 'diff',
       additions,
       deletions,
-      sizeBytes: new TextEncoder().encode(code).byteLength,
+      sizeBytes: textEncoder.encode(code).byteLength,
     };
   }
   return {
@@ -80,51 +92,64 @@ function buildComponents(
     ),
     // Fenced code blocks render their own <pre> inside the `code` renderer
     // below (so shiki tokens can be laid out per-line); avoid double-wrapping.
-    pre: ({ children }) => <>{children}</>,
+    // The provider carries no DOM element — it only flags the nested `code`
+    // renderer that this is block-level code.
+    pre: ({ children }) => (
+      <CodeBlockContext.Provider value={true}>
+        {children}
+      </CodeBlockContext.Provider>
+    ),
     code: ({ className, children, node, ...rest }) => {
       const match = /language-(\S+)/.exec(className ?? '');
       const codeText = String(children).replace(/\n$/, '');
       const position = (node as MarkdownCodeNode | undefined)?.position;
-      // A fenced code block only carries a `language-*` class when a
-      // language is specified after the ```. Language-less fences and
-      // 4-space-indented blocks still render as block-level `<pre><code>`
-      // with no className, so fall back to a newline check: anything with
-      // an embedded newline is a block, not inline code, and must go
-      // through CodeBlock (which preserves whitespace) rather than the
-      // plain inline `<code>` path (which inherits `white-space: normal`
-      // from `.tl-markdown` and collapses newlines to spaces).
-      const isBlock =
-        Boolean(match) ||
-        codeText.includes('\n') ||
-        (position?.start?.line !== undefined &&
-          position.end?.line !== undefined &&
-          position.end.line > position.start.line);
-      if (!isBlock) {
-        return (
-          <code className="tl-md-code" {...rest}>
-            {children}
-          </code>
-        );
-      }
-      const language = match?.[1] ?? 'text';
-      const offset = position?.start?.offset ?? codeText.length;
-      if (codeBlockPresentation === 'card') {
-        return (
-          <AgentDetailCard
-            card={codeCard(codeText, language, codeBlockStatus)}
-            itemId={`${keyPrefix}:code:${offset}`}
-          />
-        );
-      }
+      const inlineCode = (
+        <code className="tl-md-code" {...rest}>
+          {children}
+        </code>
+      );
+      // Read the `pre` flag through a Consumer rather than `useContext` — this
+      // renderer is a plain function react-markdown invokes for each `code`
+      // node, not a component the hooks lint recognizes.
       return (
-        <div className="tl-md-pre">
-          <CodeBlock
-            code={codeText}
-            language={language}
-            showLineNumbers={false}
-            cacheKey={`${keyPrefix}:${offset}`}
-          />
-        </div>
+        <CodeBlockContext.Consumer>
+          {(insidePre) => {
+            // Block code (fenced with or without a language, or 4-space
+            // indented) is rendered inside a `<pre>` by react-markdown, so the
+            // `pre` provider is the authoritative discriminator. Inline spans
+            // are never wrapped in a `<pre>` — even when their CommonMark
+            // source spans multiple lines — so they must NOT be promoted to a
+            // block card. Block code routes through CodeBlock (which preserves
+            // whitespace) rather than the plain inline `<code>` path (which
+            // inherits `white-space: normal` from `.tl-markdown` and collapses
+            // newlines to spaces). The newline check is a defensive fallback:
+            // inline spans collapse interior newlines to spaces, so a residual
+            // newline can only mean block code.
+            const isBlock =
+              insidePre || Boolean(match) || codeText.includes('\n');
+            if (!isBlock) return inlineCode;
+            const language = match?.[1] ?? 'text';
+            const offset = position?.start?.offset ?? codeText.length;
+            if (codeBlockPresentation === 'card') {
+              return (
+                <AgentDetailCard
+                  card={codeCard(codeText, language, codeBlockStatus)}
+                  itemId={`${keyPrefix}:code:${offset}`}
+                />
+              );
+            }
+            return (
+              <div className="tl-md-pre">
+                <CodeBlock
+                  code={codeText}
+                  language={language}
+                  showLineNumbers={false}
+                  cacheKey={`${keyPrefix}:${offset}`}
+                />
+              </div>
+            );
+          }}
+        </CodeBlockContext.Consumer>
       );
     },
     // Markdown images auto-fetch their remote `src` the instant the message

--- a/frontend/src/components/chat/AssistantMarkdown.tsx
+++ b/frontend/src/components/chat/AssistantMarkdown.tsx
@@ -75,7 +75,7 @@ function codeCard(
     status,
     content: code,
     language,
-    sizeBytes: new TextEncoder().encode(code).byteLength,
+    sizeBytes: textEncoder.encode(code).byteLength,
   };
 }
 

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -3,7 +3,9 @@ import type {
   ChannelMessage,
   ChannelMessageId,
 } from '../../../../shared/channel-chat-protocol.js';
+import type { AgentDetailCardStatusV2 } from '../../../../shared/agent-chat-protocol-v2.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
+import { AgentDetailCard } from './AgentDetailCard.js';
 import { ChannelImagePart } from './ChannelImagePart.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { respondChannelApproval } from '../../lib/api.js';
@@ -22,6 +24,28 @@ function useIdleBlink(signal: string, active: boolean): boolean {
     return () => clearTimeout(timer);
   }, [signal, active]);
   return blinking;
+}
+
+function detailStatusForMessage(
+  status: ChannelMessage['status']
+): AgentDetailCardStatusV2 {
+  if (status === 'streaming') return 'running';
+  if (status === 'failed') return 'failed';
+  if (status === 'interrupted' || status === 'truncated') return 'cancelled';
+  return 'completed';
+}
+
+function truncationLabelForMessage(message: ChannelMessage): string | null {
+  const reason =
+    message.status === 'truncated'
+      ? message.meta?.['truncationReason']
+      : message.truncated
+        ? 'size-limit'
+        : undefined;
+  if (reason === 'missing-terminal') return 'truncated · missing terminal';
+  if (reason === 'restart') return 'truncated · restart';
+  if (reason === 'size-limit') return 'truncated · 256kb limit';
+  return message.status === 'truncated' ? 'truncated' : null;
 }
 
 interface ChannelMessageRowProps {
@@ -94,22 +118,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   }
 
   const isHuman = message.sender.kind === 'human';
-  const truncationReason =
-    message.status === 'truncated'
-      ? message.meta?.['truncationReason']
-      : message.truncated
-        ? 'size-limit'
-        : undefined;
-  const truncationLabel =
-    truncationReason === 'missing-terminal'
-      ? 'truncated · missing terminal'
-      : truncationReason === 'restart'
-        ? 'truncated · restart'
-        : truncationReason === 'size-limit'
-          ? 'truncated · 256kb limit'
-          : message.status === 'truncated'
-            ? 'truncated'
-            : null;
+  const truncationLabel = truncationLabelForMessage(message);
   const rowClasses = [
     'ch-msg',
     isHuman ? 'ch-msg--user' : null,
@@ -129,10 +138,16 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       : undefined;
 
   const hasText = message.body.text.length > 0;
+  const detailStatus = detailStatusForMessage(message.status);
   const body = hasText ? (
     message.body.format === 'markdown' ? (
       <div className="ch-msg__body">
-        <AssistantMarkdown text={message.body.text} keyPrefix={message.id} />
+        <AssistantMarkdown
+          text={message.body.text}
+          keyPrefix={message.id}
+          codeBlockPresentation={isHuman ? 'plain' : 'card'}
+          codeBlockStatus={detailStatus}
+        />
       </div>
     ) : (
       <pre className="ch-msg__text ch-msg__body">{message.body.text}</pre>
@@ -145,7 +160,14 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       style={streamStyle}
       data-channel-message-seq={message.seq}
     >
-      {message.body.format === 'markdown' && (hasText || streaming) ? (
+      {message.agentDetail ? (
+        <AgentDetailCard
+          card={message.agentDetail.card}
+          itemId={message.agentDetail.itemId}
+        />
+      ) : null}
+      {message.body.format === 'markdown' &&
+      (hasText || (streaming && !message.agentDetail)) ? (
         <div className="ch-msg__body-wrap">
           {body}
           {streaming ? (

--- a/frontend/src/components/chat/useLiveReplyGrowth.ts
+++ b/frontend/src/components/chat/useLiveReplyGrowth.ts
@@ -135,7 +135,11 @@ export function useLiveReplyGrowth(
     let latestSeq = previousLatestSeq;
     for (const message of messages) {
       latestSeq = Math.max(latestSeq, message.seq);
-      if (message.threadId === null || tracker.seenReplyIds.has(message.id)) {
+      if (
+        message.threadId === null ||
+        message.agentDetail ||
+        tracker.seenReplyIds.has(message.id)
+      ) {
         continue;
       }
       tracker.seenReplyIds.add(message.id);

--- a/frontend/src/lib/chat/channel-timeline-layout.ts
+++ b/frontend/src/lib/chat/channel-timeline-layout.ts
@@ -36,6 +36,10 @@ export function deriveReplyCounts(
   const counts = new Map<ChannelMessageId, DerivedReplyCount>();
   for (const message of messages) {
     if (message.threadId === null) continue;
+    // Detail cards live in the thread (with a thread_id) for cold-resume
+    // rendering but are not conversational replies — mirror the store's
+    // reply-count SQL so live growth does not re-inflate the root count.
+    if (message.agentDetail) continue;
     const current = counts.get(message.threadId);
     const count = (current?.count ?? 0) + 1;
     let lastReplyAt = current?.lastReplyAt;

--- a/frontend/src/test-channel-timeline.tsx
+++ b/frontend/src/test-channel-timeline.tsx
@@ -41,9 +41,60 @@ function truncatedMessage(seq: number): ChannelMessage {
   };
 }
 
-const INITIAL_MESSAGES = Array.from({ length: 50 }, (_, index) =>
-  message(index + 21)
-);
+function detailMessage(
+  seq: number,
+  card: NonNullable<ChannelMessage['agentDetail']>['card']
+): ChannelMessage {
+  return {
+    ...message(seq, '', {
+      kind: 'agent',
+      id: 'agent:codex',
+      providerId: 'codex',
+    }),
+    agentDetail: { itemId: `detail-${seq}`, card },
+  };
+}
+
+const LARGE_OUTPUT = Array.from(
+  { length: 500 },
+  (_, index) => `const fixtureLine${index + 1} = ${index + 1};`
+).join('\n');
+const LARGE_DIFF = [
+  '--- a/frontend/src/channel-card.ts',
+  '+++ b/frontend/src/channel-card.ts',
+  '@@ -1,250 +1,250 @@',
+  ...Array.from({ length: 250 }, (_, index) => `-old line ${index + 1}`),
+  ...Array.from({ length: 250 }, (_, index) => `+new line ${index + 1}`),
+].join('\n');
+
+const INITIAL_MESSAGES = [
+  ...Array.from({ length: 47 }, (_, index) => message(index + 21)),
+  detailMessage(68, {
+    kind: 'thought',
+    title: 'inspect the channel renderer',
+    status: 'completed',
+    content: 'reasoning content persisted on the durable channel row',
+  }),
+  detailMessage(69, {
+    kind: 'output',
+    title: 'generate fixture output',
+    status: 'completed',
+    content: LARGE_OUTPUT,
+    language: 'typescript',
+    sizeBytes: new TextEncoder().encode(LARGE_OUTPUT).byteLength,
+  }),
+  detailMessage(70, {
+    kind: 'diff',
+    title: 'frontend/src/channel-card.ts',
+    path: 'frontend/src/channel-card.ts',
+    status: 'completed',
+    content: LARGE_DIFF,
+    language: 'diff',
+    additions: 250,
+    deletions: 250,
+    sizeBytes: new TextEncoder().encode(LARGE_DIFF).byteLength,
+  }),
+];
 
 function Fixture(): React.ReactElement {
   const [messages, setMessages] = useState(INITIAL_MESSAGES);
@@ -115,6 +166,34 @@ function Fixture(): React.ReactElement {
     });
   }, []);
 
+  const applyDetailRowUpdate = useCallback(() => {
+    setMessages((current) =>
+      current.map((row) =>
+        row.seq === 67
+          ? {
+              ...row,
+              status: 'streaming',
+              sender: {
+                kind: 'agent',
+                id: 'agent:codex',
+                providerId: 'codex',
+              },
+              body: { text: '', format: 'markdown' },
+              agentDetail: {
+                itemId: 'reason-live-browser',
+                card: {
+                  kind: 'thought',
+                  title: 'thinking',
+                  status: 'running',
+                  content: 'authoritative debounced browser row',
+                },
+              },
+            }
+          : row
+      )
+    );
+  }, []);
+
   const loadOlder = useCallback(async () => {
     if (!hasMoreOlder) return;
     setLoadingOlder(true);
@@ -161,6 +240,9 @@ function Fixture(): React.ReactElement {
         </button>
         <button data-testid="grow-stream" onClick={growStream}>
           grow stream
+        </button>
+        <button data-testid="update-detail-row" onClick={applyDetailRowUpdate}>
+          update detail row
         </button>
         <button
           data-testid="snapshot-overlap"

--- a/scripts/channel-memory-load.ts
+++ b/scripts/channel-memory-load.ts
@@ -73,9 +73,12 @@ async function main(): Promise<void> {
   let socket = new SinkSocket();
   let retention: ChannelBridgeRetentionSnapshot = {
     openStreams: 0,
+    openDetailStreams: 0,
     assistantItemIds: 0,
+    detailItemIds: 0,
     turnsWithRows: 0,
     retainedTextBytes: 0,
+    retainedDetailBytes: 0,
   };
   let durableTranscriptBytes = 0;
   const heapSamples: number[] = [];

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -1,9 +1,15 @@
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { createLogger } from './logger.js';
 import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
-import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  agentDetailCardForItem,
+  type AgentDetailCardStatusV2,
+  type AgentDetailCardV2,
+  type AgentPatchV2,
+} from '../shared/agent-chat-protocol-v2.js';
 import type { ChannelHub } from './channel-hub.js';
 import type { ChannelMessageStore } from './channel-message-store.js';
 import {
@@ -13,6 +19,8 @@ import {
 import { PACKET_IMAGE_DEGRADATION_META_KEY } from './channel-context-packet.js';
 import {
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
+  CHANNEL_AGENT_DETAIL_MAX_BYTES,
+  type ChannelAgentDetail,
   type ChannelImagePart,
   type ChannelMessage,
   type ChannelSenderRef,
@@ -43,6 +51,157 @@ const FLUSH_MAX_WAIT_MS = 2000;
 export const CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX = 256;
 /** Bound agent-produced image ingestion and durable rows per provider turn. */
 export const CHANNEL_BRIDGE_IMAGE_MAX_PER_TURN = 8;
+/** Frontend renders at most 64KiB; keep duplicated durable card payloads aligned. */
+export const CHANNEL_BRIDGE_DETAIL_MAX_CHARS = 64 * 1024;
+/** Metadata scalars are display hints, not unbounded provider payload lanes. */
+export const CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS = 1024;
+export const CHANNEL_BRIDGE_DETAIL_TITLE_MAX_CHARS = 1024;
+export const CHANNEL_BRIDGE_DETAIL_LANGUAGE_MAX_CHARS = 128;
+export const CHANNEL_BRIDGE_DETAIL_COMMAND_MAX_CHARS = 4096;
+export const CHANNEL_BRIDGE_DETAIL_PATH_MAX_CHARS = 4096;
+
+function diffCounts(content: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of content.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions += 1;
+    if (line.startsWith('-') && !line.startsWith('---')) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+/** Provider-boundary sanitizer shared by the bridge and its invariant tests. */
+export function boundChannelAgentDetail(
+  itemId: string,
+  sourceCard: AgentDetailCardV2
+): ChannelAgentDetail {
+  const boundScalar = (
+    value: string | undefined,
+    maxChars: number,
+    keepTail = false
+  ): string | undefined => {
+    if (value === undefined || value.length <= maxChars) return value;
+    return keepTail ? value.slice(-maxChars) : value.slice(0, maxChars);
+  };
+  const boundedItemId = (() => {
+    if (itemId.length <= CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS) return itemId;
+    const suffix = `#${crypto
+      .createHash('sha256')
+      .update(itemId)
+      .digest('hex')
+      .slice(0, 24)}`;
+    return `${itemId.slice(
+      0,
+      CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS - suffix.length
+    )}${suffix}`;
+  })();
+  const originalContent = sourceCard.content;
+  const keepTail =
+    sourceCard.kind === 'output' || sourceCard.kind === 'tool_call';
+  const content = boundScalar(
+    originalContent,
+    CHANNEL_BRIDGE_DETAIL_MAX_CHARS,
+    keepTail
+  );
+  const originalBytes =
+    originalContent === undefined
+      ? undefined
+      : Buffer.byteLength(originalContent, 'utf8');
+  let card: AgentDetailCardV2 = {
+    // Project the protocol contract explicitly. Provider extensions and other
+    // validator-permitted unknown keys never enter durable row metadata.
+    kind: sourceCard.kind,
+    title:
+      boundScalar(sourceCard.title, CHANNEL_BRIDGE_DETAIL_TITLE_MAX_CHARS) ??
+      '',
+    status: sourceCard.status,
+    ...(sourceCard.language !== undefined
+      ? {
+          language: boundScalar(
+            sourceCard.language,
+            CHANNEL_BRIDGE_DETAIL_LANGUAGE_MAX_CHARS
+          )!,
+        }
+      : {}),
+    ...(sourceCard.command !== undefined
+      ? {
+          command: boundScalar(
+            sourceCard.command,
+            CHANNEL_BRIDGE_DETAIL_COMMAND_MAX_CHARS,
+            true
+          )!,
+        }
+      : {}),
+    ...(sourceCard.path !== undefined
+      ? {
+          path: boundScalar(
+            sourceCard.path,
+            CHANNEL_BRIDGE_DETAIL_PATH_MAX_CHARS,
+            true
+          )!,
+        }
+      : {}),
+    ...(content !== undefined ? { content } : {}),
+    ...(sourceCard.additions !== undefined
+      ? { additions: sourceCard.additions }
+      : {}),
+    ...(sourceCard.deletions !== undefined
+      ? { deletions: sourceCard.deletions }
+      : {}),
+    ...(originalBytes !== undefined
+      ? { sizeBytes: originalBytes }
+      : sourceCard.sizeBytes !== undefined
+        ? { sizeBytes: sourceCard.sizeBytes }
+        : {}),
+    ...(sourceCard.kind === 'diff' && content
+      ? {
+          additions: sourceCard.additions ?? diffCounts(content).additions,
+          deletions: sourceCard.deletions ?? diffCounts(content).deletions,
+        }
+      : {}),
+  };
+  let detail: ChannelAgentDetail = { itemId: boundedItemId, card };
+  // JSON escaping can make a 64KiB string larger than its source bytes.
+  // Tighten deterministically until the complete typed payload fits the cap.
+  while (
+    (card.content?.length ?? 0) > 0 &&
+    Buffer.byteLength(JSON.stringify(detail), 'utf8') >
+      CHANNEL_AGENT_DETAIL_MAX_BYTES
+  ) {
+    const previousLength = card.content!.length;
+    // Always remove at least one code unit. This cannot stall at a tiny
+    // length under an escaping-heavy payload.
+    const nextLength = Math.max(
+      0,
+      Math.min(previousLength - 1, Math.floor(previousLength * 0.8))
+    );
+    const nextContent = keepTail
+      ? nextLength === 0
+        ? ''
+        : card.content!.slice(-nextLength)
+      : card.content!.slice(0, nextLength);
+    card = {
+      ...card,
+      content: nextContent,
+      ...(card.kind === 'diff'
+        ? {
+            additions: card.additions ?? diffCounts(nextContent).additions,
+            deletions: card.deletions ?? diffCounts(nextContent).deletions,
+          }
+        : {}),
+    };
+    detail = { itemId: boundedItemId, card };
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(detail), 'utf8') >
+    CHANNEL_AGENT_DETAIL_MAX_BYTES
+  ) {
+    // With the scalar caps above this is unreachable even for worst-case JSON
+    // escaping. Keep the invariant fail-closed if fields are added later.
+    throw new Error('bounded channel agent detail still exceeds payload cap');
+  }
+  return detail;
+}
 
 interface BridgeStream {
   streamKey: string;
@@ -56,6 +215,18 @@ interface BridgeStream {
   state: 'open' | 'terminal-observed' | 'released';
   flushTimer: NodeJS.Timeout | null;
   firstScheduledAt: number | null;
+}
+
+interface DetailStream {
+  streamKey: string;
+  sourceKey: string;
+  messageId: string;
+  turnId: string;
+  itemId: string;
+  card: AgentDetailCardV2;
+  reasoningSummary: string;
+  reasoningDetail: string;
+  state: 'open' | 'released';
 }
 
 interface AssistantItemAlias {
@@ -99,9 +270,12 @@ export interface BindSessionToChannelInput {
 
 export interface ChannelBridgeRetentionSnapshot {
   openStreams: number;
+  openDetailStreams: number;
   assistantItemIds: number;
+  detailItemIds: number;
   turnsWithRows: number;
   retainedTextBytes: number;
+  retainedDetailBytes: number;
 }
 
 /**
@@ -114,10 +288,10 @@ export function bindSessionToChannel(
 ): () => void {
   const { channelId, agentFramework, adapter, store, hub } = input;
   const streams = new Map<string, BridgeStream>();
-  // Item ids started as `assistantMessage`. Only these may open/mirror a channel
-  // stream. Plan/reasoning/tool items also carry `delta.text` on real adapters
-  // (e.g. the codex-native plan item `plan-<turnId>`), and §6.3 mirrors ONLY
-  // assistantMessage text — so a delta for any other item type is dropped.
+  const detailStreams = new Map<string, DetailStream>();
+  const detailItemAliases = new Map<string, string>();
+  // Assistant item aliases keep prose streams stable across provider echo ids;
+  // detail items use the same canonical source identity in their own rows.
   const assistantItemAliases = new Map<string, AssistantItemAlias>();
   // Turn ids that opened at least one channel-message stream. A `turn-completed`
   // for a turn absent here produced ZERO message rows — a silent finalization
@@ -150,6 +324,120 @@ export function bindSessionToChannel(
     return `${turnId}\u0000${canonicalItemId}`;
   }
 
+  function detailStreamKey(turnId: string, itemId: string): string {
+    return `${turnId}\u0000detail\u0000${itemId}`;
+  }
+
+  function detailStatus(
+    status: 'complete' | 'truncated' | 'interrupted' | 'failed'
+  ): AgentDetailCardStatusV2 {
+    if (status === 'failed') return 'failed';
+    if (status === 'truncated' || status === 'interrupted') return 'cancelled';
+    return 'completed';
+  }
+
+  function explicitDetailStatus(
+    status: AgentDetailCardStatusV2
+  ): status is 'completed' | 'failed' | 'cancelled' {
+    return (
+      status === 'completed' || status === 'failed' || status === 'cancelled'
+    );
+  }
+
+  function detailRowStatus(
+    status: 'completed' | 'failed' | 'cancelled'
+  ): 'complete' | 'failed' | 'interrupted' {
+    if (status === 'failed') return 'failed';
+    if (status === 'cancelled') return 'interrupted';
+    return 'complete';
+  }
+
+  function appendCardDelta(
+    stream: DetailStream,
+    patch: Extract<AgentPatchV2, { type: 'agent-item-delta-v2' }>
+  ): AgentDetailCardV2 {
+    const accumulate = (
+      current: string,
+      fragment: string,
+      mode: 'append' | 'replace' | undefined,
+      keepTail = false
+    ): string => {
+      if (mode === 'replace') {
+        return keepTail
+          ? fragment.slice(-CHANNEL_BRIDGE_DETAIL_MAX_CHARS)
+          : fragment.slice(0, CHANNEL_BRIDGE_DETAIL_MAX_CHARS);
+      }
+      if (keepTail) {
+        return `${current.slice(-CHANNEL_BRIDGE_DETAIL_MAX_CHARS)}${fragment.slice(
+          -CHANNEL_BRIDGE_DETAIL_MAX_CHARS
+        )}`.slice(-CHANNEL_BRIDGE_DETAIL_MAX_CHARS);
+      }
+      const remaining = Math.max(
+        0,
+        CHANNEL_BRIDGE_DETAIL_MAX_CHARS - current.length
+      );
+      return `${current.slice(0, CHANNEL_BRIDGE_DETAIL_MAX_CHARS)}${fragment.slice(
+        0,
+        remaining
+      )}`;
+    };
+    const card = stream.card;
+    if (card.kind === 'thought') {
+      if (typeof patch.delta.summary === 'string') {
+        stream.reasoningSummary = accumulate(
+          stream.reasoningSummary,
+          patch.delta.summary,
+          patch.mode
+        );
+      }
+      if (typeof patch.delta.detail === 'string') {
+        stream.reasoningDetail = accumulate(
+          stream.reasoningDetail,
+          patch.delta.detail,
+          patch.mode
+        );
+      }
+      if (
+        typeof patch.delta.text === 'string' &&
+        patch.delta.summary === undefined &&
+        patch.delta.detail === undefined
+      ) {
+        stream.reasoningSummary = accumulate(
+          stream.reasoningSummary,
+          patch.delta.text,
+          patch.mode
+        );
+      }
+      return {
+        ...card,
+        content: stream.reasoningDetail || stream.reasoningSummary,
+        ...(patch.delta.status ? { status: patch.delta.status } : {}),
+        ...(patch.delta.card ?? {}),
+      };
+    }
+    const fragment =
+      card.kind === 'output'
+        ? (patch.delta.output ?? patch.delta.text)
+        : card.kind === 'diff'
+          ? (patch.delta.patch ?? patch.delta.text)
+          : (patch.delta.content ?? patch.delta.output ?? patch.delta.text);
+    const content =
+      typeof fragment !== 'string'
+        ? card.content
+        : accumulate(
+            card.content ?? '',
+            fragment,
+            patch.mode,
+            card.kind === 'output' || card.kind === 'tool_call'
+          );
+    return {
+      ...card,
+      ...(content !== undefined ? { content } : {}),
+      ...(patch.delta.status ? { status: patch.delta.status } : {}),
+      ...(patch.delta.card ?? {}),
+    };
+  }
+
   function forgetAliasesForStream(streamKey: string): void {
     for (const [aliasId, alias] of assistantItemAliases) {
       if (alias.streamKey === streamKey) assistantItemAliases.delete(aliasId);
@@ -171,11 +459,23 @@ export function bindSessionToChannel(
     for (const stream of streams.values()) {
       retainedTextBytes += stream.byteLength;
     }
+    let retainedDetailBytes = 0;
+    for (const stream of detailStreams.values()) {
+      retainedDetailBytes += Buffer.byteLength(
+        JSON.stringify(stream.card),
+        'utf8'
+      );
+      retainedDetailBytes += Buffer.byteLength(stream.reasoningSummary, 'utf8');
+      retainedDetailBytes += Buffer.byteLength(stream.reasoningDetail, 'utf8');
+    }
     input.onRetentionSnapshot({
       openStreams: streams.size,
+      openDetailStreams: detailStreams.size,
       assistantItemIds: assistantItemAliases.size,
+      detailItemIds: detailItemAliases.size,
       turnsWithRows: turnsWithRows.size,
       retainedTextBytes,
+      retainedDetailBytes,
     });
   }
 
@@ -235,6 +535,183 @@ export function bindSessionToChannel(
     hub.beginStreamBroadcast(message);
     reportRetention();
     return stream;
+  }
+
+  function openDetailStream(
+    patch: Extract<
+      AgentPatchV2,
+      { type: 'agent-item-started-v2' | 'agent-item-updated-v2' }
+    >,
+    sourceCard: AgentDetailCardV2
+  ): DetailStream | null {
+    const itemId = canonicalAssistantItemId(patch.item);
+    const streamKey = detailStreamKey(patch.turnId, itemId);
+    detailItemAliases.set(patch.item.id, streamKey);
+    const existing = detailStreams.get(streamKey);
+    if (existing) return existing;
+    const sourceKey = itemSourceKey(patch.sessionId, patch.turnId, itemId);
+    if (recentFinalizedItemKeys.has(sourceKey)) {
+      if (
+        sourceCard.status !== 'completed' &&
+        sourceCard.status !== 'failed' &&
+        sourceCard.status !== 'cancelled'
+      ) {
+        detailItemAliases.delete(patch.item.id);
+        return null;
+      }
+    }
+    const agentDetail = boundChannelAgentDetail(itemId, sourceCard);
+    const parentMessageId = input.parentMessageIdForTurn?.(patch.turnId);
+    const message = store.beginStream({
+      channelId,
+      sender,
+      source: { sessionId: patch.sessionId, turnId: patch.turnId, itemId },
+      agentDetail,
+      ...(parentMessageId ? { parentMessageId } : {}),
+    });
+    if (message.status !== 'streaming') {
+      rememberFinalizedItem(sourceKey);
+      detailItemAliases.delete(patch.item.id);
+      if (explicitDetailStatus(sourceCard.status)) {
+        // Durable per-detail state machine:
+        //   provisional turn/restart terminal -> first explicit item terminal
+        //   explicit terminal -> absorbing (duplicates/conflicts are no-ops)
+        const resolved = store.resolveProvisionalAgentDetailTerminal(
+          message.id,
+          {
+            text: message.body.text,
+            status: detailRowStatus(sourceCard.status),
+            agentDetail: boundChannelAgentDetail(itemId, sourceCard),
+          }
+        );
+        if (resolved.transitioned && resolved.message) {
+          hub.completeStreamBroadcast(resolved.message);
+        }
+      }
+      reportRetention();
+      return null;
+    }
+    const stream: DetailStream = {
+      streamKey,
+      sourceKey,
+      messageId: message.id,
+      turnId: patch.turnId,
+      itemId,
+      card: agentDetail.card,
+      reasoningSummary:
+        patch.item.type === 'reasoning'
+          ? patch.item.summary.slice(0, CHANNEL_BRIDGE_DETAIL_MAX_CHARS)
+          : '',
+      reasoningDetail:
+        patch.item.type === 'reasoning'
+          ? (patch.item.detail ?? '').slice(0, CHANNEL_BRIDGE_DETAIL_MAX_CHARS)
+          : '',
+      state: 'open',
+    };
+    detailStreams.set(streamKey, stream);
+    turnsWithRows.add(patch.turnId);
+    hub.beginStreamBroadcast(message);
+    reportRetention();
+    return stream;
+  }
+
+  function finalizeDetail(
+    stream: DetailStream,
+    status: 'complete' | 'truncated' | 'interrupted' | 'failed',
+    sourceCard: AgentDetailCardV2 = stream.card,
+    authority: 'provisional' | 'explicit' = 'provisional'
+  ): void {
+    if (stream.state === 'released') return;
+    const agentDetail = boundChannelAgentDetail(stream.itemId, {
+      ...sourceCard,
+      status: detailStatus(status),
+    });
+    const message = store.finalizeStream(stream.messageId, {
+      text: '',
+      status,
+      agentDetail,
+      agentDetailTerminalAuthority: authority,
+      ...(status === 'truncated'
+        ? { truncationReason: 'missing-terminal' as const }
+        : {}),
+    });
+    stream.state = 'released';
+    detailStreams.delete(stream.streamKey);
+    for (const [aliasId, streamKey] of detailItemAliases) {
+      if (streamKey === stream.streamKey) detailItemAliases.delete(aliasId);
+    }
+    rememberFinalizedItem(stream.sourceKey);
+    reportRetention();
+    if (!message) return;
+    hub.completeStreamBroadcast(message);
+    try {
+      store.upsertMember({ channelId, kind: 'agent', id: sender.id });
+    } catch (err) {
+      logger.warn('channel bridge detail member upsert failed:', err);
+    }
+  }
+
+  function handleDetailItem(
+    patch: Extract<
+      AgentPatchV2,
+      { type: 'agent-item-started-v2' | 'agent-item-updated-v2' }
+    >
+  ): boolean {
+    // Assistant messages are the channel's prose stream. Some adapters attach
+    // a generic output card to them, but treating that hint as a detail item
+    // would consume the message before the text path and persist an empty card
+    // row. Structured cards are reserved for non-message provider items.
+    if (patch.item.type === 'assistantMessage') return false;
+    const sourceCard = patch.item.card ?? agentDetailCardForItem(patch.item);
+    if (!sourceCard || sourceCard.kind === 'message') return false;
+    const stream = openDetailStream(patch, sourceCard);
+    if (!stream) return true;
+    stream.card = boundChannelAgentDetail(stream.itemId, sourceCard).card;
+    const itemStatus = sourceCard.status;
+    if (itemStatus === 'completed') {
+      finalizeDetail(stream, 'complete', sourceCard, 'explicit');
+    } else if (itemStatus === 'failed') {
+      finalizeDetail(stream, 'failed', sourceCard, 'explicit');
+    } else if (itemStatus === 'cancelled') {
+      finalizeDetail(stream, 'interrupted', sourceCard, 'explicit');
+    } else {
+      const updated = store.updateAgentDetail(
+        stream.messageId,
+        boundChannelAgentDetail(stream.itemId, stream.card)
+      );
+      if (updated) hub.updateStreamBroadcast(updated);
+      reportRetention();
+    }
+    return true;
+  }
+
+  function handleDetailDelta(
+    patch: Extract<AgentPatchV2, { type: 'agent-item-delta-v2' }>
+  ): boolean {
+    const detail = detailStreams.get(
+      detailItemAliases.get(patch.itemId) ??
+        detailStreamKey(patch.turnId, patch.itemId)
+    );
+    if (!detail) return false;
+    detail.card = boundChannelAgentDetail(
+      detail.itemId,
+      appendCardDelta(detail, patch)
+    ).card;
+    if (patch.delta.status === 'completed') {
+      finalizeDetail(detail, 'complete', detail.card, 'explicit');
+    } else if (patch.delta.status === 'failed') {
+      finalizeDetail(detail, 'failed', detail.card, 'explicit');
+    } else if (patch.delta.status === 'cancelled') {
+      finalizeDetail(detail, 'interrupted', detail.card, 'explicit');
+    } else {
+      const updated = store.updateAgentDetail(
+        detail.messageId,
+        boundChannelAgentDetail(detail.itemId, detail.card)
+      );
+      if (updated) hub.updateStreamBroadcast(updated);
+      reportRetention();
+    }
+    return true;
   }
 
   function scheduleFlush(stream: BridgeStream): void {
@@ -528,6 +1005,11 @@ export function bindSessionToChannel(
       if (turnId !== undefined && stream.turnId !== turnId) continue;
       finalize(stream, status, stream.text);
     }
+    for (const stream of [...detailStreams.values()]) {
+      if (stream.state === 'released') continue;
+      if (turnId !== undefined && stream.turnId !== turnId) continue;
+      finalizeDetail(stream, status);
+    }
     markTurnImagesTerminal(turnId);
     // #1181 defect 4: a cleanly-completed bound-agent turn that produced no
     // channel message row is a silent failure (the reply never reached the
@@ -548,11 +1030,17 @@ export function bindSessionToChannel(
     if (turnId === undefined) {
       turnsWithRows.clear();
       assistantItemAliases.clear();
+      detailItemAliases.clear();
       reportRetention();
     } else {
       turnsWithRows.delete(turnId);
       for (const [itemId, alias] of assistantItemAliases) {
         if (alias.turnId === turnId) assistantItemAliases.delete(itemId);
+      }
+      for (const [itemId, streamKey] of detailItemAliases) {
+        if (streamKey.startsWith(`${turnId}\u0000`)) {
+          detailItemAliases.delete(itemId);
+        }
       }
       reportRetention();
     }
@@ -580,6 +1068,7 @@ export function bindSessionToChannel(
           void mirrorAgentImage(patch, parentMessageId);
           break;
         }
+        if (handleDetailItem(patch)) break;
         if (patch.item.type === 'assistantMessage') {
           const canonicalItemId = canonicalAssistantItemId(patch.item);
           const streamKey = bridgeStreamKey(patch.turnId, canonicalItemId);
@@ -603,6 +1092,7 @@ export function bindSessionToChannel(
         break;
       }
       case 'agent-item-delta-v2': {
+        if (handleDetailDelta(patch)) break;
         if (typeof patch.delta.text !== 'string') break;
         if (patch.delta.text.length === 0) break;
         const alias = assistantItemAliases.get(patch.itemId);
@@ -627,6 +1117,7 @@ export function bindSessionToChannel(
         break;
       }
       case 'agent-item-updated-v2': {
+        if (handleDetailItem(patch)) break;
         if (patch.item.type !== 'assistantMessage') break;
         const canonicalItemId = canonicalAssistantItemId(patch.item);
         const streamKey = bridgeStreamKey(patch.turnId, canonicalItemId);
@@ -696,8 +1187,7 @@ export function bindSessionToChannel(
         break;
       }
       default:
-        // Non-text items (commandExecution/fileChange/approvals/reasoning),
-        // Session snapshots and non-text items are not mirrored.
+        // Session snapshots and non-card control items are not mirrored.
         break;
     }
   }
@@ -712,7 +1202,12 @@ export function bindSessionToChannel(
         finalize(stream, 'truncated', stream.text);
       }
     }
+    for (const stream of [...detailStreams.values()]) {
+      if (stream.state !== 'released') finalizeDetail(stream, 'truncated');
+    }
     streams.clear();
+    detailStreams.clear();
+    detailItemAliases.clear();
     assistantItemAliases.clear();
     turnsWithRows.clear();
     turnImages.clear();

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -666,14 +666,23 @@ export function bindSessionToChannel(
     if (!sourceCard || sourceCard.kind === 'message') return false;
     const stream = openDetailStream(patch, sourceCard);
     if (!stream) return true;
+    const accumulated = stream.card; // capture BEFORE the terminal overwrite
     stream.card = boundChannelAgentDetail(stream.itemId, sourceCard).card;
     const itemStatus = sourceCard.status;
+    // Prefer delta-accumulated content when the terminal item card is empty,
+    // matching handleDetailDelta which finalizes from the accumulated card
+    // (#1206). Unreachable with today's codex/claude adapters (they backfill
+    // terminal content) but unguarded for other providers.
+    const terminalCard =
+      sourceCard.content || !accumulated.content
+        ? sourceCard
+        : { ...sourceCard, content: accumulated.content };
     if (itemStatus === 'completed') {
-      finalizeDetail(stream, 'complete', sourceCard, 'explicit');
+      finalizeDetail(stream, 'complete', terminalCard, 'explicit');
     } else if (itemStatus === 'failed') {
-      finalizeDetail(stream, 'failed', sourceCard, 'explicit');
+      finalizeDetail(stream, 'failed', terminalCard, 'explicit');
     } else if (itemStatus === 'cancelled') {
-      finalizeDetail(stream, 'interrupted', sourceCard, 'explicit');
+      finalizeDetail(stream, 'interrupted', terminalCard, 'explicit');
     } else {
       const updated = store.updateAgentDetail(
         stream.messageId,

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -87,6 +87,9 @@ interface Accumulator {
   /** last emitted deltaIndex (−1 before the first flush). */
   deltaIndex: number;
   coalesceTimer: NodeJS.Timeout | null;
+  /** Latest persisted full-row refresh waiting for one debounced broadcast. */
+  pendingUpdate: ChannelMessage | null;
+  updateTimer: NodeJS.Timeout | null;
 }
 
 export type ChannelMessagePostedHandler = (
@@ -121,6 +124,8 @@ export interface ChannelHub {
   broadcastCreated(message: ChannelMessage, mentions?: ChannelMention[]): void;
   beginStreamBroadcast(message: ChannelMessage): void;
   pushDelta(messageId: string, text: string): void;
+  /** Debounced authoritative full-row refresh for streaming card state. */
+  updateStreamBroadcast(message: ChannelMessage): void;
   completeStreamBroadcast(message: ChannelMessage): void;
   onMessagePosted(handler: ChannelMessagePostedHandler): () => void;
   setBadgeBroadcaster(broadcaster: ChannelBadgeBroadcaster): void;
@@ -401,6 +406,21 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     });
   }
 
+  function flushRowUpdate(messageId: string): void {
+    const acc = accumulators.get(messageId);
+    if (!acc) return;
+    acc.updateTimer = null;
+    const message = acc.pendingUpdate;
+    acc.pendingUpdate = null;
+    if (!message) return;
+    broadcast(message.channelId, {
+      type: 'channel-message-updated-v1',
+      channelId: message.channelId,
+      timestamp: nowIso(),
+      message,
+    });
+  }
+
   /**
    * Flush any pending (accumulated-but-unemitted) delta text for a channel's
    * streaming rows synchronously, before a connecting socket reads its snapshot.
@@ -517,6 +537,8 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         pendingText: '',
         deltaIndex: -1,
         coalesceTimer: null,
+        pendingUpdate: null,
+        updateTimer: null,
       });
       broadcast(message.channelId, {
         type: 'channel-message-created-v1',
@@ -541,9 +563,23 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       }
     },
 
+    updateStreamBroadcast(message) {
+      const acc = accumulators.get(message.id);
+      if (!acc || message.status !== 'streaming') return;
+      acc.pendingUpdate = message;
+      if (!acc.updateTimer) {
+        acc.updateTimer = setTimeout(
+          () => flushRowUpdate(message.id),
+          coalesceMs
+        );
+        acc.updateTimer.unref?.();
+      }
+    },
+
     completeStreamBroadcast(message) {
       const acc = accumulators.get(message.id);
       if (acc?.coalesceTimer) clearTimeout(acc.coalesceTimer);
+      if (acc?.updateTimer) clearTimeout(acc.updateTimer);
       accumulators.delete(message.id);
       broadcast(message.channelId, {
         type: 'channel-message-completed-v1',
@@ -588,6 +624,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     close() {
       for (const acc of accumulators.values()) {
         if (acc.coalesceTimer) clearTimeout(acc.coalesceTimer);
+        if (acc.updateTimer) clearTimeout(acc.updateTimer);
       }
       accumulators.clear();
       subscribers.clear();

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -49,9 +49,13 @@ const CHANNEL_SUMMARY_PREVIEW_MAX_CHARS = 200;
 export type ChannelThreadHistoryQueryMode = 'default' | 'after' | 'before';
 
 function replyCountSql(rootAlias: string): string {
+  // Detail cards (meta.agentDetail) carry a thread_id so cold-resume can render
+  // them inside the thread, but they are not conversational replies — exclude
+  // them from the root's reply count.
   return `(SELECT COUNT(*)
              FROM channel_messages replies
-            WHERE replies.thread_id = ${rootAlias}.id)`;
+            WHERE replies.thread_id = ${rootAlias}.id
+              AND json_extract(replies.meta_json, '$.agentDetail') IS NULL)`;
 }
 
 /** Production query builder exported so query-plan tests exercise exact SQL. */
@@ -1343,6 +1347,23 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
            ORDER BY last.updated_at DESC`
         )
         .all() as Array<ChannelMessageRow & { cnt?: number }>;
+      // Newest prose row per channel — the summary preview reads from this so a
+      // turn ending on a detail card (body_text='') does not blank the sidebar.
+      const previewRows = new Map<string, ChannelMessageRow>();
+      for (const row of db
+        .prepare(
+          `SELECT prose.* FROM (
+             SELECT channel_id, MAX(seq) AS max_seq
+             FROM channel_messages
+             WHERE json_extract(meta_json, '$.agentDetail') IS NULL
+             GROUP BY channel_id
+           ) agg
+           JOIN channel_messages prose
+             ON prose.channel_id = agg.channel_id AND prose.seq = agg.max_seq`
+        )
+        .all() as ChannelMessageRow[]) {
+        previewRows.set(row.channel_id, row);
+      }
       // Second pass for counts keyed by channel (kept explicit for clarity).
       const counts = new Map<string, number>();
       for (const c of db
@@ -1354,7 +1375,11 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         counts.set(c.channel_id, c.cnt);
       }
       return rows.map((row) =>
-        summaryFromLastRow(row, counts.get(row.channel_id) ?? 0)
+        summaryFromLastRow(
+          row.seq,
+          previewRows.get(row.channel_id) ?? row,
+          counts.get(row.channel_id) ?? 0
+        )
       );
     },
 
@@ -1376,7 +1401,16 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       if (!last) {
         return { channelId, latestSeq: 0, messageCount: 0, lastMessage: null };
       }
-      return summaryFromLastRow(last, count);
+      // Preview from the newest prose row; detail cards persist body_text=''.
+      const previewRow =
+        (db
+          .prepare(
+            `SELECT * FROM channel_messages WHERE channel_id = ?
+               AND json_extract(meta_json, '$.agentDetail') IS NULL
+             ORDER BY seq DESC LIMIT 1`
+          )
+          .get(channelId) as ChannelMessageRow | undefined) ?? last;
+      return summaryFromLastRow(last.seq, previewRow, count);
     },
 
     upsertMember(input) {
@@ -1550,22 +1584,30 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
     },
   };
 
+  // `latestSeq` stays the true highest seq (drives reconnect head-checks and
+  // unread math), while the preview is drawn from `previewRow` — the newest row
+  // that carries prose. Detail cards persist body_text='', so previewing off the
+  // literal last row blanks the summary whenever a turn ends on a card.
   function summaryFromLastRow(
-    row: ChannelMessageRow,
+    latestSeq: number,
+    previewRow: ChannelMessageRow,
     messageCount: number
   ): ChannelSummary {
     return {
-      channelId: row.channel_id,
-      latestSeq: row.seq,
+      channelId: previewRow.channel_id,
+      latestSeq,
       messageCount,
       lastMessage: {
-        id: row.id as ChannelMessageId,
-        seq: row.seq,
-        preview: row.body_text.slice(0, CHANNEL_SUMMARY_PREVIEW_MAX_CHARS),
-        senderId: row.sender_id,
-        senderKind: row.sender_kind as ChannelSenderRef['kind'],
-        status: row.status as ChannelMessageStatus,
-        createdAt: row.created_at,
+        id: previewRow.id as ChannelMessageId,
+        seq: previewRow.seq,
+        preview: previewRow.body_text.slice(
+          0,
+          CHANNEL_SUMMARY_PREVIEW_MAX_CHARS
+        ),
+        senderId: previewRow.sender_id,
+        senderKind: previewRow.sender_kind as ChannelSenderRef['kind'],
+        status: previewRow.status as ChannelMessageStatus,
+        createdAt: previewRow.created_at,
       },
     };
   }

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -7,9 +7,12 @@ import { createLogger } from './logger.js';
 
 import {
   CHANNEL_CHAT_PROTOCOL_VERSION,
+  CHANNEL_AGENT_DETAIL_MAX_BYTES,
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
   CHANNEL_MESSAGE_MAX_IMAGE_PARTS,
   isChannelMessagePart,
+  isChannelAgentDetail,
+  type ChannelAgentDetail,
   type ChannelBodyFormat,
   type ChannelMemberRef,
   type ChannelMention,
@@ -183,6 +186,9 @@ export interface ChannelMessageMeta {
   truncationReason?: ChannelTruncationReason;
   /** Legacy UI marker reserved exclusively for the 256KB size limit. */
   truncated?: boolean;
+  agentDetail?: ChannelAgentDetail;
+  /** Internal lifecycle marker; stripped before rows cross the wire. */
+  agentDetailTerminalAuthority?: 'provisional' | 'explicit';
   [key: string]: unknown;
 }
 
@@ -207,6 +213,7 @@ export interface BeginStreamInput {
   parentMessageId?: string;
   mentions?: ChannelMention[];
   parts?: ChannelMessagePart[];
+  agentDetail?: ChannelAgentDetail;
 }
 
 export interface FinalizeStreamInput {
@@ -218,6 +225,14 @@ export interface FinalizeStreamInput {
   truncationReason?: ChannelTruncationReason;
   /** Legacy alias for `truncationReason: 'size-limit'`. */
   truncated?: boolean;
+  agentDetail?: ChannelAgentDetail;
+  /** Detail rows distinguish turn/restart fallback from item-level terminal. */
+  agentDetailTerminalAuthority?: 'provisional' | 'explicit';
+}
+
+export interface ResolveProvisionalAgentDetailTerminalResult {
+  message: ChannelMessage | null;
+  transitioned: boolean;
 }
 
 export interface ChannelSummary {
@@ -276,6 +291,16 @@ export interface ChannelMessageStore {
   appendComplete(input: AppendCompleteInput): ChannelMessage;
   beginStream(input: BeginStreamInput): ChannelMessage;
   updateStreamText(id: string, text: string): ChannelMessage | null;
+  updateAgentDetail(
+    id: string,
+    detail: ChannelAgentDetail
+  ): ChannelMessage | null;
+  resolveProvisionalAgentDetailTerminal(
+    id: string,
+    input: Pick<FinalizeStreamInput, 'text' | 'status'> & {
+      agentDetail: ChannelAgentDetail;
+    }
+  ): ResolveProvisionalAgentDetailTerminalResult;
   finalizeStream(id: string, input: FinalizeStreamInput): ChannelMessage | null;
   getMessage(id: string): ChannelMessage | null;
   findByClientMessage(
@@ -362,6 +387,42 @@ function assertMessageParts(parts: ChannelMessagePart[] | undefined): void {
   }
 }
 
+function assertAgentDetail(detail: ChannelAgentDetail | undefined): void {
+  if (detail === undefined) return;
+  if (
+    !isChannelAgentDetail(detail) ||
+    Buffer.byteLength(JSON.stringify(detail), 'utf8') >
+      CHANNEL_AGENT_DETAIL_MAX_BYTES
+  ) {
+    throw new ChannelMessageStoreError(
+      413,
+      'channel_agent_detail_too_large',
+      'channel agent detail is invalid or exceeds the 256KB cap'
+    );
+  }
+}
+
+function assertMessagePayloadSize(
+  text: string,
+  detail: ChannelAgentDetail | undefined
+): void {
+  assertBodySize(text);
+  assertAgentDetail(detail);
+  const bytes =
+    Buffer.byteLength(text, 'utf8') +
+    (detail === undefined
+      ? 0
+      : Buffer.byteLength(JSON.stringify(detail), 'utf8'));
+  if (bytes > CHANNEL_MESSAGE_BODY_MAX_BYTES) {
+    throw new ChannelMessageStoreError(
+      413,
+      'channel_message_payload_too_large',
+      'combined channel message body and agent detail exceed the 256KB cap',
+      { bytes, maxBytes: CHANNEL_MESSAGE_BODY_MAX_BYTES }
+    );
+  }
+}
+
 function cleanLimit(
   limit: unknown,
   maxLimit = CHANNEL_HISTORY_MAX_LIMIT
@@ -426,6 +487,9 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
   ) {
     message.parts = meta.parts;
   }
+  if (isChannelAgentDetail(meta?.agentDetail)) {
+    message.agentDetail = meta.agentDetail;
+  }
   // Surface app-level meta (e.g. #1167 approval payloads) while keeping the
   // internal routing keys off the wire — providerId rides `sender.providerId`,
   // mentions/truncated have dedicated fields above.
@@ -434,6 +498,8 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
       providerId: _pid,
       mentions: _m,
       parts: _parts,
+      agentDetail: _agentDetail,
+      agentDetailTerminalAuthority: _agentDetailTerminalAuthority,
       truncated: _t,
       ...rest
     } = meta;
@@ -460,6 +526,7 @@ function buildMeta(input: {
   extra?: ChannelMessageMeta;
 }): string | null {
   assertMessageParts(input.extra?.parts);
+  assertAgentDetail(input.extra?.agentDetail);
   assertMessageParts(input.parts);
   const meta: ChannelMessageMeta = { ...(input.extra ?? {}) };
   if (input.mentions && input.mentions.length > 0)
@@ -907,7 +974,7 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
   }
 
   function appendCompleteImpl(input: AppendCompleteInput): ChannelMessage {
-    assertBodySize(input.text);
+    assertMessagePayloadSize(input.text, input.meta?.agentDetail);
     assertMessageParts(input.parts);
     assertMessageParts(input.meta?.parts);
     if (input.clientMessageId) {
@@ -984,7 +1051,7 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       if (existing) return rowToMessage(existing);
 
       const initialText = input.text ?? '';
-      assertBodySize(initialText);
+      assertMessagePayloadSize(initialText, input.agentDetail);
       assertMessageParts(input.parts);
       const threadId = resolveThread(input.channelId, input.parentMessageId);
       const now = nowIso();
@@ -1004,6 +1071,9 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         metaJson: buildMeta({
           ...(input.mentions ? { mentions: input.mentions } : {}),
           ...(input.parts ? { parts: input.parts } : {}),
+          ...(input.agentDetail
+            ? { extra: { agentDetail: input.agentDetail } }
+            : {}),
           ...(input.sender.providerId
             ? { providerId: input.sender.providerId }
             : {}),
@@ -1020,13 +1090,69 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
     },
 
     updateStreamText(id, text) {
-      assertBodySize(text);
       const row = selectById.get(id) as ChannelMessageRow | undefined;
       if (!row) return null;
+      assertMessagePayloadSize(text, parseMeta(row.meta_json)?.agentDetail);
       db.prepare(
         'UPDATE channel_messages SET body_text = @text, updated_at = @now WHERE id = @id'
       ).run({ id, text, now: nowIso() });
       return getMessageById(id);
+    },
+
+    updateAgentDetail(id, detail) {
+      const row = selectById.get(id) as ChannelMessageRow | undefined;
+      if (!row) return null;
+      assertMessagePayloadSize(row.body_text, detail);
+      const meta = parseMeta(row.meta_json) ?? {};
+      meta.agentDetail = detail;
+      db.prepare(
+        `UPDATE channel_messages
+         SET meta_json = @metaJson, updated_at = @now
+         WHERE id = @id AND status = 'streaming'`
+      ).run({
+        id,
+        metaJson: JSON.stringify(meta),
+        now: nowIso(),
+      });
+      return getMessageById(id);
+    },
+
+    resolveProvisionalAgentDetailTerminal(id, input) {
+      const row = selectById.get(id) as ChannelMessageRow | undefined;
+      if (!row) return { message: null, transitioned: false };
+      const currentMeta = parseMeta(row.meta_json) ?? {};
+      if (currentMeta.agentDetailTerminalAuthority !== 'provisional') {
+        return { message: rowToMessage(row), transitioned: false };
+      }
+      assertMessagePayloadSize(input.text, input.agentDetail);
+      const meta: ChannelMessageMeta = {
+        ...currentMeta,
+        agentDetail: input.agentDetail,
+        agentDetailTerminalAuthority: 'explicit',
+      };
+      delete meta.truncationReason;
+      delete meta.truncated;
+      const now = nowIso();
+      const result = db
+        .prepare(
+          `UPDATE channel_messages
+           SET body_text = @text, status = @status, meta_json = @metaJson,
+               updated_at = @now, completed_at = @now
+           WHERE id = @id
+             AND status != 'streaming'
+             AND json_extract(meta_json, '$.agentDetailTerminalAuthority') = 'provisional'`
+        )
+        .run({
+          id,
+          text: input.text,
+          status: input.status,
+          metaJson: JSON.stringify(meta),
+          now,
+        });
+      return {
+        message: getMessageById(id),
+        transitioned: result.changes === 1,
+      };
     },
 
     finalizeStream(id, input) {
@@ -1034,9 +1160,19 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       if (!row) return null;
       // Idempotent replay: finalizing an already-final row is a no-op.
       if (row.status !== 'streaming') return rowToMessage(row);
-      assertBodySize(input.text);
+      assertMessagePayloadSize(
+        input.text,
+        input.agentDetail ?? parseMeta(row.meta_json)?.agentDetail
+      );
       const now = nowIso();
       const meta = parseMeta(row.meta_json) ?? {};
+      if (input.agentDetail) {
+        assertAgentDetail(input.agentDetail);
+        meta.agentDetail = input.agentDetail;
+      }
+      if (input.agentDetailTerminalAuthority) {
+        meta.agentDetailTerminalAuthority = input.agentDetailTerminalAuthority;
+      }
       const truncationReason =
         input.truncationReason ??
         (input.truncated
@@ -1347,6 +1483,13 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
           for (const row of stale) {
             const meta = parseMeta(row.meta_json) ?? {};
             meta.truncationReason = 'restart';
+            if (isChannelAgentDetail(meta.agentDetail)) {
+              meta.agentDetail = {
+                ...meta.agentDetail,
+                card: { ...meta.agentDetail.card, status: 'cancelled' },
+              };
+              meta.agentDetailTerminalAuthority = 'provisional';
+            }
             // Never surface restart loss as the legacy 256KB-limit marker.
             delete meta.truncated;
             finalizeRestart.run({

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -9,12 +9,16 @@
 // and distinct (already-assigned) seqs — cross-sender corruption is structurally
 // impossible because no reducer field is shared between senders.
 
+import type { AgentDetailCardV2 } from './agent-chat-protocol-v2.js';
+
 export const CHANNEL_CHAT_PROTOCOL_VERSION = 1 as const;
 export const CHANNEL_MESSAGE_MAX_IMAGE_PARTS = 4;
 export const CHANNEL_IMAGE_ALT_MAX_LENGTH = 500;
 
 /** 256KB per-message body cap, parity with WORK_CONTEXT_MESSAGE_PAYLOAD_MAX_BYTES. */
 export const CHANNEL_MESSAGE_BODY_MAX_BYTES = 256 * 1024;
+/** Card metadata shares the message-row budget and is bounded independently. */
+export const CHANNEL_AGENT_DETAIL_MAX_BYTES = 256 * 1024;
 
 export type ChannelMessageId = `chm:${string}`;
 export type ChannelAttachmentId = `cha:${string}`;
@@ -80,6 +84,15 @@ export interface ChannelMessageSource {
   itemId?: string;
 }
 
+/**
+ * One provider-neutral agent operation attached to one durable channel row.
+ * `itemId` is the adapter-stable entity key used for in-place updates.
+ */
+export interface ChannelAgentDetail {
+  itemId: string;
+  card: AgentDetailCardV2;
+}
+
 export interface ChannelMessage {
   schemaVersion: 1;
   id: ChannelMessageId;
@@ -97,6 +110,8 @@ export interface ChannelMessage {
   replyCount?: number;
   mentions?: ChannelMention[];
   source?: ChannelMessageSource;
+  /** Present on agent activity rows; prose rows leave this absent. */
+  agentDetail?: ChannelAgentDetail;
   /**
    * Opaque row metadata surfaced to clients (#1167). System rows carry actionable
    * payloads here — e.g. an approval request `{ approvalRequestId, agentId,
@@ -148,6 +163,12 @@ export interface ChannelMessageDeltaEventV1 extends ChannelEventBaseV1 {
   delta: { text: string };
 }
 
+export interface ChannelMessageUpdatedEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-message-updated-v1';
+  /** Authoritative full streaming row; clients replace the entity by id. */
+  message: ChannelMessage;
+}
+
 export interface ChannelMessageCompletedEventV1 extends ChannelEventBaseV1 {
   type: 'channel-message-completed-v1';
   /** authoritative full row; status complete|truncated|interrupted|failed */
@@ -163,6 +184,7 @@ export type ChannelEventV1 =
   | ChannelSnapshotEventV1
   | ChannelMessageCreatedEventV1
   | ChannelMessageDeltaEventV1
+  | ChannelMessageUpdatedEventV1
   | ChannelMessageCompletedEventV1
   | ChannelResyncRequiredEventV1;
 
@@ -227,6 +249,52 @@ function isSenderRef(value: unknown): value is ChannelSenderRef {
   );
 }
 
+const AGENT_DETAIL_KINDS = new Set<string>([
+  'message',
+  'thought',
+  'tool_call',
+  'output',
+  'diff',
+]);
+const AGENT_DETAIL_STATUSES = new Set<string>([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+export function isChannelAgentDetail(
+  value: unknown
+): value is ChannelAgentDetail {
+  if (!isRecord(value) || typeof value.itemId !== 'string') return false;
+  const card = value.card;
+  if (!isRecord(card)) return false;
+  return (
+    typeof card.kind === 'string' &&
+    AGENT_DETAIL_KINDS.has(card.kind) &&
+    typeof card.title === 'string' &&
+    typeof card.status === 'string' &&
+    AGENT_DETAIL_STATUSES.has(card.status) &&
+    (card.content === undefined || typeof card.content === 'string') &&
+    (card.language === undefined || typeof card.language === 'string') &&
+    (card.command === undefined || typeof card.command === 'string') &&
+    (card.path === undefined || typeof card.path === 'string') &&
+    (card.additions === undefined ||
+      (typeof card.additions === 'number' &&
+        Number.isSafeInteger(card.additions) &&
+        card.additions >= 0)) &&
+    (card.deletions === undefined ||
+      (typeof card.deletions === 'number' &&
+        Number.isSafeInteger(card.deletions) &&
+        card.deletions >= 0)) &&
+    (card.sizeBytes === undefined ||
+      (typeof card.sizeBytes === 'number' &&
+        Number.isSafeInteger(card.sizeBytes) &&
+        card.sizeBytes >= 0))
+  );
+}
+
 function isMemberRef(value: unknown): value is ChannelMemberRef {
   return (
     isRecord(value) &&
@@ -262,6 +330,12 @@ export function isChannelMessage(value: unknown): value is ChannelMessage {
     (!Array.isArray(value.parts) ||
       value.parts.length > CHANNEL_MESSAGE_MAX_IMAGE_PARTS ||
       !value.parts.every(isChannelMessagePart))
+  ) {
+    return false;
+  }
+  if (
+    value.agentDetail !== undefined &&
+    !isChannelAgentDetail(value.agentDetail)
   ) {
     return false;
   }
@@ -327,6 +401,10 @@ export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
         typeof value.deltaIndex === 'number' &&
         isRecord(value.delta) &&
         typeof value.delta.text === 'string'
+      );
+    case 'channel-message-updated-v1':
+      return (
+        isChannelMessage(value.message) && value.message.status === 'streaming'
       );
     case 'channel-message-completed-v1':
       return isChannelMessage(value.message);
@@ -481,6 +559,26 @@ export function applyChannelEventV1(
           ...state.inFlightDelta,
           [event.messageId]: event.deltaIndex,
         },
+      };
+    }
+
+    case 'channel-message-updated-v1': {
+      const message = event.message;
+      const existing = state.byId[message.id];
+      if (!existing) return { ...state, needsCatchup: true };
+      if (existing.status !== 'streaming' || message.status !== 'streaming') {
+        return state;
+      }
+      if (message.seq !== existing.seq) {
+        return { ...state, needsCatchup: true };
+      }
+      const messages = state.messages.map((row) =>
+        row.id === message.id ? message : row
+      );
+      return {
+        ...state,
+        messages,
+        byId: { ...state.byId, [message.id]: message },
       };
     }
 

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -90,6 +90,7 @@ function agentReplies(store: ChannelMessageStore, providerId?: string) {
     (m) =>
       m.sender.kind === 'agent' &&
       m.status === 'complete' &&
+      !m.agentDetail &&
       (!providerId || m.sender.providerId === providerId)
   );
 }

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -412,6 +412,99 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(store.history('topic:detail-restart')[0]?.meta).toBeUndefined();
   });
 
+  // The adapter normalizes item cards from typed fields (commandExecution card
+  // content is derived from `output`), so these drive content through `output`
+  // and `delta.output` — the same lane real providers use.
+  function commandStarted(): AgentPatchV2 {
+    return {
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: {
+        type: 'commandExecution',
+        id: 'cmd',
+        command: 'run tests',
+        output: '',
+        status: 'running',
+      },
+    };
+  }
+  function commandDelta(output: string): AgentPatchV2 {
+    return {
+      type: 'agent-item-delta-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      itemId: 'cmd',
+      delta: { output },
+    };
+  }
+  function commandCompleted(output: string): AgentPatchV2 {
+    return {
+      type: 'agent-item-updated-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: {
+        type: 'commandExecution',
+        id: 'cmd',
+        command: 'run tests',
+        output,
+        status: 'completed',
+        completedAt: 't',
+      },
+    };
+  }
+
+  it('falls back to delta-accumulated content when a terminal item card is empty', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:detail-terminal-fallback',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(commandStarted());
+    adapter.broadcastPatch(commandDelta('accumulated terminal output'));
+    // A non-backfilling provider: the terminal item card arrives empty. The
+    // bridge must keep the delta-accumulated content rather than persist a
+    // blank card (#1206 class).
+    adapter.broadcastPatch(commandCompleted(''));
+    expect(store.history('topic:detail-terminal-fallback')[0]).toMatchObject({
+      status: 'complete',
+      agentDetail: {
+        card: { status: 'completed', content: 'accumulated terminal output' },
+      },
+    });
+  });
+
+  it('lets a non-empty terminal item card win over accumulated content', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:detail-terminal-wins',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch(commandStarted());
+    adapter.broadcastPatch(commandDelta('partial streamed output'));
+    adapter.broadcastPatch(commandCompleted('authoritative terminal output'));
+    expect(store.history('topic:detail-terminal-wins')[0]).toMatchObject({
+      status: 'complete',
+      agentDetail: {
+        card: {
+          status: 'completed',
+          content: 'authoritative terminal output',
+        },
+      },
+    });
+  });
+
   it('releases completed stream text and item ids after every turn', async () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2({ connectMs: 0, stepMs: 0 });

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -14,8 +14,14 @@ import {
 import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
 import {
   bindSessionToChannel,
+  boundChannelAgentDetail,
+  CHANNEL_BRIDGE_DETAIL_COMMAND_MAX_CHARS,
   CHANNEL_BRIDGE_FINALIZED_ITEM_CACHE_MAX,
   CHANNEL_BRIDGE_IMAGE_MAX_PER_TURN,
+  CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS,
+  CHANNEL_BRIDGE_DETAIL_LANGUAGE_MAX_CHARS,
+  CHANNEL_BRIDGE_DETAIL_PATH_MAX_CHARS,
+  CHANNEL_BRIDGE_DETAIL_TITLE_MAX_CHARS,
 } from '../server/channel-agent-bridge.js';
 import type { ChannelBridgeRetentionSnapshot } from '../server/channel-agent-bridge.js';
 import type { ChannelAttachmentStore } from '../server/channel-attachments.js';
@@ -24,6 +30,7 @@ import {
   PACKET_IMAGE_DEGRADATION_META_KEY,
 } from '../server/channel-context-packet.js';
 import {
+  CHANNEL_AGENT_DETAIL_MAX_BYTES,
   parseMentions,
   type ChannelImagePart,
   type ChannelMessage,
@@ -114,7 +121,297 @@ function turnCompleted(sessionId: string, turnId: string): AgentPatchV2 {
   };
 }
 
+function reasoningStarted(
+  sessionId: string,
+  turnId: string,
+  itemId: string
+): AgentPatchV2 {
+  return {
+    type: 'agent-item-started-v2',
+    sessionId,
+    timestamp: 't',
+    turnId,
+    item: {
+      type: 'reasoning',
+      id: itemId,
+      summary: '',
+      status: 'running',
+    },
+  };
+}
+
+function reasoningUpdated(
+  sessionId: string,
+  turnId: string,
+  itemId: string,
+  status: 'completed' | 'failed' | 'cancelled',
+  summary: string
+): AgentPatchV2 {
+  return {
+    type: 'agent-item-updated-v2',
+    sessionId,
+    timestamp: 't',
+    turnId,
+    item: {
+      type: 'reasoning',
+      id: itemId,
+      summary,
+      status,
+      completedAt: 't',
+    },
+  };
+}
+
 describe('channel-agent-bridge lifecycle', () => {
+  it('strictly bounds escaping-heavy detail content and every metadata scalar', () => {
+    const huge = '\u0000'.repeat(300 * 1024);
+    const detail = boundChannelAgentDetail(`reason-${huge}`, {
+      kind: 'thought',
+      title: huge,
+      status: 'running',
+      content: huge,
+      language: huge,
+      command: huge,
+      path: huge,
+    });
+    expect(
+      Buffer.byteLength(JSON.stringify(detail), 'utf8')
+    ).toBeLessThanOrEqual(CHANNEL_AGENT_DETAIL_MAX_BYTES);
+    expect(detail.itemId.length).toBeLessThanOrEqual(
+      CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS
+    );
+    expect(detail.card.title.length).toBeLessThanOrEqual(
+      CHANNEL_BRIDGE_DETAIL_TITLE_MAX_CHARS
+    );
+    expect(detail.card.language?.length).toBeLessThanOrEqual(
+      CHANNEL_BRIDGE_DETAIL_LANGUAGE_MAX_CHARS
+    );
+    expect(detail.card.command?.length).toBeLessThanOrEqual(
+      CHANNEL_BRIDGE_DETAIL_COMMAND_MAX_CHARS
+    );
+    expect(detail.card.path?.length).toBeLessThanOrEqual(
+      CHANNEL_BRIDGE_DETAIL_PATH_MAX_CHARS
+    );
+    expect(detail.card.content!.length).toBeLessThan(64 * 1024);
+  });
+
+  it('keeps truncated detail item ids stable and collision-resistant', () => {
+    const sharedPrefix = 'provider-item-'.repeat(100);
+    const first = boundChannelAgentDetail(`${sharedPrefix}:first`, {
+      kind: 'thought',
+      title: 'thinking',
+      status: 'running',
+    });
+    const second = boundChannelAgentDetail(`${sharedPrefix}:second`, {
+      kind: 'thought',
+      title: 'thinking',
+      status: 'running',
+    });
+
+    expect(first.itemId).toHaveLength(CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS);
+    expect(second.itemId).toHaveLength(CHANNEL_BRIDGE_DETAIL_ITEM_ID_MAX_CHARS);
+    expect(first.itemId).not.toBe(second.itemId);
+    expect(first.itemId).toMatch(/#[a-f0-9]{24}$/);
+    expect(
+      boundChannelAgentDetail(`${sharedPrefix}:first`, {
+        kind: 'thought',
+        title: 'thinking',
+        status: 'running',
+      }).itemId
+    ).toBe(first.itemId);
+  });
+
+  it('projects only known card fields before sizing durable metadata', () => {
+    const pollutedCard = {
+      kind: 'thought',
+      title: 'thinking',
+      status: 'running',
+      content: 'bounded thought',
+      providerPayload: 'x'.repeat(512 * 1024),
+      nestedProviderPayload: { secret: 'y'.repeat(512 * 1024) },
+    } as Parameters<typeof boundChannelAgentDetail>[1] &
+      Record<string, unknown>;
+
+    const detail = boundChannelAgentDetail('reason-known-fields', pollutedCard);
+    expect(detail.card).toEqual({
+      kind: 'thought',
+      title: 'thinking',
+      status: 'running',
+      content: 'bounded thought',
+      sizeBytes: 15,
+    });
+    expect(detail.card).not.toHaveProperty('providerPayload');
+    expect(detail.card).not.toHaveProperty('nestedProviderPayload');
+    expect(Buffer.byteLength(JSON.stringify(detail), 'utf8')).toBeLessThan(
+      CHANNEL_AGENT_DETAIL_MAX_BYTES
+    );
+  });
+
+  it('bounds live card and reasoning accumulators and reports detail retention', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    let retained: ChannelBridgeRetentionSnapshot | null = null;
+    bindSessionToChannel({
+      channelId: 'topic:detail-retention',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+      onRetentionSnapshot: (snapshot) => {
+        retained = snapshot;
+      },
+    });
+    adapter.broadcastPatch(reasoningStarted('s', 'turn', 'reason'));
+    for (let index = 0; index < 4; index++) {
+      adapter.broadcastPatch({
+        type: 'agent-item-delta-v2',
+        sessionId: 's',
+        timestamp: 't',
+        turnId: 'turn',
+        itemId: 'reason',
+        delta: { summary: `${index}:${'x'.repeat(128 * 1024)}` },
+      });
+    }
+
+    expect(retained).toMatchObject({
+      openDetailStreams: 1,
+      detailItemIds: 1,
+      turnsWithRows: 1,
+    });
+    expect(retained!.retainedDetailBytes).toBeLessThan(200 * 1024);
+    expect(
+      store.history('topic:detail-retention')[0]?.agentDetail?.card.content
+        ?.length
+    ).toBeLessThanOrEqual(64 * 1024);
+
+    adapter.broadcastPatch(turnCompleted('s', 'turn'));
+    expect(retained).toEqual({
+      openStreams: 0,
+      openDetailStreams: 0,
+      assistantItemIds: 0,
+      detailItemIds: 0,
+      turnsWithRows: 0,
+      retainedTextBytes: 0,
+      retainedDetailBytes: 0,
+    });
+  });
+
+  it.each(
+    (['completed', 'failed', 'interrupted'] as const).flatMap((turnStatus) =>
+      (['completed', 'failed', 'cancelled'] as const).map((itemStatus) => [
+        turnStatus,
+        itemStatus,
+      ])
+    )
+  )(
+    'allows provisional turn %s to transition once to explicit item %s',
+    (turnStatus, itemStatus) => {
+      const { store, hub } = makeStore();
+      const adapter = new MockProtocolAdapterV2();
+      const completeBroadcast = vi.spyOn(hub, 'completeStreamBroadcast');
+      bindSessionToChannel({
+        channelId: 'topic:detail-terminal-matrix',
+        agentFramework: 'codex',
+        adapter,
+        store,
+        hub,
+      });
+      adapter.broadcastPatch(reasoningStarted('s', 'turn', 'reason'));
+      adapter.broadcastPatch({
+        type: 'agent-turn-completed-v2',
+        sessionId: 's',
+        timestamp: 't',
+        turnId: 'turn',
+        status: turnStatus,
+      });
+
+      adapter.broadcastPatch(
+        reasoningUpdated(
+          's',
+          'turn',
+          'reason',
+          itemStatus,
+          `first explicit ${itemStatus}`
+        )
+      );
+      const explicitRowStatus =
+        itemStatus === 'completed'
+          ? 'complete'
+          : itemStatus === 'failed'
+            ? 'failed'
+            : 'interrupted';
+      expect(store.history('topic:detail-terminal-matrix')).toEqual([
+        expect.objectContaining({
+          status: explicitRowStatus,
+          agentDetail: expect.objectContaining({
+            card: expect.objectContaining({
+              status: itemStatus,
+              content: `first explicit ${itemStatus}`,
+            }),
+          }),
+        }),
+      ]);
+
+      // Explicit terminal is absorbing: duplicate/conflicting replay cannot
+      // rewrite either row status or card payload.
+      adapter.broadcastPatch(
+        reasoningUpdated('s', 'turn', 'reason', 'failed', 'conflicting replay')
+      );
+      expect(store.history('topic:detail-terminal-matrix')[0]).toMatchObject({
+        status: explicitRowStatus,
+        agentDetail: {
+          card: {
+            status: itemStatus,
+            content: `first explicit ${itemStatus}`,
+          },
+        },
+      });
+      expect(completeBroadcast).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  it('lets a restart-provisional detail resolve once, then absorbs replay', () => {
+    const { store, hub } = makeStore();
+    const firstAdapter = new MockProtocolAdapterV2();
+    const unbindFirst = bindSessionToChannel({
+      channelId: 'topic:detail-restart',
+      agentFramework: 'codex',
+      adapter: firstAdapter,
+      store,
+      hub,
+    });
+    firstAdapter.broadcastPatch(reasoningStarted('s', 'turn', 'reason'));
+    store.sweepStaleStreaming();
+    unbindFirst();
+    expect(store.history('topic:detail-restart')[0]).toMatchObject({
+      status: 'truncated',
+      meta: { truncationReason: 'restart' },
+      agentDetail: { card: { status: 'cancelled' } },
+    });
+
+    const resumedAdapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:detail-restart',
+      agentFramework: 'codex',
+      adapter: resumedAdapter,
+      store,
+      hub,
+    });
+    resumedAdapter.broadcastPatch(
+      reasoningUpdated('s', 'turn', 'reason', 'completed', 'resumed terminal')
+    );
+    resumedAdapter.broadcastPatch(
+      reasoningUpdated('s', 'turn', 'reason', 'failed', 'late conflict')
+    );
+    expect(store.history('topic:detail-restart')[0]).toMatchObject({
+      status: 'complete',
+      agentDetail: {
+        card: { status: 'completed', content: 'resumed terminal' },
+      },
+    });
+    expect(store.history('topic:detail-restart')[0]?.meta).toBeUndefined();
+  });
+
   it('releases completed stream text and item ids after every turn', async () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2({ connectMs: 0, stepMs: 0 });
@@ -139,13 +436,16 @@ describe('channel-agent-bridge lifecycle', () => {
       });
       expect(retained).toEqual({
         openStreams: 0,
+        openDetailStreams: 0,
         assistantItemIds: 0,
+        detailItemIds: 0,
         turnsWithRows: 0,
         retainedTextBytes: 0,
+        retainedDetailBytes: 0,
       });
     }
 
-    expect(store.history('topic:retention', { limit: 100 })).toHaveLength(50);
+    expect(store.getChannelSummary('topic:retention')?.messageCount).toBe(250);
   });
 
   it('mirrors a full assistant turn as an attributed complete row', async () => {
@@ -164,8 +464,9 @@ describe('channel-agent-bridge lifecycle', () => {
     await adapter.sendMessage({ turnId: 'turn-1', content: 'hello' });
 
     const messages = store.history('topic:test');
-    expect(messages).toHaveLength(1);
-    const message = messages[0]!;
+    expect(messages).toHaveLength(5);
+    expect(messages.filter((row) => row.agentDetail)).toHaveLength(4);
+    const message = messages.find((row) => !row.agentDetail)!;
     expect(message.status).toBe('complete');
     expect(message.sender).toMatchObject({
       kind: 'agent',
@@ -214,9 +515,10 @@ describe('channel-agent-bridge lifecycle', () => {
     ]);
 
     const messages = store.history('topic:c');
-    expect(messages).toHaveLength(2);
-    const claude = messages.find((m) => m.sender.id === 'agent:claude');
-    const codex = messages.find((m) => m.sender.id === 'agent:codex');
+    expect(messages).toHaveLength(10);
+    const prose = messages.filter((message) => !message.agentDetail);
+    const claude = prose.find((m) => m.sender.id === 'agent:claude');
+    const codex = prose.find((m) => m.sender.id === 'agent:codex');
     expect(claude?.body.text).toBe('Mock v2 response complete.');
     expect(codex?.body.text).toBe('Mock v2 response complete.');
     expect(claude?.source?.sessionId).toBe('s1');
@@ -255,9 +557,12 @@ describe('channel-agent-bridge lifecycle', () => {
     });
     expect(retained).toEqual({
       openStreams: 0,
+      openDetailStreams: 0,
       assistantItemIds: 0,
+      detailItemIds: 0,
       turnsWithRows: 0,
       retainedTextBytes: 0,
+      retainedDetailBytes: 0,
     });
   });
 
@@ -292,9 +597,12 @@ describe('channel-agent-bridge lifecycle', () => {
     ]);
     expect(retained).toEqual({
       openStreams: 0,
+      openDetailStreams: 0,
       assistantItemIds: 0,
+      detailItemIds: 0,
       turnsWithRows: 0,
       retainedTextBytes: 0,
+      retainedDetailBytes: 0,
     });
   });
 
@@ -363,9 +671,12 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(onAssistantMessageFinalized).toHaveBeenCalledOnce();
     expect(retained).toEqual({
       openStreams: 0,
+      openDetailStreams: 0,
       assistantItemIds: 0,
+      detailItemIds: 0,
       turnsWithRows: 0,
       retainedTextBytes: 0,
+      retainedDetailBytes: 0,
     });
   });
 
@@ -417,9 +728,12 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(store.history('topic:replay')).toHaveLength(1);
     expect(retained).toEqual({
       openStreams: 0,
+      openDetailStreams: 0,
       assistantItemIds: 0,
+      detailItemIds: 0,
       turnsWithRows: 0,
       retainedTextBytes: 0,
+      retainedDetailBytes: 0,
     });
   });
 
@@ -479,9 +793,12 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(beginBroadcast).not.toHaveBeenCalled();
     expect(retained).toEqual({
       openStreams: 0,
+      openDetailStreams: 0,
       assistantItemIds: 0,
+      detailItemIds: 0,
       turnsWithRows: 0,
       retainedTextBytes: 0,
+      retainedDetailBytes: 0,
     });
   });
 
@@ -701,9 +1018,12 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(store.history('topic:empty-start')[0]?.truncated).toBeUndefined();
     expect(retained).toEqual({
       openStreams: 0,
+      openDetailStreams: 0,
       assistantItemIds: 0,
+      detailItemIds: 0,
       turnsWithRows: 0,
       retainedTextBytes: 0,
+      retainedDetailBytes: 0,
     });
   });
 
@@ -1227,7 +1547,7 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(finalized).not.toHaveBeenCalled();
   });
 
-  it('does not mirror non-renderable items', () => {
+  it('mirrors reasoning and command items as stable typed channel cards', () => {
     const { store, hub } = makeStore();
     const adapter = new MockProtocolAdapterV2();
     bindSessionToChannel({
@@ -1251,7 +1571,140 @@ describe('channel-agent-bridge lifecycle', () => {
       turnId: 'turn',
       item: { type: 'reasoning', id: 'r1', summary: 'thinking' },
     });
-    expect(store.history('topic:n')).toHaveLength(0);
+    adapter.broadcastPatch(turnCompleted('s', 'turn'));
+
+    const details = store.history('topic:n');
+    expect(details).toHaveLength(2);
+    expect(details.map((message) => message.source?.itemId)).toEqual([
+      'c1',
+      'r1',
+    ]);
+    expect(details.map((message) => message.agentDetail)).toEqual([
+      expect.objectContaining({
+        itemId: 'c1',
+        card: expect.objectContaining({
+          kind: 'output',
+          title: 'ls',
+          status: 'completed',
+        }),
+      }),
+      expect.objectContaining({
+        itemId: 'r1',
+        card: expect.objectContaining({
+          kind: 'thought',
+          content: 'thinking',
+          status: 'completed',
+        }),
+      }),
+    ]);
+  });
+
+  it('preserves reasoning deltas when turn completion supplies the terminal boundary', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:reasoning',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch({
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: {
+        type: 'reasoning',
+        id: 'reason-1',
+        providerItemId: 'provider-reason-1',
+        summary: '',
+        status: 'running',
+      },
+    });
+    adapter.broadcastPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      itemId: 'reason-1',
+      delta: { summary: 'inspect ', detail: 'inspect the live channel' },
+    });
+    adapter.broadcastPatch(turnCompleted('s', 'turn'));
+
+    const [message] = store.history('topic:reasoning');
+    expect(message).toMatchObject({
+      seq: 1,
+      status: 'complete',
+      source: {
+        sessionId: 's',
+        turnId: 'turn',
+        itemId: 'provider-reason-1',
+      },
+      agentDetail: {
+        itemId: 'provider-reason-1',
+        card: {
+          kind: 'thought',
+          status: 'completed',
+          content: 'inspect the live channel',
+        },
+      },
+    });
+  });
+
+  it('applies a late authoritative detail update without appending a second row', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:late-detail',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+    });
+    adapter.broadcastPatch({
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn',
+      item: {
+        type: 'reasoning',
+        id: 'reason-1',
+        summary: '',
+        status: 'running',
+      },
+    });
+    adapter.broadcastPatch(turnCompleted('s', 'turn'));
+    const before = store.history('topic:late-detail')[0]!;
+
+    adapter.broadcastPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: 's',
+      timestamp: 't2',
+      turnId: 'turn',
+      item: {
+        type: 'reasoning',
+        id: 'reason-1',
+        summary: 'late provider summary',
+        detail: 'late authoritative reasoning detail',
+        status: 'completed',
+      },
+    });
+
+    const after = store.history('topic:late-detail');
+    expect(after).toHaveLength(1);
+    expect(after[0]).toMatchObject({
+      id: before.id,
+      seq: before.seq,
+      agentDetail: {
+        itemId: 'reason-1',
+        card: {
+          kind: 'thought',
+          status: 'completed',
+          content: 'late authoritative reasoning detail',
+        },
+      },
+    });
   });
 
   it('force-finalizes truncated when the in-flight text exceeds the 256KB cap', () => {

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -61,6 +61,14 @@ function completed(m: ChannelMessage): ChannelEventV1 {
     message: m,
   };
 }
+function updated(m: ChannelMessage): ChannelEventV1 {
+  return {
+    type: 'channel-message-updated-v1',
+    channelId: CHANNEL,
+    timestamp: 't',
+    message: m,
+  };
+}
 
 function reduce(
   state: ChannelReducerState,
@@ -85,6 +93,12 @@ describe('isChannelEventV1 validator matrix', () => {
     expect(isChannelEventV1(snapshot)).toBe(true);
     expect(isChannelEventV1(created(message()))).toBe(true);
     expect(isChannelEventV1(delta('chm:1', 0, 'x'))).toBe(true);
+    expect(isChannelEventV1(updated(message({ status: 'streaming' })))).toBe(
+      true
+    );
+    expect(isChannelEventV1(updated(message({ status: 'complete' })))).toBe(
+      false
+    );
     expect(isChannelEventV1(completed(message()))).toBe(true);
     expect(
       isChannelEventV1(
@@ -188,6 +202,46 @@ describe('isChannelEventV1 validator matrix', () => {
       )
     ).toBe(false);
   });
+
+  it('validates the typed durable agent-detail contract', () => {
+    const valid = message({
+      sender: { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+      body: { text: '', format: 'markdown' },
+      agentDetail: {
+        itemId: 'reason-1',
+        card: {
+          kind: 'thought',
+          title: 'inspect the channel',
+          status: 'completed',
+          content: 'reasoning content',
+          sizeBytes: 17,
+        },
+      },
+    });
+    expect(isChannelEventV1(created(valid))).toBe(true);
+    expect(
+      isChannelEventV1(
+        created({
+          ...valid,
+          agentDetail: {
+            ...valid.agentDetail!,
+            card: { ...valid.agentDetail!.card, kind: 'provider-secret' },
+          } as never,
+        })
+      )
+    ).toBe(false);
+    expect(
+      isChannelEventV1(
+        created({
+          ...valid,
+          agentDetail: {
+            ...valid.agentDetail!,
+            card: { ...valid.agentDetail!.card, additions: -1 },
+          },
+        })
+      )
+    ).toBe(false);
+  });
 });
 
 describe('applyChannelEventV1 reducer', () => {
@@ -246,6 +300,89 @@ describe('applyChannelEventV1 reducer', () => {
     ]);
     expect(state.byId['chm:a']?.body.text).toBe('a1a2');
     expect(state.byId['chm:b']?.body.text).toBe('b1b2');
+  });
+
+  it('replaces an authoritative streaming row by id and rejects seq drift', () => {
+    const initial = message({
+      status: 'streaming',
+      sender: { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+      body: { text: '', format: 'markdown' },
+      agentDetail: {
+        itemId: 'reason-1',
+        card: { kind: 'thought', title: 'thinking', status: 'running' },
+      },
+    });
+    let state = reduce(initialChannelReducerState(CHANNEL), [created(initial)]);
+    state = applyChannelEventV1(
+      state,
+      updated({
+        ...initial,
+        updatedAt: 'later',
+        agentDetail: {
+          itemId: 'reason-1',
+          card: {
+            kind: 'thought',
+            title: 'thinking',
+            status: 'running',
+            content: 'sanitized Codex reasoning delta',
+          },
+        },
+      })
+    );
+    expect(state.byId[initial.id]?.agentDetail?.card.content).toBe(
+      'sanitized Codex reasoning delta'
+    );
+    const drifted = applyChannelEventV1(
+      state,
+      updated({ ...initial, seq: 99 })
+    );
+    expect(drifted.needsCatchup).toBe(true);
+    expect(drifted.byId[initial.id]?.seq).toBe(1);
+  });
+
+  it('ignores a late streaming update after the row failed', () => {
+    const streaming = message({
+      status: 'streaming',
+      sender: { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+      body: { text: '', format: 'markdown' },
+      agentDetail: {
+        itemId: 'reason-1',
+        card: { kind: 'thought', title: 'thinking', status: 'running' },
+      },
+    });
+    const failed = {
+      ...streaming,
+      status: 'failed' as const,
+      agentDetail: {
+        itemId: 'reason-1',
+        card: {
+          kind: 'thought' as const,
+          title: 'thinking',
+          status: 'failed' as const,
+          content: 'provider failed',
+        },
+      },
+    };
+    const lateStreaming = {
+      ...streaming,
+      updatedAt: 'late',
+      agentDetail: {
+        itemId: 'reason-1',
+        card: {
+          kind: 'thought' as const,
+          title: 'thinking',
+          status: 'running' as const,
+          content: 'late stale content',
+        },
+      },
+    };
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(streaming),
+      completed(failed),
+      updated(lateStreaming),
+    ]);
+    expect(state.byId[streaming.id]).toEqual(failed);
+    expect(state.needsCatchup).toBe(false);
   });
 
   it('quarantines only the out-of-order stream and heals it on completed', () => {

--- a/test/channel-claude-duplicate-row.test.ts
+++ b/test/channel-claude-duplicate-row.test.ts
@@ -133,7 +133,7 @@ async function replayToRows(lines: unknown[]) {
   await new Promise((r) => setTimeout(r, 50));
   const rows = store
     .history('topic:general')
-    .filter((m) => m.sender.kind === 'agent');
+    .filter((m) => m.sender.kind === 'agent' && !m.agentDetail);
   unbind();
   hub.close();
   store.close();

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -225,6 +225,65 @@ describe('channel-hub fan-out', () => {
     }
   });
 
+  it('debounces persisted card rows and transports the latest Codex-shaped update through the reducer', () => {
+    vi.useFakeTimers();
+    const s = store();
+    const hub = hubWith(s, { coalesceMs: 50 });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq: null });
+    const started = s.beginStream({
+      channelId: 'topic:c',
+      sender: { kind: 'agent', id: 'agent:codex', providerId: 'codex' },
+      source: {
+        sessionId: 'session_synthetic_codex',
+        turnId: 'turn_synthetic_codex',
+        itemId: 'reason_synthetic_codex',
+      },
+      agentDetail: {
+        itemId: 'reason_synthetic_codex',
+        card: { kind: 'thought', title: 'thinking', status: 'running' },
+      },
+    });
+    hub.beginStreamBroadcast(started);
+    const partial = s.updateAgentDetail(started.id, {
+      itemId: 'reason_synthetic_codex',
+      card: {
+        kind: 'thought',
+        title: 'thinking',
+        status: 'running',
+        content: 'Codex synthetic thought: verify the reducer',
+      },
+    })!;
+    hub.updateStreamBroadcast(partial);
+    const latest = s.updateAgentDetail(started.id, {
+      itemId: 'reason_synthetic_codex',
+      card: {
+        kind: 'thought',
+        title: 'thinking',
+        status: 'running',
+        content:
+          'Codex synthetic thought: verify the reducer contract before applying the patch.',
+      },
+    })!;
+    hub.updateStreamBroadcast(latest);
+
+    expect(
+      sock.sent.filter((event) => event.type === 'channel-message-updated-v1')
+    ).toHaveLength(0);
+    vi.advanceTimersByTime(50);
+    const updates = sock.sent.filter(
+      (event) => event.type === 'channel-message-updated-v1'
+    );
+    expect(updates).toHaveLength(1);
+
+    let state = initialChannelReducerState('topic:c');
+    for (const event of sock.sent) state = applyChannelEventV1(state, event);
+    expect(state.byId[started.id]?.agentDetail?.card.content).toBe(
+      latest.agentDetail?.card.content
+    );
+    expect(state.needsCatchup).toBe(false);
+  });
+
   it('serves (sinceSeq, head] then live with seq continuity across the boundary', () => {
     const s = store();
     for (let i = 1; i <= 3; i++) {

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -346,7 +346,9 @@ function agentReply(store: ChannelMessageStore, channelId: string) {
     .history(channelId, { limit: 200 })
     .filter(
       (m: ChannelMessage) =>
-        m.sender.id === 'agent:mock' && m.status === 'complete'
+        m.sender.id === 'agent:mock' &&
+        m.status === 'complete' &&
+        !m.agentDetail
     );
 }
 

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -332,6 +332,145 @@ describe('channel-message-store streaming lifecycle', () => {
     expect(final?.completedAt).toBeTruthy();
   });
 
+  it('persists one typed agent card in place across reopen and snapshot reads', () => {
+    const file = dbPath();
+    const first = createChannelMessageStore(file);
+    const begun = first.beginStream({
+      channelId: 'topic:cards',
+      sender: AGENT,
+      source: { sessionId: 'sess-1', turnId: 't1', itemId: 'reason-1' },
+      agentDetail: {
+        itemId: 'reason-1',
+        card: {
+          kind: 'thought',
+          title: 'thinking',
+          status: 'running',
+          content: 'inspect',
+        },
+      },
+    });
+    const updated = first.updateAgentDetail(begun.id, {
+      itemId: 'reason-1',
+      card: {
+        kind: 'thought',
+        title: 'inspect the channel',
+        status: 'running',
+        content: 'inspect the channel bridge',
+      },
+    });
+    expect(updated?.id).toBe(begun.id);
+    const finalized = first.finalizeStream(begun.id, {
+      text: '',
+      status: 'complete',
+      agentDetail: {
+        itemId: 'reason-1',
+        card: {
+          kind: 'thought',
+          title: 'inspect the channel',
+          status: 'completed',
+          content: 'inspect the channel bridge',
+          sizeBytes: 26,
+        },
+      },
+    });
+    expect(finalized).toMatchObject({
+      id: begun.id,
+      seq: begun.seq,
+      agentDetail: {
+        itemId: 'reason-1',
+        card: { status: 'completed', content: 'inspect the channel bridge' },
+      },
+    });
+    first.close();
+
+    const reopened = store(file);
+    expect(reopened.history('topic:cards')).toEqual([
+      expect.objectContaining({
+        id: begun.id,
+        seq: begun.seq,
+        agentDetail: expect.objectContaining({
+          itemId: 'reason-1',
+          card: expect.objectContaining({
+            kind: 'thought',
+            status: 'completed',
+            content: 'inspect the channel bridge',
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it('atomically resolves a provisional detail terminal once and makes explicit terminal absorbing', () => {
+    const s = store();
+    const begun = s.beginStream({
+      channelId: 'topic:detail-fsm',
+      sender: AGENT,
+      source: { sessionId: 'sess', turnId: 'turn', itemId: 'reason' },
+      agentDetail: {
+        itemId: 'reason',
+        card: { kind: 'thought', title: 'thinking', status: 'running' },
+      },
+    });
+    s.finalizeStream(begun.id, {
+      text: '',
+      status: 'complete',
+      agentDetail: {
+        itemId: 'reason',
+        card: { kind: 'thought', title: 'thinking', status: 'completed' },
+      },
+      agentDetailTerminalAuthority: 'provisional',
+    });
+    const first = s.resolveProvisionalAgentDetailTerminal(begun.id, {
+      text: '',
+      status: 'failed',
+      agentDetail: {
+        itemId: 'reason',
+        card: {
+          kind: 'thought',
+          title: 'provider failure',
+          status: 'failed',
+          content: 'explicit failure',
+        },
+      },
+    });
+    expect(first.transitioned).toBe(true);
+    expect(first.message).toMatchObject({
+      status: 'failed',
+      agentDetail: { card: { status: 'failed', content: 'explicit failure' } },
+    });
+
+    const replay = s.resolveProvisionalAgentDetailTerminal(begun.id, {
+      text: '',
+      status: 'complete',
+      agentDetail: {
+        itemId: 'reason',
+        card: {
+          kind: 'thought',
+          title: 'late replay',
+          status: 'completed',
+          content: 'must not win',
+        },
+      },
+    });
+    expect(replay.transitioned).toBe(false);
+    expect(replay.message).toMatchObject({
+      status: 'failed',
+      agentDetail: { card: { status: 'failed', content: 'explicit failure' } },
+    });
+    s.updateAgentDetail(begun.id, {
+      itemId: 'reason',
+      card: {
+        kind: 'thought',
+        title: 'late streaming mutation',
+        status: 'running',
+      },
+    });
+    expect(s.getMessage(begun.id)).toMatchObject({
+      status: 'failed',
+      agentDetail: { card: { status: 'failed', content: 'explicit failure' } },
+    });
+  });
+
   it('finalizing an already-final row is an idempotent no-op', () => {
     const s = store();
     const begun = s.beginStream({
@@ -409,6 +548,29 @@ describe('channel-message-store streaming lifecycle', () => {
     expect(final?.truncated).toBe(true);
     expect(final?.meta).toMatchObject({ truncationReason: 'size-limit' });
     expect(s.getMessage(begun.id)?.truncated).toBe(true);
+  });
+
+  it('enforces the existing 256KB cap across body plus typed card metadata', () => {
+    const s = store();
+    expect(() =>
+      s.beginStream({
+        channelId: 'topic:bounded-card',
+        sender: AGENT,
+        source: { sessionId: 'sess', turnId: 'turn', itemId: 'detail' },
+        text: 'x'.repeat(200 * 1024),
+        agentDetail: {
+          itemId: 'detail',
+          card: {
+            kind: 'output',
+            title: 'large output',
+            status: 'running',
+            content: 'y'.repeat(100 * 1024),
+          },
+        },
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_payload_too_large' })
+    );
   });
 
   it('listResyncRows returns agent-origin rows at/below the cursor in current state', () => {
@@ -765,6 +927,32 @@ describe('channel-message-store boot sweeps', () => {
     expect(system?.kind).toBe('system');
     expect(system?.sender.kind).toBe('system');
     expect(system?.body.text).toContain('restarted before terminal output');
+  });
+
+  it('atomically marks a stale detail row and its card restart-provisional', () => {
+    const s = store();
+    const stuck = s.beginStream({
+      channelId: 'topic:restart-detail',
+      sender: AGENT,
+      source: { sessionId: 'sess', turnId: 'turn', itemId: 'reason' },
+      agentDetail: {
+        itemId: 'reason',
+        card: {
+          kind: 'thought',
+          title: 'thinking',
+          status: 'running',
+          content: 'partial thought',
+        },
+      },
+    });
+    s.sweepStaleStreaming();
+    expect(s.getMessage(stuck.id)).toMatchObject({
+      status: 'truncated',
+      meta: { truncationReason: 'restart' },
+      agentDetail: {
+        card: { status: 'cancelled', content: 'partial thought' },
+      },
+    });
   });
 
   it('sweeps orphaned rows for channel ids not in the persisted topic set', () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -864,6 +864,63 @@ describe('channel-message-store posts, threads, idempotency', () => {
     expect(c?.messageCount).toBe(2);
     expect(c?.lastMessage?.preview).toBe('second');
   });
+
+  it('previews the newest prose row when a turn ends on a detail card', () => {
+    const s = store();
+    s.appendComplete({
+      channelId: 'topic:d',
+      sender: HUMAN,
+      text: 'first prose',
+    });
+    s.appendComplete({
+      channelId: 'topic:d',
+      sender: AGENT,
+      text: 'last prose message',
+    });
+    // A detail card ends the turn: it persists body_text='' and is the newest
+    // row, so previewing off the literal last row would blank the summary.
+    const begun = s.beginStream({
+      channelId: 'topic:d',
+      sender: AGENT,
+      source: { sessionId: 'sess-d', turnId: 't-d', itemId: 'reason-d' },
+      agentDetail: {
+        itemId: 'reason-d',
+        card: {
+          kind: 'thought',
+          title: 'thinking',
+          status: 'running',
+          content: 'inspect',
+        },
+      },
+    });
+    s.finalizeStream(begun.id, {
+      text: '',
+      status: 'complete',
+      agentDetail: {
+        itemId: 'reason-d',
+        card: {
+          kind: 'thought',
+          title: 'thinking',
+          status: 'completed',
+          content: 'inspect',
+        },
+      },
+    });
+
+    const viaGet = s.getChannelSummary('topic:d');
+    // latestSeq stays the true highest seq (the detail card) so reconnect
+    // head-checks and unread math are unaffected.
+    expect(viaGet?.latestSeq).toBe(begun.seq);
+    expect(viaGet?.messageCount).toBe(3);
+    expect(viaGet?.lastMessage?.preview).toBe('last prose message');
+
+    const viaList = s
+      .listChannelSummaries()
+      .find((x) => x.channelId === 'topic:d');
+    expect(viaList?.latestSeq).toBe(begun.seq);
+    expect(viaList?.messageCount).toBe(3);
+    expect(viaList?.lastMessage?.preview).toBe('last prose message');
+  });
 });
 
 describe('channel-message-store members and bindings', () => {

--- a/test/channel-thread-e2e.test.ts
+++ b/test/channel-thread-e2e.test.ts
@@ -227,6 +227,8 @@ describe('channel thread mention round trip', () => {
         .map((message) => message.id)
     ).toEqual([root.message.id, trigger.message.id, agentReply!.id]);
     expect(thread.filter((message) => message.agentDetail)).toHaveLength(4);
-    expect(harness.store.getMessage(root.message.id)?.replyCount).toBe(6);
+    // The four detail cards persist in-thread (with a thread_id) but are not
+    // conversational replies — only the human trigger and the mock reply count.
+    expect(harness.store.getMessage(root.message.id)?.replyCount).toBe(2);
   });
 });

--- a/test/channel-thread-e2e.test.ts
+++ b/test/channel-thread-e2e.test.ts
@@ -195,14 +195,18 @@ describe('channel thread mention round trip', () => {
         .history(harness.channelId, { limit: 20 })
         .some(
           (message) =>
-            message.sender.id === 'agent:mock' && message.status === 'complete'
+            message.sender.id === 'agent:mock' &&
+            message.status === 'complete' &&
+            !message.agentDetail
         )
     );
     const agentReply = harness.store
       .history(harness.channelId, { limit: 20 })
       .find(
         (message) =>
-          message.sender.id === 'agent:mock' && message.status === 'complete'
+          message.sender.id === 'agent:mock' &&
+          message.status === 'complete' &&
+          !message.agentDetail
       );
     expect(agentReply).toMatchObject({
       body: { text: 'Mock v2 response complete.' },
@@ -217,11 +221,12 @@ describe('channel thread mention round trip', () => {
       root.message.id,
       { limit: 20 }
     );
-    expect(thread.map((message) => message.id)).toEqual([
-      root.message.id,
-      trigger.message.id,
-      agentReply!.id,
-    ]);
-    expect(harness.store.getMessage(root.message.id)?.replyCount).toBe(2);
+    expect(
+      thread
+        .filter((message) => !message.agentDetail)
+        .map((message) => message.id)
+    ).toEqual([root.message.id, trigger.message.id, agentReply!.id]);
+    expect(thread.filter((message) => message.agentDetail)).toHaveLength(4);
+    expect(harness.store.getMessage(root.message.id)?.replyCount).toBe(6);
   });
 });

--- a/test/components/assistant-markdown.test.ts
+++ b/test/components/assistant-markdown.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { AssistantMarkdown } from '../../frontend/src/components/chat/AssistantMarkdown.js';
+
+// Agent rows collapse fenced code blocks into cards; inline spans must stay
+// inline. react-markdown wraps block code in a `<pre>` while inline spans are
+// not wrapped, so classification keys off that wrapper rather than source line
+// positions — a CommonMark inline span can legally span source lines.
+describe('AssistantMarkdown code classification', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = async (text: string): Promise<void> => {
+    await act(async () => {
+      root.render(
+        React.createElement(AssistantMarkdown, {
+          text,
+          keyPrefix: 'test',
+          codeBlockPresentation: 'card',
+        })
+      );
+    });
+  };
+
+  it('keeps a multi-line-source inline code span inline, not a block card', async () => {
+    // The backtick span straddles a soft line break, so its source position
+    // spans two lines even though the rendered content is a single inline span.
+    await render('prefix `foo\nbar` suffix');
+    const inline = container.querySelector('.tl-md-code');
+    expect(inline).not.toBeNull();
+    expect(inline?.textContent).toContain('foo');
+    expect(inline?.textContent).toContain('bar');
+    expect(container.querySelector('.ch-agent-card')).toBeNull();
+  });
+
+  it('promotes a single-line fence without a language to a block card', async () => {
+    await render('```\nplain fence\n```');
+    expect(container.querySelector('.ch-agent-card')).not.toBeNull();
+    expect(container.querySelector('.tl-md-code')).toBeNull();
+  });
+
+  it('promotes a fenced block with a language to a block card', async () => {
+    await render('```ts\nconst x = 1;\n```');
+    const card = container.querySelector('.ch-agent-card');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-agent-card-kind')).toBe('output');
+    expect(container.querySelector('.tl-md-code')).toBeNull();
+  });
+});

--- a/test/components/channel-message-row.test.ts
+++ b/test/components/channel-message-row.test.ts
@@ -34,6 +34,28 @@ function truncatedMessage(reason: ChannelTruncationReason): ChannelMessage {
   };
 }
 
+function agentMessage(input: Partial<ChannelMessage>): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: 'chm:agent-card' as ChannelMessageId,
+    channelId: 'topic:eng-threads',
+    seq: 2,
+    kind: 'message',
+    status: 'complete',
+    sender: {
+      kind: 'agent',
+      id: 'agent:codex',
+      providerId: 'codex',
+    },
+    body: { text: '', format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-19T00:00:00.000Z',
+    updatedAt: '2026-07-19T00:00:00.000Z',
+    ...input,
+  };
+}
+
 describe('ChannelMessageRow truncation fidelity', () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -71,4 +93,134 @@ describe('ChannelMessageRow truncation fidelity', () => {
       expect(tags[0]?.textContent).toBe(label);
     }
   );
+
+  it('renders a persisted reasoning card collapsed and expands its content', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: agentMessage({
+            agentDetail: {
+              itemId: 'reason-1',
+              card: {
+                kind: 'thought',
+                title: 'inspect the channel renderer',
+                status: 'completed',
+                content: 'reasoning content survives channel persistence',
+              },
+            },
+          }),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.ch-agent-card__body')).toBeNull();
+    await act(async () => toggle?.click());
+    expect(
+      container.querySelector('.ch-agent-card__body')?.textContent
+    ).toContain('reasoning content survives channel persistence');
+  });
+
+  it('rerenders authoritative streaming card rows without overriding persisted status', async () => {
+    const row = (status: 'pending' | 'running', content: string) =>
+      agentMessage({
+        status: 'streaming',
+        agentDetail: {
+          itemId: 'reason-live',
+          card: {
+            kind: 'thought',
+            title: 'thinking',
+            status,
+            content,
+          },
+        },
+      });
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: row('pending', 'first persisted row'),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+    expect(container.querySelector('.ch-agent-card__status')?.textContent).toBe(
+      'pending'
+    );
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    await act(async () => toggle?.click());
+    expect(
+      container.querySelector('.ch-agent-card__body')?.textContent
+    ).toContain('first persisted row');
+
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: row('running', 'authoritative debounced row'),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+    expect(container.querySelector('.ch-agent-card__status')?.textContent).toBe(
+      'running'
+    );
+    expect(
+      container.querySelector('.ch-agent-card__body')?.textContent
+    ).toContain('authoritative debounced row');
+  });
+
+  it('collapses agent-authored markdown fences into bounded output and diff cards', async () => {
+    const output = Array.from(
+      { length: 500 },
+      (_, index) => `const line${index + 1} = ${index + 1};`
+    ).join('\n');
+    const diff = [
+      '--- a/example.ts',
+      '+++ b/example.ts',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+    ].join('\n');
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: agentMessage({
+            body: {
+              format: 'markdown',
+              text: `report\n\n\`\`\`typescript\n${output}\n\`\`\`\n\n\`\`\`diff\n${diff}\n\`\`\``,
+            },
+          }),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+
+    const cards = container.querySelectorAll('.ch-agent-card');
+    expect(cards).toHaveLength(2);
+    expect(cards[0]?.getAttribute('data-agent-card-kind')).toBe('output');
+    expect(
+      cards[0]?.querySelector('.ch-agent-card__toggle')?.textContent
+    ).toContain('500 lines');
+    expect(cards[1]?.getAttribute('data-agent-card-kind')).toBe('diff');
+    expect(
+      cards[1]?.querySelector('.ch-agent-card__toggle')?.textContent
+    ).toContain('+1 -1');
+    expect(container.querySelectorAll('.ch-agent-card__body')).toHaveLength(0);
+
+    const diffToggle = cards[1]?.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    await act(async () => diffToggle?.click());
+    expect(
+      cards[1]?.querySelectorAll('.ch-agent-card__line--added')
+    ).toHaveLength(1);
+    expect(
+      cards[1]?.querySelectorAll('.ch-agent-card__line--removed')
+    ).toHaveLength(1);
+  });
 });

--- a/test/components/channel-thread-layout.test.ts
+++ b/test/components/channel-thread-layout.test.ts
@@ -89,4 +89,39 @@ describe('channel thread timeline projections', () => {
     expect(displayedReplyCount(root, { count: 9 })).toBe(9);
     expect(displayedReplyCount(message('chm:fresh', 2), undefined)).toBe(0);
   });
+
+  it('excludes in-thread detail cards from live reply counts', () => {
+    const root = message('chm:root', 1);
+    const rows = [
+      root,
+      message('chm:reply', 2, {
+        threadId: root.id,
+        parentMessageId: root.id,
+        createdAt: '2026-07-18T12:02:00.000Z',
+      }),
+      // Detail cards carry a threadId (so cold-resume renders them in-thread)
+      // but must not count as replies nor advance the newest-reply timestamp.
+      message('chm:card', 3, {
+        threadId: root.id,
+        parentMessageId: root.id,
+        body: { text: '', format: 'markdown' },
+        agentDetail: {
+          itemId: 'reason-1',
+          card: {
+            kind: 'thought',
+            title: 'thinking',
+            status: 'completed',
+            content: 'card content',
+          },
+        },
+        createdAt: '2026-07-18T12:03:00.000Z',
+      }),
+    ];
+
+    expect(deriveReplyCounts(rows)).toEqual(
+      new Map([
+        [root.id, { count: 1, lastReplyAt: '2026-07-18T12:02:00.000Z' }],
+      ])
+    );
+  });
 });

--- a/test/e2e/channel-timeline-scroll.spec.ts
+++ b/test/e2e/channel-timeline-scroll.spec.ts
@@ -44,6 +44,84 @@ async function firstVisibleAnchor(
 }
 
 test.describe('smoke channel timeline scroll UX (#1193)', () => {
+  test('renders durable agent cards on the real channel host (#1198/#1206)', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    const thought = timeline.locator(
+      '[data-channel-message-seq="68"] .ch-agent-card'
+    );
+    const output = timeline.locator(
+      '[data-channel-message-seq="69"] .ch-agent-card'
+    );
+    const diff = timeline.locator(
+      '[data-channel-message-seq="70"] .ch-agent-card'
+    );
+
+    await expect(thought).toHaveAttribute('data-agent-card-kind', 'thought');
+    await expect(thought.locator('.ch-agent-card__body')).toHaveCount(0);
+    await thought.locator('.ch-agent-card__toggle').click();
+    await expect(thought.locator('.ch-agent-card__body')).toContainText(
+      'reasoning content persisted on the durable channel row'
+    );
+
+    await expect(output.locator('.ch-agent-card__toggle')).toContainText(
+      '500 lines'
+    );
+    await expect(output.locator('.ch-agent-card__body')).toHaveCount(0);
+    await output.locator('.ch-agent-card__toggle').click();
+    const outputBody = output.locator('.ch-agent-card__body');
+    await expect(outputBody).toBeVisible();
+    await expect(
+      output.locator('.ch-agent-card__line span[style*="color"]')
+    ).not.toHaveCount(0);
+    expect(
+      await outputBody.evaluate(
+        (element) => element.scrollHeight > element.clientHeight
+      )
+    ).toBe(true);
+
+    await expect(diff.locator('.ch-agent-card__toggle')).toContainText(
+      '+250 -250'
+    );
+    await diff.locator('.ch-agent-card__toggle').click();
+    await expect(diff.locator('.ch-agent-card__line--added')).toHaveCount(250);
+    await expect(diff.locator('.ch-agent-card__line--removed')).toHaveCount(
+      250
+    );
+    const [addedTint, removedTint] = await Promise.all([
+      diff
+        .locator('.ch-agent-card__line--added')
+        .first()
+        .evaluate((element) => getComputedStyle(element).backgroundColor),
+      diff
+        .locator('.ch-agent-card__line--removed')
+        .first()
+        .evaluate((element) => getComputedStyle(element).backgroundColor),
+    ]);
+    expect(addedTint).not.toBe('rgba(0, 0, 0, 0)');
+    expect(removedTint).not.toBe('rgba(0, 0, 0, 0)');
+    expect(addedTint).not.toBe(removedTint);
+    await expect.poll(() => bottomDistance(timeline)).toBeLessThanOrEqual(1);
+  });
+
+  test('rerenders an authoritative full-row streaming card update', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    const row = timeline.locator('[data-channel-message-seq="67"]');
+    await expect(row.locator('.ch-agent-card')).toHaveCount(0);
+    await page.getByTestId('update-detail-row').click();
+
+    const card = row.locator('.ch-agent-card');
+    await expect(card).toHaveAttribute('data-agent-card-kind', 'thought');
+    await expect(card.locator('.ch-agent-card__status')).toHaveText('running');
+    await card.locator('.ch-agent-card__toggle').click();
+    await expect(card.locator('.ch-agent-card__body')).toContainText(
+      'authoritative debounced browser row'
+    );
+  });
+
   test('surfaces a missing-terminal truncation at the timeline last hop (#1188)', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- persist bounded reasoning, tool, output, and diff detail rows in channel message storage
- stream authoritative card updates through the channel websocket protocol
- render collapsible cards and agent-authored fenced code in ChannelMessageRow
- preserve prose reply semantics and thread accounting alongside detail rows

## Root cause

The original #1198/#1206 implementation mounted AgentDetailCard only in the legacy Turn host. The live channel timeline renders ChannelMessageRow, so the shipped UI never reached the surface operators use.

## Impact

Channel agent output now gets the intended collapsible thinking/tool/output/diff cards, diff tint, syntax highlighting, bounded expansion, durable reload behavior, and live streaming updates.

## Validation

- npm run check: 0 errors, 250 standing warnings
- focused and integration Vitest: 172 passed
- pre-push changed-test gate: 489 passed across 32 files
- production fixture build: passed
- Playwright channel timeline: 12 passed
- adversarial review plus focused re-review: no open P0/P1 findings

Closes #1198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable agent detail cards for reasoning, output, and diff content in channel conversations.
  * Added collapsible cards with status, output size, and diff statistics.
  * Streaming card updates now refresh the latest content smoothly and efficiently.
  * Added support for rendering fenced code blocks as output or diff cards.

* **Bug Fixes**
  * Improved handling of interrupted, truncated, and restarted streaming details.
  * Added payload limits and validation to prevent oversized message content.
  * Preserved authoritative card updates during streaming and replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->