### PR TITLE
feat(agents): AgentProfile actor model + default-per-vendor resolver (#1233)

### DIFF
--- a/server/agent-profile-store.ts
+++ b/server/agent-profile-store.ts
@@ -1,0 +1,496 @@
+// AgentProfile store (#1233, epic #1232).
+//
+// Persists AgentProfile rows — the durable agent-kind Actor identity noun — in
+// the hub config dir beside the framework registry, reusing the self-contained
+// store pattern of `server/agent-presence-store.ts` / `server/context-packets.ts`:
+// a per-store SQLite file, a `schema_version` table with version-gated
+// migrations run inside a transaction, an `init*(configDir)` / `create*(dbPath)`
+// factory split, a `profile_json` blob column plus denormalized columns for
+// queries, and prepared statements.
+//
+// STRICTLY NON-DESTRUCTIVE: owns its own DB file (`agent-profiles.db`) and creates
+// only the new `agent_profiles` table. It never reads or mutates `config.json`,
+// any existing store/table, or any live `ChannelSenderRef` / DM row.
+//
+// ONE-DEFAULT-PER-PROVIDER (enforcement CHOICE: REJECT). Exactly one profile per
+// `providerId` may carry `isDefault: true`. `create()` REJECTS a second default
+// with a clear typed error (`agent_profile_default_exists`, HTTP 409) rather than
+// silently flipping — an intentional default change goes through `setDefault()`,
+// which flips atomically in a transaction. A partial UNIQUE index
+// (`... WHERE is_default = 1`) enforces the invariant at the DB layer as
+// defense-in-depth, so even a raced write cannot land two defaults.
+//
+// THIN OVERLAY: vendor facts (label/glyph/command/args/model-env) are NOT copied
+// onto rows. `seedBuiltIns` writes one built-in default per configured framework
+// with an EMPTY `displayName` ('') — the "inherit vendor label from the catalog"
+// sentinel — carrying no duplicated vendor prose. Seeding is idempotent via the
+// stable primary key `builtInAgentProfileId(providerId)`.
+
+import * as crypto from 'node:crypto';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import {
+  builtInAgentProfileId,
+  isAgentProfile,
+  type AgentProfile,
+  type AgentProfileAvatarRef,
+  type AgentProfileRespondTo,
+} from '../shared/agent-profile.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('agent-profile');
+
+const SCHEMA_V1 = `
+CREATE TABLE IF NOT EXISTS agent_profiles (
+  id            TEXT PRIMARY KEY,
+  provider_id   TEXT NOT NULL,
+  is_default    INTEGER NOT NULL,
+  is_built_in   INTEGER NOT NULL,
+  profile_json  TEXT NOT NULL,
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_agent_profiles_provider
+  ON agent_profiles(provider_id);
+-- One-default-per-provider invariant, enforced at the DB layer.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_profiles_one_default
+  ON agent_profiles(provider_id) WHERE is_default = 1;
+`;
+
+const MIGRATIONS: Array<{ version: number; sql: string }> = [
+  { version: 1, sql: SCHEMA_V1 },
+];
+
+interface AgentProfileRow {
+  id: string;
+  provider_id: string;
+  is_default: number;
+  is_built_in: number;
+  profile_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Framework subset needed to seed a built-in default profile. */
+export interface SeedFramework {
+  id: string;
+}
+
+/** Write input for `create`. `id` is optional (stably generated when absent). */
+export interface AgentProfileCreateInput {
+  id?: string;
+  providerId: string;
+  displayName?: string;
+  avatar?: AgentProfileAvatarRef | null;
+  systemPrompt?: string;
+  model?: string;
+  provider?: string;
+  effort?: string;
+  envVars?: Record<string, string>;
+  namePool?: string[];
+  respondTo?: AgentProfileRespondTo;
+  respondToAllowlist?: string[];
+  isDefault?: boolean;
+  isBuiltIn?: boolean;
+}
+
+export interface AgentProfileStore {
+  close(): void;
+  /**
+   * Insert a new profile. REJECTS a second `isDefault` for the same providerId
+   * with `agent_profile_default_exists` (409). Use `setDefault` to change which
+   * profile is default.
+   */
+  create(input: AgentProfileCreateInput): AgentProfile;
+  get(id: string): AgentProfile | null;
+  list(filter?: { providerId?: string }): AgentProfile[];
+  getDefaultForProvider(providerId: string): AgentProfile | null;
+  /** Atomically make `profileId` the sole default for its providerId. */
+  setDefault(profileId: string): AgentProfile;
+  delete(id: string): boolean;
+  /**
+   * Seed exactly one `isBuiltIn`+`isDefault` profile per configured framework.
+   * Idempotent: re-running neither duplicates nor flips existing rows.
+   * Returns the number of NEW built-in default rows inserted.
+   */
+  seedBuiltIns(frameworks: readonly SeedFramework[]): number;
+}
+
+export class AgentProfileStoreError extends Error {
+  readonly status: number;
+  readonly code: string;
+  constructor(status: number, code: string, message = code) {
+    super(message);
+    this.name = 'AgentProfileStoreError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/** Boot entry point: opens (and migrates) the store DB under `configDir`. */
+export function initAgentProfileStore(configDir: string): AgentProfileStore {
+  return createAgentProfileStore(path.join(configDir, 'agent-profiles.db'));
+}
+
+/** Factory taking an explicit DB path. Used directly by unit tests. */
+export function createAgentProfileStore(dbPath: string): AgentProfileStore {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  runMigrations(db);
+
+  const selectById = db.prepare(
+    `SELECT id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at
+     FROM agent_profiles WHERE id = ?`
+  );
+  const selectDefaultForProvider = db.prepare(
+    `SELECT id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at
+     FROM agent_profiles WHERE provider_id = ? AND is_default = 1`
+  );
+  const insert = db.prepare(
+    `INSERT INTO agent_profiles (
+       id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at
+     ) VALUES (
+       @id, @providerId, @isDefault, @isBuiltIn, @profileJson, @createdAt, @updatedAt
+     )`
+  );
+  const insertIgnore = db.prepare(
+    `INSERT OR IGNORE INTO agent_profiles (
+       id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at
+     ) VALUES (
+       @id, @providerId, @isDefault, @isBuiltIn, @profileJson, @createdAt, @updatedAt
+     )`
+  );
+  const clearDefault = db.prepare(
+    `UPDATE agent_profiles SET is_default = 0, profile_json = ?, updated_at = ?
+     WHERE id = ?`
+  );
+  const setDefaultRow = db.prepare(
+    `UPDATE agent_profiles SET is_default = 1, profile_json = ?, updated_at = ?
+     WHERE id = ?`
+  );
+  const deleteById = db.prepare('DELETE FROM agent_profiles WHERE id = ?');
+
+  function persist(row: {
+    id: string;
+    providerId: string;
+    isDefault: number;
+    isBuiltIn: number;
+    profile: AgentProfile;
+    createdAt: string;
+    updatedAt: string;
+  }): void {
+    try {
+      insert.run({
+        id: row.id,
+        providerId: row.providerId,
+        isDefault: row.isDefault,
+        isBuiltIn: row.isBuiltIn,
+        profileJson: JSON.stringify(row.profile),
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      });
+    } catch (err) {
+      rethrowConstraint(err, row.providerId);
+    }
+  }
+
+  return {
+    close() {
+      db.close();
+    },
+
+    create(input: AgentProfileCreateInput): AgentProfile {
+      const providerId = requireNonEmpty(input.providerId, 'providerId');
+      const isDefault = input.isDefault ?? false;
+      const id =
+        readTrimmed(input.id) ?? generateProfileId(providerId, isDefault);
+
+      if (isDefault && selectDefaultForProvider.get(providerId)) {
+        // Enforcement CHOICE: REJECT a second default (use setDefault to flip).
+        // Checked before the id-collision guard so a second default is always
+        // reported as such, even when the generated default id also collides.
+        throw new AgentProfileStoreError(
+          409,
+          'agent_profile_default_exists',
+          `Provider "${providerId}" already has a default profile; use setDefault to change it.`
+        );
+      }
+      if (selectById.get(id)) {
+        throw new AgentProfileStoreError(
+          409,
+          'agent_profile_id_exists',
+          `Agent profile "${id}" already exists.`
+        );
+      }
+
+      const profile = buildProfile(id, providerId, isDefault, input);
+      const nowIso = new Date().toISOString();
+      persist({
+        id,
+        providerId,
+        isDefault: isDefault ? 1 : 0,
+        isBuiltIn: profile.isBuiltIn ? 1 : 0,
+        profile,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      });
+      const written = getById(id);
+      if (!written) {
+        throw new AgentProfileStoreError(500, 'agent_profile_write_failed');
+      }
+      return written;
+    },
+
+    get(id: string): AgentProfile | null {
+      return getById(id);
+    },
+
+    list(filter: { providerId?: string } = {}): AgentProfile[] {
+      const clauses: string[] = [];
+      const params: unknown[] = [];
+      if (filter.providerId) {
+        clauses.push('provider_id = ?');
+        params.push(filter.providerId);
+      }
+      const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+      const stmt = db.prepare(
+        `SELECT id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at
+         FROM agent_profiles${where}
+         ORDER BY provider_id ASC, is_default DESC, id ASC`
+      );
+      return (stmt.all(...params) as AgentProfileRow[])
+        .map(rowToProfileSafe)
+        .filter((p): p is AgentProfile => p !== null);
+    },
+
+    getDefaultForProvider(providerId: string): AgentProfile | null {
+      const row = selectDefaultForProvider.get(providerId) as
+        | AgentProfileRow
+        | undefined;
+      return row ? rowToProfileSafe(row) : null;
+    },
+
+    setDefault(profileId: string): AgentProfile {
+      const target = getById(profileId);
+      if (!target) {
+        throw new AgentProfileStoreError(404, 'agent_profile_not_found');
+      }
+      if (target.isDefault) return target;
+      const nowIso = new Date().toISOString();
+      const flip = db.transaction(() => {
+        const current = selectDefaultForProvider.get(target.providerId) as
+          | AgentProfileRow
+          | undefined;
+        if (current) {
+          const currentProfile = rowToProfileSafe(current);
+          if (currentProfile) {
+            clearDefault.run(
+              JSON.stringify({ ...currentProfile, isDefault: false }),
+              nowIso,
+              current.id
+            );
+          }
+        }
+        setDefaultRow.run(
+          JSON.stringify({ ...target, isDefault: true }),
+          nowIso,
+          profileId
+        );
+      });
+      flip();
+      const written = getById(profileId);
+      if (!written) {
+        throw new AgentProfileStoreError(500, 'agent_profile_write_failed');
+      }
+      return written;
+    },
+
+    delete(id: string): boolean {
+      return deleteById.run(id).changes > 0;
+    },
+
+    seedBuiltIns(frameworks: readonly SeedFramework[]): number {
+      let inserted = 0;
+      const seed = db.transaction(() => {
+        const nowIso = new Date().toISOString();
+        for (const framework of frameworks) {
+          const providerId = readTrimmed(framework.id);
+          if (!providerId) continue;
+          const id = builtInAgentProfileId(providerId);
+          // Thin overlay: empty displayName = "inherit vendor label from catalog".
+          const profile: AgentProfile = {
+            id,
+            providerId,
+            displayName: '',
+            avatar: null,
+            isDefault: true,
+            isBuiltIn: true,
+          };
+          // Idempotent by stable PK: OR IGNORE never duplicates or flips an
+          // existing row (built-in or user-created). If some other profile is
+          // already the vendor default, the partial unique index would reject a
+          // second default — so pre-check and skip to stay non-destructive.
+          if (selectDefaultForProvider.get(providerId)) continue;
+          const changes = insertIgnore.run({
+            id,
+            providerId,
+            isDefault: 1,
+            isBuiltIn: 1,
+            profileJson: JSON.stringify(profile),
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          }).changes;
+          inserted += changes;
+        }
+      });
+      seed();
+      return inserted;
+    },
+  };
+
+  function getById(id: string): AgentProfile | null {
+    const row = selectById.get(id) as AgentProfileRow | undefined;
+    return row ? rowToProfileSafe(row) : null;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function requireNonEmpty(value: unknown, field: string): string {
+  const trimmed = readTrimmed(value);
+  if (!trimmed) {
+    throw new AgentProfileStoreError(
+      400,
+      'agent_profile_field_required',
+      `${field} is required.`
+    );
+  }
+  return trimmed;
+}
+
+function readTrimmed(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function generateProfileId(providerId: string, isDefault: boolean): string {
+  if (isDefault) return builtInAgentProfileId(providerId);
+  return `agent-profile:${providerId}:${crypto.randomUUID()}`;
+}
+
+function buildProfile(
+  id: string,
+  providerId: string,
+  isDefault: boolean,
+  input: AgentProfileCreateInput
+): AgentProfile {
+  const profile: AgentProfile = {
+    id,
+    providerId,
+    displayName: typeof input.displayName === 'string' ? input.displayName : '',
+    avatar: input.avatar ?? null,
+    isDefault,
+    isBuiltIn: input.isBuiltIn ?? false,
+  };
+  const systemPrompt = readTrimmed(input.systemPrompt);
+  if (systemPrompt) profile.systemPrompt = systemPrompt;
+  const model = readTrimmed(input.model);
+  if (model) profile.model = model;
+  const provider = readTrimmed(input.provider);
+  if (provider) profile.provider = provider;
+  const effort = readTrimmed(input.effort);
+  if (effort) profile.effort = effort;
+  if (input.envVars && typeof input.envVars === 'object') {
+    const envVars: Record<string, string> = {};
+    for (const [key, val] of Object.entries(input.envVars)) {
+      if (typeof val === 'string') envVars[key] = val;
+    }
+    if (Object.keys(envVars).length) profile.envVars = envVars;
+  }
+  if (Array.isArray(input.namePool)) {
+    const namePool = input.namePool.filter(
+      (n): n is string => typeof n === 'string' && n.trim().length > 0
+    );
+    if (namePool.length) profile.namePool = namePool;
+  }
+  if (input.respondTo) profile.respondTo = input.respondTo;
+  if (Array.isArray(input.respondToAllowlist)) {
+    const allow = input.respondToAllowlist.filter(
+      (n): n is string => typeof n === 'string' && n.trim().length > 0
+    );
+    if (allow.length) profile.respondToAllowlist = allow;
+  }
+  if (!isAgentProfile(profile)) {
+    throw new AgentProfileStoreError(400, 'agent_profile_invalid');
+  }
+  return profile;
+}
+
+function rethrowConstraint(err: unknown, providerId: string): never {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/UNIQUE constraint failed: agent_profiles\b/i.test(message)) {
+    if (/idx_agent_profiles_one_default/i.test(message)) {
+      throw new AgentProfileStoreError(
+        409,
+        'agent_profile_default_exists',
+        `Provider "${providerId}" already has a default profile; use setDefault to change it.`
+      );
+    }
+    throw new AgentProfileStoreError(409, 'agent_profile_id_exists');
+  }
+  throw err;
+}
+
+function rowToProfileSafe(row: AgentProfileRow): AgentProfile | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.profile_json) as unknown;
+  } catch {
+    logger.warn('dropped agent profile %s: corrupt profile_json', row.id);
+    return null;
+  }
+  if (!isAgentProfile(parsed)) {
+    logger.warn('dropped agent profile %s: failed validation', row.id);
+    return null;
+  }
+  // Denormalized columns are the query source of truth; reconcile the blob so a
+  // tampered blob can never disagree with its row on identity/default state.
+  return {
+    ...parsed,
+    id: row.id,
+    providerId: row.provider_id,
+    isDefault: row.is_default === 1,
+    isBuiltIn: row.is_built_in === 1,
+  };
+}
+
+// ── Migration runner (mirrors agent-presence-store.ts / context-packets.ts) ────
+function runMigrations(db: Database.Database): void {
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
+  );
+  const row = db.prepare('SELECT version FROM schema_version').get() as
+    | { version: number }
+    | undefined;
+  const hadRow = row !== undefined;
+  let currentVersion = row?.version ?? 0;
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version > currentVersion) {
+      const ver = migration.version;
+      db.transaction(() => {
+        db.exec(migration.sql);
+        if (hadRow || currentVersion > 0) {
+          db.prepare('UPDATE schema_version SET version = ?').run(ver);
+        } else {
+          db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(
+            ver
+          );
+        }
+      })();
+      currentVersion = ver;
+    }
+  }
+}

