### PR TITLE
feat(channels): profile-aware @mention autocomplete + collision disambiguation (#1236)

### DIFF
--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -9,12 +9,19 @@ import './ChannelComposer.css';
 import { useQuery } from '@tanstack/react-query';
 import type {
   ChannelImagePart,
+  ChannelMemberRef,
   ChannelMessagePart,
 } from '../../../../shared/channel-chat-protocol.js';
+import {
+  filterMentionContacts,
+  isMentionContactSelectable,
+  mentionInsertText,
+} from '../../../../shared/mention-contacts.js';
 import { createBrowserId } from '../../lib/browserId.js';
 import { fetchChannelRoster, uploadChannelImages } from '../../lib/api.js';
+import { buildMentionContacts } from '../../lib/chat/mention-contacts.js';
 import { detectTrigger } from './slashTrigger.js';
-import { MentionPalette, filterRoster } from './MentionPalette.js';
+import { MentionPalette } from './MentionPalette.js';
 
 const LINE_BREAK_INPUT_TYPES = new Set(['insertLineBreak', 'insertParagraph']);
 const LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS = 500;
@@ -41,6 +48,8 @@ interface ChannelComposerProps {
   channelId: string;
   channelTitle: string;
   placeholder?: string;
+  /** Human channel members, folded into the @mention contact set (#1236). */
+  members?: readonly ChannelMemberRef[];
   /** Idempotent send: the SAME clientMessageId is reused across manual retries. */
   onSend: (
     text: string,
@@ -60,6 +69,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   channelId,
   channelTitle,
   placeholder,
+  members,
   onSend,
   postPending,
   storeDown,
@@ -207,14 +217,20 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     enabled: trigger !== null,
     retry: false,
   });
-  // Memoize on the query string + roster data (stable primitives) so palette
-  // navigation callbacks don't churn on every keystroke that leaves both intact.
+  // Memoize on the query string + roster data + members so palette navigation
+  // callbacks don't churn on every keystroke that leaves them intact.
   const triggerQuery = trigger?.query ?? null;
   const rosterData = rosterQuery.data;
+  const contacts = useMemo(
+    () => buildMentionContacts(rosterData ?? [], members ?? []),
+    [rosterData, members]
+  );
   const entries = useMemo(
     () =>
-      triggerQuery === null ? [] : filterRoster(rosterData ?? [], triggerQuery),
-    [triggerQuery, rosterData]
+      triggerQuery === null
+        ? []
+        : filterMentionContacts(contacts, triggerQuery),
+    [triggerQuery, contacts]
   );
   const paletteVisible =
     trigger !== null && !paletteDismissed && entries.length > 0;
@@ -290,13 +306,14 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       });
   }, [draft, images, onSend, revokePreview, updateImages]);
 
-  // Splice the selected AVAILABLE agent into the draft as plain `@<id> ` text
-  // (no rich pill), replacing the active trigger span.
+  // Splice the selected SELECTABLE contact into the draft as plain mention text
+  // (no rich pill), replacing the active trigger span. The inserted text
+  // round-trips through parseMentions back to this contact's profile Actor id.
   const applyMention = useCallback(() => {
     if (!trigger) return;
     const entry = entries[activeIndex];
-    if (!entry || !entry.available) return;
-    const replacement = `@${entry.id} `;
+    if (!entry || !isMentionContactSelectable(entry)) return;
+    const replacement = `${mentionInsertText(entry)} `;
     const newDraft =
       draft.slice(0, trigger.span[0]) +
       replacement +
@@ -340,8 +357,8 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
           e.preventDefault();
           const entry = entries[activeIndex];
-          if (entry && entry.available) applyMention();
-          // Unavailable/none → no-op: swallow the key so Enter neither sends
+          if (entry && isMentionContactSelectable(entry)) applyMention();
+          // Unselectable/none → no-op: swallow the key so Enter neither sends
           // nor inserts and Tab does not move focus out of the composer.
           return;
         }
@@ -379,7 +396,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       inputEvent.preventDefault();
       if (paletteVisible) {
         const entry = entries[activeIndex];
-        if (entry && entry.available) applyMention();
+        if (entry && isMentionContactSelectable(entry)) applyMention();
         return;
       }
       submit();
@@ -453,7 +470,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       ) : null}
       <div className="ch-composer__mention-anchor">
         <MentionPalette
-          entries={entries}
+          contacts={entries}
           activeIndex={activeIndex}
           visible={paletteVisible}
         />

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -539,6 +539,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
           <ChannelComposer
             channelId={channelId}
             channelTitle={title}
+            {...(channel?.members ? { members: channel.members } : {})}
             onSend={handleSend}
             postPending={postPending}
             storeDown={storeDown}

