### PR TITLE
feat(orchestrator): persistent orchestrator lifecycle — backend spine (#1259)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1546,6 +1546,7 @@ const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'nodes.pair.requests',
   'sessions.list',
   'sessions.get',
+  'sessions.create',
   'sessions.screen',
   'work-contexts.get',
   'work-contexts.resume',
@@ -1593,6 +1594,7 @@ const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'workspace-topics.create',
   'workspace-topics.update',
   'workspace-topics.archive',
+  'channels.post',
   'roster.list',
   'roster.register',
   'roster.updateSelf',
@@ -1795,7 +1797,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|tickets start-work|branches open-session|sessions renew|sessions attach|sessions detach|sessions kill|sessions rename|sessions stream|sessions wait|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|work-contexts resume|context create|context get|context list|context pin|context unpin|work-context-artifacts publish|work-context-artifacts list|work-context-artifacts show|work-context-artifacts pin|work-context-artifacts unpin|work-context-artifacts export|work-context-artifacts doctor|handoff-artifacts attach|handoff-artifacts list|handoff-artifacts show|handoff-artifacts copy|roster list|roster register|roster update-self|cockpit list|cockpit get|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|workflow-runs publish|workflow-runs update|workflow-runs list|workflow-runs get|orchestration-runs launch|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe|settings get|settings update|webhooks status|webhooks ping) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|tickets start-work|branches open-session|sessions renew|sessions attach|sessions detach|sessions kill|sessions rename|sessions stream|sessions wait|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|work-contexts resume|context create|context get|context list|context pin|context unpin|work-context-artifacts publish|work-context-artifacts list|work-context-artifacts show|work-context-artifacts pin|work-context-artifacts unpin|work-context-artifacts export|work-context-artifacts doctor|handoff-artifacts attach|handoff-artifacts list|handoff-artifacts show|handoff-artifacts copy|channels post|roster list|roster register|roster update-self|cockpit list|cockpit get|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|workflow-runs publish|workflow-runs update|workflow-runs list|workflow-runs get|orchestration-runs launch|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe|settings get|settings update|webhooks status|webhooks ping) --json'
   );
   process.exit(1);
 }
@@ -5558,6 +5560,37 @@ async function runGatewayWorkspaceTopics(
   }
 }
 
