### PR TITLE
feat(orchestrator): minimal single-channel echo-peer — slice 4a (#1264)

### DIFF
--- a/scripts/orchestrator-peer.ts
+++ b/scripts/orchestrator-peer.ts
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { pathToFileURL } from 'node:url';
+import {
+  isChannelMessage,
+  type ChannelMessage,
+} from '../shared/channel-chat-protocol.js';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:3456';
+const DEFAULT_CAPABILITIES = ['session:read', 'context:read', 'context:write'];
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const HISTORY_LIMIT = 100;
+const TOKEN_REFRESH_RATIO = 2 / 3;
+
+export interface PeerConfig {
+  baseUrl: string;
+  pin: string;
+  actorId: string;
+  displayName: string;
+  role: string;
+  productChannelId: string;
+  capabilities: string[];
+  scope?: unknown;
+  renewable: boolean;
+  budget?: { maxTurns?: number; maxTokens?: number };
+  pollIntervalMs: number;
+}
+
+export type FetchLike = (
+  input: string | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export interface PeerAck {
+  seq: number;
+  text: string;
+}
+
+export interface MessageSelection {
+  acks: PeerAck[];
+  nextSeq: number;
+}
+
+interface TokenState {
+  token: string;
+  mintedAt: number;
+  expiresAt: number;
+}
+
+interface MintResponse {
+  token: string;
+  credential: {
+    issuedAt: string;
+    expiresAt: string;
+  };
+}
+
+interface HistoryResponse {
+  messages: ChannelMessage[];
+}
+
+export function buildAckText(message: ChannelMessage): string {
+  return `orchestrator online — ack seq ${message.seq} from ${message.sender.id}`;
+}
+
+export function selectNewMessages(
+  messages: ChannelMessage[],
+  lastSeq: number,
+  selfSenderId: string
+): MessageSelection {
+  const unseen = messages
+    .filter((message) => message.seq > lastSeq)
+    .sort((left, right) => left.seq - right.seq);
+  let nextSeq = lastSeq;
+  const acks: PeerAck[] = [];
+
+  for (const message of unseen) {
+    nextSeq = Math.max(nextSeq, message.seq);
+    if (message.sender.id === selfSenderId) continue;
+    acks.push({ seq: message.seq, text: buildAckText(message) });
+  }
+
+  return { acks, nextSeq };
+}
+
+/**
+ * Tests a token lifetime on a clock whose zero is the token's issue time.
+ * TokenManager shifts its absolute clock to that origin before calling here.
+ */
+export function needsRemint(
+  expiresAt: number,
+  now: number,
+  refreshRatio: number
+): boolean {
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0 || !Number.isFinite(now)) {
+    return true;
+  }
+  if (!Number.isFinite(refreshRatio) || refreshRatio <= 0 || refreshRatio > 1) {
+    throw new RangeError('refreshRatio must be greater than 0 and at most 1');
+  }
+  return now >= expiresAt * refreshRatio;
+}
+
+function normalizedBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+async function responseError(
+  label: string,
+  response: Response
+): Promise<Error> {
+  const detail = (await response.text()).trim();
+  return new Error(
+    `${label} failed (${response.status})${detail ? `: ${detail}` : ''}`
+  );
+}
+
+function cookieFrom(response: Response): string {
+  const raw = response.headers.get('set-cookie');
+  const cookie = raw?.split(';')[0];
+  if (!cookie) throw new Error('POST /auth did not return an auth cookie');
+  return cookie;
+}
+
+function isMintResponse(value: unknown): value is MintResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record['token'] !== 'string' ||
+    !record['token'].startsWith('relay-sac-v1.')
+  ) {
+    return false;
+  }
+  const credential = record['credential'];
+  if (typeof credential !== 'object' || credential === null) return false;
+  const credentialRecord = credential as Record<string, unknown>;
+  return (
+    typeof credentialRecord['issuedAt'] === 'string' &&
+    typeof credentialRecord['expiresAt'] === 'string'
+  );
+}
+
+export class TokenManager {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly now: () => number;
+  private readonly refreshRatio: number;
+  private cookie: string | null = null;
+  private state: TokenState | null = null;
+
+  constructor(
+    private readonly config: Pick<
+      PeerConfig,
+      'baseUrl' | 'pin' | 'actorId' | 'displayName' | 'capabilities'
+    >,
+    fetchImpl: FetchLike = globalThis.fetch,
+    now: () => number = Date.now,
+    refreshRatio = TOKEN_REFRESH_RATIO
+  ) {
+    this.baseUrl = normalizedBaseUrl(config.baseUrl);
+    this.fetchImpl = fetchImpl;
+    this.now = now;
+    if (
+      !Number.isFinite(refreshRatio) ||
+      refreshRatio <= 0 ||
+      refreshRatio > 1
+    ) {
+      throw new RangeError('refreshRatio must be greater than 0 and at most 1');
+    }
+    this.refreshRatio = refreshRatio;
+  }
+
+  async getToken(forceRemint = false): Promise<string> {
+    const currentNow = this.now();
+    if (this.state && !forceRemint) {
+      const lifetime = this.state.expiresAt - this.state.mintedAt;
+      const elapsed = Math.max(0, currentNow - this.state.mintedAt);
+      if (!needsRemint(lifetime, elapsed, this.refreshRatio)) {
+        return this.state.token;
+      }
+    }
+    return this.mintToken();
+  }
+
+  async gatewayFetch(
+    url: string,
+    command: string,
+    init: RequestInit = {}
+  ): Promise<Response> {
+    const send = async (token: string): Promise<Response> => {
+      const headers = new Headers(init.headers);
+      headers.set('authorization', `Bearer ${token}`);
+      headers.set('x-relay-cli-gateway', 'v1');
+      headers.set('x-relay-cli-command', command);
+      return this.fetchImpl(url, { ...init, headers });
+    };
+
+    let response = await send(await this.getToken());
+    if (response.status === 401) {
+      response = await send(await this.getToken(true));
+    }
+    return response;
+  }
+
+  private async authenticate(): Promise<string> {
+    const response = await this.fetchImpl(`${this.baseUrl}/auth`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pin: this.config.pin }),
+    });
+    if (!response.ok) throw await responseError('POST /auth', response);
+    return cookieFrom(response);
+  }
+
+  private async requestMint(cookie: string): Promise<Response> {
+    return this.fetchImpl(`${this.baseUrl}/cli-gateway/actor-credentials`, {
+      method: 'POST',
+      headers: {
+        cookie,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        capabilities: this.config.capabilities,
+        actor: {
+          type: 'agent',
+          id: this.config.actorId,
+          displayName: this.config.displayName,
+        },
+      }),
+    });
+  }
+
+  private async mintToken(): Promise<string> {
+    this.cookie ??= await this.authenticate();
+    let response = await this.requestMint(this.cookie);
+    if (response.status === 401) {
+      this.cookie = await this.authenticate();
+      response = await this.requestMint(this.cookie);
+    }
+    if (!response.ok) {
+      throw await responseError(
+        'POST /cli-gateway/actor-credentials',
+        response
+      );
+    }
+
+    const payload: unknown = await response.json();
+    if (!isMintResponse(payload)) {
+      throw new Error('actor credential mint returned an invalid response');
+    }
+    const issuedAt = Date.parse(payload.credential.issuedAt);
+    const expiresAt = Date.parse(payload.credential.expiresAt);
+    const lifetime = expiresAt - issuedAt;
+    if (!Number.isFinite(lifetime) || lifetime <= 0) {
+      throw new Error('actor credential mint returned an invalid lifetime');
+    }
+
+    const mintedAt = this.now();
+    this.state = {
+      token: payload.token,
+      mintedAt,
+      expiresAt: mintedAt + lifetime,
+    };
+    return payload.token;
+  }
+}
+
+function parseHistoryResponse(value: unknown): HistoryResponse {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error('channels.history returned an invalid response');
+  }
+  const messages = (value as Record<string, unknown>)['messages'];
+  if (!Array.isArray(messages) || !messages.every(isChannelMessage)) {
+    throw new Error('channels.history returned invalid messages');
+  }
+  return { messages };
+}
+
+export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', finish);
+      resolve();
+    };
+    const timeout = setTimeout(finish, ms);
+    signal.addEventListener('abort', finish, { once: true });
+    if (signal.aborted) finish();
+  });
+}
+
+export class OrchestratorPeer {
+  private readonly baseUrl: string;
+  private readonly channelPath: string;
+  private readonly tokenManager: TokenManager;
+  private cursor = 0;
+
+  constructor(
+    private readonly config: PeerConfig,
+    fetchImpl: FetchLike = globalThis.fetch,
+    now: () => number = Date.now
+  ) {
+    this.baseUrl = normalizedBaseUrl(config.baseUrl);
+    this.channelPath = `/channels/${encodeURIComponent(config.productChannelId)}`;
+    this.tokenManager = new TokenManager(config, fetchImpl, now);
+  }
+
+  get lastSeq(): number {
+    return this.cursor;
+  }
+
+  async pollOnce(): Promise<{ ackCount: number; lastSeq: number }> {
+    const historyUrl =
+      `${this.baseUrl}${this.channelPath}/messages` +
+      `?afterSeq=${this.cursor}&limit=${HISTORY_LIMIT}`;
+    const historyResponse = await this.tokenManager.gatewayFetch(
+      historyUrl,
+      'channels.history'
+    );
+    if (!historyResponse.ok) {
+      throw await responseError('channels.history', historyResponse);
+    }
+    const history = parseHistoryResponse(await historyResponse.json());
+    const selection = selectNewMessages(
+      history.messages,
+      this.cursor,
+      `agent:${this.config.actorId}`
+    );
+
+    for (const ack of selection.acks) {
+      const postResponse = await this.tokenManager.gatewayFetch(
+        `${this.baseUrl}${this.channelPath}/messages`,
+        'channels.post',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ text: ack.text }),
+        }
+      );
+      if (!postResponse.ok) {
+        throw await responseError(
+          `channels.post ack for seq ${ack.seq}`,
+          postResponse
+        );
+      }
+    }
+
+    this.cursor = selection.nextSeq;
+    return { ackCount: selection.acks.length, lastSeq: this.cursor };
+  }
+
+  async run(signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      await this.pollOnce();
+      await abortableDelay(this.config.pollIntervalMs, signal);
+    }
+  }
+}
+
+function argValue(argv: string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`expected a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+export function readPeerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: string[] = process.argv.slice(2)
+): PeerConfig {
+  const pin = argValue(argv, '--pin') ?? env['RELAY_PEER_PIN'];
+  const productChannelId =
+    argValue(argv, '--channel') ?? env['RELAY_PEER_CHANNEL_ID'];
+  if (!pin || !productChannelId) {
+    throw new Error(
+      'PIN and channel are required via --pin/--channel or RELAY_PEER_PIN/RELAY_PEER_CHANNEL_ID'
+    );
+  }
+
+  const actorId =
+    argValue(argv, '--actor-id') ??
+    env['RELAY_PEER_ACTOR_ID'] ??
+    'orchestrator-peer-v0';
+  const capabilities = (
+    argValue(argv, '--capabilities') ?? env['RELAY_PEER_CAPABILITIES']
+  )
+    ?.split(',')
+    .map((capability) => capability.trim())
+    .filter(Boolean);
+
+  return {
+    baseUrl:
+      argValue(argv, '--base-url') ??
+      env['RELAY_PEER_BASE_URL'] ??
+      env['RELAY_IDE_URL'] ??
+      DEFAULT_BASE_URL,
+    pin,
+    actorId,
+    displayName:
+      argValue(argv, '--display-name') ??
+      env['RELAY_PEER_DISPLAY_NAME'] ??
+      actorId,
+    role: env['RELAY_PEER_ROLE'] ?? 'orchestrator',
+    productChannelId,
+    capabilities:
+      capabilities && capabilities.length
+        ? capabilities
+        : [...DEFAULT_CAPABILITIES],
+    renewable: true,
+    pollIntervalMs: positiveInteger(
+      argValue(argv, '--poll-interval-ms') ??
+        env['RELAY_PEER_POLL_INTERVAL_MS'],
+      DEFAULT_POLL_INTERVAL_MS
+    ),
+  };
+}
+
+export async function main(): Promise<void> {
+  const config = readPeerConfig();
+  const controller = new AbortController();
+  const stop = (): void => controller.abort();
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+
+  try {
+    console.log(
+      `orchestrator peer ${config.actorId} polling ${config.productChannelId}`
+    );
+    await new OrchestratorPeer(config).run(controller.signal);
+  } finally {
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+  }
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/test/orchestrator-peer.test.ts
+++ b/test/orchestrator-peer.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  OrchestratorPeer,
+  TokenManager,
+  abortableDelay,
+  buildAckText,
+  needsRemint,
+  selectNewMessages,
+  type FetchLike,
+  type PeerConfig,
+} from '../scripts/orchestrator-peer.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../shared/channel-chat-protocol.js';
+
+const CONFIG: PeerConfig = {
+  baseUrl: 'http://relay.test/',
+  pin: 'test-pin',
+  actorId: 'echo-peer',
+  displayName: 'Echo Peer',
+  role: 'orchestrator',
+  productChannelId: 'topic:general',
+  capabilities: ['session:read', 'context:read', 'context:write'],
+  renewable: true,
+  pollIntervalMs: 10,
+};
+
+function message(
+  seq: number,
+  senderId: string,
+  text = 'hello'
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: CONFIG.productChannelId,
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: {
+      kind: senderId.startsWith('agent:') ? 'agent' : 'human',
+      id: senderId,
+    },
+    body: { text, format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+  };
+}
+
+function jsonResponse(
+  body: unknown,
+  init: ResponseInit = { status: 200 }
+): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+function minted(token: string): Response {
+  return jsonResponse(
+    {
+      token,
+      credential: {
+        issuedAt: '2026-07-24T00:00:00.000Z',
+        expiresAt: '2026-07-24T00:05:00.000Z',
+      },
+    },
+    { status: 201 }
+  );
+}
+
+describe('orchestrator peer pure seams', () => {
+  it('selectNewMessages skips own posts, advances seq, and emits acks for others', () => {
+    const selection = selectNewMessages(
+      [
+        message(4, 'agent:echo-peer'),
+        message(3, 'human:operator'),
+        message(2, 'human:old'),
+      ],
+      2,
+      'agent:echo-peer'
+    );
+
+    expect(selection).toEqual({
+      acks: [
+        {
+          seq: 3,
+          text: 'orchestrator online — ack seq 3 from human:operator',
+        },
+      ],
+      nextSeq: 4,
+    });
+    expect(buildAckText(message(7, 'agent:worker'))).toBe(
+      'orchestrator online — ack seq 7 from agent:worker'
+    );
+  });
+
+  it('needsRemint fires inside the refresh window', () => {
+    expect(needsRemint(300_000, 199_999, 2 / 3)).toBe(false);
+    expect(needsRemint(300_000, 200_000, 2 / 3)).toBe(true);
+    expect(needsRemint(300_000, 299_999, 1)).toBe(false);
+    expect(needsRemint(300_000, 300_000, 1)).toBe(true);
+  });
+
+  it('abortableDelay removes listeners on timeout and clears timers on abort', async () => {
+    vi.useFakeTimers();
+    try {
+      const timed = new AbortController();
+      const removeTimed = vi.spyOn(timed.signal, 'removeEventListener');
+      const completed = abortableDelay(100, timed.signal);
+      await vi.advanceTimersByTimeAsync(100);
+      await completed;
+
+      expect(removeTimed).toHaveBeenCalledWith('abort', expect.any(Function));
+      expect(vi.getTimerCount()).toBe(0);
+
+      const aborted = new AbortController();
+      const interrupted = abortableDelay(100, aborted.signal);
+      expect(vi.getTimerCount()).toBe(1);
+      aborted.abort();
+      await interrupted;
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('orchestrator peer gateway cycle', () => {
+  it('runs mint, poll, and one post with exact gateway headers and no self ack', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn<FetchLike>(async (input, init = {}) => {
+      const url = input.toString();
+      calls.push({ url, init });
+      if (url.endsWith('/auth')) {
+        return jsonResponse(
+          { ok: true },
+          { headers: { 'set-cookie': 'token=browser-cookie; HttpOnly' } }
+        );
+      }
+      if (url.endsWith('/cli-gateway/actor-credentials')) {
+        return minted('relay-sac-v1.first');
+      }
+      if (url.includes('?afterSeq=0&limit=100')) {
+        return jsonResponse({
+          messages: [
+            message(1, 'human:operator'),
+            message(2, 'agent:echo-peer'),
+          ],
+        });
+      }
+      if (url.endsWith('/channels/topic%3Ageneral/messages')) {
+        return jsonResponse(
+          { message: message(3, 'agent:echo-peer') },
+          { status: 201 }
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const peer = new OrchestratorPeer(CONFIG, fetchMock, () =>
+      Date.parse('2026-07-24T00:00:00.000Z')
+    );
+    await expect(peer.pollOnce()).resolves.toEqual({
+      ackCount: 1,
+      lastSeq: 2,
+    });
+
+    expect(calls).toHaveLength(4);
+    const authBody = JSON.parse(String(calls[0]?.init.body)) as unknown;
+    expect(authBody).toEqual({ pin: 'test-pin' });
+    const mintBody = JSON.parse(String(calls[1]?.init.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(mintBody).toEqual({
+      capabilities: CONFIG.capabilities,
+      actor: {
+        type: 'agent',
+        id: 'echo-peer',
+        displayName: 'Echo Peer',
+      },
+    });
+    expect(mintBody).not.toHaveProperty('scope');
+    expect(new Headers(calls[1]?.init.headers).get('cookie')).toBe(
+      'token=browser-cookie'
+    );
+
+    const gatewayCalls = calls.slice(2);
+    expect(gatewayCalls).toHaveLength(2);
+    for (const call of gatewayCalls) {
+      const headers = new Headers(call.init.headers);
+      expect(headers.get('authorization')).toBe('Bearer relay-sac-v1.first');
+      expect(headers.get('x-relay-cli-gateway')).toBe('v1');
+    }
+    expect(
+      new Headers(gatewayCalls[0]?.init.headers).get('x-relay-cli-command')
+    ).toBe('channels.history');
+    expect(
+      new Headers(gatewayCalls[1]?.init.headers).get('x-relay-cli-command')
+    ).toBe('channels.post');
+    expect(JSON.parse(String(gatewayCalls[1]?.init.body))).toEqual({
+      text: 'orchestrator online — ack seq 1 from human:operator',
+    });
+  });
+
+  it('re-mints once and retries a gateway 401', async () => {
+    let mintCount = 0;
+    let gatewayCount = 0;
+    const gatewayHeaders: Headers[] = [];
+    const fetchMock = vi.fn<FetchLike>(async (input, init) => {
+      const url = input.toString();
+      if (url.endsWith('/auth')) {
+        return jsonResponse(
+          { ok: true },
+          { headers: { 'set-cookie': 'token=browser-cookie; HttpOnly' } }
+        );
+      }
+      if (url.endsWith('/cli-gateway/actor-credentials')) {
+        mintCount += 1;
+        return minted(`relay-sac-v1.token-${mintCount}`);
+      }
+      gatewayCount += 1;
+      gatewayHeaders.push(new Headers(init?.headers));
+      return gatewayCount === 1
+        ? new Response(null, { status: 401 })
+        : jsonResponse({ messages: [] });
+    });
+
+    const manager = new TokenManager(CONFIG, fetchMock, () =>
+      Date.parse('2026-07-24T00:00:00.000Z')
+    );
+    const response = await manager.gatewayFetch(
+      'http://relay.test/channels/topic%3Ageneral/messages',
+      'channels.history'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mintCount).toBe(2);
+    expect(gatewayCount).toBe(2);
+    expect(
+      gatewayHeaders.map((headers) => ({
+        authorization: headers.get('authorization'),
+        gateway: headers.get('x-relay-cli-gateway'),
+        command: headers.get('x-relay-cli-command'),
+      }))
+    ).toEqual([
+      {
+        authorization: 'Bearer relay-sac-v1.token-1',
+        gateway: 'v1',
+        command: 'channels.history',
+      },
+      {
+        authorization: 'Bearer relay-sac-v1.token-2',
+        gateway: 'v1',
+        command: 'channels.history',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
First increment of the persistent gateway-peer orchestrator — epic #1242 slice 4 (ADR-017 brain-as-peer). Base case, shipped-primitives only, **no server runtime changes** (2 new files).

## What
A standalone peer binary (`scripts/orchestrator-peer.ts`) that:
- bootstraps a scoped actor token (PIN → cookie → mint; caps `session:read+context:read+context:write`, no explicit scope) and re-mints at ~2/3 TTL + once on a 401,
- polls ONE product channel via `channels.history` on a seq cursor,
- echoes an ack via `channels.post` as `agent:<actorId>` for every new message that isn't its own (**self-skip** prevents an echo loop),
- graceful SIGINT/SIGTERM loop, injectable fetch+clock.

`PeerConfig` is **profile-forward-compatible** (`{caps, scope, renewable, budget, channel-binding}`) so the agent-profile-as-credential-policy layer (the #1232 merge) slots in later without reshaping.

## Proof
- Unit tests (`test/orchestrator-peer.test.ts`, 5): self-skip + cursor advance, re-mint timing, 401 one-shot retry, full mint→poll→post cycle asserting the 3 headers + exact verbs, abort cleanup. `npm run check` clean.
- **Live on daily-hub nightly 759:** human post `→` echoed as `agent:orch-4a-proof`; `latestSeq` stayed flat across polls (self-skip holds — no echo loop, the worst-case failure).
- codex-cli wrote; cavecrew-reviewer (different model) audited echo-loop/re-mint/headers/shutdown → **no issues**.

## Notes
- Run from built output: `node dist/scripts/orchestrator-peer.js` (a TS parameter property makes `node --experimental-strip-types` on the `.ts` unsupported).
- Known 4a limitation (by design): stateless cursor starts at 0, so a restart re-acks history — durable cursor lands in 4e.

Refs #1242 · Closes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)