### PR TITLE
fix(workspace-groups): gate --add-dir to claude in multi-repo spawns (#1238)

### DIFF
--- a/server/workspace-groups.ts
+++ b/server/workspace-groups.ts
@@ -126,8 +126,6 @@ function buildFinalArgs(
   combinedClaudeArgs: string[];
   finalArgs: string[];
 } {
-  const addDirArgs = additionalDirs.flatMap((dir) => ['--add-dir', dir]);
-
   const sessionOverrides: Parameters<typeof resolveSessionSettings>[2] = {};
   if (overrides.agent !== undefined)
     sessionOverrides.agent = overrides.agent as AgentType;
@@ -144,10 +142,16 @@ function buildFinalArgs(
     workspaceId
   );
   const resolvedAgent = resolved.agent;
-  // config.claudeArgs carries Claude-specific flags (--model/--effort); folding
-  // them into codex/opencode/hermes spawns exits those CLIs with code 2. Gate
-  // to the claude agent only. --add-dir (multi-repo) composition is unchanged.
+  // config.claudeArgs carries Claude-specific flags (--model/--effort) and
+  // --add-dir is likewise a Claude-only multi-repo flag; folding either into
+  // codex/opencode/hermes spawns exits those CLIs with code 2 (#1238, same
+  // class as #1237). Gate BOTH to the claude agent. No other framework declares
+  // a multi-repo flag, so non-claude group spawns launch in the primary repo.
   const agentClaudeArgs = resolvedAgent === 'claude' ? resolved.claudeArgs : [];
+  const addDirArgs =
+    resolvedAgent === 'claude'
+      ? additionalDirs.flatMap((dir) => ['--add-dir', dir])
+      : [];
   const combinedClaudeArgs = [...agentClaudeArgs, ...addDirArgs];
   const baseArgs = [
     ...combinedClaudeArgs,

--- a/test/workspace-groups.test.ts
+++ b/test/workspace-groups.test.ts
@@ -562,3 +562,59 @@ test('workspace claude session keeps config claudeArgs in spawn args', async () 
     expect.arrayContaining(['--model', 'opus', '--effort', 'high'])
   );
 });
+
+// --add-dir is a Claude-only multi-repo flag; it must not leak into a non-claude
+// multi-repo workspace-group spawn (#1238, same class as #1237): codex exits
+// code 2 within ~1s on the unrecognized flag.
+test('workspace codex multi-repo session omits --add-dir from spawn args', async () => {
+  const repoA = path.join(tmpDir, 'repo-codex-a');
+  const repoB = path.join(tmpDir, 'repo-codex-b');
+  fs.mkdirSync(repoA, { recursive: true });
+  fs.mkdirSync(repoB, { recursive: true });
+  writeConfig({
+    configVersion: 4,
+    repos: [repoA, repoB],
+    workspaces: [
+      { id: 'ws-1', name: 'Ws', repos: [repoA, repoB], order: 0 },
+    ],
+  });
+  const sessionDeps = fakeSessionDeps();
+  await startServer(configPath, sessionDeps);
+
+  const result = await req('POST', '/workspace-groups/ws-1/session', {
+    agent: 'codex',
+  });
+  expect(result.status).toBe(201);
+  expect(sessionDeps.sessions.create).toHaveBeenCalledTimes(1);
+  const createParams = sessionDeps.sessions.create.mock.calls[0][0];
+  expect(createParams.agent).toBe('codex');
+  expect(createParams.args).not.toContain('--add-dir');
+  expect(createParams.args).not.toContain(repoB);
+});
+
+test('workspace claude multi-repo session keeps --add-dir for extra repos', async () => {
+  const repoA = path.join(tmpDir, 'repo-claude-a');
+  const repoB = path.join(tmpDir, 'repo-claude-b');
+  fs.mkdirSync(repoA, { recursive: true });
+  fs.mkdirSync(repoB, { recursive: true });
+  writeConfig({
+    configVersion: 4,
+    repos: [repoA, repoB],
+    workspaces: [
+      { id: 'ws-1', name: 'Ws', repos: [repoA, repoB], order: 0 },
+    ],
+  });
+  const sessionDeps = fakeSessionDeps();
+  await startServer(configPath, sessionDeps);
+
+  const result = await req('POST', '/workspace-groups/ws-1/session', {
+    agent: 'claude',
+  });
+  expect(result.status).toBe(201);
+  expect(sessionDeps.sessions.create).toHaveBeenCalledTimes(1);
+  const createParams = sessionDeps.sessions.create.mock.calls[0][0];
+  expect(createParams.agent).toBe('claude');
+  expect(createParams.args).toEqual(
+    expect.arrayContaining(['--add-dir', repoB])
+  );
+});


### PR DESCRIPTION
Closes #1238 (same leak class as #1237).

## Problem
`--add-dir` is a Claude-only multi-repo flag. `buildFinalArgs` composed it into `combinedClaudeArgs` for **all** agents, so a codex/opencode/hermes workspace-group launch with 2+ repos spawned with an unrecognized flag → exit code 2 within ~1s.

## Fix
Gate `addDirArgs` to `resolvedAgent === 'claude'` (alongside the existing `claudeArgs` gate). No other framework declares a multi-repo flag, so non-claude group spawns launch in the primary repo rather than crash.

## Tests (mirror the #1237 no-leak pattern for the multi-repo path)
- `codex multi-repo session omits --add-dir` + the extra repo path
- `claude multi-repo session keeps --add-dir for the extra repo`
- `npm run check` clean (0 errors); `workspace-groups.test.ts` 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected multi-repository session launches so Claude-only directory arguments are applied only when using Claude.
  - Prevented unsupported directory flags and extra repository paths from being passed to Codex sessions.
  - Preserved expected additional repository handling for Claude sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->