### PR TITLE
fix(sessions): resource-hygiene sweep — session-teardown cleanup gaps (#1244)

### DIFF
--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -259,9 +259,15 @@ export type HubNodePtyInputRecorder = (input: {
   data: string;
 }) => void;
 
+export type HubNodePtyControlSessionReleaser = (
+  nodeId: string,
+  sessionId: string
+) => void;
+
 export interface HubNodeLinkManagerOptions {
   inventoryValidator?: HubNodeLinkInventoryValidator;
   ptyInputRecorder?: HubNodePtyInputRecorder;
+  releaseRoutedPtyControlSession?: HubNodePtyControlSessionReleaser;
 }
 
 export class HubNodeLinkManager {
@@ -272,6 +278,7 @@ export class HubNodeLinkManager {
   private readonly eventHandlers = new Set<NodeEventHandler>();
   private readonly inventoryValidator?: HubNodeLinkInventoryValidator;
   private readonly ptyInputRecorder?: HubNodePtyInputRecorder;
+  private readonly releaseRoutedPtyControlSession?: HubNodePtyControlSessionReleaser;
 
   constructor(options: HubNodeLinkManagerOptions = {}) {
     if (options.inventoryValidator) {
@@ -279,6 +286,10 @@ export class HubNodeLinkManager {
     }
     if (options.ptyInputRecorder) {
       this.ptyInputRecorder = options.ptyInputRecorder;
+    }
+    if (options.releaseRoutedPtyControlSession) {
+      this.releaseRoutedPtyControlSession =
+        options.releaseRoutedPtyControlSession;
     }
   }
 
@@ -609,6 +620,10 @@ export class HubNodeLinkManager {
     }
     if (message.type === 'pty.exit') {
       this.ptyStreams.delete(message.streamId!);
+      this.releaseRoutedPtyControlSession?.(
+        stream.nodeId,
+        stream.sessionId
+      );
       if (browserWs.readyState === browserWs.OPEN) browserWs.close(1000);
       return true;
     }
@@ -655,6 +670,10 @@ export class HubNodeLinkManager {
     for (const [streamId, stream] of Array.from(this.ptyStreams)) {
       if (stream.nodeId !== nodeId || stream.nodeWs !== ws) continue;
       this.ptyStreams.delete(streamId);
+      // An ungraceful link drop is terminal for the stream — release the routed
+      // control-session entry too, so it doesn't leak until an explicit node
+      // revoke (#1244 item 3 review). Idempotent; a same-id reconnect recreates.
+      this.releaseRoutedPtyControlSession?.(stream.nodeId, stream.sessionId);
       if (stream.browserWs.readyState === stream.browserWs.OPEN) {
         stream.browserWs.close(1011, 'node link closed');
       }

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -183,6 +183,11 @@ interface HubNodeRouterOptions {
     expiresAt: string;
     now?: Date;
   }) => ReturnType<InMemorySessionEnvelopeRegistry['renew']>;
+  releaseRoutedPtyControlSession?: (
+    nodeId: string,
+    sessionId: string
+  ) => void;
+  releaseRoutedPtyControlSessionsForNode?: (nodeId: string) => void;
   confirmations?: ConfirmationChallengeStore;
   operatorHandshakeGrants?: HandshakeGrantRegistry;
   auditSink?: RoutedSessionAuditSink;
@@ -3945,6 +3950,10 @@ export function createHubNodeRouter(
         return;
       }
       auditLifecycleRevocation(options.auditSink, summary, body);
+      options.releaseRoutedPtyControlSession?.(
+        summary.nodeId,
+        summary.sessionId
+      );
       res.json({ session: summary });
     }
   );
@@ -3985,6 +3994,10 @@ export function createHubNodeRouter(
       auditLifecycleRevocation(options.auditSink, summary, {
         method: 'DELETE',
       });
+      options.releaseRoutedPtyControlSession?.(
+        summary.nodeId,
+        summary.sessionId
+      );
       res.json({ session: summary });
     }
   );
@@ -4795,6 +4808,7 @@ export function createHubNodeRouter(
           }
         );
         envelopes.delete(sessionId, nodeId);
+        options.releaseRoutedPtyControlSession?.(nodeId, sessionId);
         res.json({
           ...(typeof payload === 'object' && payload !== null
             ? (payload as Record<string, unknown>)
@@ -4844,6 +4858,7 @@ export function createHubNodeRouter(
         now: now(),
         auditSink: options.auditSink,
       });
+      options.releaseRoutedPtyControlSessionsForNode?.(nodeId);
       res.json({
         node,
         events: revokedSessions.map((session) => ({

--- a/server/index.ts
+++ b/server/index.ts
@@ -1236,7 +1236,7 @@ function createHandoffDestinationLauncher(params: {
   startupConfig: Config;
   configDir: string;
   getConfig: () => Config;
-  watchCwd: (cwd: string) => void;
+  watchSessionCwd: (sessionId: string, cwd: string) => void;
 }): (input: HandoffDestinationLaunchInput) => Promise<
   | {
       ok: true;
@@ -1327,7 +1327,7 @@ function createHandoffDestinationLauncher(params: {
           session.id,
           terminalBriefCommand(input.handoffBrief)
         );
-        params.watchCwd(session.cwd);
+        params.watchSessionCwd(session.id, session.cwd);
         return { ok: true, session, acknowledgedBrief: true };
       }
 
@@ -1386,7 +1386,7 @@ function createHandoffDestinationLauncher(params: {
         // Pipeline-handoff destination is spawned by the source session.
         spawnedBySessionId: input.request.source.sessionId,
       });
-      params.watchCwd(session.cwd);
+      params.watchSessionCwd(session.id, session.cwd);
       return { ok: true, session, acknowledgedBrief: true };
     } catch (err) {
       return {
@@ -1985,6 +1985,8 @@ async function main(): Promise<void> {
   const hubNodeLinks = createHubNodeLinkManager({
     inventoryValidator: repoInventoryFeature.validateInventoryPayload,
     ptyInputRecorder: sessions.recordRoutedPtyInput,
+    releaseRoutedPtyControlSession:
+      sessions.releaseRoutedPtyControlSession,
   });
   const remoteSessionReadModelCache = createRemoteSessionReadModelCache();
   const credentialRotationScheduler = startCredentialRotationScheduler({
@@ -3060,6 +3062,10 @@ async function main(): Promise<void> {
       confirmations: confirmationChallenges,
       sessionEnvelopes: sessionEnvelopeRegistry,
       renewLocalSession: localRelayNode.sessions.renew,
+      releaseRoutedPtyControlSession:
+        sessions.releaseRoutedPtyControlSession,
+      releaseRoutedPtyControlSessionsForNode:
+        sessions.releaseRoutedPtyControlSessionsForNode,
       workContextStore,
       readModelCache: remoteSessionReadModelCache,
       sourceDiagnostics: {
@@ -3602,21 +3608,12 @@ async function main(): Promise<void> {
   const watcher = new WorktreeWatcher();
   watcher.rebuild(getConfig().repos || []);
 
-  // gitWatcher lifecycle: `gitWatcher.watch(cwd)` is refcounted per session at
-  // each session-create site; `gitWatcher.unwatch(cwd)` must be called once per
-  // matching teardown. It is wired to the explicit teardown paths — DELETE
-  // /sessions/:id and the DELETE /worktrees force-kill loop (#1244). A session
-  // that exits on its own (PTY dies without an explicit DELETE) is NOT unwatched
-  // here: a central sessions.onSessionEnd → unwatch is deliberately avoided
-  // because PTY sessions fire session-end twice on explicit kill (kill() +
-  // pty-exit cleanup), which would over-decrement the refcount and close a
-  // watcher another session at the same cwd still needs. The residual leak is
-  // now bounded — post-#1249/#1251 the GitWatcher maintains its own recursion and
-  // attaches one non-recursive fs.watch per non-ignored directory at every depth,
-  // pruning IGNORED_DIRS (node_modules/.git/.worktrees/…) at each level and
-  // capping total watches — so it can no longer wedge the event loop.
-  // Follow-up: single-fire session-end + central unwatch (tracked in #1244).
+  // GitWatcher owns one refcounted cwd watch per session id. Central session-end
+  // cleanup is safe even though PTY explicit kill can fire session-end twice:
+  // unwatchSession(id) consumes that session's ownership once and subsequent
+  // notifications are no-ops, without decrementing another session at the cwd.
   const gitWatcher = new GitWatcher();
+  sessions.onSessionEnd((sessionId) => gitWatcher.unwatchSession(sessionId));
 
   const server = http.createServer(app);
   const { broadcastEvent, broadcastBranchChanged } = setupWebSocket(
@@ -3941,7 +3938,8 @@ async function main(): Promise<void> {
         startupConfig,
         configDir,
         getConfig,
-        watchCwd: (cwd) => gitWatcher.watch(cwd),
+        watchSessionCwd: (sessionId, cwd) =>
+          gitWatcher.watchSession(sessionId, cwd),
       }),
     })
   );
@@ -4393,7 +4391,7 @@ async function main(): Promise<void> {
   // Periodic rate limit snapshot recording (every 5 minutes)
   let lastRateLimitSnapshot = 0;
   const RATE_LIMIT_SNAPSHOT_INTERVAL = 5 * 60 * 1000;
-  setInterval(() => {
+  const rateLimitSnapshotTimer = setInterval(() => {
     const now = Date.now();
     if (now - lastRateLimitSnapshot < RATE_LIMIT_SNAPSHOT_INTERVAL) return;
     const account = Object.values(getAccountTelemetry())
@@ -4413,9 +4411,10 @@ async function main(): Promise<void> {
       timestamp: new Date().toISOString(),
     });
   }, 60_000);
+  rateLimitSnapshotTimer.unref();
 
   // Schedule daily retention cleanup
-  setInterval(
+  const retentionCleanupTimer = setInterval(
     () => {
       try {
         runRetentionCleanup();
@@ -4425,6 +4424,7 @@ async function main(): Promise<void> {
     },
     24 * 60 * 60 * 1000
   );
+  retentionCleanupTimer.unref();
 
   // Populate session metadata cache in background (non-blocking)
   populateMetaCache().catch(() => {});
@@ -5628,10 +5628,6 @@ async function main(): Promise<void> {
     // Force: kill active sessions in this worktree first
     if (force) {
       for (const sessionId of worktreeSessions) {
-        // Capture cwd before kill so we can release the git watcher. #1244:
-        // this teardown path previously killed sessions without unwatching,
-        // leaking a working-tree watcher per force-deleted worktree.
-        const killedCwd = localRelayNode.sessions.get(sessionId)?.cwd;
         try {
           localRelayNode.sessions.kill(sessionId);
         } catch (err) {
@@ -5640,7 +5636,6 @@ async function main(): Promise<void> {
             err instanceof Error ? err.message : err
           );
         }
-        if (killedCwd) gitWatcher.unwatch(killedCwd);
       }
     }
 
@@ -5861,7 +5856,7 @@ async function main(): Promise<void> {
         sendSessionCreateError(res, err, freshConfig.maxPtySessions);
         return;
       }
-      gitWatcher.watch(session.cwd);
+      gitWatcher.watchSession(session.id, session.cwd);
       const associationError = associateSessionWithWorkContext(
         workContextStore,
         workContextId,
@@ -5975,7 +5970,7 @@ async function main(): Promise<void> {
             initialPrompt: computedInitialPrompt,
           }),
         });
-        gitWatcher.watch(session.cwd);
+        gitWatcher.watchSession(session.id, session.cwd);
         const associationError = associateSessionWithWorkContext(
           workContextStore,
           workContextId,
@@ -6047,7 +6042,7 @@ async function main(): Promise<void> {
       return;
     }
 
-    gitWatcher.watch(session.cwd);
+    gitWatcher.watchSession(session.id, session.cwd);
 
     if (ticketContext) {
       transitionOnSessionCreate(ticketContext).catch((err: unknown) => {
@@ -6079,10 +6074,8 @@ async function main(): Promise<void> {
     }
     const id = req.params['id'] as string;
     try {
-      const sessionToDelete = localRelayNode.sessions.get(id);
       localRelayNode.sessions.kill(id);
       push.removeSession(id);
-      if (sessionToDelete) gitWatcher.unwatch(sessionToDelete.cwd);
       res.json({ ok: true, id, sessionId: id, killed: true });
     } catch (_) {
       res.status(404).json({ error: 'Session not found' });
@@ -6364,7 +6357,11 @@ async function main(): Promise<void> {
 
   // Clean expired browser content tokens every hour
   const BROWSER_TOKEN_TTL = 24 * 60 * 60 * 1000;
-  setInterval(() => cleanExpiredTokens(BROWSER_TOKEN_TTL), 60 * 60 * 1000);
+  const browserTokenCleanupTimer = setInterval(
+    () => cleanExpiredTokens(BROWSER_TOKEN_TTL),
+    60 * 60 * 1000
+  );
+  browserTokenCleanupTimer.unref();
 
   const devInstance =
     process.env.RELAY_IDE_DEV_INSTANCE === '1' ||
@@ -6383,6 +6380,9 @@ async function main(): Promise<void> {
     branchWatcher.close();
     refWatcher.close();
     gitWatcher.close();
+    clearInterval(rateLimitSnapshotTimer);
+    clearInterval(retentionCleanupTimer);
+    clearInterval(browserTokenCleanupTimer);
     server.close();
     credentialRotationScheduler?.stop();
     await flushHubNodeHeartbeatsBestEffort('graceful shutdown');
@@ -6462,7 +6462,7 @@ async function main(): Promise<void> {
           `Restored ${restoredCount} session(s) from previous update.`
         );
         for (const session of localRelayNode.sessions.list()) {
-          gitWatcher.watch(session.cwd);
+          gitWatcher.watchSession(session.id, session.cwd);
         }
       },
       failed: (err) => {

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -1248,6 +1248,7 @@ export function createPtySession(
         session.restored = false;
         if (idleTimer) clearTimeout(idleTimer);
         if (metaFlushTimer) clearTimeout(metaFlushTimer);
+        releasePtySessionResources(session, id);
         return;
       }
 
@@ -1388,7 +1389,20 @@ function runExitCleanup(
     }
   }
   sessionsMap.delete(id);
+  releasePtySessionResources(session, id);
+}
+
+/**
+ * Release the heavyweight live PTY/vt state while leaving session metadata and
+ * scrollback available to cold-resume callers. Idempotent for overlapping
+ * explicit-kill and PTY-exit cleanup.
+ */
+function releasePtySessionResources(session: PtySession, id: string): void {
   session.terminalModel?.dispose();
+  delete session.terminalModel;
+  delete session.terminalStream;
+  session.terminalStreamSubscribers?.splice(0);
+  delete session.terminalStreamSubscribers;
   if (!session.preserveRuntimeFilesOnExit) {
     const tmpDir = path.join(os.tmpdir(), 'relay-ide', id);
     fs.rm(tmpDir, { recursive: true, force: true }, () => {});

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -1422,6 +1422,25 @@ function recordRoutedPtyInput(input: {
   recordHumanPtyInput(session, input.data, controlEngineOptions());
 }
 
+function releaseRoutedPtyControlSession(
+  nodeId: string,
+  sessionId: string
+): boolean {
+  return routedPtyControlSessions.delete(
+    createGlobalSessionId(nodeId, sessionId)
+  );
+}
+
+function releaseRoutedPtyControlSessionsForNode(nodeId: string): number {
+  let released = 0;
+  for (const [globalSessionId, session] of routedPtyControlSessions) {
+    if (session.nodeId !== nodeId) continue;
+    routedPtyControlSessions.delete(globalSessionId);
+    released++;
+  }
+  return released;
+}
+
 function controlAction(
   id: string,
   action: ControlModeAction
@@ -2846,6 +2865,8 @@ export {
   write,
   supervisorWrite,
   recordRoutedPtyInput,
+  releaseRoutedPtyControlSession,
+  releaseRoutedPtyControlSessionsForNode,
   controlAction,
   acknowledgeInterventions,
   handBackToAgent,

--- a/server/watcher.ts
+++ b/server/watcher.ts
@@ -710,6 +710,32 @@ interface WorkspaceWatchEntry {
 export class GitWatcher extends EventEmitter {
   private watchers = new Map<string, WorkspaceWatchEntry>();
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private sessionWorkspaces = new Map<string, string>();
+
+  /**
+   * Acquire one workspace-watch reference for a session. A session owns at
+   * most one reference: repeated registration is a no-op, while moving the
+   * same session to another cwd releases the old reference first.
+   */
+  watchSession(sessionId: string, workspacePath: string): void {
+    const existingPath = this.sessionWorkspaces.get(sessionId);
+    if (existingPath === workspacePath) return;
+    if (existingPath !== undefined) this.unwatch(existingPath);
+    this.sessionWorkspaces.set(sessionId, workspacePath);
+    this.watch(workspacePath);
+  }
+
+  /**
+   * Release the workspace-watch reference owned by this session. Idempotent so
+   * duplicate session-end notifications cannot decrement another session's
+   * shared cwd reference.
+   */
+  unwatchSession(sessionId: string): void {
+    const workspacePath = this.sessionWorkspaces.get(sessionId);
+    if (workspacePath === undefined) return;
+    this.sessionWorkspaces.delete(sessionId);
+    this.unwatch(workspacePath);
+  }
 
   watch(workspacePath: string): void {
     const existing = this.watchers.get(workspacePath);
@@ -1129,6 +1155,7 @@ export class GitWatcher extends EventEmitter {
       this.closeEntry(entry);
     }
     this.watchers.clear();
+    this.sessionWorkspaces.clear();
     for (const timer of this.debounceTimers.values()) {
       clearTimeout(timer);
     }

--- a/server/workspace-groups.ts
+++ b/server/workspace-groups.ts
@@ -57,7 +57,7 @@ interface SessionDeps {
     list?: () => Array<{ mode?: string; status?: string }>;
     nextAgentName: () => string;
   };
-  gitWatcher: { watch(cwd: string): void };
+  gitWatcher: { watchSession(sessionId: string, cwd: string): void };
   configPath: string;
 }
 
@@ -591,7 +591,7 @@ export function createWorkspaceGroupsRouter(
             });
           }
 
-          sessionDeps.gitWatcher.watch(session.cwd);
+          sessionDeps.gitWatcher.watchSession(session.id, session.cwd);
 
           const response: Record<string, unknown> = { ...session };
           if (failures.length > 0) {

--- a/test/git-watcher.test.ts
+++ b/test/git-watcher.test.ts
@@ -151,4 +151,53 @@ describe('GitWatcher', () => {
     // Now closed (refCount = 0)
     watcher.close();
   });
+
+  it('releases each session watch exactly once when session-end fires twice', () => {
+    const watcher = new GitWatcher();
+    watcher.watchSession('session-a', repoDir);
+    watcher.watchSession('session-b', repoDir);
+
+    watcher.unwatchSession('session-a');
+    watcher.unwatchSession('session-a');
+
+    const entry = (
+      watcher as unknown as {
+        watchers: Map<string, { refCount: number }>;
+      }
+    ).watchers.get(repoDir);
+    expect(entry?.refCount).toBe(1);
+
+    watcher.unwatchSession('session-b');
+    expect(
+      (
+        watcher as unknown as {
+          watchers: Map<string, { refCount: number }>;
+        }
+      ).watchers.has(repoDir)
+    ).toBe(false);
+    watcher.close();
+  });
+
+  it('moves an existing session watch without retaining its old cwd', () => {
+    const otherRepoDir = path.join(tmpDir, 'other-repo');
+    fs.mkdirSync(path.join(otherRepoDir, '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(otherRepoDir, '.git', 'HEAD'),
+      'ref: refs/heads/main\n'
+    );
+
+    const watcher = new GitWatcher();
+    watcher.watchSession('moving-session', repoDir);
+    watcher.watchSession('moving-session', repoDir);
+    watcher.watchSession('moving-session', otherRepoDir);
+
+    const entries = (
+      watcher as unknown as {
+        watchers: Map<string, { refCount: number }>;
+      }
+    ).watchers;
+    expect(entries.has(repoDir)).toBe(false);
+    expect(entries.get(otherRepoDir)?.refCount).toBe(1);
+    watcher.close();
+  });
 });

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -1431,6 +1431,7 @@ describe('hub node routes and link', () => {
     const sessionEnvelopes = createSessionEnvelopeRegistry();
     const auditEntries: unknown[] = [];
     const createRequests: Array<Record<string, unknown>> = [];
+    const releaseRoutedPtyControlSession = vi.fn();
     const nodeLinks = {
       hasActiveNode: () => true,
       request: async (
@@ -1465,6 +1466,7 @@ describe('hub node routes and link', () => {
         registry,
         nodeLinks: nodeLinks as never,
         sessionEnvelopes,
+        releaseRoutedPtyControlSession,
         now: () => now,
         auditSink: {
           append: (entry) => auditEntries.push(entry),
@@ -1653,6 +1655,7 @@ describe('hub node routes and link', () => {
         details: { reasonCode: 'AMBIGUOUS_LOCAL_SESSION_ID', matches: 2 },
       },
     });
+    expect(releaseRoutedPtyControlSession).not.toHaveBeenCalled();
 
     const revokeRes = await fetch(
       `${base}/hub/scoped-sessions/remote-session/revoke`,
@@ -1678,6 +1681,11 @@ describe('hub node routes and link', () => {
       decision: 'revoked',
       reasonCode: 'SESSION_REVOKED',
     });
+    expect(releaseRoutedPtyControlSession).toHaveBeenCalledOnce();
+    expect(releaseRoutedPtyControlSession).toHaveBeenCalledWith(
+      exchanged.node.nodeId,
+      'remote-session'
+    );
 
     const activeOnlyRes = await fetch(
       `${base}/hub/scoped-sessions?includeRevoked=0`,

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -5,7 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import express from 'express';
 import { WebSocket } from 'ws';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeRouter } from '../server/hub-node-router.js';
 import { createHubNodeLinkManager } from '../server/hub-node-link.js';
@@ -287,7 +287,16 @@ describe('hub-routed node session create and attach', () => {
     while (cleanup.length > 0) await cleanup.pop()?.();
   });
 
-  async function startHub(now = () => new Date('2026-01-02T03:04:05.000Z')) {
+  async function startHub(
+    now = () => new Date('2026-01-02T03:04:05.000Z'),
+    routedControlCleanup: {
+      releaseRoutedPtyControlSession?: (
+        nodeId: string,
+        sessionId: string
+      ) => void;
+      releaseRoutedPtyControlSessionsForNode?: (nodeId: string) => void;
+    } = {}
+  ) {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'relay-hub-session-route-')
     );
@@ -350,6 +359,7 @@ describe('hub-routed node session create and attach', () => {
         requireAuth,
         cliGatewayAuth,
         cliGatewayAuthForActorCommand,
+        ...routedControlCleanup,
       })
     );
     const server = http.createServer(app);
@@ -948,7 +958,11 @@ describe('hub-routed node session create and attach', () => {
   });
 
   it('routes remote session delete to the selected connected node', async () => {
-    const { base, wsBase, sessionEnvelopes, registry } = await startHub();
+    const releaseRoutedPtyControlSession = vi.fn();
+    const { base, wsBase, sessionEnvelopes, registry } = await startHub(
+      undefined,
+      { releaseRoutedPtyControlSession }
+    );
     const { token, nodeId } = await pairNode(base);
     grantNodeCapabilitiesForTest(registry, nodeId, ['session:control:kill']);
     seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
@@ -994,6 +1008,11 @@ describe('hub-routed node session create and attach', () => {
       sessionId: 'remote-session-1',
       nodeId,
     });
+    expect(releaseRoutedPtyControlSession).toHaveBeenCalledOnce();
+    expect(releaseRoutedPtyControlSession).toHaveBeenCalledWith(
+      nodeId,
+      'remote-session-1'
+    );
   });
 
   it('routes remote session rename to the selected connected node', async () => {
@@ -1051,7 +1070,10 @@ describe('hub-routed node session create and attach', () => {
   });
 
   it('returns NODE_OFFLINE when deleting a remote session on a node with no live reverse link', async () => {
-    const { base } = await startHub();
+    const releaseRoutedPtyControlSession = vi.fn();
+    const { base } = await startHub(undefined, {
+      releaseRoutedPtyControlSession,
+    });
     const { nodeId } = await pairNode(base);
 
     const res = await fetch(
@@ -1066,6 +1088,27 @@ describe('hub-routed node session create and attach', () => {
     expect(await res.json()).toMatchObject({
       error: { code: 'NODE_OFFLINE', retryable: true },
     });
+    expect(releaseRoutedPtyControlSession).not.toHaveBeenCalled();
+  });
+
+  it('releases all routed control sessions when a node is revoked', async () => {
+    const releaseRoutedPtyControlSessionsForNode = vi.fn();
+    const { base } = await startHub(undefined, {
+      releaseRoutedPtyControlSessionsForNode,
+    });
+    const { nodeId } = await pairNode(base);
+
+    const res = await fetch(
+      `${base}/nodes/${encodeURIComponent(nodeId)}`,
+      {
+        method: 'DELETE',
+        headers: { 'x-test-auth': 'yes' },
+      }
+    );
+
+    expect(res.status).toBe(200);
+    expect(releaseRoutedPtyControlSessionsForNode).toHaveBeenCalledOnce();
+    expect(releaseRoutedPtyControlSessionsForNode).toHaveBeenCalledWith(nodeId);
   });
 
   it('does not trust node-provided scoped identity fields when worktree scope is absent', async () => {

--- a/test/node-link-pty-host.test.ts
+++ b/test/node-link-pty-host.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import express from 'express';
 import type { WebSocket } from 'ws';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeLinkManager } from '../server/hub-node-link.js';
 import { setupWebSocket } from '../server/ws.js';
@@ -418,8 +418,10 @@ describe('node link pty host (integration)', () => {
       sessionId: string;
       data: string;
     }> = [];
+    const releaseRoutedPtyControlSession = vi.fn();
     const linkManager = createHubNodeLinkManager({
       ptyInputRecorder: (input) => remoteInputRecords.push(input),
+      releaseRoutedPtyControlSession,
     });
     const server = http.createServer(express());
     setupWebSocket(
@@ -538,5 +540,52 @@ describe('node link pty host (integration)', () => {
         data: 'echo hi',
       },
     ]);
+
+    const firstStreamId = Array.from(
+      (
+        linkManager as unknown as {
+          ptyStreams: Map<string, unknown>;
+        }
+      ).ptyStreams.keys()
+    )[0]!;
+    expect(
+      linkManager.handleEnvelope({
+        protocol: RELAY_NODE_LINK_PROTOCOL,
+        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+        nodeId: exchanged.credential.nodeId,
+        channel: 'pty',
+        type: 'pty.error',
+        streamId: firstStreamId,
+        timestamp: new Date().toISOString(),
+        error: {
+          code: 'INTERNAL',
+          message: 'transient input error',
+          retryable: true,
+        },
+      })
+    ).toBe(true);
+    expect(releaseRoutedPtyControlSession).not.toHaveBeenCalled();
+
+    linkManager.attachPty(
+      exchanged.credential.nodeId,
+      'session-int',
+      browserStub
+    );
+    await expect
+      .poll(() => factory.attachments.length, { timeout: 2_000 })
+      .toBe(2);
+    factory.exit({ exitCode: 0 });
+    await expect
+      .poll(() => releaseRoutedPtyControlSession.mock.calls.length, {
+        timeout: 2_000,
+      })
+      .toBe(1);
+    expect(releaseRoutedPtyControlSession).toHaveBeenCalledWith(
+      exchanged.credential.nodeId,
+      'session-int'
+    );
+    factory.exit({ exitCode: 0 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(releaseRoutedPtyControlSession).toHaveBeenCalledOnce();
   });
 });

--- a/test/pty-handler.test.ts
+++ b/test/pty-handler.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, afterEach, expect } from 'vitest';
+import { describe, it, afterEach, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as sessions from '../server/sessions.js';
-import type { PtySession, EventSourceType } from '../server/types.js';
+import type {
+  PtySession,
+  EventSourceType,
+  Session,
+} from '../server/types.js';
 
 import {
   buildStatusLineRelayScript,
@@ -233,6 +237,48 @@ describe('framework-driven PTY handler', () => {
     await expect(
       sessions.captureTerminalVisibleText(result.id)
     ).resolves.toContain('relay-pty-ok');
+  });
+
+  it('releases restored-exit PTY resources while retaining cold-resume metadata', async () => {
+    const id = `restored-exit-${Date.now()}`;
+    const sessionMap = new Map<string, Session>();
+    const onSessionEnd = vi.fn();
+    const { createPtySession } = await import('../server/pty-handler.js');
+    const { session } = createPtySession(
+      {
+        id,
+        type: 'terminal',
+        agent: 'claude',
+        cwd: '/tmp',
+        command: '/bin/sh',
+        args: ['-c', 'sleep 0.1'],
+        restored: true,
+        initialScrollback: ['retained scrollback'],
+        callbacks: { onSessionEnd: [onSessionEnd] },
+      },
+      sessionMap
+    );
+    const terminalModel = session.terminalModel!;
+    const dispose = vi.spyOn(terminalModel, 'dispose');
+    session.terminalStreamSubscribers!.push(() => {});
+    const runtimeDir = path.join(os.tmpdir(), 'relay-ide', id);
+    fs.mkdirSync(runtimeDir, { recursive: true });
+    fs.writeFileSync(path.join(runtimeDir, 'resource-marker'), 'live');
+
+    await expect
+      .poll(() => session.status, { timeout: 5_000 })
+      .toBe('disconnected');
+    await expect
+      .poll(() => fs.existsSync(runtimeDir), { timeout: 5_000 })
+      .toBe(false);
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(session.terminalModel).toBeUndefined();
+    expect(session.terminalStream).toBeUndefined();
+    expect(session.terminalStreamSubscribers).toBeUndefined();
+    expect(session.scrollback.join('')).toContain('retained scrollback');
+    expect(sessionMap.get(id)).toBe(session);
+    expect(onSessionEnd).not.toHaveBeenCalled();
   });
 
   it('preserves workContextId when relay-pty retries without --continue', async () => {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -76,6 +76,49 @@ describe('buildAgentArgs cold-resume claudeArgs leak gate', () => {
   });
 });
 
+describe('routed PTY control-session cleanup', () => {
+  it('releases a routed control session idempotently', () => {
+    sessions.recordRoutedPtyInput({
+      nodeId: 'remote-cleanup',
+      sessionId: 'session-one',
+      data: 'x',
+    });
+
+    expect(
+      sessions.releaseRoutedPtyControlSession(
+        'remote-cleanup',
+        'session-one'
+      )
+    ).toBe(true);
+    expect(
+      sessions.releaseRoutedPtyControlSession(
+        'remote-cleanup',
+        'session-one'
+      )
+    ).toBe(false);
+  });
+
+  it('releases every routed control session owned by a revoked node', () => {
+    sessions.recordRoutedPtyInput({
+      nodeId: 'remote-revoked',
+      sessionId: 'session-one',
+      data: 'x',
+    });
+    sessions.recordRoutedPtyInput({
+      nodeId: 'remote-revoked',
+      sessionId: 'session-two',
+      data: 'y',
+    });
+
+    expect(
+      sessions.releaseRoutedPtyControlSessionsForNode('remote-revoked')
+    ).toBe(2);
+    expect(
+      sessions.releaseRoutedPtyControlSessionsForNode('remote-revoked')
+    ).toBe(0);
+  });
+});
+
 describe('initial prompt delivery', () => {
   it('passes a Codex initial prompt as the final distinct argv element', async () => {
     const probeDir = fs.mkdtempSync(

--- a/test/workspace-groups.test.ts
+++ b/test/workspace-groups.test.ts
@@ -84,7 +84,7 @@ function fakeSessionDeps() {
       list: () => [],
       nextAgentName: () => 'Agent 1',
     },
-    gitWatcher: { watch: vi.fn() },
+    gitWatcher: { watchSession: vi.fn() },
     configPath,
   };
 }


### PR DESCRIPTION
Closes #1244 (items 1-4; item 5 idle-TTL reaper is product-gated, deferred). Refs #1243.

Session-teardown cleanup gaps from the 2026-07-22 live audit — individually low-impact, batched into one sweep.

1. **Restored-PTY exit releases heavy resources** — restored-exit returned before cleanup, retaining `terminalModel` + `terminalStream` + tmp dir. New idempotent `releasePtySessionResources` frees them on both restored-exit and `runExitCleanup`; record/scrollback (persisted on disk, independent of the model)/cold-resume metadata untouched.
2. **GitWatcher unwatch on ALL teardown paths, double-fire safe** — was DELETE-only → inotify WD leak. Per-session ownership (`watchSession`/`unwatchSession` keyed by session id) + central `onSessionEnd`; idempotent release absorbs the PTY double-fire without over-decrementing a co-located cwd's refcount.
3. **routedPtyControlSessions released** — per-session + node-wide delete APIs wired into revoke/delete, confirmed remote kill, node revoke, natural remote pty-exit, and ungraceful node-link drop. `pty.error` stays non-releasing (attach-failure, pre-input, non-terminal).
4. **Three global setIntervals** stored, `unref`'d, `clearInterval`'d in `gracefulShutdown`.

## Review
- Written by codex-cli. Item 2 verified by the coordinator. **Opus adversarial review** (cold-resume safety, use-after-free on the deleted fields, federated routed-control lifecycle, `fireSessionEnd` coverage) → **SAFE-TO-SHIP**; its one LOW finding (routed-control leak on ungraceful node-link drop) is **fixed in this PR**.
- Tests: git-watcher / pty-handler / sessions / hub-node suites — 188 pass across the touched files. `npm run check` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of routed terminal sessions when connections close, sessions are revoked, or nodes are removed.
  * Ensured terminal resources and temporary runtime files are released reliably after exit.
  * Improved workspace change tracking when sessions switch workspaces or end.

* **Reliability**
  * Prevented background maintenance tasks from keeping the server running during shutdown.
  * Added safeguards to avoid duplicate cleanup and stale session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->