+async function runGatewayChannels(gatewayArgs: string[]): Promise<never> {
+  if (gatewayArgs[1] === 'post') {
+    const input = parseGatewayInputObject(
+      'channels.post',
+      gatewayArgs.slice(2)
+    );
+    const channelId =
+      typeof input['channelId'] === 'string' ? input['channelId'].trim() : '';
+    if (!channelId) {
+      gatewayInvalid(
+        'channels.post',
+        'channelId is required and must be a non-empty string',
+        { field: 'channelId' }
+      );
+    }
+    const body = { ...input };
+    delete body['channelId'];
+    const result = await gatewayHttpJson({
+      commandName: 'channels.post',
+      pathName: `/channels/${encodeURIComponent(channelId)}/messages`,
+      method: 'POST',
+      body,
+      capabilities: ['context:write'],
+    });
+    printGatewayEnvelope(gatewayOk('channels.post', result), 0);
+  }
+  gatewayInvalid('channels.post', 'unknown channels command', {
+    args: gatewayArgs,
+  });
+}
+
 async function runGatewayRoster(gatewayArgs: string[]): Promise<never> {
   const subcommand = gatewayArgs[1];
   const rosterArgs = gatewayArgs.slice(2);
@@ -5869,6 +5902,7 @@ async function runGatewayV1(): Promise<never> {
       'pr-overseer': runGatewayPrOverseer,
       'workspace-surfaces': runGatewayWorkspaceSurfaces,
       'workspace-topics': runGatewayWorkspaceTopics,
+      channels: runGatewayChannels,
       roster: runGatewayRoster,
       cockpit: runGatewayCockpit,
       artifacts: runGatewayArtifacts,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../../shared/identity.js';
 import type { SessionEnvelope } from '../../../shared/session-envelope.js';
 import type { SessionDurabilityState } from '../../../shared/session-durability.js';
+import type { AgentRole } from '../../../shared/agent-roster.js';
 import type {
   RepoIdentityWarning,
   ResolvedRemoteIdentity,
@@ -160,6 +161,8 @@ export interface SessionSummary {
   id: string;
   type: 'agent' | 'terminal';
   agent: AgentType;
+  /** Durable collaboration role. A hint for routing/UI, not authorization. */
+  role?: AgentRole;
   mode?: 'pty' | 'web' | undefined;
   repoName?: string;
   repoPath?: string;

--- a/server/actor-session-create-policy.ts
+++ b/server/actor-session-create-policy.ts
@@ -1,0 +1,27 @@
+export const CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED =
+  'CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED' as const;
+
+export type ActorSessionCreateRolePolicy =
+  | { ok: true; explicitRole: undefined }
+  | {
+      ok: false;
+      explicitRole: 'orchestrator';
+      reasonCode: typeof CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED;
+    };
+
+/**
+ * Actor-created sessions are workers. Agent roster defaults are display hints,
+ * so only a caller's explicit durable role participates in this policy.
+ */
+export function actorSessionCreateRolePolicy(
+  body: Readonly<Record<string, unknown>>
+): ActorSessionCreateRolePolicy {
+  if (body['role'] !== 'orchestrator') {
+    return { ok: true, explicitRole: undefined };
+  }
+  return {
+    ok: false,
+    explicitRole: 'orchestrator',
+    reasonCode: CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED,
+  };
+}

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -135,6 +135,11 @@ export interface ChannelAgentBinder {
     mentions: ChannelMention[]
   ): void;
   ensureBinding(channelId: string, framework: string): Promise<LiveBinding>;
+  /** Designate or resume the one orchestrator bound to a product channel. */
+  ensureOrchestrator(
+    channelId: string,
+    framework?: string
+  ): Promise<LiveBinding>;
   interrupt(channelId: string, agentId: string): Promise<void>;
   respondToApproval(
     channelId: string,
@@ -202,6 +207,20 @@ export class ChannelAgentNoActiveTurnError extends Error {
   constructor(message = 'agent has no active turn') {
     super(message);
     this.name = 'ChannelAgentNoActiveTurnError';
+  }
+}
+
+export class ChannelAgentRoleConflictError extends Error {
+  constructor(
+    readonly channelId: string,
+    readonly framework: string,
+    readonly sessionId: string,
+    readonly actualRole: string
+  ) {
+    super(
+      `channel ${channelId} already binds @${framework} to session ${sessionId} with role ${actualRole}; expected orchestrator`
+    );
+    this.name = 'ChannelAgentRoleConflictError';
   }
 }
 
@@ -510,7 +529,8 @@ export function createChannelAgentBinder(
 
   async function doEnsureBinding(
     channelId: string,
-    framework: string
+    framework: string,
+    requiredRole?: 'orchestrator'
   ): Promise<LiveBinding> {
     if (closed) throw new BinderClosedError();
     const key = bindingKey(channelId, framework);
@@ -520,7 +540,17 @@ export function createChannelAgentBinder(
     const existing = live.get(key);
     if (existing?.adapter && existing.sessionId) {
       const session = healthySession(existing.sessionId, framework);
-      if (session && session.adapterV2 === existing.adapter) return existing;
+      if (session && session.adapterV2 === existing.adapter) {
+        if (requiredRole && session.role !== requiredRole) {
+          throw new ChannelAgentRoleConflictError(
+            channelId,
+            framework,
+            session.id,
+            session.role ?? 'unknown'
+          );
+        }
+        return existing;
+      }
     }
 
     // Sender attribution label (#1234): the vendor DEFAULT profile inherits the
@@ -533,6 +563,14 @@ export function createChannelAgentBinder(
     const row = store.getBinding(channelId, framework);
     const restored = healthySession(row?.sessionId ?? null, framework);
     if (restored) {
+      if (requiredRole && restored.role !== requiredRole) {
+        throw new ChannelAgentRoleConflictError(
+          channelId,
+          framework,
+          restored.id,
+          restored.role ?? 'unknown'
+        );
+      }
       return attachSession(
         channelId,
         framework,
@@ -570,6 +608,7 @@ export function createChannelAgentBinder(
         displayName,
         port: deps.port,
         configDir: deps.configDir,
+        ...(requiredRole ? { role: requiredRole } : {}),
         ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
         ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
         ...(yolo ? { permissionMode: YOLO_PERMISSION_MODE } : {}),
@@ -610,6 +649,38 @@ export function createChannelAgentBinder(
     // Store the promise BEFORE any await so two concurrent mentions of the same
     // framework in one channel single-flight to exactly one spawn.
     const promise = doEnsureBinding(channelId, framework).finally(() => {
+      inflight.delete(key);
+    });
+    inflight.set(key, promise);
+    return promise;
+  }
+
+  async function ensureOrchestrator(
+    channelId: string,
+    framework = 'claude'
+  ): Promise<LiveBinding> {
+    const key = bindingKey(channelId, framework);
+    const pending = inflight.get(key);
+    if (pending) {
+      const binding = await pending;
+      const session = binding.sessionId
+        ? healthySession(binding.sessionId, framework)
+        : null;
+      if (!session || session.role !== 'orchestrator') {
+        throw new ChannelAgentRoleConflictError(
+          channelId,
+          framework,
+          binding.sessionId ?? 'unknown',
+          session?.role ?? 'unknown'
+        );
+      }
+      return binding;
+    }
+    const promise = doEnsureBinding(
+      channelId,
+      framework,
+      'orchestrator'
+    ).finally(() => {
       inflight.delete(key);
     });
     inflight.set(key, promise);
@@ -1115,6 +1186,19 @@ export function createChannelAgentBinder(
    */
   function routeWithBrake(message: ChannelMessage, frameworks: string[]): void {
     if (frameworks.length === 0) return;
+    const sourceSession = message.source?.sessionId
+      ? deps.sessions.get(message.source.sessionId)
+      : undefined;
+    if (sourceSession?.role === 'orchestrator') {
+      // The orchestrator is the channel's Relay-managed driver, not a fan-out
+      // participant. It must keep coordinating even after worker traffic trips
+      // the brake, and its turns must not consume the worker-turn allowance.
+      // Human posts still reset the ordinary brake state below.
+      for (const framework of frameworks) {
+        routeOne(message, framework);
+      }
+      return;
+    }
     const turnKey = agentTurnBrakeKey(message);
     let state = consecutiveAgentTurns.get(message.channelId);
     if (!state) {
@@ -1264,6 +1348,7 @@ export function createChannelAgentBinder(
   return {
     handleMessagePosted,
     ensureBinding,
+    ensureOrchestrator,
     interrupt,
     respondToApproval,
     rosterForChannel,

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -123,6 +123,10 @@ export interface ChannelChatRouterDeps {
   binder?: ChannelAgentBinder | null;
   /** framework ids for @-mention resolution (v2 adapter registry + topic default). */
   knownProviderIds?: readonly string[];
+  /** Live session lookup used to authenticate privileged source attribution. */
+  getSession?: (
+    sessionId: string
+  ) => { role?: string; status?: string } | undefined;
   /** byte budget for one history response body (defaults to 4MB). */
   historyMaxBytes?: number;
   requireAuth?: RequestHandler;
@@ -315,6 +319,22 @@ function deriveSender(req: Request): ChannelSenderRef {
   return { kind: 'human', id: 'human:operator', displayName: 'Operator' };
 }
 
+/**
+ * Persistent-orchestrator credentials use their actor id as authoritative
+ * backing-session provenance. Other actor credentials stay unattributed and
+ * therefore remain subject to the ordinary agent brake.
+ */
+export function authenticatedSourceSessionId(
+  credential: ReturnType<typeof authenticatedCliGatewayActorCredential>,
+  getSession: ChannelChatRouterDeps['getSession']
+): string | undefined {
+  if (credential?.metadata?.reason !== 'persistent-orchestrator') {
+    return undefined;
+  }
+  const session = getSession?.(credential.actor.id);
+  return session?.role === 'orchestrator' ? credential.actor.id : undefined;
+}
+
 function mapStoreError(res: Response, error: unknown): void {
   if (error instanceof ChannelAttachmentStoreError) {
     const code: RelayCliGatewayErrorCode =
@@ -405,6 +425,7 @@ function postToChannel(
   input: {
     channelId: string;
     sender: ChannelSenderRef;
+    sourceSessionId?: string;
     text: string;
     format?: ChannelBodyFormat;
     parentMessageId?: string;
@@ -426,6 +447,9 @@ function postToChannel(
       : {}),
     ...(input.mentions.length ? { mentions: input.mentions } : {}),
     ...(input.parts?.length ? { parts: input.parts } : {}),
+    ...(input.sourceSessionId
+      ? { source: { sessionId: input.sourceSessionId } }
+      : {}),
   });
   store.upsertMember({
     channelId: input.channelId,
@@ -717,13 +741,20 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
 
     // [MF] Reject a client-supplied sender field outright — attribution is
     // ALWAYS server-derived from the auth lane, never forgeable from the body.
-    if ('sender' in body) {
+    if ('sender' in body || 'source' in body) {
+      const field = 'sender' in body ? 'sender' : 'source';
       sendGatewayError(
         res,
         'INVALID_ARGUMENT',
-        'sender is server-derived and must not be supplied in the request body',
+        `${field} is server-derived and must not be supplied in the request body`,
         false,
-        { field: 'sender', reasonCode: 'CHANNEL_SENDER_NOT_ALLOWED' }
+        {
+          field,
+          reasonCode:
+            field === 'sender'
+              ? 'CHANNEL_SENDER_NOT_ALLOWED'
+              : 'CHANNEL_SOURCE_NOT_ALLOWED',
+        }
       );
       return;
     }
@@ -834,6 +865,10 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         : undefined;
 
     const sender = deriveSender(req);
+    const sourceSessionId = authenticatedSourceSessionId(
+      authenticatedCliGatewayActorCredential(req),
+      deps.getSession
+    );
 
     // clientMessageId idempotency: return the existing row without re-broadcast.
     if (clientMessageId) {
@@ -860,6 +895,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       const message = postToChannel(store, deps.hub, {
         channelId: id,
         sender,
+        ...(sourceSessionId ? { sourceSessionId } : {}),
         text,
         ...(format ? { format } : {}),
         ...(parentMessageId ? { parentMessageId } : {}),

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -20,6 +20,7 @@ import {
   type ChannelMessageId,
   type ChannelMessageKind,
   type ChannelMessagePart,
+  type ChannelMessageSource,
   type ChannelMessageStatus,
   type ChannelTruncationReason,
   type ChannelSenderRef,
@@ -207,6 +208,8 @@ export interface AppendCompleteInput {
   mentions?: ChannelMention[];
   parts?: ChannelMessagePart[];
   meta?: ChannelMessageMeta;
+  /** Server-derived backing session for authenticated agent posts. */
+  source?: Pick<ChannelMessageSource, 'sessionId'>;
 }
 
 export interface BeginStreamInput {
@@ -1019,7 +1022,7 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
           : {}),
         ...(input.meta ? { extra: input.meta } : {}),
       }),
-      sourceSessionId: null,
+      sourceSessionId: input.source?.sessionId ?? null,
       sourceTurnId: null,
       sourceItemId: null,
       clientMessageId: input.clientMessageId ?? null,

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -146,6 +146,11 @@ export interface CliGatewayActorIssueInput {
   correlationId?: unknown;
 }
 
+export type PersistentOrchestratorCredentialIssueInput = Omit<
+  CliGatewayActorIssueInput,
+  'metadata'
+>;
+
 export interface CliGatewayGrantActorLifecycleInput extends CliGatewayActorIssueInput {
   grantHandle?: unknown;
   audience?: unknown;
@@ -479,13 +484,28 @@ export function cliGatewayActorFailure(input: {
   };
 }
 
-export function issueCliGatewayActorCredential(
+function credentialIssueMetadata(
+  metadata: unknown
+): Record<string, unknown> | undefined {
+  if (!isRecord(metadata)) return undefined;
+  const sanitized = { ...metadata };
+  if (sanitized['reason'] === 'persistent-orchestrator') {
+    delete sanitized['reason'];
+  }
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+function issueCliGatewayActorCredentialInternal(
   registry: ScopedActorCredentialRegistry,
-  input: CliGatewayActorIssueInput = {}
+  input: CliGatewayActorIssueInput,
+  persistentOrchestrator: boolean
 ): { token: string; credential: ScopedActorCredentialRecord } {
   const scope = coerceScope(input.scope);
   const capabilities = coerceCapabilities(input.capabilities);
   const ttlMs = typeof input.ttlMs === 'number' ? input.ttlMs : 5 * 60 * 1000;
+  const metadata = persistentOrchestrator
+    ? { reason: 'persistent-orchestrator' }
+    : credentialIssueMetadata(input.metadata);
   return registry.issue({
     actor: coerceActor(input.actor),
     issuer: coerceIssuer(input.issuer),
@@ -496,11 +516,29 @@ export function issueCliGatewayActorCredential(
     ...(typeof input.expiresAt === 'string'
       ? { expiresAt: input.expiresAt }
       : {}),
-    ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
+    ...(metadata ? { metadata } : {}),
     ...(typeof input.correlationId === 'string'
       ? { correlationId: input.correlationId }
       : {}),
   });
+}
+
+export function issueCliGatewayActorCredential(
+  registry: ScopedActorCredentialRegistry,
+  input: CliGatewayActorIssueInput = {}
+): { token: string; credential: ScopedActorCredentialRecord } {
+  return issueCliGatewayActorCredentialInternal(registry, input, false);
+}
+
+/**
+ * Trusted in-process issuer for the persistent orchestrator lease. External
+ * issue/grant inputs cannot set this security-weighted reason marker.
+ */
+export function issuePersistentOrchestratorCliGatewayActorCredential(
+  registry: ScopedActorCredentialRegistry,
+  input: PersistentOrchestratorCredentialIssueInput
+): { token: string; credential: ScopedActorCredentialRecord } {
+  return issueCliGatewayActorCredentialInternal(registry, input, true);
 }
 
 export function issueCliGatewayActorCredentialWithGrant(
@@ -510,6 +548,7 @@ export function issueCliGatewayActorCredentialWithGrant(
 ): { token: string; credential: ScopedActorCredentialRecord } {
   const request = strictGrantLifecycleRequest(input);
   const grant = validateCliGatewayLifecycleGrant(grantRegistry, request, true);
+  const metadata = credentialIssueMetadata(input.metadata);
   const issued = registry.issue({
     actor: request.actor,
     issuer: {
@@ -524,7 +563,7 @@ export function issueCliGatewayActorCredentialWithGrant(
     scope: request.scope,
     ...(request.ttlMs != null ? { ttlMs: request.ttlMs } : {}),
     ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
-    ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
+    ...(metadata ? { metadata } : {}),
     correlationId: request.correlationId,
   });
   return issued;
@@ -610,6 +649,7 @@ export function rotateCliGatewayActorCredentialWithGrant(
     actor: existing.actor,
   });
   const grant = validateCliGatewayLifecycleGrant(grantRegistry, request, true);
+  const metadata = credentialIssueMetadata(input.metadata);
   const issued = registry.issue({
     actor: existing.actor,
     issuer: {
@@ -624,7 +664,7 @@ export function rotateCliGatewayActorCredentialWithGrant(
     scope: existing.scope,
     ...(request.ttlMs != null ? { ttlMs: request.ttlMs } : {}),
     ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
-    ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
+    ...(metadata ? { metadata } : {}),
     correlationId: request.correlationId,
   });
   const revoked = registry.revoke(credentialId, {

--- a/server/index.ts
+++ b/server/index.ts
@@ -233,7 +233,11 @@ import { createWorkflowRunRouter } from './features/workflow-run-router.js';
 import { createAutomationRunRouter } from './features/automation-run-router.js';
 import { createPrOverseerRouter } from './features/pr-overseer-router.js';
 import { createAgentRosterRouter } from './features/agent-roster-router.js';
-import { buildAttentionEventInput } from '../shared/agent-roster.js';
+import {
+  AGENT_ROLES,
+  buildAttentionEventInput,
+  type AgentRole,
+} from '../shared/agent-roster.js';
 import { createWorkContextMessageRouter } from './features/work-context-message-router.js';
 import {
   initChannelMessageStore,
@@ -366,6 +370,7 @@ import {
   isCliGatewayActorTokenRequest,
   issueCliGatewayActorCredential,
   issueCliGatewayActorCredentialWithGrant,
+  issuePersistentOrchestratorCliGatewayActorCredential,
   listCliGatewayActorCredentialsWithGrant,
   revokeCliGatewayActorCredentialWithGrant,
   rotateCliGatewayActorCredentialWithGrant,
@@ -375,6 +380,7 @@ import {
   type CliGatewayActorIssueInput,
   type CliGatewayActorReadCommand,
 } from './cli-gateway-actor-auth.js';
+import { actorSessionCreateRolePolicy } from './actor-session-create-policy.js';
 import {
   RELAY_CAPABILITY_BITS,
   type RelayCapabilityBit,
@@ -2768,7 +2774,29 @@ async function main(): Promise<void> {
       Boolean(target.repoId) &&
       (credential.scope.repoIds?.length ?? 0) > 0 &&
       pathIsWithin(target.repoId!, target.path);
-    if (!hasAuthorizedPathScope && !hasAuthorizedRepoScope) {
+    const persistentOrchestratorSession =
+      credential.metadata?.reason === 'persistent-orchestrator'
+        ? sessions.get(credential.actor.id)
+        : undefined;
+    const requestedParent = compactRequestPath(
+      target.body['spawnedBySessionId']
+    );
+    const isBoundPersistentOrchestrator =
+      persistentOrchestratorSession?.mode === 'web' &&
+      persistentOrchestratorSession.role === 'orchestrator' &&
+      persistentOrchestratorSession.status === 'active' &&
+      requestedParent === credential.actor.id &&
+      [
+        persistentOrchestratorSession.cwd,
+        persistentOrchestratorSession.repoPath,
+      ]
+        .filter((root): root is string => Boolean(root))
+        .some((root) => pathIsWithin(root, target.path));
+    if (
+      !hasAuthorizedPathScope &&
+      !hasAuthorizedRepoScope &&
+      !isBoundPersistentOrchestrator
+    ) {
       sendCliGatewayActorFailure(
         res,
         cliGatewayActorFailure({ reason: 'missing_scope' })
@@ -2776,6 +2804,21 @@ async function main(): Promise<void> {
       return;
     }
     const body = target.body;
+    const rolePolicy = actorSessionCreateRolePolicy(body);
+    if (!rolePolicy.ok) {
+      res.status(403).json({
+        error: {
+          code: 'FORBIDDEN',
+          reasonCode: rolePolicy.reasonCode,
+          message:
+            'scoped CLI actors may create worker sessions only; the orchestrator role requires the browser operator lane',
+          retryable: false,
+          lane: 'denied',
+          acceptedLanes: ['browser-cookie-lane'],
+        },
+      });
+      return;
+    }
     if (body['type'] === 'terminal') {
       res.status(403).json({
         error: {
@@ -2790,15 +2833,17 @@ async function main(): Promise<void> {
       });
       return;
     }
-    const credentialSessionId = credential.scope.sessionIds?.[0];
-    const requestedParent =
+    const credentialSessionId =
+      credential.scope.sessionIds?.[0] ??
+      (isBoundPersistentOrchestrator ? credential.actor.id : undefined);
+    const requestedParentSessionId =
       typeof body['spawnedBySessionId'] === 'string'
         ? body['spawnedBySessionId']
         : undefined;
     if (
       credentialSessionId &&
-      requestedParent &&
-      requestedParent !== credentialSessionId
+      requestedParentSessionId &&
+      requestedParentSessionId !== credentialSessionId
     ) {
       sendCliGatewayActorFailure(
         res,
@@ -2837,6 +2882,13 @@ async function main(): Promise<void> {
       workerId,
       displayName: workerDisplayName,
     });
+    const persistentOrchestratorSessionId =
+      credential.metadata?.reason === 'persistent-orchestrator' &&
+      sessions.get(credential.actor.id)?.role === 'orchestrator'
+        ? credential.actor.id
+        : undefined;
+    const ownerSessionId =
+      credential.scope.sessionIds?.[0] ?? persistentOrchestratorSessionId;
     const owner = {
       kind: 'agent' as const,
       id: `agent:${credential.actor.id}`,
@@ -2846,9 +2898,7 @@ async function main(): Promise<void> {
       ...(credential.scope.nodeIds?.[0]
         ? { nodeId: credential.scope.nodeIds[0] }
         : {}),
-      ...(credential.scope.sessionIds?.[0]
-        ? { sessionId: credential.scope.sessionIds[0] }
-        : {}),
+      ...(ownerSessionId ? { sessionId: ownerSessionId } : {}),
     };
     return {
       ...workerState,
@@ -3161,6 +3211,7 @@ async function main(): Promise<void> {
       topicStore: workspaceTopicStore,
       binder: channelAgentBinder,
       knownProviderIds: Object.keys(v2Adapters),
+      getSession: (sessionId) => sessions.get(sessionId),
       requireAuth: requireCliGatewayAuth,
       requireReadActorAuth: requireCliGatewayAuthForActorCommand,
       requireWriteActorAuth: requireCliGatewayAuthForActorCommand,
@@ -3769,9 +3820,18 @@ async function main(): Promise<void> {
   });
 
   // Configure session defaults for hooks injection (startup-only — changing these requires restart)
-  sessions.configure(
-    buildSessionConfig(startupConfig, configDir, securityAuditLog)
-  );
+  sessions.configure({
+    ...buildSessionConfig(startupConfig, configDir, securityAuditLog),
+    orchestratorCredentials: {
+      issueCredential: (input) =>
+        issuePersistentOrchestratorCliGatewayActorCredential(
+          cliGatewayActorRegistry,
+          input
+        ),
+      revokeCredential: (credentialId, input) =>
+        cliGatewayActorRegistry.revoke(credentialId, input),
+    },
+  });
 
   // Mount hooks router BEFORE auth middleware — hook callbacks come from localhost Claude Code
   const hooksRouter = createHooksRouter({
@@ -5727,6 +5787,7 @@ async function main(): Promise<void> {
         type = 'agent',
         mode,
         agent,
+        role,
         yolo,
         terminalBackend,
         claudeArgs,
@@ -5752,6 +5813,7 @@ async function main(): Promise<void> {
         type?: 'agent' | 'terminal';
         mode?: 'pty' | 'web';
         agent?: AgentType;
+        role?: AgentRole;
         yolo?: boolean;
         terminalBackend?: TerminalBackend;
         claudeArgs?: string[];
@@ -5779,6 +5841,16 @@ async function main(): Promise<void> {
           repoName: string;
         };
       };
+
+      if (
+        role !== undefined &&
+        !(AGENT_ROLES as readonly string[]).includes(role)
+      ) {
+        res.status(400).json({
+          error: `role must be one of: ${AGENT_ROLES.join(', ')}`,
+        });
+        return;
+      }
 
       // Read config once for the lifetime of this request
       const freshConfig = getConfig();
@@ -5928,6 +6000,12 @@ async function main(): Promise<void> {
       // original native-Hermes launch path.
       const requestedMode =
         mode ?? (resolvedAgent === 'hermes' ? 'web' : 'pty');
+      if (role !== undefined && requestedMode !== 'web') {
+        res.status(400).json({
+          error: 'role is only supported for web agent sessions',
+        });
+        return;
+      }
       if (requestedMode === 'web') {
         const webAvailability = await validateAgentWebRuntimeAvailable(
           freshConfig,
@@ -5949,6 +6027,7 @@ async function main(): Promise<void> {
             ...(actorWorkerSessionId ? { id: actorWorkerSessionId } : {}),
             ...(spawnedBySessionId !== undefined ? { spawnedBySessionId } : {}),
             agentType: resolvedAgent,
+            ...(role !== undefined ? { role } : {}),
             cwd,
             repoPath: requestedRepoPath,
             repoName: name,

--- a/server/orchestrator-credential-lifecycle.ts
+++ b/server/orchestrator-credential-lifecycle.ts
@@ -1,0 +1,339 @@
+import {
+  DEFAULT_SCOPED_ACTOR_CREDENTIAL_MAX_TTL_MS,
+  type ScopedActorCredentialRecord,
+  type ScopedActorCredentialRegistry,
+} from '../shared/scoped-actor-credentials.js';
+import type { CliGatewayActorIssueInput } from './cli-gateway-actor-auth.js';
+
+export const ORCHESTRATOR_ACTOR_CAPABILITIES = [
+  'session:read',
+  'context:read',
+  'context:write',
+  'session:create:agent',
+] as const;
+
+export const ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS =
+  DEFAULT_SCOPED_ACTOR_CREDENTIAL_MAX_TTL_MS;
+export const ORCHESTRATOR_ACTOR_REFRESH_RATIO = 1 / 2;
+export const ORCHESTRATOR_ACTOR_REFRESH_DEADLINE_SAFETY_MS = 1_000;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface OrchestratorCredentialIssueResult {
+  token: string;
+  credential: ScopedActorCredentialRecord;
+}
+
+export interface OrchestratorCredentialLifecycleDeps {
+  issueCredential: (
+    input: Omit<CliGatewayActorIssueInput, 'metadata'>
+  ) => OrchestratorCredentialIssueResult;
+  revokeCredential: (
+    credentialId: string,
+    input: Parameters<ScopedActorCredentialRegistry['revoke']>[1]
+  ) => unknown;
+  applyRuntimeEnv: (processEnv: Record<string, string>) => Promise<void>;
+  failClosed: (error: Error) => void | Promise<void>;
+  now?: () => number;
+  setTimeout?: (callback: () => void, delayMs: number) => TimerHandle;
+  clearTimeout?: (timer: TimerHandle) => void;
+}
+
+export interface StartOrchestratorCredentialLifecycleInput {
+  sessionId: string;
+  port: number;
+  displayName?: string;
+}
+
+function publicLifecycleError(message: string): Error {
+  // Never retain the issuer/apply error as `cause`: an adapter or credential
+  // provider may include environment material in its error details.
+  return new Error(message);
+}
+
+function credentialRefreshDelay(
+  credential: ScopedActorCredentialRecord,
+  now: number
+): number | null {
+  const issuedAt = Date.parse(credential.issuedAt);
+  const expiresAt = Date.parse(credential.expiresAt);
+  const lifetime = expiresAt - issuedAt;
+  if (
+    !Number.isFinite(issuedAt) ||
+    !Number.isFinite(expiresAt) ||
+    !Number.isFinite(lifetime) ||
+    lifetime <= 0
+  ) {
+    return null;
+  }
+  return Math.max(
+    0,
+    issuedAt + lifetime * ORCHESTRATOR_ACTOR_REFRESH_RATIO - now
+  );
+}
+
+/**
+ * Runtime-only credential lease for one persistent orchestrator session.
+ *
+ * The initial credential is minted synchronously before the caller creates the
+ * adapter. Rotations are ordered mint -> runtime apply -> current swap -> old
+ * revoke, so a failed replacement never revokes the last usable credential.
+ */
+export class OrchestratorCredentialLifecycle {
+  private readonly now: () => number;
+  private readonly scheduleTimeout: (
+    callback: () => void,
+    delayMs: number
+  ) => TimerHandle;
+  private readonly cancelTimeout: (timer: TimerHandle) => void;
+  private current: OrchestratorCredentialIssueResult;
+  private timer: TimerHandle | null = null;
+  private applyDeadline: { timer: TimerHandle; cancel: () => void } | undefined;
+  private stopped = false;
+  private rotationPromise: Promise<void> | null = null;
+
+  constructor(
+    private readonly input: StartOrchestratorCredentialLifecycleInput,
+    private readonly deps: OrchestratorCredentialLifecycleDeps
+  ) {
+    this.now = deps.now ?? Date.now;
+    this.scheduleTimeout = deps.setTimeout ?? setTimeout;
+    this.cancelTimeout = deps.clearTimeout ?? clearTimeout;
+    this.current = this.issueInitial();
+    this.scheduleRefresh();
+  }
+
+  /** Initial runtime overlay; callers pass this to AdapterConfig.processEnv. */
+  get processEnv(): Record<string, string> {
+    return this.runtimeEnv(this.current.token);
+  }
+
+  /** Exposed for deterministic lifecycle tests and operator-driven recovery. */
+  refreshNow(): Promise<void> {
+    if (this.stopped) return Promise.resolve();
+    if (this.rotationPromise) return this.rotationPromise;
+    const rotation = this.rotate();
+    this.rotationPromise = rotation;
+    void rotation.finally(() => {
+      if (this.rotationPromise === rotation) this.rotationPromise = null;
+    });
+    return rotation;
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.clearRefreshTimer();
+    this.cancelApplyDeadline();
+    this.safeRevoke(this.current.credential.id, 'orchestrator-session-ended');
+  }
+
+  private issueInitial(): OrchestratorCredentialIssueResult {
+    let issued: OrchestratorCredentialIssueResult;
+    try {
+      issued = this.issue();
+    } catch {
+      throw publicLifecycleError(
+        'Failed to provision orchestrator actor credential'
+      );
+    }
+    if (credentialRefreshDelay(issued.credential, this.now()) === null) {
+      this.safeRevoke(issued.credential.id, 'invalid-credential-lifetime');
+      throw publicLifecycleError(
+        'Failed to provision orchestrator actor credential'
+      );
+    }
+    return issued;
+  }
+
+  private issue(): OrchestratorCredentialIssueResult {
+    return this.deps.issueCredential({
+      actor: {
+        type: 'agent',
+        id: this.input.sessionId,
+        ...(this.input.displayName
+          ? { displayName: this.input.displayName }
+          : {}),
+      },
+      issuer: {
+        id: 'relay-ide',
+        displayName: 'Relay',
+      },
+      capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+      ttlMs: ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS,
+    });
+  }
+
+  private scheduleRefresh(): void {
+    if (this.stopped) return;
+    const delay = credentialRefreshDelay(this.current.credential, this.now());
+    if (delay === null) {
+      this.triggerFailClosed(
+        publicLifecycleError(
+          'Orchestrator actor credential lifetime is invalid'
+        )
+      );
+      return;
+    }
+    this.clearRefreshTimer();
+    this.timer = this.scheduleTimeout(() => {
+      this.timer = null;
+      void this.refreshNow();
+    }, delay);
+    this.timer.unref?.();
+  }
+
+  private clearRefreshTimer(): void {
+    if (!this.timer) return;
+    this.cancelTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private async rotate(): Promise<void> {
+    let replacement: OrchestratorCredentialIssueResult | null = null;
+    try {
+      replacement = this.issue();
+      if (credentialRefreshDelay(replacement.credential, this.now()) === null) {
+        throw publicLifecycleError(
+          'Orchestrator actor credential lifetime is invalid'
+        );
+      }
+      if (this.stopped) {
+        this.safeRevoke(
+          replacement.credential.id,
+          'orchestrator-session-ended'
+        );
+        return;
+      }
+
+      await this.applyBeforeCurrentExpires(this.runtimeEnv(replacement.token));
+      if (this.stopped) {
+        this.safeRevoke(
+          replacement.credential.id,
+          'orchestrator-session-ended'
+        );
+        return;
+      }
+
+      const previous = this.current;
+      this.current = replacement;
+      replacement = null;
+      this.safeRevoke(previous.credential.id, 'orchestrator-token-rotated');
+      this.scheduleRefresh();
+    } catch {
+      if (replacement) {
+        this.safeRevoke(
+          replacement.credential.id,
+          'orchestrator-token-refresh-failed'
+        );
+      }
+      if (!this.stopped) {
+        this.clearRefreshTimer();
+        this.triggerFailClosed(
+          publicLifecycleError(
+            'Failed to refresh orchestrator actor credential'
+          )
+        );
+      }
+    }
+  }
+
+  private safeRevoke(credentialId: string, reason: string): void {
+    try {
+      this.deps.revokeCredential(credentialId, {
+        revokedBy: 'relay-ide',
+        reason,
+      });
+    } catch {
+      // The lease is already unusable or ending. Revocation is best effort and
+      // must never re-expose credential material through an error path.
+    }
+  }
+
+  private runtimeEnv(token: string): Record<string, string> {
+    return {
+      RELAY_IDE_ACTOR_TOKEN: token,
+      RELAY_IDE_PORT: String(this.input.port),
+      RELAY_IDE_SESSION_ID: this.input.sessionId,
+    };
+  }
+
+  private applyBeforeCurrentExpires(
+    processEnv: Record<string, string>
+  ): Promise<void> {
+    const expiresAt = Date.parse(this.current.credential.expiresAt);
+    const remainingMs =
+      expiresAt - this.now() - ORCHESTRATOR_ACTOR_REFRESH_DEADLINE_SAFETY_MS;
+    if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+      return Promise.reject(
+        publicLifecycleError(
+          'Orchestrator actor credential refresh deadline elapsed'
+        )
+      );
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (this.applyDeadline) {
+          this.cancelTimeout(this.applyDeadline.timer);
+          this.applyDeadline = undefined;
+        }
+        if (error) reject(error);
+        else resolve();
+      };
+      const timer = this.scheduleTimeout(
+        () =>
+          finish(
+            publicLifecycleError(
+              'Orchestrator actor credential refresh deadline elapsed'
+            )
+          ),
+        remainingMs
+      );
+      timer.unref?.();
+      this.applyDeadline = {
+        timer,
+        cancel: () =>
+          finish(
+            publicLifecycleError(
+              'Orchestrator actor credential refresh was cancelled'
+            )
+          ),
+      };
+      void this.deps.applyRuntimeEnv(processEnv).then(
+        () => finish(),
+        () =>
+          finish(
+            publicLifecycleError(
+              'Failed to apply orchestrator actor credential'
+            )
+          )
+      );
+    });
+  }
+
+  private cancelApplyDeadline(): void {
+    const deadline = this.applyDeadline;
+    if (!deadline) return;
+    deadline.cancel();
+  }
+
+  private triggerFailClosed(error: Error): void {
+    try {
+      void Promise.resolve(this.deps.failClosed(error)).catch(() => {});
+    } catch {
+      // The callback owns termination/reporting. A callback failure must not
+      // restart the refresh loop or surface credential-bearing internals.
+    }
+  }
+}
+
+export function startOrchestratorCredentialLifecycle(
+  input: StartOrchestratorCredentialLifecycleInput,
+  deps: OrchestratorCredentialLifecycleDeps
+): OrchestratorCredentialLifecycle {
+  return new OrchestratorCredentialLifecycle(input, deps);
+}

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -51,6 +51,11 @@ export interface ProtocolAdapterV2 {
   connect(config: AdapterConfig): Promise<void>;
   disconnect(): Promise<void>;
   /**
+   * Replace the runtime-only environment used by an owned subprocess.
+   * Implementations must prevent later queued work from using the old process.
+   */
+  refreshRuntimeEnv?(processEnv: Record<string, string>): Promise<void>;
+  /**
    * Transport-level reconnect with no state change. Tears down and re-establishes
    * the underlying connection using the same session configuration as before.
    * Use when the transport drops and you want to continue the same session state.

--- a/server/protocol-adapter.ts
+++ b/server/protocol-adapter.ts
@@ -25,6 +25,16 @@ export interface AdapterConfig {
   permissionMode?: string;
   /** Model override (e.g. 'claude-opus-4-6') */
   model?: string;
+  /**
+   * Runtime-only subprocess environment overlay. Credentials belong here, not
+   * in `extra`, because provider options are persisted with web-session state.
+   */
+  processEnv?: Record<string, string>;
+  /**
+   * Relay-authored system-prompt appendix. Adapters translate this semantic
+   * field into their provider-specific launch argument.
+   */
+  systemPromptAppendix?: string;
   /** Additional agent-specific configuration */
   extra?: Record<string, unknown>;
 }

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -615,6 +615,7 @@ export class ClaudeProtocolAdapter
   private claudeSessionId: string | null = null;
 
   private activeTurnId: string | null = null;
+  private activeTurnInput: AgentSendMessageInputV2 | null = null;
   private activeStartedAt: string | null = null;
   private turnStartedAtMs: number | null = null;
   private completedActiveTurn = false;
@@ -623,8 +624,19 @@ export class ClaudeProtocolAdapter
   private slashCommandsEmitted = false;
   private providerExtensionSeq = 0;
   private interruptSeq = 0;
+  private runtimeEnvRefreshTurnSeq = 0;
 
   private readonly queue: QueuedClaudeMessage[] = [];
+  private pendingRuntimeEnvRefresh:
+    | {
+        processEnv: Record<string, string>;
+        waiters: Array<{
+          resolve: () => void;
+          reject: (error: Error) => void;
+        }>;
+      }
+    | undefined;
+  private runtimeEnvRefreshApplying = false;
   private readonly pendingApprovals = new Map<string, PendingApproval>();
   private readonly approvalStallTimers = new Map<string, NodeJS.Timeout>();
   private readonly pendingInterrupts = new Map<string, () => void>();
@@ -750,11 +762,79 @@ export class ClaudeProtocolAdapter
     this.emitSessionUpdate({ slashCommands: RELAY_CLAUDE_COMMANDS });
   }
 
+  async refreshRuntimeEnv(processEnv: Record<string, string>): Promise<void> {
+    if (!this.config) {
+      throw new Error('Cannot refresh Claude runtime env before connect');
+    }
+    const nextEnv = { ...processEnv };
+    if (this.activeTurnId === null) {
+      await this.applyRuntimeEnvRefresh(nextEnv);
+      return;
+    }
+
+    let forceBoundary = false;
+    const applied = new Promise<void>((resolve, reject) => {
+      if (this.pendingRuntimeEnvRefresh) {
+        this.pendingRuntimeEnvRefresh.processEnv = nextEnv;
+        this.pendingRuntimeEnvRefresh.waiters.push({ resolve, reject });
+      } else {
+        this.pendingRuntimeEnvRefresh = {
+          processEnv: nextEnv,
+          waiters: [{ resolve, reject }],
+        };
+        forceBoundary = true;
+      }
+    });
+    if (forceBoundary) {
+      void this.forceRuntimeEnvRefreshBoundary().catch((error: unknown) => {
+        const refreshError =
+          error instanceof Error
+            ? error
+            : new Error('Claude runtime env refresh boundary failed');
+        this.rejectPendingRuntimeEnvRefresh(refreshError);
+        this.rejectQueued(refreshError);
+      });
+    }
+    return applied;
+  }
+
+  /**
+   * A subprocess cannot receive a replacement token mid-turn. End the current
+   * turn deliberately, put its input at the front of the queue under a fresh
+   * turn id, apply the environment while idle, then resume that work.
+   */
+  private async forceRuntimeEnvRefreshBoundary(): Promise<void> {
+    const activeTurnId = this.activeTurnId;
+    const activeInput = this.activeTurnInput;
+    if (!activeTurnId || !activeInput) {
+      this.drainQueue();
+      return;
+    }
+    const interrupted = await this.interruptTurn(
+      { turnId: activeTurnId },
+      true
+    );
+    if (interrupted) {
+      this.queue.unshift({
+        input: {
+          ...activeInput,
+          turnId: `${activeInput.turnId}-credential-refresh-${++this.runtimeEnvRefreshTurnSeq}`,
+        },
+        resolve: () => {},
+        reject: () => {},
+      });
+      this.drainQueue();
+    }
+  }
+
   protected async onDisconnect(): Promise<void> {
     this._status = 'disconnected';
     this.registry.unregister(this.registrySessionId);
 
     this.rejectQueued(new Error('Claude adapter disconnected'));
+    this.rejectPendingRuntimeEnvRefresh(
+      new Error('Claude adapter disconnected during runtime env refresh')
+    );
 
     // Auto-deny outstanding approvals before the child is killed (§7.4).
     for (const requestId of [...this.pendingApprovals.keys()]) {
@@ -772,6 +852,7 @@ export class ClaudeProtocolAdapter
     const dead = this.client;
     this.client = null;
     this.activeTurnId = null;
+    this.activeTurnInput = null;
     this.activeStartedAt = null;
     this.turnStartedAtMs = null;
     this.completedActiveTurn = false;
@@ -813,6 +894,7 @@ export class ClaudeProtocolAdapter
     const dead = this.client;
     this.client = null;
     this.activeTurnId = null;
+    this.activeTurnInput = null;
     this.activeStartedAt = null;
     this.turnStartedAtMs = null;
     this.completedActiveTurn = false;
@@ -868,7 +950,11 @@ export class ClaudeProtocolAdapter
     }
     this.lastActivityAt = Date.now();
 
-    if (this.activeTurnId !== null) {
+    if (
+      this.activeTurnId !== null ||
+      this.pendingRuntimeEnvRefresh !== undefined ||
+      this.runtimeEnvRefreshApplying
+    ) {
       return new Promise<void>((resolve, reject) => {
         this.queue.push({ input, resolve, reject });
         this.emitLiveState({
@@ -883,9 +969,16 @@ export class ClaudeProtocolAdapter
   }
 
   async interrupt(input: AgentInterruptInputV2): Promise<void> {
-    if (this.activeTurnId === null) return;
+    await this.interruptTurn(input, false);
+  }
+
+  private async interruptTurn(
+    input: AgentInterruptInputV2,
+    deferDrain: boolean
+  ): Promise<boolean> {
+    if (this.activeTurnId === null) return false;
     if (input.turnId !== undefined && input.turnId !== this.activeTurnId)
-      return;
+      return false;
 
     // Capture the turn this interrupt targets. The ack/timeout race below spans
     // an await; during that window the CLI's own `result` line for this turn can
@@ -913,22 +1006,22 @@ export class ClaudeProtocolAdapter
 
       // The targeted turn already ended on its own during the ack window — the
       // warm child (and any newly drained turn) must be left untouched.
-      if (this.activeTurnId !== targetTurnId) return;
+      if (this.activeTurnId !== targetTurnId) return false;
 
       if (outcome === 'timeout') {
         // No receipt — fall back to the SIGTERM ladder and evict (§3).
         const dead = this.client;
         this.client = null;
         if (dead) await dead.stop().catch(() => undefined);
-        if (this.activeTurnId !== targetTurnId) return;
+        if (this.activeTurnId !== targetTurnId) return false;
         this.completeActiveTurn('interrupted');
-        this.drainQueue();
-        return;
+        if (!deferDrain) this.drainQueue();
+        return true;
       }
     }
 
     // Acked (or no live child): complete as interrupted, stay warm.
-    if (this.activeTurnId !== targetTurnId) return;
+    if (this.activeTurnId !== targetTurnId) return false;
     const hasQueuedFollowUp = this.queue.length > 0;
     this.completeActiveTurn('interrupted');
     // The warm child may still flush this turn's trailing lines (its `result`,
@@ -936,7 +1029,8 @@ export class ClaudeProtocolAdapter
     // is about to drain onto the same child, suppress that stale tail so it is
     // not attributed to the next turn (§14).
     if (hasQueuedFollowUp) this.suppressInterruptedTail = true;
-    this.drainQueue();
+    if (!deferDrain) this.drainQueue();
+    return true;
   }
 
   async respondToApproval(input: AgentApprovalResponseInputV2): Promise<void> {
@@ -1047,6 +1141,7 @@ export class ClaudeProtocolAdapter
 
     const startedAt = nowIso();
     this.activeTurnId = input.turnId;
+    this.activeTurnInput = input;
     this.activeStartedAt = startedAt;
     this.turnStartedAtMs = Date.now();
     this.completedActiveTurn = false;
@@ -1256,6 +1351,9 @@ export class ClaudeProtocolAdapter
     args.push('--permission-mode', mode);
 
     if (config.model) args.push('--model', config.model);
+    if (config.systemPromptAppendix?.trim()) {
+      args.push('--append-system-prompt', config.systemPromptAppendix);
+    }
 
     const extra = isRecord(config.extra) ? config.extra : {};
     const additionalDirs = extra.additionalDirectories;
@@ -1283,7 +1381,11 @@ export class ClaudeProtocolAdapter
   }
 
   private buildEnv(): Record<string, string> {
-    const env = cleanEnv(); // strips CLAUDECODE (nesting rule)
+    const env = {
+      ...cleanEnv(),
+      ...(this.config?.processEnv ?? {}),
+    };
+    delete env.CLAUDECODE; // preserve the nesting rule across trusted overlays
     delete env.CLAUDE_CODE_ENTRYPOINT; // avoid inheriting a stale value
     return env;
   }
@@ -2358,6 +2460,7 @@ export class ClaudeProtocolAdapter
     });
 
     this.activeTurnId = null;
+    this.activeTurnInput = null;
     this.activeStartedAt = null;
     this.turnStartedAtMs = null;
     this.streamedTextItems.clear();
@@ -2382,6 +2485,26 @@ export class ClaudeProtocolAdapter
 
   private drainQueue(): void {
     if (this._status !== 'connected' || this.activeTurnId !== null) return;
+    if (this.runtimeEnvRefreshApplying) return;
+    const pendingRefresh = this.pendingRuntimeEnvRefresh;
+    if (pendingRefresh) {
+      this.pendingRuntimeEnvRefresh = undefined;
+      this.runtimeEnvRefreshApplying = true;
+      void this.applyRuntimeEnvRefresh(pendingRefresh.processEnv).then(
+        () => {
+          this.runtimeEnvRefreshApplying = false;
+          for (const waiter of pendingRefresh.waiters) waiter.resolve();
+          this.drainQueue();
+        },
+        () => {
+          this.runtimeEnvRefreshApplying = false;
+          const error = new Error('Claude runtime env refresh failed');
+          for (const waiter of pendingRefresh.waiters) waiter.reject(error);
+          this.rejectQueued(error);
+        }
+      );
+      return;
+    }
     const queued = this.queue.shift();
     if (!queued) return;
     try {
@@ -2399,6 +2522,28 @@ export class ClaudeProtocolAdapter
     const queued = this.queue.splice(0);
     for (const message of queued) message.reject(err);
     if (queued.length > 0) this.emitLiveState({ queueLength: 0 });
+  }
+
+  private async applyRuntimeEnvRefresh(
+    processEnv: Record<string, string>
+  ): Promise<void> {
+    if (!this.config) {
+      throw new Error('Cannot refresh Claude runtime env before connect');
+    }
+    this.config.processEnv = {
+      ...(this.config.processEnv ?? {}),
+      ...processEnv,
+    };
+    const dead = this.client;
+    this.client = null;
+    if (dead) await dead.stop();
+  }
+
+  private rejectPendingRuntimeEnvRefresh(error: Error): void {
+    const pending = this.pendingRuntimeEnvRefresh;
+    this.pendingRuntimeEnvRefresh = undefined;
+    if (!pending) return;
+    for (const waiter of pending.waiters) waiter.reject(error);
   }
 
   // ── Emit helpers ───────────────────────────────────────────────────────────

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -10,6 +10,7 @@ import {
   type ControlStateSummary,
 } from '../shared/control-state.js';
 import { createLogger } from './logger.js';
+import type { AgentRole } from '../shared/agent-roster.js';
 
 const logger = createLogger('relay-state-db');
 
@@ -109,6 +110,7 @@ ON CONFLICT(id) DO UPDATE SET
 export interface WebSessionMeta {
   type: string;
   agent: string;
+  role?: AgentRole;
   spawnedBySessionId?: string;
   repoName?: string;
   customCommand: string | null;
@@ -449,6 +451,7 @@ function writeUpsert(session: WebSession): void {
   const meta: WebSessionMeta = {
     type: session.type,
     agent: session.agent,
+    ...(session.role !== undefined ? { role: session.role } : {}),
     ...(session.spawnedBySessionId !== undefined
       ? { spawnedBySessionId: session.spawnedBySessionId }
       : {}),

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -113,6 +113,11 @@ import {
   type TerminalInputKey,
 } from './terminal-model-backend.js';
 import { cleanupSessionImageTempDir } from './session-image-ingress.js';
+import {
+  startOrchestratorCredentialLifecycle,
+  type OrchestratorCredentialLifecycle,
+  type OrchestratorCredentialLifecycleDeps,
+} from './orchestrator-credential-lifecycle.js';
 
 const logger = createLogger('sessions');
 
@@ -277,6 +282,17 @@ let defaultSecurityAuditSink:
   | { append(input: SecurityAuditEntryInput): unknown }
   | undefined;
 let defaultMaxScrollbackPerSessionBytes: number | undefined;
+let defaultOrchestratorCredentialAuthority:
+  | Pick<
+      OrchestratorCredentialLifecycleDeps,
+      'issueCredential' | 'revokeCredential'
+    >
+  | undefined;
+const orchestratorCredentialLeases = new Map<
+  string,
+  OrchestratorCredentialLifecycle
+>();
+const orchestratorFailClosedSessions = new Set<string>();
 
 function configure(opts: {
   port?: number;
@@ -285,6 +301,10 @@ function configure(opts: {
   interventionDebounceMs?: number;
   coDrivenAutoRevertMs?: number;
   securityAuditSink?: { append(input: SecurityAuditEntryInput): unknown };
+  orchestratorCredentials?: Pick<
+    OrchestratorCredentialLifecycleDeps,
+    'issueCredential' | 'revokeCredential'
+  >;
   /** Global scrollback cap across all sessions in bytes. Default: 4 MB. */
   maxScrollbackGlobalBytes?: number;
   /** Per-session scrollback cap in bytes. Default: 256 KB. */
@@ -296,12 +316,123 @@ function configure(opts: {
   defaultInterventionDebounceMs = opts.interventionDebounceMs;
   defaultCoDrivenAutoRevertMs = opts.coDrivenAutoRevertMs;
   defaultSecurityAuditSink = opts.securityAuditSink;
+  defaultOrchestratorCredentialAuthority = opts.orchestratorCredentials;
   if (opts.maxScrollbackGlobalBytes !== undefined) {
     globalScrollbackCapBytes = opts.maxScrollbackGlobalBytes;
   }
   if (opts.maxScrollbackPerSessionBytes !== undefined) {
     defaultMaxScrollbackPerSessionBytes = opts.maxScrollbackPerSessionBytes;
   }
+}
+
+function stopOrchestratorCredentialLease(sessionId: string): void {
+  const lease = orchestratorCredentialLeases.get(sessionId);
+  if (!lease) return;
+  orchestratorCredentialLeases.delete(sessionId);
+  lease.stop();
+}
+
+function orchestratorRuntimeIsDisconnected(session: WebSession): boolean {
+  if (
+    session.status === 'disconnected' ||
+    session.agentSessionV2.live.status === 'disconnected'
+  ) {
+    return true;
+  }
+  // Restore creates the durable wrapper before connecting its adapter. That
+  // one fenced pre-connect state is not a runtime loss; every other
+  // disconnected adapter state ends the privileged lease.
+  return (
+    session.adapterV2.status === 'disconnected' &&
+    session.restoreState !== 'restoring'
+  );
+}
+
+function failClosedOrchestratorSession(sessionId: string): void {
+  if (orchestratorFailClosedSessions.has(sessionId)) return;
+  orchestratorFailClosedSessions.add(sessionId);
+  try {
+    if (sessions.has(sessionId)) kill(sessionId);
+  } finally {
+    orchestratorFailClosedSessions.delete(sessionId);
+  }
+}
+
+function prepareOrchestratorWebCreate(params: CreateWebParams): {
+  params: CreateWebParams;
+  lease?: OrchestratorCredentialLifecycle;
+} {
+  if (params.role !== 'orchestrator') return { params };
+
+  const authority = defaultOrchestratorCredentialAuthority;
+  if (!authority) {
+    throw new Error(
+      'Orchestrator actor credential authority is not configured'
+    );
+  }
+  const id = params.id ?? crypto.randomBytes(8).toString('hex');
+  if (orchestratorCredentialLeases.has(id)) {
+    throw new Error(`Orchestrator credential lease already exists for ${id}`);
+  }
+  const lease = startOrchestratorCredentialLifecycle(
+    {
+      sessionId: id,
+      port: params.port,
+      ...(params.displayName ? { displayName: params.displayName } : {}),
+    },
+    {
+      ...authority,
+      applyRuntimeEnv: async (processEnv) => {
+        const session = sessions.get(id);
+        if (
+          session?.mode !== 'web' ||
+          session.role !== 'orchestrator' ||
+          orchestratorRuntimeIsDisconnected(session)
+        ) {
+          stopOrchestratorCredentialLease(id);
+          throw new Error(
+            'Orchestrator session unavailable during credential refresh'
+          );
+        }
+        const refreshRuntimeEnv = session.adapterV2.refreshRuntimeEnv;
+        if (!refreshRuntimeEnv) {
+          throw new Error(
+            'Orchestrator adapter cannot refresh its runtime environment'
+          );
+        }
+        await refreshRuntimeEnv.call(session.adapterV2, processEnv);
+      },
+      failClosed: () => failClosedOrchestratorSession(id),
+    }
+  );
+  return {
+    params: {
+      ...params,
+      id,
+      processEnv: {
+        ...(params.processEnv ?? {}),
+        ...lease.processEnv,
+      },
+    },
+    lease,
+  };
+}
+
+function retainOrchestratorCredentialLease(
+  sessionId: string,
+  lease: OrchestratorCredentialLifecycle | undefined
+): void {
+  if (!lease) return;
+  const session = sessions.get(sessionId);
+  if (
+    session?.mode !== 'web' ||
+    session.role !== 'orchestrator' ||
+    orchestratorRuntimeIsDisconnected(session)
+  ) {
+    lease.stop();
+    return;
+  }
+  orchestratorCredentialLeases.set(sessionId, lease);
 }
 
 function withLocalIdentity<T extends SessionSummary>(
@@ -596,6 +727,12 @@ export function onBackendStateChange(cb: BackendStateChangeCallback): void {
 }
 
 export function fireBackendStateIfChanged(session: Session): void {
+  if (
+    session.mode === 'web' &&
+    orchestratorRuntimeIsDisconnected(session)
+  ) {
+    stopOrchestratorCredentialLease(session.id);
+  }
   const newState = computeBackendState(session);
 
   let permissionType: 'approval' | 'question' | undefined;
@@ -1075,6 +1212,7 @@ function list(): SessionSummary[] {
           : {}),
         type: s.type,
         agent: s.agent,
+        ...(s.role !== undefined ? { role: s.role } : {}),
         mode: s.mode,
         ...(s.repoPath ? { repoPath: s.repoPath } : {}),
         ...(s.worktreePath !== undefined
@@ -1178,6 +1316,7 @@ function kill(id: string): void {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
+  stopOrchestratorCredentialLease(id);
   if (session.mode === 'pty') {
     void terminatePtySession(session, 'explicit-session-kill');
   } else {
@@ -1227,6 +1366,7 @@ function detachForRestart(id: string): void {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
+  stopOrchestratorCredentialLease(id);
   if (session.mode === 'pty') {
     session.preserveRuntimeFilesOnExit = true;
     try {
@@ -2078,6 +2218,7 @@ async function restoreWebSessionFromDb(
       ? { spawnedBySessionId: row.meta.spawnedBySessionId }
       : {}),
     agentType: row.meta.adapterType,
+    ...(row.meta.role !== undefined ? { role: row.meta.role } : {}),
     cwd: row.cwd,
     ...(restoredRepoPath !== undefined
       ? {
@@ -2112,12 +2253,22 @@ async function restoreWebSessionFromDb(
   // persisted DB row with a freshly-initialized blank transcript before we
   // copy back agentSessionV2 below — a process death in that window would
   // lose the session.
-  const { session, config } = await createWebSession(
-    createParams,
-    sessions,
-    fireBackendStateIfChanged,
-    { skipInitialPersist: true, deferConnect: true }
-  );
+  const preparedCreate = prepareOrchestratorWebCreate(createParams);
+  let created: Awaited<ReturnType<typeof createWebSession>>;
+  try {
+    created = await createWebSession(
+      preparedCreate.params,
+      sessions,
+      fireBackendStateIfChanged,
+      { skipInitialPersist: true, deferConnect: true }
+    );
+  } catch (error) {
+    preparedCreate.lease?.stop();
+    throw error;
+  }
+  const { session, config } = created;
+  session.restoreState = 'restoring';
+  retainOrchestratorCredentialLease(session.id, preparedCreate.lease);
 
   // Replace the freshly-created blank transcript with the persisted one.
   const persistedAgentSessionV2 = structuredClone(row.agentSessionV2);
@@ -2137,7 +2288,6 @@ async function restoreWebSessionFromDb(
   session.createdAt = new Date(row.createdAt).toISOString();
   session.lastActivity = new Date(row.lastActivity).toISOString();
   session.status = row.status === 'archived' ? 'disconnected' : row.status;
-  session.restoreState = 'restoring';
 
   // Derive runtime state from the persisted live snapshot, mirroring the
   // mapping in web-session-handler's adapter listener.
@@ -2754,11 +2904,19 @@ async function populateMetaCache(): Promise<void> {
 async function createWeb(
   params: CreateWebParams
 ): Promise<{ session: WebSession }> {
-  const result = await createWebSession(
-    params,
-    sessions,
-    fireBackendStateIfChanged
-  );
+  const preparedCreate = prepareOrchestratorWebCreate(params);
+  let result: Awaited<ReturnType<typeof createWebSession>>;
+  try {
+    result = await createWebSession(
+      preparedCreate.params,
+      sessions,
+      fireBackendStateIfChanged
+    );
+  } catch (error) {
+    preparedCreate.lease?.stop();
+    throw error;
+  }
+  retainOrchestratorCredentialLease(result.session.id, preparedCreate.lease);
   if (result.session.sessionEnvelope) {
     sessionEnvelopeRegistry.upsert(result.session.sessionEnvelope);
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -33,7 +33,10 @@ import type { SessionDurabilityState } from '../shared/session-durability.js';
 // Runtime value import (#955): the single shared authoring source for the
 // launch-time collaboration system-prompt appendix. `shared/agent-roster.ts`
 // has no `server/` imports, so this stays a one-way, cycle-free dependency.
-import { collaborationPromptAppendix } from '../shared/agent-roster.js';
+import {
+  collaborationPromptAppendix,
+  type AgentRole,
+} from '../shared/agent-roster.js';
 import type { TerminalModelBackend } from './terminal-model-backend.js';
 
 export type AgentState =
@@ -304,7 +307,8 @@ export const AGENT_YOLO_ARGS: Record<string, string[]> = Object.fromEntries(
  * never enters serialized session state.
  */
 export function collaborationPromptArgsForFramework(
-  framework: AgentFramework
+  framework: AgentFramework,
+  role?: AgentRole
 ): string[] {
   if (
     !framework.capabilities.supportsCollaborationPrompt ||
@@ -314,7 +318,10 @@ export function collaborationPromptArgsForFramework(
   }
   return [
     framework.collaborationPromptArg,
-    collaborationPromptAppendix({ provider: framework.id }),
+    collaborationPromptAppendix({
+      provider: framework.id,
+      ...(role ? { role } : {}),
+    }),
   ];
 }
 
@@ -331,6 +338,8 @@ interface BaseSession {
   nodeId?: NodeId;
   type: SessionType;
   agent: AgentType;
+  /** Durable collaboration role. A hint for routing/UI, not authorization. */
+  role?: AgentRole;
   mode: SessionMode;
   /**
    * Filesystem path of the repo this session is bound to. Omitted for
@@ -453,6 +462,8 @@ export interface SessionSummary {
   spawnedBySessionId?: string;
   type: SessionType;
   agent: AgentType;
+  /** Durable collaboration role. A hint for routing/UI, not authorization. */
+  role?: AgentRole;
   mode: SessionMode;
   /**
    * Filesystem path of the repo this session is bound to. Optional so

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -22,6 +22,11 @@ import {
   type ControlStateSummary,
 } from '../shared/control-state.js';
 import { createLocalCompatibilitySessionEnvelope } from '../shared/session-envelope.js';
+import {
+  collaborationPromptAppendix,
+  roleForAgent,
+  type AgentRole,
+} from '../shared/agent-roster.js';
 
 const logger = createLogger('web-session');
 const restoreSnapshotFencedAdapters = new WeakSet<ProtocolAdapterV2>();
@@ -79,6 +84,8 @@ export interface CreateWebParams {
   id?: string;
   spawnedBySessionId?: string;
   agentType: string;
+  role?: AgentRole;
+  roleOverrides?: Readonly<Record<string, AgentRole>>;
   cwd: string;
   repoPath?: string | undefined;
   repoName?: string | undefined;
@@ -89,6 +96,8 @@ export interface CreateWebParams {
   configDir: string;
   permissionMode?: string;
   model?: string;
+  /** Runtime-only subprocess env; never copied into persisted provider options. */
+  processEnv?: Record<string, string>;
   sessionLane?: SessionLane | undefined;
   workspaceId?: string;
   additionalDirs?: string[];
@@ -110,6 +119,13 @@ export async function createWebSession(
   const activeRuntime = adapterV2;
   const hookToken = params.hookToken ?? crypto.randomBytes(16).toString('hex');
   const createdAt = new Date().toISOString();
+  const displayRole =
+    params.role ?? roleForAgent(params.agentType, params.roleOverrides);
+  if (params.role === 'orchestrator' && !adapterV2.refreshRuntimeEnv) {
+    throw new Error(
+      `Agent adapter ${params.agentType} does not support orchestrator credential refresh`
+    );
+  }
   const normalizedControlState = normalizeControlStateSummary(
     params.controlState ?? createLegacyControlStateSummary()
   );
@@ -123,6 +139,7 @@ export async function createWebSession(
     nodeId: DEFAULT_LOCAL_NODE_ID,
     type: 'agent',
     agent: params.agentType as AgentType,
+    ...(params.role !== undefined ? { role: params.role } : {}),
     ...(params.repoPath ? { repoPath: params.repoPath } : {}),
     ...(params.repoPath ? { worktreePath: params.worktreePath ?? null } : {}),
     cwd: params.cwd,
@@ -202,6 +219,13 @@ export async function createWebSession(
     sessionId: id,
     hookToken,
     configDir: params.configDir,
+    systemPromptAppendix: collaborationPromptAppendix({
+      provider: params.agentType,
+      role: displayRole,
+    }),
+    ...(params.processEnv !== undefined
+      ? { processEnv: { ...params.processEnv } }
+      : {}),
     ...(params.permissionMode !== undefined
       ? { permissionMode: params.permissionMode }
       : {}),

--- a/shared/agent-roster.ts
+++ b/shared/agent-roster.ts
@@ -198,6 +198,7 @@ export interface RosterSessionInput {
   globalSessionId?: string | undefined;
   nodeId?: string | undefined;
   agent?: string | undefined;
+  role?: AgentRole | undefined;
   type?: string | undefined;
   displayName?: string | undefined;
   repoPath?: string | undefined;
@@ -255,7 +256,7 @@ export function projectRosterEntry(
     ...(session.nodeId ? { nodeId: session.nodeId } : {}),
     provider,
     sessionType: session.type ?? 'agent',
-    role: roleForAgent(provider, extras.roleOverrides),
+    role: session.role ?? roleForAgent(provider, extras.roleOverrides),
     displayName: session.displayName ?? session.id,
     ...(session.repoPath ? { repoPath: session.repoPath } : {}),
     ...(session.repoName ? { repoName: session.repoName } : {}),
@@ -352,7 +353,7 @@ export function buildAttentionEventInput(
       pendingInboxCount: attention.pendingInboxCount,
       ...(opts.permissionType ? { permissionType: opts.permissionType } : {}),
       provider,
-      role: roleForAgent(provider, opts.roleOverrides),
+      role: session.role ?? roleForAgent(provider, opts.roleOverrides),
       sessionType: session.type ?? 'agent',
       ...(session.repoName ? { repoName: session.repoName } : {}),
       ...(session.branchName ? { branchName: session.branchName } : {}),
@@ -385,6 +386,18 @@ export function collaborationPromptAppendix(
   } = {}
 ): string {
   const role = input.role ?? roleForAgent(input.provider);
+  if (role === 'orchestrator') {
+    return [
+      'You are the operator’s Relay-managed orchestrator in a product channel.',
+      '',
+      '- Coordinate implementation workers; do not perform every task yourself.',
+      '- Narrate decisions and summarize progress with `relay-ide v1 channels post --json`.',
+      '- Spawn a worker into an implementation channel with `relay-ide v1 sessions create --json`, then steer it with an explicit `@mention`.',
+      '- Watch worker state with `relay-ide v1 roster list --json` and `relay-ide v1 events subscribe --topic attention --json`.',
+      '- Keep fan-out ownership and pending work in your own conversation context; Relay preserves session lineage.',
+      '- Keep every routed reply explicitly addressed to its intended operator or agent.',
+    ].join('\n');
+  }
   return [
     `You are a Relay-managed agent session (role: ${role}). You are not an isolated terminal — other agents and operators can see and message you through Relay. Use Relay's CLI gateway to collaborate instead of polling:`,
     '',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -98,6 +98,7 @@ export type RelayCliGatewayCommand =
   | 'workspace-topics.create'
   | 'workspace-topics.update'
   | 'workspace-topics.archive'
+  | 'channels.post'
   | 'roster.list'
   | 'roster.register'
   | 'roster.updateSelf'
@@ -680,6 +681,7 @@ const sessionDescriptorSchema: RelayJsonSchema = {
     spawnedBySessionId: stringSchema,
     type: { type: 'string', enum: ['agent', 'terminal'] },
     agent: stringSchema,
+    role: { type: 'string', enum: [...AGENT_ROLES] },
     mode: { type: 'string', enum: ['pty', 'web'] },
     nodeId: stringSchema,
     globalSessionId: stringSchema,
@@ -1366,6 +1368,12 @@ const createSessionInputSchema: RelayJsonSchema = {
     type: { type: 'string', enum: ['agent', 'terminal'], default: 'agent' },
     mode: { type: 'string', enum: ['pty', 'web'] },
     agent: stringSchema,
+    role: {
+      type: 'string',
+      enum: [...AGENT_ROLES],
+      description:
+        'Collaboration role for a web agent session. The orchestrator role is operator-designated and cannot be self-assigned by an actor-created worker.',
+    },
     yolo: booleanSchema,
     cols: { type: 'number', minimum: 1, maximum: 500 },
     rows: { type: 'number', minimum: 1, maximum: 200 },
@@ -3720,6 +3728,50 @@ const cockpitGetOutputDataSchema: RelayJsonSchema = {
     },
   },
   required: ['generatedAt', 'selector', 'item', 'actionHints', 'readFirst'],
+};
+
+const channelMessagePartSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    type: { const: 'image' },
+    id: stringSchema,
+    mime: {
+      type: 'string',
+      enum: ['image/png', 'image/jpeg', 'image/webp', 'image/gif'],
+    },
+    w: { type: 'number' },
+    h: { type: 'number' },
+    bytes: { type: 'number' },
+    alt: stringSchema,
+  },
+  required: ['type', 'id', 'mime', 'w', 'h', 'bytes'],
+};
+
+const channelPostInputSchema: RelayJsonSchema = {
+  title: 'ChannelsPostInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    channelId: stringSchema,
+    text: stringSchema,
+    format: { type: 'string', enum: ['markdown', 'text'] },
+    parentMessageId: stringSchema,
+    threadId: nullableStringSchema,
+    clientMessageId: stringSchema,
+    parts: { type: 'array', items: channelMessagePartSchema },
+  },
+  required: ['channelId', 'text'],
+};
+
+const channelPostOutputDataSchema: RelayJsonSchema = {
+  title: 'ChannelsPostData',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    message: { type: 'object', additionalProperties: true },
+  },
+  required: ['message'],
 };
 
 const okOutput = (title: string, data: RelayJsonSchema): RelayJsonSchema => ({
@@ -6904,6 +6956,35 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'SESSION_CONFLICT',
       'SERVER_UNAVAILABLE',
       'INTERNAL',
+    ],
+  },
+  {
+    name: 'channels.post',
+    cli: [
+      'relay-ide',
+      'v1',
+      'channels',
+      'post',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
+    summary:
+      'Post a human- or agent-attributed message to a product channel; sender and source are always derived by the server.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:write'],
+    inputSchema: channelPostInputSchema,
+    outputSchema: okOutput('ChannelsPostOutput', channelPostOutputDataSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'SESSION_CONFLICT',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
     ],
   },
   {

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -3,6 +3,7 @@ import type {
   RelayCliGatewayError,
   RelayCliGatewayErrorCode,
 } from './cli-gateway-contract.js';
+import { AGENT_ROLES } from './agent-roster.js';
 
 export interface GatewayCreateValidationOk {
   ok: true;
@@ -29,6 +30,7 @@ const createSessionAllowedFields = new Set([
   'type',
   'mode',
   'agent',
+  'role',
   'yolo',
   'terminalBackend',
   'cols',
@@ -77,6 +79,7 @@ const stringFields = [
   'repoPath',
   'cwd',
   'agent',
+  'role',
   'terminalBackend',
   'branchName',
   'displayName',
@@ -102,6 +105,7 @@ const localCreateSupportedFields = [
   'type',
   'mode',
   'agent',
+  'role',
   'yolo',
   'terminalBackend',
   'cols',
@@ -468,6 +472,15 @@ function validateCreateEnums(
     return invalidCreateInput('sessions.create mode must be pty or web', {
       field: 'mode',
     });
+  }
+  if (
+    input['role'] !== undefined &&
+    !(AGENT_ROLES as readonly unknown[]).includes(input['role'])
+  ) {
+    return invalidCreateInput(
+      `sessions.create role must be one of: ${AGENT_ROLES.join(', ')}`,
+      { field: 'role' }
+    );
   }
   if (
     input['terminalBackend'] !== undefined &&

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -169,6 +169,7 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'workspace-topics.create': 'create workspace topic',
   'workspace-topics.update': 'update workspace topic',
   'workspace-topics.archive': 'archive workspace topic',
+  'channels.post': 'post channel message',
   'roster.list': 'list active agent roster',
   'roster.register': 'register self-declared agent presence',
   'roster.updateSelf': 'update self-declared agent presence',
@@ -253,6 +254,7 @@ const WRITE_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
   'workspace-surfaces.publish',
   'workspace-topics.create',
   'workspace-topics.update',
+  'channels.post',
   'repos.add',
   'workspaces.launch',
   'worktrees.create',
@@ -313,6 +315,7 @@ function scopeKindsForGatewayCommand(
   if (name.startsWith('cockpit.') || name.startsWith('orchestration-runs.'))
     return ['work-context', 'session'];
   if (name.startsWith('context.')) return ['work-context', 'session'];
+  if (name.startsWith('channels.')) return ['work-context', 'session'];
   if (name.startsWith('inbox.')) return ['session', 'work-context'];
   if (name.startsWith('handoffs.'))
     return ['repo', 'worktree', 'work-context', 'session'];

--- a/test/actor-session-create-policy.test.ts
+++ b/test/actor-session-create-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  actorSessionCreateRolePolicy,
+  CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED,
+} from '../server/actor-session-create-policy.js';
+
+describe('actor session create role policy', () => {
+  it.each(['hermes', 'codex', 'claude'])(
+    'allows %s as a normal worker when no durable role is explicit',
+    (agent) => {
+      expect(
+        actorSessionCreateRolePolicy({ agent, mode: 'web' })
+      ).toEqual({
+        ok: true,
+        explicitRole: undefined,
+      });
+    }
+  );
+
+  it('denies an explicit durable orchestrator role', () => {
+    expect(
+      actorSessionCreateRolePolicy({
+        agent: 'hermes',
+        mode: 'web',
+        role: 'orchestrator',
+      })
+    ).toEqual({
+      ok: false,
+      explicitRole: 'orchestrator',
+      reasonCode: CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED,
+    });
+  });
+});

--- a/test/agent-collaboration-prompt.test.ts
+++ b/test/agent-collaboration-prompt.test.ts
@@ -60,6 +60,21 @@ describe('collaborationPromptArgsForFramework (#955)', () => {
     }
   });
 
+  it('threads an explicit orchestrator role into the shared appendix', () => {
+    const args = collaborationPromptArgsForFramework(
+      BUILTIN_FRAMEWORKS.claude,
+      'orchestrator'
+    );
+    expect(args).toEqual([
+      '--append-system-prompt',
+      collaborationPromptAppendix({
+        provider: 'claude',
+        role: 'orchestrator',
+      }),
+    ]);
+    expect(args[1]).toContain('product channel');
+  });
+
   it('embeds no raw transcripts/secrets/provider-store paths in the prompt', () => {
     const appendix = collaborationPromptArgsForFramework(
       BUILTIN_FRAMEWORKS.claude

--- a/test/agent-roster.test.ts
+++ b/test/agent-roster.test.ts
@@ -133,6 +133,14 @@ describe('projectRosterEntry', () => {
     ]);
   });
 
+  it('prefers a durable per-session role over the provider default', () => {
+    const entry = projectRosterEntry({
+      ...session,
+      role: 'orchestrator',
+    });
+    expect(entry.role).toBe('orchestrator');
+  });
+
   it('is redaction-safe — never carries transcript/prompt/env/token fields', () => {
     const entry = projectRosterEntry(
       {
@@ -193,5 +201,21 @@ describe('collaborationPromptAppendix', () => {
     expect(text).toContain('events subscribe --topic attention');
     expect(text.toLowerCase()).not.toContain('tmux');
     expect(text.toLowerCase()).not.toContain('pty');
+  });
+
+  it('provides a concise orchestrator playbook without inaccessible inbox subscription guidance', () => {
+    const text = collaborationPromptAppendix({
+      provider: 'claude',
+      role: 'orchestrator',
+    });
+    expect(text).toContain('product channel');
+    expect(text).toContain('relay-ide v1 channels post');
+    expect(text).toContain('relay-ide v1 sessions create');
+    expect(text).toContain('explicit `@mention`');
+    expect(text).toContain('relay-ide v1 roster list');
+    expect(text).toContain('events subscribe --topic attention');
+    expect(text).toContain('own conversation context');
+    expect(text).toContain('explicitly addressed');
+    expect(text).not.toContain('events subscribe --topic inbox');
   });
 });

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -15,6 +15,7 @@ import {
   type ProtocolAdapterV2,
 } from '../server/protocol-adapter-v2.js';
 import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
+import type { AgentRole } from '../shared/agent-roster.js';
 import {
   createChannelMessageStore,
   type ChannelMessageStore,
@@ -57,6 +58,12 @@ const AGENT_SENDER: ChannelSenderRef = {
   id: 'agent:orchestrator',
   providerId: 'orchestrator',
   displayName: 'orchestrator',
+};
+const CLAUDE_AGENT_SENDER: ChannelSenderRef = {
+  kind: 'agent',
+  id: 'agent-profile:claude:default',
+  providerId: 'claude',
+  displayName: 'Claude',
 };
 
 function makeStore(): { store: ChannelMessageStore; hub: ChannelHub } {
@@ -124,13 +131,15 @@ function postAgentTurnRow(
   turnId: string,
   itemId: string,
   text: string,
-  knownIds: string[]
+  knownIds: string[],
+  sessionId = 'session:orchestrator',
+  sender: ChannelSenderRef = AGENT_SENDER
 ): ChannelMessage {
   const mentions = parseMentions(text, knownIds);
   const stream = store.beginStream({
     channelId: CH,
-    sender: AGENT_SENDER,
-    source: { sessionId: 'session:orchestrator', turnId, itemId },
+    sender,
+    source: { sessionId, turnId, itemId },
     ...(mentions.length ? { mentions } : {}),
   });
   const message = store.finalizeStream(stream.id, {
@@ -764,6 +773,12 @@ interface SessionsHarness {
   adapterFor: (sessionId: string) => ProtocolAdapterV2;
   fireEnd: (sessionId: string) => void;
   forgetWithoutEnd: (sessionId: string) => void;
+  registerSourceSession: (sessionId: string, role: AgentRole) => void;
+  registerRestoredWebSession: (
+    sessionId: string,
+    agentType: string,
+    role: AgentRole
+  ) => Promise<void>;
   lastCreateParams: () => CreateWebParams | undefined;
 }
 
@@ -797,6 +812,7 @@ function makeSessions(
         id,
         mode: 'web',
         agent: params.agentType,
+        ...(params.role !== undefined ? { role: params.role } : {}),
         adapterV2: adapter,
         cwd: params.cwd,
       } as unknown as WebSession;
@@ -826,6 +842,31 @@ function makeSessions(
     },
     forgetWithoutEnd: (id) => {
       created.delete(id);
+    },
+    registerSourceSession: (id, role) => {
+      created.set(id, {
+        session: { id, role } as unknown as WebSession,
+      });
+    },
+    registerRestoredWebSession: async (id, agentType, role) => {
+      const adapter = build(agentType);
+      await adapter.connect({
+        cwd: '/tmp',
+        port: 0,
+        sessionId: id,
+        hookToken: 't',
+        configDir: '/tmp',
+      });
+      created.set(id, {
+        session: {
+          id,
+          mode: 'web',
+          agent: agentType,
+          role,
+          adapterV2: adapter,
+          cwd: '/tmp',
+        } as unknown as WebSession,
+      });
     },
     lastCreateParams: () => lastParams,
   };
@@ -882,6 +923,72 @@ function makeBinder(cfg: {
 // ── tests ────────────────────────────────────────────────────────────────────
 
 describe('channel-agent-binder — lifecycle', () => {
+  it('designates an orchestrator without submitting a turn', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+
+    const binding = await binder.ensureOrchestrator(CH, 'mock');
+
+    expect(binding.sessionId).toBe(sessions.firstSessionId());
+    expect(sessions.lastCreateParams()).toMatchObject({
+      agentType: 'mock',
+      role: 'orchestrator',
+    });
+    expect(agentReplies(store)).toHaveLength(0);
+  });
+
+  it('reuses a restored orchestrator binding', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const sessionId = 'session:restored-driver';
+    await sessions.registerRestoredWebSession(
+      sessionId,
+      'mock',
+      'orchestrator'
+    );
+    store.upsertBinding({
+      channelId: CH,
+      agentFramework: 'mock',
+      sessionId,
+    });
+
+    const binding = await binder.ensureOrchestrator(CH, 'mock');
+
+    expect(binding.sessionId).toBe(sessionId);
+    expect(sessions.spawns()).toBe(0);
+  });
+
+  it('rejects a restored healthy non-orchestrator binding', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const sessionId = 'session:restored-worker';
+    await sessions.registerRestoredWebSession(
+      sessionId,
+      'mock',
+      'implementer'
+    );
+    store.upsertBinding({
+      channelId: CH,
+      agentFramework: 'mock',
+      sessionId,
+    });
+
+    await expect(binder.ensureOrchestrator(CH, 'mock')).rejects.toThrow(
+      /already binds @mock.*role implementer/
+    );
+    expect(sessions.spawns()).toBe(0);
+    expect(store.getBinding(CH, 'mock')?.sessionId).toBe(sessionId);
+  });
+
   it('first mention spawns exactly one session and streams the reply as agent:mock', async () => {
     const { binder, store, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
@@ -1533,6 +1640,206 @@ describe('channel-agent-binder — delivery + idempotency', () => {
 });
 
 describe('channel-agent-binder — agent-to-agent brake', () => {
+  it('does not grant the brake exemption from a self-declared orchestrator presence role', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+
+    for (let index = 0; index < MAX_CONSECUTIVE_AGENT_TURNS; index += 1) {
+      postAgentTurnRow(
+        store,
+        binder,
+        `self-declared-${index}`,
+        'item-0',
+        `@mock self-declared orchestrator ${index}`,
+        ['mock'],
+        'session:not-registered',
+        AGENT_SENDER
+      );
+    }
+    await waitFor(
+      () => agentReplies(store, 'mock').length === MAX_CONSECUTIVE_AGENT_TURNS
+    );
+
+    postAgentTurnRow(
+      store,
+      binder,
+      'self-declared-cap',
+      'item-0',
+      '@mock should be braked',
+      ['mock'],
+      'session:not-registered',
+      AGENT_SENDER
+    );
+    await waitFor(() =>
+      systemRows(store).some((message) =>
+        message.body.text.includes('Mention chain paused')
+      )
+    );
+    expect(agentReplies(store, 'mock')).toHaveLength(
+      MAX_CONSECUTIVE_AGENT_TURNS
+    );
+  });
+
+  it('does not charge orchestrator turns against the worker-turn allowance', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const driverSessionId = 'session:driver';
+    const workerSessionId = 'session:worker';
+    sessions.registerSourceSession(driverSessionId, 'orchestrator');
+    sessions.registerSourceSession(workerSessionId, 'implementer');
+
+    for (let index = 0; index < MAX_CONSECUTIVE_AGENT_TURNS + 1; index += 1) {
+      postAgentTurnRow(
+        store,
+        binder,
+        `driver-turn-${index}`,
+        'item-0',
+        `@mock coordinate ${index}`,
+        ['mock'],
+        driverSessionId,
+        CLAUDE_AGENT_SENDER
+      );
+    }
+    await waitFor(
+      () =>
+        agentReplies(store, 'mock').length ===
+        MAX_CONSECUTIVE_AGENT_TURNS + 1
+    );
+    expect(
+      systemRows(store).filter((message) =>
+        message.body.text.includes('Mention chain paused')
+      )
+    ).toHaveLength(0);
+
+    for (let index = 0; index < MAX_CONSECUTIVE_AGENT_TURNS; index += 1) {
+      postAgentTurnRow(
+        store,
+        binder,
+        `worker-turn-${index}`,
+        'item-0',
+        `@mock worker ${index}`,
+        ['mock'],
+        workerSessionId,
+        AGENT_SENDER
+      );
+    }
+    await waitFor(
+      () =>
+        agentReplies(store, 'mock').length ===
+        MAX_CONSECUTIVE_AGENT_TURNS * 2 + 1
+    );
+    postAgentTurnRow(
+      store,
+      binder,
+      'worker-turn-cap',
+      'item-0',
+      '@mock worker cap',
+      ['mock'],
+      workerSessionId,
+      AGENT_SENDER
+    );
+    await waitFor(() =>
+      systemRows(store).some((message) =>
+        message.body.text.includes('Mention chain paused')
+      )
+    );
+    expect(agentReplies(store, 'mock')).toHaveLength(
+      MAX_CONSECUTIVE_AGENT_TURNS * 2 + 1
+    );
+  });
+
+  it('lets the orchestrator route through a paused brake while human reset restores workers', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const driverSessionId = 'session:driver';
+    const workerSessionId = 'session:worker';
+    sessions.registerSourceSession(driverSessionId, 'orchestrator');
+    sessions.registerSourceSession(workerSessionId, 'implementer');
+
+    for (let index = 0; index < MAX_CONSECUTIVE_AGENT_TURNS; index += 1) {
+      postAgentTurnRow(
+        store,
+        binder,
+        `worker-pause-${index}`,
+        'item-0',
+        `@mock worker ${index}`,
+        ['mock'],
+        workerSessionId,
+        AGENT_SENDER
+      );
+    }
+    await waitFor(
+      () => agentReplies(store, 'mock').length === MAX_CONSECUTIVE_AGENT_TURNS
+    );
+    postAgentTurnRow(
+      store,
+      binder,
+      'worker-pause-cap',
+      'item-0',
+      '@mock pause',
+      ['mock'],
+      workerSessionId,
+      AGENT_SENDER
+    );
+    await waitFor(() =>
+      systemRows(store).some((message) =>
+        message.body.text.includes('Mention chain paused')
+      )
+    );
+
+    postAgentTurnRow(
+      store,
+      binder,
+      'driver-after-pause',
+      'item-0',
+      '@mock keep coordinating',
+      ['mock'],
+      driverSessionId,
+      CLAUDE_AGENT_SENDER
+    );
+    await waitFor(
+      () =>
+        agentReplies(store, 'mock').length ===
+        MAX_CONSECUTIVE_AGENT_TURNS + 1
+    );
+    expect(
+      systemRows(store).filter((message) =>
+        message.body.text.includes('Mention chain paused')
+      )
+    ).toHaveLength(1);
+
+    post(store, binder, '@mock human reset', ['mock'], OPERATOR);
+    await waitFor(
+      () =>
+        agentReplies(store, 'mock').length ===
+        MAX_CONSECUTIVE_AGENT_TURNS + 2
+    );
+    postAgentTurnRow(
+      store,
+      binder,
+      'worker-after-reset',
+      'item-0',
+      '@mock worker resumed',
+      ['mock'],
+      workerSessionId,
+      AGENT_SENDER
+    );
+    await waitFor(
+      () =>
+        agentReplies(store, 'mock').length ===
+        MAX_CONSECUTIVE_AGENT_TURNS + 3
+    );
+  });
+
   it('counts one provider turn once across item rows and mention fanout', async () => {
     const build = (agentType: string) =>
       agentType === 'a'

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -23,7 +23,10 @@ import {
   type ChannelHub,
   type ChannelSocket,
 } from '../server/channel-hub.js';
-import { createChannelChatRouter } from '../server/channel-chat-router.js';
+import {
+  authenticatedSourceSessionId,
+  createChannelChatRouter,
+} from '../server/channel-chat-router.js';
 import {
   CHANNEL_IMAGE_MAX_BYTES,
   createChannelAttachmentStore,
@@ -467,6 +470,35 @@ describe('channel routes — attribution', () => {
       kind: 'agent',
       id: 'agent:claude',
     });
+  });
+
+  it('attributes persistent-orchestrator posts only to a matching durable orchestrator session', () => {
+    const roles: Readonly<Record<string, string>> = {
+      'session:orchestrator': 'orchestrator',
+      'session:worker': 'implementer',
+    };
+    const getSession = (sessionId: string) => {
+      const role = roles[sessionId];
+      return role ? { role, status: 'active' } : undefined;
+    };
+    const credential = (actorId: string) =>
+      ({
+        actor: { type: 'agent', id: actorId },
+        metadata: { reason: 'persistent-orchestrator' },
+      }) as unknown as ScopedActorCredentialRecord;
+
+    expect(
+      authenticatedSourceSessionId(
+        credential('session:orchestrator'),
+        getSession
+      )
+    ).toBe('session:orchestrator');
+    expect(
+      authenticatedSourceSessionId(credential('session:worker'), getSession)
+    ).toBeUndefined();
+    expect(
+      authenticatedSourceSessionId(credential('session:stale'), getSession)
+    ).toBeUndefined();
   });
 });
 

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -11,6 +11,7 @@ import {
   classifyCliGatewayCredentialLane,
   issueCliGatewayActorCredential,
   issueCliGatewayActorCredentialWithGrant,
+  issuePersistentOrchestratorCliGatewayActorCredential,
   listCliGatewayActorCredentialsWithGrant,
   revokeCliGatewayActorCredentialWithGrant,
   rotateCliGatewayActorCredentialWithGrant,
@@ -134,6 +135,46 @@ test('issues and validates bounded read-only CLI gateway actor credentials', () 
     correlationId: 'corr-cli-1',
   });
   expect(validation).toMatchObject({ ok: true, grantedBits: ['session:read'] });
+});
+
+test('reserves the persistent-orchestrator reason for the internal lease issuer', () => {
+  const scopedRegistry = registry();
+  const ordinary = issueCliGatewayActorCredential(scopedRegistry, {
+    metadata: {
+      reason: 'persistent-orchestrator',
+      trace: 'ordinary',
+    },
+  });
+  expect(ordinary.credential.metadata?.reason).toBeUndefined();
+
+  const grants = grantRegistry();
+  const grantBacked = issueCliGatewayActorCredentialWithGrant(
+    scopedRegistry,
+    grants,
+    {
+      ...grantLifecycleInput(
+        approveGrant(grants, 'grant-reserved-reason'),
+        'reserved-reason'
+      ),
+      metadata: {
+        reason: 'persistent-orchestrator',
+        trace: 'grant',
+      },
+    }
+  );
+  expect(grantBacked.credential.metadata?.reason).toBeUndefined();
+
+  const internal = issuePersistentOrchestratorCliGatewayActorCredential(
+    scopedRegistry,
+    {
+      actor: { type: 'agent', id: 'orchestrator-session' },
+      issuer: { id: 'relay-ide' },
+      capabilities: ['session:read'],
+    }
+  );
+  expect(internal.credential.metadata).toEqual({
+    reason: 'persistent-orchestrator',
+  });
 });
 
 test('validates WorkContext-scoped actor credentials against exact artifact read scopes', () => {

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -234,6 +234,7 @@ describe('CLI gateway contract', () => {
       'workspace-topics.create',
       'workspace-topics.update',
       'workspace-topics.archive',
+      'channels.post',
       'roster.list',
       'roster.register',
       'roster.updateSelf',

--- a/test/cli-gateway/channels-post.test.ts
+++ b/test/cli-gateway/channels-post.test.ts
@@ -1,0 +1,211 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { commandSpec } from '../../shared/cli-gateway-contract.js';
+
+const RELAY_BIN = path.resolve('dist/bin/relay-ide.js');
+const FETCH_PRELOAD = pathToFileURL(
+  path.resolve('test/fixtures/cli-gateway/mock-fetch.mjs')
+).href;
+
+function runCli(
+  args: string[],
+  env: NodeJS.ProcessEnv
+): Promise<{
+  envelope: Record<string, unknown>;
+  request: Record<string, unknown>;
+}> {
+  const captureDir = mkdtempSync(path.join(tmpdir(), 'relay-cli-fetch-'));
+  const capturePath = path.join(captureDir, 'request.json');
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [RELAY_BIN, ...args],
+      {
+        encoding: 'utf8',
+        env: {
+          ...env,
+          NODE_OPTIONS: `--import=${FETCH_PRELOAD}`,
+          RELAY_TEST_FETCH_CAPTURE: capturePath,
+        },
+        timeout: 10_000,
+      },
+      (error, stdout, stderr) => {
+        try {
+          if (error) {
+            reject(
+              new Error(
+                `CLI failed (${String(error.code)}): ${stderr || stdout}`
+              )
+            );
+            return;
+          }
+          resolve({
+            envelope: JSON.parse(stdout) as Record<string, unknown>,
+            request: JSON.parse(
+              readFileSync(capturePath, 'utf8')
+            ) as Record<string, unknown>,
+          });
+        } finally {
+          rmSync(captureDir, { recursive: true, force: true });
+        }
+      }
+    );
+  });
+}
+
+beforeAll(() => {
+  execFileSync('npm', ['run', 'build:server'], {
+    cwd: path.resolve('.'),
+    env: process.env,
+    stdio: 'inherit',
+  });
+}, 60_000);
+
+describe('channels.post CLI gateway command', () => {
+  it('declares the typed channel message input and context write capability', () => {
+    const spec = commandSpec('channels.post');
+
+    expect(spec.cli).toEqual([
+      'relay-ide',
+      'v1',
+      'channels',
+      'post',
+      '--input-json',
+      '<json>',
+      '--json',
+    ]);
+    expect(spec.capabilityHints).toEqual(['context:write']);
+    expect(spec.inputSchema).toMatchObject({
+      type: 'object',
+      additionalProperties: false,
+      required: ['channelId', 'text'],
+      properties: {
+        channelId: { type: 'string' },
+        text: { type: 'string' },
+        format: { enum: ['markdown', 'text'] },
+        parentMessageId: { type: 'string' },
+        threadId: { type: ['string', 'null'] },
+        clientMessageId: { type: 'string' },
+        parts: { type: 'array' },
+      },
+    });
+    expect(spec.inputSchema.properties).not.toHaveProperty('sender');
+    expect(spec.inputSchema.properties).not.toHaveProperty('source');
+  });
+
+  it('uses the actor token lane and forwards the route body exactly', async () => {
+    const input = {
+      channelId: 'product/main',
+      text: 'Worker one is ready.',
+      format: 'markdown',
+      parentMessageId: 'chm:root',
+      threadId: 'chm:root',
+      clientMessageId: 'orchestrator-update-1',
+      parts: [
+        {
+          type: 'image',
+          id: 'cha:diagram',
+          mime: 'image/png',
+          w: 640,
+          h: 480,
+          bytes: 1024,
+          alt: 'Worker dependency diagram',
+        },
+      ],
+    };
+
+    const { envelope, request } = await runCli(
+      [
+        'v1',
+        'channels',
+        'post',
+        '--input-json',
+        JSON.stringify(input),
+        '--json',
+      ],
+      {
+        ...process.env,
+        RELAY_IDE_PORT: '4567',
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test-actor.[REDACTED]',
+        RELAY_IDE_BROWSER_TOKEN: '',
+      }
+    );
+
+    expect(envelope).toMatchObject({
+      ok: true,
+      command: 'channels.post',
+      data: { message: { id: 'chm:test' } },
+    });
+    expect(request).toMatchObject({
+      method: 'POST',
+      url: 'http://127.0.0.1:4567/channels/product%2Fmain/messages',
+      body: {
+        text: input.text,
+        format: input.format,
+        parentMessageId: input.parentMessageId,
+        threadId: input.threadId,
+        clientMessageId: input.clientMessageId,
+        parts: input.parts,
+      },
+      headers: {
+        Authorization: 'Bearer relay-sac-v1.test-actor.[REDACTED]',
+        'Content-Type': 'application/json',
+        'x-relay-cli-gateway': 'v1',
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'channels.post',
+        'x-relay-capabilities': 'context:write',
+      },
+    });
+    expect(request.body).not.toHaveProperty('channelId');
+  });
+
+  it('allows the actor token lane to create worker sessions', async () => {
+    const input = {
+      cwd: '/repo',
+      type: 'agent',
+      mode: 'web',
+      agent: 'claude',
+    };
+
+    const { envelope, request } = await runCli(
+      [
+        'v1',
+        'sessions',
+        'create',
+        '--input-json',
+        JSON.stringify(input),
+        '--json',
+      ],
+      {
+        ...process.env,
+        RELAY_IDE_PORT: '4567',
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test-actor.[REDACTED]',
+        RELAY_IDE_BROWSER_TOKEN: '',
+      }
+    );
+
+    expect(envelope).toMatchObject({
+      ok: true,
+      command: 'sessions.create',
+      data: { id: 'worker-session' },
+    });
+    expect(request).toMatchObject({
+      method: 'POST',
+      url: 'http://127.0.0.1:4567/sessions',
+      body: input,
+      headers: {
+        Authorization: 'Bearer relay-sac-v1.test-actor.[REDACTED]',
+        'Content-Type': 'application/json',
+        'x-relay-cli-gateway': 'v1',
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'sessions.create',
+        'x-relay-capabilities': 'session:create:agent',
+      },
+    });
+  });
+});

--- a/test/cli-gateway/session-display-name.test.ts
+++ b/test/cli-gateway/session-display-name.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { commandSpec } from '../../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../../shared/cli-gateway-runtime.js';
 
 const REPO_CWD = '/home/dev/repo';
@@ -25,5 +26,43 @@ describe('sessions.create displayName', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe('INVALID_ARGUMENT');
+  });
+});
+
+describe('sessions.create role', () => {
+  it('declares the role enum on create input and session descriptors', () => {
+    const create = commandSpec('sessions.create');
+    expect(create.inputSchema.properties?.['role']?.enum).toContain(
+      'orchestrator'
+    );
+    expect(
+      create.outputSchema.properties?.['data']?.properties?.['role']?.enum
+    ).toContain('orchestrator');
+  });
+
+  it('accepts a known collaboration role', () => {
+    const result = validateAndSanitizeGatewayCreateInput({
+      cwd: REPO_CWD,
+      type: 'agent',
+      mode: 'web',
+      agent: 'claude',
+      role: 'orchestrator',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok !== true) return;
+    expect(result.input['role']).toBe('orchestrator');
+  });
+
+  it('rejects an unknown collaboration role', () => {
+    const result = validateAndSanitizeGatewayCreateInput({
+      cwd: REPO_CWD,
+      type: 'agent',
+      mode: 'web',
+      role: 'manager',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('INVALID_ARGUMENT');
+    expect(result.error.details?.['field']).toBe('role');
   });
 });

--- a/test/fixtures/cli-gateway/mock-fetch.mjs
+++ b/test/fixtures/cli-gateway/mock-fetch.mjs
@@ -1,0 +1,35 @@
+import { writeFileSync } from 'node:fs';
+
+globalThis.fetch = async (url, init = {}) => {
+  const body =
+    typeof init.body === 'string' && init.body.length > 0
+      ? JSON.parse(init.body)
+      : undefined;
+  const capturePath = process.env.RELAY_TEST_FETCH_CAPTURE;
+  if (!capturePath) {
+    throw new Error('RELAY_TEST_FETCH_CAPTURE is required');
+  }
+  writeFileSync(
+    capturePath,
+    JSON.stringify({
+      url: String(url),
+      method: init.method,
+      headers: init.headers,
+      body,
+    })
+  );
+  const data = String(url).includes('/channels/')
+    ? { message: { id: 'chm:test' } }
+    : {
+        id: 'worker-session',
+        type: 'agent',
+        mode: 'web',
+        agent: 'claude',
+        cwd: '/repo',
+        status: 'active',
+      };
+  return new Response(JSON.stringify(data), {
+    status: 201,
+    headers: { 'content-type': 'application/json' },
+  });
+};

--- a/test/orchestrator-credential-lifecycle.test.ts
+++ b/test/orchestrator-credential-lifecycle.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+import {
+  ORCHESTRATOR_ACTOR_CAPABILITIES,
+  ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS,
+  startOrchestratorCredentialLifecycle,
+  type OrchestratorCredentialLifecycleDeps,
+} from '../server/orchestrator-credential-lifecycle.js';
+
+const START_MS = Date.parse('2026-07-25T00:00:00.000Z');
+
+function credential(
+  id: string,
+  issuedAtMs: number
+): ScopedActorCredentialRecord {
+  return {
+    id,
+    actor: { type: 'agent', id: 'session-orchestrator' },
+    issuer: { id: 'relay-ide' },
+    audience: 'relay:cli-gateway:v1',
+    capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+    scope: { taskRefs: ['relay:cli-gateway:v1:read'] },
+    metadata: { reason: 'persistent-orchestrator' },
+    issuedAt: new Date(issuedAtMs).toISOString(),
+    expiresAt: new Date(
+      issuedAtMs + ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS
+    ).toISOString(),
+    correlationId: `correlation-${id}`,
+  };
+}
+
+function harness(
+  options: {
+    issueError?: Error;
+    applyError?: Error;
+  } = {}
+): {
+  deps: OrchestratorCredentialLifecycleDeps;
+  issueCredential: ReturnType<typeof vi.fn>;
+  revokeCredential: ReturnType<typeof vi.fn>;
+  applyRuntimeEnv: ReturnType<typeof vi.fn>;
+  failClosed: ReturnType<typeof vi.fn>;
+  events: string[];
+} {
+  let issueCount = 0;
+  const events: string[] = [];
+  const issueCredential = vi.fn(() => {
+    if (options.issueError) throw options.issueError;
+    issueCount++;
+    const id = `credential-${issueCount}`;
+    events.push(`issue:${id}`);
+    return {
+      token: `relay-sac-v1.${id}.secret-${issueCount}`,
+      credential: credential(id, Date.now()),
+    };
+  });
+  const revokeCredential = vi.fn((id: string) => {
+    events.push(`revoke:${id}`);
+  });
+  const applyRuntimeEnv = vi.fn(async () => {
+    events.push('apply');
+    if (options.applyError) throw options.applyError;
+  });
+  const failClosed = vi.fn(() => {
+    events.push('fail-closed');
+  });
+  return {
+    deps: {
+      issueCredential,
+      revokeCredential,
+      applyRuntimeEnv,
+      failClosed,
+    },
+    issueCredential,
+    revokeCredential,
+    applyRuntimeEnv,
+    failClosed,
+    events,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('OrchestratorCredentialLifecycle', () => {
+  it('mints the exact bounded actor credential before adapter creation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness();
+
+    const lease = startOrchestratorCredentialLifecycle(
+      {
+        sessionId: 'session-orchestrator',
+        port: 4567,
+        displayName: 'Product orchestrator',
+      },
+      h.deps
+    );
+
+    expect(h.issueCredential).toHaveBeenCalledWith({
+      actor: {
+        type: 'agent',
+        id: 'session-orchestrator',
+        displayName: 'Product orchestrator',
+      },
+      issuer: { id: 'relay-ide', displayName: 'Relay' },
+      capabilities: [...ORCHESTRATOR_ACTOR_CAPABILITIES],
+      ttlMs: 15 * 60 * 1000,
+    });
+    expect(lease.processEnv).toEqual({
+      RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-1.secret-1',
+      RELAY_IDE_PORT: '4567',
+      RELAY_IDE_SESSION_ID: 'session-orchestrator',
+    });
+    expect(h.applyRuntimeEnv).not.toHaveBeenCalled();
+
+    lease.stop();
+  });
+
+  it('refreshes at half lifetime and revokes old only after apply', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness();
+    const lease = startOrchestratorCredentialLifecycle(
+      { sessionId: 'session-orchestrator', port: 4567 },
+      h.deps
+    );
+
+    await vi.advanceTimersByTimeAsync(7.5 * 60 * 1000 - 1);
+    expect(h.issueCredential).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(h.applyRuntimeEnv).toHaveBeenCalledWith({
+      RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-2.secret-2',
+      RELAY_IDE_PORT: '4567',
+      RELAY_IDE_SESSION_ID: 'session-orchestrator',
+    });
+    expect(h.events).toEqual([
+      'issue:credential-1',
+      'issue:credential-2',
+      'apply',
+      'revoke:credential-1',
+    ]);
+    expect(lease.processEnv).toEqual({
+      RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-2.secret-2',
+      RELAY_IDE_PORT: '4567',
+      RELAY_IDE_SESSION_ID: 'session-orchestrator',
+    });
+
+    lease.stop();
+  });
+
+  it('stops the timer and revokes the current credential on session end', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness();
+    const lease = startOrchestratorCredentialLifecycle(
+      { sessionId: 'session-orchestrator', port: 4567 },
+      h.deps
+    );
+
+    lease.stop();
+    await vi.advanceTimersByTimeAsync(ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS);
+
+    expect(h.issueCredential).toHaveBeenCalledTimes(1);
+    expect(h.revokeCredential).toHaveBeenCalledTimes(1);
+    expect(h.revokeCredential).toHaveBeenCalledWith('credential-1', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-session-ended',
+    });
+  });
+
+  it('fails initial provisioning without exposing issuer error material', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness({
+      issueError: new Error(
+        'issuer failed around relay-sac-v1.private.secret-material'
+      ),
+    });
+
+    expect(() =>
+      startOrchestratorCredentialLifecycle(
+        { sessionId: 'session-orchestrator', port: 4567 },
+        h.deps
+      )
+    ).toThrowError('Failed to provision orchestrator actor credential');
+    try {
+      startOrchestratorCredentialLifecycle(
+        { sessionId: 'session-orchestrator', port: 4567 },
+        h.deps
+      );
+    } catch (error) {
+      expect(String(error)).not.toContain('secret-material');
+    }
+  });
+
+  it('revokes a failed replacement and requests fail-closed termination', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    const h = harness({
+      applyError: new Error(
+        'env apply failed for relay-sac-v1.private.secret-material'
+      ),
+    });
+    const lease = startOrchestratorCredentialLifecycle(
+      { sessionId: 'session-orchestrator', port: 4567 },
+      h.deps
+    );
+
+    await lease.refreshNow();
+
+    expect(h.revokeCredential).toHaveBeenCalledWith('credential-2', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-token-refresh-failed',
+    });
+    expect(h.revokeCredential).not.toHaveBeenCalledWith(
+      'credential-1',
+      expect.anything()
+    );
+    expect(h.failClosed).toHaveBeenCalledTimes(1);
+    const error = h.failClosed.mock.calls[0]?.[0];
+    expect(String(error)).toBe(
+      'Error: Failed to refresh orchestrator actor credential'
+    );
+    expect(String(error)).not.toContain('secret-material');
+
+    lease.stop();
+  });
+
+  it('fails closed before expiry when runtime application stays blocked', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START_MS);
+    let releaseApply: (() => void) | undefined;
+    const h = harness();
+    h.deps.applyRuntimeEnv = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseApply = resolve;
+        })
+    );
+    const lease = startOrchestratorCredentialLifecycle(
+      { sessionId: 'session-orchestrator', port: 4567 },
+      h.deps
+    );
+
+    const refresh = lease.refreshNow();
+    await vi.advanceTimersByTimeAsync(
+      ORCHESTRATOR_ACTOR_CREDENTIAL_TTL_MS - 1_000
+    );
+    await refresh;
+
+    expect(h.failClosed).toHaveBeenCalledTimes(1);
+    expect(h.revokeCredential).toHaveBeenCalledWith('credential-2', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-token-refresh-failed',
+    });
+    expect(h.revokeCredential).not.toHaveBeenCalledWith(
+      'credential-1',
+      expect.anything()
+    );
+
+    releaseApply?.();
+    lease.stop();
+  });
+});

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
+import http from 'node:http';
 import { hashPin } from '../server/auth.js';
 import {
   closeRelayStateDb,
@@ -642,6 +643,8 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
   const configPath = path.join(tmpDir, 'config.json');
   const binDir = path.join(tmpDir, 'bin');
   const codexStub = path.join(binDir, 'codex');
+  const claudeStub = path.join(binDir, 'claude');
+  const hermesStub = path.join(binDir, 'hermes');
   const authorizedDir = path.join(tmpDir, 'authorized');
   const authorizedLink = path.join(tmpDir, 'authorized-link');
   const topicOutsideDir = path.join(tmpDir, 'topic-outside');
@@ -655,6 +658,10 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
     '#!/usr/bin/env node\nprocess.stdin.resume();\nsetInterval(() => {}, 1000);\n'
   );
   fs.chmodSync(codexStub, 0o755);
+  for (const stub of [claudeStub, hermesStub]) {
+    fs.copyFileSync(codexStub, stub);
+    fs.chmodSync(stub, 0o755);
+  }
   fs.writeFileSync(
     configPath,
     JSON.stringify({
@@ -666,12 +673,35 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
     })
   );
 
+  const hermesGateway = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (req.url === '/v1/models') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ data: [] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve) =>
+    hermesGateway.listen(0, '127.0.0.1', resolve)
+  );
+  const hermesAddress = hermesGateway.address();
+  if (!hermesAddress || typeof hermesAddress === 'string') {
+    throw new Error('Hermes test gateway did not bind');
+  }
+
   const child = startServer({
     env: {
       RELAY_IDE_CONFIG: configPath,
       RELAY_IDE_PORT: '0',
       HOME: tmpDir,
       PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      HERMES_API_ENDPOINT: `http://127.0.0.1:${hermesAddress.port}`,
     },
   });
 
@@ -760,6 +790,93 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
       'x-relay-cli-command': 'sessions.create',
     };
 
+    const credentialsBeforeHermes = await fetch(
+      `${base}/cli-gateway/actor-credentials`,
+      { headers: { cookie } }
+    ).then((response) =>
+      expectJsonStatus<{
+        credentials: Array<{ metadata?: { reason?: string } }>;
+      }>(response, 200, 'credential list before actor Hermes create')
+    );
+    const actorHermesCreate = await fetch(`${base}/sessions`, {
+      method: 'POST',
+      headers: actorHeaders,
+      body: JSON.stringify({
+        cwd: authorizedLink,
+        type: 'agent',
+        mode: 'web',
+        agent: 'hermes',
+        spawnedBySessionId: orchestratorSessionId,
+      }),
+    });
+    const actorHermes = await expectJsonStatus<{
+      id: string;
+      agent: string;
+      role?: string;
+    }>(actorHermesCreate, 201, 'actor Hermes web worker create');
+    expect(actorHermes.agent).toBe('hermes');
+    expect(actorHermes.role).toBeUndefined();
+    const credentialsAfterHermes = await fetch(
+      `${base}/cli-gateway/actor-credentials`,
+      { headers: { cookie } }
+    ).then((response) =>
+      expectJsonStatus<{
+        credentials: Array<{ metadata?: { reason?: string } }>;
+      }>(response, 200, 'credential list after actor Hermes create')
+    );
+    expect(credentialsAfterHermes.credentials).toHaveLength(
+      credentialsBeforeHermes.credentials.length
+    );
+    expect(
+      credentialsAfterHermes.credentials.filter(
+        (credential) =>
+          credential.metadata?.reason === 'persistent-orchestrator'
+      )
+    ).toHaveLength(0);
+
+    const actorClaudeCreate = await fetch(`${base}/sessions`, {
+      method: 'POST',
+      headers: actorHeaders,
+      body: JSON.stringify({
+        cwd: authorizedLink,
+        type: 'agent',
+        mode: 'web',
+        agent: 'claude',
+        spawnedBySessionId: orchestratorSessionId,
+      }),
+    });
+    const actorClaude = await expectJsonStatus<{
+      agent: string;
+      role?: string;
+    }>(actorClaudeCreate, 201, 'actor Claude web worker create');
+    expect(actorClaude).toMatchObject({ agent: 'claude' });
+    expect(actorClaude.role).toBeUndefined();
+
+    const explicitOrchestratorCreate = await fetch(`${base}/sessions`, {
+      method: 'POST',
+      headers: actorHeaders,
+      body: JSON.stringify({
+        cwd: authorizedLink,
+        type: 'agent',
+        mode: 'web',
+        agent: 'claude',
+        role: 'orchestrator',
+        spawnedBySessionId: orchestratorSessionId,
+      }),
+    });
+    await expectJsonStatus<{
+      error: { code: string; reasonCode: string };
+    }>(
+      explicitOrchestratorCreate,
+      403,
+      'actor explicit orchestrator role create'
+    ).then((body) => {
+      expect(body.error).toMatchObject({
+        code: 'FORBIDDEN',
+        reasonCode: 'CLI_ACTOR_ORCHESTRATOR_ROLE_UNSUPPORTED',
+      });
+    });
+
     const inScopeCreate = await fetch(`${base}/sessions`, {
       method: 'POST',
       headers: actorHeaders,
@@ -775,6 +892,7 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
       id: string;
       cwd: string;
       spawnedBySessionId?: string;
+      role?: string;
       activeActors?: Array<{
         kind: string;
         id?: string;
@@ -784,6 +902,7 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
     }>(inScopeCreate, 201, 'in-scope actor sessions.create');
     expect(created.cwd).toBe(canonicalAuthorizedPath);
     expect(created.spawnedBySessionId).toBe(orchestratorSessionId);
+    expect(created.role).toBeUndefined();
     expect(created.activeWorker?.id).toBe(created.id);
     expect(created.activeActors).toEqual(
       expect.arrayContaining([
@@ -862,6 +981,9 @@ test('scoped actor sessions.create spawns an in-scope controlled worker and reje
     );
   } finally {
     await killAndWait(child);
+    await new Promise<void>((resolve, reject) =>
+      hermesGateway.close((error) => (error ? reject(error) : resolve()))
+    );
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(outsideDir, { recursive: true, force: true });
   }

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -253,6 +253,11 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       ...baseConfig(),
       model: 'sonnet',
       permissionMode: 'default',
+      processEnv: {
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.runtime-only.test-token',
+        CLAUDECODE: 'must-still-be-stripped',
+      },
+      systemPromptAppendix: 'Relay orchestrator playbook',
       extra: {
         additionalDirectories: ['/extra/dir'],
         yolo: true,
@@ -300,6 +305,10 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     expect(args[args.indexOf('--model') + 1]).toBe('sonnet');
     expect(args).toContain('--add-dir');
     expect(args[args.indexOf('--add-dir') + 1]).toBe('/extra/dir');
+    expect(args).toContain('--append-system-prompt');
+    expect(args[args.indexOf('--append-system-prompt') + 1]).toBe(
+      'Relay orchestrator playbook'
+    );
     expect(args).toContain('--dangerously-skip-permissions');
     // No --resume on a first spawn (no session id yet).
     expect(args).not.toContain('--resume');
@@ -315,7 +324,158 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     expect(args).not.toContain('-r=alias-session');
     // CLAUDECODE stripped from the child env.
     expect(options.env.CLAUDECODE).toBeUndefined();
+    expect(options.env.RELAY_IDE_ACTOR_TOKEN).toBe(
+      'relay-sac-v1.runtime-only.test-token'
+    );
 
+    await adapter.disconnect();
+  });
+
+  it('interrupts and requeues a long active turn before refreshing runtime env', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    const patches = collectPatches(adapter);
+    await adapter.connect({
+      ...baseConfig(),
+      processEnv: {
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-old.redacted',
+      },
+    });
+
+    await adapter.sendMessage({ turnId: 'turn-A', content: 'a' });
+    const oldChild = harness.latest().child;
+    await oldChild.waitForFrames(1);
+    oldChild.serverWrite({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-refresh',
+    });
+    const queuedTurn = adapter.sendMessage({
+      turnId: 'turn-B',
+      content: 'b',
+    });
+    const refresh = adapter.refreshRuntimeEnv({
+      RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-new.redacted',
+    });
+
+    expect(harness.spawns).toHaveLength(1);
+    await oldChild.waitForFrames(2);
+    expect(oldChild.frames()[1]).toMatchObject({
+      type: 'control_request',
+      request: { subtype: 'interrupt' },
+    });
+    oldChild.serverWrite({
+      type: 'control_response',
+      response: { subtype: 'success', request_id: 'relay-int-1' },
+    });
+
+    await refresh;
+
+    expect(harness.spawns).toHaveLength(2);
+    expect(harness.spawns[0]?.options.env.RELAY_IDE_ACTOR_TOKEN).toBe(
+      'relay-sac-v1.credential-old.redacted'
+    );
+    const replacement = harness.latest();
+    expect(replacement.options.env.RELAY_IDE_ACTOR_TOKEN).toBe(
+      'relay-sac-v1.credential-new.redacted'
+    );
+    expect(replacement.args).toContain('--resume');
+    expect(replacement.child.frames()[0]).toMatchObject({
+      message: { content: 'a' },
+    });
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-turn-completed-v2' &&
+          patch.turnId === 'turn-A' &&
+          patch.status === 'interrupted'
+      )
+    ).toBe(true);
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-turn-started-v2' &&
+          patch.turn.id === 'turn-A-credential-refresh-1'
+      )
+    ).toBe(true);
+
+    replacement.child.serverWrite({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-refresh',
+    });
+    replacement.child.serverWrite(successResult());
+    await queuedTurn;
+    expect(replacement.child.frames()[1]).toMatchObject({
+      message: { content: 'b' },
+    });
+    replacement.child.serverWrite(successResult());
+    await adapter.disconnect();
+  });
+
+  it('does not requeue when the active turn completes during the refresh interrupt race', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    const patches = collectPatches(adapter);
+    await adapter.connect({
+      ...baseConfig(),
+      processEnv: {
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-old.redacted',
+      },
+    });
+
+    await adapter.sendMessage({ turnId: 'turn-A', content: 'a' });
+    const oldChild = harness.latest().child;
+    await oldChild.waitForFrames(1);
+    oldChild.serverWrite({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-refresh-race',
+    });
+    const queuedTurn = adapter.sendMessage({
+      turnId: 'turn-B',
+      content: 'b',
+    });
+    const refresh = adapter.refreshRuntimeEnv({
+      RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-new.redacted',
+    });
+    await oldChild.waitForFrames(2);
+
+    oldChild.serverWrite(successResult());
+    oldChild.serverWrite({
+      type: 'control_response',
+      response: { subtype: 'success', request_id: 'relay-int-1' },
+    });
+
+    await refresh;
+    await queuedTurn;
+
+    expect(harness.spawns).toHaveLength(2);
+    const replacement = harness.latest();
+    expect(replacement.child.frames()[0]).toMatchObject({
+      message: { content: 'b' },
+    });
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-turn-started-v2' &&
+          patch.turn.id.includes('credential-refresh')
+      )
+    ).toBe(false);
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-turn-completed-v2' &&
+          patch.turnId === 'turn-A'
+      )
+    ).toHaveLength(1);
+
+    replacement.child.serverWrite({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-refresh-race',
+    });
+    replacement.child.serverWrite(successResult());
     await adapter.disconnect();
   });
 

--- a/test/server/relay-state-db.test.ts
+++ b/test/server/relay-state-db.test.ts
@@ -90,6 +90,7 @@ describe('relay-state-db', () => {
   it('upserts and round-trips a web session', () => {
     const session = fakeWebSession({
       spawnedBySessionId: 'orchestrator-session',
+      role: 'orchestrator',
     });
     upsertWebSessionNow(session);
 
@@ -102,6 +103,7 @@ describe('relay-state-db', () => {
     expect(row.agentSessionV2.id).toBe('sess-1');
     expect(row.meta.adapterType).toBe('claude');
     expect(row.meta.spawnedBySessionId).toBe('orchestrator-session');
+    expect(row.meta.role).toBe('orchestrator');
     expect(row.status).toBe('active');
   });
 

--- a/test/sessions-orchestrator-credential.test.ts
+++ b/test/sessions-orchestrator-credential.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentPatchHandlerV2,
+  AgentSendMessageInputV2,
+  AdapterConfig,
+  ProtocolAdapterV2,
+} from '../server/protocol-adapter-v2.js';
+import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
+
+const connect = vi.fn<(config: AdapterConfig) => Promise<void>>();
+const disconnect = vi.fn<() => Promise<void>>();
+const refreshRuntimeEnv =
+  vi.fn<(processEnv: Record<string, string>) => Promise<void>>();
+let supportsRuntimeEnvRefresh = true;
+let adapterStatus: 'connected' | 'disconnected' = 'connected';
+
+class OrchestratorTestAdapter implements ProtocolAdapterV2 {
+  readonly agentType = 'mock';
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities = emptyAgentSessionV2({
+    id: 'capabilities',
+    provider: 'mock',
+    cwd: '/tmp',
+    capabilities: {
+      resume: true,
+      text: true,
+      queue: true,
+      interrupt: true,
+    },
+  }).capabilities;
+  get status(): 'connected' | 'disconnected' {
+    return adapterStatus;
+  }
+  refreshRuntimeEnv?: (processEnv: Record<string, string>) => Promise<void>;
+
+  constructor() {
+    if (supportsRuntimeEnvRefresh) {
+      this.refreshRuntimeEnv = (processEnv) => refreshRuntimeEnv(processEnv);
+    }
+  }
+
+  async connect(config: AdapterConfig): Promise<void> {
+    await connect(config);
+  }
+  async disconnect(): Promise<void> {
+    await disconnect();
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(_sessionId: string): Promise<void> {}
+  async sendMessage(_input: AgentSendMessageInputV2): Promise<void> {}
+  async interrupt(_input: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(
+    _input: AgentApprovalResponseInputV2
+  ): Promise<void> {}
+  async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {}
+  onPatch(_handler: AgentPatchHandlerV2): () => void {
+    return () => {};
+  }
+  broadcastPatch(): void {}
+}
+
+vi.mock('../server/protocol-adapters/index.js', () => ({
+  createAdapterV2: () => new OrchestratorTestAdapter(),
+}));
+
+function issuedCredential(
+  id: string,
+  token: string
+): { token: string; credential: ScopedActorCredentialRecord } {
+  const issuedAt = Date.now();
+  return {
+    token,
+    credential: {
+      id,
+      actor: { type: 'agent', id: 'orchestrator-session' },
+      issuer: { id: 'relay-ide' },
+      audience: 'relay:cli-gateway:v1',
+      capabilities: [
+        'session:read',
+        'context:read',
+        'context:write',
+        'session:create:agent',
+      ],
+      scope: { taskRefs: ['relay:cli-gateway:v1:read'] },
+      metadata: { reason: 'persistent-orchestrator' },
+      issuedAt: new Date(issuedAt).toISOString(),
+      expiresAt: new Date(issuedAt + 15 * 60 * 1000).toISOString(),
+      correlationId: `correlation-${id}`,
+    },
+  };
+}
+
+describe('sessions orchestrator credential integration', () => {
+  beforeEach(() => {
+    connect.mockReset().mockResolvedValue();
+    disconnect.mockReset().mockResolvedValue();
+    refreshRuntimeEnv.mockReset().mockResolvedValue();
+    supportsRuntimeEnvRefresh = true;
+    adapterStatus = 'connected';
+  });
+
+  afterEach(async () => {
+    const sessions = await import('../server/sessions.js');
+    for (const session of sessions.list()) {
+      try {
+        sessions.kill(session.id);
+      } catch {
+        // already fail-closed
+      }
+    }
+    sessions.configure({});
+    vi.useRealTimers();
+  });
+
+  it('mints before connect, injects runtime identity, and revokes on end', async () => {
+    const events: string[] = [];
+    const issueCredential = vi.fn(() => {
+      events.push('issue');
+      return issuedCredential(
+        'credential-1',
+        'relay-sac-v1.credential-1.redacted'
+      );
+    });
+    connect.mockImplementation(async () => {
+      events.push('connect');
+    });
+    const revokeCredential = vi.fn(() => {
+      events.push('revoke');
+    });
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir: '/tmp',
+      orchestratorCredentials: { issueCredential, revokeCredential },
+    });
+
+    const { session } = await sessions.createWeb({
+      id: 'orchestrator-session',
+      role: 'orchestrator',
+      agentType: 'mock',
+      cwd: '/tmp',
+      displayName: 'Product orchestrator',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(events.slice(0, 2)).toEqual(['issue', 'connect']);
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processEnv: {
+          RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.credential-1.redacted',
+          RELAY_IDE_PORT: '4567',
+          RELAY_IDE_SESSION_ID: 'orchestrator-session',
+        },
+      })
+    );
+    expect(session.role).toBe('orchestrator');
+
+    sessions.kill(session.id);
+    expect(revokeCredential).toHaveBeenCalledWith('credential-1', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-session-ended',
+    });
+  });
+
+  it('fails before adapter connect when initial minting fails', async () => {
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir: '/tmp',
+      orchestratorCredentials: {
+        issueCredential: () => {
+          throw new Error('secret issuer details');
+        },
+        revokeCredential: vi.fn(),
+      },
+    });
+
+    await expect(
+      sessions.createWeb({
+        id: 'orchestrator-session',
+        role: 'orchestrator',
+        agentType: 'mock',
+        cwd: '/tmp',
+        displayName: 'Product orchestrator',
+        port: 4567,
+        configDir: '/tmp',
+      })
+    ).rejects.toThrow('Failed to provision orchestrator actor credential');
+    expect(connect).not.toHaveBeenCalled();
+    expect(sessions.get('orchestrator-session')).toBeUndefined();
+  });
+
+  it('keeps a derived Hermes display role unprivileged without minting a credential', async () => {
+    supportsRuntimeEnvRefresh = false;
+    const issueCredential = vi.fn(() =>
+      issuedCredential(
+        'credential-should-not-exist',
+        'relay-sac-v1.credential-should-not-exist.redacted'
+      )
+    );
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir: '/tmp',
+      orchestratorCredentials: {
+        issueCredential,
+        revokeCredential: vi.fn(),
+      },
+    });
+
+    const { session } = await sessions.createWeb({
+      id: 'hermes-worker-session',
+      agentType: 'hermes',
+      cwd: '/tmp',
+      displayName: 'Hermes worker',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    expect(session.role).toBeUndefined();
+    expect(issueCredential).not.toHaveBeenCalled();
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPromptAppendix: expect.stringContaining(
+          'operator’s Relay-managed orchestrator'
+        ),
+      })
+    );
+  });
+
+  it('revokes and rejects an orchestrator adapter without env refresh', async () => {
+    supportsRuntimeEnvRefresh = false;
+    const revokeCredential = vi.fn();
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir: '/tmp',
+      orchestratorCredentials: {
+        issueCredential: () =>
+          issuedCredential(
+            'credential-unsupported',
+            'relay-sac-v1.credential-unsupported.redacted'
+          ),
+        revokeCredential,
+      },
+    });
+
+    await expect(
+      sessions.createWeb({
+        id: 'orchestrator-session',
+        role: 'orchestrator',
+        agentType: 'mock',
+        cwd: '/tmp',
+        displayName: 'Product orchestrator',
+        port: 4567,
+        configDir: '/tmp',
+      })
+    ).rejects.toThrow('does not support orchestrator credential refresh');
+    expect(connect).not.toHaveBeenCalled();
+    expect(revokeCredential).toHaveBeenCalledWith('credential-unsupported', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-session-ended',
+    });
+  });
+
+  it('kills the session when scheduled credential application fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-07-25T00:00:00.000Z');
+    let issueCount = 0;
+    const revokeCredential = vi.fn();
+    refreshRuntimeEnv.mockRejectedValue(
+      new Error('runtime refresh failed around secret material')
+    );
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir: '/tmp',
+      orchestratorCredentials: {
+        issueCredential: () => {
+          issueCount++;
+          return issuedCredential(
+            `credential-${issueCount}`,
+            `relay-sac-v1.credential-${issueCount}.redacted`
+          );
+        },
+        revokeCredential,
+      },
+    });
+
+    await sessions.createWeb({
+      id: 'orchestrator-session',
+      role: 'orchestrator',
+      agentType: 'mock',
+      cwd: '/tmp',
+      displayName: 'Product orchestrator',
+      port: 4567,
+      configDir: '/tmp',
+    });
+
+    await vi.advanceTimersByTimeAsync(7.5 * 60 * 1000);
+
+    expect(sessions.get('orchestrator-session')).toBeUndefined();
+    expect(revokeCredential).toHaveBeenCalledWith('credential-2', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-token-refresh-failed',
+    });
+    expect(revokeCredential).toHaveBeenCalledWith('credential-1', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-session-ended',
+    });
+  });
+
+  it('stops and removes the lease when the adapter becomes disconnected', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-07-25T00:00:00.000Z');
+    let issueCount = 0;
+    const revokeCredential = vi.fn();
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir: '/tmp',
+      orchestratorCredentials: {
+        issueCredential: () => {
+          issueCount++;
+          return issuedCredential(
+            `credential-${issueCount}`,
+            `relay-sac-v1.credential-${issueCount}.redacted`
+          );
+        },
+        revokeCredential,
+      },
+    });
+
+    const { session } = await sessions.createWeb({
+      id: 'orchestrator-session',
+      role: 'orchestrator',
+      agentType: 'mock',
+      cwd: '/tmp',
+      displayName: 'Product orchestrator',
+      port: 4567,
+      configDir: '/tmp',
+    });
+    adapterStatus = 'disconnected';
+    sessions.fireBackendStateIfChanged(session);
+
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+    expect(sessions.get(session.id)).toBe(session);
+    expect(issueCount).toBe(1);
+    expect(refreshRuntimeEnv).not.toHaveBeenCalled();
+    expect(revokeCredential).toHaveBeenCalledTimes(1);
+    expect(revokeCredential).toHaveBeenCalledWith('credential-1', {
+      revokedBy: 'relay-ide',
+      reason: 'orchestrator-session-ended',
+    });
+  });
+});

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -21,6 +21,7 @@ import type {
 } from '../server/protocol-adapter-v2.js';
 import { getSessionCategory } from '../server/session-attribution.js';
 import type { WebSession } from '../server/types.js';
+import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
 
 const capabilities: AgentCapabilitySetV2 = {
   text: true,
@@ -52,6 +53,8 @@ const resumeSession = vi.fn();
 const reconnect = vi.fn();
 const connect = vi.fn();
 const disconnect = vi.fn();
+const refreshRuntimeEnv = vi.fn();
+let supportsRuntimeEnvRefresh = true;
 let emitBlankSnapshotOnConnect = false;
 let emitPatchOnDisconnect: AgentPatchV2 | undefined;
 
@@ -59,11 +62,25 @@ class RestoreFailureAdapter implements ProtocolAdapterV2 {
   readonly agentType = 'claude';
   readonly runtimeOwnership = 'attached' as const;
   readonly capabilities = capabilities;
-  readonly status: AdapterStatus = 'connected';
+  private adapterStatus: AdapterStatus = 'disconnected';
   private handlers = new Set<AgentPatchHandlerV2>();
+  refreshRuntimeEnv?: (processEnv: Record<string, string>) => Promise<void>;
+
+  constructor() {
+    if (supportsRuntimeEnvRefresh) {
+      this.refreshRuntimeEnv = async (processEnv) => {
+        await refreshRuntimeEnv(processEnv);
+      };
+    }
+  }
+
+  get status(): AdapterStatus {
+    return this.adapterStatus;
+  }
 
   async connect(config: AdapterConfig): Promise<void> {
     await connect(config);
+    this.adapterStatus = 'connected';
     if (emitBlankSnapshotOnConnect) {
       this.emit({
         type: 'agent-session-snapshot-v2',
@@ -79,6 +96,7 @@ class RestoreFailureAdapter implements ProtocolAdapterV2 {
     }
   }
   async disconnect(): Promise<void> {
+    this.adapterStatus = 'disconnected';
     if (emitPatchOnDisconnect) this.emit(emitPatchOnDisconnect);
     this.handlers.clear();
     await disconnect();
@@ -125,6 +143,33 @@ vi.mock('../server/protocol-adapters/index.js', () => ({
   },
 }));
 
+function restoredOrchestratorCredential(
+  id: string,
+  sessionId: string
+): { token: string; credential: ScopedActorCredentialRecord } {
+  const issuedAt = Date.now();
+  return {
+    token: `relay-sac-v1.${id}.redacted`,
+    credential: {
+      id,
+      actor: { type: 'agent', id: sessionId },
+      issuer: { id: 'relay-ide' },
+      audience: 'relay:cli-gateway:v1',
+      capabilities: [
+        'session:read',
+        'context:read',
+        'context:write',
+        'session:create:agent',
+      ],
+      scope: { taskRefs: ['relay:cli-gateway:v1:read'] },
+      metadata: { reason: 'persistent-orchestrator' },
+      issuedAt: new Date(issuedAt).toISOString(),
+      expiresAt: new Date(issuedAt + 15 * 60 * 1000).toISOString(),
+      correlationId: `correlation-${id}`,
+    },
+  };
+}
+
 describe('web session restore failure recovery', () => {
   let configDir: string;
 
@@ -140,6 +185,8 @@ describe('web session restore failure recovery', () => {
     resumeSession.mockReset();
     connect.mockReset();
     disconnect.mockReset();
+    refreshRuntimeEnv.mockReset();
+    supportsRuntimeEnvRefresh = true;
     latestAdapter = undefined;
     createdAdapters.length = 0;
     emitBlankSnapshotOnConnect = false;
@@ -185,6 +232,7 @@ describe('web session restore failure recovery', () => {
         meta: {
           type: 'agent',
           agent: 'claude',
+          role: 'orchestrator',
           spawnedBySessionId: 'orchestrator-session',
           repoName: 'relay-ide',
           customCommand: null,
@@ -213,7 +261,18 @@ describe('web session restore failure recovery', () => {
     ]);
 
     const sessions = await import('../server/sessions.js');
-    sessions.configure({ port: 4567, configDir });
+    sessions.configure({
+      port: 4567,
+      configDir,
+      orchestratorCredentials: {
+        issueCredential: () =>
+          restoredOrchestratorCredential(
+            'restore-credential',
+            'web-restore-failure'
+          ),
+        revokeCredential: vi.fn(),
+      },
+    });
 
     const restored = await sessions.restoreFromDisk(configDir);
 
@@ -229,6 +288,10 @@ describe('web session restore failure recovery', () => {
     if (session?.mode !== 'web') throw new Error('expected web session');
     expect(session.hookToken).toBe('restored-hook-token');
     expect(session.spawnedBySessionId).toBe('orchestrator-session');
+    expect(session.role).toBe('orchestrator');
+    expect(sessions.list().find((entry) => entry.id === session.id)?.role).toBe(
+      'orchestrator'
+    );
     expect(session.needsBranchRename).toBe(true);
     expect(session.workspaceId).toBe('workspace-1');
     expect(session.additionalDirs).toEqual([path.join(configDir, 'extra')]);
@@ -255,6 +318,78 @@ describe('web session restore failure recovery', () => {
       )
     ).toBe(true);
     expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
+  });
+
+  it('retains an explicit orchestrator credential through successful restore and revokes it on kill', async () => {
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-orchestrator-success',
+        vendor: 'claude',
+        vendorSessionId: 'stored-orchestrator-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'restored orchestrator',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-orchestrator-success',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: {
+            claudeSessionId: 'stored-orchestrator-provider-session',
+          },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          role: 'orchestrator',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'orchestrator-success-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+    const revokeCredential = vi.fn();
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({
+      port: 4567,
+      configDir,
+      orchestratorCredentials: {
+        issueCredential: () =>
+          restoredOrchestratorCredential(
+            'orchestrator-success-credential',
+            'web-restore-orchestrator-success'
+          ),
+        revokeCredential,
+      },
+    });
+
+    expect(await sessions.restoreFromDisk(configDir)).toBe(1);
+    await vi.waitFor(() =>
+      expect(resumeSession).toHaveBeenCalledWith(
+        'stored-orchestrator-provider-session'
+      )
+    );
+    const session = sessions.get('web-restore-orchestrator-success');
+    expect(session?.role).toBe('orchestrator');
+    await vi.waitFor(() => expect(session?.restoreState).toBeUndefined());
+    expect(revokeCredential).not.toHaveBeenCalled();
+
+    sessions.kill('web-restore-orchestrator-success');
+    expect(revokeCredential).toHaveBeenCalledTimes(1);
+    expect(revokeCredential).toHaveBeenCalledWith(
+      'orchestrator-success-credential',
+      {
+        revokedBy: 'relay-ide',
+        reason: 'orchestrator-session-ended',
+      }
+    );
   });
 
   it('fences blank connect snapshots and resumes from the persisted transcript identity', async () => {
@@ -841,7 +976,8 @@ describe('web session restore failure recovery', () => {
     expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
   });
 
-  it('resumes a persisted Hermes session from its stored response id', async () => {
+  it('resumes a persisted Hermes session from its stored response id as a normal worker', async () => {
+    supportsRuntimeEnvRefresh = false;
     loadAllWebSessions.mockReturnValueOnce([
       {
         id: 'web-restore-hermes',
@@ -885,6 +1021,7 @@ describe('web session restore failure recovery', () => {
     await vi.waitFor(() =>
       expect(resumeSession).toHaveBeenCalledWith('resp_stored')
     );
+    expect(sessions.get('web-restore-hermes')?.role).toBeUndefined();
     expect(reconnect).not.toHaveBeenCalled();
   });
 });

--- a/test/web-session-handler.test.ts
+++ b/test/web-session-handler.test.ts
@@ -201,7 +201,7 @@ describe('createWebSession', () => {
   });
 
   it('creates a web session and adds it to sessionsMap', async () => {
-    const { session } = await createWebSession(
+    const { session, config } = await createWebSession(
       {
         agentType: 'mock',
         cwd: '/repo',
@@ -218,12 +218,58 @@ describe('createWebSession', () => {
 
     expect(session.mode).toBe('web');
     expect(session.adapterType).toBe('mock');
+    expect(session.role).toBeUndefined();
+    expect(config.systemPromptAppendix).toContain('role: collaborator');
     expect(session.controlState).toMatchObject({
       controlMode: 'human-driven',
       controlFreshness: 'unknown',
     });
     expect(sessionsMap.has(session.id)).toBe(true);
     expect(sessionsMap.get(session.id)).toBe(session);
+  });
+
+  it('persists an explicit role and threads its playbook into web adapter config', async () => {
+    const { session, config } = await createWebSession(
+      {
+        agentType: 'claude',
+        role: 'orchestrator',
+        cwd: '/repo',
+        displayName: 'Product orchestrator',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    expect(session.role).toBe('orchestrator');
+    expect(config.systemPromptAppendix).toContain(
+      'operator’s Relay-managed orchestrator'
+    );
+    expect(config.systemPromptAppendix).toContain(
+      'events subscribe --topic attention'
+    );
+    expect(config.systemPromptAppendix).not.toContain(
+      'events subscribe --topic inbox'
+    );
+  });
+
+  it('uses role overrides only for display when an explicit role is absent', async () => {
+    const { session, config } = await createWebSession(
+      {
+        agentType: 'mock',
+        roleOverrides: { mock: 'reviewer' },
+        cwd: '/repo',
+        displayName: 'Review agent',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    expect(session.role).toBeUndefined();
+    expect(config.systemPromptAppendix).toContain('role: reviewer');
   });
 
   it('uses provided control state independently from web transport mode', async () => {


### PR DESCRIPTION
Slice 4 of epic #1242 (**Option B**, operator-confirmed): a durable channel-bound agent session with `role=orchestrator` that holds a scoped actor token in its env and drives the product channel exempt from the consecutive-agent-turns brake. This is the **backend spine**; live end-to-end proof lands as part B.

## What
- **Role decoupling (security-critical):** durable `session.role` is persisted ONLY from an explicit `params.role` (operator / `ensureOrchestrator` lane). `roleForAgent` stays a display-only hint and never triggers the privileged path — closing a latent escalation where `hermes`/`ebi` (which map to `orchestrator` by default) could self-promote a worker actor into a credentialed, brake-exempt orchestrator, and fixing a native Hermes web-session create/restore regression.
- **Actor policy:** scoped actors create workers only; explicit `role=orchestrator` → 403; `hermes`/`codex`/`claude` workers unaffected.
- **Credential lifecycle:** minimal caps (`session:read`, `context:read`, `context:write`, `session:create:agent`); 15-min lease; refresh at half-TTL; ordering mint→apply→swap→revoke (last usable credential never revoked early); rotation interrupts+requeues an active turn so a live token never expires mid-turn; lease stopped+revoked on kill/detach **and** genuine adapter disconnect; `reason:'persistent-orchestrator'` reserved to an internal issuer (stripped from external issue inputs).
- **Brake exemption:** orchestrator-role source (server-derived durable role) bypasses the 4-turn brake; non-orchestrator agents unchanged; human posts still reset.
- **`channels.post`** gateway verb for orchestrator narration (+ command manifest scope-kinds); `source.sessionId` attribution stamped only when the actor resolves to a live orchestrator session.
- **Orchestrator playbook** appendix + web-session collaboration-prompt injection; `ensureOrchestrator(channelId, framework)` designate/spawn/resume hook.

## Security
Token never logged, persisted, or surfaced (roster/summary carry `role` only); all lifecycle errors drop `cause` to avoid env-material leakage. Reviewed adversarially; the P1 role-derivation escalation + P2s (disconnect lease churn, long-turn token expiry) found and fixed before this PR.

## Verify
- `npm run check`: 0 errors
- changed-scope suite: 152 files / 1884 tests pass; 7 server-startup HTTP integration tests (actor create/deny + Hermes credential-count) pass
- (pre-push flagged a known subprocess-contention flake; full changed-set is green on isolated re-run)

Part B (follow-up): wire a real product channel + token-frugal live proof (operator posts → orchestrator narrates + delegates a hello-world worker).

Refs #1259, #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for posting messages to channels through the CLI gateway.
  * Added session collaboration roles, including orchestrator role support, persistence, display, and role-specific prompts.
  * Added secure source-session attribution for orchestrator channel messages.
  * Added automatic credential refresh and fail-closed handling for orchestrator sessions.
  * Added runtime environment and system-prompt configuration for hosted agent sessions.

* **Bug Fixes**
  * Improved channel routing and restored-session role validation.
  * Prevented unauthorized role metadata and client-supplied message attribution fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->