### PR TITLE
fix(sessions): bound web_sessions agent transcript growth (#1243)

### DIFF
--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -344,6 +344,13 @@ export interface ChannelMessageStore {
   listMembers(channelId: string): ChannelMemberRef[];
   findDmChannel(memberIdA: string, memberIdB: string): string | null;
   getBinding(channelId: string, agentFramework: string): ChannelBinding | null;
+  /**
+   * Distinct non-null `session_id`s across every channel binding. Feeds the
+   * relay-state-db age-reaper's protection set (#1248) so a web_session still
+   * bound as an open channel's agent is never reaped, preserving its resume
+   * anchor even when its `last_activity` is older than the retention window.
+   */
+  listBoundSessionIds(): string[];
   upsertBinding(input: {
     channelId: string;
     agentFramework: string;
@@ -1458,6 +1465,15 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
 
     getBinding(channelId, agentFramework) {
       return getBindingImpl(channelId, agentFramework);
+    },
+
+    listBoundSessionIds() {
+      const rows = db
+        .prepare(
+          'SELECT DISTINCT session_id FROM channel_agent_bindings WHERE session_id IS NOT NULL'
+        )
+        .all() as Array<{ session_id: string }>;
+      return rows.map((row) => row.session_id);
     },
 
     upsertBinding(input) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -90,6 +90,7 @@ import {
   initRelayStateDb,
   closeRelayStateDb,
   flushAllPendingWrites as flushRelayStateWrites,
+  setReapProtectedSessionIdsProvider,
 } from './relay-state-db.js';
 import {
   createWorkContextRouter,
@@ -2145,6 +2146,21 @@ async function main(): Promise<void> {
       channelAgentBinder.handleMessagePosted(message, mentions)
     );
   }
+
+  // Teach the relay-state-db age-reaper (#1248) which web_sessions must never be
+  // evicted: every session live in the in-memory map (including disconnected-
+  // but-retained ones a channel binding may rebind) plus every session still
+  // referenced by an open channel binding. Without this the reaper could drop a
+  // stale-but-still-wanted session's row and destroy its resume anchor.
+  setReapProtectedSessionIdsProvider(() => {
+    const protectedIds = new Set<string>(sessions.liveSessionIds());
+    if (channelMessageStore) {
+      for (const id of channelMessageStore.listBoundSessionIds()) {
+        protectedIds.add(id);
+      }
+    }
+    return protectedIds;
+  });
   const cliGatewayEventBus = createCliGatewayEventBus();
 
   try {

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -18,8 +18,18 @@ let upsertWebStmt: Database.Statement | null = null;
 let deleteWebStmt: Database.Statement | null = null;
 let markStatusStmt: Database.Statement | null = null;
 let loadAllWebStmt: Database.Statement | null = null;
-let reapDisconnectedStmt: Database.Statement | null = null;
+let reapCandidatesStmt: Database.Statement | null = null;
 let maintenanceTimer: NodeJS.Timeout | null = null;
+/**
+ * Resolver for session ids the reaper must never delete: those live in the
+ * in-memory session map AND those still bound to an open channel. Registered by
+ * the wiring layer (server/index.ts) which owns both the session map and the
+ * channel-binding store; relay-state-db cannot reach either directly. Until it
+ * is registered the timer-driven reap fails safe (no-op) rather than risk
+ * dropping a resume anchor. Reset on close for test isolation.
+ */
+let reapProtectedIdsProvider: (() => Iterable<string>) | null = null;
+let warnedNoReapProvider = false;
 
 // ── Storage-hygiene tunables (#1243) ──────────────────────────────────────
 /**
@@ -28,10 +38,18 @@ let maintenanceTimer: NodeJS.Timeout | null = null;
  * makes SQLite truncate the WAL back to this bound after each checkpoint.
  */
 const JOURNAL_SIZE_LIMIT_BYTES = 4 * 1024 * 1024;
-/** Restore at most the most-recent K non-archived rows on boot. */
-const MAX_RESTORE_SESSIONS = 50;
-/** Disconnected rows older than this are reaped (boot + interval). */
-const DISCONNECTED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * Age-reap window (#1248). A web_session whose `last_activity` predates this is
+ * evicted regardless of status EXCEPT `archived` (a deliberate user keep backing
+ * the archive browse/restore lane). The v2 reducer derives an idle session to
+ * status `active` — never `disconnected` — so a status-scoped reaper leaks idle
+ * rows forever; gating on age instead bounds total row count over time. This is
+ * what makes restoring ALL non-archived rows on boot safe (count stays bounded
+ * without a restore LIMIT). Live/connected and still-channel-bound sessions are
+ * excluded via {@link reapProtectedIdsProvider} even when old, so resume anchors
+ * are never dropped.
+ */
+const WEB_SESSION_IDLE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 /** Periodic checkpoint + freelist-reclaim + reap cadence. */
 const MAINTENANCE_INTERVAL_MS = 10 * 60 * 1000;
 
@@ -173,32 +191,32 @@ export function initRelayStateDb(configDir: string): void {
   markStatusStmt = db.prepare(
     'UPDATE web_sessions SET status = ?, last_activity = ? WHERE id = ?'
   );
-  // Restore only the most-recent K rows (belt-and-suspenders bound on boot rss
-  // even if the reaper has not yet caught a backlog), returned oldest-first so
-  // display-name counter sync and ordering match the historical behaviour.
+  // Restore ALL non-archived rows on boot (#1248), oldest-first so display-name
+  // counter sync and ordering match historical behaviour. There is deliberately
+  // no LIMIT: a restore cap silently dropped older sessions from the in-memory
+  // map, which broke channel-agent resume (the binder respawned a fresh session
+  // with a new providerSession) and orphaned direct sessions past the cap. The
+  // per-session transcript cap already bounds each row's memory; total row count
+  // is bounded instead by the age-reaper below.
   loadAllWebStmt = db.prepare(
     `SELECT id, vendor, vendor_session_id, cwd, repo_path, worktree_path,
             branch_name, display_name, workspace_id, agent_session_v2_json,
             meta_json, created_at, last_activity, status
-     FROM (
-       SELECT id, vendor, vendor_session_id, cwd, repo_path, worktree_path,
-              branch_name, display_name, workspace_id, agent_session_v2_json,
-              meta_json, created_at, last_activity, status
-       FROM web_sessions
-       WHERE status != 'archived'
-       ORDER BY last_activity DESC
-       LIMIT @limit
-     )
+     FROM web_sessions
+     WHERE status != 'archived'
      ORDER BY last_activity ASC`
   );
-  reapDisconnectedStmt = db.prepare(
-    `DELETE FROM web_sessions
-      WHERE status = 'disconnected' AND last_activity < @cutoff`
+  reapCandidatesStmt = db.prepare(
+    `SELECT id FROM web_sessions
+      WHERE status != 'archived' AND last_activity < @cutoff`
   );
 
-  // Boot-time reclaim + reap, then a periodic pass so a long-lived hub keeps
-  // the WAL checkpointed, the freelist returned, and stale rows evicted.
-  reapStaleWebSessions();
+  // Boot-time reclaim keeps the WAL checkpointed + freelist returned. Reaping is
+  // deferred to the periodic timer, NOT run here: at boot the in-memory session
+  // map is empty and the protected-id provider is not yet registered, so an
+  // eager reap could delete a stale-but-wanted row that restore is about to
+  // bring back / rebind. By the first interval tick, restore and provider
+  // registration have completed and the reap consults the live protection set.
   runRelayStateDbMaintenance();
   maintenanceTimer = setInterval(() => {
     reapStaleWebSessions();
@@ -208,23 +226,66 @@ export function initRelayStateDb(configDir: string): void {
 }
 
 /**
- * Delete `disconnected` rows whose last activity predates the TTL. Never
- * touches `active` (live/connected) or `archived` rows. Returns the count
- * removed (0 when the store is closed or nothing was stale).
+ * Register (or clear with `null`) the resolver for session ids the reaper must
+ * never delete. Production supplies the union of live in-memory session ids and
+ * session ids still referenced by an open channel binding, so a recent OR still-
+ * bound session survives even when its `last_activity` is older than the window.
  */
-export function reapStaleWebSessions(): number {
-  if (!db || !reapDisconnectedStmt) return 0;
-  try {
-    const result = reapDisconnectedStmt.run({
-      cutoff: Date.now() - DISCONNECTED_TTL_MS,
-    });
-    if (result.changes > 0) {
-      logger.info(
-        'reaped %d stale disconnected web session(s)',
-        result.changes
-      );
+export function setReapProtectedSessionIdsProvider(
+  provider: (() => Iterable<string>) | null
+): void {
+  reapProtectedIdsProvider = provider;
+}
+
+/**
+ * Delete web_session rows whose `last_activity` predates {@link
+ * WEB_SESSION_IDLE_TTL_MS}, regardless of status EXCEPT `archived`. Protected
+ * ids — live/connected sessions and sessions still bound to an open channel —
+ * are excluded so resume anchors are never dropped. Returns the count removed.
+ *
+ * Protection resolves from `options.protectedIds` when given (tests), otherwise
+ * from the registered provider (production). With neither available the reap is
+ * a no-op: failing safe beats risking deletion of a live or still-bound session.
+ */
+export function reapStaleWebSessions(options?: {
+  protectedIds?: Iterable<string>;
+  nowMs?: number;
+}): number {
+  if (!db || !reapCandidatesStmt || !deleteWebStmt) return 0;
+
+  let protectedIds: Set<string>;
+  if (options?.protectedIds !== undefined) {
+    protectedIds = new Set(options.protectedIds);
+  } else if (reapProtectedIdsProvider) {
+    try {
+      protectedIds = new Set(reapProtectedIdsProvider());
+    } catch (err) {
+      logger.warn('reap protected-id provider threw: %s', err);
+      return 0;
     }
-    return result.changes;
+  } else {
+    if (!warnedNoReapProvider) {
+      warnedNoReapProvider = true;
+      logger.warn('reap skipped: no protected-id provider registered');
+    }
+    return 0;
+  }
+
+  const cutoff = (options?.nowMs ?? Date.now()) - WEB_SESSION_IDLE_TTL_MS;
+  try {
+    const candidates = reapCandidatesStmt.all({ cutoff }) as Array<{
+      id: string;
+    }>;
+    const doomed = candidates
+      .map((row) => row.id)
+      .filter((id) => !protectedIds.has(id));
+    if (doomed.length === 0) return 0;
+    const reap = db.transaction((ids: string[]) => {
+      for (const id of ids) deleteWebStmt!.run(id);
+    });
+    reap(doomed);
+    logger.info('reaped %d stale web session(s) by age', doomed.length);
+    return doomed.length;
   } catch (err) {
     logger.warn('reap failed: %s', err);
     return 0;
@@ -257,6 +318,10 @@ export function closeRelayStateDb(): void {
     clearInterval(maintenanceTimer);
     maintenanceTimer = null;
   }
+  // Drop the reaper protection resolver so a re-init (and test isolation) starts
+  // from a clean slate rather than a provider closed over a stale session map.
+  reapProtectedIdsProvider = null;
+  warnedNoReapProvider = false;
   if (db) {
     // Final reclaim so a clean shutdown leaves a truncated WAL + returned
     // freelist rather than the ~15MB high-water marks issue #1243 documented.
@@ -267,7 +332,7 @@ export function closeRelayStateDb(): void {
     deleteWebStmt = null;
     markStatusStmt = null;
     loadAllWebStmt = null;
-    reapDisconnectedStmt = null;
+    reapCandidatesStmt = null;
   }
 }
 
@@ -461,7 +526,7 @@ export function markWebSessionStatus(
 export function loadAllWebSessions(): LoadedWebSessionRow[] {
   if (!db || !loadAllWebStmt) return [];
 
-  const rows = loadAllWebStmt.all({ limit: MAX_RESTORE_SESSIONS }) as Array<{
+  const rows = loadAllWebStmt.all() as Array<{
     id: string;
     vendor: string;
     vendor_session_id: string | null;

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -1,7 +1,10 @@
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import type { WebSession } from './types.js';
-import type { AgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  capAgentSessionTranscriptV2,
+  type AgentSessionV2,
+} from '../shared/agent-chat-protocol-v2.js';
 import {
   normalizeControlStateSummary,
   type ControlStateSummary,
@@ -15,6 +18,22 @@ let upsertWebStmt: Database.Statement | null = null;
 let deleteWebStmt: Database.Statement | null = null;
 let markStatusStmt: Database.Statement | null = null;
 let loadAllWebStmt: Database.Statement | null = null;
+let reapDisconnectedStmt: Database.Statement | null = null;
+let maintenanceTimer: NodeJS.Timeout | null = null;
+
+// ── Storage-hygiene tunables (#1243) ──────────────────────────────────────
+/**
+ * Cap the WAL high-water mark. A single multi-MB blob transaction otherwise
+ * pins the WAL to its size until a full checkpoint runs; journal_size_limit
+ * makes SQLite truncate the WAL back to this bound after each checkpoint.
+ */
+const JOURNAL_SIZE_LIMIT_BYTES = 4 * 1024 * 1024;
+/** Restore at most the most-recent K non-archived rows on boot. */
+const MAX_RESTORE_SESSIONS = 50;
+/** Disconnected rows older than this are reaped (boot + interval). */
+const DISCONNECTED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** Periodic checkpoint + freelist-reclaim + reap cadence. */
+const MAINTENANCE_INTERVAL_MS = 10 * 60 * 1000;
 
 const SCHEMA_V1 = `
 CREATE TABLE IF NOT EXISTS web_sessions (
@@ -106,6 +125,22 @@ export function initRelayStateDb(configDir: string): void {
   db = new Database(dbPath);
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
+  // Reclaim the freelist to the OS instead of letting it grow unbounded
+  // (issue #1243: ~15MB of orphaned overflow pages never returned). A
+  // pre-existing db created with auto_vacuum=NONE (0) only adopts the new mode
+  // after a one-time VACUUM — gate that on the current mode so it runs at most
+  // once (VACUUM flips the pragma to 2), never on every boot.
+  try {
+    const autoVacuum = db.pragma('auto_vacuum', { simple: true }) as number;
+    if (autoVacuum !== 2) {
+      db.pragma('auto_vacuum = INCREMENTAL');
+      // Must run outside any transaction; nothing is open here yet.
+      db.exec('VACUUM');
+    }
+  } catch (err) {
+    logger.warn('auto_vacuum conversion failed: %s', err);
+  }
+  db.pragma(`journal_size_limit = ${JOURNAL_SIZE_LIMIT_BYTES}`);
 
   db.exec(
     `CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)`
@@ -138,26 +173,101 @@ export function initRelayStateDb(configDir: string): void {
   markStatusStmt = db.prepare(
     'UPDATE web_sessions SET status = ?, last_activity = ? WHERE id = ?'
   );
+  // Restore only the most-recent K rows (belt-and-suspenders bound on boot rss
+  // even if the reaper has not yet caught a backlog), returned oldest-first so
+  // display-name counter sync and ordering match the historical behaviour.
   loadAllWebStmt = db.prepare(
     `SELECT id, vendor, vendor_session_id, cwd, repo_path, worktree_path,
             branch_name, display_name, workspace_id, agent_session_v2_json,
             meta_json, created_at, last_activity, status
-     FROM web_sessions
-     WHERE status != 'archived'
+     FROM (
+       SELECT id, vendor, vendor_session_id, cwd, repo_path, worktree_path,
+              branch_name, display_name, workspace_id, agent_session_v2_json,
+              meta_json, created_at, last_activity, status
+       FROM web_sessions
+       WHERE status != 'archived'
+       ORDER BY last_activity DESC
+       LIMIT @limit
+     )
      ORDER BY last_activity ASC`
   );
+  reapDisconnectedStmt = db.prepare(
+    `DELETE FROM web_sessions
+      WHERE status = 'disconnected' AND last_activity < @cutoff`
+  );
+
+  // Boot-time reclaim + reap, then a periodic pass so a long-lived hub keeps
+  // the WAL checkpointed, the freelist returned, and stale rows evicted.
+  reapStaleWebSessions();
+  runRelayStateDbMaintenance();
+  maintenanceTimer = setInterval(() => {
+    reapStaleWebSessions();
+    runRelayStateDbMaintenance();
+  }, MAINTENANCE_INTERVAL_MS);
+  maintenanceTimer.unref();
+}
+
+/**
+ * Delete `disconnected` rows whose last activity predates the TTL. Never
+ * touches `active` (live/connected) or `archived` rows. Returns the count
+ * removed (0 when the store is closed or nothing was stale).
+ */
+export function reapStaleWebSessions(): number {
+  if (!db || !reapDisconnectedStmt) return 0;
+  try {
+    const result = reapDisconnectedStmt.run({
+      cutoff: Date.now() - DISCONNECTED_TTL_MS,
+    });
+    if (result.changes > 0) {
+      logger.info(
+        'reaped %d stale disconnected web session(s)',
+        result.changes
+      );
+    }
+    return result.changes;
+  } catch (err) {
+    logger.warn('reap failed: %s', err);
+    return 0;
+  }
+}
+
+/**
+ * Truncate the WAL and return freed pages to the OS. Mirrors the
+ * `wal_checkpoint(TRUNCATE)` pattern in analytics.ts; `incremental_vacuum`
+ * reclaims the freelist that auto_vacuum=INCREMENTAL accumulates.
+ */
+export function runRelayStateDbMaintenance(): void {
+  if (!db) return;
+  try {
+    db.pragma('wal_checkpoint(TRUNCATE)');
+  } catch {
+    /* best-effort */
+  }
+  try {
+    db.pragma('incremental_vacuum');
+  } catch {
+    /* best-effort */
+  }
 }
 
 export function closeRelayStateDb(): void {
   flushAllPendingWrites();
   archivedIds.clear();
+  if (maintenanceTimer) {
+    clearInterval(maintenanceTimer);
+    maintenanceTimer = null;
+  }
   if (db) {
+    // Final reclaim so a clean shutdown leaves a truncated WAL + returned
+    // freelist rather than the ~15MB high-water marks issue #1243 documented.
+    runRelayStateDbMaintenance();
     db.close();
     db = null;
     upsertWebStmt = null;
     deleteWebStmt = null;
     markStatusStmt = null;
     loadAllWebStmt = null;
+    reapDisconnectedStmt = null;
   }
 }
 
@@ -254,8 +364,21 @@ export function flushAllPendingWrites(): void {
 function writeUpsert(session: WebSession): void {
   if (!upsertWebStmt) return;
 
-  const vendor = session.agentSessionV2.provider;
-  const vendorSessionId = pickVendorSessionId(session.agentSessionV2);
+  // Bound the transcript before it hits disk (#1243). Capping at the persist
+  // boundary — the single ≤1/s sink both debounced and immediate writes flow
+  // through — bounds the on-disk blob AND, by writing the trimmed structure
+  // back into the live session, the in-memory transcript (and thus the
+  // boot-time restore rss). Doing it here rather than per-append also keeps the
+  // reducer's immutable `[...items, item]` rebuild off an ever-growing array.
+  const cappedAgentSessionV2 = capAgentSessionTranscriptV2(
+    session.agentSessionV2
+  );
+  if (cappedAgentSessionV2 !== session.agentSessionV2) {
+    session.agentSessionV2 = cappedAgentSessionV2;
+  }
+
+  const vendor = cappedAgentSessionV2.provider;
+  const vendorSessionId = pickVendorSessionId(cappedAgentSessionV2);
 
   const meta: WebSessionMeta = {
     type: session.type,
@@ -283,7 +406,7 @@ function writeUpsert(session: WebSession): void {
       branchName: session.branchName ?? null,
       displayName: session.displayName ?? null,
       workspaceId: session.workspaceId ?? null,
-      agentSessionV2Json: JSON.stringify(session.agentSessionV2),
+      agentSessionV2Json: JSON.stringify(cappedAgentSessionV2),
       metaJson: JSON.stringify(meta),
       createdAt: toEpochMs(session.createdAt),
       lastActivity: toEpochMs(session.lastActivity),
@@ -338,7 +461,7 @@ export function markWebSessionStatus(
 export function loadAllWebSessions(): LoadedWebSessionRow[] {
   if (!db || !loadAllWebStmt) return [];
 
-  const rows = loadAllWebStmt.all() as Array<{
+  const rows = loadAllWebStmt.all({ limit: MAX_RESTORE_SESSIONS }) as Array<{
     id: string;
     vendor: string;
     vendor_session_id: string | null;
@@ -358,9 +481,14 @@ export function loadAllWebSessions(): LoadedWebSessionRow[] {
   const out: LoadedWebSessionRow[] = [];
   for (const row of rows) {
     try {
-      const agentSession = JSON.parse(
-        row.agent_session_v2_json
-      ) as AgentSessionV2;
+      // Cap the parsed blob before it is cloned into the live session (#1243).
+      // A row persisted before this fix landed can still be the observed 14.9MB
+      // blob; capping here bounds the restore-time JSON.parse + structuredClone
+      // burst, and the next persist rewrites the trimmed blob so disk
+      // self-heals.
+      const agentSession = capAgentSessionTranscriptV2(
+        JSON.parse(row.agent_session_v2_json) as AgentSessionV2
+      );
       const meta = JSON.parse(row.meta_json) as WebSessionMeta;
       out.push({
         id: row.id,

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -786,6 +786,16 @@ function get(id: string): Session | undefined {
   return sessions.get(id);
 }
 
+/**
+ * Ids of every session currently in the in-memory map — live/connected AND
+ * disconnected-but-retained. The relay-state-db age-reaper (#1248) treats these
+ * as protected so an idle-but-in-memory session (a channel binding still points
+ * at these to rebind) is never evicted from disk regardless of its age.
+ */
+function liveSessionIds(): string[] {
+  return [...sessions.keys()];
+}
+
 function sessionScrollbackCapacityMetadata(session: PtySession): {
   bytesDropped: number;
   capacityBytes: number;
@@ -2581,8 +2591,11 @@ async function restoreWebSessionsFromDb(
   reattachTimeoutMs: number
 ): Promise<number> {
   let restored = 0;
-  // Web sessions live in relay-state.db. No staleness wipe — DB rows persist
-  // until user archives or closes the session.
+  // Web sessions live in relay-state.db. Rows persist until the user archives or
+  // closes the session, OR until the relay-state-db age-reaper (#1248) evicts a
+  // row idle past its retention window — but never one that is live in-memory or
+  // still bound to an open channel, so resume anchors survive. loadAllWebSessions
+  // restores ALL non-archived rows (no restore cap); the reaper bounds count.
   for (const row of loadAllWebSessions()) {
     if (webSessionRestoreShutdown) break;
     try {
@@ -2796,6 +2809,7 @@ export {
   renew,
   createWeb,
   get,
+  liveSessionIds,
   list,
   kill,
   detachForRestart,

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -1023,6 +1023,225 @@ export function applyAgentPatchV2(
   }
 }
 
+// ── Transcript FIFO cap (#1243) ───────────────────────────────────────────
+//
+// `AgentSessionV2.turns` is otherwise unbounded: every streamed delta appends
+// to `turns[].items[]`, so a long-lived channel-agent web session grows the
+// persisted `agent_session_v2_json` blob (and the boot-time restore that
+// JSON.parses + structuredClones it) without limit. We bound the transcript to
+// a FIFO byte budget, mirroring the 256KB PTY scrollback / 256KB
+// MAX_IMPORT_TRANSCRIPT_BYTES import discipline: the most-recent tail (what
+// resume + rendering actually need — provider resume rides the resume id, not
+// this display transcript) is preserved, oldest turns/items are trimmed first,
+// and a single oversized item's output/card is truncated so one giant tool
+// result cannot blow the budget on its own.
+
+/** Total FIFO byte budget for a persisted/in-memory transcript. 512KB is 2x the
+ *  256KB scrollback/import discipline — a single channel-agent turn can be
+ *  large, and the tail is display-only — while still crushing the observed
+ *  14.9MB blob ~30x (and the boot rss it amplifies into) back to a bounded
+ *  size. */
+export const MAX_TRANSCRIPT_BYTES = 512_000;
+/** Byte budget for a single item. A 2MB tool output shouldn't consume the whole
+ *  transcript budget, so an oversized item's dominant text field(s) are
+ *  truncated in place before any FIFO turn/item eviction runs. */
+export const MAX_ITEM_BYTES = 128_000;
+
+function encodedByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function jsonByteLength(value: unknown): number {
+  return encodedByteLength(JSON.stringify(value) ?? '');
+}
+
+/** Truncate a string to fit `maxBytes` (UTF-8), appending an elision marker. */
+function truncateToBytes(input: string, maxBytes: number): string {
+  const enc = new TextEncoder();
+  const originalBytes = enc.encode(input).byteLength;
+  if (originalBytes <= maxBytes) return input;
+  // Reserve headroom for the marker, then binary-search the longest prefix that
+  // fits so we never emit a partial multi-byte code point.
+  const target = Math.max(0, maxBytes - 48);
+  let lo = 0;
+  let hi = input.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (enc.encode(input.slice(0, mid)).byteLength <= target) lo = mid;
+    else hi = mid - 1;
+  }
+  const kept = input.slice(0, lo);
+  const elided = originalBytes - enc.encode(kept).byteLength;
+  return `${kept}\n… [truncated ${elided} bytes]`;
+}
+
+function truncateUnknownToBytes(value: unknown, maxBytes: number): unknown {
+  const asString =
+    typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+  if (encodedByteLength(asString) <= maxBytes) return value;
+  return truncateToBytes(asString, maxBytes);
+}
+
+/**
+ * Shrink a single item under `maxBytes` by truncating its dominant text-bearing
+ * field(s) and normalized card content. Structure-preserving: the item keeps
+ * its id/type/status so the reducer and renderer still accept it.
+ */
+function truncateItemToBudget(
+  item: AgentItemV2,
+  maxBytes: number
+): AgentItemV2 {
+  if (jsonByteLength(item) <= maxBytes) return item;
+
+  const fieldBudget = Math.max(1_000, Math.floor(maxBytes * 0.6));
+  const next = { ...item } as AgentItemV2;
+
+  if (next.card?.content !== undefined) {
+    next.card = {
+      ...next.card,
+      content: truncateToBytes(next.card.content, fieldBudget),
+    };
+  }
+
+  switch (next.type) {
+    case 'assistantMessage':
+      next.text = truncateToBytes(next.text, fieldBudget);
+      break;
+    case 'userMessage':
+      next.text = truncateToBytes(next.text, fieldBudget);
+      if (next.expandedText) {
+        next.expandedText = truncateToBytes(next.expandedText, fieldBudget);
+      }
+      break;
+    case 'reasoning':
+      next.summary = truncateToBytes(next.summary, fieldBudget);
+      if (next.detail) next.detail = truncateToBytes(next.detail, fieldBudget);
+      break;
+    case 'plan':
+      next.text = truncateToBytes(next.text, fieldBudget);
+      break;
+    case 'commandExecution':
+      next.output = truncateToBytes(next.output, fieldBudget);
+      break;
+    case 'fileChange':
+      if (next.patch) next.patch = truncateToBytes(next.patch, fieldBudget);
+      break;
+    case 'dynamicToolCall':
+      if (typeof next.content === 'string') {
+        next.content = truncateToBytes(next.content, fieldBudget);
+      }
+      if (next.result !== undefined) {
+        next.result = truncateUnknownToBytes(next.result, fieldBudget);
+      }
+      break;
+    case 'mcpToolCall':
+      if (next.result !== undefined) {
+        next.result = truncateUnknownToBytes(next.result, fieldBudget);
+      }
+      break;
+    case 'compaction':
+      next.summary = truncateToBytes(next.summary, fieldBudget);
+      break;
+    case 'errorMessage':
+      next.message = truncateToBytes(next.message, fieldBudget);
+      break;
+    case 'providerExtension':
+      next.payload = { truncated: true, namespace: next.namespace };
+      break;
+    default:
+      break;
+  }
+
+  // A pathological item may still be over budget through bulky structured
+  // fields (arguments / metadata). Drop those before giving up — they are the
+  // least resume-relevant part of a display item.
+  if (jsonByteLength(next) > maxBytes) {
+    if ('arguments' in next && next.arguments !== undefined) {
+      delete (next as { arguments?: unknown }).arguments;
+    }
+    if (next.metadata !== undefined) delete next.metadata;
+  }
+
+  return next;
+}
+
+function transcriptByteLength(turns: AgentTurnV2[]): number {
+  return jsonByteLength(turns);
+}
+
+/** FIFO-drop oldest items across turns until under budget, preserving the tail
+ *  and never leaving a retained turn with zero items. */
+function trimItemsFifo(turns: AgentTurnV2[], maxBytes: number): AgentTurnV2[] {
+  const result = turns.map((turn) => ({ ...turn, items: [...turn.items] }));
+  const totalItems = (): number =>
+    result.reduce((sum, turn) => sum + turn.items.length, 0);
+
+  while (totalItems() > 1 && transcriptByteLength(result) > maxBytes) {
+    const idx = result.findIndex((turn) => turn.items.length > 0);
+    if (idx === -1) break;
+    result[idx]!.items.shift();
+    // Drop a now-empty turn unless it is the only turn left (which must keep at
+    // least one item — the loop guard guarantees it does).
+    if (result[idx]!.items.length === 0 && result.length > 1) {
+      result.splice(idx, 1);
+    }
+  }
+  return result;
+}
+
+/**
+ * Bound an {@link AgentSessionV2} transcript to a FIFO byte budget (#1243).
+ *
+ * 1. Truncate any single oversized item's dominant text/card content.
+ * 2. FIFO-drop oldest whole turns while over budget (never the active turn).
+ * 3. If a single retained turn is still too big, FIFO-drop its oldest items,
+ *    preserving the most-recent tail.
+ *
+ * Returns the same reference when already within budget (cheap fast path).
+ */
+export function capAgentSessionTranscriptV2(
+  session: AgentSessionV2,
+  maxTranscriptBytes: number = MAX_TRANSCRIPT_BYTES,
+  maxItemBytes: number = MAX_ITEM_BYTES
+): AgentSessionV2 {
+  const activeTurnId = session.live.activeTurnId;
+
+  // Pass 1: truncate oversized single items (structure-preserving).
+  let itemsMutated = false;
+  const truncatedTurns = session.turns.map((turn) => {
+    let changed = false;
+    const items = turn.items.map((item) => {
+      const capped = truncateItemToBudget(item, maxItemBytes);
+      if (capped !== item) changed = true;
+      return capped;
+    });
+    if (!changed) return turn;
+    itemsMutated = true;
+    return { ...turn, items };
+  });
+
+  if (transcriptByteLength(truncatedTurns) <= maxTranscriptBytes) {
+    return itemsMutated ? { ...session, turns: truncatedTurns } : session;
+  }
+
+  // Pass 2: FIFO-drop oldest whole turns.
+  let working = [...truncatedTurns];
+  while (
+    working.length > 1 &&
+    transcriptByteLength(working) > maxTranscriptBytes
+  ) {
+    if (working[0]!.id === activeTurnId) break;
+    working.shift();
+  }
+
+  // Pass 3: single retained turn still too big → trim its oldest items.
+  if (transcriptByteLength(working) > maxTranscriptBytes) {
+    working = trimItemsFifo(working, maxTranscriptBytes);
+  }
+
+  return { ...session, turns: working };
+}
+
 function completeLiveStateForActiveTurn(
   session: AgentSessionV2,
   patch: AgentTurnCompletedPatchV2

--- a/test/agent-transcript-cap.test.ts
+++ b/test/agent-transcript-cap.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  capAgentSessionTranscriptV2,
+  emptyAgentSessionV2,
+  MAX_ITEM_BYTES,
+  MAX_TRANSCRIPT_BYTES,
+  type AgentItemV2,
+  type AgentSessionV2,
+  type AgentTurnV2,
+} from '../shared/agent-chat-protocol-v2.js';
+
+function bytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function commandItem(id: string, outputBytes: number): AgentItemV2 {
+  return {
+    type: 'commandExecution',
+    id,
+    command: 'echo',
+    output: 'x'.repeat(outputBytes),
+    status: 'completed',
+    startedAt: '2026-07-22T00:00:00.000Z',
+    completedAt: '2026-07-22T00:00:01.000Z',
+  };
+}
+
+function turn(id: string, items: AgentItemV2[]): AgentTurnV2 {
+  return {
+    id,
+    status: 'completed',
+    inputMessageId: `${id}-input`,
+    items,
+    startedAt: '2026-07-22T00:00:00.000Z',
+    completedAt: '2026-07-22T00:00:02.000Z',
+  };
+}
+
+function sessionWith(
+  turns: AgentTurnV2[],
+  activeTurnId: string | null = null
+): AgentSessionV2 {
+  const session = emptyAgentSessionV2({
+    id: 'cap-test',
+    provider: 'claude',
+    cwd: '/repo',
+  });
+  session.turns = turns;
+  session.live.activeTurnId = activeTurnId;
+  return session;
+}
+
+describe('capAgentSessionTranscriptV2', () => {
+  it('returns the same reference when already within budget', () => {
+    const session = sessionWith([turn('t1', [commandItem('i1', 100)])]);
+    const capped = capAgentSessionTranscriptV2(session);
+    expect(capped).toBe(session);
+  });
+
+  it('trims an over-budget transcript to the most-recent turns (FIFO)', () => {
+    // 8 turns of ~100KB each = ~800KB, over the 512KB budget.
+    const turns = Array.from({ length: 8 }, (_, i) =>
+      turn(`t${i}`, [commandItem(`t${i}-item`, 100_000)])
+    );
+    const session = sessionWith(turns);
+
+    const capped = capAgentSessionTranscriptV2(session);
+
+    expect(bytes(capped.turns)).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+    // Oldest turns dropped, newest preserved.
+    const keptIds = capped.turns.map((t) => t.id);
+    expect(keptIds).toContain('t7');
+    expect(keptIds).not.toContain('t0');
+    // FIFO: retained ids are a contiguous most-recent suffix.
+    expect(keptIds).toEqual([...keptIds].sort());
+    expect(keptIds[keptIds.length - 1]).toBe('t7');
+  });
+
+  it('truncates an oversized single item in place before FIFO eviction', () => {
+    // One turn, one item whose output alone exceeds MAX_ITEM_BYTES.
+    const session = sessionWith([turn('t1', [commandItem('big', 2_000_000)])]);
+
+    const capped = capAgentSessionTranscriptV2(session);
+
+    // Structure preserved: still one turn, one item, same id/type.
+    expect(capped.turns).toHaveLength(1);
+    expect(capped.turns[0]!.items).toHaveLength(1);
+    const item = capped.turns[0]!.items[0]!;
+    expect(item.id).toBe('big');
+    expect(item.type).toBe('commandExecution');
+    expect(bytes(item)).toBeLessThanOrEqual(MAX_ITEM_BYTES);
+    expect((item as { output: string }).output).toMatch(/truncated \d+ bytes/);
+    expect(bytes(capped.turns)).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+  });
+
+  it('never leaves a retained turn with zero items', () => {
+    const turns = Array.from({ length: 6 }, (_, i) =>
+      turn(`t${i}`, [
+        commandItem(`t${i}-a`, 60_000),
+        commandItem(`t${i}-b`, 60_000),
+        commandItem(`t${i}-c`, 60_000),
+      ])
+    );
+    const session = sessionWith(turns);
+
+    const capped = capAgentSessionTranscriptV2(session);
+
+    for (const t of capped.turns) {
+      expect(t.items.length).toBeGreaterThan(0);
+    }
+    expect(bytes(capped.turns)).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+  });
+
+  it('preserves the active turn even when it is the oldest', () => {
+    // Active turn t0 is oldest; budget forces eviction, but t0 must survive.
+    const turns = [
+      turn('t0', [commandItem('t0-item', 300_000)]),
+      turn('t1', [commandItem('t1-item', 300_000)]),
+      turn('t2', [commandItem('t2-item', 300_000)]),
+    ];
+    const session = sessionWith(turns, 't0');
+
+    const capped = capAgentSessionTranscriptV2(session);
+
+    expect(capped.turns.map((t) => t.id)).toContain('t0');
+  });
+
+  it('bounds a single huge active turn by trimming its oldest items', () => {
+    // One active turn with many items far exceeding the budget: item-level FIFO
+    // must keep the tail and stay under budget.
+    const items = Array.from({ length: 40 }, (_, i) =>
+      commandItem(`item-${i}`, 50_000)
+    );
+    const session = sessionWith([turn('t1', items)], 't1');
+
+    const capped = capAgentSessionTranscriptV2(session);
+
+    expect(capped.turns).toHaveLength(1);
+    expect(bytes(capped.turns)).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+    const keptIds = capped.turns[0]!.items.map((i) => i.id);
+    // Tail preserved (most-recent item survives), oldest evicted.
+    expect(keptIds).toContain('item-39');
+    expect(keptIds).not.toContain('item-0');
+    expect(capped.turns[0]!.items.length).toBeGreaterThan(0);
+  });
+
+  it('leaves provider/live/session identity untouched', () => {
+    const turns = Array.from({ length: 8 }, (_, i) =>
+      turn(`t${i}`, [commandItem(`t${i}-item`, 100_000)])
+    );
+    const session = sessionWith(turns);
+    session.providerSession = { claudeSessionId: 'resume-abc' };
+
+    const capped = capAgentSessionTranscriptV2(session);
+
+    expect(capped.provider).toBe('claude');
+    expect(capped.providerSession).toEqual({ claudeSessionId: 'resume-abc' });
+    expect(capped.config.cwd).toBe('/repo');
+  });
+});

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -962,6 +962,29 @@ describe('channel-message-store members and bindings', () => {
     expect(updated.sessionId).toBe('sess-9');
     expect(updated.providerSession).toEqual({ claudeSessionId: 'abc' });
   });
+
+  it('lists distinct non-null bound session ids (reaper protection) (#1248)', () => {
+    const s = store();
+    // Bound sessions across two channels; one binding has no session yet.
+    s.upsertBinding({
+      channelId: 'topic:a',
+      agentFramework: 'claude',
+      sessionId: 'sess-a',
+    });
+    s.upsertBinding({
+      channelId: 'topic:b',
+      agentFramework: 'codex',
+      sessionId: 'sess-b',
+    });
+    s.upsertBinding({
+      channelId: 'topic:c',
+      agentFramework: 'claude',
+      providerSession: { claudeSessionId: 'no-session-yet' },
+    });
+
+    const bound = s.listBoundSessionIds().sort();
+    expect(bound).toEqual(['sess-a', 'sess-b']);
+  });
 });
 
 describe('channel-message-store boot sweeps', () => {

--- a/test/server/relay-state-db.test.ts
+++ b/test/server/relay-state-db.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   initRelayStateDb,
@@ -11,9 +12,16 @@ import {
   loadAllWebSessions,
   deleteWebSession,
   markWebSessionStatus,
+  reapStaleWebSessions,
+  runRelayStateDbMaintenance,
 } from '../../server/relay-state-db.js';
 import type { WebSession } from '../../server/types.js';
-import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+import {
+  emptyAgentSessionV2,
+  MAX_TRANSCRIPT_BYTES,
+  type AgentItemV2,
+  type AgentTurnV2,
+} from '../../shared/agent-chat-protocol-v2.js';
 
 vi.mock('../../server/logger.js', () => ({
   createLogger: () => ({
@@ -187,5 +195,130 @@ describe('relay-state-db', () => {
 
     const rows = loadAllWebSessions();
     expect(rows[0]!.vendorSessionId).toBeNull();
+  });
+
+  it('caps an oversized transcript on persist and cold-resume (#1243)', () => {
+    const bigTurn = (id: string): AgentTurnV2 => ({
+      id,
+      status: 'completed',
+      inputMessageId: `${id}-input`,
+      startedAt: '2026-07-22T00:00:00.000Z',
+      completedAt: '2026-07-22T00:00:02.000Z',
+      items: [
+        {
+          type: 'commandExecution',
+          id: `${id}-cmd`,
+          command: 'echo',
+          output: 'x'.repeat(200_000),
+          status: 'completed',
+          startedAt: '2026-07-22T00:00:00.000Z',
+          completedAt: '2026-07-22T00:00:01.000Z',
+        } satisfies AgentItemV2,
+      ],
+    });
+
+    const session = fakeWebSession();
+    // ~1.6MB transcript across 8 turns — well over the 512KB budget.
+    session.agentSessionV2.turns = Array.from({ length: 8 }, (_, i) =>
+      bigTurn(`turn-${i}`)
+    );
+
+    upsertWebSessionNow(session);
+
+    // In-memory transcript is trimmed in place (bounds the live/boot rss).
+    expect(
+      Buffer.byteLength(JSON.stringify(session.agentSessionV2.turns), 'utf8')
+    ).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+
+    // Cold-resume: the persisted blob restores as a valid, bounded session that
+    // preserves the most-recent turn tail.
+    const rows = loadAllWebSessions();
+    expect(rows).toHaveLength(1);
+    const restored = rows[0]!.agentSessionV2;
+    expect(
+      Buffer.byteLength(JSON.stringify(restored.turns), 'utf8')
+    ).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+    expect(restored.turns.map((t) => t.id)).toContain('turn-7');
+    expect(restored.turns.map((t) => t.id)).not.toContain('turn-0');
+    for (const t of restored.turns) expect(t.items.length).toBeGreaterThan(0);
+  });
+
+  it('reaps stale disconnected rows but keeps recent and active ones', () => {
+    const now = Date.now();
+    const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString();
+
+    const staleDisconnected = fakeWebSession({
+      id: 'stale',
+      lastActivity: eightDaysAgo,
+    });
+    staleDisconnected.agentSessionV2.live.status = 'disconnected';
+
+    const recentDisconnected = fakeWebSession({
+      id: 'recent',
+      lastActivity: oneHourAgo,
+    });
+    recentDisconnected.agentSessionV2.live.status = 'disconnected';
+
+    const activeOld = fakeWebSession({
+      id: 'active-old',
+      lastActivity: eightDaysAgo,
+    });
+    // live.status stays idle -> derived status 'active'.
+
+    upsertWebSessionNow(staleDisconnected);
+    upsertWebSessionNow(recentDisconnected);
+    upsertWebSessionNow(activeOld);
+
+    const removed = reapStaleWebSessions();
+    expect(removed).toBe(1);
+
+    const ids = loadAllWebSessions().map((r) => r.id);
+    expect(ids).not.toContain('stale');
+    expect(ids).toContain('recent');
+    expect(ids).toContain('active-old');
+  });
+
+  it('enables incremental auto_vacuum and truncates the WAL on maintenance', () => {
+    const session = fakeWebSession();
+    session.agentSessionV2.turns = [
+      {
+        id: 'turn-0',
+        status: 'completed',
+        inputMessageId: 'in',
+        startedAt: '2026-07-22T00:00:00.000Z',
+        completedAt: '2026-07-22T00:00:01.000Z',
+        items: [
+          {
+            type: 'commandExecution',
+            id: 'c',
+            command: 'echo',
+            output: 'y'.repeat(50_000),
+            status: 'completed',
+            startedAt: '2026-07-22T00:00:00.000Z',
+            completedAt: '2026-07-22T00:00:01.000Z',
+          } satisfies AgentItemV2,
+        ],
+      },
+    ];
+    upsertWebSessionNow(session);
+    deleteWebSession(session.id); // orphan pages onto the freelist
+
+    runRelayStateDbMaintenance();
+
+    // Independent connection: auto_vacuum is INCREMENTAL (2) and the WAL was
+    // truncated back toward zero by wal_checkpoint(TRUNCATE).
+    const probe = new Database(path.join(dir, 'relay-state.db'), {
+      readonly: true,
+    });
+    try {
+      expect(probe.pragma('auto_vacuum', { simple: true })).toBe(2);
+    } finally {
+      probe.close();
+    }
+    const walPath = path.join(dir, 'relay-state.db-wal');
+    if (fs.existsSync(walPath)) {
+      expect(fs.statSync(walPath).size).toBeLessThan(1024 * 1024);
+    }
   });
 });

--- a/test/server/relay-state-db.test.ts
+++ b/test/server/relay-state-db.test.ts
@@ -13,6 +13,7 @@ import {
   deleteWebSession,
   markWebSessionStatus,
   reapStaleWebSessions,
+  setReapProtectedSessionIdsProvider,
   runRelayStateDbMaintenance,
 } from '../../server/relay-state-db.js';
 import type { WebSession } from '../../server/types.js';
@@ -243,40 +244,156 @@ describe('relay-state-db', () => {
     for (const t of restored.turns) expect(t.items.length).toBeGreaterThan(0);
   });
 
-  it('reaps stale disconnected rows but keeps recent and active ones', () => {
+  it('restores ALL non-archived rows on boot (no restore cap) (#1248)', () => {
+    // >50 rows: the removed MAX_RESTORE_SESSIONS cap used to drop the oldest,
+    // which broke channel-agent resume (binder respawned a fresh session) and
+    // orphaned direct sessions past the cap. All must restore, resume anchor
+    // (vendorSessionId) intact.
+    for (let i = 0; i < 60; i++) {
+      const session = fakeWebSession({
+        id: `sess-${i}`,
+        lastActivity: new Date(
+          Date.parse('2026-04-29T00:00:00Z') + i * 1000
+        ).toISOString(),
+      });
+      session.agentSessionV2 = emptyAgentSessionV2({
+        id: `sess-${i}`,
+        provider: 'claude',
+        cwd: '/repo',
+        capabilities: { resume: true },
+        providerSession: { claudeSessionId: `claude-${i}` },
+      });
+      upsertWebSessionNow(session);
+    }
+
+    const rows = loadAllWebSessions();
+    expect(rows).toHaveLength(60);
+    const ids = rows.map((r) => r.id);
+    // Oldest (sess-0) and newest (sess-59) both present — nothing dropped.
+    expect(ids).toContain('sess-0');
+    expect(ids).toContain('sess-59');
+    // Resume anchor survives for the oldest row.
+    const oldest = rows.find((r) => r.id === 'sess-0')!;
+    expect(oldest.vendorSessionId).toBe('claude-0');
+  });
+
+  it('age-reaps an old idle status=active row (v2 idle derives to active) (#1248)', () => {
     const now = Date.now();
     const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
-    const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString();
-
-    const staleDisconnected = fakeWebSession({
-      id: 'stale',
-      lastActivity: eightDaysAgo,
-    });
-    staleDisconnected.agentSessionV2.live.status = 'disconnected';
-
-    const recentDisconnected = fakeWebSession({
-      id: 'recent',
-      lastActivity: oneHourAgo,
-    });
-    recentDisconnected.agentSessionV2.live.status = 'disconnected';
 
     const activeOld = fakeWebSession({
       id: 'active-old',
       lastActivity: eightDaysAgo,
     });
-    // live.status stays idle -> derived status 'active'.
-
-    upsertWebSessionNow(staleDisconnected);
-    upsertWebSessionNow(recentDisconnected);
+    // live.status stays idle -> derived status 'active'. A status-scoped reaper
+    // would leak this forever; the age reaper evicts it.
     upsertWebSessionNow(activeOld);
 
-    const removed = reapStaleWebSessions();
+    const removed = reapStaleWebSessions({ protectedIds: new Set() });
+    expect(removed).toBe(1);
+    expect(loadAllWebSessions().map((r) => r.id)).not.toContain('active-old');
+  });
+
+  it('age-reaps old rows regardless of status but keeps recent ones (#1248)', () => {
+    const now = Date.now();
+    const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString();
+
+    const staleDisconnected = fakeWebSession({
+      id: 'stale-disc',
+      lastActivity: eightDaysAgo,
+    });
+    staleDisconnected.agentSessionV2.live.status = 'disconnected';
+
+    const staleActive = fakeWebSession({
+      id: 'stale-active',
+      lastActivity: eightDaysAgo,
+    });
+
+    const recent = fakeWebSession({ id: 'recent', lastActivity: oneHourAgo });
+
+    upsertWebSessionNow(staleDisconnected);
+    upsertWebSessionNow(staleActive);
+    upsertWebSessionNow(recent);
+
+    const removed = reapStaleWebSessions({ protectedIds: new Set() });
+    expect(removed).toBe(2);
+
+    const ids = loadAllWebSessions().map((r) => r.id);
+    expect(ids).not.toContain('stale-disc');
+    expect(ids).not.toContain('stale-active');
+    expect(ids).toContain('recent');
+  });
+
+  it('never reaps a live-in-memory or channel-bound session even when old (#1248)', () => {
+    const now = Date.now();
+    const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+
+    const liveOld = fakeWebSession({
+      id: 'live-old',
+      lastActivity: eightDaysAgo,
+    });
+    const boundOld = fakeWebSession({
+      id: 'bound-old',
+      lastActivity: eightDaysAgo,
+    });
+    boundOld.agentSessionV2.live.status = 'disconnected';
+    const unprotectedOld = fakeWebSession({
+      id: 'unprotected-old',
+      lastActivity: eightDaysAgo,
+    });
+
+    upsertWebSessionNow(liveOld);
+    upsertWebSessionNow(boundOld);
+    upsertWebSessionNow(unprotectedOld);
+
+    // Protection set = live map ids + channel-bound session ids.
+    const removed = reapStaleWebSessions({
+      protectedIds: new Set(['live-old', 'bound-old']),
+    });
     expect(removed).toBe(1);
 
     const ids = loadAllWebSessions().map((r) => r.id);
-    expect(ids).not.toContain('stale');
-    expect(ids).toContain('recent');
-    expect(ids).toContain('active-old');
+    expect(ids).toContain('live-old');
+    expect(ids).toContain('bound-old');
+    expect(ids).not.toContain('unprotected-old');
+  });
+
+  it('reaper reads the registered protection provider (#1248)', () => {
+    const now = Date.now();
+    const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+
+    upsertWebSessionNow(
+      fakeWebSession({ id: 'protected-old', lastActivity: eightDaysAgo })
+    );
+    upsertWebSessionNow(
+      fakeWebSession({ id: 'doomed-old', lastActivity: eightDaysAgo })
+    );
+
+    setReapProtectedSessionIdsProvider(() => ['protected-old']);
+    try {
+      const removed = reapStaleWebSessions();
+      expect(removed).toBe(1);
+      const ids = loadAllWebSessions().map((r) => r.id);
+      expect(ids).toContain('protected-old');
+      expect(ids).not.toContain('doomed-old');
+    } finally {
+      setReapProtectedSessionIdsProvider(null);
+    }
+  });
+
+  it('reap is a no-op when no protection is resolvable (fail-safe) (#1248)', () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    upsertWebSessionNow(
+      fakeWebSession({ id: 'old', lastActivity: eightDaysAgo })
+    );
+
+    // No explicit set, no provider registered -> skip rather than risk dropping
+    // a live/bound session's resume anchor.
+    expect(reapStaleWebSessions()).toBe(0);
+    expect(loadAllWebSessions().map((r) => r.id)).toContain('old');
   });
 
   it('enables incremental auto_vacuum and truncates the WAL on maintenance', () => {


### PR DESCRIPTION
Closes #1243.

`web_sessions` backs **channel-agent sessions** (`channel-agent-binder.ts → sessions.createWeb`): @-mention an agent in a channel → a web session whose full `AgentSessionV2` transcript persists to `web_sessions.agent_session_v2_json` with **no cap**. On the daily hub one 14.9MB blob drove a 30MB `relay-state.db` (~15MB dead freelist + ~15MB WAL never reclaimed) and a **2.6GB boot rss** (JSON.parse + double `structuredClone` of every non-archived row on restore). This is the backend the ChatView frontend retirement (#1224/#1239) could not drop.

## Cap value + rationale (keystone)
`MAX_TRANSCRIPT_BYTES = 512_000` (total FIFO byte budget), `MAX_ITEM_BYTES = 128_000` (single item).

512KB is 2× the existing 256KB PTY-scrollback / `MAX_IMPORT_TRANSCRIPT_BYTES` discipline. A single channel-agent turn can be large and the transcript is **display-only** (provider resume rides the resume id in `providerSession`, not this transcript), so a generous tail is safe — while 512KB still crushes the observed 14.9MB blob ~30× and the boot rss it amplifies into. `capAgentSessionTranscriptV2` (pure, in `shared/agent-chat-protocol-v2.ts`):
1. **Truncate oversized single items in place** — a 2MB tool output has its dominant text field(s) + normalized card content elided (`… [truncated N bytes]`), structure preserved (same id/type/status), so one giant item can't blow the budget.
2. **FIFO-drop oldest whole turns** while over budget — **never the active turn**.
3. If a single retained turn is still too big, **FIFO-drop its oldest items**, preserving the most-recent tail and **never leaving a zero-item turn**.

Applied at **two chokepoints**:
- **Persist** (`writeUpsert`, the ≤1/s sink all debounced + immediate writes flow through): caps the blob before it hits disk **and writes the trimmed structure back into the live session**, so the in-memory transcript (and thus the boot-restore rss) is bounded too — and the reducer's immutable `[...items, item]` rebuild stays off an ever-growing array. Chosen over per-append capping to avoid re-serializing the transcript on every streamed delta (O(n²)).
- **Load** (`loadAllWebSessions`): caps the parsed blob before it's cloned into the live session, bounding the restore burst for a pre-existing oversized row; the next persist rewrites the trimmed blob so **disk self-heals**.

Provider / `live` / `providerSession` identity is untouched → **cold-resume still renders + resumes correctly** (verified below).

## Vacuum + checkpoint (reclaim freelist + WAL)
In `initRelayStateDb`: one-time **guarded** `auto_vacuum=INCREMENTAL` conversion — `VACUUM` runs only when the mode isn't already INCREMENTAL (i.e. once; `VACUUM` flips the pragma to `2`, so it never runs on subsequent boots), plus `journal_size_limit = 4MB`. A boot + 10-min-interval + on-close `wal_checkpoint(TRUNCATE)` + `incremental_vacuum` returns the freelist and truncates the WAL (mirrors the `analytics.ts:363` pattern). Migration-safe: `VACUUM` runs before any transaction is open.

## Reaper
Boot + 10-min-interval `DELETE` of `status='disconnected'` rows older than **7 days** (never `active`/connected, never `archived`). Plus a **most-recent-50 `LIMIT`** on the restore query as a belt-and-suspenders boot-rss bound. Replaces the never-called `markWebSessionStatus('archived')` dead path.

## Deferred follow-up (issue item b — optional)
Stopping the per-debounce **full-blob re-serialization** (append-only patch rows / snapshot, or skip-write-when-unchanged) is deferred. The 512KB cap already shrinks each rewrite ~30×, so it's no longer urgent. Noted here explicitly.

## Channel-agent persist/resume confirmation
Channel-agent create/persist/resume is preserved: the cap only trims `turns[]`, leaving `provider`, `live`, `providerSession`, `config`, `capabilities` intact — so `pickVendorSessionId`/`deriveStatus` and the `sessions.ts` reattach path (which resumes via `providerSession`) are unaffected. New test `caps an oversized transcript on persist and cold-resume` writes a ~1.6MB transcript through `upsertWebSessionNow`, asserts the in-memory + persisted blobs are ≤512KB, then `loadAllWebSessions()` restores a **valid bounded** session preserving the most-recent turn tail with no zero-item turns. The full `web-session-v2`, `web-session-handler`, `channel-agent-binder`, `channel-agent-bridge`, `sessions-web-restore`, and `sessions` suites stay green.

## Validation
- `npm run check` → 0 errors; `npm run build` → green.
- New `test/agent-transcript-cap.test.ts` (7 tests): FIFO trim to recent turns, single-item truncation, zero-item-turn invariant, active-turn preservation, huge-turn item-level FIFO, identity preserved, under-budget fast path.
- Extended `test/server/relay-state-db.test.ts` (+3): persist + cold-resume cap round-trip, reaper deletes stale-disconnected while keeping recent + active, `auto_vacuum=2` + WAL truncated after maintenance.
- Related suites green: `web-session-v2`, `web-session-handler`, `channel-agent-binder`, `channel-agent-bridge(+zero-row)`, `channel-agent-status-reconcile`, `sessions-web-restore`, `global-scrollback-cap`, `sessions`, `server-startup` (208 targeted tests).
- Pre-push hook ran the changed-file vitest set: **705 passed, 9 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Prevents agent session transcripts from growing beyond safe size limits while preserving recent conversation content and the active session.
  - Restores only the most recent non-archived sessions during startup, improving resume performance.
  - Automatically removes stale disconnected web sessions.
  - Performs background storage maintenance to help control database and WAL growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->