--- a/server/agent-profile-store.ts
+++ b/server/agent-profile-store.ts
@@ -111,9 +111,12 @@ export interface AgentProfileStore {
   setDefault(profileId: string): AgentProfile;
   delete(id: string): boolean;
   /**
-   * Seed exactly one `isBuiltIn`+`isDefault` profile per configured framework.
-   * Idempotent: re-running neither duplicates nor flips existing rows.
-   * Returns the number of NEW built-in default rows inserted.
+   * Seed/repair exactly one `isBuiltIn`+`isDefault` profile per configured
+   * framework. Idempotent when a default already exists (no duplicate, no flip);
+   * self-healing when a provider has a survivor row but zero defaults (promotes
+   * the survivor at the stable built-in PK, or inserts a built-in default,
+   * atomically). Returns the number of NEW built-in default rows inserted —
+   * in-place promotions/repairs are not counted.
    */
   seedBuiltIns(frameworks: readonly SeedFramework[]): number;
 }
@@ -156,19 +159,20 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
        @id, @providerId, @isDefault, @isBuiltIn, @profileJson, @createdAt, @updatedAt
      )`
   );
-  const insertIgnore = db.prepare(
-    `INSERT OR IGNORE INTO agent_profiles (
-       id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at
-     ) VALUES (
-       @id, @providerId, @isDefault, @isBuiltIn, @profileJson, @createdAt, @updatedAt
-     )`
-  );
   const clearDefault = db.prepare(
     `UPDATE agent_profiles SET is_default = 0, profile_json = ?, updated_at = ?
      WHERE id = ?`
   );
   const setDefaultRow = db.prepare(
     `UPDATE agent_profiles SET is_default = 1, profile_json = ?, updated_at = ?
