### PR TITLE
feat(orchestrator): spawn + instruct workers via @-mention — slice 4c bootstrap (#1268)

### DIFF
--- a/scripts/orchestrator-peer.ts
+++ b/scripts/orchestrator-peer.ts
@@ -21,6 +21,7 @@ export interface PeerConfig {
   role: string;
   productChannelId: string;
   implChannelId: string;
+  workerFramework: string;
   capabilities: string[];
   scope?: unknown;
   renewable: boolean;
@@ -69,6 +70,13 @@ export function buildInstruction(message: ChannelMessage): string {
   return `instruction (relayed from product): ${message.body.text}`;
 }
 
+export function buildWorkerMention(
+  framework: string,
+  message: ChannelMessage
+): string {
+  return `@${framework} ${message.body.text}`;
+}
+
 export function buildRollup(message: ChannelMessage): string {
   return `rollup (from impl): ${message.body.text}`;
 }
@@ -86,9 +94,25 @@ export function selectNewMessages(
   const acks: PeerAck[] = [];
 
   for (const message of unseen) {
+    // The peer's own posts are written complete; skip + advance past them.
+    if (message.sender.id === selfSenderId) {
+      nextSeq = Math.max(nextSeq, message.seq);
+      continue;
+    }
+    // A still-streaming message has no finalized text yet (a live worker reply
+    // begins empty and fills in). Relaying it now would carry empty/partial
+    // content AND advance the cursor past it, so the finalized text is never
+    // relayed. HOLD the cursor before it — re-read next poll — so it is relayed
+    // exactly once, when complete. Messages finalize in seq order, so an
+    // in-progress message correctly blocks the higher seqs behind it.
+    if (message.status === 'streaming') break;
     nextSeq = Math.max(nextSeq, message.seq);
-    if (message.sender.id === selfSenderId) continue;
-    acks.push({ seq: message.seq, text: buildText(message) });
+    // Relay only messages that carry final content. 'complete'/'truncated' have
+    // finalized text; 'interrupted'/'failed' are terminal with no useful reply —
+    // advance past them without relaying.
+    if (message.status === 'complete' || message.status === 'truncated') {
+      acks.push({ seq: message.seq, text: buildText(message) });
+    }
   }
 
   return { acks, nextSeq };
@@ -389,7 +413,7 @@ export class OrchestratorPeer {
       this.productChannelPath,
       this.implChannelPath,
       this.productCursor,
-      buildInstruction,
+      (message) => buildWorkerMention(this.config.workerFramework, message),
       'instruction'
     );
     this.productCursor = productSelection.nextSeq;
@@ -475,6 +499,10 @@ export function readPeerConfig(
     role: env['RELAY_PEER_ROLE'] ?? 'orchestrator',
     productChannelId,
     implChannelId,
+    workerFramework:
+      argValue(argv, '--worker-framework') ??
+      env['RELAY_PEER_WORKER_FRAMEWORK'] ??
+      'codex',
     capabilities:
       capabilities && capabilities.length
         ? capabilities

--- a/scripts/orchestrator-peer.ts
+++ b/scripts/orchestrator-peer.ts
@@ -103,8 +103,13 @@ export function selectNewMessages(
     // begins empty and fills in). Relaying it now would carry empty/partial
     // content AND advance the cursor past it, so the finalized text is never
     // relayed. HOLD the cursor before it — re-read next poll — so it is relayed
-    // exactly once, when complete. Messages finalize in seq order, so an
-    // in-progress message correctly blocks the higher seqs behind it.
+    // exactly once, when complete. A stale stream is not a permanent hold: the
+    // bridge finalizes an open row (truncated/failed) on turn-complete, error,
+    // idle, or session-end. Caveat: this break blocks any HIGHER-seq message
+    // behind an earlier streaming one. With the current one-worker-per-impl
+    // relay that's a single stream at a time (fine); if a future slice runs
+    // concurrent cross-sender streams in one channel, an earlier open stream can
+    // briefly head-of-line-block a later finished one (bounded, no data loss).
     if (message.status === 'streaming') break;
     nextSeq = Math.max(nextSeq, message.seq);
     // Relay only messages that carry final content. 'complete'/'truncated' have

--- a/test/orchestrator-peer.test.ts
+++ b/test/orchestrator-peer.test.ts
@@ -148,6 +148,26 @@ describe('orchestrator peer pure seams', () => {
     );
     expect(failed.acks).toEqual([]);
     expect(failed.nextSeq).toBe(3);
+
+    // 'truncated' (size-capped but final) IS relayed — it carries real content.
+    const truncated = selectNewMessages(
+      [message(4, 'agent:worker', 'partial reply', CONFIG.implChannelId, 'truncated')],
+      3,
+      'agent:echo-peer'
+    );
+    expect(truncated.acks).toEqual([
+      { seq: 4, text: 'orchestrator online — ack seq 4 from agent:worker' },
+    ]);
+    expect(truncated.nextSeq).toBe(4);
+
+    // A terminal 'interrupted' reply is advanced past without relay (like failed).
+    const interrupted = selectNewMessages(
+      [message(5, 'agent:worker', 'cut off', CONFIG.implChannelId, 'interrupted')],
+      4,
+      'agent:echo-peer'
+    );
+    expect(interrupted.acks).toEqual([]);
+    expect(interrupted.nextSeq).toBe(5);
   });
 
   it('builds canned instruction and rollup text', () => {

--- a/test/orchestrator-peer.test.ts
+++ b/test/orchestrator-peer.test.ts
@@ -7,15 +7,17 @@ import {
   buildAckText,
   buildInstruction,
   buildRollup,
+  buildWorkerMention,
   needsRemint,
   readPeerConfig,
   selectNewMessages,
   type FetchLike,
   type PeerConfig,
 } from '../scripts/orchestrator-peer.js';
-import type {
-  ChannelMessage,
-  ChannelMessageId,
+import {
+  parseMentions,
+  type ChannelMessage,
+  type ChannelMessageId,
 } from '../shared/channel-chat-protocol.js';
 
 const CONFIG: PeerConfig = {
@@ -26,6 +28,7 @@ const CONFIG: PeerConfig = {
   role: 'orchestrator',
   productChannelId: 'topic:general',
   implChannelId: 'topic:implementation',
+  workerFramework: 'codex',
   capabilities: ['session:read', 'context:read', 'context:write'],
   renewable: true,
   pollIntervalMs: 10,
@@ -35,7 +38,8 @@ function message(
   seq: number,
   senderId: string,
   text = 'hello',
-  channelId = CONFIG.productChannelId
+  channelId = CONFIG.productChannelId,
+  status: ChannelMessage['status'] = 'complete'
 ): ChannelMessage {
   return {
     schemaVersion: 1,
@@ -43,7 +47,7 @@ function message(
     channelId,
     seq,
     kind: 'message',
-    status: 'complete',
+    status,
     sender: {
       kind: senderId.startsWith('agent:') ? 'agent' : 'human',
       id: senderId,
@@ -105,6 +109,47 @@ describe('orchestrator peer pure seams', () => {
     );
   });
 
+  it('holds the cursor on a still-streaming message and relays it once complete', () => {
+    // A live worker reply begins as a streaming, empty-bodied message. The peer
+    // must NOT relay it yet, and must NOT advance past it (else the finalized
+    // text is lost) — the failure the 4c live proof surfaced (empty rollup).
+    const streaming = selectNewMessages(
+      [message(2, 'agent:worker', '', CONFIG.implChannelId, 'streaming')],
+      1,
+      'agent:echo-peer'
+    );
+    expect(streaming.acks).toEqual([]);
+    expect(streaming.nextSeq).toBe(1); // cursor held BEFORE the streaming msg
+
+    // Next poll: the same message has finalized → relayed exactly once, advanced.
+    const completed = selectNewMessages(
+      [
+        message(
+          2,
+          'agent:worker',
+          'WORKER_OK',
+          CONFIG.implChannelId,
+          'complete'
+        ),
+      ],
+      1,
+      'agent:echo-peer'
+    );
+    expect(completed.acks).toEqual([
+      { seq: 2, text: 'orchestrator online — ack seq 2 from agent:worker' },
+    ]);
+    expect(completed.nextSeq).toBe(2);
+
+    // A terminal 'failed' reply carries no useful text: advance past, no relay.
+    const failed = selectNewMessages(
+      [message(3, 'agent:worker', '', CONFIG.implChannelId, 'failed')],
+      2,
+      'agent:echo-peer'
+    );
+    expect(failed.acks).toEqual([]);
+    expect(failed.nextSeq).toBe(3);
+  });
+
   it('builds canned instruction and rollup text', () => {
     expect(buildInstruction(message(1, 'human:operator', 'ship it'))).toBe(
       'instruction (relayed from product): ship it'
@@ -114,16 +159,29 @@ describe('orchestrator peer pure seams', () => {
     );
   });
 
-  it('reads both channel ids from args or environment', () => {
+  it('builds a worker mention recognized as the configured framework', () => {
+    const text = buildWorkerMention(
+      'codex',
+      message(1, 'human:operator', 'ship it')
+    );
+
+    expect(parseMentions(text, ['codex'])).toEqual([
+      { raw: '@codex', providerId: 'codex' },
+    ]);
+  });
+
+  it('reads channel ids and worker framework from args or environment', () => {
     const fromEnvironment = readPeerConfig({
       RELAY_PEER_PIN: 'environment-pin',
       RELAY_PEER_CHANNEL_ID: 'topic:product-environment',
       RELAY_PEER_IMPL_CHANNEL_ID: 'topic:impl-environment',
+      RELAY_PEER_WORKER_FRAMEWORK: 'claude',
     });
     expect(fromEnvironment.productChannelId).toBe(
       'topic:product-environment'
     );
     expect(fromEnvironment.implChannelId).toBe('topic:impl-environment');
+    expect(fromEnvironment.workerFramework).toBe('claude');
 
     const fromArgs = readPeerConfig(
       {
@@ -138,11 +196,21 @@ describe('orchestrator peer pure seams', () => {
         'topic:product-argument',
         '--impl-channel',
         'topic:impl-argument',
+        '--worker-framework',
+        'codex-argument',
       ]
     );
     expect(fromArgs.pin).toBe('argument-pin');
     expect(fromArgs.productChannelId).toBe('topic:product-argument');
     expect(fromArgs.implChannelId).toBe('topic:impl-argument');
+    expect(fromArgs.workerFramework).toBe('codex-argument');
+
+    const withDefault = readPeerConfig({
+      RELAY_PEER_PIN: 'environment-pin',
+      RELAY_PEER_CHANNEL_ID: 'topic:product-environment',
+      RELAY_PEER_IMPL_CHANNEL_ID: 'topic:impl-environment',
+    });
+    expect(withDefault.workerFramework).toBe('codex');
   });
 
   it('needsRemint fires inside the refresh window', () => {
@@ -178,7 +246,7 @@ describe('orchestrator peer pure seams', () => {
 });
 
 describe('orchestrator peer gateway cycle', () => {
-  it('relays a product message as one instruction into impl with exact gateway recipe', async () => {
+  it('relays a product message as one worker mention into impl with exact gateway recipe', async () => {
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const fetchMock = vi.fn<FetchLike>(async (input, init = {}) => {
       const url = input.toString();
@@ -214,7 +282,7 @@ describe('orchestrator peer gateway cycle', () => {
             message: message(
               1,
               'agent:echo-peer',
-              'instruction (relayed from product): build feature',
+              '@codex build feature',
               CONFIG.implChannelId
             ),
           },
@@ -278,7 +346,7 @@ describe('orchestrator peer gateway cycle', () => {
       new Headers(gatewayCalls[1]?.init.headers).get('content-type')
     ).toBe('application/json');
     expect(JSON.parse(String(gatewayCalls[1]?.init.body))).toEqual({
-      text: 'instruction (relayed from product): build feature',
+      text: '@codex build feature',
     });
     expect(gatewayCalls[2]?.url).toBe(
       'http://relay.test/channels/topic%3Aimplementation/messages?afterSeq=0&limit=100'
@@ -367,7 +435,7 @@ describe('orchestrator peer gateway cycle', () => {
     });
   });
 
-  it('self-skips own posts in both channels without cross-channel ping-pong', async () => {
+  it('self-skips its own worker mention in impl without cross-channel ping-pong', async () => {
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const fetchMock = vi.fn<FetchLike>(async (input, init = {}) => {
       const url = input.toString();
@@ -400,7 +468,7 @@ describe('orchestrator peer gateway cycle', () => {
             message(
               7,
               'agent:echo-peer',
-              'own instruction',
+              '@codex build feature',
               CONFIG.implChannelId
             ),
           ],


### PR DESCRIPTION
The **bootstrap slice** of epic #1242 — after this the orchestrator drives real workers end-to-end inside Relay. Peer-only, **no server changes**; the turn-brake is intentionally untouched (enforced-budget replacement is a later slice, not a brake-off flag).

## What
- Product→impl instruction is now an `@<framework>` **mention** → the shipped #1167 binder spawns a `(impl-channel, framework)` worker. `buildWorkerMention` format verified against `parseMentions`. `workerFramework` config (default `codex`).
- The worker's reply rolls up to product via the existing 4b path.

## Live-proof-driven fix (dogfooding caught what mocks couldn't)
A real worker reply **streams** (streaming → complete). The peer was reading it mid-stream — relaying empty text and advancing the cursor past it, so the finalized reply was lost (empty rollup). `selectNewMessages` now **holds** the cursor on a `streaming` message (relays once `complete`), relays `complete`/`truncated`, and advances past terminal `interrupted`/`failed` without relaying. Improves 4a/4b too.

## Proof
- codex-cli wrote the mention delta; the streaming fix + test added on review of the live proof.
- 12/12 tests (incl. streaming-hold + terminal-status handling); `npm run check` clean.
- **Live on daily-hub nightly 759:** human "reply WORKER_OK" in product → peer `@codex` into impl → **binder spawned a codex worker** → worker replied `WORKER_OK` → product rollup carried `rollup (from impl): WORKER_OK`. Worker reaped after.

## Notes
- Turn-brake untouched (sustained agent-only dispatch pauses at 4 turns; enforced budget primitive is its own later slice per the design critique).
- Run from built output: `node dist/scripts/orchestrator-peer.js`.

Refs #1242 · Closes #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)