### PR TITLE
Slice 3: scoped-actor sessions.create — orchestrator worker spawn (#1257)

### DIFF
--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -30,6 +30,7 @@ export const CLI_GATEWAY_CORRELATION_ID_HEADER =
   'x-relay-correlation-id' as const;
 export const CLI_GATEWAY_ACTOR_GRANT_CAPABILITIES = [
   'session:read',
+  'session:create:agent',
   'context:read',
   'context:write',
   'inbox:read',
@@ -82,6 +83,7 @@ export type CliGatewayActorReadCommand =
   (typeof CLI_GATEWAY_ACTOR_READ_COMMANDS)[number];
 
 export const CLI_GATEWAY_ACTOR_WRITE_COMMANDS = [
+  'sessions.create',
   'context.create',
   'context.pin',
   'context.unpin',
@@ -331,6 +333,7 @@ export function isSupportedCliGatewayActorRequest(
 export function cliGatewayActorCommandCapabilities(
   command: CliGatewayActorCommand
 ): readonly RelayCapabilityBit[] {
+  if (command === 'sessions.create') return ['session:create:agent'];
   if (command === 'events.subscribe') return ['context:read'];
   // context/inbox reads must resolve to their read capability BEFORE the generic
   // read fallback (session:read) and the `startsWith('context.'|'inbox.')` write

--- a/server/index.ts
+++ b/server/index.ts
@@ -2407,6 +2407,7 @@ async function main(): Promise<void> {
       globalSessionIds?: string[];
       workContextIds?: string[];
       repoIds?: string[];
+      pathPrefixes?: string[];
       taskRefs?: string[];
     },
     expectedCommand?: CliGatewayActorCommand,
@@ -2485,6 +2486,7 @@ async function main(): Promise<void> {
             sessionIds?: string[];
             globalSessionIds?: string[];
             repoIds?: string[];
+            pathPrefixes?: string[];
             taskRefs?: string[];
           }
         | undefined;
@@ -2588,6 +2590,263 @@ async function main(): Promise<void> {
     }
     requireCliGatewayAuth(req, res, next);
   };
+
+  type ActorSessionCreateTarget =
+    | {
+        ok: true;
+        path: string;
+        repoId?: string;
+        body: Record<string, unknown>;
+        topic?: WorkspaceTopic;
+      }
+    | {
+        ok: false;
+        reason: 'missing_scope' | 'wrong_path_scope' | 'wrong_repo_scope';
+      };
+
+  const actorSessionCreateTargets = new WeakMap<
+    express.Request,
+    ActorSessionCreateTarget
+  >();
+  const invalidActorSessionCreatePath =
+    '/.relay-invalid-actor-session-create-target';
+
+  function actorSessionCreateTarget(
+    req: express.Request
+  ): ActorSessionCreateTarget {
+    const cached = actorSessionCreateTargets.get(req);
+    if (cached) return cached;
+    const rawBody = isRecord(req.body) ? req.body : {};
+    const validated = validateAndSanitizeLocalGatewayCreateInput(rawBody);
+    if (!validated.ok) {
+      const missing = { ok: false, reason: 'missing_scope' } as const;
+      actorSessionCreateTargets.set(req, missing);
+      return missing;
+    }
+    let body = validated.input;
+    let topic: WorkspaceTopic | undefined;
+    const workspaceTopicId = compactRequestPath(body['workspaceTopicId']);
+    if (workspaceTopicId) {
+      topic = workspaceTopicStore?.get(workspaceTopicId) ?? undefined;
+      if (!topic || topic.status === 'archived') {
+        const missing = { ok: false, reason: 'missing_scope' } as const;
+        actorSessionCreateTargets.set(req, missing);
+        return missing;
+      }
+      body = {
+        ...body,
+        ...buildWorkspaceTopicSessionCreateBody({
+          topic,
+          overrides: body,
+        }),
+        workspaceTopicId: topic.id,
+      };
+    }
+    const requestedRepoPath = compactRequestPath(body['repoPath']);
+    const requestedWorktreePath = compactRequestPath(body['worktreePath']);
+    const requestedCwd = compactRequestPath(body['cwd']);
+    const requestedTarget =
+      requestedWorktreePath ?? requestedCwd ?? requestedRepoPath;
+    if (!requestedTarget) {
+      const missing = { ok: false, reason: 'missing_scope' } as const;
+      actorSessionCreateTargets.set(req, missing);
+      return missing;
+    }
+    let canonicalTarget: string;
+    try {
+      canonicalTarget = fs.realpathSync(requestedTarget);
+    } catch {
+      const wrongPath = { ok: false, reason: 'wrong_path_scope' } as const;
+      actorSessionCreateTargets.set(req, wrongPath);
+      return wrongPath;
+    }
+    if (!requestedRepoPath) {
+      const canonicalBody = { ...body };
+      if (requestedWorktreePath) {
+        canonicalBody['worktreePath'] = canonicalTarget;
+      } else if (requestedCwd) {
+        canonicalBody['cwd'] = canonicalTarget;
+      }
+      const target = {
+        ok: true,
+        path: canonicalTarget,
+        body: canonicalBody,
+        ...(topic ? { topic } : {}),
+      } as const;
+      actorSessionCreateTargets.set(req, target);
+      return target;
+    }
+    try {
+      const canonicalRepoPath = fs.realpathSync(requestedRepoPath);
+      const canonicalBody = {
+        ...body,
+        repoPath: canonicalRepoPath,
+        ...(requestedWorktreePath
+          ? { worktreePath: canonicalTarget }
+          : requestedCwd
+            ? { cwd: canonicalTarget }
+            : {}),
+      };
+      const target = {
+        ok: true,
+        path: canonicalTarget,
+        repoId: canonicalRepoPath,
+        body: canonicalBody,
+        ...(topic ? { topic } : {}),
+      } as const;
+      actorSessionCreateTargets.set(req, target);
+      return target;
+    } catch {
+      const wrongRepo = { ok: false, reason: 'wrong_repo_scope' } as const;
+      actorSessionCreateTargets.set(req, wrongRepo);
+      return wrongRepo;
+    }
+  }
+
+  function actorSessionCreateScopeForRequest(req: express.Request): {
+    repoIds?: string[];
+    pathPrefixes: string[];
+    sessionIds?: string[];
+  } {
+    const target = actorSessionCreateTarget(req);
+    if (!target.ok) {
+      return { pathPrefixes: [invalidActorSessionCreatePath] };
+    }
+    const spawnedBySessionId = compactRequestPath(
+      target.body['spawnedBySessionId']
+    );
+    return {
+      ...(target.repoId ? { repoIds: [target.repoId] } : {}),
+      pathPrefixes: [target.path],
+      ...(spawnedBySessionId
+        ? { sessionIds: [spawnedBySessionId] }
+        : {}),
+    };
+  }
+
+  function pathIsWithin(parent: string, child: string): boolean {
+    const relative = path.relative(parent, child);
+    return (
+      relative === '' ||
+      (!relative.startsWith('..') && !path.isAbsolute(relative))
+    );
+  }
+
+  const requireActorSessionCreatePolicy: express.RequestHandler = (
+    req,
+    res,
+    next
+  ) => {
+    const credential = authenticatedCliGatewayActorCredential(req);
+    if (!credential) {
+      next();
+      return;
+    }
+    const target = actorSessionCreateTarget(req);
+    if (!target.ok) {
+      sendCliGatewayActorFailure(
+        res,
+        cliGatewayActorFailure({ reason: target.reason })
+      );
+      return;
+    }
+    const hasAuthorizedPathScope =
+      (credential.scope.pathPrefixes?.length ?? 0) > 0;
+    const hasAuthorizedRepoScope =
+      Boolean(target.repoId) &&
+      (credential.scope.repoIds?.length ?? 0) > 0 &&
+      pathIsWithin(target.repoId!, target.path);
+    if (!hasAuthorizedPathScope && !hasAuthorizedRepoScope) {
+      sendCliGatewayActorFailure(
+        res,
+        cliGatewayActorFailure({ reason: 'missing_scope' })
+      );
+      return;
+    }
+    const body = target.body;
+    if (body['type'] === 'terminal') {
+      res.status(403).json({
+        error: {
+          code: 'FORBIDDEN',
+          reasonCode: 'CLI_ACTOR_SESSION_TYPE_UNSUPPORTED',
+          message:
+            'scoped CLI actors may create agent worker sessions only; terminal creation requires the browser lane',
+          retryable: false,
+          lane: 'denied',
+          acceptedLanes: ['scoped-actor-credential'],
+        },
+      });
+      return;
+    }
+    const credentialSessionId = credential.scope.sessionIds?.[0];
+    const requestedParent =
+      typeof body['spawnedBySessionId'] === 'string'
+        ? body['spawnedBySessionId']
+        : undefined;
+    if (
+      credentialSessionId &&
+      requestedParent &&
+      requestedParent !== credentialSessionId
+    ) {
+      sendCliGatewayActorFailure(
+        res,
+        cliGatewayActorFailure({ reason: 'wrong_session_scope' })
+      );
+      return;
+    }
+    if (credentialSessionId) {
+      body['spawnedBySessionId'] = credentialSessionId;
+      if (isRecord(req.body)) {
+        req.body['spawnedBySessionId'] = credentialSessionId;
+      }
+    } else {
+      // A caller-provided lineage id is identity-like attribution. Without a
+      // credential-bound session id it is unverified, so omit it fail-closed.
+      delete body['spawnedBySessionId'];
+      if (isRecord(req.body)) {
+        delete req.body['spawnedBySessionId'];
+      }
+    }
+    next();
+  };
+
+  function actorSessionCreateControlState(
+    req: express.Request,
+    workerId: string,
+    workerDisplayName: string
+  ): ReturnType<typeof createAgentDrivenInitialControlState> {
+    const credential = authenticatedCliGatewayActorCredential(req);
+    if (!credential) {
+      throw new Error(
+        'actor session control state requires an authenticated actor credential'
+      );
+    }
+    const workerState = createAgentDrivenInitialControlState({
+      workerId,
+      displayName: workerDisplayName,
+    });
+    const owner = {
+      kind: 'agent' as const,
+      id: `agent:${credential.actor.id}`,
+      ...(credential.actor.displayName
+        ? { displayName: credential.actor.displayName }
+        : {}),
+      ...(credential.scope.nodeIds?.[0]
+        ? { nodeId: credential.scope.nodeIds[0] }
+        : {}),
+      ...(credential.scope.sessionIds?.[0]
+        ? { sessionId: credential.scope.sessionIds[0] }
+        : {}),
+    };
+    return {
+      ...workerState,
+      activeActors: [...workerState.activeActors, owner],
+      // activeWorker remains the spawned worker. The authenticated orchestrator
+      // is an additional controlling actor, never a body-supplied replacement.
+      activeWorker: workerState.activeWorker,
+      controlReason: 'scoped-actor-spawned-agent-worker',
+    };
+  }
 
   const requireScopedSessionAuth: express.RequestHandler = (req, res, next) => {
     if (isCliGatewayActorTokenRequest(req)) {
@@ -5436,13 +5695,26 @@ async function main(): Promise<void> {
   }
 
   // POST /sessions — unified endpoint for agent and terminal sessions
-  app.post('/sessions', requireCliGatewayAuth, async (req, res) => {
-    const requestedCreateBody = sessionCreateBodyFromRequest(req, res);
+  const requireCliGatewaySessionCreateAuth =
+    requireCliGatewayAuthForActorCommand('sessions.create', {
+      scopeForRequest: actorSessionCreateScopeForRequest,
+    });
+  app.post('/sessions', requireCliGatewaySessionCreateAuth, requireActorSessionCreatePolicy, async (req, res) => {
+    const actorTarget = authenticatedCliGatewayActorCredential(req)
+      ? actorSessionCreateTarget(req)
+      : undefined;
+    const requestedCreateBody =
+      actorTarget?.ok === true
+        ? actorTarget.body
+        : sessionCreateBodyFromRequest(req, res);
     if (!requestedCreateBody) return;
-    const topicCreate = resolveWorkspaceTopicSessionCreate(
-      requestedCreateBody,
-      res
-    );
+    const topicCreate =
+      actorTarget?.ok === true
+        ? {
+            body: actorTarget.body,
+            ...(actorTarget.topic ? { topic: actorTarget.topic } : {}),
+          }
+        : resolveWorkspaceTopicSessionCreate(requestedCreateBody, res);
     if (!topicCreate) return;
     const createBody = topicCreate.body;
     const workspaceTopic = topicCreate.topic;
@@ -5661,8 +5933,12 @@ async function main(): Promise<void> {
         requestedDisplayName,
         sessions.nextAgentName
       );
+      const actorWorkerSessionId = authenticatedCliGatewayActorCredential(req)
+        ? crypto.randomBytes(8).toString('hex')
+        : undefined;
       try {
         const { session } = await localRelayNode.sessions.createWeb({
+          ...(actorWorkerSessionId ? { id: actorWorkerSessionId } : {}),
           ...(spawnedBySessionId !== undefined ? { spawnedBySessionId } : {}),
           agentType: resolvedAgent,
           cwd,
@@ -5674,6 +5950,15 @@ async function main(): Promise<void> {
           port: startupConfig.port,
           configDir,
           sessionLane,
+          ...(actorWorkerSessionId
+            ? {
+                controlState: actorSessionCreateControlState(
+                  req,
+                  actorWorkerSessionId,
+                  displayName
+                ),
+              }
+            : {}),
           ...buildHermesCreateExtra(resolvedAgent, {
             workspaceTopic,
             repoPath: requestedRepoPath,
@@ -5713,10 +5998,14 @@ async function main(): Promise<void> {
       requestedDisplayName,
       sessions.nextAgentName
     );
+    const actorWorkerSessionId = authenticatedCliGatewayActorCredential(req)
+      ? crypto.randomBytes(8).toString('hex')
+      : undefined;
 
     let session: CreateResult;
     try {
       session = createAgentSessionRecord({
+        ...(actorWorkerSessionId ? { id: actorWorkerSessionId } : {}),
         ...(spawnedBySessionId !== undefined ? { spawnedBySessionId } : {}),
         repoName: name,
         repoPath: requestedRepoPath,
@@ -5738,6 +6027,15 @@ async function main(): Promise<void> {
         claudeFullscreen: freshConfig.claudeFullscreen,
         sessionLane,
         workContextId,
+        ...(actorWorkerSessionId
+          ? {
+              controlState: actorSessionCreateControlState(
+                req,
+                actorWorkerSessionId,
+                displayName
+              ),
+            }
+          : {}),
         portVariables,
         scrollbackBytes: resolved.scrollbackBytes,
         envOverrides: sessionEnvOverrides,

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -541,6 +541,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
 test('classifies explicitly scoped CLI gateway actor write routes into the actor lane', () => {
   const token = 'relay-sac-v1.credential-id.[REDACTED]';
   expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toEqual([
+    'sessions.create',
     'context.create',
     'context.pin',
     'context.unpin',
@@ -636,6 +637,9 @@ test('classifies explicitly scoped CLI gateway actor write routes into the actor
 test('maps write actor commands to required Relay capability bits', () => {
   expect(cliGatewayActorCommandCapabilities('nodes.list')).toEqual([
     'session:read',
+  ]);
+  expect(cliGatewayActorCommandCapabilities('sessions.create')).toEqual([
+    'session:create:agent',
   ]);
   expect(cliGatewayActorCommandCapabilities('context.create')).toEqual([
     'context:write',
@@ -941,7 +945,7 @@ test('denies grant-backed CLI actor lifecycle expansion and lane-mixing attempts
 
   const denialCases = [
     [{ audience: 'relay:operator-handshake:v1' }, 'audience_expansion'],
-    [{ capabilities: ['session:create:agent'] }, 'capability_expansion'],
+    [{ capabilities: ['session:create:terminal'] }, 'capability_expansion'],
     [{ capabilities: ['definitely:not-a-capability'] }, 'unknown_capability'],
     [{ capabilities: ['*'] }, 'capability_expansion'],
     [{ scope: {} }, 'scope_required'],

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -631,3 +631,238 @@ test('protected hub accepts grant-backed CLI actor credential for nodes.list wit
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test('scoped actor sessions.create spawns an in-scope controlled worker and rejects an out-of-scope cwd', async () => {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-cli-actor-session-create-')
+  );
+  const outsideDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-cli-actor-session-outside-')
+  );
+  const configPath = path.join(tmpDir, 'config.json');
+  const binDir = path.join(tmpDir, 'bin');
+  const codexStub = path.join(binDir, 'codex');
+  const authorizedDir = path.join(tmpDir, 'authorized');
+  const authorizedLink = path.join(tmpDir, 'authorized-link');
+  const topicOutsideDir = path.join(tmpDir, 'topic-outside');
+  const pin = '246810';
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(authorizedDir);
+  fs.mkdirSync(topicOutsideDir);
+  fs.symlinkSync(authorizedDir, authorizedLink, 'dir');
+  fs.writeFileSync(
+    codexStub,
+    '#!/usr/bin/env node\nprocess.stdin.resume();\nsetInterval(() => {}, 1000);\n'
+  );
+  fs.chmodSync(codexStub, 0o755);
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      port: 0,
+      host: '127.0.0.1',
+      repos: [tmpDir],
+      pinHash: await hashPin(pin),
+      cookieTTL: '1h',
+    })
+  );
+
+  const child = startServer({
+    env: {
+      RELAY_IDE_CONFIG: configPath,
+      RELAY_IDE_PORT: '0',
+      HOME: tmpDir,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    },
+  });
+
+  try {
+    const port = await waitForListeningPort(child);
+    const base = `http://127.0.0.1:${port}`;
+    const canonicalRepoPath = fs.realpathSync(tmpDir);
+    const canonicalAuthorizedPath = fs.realpathSync(authorizedDir);
+    const orchestratorSessionId = 'orchestrator-session-1257';
+
+    const login = await fetch(`${base}/auth`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pin }),
+    });
+    await expectJsonStatus<{ ok: true }>(login, 200, 'PIN login');
+    const cookie = cookieFromSetCookie(login.headers);
+
+    const grantRequest = await fetch(`${base}/hub/operator-handshake-grants`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        actor: {
+          type: 'agent',
+          id: 'orchestrator-1257',
+          displayName: 'Issue 1257 orchestrator',
+        },
+        issuer: { id: 'browser-operator-test' },
+        audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+        capabilities: ['session:create:agent'],
+        scope: {
+          sessionIds: [orchestratorSessionId],
+          pathPrefixes: [canonicalAuthorizedPath],
+        },
+        ttlMs: 60_000,
+      }),
+    });
+    const requested = await expectJsonStatus<{ grant: { id: string } }>(
+      grantRequest,
+      201,
+      'operator session-create grant request'
+    );
+
+    const grantApproval = await fetch(
+      `${base}/hub/operator-handshake-grants/${encodeURIComponent(requested.grant.id)}/approve`,
+      {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({ approvedBy: { id: 'browser-operator-test' } }),
+      }
+    );
+    const approved = await expectJsonStatus<{ handle: string }>(
+      grantApproval,
+      200,
+      'operator session-create grant approval'
+    );
+
+    const minted = await fetch(`${base}/cli-gateway/actor-credentials`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grantHandle: approved.handle,
+        audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+        actor: {
+          type: 'agent',
+          id: 'orchestrator-1257',
+          displayName: 'Issue 1257 orchestrator',
+        },
+        capabilities: ['session:create:agent'],
+        scope: {
+          sessionIds: [orchestratorSessionId],
+          pathPrefixes: [canonicalAuthorizedPath],
+        },
+        ttlMs: 60_000,
+      }),
+    });
+    const issued = await expectJsonStatus<{ token: string }>(
+      minted,
+      201,
+      'grant-backed session-create actor credential mint'
+    );
+    const actorHeaders = {
+      authorization: `Bearer ${issued.token}`,
+      'content-type': 'application/json',
+      'x-relay-cli-gateway': 'v1',
+      'x-relay-cli-command': 'sessions.create',
+    };
+
+    const inScopeCreate = await fetch(`${base}/sessions`, {
+      method: 'POST',
+      headers: actorHeaders,
+      body: JSON.stringify({
+        cwd: authorizedLink,
+        type: 'agent',
+        agent: 'codex',
+        displayName: 'Scoped worker',
+        spawnedBySessionId: orchestratorSessionId,
+      }),
+    });
+    const created = await expectJsonStatus<{
+      id: string;
+      cwd: string;
+      spawnedBySessionId?: string;
+      activeActors?: Array<{
+        kind: string;
+        id?: string;
+        sessionId?: string;
+      }>;
+      activeWorker?: { id?: string };
+    }>(inScopeCreate, 201, 'in-scope actor sessions.create');
+    expect(created.cwd).toBe(canonicalAuthorizedPath);
+    expect(created.spawnedBySessionId).toBe(orchestratorSessionId);
+    expect(created.activeWorker?.id).toBe(created.id);
+    expect(created.activeActors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'agent', id: created.id }),
+        expect.objectContaining({
+          kind: 'agent',
+          id: 'agent:orchestrator-1257',
+          sessionId: orchestratorSessionId,
+        }),
+      ])
+    );
+
+    const topicCreate = await fetch(`${base}/workspace-topics`, {
+      method: 'POST',
+      headers: {
+        cookie,
+        'content-type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify({
+        id: 'topic:actor-scope-bypass-1257',
+        workspaceId: 'ws-actor-scope-1257',
+        title: 'Actor scope bypass regression',
+        routingDefaults: {
+          repoPath: canonicalRepoPath,
+          worktreePath: fs.realpathSync(topicOutsideDir),
+        },
+      }),
+    });
+    await expectJsonStatus<{ topic: { id: string } }>(
+      topicCreate,
+      201,
+      'workspace topic bypass fixture'
+    );
+
+    const topicBypassCreate = await fetch(`${base}/sessions`, {
+      method: 'POST',
+      headers: actorHeaders,
+      body: JSON.stringify({
+        cwd: authorizedLink,
+        workspaceTopicId: 'topic:actor-scope-bypass-1257',
+        type: 'agent',
+        agent: 'codex',
+        spawnedBySessionId: orchestratorSessionId,
+      }),
+    });
+    await expectJsonStatus<{
+      error: { code: string; reasonCode: string };
+    }>(topicBypassCreate, 403, 'topic-expanded out-of-scope actor create').then(
+      (body) => {
+        expect(body.error).toMatchObject({
+          code: 'FORBIDDEN',
+          reasonCode: 'CLI_ACTOR_WRONG_PATH_SCOPE',
+        });
+      }
+    );
+
+    const outOfScopeCreate = await fetch(`${base}/sessions`, {
+      method: 'POST',
+      headers: actorHeaders,
+      body: JSON.stringify({
+        cwd: fs.realpathSync(outsideDir),
+        type: 'agent',
+        agent: 'codex',
+      }),
+    });
+    await expectJsonStatus<{
+      error: { code: string; reasonCode: string };
+    }>(outOfScopeCreate, 403, 'out-of-scope actor sessions.create').then(
+      (body) => {
+        expect(body.error).toMatchObject({
+          code: 'FORBIDDEN',
+          reasonCode: 'CLI_ACTOR_WRONG_PATH_SCOPE',
+        });
+      }
+    );
+  } finally {
+    await killAndWait(child);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Slice 3 of epic #1242 — scoped-actor `sessions.create`

Lets a scoped-actor **orchestrator** spawn agent-worker sessions in a repo/worktree it is scoped to — the controlled counterpart to #1167 spawn-by-mention (which only spawns in the binder's default cwd, verified live to be the operator home dir).

### Change
- `sessions.create` added to the CLI-gateway actor **write** allowlist, gated on the existing `session:create:agent` capability (terminal creation stays browser-lane).
- Two-layer, fail-closed enforcement (`server/index.ts`):
  - **Layer A** `requireCliGatewayAuthForActorCommand('sessions.create', scopeForRequest)` — derives required `{repoIds, pathPrefixes}` from the **realpath-canonicalized** target; the registry (`pathMatchesCredentialPrefix`) checks the target is *within* a credential prefix.
  - **Layer B** `requireActorSessionCreatePolicy` — requires the credential to actually carry path/repo scope (compensates the registry's dimension rule-skip), blocks `type:'terminal'`, server-derives owner `agent:<actor id>`, forces `spawnedBySessionId` to the credential-bound session id (or deletes it).
- Paths realpath-canonicalized before scope derivation; the **exact canonical body is reused for launch** (closes symlink / workspace-topic-injection divergence + TOCTOU).
- Browser-lane create unchanged. No UI.

### Review
- Written by codex-cli; **Opus adversarial scope-escape review** (all 7 vectors: symlink TOCTOU, `..` traversal, topic-injection, hidden-cwd field, layer-skip/alternate-route, prefix-boundary, registry rule-skip) → **SAFE-TO-SHIP**, no scope-escape or fail-open. Only residual = inherent realpath→spawn TOCTOU (low; needs local FS write race).
- Tests: `cli-gateway-actor-auth` + `server-startup` **27/27**; `npm run check` clean.

### Acceptance
- In-scope actor token creates a session via the gateway; out-of-scope `cwd`/`repoPath`/topic path → `403 CLI_ACTOR_WRONG_PATH_SCOPE`; no-path/repo-scope credential → `missing_scope`.
- Spawn carries `spawnedBySessionId`; owner server-derived. No browser-lane regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
