### PR TITLE
feat(orchestrator): operator designate-orchestrator route + #1259 live proof (#1242)

### DIFF
--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -27,6 +27,7 @@ import {
 import {
   ChannelAgentNoActiveTurnError,
   ChannelAgentNotFoundError,
+  ChannelAgentRoleConflictError,
   type ChannelAgentBinder,
 } from './channel-agent-binder.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
@@ -922,6 +923,47 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       .rosterForChannel(topic.id)
       .then((roster) => res.json({ roster }))
       .catch((error) => mapStoreError(res, error));
+  });
+
+  // #1259 slice 4: operator designates (spawns / resumes) the persistent
+  // orchestrator for a product channel. Operator lane ONLY — scoped actors are
+  // forbidden from creating orchestrator-role sessions (see the actor
+  // session-create policy); the durable orchestrator role is granted here.
+  router.post('/channels/:id/orchestrator', auth, (req, res) => {
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    const binder = binderOr503(res, deps.binder);
+    if (!binder) return;
+    const requested = req.query['framework'];
+    const framework =
+      typeof requested === 'string' && requested.length > 0
+        ? requested
+        : 'claude';
+    binder
+      .ensureOrchestrator(topic.id, framework)
+      .then((binding) =>
+        res.json({
+          ok: true,
+          orchestrator: {
+            sessionId: binding.sessionId ?? null,
+            status: binding.status ?? 'idle',
+            framework,
+          },
+        })
+      )
+      .catch((error) => {
+        if (error instanceof ChannelAgentRoleConflictError) {
+          sendGatewayError(
+            res,
+            'SESSION_CONFLICT',
+            'channel already bound to a non-orchestrator session',
+            false,
+            { channelId: topic.id, reasonCode: 'CHANNEL_ROLE_CONFLICT' }
+          );
+          return;
+        }
+        mapStoreError(res, error);
+      });
   });
 
   // #1167 §7: interrupt the agent's active turn.

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -28,6 +28,10 @@ import {
   createChannelChatRouter,
 } from '../server/channel-chat-router.js';
 import {
+  ChannelAgentRoleConflictError,
+  type ChannelAgentBinder,
+} from '../server/channel-agent-binder.js';
+import {
   CHANNEL_IMAGE_MAX_BYTES,
   createChannelAttachmentStore,
   type ChannelAttachmentStore,
@@ -65,6 +69,7 @@ async function harness(
     withAttachmentStore?: boolean;
     historyMaxBytes?: number;
     withAuth?: boolean;
+    binder?: Partial<ChannelAgentBinder>;
   } = {}
 ): Promise<Harness> {
   const dir = tmpDir();
@@ -108,6 +113,9 @@ async function harness(
         options.withAttachmentStore === false ? null : attachmentStore,
       hub,
       topicStore,
+      ...(options.binder
+        ? { binder: options.binder as unknown as ChannelAgentBinder }
+        : {}),
       ...(options.withAuth
         ? {
             requireAuth: (req, res, next) => {
@@ -1177,5 +1185,86 @@ describe('channel routes — gateway capability mapping', () => {
     expect(cliGatewayActorCommandCapabilities('channels.post')).toEqual([
       'context:write',
     ]);
+  });
+});
+
+describe('channel routes — orchestrator designation (#1259)', () => {
+  it('designates the persistent orchestrator via ensureOrchestrator', async () => {
+    const calls: Array<{ channelId: string; framework: string }> = [];
+    const h = await harness({
+      binder: {
+        ensureOrchestrator: async (channelId: string, framework: string) => {
+          calls.push({ channelId, framework });
+          return { sessionId: 'orch-1', status: 'idle' } as never;
+        },
+      },
+    });
+    const res = await req<{
+      ok: boolean;
+      orchestrator: { sessionId: string; status: string; framework: string };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/orchestrator?framework=claude`,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.orchestrator).toEqual({
+      sessionId: 'orch-1',
+      status: 'idle',
+      framework: 'claude',
+    });
+    expect(calls).toEqual([{ channelId: h.channelId, framework: 'claude' }]);
+  });
+
+  it('defaults the framework to claude when omitted', async () => {
+    const seen: string[] = [];
+    const h = await harness({
+      binder: {
+        ensureOrchestrator: async (_channelId: string, framework: string) => {
+          seen.push(framework);
+          return { sessionId: 'orch-2', status: 'idle' } as never;
+        },
+      },
+    });
+    const res = await req<{ ok: boolean }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/orchestrator`,
+    });
+    expect(res.status).toBe(200);
+    expect(seen).toEqual(['claude']);
+  });
+
+  it('maps a role conflict to SESSION_CONFLICT', async () => {
+    const h = await harness({
+      binder: {
+        ensureOrchestrator: async () => {
+          throw new ChannelAgentRoleConflictError(
+            'topic:x',
+            'claude',
+            'sess-x',
+            'implementer'
+          );
+        },
+      },
+    });
+    const res = await req<{ error: { reasonCode?: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/orchestrator`,
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('returns 503 when no binder is configured', async () => {
+    const h = await harness();
+    const res = await req<{ error: unknown }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/orchestrator`,
+    });
+    expect(res.status).toBe(503);
   });
 });


### PR DESCRIPTION
Follow-up to #1271 (the #1259 backend spine): the operator-facing **designate** action + the live proof that de-risks the spine end-to-end.

## What
`POST /channels/:id/orchestrator?framework=claude` → `binder.ensureOrchestrator`, spawning/resuming a durable `role=orchestrator` session bound to the channel. **Operator lane only** (cookie auth) — scoped actors are forbidden from creating orchestrator sessions by the actor session-create policy. Role conflict → `SESSION_CONFLICT`; no binder → 503. This is the designate action behind #1242 **Slice 5** (product-channel UX).

## Live proof (this session, token-frugal)
Booted an isolated dev hub on the merged spine and ran the full loop:
```
POST /channels/topic:.../orchestrator?framework=claude
  → {ok:true, orchestrator:{sessionId:"91f007c5f74394d8", status:"idle", framework:"claude"}}
/sessions → 91f007c5f74394d8 role=orchestrator          (durable role confirmed)
operator posts "@claude reply with exactly: ok"
[claude-adapter] spawning claude subprocess { sessionId:"91f007c5f74394d8", resume:false }
channel seq2 agent :: ok                                 (real turn returned)
hub errors: 0
```
Confirms: designate → orchestrator session with durable role + a scoped actor-credential lease + `RELAY_IDE_ACTOR_TOKEN` injected into the claude subprocess env (mint is silent by design; fail-closed would have thrown and blocked the spawn) → real subprocess runs a turn. The gateway-peer narration loop (orchestrator calling `channels.post`/`sessions.create` via its token) is exercised by Slice 5's purpose-built playbook prompt, not this literal "reply ok" check.

## Verify
- `npm run check`: 0 errors
- `test/channel-routes.test.ts`: 30 pass (4 new: designate success, framework default, role-conflict→409, no-binder→503)

Refs #1259, #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for binding a channel to a persistent orchestrator session.
  * Orchestrator details now include session status, session ID, and selected framework.
  * Supports optional framework selection, defaulting to Claude when unspecified or invalid.

* **Bug Fixes**
  * Channel role conflicts now return a clear conflict response.
  * Requests return an appropriate service-unavailable response when orchestration is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->