### PR TITLE
feat(chat): operator↔orchestrator UX — designate control + orchestrator badge (#1242 slice 5)

### DIFF
--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -48,6 +48,7 @@
 }
 
 .ch-header__title {
+  min-width: 0;
   color: var(--text);
   font-weight: 700;
   text-transform: lowercase;
@@ -74,6 +75,7 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
+  flex-shrink: 1;
   overflow: hidden;
 }
 
@@ -132,6 +134,51 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 12ch;
+}
+
+/* Role is a structural, monochrome tag. Agent identity remains the resolved
+   sender color on the reused vendor glyph; this adds no second color system. */
+.ch-agent-chip__role {
+  padding: 0 3px;
+  border: 1px solid currentColor;
+  color: inherit;
+  font-size: 0.65rem;
+  line-height: 1.2;
+  text-transform: lowercase;
+}
+
+/* Inline operator control: outline-only and transparent on the primary black
+   header surface, never a floating --surface treatment. */
+.ch-designate-orchestrator {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--accent);
+  border-radius: 0;
+  background: transparent;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
+  text-transform: lowercase;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.ch-designate-orchestrator:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.ch-designate-orchestrator:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ch-designate-orchestrator__progress {
+  color: currentColor;
+  font-size: inherit;
 }
 
 .ch-agent-chip__stop {
@@ -745,6 +792,26 @@
 @media (max-width: 767px) {
   .ch-header {
     padding: 8px 10px;
+  }
+
+  .ch-header__meta {
+    display: none;
+  }
+
+  .ch-header__title {
+    flex: 1 1 auto;
+  }
+
+  /* Retain the role distinction in the shared mobile header without consuming
+     the full desktop label width. The DOM text stays "orchestrator" for AT. */
+  .ch-agent-chip__role {
+    padding: 0 2px;
+    font-size: 0;
+  }
+
+  .ch-agent-chip__role::after {
+    content: 'orch';
+    font-size: 0.65rem;
   }
 
   .ch-tl {

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import type { ChannelMessagePart } from '../../../../shared/channel-chat-protocol.js';
 import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
+import type { AgentRole } from '../../../../shared/agent-roster.js';
 import './ChannelView.css';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useChannelChatSocket } from '../../hooks/useChannelChatSocket.js';
@@ -14,6 +15,7 @@ import {
   fetchWorkspaceTopic,
   restoreWorkspaceTopic,
   fetchChannelRoster,
+  designateChannelOrchestrator,
   interruptChannelAgent,
   HttpError,
   type ChannelAgentStatus,
@@ -31,6 +33,7 @@ import {
 } from '../../lib/stores/channel-agent-status.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { AgentBadge } from '../AgentBadge.js';
+import { TuiProgress } from '../TuiProgress.js';
 import { ChannelTimeline } from './ChannelTimeline.js';
 import { ChannelComposer } from './ChannelComposer.js';
 import { ChannelThreadPanel } from './ChannelThreadPanel.js';
@@ -153,6 +156,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       setRestorePending(false);
     }
   }, [channelId, queryClient]);
+
+  const [designatePending, setDesignatePending] = useState(false);
 
   const handleSend = useCallback(
     async (
@@ -338,6 +343,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     const chips: Array<{
       agentId: string;
       status: ChannelAgentStatus;
+      role?: AgentRole;
       identity: ReturnType<typeof resolveSenderIdentity>;
     }> = [];
     for (const agentId of candidateIds) {
@@ -363,7 +369,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         providerId: agentId,
         ...(entry?.displayName ? { displayName: entry.displayName } : {}),
       });
-      chips.push({ agentId, status, identity });
+      chips.push({
+        agentId,
+        status,
+        ...(entry?.role ? { role: entry.role } : {}),
+        identity,
+      });
     }
     return chips;
   }, [
@@ -382,6 +393,25 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       void interruptChannelAgent(channelId, agentId).catch(() => {});
     },
     [channelId]