+     WHERE id = ?`
+  );
+  // Self-heal a zero-default vendor: force a survivor at the stable built-in PK
+  // to be the built-in default. Sets is_built_in = 1 (not just is_default) so a
+  // demoted user row promoted here honors the isDefault+isBuiltIn contract.
+  const promoteBuiltInDefault = db.prepare(
+    `UPDATE agent_profiles
+       SET is_default = 1, is_built_in = 1, profile_json = ?, updated_at = ?
      WHERE id = ?`
   );
   const deleteById = db.prepare('DELETE FROM agent_profiles WHERE id = ?');
@@ -319,7 +323,41 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
         for (const framework of frameworks) {
           const providerId = readTrimmed(framework.id);
           if (!providerId) continue;
+
+          // Idempotent: a default (built-in OR user-chosen) already exists —
+          // leave it untouched so re-seeding never duplicates or flips a live
+          // default. This also keeps seeding non-destructive of a user's choice.
+          if (selectDefaultForProvider.get(providerId)) continue;
+
+          // Self-healing: the provider has NO default (e.g. its default row was
+          // demoted or deleted, leaving a survivor at is_default = 0). Restore
+          // exactly one built-in default atomically inside this transaction,
+          // consistent with setDefault's flip. Because the pre-check above proved
+          // no default exists, promoting/inserting cannot collide with the
+          // partial one-default-per-provider unique index.
           const id = builtInAgentProfileId(providerId);
+          const existing = selectById.get(id) as AgentProfileRow | undefined;
+          if (existing) {
+            // A survivor lives at the stable built-in PK but is not the default:
+            // promote it in place (never a duplicate row), preserving any overlay
+            // content while forcing the built-in-default flags on.
+            const survivor = rowToProfileSafe(existing);
+            const healed: AgentProfile = survivor
+              ? { ...survivor, isDefault: true, isBuiltIn: true }
+              : {
+                  id,
+                  providerId,
+                  displayName: '',
+                  avatar: null,
+                  isDefault: true,
+                  isBuiltIn: true,
+                };
+            promoteBuiltInDefault.run(JSON.stringify(healed), nowIso, id);
+            // A heal is not a NEW row; the return count tracks inserts only.
+            continue;
+          }
+
+          // No row at the stable built-in PK — insert the thin built-in default.
           // Thin overlay: empty displayName = "inherit vendor label from catalog".
           const profile: AgentProfile = {
             id,
@@ -329,12 +367,7 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
             isDefault: true,
             isBuiltIn: true,
           };
-          // Idempotent by stable PK: OR IGNORE never duplicates or flips an
-          // existing row (built-in or user-created). If some other profile is
-          // already the vendor default, the partial unique index would reject a
-          // second default — so pre-check and skip to stay non-destructive.
-          if (selectDefaultForProvider.get(providerId)) continue;
-          const changes = insertIgnore.run({
+          inserted += insert.run({
             id,
             providerId,
             isDefault: 1,
@@ -343,7 +376,6 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
             createdAt: nowIso,
             updatedAt: nowIso,
           }).changes;
-          inserted += changes;
         }
       });
       seed();
@@ -428,10 +460,20 @@ function buildProfile(
   return profile;
 }
 
-function rethrowConstraint(err: unknown, providerId: string): never {
+/**
+ * Map a UNIQUE-constraint failure onto a typed store error. Exported for tests:
+ * the create() pre-check makes the partial-index branch reachable only under a
+ * cross-process race, so it is exercised directly with the real SQLite messages.
+ */
+export function rethrowConstraint(err: unknown, providerId: string): never {
   const message = err instanceof Error ? err.message : String(err);
-  if (/UNIQUE constraint failed: agent_profiles\b/i.test(message)) {
-    if (/idx_agent_profiles_one_default/i.test(message)) {
+  if (/UNIQUE constraint failed: agent_profiles\./i.test(message)) {
+    // SQLite names the COLUMN, not the index, in a UNIQUE violation message:
+    //   two-defaults (partial unique index) -> "...agent_profiles.provider_id"
+    //   id collision (primary key)          -> "...agent_profiles.id"
+    // Distinguish on the column token so a raced second default maps to the
+    // right code instead of being mis-reported as an id collision.
+    if (/agent_profiles\.provider_id\b/i.test(message)) {
       throw new AgentProfileStoreError(
         409,
         'agent_profile_default_exists',

--- a/server/index.ts
+++ b/server/index.ts
@@ -1645,11 +1645,16 @@ function presenceActorIdFromRequest(req: express.Request): string | undefined {
  */
 function initAgentProfileStoreBestEffort(
   configDir: string,
-  frameworks: readonly { id: string }[]
+  config: Config
 ): AgentProfileStore | null {
   try {
     const store = initAgentProfileStore(configDir);
-    store.seedBuiltIns(frameworks);
+    // Enumerate configured frameworks INSIDE the guard: resolveFramework throws
+    // for a malformed fully-custom framework entry (missing command/args/parser/
+    // capabilities) that config loading does not validate. Keeping it here lets
+    // that resolution throw degrade to "no profile rows" instead of escaping the
+    // best-effort guard and crashing hub boot.
+    store.seedBuiltIns(listConfiguredFrameworks(config.frameworks));
     return store;
   } catch (err) {
     logger.warn(
@@ -2068,7 +2073,7 @@ async function main(): Promise<void> {
   // "no profile rows" rather than failing boot. NO live-row re-key ships here.
   const agentProfileStore = initAgentProfileStoreBestEffort(
     configDir,
-    listConfiguredFrameworks(getConfig().frameworks)
+    getConfig()
   );
 
   // WorkContext artifact store (#889/#890). Own SQLite/payload files; routes

--- a/server/index.ts
+++ b/server/index.ts
@@ -107,6 +107,10 @@ import {
   type AgentPresenceStore,
 } from './agent-presence-store.js';
 import {
+  initAgentProfileStore,
+  type AgentProfileStore,
+} from './agent-profile-store.js';
+import {
   initInterventionLog,
   closeInterventionLog,
 } from './intervention-log.js';
@@ -1633,6 +1637,29 @@ function presenceActorIdFromRequest(req: express.Request): string | undefined {
   return authenticatedCliGatewayActorCredential(req)?.actor?.id;
 }
 
+/**
+ * Boot the #1233 AgentProfile store and seed one built-in default profile per
+ * CONFIGURED framework, or `null` when init fails (agent-profile identity then
+ * simply has no rows this boot). Seeding is idempotent — safe every startup.
+ * Extracted from `main()` to keep that boot function under the complexity gate.
+ */
+function initAgentProfileStoreBestEffort(
+  configDir: string,
+  frameworks: readonly { id: string }[]
+): AgentProfileStore | null {
+  try {
+    const store = initAgentProfileStore(configDir);
+    store.seedBuiltIns(frameworks);
+    return store;
+  } catch (err) {
+    logger.warn(
+      'Agent profile store disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
 function initWorkflowRunStoreBestEffort(
   configDir: string
 ): WorkflowRunStore | null {
@@ -2034,6 +2061,15 @@ async function main(): Promise<void> {
   // overlay. Guarded so a DB error degrades to "no explicit presence" (the
   // roster falls back to the derived projection) rather than failing boot.
   const agentPresenceStore = initAgentPresenceStoreBestEffort(configDir);
+
+  // AgentProfile store (#1233, epic #1232). Own SQLite file (`agent-profiles.db`);
+  // new table only, non-destructive. Seeds one built-in default profile per
+  // configured framework at boot (idempotent). Guarded so a DB error degrades to
+  // "no profile rows" rather than failing boot. NO live-row re-key ships here.
+  const agentProfileStore = initAgentProfileStoreBestEffort(
+    configDir,
+    listConfiguredFrameworks(getConfig().frameworks)
+  );
 
   // WorkContext artifact store (#889/#890). Own SQLite/payload files; routes
   // degrade to typed 503 when initialization fails so hub startup stays useful.
@@ -5911,6 +5947,7 @@ async function main(): Promise<void> {
         iaStore?.close();
         contextPacketStore?.close();
         agentPresenceStore?.close();
+        agentProfileStore?.close();
         workContextArtifactStore?.close();
         workflowRunStore?.close();
         automationRunStore?.close();
@@ -6003,6 +6040,7 @@ async function main(): Promise<void> {
     iaStore?.close();
     contextPacketStore?.close();
     agentPresenceStore?.close();
+    agentProfileStore?.close();
     workContextArtifactStore?.close();
     workflowRunStore?.close();
     automationRunStore?.close();

--- a/shared/agent-profile.ts
+++ b/shared/agent-profile.ts
@@ -1,0 +1,267 @@
+// AgentProfile: the durable agent-kind Actor identity noun (#1233, epic #1232).
+//
+// An AgentProfile is a thin, per-hub overlay on a vendor framework
+// (`server/types.ts` `AgentFramework` / `BUILTIN_FRAMEWORKS`), keyed on a stable
+// profile id that is DISTINCT from the bare vendor id. `AgentProfile.id` IS the
+// actor id populated into `WorkContextMessageActor.id` (`shared/work-context-message.ts`)
+// and is an `'agent'`-kind actor per `WorkContextActorKind` (`shared/work-context.ts`).
+//
+// `@claude` / `@codex` become the DEFAULT profile of their vendor, not the only
+// contact — users later add more profiles that share one `providerId`
+// ("Backend Claude", "Reviewer Codex"). Exactly one profile per `providerId`
+// carries `isDefault: true`.
+//
+// THIN OVERLAY: vendor facts (default label/glyph, command, args, model-env-var
+// names) are NEVER copied onto a profile row. They are read from the framework
+// catalog by `providerId` at use time. A built-in default profile therefore
+// seeds with an EMPTY `displayName` ('') — the "inherit the vendor label from the
+// catalog" sentinel — carrying no duplicated vendor prose.
+//
+// boundaryCheck (#1231): AgentProfile rows are local hub sqlite/config Actor rows.
+// No Nostr keypair identity, no `community_id` scoping, no signed Persona Pack.
+
+export const AGENT_PROFILE_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Reference to an uploaded avatar blob. The avatar is a BLOB-REF ONLY in this
+ * slice — DESIGN.md forbids rendering it here (no emoji, no inline image), so
+ * this carries addressing metadata for a later rendering slice, never bytes.
+ */
+export interface AgentProfileAvatarRef {
+  /** Content-addressed blob id (e.g. an uploaded attachment id). */
+  id: string;
+  sha256?: string;
+  mediaType?: string;
+  byteCount?: number;
+}
+
+/**
+ * Who a profile responds to when @-mentioned. Advisory policy carried on the
+ * profile; enforcement lives in later routing slices, not here.
+ */
+export type AgentProfileRespondTo = 'owner-only' | 'allowlist' | 'anyone';
+
+export interface AgentProfile {
+  /**
+   * Stable actor id, distinct from the bare vendor id. IS the
+   * `WorkContextMessageActor.id` for this agent. Built-in defaults use
+   * `builtInAgentProfileId(providerId)`.
+   */
+  id: string;
+  /** Framework catalog key (`AgentFramework.id`): claude/codex/opencode/hermes/custom. */
+  providerId: string;
+  /**
+   * Free-form, possibly multi-word display name. EMPTY ('') on a built-in
+   * default means "inherit the vendor label from the framework catalog by
+   * `providerId`" — vendor facts are not duplicated onto the row.
+   */
+  displayName: string;
+  /** Uploaded avatar blob-ref, or null. Never rendered in this slice. */
+  avatar: AgentProfileAvatarRef | null;
+  /** Optional launch-time system-prompt overlay text. */
+  systemPrompt?: string;
+  /** Optional model override (vendor-interpreted). */
+  model?: string;
+  /** Optional provider override (vendor-interpreted). */
+  provider?: string;
+  /** Optional reasoning-effort override (vendor-interpreted). */
+  effort?: string;
+  /** Optional extra environment variables applied at launch. */
+  envVars?: Record<string, string>;
+  /** Optional pool of alternate names this profile also answers to. */
+  namePool?: string[];
+  /** Optional respond-to policy (advisory in this slice). */
+  respondTo?: AgentProfileRespondTo;
+  /** Actor ids allowed when `respondTo === 'allowlist'`. */
+  respondToAllowlist?: string[];
+  /** Exactly one profile per `providerId` is the default. */
+  isDefault: boolean;
+  /** Seeded, non-user-authored profile. */
+  isBuiltIn: boolean;
+}
+
+/**
+ * Minimal contact shape the resolver / shim need. Accepts full `AgentProfile`
+ * rows or any lighter list carrying these fields.
+ */
+export type AgentProfileContact = Pick<
+  AgentProfile,
+  'id' | 'providerId' | 'displayName' | 'isDefault' | 'isBuiltIn'
+>;
+
+/** Stable id for the built-in default profile of a vendor. Distinct from `<vendor>`. */
+export function builtInAgentProfileId(providerId: string): string {
+  return `agent-profile:${providerId}:default`;
+}
+
+/**
+ * Normalize a mention token or display name for matching: strip a leading `@`,
+ * lowercase, collapse internal whitespace, and trim. Case-insensitive matching
+ * over free-form multi-word names hangs off this.
+ */
+export function normalizeMentionToken(token: string): string {
+  return token.replace(/^@+/, '').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Deterministic collision tiebreak between two candidate profiles that matched
+ * a mention equally (same normalized display name, or an equal-length prefix
+ * match). Order: (1) default wins, (2) built-in wins, (3) lexicographically
+ * smallest `id` wins. Returns the WINNER.
+ */
+function preferProfile(
+  a: AgentProfileContact,
+  b: AgentProfileContact
+): AgentProfileContact {
+  if (a.isDefault !== b.isDefault) return a.isDefault ? a : b;
+  if (a.isBuiltIn !== b.isBuiltIn) return a.isBuiltIn ? a : b;
+  return a.id <= b.id ? a : b;
+}
+
+/**
+ * Resolve an @-mention token to a single profile.
+ *
+ * Resolution order:
+ *  1. VENDOR ALIAS — if the normalized token exactly equals a `providerId` that
+ *     has a default profile, return that default. `@claude` → the default claude
+ *     profile. Vendor alias always wins over a same-named custom profile.
+ *  2. NAMED, LONGEST-MATCH-FIRST, CASE-INSENSITIVE — over non-empty display
+ *     names: a profile matches when its normalized display name equals the token
+ *     OR is a whitespace-boundary prefix of the token (so "backend claude"
+ *     matches "Backend Claude" even alongside a shorter "Backend"). The longest
+ *     matching name wins; ties break via `preferProfile` (default > built-in >
+ *     smallest id).
+ *
+ * Returns `null` when nothing matches. Built-in defaults carry an EMPTY display
+ * name and so are never reachable via the named path — only via their vendor
+ * alias — which is exactly why `@claude` keeps working while an unnamed default
+ * never shadows a user-named profile.
+ */
+export function resolveProfileForMention<T extends AgentProfileContact>(
+  token: string,
+  contactSet: readonly T[]
+): T | null {
+  const norm = normalizeMentionToken(token);
+  if (!norm) return null;
+
+  // 1. Vendor alias → that vendor's default profile.
+  let vendorDefault: T | null = null;
+  for (const profile of contactSet) {
+    if (profile.isDefault && profile.providerId.toLowerCase() === norm) {
+      vendorDefault = vendorDefault
+        ? (preferProfile(vendorDefault, profile) as T)
+        : profile;
+    }
+  }
+  if (vendorDefault) return vendorDefault;
+
+  // 2. Named, longest-match-first, case-insensitive.
+  let best: T | null = null;
+  let bestLen = -1;
+  for (const profile of contactSet) {
+    const name = normalizeMentionToken(profile.displayName);
+    if (!name) continue;
+    const matches = norm === name || norm.startsWith(`${name} `);
+    if (!matches) continue;
+    if (name.length > bestLen) {
+      best = profile;
+      bestLen = name.length;
+    } else if (name.length === bestLen && best) {
+      best = preferProfile(best, profile) as T;
+    }
+  }
+  return best;
+}
+
+const HISTORICAL_AGENT_SENDER_PREFIX = 'agent:';
+
+/**
+ * Extract the vendor framework id from a historical `agent:<framework>` sender
+ * id. Returns `null` for anything that is not an `agent:<framework>` id (e.g.
+ * `human:<id>`, `system`, or an already-profile-keyed id). Kept narrow: a bare
+ * `agent:` with no framework, or a compound `agent:<a>:<b>` id, is not a legacy
+ * framework sender and yields `null`.
+ */
+export function parseHistoricalAgentSenderProviderId(
+  senderId: string
+): string | null {
+  if (!senderId.startsWith(HISTORICAL_AGENT_SENDER_PREFIX)) return null;
+  const rest = senderId.slice(HISTORICAL_AGENT_SENDER_PREFIX.length);
+  if (!rest || rest.includes(':') || rest.includes('/')) return null;
+  return rest;
+}
+
+/**
+ * READ-TIME SHIM (#1233): map a historical `agent:<framework>` sender id to that
+ * vendor's DEFAULT profile id at read time. Pure resolution — it NEVER rewrites
+ * stored rows. The destructive sender re-key lives in a later slice; this helper
+ * is what that slice builds on.
+ *
+ * Returns the default profile id for the vendor, or `null` when the sender id is
+ * not a legacy `agent:<framework>` id or the vendor has no default profile in
+ * `contactSet`.
+ */
+export function resolveHistoricalAgentSenderProfileId(
+  senderId: string,
+  contactSet: readonly AgentProfileContact[]
+): string | null {
+  const providerId = parseHistoricalAgentSenderProviderId(senderId);
+  if (!providerId) return null;
+  const target = providerId.toLowerCase();
+  let match: AgentProfileContact | null = null;
+  for (const profile of contactSet) {
+    if (profile.isDefault && profile.providerId.toLowerCase() === target) {
+      match = match ? preferProfile(match, profile) : profile;
+    }
+  }
+  return match ? match.id : null;
+}
+
+/** Runtime guard for a stored/parsed AgentProfile row. */
+export function isAgentProfile(value: unknown): value is AgentProfile {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  const isOptString = (x: unknown): boolean =>
+    x === undefined || typeof x === 'string';
+  const isOptStringArray = (x: unknown): boolean =>
+    x === undefined ||
+    (Array.isArray(x) && x.every((i) => typeof i === 'string'));
+  const avatarOk =
+    v.avatar === null ||
+    (typeof v.avatar === 'object' &&
+      v.avatar !== null &&
+      typeof (v.avatar as Record<string, unknown>).id === 'string');
+  const envVarsOk =
+    v.envVars === undefined ||
+    (typeof v.envVars === 'object' &&
+      v.envVars !== null &&
+      !Array.isArray(v.envVars) &&
+      Object.values(v.envVars as Record<string, unknown>).every(
+        (x) => typeof x === 'string'
+      ));
+  const respondToOk =
+    v.respondTo === undefined ||
+    v.respondTo === 'owner-only' ||
+    v.respondTo === 'allowlist' ||
+    v.respondTo === 'anyone';
+  return (
+    typeof v.id === 'string' &&
+    v.id.length > 0 &&
+    typeof v.providerId === 'string' &&
+    v.providerId.length > 0 &&
+    typeof v.displayName === 'string' &&
+    avatarOk &&
+    isOptString(v.systemPrompt) &&
+    isOptString(v.model) &&
+    isOptString(v.provider) &&
+    isOptString(v.effort) &&
+    envVarsOk &&
+    isOptStringArray(v.namePool) &&
+    respondToOk &&
+    isOptStringArray(v.respondToAllowlist) &&
+    typeof v.isDefault === 'boolean' &&
+    typeof v.isBuiltIn === 'boolean'
+  );
+}

--- a/test/agent-profile-store.test.ts
+++ b/test/agent-profile-store.test.ts
@@ -1,0 +1,233 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  builtInAgentProfileId,
+  resolveHistoricalAgentSenderProfileId,
+} from '../shared/agent-profile.js';
+import {
+  AgentProfileStoreError,
+  createAgentProfileStore,
+  type AgentProfileStore,
+  type SeedFramework,
+} from '../server/agent-profile-store.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const tmpDirs: string[] = [];
+const openStores: AgentProfileStore[] = [];
+
+function makeStore(): AgentProfileStore {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-agent-profile-test-')
+  );
+  tmpDirs.push(dir);
+  const store = createAgentProfileStore(path.join(dir, 'agent-profiles.db'));
+  openStores.push(store);
+  return store;
+}
+
+const FRAMEWORKS: SeedFramework[] = [
+  { id: 'claude' },
+  { id: 'codex' },
+  { id: 'opencode' },
+  { id: 'hermes' },
+];
+
+afterEach(() => {
+  while (openStores.length) {
+    try {
+      openStores.pop()?.close();
+    } catch {
+      // already closed
+    }
+  }
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('seedBuiltIns — one built-in default per configured framework', () => {
+  it('seeds exactly one isBuiltIn+isDefault profile per framework', () => {
+    const store = makeStore();
+    const inserted = store.seedBuiltIns(FRAMEWORKS);
+    expect(inserted).toBe(FRAMEWORKS.length);
+
+    const all = store.list();
+    expect(all).toHaveLength(FRAMEWORKS.length);
+    for (const framework of FRAMEWORKS) {
+      const rows = store.list({ providerId: framework.id });
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row.id).toBe(builtInAgentProfileId(framework.id));
+      expect(row.isDefault).toBe(true);
+      expect(row.isBuiltIn).toBe(true);
+      // Thin overlay: vendor label is NOT duplicated onto the row.
+      expect(row.displayName).toBe('');
+      expect(row.avatar).toBeNull();
+    }
+  });
+
+  it('is idempotent: seeding twice yields identical rows', () => {
+    const store = makeStore();
+    const first = store.seedBuiltIns(FRAMEWORKS);
+    const before = store.list();
+    const second = store.seedBuiltIns(FRAMEWORKS);
+    const after = store.list();
+
+    expect(first).toBe(FRAMEWORKS.length);
+    expect(second).toBe(0); // no new rows on the second run
+    expect(after).toHaveLength(before.length);
+    expect(after.map((p) => p.id).sort()).toEqual(
+      before.map((p) => p.id).sort()
+    );
+  });
+
+  it('does not flip an existing user-chosen default when re-seeding', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const custom = store.create({
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+    });
+    store.setDefault(custom.id);
+    expect(store.getDefaultForProvider('claude')?.id).toBe(custom.id);
+
+    // Re-seeding must not resurrect the built-in default or duplicate rows.
+    const inserted = store.seedBuiltIns([{ id: 'claude' }]);
+    expect(inserted).toBe(0);
+    expect(store.getDefaultForProvider('claude')?.id).toBe(custom.id);
+  });
+});
+
+describe('one-default-per-provider invariant (enforcement CHOICE: reject)', () => {
+  it('rejects creating a second default for the same provider', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    expect(() =>
+      store.create({
+        providerId: 'claude',
+        displayName: 'Another Default',
+        isDefault: true,
+      })
+    ).toThrowError(AgentProfileStoreError);
+
+    try {
+      store.create({
+        providerId: 'claude',
+        displayName: 'Another Default',
+        isDefault: true,
+      });
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AgentProfileStoreError);
+      expect((err as AgentProfileStoreError).code).toBe(
+        'agent_profile_default_exists'
+      );
+      expect((err as AgentProfileStoreError).status).toBe(409);
+    }
+    // Still exactly one default for claude.
+    expect(
+      store.list({ providerId: 'claude' }).filter((p) => p.isDefault)
+    ).toHaveLength(1);
+  });
+
+  it('allows creating additional NON-default profiles for a provider', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const extra = store.create({
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+    });
+    expect(extra.isDefault).toBe(false);
+    expect(store.list({ providerId: 'claude' })).toHaveLength(2);
+  });
+
+  it('setDefault atomically flips the default (old one cleared)', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const oldDefaultId = builtInAgentProfileId('claude');
+    const custom = store.create({
+      providerId: 'claude',
+      displayName: 'Reviewer Claude',
+    });
+
+    const promoted = store.setDefault(custom.id);
+    expect(promoted.isDefault).toBe(true);
+    expect(store.get(oldDefaultId)?.isDefault).toBe(false);
+    expect(store.getDefaultForProvider('claude')?.id).toBe(custom.id);
+    // Invariant holds: still exactly one default.
+    expect(
+      store.list({ providerId: 'claude' }).filter((p) => p.isDefault)
+    ).toHaveLength(1);
+  });
+
+  it('carries optional overlay fields but never vendor facts', () => {
+    const store = makeStore();
+    const p = store.create({
+      providerId: 'codex',
+      displayName: 'Fast Codex',
+      model: 'gpt-x',
+      effort: 'high',
+      envVars: { FOO: 'bar' },
+      namePool: ['fast', 'zippy'],
+      respondTo: 'allowlist',
+      respondToAllowlist: ['human:owner'],
+    });
+    expect(p.model).toBe('gpt-x');
+    expect(p.effort).toBe('high');
+    expect(p.envVars).toEqual({ FOO: 'bar' });
+    expect(p.namePool).toEqual(['fast', 'zippy']);
+    expect(p.respondTo).toBe('allowlist');
+    expect(p.respondToAllowlist).toEqual(['human:owner']);
+  });
+});
+
+describe('read-time shim over the store', () => {
+  it('maps agent:<framework> to the seeded default profile id', () => {
+    const store = makeStore();
+    store.seedBuiltIns(FRAMEWORKS);
+    const contacts = store.list();
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:claude', contacts)
+    ).toBe(builtInAgentProfileId('claude'));
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:hermes', contacts)
+    ).toBe(builtInAgentProfileId('hermes'));
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:unknown', contacts)
+    ).toBeNull();
+  });
+});
+
+describe('persistence across reopen', () => {
+  it('reads seeded rows back after reopening the DB file', () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-agent-profile-test-')
+    );
+    tmpDirs.push(dir);
+    const dbPath = path.join(dir, 'agent-profiles.db');
+
+    const first = createAgentProfileStore(dbPath);
+    first.seedBuiltIns(FRAMEWORKS);
+    first.close();
+
+    const second = createAgentProfileStore(dbPath);
+    openStores.push(second);
+    expect(second.list()).toHaveLength(FRAMEWORKS.length);
+    // Re-seeding the reopened store stays idempotent.
+    expect(second.seedBuiltIns(FRAMEWORKS)).toBe(0);
+  });
+});

--- a/test/agent-profile-store.test.ts
+++ b/test/agent-profile-store.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -11,9 +12,11 @@ import {
 import {
   AgentProfileStoreError,
   createAgentProfileStore,
+  rethrowConstraint,
   type AgentProfileStore,
   type SeedFramework,
 } from '../server/agent-profile-store.js';
+import { listConfiguredFrameworks } from '../server/frameworks.js';
 
 vi.mock('../server/logger.js', () => ({
   createLogger: () => ({
@@ -110,6 +113,102 @@ describe('seedBuiltIns — one built-in default per configured framework', () =>
     expect(inserted).toBe(0);
     expect(store.getDefaultForProvider('claude')?.id).toBe(custom.id);
   });
+
+  it('self-heals a provider left with ZERO defaults (#1241 FIX 2)', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const builtInId = builtInAgentProfileId('claude');
+
+    // Drive the provider into a zero-default state: promote a user profile
+    // (demotes the built-in survivor to is_default = 0), then delete the
+    // promoted default — leaving one row for 'claude' with NO default at all.
+    const custom = store.create({ providerId: 'claude', displayName: 'Temp' });
+    store.setDefault(custom.id);
+    expect(store.get(builtInId)?.isDefault).toBe(false);
+    store.delete(custom.id);
+    expect(store.getDefaultForProvider('claude')).toBeNull();
+
+    // Seeding must HEAL the invariant: promote the surviving built-in row back
+    // to the sole default rather than leaving the vendor default-less (the old
+    // INSERT OR IGNORE path could not restore it because the PK already existed).
+    const inserted = store.seedBuiltIns([{ id: 'claude' }]);
+    expect(inserted).toBe(0); // a promotion, not a NEW row
+    const healed = store.getDefaultForProvider('claude');
+    expect(healed?.id).toBe(builtInId);
+    expect(healed?.isDefault).toBe(true);
+    expect(healed?.isBuiltIn).toBe(true);
+    const claudeRows = store.list({ providerId: 'claude' });
+    expect(claudeRows).toHaveLength(1);
+    expect(claudeRows.filter((p) => p.isDefault)).toHaveLength(1);
+
+    // Idempotent after healing: a further seed changes nothing.
+    expect(store.seedBuiltIns([{ id: 'claude' }])).toBe(0);
+    expect(store.getDefaultForProvider('claude')?.id).toBe(builtInId);
+    expect(store.list({ providerId: 'claude' })).toHaveLength(1);
+  });
+});
+
+describe('best-effort init survives a malformed custom framework (#1241 FIX 1)', () => {
+  // A hand-edited / half-registered fully-custom framework: config loading does
+  // NOT validate command/continueArgs/yoloArgs/parserType/eventSource/capabilities,
+  // so resolveFramework throws for it only at enumeration time.
+  const malformedFrameworks = {
+    'broken-custom': { id: 'broken-custom', displayName: 'Broken Custom' },
+  };
+
+  it('listConfiguredFrameworks throws for the malformed entry', () => {
+    // This is the throw that, pre-fix, escaped the best-effort guard: it was the
+    // argument evaluated OUTSIDE the try/catch, so it crashed hub boot.
+    expect(() => listConfiguredFrameworks(malformedFrameworks)).toThrow(
+      /broken-custom/
+    );
+  });
+
+  it('guarded init degrades to no profile rows instead of crashing boot', () => {
+    // Mirrors server/index.ts initAgentProfileStoreBestEffort AFTER FIX 1: the
+    // framework enumeration runs INSIDE the try, so a resolution throw degrades
+    // to "store with no seeded rows" rather than propagating and setting
+    // exitCode = 1. (index.ts self-runs main() on import, so the wrapper itself
+    // is not unit-importable; this reproduces its exact shape.)
+    function initGuarded(
+      dbPath: string,
+      frameworks?: Parameters<typeof listConfiguredFrameworks>[0]
+    ): AgentProfileStore | null {
+      let store: AgentProfileStore | null = null;
+      try {
+        store = createAgentProfileStore(dbPath);
+        store.seedBuiltIns(listConfiguredFrameworks(frameworks));
+        return store;
+      } catch {
+        store?.close();
+        return null;
+      }
+    }
+
+    const badDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-agent-profile-test-')
+    );
+    tmpDirs.push(badDir);
+    let badStore: AgentProfileStore | null = null;
+    expect(() => {
+      badStore = initGuarded(
+        path.join(badDir, 'agent-profiles.db'),
+        malformedFrameworks
+      );
+    }).not.toThrow();
+    // Boot survived; the guard returned null (no rows seeded) rather than throwing.
+    expect(badStore).toBeNull();
+
+    // The clean all-builtin case still seeds normally through the same path.
+    const goodDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-agent-profile-test-')
+    );
+    tmpDirs.push(goodDir);
+    const goodStore = initGuarded(path.join(goodDir, 'agent-profiles.db'));
+    expect(goodStore).not.toBeNull();
+    openStores.push(goodStore!);
+    expect(goodStore!.list().length).toBeGreaterThan(0);
+  });
 });
 
 describe('one-default-per-provider invariant (enforcement CHOICE: reject)', () => {
@@ -142,6 +241,71 @@ describe('one-default-per-provider invariant (enforcement CHOICE: reject)', () =
     expect(
       store.list({ providerId: 'claude' }).filter((p) => p.isDefault)
     ).toHaveLength(1);
+  });
+
+  it('maps the raced partial-index violation to agent_profile_default_exists (#1241 FIX 3)', () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-agent-profile-test-')
+    );
+    tmpDirs.push(dir);
+    const dbPath = path.join(dir, 'agent-profiles.db');
+    const store = createAgentProfileStore(dbPath);
+    openStores.push(store);
+    store.seedBuiltIns([{ id: 'claude' }]); // one default row for claude
+
+    // create()'s pre-check makes the partial-index branch unreachable in-process,
+    // so reproduce a cross-process race: raw-insert a SECOND default row for the
+    // same provider directly against the store's db file, bypassing the pre-check.
+    const raw = new Database(dbPath);
+    let realErr: unknown;
+    try {
+      raw
+        .prepare(
+          `INSERT INTO agent_profiles (id, provider_id, is_default, is_built_in, profile_json, created_at, updated_at)
+           VALUES (?, ?, 1, 1, '{}', 'now', 'now')`
+        )
+        .run('agent-profile:claude:raced', 'claude');
+    } catch (err) {
+      realErr = err;
+    } finally {
+      raw.close();
+    }
+    // The real SQLite message names the COLUMN (provider_id), not the index —
+    // this is exactly the token rethrowConstraint now keys on.
+    expect(realErr).toBeInstanceOf(Error);
+    expect((realErr as Error).message).toMatch(/agent_profiles\.provider_id/);
+
+    // rethrowConstraint maps that real message to the default-exists code
+    // (previously mis-reported as agent_profile_id_exists).
+    try {
+      rethrowConstraint(realErr, 'claude');
+      throw new Error('expected rethrowConstraint to throw');
+    } catch (mapped) {
+      expect(mapped).toBeInstanceOf(AgentProfileStoreError);
+      expect((mapped as AgentProfileStoreError).code).toBe(
+        'agent_profile_default_exists'
+      );
+      expect((mapped as AgentProfileStoreError).status).toBe(409);
+    }
+  });
+
+  it('maps an id (primary-key) collision to agent_profile_id_exists (#1241 FIX 3)', () => {
+    // The PK-collision message names agent_profiles.id — the id-exists branch.
+    try {
+      rethrowConstraint(
+        new Error('UNIQUE constraint failed: agent_profiles.id'),
+        'claude'
+      );
+      throw new Error('expected rethrowConstraint to throw');
+    } catch (mapped) {
+      expect(mapped).toBeInstanceOf(AgentProfileStoreError);
+      expect((mapped as AgentProfileStoreError).code).toBe(
+        'agent_profile_id_exists'
+      );
+    }
+    // A non-constraint error is rethrown unchanged (not remapped to a store error).
+    const other = new Error('database is locked');
+    expect(() => rethrowConstraint(other, 'claude')).toThrow(other);
   });
 
   it('allows creating additional NON-default profiles for a provider', () => {

--- a/test/agent-profile.test.ts
+++ b/test/agent-profile.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  builtInAgentProfileId,
+  isAgentProfile,
+  normalizeMentionToken,
+  parseHistoricalAgentSenderProviderId,
+  resolveHistoricalAgentSenderProfileId,
+  resolveProfileForMention,
+  type AgentProfile,
+} from '../shared/agent-profile.js';
+
+function profile(
+  overrides: Partial<AgentProfile> & { id: string }
+): AgentProfile {
+  return {
+    providerId: 'claude',
+    displayName: '',
+    avatar: null,
+    isDefault: false,
+    isBuiltIn: false,
+    ...overrides,
+  };
+}
+
+/** Built-in defaults carry an EMPTY display name (inherit vendor label). */
+const claudeDefault = profile({
+  id: builtInAgentProfileId('claude'),
+  providerId: 'claude',
+  displayName: '',
+  isDefault: true,
+  isBuiltIn: true,
+});
+const codexDefault = profile({
+  id: builtInAgentProfileId('codex'),
+  providerId: 'codex',
+  displayName: '',
+  isDefault: true,
+  isBuiltIn: true,
+});
+const backend = profile({
+  id: 'agent-profile:claude:backend',
+  providerId: 'claude',
+  displayName: 'Backend',
+});
+const backendClaude = profile({
+  id: 'agent-profile:claude:backend-claude',
+  providerId: 'claude',
+  displayName: 'Backend Claude',
+});
+
+const contactSet: AgentProfile[] = [
+  claudeDefault,
+  codexDefault,
+  backend,
+  backendClaude,
+];
+
+describe('resolveProfileForMention — vendor alias', () => {
+  it('resolves @claude to the default claude profile', () => {
+    expect(resolveProfileForMention('@claude', contactSet)).toBe(claudeDefault);
+  });
+
+  it('resolves the bare token (no @) as a vendor alias too', () => {
+    expect(resolveProfileForMention('codex', contactSet)).toBe(codexDefault);
+  });
+
+  it('is case-insensitive on the vendor alias', () => {
+    expect(resolveProfileForMention('@CLAUDE', contactSet)).toBe(claudeDefault);
+  });
+
+  it('vendor alias wins over a same-named custom profile', () => {
+    const namedClaude = profile({
+      id: 'agent-profile:claude:literal',
+      providerId: 'claude',
+      displayName: 'claude',
+    });
+    // Even with a custom profile literally named "claude", @claude → the default.
+    expect(
+      resolveProfileForMention('@claude', [...contactSet, namedClaude])
+    ).toBe(claudeDefault);
+  });
+});
+
+describe('resolveProfileForMention — named, longest-match-first', () => {
+  it('matches the longest display name when names nest', () => {
+    expect(resolveProfileForMention('@Backend Claude', contactSet)).toBe(
+      backendClaude
+    );
+  });
+
+  it('still matches the shorter name for the shorter token', () => {
+    expect(resolveProfileForMention('@Backend', contactSet)).toBe(backend);
+  });
+
+  it('is case-insensitive on multi-word names', () => {
+    expect(resolveProfileForMention('@backend claude', contactSet)).toBe(
+      backendClaude
+    );
+  });
+
+  it('longest-match-first over a whitespace-boundary prefix', () => {
+    // "backend claude reviewer" prefix-matches "Backend Claude", not "Backend".
+    expect(
+      resolveProfileForMention('@backend claude reviewer', contactSet)
+    ).toBe(backendClaude);
+  });
+
+  it('does not partial-match across a word boundary', () => {
+    // "backendc" is neither an exact name nor a boundary prefix of any name.
+    expect(resolveProfileForMention('@backendc', contactSet)).toBeNull();
+  });
+
+  it('built-in defaults (empty name) are never reached by the named path', () => {
+    // An empty token normalizes away and resolves to nothing.
+    expect(resolveProfileForMention('@', contactSet)).toBeNull();
+    expect(resolveProfileForMention('   ', contactSet)).toBeNull();
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(resolveProfileForMention('@nobody', contactSet)).toBeNull();
+  });
+});
+
+describe('resolveProfileForMention — collision tiebreak', () => {
+  it('prefers the default profile on an equal-name collision', () => {
+    const a = profile({
+      id: 'agent-profile:claude:aaa',
+      displayName: 'Reviewer',
+      isDefault: false,
+    });
+    const b = profile({
+      id: 'agent-profile:codex:bbb',
+      providerId: 'codex',
+      displayName: 'Reviewer',
+      isDefault: true,
+    });
+    // Both named "Reviewer"; the default (b) wins the tiebreak.
+    expect(resolveProfileForMention('@Reviewer', [a, b])).toBe(b);
+  });
+
+  it('prefers built-in over user-created when neither is default', () => {
+    const userMade = profile({
+      id: 'agent-profile:claude:zzz',
+      displayName: 'Reviewer',
+      isBuiltIn: false,
+    });
+    const builtIn = profile({
+      id: 'agent-profile:codex:yyy',
+      providerId: 'codex',
+      displayName: 'Reviewer',
+      isBuiltIn: true,
+    });
+    expect(resolveProfileForMention('@Reviewer', [userMade, builtIn])).toBe(
+      builtIn
+    );
+  });
+
+  it('breaks a full tie by lexicographically smallest id', () => {
+    const first = profile({ id: 'agent-profile:a', displayName: 'Reviewer' });
+    const second = profile({ id: 'agent-profile:b', displayName: 'Reviewer' });
+    // Deterministic regardless of input order.
+    expect(resolveProfileForMention('@Reviewer', [second, first])).toBe(first);
+    expect(resolveProfileForMention('@Reviewer', [first, second])).toBe(first);
+  });
+});
+
+describe('read-time shim — resolveHistoricalAgentSenderProfileId', () => {
+  it('maps agent:<framework> to that vendor default profile id', () => {
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:claude', contactSet)
+    ).toBe(builtInAgentProfileId('claude'));
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:codex', contactSet)
+    ).toBe(builtInAgentProfileId('codex'));
+  });
+
+  it('is case-insensitive on the framework id', () => {
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:CLAUDE', contactSet)
+    ).toBe(builtInAgentProfileId('claude'));
+  });
+
+  it('returns null for non-agent sender ids', () => {
+    expect(
+      resolveHistoricalAgentSenderProfileId('human:abc', contactSet)
+    ).toBeNull();
+    expect(
+      resolveHistoricalAgentSenderProfileId('system', contactSet)
+    ).toBeNull();
+  });
+
+  it('returns null for a bare or compound agent id', () => {
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:', contactSet)
+    ).toBeNull();
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:claude:default', contactSet)
+    ).toBeNull();
+  });
+
+  it('returns null when the vendor has no default in the contact set', () => {
+    expect(
+      resolveHistoricalAgentSenderProfileId('agent:hermes', contactSet)
+    ).toBeNull();
+  });
+});
+
+describe('parseHistoricalAgentSenderProviderId', () => {
+  it('extracts the framework id from a legacy sender', () => {
+    expect(parseHistoricalAgentSenderProviderId('agent:codex')).toBe('codex');
+  });
+  it('rejects non-legacy shapes', () => {
+    expect(parseHistoricalAgentSenderProviderId('human:x')).toBeNull();
+    expect(parseHistoricalAgentSenderProviderId('agent:')).toBeNull();
+    expect(parseHistoricalAgentSenderProviderId('agent:a:b')).toBeNull();
+  });
+});
+
+describe('normalizeMentionToken', () => {
+  it('strips @, lowercases, and collapses whitespace', () => {
+    expect(normalizeMentionToken('@@Backend   Claude ')).toBe('backend claude');
+  });
+});
+
+describe('isAgentProfile', () => {
+  it('accepts a minimal valid profile', () => {
+    expect(isAgentProfile(claudeDefault)).toBe(true);
+  });
+  it('rejects a row missing required fields', () => {
+    expect(isAgentProfile({ id: 'x' })).toBe(false);
+    expect(isAgentProfile(null)).toBe(false);
+    expect(isAgentProfile({ ...claudeDefault, isDefault: 'yes' })).toBe(false);
+  });
+});

--- a/test/server-shutdown-contract.test.ts
+++ b/test/server-shutdown-contract.test.ts
@@ -29,12 +29,13 @@ describe('server shutdown store closing contract', () => {
       'workContextMessageStore?.close();'
     );
     expect(gracefulShutdownSource).toContain('agentPresenceStore?.close();');
+    expect(gracefulShutdownSource).toContain('agentProfileStore?.close();');
     expect(gracefulShutdownSource).toContain('workspaceSurfaceStore?.close();');
     expect(gracefulShutdownSource).toContain(
       'channelAttachmentStore?.close();'
     );
     expect(gracefulShutdownSource).toMatch(
-      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelAgentBinder\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+channelAttachmentStore\?\.close\(\);\s+closeInterventionLog\(\);/
+      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+agentProfileStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelAgentBinder\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+channelAttachmentStore\?\.close\(\);\s+closeInterventionLog\(\);/
     );
   });
 
@@ -51,12 +52,13 @@ describe('server shutdown store closing contract', () => {
     expect(updateRestartStart).toBeGreaterThanOrEqual(0);
     expect(updateResponseStart).toBeGreaterThan(updateRestartStart);
     expect(updateRestartSource).toContain('agentPresenceStore?.close();');
+    expect(updateRestartSource).toContain('agentProfileStore?.close();');
     expect(updateRestartSource).toContain('workContextArtifactStore?.close();');
     expect(updateRestartSource).toContain('workContextMessageStore?.close();');
     expect(updateRestartSource).toContain('workspaceSurfaceStore?.close();');
     expect(updateRestartSource).toContain('channelAttachmentStore?.close();');
     expect(updateRestartSource).toMatch(
-      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelAgentBinder\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+channelAttachmentStore\?\.close\(\);/
+      /contextPacketStore\?\.close\(\);\s+agentPresenceStore\?\.close\(\);\s+agentProfileStore\?\.close\(\);\s+workContextArtifactStore\?\.close\(\);\s+workflowRunStore\?\.close\(\);\s+automationRunStore\?\.close\(\);\s+workspaceSurfaceStore\?\.close\(\);\s+workspaceTopicStore\?\.close\(\);\s+prOverseerStore\?\.close\(\);\s+workContextMessageStore\?\.close\(\);\s+channelAgentBinder\?\.close\(\);\s+channelHub\.close\(\);\s+channelMessageStore\?\.close\(\);\s+channelAttachmentStore\?\.close\(\);/
     );
   });
 });


### PR DESCRIPTION
Keystone slice of epic #1232 (Slack-style workspace UX parity + agent profiles). Introduces the durable agent-kind Actor identity noun the whole epic hangs on. **Model + seed + resolver + read-time shim only.**

## What shipped

- **`shared/agent-profile.ts`** — the `AgentProfile` type placed beside the shared actor nouns (`work-context.ts` / `work-context-message.ts`). `AgentProfile.id` **IS** the `WorkContextMessageActor.id` (an `'agent'`-kind actor), keyed on a stable profile id distinct from the bare vendor id. Fields: `id, providerId, displayName, avatar (blob-ref | null), systemPrompt?, model?, provider?, effort?, envVars?, namePool?, respondTo?, respondToAllowlist?, isDefault, isBuiltIn`. Does **not** overload the deprecated `source` union in `chat-events.ts`. Also exports the `@vendor → default` resolver, the read-time shim, and an `isAgentProfile` guard.
- **`server/agent-profile-store.ts`** — a self-contained sqlite store in the config dir beside the framework registry (own `agent-profiles.db`, non-destructive, same pattern as `agent-presence-store.ts`). Never touches `config.json` or any existing table.
- **`server/index.ts`** — best-effort boot init + idempotent seed over `listConfiguredFrameworks(getConfig().frameworks)`; close on shutdown. 38 additive lines.
- **Seed** — `seedBuiltIns()` writes exactly one `isBuiltIn:true, isDefault:true` profile per **configured** framework. **Thin overlay:** the seeded row carries an **empty `displayName`** ("inherit vendor label from the catalog by `providerId`") — vendor facts (label/glyph/command/args/model-env) are never copied onto the row. Idempotent via the stable PK `builtInAgentProfileId(providerId)` = `agent-profile:<vendor>:default`.

## One-default-per-vendor enforcement — CHOICE: **reject**

`create()` **rejects** a second `isDefault` for the same `providerId` with a typed **409 `agent_profile_default_exists`** (clear error) rather than silently flipping. An intentional default change goes through `setDefault()`, which flips atomically in a transaction. A **partial UNIQUE index** (`... WHERE is_default = 1`) enforces the invariant at the DB layer as defense-in-depth, so even a raced write cannot land two defaults.

## Resolver collision tiebreak (deterministic)

`resolveProfileForMention(token, contactSet)`:
1. **Vendor alias** — normalized token == a `providerId` with a default → that default. `@claude` → default claude profile (matched by `providerId`, not name), and vendor alias **always wins** over a same-named custom profile.
2. **Named, longest-match-first, case-insensitive** — over non-empty display names; a profile matches on exact name or a whitespace-boundary prefix, longest name wins.

On an equal-name collision the tiebreak is: **(1) default > (2) built-in > (3) lexicographically-smallest `id`** — fully deterministic regardless of input order.

## Read-time shim (no re-key)

`resolveHistoricalAgentSenderProfileId('agent:<framework>', contactSet)` maps a historical sender id to that vendor's default profile id **at read time**. It is a pure resolution helper — it **never rewrites** stored `ChannelSenderRef`/DM rows. The destructive sender re-key and DM migration are later slices.

## Scope statement: no UI / no live-row re-key

Diff is 5 files (`shared/agent-profile.ts`, `server/agent-profile-store.ts`, `server/index.ts`, 2 tests). Verified: **no `frontend/`, `.tsx`, `.css`, or component files**; **no `UPDATE`/`DELETE` against any live `ChannelSenderRef`/channel/DM table** (the only `UPDATE`s target the new `agent_profiles` table's `setDefault` flip).

## boundaryCheck (#1231)

Profiles are local hub sqlite/config Actor rows only — no Nostr keypair identity, no `community_id` scoping, no signed Persona Pack.

## Validation evidence

- `npm run check` → **0 errors** (pre-existing repo-wide warnings only; none in new files).
- `npm test -- test/agent-profile.test.ts test/agent-profile-store.test.ts` → **33 passed** (resolver default alias / named longest-match / case-insensitive / collision tiebreak; one-default reject; idempotent seeding; setDefault flip; persistence across reopen; read-time shim).
- Adjacent suites (`agent-presence-store`, `frameworks-api`, `framework-types`) → 42 passed, no regressions.
- Pre-push hook ran changed tests → **81 passed**.
- `npm run build` → clean (pre-existing codemirror/chunk-size warnings only).

Closes #1233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent agent profiles with support for creating, listing, updating defaults, and deleting profiles.
  - Added built-in default profiles for configured frameworks, seeded automatically during server startup.
  - Added profile selection through normalized mentions, including support for legacy agent identifiers.
  - Added configurable profile details such as models, prompts, avatars, environment variables, and response policies.

- **Bug Fixes**
  - Preserved compatibility with historical agent sender identifiers.
  - Prevented multiple default profiles from being assigned to the same provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->