### PR TITLE
fix(codex): drive initialPrompt as native positional arg (#1240)

### DIFF
--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -644,6 +644,8 @@ function create({
   ...rest
 }: CreateParams): CreateResult {
   const id = providedId || crypto.randomBytes(8).toString('hex');
+  const nativeInitialPrompt =
+    agent === 'codex' && initialPrompt ? initialPrompt : undefined;
 
   const ptyParams: CreatePtyParams = {
     ...rest,
@@ -651,7 +653,11 @@ function create({
     agent,
     cols,
     rows,
-    args,
+    // Codex accepts the first turn as a native positional argument for both
+    // fresh (`codex [flags] <PROMPT>`) and resumed
+    // (`codex resume --last [flags] <PROMPT>`) sessions. Keep it as a
+    // distinct argv element so the TUI never has to receive a typed fallback.
+    args: nativeInitialPrompt ? [...args, nativeInitialPrompt] : args,
     port: port ?? defaultPort,
     forceOutputParser: forceOutputParser ?? defaultForceOutputParser,
     configDir: rest.configDir ?? defaultConfigDir,
@@ -711,7 +717,7 @@ function create({
   if (branchRenamePrompt) {
     ptySession.branchRenamePrompt = branchRenamePrompt;
   }
-  if (initialPrompt) {
+  if (initialPrompt && !nativeInitialPrompt) {
     ptySession.initialPrompt = initialPrompt;
   }
   if (workspaceId) {
@@ -732,7 +738,7 @@ function create({
     agentType: agent,
     startedAt: new Date().toISOString(),
   });
-  if (initialPrompt) {
+  if (initialPrompt && !nativeInitialPrompt) {
     // One-shot injection, guarded by ptySession.initialPrompt. The submit CR
     // is a second deferred write (canonical Enter, CR not LF): TUI input
     // loops coalesce a text+newline chunk into a paste and leave the prompt

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -76,6 +76,120 @@ describe('buildAgentArgs cold-resume claudeArgs leak gate', () => {
   });
 });
 
+describe('initial prompt delivery', () => {
+  it('passes a Codex initial prompt as the final distinct argv element', async () => {
+    const probeDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-codex-argv-')
+    );
+    const probePath = path.join(probeDir, 'argv-probe.mjs');
+    fs.writeFileSync(
+      probePath,
+      [
+        "process.stdout.write('ARGV=' + JSON.stringify(process.argv.slice(2)));",
+        'setTimeout(() => {}, 10_000);',
+      ].join('\n'),
+      'utf-8'
+    );
+    const initialPrompt = 'fix spaces; $(never-shell-interpolate) && verify';
+    const cases = [
+      {
+        name: 'fresh',
+        args: ['--ask-for-approval', 'never'],
+      },
+      {
+        name: 'resume',
+        args: ['resume', '--last', '--ask-for-approval', 'never'],
+      },
+    ];
+
+    try {
+      for (const testCase of cases) {
+        const result = sessions.create({
+          repoName: `codex-${testCase.name}`,
+          repoPath: '/tmp',
+          worktreePath: null,
+          cwd: '/tmp',
+          agent: 'codex',
+          command: process.execPath,
+          args: [probePath, ...testCase.args],
+          initialPrompt,
+        });
+        createdIds.push(result.id);
+
+        let output = '';
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          output =
+            (
+              sessions.get(result.id) as PtySession | undefined
+            )?.scrollback.join('') ?? '';
+          if (output.includes('ARGV=')) break;
+          await delay(10);
+        }
+
+        expect(output).toContain(
+          `ARGV=${JSON.stringify([...testCase.args, initialPrompt])}`
+        );
+        expect(
+          (sessions.get(result.id) as PtySession | undefined)?.initialPrompt
+        ).toBeUndefined();
+      }
+    } finally {
+      fs.rmSync(probeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('schedules typed injection for Claude but not Codex', () => {
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    try {
+      const codex = sessions.create({
+        repoName: 'codex-native-prompt',
+        repoPath: '/tmp',
+        worktreePath: null,
+        cwd: '/tmp',
+        agent: 'codex',
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 10_000);'],
+        initialPrompt: 'native prompt',
+      });
+      createdIds.push(codex.id);
+
+      expect(timeoutSpy.mock.calls.some((call) => call[1] === 8000)).toBe(
+        false
+      );
+      expect(
+        (sessions.get(codex.id) as PtySession | undefined)?.initialPrompt
+      ).toBeUndefined();
+
+      timeoutSpy.mockClear();
+      const claude = sessions.create({
+        repoName: 'claude-typed-prompt',
+        repoPath: '/tmp',
+        worktreePath: null,
+        cwd: '/tmp',
+        agent: 'claude',
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 10_000);'],
+        initialPrompt: 'typed prompt',
+      });
+      createdIds.push(claude.id);
+
+      const fallbackCallIndex = timeoutSpy.mock.calls.findIndex(
+        (call) => call[1] === 8000
+      );
+      expect(fallbackCallIndex).toBeGreaterThanOrEqual(0);
+      expect(
+        (sessions.get(claude.id) as PtySession | undefined)?.initialPrompt
+      ).toBe('typed prompt');
+
+      const fallbackTimer = timeoutSpy.mock.results[fallbackCallIndex]
+        ?.value as ReturnType<typeof setTimeout> | undefined;
+      if (fallbackTimer) clearTimeout(fallbackTimer);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+});
+
 describe('sessions', () => {
   it('list returns empty array initially', () => {
     const result = sessions.list();


### PR DESCRIPTION
Fixes #1240 — codex PTY sessions spawned via Relay never ran their initialPrompt turn (stuck agentState=initializing). Root cause (codex-cli analysis): Relay waited for a waiting-for-input readiness the no-op codex parser never emits; the ~8s blind typed-injection fallback typed into codex 0.144's TUI before its composer accepted input, losing the one-shot prompt.

Fix: deliver initialPrompt as codex's NATIVE positional arg — codex [flags] <PROMPT> (fresh) / codex resume --last [flags] <PROMPT> (resume), a distinct argv element (never shell-interpolated). For codex, skip ptySession.initialPrompt storage + typed-injection fallback (no double-submit); claude/others unchanged; claude flags stay codex-gated. Codex parser readiness = follow-up (0.144 markers not evident, not guessed).

Written/analyzed via codex-cli; diff reviewed + independently verified (check 0 errors; test/sessions.test.ts 58 passed). Verified LIVE on the stable hub next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)