### PR TITLE
feat(orchestrator): two-channel read + relay — slice 4b (#1266)

### DIFF
--- a/scripts/orchestrator-peer.ts
+++ b/scripts/orchestrator-peer.ts
@@ -20,6 +20,7 @@ export interface PeerConfig {
   displayName: string;
   role: string;
   productChannelId: string;
+  implChannelId: string;
   capabilities: string[];
   scope?: unknown;
   renewable: boolean;
@@ -64,10 +65,19 @@ export function buildAckText(message: ChannelMessage): string {
   return `orchestrator online — ack seq ${message.seq} from ${message.sender.id}`;
 }
 
+export function buildInstruction(message: ChannelMessage): string {
+  return `instruction (relayed from product): ${message.body.text}`;
+}
+
+export function buildRollup(message: ChannelMessage): string {
+  return `rollup (from impl): ${message.body.text}`;
+}
+
 export function selectNewMessages(
   messages: ChannelMessage[],
   lastSeq: number,
-  selfSenderId: string
+  selfSenderId: string,
+  buildText: (message: ChannelMessage) => string = buildAckText
 ): MessageSelection {
   const unseen = messages
     .filter((message) => message.seq > lastSeq)
@@ -78,7 +88,7 @@ export function selectNewMessages(
   for (const message of unseen) {
     nextSeq = Math.max(nextSeq, message.seq);
     if (message.sender.id === selfSenderId) continue;
-    acks.push({ seq: message.seq, text: buildAckText(message) });
+    acks.push({ seq: message.seq, text: buildText(message) });
   }
 
   return { acks, nextSeq };
@@ -296,9 +306,11 @@ export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
 
 export class OrchestratorPeer {
   private readonly baseUrl: string;
-  private readonly channelPath: string;
+  private readonly productChannelPath: string;
+  private readonly implChannelPath: string;
   private readonly tokenManager: TokenManager;
-  private cursor = 0;
+  private productCursor = 0;
+  private implCursor = 0;
 
   constructor(
     private readonly config: PeerConfig,
@@ -306,18 +318,31 @@ export class OrchestratorPeer {
     now: () => number = Date.now
   ) {
     this.baseUrl = normalizedBaseUrl(config.baseUrl);
-    this.channelPath = `/channels/${encodeURIComponent(config.productChannelId)}`;
+    this.productChannelPath =
+      `/channels/${encodeURIComponent(config.productChannelId)}`;
+    this.implChannelPath =
+      `/channels/${encodeURIComponent(config.implChannelId)}`;
     this.tokenManager = new TokenManager(config, fetchImpl, now);
   }
 
-  get lastSeq(): number {
-    return this.cursor;
+  get productLastSeq(): number {
+    return this.productCursor;
   }
 
-  async pollOnce(): Promise<{ ackCount: number; lastSeq: number }> {
+  get implLastSeq(): number {
+    return this.implCursor;
+  }
+
+  private async relayChannel(
+    sourceChannelPath: string,
+    targetChannelPath: string,
+    cursor: number,
+    buildText: (message: ChannelMessage) => string,
+    relayKind: 'instruction' | 'rollup'
+  ): Promise<MessageSelection> {
     const historyUrl =
-      `${this.baseUrl}${this.channelPath}/messages` +
-      `?afterSeq=${this.cursor}&limit=${HISTORY_LIMIT}`;
+      `${this.baseUrl}${sourceChannelPath}/messages` +
+      `?afterSeq=${cursor}&limit=${HISTORY_LIMIT}`;
     const historyResponse = await this.tokenManager.gatewayFetch(
       historyUrl,
       'channels.history'
@@ -328,13 +353,14 @@ export class OrchestratorPeer {
     const history = parseHistoryResponse(await historyResponse.json());
     const selection = selectNewMessages(
       history.messages,
-      this.cursor,
-      `agent:${this.config.actorId}`
+      cursor,
+      `agent:${this.config.actorId}`,
+      buildText
     );
 
     for (const ack of selection.acks) {
       const postResponse = await this.tokenManager.gatewayFetch(
-        `${this.baseUrl}${this.channelPath}/messages`,
+        `${this.baseUrl}${targetChannelPath}/messages`,
         'channels.post',
         {
           method: 'POST',
@@ -344,14 +370,45 @@ export class OrchestratorPeer {
       );
       if (!postResponse.ok) {
         throw await responseError(
-          `channels.post ack for seq ${ack.seq}`,
+          `channels.post ${relayKind} for seq ${ack.seq}`,
           postResponse
         );
       }
     }
 
-    this.cursor = selection.nextSeq;
-    return { ackCount: selection.acks.length, lastSeq: this.cursor };
+    return selection;
+  }
+
+  async pollOnce(): Promise<{
+    instructionCount: number;
+    rollupCount: number;
+    productLastSeq: number;
+    implLastSeq: number;
+  }> {
+    const productSelection = await this.relayChannel(
+      this.productChannelPath,
+      this.implChannelPath,
+      this.productCursor,
+      buildInstruction,
+      'instruction'
+    );
+    this.productCursor = productSelection.nextSeq;
+
+    const implSelection = await this.relayChannel(
+      this.implChannelPath,
+      this.productChannelPath,
+      this.implCursor,
+      buildRollup,
+      'rollup'
+    );
+    this.implCursor = implSelection.nextSeq;
+
+    return {
+      instructionCount: productSelection.acks.length,
+      rollupCount: implSelection.acks.length,
+      productLastSeq: this.productCursor,
+      implLastSeq: this.implCursor,
+    };
   }
 
   async run(signal: AbortSignal): Promise<void> {
@@ -383,9 +440,12 @@ export function readPeerConfig(
   const pin = argValue(argv, '--pin') ?? env['RELAY_PEER_PIN'];
   const productChannelId =
     argValue(argv, '--channel') ?? env['RELAY_PEER_CHANNEL_ID'];
-  if (!pin || !productChannelId) {
+  const implChannelId =
+    argValue(argv, '--impl-channel') ??
+    env['RELAY_PEER_IMPL_CHANNEL_ID'];
+  if (!pin || !productChannelId || !implChannelId) {
     throw new Error(
-      'PIN and channel are required via --pin/--channel or RELAY_PEER_PIN/RELAY_PEER_CHANNEL_ID'
+      'PIN, product channel, and impl channel are required via --pin/--channel/--impl-channel or RELAY_PEER_PIN/RELAY_PEER_CHANNEL_ID/RELAY_PEER_IMPL_CHANNEL_ID'
     );
   }
 
@@ -414,6 +474,7 @@ export function readPeerConfig(
       actorId,
     role: env['RELAY_PEER_ROLE'] ?? 'orchestrator',
     productChannelId,
+    implChannelId,
     capabilities:
       capabilities && capabilities.length
         ? capabilities
@@ -436,7 +497,7 @@ export async function main(): Promise<void> {
 
   try {
     console.log(
-      `orchestrator peer ${config.actorId} polling ${config.productChannelId}`
+      `orchestrator peer ${config.actorId} polling ${config.productChannelId} and ${config.implChannelId}`
     );
     await new OrchestratorPeer(config).run(controller.signal);
   } finally {

--- a/test/orchestrator-peer.test.ts
+++ b/test/orchestrator-peer.test.ts
@@ -5,7 +5,10 @@ import {
   TokenManager,
   abortableDelay,
   buildAckText,
+  buildInstruction,
+  buildRollup,
   needsRemint,
+  readPeerConfig,
   selectNewMessages,
   type FetchLike,
   type PeerConfig,
@@ -22,6 +25,7 @@ const CONFIG: PeerConfig = {
   displayName: 'Echo Peer',
   role: 'orchestrator',
   productChannelId: 'topic:general',
+  implChannelId: 'topic:implementation',
   capabilities: ['session:read', 'context:read', 'context:write'],
   renewable: true,
   pollIntervalMs: 10,
@@ -30,12 +34,13 @@ const CONFIG: PeerConfig = {
 function message(
   seq: number,
   senderId: string,
-  text = 'hello'
+  text = 'hello',
+  channelId = CONFIG.productChannelId
 ): ChannelMessage {
   return {
     schemaVersion: 1,
     id: `chm:${seq}` as ChannelMessageId,
-    channelId: CONFIG.productChannelId,
+    channelId,
     seq,
     kind: 'message',
     status: 'complete',
@@ -100,6 +105,46 @@ describe('orchestrator peer pure seams', () => {
     );
   });
 
+  it('builds canned instruction and rollup text', () => {
+    expect(buildInstruction(message(1, 'human:operator', 'ship it'))).toBe(
+      'instruction (relayed from product): ship it'
+    );
+    expect(buildRollup(message(2, 'agent:worker', 'done'))).toBe(
+      'rollup (from impl): done'
+    );
+  });
+
+  it('reads both channel ids from args or environment', () => {
+    const fromEnvironment = readPeerConfig({
+      RELAY_PEER_PIN: 'environment-pin',
+      RELAY_PEER_CHANNEL_ID: 'topic:product-environment',
+      RELAY_PEER_IMPL_CHANNEL_ID: 'topic:impl-environment',
+    });
+    expect(fromEnvironment.productChannelId).toBe(
+      'topic:product-environment'
+    );
+    expect(fromEnvironment.implChannelId).toBe('topic:impl-environment');
+
+    const fromArgs = readPeerConfig(
+      {
+        RELAY_PEER_PIN: 'environment-pin',
+        RELAY_PEER_CHANNEL_ID: 'topic:product-environment',
+        RELAY_PEER_IMPL_CHANNEL_ID: 'topic:impl-environment',
+      },
+      [
+        '--pin',
+        'argument-pin',
+        '--channel',
+        'topic:product-argument',
+        '--impl-channel',
+        'topic:impl-argument',
+      ]
+    );
+    expect(fromArgs.pin).toBe('argument-pin');
+    expect(fromArgs.productChannelId).toBe('topic:product-argument');
+    expect(fromArgs.implChannelId).toBe('topic:impl-argument');
+  });
+
   it('needsRemint fires inside the refresh window', () => {
     expect(needsRemint(300_000, 199_999, 2 / 3)).toBe(false);
     expect(needsRemint(300_000, 200_000, 2 / 3)).toBe(true);
@@ -133,7 +178,7 @@ describe('orchestrator peer pure seams', () => {
 });
 
 describe('orchestrator peer gateway cycle', () => {
-  it('runs mint, poll, and one post with exact gateway headers and no self ack', async () => {
+  it('relays a product message as one instruction into impl with exact gateway recipe', async () => {
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const fetchMock = vi.fn<FetchLike>(async (input, init = {}) => {
       const url = input.toString();
@@ -147,17 +192,32 @@ describe('orchestrator peer gateway cycle', () => {
       if (url.endsWith('/cli-gateway/actor-credentials')) {
         return minted('relay-sac-v1.first');
       }
-      if (url.includes('?afterSeq=0&limit=100')) {
+      if (
+        url.endsWith(
+          '/channels/topic%3Ageneral/messages?afterSeq=0&limit=100'
+        )
+      ) {
         return jsonResponse({
-          messages: [
-            message(1, 'human:operator'),
-            message(2, 'agent:echo-peer'),
-          ],
+          messages: [message(1, 'human:operator', 'build feature')],
         });
       }
-      if (url.endsWith('/channels/topic%3Ageneral/messages')) {
+      if (
+        url.endsWith(
+          '/channels/topic%3Aimplementation/messages?afterSeq=0&limit=100'
+        )
+      ) {
+        return jsonResponse({ messages: [] });
+      }
+      if (url.endsWith('/channels/topic%3Aimplementation/messages')) {
         return jsonResponse(
-          { message: message(3, 'agent:echo-peer') },
+          {
+            message: message(
+              1,
+              'agent:echo-peer',
+              'instruction (relayed from product): build feature',
+              CONFIG.implChannelId
+            ),
+          },
           { status: 201 }
         );
       }
@@ -168,11 +228,13 @@ describe('orchestrator peer gateway cycle', () => {
       Date.parse('2026-07-24T00:00:00.000Z')
     );
     await expect(peer.pollOnce()).resolves.toEqual({
-      ackCount: 1,
-      lastSeq: 2,
+      instructionCount: 1,
+      rollupCount: 0,
+      productLastSeq: 1,
+      implLastSeq: 0,
     });
 
-    expect(calls).toHaveLength(4);
+    expect(calls).toHaveLength(5);
     const authBody = JSON.parse(String(calls[0]?.init.body)) as unknown;
     expect(authBody).toEqual({ pin: 'test-pin' });
     const mintBody = JSON.parse(String(calls[1]?.init.body)) as Record<
@@ -193,21 +255,245 @@ describe('orchestrator peer gateway cycle', () => {
     );
 
     const gatewayCalls = calls.slice(2);
-    expect(gatewayCalls).toHaveLength(2);
+    expect(gatewayCalls).toHaveLength(3);
     for (const call of gatewayCalls) {
       const headers = new Headers(call.init.headers);
       expect(headers.get('authorization')).toBe('Bearer relay-sac-v1.first');
       expect(headers.get('x-relay-cli-gateway')).toBe('v1');
     }
+    expect(gatewayCalls[0]?.url).toBe(
+      'http://relay.test/channels/topic%3Ageneral/messages?afterSeq=0&limit=100'
+    );
     expect(
       new Headers(gatewayCalls[0]?.init.headers).get('x-relay-cli-command')
     ).toBe('channels.history');
+    expect(gatewayCalls[1]?.url).toBe(
+      'http://relay.test/channels/topic%3Aimplementation/messages'
+    );
+    expect(gatewayCalls[1]?.init.method).toBe('POST');
     expect(
       new Headers(gatewayCalls[1]?.init.headers).get('x-relay-cli-command')
     ).toBe('channels.post');
+    expect(
+      new Headers(gatewayCalls[1]?.init.headers).get('content-type')
+    ).toBe('application/json');
     expect(JSON.parse(String(gatewayCalls[1]?.init.body))).toEqual({
-      text: 'orchestrator online — ack seq 1 from human:operator',
+      text: 'instruction (relayed from product): build feature',
     });
+    expect(gatewayCalls[2]?.url).toBe(
+      'http://relay.test/channels/topic%3Aimplementation/messages?afterSeq=0&limit=100'
+    );
+    expect(
+      new Headers(gatewayCalls[2]?.init.headers).get('x-relay-cli-command')
+    ).toBe('channels.history');
+  });
+
+  it('relays an impl message as one rollup into product', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn<FetchLike>(async (input, init = {}) => {
+      const url = input.toString();
+      calls.push({ url, init });
+      if (url.endsWith('/auth')) {
+        return jsonResponse(
+          { ok: true },
+          { headers: { 'set-cookie': 'token=browser-cookie; HttpOnly' } }
+        );
+      }
+      if (url.endsWith('/cli-gateway/actor-credentials')) {
+        return minted('relay-sac-v1.first');
+      }
+      if (
+        url.endsWith(
+          '/channels/topic%3Ageneral/messages?afterSeq=0&limit=100'
+        )
+      ) {
+        return jsonResponse({ messages: [] });
+      }
+      if (
+        url.endsWith(
+          '/channels/topic%3Aimplementation/messages?afterSeq=0&limit=100'
+        )
+      ) {
+        return jsonResponse({
+          messages: [
+            message(
+              4,
+              'agent:worker',
+              'implementation complete',
+              CONFIG.implChannelId
+            ),
+          ],
+        });
+      }
+      if (url.endsWith('/channels/topic%3Ageneral/messages')) {
+        return jsonResponse(
+          {
+            message: message(
+              1,
+              'agent:echo-peer',
+              'rollup (from impl): implementation complete'
+            ),
+          },
+          { status: 201 }
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const peer = new OrchestratorPeer(CONFIG, fetchMock, () =>
+      Date.parse('2026-07-24T00:00:00.000Z')
+    );
+    await expect(peer.pollOnce()).resolves.toEqual({
+      instructionCount: 0,
+      rollupCount: 1,
+      productLastSeq: 0,
+      implLastSeq: 4,
+    });
+
+    const gatewayCalls = calls.slice(2);
+    expect(gatewayCalls).toHaveLength(3);
+    const post = gatewayCalls[2];
+    expect(post?.url).toBe(
+      'http://relay.test/channels/topic%3Ageneral/messages'
+    );
+    expect(post?.init.method).toBe('POST');
+    const headers = new Headers(post?.init.headers);
+    expect(headers.get('authorization')).toBe('Bearer relay-sac-v1.first');
+    expect(headers.get('x-relay-cli-gateway')).toBe('v1');
+    expect(headers.get('x-relay-cli-command')).toBe('channels.post');
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(JSON.parse(String(post?.init.body))).toEqual({
+      text: 'rollup (from impl): implementation complete',
+    });
+  });
+
+  it('self-skips own posts in both channels without cross-channel ping-pong', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn<FetchLike>(async (input, init = {}) => {
+      const url = input.toString();
+      calls.push({ url, init });
+      if (url.endsWith('/auth')) {
+        return jsonResponse(
+          { ok: true },
+          { headers: { 'set-cookie': 'token=browser-cookie; HttpOnly' } }
+        );
+      }
+      if (url.endsWith('/cli-gateway/actor-credentials')) {
+        return minted('relay-sac-v1.first');
+      }
+      if (
+        url.endsWith(
+          '/channels/topic%3Ageneral/messages?afterSeq=0&limit=100'
+        )
+      ) {
+        return jsonResponse({
+          messages: [message(3, 'agent:echo-peer', 'own rollup')],
+        });
+      }
+      if (
+        url.endsWith(
+          '/channels/topic%3Aimplementation/messages?afterSeq=0&limit=100'
+        )
+      ) {
+        return jsonResponse({
+          messages: [
+            message(
+              7,
+              'agent:echo-peer',
+              'own instruction',
+              CONFIG.implChannelId
+            ),
+          ],
+        });
+      }
+      if (url.includes('/channels/') && url.includes('/messages?afterSeq=')) {
+        return jsonResponse({ messages: [] });
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const peer = new OrchestratorPeer(CONFIG, fetchMock, () =>
+      Date.parse('2026-07-24T00:00:00.000Z')
+    );
+    await expect(peer.pollOnce()).resolves.toEqual({
+      instructionCount: 0,
+      rollupCount: 0,
+      productLastSeq: 3,
+      implLastSeq: 7,
+    });
+    await expect(peer.pollOnce()).resolves.toEqual({
+      instructionCount: 0,
+      rollupCount: 0,
+      productLastSeq: 3,
+      implLastSeq: 7,
+    });
+
+    const channelPosts = calls.filter(
+      (call) =>
+        call.url.includes('/channels/') &&
+        call.init.method?.toUpperCase() === 'POST'
+    );
+    expect(channelPosts).toEqual([]);
+  });
+
+  it('advances product and impl cursors independently', async () => {
+    const historyUrls: string[] = [];
+    let productPoll = 0;
+    const fetchMock = vi.fn<FetchLike>(async (input) => {
+      const url = input.toString();
+      if (url.endsWith('/auth')) {
+        return jsonResponse(
+          { ok: true },
+          { headers: { 'set-cookie': 'token=browser-cookie; HttpOnly' } }
+        );
+      }
+      if (url.endsWith('/cli-gateway/actor-credentials')) {
+        return minted('relay-sac-v1.first');
+      }
+      historyUrls.push(url);
+      if (url.includes('/channels/topic%3Ageneral/')) {
+        productPoll += 1;
+        return jsonResponse({
+          messages:
+            productPoll === 1
+              ? [message(5, 'agent:echo-peer')]
+              : [message(6, 'agent:echo-peer')],
+        });
+      }
+      if (url.includes('/channels/topic%3Aimplementation/')) {
+        return jsonResponse({
+          messages:
+            historyUrls.length === 2
+              ? [
+                  message(
+                    2,
+                    'agent:echo-peer',
+                    'own instruction',
+                    CONFIG.implChannelId
+                  ),
+                ]
+              : [],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const peer = new OrchestratorPeer(CONFIG, fetchMock, () =>
+      Date.parse('2026-07-24T00:00:00.000Z')
+    );
+    await peer.pollOnce();
+    await expect(peer.pollOnce()).resolves.toMatchObject({
+      productLastSeq: 6,
+      implLastSeq: 2,
+    });
+    expect(peer.productLastSeq).toBe(6);
+    expect(peer.implLastSeq).toBe(2);
+    expect(historyUrls).toEqual([
+      'http://relay.test/channels/topic%3Ageneral/messages?afterSeq=0&limit=100',
+      'http://relay.test/channels/topic%3Aimplementation/messages?afterSeq=0&limit=100',
+      'http://relay.test/channels/topic%3Ageneral/messages?afterSeq=5&limit=100',
+      'http://relay.test/channels/topic%3Aimplementation/messages?afterSeq=2&limit=100',
+    ]);
   });
 
   it('re-mints once and retries a gateway 401', async () => {


### PR DESCRIPTION
Slice 4b of epic #1242. Extends the 4a echo-peer to TWO channels with two-way relay. **No server changes** (peer script only).

## What
- Adds `implChannelId` (+ `--impl-channel` / `RELAY_PEER_IMPL_CHANNEL_ID`).
- Independent per-channel seq cursors.
- product non-self msg → `buildInstruction()` into impl; impl non-self msg → `buildRollup()` into product.
- Both directions self-skip the peer's own posts via the same `agent:<actorId>` → an instruction posted into impl is never re-relayed as a rollup, and vice versa (no ping-pong).
- Canned transforms (routing, not intelligence — the reasoning brain is a later slice).

## Proof
- codex-cli wrote; cavecrew-reviewer (different model) → **no issues** (loop-safety, independent cursors, direction, 4a regression).
- 10/10 tests; `npm run check` clean.
- **Live on daily-hub nightly 759** with two fresh channels: human "build the login page" in product → `instruction (relayed from product)` in impl; worker "login page done" in impl → `rollup (from impl)` in product; both channels then **froze at seq 2** (the peer's own posts were not re-relayed).

## Notes
- Inherited P2 (predates 4b, out of scope): partial multi-message batch failure can duplicate a relay on retry — exactly-once lands in 4e (durable cursor).
- Run from built output: `node dist/scripts/orchestrator-peer.js`.

Refs #1242 · Closes #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-way relaying between product and implementation channels.
  * Product messages are relayed as instructions, while implementation messages are relayed as rollups.
  * Added separate tracking for message progress in each channel.
  * Added configuration support for specifying the implementation channel through environment variables or command-line options.

* **Bug Fixes**
  * Prevented relayed messages from creating cross-channel ping-pong loops.
  * Ensured each channel’s message history advances independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->