+  );
+
+  const handleDesignateOrchestrator = useCallback(async () => {
+    setDesignatePending(true);
+    try {
+      await designateChannelOrchestrator(channelId);
+      await queryClient.invalidateQueries({
+        queryKey: ['channel-roster', channelId],
+      });
+    } catch {
+      // Keep the affordance available for a retry; API errors stay local to this
+      // operator control just as interrupt races do.
+    } finally {
+      setDesignatePending(false);
+    }
+  }, [channelId, queryClient]);
+
+  const hasOrchestrator = agentChips.some(
+    (chip) => chip.role === 'orchestrator'
   );
 
   const channelNotFound =
@@ -446,7 +476,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
                 <span
                   key={chip.agentId}
                   className={`ch-agent-chip ch-agent-chip--${chip.status}`}
-                  title={`${chip.identity.label} · ${chip.status}`}
+                  title={`${chip.identity.label}${
+                    chip.role ? ` · ${chip.role}` : ''
+                  } · ${chip.status}`}
                 >
                   {chip.identity.glyph ? (
                     <span
@@ -461,6 +493,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
                   <span className="ch-agent-chip__name">
                     {chip.identity.label}
                   </span>
+                  {chip.role === 'orchestrator' ? (
+                    <span className="ch-agent-chip__role">orchestrator</span>
+                  ) : null}
                   {canInterrupt ? (
                     <button
                       type="button"
@@ -476,6 +511,26 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               );
             })}
           </span>
