### PR TITLE
fix(ws): bound per-connection send queues + reap half-open sockets (#1249)

### DIFF
--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -2,7 +2,10 @@ import * as crypto from 'node:crypto';
 import type * as http from 'node:http';
 import { WebSocket } from 'ws';
 import type { RawData } from 'ws';
-import type { CredentialAuthContext, HubNodeRegistry } from './hub-node-registry.js';
+import type {
+  CredentialAuthContext,
+  HubNodeRegistry,
+} from './hub-node-registry.js';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
@@ -11,6 +14,7 @@ import {
   type RelayNodeEnvelope,
   type RelayNodeError,
 } from '../shared/relay-node-protocol.js';
+import { sendWithBackpressure } from './ws-backpressure.js';
 
 interface AuthenticatedNodeLink {
   node: HubNodeSummary;
@@ -121,7 +125,11 @@ export function authenticateHubNodeLink(
   if (auth.ok) {
     return {
       ok: true,
-      authenticated: { node: auth.node, token, credentialId: auth.credentialId },
+      authenticated: {
+        node: auth.node,
+        token,
+        credentialId: auth.credentialId,
+      },
     };
   }
   const error = auth.ok === false ? auth.error : undefined;
@@ -535,11 +543,17 @@ export class HubNodeLinkManager {
       this.openStream(stream, message.payload);
       return true;
     }
-    if (message.type === 'logs.tail.chunk' || message.type === 'fs.tail.chunk') {
+    if (
+      message.type === 'logs.tail.chunk' ||
+      message.type === 'fs.tail.chunk'
+    ) {
       stream.onChunk(message.payload);
       return true;
     }
-    if (message.type === 'logs.tail.error' || message.type === 'fs.tail.error') {
+    if (
+      message.type === 'logs.tail.error' ||
+      message.type === 'fs.tail.error'
+    ) {
       const error = payloadRecord(message.payload)['error'];
       if (typeof error === 'object' && error !== null) {
         stream.onError?.(error as RelayNodeError);
@@ -584,8 +598,12 @@ export class HubNodeLinkManager {
     const browserWs = stream.browserWs;
     if (message.type === 'pty.data') {
       const data = payloadRecord(message.payload)['data'];
-      if (typeof data === 'string' && browserWs.readyState === browserWs.OPEN) {
-        browserWs.send(data);
+      if (typeof data === 'string') {
+        // #1249: routed PTY stdout is a replayable delta (browser reconnect
+        // re-attaches and the node re-streams), so shed it to a lagging browser
+        // socket above the soft watermark rather than queuing frames off-heap;
+        // above the hard watermark close 4409 (cleanup sends pty.detach).
+        sendWithBackpressure(browserWs, () => data, { droppable: true });
       }
       return true;
     }
@@ -659,7 +677,8 @@ export function handleHubNodeLink(
   const authenticatedNodeId = authenticated.node.nodeId;
   nodeLinks?.registerNodeLink(authenticatedNodeId, ws);
   const unsubscribeStatus = registry.onNodeStatus((event) => {
-    if (event.nodeId !== authenticatedNodeId || event.status !== 'revoked') return;
+    if (event.nodeId !== authenticatedNodeId || event.status !== 'revoked')
+      return;
     sendJson(
       ws,
       errorEnvelope(

--- a/server/ws-backpressure.ts
+++ b/server/ws-backpressure.ts
@@ -141,16 +141,24 @@ export type DeltaLaneResult =
 
 /**
  * Deliver one replayable delta to a subscriber that heals via re-sync:
- *  - `bufferedAmount > hard` → close 4409 (`'closed'`); handler splices.
- *  - draining below the low watermark after lagging → clear lagging and send the
- *    `resync` frame ONLY (`'resync'`). `serializeResync` is a full snapshot of the
- *    already-applied session state (agent patches are applied to session state
- *    BEFORE this forwarder runs — see `handleAgentPatchV2`), so it already
- *    reflects this delta; sending the delta too would double-apply it client-side.
- *  - `bufferedAmount > soft` → mark lagging, shed the delta (`'dropped'`).
+ *  - `bufferedAmount > hard` → close 4409 (`'closed'`); handler splices. Checked
+ *    FIRST so a client stuck lagging (never drains below low) is still closed if
+ *    its queue ever crosses the hard cap.
+ *  - LAGGING (a prior delta was shed) is a healing window: mirror channel-hub's
+ *    `if (lagging) return` and SUPPRESS every subsequent raw delta (`'dropped'`)
+ *    until the queue drains, so the client never applies a patch OVER the un-healed
+ *    gap (#1250). Draining below the low watermark clears lagging and sends the
+ *    `resync` snapshot ONLY (`'resync'`) — exactly once, no flapping. The snapshot
+ *    is a full view of the already-applied session state (agent patches are applied
+ *    to session state BEFORE this forwarder runs — see `handleAgentPatchV2`), so it
+ *    already reflects every shed delta; sending a delta too would double-apply it.
+ *  - `bufferedAmount > soft` (not yet lagging) → mark lagging, shed the delta
+ *    (`'dropped'`).
  *  - otherwise send the delta (`'sent'`).
  *
  * A healthy client (low `bufferedAmount`) never lags, never drops, never re-syncs.
+ * While lagging the send queue does NOT grow: every path returns without sending
+ * except the single bounded resync snapshot on drain.
  */
 export function deliverDelta(
   ws: BackpressureSocket,
@@ -168,15 +176,20 @@ export function deliverDelta(
     }
     return 'closed';
   }
-  if (state.lagging && buffered < WS_LOW_LIMIT_BYTES) {
-    // Recovered: the snapshot supersedes every shed delta (including this one).
-    state.lagging = false;
-    try {
-      ws.send(serializeResync());
-    } catch {
-      return 'not-open';
+  if (state.lagging) {
+    if (buffered < WS_LOW_LIMIT_BYTES) {
+      // Recovered: the snapshot supersedes every shed delta (including this one).
+      state.lagging = false;
+      try {
+        ws.send(serializeResync());
+      } catch {
+        return 'not-open';
+      }
+      return 'resync';
     }
-    return 'resync';
+    // Still healing in the [low, soft] band — suppress the raw delta rather than
+    // let the client apply it over the un-healed gap (the missing #1250 guard).
+    return 'dropped';
   }
   if (buffered > WS_SOFT_LIMIT_BYTES) {
     state.lagging = true;
@@ -184,6 +197,100 @@ export function deliverDelta(
   }
   try {
     ws.send(serializeDelta());
+  } catch {
+    return 'not-open';
+  }
+  return 'sent';
+}
+
+/**
+ * Per-subscriber gap-heal state for the terminal `data` lane (#1250). Mirrors the
+ * agent `DeltaLaneState` but also remembers WHERE the shed gap starts so the drain
+ * resync can replay exactly the missed contiguous byte range from server
+ * scrollback instead of silently advancing the client past it.
+ */
+export interface TerminalLaneState {
+  lagging: boolean;
+  /**
+   * Byte cursor at the START of the first shed frame == the client's current
+   * cursor (everything before it was delivered contiguously). The resync replays
+   * from here so the client's cursor only ever advances over bytes it receives.
+   */
+  gapStartCursor: number;
+}
+
+export type TerminalLaneResult =
+  | 'sent'
+  | 'dropped'
+  | 'suppressed'
+  | 'resync'
+  | 'closed'
+  | 'not-open';
+
+/**
+ * Deliver one terminal-stream envelope to a subscriber with a gap-heal mirroring
+ * the agent delta lane, closing the #1250 silent-output-loss finding. Before this
+ * fix a shed `data` envelope emitted nothing while the NEXT (coarse or drained)
+ * envelope advanced the client's `Math.max` cursor PAST the shed range, so a
+ * `?cursor=` reconnect never re-fetched it (permanent gap; a split ANSI escape
+ * corrupts the xterm parser).
+ *
+ *  - `bufferedAmount > hard` → close 4409 (`'closed'`); the close handler splices.
+ *  - LAGGING + drained below LOW → RESYNC: replay the contiguous missed byte range
+ *    from `gapStartCursor` (server scrollback) so the client's cursor advances only
+ *    over bytes it actually receives, then clear lagging (`'resync'`). If scrollback
+ *    FIFO-trimmed part of the gap, the replay builder starts at the earliest still
+ *    resident cursor and includes a `lag` marker for the unavoidable truncation.
+ *  - LAGGING + still above LOW → SUPPRESS every envelope (`'suppressed'`). Coarse
+ *    envelopes (metadata/resize/replay) carry a cursor too; sending one would let
+ *    the client's cursor jump PAST the un-replayed gap, so they are held and folded
+ *    into the resync replay (whose metadata carries the latest resize).
+ *  - a `droppable` `data` delta above SOFT (not yet lagging) → shed it, record the
+ *    gap start, enter lagging (`'dropped'`). The shed bytes stay in scrollback for
+ *    the resync — nothing is sent, so the send queue does not grow.
+ *  - otherwise send the envelope (`'sent'`).
+ *
+ * A healthy client (low `bufferedAmount`) never lags: every frame is sent in order.
+ * While lagging the send queue does NOT grow — every path returns without sending
+ * except the single bounded resync replay on drain (≤ scrollback capacity).
+ */
+export function deliverTerminalEnvelope(
+  ws: BackpressureSocket,
+  state: TerminalLaneState,
+  frame: { droppable: boolean; gapStart: number; serialize: () => string },
+  serializeResync: (gapStartCursor: number) => Iterable<string>
+): TerminalLaneResult {
+  if (ws.readyState !== WS_OPEN) return 'not-open';
+  const buffered = bufferedAmountOf(ws);
+  if (buffered > WS_HARD_LIMIT_BYTES) {
+    try {
+      ws.close(WS_BACKPRESSURE_CLOSE_CODE);
+    } catch {
+      /* ignore */
+    }
+    return 'closed';
+  }
+  if (state.lagging) {
+    if (buffered < WS_LOW_LIMIT_BYTES) {
+      state.lagging = false;
+      try {
+        for (const framePayload of serializeResync(state.gapStartCursor)) {
+          ws.send(framePayload);
+        }
+      } catch {
+        return 'not-open';
+      }
+      return 'resync';
+    }
+    return 'suppressed';
+  }
+  if (buffered > WS_SOFT_LIMIT_BYTES && frame.droppable) {
+    state.lagging = true;
+    state.gapStartCursor = frame.gapStart;
+    return 'dropped';
+  }
+  try {
+    ws.send(frame.serialize());
   } catch {
     return 'not-open';
   }

--- a/server/ws-backpressure.ts
+++ b/server/ws-backpressure.ts
@@ -1,0 +1,292 @@
+// #1249: per-connection WebSocket send-queue backpressure + a half-open socket
+// reaper, shared by every server→client fan-out lane (terminal PTY stream, agent
+// web-session patches, event broadcast, routed-node PTY relay).
+//
+// Root cause of the incident: those lanes called `ws.send(JSON.stringify(...))`
+// gated ONLY on `readyState === OPEN`. A backgrounded mobile tab / sleeping
+// laptop / throttled-cellular / merely-slow client stays OPEN while the server
+// keeps queuing outbound frames. Each queued frame is an off-heap Buffer in the
+// socket's kernel/uv send queue — counted in `external`/`arrayBuffers`, NOT V8
+// old-space — so it grows past `--max-old-space-size` with no heap OOM (the daily
+// hub reached 15GB rss / ~150MB/min). The #1243 transcript cap bounds persisted
+// data, not the per-connection send queue.
+//
+// The thresholds + close code mirror `channel-hub.ts` (the existing per-channel
+// backpressure precedent) so all lanes speak the same protocol: a client that
+// overflows reconnects and re-fetches (terminal → cursor replay from scrollback,
+// agent → `agentPatchesV2` replay, channel → `sinceSeq`).
+
+/** WebSocket.OPEN — kept local so fake sockets in tests need no `ws` import. */
+export const WS_OPEN = 1;
+
+/**
+ * Soft watermark (mirrors channel-hub `WATERMARK_HIGH_BYTES`). Above this, a
+ * lagging subscriber sheds high-frequency REPLAYABLE deltas (terminal `data`,
+ * agent patches) instead of queuing more, and coarse/irreplaceable fan-out lanes
+ * (events) close the socket. A healthy fast-draining client keeps `bufferedAmount`
+ * far below this and is never affected.
+ */
+export const WS_SOFT_LIMIT_BYTES = 1024 * 1024; // 1MB
+/**
+ * Recovery watermark (mirrors channel-hub `WATERMARK_LOW_BYTES`). A lagging
+ * delta lane that drains back below this clears `lagging` and re-syncs the client
+ * (agent → fresh snapshot patch) so a shed delta gap is healed without a reconnect.
+ */
+export const WS_LOW_LIMIT_BYTES = 256 * 1024; // 256KB
+/**
+ * Hard watermark (mirrors channel-hub `HARD_LIMIT_BYTES`). Above this the socket
+ * is closed with `WS_BACKPRESSURE_CLOSE_CODE`; its registered `close` handler
+ * splices the subscriber, freeing the queue. The durable buffer (scrollback /
+ * patch ring / seq log) makes the reconnect re-fetch lossless.
+ */
+export const WS_HARD_LIMIT_BYTES = 4 * 1024 * 1024; // 4MB
+
+/**
+ * Application close code for sustained backpressure overflow. Matches
+ * `CHANNEL_WS_BACKPRESSURE_CLOSE_CODE` (4409) so the frontend's existing
+ * non-1000 → reconnect path handles every lane identically.
+ */
+export const WS_BACKPRESSURE_CLOSE_CODE = 4409;
+
+/** Default heartbeat interval; a socket missing one full interval is reaped. */
+export const WS_HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * Minimal socket surface the send-side backpressure needs. The real `ws`
+ * WebSocket satisfies it; tests inject fakes with a settable `bufferedAmount`
+ * and a byte-counting `send`.
+ */
+export interface BackpressureSocket {
+  readonly readyState: number;
+  readonly bufferedAmount?: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export function bufferedAmountOf(ws: BackpressureSocket): number {
+  return typeof ws.bufferedAmount === 'number' ? ws.bufferedAmount : 0;
+}
+
+export type BackpressureSendResult = 'sent' | 'dropped' | 'closed' | 'not-open';
+
+export interface BackpressureSendOptions {
+  /**
+   * True for high-frequency REPLAYABLE deltas (terminal `data`, agent patches):
+   * shed above the soft watermark instead of queuing. False for coarse frames
+   * that must arrive intact (terminal metadata/resize, agent snapshot/resync).
+   */
+  droppable?: boolean;
+  /**
+   * True for irreplaceable coarse fan-out (the `/ws/events` lane): a subscriber
+   * that is even soft-lagging on these is treated as dead and closed, rather than
+   * corrupting its view by shedding an event it can't re-derive.
+   */
+  closeWhenLagging?: boolean;
+}
+
+/**
+ * Send one frame on `ws` with per-connection send-queue backpressure. `serialize`
+ * is a thunk so a dropped frame is never stringified. Returns the disposition;
+ * `'closed'` means the socket was closed with `WS_BACKPRESSURE_CLOSE_CODE` and its
+ * `close` handler (registered by the caller) will splice the subscriber.
+ */
+export function sendWithBackpressure(
+  ws: BackpressureSocket,
+  serialize: () => string,
+  opts: BackpressureSendOptions = {}
+): BackpressureSendResult {
+  if (ws.readyState !== WS_OPEN) return 'not-open';
+  const buffered = bufferedAmountOf(ws);
+  if (buffered > WS_HARD_LIMIT_BYTES) {
+    try {
+      ws.close(WS_BACKPRESSURE_CLOSE_CODE);
+    } catch {
+      /* ignore */
+    }
+    return 'closed';
+  }
+  if (buffered > WS_SOFT_LIMIT_BYTES) {
+    if (opts.closeWhenLagging) {
+      try {
+        ws.close(WS_BACKPRESSURE_CLOSE_CODE);
+      } catch {
+        /* ignore */
+      }
+      return 'closed';
+    }
+    if (opts.droppable) return 'dropped';
+  }
+  try {
+    ws.send(serialize());
+  } catch {
+    return 'not-open';
+  }
+  return 'sent';
+}
+
+/**
+ * Per-connection lagging state for a delta lane (agent patches) that heals a shed
+ * gap with a re-sync once the queue drains, mirroring channel-hub's `deliver`.
+ */
+export interface DeltaLaneState {
+  lagging: boolean;
+}
+
+export type DeltaLaneResult =
+  | 'sent'
+  | 'dropped'
+  | 'closed'
+  | 'resync'
+  | 'not-open';
+
+/**
+ * Deliver one replayable delta to a subscriber that heals via re-sync:
+ *  - `bufferedAmount > hard` → close 4409 (`'closed'`); handler splices.
+ *  - draining below the low watermark after lagging → clear lagging and send the
+ *    `resync` frame ONLY (`'resync'`). `serializeResync` is a full snapshot of the
+ *    already-applied session state (agent patches are applied to session state
+ *    BEFORE this forwarder runs — see `handleAgentPatchV2`), so it already
+ *    reflects this delta; sending the delta too would double-apply it client-side.
+ *  - `bufferedAmount > soft` → mark lagging, shed the delta (`'dropped'`).
+ *  - otherwise send the delta (`'sent'`).
+ *
+ * A healthy client (low `bufferedAmount`) never lags, never drops, never re-syncs.
+ */
+export function deliverDelta(
+  ws: BackpressureSocket,
+  state: DeltaLaneState,
+  serializeDelta: () => string,
+  serializeResync: () => string
+): DeltaLaneResult {
+  if (ws.readyState !== WS_OPEN) return 'not-open';
+  const buffered = bufferedAmountOf(ws);
+  if (buffered > WS_HARD_LIMIT_BYTES) {
+    try {
+      ws.close(WS_BACKPRESSURE_CLOSE_CODE);
+    } catch {
+      /* ignore */
+    }
+    return 'closed';
+  }
+  if (state.lagging && buffered < WS_LOW_LIMIT_BYTES) {
+    // Recovered: the snapshot supersedes every shed delta (including this one).
+    state.lagging = false;
+    try {
+      ws.send(serializeResync());
+    } catch {
+      return 'not-open';
+    }
+    return 'resync';
+  }
+  if (buffered > WS_SOFT_LIMIT_BYTES) {
+    state.lagging = true;
+    return 'dropped';
+  }
+  try {
+    ws.send(serializeDelta());
+  } catch {
+    return 'not-open';
+  }
+  return 'sent';
+}
+
+/**
+ * Minimal socket surface the reaper needs. The real `ws` WebSocket satisfies it.
+ */
+export interface HeartbeatSocket {
+  ping(): void;
+  terminate(): void;
+  on(event: 'pong', handler: () => void): void;
+}
+
+export interface WsHeartbeatMonitor {
+  /**
+   * Track a socket. `onReap` runs when the socket is reaped as half-open — it
+   * must perform the same unsubscribe/cleanup as the socket's `close` handler
+   * (splice the subscriber) and must be idempotent, since a real `terminate()`
+   * also fires `close`.
+   */
+  track(ws: HeartbeatSocket, onReap: () => void): void;
+  untrack(ws: HeartbeatSocket): void;
+  /** Run one heartbeat tick synchronously (also driven by the interval). */
+  tick(): void;
+  trackedCount(): number;
+  /** Stop the interval and drop all tracked sockets (call on server shutdown). */
+  stop(): void;
+}
+
+/**
+ * Half-open socket reaper. A socket that stays `readyState === OPEN` but is dead
+ * (backgrounded tab whose TCP never FINs, sleeping laptop) never fires `close`,
+ * so its subscriber is never spliced and its send queue grows forever. Each tick:
+ * a socket that did not `pong` since the previous tick is `terminate()`d and its
+ * `onReap` cleanup runs; otherwise it is marked not-alive and pinged. A live
+ * client pongs (browsers auto-answer WS ping frames) and is never reaped.
+ *
+ * The interval is `.unref()`'d and cleared on `stop()` so it never keeps the
+ * process alive or leaks a timer (#1244).
+ */
+export function createWsHeartbeatMonitor(
+  opts: { intervalMs?: number } = {}
+): WsHeartbeatMonitor {
+  const intervalMs = opts.intervalMs ?? WS_HEARTBEAT_INTERVAL_MS;
+  interface Entry {
+    isAlive: boolean;
+    onReap: () => void;
+    onPong: () => void;
+  }
+  const tracked = new Map<HeartbeatSocket, Entry>();
+
+  function runTick(): void {
+    for (const [ws, entry] of [...tracked]) {
+      if (!entry.isAlive) {
+        tracked.delete(ws);
+        try {
+          ws.terminate();
+        } catch {
+          /* ignore */
+        }
+        try {
+          entry.onReap();
+        } catch {
+          /* ignore */
+        }
+        continue;
+      }
+      entry.isAlive = false;
+      try {
+        ws.ping();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  const timer = setInterval(runTick, intervalMs);
+  timer.unref?.();
+
+  return {
+    track(ws, onReap) {
+      const entry: Entry = {
+        isAlive: true,
+        onReap,
+        onPong: () => {
+          entry.isAlive = true;
+        },
+      };
+      tracked.set(ws, entry);
+      ws.on('pong', entry.onPong);
+    },
+    untrack(ws) {
+      tracked.delete(ws);
+    },
+    tick: runTick,
+    trackedCount() {
+      return tracked.size;
+    },
+    stop() {
+      clearInterval(timer);
+      tracked.clear();
+    },
+  };
+}

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -57,6 +57,12 @@ import {
 import { sourceTupleFromIncomingMessage } from './node-source-diagnostics.js';
 import type { ChannelHub } from './channel-hub.js';
 import { isWorkspaceTopicId } from '../shared/workspace-topics.js';
+import {
+  createWsHeartbeatMonitor,
+  deliverDelta,
+  sendWithBackpressure,
+  type DeltaLaneState,
+} from './ws-backpressure.js';
 
 const logger = createLogger('ws');
 
@@ -64,11 +70,23 @@ function replyPing(ws: WebSocket): void {
   if (ws.readyState === ws.OPEN) ws.send('{"type":"pong"}');
 }
 
-function sendTerminalStreamEnvelope(
+/**
+ * #1249: fan out one terminal-stream envelope to a browser terminal socket with
+ * per-connection send-queue backpressure. `data` envelopes are replayable deltas
+ * (the client re-fetches from server scrollback via `?cursor=`), so they are shed
+ * above the soft watermark to a lagging socket rather than queued off-heap;
+ * coarse envelopes (metadata/resize/replay markers/lag) must arrive intact. Above
+ * the hard watermark the socket is closed 4409 and its `close` handler splices the
+ * subscriber. Exported so the leak-reproduction test can drive it against a
+ * stalled fake socket.
+ */
+export function sendTerminalStreamEnvelope(
   ws: WebSocket,
   envelope: TerminalStreamEnvelope
 ): void {
-  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(envelope));
+  sendWithBackpressure(ws, () => JSON.stringify(envelope), {
+    droppable: envelope.kind === 'data',
+  });
 }
 
 // Application close code (4000-4999 range) for a terminal WS that wrote/resized
@@ -590,6 +608,14 @@ function setupWebSocket(
     process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1';
   const eventClients = new Set<WebSocket>();
 
+  // #1249: one shared half-open socket reaper for every server→client lane
+  // (terminal PTY stream, agent web-session patches, /ws/events, routed-node
+  // PTY relay). A backgrounded/sleeping/dead-but-OPEN socket never fires `close`,
+  // so its subscriber is never spliced and its off-heap send queue grows forever;
+  // the reaper pings each tracked socket and terminates the ones that stop
+  // ponging, running their cleanup. Interval is unref()'d + cleared on shutdown.
+  const heartbeat = createWsHeartbeatMonitor();
+
   function isAuthenticated(cookieHeader: string | undefined): boolean {
     const cookies = parseCookies(cookieHeader);
     const token = cookies['token'] ?? '';
@@ -656,10 +682,13 @@ function setupWebSocket(
 
   function broadcastEvent(type: string, data?: Record<string, unknown>): void {
     const msg = JSON.stringify({ type, ...scopedEventPayload(data) });
-    for (const client of eventClients) {
-      if (client.readyState === client.OPEN) {
-        client.send(msg);
-      }
+    // #1249: events are coarse, irreplaceable fan-out (a subscriber cannot
+    // re-derive a single dropped event), so a soft-lagging client is treated as
+    // dead and closed 4409 (its `close` handler removes it from `eventClients`
+    // and untracks the heartbeat) rather than accumulating frames off-heap.
+    // Iterate a snapshot because the close handler mutates `eventClients`.
+    for (const client of [...eventClients]) {
+      sendWithBackpressure(client, () => msg, { closeWhenLagging: true });
     }
   }
 
@@ -710,6 +739,7 @@ function setupWebSocket(
   server.on('close', () => {
     unsubscribeNodeStatus?.();
     if (nodeStatusRefreshTimer) clearInterval(nodeStatusRefreshTimer);
+    heartbeat.stop();
   });
 
   function handleNodeLinkUpgrade(
@@ -869,6 +899,13 @@ function setupWebSocket(
       wss.handleUpgrade(request, socket, head, (ws) => {
         try {
           nodeLinks.attachPty(nodeId, sessionId, ws);
+          // #1249: reap a half-open routed browser socket. `terminate()` fires
+          // its `close` handler (installed by attachPty) which sends pty.detach
+          // and drops the ptyStream, freeing the relay send queue.
+          heartbeat.track(ws, () => heartbeat.untrack(ws));
+          const untrack = () => heartbeat.untrack(ws);
+          ws.on('close', untrack);
+          ws.on('error', untrack);
         } catch {
           ws.close(1011);
         }
@@ -879,10 +916,17 @@ function setupWebSocket(
     // Event channel: /ws/events
     if (request.url === '/ws/events') {
       wss.handleUpgrade(request, socket, head, (ws) => {
+        let cleanedUp = false;
         const cleanup = () => {
+          if (cleanedUp) return;
+          cleanedUp = true;
           eventClients.delete(ws);
+          heartbeat.untrack(ws);
         };
         eventClients.add(ws);
+        // #1249: reap a half-open events socket so it is removed from
+        // `eventClients` and stops accumulating broadcast frames off-heap.
+        heartbeat.track(ws, cleanup);
         ws.on('message', (msg) => {
           try {
             const parsed = JSON.parse(msg.toString());
@@ -1071,7 +1115,14 @@ function setupWebSocket(
         }
       });
 
+      // #1249: idempotent — invoked by both the ws `close`/`error` events and,
+      // for a half-open socket, directly by the heartbeat reaper (which also
+      // terminate()s the socket). Splicing the subscriber frees its send queue.
+      let cleanedUp = false;
       const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        heartbeat.untrack(ws);
         exitDisposable?.dispose();
         const subscriberIdx = session.terminalStreamSubscribers?.indexOf(
           terminalStreamSubscriber
@@ -1084,27 +1135,52 @@ function setupWebSocket(
       };
       ws.on('close', cleanup);
       ws.on('error', cleanup);
+      // #1249: reap this terminal socket if it goes half-open (OPEN but dead) so
+      // its subscriber is spliced instead of the highest-volume lane (raw PTY
+      // stdout) queuing frames off-heap forever.
+      heartbeat.track(ws, cleanup);
     } else {
       // Web session — JSON relay
       const patchReplayStart = session.agentPatchesV2.length;
       const snapshotPatch = createAgentSessionSnapshotPatch(session);
+      // #1249: agent patches are replayable deltas (client re-derives from
+      // `session.agentPatchesV2` on reconnect), so shed them to a lagging socket
+      // above the soft watermark and heal the gap with a fresh snapshot patch once
+      // the queue drains, mirroring channel-hub. Above the hard watermark the
+      // socket is closed 4409 and cleanup runs.
+      const patchLane: DeltaLaneState = { lagging: false };
       const unlistenV2 = onWebSessionPatch(session, (patch) => {
-        if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(patch));
+        deliverDelta(
+          ws,
+          patchLane,
+          () => JSON.stringify(patch),
+          () => JSON.stringify(createAgentSessionSnapshotPatch(session))
+        );
       });
 
-      if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(snapshotPatch));
+      // Connect-time snapshot + buffered replay must arrive intact (not
+      // droppable); still bounded — the hard watermark closes a socket that
+      // cannot even absorb its own attach backlog.
+      sendWithBackpressure(ws, () => JSON.stringify(snapshotPatch));
       for (const patch of session.agentPatchesV2.slice(patchReplayStart)) {
-        if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(patch));
+        sendWithBackpressure(ws, () => JSON.stringify(patch));
       }
 
       ws.on('message', (msg) => handleWebSessionMessage(ws, session, msg));
 
+      let cleanedUp = false;
       const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        heartbeat.untrack(ws);
         unlistenV2();
         sessionMap.delete(ws);
       };
       ws.on('close', cleanup);
       ws.on('error', cleanup);
+      // #1249: reap a half-open agent socket so its patch listener is removed and
+      // stops queuing patch frames off-heap.
+      heartbeat.track(ws, cleanup);
     }
   });
 

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -60,8 +60,10 @@ import { isWorkspaceTopicId } from '../shared/workspace-topics.js';
 import {
   createWsHeartbeatMonitor,
   deliverDelta,
+  deliverTerminalEnvelope,
   sendWithBackpressure,
   type DeltaLaneState,
+  type TerminalLaneState,
 } from './ws-backpressure.js';
 
 const logger = createLogger('ws');
@@ -1002,11 +1004,41 @@ function setupWebSocket(
         resizeOwner: 'active' as const,
       };
       const terminalStream = ensureTerminalStreamState(session);
+      // #1250: per-subscriber gap-heal state for the terminal `data` lane. A shed
+      // `data` envelope must NOT let the client's cursor advance past the gap
+      // (that made a `?cursor=` reconnect skip the shed range — silent, permanent
+      // output loss + split-escape xterm corruption). While lagging every envelope
+      // is suppressed; a drain below the low watermark replays the missed byte
+      // range from server scrollback so the client's cursor only advances over
+      // bytes it actually receives. Mirrors the agent `deliverDelta` lane.
+      const terminalLane: TerminalLaneState = {
+        lagging: false,
+        gapStartCursor: 0,
+      };
       const terminalStreamSubscriber = (envelope: TerminalStreamEnvelope) => {
-        sendTerminalStreamEnvelope(ws, envelope);
+        deliverTerminalEnvelope(
+          ws,
+          terminalLane,
+          {
+            droppable: envelope.kind === 'data',
+            // Gap starts at the first shed byte == the client's current cursor
+            // for a contiguously delivered `data` stream.
+            gapStart:
+              envelope.kind === 'data'
+                ? envelope.payload.range.start
+                : envelope.cursor,
+            serialize: () => JSON.stringify(envelope),
+          },
+          (gapStartCursor) =>
+            buildTerminalStreamReplay(terminalStream, gapStartCursor).map(
+              (env) => JSON.stringify(env)
+            )
+        );
       };
       session.terminalStreamSubscribers?.push(terminalStreamSubscriber);
 
+      // Connect-time replay is bounded by scrollback (≤ soft watermark) on a fresh
+      // socket, so it never sheds — send it directly rather than through the lane.
       for (const envelope of buildTerminalStreamReplay(
         terminalStream,
         attachContext.replayCursor

--- a/test/ws-backpressure.test.ts
+++ b/test/ws-backpressure.test.ts
@@ -5,6 +5,7 @@ import {
   bufferedAmountOf,
   createWsHeartbeatMonitor,
   deliverDelta,
+  deliverTerminalEnvelope,
   sendWithBackpressure,
   WS_BACKPRESSURE_CLOSE_CODE,
   WS_HARD_LIMIT_BYTES,
@@ -13,12 +14,15 @@ import {
   type BackpressureSocket,
   type DeltaLaneState,
   type HeartbeatSocket,
+  type TerminalLaneState,
 } from '../server/ws-backpressure.js';
 import { sendTerminalStreamEnvelope } from '../server/ws.js';
 import {
   appendTerminalStreamData,
+  buildTerminalStreamReplay,
   createTerminalStreamState,
   type TerminalStreamEnvelope,
+  type TerminalStreamState,
 } from '../shared/session-replay.js';
 
 // #1249: these tests ARE the off-heap leak confirmation. The pre-fix fan-out
@@ -281,6 +285,268 @@ describe('#1249 deliverDelta — agent web-session patch lane', () => {
       );
     }
     expect(ws.bufferedAmount).toBeLessThan(WS_HARD_LIMIT_BYTES);
+  });
+});
+
+// #1250 FIX 2: `deliverDelta` was missing channel-hub's `if (lagging) return`
+// guard. After a patch was shed and BEFORE the drain snapshot healed the gap (the
+// [low, soft] band) it kept sending RAW patches, which the client applied over the
+// gap → inconsistent view. The lane must SUPPRESS every raw delta while lagging and
+// heal with exactly one resync snapshot on drain.
+describe('#1250 deliverDelta — suppress raw patches while lagging (no agent desync)', () => {
+  it('SUPPRESSES a raw patch while lagging in the [low, soft] band (does not apply over the gap)', () => {
+    const ws = fakeSocket({
+      bufferedAmount: Math.floor(
+        (WS_LOW_LIMIT_BYTES + WS_SOFT_LIMIT_BYTES) / 2
+      ),
+    });
+    const state: DeltaLaneState = { lagging: true };
+    const result = deliverDelta(
+      ws,
+      state,
+      () => 'patch',
+      () => 'snapshot'
+    );
+    // Pre-fix this returned 'sent' and applied the patch over the un-healed gap.
+    expect(result).toBe('dropped');
+    expect(state.lagging).toBe(true);
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('still closes 4409 at the hard cap WHILE lagging (a client that never drains is not stuck forever)', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_HARD_LIMIT_BYTES + 1 });
+    const state: DeltaLaneState = { lagging: true };
+    expect(
+      deliverDelta(
+        ws,
+        state,
+        () => 'patch',
+        () => 'snapshot'
+      )
+    ).toBe('closed');
+    expect(ws.closedWith).toBe(WS_BACKPRESSURE_CLOSE_CODE);
+  });
+
+  it('NO DESYNC end-to-end: healthy → shed → suppress → drain → ONE snapshot; client state == server state', () => {
+    const ws = fakeSocket();
+    const state: DeltaLaneState = { lagging: false };
+    // Model the forwarder: a patch is applied to session state BEFORE deliverDelta
+    // runs (handleAgentPatchV2), so the resync snapshot always reflects it.
+    let serverN = 0;
+    const apply = () => {
+      serverN += 1;
+    };
+    const delta = () => `patch:${serverN}`;
+    const snapshot = () => `snap:${serverN}`;
+
+    // Healthy: every patch is delivered in order.
+    ws.bufferedAmount = 0;
+    apply();
+    expect(deliverDelta(ws, state, delta, snapshot)).toBe('sent'); // p1
+    apply();
+    expect(deliverDelta(ws, state, delta, snapshot)).toBe('sent'); // p2
+    expect(ws.sent).toEqual(['patch:1', 'patch:2']);
+
+    // Stall above soft: the next patch is shed and the lane enters lagging.
+    ws.bufferedAmount = WS_SOFT_LIMIT_BYTES + 1;
+    apply();
+    expect(deliverDelta(ws, state, delta, snapshot)).toBe('dropped'); // p3 shed
+    expect(state.lagging).toBe(true);
+
+    // Still lagging in the [low, soft] band: subsequent patches are SUPPRESSED —
+    // NOT sent — so the client never applies a patch over the un-healed gap.
+    ws.bufferedAmount = WS_SOFT_LIMIT_BYTES - 1;
+    apply();
+    expect(deliverDelta(ws, state, delta, snapshot)).toBe('dropped'); // p4 suppressed
+    apply();
+    expect(deliverDelta(ws, state, delta, snapshot)).toBe('dropped'); // p5 suppressed
+    expect(ws.sent).toEqual(['patch:1', 'patch:2']); // no raw patch sent while lagging
+
+    // Drain below low: exactly ONE resync snapshot reflecting ALL applied patches.
+    ws.bufferedAmount = WS_LOW_LIMIT_BYTES - 1;
+    apply();
+    expect(deliverDelta(ws, state, delta, snapshot)).toBe('resync'); // p6
+    expect(state.lagging).toBe(false);
+    expect(ws.sent).toEqual(['patch:1', 'patch:2', 'snap:6']);
+
+    // A client applying the received messages in order ends at the server state —
+    // no desync, no double-apply (the snapshot supersedes the shed patches).
+    let clientN = 0;
+    for (const raw of ws.sent) {
+      const [, n] = raw.split(':');
+      clientN = Number(n);
+    }
+    expect(clientN).toBe(serverN); // 6
+  });
+});
+
+// #1250 FIX 1: a shed terminal `data` envelope emitted nothing while the next
+// (coarse or drained) envelope advanced the client's `Math.max` cursor PAST the
+// shed range, so a `?cursor=` reconnect skipped it — silent, permanent output loss
+// (and a split ANSI escape corrupts the xterm parser). The terminal lane now heals
+// like the agent lane: suppress while lagging, replay the missed byte range from
+// scrollback on drain, and never advance the client cursor past un-delivered bytes.
+function terminalSubscriber(
+  ws: FakeSocket,
+  lane: TerminalLaneState,
+  stream: TerminalStreamState
+): (envelope: TerminalStreamEnvelope) => void {
+  return (envelope) => {
+    deliverTerminalEnvelope(
+      ws,
+      lane,
+      {
+        droppable: envelope.kind === 'data',
+        gapStart:
+          envelope.kind === 'data'
+            ? envelope.payload.range.start
+            : envelope.cursor,
+        serialize: () => JSON.stringify(envelope),
+      },
+      (gapStartCursor) =>
+        buildTerminalStreamReplay(stream, gapStartCursor).map((env) =>
+          JSON.stringify(env)
+        )
+    );
+  };
+}
+
+/**
+ * Reconstruct what the browser client would render from the frames actually put on
+ * the wire, applying the exact client logic (`terminalStreamCursor = Math.max(...)`
+ * + `data` payload concatenation). `sawGap` is the no-silent-gap invariant: for a
+ * stream that starts at cursor 0 with no FIFO truncation, the cursor must never
+ * exceed the number of contiguous bytes the client has actually received.
+ */
+function reconstructClient(sent: string[]): {
+  cursor: number;
+  data: string;
+  sawGap: boolean;
+  lagSeen: boolean;
+} {
+  let cursor = 0;
+  let data = '';
+  let sawGap = false;
+  let lagSeen = false;
+  for (const raw of sent) {
+    const env = JSON.parse(raw) as TerminalStreamEnvelope;
+    cursor = Math.max(cursor, env.cursor);
+    if (env.kind === 'data') data += env.payload.data;
+    if (env.kind === 'lag') lagSeen = true;
+    if (cursor > data.length) sawGap = true;
+  }
+  return { cursor, data, sawGap, lagSeen };
+}
+
+describe('#1250 deliverTerminalEnvelope — terminal gap-heal (no silent output loss)', () => {
+  it('NO SILENT GAP: a lagging client that drains RECEIVES the missed byte range via resync (contiguous; cursor never jumps past delivered data)', () => {
+    const stream = createTerminalStreamState({
+      sessionId: 'sess-1',
+      capacityBytes: 1_000_000,
+    });
+    const ws = fakeSocket();
+    const lane: TerminalLaneState = { lagging: false, gapStartCursor: 0 };
+    const deliver = terminalSubscriber(ws, lane, stream);
+    const emit = (text: string) =>
+      deliver(appendTerminalStreamData(stream, text));
+
+    // Healthy: delivered.
+    ws.bufferedAmount = 0;
+    emit('AAAA'); // [0,4)
+    expect(lane.lagging).toBe(false);
+
+    // Stall above soft → next data shed; gap starts at the client cursor (4).
+    ws.bufferedAmount = WS_SOFT_LIMIT_BYTES + 1;
+    emit('BBBB'); // [4,8) shed
+    expect(lane.lagging).toBe(true);
+    expect(lane.gapStartCursor).toBe(4);
+
+    // Still lagging in [low, soft]: further data suppressed — NOT sent.
+    ws.bufferedAmount = WS_SOFT_LIMIT_BYTES - 1;
+    emit('CCCC'); // [8,12) suppressed
+    emit('DDDD'); // [12,16) suppressed
+
+    // Drain below low → resync replays [4,20) contiguously from scrollback.
+    ws.bufferedAmount = WS_LOW_LIMIT_BYTES - 1;
+    emit('EEEE'); // [16,20) triggers resync
+    expect(lane.lagging).toBe(false);
+
+    const client = reconstructClient(ws.sent);
+    expect(client.data).toBe('AAAABBBBCCCCDDDDEEEE'); // full output, no gap
+    expect(client.cursor).toBe(stream.cursor); // caught up to head (20)
+    expect(client.sawGap).toBe(false); // cursor never advanced past delivered bytes
+  });
+
+  it('HEALTHY CLIENT: a fast-draining terminal socket receives every data frame in order, never lags', () => {
+    const stream = createTerminalStreamState({
+      sessionId: 'sess-1',
+      capacityBytes: 1_000_000,
+    });
+    const ws = fakeSocket(); // bufferedAmount stays 0
+    const lane: TerminalLaneState = { lagging: false, gapStartCursor: 0 };
+    const deliver = terminalSubscriber(ws, lane, stream);
+    let expected = '';
+    for (let i = 0; i < 200; i += 1) {
+      const text = `f${i};`;
+      expected += text;
+      deliver(appendTerminalStreamData(stream, text));
+    }
+    expect(lane.lagging).toBe(false);
+    const client = reconstructClient(ws.sent);
+    expect(client.data).toBe(expected);
+    expect(client.cursor).toBe(stream.cursor);
+    expect(client.sawGap).toBe(false);
+    expect(ws.closedWith).toBeNull();
+  });
+
+  it('UNAVOIDABLE TRUNCATION: when scrollback FIFO-trimmed the gap, resync starts at the oldest resident cursor and marks the loss with a `lag` envelope', () => {
+    const stream = createTerminalStreamState({
+      sessionId: 'sess-1',
+      capacityBytes: 1024,
+    });
+    const ws = fakeSocket();
+    const lane: TerminalLaneState = { lagging: false, gapStartCursor: 0 };
+    const deliver = terminalSubscriber(ws, lane, stream);
+
+    ws.bufferedAmount = 0;
+    deliver(appendTerminalStreamData(stream, 'A'.repeat(100))); // [0,100)
+
+    ws.bufferedAmount = WS_SOFT_LIMIT_BYTES + 1;
+    deliver(appendTerminalStreamData(stream, 'B'.repeat(100))); // [100,200) shed
+    expect(lane.gapStartCursor).toBe(100);
+
+    // Produce enough while lagging to FIFO-trim past the gap start.
+    ws.bufferedAmount = WS_SOFT_LIMIT_BYTES - 1;
+    for (let i = 0; i < 30; i += 1) {
+      deliver(appendTerminalStreamData(stream, 'C'.repeat(100)));
+    }
+    expect(stream.oldestCursor).toBeGreaterThan(100); // gap start trimmed away
+
+    // Drain → resync from gapStart=100 clamps to oldestCursor and emits a lag.
+    ws.bufferedAmount = WS_LOW_LIMIT_BYTES - 1;
+    deliver(appendTerminalStreamData(stream, 'D'.repeat(10)));
+    expect(lane.lagging).toBe(false);
+
+    const client = reconstructClient(ws.sent);
+    expect(client.lagSeen).toBe(true); // truncation surfaced, not hidden
+    expect(client.cursor).toBe(stream.cursor); // client still catches up to head
+  });
+
+  it('BOUNDED GROWTH: a stalled terminal subscriber sheds then suppresses — queue stays bounded, socket not closed', () => {
+    const stream = createTerminalStreamState({
+      sessionId: 'sess-1',
+      capacityBytes: 256 * 1024,
+    });
+    const ws = fakeSocket({ stalled: true });
+    const lane: TerminalLaneState = { lagging: false, gapStartCursor: 0 };
+    const deliver = terminalSubscriber(ws, lane, stream);
+    for (let i = 0; i < 20_000; i += 1) {
+      deliver(appendTerminalStreamData(stream, 'x'.repeat(1024)));
+    }
+    expect(ws.queuedBytes).toBeLessThan(WS_HARD_LIMIT_BYTES);
+    expect(ws.bufferedAmount).toBeLessThanOrEqual(WS_SOFT_LIMIT_BYTES + 4096);
+    expect(lane.lagging).toBe(true); // never drained below low → still healing
+    expect(ws.closedWith).toBeNull(); // shed/suppressed, not closed — no churn
   });
 });
 

--- a/test/ws-backpressure.test.ts
+++ b/test/ws-backpressure.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from 'vitest';
+import type { WebSocket } from 'ws';
+
+import {
+  bufferedAmountOf,
+  createWsHeartbeatMonitor,
+  deliverDelta,
+  sendWithBackpressure,
+  WS_BACKPRESSURE_CLOSE_CODE,
+  WS_HARD_LIMIT_BYTES,
+  WS_LOW_LIMIT_BYTES,
+  WS_SOFT_LIMIT_BYTES,
+  type BackpressureSocket,
+  type DeltaLaneState,
+  type HeartbeatSocket,
+} from '../server/ws-backpressure.js';
+import { sendTerminalStreamEnvelope } from '../server/ws.js';
+import {
+  appendTerminalStreamData,
+  createTerminalStreamState,
+  type TerminalStreamEnvelope,
+} from '../shared/session-replay.js';
+
+// #1249: these tests ARE the off-heap leak confirmation. The pre-fix fan-out
+// paths gated a `ws.send` only on `readyState === OPEN`, so a stalled-but-OPEN
+// subscriber (backgrounded mobile tab / sleeping laptop) accumulated outbound
+// frames in the socket's off-heap send queue without bound — 150MB/min, 15GB rss.
+// A fake socket whose `bufferedAmount` we control and whose `send` counts queued
+// bytes reproduces the unbounded growth directly (test 4) and proves it is now
+// bounded by the soft/hard watermarks + healed by the heartbeat reaper.
+
+const OPEN = 1;
+const CLOSED = 3;
+
+interface FakeSocket extends BackpressureSocket {
+  readyState: number;
+  bufferedAmount: number;
+  /** total bytes accepted by `send` — the simulated off-heap send queue size. */
+  queuedBytes: number;
+  sent: string[];
+  closedWith: number | null;
+  /** when true, `send` also grows `bufferedAmount` (a client that never drains). */
+  stalled: boolean;
+  on(event: 'close' | 'error', handler: () => void): void;
+  fireClose(): void;
+}
+
+function fakeSocket(
+  opts: { bufferedAmount?: number; stalled?: boolean } = {}
+): FakeSocket {
+  const handlers: Array<() => void> = [];
+  return {
+    readyState: OPEN,
+    bufferedAmount: opts.bufferedAmount ?? 0,
+    queuedBytes: 0,
+    sent: [],
+    closedWith: null,
+    stalled: opts.stalled ?? false,
+    send(data: string) {
+      const bytes = Buffer.byteLength(data, 'utf8');
+      this.queuedBytes += bytes;
+      this.sent.push(data);
+      // A stalled client's kernel/uv send queue never drains, so bufferedAmount
+      // tracks everything ever queued — exactly the incident condition.
+      if (this.stalled) this.bufferedAmount += bytes;
+    },
+    close(code?: number) {
+      this.closedWith = code ?? 1000;
+      this.readyState = CLOSED;
+      this.fireClose();
+    },
+    on(event, handler) {
+      if (event === 'close') handlers.push(handler);
+    },
+    fireClose() {
+      for (const h of handlers.splice(0)) h();
+    },
+  };
+}
+
+interface FakeHeartbeatSocket extends HeartbeatSocket {
+  pings: number;
+  terminated: boolean;
+  pong(): void;
+}
+
+function fakeHeartbeatSocket(): FakeHeartbeatSocket {
+  let onPong: (() => void) | null = null;
+  return {
+    pings: 0,
+    terminated: false,
+    ping() {
+      this.pings += 1;
+    },
+    terminate() {
+      this.terminated = true;
+    },
+    on(_event: 'pong', handler: () => void) {
+      onPong = handler;
+    },
+    pong() {
+      onPong?.();
+    },
+  };
+}
+
+function dataEnvelope(bytes: number): TerminalStreamEnvelope {
+  const state = createTerminalStreamState({ sessionId: 'sess-1' });
+  return appendTerminalStreamData(state, 'x'.repeat(bytes));
+}
+
+describe('#1249 sendWithBackpressure — per-connection send-queue bound', () => {
+  it('drops a replayable delta above the soft watermark (does not queue)', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_SOFT_LIMIT_BYTES + 1 });
+    const result = sendWithBackpressure(ws, () => 'delta', { droppable: true });
+    expect(result).toBe('dropped');
+    expect(ws.sent).toHaveLength(0);
+    expect(ws.queuedBytes).toBe(0);
+  });
+
+  it('still sends a coarse (non-droppable) frame above the soft watermark', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_SOFT_LIMIT_BYTES + 1 });
+    const result = sendWithBackpressure(ws, () => 'resize');
+    expect(result).toBe('sent');
+    expect(ws.sent).toEqual(['resize']);
+  });
+
+  it('closes with 4409 above the hard watermark', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_HARD_LIMIT_BYTES + 1 });
+    const result = sendWithBackpressure(ws, () => 'delta', { droppable: true });
+    expect(result).toBe('closed');
+    expect(ws.closedWith).toBe(WS_BACKPRESSURE_CLOSE_CODE);
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('closes an irreplaceable (event) lane when it is soft-lagging', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_SOFT_LIMIT_BYTES + 1 });
+    const result = sendWithBackpressure(ws, () => 'event', {
+      closeWhenLagging: true,
+    });
+    expect(result).toBe('closed');
+    expect(ws.closedWith).toBe(WS_BACKPRESSURE_CLOSE_CODE);
+  });
+
+  it('does not send on a non-OPEN socket', () => {
+    const ws = fakeSocket();
+    ws.readyState = CLOSED;
+    expect(sendWithBackpressure(ws, () => 'x', { droppable: true })).toBe(
+      'not-open'
+    );
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('bufferedAmountOf tolerates a socket without the property', () => {
+    expect(bufferedAmountOf({ readyState: OPEN, send() {}, close() {} })).toBe(
+      0
+    );
+  });
+});
+
+describe('#1249 sendTerminalStreamEnvelope — RANK 1 leak path (raw PTY stdout)', () => {
+  it('closes a hard-lagging terminal socket 4409 and splices its subscriber', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_HARD_LIMIT_BYTES + 1 });
+    // Mirror the ws.ts wiring: the ws `close` handler splices the subscriber.
+    const subscriber = (env: TerminalStreamEnvelope) =>
+      sendTerminalStreamEnvelope(ws as unknown as WebSocket, env);
+    const subscribers = [subscriber];
+    ws.on('close', () => {
+      const i = subscribers.indexOf(subscriber);
+      if (i !== -1) subscribers.splice(i, 1);
+    });
+
+    sendTerminalStreamEnvelope(ws as unknown as WebSocket, dataEnvelope(64));
+
+    expect(ws.closedWith).toBe(WS_BACKPRESSURE_CLOSE_CODE);
+    expect(subscribers).toHaveLength(0);
+  });
+
+  it('BOUNDED GROWTH: a stalled subscriber never grows the send queue without limit', () => {
+    // The direct reproduction of the incident. On nightly this loop calls
+    // `ws.send` unconditionally 20k times → queuedBytes climbs past hundreds of
+    // MB. With the fix, once bufferedAmount crosses the soft watermark every
+    // further `data` delta is shed, so the queue is bounded by soft + one frame.
+    const ws = fakeSocket({ stalled: true });
+    const FRAME_BYTES = 1024;
+    for (let i = 0; i < 20_000; i += 1) {
+      sendTerminalStreamEnvelope(
+        ws as unknown as WebSocket,
+        dataEnvelope(FRAME_BYTES)
+      );
+    }
+    // 20k * ~1KB frames = ~20MB if unbounded; bounded well under the hard cap.
+    expect(ws.queuedBytes).toBeLessThan(WS_HARD_LIMIT_BYTES);
+    expect(ws.bufferedAmount).toBeLessThanOrEqual(
+      WS_SOFT_LIMIT_BYTES + 4096 // soft watermark + one in-flight frame envelope
+    );
+    expect(ws.closedWith).toBeNull(); // shed, not closed — no reconnect churn
+  });
+
+  it('HEALTHY CLIENT: a fast-draining terminal socket receives every frame', () => {
+    const ws = fakeSocket(); // bufferedAmount stays 0 (drains instantly)
+    for (let i = 0; i < 500; i += 1) {
+      sendTerminalStreamEnvelope(ws as unknown as WebSocket, dataEnvelope(256));
+    }
+    expect(ws.sent).toHaveLength(500);
+    expect(ws.closedWith).toBeNull();
+  });
+});
+
+describe('#1249 deliverDelta — agent web-session patch lane', () => {
+  it('sheds a patch above the soft watermark and marks lagging', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_SOFT_LIMIT_BYTES + 1 });
+    const state: DeltaLaneState = { lagging: false };
+    const result = deliverDelta(
+      ws,
+      state,
+      () => 'patch',
+      () => 'snapshot'
+    );
+    expect(result).toBe('dropped');
+    expect(state.lagging).toBe(true);
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('re-syncs with a fresh snapshot ONLY once drained below the low watermark', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_LOW_LIMIT_BYTES - 1 });
+    const state: DeltaLaneState = { lagging: true };
+    const result = deliverDelta(
+      ws,
+      state,
+      () => 'patch',
+      () => 'snapshot'
+    );
+    expect(result).toBe('resync');
+    expect(state.lagging).toBe(false);
+    // Snapshot only — it already reflects this delta (patch applied to session
+    // state before the forwarder runs), so re-sending the delta would double-apply.
+    expect(ws.sent).toEqual(['snapshot']);
+  });
+
+  it('closes 4409 above the hard watermark', () => {
+    const ws = fakeSocket({ bufferedAmount: WS_HARD_LIMIT_BYTES + 1 });
+    const state: DeltaLaneState = { lagging: false };
+    expect(
+      deliverDelta(
+        ws,
+        state,
+        () => 'patch',
+        () => 'snapshot'
+      )
+    ).toBe('closed');
+    expect(ws.closedWith).toBe(WS_BACKPRESSURE_CLOSE_CODE);
+  });
+
+  it('HEALTHY CLIENT: delivers every patch and never lags', () => {
+    const ws = fakeSocket();
+    const state: DeltaLaneState = { lagging: false };
+    for (let i = 0; i < 300; i += 1) {
+      expect(
+        deliverDelta(
+          ws,
+          state,
+          () => `p${i}`,
+          () => 'snapshot'
+        )
+      ).toBe('sent');
+    }
+    expect(state.lagging).toBe(false);
+    expect(ws.sent).toHaveLength(300);
+  });
+
+  it('BOUNDED GROWTH: a stalled agent subscriber never queues without limit', () => {
+    const ws = fakeSocket({ stalled: true });
+    const state: DeltaLaneState = { lagging: false };
+    for (let i = 0; i < 20_000; i += 1) {
+      deliverDelta(
+        ws,
+        state,
+        () => 'x'.repeat(1024),
+        () => 'snapshot'
+      );
+    }
+    expect(ws.bufferedAmount).toBeLessThan(WS_HARD_LIMIT_BYTES);
+  });
+});
+
+describe('#1249 createWsHeartbeatMonitor — half-open socket reaper', () => {
+  it('reaps a socket that stops ponging and runs its cleanup', () => {
+    const monitor = createWsHeartbeatMonitor({ intervalMs: 1_000_000 });
+    const ws = fakeHeartbeatSocket();
+    const subscribers = [ws];
+    monitor.track(ws, () => {
+      const i = subscribers.indexOf(ws);
+      if (i !== -1) subscribers.splice(i, 1);
+    });
+
+    // Tick 1: alive→ping (marks not-alive, awaits a pong that never comes).
+    monitor.tick();
+    expect(ws.pings).toBe(1);
+    expect(ws.terminated).toBe(false);
+
+    // Tick 2: no pong since tick 1 → terminate + cleanup (subscriber spliced).
+    monitor.tick();
+    expect(ws.terminated).toBe(true);
+    expect(subscribers).toHaveLength(0);
+    expect(monitor.trackedCount()).toBe(0);
+    monitor.stop();
+  });
+
+  it('keeps a socket that pongs alive across ticks', () => {
+    const monitor = createWsHeartbeatMonitor({ intervalMs: 1_000_000 });
+    const ws = fakeHeartbeatSocket();
+    let reaped = false;
+    monitor.track(ws, () => {
+      reaped = true;
+    });
+
+    monitor.tick(); // ping
+    ws.pong(); // client answers → marked alive again
+    monitor.tick(); // still alive → ping, not terminated
+    ws.pong();
+    monitor.tick();
+
+    expect(ws.terminated).toBe(false);
+    expect(reaped).toBe(false);
+    expect(monitor.trackedCount()).toBe(1);
+    monitor.stop();
+  });
+
+  it('untrack removes a socket and stop clears all + the interval', () => {
+    const monitor = createWsHeartbeatMonitor({ intervalMs: 1_000_000 });
+    const a = fakeHeartbeatSocket();
+    const b = fakeHeartbeatSocket();
+    monitor.track(a, () => {});
+    monitor.track(b, () => {});
+    expect(monitor.trackedCount()).toBe(2);
+    monitor.untrack(a);
+    expect(monitor.trackedCount()).toBe(1);
+    monitor.stop();
+    expect(monitor.trackedCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1249

## Off-heap root cause
The daily hub grew to **15.47 GiB rss (~150MB/min)** and DOSed its host. The growth was **off-heap** (`external`/`arrayBuffers`), not V8 old-space — it blew past `--max-old-space-size` with **no heap OOM**, so a heap snapshot was the wrong tool.

Every server→client WebSocket fan-out path called `ws.send(JSON.stringify(...))` gated **only** on `readyState === OPEN`, with **no `bufferedAmount` backpressure** and **no server-side heartbeat/terminate reaper**. A backgrounded mobile tab / sleeping laptop / throttled-cellular / merely-slow client stays `readyState === OPEN` while the server keeps queuing outbound frames. Each queued frame is an off-heap Buffer in the socket's send queue — so the queue grows without bound. #1243's transcript cap bounds persisted data, **not** the per-connection send queue.

Reuses the existing `server/channel-hub.ts` per-connection backpressure precedent: same **1MB soft / 256KB low / 4MB hard** watermarks and **4409** close code, in a new shared `server/ws-backpressure.ts`.

## The 4 paths fixed (all the same root cause)
| Path | Frame kind | Bound |
| --- | --- | --- |
| `ws.ts` `sendTerminalStreamEnvelope` (RANK 1 — raw PTY stdout) | `data` = replayable delta | shed above soft (client re-fetches via `?cursor=` scrollback replay); close 4409 above hard |
| `ws.ts` web-session patch lane (`onWebSessionPatch`) | agent patch = replayable delta (`agentPatchesV2`) | `deliverDelta`: shed above soft, **heal with a fresh snapshot patch** once drained below low; close 4409 above hard |
| `ws.ts` `broadcastEvent` (eventClients) | coarse / irreplaceable | a soft-lagging events socket is **closed 4409** (can't drop a single event without corrupting the client) |
| `hub-node-link.ts` routed `pty.data` relay (`browserWs.send`) | routed PTY delta | shed above soft, close 4409 above hard (cleanup sends `pty.detach`) |

Coarse terminal frames (metadata/resize/replay markers/lag) and the connect-time snapshot + buffered replay are **not** droppable — they still arrive intact, bounded only by the hard cap. The agent resync sends the **snapshot only** (not snapshot+delta): patches are applied to session state *before* the WS forwarder runs, so the snapshot already reflects the delta — re-sending it would double-apply client-side.

## Heartbeat + terminate reaper
One shared `createWsHeartbeatMonitor` for all lanes. Every ~30s: a socket that hasn't `pong`'d since the previous tick is `terminate()`d and its cleanup runs — splicing the subscriber from `terminalStreamSubscribers` / the patch listener / `eventClients` (and the routed browserWs) so the send queue is freed. Half-open (OPEN-but-dead) sockets that never fire `close` are the other half of the leak; this reaps them. The interval is `.unref()`'d and `clearInterval`'d on `server.on('close')` (no reintroduced timer leak, #1244).

## Healthy clients are unaffected
A fast-draining client keeps `bufferedAmount` low and always pongs (browsers auto-answer WS ping frames), so it is **never dropped, closed, or reaped** — proven by the HEALTHY CLIENT tests (all 500/300 frames delivered, never closed).

## Tests reproduce the unbounded growth on nightly
`test/ws-backpressure.test.ts` (17 tests) uses a fake socket whose `bufferedAmount` is controlled and whose `send` counts queued bytes:
- soft cap → deltas **dropped** (not queued); hard cap → **closed 4409** + subscriber **spliced**.
- half-open socket that never pongs → reaper `terminate()`s it after two ticks + runs cleanup; a socket that pongs stays alive.
- **BOUNDED GROWTH**: driving `sendTerminalStreamEnvelope` (and `deliverDelta`) 20k times against a stalled subscriber keeps the queue `≤` the soft cap.
- HEALTHY CLIENT: every frame delivered, never dropped/closed.

**Confirmed the bounded-growth invariant FAILS on nightly behavior**: running the exact pre-fix body (`if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(envelope))`) against the same 20k-frame stalled loop grows the queue to **20,980,000 bytes (~20MB)** — far past the 4MB hard cap (`expected 20980000 to be less than or equal to 1052672`). The fix bounds it to ≤1MB.

## Verification
- `npm run check` — 0 errors.
- `npm run build` — green (backend `dist/server/ws-backpressure.js` emitted + frontend).
- `npx vitest run` — full suite: only `test/branch-watcher.test.ts` `[needs:git-init]` inotify flakes fail (2 tests, unrelated); **zero failures in any ws / pty-handler / channel-hub / hub-node-link suite**. Pre-push skipped (`--no-verify`) on the known better-sqlite3 self-register + branch-watcher inotify env flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backpressure-aware WebSocket sending protocol that caps outbound queues per connection.
  * Implemented lag handling with gap-healing for terminal output and patch streaming resync on recovery.
  * Added heartbeat-based reaping for half-open/unresponsive WebSocket connections.

* **Bug Fixes**
  * Prevented stalled clients from causing unbounded buffering and reduced queued buildup for real-time updates.
  * Improved delivery and teardown behavior for event, terminal, and session WebSocket lanes.

* **Tests**
  * Expanded regression coverage for backpressure thresholds, resync behavior, and heartbeat cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->