### PR TITLE
feat(channels): re-key sender attribution to profile Actor id (#1234)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -28,6 +28,7 @@ import type {
   WorkflowRunState,
 } from '../../../shared/workflow-run.js';
 import type { RosterAttention } from '../../../shared/agent-roster.js';
+import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
 import {
   parseMentions,
   type ChannelMessage,
@@ -315,7 +316,9 @@ function TopicBadge({ item }: { item: TopicNavItem }) {
   if (item.isDirectMessage && item.dmProviderId) {
     const identity = resolveSenderIdentity({
       kind: 'agent',
-      id: `agent:${item.dmProviderId}`,
+      // A DM row targets a vendor, i.e. its DEFAULT profile — key on the profile
+      // Actor id so the sidebar dot keeps the curated vendor token (#1234).
+      id: builtInAgentProfileId(item.dmProviderId),
       providerId: item.dmProviderId,
     });
     return (

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import type { ChannelMessagePart } from '../../../../shared/channel-chat-protocol.js';
+import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
 import './ChannelView.css';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useChannelChatSocket } from '../../hooks/useChannelChatSocket.js';
@@ -82,7 +83,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const dmIdentity = dmProviderId
     ? resolveSenderIdentity({
         kind: 'agent',
-        id: `agent:${dmProviderId}`,
+        // A DM targets a vendor, i.e. its DEFAULT profile — key on the profile
+        // Actor id so it keeps the curated vendor token (#1234).
+        id: builtInAgentProfileId(dmProviderId),
         providerId: dmProviderId,
       })
     : null;
@@ -310,8 +313,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     for (const message of reducer.messages) {
       if (message.status !== 'streaming' || message.sender.kind !== 'agent')
         continue;
-      const providerId =
-        message.sender.providerId ?? message.sender.id.replace(/^agent:/, '');
+      // providerId is authoritative from the explicit field — the id is now a
+      // profile Actor id, not `agent:<framework>`, so never strip it (#1234).
+      const providerId = message.sender.providerId;
       if (providerId) ids.add(providerId);
     }
     return ids;
@@ -353,7 +357,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       if (entry?.binding == null && status === 'idle' && !streaming) continue;
       const identity = resolveSenderIdentity({
         kind: 'agent',
-        id: `agent:${agentId}`,
+        // Roster/presence chips represent a vendor's DEFAULT profile — key on the
+        // profile Actor id so the chip keeps the curated vendor token (#1234).
+        id: builtInAgentProfileId(agentId),
         providerId: agentId,
         ...(entry?.displayName ? { displayName: entry.displayName } : {}),
       });

--- a/frontend/src/components/chat/MentionPalette.tsx
+++ b/frontend/src/components/chat/MentionPalette.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './MentionPalette.css';
 import type { RosterEntry } from '../../lib/api.js';
+import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { AgentBadge } from '../AgentBadge.js';
 
@@ -50,7 +51,9 @@ export const MentionPalette: React.FC<MentionPaletteProps> = ({
       {entries.map((entry, index) => {
         const identity = resolveSenderIdentity({
           kind: 'agent',
-          id: `agent:${entry.id}`,
+          // Roster entries are vendors, i.e. their DEFAULT profile — key on the
+          // profile Actor id so the palette keeps the curated vendor token (#1234).
+          id: builtInAgentProfileId(entry.id),
           providerId: entry.id,
           displayName: entry.displayName,
         });

--- a/frontend/src/lib/chat/channel-timeline-layout.ts
+++ b/frontend/src/lib/chat/channel-timeline-layout.ts
@@ -13,6 +13,7 @@ import type {
   ChannelMessageId,
   ChannelSenderRef,
 } from '../../../../shared/channel-chat-protocol.js';
+import { resolveRenderSenderId } from './sender-identity.js';
 
 /** Slack-standard grouping window: same-sender messages within 5 minutes group. */
 export const GROUP_WINDOW_MS = 5 * 60 * 1000;
@@ -184,9 +185,13 @@ export function buildTimelineNodes(
     }
 
     if (group) {
+      // Key on the RENDER id so a legacy `agent:<vendor>` row coalesces with a
+      // new `agent-profile:<vendor>:default` row instead of splitting at the
+      // re-key boundary (#1245); non-legacy ids resolve to themselves.
       const sameSender =
         group.sender.kind === message.sender.kind &&
-        group.sender.id === message.sender.id;
+        resolveRenderSenderId(group.sender) ===
+          resolveRenderSenderId(message.sender);
       const withinWindow =
         createdMsSafe - group.lastCreatedMs <= GROUP_WINDOW_MS;
       if (!sameSender || !withinWindow) flush();

--- a/frontend/src/lib/chat/sender-identity.ts
+++ b/frontend/src/lib/chat/sender-identity.ts
@@ -1,12 +1,21 @@
-// Sender identity visual system for the channel timeline (#1166).
+// Sender identity visual system for the channel timeline (#1166, re-keyed #1234).
 //
 // Resolves a `ChannelSenderRef` to a stable color / glyph / label. Human is
-// always "you" (right-aligned bubble, no name chrome). Known agent frameworks
-// map to fixed CSS custom properties (defined in App.css, each reusing an
-// existing DESIGN.md identity token — no invented hex values); long-tail custom
-// providers fall back to the existing hash-based `deriveColor`. Reused verbatim
-// by the future @mention pill (#1167) and sidebar presence dot — do not fork.
+// always "you" (right-aligned bubble, no name chrome). `providerId` is ALWAYS
+// read from the explicit `ChannelSenderRef.providerId` field — never derived by
+// stripping `agent:` off the id, because `id` is now a profile Actor id
+// (`agent-profile:<vendor>:default` for a vendor's built-in default), not
+// `agent:<framework>` (#1234).
+//
+// Color re-key (#1234): a vendor's DEFAULT profile keeps its curated
+// `var(--sender-<vendor>)` DESIGN.md token; only NON-default profiles hash via
+// `deriveColor(profileActorId)` over the 12-color palette, so two profiles of one
+// vendor render distinct colors while SHARING the vendor glyph. The profile
+// name/initials carry identity by construction; color is decorative. Reused
+// verbatim by the @mention palette, sidebar DM dot, and streaming/presence chip —
+// do not fork.
 import type { ChannelSenderRef } from '../../../../shared/channel-chat-protocol.js';
+import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
 import { deriveColor } from '../colors.js';
 
 export type KnownAgentGlyph = 'claude' | 'codex' | 'hermes' | 'opencode';
@@ -58,11 +67,17 @@ export function resolveSenderIdentity(
       kind: 'system',
     };
   }
-  const providerId = sender.providerId ?? sender.id.replace(/^agent:/, '');
+  // providerId is authoritative from the explicit field — never from the id.
+  const providerId = sender.providerId ?? '';
+  // A DEFAULT (built-in) profile's id is exactly `agent-profile:<vendor>:default`.
+  // Only then does it keep the curated vendor token; every non-default profile
+  // hashes on its own Actor id so same-vendor profiles are visually distinct.
+  const isDefaultProfile =
+    providerId !== '' && sender.id === builtInAgentProfileId(providerId);
   const knownVar = KNOWN_AGENT_COLOR_VAR[providerId];
-  const colorVar = knownVar
-    ? `var(${knownVar})`
-    : deriveColor(`sender:agent:${providerId}`);
+  const colorVar =
+    isDefaultProfile && knownVar ? `var(${knownVar})` : deriveColor(sender.id);
+  // The vendor glyph is shared across all of a vendor's profiles (default or not).
   const glyph = isKnownGlyph(providerId) ? providerId : null;
   return {
     label: sender.displayName ?? providerId,

--- a/frontend/src/lib/chat/sender-identity.ts
+++ b/frontend/src/lib/chat/sender-identity.ts
@@ -15,7 +15,10 @@
 // verbatim by the @mention palette, sidebar DM dot, and streaming/presence chip —
 // do not fork.
 import type { ChannelSenderRef } from '../../../../shared/channel-chat-protocol.js';
-import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
+import {
+  builtInAgentProfileId,
+  parseHistoricalAgentSenderProviderId,
+} from '../../../../shared/agent-profile.js';
 import { deriveColor } from '../colors.js';
 
 export type KnownAgentGlyph = 'claude' | 'codex' | 'hermes' | 'opencode';
@@ -48,6 +51,34 @@ function isKnownGlyph(value: string): value is KnownAgentGlyph {
   return (KNOWN_AGENT_GLYPHS as readonly string[]).includes(value);
 }
 
+/**
+ * Effective RENDER id for a sender (#1245). Channel rows persisted BEFORE the
+ * #1234 attribution re-key carry the bare `agent:<vendor>` sender id, while the
+ * re-key stamps new agent rows with the profile Actor id
+ * (`builtInAgentProfileId(vendor)` for a vendor's built-in default). Reading a
+ * legacy row back verbatim would drop it from its curated `var(--sender-<vendor>)`
+ * color (the default-profile check below keys on the profile id) and split it
+ * from new `agent-profile:<vendor>:default` rows in timeline grouping.
+ *
+ * Map a legacy `agent:<vendor>` id to that vendor's built-in default profile id
+ * for RENDER decisions only — color here and the grouping key in
+ * `channel-timeline-layout.ts`. This is deliberately NOT a store/wire mutation:
+ * the CLI-gateway actor lane (`channel-chat-router.ts` `deriveSender`) also
+ * emits `agent:<actorId>` on the wire and that attribution must stay byte-exact,
+ * so the heal lives at the render boundary instead of `rowToMessage`. Only
+ * re-maps when the parsed vendor equals the authoritative `providerId` (a true
+ * legacy vendor-default row); already-migrated `agent-profile:*`, human, and
+ * system ids pass through unchanged.
+ */
+export function resolveRenderSenderId(sender: ChannelSenderRef): string {
+  if (sender.kind !== 'agent') return sender.id;
+  const providerId = sender.providerId ?? '';
+  if (providerId === '') return sender.id;
+  const legacyVendor = parseHistoricalAgentSenderProviderId(sender.id);
+  if (legacyVendor === null || legacyVendor !== providerId) return sender.id;
+  return builtInAgentProfileId(providerId);
+}
+
 export function resolveSenderIdentity(
   sender: ChannelSenderRef
 ): SenderIdentity {
@@ -69,14 +100,17 @@ export function resolveSenderIdentity(
   }
   // providerId is authoritative from the explicit field — never from the id.
   const providerId = sender.providerId ?? '';
+  // Heal legacy `agent:<vendor>` rows to the vendor built-in default id for the
+  // color decision (#1245) without touching the wire id.
+  const renderId = resolveRenderSenderId(sender);
   // A DEFAULT (built-in) profile's id is exactly `agent-profile:<vendor>:default`.
   // Only then does it keep the curated vendor token; every non-default profile
   // hashes on its own Actor id so same-vendor profiles are visually distinct.
   const isDefaultProfile =
-    providerId !== '' && sender.id === builtInAgentProfileId(providerId);
+    providerId !== '' && renderId === builtInAgentProfileId(providerId);
   const knownVar = KNOWN_AGENT_COLOR_VAR[providerId];
   const colorVar =
-    isDefaultProfile && knownVar ? `var(${knownVar})` : deriveColor(sender.id);
+    isDefaultProfile && knownVar ? `var(${knownVar})` : deriveColor(renderId);
   // The vendor glyph is shared across all of a vendor's profiles (default or not).
   const glyph = isKnownGlyph(providerId) ? providerId : null;
   return {

--- a/frontend/src/test-channel-timeline.tsx
+++ b/frontend/src/test-channel-timeline.tsx
@@ -14,7 +14,7 @@ function message(
   text = `timeline row ${seq}`,
   sender: ChannelMessage['sender'] = seq % 2 === 0
     ? { kind: 'human', id: 'human:operator' }
-    : { kind: 'agent', id: 'agent:codex', providerId: 'codex' }
+    : { kind: 'agent', id: 'agent-profile:codex:default', providerId: 'codex' }
 ): ChannelMessage {
   const createdAt = new Date(Date.UTC(2026, 6, 18, 10, seq)).toISOString();
   return {
@@ -48,7 +48,7 @@ function detailMessage(
   return {
     ...message(seq, '', {
       kind: 'agent',
-      id: 'agent:codex',
+      id: 'agent-profile:codex:default',
       providerId: 'codex',
     }),
     agentDetail: { itemId: `detail-${seq}`, card },
@@ -175,7 +175,7 @@ function Fixture(): React.ReactElement {
               status: 'streaming',
               sender: {
                 kind: 'agent',
-                id: 'agent:codex',
+                id: 'agent-profile:codex:default',
                 providerId: 'codex',
               },
               body: { text: '', format: 'markdown' },
@@ -211,7 +211,7 @@ function Fixture(): React.ReactElement {
         ...current,
         message(latest + 1, 'concurrent catch-up', {
           kind: 'agent',
-          id: 'agent:codex',
+          id: 'agent-profile:codex:default',
           providerId: 'codex',
         }),
       ];

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -20,6 +20,7 @@ import type { CreateWebParams } from './web-session-handler.js';
 import type { Session, WebSession } from './types.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import {
   parseMentions,
   type ChannelMention,
@@ -347,6 +348,20 @@ export function createChannelAgentBinder(
     return targets.find((target) => target.id === framework);
   }
 
+  /**
+   * Vendor catalog label for the DEFAULT profile's `ChannelSenderRef.displayName`
+   * (#1234). Reuses the (cached) mention-target probe as the label source and
+   * fails soft to the raw framework id so an availability-probe error never blocks
+   * a spawn or an attribution stamp.
+   */
+  async function senderLabelFor(framework: string): Promise<string> {
+    try {
+      return (await resolveTarget(framework))?.displayName ?? framework;
+    } catch {
+      return framework;
+    }
+  }
+
   // ── status ──────────────────────────────────────────────────────────────────
 
   function setStatus(binding: LiveBinding, status: ChannelAgentStatus): void {
@@ -420,6 +435,7 @@ export function createChannelAgentBinder(
     channelId: string,
     framework: string,
     displayName: string,
+    senderDisplayName: string,
     session: { id: string; adapterV2: ProtocolAdapterV2 }
   ): LiveBinding {
     const key = bindingKey(channelId, framework);
@@ -454,7 +470,11 @@ export function createChannelAgentBinder(
         ? { attachmentStore: deps.attachmentStore }
         : {}),
       hub,
-      displayName,
+      // Sender attribution (#1234): the durable ChannelSenderRef carries the
+      // vendor DEFAULT profile Actor id + the vendor catalog label, NOT the
+      // session/tab composite (`binding.displayName`). One session == one profile.
+      profileActorId: builtInAgentProfileId(framework),
+      displayName: senderDisplayName,
       parentMessageIdForTurn: (turnId) => parentForTurn(binding, turnId),
       onAssistantMessageFinalized: (message) =>
         handleAssistantFinalized(message),
@@ -503,11 +523,23 @@ export function createChannelAgentBinder(
       if (session && session.adapterV2 === existing.adapter) return existing;
     }
 
+    // Sender attribution label (#1234): the vendor DEFAULT profile inherits the
+    // framework catalog label (built-in default profiles carry an empty stored
+    // displayName). Resolved past the reuse fast-path so a hot rebind pays no
+    // availability probe; failures fall back to the raw framework id.
+    const senderDisplayName = await senderLabelFor(framework);
+
     // 3. Rebind a restored session that survived a live reconnect / restart.
     const row = store.getBinding(channelId, framework);
     const restored = healthySession(row?.sessionId ?? null, framework);
     if (restored) {
-      return attachSession(channelId, framework, displayName, restored);
+      return attachSession(
+        channelId,
+        framework,
+        displayName,
+        senderDisplayName,
+        restored
+      );
     }
 
     // 3.5 Cross-node guard (Amendment 1): a remote-node topic must fail visibly,
@@ -556,6 +588,7 @@ export function createChannelAgentBinder(
       channelId,
       framework,
       displayName,
+      senderDisplayName,
       created.session
     );
     store.upsertBinding({

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { createLogger } from './logger.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
 import {
   agentDetailCardForItem,
@@ -253,7 +254,22 @@ export interface BindSessionToChannelInput {
   /** Shared sender-neutral attachment lane for agent-produced image items. */
   attachmentStore?: ChannelAttachmentStore | null;
   hub: ChannelHub;
+  /**
+   * Profile display label stamped onto the durable `ChannelSenderRef.displayName`
+   * (#1234). For a vendor's DEFAULT profile this is the framework catalog label
+   * (built-in defaults carry an empty stored displayName — the caller resolves the
+   * vendor label by `providerId` and passes it here). Distinct from the session/tab
+   * display name.
+   */
   displayName?: string;
+  /**
+   * Profile Actor id stamped onto `ChannelSenderRef.id` (#1234, epic #1232). Since
+   * no custom profiles exist yet, every agent session maps to its vendor's DEFAULT
+   * profile; callers pass `builtInAgentProfileId(vendor)`. Defaults to the vendor
+   * built-in default id when omitted so the `agent:<framework>` id format is gone
+   * regardless of caller.
+   */
+  profileActorId?: string;
   /** Resolve the immediate parent for a routed turn, if it began in a thread. */
   parentMessageIdForTurn?: (turnId: string) => string | undefined;
   /**
@@ -479,9 +495,13 @@ export function bindSessionToChannel(
     });
   }
 
+  // Attribution re-key (#1234): the sender identity slot IS the profile Actor id,
+  // not the bare `agent:<framework>` format. `providerId` stays the vendor so the
+  // renderer reads it explicitly (never by stripping `agent:` off the id), and the
+  // vendor glyph is shared across a vendor's profiles.
   const sender: ChannelSenderRef = {
     kind: 'agent',
-    id: `agent:${agentFramework}`,
+    id: input.profileActorId ?? builtInAgentProfileId(agentFramework),
     providerId: agentFramework,
     ...(input.displayName ? { displayName: input.displayName } : {}),
   };

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -58,10 +58,16 @@ export type ChannelBodyFormat = 'markdown' | 'text';
 
 export interface ChannelSenderRef {
   kind: ChannelSenderKind;
-  /** 'human:<actorId>' | 'agent:<frameworkId>' | 'system' */
+  /**
+   * Actor identity slot. `'human:<actorId>'` | `'system'` | for agents the
+   * profile Actor id (`agent-profile:<vendor>:default` for a vendor's built-in
+   * default; `agent-profile:<vendor>:<uuid>` for a custom profile) — NOT
+   * `agent:<framework>` (#1234). Read `providerId` for the vendor, never by
+   * stripping this id.
+   */
   id: string;
   displayName?: string;
-  /** agent framework id (claude/codex/hermes/opencode) */
+  /** agent framework/vendor id (claude/codex/hermes/opencode) */
   providerId?: string;
   /** backing adapter session (slice 4 fills) */
   sessionId?: string;

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -892,7 +892,7 @@ describe('channel-agent-binder — lifecycle', () => {
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     expect(sessions.spawns()).toBe(1);
     const reply = agentReplies(store, 'mock')[0]!;
-    expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.sender.id).toBe('agent-profile:mock:default');
     expect(reply.body.text).toBe('Mock v2 response complete.');
     expect(reply.threadId).toBeNull();
     expect(reply.parentMessageId).toBeNull();

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -563,7 +563,7 @@ describe('channel-agent-bridge lifecycle', () => {
     expect(message.status).toBe('complete');
     expect(message.sender).toMatchObject({
       kind: 'agent',
-      id: 'agent:claude',
+      id: 'agent-profile:claude:default',
       providerId: 'claude',
     });
     expect(message.body.text).toBe('Mock v2 response complete.');
@@ -573,8 +573,67 @@ describe('channel-agent-bridge lifecycle', () => {
       itemId: 'assistant-turn-1',
     });
     expect(
-      store.listMembers('topic:test').some((m) => m.id === 'agent:claude')
+      store
+        .listMembers('topic:test')
+        .some((m) => m.id === 'agent-profile:claude:default')
     ).toBe(true);
+  });
+
+  it('stamps the sender as the vendor DEFAULT profile: id=profile, providerId=vendor, displayName=catalog label (#1234)', async () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 });
+    await adapter.connect(config('sess-p'));
+    const unbind = bindSessionToChannel({
+      channelId: 'topic:profile',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+      // The binder resolves a built-in default profile's empty stored displayName
+      // to the framework catalog label and passes it here.
+      displayName: 'Claude Code',
+    });
+    cleanup.push(unbind);
+
+    await adapter.sendMessage({ turnId: 'turn-p', content: 'hello' });
+
+    const message = store
+      .history('topic:profile')
+      .find((row) => !row.agentDetail)!;
+    // The `agent:<framework>` id format is gone — the id IS the profile Actor id.
+    expect(message.sender.id).toBe('agent-profile:claude:default');
+    expect(message.sender.id.startsWith('agent:')).toBe(false);
+    expect(message.sender.providerId).toBe('claude');
+    expect(message.sender.displayName).toBe('Claude Code');
+    // No new per-message identity carrier on the sender ref.
+    expect(
+      Object.prototype.hasOwnProperty.call(message.sender, 'profileId')
+    ).toBe(false);
+  });
+
+  it('stamps an explicit profileActorId onto the sender id, keeping providerId=vendor (#1234)', async () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 });
+    await adapter.connect(config('sess-c'));
+    const unbind = bindSessionToChannel({
+      channelId: 'topic:custom',
+      agentFramework: 'claude',
+      adapter,
+      store,
+      hub,
+      profileActorId: 'agent-profile:claude:backend-xyz',
+      displayName: 'Backend Claude',
+    });
+    cleanup.push(unbind);
+
+    await adapter.sendMessage({ turnId: 'turn-c', content: 'hello' });
+
+    const message = store
+      .history('topic:custom')
+      .find((row) => !row.agentDetail)!;
+    expect(message.sender.id).toBe('agent-profile:claude:backend-xyz');
+    expect(message.sender.providerId).toBe('claude');
+    expect(message.sender.displayName).toBe('Backend Claude');
   });
 
   it('keeps two concurrent bound sessions from cross-contaminating in one channel', async () => {
@@ -610,8 +669,12 @@ describe('channel-agent-bridge lifecycle', () => {
     const messages = store.history('topic:c');
     expect(messages).toHaveLength(10);
     const prose = messages.filter((message) => !message.agentDetail);
-    const claude = prose.find((m) => m.sender.id === 'agent:claude');
-    const codex = prose.find((m) => m.sender.id === 'agent:codex');
+    const claude = prose.find(
+      (m) => m.sender.id === 'agent-profile:claude:default'
+    );
+    const codex = prose.find(
+      (m) => m.sender.id === 'agent-profile:codex:default'
+    );
     expect(claude?.body.text).toBe('Mock v2 response complete.');
     expect(codex?.body.text).toBe('Mock v2 response complete.');
     expect(claude?.source?.sessionId).toBe('s1');
@@ -918,7 +981,7 @@ describe('channel-agent-bridge lifecycle', () => {
     });
     expect(messages[0]!.sender).toMatchObject({
       kind: 'agent',
-      id: 'agent:hermes',
+      id: 'agent-profile:hermes:default',
     });
   });
 

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -346,7 +346,7 @@ function agentReply(store: ChannelMessageStore, channelId: string) {
     .history(channelId, { limit: 200 })
     .filter(
       (m: ChannelMessage) =>
-        m.sender.id === 'agent:mock' &&
+        m.sender.id === 'agent-profile:mock:default' &&
         m.status === 'complete' &&
         !m.agentDetail
     );
@@ -365,7 +365,7 @@ describe('mention routing — end-to-end via the router', () => {
     expect(res.body.message.sender.kind).toBe('human');
     await waitFor(() => agentReply(h.store, h.channelId).length === 1);
     const reply = agentReply(h.store, h.channelId)[0]!;
-    expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.sender.id).toBe('agent-profile:mock:default');
     expect(reply.body.text).toBe('Mock v2 response complete.');
     expect(reply.threadId).toBeNull();
     expect(reply.parentMessageId).toBeNull();
@@ -392,7 +392,9 @@ describe('mention routing — end-to-end via the router', () => {
       id: 'agent:orchestrator',
     });
     await waitFor(() => agentReply(h.store, h.channelId).length === 1);
-    expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe('agent:mock');
+    expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe(
+      'agent-profile:mock:default'
+    );
   });
 
   it('a threaded mention receives only thread context and replies in that thread', async () => {
@@ -437,7 +439,7 @@ describe('mention routing — end-to-end via the router', () => {
     expect(adapter.contents[0]).toContain('prior thread detail');
     expect(adapter.contents[0]).not.toContain('unrelated top-level update');
     const reply = agentReply(h.store, h.channelId)[0]!;
-    expect(reply.sender.id).toBe('agent:mock');
+    expect(reply.sender.id).toBe('agent-profile:mock:default');
     expect(reply.body.text).toBe('thread ack');
     expect(reply.threadId).toBe(root.body.message.id);
     expect(reply.parentMessageId).toBe(trigger.body.message.id);
@@ -618,7 +620,9 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
     });
     // Routing works through the real auth lane.
     await waitFor(() => agentReply(h.store, h.channelId).length >= 1);
-    expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe('agent:mock');
+    expect(agentReply(h.store, h.channelId)[0]!.sender.id).toBe(
+      'agent-profile:mock:default'
+    );
 
     // Brake accounting: further agent-sender posts count toward the cap. Posting
     // past MAX trips the pause row — a browser (human) sender never would, proving

--- a/test/channel-thread-e2e.test.ts
+++ b/test/channel-thread-e2e.test.ts
@@ -195,7 +195,7 @@ describe('channel thread mention round trip', () => {
         .history(harness.channelId, { limit: 20 })
         .some(
           (message) =>
-            message.sender.id === 'agent:mock' &&
+            message.sender.id === 'agent-profile:mock:default' &&
             message.status === 'complete' &&
             !message.agentDetail
         )
@@ -204,7 +204,7 @@ describe('channel thread mention round trip', () => {
       .history(harness.channelId, { limit: 20 })
       .find(
         (message) =>
-          message.sender.id === 'agent:mock' &&
+          message.sender.id === 'agent-profile:mock:default' &&
           message.status === 'complete' &&
           !message.agentDetail
       );

--- a/test/components/channel-timeline-grouping.test.ts
+++ b/test/components/channel-timeline-grouping.test.ts
@@ -217,6 +217,63 @@ describe('buildTimelineNodes — grouping rules', () => {
     expect(groupSeqs(nodes[1]!)).toEqual([1, 2]);
   });
 
+  it('coalesces a legacy agent:<vendor> row with a new agent-profile:<vendor>:default row (#1245)', () => {
+    // A pre-#1234 legacy row (wire id `agent:claude`, unchanged on the wire) and
+    // a new default-profile row are the SAME sender after the render-time heal,
+    // so they must coalesce instead of splitting at the re-key boundary.
+    const nodes = buildTimelineNodes(
+      [
+        msg({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          createdAt: '2026-07-18T10:00:00.000Z',
+          sender: { kind: 'agent', id: 'agent:claude', providerId: 'claude' },
+        }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          createdAt: '2026-07-18T10:01:00.000Z',
+          sender: {
+            kind: 'agent',
+            id: 'agent-profile:claude:default',
+            providerId: 'claude',
+            displayName: 'Claude Code',
+          },
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group']);
+    expect(groupSeqs(nodes[1]!)).toEqual([1, 2]);
+  });
+
+  it('still splits a legacy agent:<vendor> row from a DIFFERENT vendor default (#1245)', () => {
+    const nodes = buildTimelineNodes(
+      [
+        msg({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          createdAt: '2026-07-18T10:00:00.000Z',
+          sender: { kind: 'agent', id: 'agent:claude', providerId: 'claude' },
+        }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          createdAt: '2026-07-18T10:01:00.000Z',
+          sender: {
+            kind: 'agent',
+            id: 'agent-profile:codex:default',
+            providerId: 'codex',
+          },
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group', 'group']);
+    expect(groupSeqs(nodes[1]!)).toEqual([1]);
+    expect(groupSeqs(nodes[2]!)).toEqual([2]);
+  });
+
   it('breaks a same-sender group across a day boundary within the window (§5.1)', () => {
     // Same sender, only 3 minutes apart (well inside GROUP_WINDOW_MS), but they
     // straddle local midnight — the day boundary MUST still split the group and

--- a/test/components/channel-timeline-grouping.test.ts
+++ b/test/components/channel-timeline-grouping.test.ts
@@ -154,6 +154,69 @@ describe('buildTimelineNodes — grouping rules', () => {
     expect(kinds(nodes)).toEqual(['day-divider', 'group', 'group']);
   });
 
+  it('breaks the group between two profiles of ONE vendor (grouping keys on the profile Actor id, #1234)', () => {
+    // Same vendor (providerId 'claude'), same glyph, only 1 minute apart — but
+    // two DISTINCT profile Actor ids must NOT collapse into one visual group.
+    const nodes = buildTimelineNodes(
+      [
+        msg({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          createdAt: '2026-07-18T10:00:00.000Z',
+          sender: {
+            kind: 'agent',
+            id: 'agent-profile:claude:default',
+            providerId: 'claude',
+            displayName: 'Claude Code',
+          },
+        }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          createdAt: '2026-07-18T10:01:00.000Z',
+          sender: {
+            kind: 'agent',
+            id: 'agent-profile:claude:backend-xyz',
+            providerId: 'claude',
+            displayName: 'Backend Claude',
+          },
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group', 'group']);
+    expect(groupSeqs(nodes[1]!)).toEqual([1]);
+    expect(groupSeqs(nodes[2]!)).toEqual([2]);
+  });
+
+  it('coalesces consecutive messages from ONE profile within the window (#1234)', () => {
+    const sender = {
+      kind: 'agent' as const,
+      id: 'agent-profile:claude:backend-xyz',
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+    };
+    const nodes = buildTimelineNodes(
+      [
+        msg({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          createdAt: '2026-07-18T10:00:00.000Z',
+          sender,
+        }),
+        msg({
+          id: 'chm:2' as ChannelMessageId,
+          seq: 2,
+          createdAt: '2026-07-18T10:02:00.000Z',
+          sender,
+        }),
+      ],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'group']);
+    expect(groupSeqs(nodes[1]!)).toEqual([1, 2]);
+  });
+
   it('breaks a same-sender group across a day boundary within the window (§5.1)', () => {
     // Same sender, only 3 minutes apart (well inside GROUP_WINDOW_MS), but they
     // straddle local midnight — the day boundary MUST still split the group and

--- a/test/lib/chat/sender-identity.test.ts
+++ b/test/lib/chat/sender-identity.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { resolveSenderIdentity } from '../../../frontend/src/lib/chat/sender-identity.js';
+import { deriveColor } from '../../../frontend/src/lib/colors.js';
+import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
 
 describe('resolveSenderIdentity', () => {
   it('renders human as "you" with no glyph and the text color', () => {
@@ -32,11 +34,11 @@ describe('resolveSenderIdentity', () => {
     ['hermes', 'var(--sender-hermes)'],
     ['opencode', 'var(--sender-opencode)'],
   ] as const)(
-    'maps known agent %s to its fixed color token and glyph',
+    'keeps the curated vendor token + glyph for the %s DEFAULT profile',
     (providerId, colorVar) => {
       const id = resolveSenderIdentity({
         kind: 'agent',
-        id: `agent:${providerId}`,
+        id: builtInAgentProfileId(providerId),
         providerId,
       });
       expect(id.kind).toBe('agent');
@@ -46,22 +48,66 @@ describe('resolveSenderIdentity', () => {
     }
   );
 
-  it('derives providerId from the id when the field is absent', () => {
-    const id = resolveSenderIdentity({ kind: 'agent', id: 'agent:claude' });
+  it('hashes a NON-default profile via deriveColor(profileActorId) while sharing the vendor glyph', () => {
+    const profileId = 'agent-profile:claude:backend-abc';
+    const id = resolveSenderIdentity({
+      kind: 'agent',
+      id: profileId,
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+    });
+    // NOT the curated token — a concrete hex hashed on the profile Actor id.
+    expect(id.colorVar).toBe(deriveColor(profileId));
+    expect(id.colorVar.startsWith('#')).toBe(true);
+    expect(id.colorVar).not.toBe('var(--sender-claude)');
+    // The vendor glyph is shared across a vendor's profiles.
+    expect(id.glyph).toBe('claude');
+    expect(id.label).toBe('Backend Claude');
+  });
+
+  it('renders two non-default profiles of one vendor with distinct colors, same glyph', () => {
+    const a = resolveSenderIdentity({
+      kind: 'agent',
+      id: 'agent-profile:claude:backend-1',
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+    });
+    const b = resolveSenderIdentity({
+      kind: 'agent',
+      id: 'agent-profile:claude:reviewer-2',
+      providerId: 'claude',
+      displayName: 'Reviewer Claude',
+    });
+    expect(a.glyph).toBe('claude');
+    expect(b.glyph).toBe('claude');
+    expect(a.colorVar).not.toBe(b.colorVar);
+    expect(a.colorVar).toBe(deriveColor('agent-profile:claude:backend-1'));
+    expect(b.colorVar).toBe(deriveColor('agent-profile:claude:reviewer-2'));
+  });
+
+  it('sources providerId from the explicit field, NOT by stripping the id', () => {
+    // The id is a profile Actor id that does not contain "claude"; providerId is
+    // still resolved from the field, so the vendor glyph + default token resolve.
+    const id = resolveSenderIdentity({
+      kind: 'agent',
+      id: builtInAgentProfileId('claude'),
+      providerId: 'claude',
+    });
     expect(id.glyph).toBe('claude');
     expect(id.colorVar).toBe('var(--sender-claude)');
   });
 
-  it('falls back to a hash-derived color and null glyph for custom providers', () => {
+  it('falls back to a hash-derived color and null glyph for a custom-vendor default profile', () => {
     const id = resolveSenderIdentity({
       kind: 'agent',
-      id: 'agent:custom:acme',
-      providerId: 'custom:acme',
+      id: builtInAgentProfileId('custom-acme'),
+      providerId: 'custom-acme',
       displayName: 'Acme Bot',
     });
     expect(id.glyph).toBe(null);
     expect(id.label).toBe('Acme Bot');
-    // Not a sender token — a concrete hex from the hash palette.
+    // No curated token for an unknown vendor — a concrete hex from the palette.
+    expect(id.colorVar).toBe(deriveColor(builtInAgentProfileId('custom-acme')));
     expect(id.colorVar.startsWith('#')).toBe(true);
   });
 });

--- a/test/lib/chat/sender-identity.test.ts
+++ b/test/lib/chat/sender-identity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveSenderIdentity } from '../../../frontend/src/lib/chat/sender-identity.js';
+import {
+  resolveSenderIdentity,
+  resolveRenderSenderId,
+} from '../../../frontend/src/lib/chat/sender-identity.js';
 import { deriveColor } from '../../../frontend/src/lib/colors.js';
 import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
 
@@ -109,5 +112,74 @@ describe('resolveSenderIdentity', () => {
     // No curated token for an unknown vendor — a concrete hex from the palette.
     expect(id.colorVar).toBe(deriveColor(builtInAgentProfileId('custom-acme')));
     expect(id.colorVar.startsWith('#')).toBe(true);
+  });
+
+  // #1245: rows persisted BEFORE the #1234 re-key carry the bare `agent:<vendor>`
+  // sender id. Heal the curated color at the render boundary WITHOUT mutating the
+  // wire id (the CLI-gateway lane also emits `agent:<actorId>` and must stay
+  // byte-exact — see test/channel-routes.test.ts).
+  it.each([
+    ['claude', 'var(--sender-claude)'],
+    ['codex', 'var(--sender-codex)'],
+    ['hermes', 'var(--sender-hermes)'],
+    ['opencode', 'var(--sender-opencode)'],
+  ] as const)(
+    'heals a legacy agent:%s row to the curated vendor token + glyph',
+    (providerId, colorVar) => {
+      const id = resolveSenderIdentity({
+        kind: 'agent',
+        id: `agent:${providerId}`,
+        providerId,
+      });
+      expect(id.colorVar).toBe(colorVar);
+      // NOT a hash of the legacy wire id (the exact P2 the re-key regressed).
+      expect(id.colorVar).not.toBe(deriveColor(`agent:${providerId}`));
+      expect(id.glyph).toBe(providerId);
+    }
+  );
+
+  it('heals a legacy custom-vendor row to its built-in default hash, no curated token', () => {
+    const id = resolveSenderIdentity({
+      kind: 'agent',
+      id: 'agent:acme',
+      providerId: 'acme',
+    });
+    expect(id.glyph).toBe(null);
+    // Hashes on the built-in default id (matching a new agent-profile:acme:default
+    // row), not on the legacy `agent:acme` wire id.
+    expect(id.colorVar).toBe(deriveColor(builtInAgentProfileId('acme')));
+    expect(id.colorVar).not.toBe(deriveColor('agent:acme'));
+  });
+
+  it('resolveRenderSenderId heals only legacy vendor-default ids, else passes through', () => {
+    // Legacy vendor-default row → the vendor built-in default profile id.
+    expect(
+      resolveRenderSenderId({
+        kind: 'agent',
+        id: 'agent:claude',
+        providerId: 'claude',
+      })
+    ).toBe(builtInAgentProfileId('claude'));
+    // Already-migrated non-default profile → unchanged.
+    expect(
+      resolveRenderSenderId({
+        kind: 'agent',
+        id: 'agent-profile:claude:backend-xyz',
+        providerId: 'claude',
+      })
+    ).toBe('agent-profile:claude:backend-xyz');
+    // Human sender → unchanged.
+    expect(resolveRenderSenderId({ kind: 'human', id: 'human:operator' })).toBe(
+      'human:operator'
+    );
+    // A row whose parsed vendor disagrees with the authoritative providerId is
+    // left alone (never seen from the bridge, but the guard stays precise).
+    expect(
+      resolveRenderSenderId({
+        kind: 'agent',
+        id: 'agent:codex',
+        providerId: 'claude',
+      })
+    ).toBe('agent:codex');
   });
 });


### PR DESCRIPTION
Slice 2 of epic #1232. Re-keys channel message **sender attribution** off the vendor and onto the **profile Actor id**, so two profiles of one vendor become distinguishable in the timeline. Builds on keystone #1233 (AgentProfile model + `builtInAgentProfileId(vendor)` → `agent-profile:<vendor>:default`).

## What re-keyed

- **Bridge stamps the existing `ChannelSenderRef` slot** (`server/channel-agent-bridge.ts`): `id` = the profile Actor id, `providerId` = vendor (always), `displayName` = profile name. No custom profiles exist yet, so every agent session maps to its vendor's **DEFAULT** profile via `builtInAgentProfileId(vendor)`. The `agent:<framework>` id format is **gone**. A `profileActorId?` input was added to `BindSessionToChannelInput` (forward-compat; defaults to the vendor built-in default id).
- **session → default-profile-id**: `server/channel-agent-binder.ts` passes `profileActorId: builtInAgentProfileId(framework)` and resolves the **displayName**. Because a built-in default profile carries an *empty* stored `displayName` (thin-overlay sentinel), the binder reads the **vendor's catalog label** from the framework catalog (via the cached mention-target probe, fail-soft to the framework id) and passes it as the sender displayName. The session/tab composite (`#topic · framework`) stays on the session identity, decoupled from attribution.

## default-keeps-vendor-token rule

`frontend/src/lib/chat/sender-identity.ts`: a profile is **default** iff `sender.id === builtInAgentProfileId(sender.providerId)`. DEFAULT (built-in) profiles keep their curated `var(--sender-<vendor>)` DESIGN.md token; **only non-default profiles** hash via `deriveColor(profileActorId)` over the 12-color palette. The **vendor glyph is shared** across a vendor's profiles (default or not). Same rule applied to the sidebar DM dot and streaming/presence chip.

## every `agent:`-strip site fixed

`providerId` now ALWAYS comes from the explicit `ChannelSenderRef.providerId` field, never by stripping `agent:` off the id:
- `frontend/src/lib/chat/sender-identity.ts` — dropped the `sender.id.replace(/^agent:/, '')` fallback.
- `frontend/src/components/chat/ChannelView.tsx:314` — `streamingProviderIds` reads `providerId` directly (drives streaming/presence chip).
- `server/channel-agent-bridge.ts` `upsertMember(id: sender.id)` — rides `sender.id`, so re-keys automatically to the profile id.

Synthetic vendor senders re-keyed to `builtInAgentProfileId(vendor)` so they still resolve as their vendor's default (keep token + glyph): `ChannelView` `dmIdentity` + roster chips, `MentionPalette`, `TopicSidebarShell` DM dot, and the dev preview harness. Repo-wide grep confirmed the remaining `agent:` sites are out of scope (gateway-actor `deriveSender` in `channel-chat-router.ts`, the legacy Claude echo-alias heal migration in `channel-message-store.ts`, and non-channel identity domains).

## grouping key change

`channel-timeline-layout.ts` `buildTimelineNodes` already groups on `sender.kind && sender.id`; re-keying `sender.id` to the profile Actor id means two same-vendor profiles posting alternately **do not** collapse, while one profile's consecutive messages still coalesce. Locked with tests.

## AgentAssistantMessageItemV2 untouched + no avatars

`shared/agent-chat-protocol-v2.ts` is **unchanged** (verified by `git diff --stat` = empty). No new `ChannelSenderRef.profileId` field (JSDoc-only edit to the existing `id`). **No avatar rendering** (avatars are slice #1235). boundaryCheck: the one existing identity renderer (`resolveSenderIdentity`) re-keyed on Actor.id — no second renderer, no per-message receipts.

## Note on the federated envelope

There is **no channel → `WorkContextMessageActor` emission** in the codebase today (the only agent-actor envelope is the external CLI-gateway lane, keyed on an arbitrary actor id, not a framework profile). The keystone already established `AgentProfile.id` **is** the `WorkContextMessageActor.id`; the profile id now rides `ChannelSenderRef.id`, which is the channel's actor identity. No new emission path was invented (would be a second renderer, violating boundaryCheck).

## Validation

- `npm run check` — **0 errors** (tsc backend + frontend + tests + lint).
- `npm run build` — ok.
- New tests: default-keeps-vendor-token, non-default-hashes-via-`deriveColor`, two same-vendor profiles distinct (same glyph), providerId-from-field-not-id, custom-vendor-default fallback; bridge stamping (id=profile / providerId=vendor / displayName=catalog-label + explicit profileActorId); grouping boundary between two same-vendor profiles + coalesce within one.
- Existing green: `channel-agent-bridge`, `channel-agent-binder`, `channel-mention-e2e`, `channel-thread-e2e`, `channel-message-row`, `channel-timeline-*`, `mention-palette`, `topic-sidebar-shell`, `channel-message-store`, `channel-routes` (pre-push changed-test run: 31 files / 505 tests passed).

Closes #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent messages now display consistent profile-based identities across direct messages, channels, mentions, threads, and presence indicators.
  - Custom agent profiles receive distinct visual identities while retaining their provider’s glyph and attribution.

- **Bug Fixes**
  - Improved message grouping so profile changes and legacy agent messages render correctly without unnecessary breaks.
  - Preserved recognizable colors and labels for previously stored messages using older agent identifiers.
  - Sender attribution now remains consistent across restored, reused, and newly started agent sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->