+        ) : null}
+        {rosterChipsQuery.isSuccess && !hasOrchestrator ? (
+          <button
+            type="button"
+            className="ch-designate-orchestrator"
+            onClick={() => void handleDesignateOrchestrator()}
+            disabled={designatePending}
+          >
+            {designatePending ? (
+              <>
+                <TuiProgress
+                  variant="braille"
+                  className="ch-designate-orchestrator__progress"
+                />{' '}
+                designating
+              </>
+            ) : (
+              'designate orchestrator'
+            )}
+          </button>
         ) : null}
         <span className="ch-header__spacer" />
         {disconnected ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { WorkbenchLayout } from '../../../shared/workbench-layout-types.js';
-import type { AgentRoster } from '../../../shared/agent-roster.js';
+import type { AgentRole, AgentRoster } from '../../../shared/agent-roster.js';
 import type {
   AnchorRef,
   AnchorState,
@@ -1914,6 +1914,8 @@ export interface RosterEntry {
   /** False when the framework cannot currently be routed to (see `reason`). */
   available: boolean;
   reason: string | null;
+  /** Present for a bound session when its collaboration role is known. */
+  role?: AgentRole;
   /** Present when a live session is bound to this agent in the channel. */
   binding: { sessionId: string; status: ChannelAgentStatus } | null;
 }
@@ -1981,6 +1983,41 @@ export async function interruptChannelAgent(
       `/channels/${encodeURIComponent(channelId)}/agents/${encodeURIComponent(
         agentId
       )}/interrupt`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({}),
+      }
+    )
+  );
+}
+
+/** Persistent orchestrator binding created by the operator lane. */
+export interface ChannelOrchestratorDesignation {
+  ok: true;
+  orchestrator: {
+    sessionId: string | null;
+    status: ChannelAgentStatus;
+    framework: string;
+  };
+}
+
+/**
+ * Designate (or resume) the persistent orchestrator for a product channel.
+ * This route is cookie-authenticated: it keeps the standard operator channel
+ * capability header but intentionally has no actor-token path.
+ */
+export async function designateChannelOrchestrator(
+  channelId: string,
+  framework = 'claude'
+): Promise<ChannelOrchestratorDesignation> {
+  const params = new URLSearchParams({ framework });
+  return json<ChannelOrchestratorDesignation>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/orchestrator?${params.toString()}`,
       {
         method: 'POST',
         headers: {

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -27,6 +27,7 @@ import {
   type ChannelMessage,
 } from '../shared/channel-chat-protocol.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
+import type { AgentRole } from '../shared/agent-roster.js';
 
 // @-mention routing binder (#1167, slice 4). One module owns the whole loop:
 // subscribe to hub.onMessagePosted → resolve mentions → ensure a (channel,
@@ -93,6 +94,7 @@ export interface ChannelAgentRosterEntry {
   kind: 'framework';
   available: boolean;
   reason: string | null;
+  role?: AgentRole;
   binding: { sessionId: string; status: ChannelAgentStatus } | null;
 }
 
@@ -1332,12 +1334,14 @@ export function createChannelAgentBinder(
       const binding = live.get(bindingKey(channelId, target.id));
       const row = store.getBinding(channelId, target.id);
       const sessionId = binding?.sessionId ?? row?.sessionId ?? null;
+      const session = sessionId ? deps.sessions.get(sessionId) : undefined;
       return {
         id: target.id,
         displayName: target.displayName,
         kind: 'framework',
         available: target.available,
         reason: target.reason,
+        ...(session?.role !== undefined ? { role: session.role } : {}),
         binding: sessionId
           ? { sessionId, status: binding?.status ?? 'idle' }
           : null,

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -2008,6 +2008,33 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
 });
 
 describe('channel-agent-binder — roster + availability', () => {
+  it('surfaces bound session roles in the channel roster', async () => {
+    const { binder, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        ...MOCK_TARGETS,
+        {
+          id: 'worker',
+          displayName: 'Worker',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['mock', 'worker'],
+    });
+
+    await binder.ensureOrchestrator(CH, 'mock');
+    await binder.ensureBinding(CH, 'worker');
+
+    const roster = await binder.rosterForChannel(CH);
+    expect(roster.find((entry) => entry.id === 'mock')?.role).toBe(
+      'orchestrator'
+    );
+    expect(roster.find((entry) => entry.id === 'worker')?.role).toBeUndefined();
+    expect(sessions.spawns()).toBe(2);
+  });
+
   it('reports availability, reasons, and live binding status', async () => {
     const { binder, store } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -1,0 +1,241 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  designateChannelOrchestrator: vi.fn(),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+    designateChannelOrchestrator: mocks.designateChannelOrchestrator,
+  };
+});
+
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: 'topic:operator-lane',
+      title: 'operator lane',
+      visibility: 'default',
+      archived: false,
+      latestSeq: 0,
+      messageCount: 0,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: 'topic:operator-lane',
+      messages: [],
+      lastSeq: 0,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    fullSnapshotRevision: 0,
+    post: vi.fn(),
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+vi.mock('../../frontend/src/components/chat/ChannelTimeline.js', () => ({
+  ChannelTimeline: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
+  ChannelComposer: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
+  ChannelThreadPanel: () => null,
+}));
+
+const { ChannelView } = await import(
+  '../../frontend/src/components/chat/ChannelView.js'
+);
+
+const CHANNEL_ID = 'topic:operator-lane';
+
+function topicFixture() {
+  return {
+    id: CHANNEL_ID,
+    workspaceId: 'workspace:local',
+    display: { title: 'operator lane' },
+    routingDefaults: {},
+  };
+}
+
+function rosterEntry(role?: 'orchestrator' | 'implementer') {
+  return {
+    id: 'claude',
+    displayName: 'claude',
+    kind: 'framework' as const,
+    available: true,
+    reason: null,
+    ...(role ? { role } : {}),
+    binding: {
+      sessionId: 'session:claude-1',
+      status: 'idle' as const,
+    },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let queryClient: QueryClient;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function render(): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(ChannelView, { channelId: CHANNEL_ID })
+      )
+    );
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  mocks.fetchWorkspaceTopic.mockReset();
+  mocks.fetchChannelRoster.mockReset();
+  mocks.designateChannelOrchestrator.mockReset();
+  mocks.fetchWorkspaceTopic.mockResolvedValue(topicFixture());
+  vi.stubGlobal('matchMedia', () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  queryClient.clear();
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('ChannelView orchestrator control (#1242)', () => {
+  it('waits for the roster before offering designation', async () => {
+    let resolveRoster: ((entries: ReturnType<typeof rosterEntry>[]) => void) | null = null;
+    mocks.fetchChannelRoster.mockReturnValue(
+      new Promise<ReturnType<typeof rosterEntry>[]>((resolve) => {
+        resolveRoster = resolve;
+      })
+    );
+
+    await render();
+
+    expect(container.querySelector('.ch-designate-orchestrator')).toBeNull();
+
+    resolveRoster?.([rosterEntry('implementer')]);
+    await flush();
+
+    expect(container.querySelector('.ch-designate-orchestrator')).not.toBeNull();
+  });
+
+  it('designates from the missing-orchestrator header and invalidates its roster', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+    mocks.designateChannelOrchestrator.mockResolvedValue({
+      ok: true,
+      orchestrator: {
+        sessionId: 'session:orchestrator-1',
+        status: 'idle',
+        framework: 'claude',
+      },
+    });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await render();
+
+    const designate = container.querySelector<HTMLButtonElement>(
+      '.ch-designate-orchestrator'
+    );
+    expect(designate?.textContent).toContain('designate orchestrator');
+
+    await act(async () => designate?.click());
+
+    expect(mocks.designateChannelOrchestrator).toHaveBeenCalledWith(CHANNEL_ID);
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ['channel-roster', CHANNEL_ID],
+    });
+  });
+
+  it('uses the braille text-motion state while designation is pending', async () => {
+    let resolveDesignation: (() => void) | null = null;
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+    mocks.designateChannelOrchestrator.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDesignation = resolve;
+      })
+    );
+
+    await render();
+
+    const designate = container.querySelector<HTMLButtonElement>(
+      '.ch-designate-orchestrator'
+    );
+    act(() => designate?.click());
+    await flush();
+
+    expect(designate?.disabled).toBe(true);
+    expect(designate?.textContent).toContain('designating');
+    expect(designate?.querySelector('[role="status"]')).not.toBeNull();
+
+    resolveDesignation?.();
+    await flush();
+  });
+
+  it('marks a roster orchestrator with the compact lowercase role tag', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('orchestrator')]);
+
+    await render();
+
+    const chip = container.querySelector('.ch-agent-chip');
+    expect(chip?.textContent).toContain('orchestrator');
+    expect(chip?.querySelector('.ch-agent-chip__role')?.textContent).toBe(
+      'orchestrator'
+    );
+    expect(container.querySelector('.ch-designate-orchestrator')).toBeNull();
+  });
+});


### PR DESCRIPTION
#1242 **Slice 5** — the operator's conversation-with-the-orchestrator surface, on the locked model: **DM = 2-member channel, no separate primitive**. A "product channel" is simply a channel with an orchestrator-role agent designated (the #1272 designate route).

## What
- **Roster carries role:** `ChannelAgentRosterEntry` gains `role?`; `rosterForChannel` projects the bound session's `role` (via `deps.sessions`) so orchestrator designation is readable client-side.
- **API:** `designateChannelOrchestrator()` → `POST /channels/:id/orchestrator`; `role` added to the channel `RosterEntry` type.
- **Designate control:** ChannelView header shows a "designate orchestrator" affordance **only when the roster has loaded and no orchestrator is bound**; braille `TuiProgress` while pending; exact roster-query invalidation on success.
- **Orchestrator badge:** role-aware header chips render a lowercase monochrome `orchestrator` tag (→ `orch` on mobile) on the bound orchestrator, reusing the existing `AgentBadge` + `resolveSenderIdentity` color — **no second identity/color system**.

## DESIGN.md
0px radius; accent-outline **transparent** control (no solid fill); no floating `--surface` for the inline header control; no emoji; text-motion (braille) liveness; lowercase copy. Reviewed for divergence — clean.

## Deferred
Nav-level product-channel marker: the sidebar has no list-level designation field; adding one would require per-channel roster fan-out. Deferred rather than fan out.

## Verify
`npm run check`: 0 errors. 57 tests (backend role projection + 4 ChannelView orchestrator tests). Suggested: a quick narrow-width browser glance (overflow handled structurally via flex-shrink + compact mobile tag).

Refs #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)