--- a/frontend/src/components/chat/MentionPalette.css
+++ b/frontend/src/components/chat/MentionPalette.css
@@ -1,6 +1,7 @@
-/* @mention palette (#1167). Structural + visual sibling of `.slash*`
-   (Composer.css): same absolute float above the composer, same surface/border
-   tokens, same active-row `>` marker. Only DESIGN.md tokens — no new colors. */
+/* @mention palette (#1167, profile-aware #1236). Structural + visual sibling of
+   `.slash*` (Composer.css): same absolute float above the composer, same
+   surface/border tokens, same active-row `>` marker. Only DESIGN.md tokens — no
+   new colors, zero border-radius, monospace throughout. */
 
 .mention-palette {
   position: absolute;
@@ -18,33 +19,38 @@
 
 .mention-palette__row {
   position: relative;
-  display: grid;
-  grid-template-columns: 16px minmax(0, auto) minmax(0, 1fr);
-  align-items: center;
-  gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   padding: 6px 10px 6px 18px;
   color: var(--text-muted);
   min-width: 0;
 }
 
-.mention-palette__row:not(.mention-palette__row--unavailable):hover,
-.mention-palette__row--active:not(.mention-palette__row--unavailable) {
+.mention-palette__main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mention-palette__row:not(.mention-palette__row--inert):hover,
+.mention-palette__row--active:not(.mention-palette__row--inert) {
   background: var(--surface-hover);
   color: var(--text);
 }
 
-.mention-palette__row--active:not(.mention-palette__row--unavailable)::before {
+.mention-palette__row--active:not(.mention-palette__row--inert)::before {
   content: '>';
   position: absolute;
   left: 4px;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 9px;
   line-height: 1;
   color: var(--accent);
 }
 
-/* Unavailable rows stay visible but read as inert (greyed, no highlight). */
-.mention-palette__row--unavailable {
+/* Inert rows (unavailable OR not in channel) stay visible but read as inert. */
+.mention-palette__row--inert {
   opacity: 0.45;
   cursor: not-allowed;
 }
@@ -55,6 +61,7 @@
   justify-content: center;
   width: 16px;
   height: 16px;
+  flex: none;
 }
 
 .mention-palette__name {
@@ -67,6 +74,30 @@
   min-width: 0;
 }
 
+/* Plain monospace collision token — NOT a badge (DESIGN.md). */
+.mention-palette__disambiguator {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+  flex: none;
+}
+
+.mention-palette__kind {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  white-space: nowrap;
+  flex: none;
+}
+
+.mention-palette__owner {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+  flex: none;
+}
+
 .mention-palette__id {
   color: var(--text-muted);
   font-size: var(--font-size-xs);
@@ -74,14 +105,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  flex: 0 1 auto;
 }
 
-.mention-palette__reason {
-  grid-column: 1 / -1;
+.mention-palette__state {
   color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-style: italic;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  padding-left: 24px;
 }

--- a/frontend/src/components/chat/MentionPalette.tsx
+++ b/frontend/src/components/chat/MentionPalette.tsx
@@ -56,7 +56,12 @@ export const MentionPalette: React.FC<MentionPaletteProps> = ({
     <div
       className="mention-palette"
       role="listbox"
-      aria-label="mention contacts"
+      // Accessible name is the stable `agents` contract the composer e2e locates
+      // (`getByRole('listbox', { name: 'agents' })`). The set now also carries
+      // humans/custom profiles (#1236), but the palette's addressable-agents
+      // identity — and the test/a11y name — stays `agents`; renaming it silently
+      // broke the mention e2e once already.
+      aria-label="agents"
       style={{ display: visible ? undefined : 'none' }}
     >
       {contacts.map((contact, index) => {

--- a/frontend/src/components/chat/MentionPalette.tsx
+++ b/frontend/src/components/chat/MentionPalette.tsx
@@ -1,43 +1,54 @@
 import React from 'react';
 import './MentionPalette.css';
-import type { RosterEntry } from '../../lib/api.js';
-import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
+import {
+  type MentionContact,
+  type MentionContactKind,
+  isMentionContactSelectable,
+  mentionInsertText,
+} from '../../../../shared/mention-contacts.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { AgentBadge } from '../AgentBadge.js';
 
-/**
- * Prefix-filter the channel roster by `id`/`displayName` (case-insensitive).
- * Unavailable entries are intentionally KEPT — they render greyed and
- * non-selectable so the operator can see who is in the channel but currently
- * unroutable (and why, via the `reason` tooltip). Empty query returns all rows.
- */
-export function filterRoster(
-  roster: RosterEntry[],
-  query: string
-): RosterEntry[] {
-  const q = query.toLowerCase();
-  if (q.length === 0) return roster;
-  return roster.filter(
-    (entry) =>
-      entry.id.toLowerCase().startsWith(q) ||
-      entry.displayName.toLowerCase().startsWith(q)
+/** Human-facing kind label — FZF/`>`-palette vocabulary, lowercase, no badge chrome. */
+const KIND_LABEL: Record<MentionContactKind, string> = {
+  profile: 'profile',
+  'vendor-default': 'vendor',
+  human: 'human',
+};
+
+/** Flat monochrome line icon for a human contact (DESIGN.md: SVG line icons, no emoji). */
+function HumanGlyph(): React.ReactElement {
+  return (
+    <svg
+      className="agent-badge"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 21c0-4 3.6-7 8-7s8 3 8 7" />
+    </svg>
   );
 }
 
 interface MentionPaletteProps {
-  entries: RosterEntry[];
+  contacts: MentionContact[];
   activeIndex: number;
   visible: boolean;
 }
 
 /**
- * Presentational `@mention` palette. Keyboard navigation lives in the parent
- * (ChannelComposer), mirroring SlashPalette. Selecting an available row inserts
- * plain `@<id> ` text — no rich pill. Unavailable rows are greyed, carry
- * `aria-disabled` + the `reason` as their `title`, and are never selectable.
+ * Presentational profile-aware `@mention` palette. Keyboard navigation lives in
+ * the parent (ChannelComposer), mirroring SlashPalette. Selecting a selectable
+ * row inserts the contact's plain mention text — no rich pill. Inert rows
+ * (unavailable, or not a channel member) render greyed, carry `aria-disabled`,
+ * and are never selectable.
  */
 export const MentionPalette: React.FC<MentionPaletteProps> = ({
-  entries,
+  contacts,
   activeIndex,
   visible,
 }) => {
@@ -45,52 +56,93 @@ export const MentionPalette: React.FC<MentionPaletteProps> = ({
     <div
       className="mention-palette"
       role="listbox"
-      aria-label="agents"
+      aria-label="mention contacts"
       style={{ display: visible ? undefined : 'none' }}
     >
-      {entries.map((entry, index) => {
-        const identity = resolveSenderIdentity({
-          kind: 'agent',
-          // Roster entries are vendors, i.e. their DEFAULT profile — key on the
-          // profile Actor id so the palette keeps the curated vendor token (#1234).
-          id: builtInAgentProfileId(entry.id),
-          providerId: entry.id,
-          displayName: entry.displayName,
-        });
+      {contacts.map((contact, index) => {
+        const isAgent = contact.kind !== 'human';
+        const identity = isAgent
+          ? resolveSenderIdentity({
+              kind: 'agent',
+              // Contacts already carry the re-keyed profile Actor id (#1234):
+              // a vendor default is `builtInAgentProfileId(vendor)`, a custom
+              // profile its own id. Pass it straight through — the single id
+              // scheme keeps default profiles on the curated `var(--sender-*)`
+              // token and hashes non-defaults, with no `agent:<vendor>` re-map.
+              id: contact.id,
+              providerId: contact.providerId,
+              displayName: contact.displayName,
+            })
+          : null;
         const active = index === activeIndex;
-        const unavailable = !entry.available;
+        const selectable = isMentionContactSelectable(contact);
+        const inert = !selectable;
+        const notInChannel = !contact.inChannel;
+        const title = !contact.available
+          ? (contact.reason ?? undefined)
+          : notInChannel
+            ? 'not a member of this channel'
+            : undefined;
         const rowClass = [
           'mention-palette__row',
-          active ? 'mention-palette__row--active' : null,
-          unavailable ? 'mention-palette__row--unavailable' : null,
+          active && selectable ? 'mention-palette__row--active' : null,
+          inert ? 'mention-palette__row--inert' : null,
         ]
           .filter(Boolean)
           .join(' ');
+        const glyphColor =
+          inert || !identity ? undefined : { color: identity.colorVar };
         return (
           <div
-            key={entry.id}
+            key={contact.id}
             className={rowClass}
             role="option"
             aria-selected={active}
-            {...(unavailable ? { 'aria-disabled': true } : {})}
-            {...(unavailable && entry.reason ? { title: entry.reason } : {})}
+            {...(inert ? { 'aria-disabled': true } : {})}
+            {...(title ? { title } : {})}
           >
-            <span
-              className="mention-palette__glyph"
-              style={unavailable ? undefined : { color: identity.colorVar }}
-              aria-hidden="true"
-            >
-              {identity.glyph ? <AgentBadge agent={identity.glyph} /> : '@'}
-            </span>
-            <span
-              className="mention-palette__name"
-              style={unavailable ? undefined : { color: identity.colorVar }}
-            >
-              {entry.displayName}
-            </span>
-            <span className="mention-palette__id">@{entry.id}</span>
-            {unavailable && entry.reason ? (
-              <span className="mention-palette__reason">{entry.reason}</span>
+            <div className="mention-palette__main">
+              <span
+                className="mention-palette__glyph"
+                style={glyphColor}
+                aria-hidden="true"
+              >
+                {identity ? (
+                  <AgentBadge agent={identity.glyph ?? contact.providerId} />
+                ) : (
+                  <HumanGlyph />
+                )}
+              </span>
+              <span
+                className="mention-palette__name"
+                style={
+                  inert || !identity ? undefined : { color: identity.colorVar }
+                }
+              >
+                {contact.displayName}
+              </span>
+              {contact.disambiguator ? (
+                <span
+                  className="mention-palette__disambiguator"
+                  aria-label="local id"
+                >
+                  {contact.disambiguator}
+                </span>
+              ) : null}
+              <span className="mention-palette__kind">
+                {KIND_LABEL[contact.kind]}
+              </span>
+              {contact.owner ? (
+                <span className="mention-palette__owner">{contact.owner}</span>
+              ) : null}
+              <span className="mention-palette__id">
+                {mentionInsertText(contact)}
+              </span>
+            </div>
+            {notInChannel ? (
+              <span className="mention-palette__state">not in channel</span>
+            ) : !contact.available && contact.reason ? (
+              <span className="mention-palette__state">{contact.reason}</span>
             ) : null}
           </div>
         );

--- a/frontend/src/lib/chat/mention-contacts.ts
+++ b/frontend/src/lib/chat/mention-contacts.ts
@@ -1,0 +1,63 @@
+// Build the @mention palette's contact set (#1236, slice 4).
+//
+// v1 SOURCE = CLIENT-SIDE SYNTHESIS, no new server endpoint. Agent contacts are
+// the vendor DEFAULT profiles synthesized from the channel roster the composer
+// already fetches (`GET /channels/:id/roster`), each keyed on
+// `builtInAgentProfileId(vendor)`. Human contacts come from the channel members
+// the composer already receives. When a later slice adds custom-profile
+// creation those rows slot in as `kind: 'profile'` with their own ids — this
+// builder is the only place that changes.
+
+import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
+import {
+  annotateMentionCollisions,
+  type MentionContact,
+} from '../../../../shared/mention-contacts.js';
+import type { ChannelMemberRef } from '../../../../shared/channel-chat-protocol.js';
+import type { RosterEntry } from '../api.js';
+
+/**
+ * Synthesize the palette contact set from the framework roster (vendor defaults)
+ * plus human channel members, then annotate same-name collisions with a stable
+ * local id token. Ordering: agents first (roster order), then humans.
+ */
+export function buildMentionContacts(
+  roster: readonly RosterEntry[],
+  members: readonly ChannelMemberRef[] = []
+): MentionContact[] {
+  const contacts: MentionContact[] = [];
+  for (const framework of roster) {
+    contacts.push({
+      id: builtInAgentProfileId(framework.id),
+      providerId: framework.id,
+      displayName: framework.displayName,
+      kind: 'vendor-default',
+      owner: 'system',
+      available: framework.available,
+      reason: framework.reason,
+      inChannel: true,
+      isDefault: true,
+      isBuiltIn: true,
+    });
+  }
+  const seenHumans = new Set<string>();
+  for (const member of members) {
+    if (member.kind !== 'human') continue;
+    if (seenHumans.has(member.id)) continue;
+    seenHumans.add(member.id);
+    const label = member.id.replace(/^human:/, '');
+    contacts.push({
+      id: member.id,
+      providerId: 'human',
+      displayName: label,
+      kind: 'human',
+      owner: '',
+      available: true,
+      reason: null,
+      inChannel: true,
+      isDefault: false,
+      isBuiltIn: false,
+    });
+  }
+  return annotateMentionCollisions(contacts);
+}

--- a/shared/agent-profile.ts
+++ b/shared/agent-profile.ts
@@ -173,6 +173,70 @@ export function resolveProfileForMention<T extends AgentProfileContact>(
   return best;
 }
 
+/**
+ * Delimiter separating a mention's display name from its short local
+ * disambiguator token in inserted mention text (e.g. `@Reviewer#ab12cd`). Kept
+ * as a shared const so the palette's insert-text writer and `parseMentions`
+ * reader never drift.
+ */
+export const MENTION_DISAMBIGUATOR_DELIMITER = '#';
+
+/** Alphanumeric-only, lowercased view of a local Actor id (for suffix slices). */
+function alnumId(id: string): string {
+  return id.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+/**
+ * Assign each DISPLAY-NAME-colliding profile a SHORT, STABLE, GROUP-UNIQUE token
+ * sliced from the TAIL of its local Actor id — never an npub / public key and
+ * never a team/community directory lookup (boundaryCheck #1231). Only contacts
+ * that share a normalized, NON-EMPTY display name get a token; unique names and
+ * empty-name vendor defaults (reachable only via their vendor alias) are left
+ * out. The slice length grows from 6 until every member of a collision group is
+ * distinguishable, so the token is always both a genuine id suffix and
+ * unambiguous within its group. Deterministic and input-order independent, so
+ * the palette writer and `parseMentions` reader compute identical tokens from
+ * the same contact set.
+ */
+export function computeMentionDisambiguators(
+  contacts: readonly Pick<AgentProfileContact, 'id' | 'displayName'>[]
+): Map<string, string> {
+  const groups = new Map<
+    string,
+    Pick<AgentProfileContact, 'id' | 'displayName'>[]
+  >();
+  for (const contact of contacts) {
+    const name = normalizeMentionToken(contact.displayName);
+    if (!name) continue;
+    const bucket = groups.get(name);
+    if (bucket) bucket.push(contact);
+    else groups.set(name, [contact]);
+  }
+  const tokens = new Map<string, string>();
+  for (const bucket of groups.values()) {
+    if (bucket.length < 2) continue;
+    const maxLen = Math.max(6, ...bucket.map((c) => alnumId(c.id).length));
+    let len = 6;
+    for (; len <= maxLen; len++) {
+      const seen = new Set<string>();
+      let unique = true;
+      for (const contact of bucket) {
+        const slice = alnumId(contact.id).slice(-len);
+        if (seen.has(slice)) {
+          unique = false;
+          break;
+        }
+        seen.add(slice);
+      }
+      if (unique) break;
+    }
+    for (const contact of bucket) {
+      tokens.set(contact.id, alnumId(contact.id).slice(-len));
+    }
+  }
+  return tokens;
+}
+
 const HISTORICAL_AGENT_SENDER_PREFIX = 'agent:';
 
 /**

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -10,6 +10,12 @@
 // impossible because no reducer field is shared between senders.
 
 import type { AgentDetailCardV2 } from './agent-chat-protocol-v2.js';
+import {
+  computeMentionDisambiguators,
+  normalizeMentionToken,
+  resolveProfileForMention,
+  type AgentProfileContact,
+} from './agent-profile.js';
 
 export const CHANNEL_CHAT_PROTOCOL_VERSION = 1 as const;
 export const CHANNEL_MESSAGE_MAX_IMAGE_PARTS = 4;
@@ -82,6 +88,13 @@ export interface ChannelMemberRef {
 export interface ChannelMention {
   raw: string;
   providerId?: string;
+  /**
+   * Resolved profile Actor id (`AgentProfile.id`) when `parseMentions` is given
+   * a contact set (#1236). Additive + optional: rows parsed without a contact
+   * set — every current server caller — leave this absent, and `providerId`
+   * stays populated for the legacy vendor-alias path.
+   */
+  profileId?: string;
 }
 
 export interface ChannelMessageSource {
@@ -652,15 +665,28 @@ export function mergeHistoryPage(
  * `providerId`. Both are persisted so alias policy (`@Claude` vs `@claude`,
  * custom providers) can change later without a data migration. #1167 inherits
  * this hardened tokenizer.
+ *
+ * When a profile `contacts` set is supplied (#1236) each mention additionally
+ * resolves to a profile Actor id: multi-word display names match
+ * LONGEST-MATCH-FIRST, `@<vendor>` resolves to that vendor's default profile,
+ * and a trailing `#<token>` disambiguates same-name collisions. Resolution
+ * delegates to the keystone `resolveProfileForMention` (vendor alias + tiebreak
+ * are NOT reimplemented here). Callers that pass no contacts — every current
+ * server caller — keep the exact single-token behavior above.
  */
 export function parseMentions(
   text: string,
-  knownProviderIds: readonly string[] = []
+  knownProviderIds: readonly string[] = [],
+  contacts?: readonly AgentProfileContact[]
 ): ChannelMention[] {
   const known = new Map<string, string>();
   for (const id of knownProviderIds) known.set(id.toLowerCase(), id);
 
   const masked = maskCodeSpans(text);
+  if (contacts && contacts.length > 0) {
+    return parseMentionsWithContacts(text, masked, known, contacts);
+  }
+
   const mentionPattern = /(^|[^A-Za-z0-9_.])@([A-Za-z][A-Za-z0-9_-]*)/g;
   const seen = new Set<string>();
   const mentions: ChannelMention[] = [];
@@ -675,6 +701,129 @@ export function parseMentions(
     mentions.push({
       raw: `@${name}`,
       ...(providerId ? { providerId } : {}),
+    });
+  }
+  return mentions;
+}
+
+/** Word count of a normalized display name (empty name → 0). */
+function nameWordCount(displayName: string): number {
+  const norm = normalizeMentionToken(displayName);
+  return norm ? norm.split(' ').length : 0;
+}
+
+/**
+ * Profile-aware mention scan. Reads a greedy run of words after each `@`, then
+ * resolves LONGEST-EXACT-FIRST: for k words down to 1 it asks
+ * `resolveProfileForMention` for the k-word phrase and keeps the match only when
+ * the resolved name consumes exactly k words (a shorter name matched by prefix
+ * is rejected so trailing prose is never swallowed). A `#<token>` immediately
+ * following the consumed name selects a specific member of a same-name group.
+ */
+function parseMentionsWithContacts(
+  text: string,
+  masked: string,
+  known: Map<string, string>,
+  contacts: readonly AgentProfileContact[]
+): ChannelMention[] {
+  const disambTokens = computeMentionDisambiguators(contacts);
+  const maxWords = Math.min(
+    8,
+    Math.max(1, ...contacts.map((c) => nameWordCount(c.displayName)))
+  );
+  const boundary = /(^|[^A-Za-z0-9_.])@/g;
+  const firstWord = /^[A-Za-z][A-Za-z0-9_-]*/;
+  const contWord = /^ ([A-Za-z0-9_-]+)/;
+  const disambPattern = /^#([A-Za-z0-9]+)/;
+
+  const seen = new Set<string>();
+  const mentions: ChannelMention[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = boundary.exec(masked)) !== null) {
+    const atIndex = match.index + match[0].length - 1;
+    let cursor = atIndex + 1;
+    const first = firstWord.exec(masked.slice(cursor));
+    if (!first) continue;
+
+    const words: Array<{ text: string; end: number }> = [
+      { text: first[0], end: cursor + first[0].length },
+    ];
+    cursor += first[0].length;
+    while (words.length < maxWords) {
+      const cont = contWord.exec(masked.slice(cursor));
+      if (!cont) break;
+      cursor += cont[0].length;
+      words.push({ text: cont[1]!, end: cursor });
+    }
+
+    let disamb: string | null = null;
+    let disambEnd = -1;
+    const dm = disambPattern.exec(masked.slice(cursor));
+    if (dm) {
+      disamb = dm[1]!.toLowerCase();
+      disambEnd = cursor + dm[0].length;
+    }
+
+    // Longest-exact-first resolution over the greedy word run.
+    let winner: AgentProfileContact | null = null;
+    let consumed = 0;
+    for (let k = words.length; k >= 1; k--) {
+      const candidate = words
+        .slice(0, k)
+        .map((w) => w.text)
+        .join(' ');
+      const resolved = resolveProfileForMention(candidate, contacts);
+      if (!resolved) continue;
+      const matchedLen = nameWordCount(resolved.displayName) || 1;
+      if (matchedLen !== k) continue; // prefix-matched a shorter name — back off
+      winner = resolved;
+      consumed = k;
+      break;
+    }
+
+    let rawEnd: number;
+    let providerId: string | undefined;
+    let profileId: string | undefined;
+    if (winner) {
+      consumed = consumed || 1;
+      rawEnd = words[consumed - 1]!.end;
+      providerId = winner.providerId;
+      profileId = winner.id;
+      // A `#token` right after the consumed name picks a same-name collision peer.
+      if (disamb && consumed === words.length && disambEnd > 0) {
+        const nameNorm = normalizeMentionToken(
+          words
+            .slice(0, consumed)
+            .map((w) => w.text)
+            .join(' ')
+        );
+        const target = contacts.find(
+          (c) =>
+            normalizeMentionToken(c.displayName) === nameNorm &&
+            disambTokens.get(c.id) === disamb
+        );
+        if (target) {
+          providerId = target.providerId;
+          profileId = target.id;
+          rawEnd = disambEnd;
+        }
+      }
+    } else {
+      // Unresolved: keep the single leading token, provider-tagged if known.
+      rawEnd = words[0]!.end;
+      providerId = known.get(words[0]!.text.toLowerCase());
+      profileId = undefined;
+    }
+
+    const raw = text.slice(atIndex, rawEnd);
+    const dedupeKey = profileId ?? raw.toLowerCase();
+    boundary.lastIndex = rawEnd;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    mentions.push({
+      raw,
+      ...(providerId ? { providerId } : {}),
+      ...(profileId ? { profileId } : {}),
     });
   }
   return mentions;

--- a/shared/mention-contacts.ts
+++ b/shared/mention-contacts.ts
@@ -1,0 +1,148 @@
+// Profile-aware @mention contact set (#1236, epic #1232, slice 4).
+//
+// The @mention palette resolves against a CONTACT SET, not a bare vendor list.
+// A contact is one addressable participant: a custom AgentProfile, a vendor
+// DEFAULT profile (`agent-profile:<vendor>:default`), or a human channel member.
+// The set is profile-aware and collision-ready today even though the only live
+// agent contacts are vendor defaults synthesized from the framework list — when
+// a later slice adds custom-profile creation, those rows slot in as `kind:
+// 'profile'` with their own ids and no other machinery changes.
+//
+// boundaryCheck (#1231): every id here is a LOCAL hub Actor id. The collision
+// disambiguator is a slice of that local id — never an npub / public key, never
+// a team/community directory handle.
+
+import {
+  computeMentionDisambiguators,
+  normalizeMentionToken,
+  resolveProfileForMention,
+  MENTION_DISAMBIGUATOR_DELIMITER,
+  type AgentProfileContact,
+} from './agent-profile.js';
+
+/**
+ * `profile` = user-authored custom profile (a later slice); `vendor-default` =
+ * the built-in default profile of a configured framework; `human` = a human
+ * channel member.
+ */
+export type MentionContactKind = 'profile' | 'vendor-default' | 'human';
+
+/** One addressable @mention candidate rendered in the palette + fed to resolution. */
+export interface MentionContact {
+  /** Local Actor id — the value `parseMentions` writes into `ChannelMention.profileId`. */
+  id: string;
+  /** Vendor framework id for agents, `'human'` for humans. */
+  providerId: string;
+  /** Free-form, possibly multi-word display label shown in the palette. */
+  displayName: string;
+  kind: MentionContactKind;
+  /** Owner label: `'system'` for a built-in vendor default; owner for a custom profile. */
+  owner: string;
+  /** Routable right now (vendor availability). Unavailable rows render inert. */
+  available: boolean;
+  /** Why unavailable, when `available` is false. */
+  reason: string | null;
+  /** Member of THIS channel. Non-members render a "not in channel" affordance. */
+  inChannel: boolean;
+  /** Vendor default of its `providerId` (drives the `@<vendor>` alias). */
+  isDefault: boolean;
+  /** Seeded, non-user-authored. */
+  isBuiltIn: boolean;
+  /** Short stable local-id token, present only when a display name collides. */
+  disambiguator?: string;
+}
+
+/**
+ * Resolver-facing view of a contact set. Vendor defaults are collapsed to an
+ * EMPTY display name so they are reachable ONLY via their vendor alias
+ * (`@claude`), never by their catalog label — mirroring the keystone contract
+ * (`shared/agent-profile.ts`) so a user-named profile is never shadowed by a
+ * vendor default in the longest-match path.
+ */
+export function toResolverContacts(
+  contacts: readonly MentionContact[]
+): AgentProfileContact[] {
+  return contacts.map((contact) => ({
+    id: contact.id,
+    providerId: contact.providerId,
+    displayName: contact.kind === 'vendor-default' ? '' : contact.displayName,
+    isDefault: contact.isDefault,
+    isBuiltIn: contact.isBuiltIn,
+  }));
+}
+
+/**
+ * Stamp a stable local disambiguator token onto every contact whose display
+ * name collides with another's. Computed over the resolver view so the tokens
+ * match exactly what `parseMentions` recomputes at read time.
+ */
+export function annotateMentionCollisions(
+  contacts: readonly MentionContact[]
+): MentionContact[] {
+  const tokens = computeMentionDisambiguators(toResolverContacts(contacts));
+  return contacts.map((contact) => {
+    const token = tokens.get(contact.id);
+    return token ? { ...contact, disambiguator: token } : contact;
+  });
+}
+
+/**
+ * The EXACT text the palette inserts for a picked contact. Round-trips through
+ * `parseMentions` back to `contact.id`:
+ *  - vendor default → `@<vendorId>` (unambiguous vendor alias),
+ *  - colliding name → `@<displayName>#<token>`,
+ *  - otherwise      → `@<displayName>`.
+ */
+export function mentionInsertText(contact: MentionContact): string {
+  if (contact.kind === 'vendor-default') return `@${contact.providerId}`;
+  if (contact.disambiguator) {
+    return `@${contact.displayName}${MENTION_DISAMBIGUATOR_DELIMITER}${contact.disambiguator}`;
+  }
+  return `@${contact.displayName}`;
+}
+
+/** A contact is pickable only when routable AND a member of the channel. */
+export function isMentionContactSelectable(contact: MentionContact): boolean {
+  return contact.available && contact.inChannel;
+}
+
+/**
+ * Case-insensitive prefix filter over display name, vendor id, and the local-id
+ * disambiguator token. Unavailable / not-in-channel contacts are intentionally
+ * KEPT (they render inert) so the operator still sees who exists. Empty query
+ * returns the whole set.
+ */
+export function filterMentionContacts(
+  contacts: readonly MentionContact[],
+  query: string
+): MentionContact[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) return [...contacts];
+  return contacts.filter(
+    (contact) =>
+      contact.displayName.toLowerCase().startsWith(q) ||
+      contact.providerId.toLowerCase().startsWith(q) ||
+      (contact.disambiguator !== undefined &&
+        contact.disambiguator.startsWith(q))
+  );
+}
+
+/**
+ * Resolve a single token (as typed, e.g. `@Backend Claude`) against a contact
+ * set to its resolved contact, delegating to the keystone
+ * `resolveProfileForMention` for the vendor-alias + longest-match + tiebreak
+ * rules. Convenience for callers that hold `MentionContact[]` rather than the
+ * resolver shape; returns the original `MentionContact` (not the resolver view).
+ */
+export function resolveMentionContact(
+  token: string,
+  contacts: readonly MentionContact[]
+): MentionContact | null {
+  const resolverContacts = toResolverContacts(contacts);
+  const resolved = resolveProfileForMention(token, resolverContacts);
+  if (!resolved) return null;
+  return contacts.find((contact) => contact.id === resolved.id) ?? null;
+}
+
+// Re-exported so palette / composer code has one import site for mention wiring.
+export { normalizeMentionToken, MENTION_DISAMBIGUATOR_DELIMITER };

--- a/test/components/mention-palette.test.ts
+++ b/test/components/mention-palette.test.ts
@@ -3,10 +3,14 @@
 import React, { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
+import { MentionPalette } from '../../frontend/src/components/chat/MentionPalette.js';
+import { buildMentionContacts } from '../../frontend/src/lib/chat/mention-contacts.js';
 import {
-  MentionPalette,
-  filterRoster,
-} from '../../frontend/src/components/chat/MentionPalette.js';
+  annotateMentionCollisions,
+  filterMentionContacts,
+  type MentionContact,
+} from '../../shared/mention-contacts.js';
+import { builtInAgentProfileId } from '../../shared/agent-profile.js';
 import type { RosterEntry } from '../../frontend/src/lib/api.js';
 
 (
@@ -40,22 +44,60 @@ const roster: RosterEntry[] = [
   },
 ];
 
-describe('filterRoster', () => {
-  it('prefix-filters by id and displayName (case-insensitive)', () => {
-    expect(filterRoster(roster, 'h').map((e) => e.id)).toEqual(['hermes']);
-    expect(filterRoster(roster, 'Cod').map((e) => e.id)).toEqual(['codex']);
+describe('buildMentionContacts', () => {
+  it('synthesizes a vendor-default profile per framework, keyed on the built-in id', () => {
+    const contacts = buildMentionContacts(roster);
+    expect(contacts.map((c) => c.id)).toEqual([
+      builtInAgentProfileId('claude'),
+      builtInAgentProfileId('codex'),
+      builtInAgentProfileId('hermes'),
+    ]);
+    for (const c of contacts) {
+      expect(c.kind).toBe('vendor-default');
+      expect(c.owner).toBe('system');
+      expect(c.isDefault).toBe(true);
+      expect(c.isBuiltIn).toBe(true);
+      expect(c.inChannel).toBe(true);
+    }
+    const codex = contacts.find((c) => c.providerId === 'codex')!;
+    expect(codex.available).toBe(false);
+    expect(codex.reason).toBe('no api key configured');
   });
 
-  it('keeps unavailable entries in the filtered list', () => {
-    // 'c' matches both claude (available) and codex (unavailable) — the
-    // unavailable one is retained (rendered greyed/non-selectable, not dropped).
-    const result = filterRoster(roster, 'c');
-    expect(result.map((e) => e.id)).toEqual(['claude', 'codex']);
-    expect(result.some((e) => !e.available)).toBe(true);
+  it('folds human members in as human contacts (prefix-stripped label)', () => {
+    const contacts = buildMentionContacts(roster, [
+      { kind: 'human', id: 'human:alex', joinedAt: 't' },
+      { kind: 'agent', id: 'agent:mock', joinedAt: 't' },
+    ]);
+    const human = contacts.find((c) => c.kind === 'human')!;
+    expect(human.id).toBe('human:alex');
+    expect(human.displayName).toBe('alex');
+    expect(human.providerId).toBe('human');
+    // agent members are not folded in as humans.
+    expect(contacts.filter((c) => c.kind === 'human')).toHaveLength(1);
+  });
+});
+
+describe('filterMentionContacts', () => {
+  const contacts = buildMentionContacts(roster);
+
+  it('prefix-filters by display name / vendor id (case-insensitive)', () => {
+    expect(
+      filterMentionContacts(contacts, 'h').map((c) => c.providerId)
+    ).toEqual(['hermes']);
+    expect(
+      filterMentionContacts(contacts, 'Cod').map((c) => c.providerId)
+    ).toEqual(['codex']);
   });
 
-  it('returns the whole roster for an empty query', () => {
-    expect(filterRoster(roster, '')).toHaveLength(3);
+  it('keeps unavailable contacts in the filtered list', () => {
+    const result = filterMentionContacts(contacts, 'c');
+    expect(result.map((c) => c.providerId)).toEqual(['claude', 'codex']);
+    expect(result.some((c) => !c.available)).toBe(true);
+  });
+
+  it('returns the whole set for an empty query', () => {
+    expect(filterMentionContacts(contacts, '')).toHaveLength(3);
   });
 });
 
@@ -74,43 +116,112 @@ describe('MentionPalette rendering', () => {
     container.remove();
   });
 
-  it('renders one option per entry and marks unavailable rows disabled with the reason title', async () => {
-    await act(async () => {
+  function render(contacts: MentionContact[]): void {
+    act(() => {
       root.render(
         React.createElement(MentionPalette, {
-          entries: roster,
+          contacts,
           activeIndex: 0,
           visible: true,
         })
       );
     });
+  }
 
+  it('renders one option per contact, with a kind tag and an owner label', () => {
+    render(buildMentionContacts(roster));
     const options = Array.from(
       container.querySelectorAll('[role="option"]')
     ) as HTMLElement[];
     expect(options).toHaveLength(3);
-
-    // Available rows are selectable (no aria-disabled).
-    const claudeRow = options[0]!;
-    expect(claudeRow.getAttribute('aria-disabled')).toBeNull();
-    expect(claudeRow.textContent).toContain('Claude');
-
-    // The unavailable row is greyed, aria-disabled, and exposes its reason as a
-    // hover title.
-    const codexRow = container.querySelector(
-      '.mention-palette__row--unavailable'
-    ) as HTMLElement;
-    expect(codexRow).not.toBeNull();
-    expect(codexRow.getAttribute('aria-disabled')).toBe('true');
-    expect(codexRow.getAttribute('title')).toBe('no api key configured');
-    expect(codexRow.getAttribute('role')).toBe('option');
+    const claude = options[0]!;
+    expect(claude.textContent).toContain('Claude');
+    expect(claude.querySelector('.mention-palette__kind')?.textContent).toBe(
+      'vendor'
+    );
+    expect(claude.querySelector('.mention-palette__owner')?.textContent).toBe(
+      'system'
+    );
   });
 
-  it('hides the listbox when not visible', async () => {
-    await act(async () => {
+  it('marks an unavailable contact inert with its reason as the hover title', () => {
+    render(buildMentionContacts(roster));
+    const inert = container.querySelector(
+      '.mention-palette__row--inert'
+    ) as HTMLElement;
+    expect(inert).not.toBeNull();
+    expect(inert.getAttribute('aria-disabled')).toBe('true');
+    expect(inert.getAttribute('title')).toBe('no api key configured');
+    expect(inert.textContent).toContain('no api key configured');
+  });
+
+  it('renders a not-in-channel state and marks the row inert', () => {
+    const notMember: MentionContact = {
+      id: 'agent-profile:claude:reviewer',
+      providerId: 'claude',
+      displayName: 'Reviewer',
+      kind: 'profile',
+      owner: 'donovan',
+      available: true,
+      reason: null,
+      inChannel: false,
+      isDefault: false,
+      isBuiltIn: false,
+    };
+    render([notMember]);
+    const row = container.querySelector('[role="option"]') as HTMLElement;
+    expect(row.className).toContain('mention-palette__row--inert');
+    expect(row.getAttribute('aria-disabled')).toBe('true');
+    expect(
+      container.querySelector('.mention-palette__state')?.textContent
+    ).toBe('not in channel');
+    // owner label surfaces for a custom profile.
+    expect(
+      container.querySelector('.mention-palette__owner')?.textContent
+    ).toBe('donovan');
+  });
+
+  it('renders a monospace disambiguator token for same-name collisions', () => {
+    const collide: MentionContact[] = [
+      {
+        id: 'agent-profile:claude:aaaaaa',
+        providerId: 'claude',
+        displayName: 'Reviewer',
+        kind: 'profile',
+        owner: 'donovan',
+        available: true,
+        reason: null,
+        inChannel: true,
+        isDefault: false,
+        isBuiltIn: false,
+      },
+      {
+        id: 'agent-profile:codex:bbbbbb',
+        providerId: 'codex',
+        displayName: 'Reviewer',
+        kind: 'profile',
+        owner: 'donovan',
+        available: true,
+        reason: null,
+        inChannel: true,
+        isDefault: false,
+        isBuiltIn: false,
+      },
+    ];
+    // Annotate exactly as the builder does before rendering.
+    render(annotateMentionCollisions(collide));
+    const tokens = Array.from(
+      container.querySelectorAll('.mention-palette__disambiguator')
+    ).map((el) => el.textContent);
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).not.toBe(tokens[1]);
+  });
+
+  it('hides the listbox when not visible', () => {
+    act(() => {
       root.render(
         React.createElement(MentionPalette, {
-          entries: roster,
+          contacts: buildMentionContacts(roster),
           activeIndex: 0,
           visible: false,
         })

--- a/test/components/mention-palette.test.ts
+++ b/test/components/mention-palette.test.ts
@@ -217,6 +217,32 @@ describe('MentionPalette rendering', () => {
     expect(tokens[0]).not.toBe(tokens[1]);
   });
 
+  it('exposes the `agents` accessible name the composer e2e locates (regression #1246)', () => {
+    // The channel-thread mention e2e finds the palette via
+    // getByRole('listbox', { name: 'agents' }); a rename to "mention contacts"
+    // silently broke it while unit CI stayed green. Pin the name here so the
+    // contract has unit-level backpressure.
+    render(buildMentionContacts(roster));
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    expect(listbox.getAttribute('aria-label')).toBe('agents');
+  });
+
+  it('opens with only vendor defaults when members are empty (mirrors the thread e2e)', () => {
+    // The thread composer receives no `members`, yet typing `@` must still open
+    // the palette on the roster-derived vendor defaults — the paletteVisible
+    // gate keys on a non-empty contact set, so an empty members list must not
+    // collapse it to zero rows.
+    const contacts = buildMentionContacts(roster, []);
+    expect(contacts.length).toBeGreaterThan(0);
+    expect(filterMentionContacts(contacts, '')).toHaveLength(contacts.length);
+    render(contacts);
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    expect(listbox.style.display).not.toBe('none');
+    expect(
+      container.querySelectorAll('[role="option"]').length
+    ).toBeGreaterThan(0);
+  });
+
   it('hides the listbox when not visible', () => {
     act(() => {
       root.render(

--- a/test/lib/mention-contacts.test.ts
+++ b/test/lib/mention-contacts.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  builtInAgentProfileId,
+  computeMentionDisambiguators,
+} from '../../shared/agent-profile.js';
+import {
+  annotateMentionCollisions,
+  filterMentionContacts,
+  isMentionContactSelectable,
+  mentionInsertText,
+  resolveMentionContact,
+  toResolverContacts,
+  type MentionContact,
+} from '../../shared/mention-contacts.js';
+
+function vendorDefault(providerId: string, label: string): MentionContact {
+  return {
+    id: builtInAgentProfileId(providerId),
+    providerId,
+    displayName: label,
+    kind: 'vendor-default',
+    owner: 'system',
+    available: true,
+    reason: null,
+    inChannel: true,
+    isDefault: true,
+    isBuiltIn: true,
+  };
+}
+
+function customProfile(
+  id: string,
+  providerId: string,
+  displayName: string
+): MentionContact {
+  return {
+    id,
+    providerId,
+    displayName,
+    kind: 'profile',
+    owner: 'donovan',
+    available: true,
+    reason: null,
+    inChannel: true,
+    isDefault: false,
+    isBuiltIn: false,
+  };
+}
+
+describe('computeMentionDisambiguators', () => {
+  it('assigns a unique token to each member of a same-name group only', () => {
+    const tokens = computeMentionDisambiguators([
+      { id: 'agent-profile:claude:aaaaaa', displayName: 'Reviewer' },
+      { id: 'agent-profile:codex:bbbbbb', displayName: 'Reviewer' },
+      { id: 'agent-profile:claude:solo', displayName: 'Backend' },
+    ]);
+    const a = tokens.get('agent-profile:claude:aaaaaa');
+    const b = tokens.get('agent-profile:codex:bbbbbb');
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+    // The lone "Backend" name is not a collision — no token.
+    expect(tokens.get('agent-profile:claude:solo')).toBeUndefined();
+  });
+
+  it('grows the id slice until same-suffix ids are still distinguishable', () => {
+    // Both ids end in "reviewer"; the token must reach back past the common tail.
+    const tokens = computeMentionDisambiguators([
+      { id: 'agent-profile:claude:reviewer', displayName: 'Reviewer' },
+      { id: 'agent-profile:codex:reviewer', displayName: 'Reviewer' },
+    ]);
+    const a = tokens.get('agent-profile:claude:reviewer')!;
+    const b = tokens.get('agent-profile:codex:reviewer')!;
+    expect(a).not.toBe(b);
+  });
+
+  it('ignores empty display names (vendor defaults)', () => {
+    const tokens = computeMentionDisambiguators([
+      { id: builtInAgentProfileId('claude'), displayName: '' },
+      { id: builtInAgentProfileId('codex'), displayName: '' },
+    ]);
+    expect(tokens.size).toBe(0);
+  });
+});
+
+describe('toResolverContacts', () => {
+  it('blanks the vendor-default display name (alias-only) but keeps others', () => {
+    const resolver = toResolverContacts([
+      vendorDefault('claude', 'Claude'),
+      customProfile('agent-profile:claude:backend', 'claude', 'Backend'),
+    ]);
+    expect(resolver[0]!.displayName).toBe('');
+    expect(resolver[1]!.displayName).toBe('Backend');
+  });
+});
+
+describe('annotateMentionCollisions', () => {
+  it('stamps a disambiguator on colliding names and leaves unique ones bare', () => {
+    const annotated = annotateMentionCollisions([
+      customProfile('agent-profile:claude:aaaaaa', 'claude', 'Reviewer'),
+      customProfile('agent-profile:codex:bbbbbb', 'codex', 'Reviewer'),
+      customProfile('agent-profile:claude:cccccc', 'claude', 'Backend'),
+    ]);
+    expect(annotated[0]!.disambiguator).toBeDefined();
+    expect(annotated[1]!.disambiguator).toBeDefined();
+    expect(annotated[0]!.disambiguator).not.toBe(annotated[1]!.disambiguator);
+    expect(annotated[2]!.disambiguator).toBeUndefined();
+  });
+});
+
+describe('mentionInsertText', () => {
+  it('inserts the vendor alias for a vendor default', () => {
+    expect(mentionInsertText(vendorDefault('claude', 'Claude'))).toBe(
+      '@claude'
+    );
+  });
+
+  it('inserts the display name for a unique named profile', () => {
+    expect(
+      mentionInsertText(
+        customProfile(
+          'agent-profile:claude:backend',
+          'claude',
+          'Backend Claude'
+        )
+      )
+    ).toBe('@Backend Claude');
+  });
+
+  it('appends the disambiguator token for a collision', () => {
+    const [a] = annotateMentionCollisions([
+      customProfile('agent-profile:claude:aaaaaa', 'claude', 'Reviewer'),
+      customProfile('agent-profile:codex:bbbbbb', 'codex', 'Reviewer'),
+    ]);
+    expect(mentionInsertText(a!)).toBe(`@Reviewer#${a!.disambiguator}`);
+  });
+});
+
+describe('resolveMentionContact', () => {
+  const contacts = [
+    vendorDefault('claude', 'Claude'),
+    customProfile('agent-profile:claude:backend', 'claude', 'Backend'),
+    customProfile(
+      'agent-profile:claude:backend-claude',
+      'claude',
+      'Backend Claude'
+    ),
+  ];
+
+  it('resolves a vendor alias to the vendor default contact', () => {
+    expect(resolveMentionContact('@claude', contacts)?.id).toBe(
+      builtInAgentProfileId('claude')
+    );
+  });
+
+  it('resolves the longest display name over a shorter prefix', () => {
+    expect(resolveMentionContact('@Backend Claude', contacts)?.id).toBe(
+      'agent-profile:claude:backend-claude'
+    );
+    expect(resolveMentionContact('@Backend', contacts)?.id).toBe(
+      'agent-profile:claude:backend'
+    );
+  });
+});
+
+describe('isMentionContactSelectable', () => {
+  it('is true only when available and in channel', () => {
+    const base = vendorDefault('claude', 'Claude');
+    expect(isMentionContactSelectable(base)).toBe(true);
+    expect(isMentionContactSelectable({ ...base, available: false })).toBe(
+      false
+    );
+    expect(isMentionContactSelectable({ ...base, inChannel: false })).toBe(
+      false
+    );
+  });
+});
+
+describe('filterMentionContacts', () => {
+  it('matches on the disambiguator token too', () => {
+    const contacts = annotateMentionCollisions([
+      customProfile('agent-profile:claude:aaaaaa', 'claude', 'Reviewer'),
+      customProfile('agent-profile:codex:bbbbbb', 'codex', 'Reviewer'),
+    ]);
+    const token = contacts[0]!.disambiguator!;
+    const result = filterMentionContacts(contacts, token);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('agent-profile:claude:aaaaaa');
+  });
+});

--- a/test/lib/parse-mentions-profiles.test.ts
+++ b/test/lib/parse-mentions-profiles.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMentions } from '../../shared/channel-chat-protocol.js';
+import { builtInAgentProfileId } from '../../shared/agent-profile.js';
+import {
+  annotateMentionCollisions,
+  mentionInsertText,
+  toResolverContacts,
+  type MentionContact,
+} from '../../shared/mention-contacts.js';
+
+function vendorDefault(providerId: string, label: string): MentionContact {
+  return {
+    id: builtInAgentProfileId(providerId),
+    providerId,
+    displayName: label,
+    kind: 'vendor-default',
+    owner: 'system',
+    available: true,
+    reason: null,
+    inChannel: true,
+    isDefault: true,
+    isBuiltIn: true,
+  };
+}
+
+function customProfile(
+  id: string,
+  providerId: string,
+  displayName: string
+): MentionContact {
+  return {
+    id,
+    providerId,
+    displayName,
+    kind: 'profile',
+    owner: 'donovan',
+    available: true,
+    reason: null,
+    inChannel: true,
+    isDefault: false,
+    isBuiltIn: false,
+  };
+}
+
+// SYNTHETIC contact set: no custom-profile creation UI exists yet, so the
+// multi-word / collision machinery is proven against hand-built profiles that
+// share a vendor and, deliberately, a display name.
+const CONTACTS = annotateMentionCollisions([
+  vendorDefault('claude', 'Claude'),
+  vendorDefault('codex', 'Codex'),
+  customProfile('agent-profile:claude:backend', 'claude', 'Backend'),
+  customProfile(
+    'agent-profile:claude:backend-claude',
+    'claude',
+    'Backend Claude'
+  ),
+  customProfile('agent-profile:claude:rev1', 'claude', 'Reviewer'),
+  customProfile('agent-profile:codex:rev2', 'codex', 'Reviewer'),
+  {
+    id: 'human:alex',
+    providerId: 'human',
+    displayName: 'alex',
+    kind: 'human',
+    owner: '',
+    available: true,
+    reason: null,
+    inChannel: true,
+    isDefault: false,
+    isBuiltIn: false,
+  },
+]);
+const RESOLVER = toResolverContacts(CONTACTS);
+
+const rev1 = CONTACTS.find((c) => c.id === 'agent-profile:claude:rev1')!;
+const rev2 = CONTACTS.find((c) => c.id === 'agent-profile:codex:rev2')!;
+
+describe('parseMentions — vendor-default alias', () => {
+  it('resolves @claude to the vendor default profile id', () => {
+    expect(parseMentions('ping @claude now', [], RESOLVER)).toEqual([
+      {
+        raw: '@claude',
+        providerId: 'claude',
+        profileId: builtInAgentProfileId('claude'),
+      },
+    ]);
+  });
+
+  it('is case-insensitive on the alias', () => {
+    const [m] = parseMentions('@CLAUDE', [], RESOLVER);
+    expect(m?.profileId).toBe(builtInAgentProfileId('claude'));
+  });
+});
+
+describe('parseMentions — named, longest-match-first', () => {
+  it('prefers a multi-word name over a shorter prefix', () => {
+    expect(parseMentions('@Backend Claude ship it', [], RESOLVER)).toEqual([
+      {
+        raw: '@Backend Claude',
+        providerId: 'claude',
+        profileId: 'agent-profile:claude:backend-claude',
+      },
+    ]);
+  });
+
+  it('still resolves the shorter name for the shorter token', () => {
+    expect(parseMentions('@Backend please', [], RESOLVER)).toEqual([
+      {
+        raw: '@Backend',
+        providerId: 'claude',
+        profileId: 'agent-profile:claude:backend',
+      },
+    ]);
+  });
+
+  it('does not swallow trailing prose past the matched name', () => {
+    // "backend now" is not a profile name; only "backend" is consumed.
+    const [m] = parseMentions('@Backend now go', [], RESOLVER);
+    expect(m?.raw).toBe('@Backend');
+    expect(m?.profileId).toBe('agent-profile:claude:backend');
+  });
+
+  it('resolves a human contact by name', () => {
+    const [m] = parseMentions('hey @alex look', [], RESOLVER);
+    expect(m?.profileId).toBe('human:alex');
+    expect(m?.providerId).toBe('human');
+  });
+});
+
+describe('parseMentions — collision disambiguation', () => {
+  it('resolves a bare colliding name to the deterministic tiebreak winner', () => {
+    const [m] = parseMentions('@Reviewer', [], RESOLVER);
+    // smallest id wins the keystone tiebreak: claude:rev1 < codex:rev2.
+    expect(m?.profileId).toBe('agent-profile:claude:rev1');
+  });
+
+  it('a #token selects the specific same-name profile', () => {
+    const [a] = parseMentions(`@Reviewer#${rev1.disambiguator}`, [], RESOLVER);
+    expect(a?.profileId).toBe('agent-profile:claude:rev1');
+    const [b] = parseMentions(`@Reviewer#${rev2.disambiguator}`, [], RESOLVER);
+    expect(b?.profileId).toBe('agent-profile:codex:rev2');
+  });
+
+  it('a #token that matches no peer falls back to the resolver winner', () => {
+    const [m] = parseMentions('@Reviewer#zzzzzz', [], RESOLVER);
+    expect(m?.profileId).toBe('agent-profile:claude:rev1');
+  });
+});
+
+describe('parseMentions — round-trip', () => {
+  it('every inserted mention text parses back to the same profile Actor id', () => {
+    for (const contact of CONTACTS) {
+      const text = mentionInsertText(contact);
+      const [m] = parseMentions(text, [], RESOLVER);
+      expect(m, `round-trip for ${contact.id}`).toBeDefined();
+      expect(m!.profileId, `round-trip for ${contact.id}`).toBe(contact.id);
+    }
+  });
+});
+
+describe('parseMentions — hardening carried over', () => {
+  it('dedupes repeated resolved mentions by profile id', () => {
+    expect(parseMentions('@claude @Claude @claude', [], RESOLVER)).toEqual([
+      {
+        raw: '@claude',
+        providerId: 'claude',
+        profileId: builtInAgentProfileId('claude'),
+      },
+    ]);
+  });
+
+  it('ignores mentions inside code spans', () => {
+    expect(parseMentions('```\n@claude\n```', [], RESOLVER)).toEqual([]);
+    expect(parseMentions('run `@Reviewer`', [], RESOLVER)).toEqual([]);
+  });
+
+  it('ignores emails and a bare @', () => {
+    expect(parseMentions('mail foo@bar.com', [], RESOLVER)).toEqual([]);
+    expect(parseMentions('meet @ noon', [], RESOLVER)).toEqual([]);
+  });
+
+  it('keeps an unresolved mention with its raw token, provider-tagged if known', () => {
+    const out = parseMentions('@nobody and @hermes', ['hermes'], RESOLVER);
+    expect(out).toEqual([
+      { raw: '@nobody' },
+      { raw: '@hermes', providerId: 'hermes' },
+    ]);
+  });
+});


### PR DESCRIPTION
Slice 4 of epic #1232. Makes `@mention` autocomplete profile-aware and collision-ready, resolving against a **contact set** rather than a bare vendor list. Builds on the merged keystone #1233 (`AgentProfile`, `resolveProfileForMention`, `builtInAgentProfileId`).

## Contact-set source: client-side synthesis (no new endpoint)
Chose **client-side synthesis** over a server profiles-list endpoint, per the slice guidance to stay tight and because the only live agent contacts today are vendor defaults:
- **Agent contacts** = vendor DEFAULT profiles synthesized from the channel roster the composer already fetches (`GET /channels/:id/roster`), each keyed on `builtInAgentProfileId(vendor)`, `providerId = vendor`, label from the framework catalog, kind `vendor-default`, owner `system`.
- **Human contacts** = the channel members `ChannelView` already holds (`channel.members`), kind `human`.
- The set is fed through the keystone `resolveProfileForMention` shape, so when a later slice adds custom-profile creation those rows slot in as kind `profile` with their own ids — `buildMentionContacts` is the only place that changes. No custom-profile CRUD and no avatar UI added (avatars are slice #1235).

## Resolution reuses the keystone resolver
`parseMentions` gains an optional contact set. It reads a greedy word run after each `@` and resolves **longest-exact-first**, delegating vendor-alias + tiebreak to the keystone `resolveProfileForMention` (not reimplemented):
- `@<vendor>` → that vendor's default profile id (alias path; vendor defaults carry an empty resolver name so a user-named profile is never shadowed).
- Multi-word names beat a shorter prefix (`@Backend Claude` > `@Backend`); an over-consume guard rejects a shorter name matched by prefix so trailing prose is never swallowed.
- Case-insensitive; dedupes by resolved profile id; still skips code spans / emails / bare `@`.
- Sets `ChannelMention.profileId` (new, additive/optional) and keeps `providerId` populated. Every current server caller passes no contact set and is byte-for-byte unchanged.

## Collision disambiguation (local id only)
`computeMentionDisambiguators` stamps same-display-name contacts with a **short stable slice of the local Actor id**, grown until unique within the group. The palette renders it as plain monospace text (not a badge). Inserted text for a collision is `@Name#<token>`; `parseMentions` recomputes the identical tokens from the same contact set and selects the right peer.

**boundaryCheck (#1231):** every id is a local hub Actor id; the disambiguator is an id slice — never an npub/public key, no team/community directory.

## Round-trip guarantee
`mentionInsertText(contact)` (what the palette inserts) round-trips through `parseMentions` back to the same profile Actor id — vendor alias, multi-word name, and `#token` collision all covered by a parametrized test over the synthetic contact set.

## Palette (DESIGN.md)
Each row shows a kind tag (`profile`/`vendor`/`human`), owner label, a not-in-channel state, and the collision token. No emoji, zero border-radius, flat monochrome SVG line icons (human glyph added), FZF/`>` command-palette vocabulary, monospace token.

## Validation
- `npm run check` — 0 errors (pre-existing warnings only).
- `npm run build` — passes.
- New: `test/lib/parse-mentions-profiles.test.ts`, `test/lib/mention-contacts.test.ts`; rewritten `test/components/mention-palette.test.ts`. Existing `test/agent-profile.test.ts`, `test/channel-chat-protocol.test.ts`, `test/lib/mention-trigger.test.ts`, `test/channel-agent-binder.test.ts`, `test/channel-agent-bridge.test.ts`, `test/channel-mention-e2e.test.ts` stay green.
- Pre-push ran 527 changed-related tests: all pass.

Closes #1236