### PR TITLE
fix(watcher): stop recursively watching node_modules — daily-hub event-loop wedge (#1249)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3331,6 +3331,18 @@ async function main(): Promise<void> {
   const watcher = new WorktreeWatcher();
   watcher.rebuild(getConfig().repos || []);
 
+  // gitWatcher lifecycle: `gitWatcher.watch(cwd)` is refcounted per session at
+  // each session-create site; `gitWatcher.unwatch(cwd)` must be called once per
+  // matching teardown. It is wired to the explicit teardown paths — DELETE
+  // /sessions/:id and the DELETE /worktrees force-kill loop (#1244). A session
+  // that exits on its own (PTY dies without an explicit DELETE) is NOT unwatched
+  // here: a central sessions.onSessionEnd → unwatch is deliberately avoided
+  // because PTY sessions fire session-end twice on explicit kill (kill() +
+  // pty-exit cleanup), which would over-decrement the refcount and close a
+  // watcher another session at the same cwd still needs. The residual leak is
+  // now bounded — post-#1249 a watcher only covers non-ignored top-level source
+  // dirs, never node_modules — so it can no longer wedge the event loop.
+  // Follow-up: single-fire session-end + central unwatch (tracked in #1244).
   const gitWatcher = new GitWatcher();
 
   const server = http.createServer(app);
@@ -5343,6 +5355,10 @@ async function main(): Promise<void> {
     // Force: kill active sessions in this worktree first
     if (force) {
       for (const sessionId of worktreeSessions) {
+        // Capture cwd before kill so we can release the git watcher. #1244:
+        // this teardown path previously killed sessions without unwatching,
+        // leaking a working-tree watcher per force-deleted worktree.
+        const killedCwd = localRelayNode.sessions.get(sessionId)?.cwd;
         try {
           localRelayNode.sessions.kill(sessionId);
         } catch (err) {
@@ -5351,6 +5367,7 @@ async function main(): Promise<void> {
             err instanceof Error ? err.message : err
           );
         }
+        if (killedCwd) gitWatcher.unwatch(killedCwd);
       }
     }
 

--- a/server/watcher.ts
+++ b/server/watcher.ts
@@ -640,7 +640,14 @@ export class RefWatcher {
 
 // Directories to ignore when watching the working tree.
 // These never contain user-authored source files worth diffing.
-const IGNORED_DIRS = new Set([
+// IMPORTANT: these are pruned at EVERY level of the walk (not just the top),
+// so nested trees such as `.worktrees/<wt>/node_modules` or a monorepo's
+// `packages/<pkg>/node_modules` are never descended into (#1249 / PR #1251
+// review P0: nested node_modules re-wedged the hub even after top-level
+// exclusion). `.worktrees` and `.claude` are ignored because the dogfood
+// checkout keeps sibling worktrees and generated agent config there — both
+// are large, gitignored, and never source worth diffing from the root.
+export const IGNORED_DIRS = new Set([
   '.git',
   'node_modules',
   '.next',
@@ -658,25 +665,34 @@ const IGNORED_DIRS = new Set([
   '.turbo',
   '.cache',
   '.parcel-cache',
+  '.worktrees',
+  '.claude',
 ]);
 
-// Safety cap on the number of recursive top-level sub-watches per workspace.
-// A normal repo has a handful of source dirs; anything much larger is either
-// pathological or a directory we should not be walking. We attach up to this
-// many recursive watches and warn (never silently watch unbounded).
-const MAX_RECURSIVE_SUBDIR_WATCHES = 64;
+// Safety cap on the total number of per-directory watches per workspace.
+// The walk prunes IGNORED_DIRS at every level, so a normal source tree is
+// hundreds-to-low-thousands of dirs. This cap bounds a pathological
+// non-ignored tree; hitting it logs a WARN describing the partial coverage
+// (never a silent cap — #1244).
+const MAX_WATCHED_DIRS = 8192;
+
+// Debounce for reconciling a single directory's watch set after a create/delete
+// ('rename') event. Collapses bursts (e.g. a tool writing many files into a
+// watched dir) into one cheap, non-recursive re-read of that ONE directory.
+const RESCAN_DEBOUNCE_MS = 250;
 
 interface WorkspaceWatchEntry {
-  // Non-recursive watch on the workspace root: catches top-level file edits and
-  // the creation of new top-level directories (so we can attach a sub-watch).
-  rootWatcher?: fs.FSWatcher | undefined;
-  // Recursive watches, one per NON-ignored top-level directory. Keyed by the
-  // directory name so a rescan can skip dirs it already watches.
-  subWatchers: Map<string, fs.FSWatcher>;
+  // One NON-recursive fs.watch per NON-ignored directory in the tree, keyed by
+  // absolute directory path. Node's recursive fs.watch cannot prune per-level,
+  // so we maintain the recursion ourselves and skip IGNORED_DIRS at every depth.
+  dirWatchers: Map<string, fs.FSWatcher>;
   // .git/HEAD watch for commits / branch switches.
   headWatcher?: fs.FSWatcher | undefined;
-  // Debounce timer for the bounded top-level rescan (new dir detection).
-  rescanTimer?: ReturnType<typeof setTimeout> | null;
+  // Per-directory debounce timers for create/delete reconciliation, keyed by
+  // the directory whose children changed.
+  rescanTimers: Map<string, ReturnType<typeof setTimeout>>;
+  // Set once we log the cap WARN so a workspace warns at most once.
+  cappedWarned: boolean;
   refCount: number;
 }
 
@@ -692,24 +708,27 @@ export class GitWatcher extends EventEmitter {
     }
 
     const entry: WorkspaceWatchEntry = {
-      subWatchers: new Map(),
-      rescanTimer: null,
+      dirWatchers: new Map(),
+      rescanTimers: new Map(),
+      cappedWarned: false,
       refCount: 1,
     };
 
-    // 1. Watch the working tree for file edits WITHOUT recursing into
-    //    IGNORED_DIRS (#1249). Node's recursive fs.watch on Linux is
-    //    implemented in JS: it walks + stats + inotify-watches EVERY
-    //    subdirectory. A single fs.watch(root, {recursive:true}) therefore
-    //    walks node_modules (100k+ files) at setup and re-walks on events,
-    //    wedging the event loop — filtering in the callback is too late.
-    //    Instead: watch the root non-recursively (top-level file edits + new
-    //    top-level dir detection) and add a recursive watch to each
-    //    non-ignored top-level directory only. .git/ changes are still
-    //    filtered in the callback (defense in depth) so git-status calls
+    // 1. Watch the working tree for file edits with a CUSTOM per-level-pruning
+    //    recursive watcher (#1249 / PR #1251 review P0). Node's recursive
+    //    fs.watch on Linux is implemented in JS: it walks + stats +
+    //    inotify-watches EVERY subdirectory with NO per-level exclusion, so it
+    //    always descends node_modules (100k+ files) — even a `fs.watch(dir,
+    //    {recursive:true})` on a *non-ignored* top-level dir still walks any
+    //    node_modules nested underneath it (a monorepo `packages/*/node_modules`
+    //    or the dogfood checkout's `.worktrees/*/node_modules`, which is LARGER
+    //    than the root node_modules). We therefore walk the tree ourselves,
+    //    pruning IGNORED_DIRS at every level, and attach a NON-recursive watch
+    //    to each non-ignored directory. Create/delete of a child re-reads that
+    //    one directory (cheap) to add/drop watches dynamically. IGNORED_DIRS is
+    //    also filtered in each callback (defense in depth) so git-status calls
     //    never cause feedback loops.
-    entry.rootWatcher = this.createRootWatcher(workspacePath, entry);
-    this.attachTopLevelSubWatchers(workspacePath, entry);
+    this.walkAndWatch(workspacePath, entry, workspacePath);
 
     // 2. Watch .git/HEAD for commits and branch switches.
     //    Single-file watch, no feedback loop risk (HEAD only changes on checkout/commit).
@@ -739,11 +758,7 @@ export class GitWatcher extends EventEmitter {
       // .git doesn't exist or isn't readable — skip HEAD watching
     }
 
-    if (
-      !entry.rootWatcher &&
-      entry.subWatchers.size === 0 &&
-      !entry.headWatcher
-    ) {
+    if (entry.dirWatchers.size === 0 && !entry.headWatcher) {
       return;
     }
 
@@ -751,169 +766,217 @@ export class GitWatcher extends EventEmitter {
   }
 
   /**
-   * Watch the workspace root NON-recursively. Detects top-level file edits and
-   * the creation of new top-level directories. On a rename/create event we may
-   * schedule a bounded, debounced rescan to attach a recursive watch to a newly
-   * added non-ignored directory — but never a per-event re-walk of the tree.
+   * Walk the tree rooted at `startDir`, pruning IGNORED_DIRS at EVERY level, and
+   * attach a NON-recursive fs.watch to each non-ignored directory. Iterative
+   * (explicit stack) so a deep tree can't blow the call stack. Bounded by
+   * MAX_WATCHED_DIRS: once the cap is hit, remaining directories are skipped and
+   * a single WARN is logged (never a silent cap). An ignored directory is never
+   * counted toward the cap — the walk skips it before it is ever pushed.
    */
-  private createRootWatcher(
+  private walkAndWatch(
     workspacePath: string,
-    entry: WorkspaceWatchEntry
+    entry: WorkspaceWatchEntry,
+    startDir: string
+  ): void {
+    const stack: string[] = [startDir];
+    let skipped = 0;
+    let cappedHit = false;
+
+    while (stack.length > 0) {
+      const dir = stack.pop()!;
+      if (entry.dirWatchers.has(dir)) continue;
+
+      if (entry.dirWatchers.size >= MAX_WATCHED_DIRS) {
+        skipped++;
+        cappedHit = true;
+        continue;
+      }
+
+      const watcher = this.createDirWatcher(workspacePath, entry, dir);
+      if (watcher) entry.dirWatchers.set(dir, watcher);
+
+      let dirents: fs.Dirent[];
+      try {
+        dirents = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        // Directory vanished or is unreadable — nothing more to enqueue.
+        continue;
+      }
+      for (const dirent of dirents) {
+        if (!dirent.isDirectory()) continue;
+        if (IGNORED_DIRS.has(dirent.name)) continue; // prune at EVERY level
+        const child = path.join(dir, dirent.name);
+        if (!entry.dirWatchers.has(child)) stack.push(child);
+      }
+    }
+
+    if (cappedHit && !entry.cappedWarned) {
+      entry.cappedWarned = true;
+      logger.warn(
+        `[GitWatcher] ${workspacePath}: reached watch cap of ${MAX_WATCHED_DIRS} directories; skipped at least ${skipped} — change detection is PARTIAL for this workspace (edits in directories beyond the cap will not auto-refresh changed-files)`
+      );
+    }
+  }
+
+  /**
+   * Create a single NON-recursive fs.watch for `dir`. Its callback filters
+   * IGNORED_DIRS children (defense in depth) and, on a 'rename' (child created
+   * or deleted), schedules a debounced reconcile of THIS directory only — cheap,
+   * because it re-reads one directory non-recursively, never the whole tree.
+   */
+  private createDirWatcher(
+    workspacePath: string,
+    entry: WorkspaceWatchEntry,
+    dir: string
   ): fs.FSWatcher | undefined {
     try {
-      const rootWatcher = fs.watch(
-        workspacePath,
+      const watcher = fs.watch(
+        dir,
         { persistent: false },
         (event, filename) => {
-          if (!filename) return;
-          const name = String(filename);
-          const firstSegment = name.split(path.sep)[0] ?? '';
-          if (IGNORED_DIRS.has(firstSegment)) return;
-          // A rename at the top level may be a newly created source dir —
-          // schedule a bounded, debounced rescan to attach a watch to it.
+          if (filename) {
+            // A non-recursive watch reports the changed direct child. Skip
+            // ignored children so a newly created node_modules / .worktrees
+            // neither gets watched nor spams git-status.
+            const firstSegment = String(filename).split(path.sep)[0] ?? '';
+            if (IGNORED_DIRS.has(firstSegment)) return;
+          }
           if (event === 'rename') {
-            this.scheduleTopLevelRescan(workspacePath, entry);
+            // Child dir created or removed — reconcile watches for this dir.
+            this.scheduleDirRescan(workspacePath, entry, dir);
           }
           this.debouncedEmit(workspacePath);
         }
       );
-      rootWatcher.on('error', (err) => {
+      watcher.on('error', () => {
+        /* per-dir watch is best-effort */
+      });
+      return watcher;
+    } catch (err: unknown) {
+      if (dir === workspacePath) {
+        const msg = err instanceof Error ? err.message : String(err);
         logger.warn(
-          '[GitWatcher] working-tree root watch failed for',
+          '[GitWatcher] could not watch working tree for',
           workspacePath,
           '—',
-          err.message
+          msg
         );
         logger.warn(
           '[GitWatcher] changed-files may not auto-refresh for this workspace. On Linux, try: sysctl fs.inotify.max_user_watches=524288'
         );
-      });
-      return rootWatcher;
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      logger.warn(
-        '[GitWatcher] could not watch working tree for',
-        workspacePath,
-        '—',
-        msg
-      );
+      }
+      // Nested per-dir watch failures are non-fatal and stay quiet.
       return undefined;
     }
   }
 
   /**
-   * Attach a recursive fs.watch to each NON-ignored top-level directory that is
-   * not already watched. Reads only the top level (never walks into
-   * IGNORED_DIRS such as node_modules). Bounded by MAX_RECURSIVE_SUBDIR_WATCHES;
-   * excess directories are skipped with a warning (never silent unbounded
-   * watching).
+   * Debounce a reconcile of a single directory. At most one reconcile is pending
+   * per directory, so a burst of create/delete events collapses to one
+   * non-recursive readdir of that directory.
    */
-  private attachTopLevelSubWatchers(
+  private scheduleDirRescan(
     workspacePath: string,
-    entry: WorkspaceWatchEntry
+    entry: WorkspaceWatchEntry,
+    dir: string
+  ): void {
+    if (entry.rescanTimers.has(dir)) return;
+    const timer = setTimeout(() => {
+      entry.rescanTimers.delete(dir);
+      // Ignore if this entry has been torn down / replaced in the meantime.
+      if (this.watchers.get(workspacePath) !== entry) return;
+      this.reconcileDir(workspacePath, entry, dir);
+    }, RESCAN_DEBOUNCE_MS);
+    entry.rescanTimers.set(dir, timer);
+  }
+
+  /**
+   * Re-read ONE directory (non-recursively) and reconcile its child watches:
+   * walk+watch newly created non-ignored subdirs, and drop watches for direct
+   * child directories that were removed (unwatching their whole subtree). If the
+   * directory itself is gone, unwatch it and everything under it.
+   */
+  private reconcileDir(
+    workspacePath: string,
+    entry: WorkspaceWatchEntry,
+    dir: string
   ): void {
     let dirents: fs.Dirent[];
     try {
-      dirents = fs.readdirSync(workspacePath, { withFileTypes: true });
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      logger.warn(
-        '[GitWatcher] could not read top-level entries for',
-        workspacePath,
-        '—',
-        msg
-      );
+      dirents = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      // Directory removed or unreadable — drop it and all descendant watches.
+      this.unwatchSubtree(entry, dir);
       return;
     }
 
-    let skipped = 0;
+    const liveChildDirs = new Set<string>();
     for (const dirent of dirents) {
       if (!dirent.isDirectory()) continue;
-      if (IGNORED_DIRS.has(dirent.name)) continue;
-      if (entry.subWatchers.has(dirent.name)) continue;
-      if (entry.subWatchers.size >= MAX_RECURSIVE_SUBDIR_WATCHES) {
-        skipped++;
-        continue;
-      }
-      const dirPath = path.join(workspacePath, dirent.name);
-      try {
-        const subWatcher = fs.watch(
-          dirPath,
-          { persistent: false, recursive: true },
-          (_event, filename) => {
-            if (filename) {
-              // Defense in depth: skip nested ignored dirs (e.g. a source dir
-              // that itself contains a node_modules) so a monorepo package's
-              // deps don't spam git-status.
-              const firstSegment = String(filename).split(path.sep)[0] ?? '';
-              if (IGNORED_DIRS.has(firstSegment)) return;
-            }
-            this.debouncedEmit(workspacePath);
-          }
-        );
-        subWatcher.on('error', () => {
-          /* per-dir watch is best-effort */
-        });
-        entry.subWatchers.set(dirent.name, subWatcher);
-      } catch {
-        // Individual directory watch failure is non-fatal.
+      if (IGNORED_DIRS.has(dirent.name)) continue; // prune ignored children
+      const child = path.join(dir, dirent.name);
+      liveChildDirs.add(child);
+      if (!entry.dirWatchers.has(child)) {
+        // Newly created non-ignored subdir — walk + watch it (bounded, pruned).
+        this.walkAndWatch(workspacePath, entry, child);
       }
     }
 
-    if (skipped > 0) {
-      logger.warn(
-        `[GitWatcher] ${workspacePath}: capped recursive watches at ${MAX_RECURSIVE_SUBDIR_WATCHES}; skipped ${skipped} top-level director${
-          skipped === 1 ? 'y' : 'ies'
-        } — changed-files may miss edits in unwatched top-level directories`
-      );
+    // Drop watches for direct child directories that no longer exist. A
+    // non-recursive watch on `dir` only reports its own direct children, so we
+    // only reconcile this level; nested changes are handled by nested watches.
+    for (const watched of [...entry.dirWatchers.keys()]) {
+      if (path.dirname(watched) !== dir) continue;
+      if (!liveChildDirs.has(watched)) {
+        this.unwatchSubtree(entry, watched);
+      }
     }
   }
 
   /**
-   * Schedule a single bounded, debounced rescan of the workspace top level to
-   * attach watches to newly created non-ignored directories. At most one rescan
-   * is pending per workspace, so a burst of rename events collapses to one
-   * top-level readdir — never a per-event re-walk.
+   * Close and forget the watch on `root` and every watched directory beneath it,
+   * plus any pending reconcile timers in that subtree. Idempotent.
    */
-  private scheduleTopLevelRescan(
-    workspacePath: string,
-    entry: WorkspaceWatchEntry
-  ): void {
-    if (entry.rescanTimer) return;
-    entry.rescanTimer = setTimeout(() => {
-      entry.rescanTimer = null;
-      // Ignore if this entry has been torn down / replaced in the meantime.
-      if (this.watchers.get(workspacePath) !== entry) return;
-      this.attachTopLevelSubWatchers(workspacePath, entry);
-    }, 1000);
+  private unwatchSubtree(entry: WorkspaceWatchEntry, root: string): void {
+    const prefix = root + path.sep;
+    for (const [watchedPath, watcher] of [...entry.dirWatchers]) {
+      if (watchedPath === root || watchedPath.startsWith(prefix)) {
+        try {
+          watcher.close();
+        } catch {
+          // ignore
+        }
+        entry.dirWatchers.delete(watchedPath);
+      }
+    }
+    for (const [timerPath, timer] of [...entry.rescanTimers]) {
+      if (timerPath === root || timerPath.startsWith(prefix)) {
+        clearTimeout(timer);
+        entry.rescanTimers.delete(timerPath);
+      }
+    }
   }
 
   private closeEntry(entry: WorkspaceWatchEntry): void {
-    if (entry.rescanTimer) {
-      clearTimeout(entry.rescanTimer);
-      entry.rescanTimer = null;
+    for (const timer of entry.rescanTimers.values()) {
+      clearTimeout(timer);
     }
-    if (entry.rootWatcher) {
+    entry.rescanTimers.clear();
+    for (const watcher of entry.dirWatchers.values()) {
       try {
-        entry.rootWatcher.close();
+        watcher.close();
       } catch {
         // ignore
       }
     }
-    for (const subWatcher of entry.subWatchers.values()) {
-      try {
-        subWatcher.close();
-      } catch {
-        // ignore
-      }
-    }
-    entry.subWatchers.clear();
+    entry.dirWatchers.clear();
     if (entry.headWatcher) {
       try {
         entry.headWatcher.close();
       } catch {
         // ignore
       }
+      entry.headWatcher = undefined;
     }
   }
 

--- a/server/watcher.ts
+++ b/server/watcher.ts
@@ -660,15 +660,28 @@ const IGNORED_DIRS = new Set([
   '.parcel-cache',
 ]);
 
+// Safety cap on the number of recursive top-level sub-watches per workspace.
+// A normal repo has a handful of source dirs; anything much larger is either
+// pathological or a directory we should not be walking. We attach up to this
+// many recursive watches and warn (never silently watch unbounded).
+const MAX_RECURSIVE_SUBDIR_WATCHES = 64;
+
+interface WorkspaceWatchEntry {
+  // Non-recursive watch on the workspace root: catches top-level file edits and
+  // the creation of new top-level directories (so we can attach a sub-watch).
+  rootWatcher?: fs.FSWatcher | undefined;
+  // Recursive watches, one per NON-ignored top-level directory. Keyed by the
+  // directory name so a rescan can skip dirs it already watches.
+  subWatchers: Map<string, fs.FSWatcher>;
+  // .git/HEAD watch for commits / branch switches.
+  headWatcher?: fs.FSWatcher | undefined;
+  // Debounce timer for the bounded top-level rescan (new dir detection).
+  rescanTimer?: ReturnType<typeof setTimeout> | null;
+  refCount: number;
+}
+
 export class GitWatcher extends EventEmitter {
-  private watchers = new Map<
-    string,
-    {
-      treeWatcher: fs.FSWatcher;
-      headWatcher?: fs.FSWatcher | undefined;
-      refCount: number;
-    }
-  >();
+  private watchers = new Map<string, WorkspaceWatchEntry>();
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   watch(workspacePath: string): void {
@@ -678,44 +691,25 @@ export class GitWatcher extends EventEmitter {
       return;
     }
 
-    let treeWatcher: fs.FSWatcher | undefined;
-    let headWatcher: fs.FSWatcher | undefined;
+    const entry: WorkspaceWatchEntry = {
+      subWatchers: new Map(),
+      rescanTimer: null,
+      refCount: 1,
+    };
 
-    // 1. Watch the working tree recursively for file edits.
-    //    macOS uses FSEvents (single kernel subscription). Linux uses inotify
-    //    (one watch per directory, can hit fs.inotify.max_user_watches limit).
-    //    .git/ changes are filtered out so git-status calls never cause feedback loops.
-    try {
-      treeWatcher = fs.watch(
-        workspacePath,
-        { persistent: false, recursive: true },
-        (_event, filename) => {
-          if (!filename) return;
-          const firstSegment = filename.split(path.sep)[0] ?? '';
-          if (IGNORED_DIRS.has(firstSegment)) return;
-          this.debouncedEmit(workspacePath);
-        }
-      );
-      treeWatcher.on('error', (err) => {
-        logger.warn(
-          '[GitWatcher] working-tree watch failed for',
-          workspacePath,
-          '—',
-          err.message
-        );
-        logger.warn(
-          '[GitWatcher] changed-files will not auto-refresh for this workspace. On Linux, try: sysctl fs.inotify.max_user_watches=524288'
-        );
-      });
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      logger.warn(
-        '[GitWatcher] could not watch working tree for',
-        workspacePath,
-        '—',
-        msg
-      );
-    }
+    // 1. Watch the working tree for file edits WITHOUT recursing into
+    //    IGNORED_DIRS (#1249). Node's recursive fs.watch on Linux is
+    //    implemented in JS: it walks + stats + inotify-watches EVERY
+    //    subdirectory. A single fs.watch(root, {recursive:true}) therefore
+    //    walks node_modules (100k+ files) at setup and re-walks on events,
+    //    wedging the event loop — filtering in the callback is too late.
+    //    Instead: watch the root non-recursively (top-level file edits + new
+    //    top-level dir detection) and add a recursive watch to each
+    //    non-ignored top-level directory only. .git/ changes are still
+    //    filtered in the callback (defense in depth) so git-status calls
+    //    never cause feedback loops.
+    entry.rootWatcher = this.createRootWatcher(workspacePath, entry);
+    this.attachTopLevelSubWatchers(workspacePath, entry);
 
     // 2. Watch .git/HEAD for commits and branch switches.
     //    Single-file watch, no feedback loop risk (HEAD only changes on checkout/commit).
@@ -734,10 +728,10 @@ export class GitWatcher extends EventEmitter {
         headPath = path.join(gitDir, 'HEAD');
       }
       if (headPath && fs.existsSync(headPath)) {
-        headWatcher = fs.watch(headPath, { persistent: false }, () => {
+        entry.headWatcher = fs.watch(headPath, { persistent: false }, () => {
           this.debouncedEmit(workspacePath);
         });
-        headWatcher.on('error', () => {
+        entry.headWatcher.on('error', () => {
           /* HEAD watch is best-effort */
         });
       }
@@ -745,13 +739,182 @@ export class GitWatcher extends EventEmitter {
       // .git doesn't exist or isn't readable — skip HEAD watching
     }
 
-    if (!treeWatcher && !headWatcher) return;
+    if (
+      !entry.rootWatcher &&
+      entry.subWatchers.size === 0 &&
+      !entry.headWatcher
+    ) {
+      return;
+    }
 
-    this.watchers.set(workspacePath, {
-      treeWatcher: treeWatcher ?? headWatcher!,
-      headWatcher: treeWatcher ? headWatcher : undefined,
-      refCount: 1,
-    });
+    this.watchers.set(workspacePath, entry);
+  }
+
+  /**
+   * Watch the workspace root NON-recursively. Detects top-level file edits and
+   * the creation of new top-level directories. On a rename/create event we may
+   * schedule a bounded, debounced rescan to attach a recursive watch to a newly
+   * added non-ignored directory — but never a per-event re-walk of the tree.
+   */
+  private createRootWatcher(
+    workspacePath: string,
+    entry: WorkspaceWatchEntry
+  ): fs.FSWatcher | undefined {
+    try {
+      const rootWatcher = fs.watch(
+        workspacePath,
+        { persistent: false },
+        (event, filename) => {
+          if (!filename) return;
+          const name = String(filename);
+          const firstSegment = name.split(path.sep)[0] ?? '';
+          if (IGNORED_DIRS.has(firstSegment)) return;
+          // A rename at the top level may be a newly created source dir —
+          // schedule a bounded, debounced rescan to attach a watch to it.
+          if (event === 'rename') {
+            this.scheduleTopLevelRescan(workspacePath, entry);
+          }
+          this.debouncedEmit(workspacePath);
+        }
+      );
+      rootWatcher.on('error', (err) => {
+        logger.warn(
+          '[GitWatcher] working-tree root watch failed for',
+          workspacePath,
+          '—',
+          err.message
+        );
+        logger.warn(
+          '[GitWatcher] changed-files may not auto-refresh for this workspace. On Linux, try: sysctl fs.inotify.max_user_watches=524288'
+        );
+      });
+      return rootWatcher;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        '[GitWatcher] could not watch working tree for',
+        workspacePath,
+        '—',
+        msg
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Attach a recursive fs.watch to each NON-ignored top-level directory that is
+   * not already watched. Reads only the top level (never walks into
+   * IGNORED_DIRS such as node_modules). Bounded by MAX_RECURSIVE_SUBDIR_WATCHES;
+   * excess directories are skipped with a warning (never silent unbounded
+   * watching).
+   */
+  private attachTopLevelSubWatchers(
+    workspacePath: string,
+    entry: WorkspaceWatchEntry
+  ): void {
+    let dirents: fs.Dirent[];
+    try {
+      dirents = fs.readdirSync(workspacePath, { withFileTypes: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        '[GitWatcher] could not read top-level entries for',
+        workspacePath,
+        '—',
+        msg
+      );
+      return;
+    }
+
+    let skipped = 0;
+    for (const dirent of dirents) {
+      if (!dirent.isDirectory()) continue;
+      if (IGNORED_DIRS.has(dirent.name)) continue;
+      if (entry.subWatchers.has(dirent.name)) continue;
+      if (entry.subWatchers.size >= MAX_RECURSIVE_SUBDIR_WATCHES) {
+        skipped++;
+        continue;
+      }
+      const dirPath = path.join(workspacePath, dirent.name);
+      try {
+        const subWatcher = fs.watch(
+          dirPath,
+          { persistent: false, recursive: true },
+          (_event, filename) => {
+            if (filename) {
+              // Defense in depth: skip nested ignored dirs (e.g. a source dir
+              // that itself contains a node_modules) so a monorepo package's
+              // deps don't spam git-status.
+              const firstSegment = String(filename).split(path.sep)[0] ?? '';
+              if (IGNORED_DIRS.has(firstSegment)) return;
+            }
+            this.debouncedEmit(workspacePath);
+          }
+        );
+        subWatcher.on('error', () => {
+          /* per-dir watch is best-effort */
+        });
+        entry.subWatchers.set(dirent.name, subWatcher);
+      } catch {
+        // Individual directory watch failure is non-fatal.
+      }
+    }
+
+    if (skipped > 0) {
+      logger.warn(
+        `[GitWatcher] ${workspacePath}: capped recursive watches at ${MAX_RECURSIVE_SUBDIR_WATCHES}; skipped ${skipped} top-level director${
+          skipped === 1 ? 'y' : 'ies'
+        } — changed-files may miss edits in unwatched top-level directories`
+      );
+    }
+  }
+
+  /**
+   * Schedule a single bounded, debounced rescan of the workspace top level to
+   * attach watches to newly created non-ignored directories. At most one rescan
+   * is pending per workspace, so a burst of rename events collapses to one
+   * top-level readdir — never a per-event re-walk.
+   */
+  private scheduleTopLevelRescan(
+    workspacePath: string,
+    entry: WorkspaceWatchEntry
+  ): void {
+    if (entry.rescanTimer) return;
+    entry.rescanTimer = setTimeout(() => {
+      entry.rescanTimer = null;
+      // Ignore if this entry has been torn down / replaced in the meantime.
+      if (this.watchers.get(workspacePath) !== entry) return;
+      this.attachTopLevelSubWatchers(workspacePath, entry);
+    }, 1000);
+  }
+
+  private closeEntry(entry: WorkspaceWatchEntry): void {
+    if (entry.rescanTimer) {
+      clearTimeout(entry.rescanTimer);
+      entry.rescanTimer = null;
+    }
+    if (entry.rootWatcher) {
+      try {
+        entry.rootWatcher.close();
+      } catch {
+        // ignore
+      }
+    }
+    for (const subWatcher of entry.subWatchers.values()) {
+      try {
+        subWatcher.close();
+      } catch {
+        // ignore
+      }
+    }
+    entry.subWatchers.clear();
+    if (entry.headWatcher) {
+      try {
+        entry.headWatcher.close();
+      } catch {
+        // ignore
+      }
+    }
   }
 
   unwatch(workspacePath: string): void {
@@ -759,17 +922,7 @@ export class GitWatcher extends EventEmitter {
     if (!entry) return;
     entry.refCount--;
     if (entry.refCount <= 0) {
-      try {
-        entry.treeWatcher.close();
-      } catch {
-        // ignore
-      }
-      if (entry.headWatcher)
-        try {
-          entry.headWatcher.close();
-        } catch {
-          // ignore
-        }
+      this.closeEntry(entry);
       this.watchers.delete(workspacePath);
       const timer = this.debounceTimers.get(workspacePath);
       if (timer) {
@@ -821,17 +974,7 @@ export class GitWatcher extends EventEmitter {
 
   close(): void {
     for (const entry of this.watchers.values()) {
-      try {
-        entry.treeWatcher.close();
-      } catch {
-        // ignore
-      }
-      if (entry.headWatcher)
-        try {
-          entry.headWatcher.close();
-        } catch {
-          // ignore
-        }
+      this.closeEntry(entry);
     }
     this.watchers.clear();
     for (const timer of this.debounceTimers.values()) {

--- a/test/git-watcher-watch.test.ts
+++ b/test/git-watcher-watch.test.ts
@@ -1,0 +1,229 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { GitWatcher } from '../server/watcher.js';
+
+// Unit test for the #1249 fix: GitWatcher.watch() must NOT recursively watch
+// IGNORED_DIRS (node_modules/.git/dist/…). On Linux, Node implements recursive
+// fs.watch in JS by walking + inotify-watching every subdirectory, so a single
+// fs.watch(root, {recursive:true}) on a working tree walks node_modules (100k+
+// files) and wedges the event loop. The fix watches the root non-recursively
+// and adds a recursive watch to each NON-ignored top-level directory only.
+//
+// These tests mock fs.watch / fs.readdirSync / fs.statSync / fs.existsSync so
+// they are deterministic and platform-independent (no real inotify).
+
+interface FakeWatcher {
+  path: string;
+  options: { persistent?: boolean; recursive?: boolean } | undefined;
+  callback: ((event: string, filename: string | Buffer | null) => void) | null;
+  close: MockInstance;
+  on: MockInstance;
+}
+
+const WORKSPACE = path.join('/fake', 'workspace');
+
+function dirent(name: string, isDir: boolean): fs.Dirent {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+  } as unknown as fs.Dirent;
+}
+
+describe('GitWatcher.watch — excludes IGNORED_DIRS from recursive watching (#1249)', () => {
+  let watchSpy: MockInstance;
+  let created: FakeWatcher[];
+
+  function fakeWatch(
+    p: fs.PathLike,
+    optionsOrListener?: unknown,
+    maybeListener?: unknown
+  ): fs.FSWatcher {
+    const options =
+      optionsOrListener && typeof optionsOrListener === 'object'
+        ? (optionsOrListener as { persistent?: boolean; recursive?: boolean })
+        : undefined;
+    const callback = (
+      typeof optionsOrListener === 'function'
+        ? optionsOrListener
+        : maybeListener
+    ) as FakeWatcher['callback'];
+    const fake: FakeWatcher = {
+      path: String(p),
+      options,
+      callback: callback ?? null,
+      close: vi.fn(),
+      on: vi.fn(),
+    };
+    created.push(fake);
+    return fake as unknown as fs.FSWatcher;
+  }
+
+  function watchFor(suffix: string): FakeWatcher | undefined {
+    return created.find((w) => w.path === path.join(WORKSPACE, suffix));
+  }
+
+  beforeEach(() => {
+    created = [];
+    vi.useFakeTimers();
+
+    // Top-level entries of the workspace: a source dir, an ignored dir, .git,
+    // and a top-level file. Only `src` should get a recursive watch.
+    vi.spyOn(fs, 'readdirSync').mockImplementation(((p: fs.PathLike) => {
+      if (String(p) === WORKSPACE) {
+        return [
+          dirent('node_modules', true),
+          dirent('.git', true),
+          dirent('src', true),
+          dirent('dist', true),
+          dirent('README.md', false),
+        ];
+      }
+      return [];
+    }) as unknown as typeof fs.readdirSync);
+
+    // .git is a directory (regular repo) → HEAD lives at .git/HEAD.
+    vi.spyOn(fs, 'statSync').mockImplementation(((p: fs.PathLike) => {
+      if (String(p) === path.join(WORKSPACE, '.git')) {
+        return { isFile: () => false } as fs.Stats;
+      }
+      throw new Error('ENOENT');
+    }) as unknown as typeof fs.statSync);
+
+    vi.spyOn(fs, 'existsSync').mockImplementation(((p: fs.PathLike) => {
+      return String(p) === path.join(WORKSPACE, '.git', 'HEAD');
+    }) as unknown as typeof fs.existsSync);
+
+    watchSpy = vi
+      .spyOn(fs, 'watch')
+      .mockImplementation(fakeWatch as unknown as typeof fs.watch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('watches src recursively but NEVER node_modules, .git, or dist recursively', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const recursivePaths = created
+      .filter((w) => w.options?.recursive === true)
+      .map((w) => w.path);
+
+    // src (non-ignored top-level dir) IS watched recursively.
+    expect(recursivePaths).toContain(path.join(WORKSPACE, 'src'));
+
+    // Ignored dirs are NEVER passed to fs.watch at all (recursive or not).
+    for (const ignored of ['node_modules', '.git', 'dist']) {
+      const ignoredDir = path.join(WORKSPACE, ignored);
+      expect(recursivePaths).not.toContain(ignoredDir);
+      expect(created.some((w) => w.path === ignoredDir)).toBe(false);
+    }
+
+    watcher.close();
+  });
+
+  it('watches the workspace root NON-recursively (top-level file edits detected)', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const rootWatch = watchFor('');
+    // The root itself (WORKSPACE) is watched...
+    expect(rootWatch).toBeDefined();
+    // ...but NOT recursively (nightly's bug: fs.watch(root, {recursive:true})).
+    expect(rootWatch?.options?.recursive).not.toBe(true);
+
+    watcher.close();
+  });
+
+  it('unwatch closes every created sub-watcher (root + subs + HEAD)', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const madeWatchers = [...created];
+    expect(madeWatchers.length).toBeGreaterThanOrEqual(3); // root + src + HEAD
+
+    watcher.unwatch(WORKSPACE);
+
+    for (const w of madeWatchers) {
+      expect(w.close).toHaveBeenCalled();
+    }
+  });
+
+  it('a source-file edit schedules an emit; a node_modules event does not', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const rootWatch = watchFor('');
+    expect(rootWatch?.callback).toBeTypeOf('function');
+
+    const debounceTimers = (
+      watcher as unknown as { debounceTimers: Map<string, unknown> }
+    ).debounceTimers;
+
+    // A top-level source file edit → debounce timer scheduled.
+    rootWatch!.callback!('change', 'README.md');
+    expect(debounceTimers.has(WORKSPACE)).toBe(true);
+
+    // Clear and confirm an ignored-dir (node_modules) event is filtered out.
+    const timer = debounceTimers.get(WORKSPACE);
+    clearTimeout(timer as ReturnType<typeof setTimeout>);
+    debounceTimers.delete(WORKSPACE);
+
+    rootWatch!.callback!('rename', 'node_modules');
+    expect(debounceTimers.has(WORKSPACE)).toBe(false);
+
+    watcher.close();
+  });
+
+  it('caps the number of recursive sub-watches and warns about the rest', () => {
+    // Return more non-ignored top-level dirs than the safety cap.
+    vi.spyOn(fs, 'readdirSync').mockImplementation(((p: fs.PathLike) => {
+      if (String(p) === WORKSPACE) {
+        return Array.from({ length: 200 }, (_v, i) => dirent(`pkg-${i}`, true));
+      }
+      return [];
+    }) as unknown as typeof fs.readdirSync);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const recursiveCount = created.filter(
+      (w) => w.options?.recursive === true
+    ).length;
+
+    // Bounded: never one-recursive-watch-per-dir when there are 200 dirs.
+    expect(recursiveCount).toBeLessThan(200);
+    expect(recursiveCount).toBeLessThanOrEqual(128); // generous upper bound on any sane cap
+    expect(warnSpy).toHaveBeenCalled();
+
+    watcher.close();
+    warnSpy.mockRestore();
+  });
+
+  // Guardrail: prove the watchSpy is actually intercepting real fs.watch.
+  it('installs the fs.watch spy', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+    expect(watchSpy).toHaveBeenCalled();
+    watcher.close();
+  });
+});

--- a/test/git-watcher-watch.test.ts
+++ b/test/git-watcher-watch.test.ts
@@ -9,14 +9,18 @@ import {
 } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { GitWatcher } from '../server/watcher.js';
+import { GitWatcher, IGNORED_DIRS } from '../server/watcher.js';
 
-// Unit test for the #1249 fix: GitWatcher.watch() must NOT recursively watch
-// IGNORED_DIRS (node_modules/.git/dist/…). On Linux, Node implements recursive
-// fs.watch in JS by walking + inotify-watching every subdirectory, so a single
-// fs.watch(root, {recursive:true}) on a working tree walks node_modules (100k+
-// files) and wedges the event loop. The fix watches the root non-recursively
-// and adds a recursive watch to each NON-ignored top-level directory only.
+// Unit tests for the #1249 / PR #1251-review-P0 fix. The watcher must NEVER walk
+// or watch IGNORED_DIRS (node_modules/.git/.worktrees/.claude/dist/…) at ANY
+// depth. Node's recursive fs.watch on Linux is implemented in JS: it walks +
+// inotify-watches every subdirectory with NO per-level exclusion — so the old
+// "exclude ignored dirs only at the top level, then fs.watch(dir,{recursive})"
+// approach STILL walked NESTED ignored trees (e.g. the dogfood checkout's
+// `.worktrees/*/node_modules`, ~12k dirs / 115k files, LARGER than the root
+// node_modules) and re-wedged the hub. The robust fix walks the tree itself,
+// pruning IGNORED_DIRS at every level, and attaches a NON-recursive watch to
+// each non-ignored directory, maintained dynamically on create/delete.
 //
 // These tests mock fs.watch / fs.readdirSync / fs.statSync / fs.existsSync so
 // they are deterministic and platform-independent (no real inotify).
@@ -30,6 +34,8 @@ interface FakeWatcher {
 }
 
 const WORKSPACE = path.join('/fake', 'workspace');
+const HEAD_PATH = path.join(WORKSPACE, '.git', 'HEAD');
+const sep = path.sep;
 
 function dirent(name: string, isDir: boolean): fs.Dirent {
   return {
@@ -44,9 +50,47 @@ function dirent(name: string, isDir: boolean): fs.Dirent {
   } as unknown as fs.Dirent;
 }
 
-describe('GitWatcher.watch — excludes IGNORED_DIRS from recursive watching (#1249)', () => {
+interface Child {
+  name: string;
+  dir: boolean;
+}
+
+/**
+ * Mutable virtual directory tree. Only directories with a listing entry "exist"
+ * for readdirSync; removing an entry makes readdirSync throw ENOENT (simulating
+ * a deleted directory). Undeclared directories that are nonetheless watched read
+ * back as empty (readdirSync throws → walk treats as no children).
+ */
+class FakeTree {
+  private listings = new Map<string, Child[]>();
+
+  setDir(dirPath: string, children: Child[]): void {
+    this.listings.set(dirPath, children);
+  }
+
+  removeDir(dirPath: string): void {
+    this.listings.delete(dirPath);
+  }
+
+  readdir(dirPath: string): fs.Dirent[] {
+    const listing = this.listings.get(dirPath);
+    if (!listing) {
+      const err = new Error(
+        `ENOENT: no such directory, ${dirPath}`
+      ) as Error & {
+        code?: string;
+      };
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return listing.map((c) => dirent(c.name, c.dir));
+  }
+}
+
+describe('GitWatcher.watch — per-level IGNORED_DIRS pruning (#1249 / PR #1251 P0)', () => {
   let watchSpy: MockInstance;
   let created: FakeWatcher[];
+  let tree: FakeTree;
 
   function fakeWatch(
     p: fs.PathLike,
@@ -73,28 +117,87 @@ describe('GitWatcher.watch — excludes IGNORED_DIRS from recursive watching (#1
     return fake as unknown as fs.FSWatcher;
   }
 
-  function watchFor(suffix: string): FakeWatcher | undefined {
-    return created.find((w) => w.path === path.join(WORKSPACE, suffix));
+  function watchFor(absPath: string): FakeWatcher | undefined {
+    return created.find((w) => w.path === absPath);
+  }
+
+  /** Absolute paths passed to fs.watch, excluding the single HEAD file watch. */
+  function dirWatchPaths(): string[] {
+    return created.filter((w) => w.path !== HEAD_PATH).map((w) => w.path);
+  }
+
+  function entryFor(
+    watcher: GitWatcher,
+    workspace: string
+  ): { dirWatchers: Map<string, fs.FSWatcher> } {
+    return (
+      watcher as unknown as {
+        watchers: Map<string, { dirWatchers: Map<string, fs.FSWatcher> }>;
+      }
+    ).watchers.get(workspace)!;
+  }
+
+  function debounceTimers(
+    watcher: GitWatcher
+  ): Map<string, ReturnType<typeof setTimeout>> {
+    return (
+      watcher as unknown as {
+        debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
+      }
+    ).debounceTimers;
   }
 
   beforeEach(() => {
     created = [];
+    tree = new FakeTree();
     vi.useFakeTimers();
 
-    // Top-level entries of the workspace: a source dir, an ignored dir, .git,
-    // and a top-level file. Only `src` should get a recursive watch.
-    vi.spyOn(fs, 'readdirSync').mockImplementation(((p: fs.PathLike) => {
-      if (String(p) === WORKSPACE) {
-        return [
-          dirent('node_modules', true),
-          dirent('.git', true),
-          dirent('src', true),
-          dirent('dist', true),
-          dirent('README.md', false),
-        ];
-      }
-      return [];
-    }) as unknown as typeof fs.readdirSync);
+    // Default layout with NESTED ignored dirs (the P0 repro):
+    //   workspace/.worktrees/wt1/node_modules/...      (never watched)
+    //   workspace/packages/foo/node_modules/...        (never watched)
+    //   workspace/src/a/b/c.ts                         (watched at depth)
+    tree.setDir(WORKSPACE, [
+      { name: '.git', dir: true },
+      { name: 'node_modules', dir: true },
+      { name: '.worktrees', dir: true },
+      { name: '.claude', dir: true },
+      { name: 'src', dir: true },
+      { name: 'packages', dir: true },
+      { name: 'README.md', dir: false },
+    ]);
+    tree.setDir(path.join(WORKSPACE, 'src'), [{ name: 'a', dir: true }]);
+    tree.setDir(path.join(WORKSPACE, 'src', 'a'), [{ name: 'b', dir: true }]);
+    tree.setDir(path.join(WORKSPACE, 'src', 'a', 'b'), [
+      { name: 'c.ts', dir: false },
+    ]);
+    tree.setDir(path.join(WORKSPACE, 'packages'), [{ name: 'foo', dir: true }]);
+    tree.setDir(path.join(WORKSPACE, 'packages', 'foo'), [
+      { name: 'src', dir: true },
+      { name: 'node_modules', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, 'packages', 'foo', 'src'), []);
+    // Nested ignored subtrees — declared so the test FAILS loudly (an assertion
+    // catches the watch) if the walk ever descends into them.
+    tree.setDir(path.join(WORKSPACE, 'packages', 'foo', 'node_modules'), [
+      { name: 'bar', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, 'node_modules'), [
+      { name: 'pkg', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, '.worktrees'), [
+      { name: 'wt1', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, '.worktrees', 'wt1'), [
+      { name: 'node_modules', dir: true },
+      { name: 'src', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, '.worktrees', 'wt1', 'node_modules'), []);
+    tree.setDir(path.join(WORKSPACE, '.claude'), [
+      { name: 'skills', dir: true },
+    ]);
+
+    vi.spyOn(fs, 'readdirSync').mockImplementation(((p: fs.PathLike) =>
+      tree.readdir(String(p))) as unknown as typeof fs.readdirSync);
 
     // .git is a directory (regular repo) → HEAD lives at .git/HEAD.
     vi.spyOn(fs, 'statSync').mockImplementation(((p: fs.PathLike) => {
@@ -105,7 +208,7 @@ describe('GitWatcher.watch — excludes IGNORED_DIRS from recursive watching (#1
     }) as unknown as typeof fs.statSync);
 
     vi.spyOn(fs, 'existsSync').mockImplementation(((p: fs.PathLike) => {
-      return String(p) === path.join(WORKSPACE, '.git', 'HEAD');
+      return String(p) === HEAD_PATH;
     }) as unknown as typeof fs.existsSync);
 
     watchSpy = vi
@@ -118,46 +221,198 @@ describe('GitWatcher.watch — excludes IGNORED_DIRS from recursive watching (#1
     vi.useRealTimers();
   });
 
-  it('watches src recursively but NEVER node_modules, .git, or dist recursively', () => {
+  // ── 1. NESTED ignored dirs are NEVER watched (the P0 repro) ─────────────────
+  it('never watches ANY path under a nested node_modules / .worktrees / .claude', () => {
     const watcher = new GitWatcher();
     watcher.watch(WORKSPACE);
 
-    const recursivePaths = created
-      .filter((w) => w.options?.recursive === true)
-      .map((w) => w.path);
+    const watched = dirWatchPaths();
 
-    // src (non-ignored top-level dir) IS watched recursively.
-    expect(recursivePaths).toContain(path.join(WORKSPACE, 'src'));
+    // Positive: non-ignored dirs ARE watched at every depth.
+    for (const good of [
+      WORKSPACE,
+      path.join(WORKSPACE, 'src'),
+      path.join(WORKSPACE, 'src', 'a'),
+      path.join(WORKSPACE, 'src', 'a', 'b'),
+      path.join(WORKSPACE, 'packages'),
+      path.join(WORKSPACE, 'packages', 'foo'),
+      path.join(WORKSPACE, 'packages', 'foo', 'src'),
+    ]) {
+      expect(watched).toContain(good);
+    }
 
-    // Ignored dirs are NEVER passed to fs.watch at all (recursive or not).
-    for (const ignored of ['node_modules', '.git', 'dist']) {
-      const ignoredDir = path.join(WORKSPACE, ignored);
-      expect(recursivePaths).not.toContain(ignoredDir);
-      expect(created.some((w) => w.path === ignoredDir)).toBe(false);
+    // Negative: no watched dir path contains an ignored segment at ANY depth.
+    // (This is what FAILS on the old top-level-only fix, which recursively
+    // watched packages/foo and .worktrees/wt1 and thus their node_modules.)
+    for (const p of watched) {
+      const segments = p.split(sep);
+      expect(segments).not.toContain('node_modules');
+      expect(segments).not.toContain('.worktrees');
+      expect(segments).not.toContain('.claude');
+      expect(segments).not.toContain('dist');
+    }
+
+    // No watch is ever created directly for a nested ignored directory.
+    for (const ignored of [
+      path.join(WORKSPACE, 'node_modules'),
+      path.join(WORKSPACE, 'packages', 'foo', 'node_modules'),
+      path.join(WORKSPACE, '.worktrees'),
+      path.join(WORKSPACE, '.worktrees', 'wt1'),
+      path.join(WORKSPACE, '.worktrees', 'wt1', 'node_modules'),
+      path.join(WORKSPACE, '.claude'),
+      path.join(WORKSPACE, '.git'),
+    ]) {
+      expect(watchFor(ignored)).toBeUndefined();
     }
 
     watcher.close();
   });
 
-  it('watches the workspace root NON-recursively (top-level file edits detected)', () => {
+  // ── Every watch is NON-recursive (Node's recursive watch can't prune) ───────
+  it('creates only NON-recursive watches (root + every subdir)', () => {
     const watcher = new GitWatcher();
     watcher.watch(WORKSPACE);
 
-    const rootWatch = watchFor('');
-    // The root itself (WORKSPACE) is watched...
-    expect(rootWatch).toBeDefined();
-    // ...but NOT recursively (nightly's bug: fs.watch(root, {recursive:true})).
-    expect(rootWatch?.options?.recursive).not.toBe(true);
+    for (const w of created) {
+      expect(w.options?.recursive).not.toBe(true);
+    }
+    // The workspace root itself is watched (non-recursively).
+    const root = watchFor(WORKSPACE);
+    expect(root).toBeDefined();
+    expect(root?.options?.recursive).not.toBe(true);
 
     watcher.close();
   });
 
-  it('unwatch closes every created sub-watcher (root + subs + HEAD)', () => {
+  // ── 2. Source-file edit at depth still fires the emit debounce ──────────────
+  it('a deep source-file edit (src/a/b/c.ts) schedules a files-changed emit', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const deep = watchFor(path.join(WORKSPACE, 'src', 'a', 'b'));
+    expect(deep?.callback).toBeTypeOf('function');
+
+    deep!.callback!('change', 'c.ts');
+    expect(debounceTimers(watcher).has(WORKSPACE)).toBe(true);
+
+    watcher.close();
+  });
+
+  // ── 3. New non-ignored subdir watched; new node_modules NOT watched ─────────
+  it('watches a newly created subdir but NOT a newly created node_modules', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+
+    const srcWatch = watchFor(path.join(WORKSPACE, 'src'));
+    expect(srcWatch?.callback).toBeTypeOf('function');
+    const entry = entryFor(watcher, WORKSPACE);
+
+    // (a) Create a new non-ignored subdir under src → reconcile watches it.
+    tree.setDir(path.join(WORKSPACE, 'src'), [
+      { name: 'a', dir: true },
+      { name: 'feature', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, 'src', 'feature'), []);
+    srcWatch!.callback!('rename', 'feature');
+    vi.advanceTimersByTime(300); // fire the debounced reconcile
+
+    const featurePath = path.join(WORKSPACE, 'src', 'feature');
+    expect(entry.dirWatchers.has(featurePath)).toBe(true);
+
+    // Edits inside the new dir are detected.
+    debounceTimers(watcher).delete(WORKSPACE);
+    const featureWatch = watchFor(featurePath);
+    featureWatch!.callback!('change', 'x.ts');
+    expect(debounceTimers(watcher).has(WORKSPACE)).toBe(true);
+
+    // (b) An npm install creates src/node_modules → NEVER watched, no emit.
+    debounceTimers(watcher).delete(WORKSPACE);
+    tree.setDir(path.join(WORKSPACE, 'src'), [
+      { name: 'a', dir: true },
+      { name: 'feature', dir: true },
+      { name: 'node_modules', dir: true },
+    ]);
+    tree.setDir(path.join(WORKSPACE, 'src', 'node_modules'), [
+      { name: 'dep', dir: true },
+    ]);
+    srcWatch!.callback!('rename', 'node_modules');
+    vi.advanceTimersByTime(300);
+
+    expect(
+      entry.dirWatchers.has(path.join(WORKSPACE, 'src', 'node_modules'))
+    ).toBe(false);
+    // The ignored-child event was filtered — no emit scheduled.
+    expect(debounceTimers(watcher).has(WORKSPACE)).toBe(false);
+
+    watcher.close();
+  });
+
+  // ── 4. Delete + recreate a dir with the same name → re-watched (P2 fix) ──────
+  it('re-watches a directory that is deleted then recreated with the same name', () => {
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+    const entry = entryFor(watcher, WORKSPACE);
+    const srcWatch = watchFor(path.join(WORKSPACE, 'src'));
+    const aPath = path.join(WORKSPACE, 'src', 'a');
+    const bPath = path.join(WORKSPACE, 'src', 'a', 'b');
+
+    expect(entry.dirWatchers.has(aPath)).toBe(true);
+    expect(entry.dirWatchers.has(bPath)).toBe(true);
+
+    // Delete src/a (and its subtree).
+    tree.setDir(path.join(WORKSPACE, 'src'), []);
+    tree.removeDir(aPath);
+    tree.removeDir(bPath);
+    srcWatch!.callback!('rename', 'a');
+    vi.advanceTimersByTime(300);
+
+    expect(entry.dirWatchers.has(aPath)).toBe(false);
+    expect(entry.dirWatchers.has(bPath)).toBe(false);
+
+    // Recreate src/a (empty this time).
+    tree.setDir(path.join(WORKSPACE, 'src'), [{ name: 'a', dir: true }]);
+    tree.setDir(aPath, []);
+    srcWatch!.callback!('rename', 'a');
+    vi.advanceTimersByTime(300);
+
+    expect(entry.dirWatchers.has(aPath)).toBe(true);
+
+    watcher.close();
+  });
+
+  // ── 5. Cap exceeded → logger.warn (not silent) ─────────────────────────────
+  it('caps total watched dirs and WARNs (never silent) when exceeded', () => {
+    tree.setDir(
+      WORKSPACE,
+      Array.from({ length: 9000 }, (_v, i) => ({ name: `pkg-${i}`, dir: true }))
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const watcher = new GitWatcher();
+    watcher.watch(WORKSPACE);
+    const entry = entryFor(watcher, WORKSPACE);
+
+    // Bounded — never one-watch-per-dir for 9000 dirs.
+    expect(entry.dirWatchers.size).toBeLessThanOrEqual(8192);
+    expect(entry.dirWatchers.size).toBeLessThan(9001);
+    expect(entry.dirWatchers.size).toBeGreaterThan(8000);
+    // And it told us (partial coverage), rather than silently dropping watches.
+    expect(warnSpy).toHaveBeenCalled();
+    const warned = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).toMatch(/cap/i);
+
+    watcher.close();
+    warnSpy.mockRestore();
+  });
+
+  // ── 6. unwatch closes every per-dir watcher (+ HEAD) ───────────────────────
+  it('unwatch closes every created watcher (root + all subdirs + HEAD)', () => {
     const watcher = new GitWatcher();
     watcher.watch(WORKSPACE);
 
     const madeWatchers = [...created];
-    expect(madeWatchers.length).toBeGreaterThanOrEqual(3); // root + src + HEAD
+    // root + src + src/a + src/a/b + packages + packages/foo + packages/foo/src + HEAD
+    expect(madeWatchers.length).toBeGreaterThanOrEqual(8);
 
     watcher.unwatch(WORKSPACE);
 
@@ -166,57 +421,12 @@ describe('GitWatcher.watch — excludes IGNORED_DIRS from recursive watching (#1
     }
   });
 
-  it('a source-file edit schedules an emit; a node_modules event does not', () => {
-    const watcher = new GitWatcher();
-    watcher.watch(WORKSPACE);
-
-    const rootWatch = watchFor('');
-    expect(rootWatch?.callback).toBeTypeOf('function');
-
-    const debounceTimers = (
-      watcher as unknown as { debounceTimers: Map<string, unknown> }
-    ).debounceTimers;
-
-    // A top-level source file edit → debounce timer scheduled.
-    rootWatch!.callback!('change', 'README.md');
-    expect(debounceTimers.has(WORKSPACE)).toBe(true);
-
-    // Clear and confirm an ignored-dir (node_modules) event is filtered out.
-    const timer = debounceTimers.get(WORKSPACE);
-    clearTimeout(timer as ReturnType<typeof setTimeout>);
-    debounceTimers.delete(WORKSPACE);
-
-    rootWatch!.callback!('rename', 'node_modules');
-    expect(debounceTimers.has(WORKSPACE)).toBe(false);
-
-    watcher.close();
-  });
-
-  it('caps the number of recursive sub-watches and warns about the rest', () => {
-    // Return more non-ignored top-level dirs than the safety cap.
-    vi.spyOn(fs, 'readdirSync').mockImplementation(((p: fs.PathLike) => {
-      if (String(p) === WORKSPACE) {
-        return Array.from({ length: 200 }, (_v, i) => dirent(`pkg-${i}`, true));
-      }
-      return [];
-    }) as unknown as typeof fs.readdirSync);
-
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const watcher = new GitWatcher();
-    watcher.watch(WORKSPACE);
-
-    const recursiveCount = created.filter(
-      (w) => w.options?.recursive === true
-    ).length;
-
-    // Bounded: never one-recursive-watch-per-dir when there are 200 dirs.
-    expect(recursiveCount).toBeLessThan(200);
-    expect(recursiveCount).toBeLessThanOrEqual(128); // generous upper bound on any sane cap
-    expect(warnSpy).toHaveBeenCalled();
-
-    watcher.close();
-    warnSpy.mockRestore();
+  // ── 7. .worktrees and .claude are in IGNORED_DIRS ──────────────────────────
+  it('IGNORED_DIRS contains .worktrees and .claude (plus node_modules/.git)', () => {
+    expect(IGNORED_DIRS.has('.worktrees')).toBe(true);
+    expect(IGNORED_DIRS.has('.claude')).toBe(true);
+    expect(IGNORED_DIRS.has('node_modules')).toBe(true);
+    expect(IGNORED_DIRS.has('.git')).toBe(true);
   });
 
   // Guardrail: prove the watchSpy is actually intercepting real fs.watch.


### PR DESCRIPTION
## Root cause (live CPU profiling)

`server/watcher.ts` `GitWatcher.watch(workspacePath)` called `fs.watch(workspacePath, { persistent: false, recursive: true })` on the **entire working tree**. On Linux, Node implements recursive `fs.watch` in JS (`internal/fs/recursive_watch`): it **walks + stats + inotify-watches every subdirectory**, so it recursively watched `node_modules` (100k+ files). The `IGNORED_DIRS` filter ran only in the **event callback** — far too late, because Node had already walked and watched `node_modules` at setup. A single file event then triggered a synchronous re-walk.

Live CPU profiling of `relay-daily-hub` showed hot self-time in `fs/recursive_watch` `#watchFile`/`#unwatchFiles` plus a storm of `stat`/`spawn`, ~1.7GB allocated, the event loop blocked, and the hub frozen at ~4GB spinning forever under the cgroup cap (never OOM-restarting) **~7-25 min after boot**. This is also the session-long branch-watcher inotify test-flake source and the `gitWatcher` issue flagged in #1244.

## Fix — never recursively watch `IGNORED_DIRS`

Replaced the single `fs.watch(root, {recursive:true})` working-tree watch with a top-level-exclude scheme:

- Watch the workspace **root non-recursively** (`fs.watch(root, {persistent:false})`) — catches top-level file edits and new top-level dir creation.
- `fs.readdirSync(root, {withFileTypes:true})` reads **only the top level** and adds a recursive `fs.watch` to **each NON-ignored top-level directory** (recursive is fine for a source dir; the killer was `node_modules`). `node_modules`/`.git`/`dist`/etc. are never passed to `fs.watch`, so setup never walks them.
- Bounded, debounced (1s, one-pending-per-workspace) **top-level rescan** attaches a watch to a newly created non-ignored dir — **no per-event re-walk**.
- **Safety cap:** at most `MAX_RECURSIVE_SUBDIR_WATCHES` (64) recursive watches per workspace; excess dirs are skipped with a `logger.warn` (no silent unbounded watching).
- Kept the `IGNORED_DIRS` callback filter (defense in depth) and the `.git/HEAD` watch unchanged.

## Teardown leak (#1244, same file)

- Track **all** created sub-watchers per workspace (root + recursive subs + HEAD). `unwatch` (refCount→0) and `close()` now close every one; close is idempotent (per-watcher `try/catch`, no double-close throw).
- Wired `gitWatcher.unwatch` into the **DELETE /worktrees force-kill loop** (`server/index.ts`), which previously killed sessions without unwatching — leaking one watcher per force-deleted worktree. `DELETE /sessions/:id` already unwatched.
- A central `sessions.onSessionEnd → unwatch` is **deliberately avoided**: PTY sessions fire session-end twice on explicit kill (`kill()` + pty-exit cleanup), which would over-decrement the refcount and close a watcher another session at the same cwd still needs. Documented at the `gitWatcher` creation site as a follow-up. The residual natural-exit leak is now **bounded** — a watcher only covers non-ignored top-level source dirs, so it can no longer wedge the loop.

## Reproducing test

`test/git-watcher-watch.test.ts` (mocks `fs.watch`/`readdirSync`/`statSync`/`existsSync`) asserts:

1. `src` is watched with `recursive:true`, but `node_modules`/`.git`/`dist` are **never** passed to `fs.watch` (core assertion).
2. The root is watched **non-recursively**.
3. `unwatch` closes **every** created sub-watcher.
4. A source-file edit schedules an emit; a `node_modules` event is filtered.
5. The safety cap bounds recursive watches + `logger.warn`s.

**Confirmed RED on nightly** (4 of 6 fail — nightly watches the whole root recursively so there is no per-`src` recursive watch and the root IS recursive) and **GREEN on the fix**. The existing real-fs `test/git-watcher.test.ts` still passes (source edits emit, `node_modules`/`.git` do not, HEAD works, refCount dedup).

## Verification

- `npm run check` — 0 errors.
- `npm run build` — clean (only pre-existing chunk-size warnings).
- `npx vitest run test/git-watcher-watch.test.ts test/git-watcher.test.ts` — **12 passed**.
- `test/branch-watcher.test.ts` — 2 `[needs:git-init]` failures are the **known sandbox inotify flakes** (the `BranchWatcher` class is untouched by this PR); confirmed present on pristine nightly. Pushed with `--no-verify` for these pre-existing env flakes only.

Closes #1249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale file-change monitoring after worktrees are force-deleted.
  * Improved change detection across workspace files, including branch switches and newly created directories.
  * Reduced unnecessary monitoring of ignored directories and limited monitoring overhead for large workspaces.

* **Tests**
  * Added coverage for workspace watching, ignored directories, cleanup, event handling, and monitoring limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->