### PR TITLE
feat(cockpit): orchestrator→workers lineage tree (#1242 slice 6)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -952,6 +952,139 @@
   font-size: 0.58rem;
 }
 
+/* #1242: Session lineage is deliberately separate from workflow-run lanes.
+   Every row follows DESIGN.md's sidebar grid: padding / 24px icon / content /
+   36px action / padding. A worker's entire grid moves exactly one icon slot. */
+.session-lineage-tree {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.session-lineage-tree__header,
+.session-lineage-tree__bucket-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 var(--sidebar-padding-x);
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.session-lineage-tree__header > span:first-child,
+.session-lineage-tree__bucket-label {
+  color: var(--accent);
+}
+
+.session-lineage-tree__list,
+.session-lineage-tree__branch,
+.session-lineage-tree__bucket {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.session-lineage-tree__bucket {
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.session-lineage-tree__item {
+  margin: 0;
+  padding: 0;
+}
+
+.session-lineage-tree__row {
+  display: grid;
+  grid-template-columns:
+    var(--icon-slot-width) minmax(0, 1fr)
+    var(--action-slot-width);
+  align-items: center;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 var(--sidebar-padding-x) 0
+    calc(
+      var(--sidebar-padding-x) +
+        (var(--session-lineage-depth, 0) * var(--icon-slot-width))
+    );
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  text-align: left;
+}
+
+.session-lineage-tree__row:not(:disabled) {
+  cursor: pointer;
+}
+
+.session-lineage-tree__row:hover:not(:disabled),
+.session-lineage-tree__row:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text);
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.session-lineage-tree__row:disabled {
+  cursor: default;
+}
+
+.session-lineage-tree__icon,
+.session-lineage-tree__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.session-lineage-tree__content {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  padding: 0 8px;
+}
+
+.session-lineage-tree__name,
+.session-lineage-tree__meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-lineage-tree__name {
+  color: var(--text);
+  font-weight: 650;
+}
+
+.session-lineage-tree__meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.session-lineage-tree__role {
+  color: var(--accent);
+}
+
+.session-lineage-tree__action {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.session-lineage-tree__row--active .session-lineage-tree__action {
+  color: var(--status-info);
+}
+
 .topic-shell-state {
   padding: 16px 12px;
   color: var(--text-muted);

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -60,6 +60,8 @@ import {
 } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
 import { resolveSenderIdentity } from '../lib/chat/sender-identity.js';
+import { buildSessionLineage } from '../lib/session-lineage.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
 import {
   hasUnseenActivity,
   useChannelActivityStore,
@@ -595,6 +597,159 @@ function ParticipantRoster({
   );
 }
 
+function sessionLineageStatus(session: SessionSummary): 'idle' | 'active' {
+  return session.idle ? 'idle' : 'active';
+}
+
+function SessionLineageRow({
+  session,
+  depth,
+  onSelectSession,
+}: {
+  session: SessionSummary;
+  depth: number;
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const status = sessionLineageStatus(session);
+  const selectKey = scopedSessionKey(session);
+  const identity = resolveSenderIdentity({
+    kind: 'agent',
+    id: selectKey,
+    providerId: session.agent,
+    displayName: session.displayName,
+  });
+  const rowStyle = { '--session-lineage-depth': depth } as CSSProperties;
+  return (
+    <li className="session-lineage-tree__item" style={rowStyle}>
+      <button
+        type="button"
+        className={`session-lineage-tree__row session-lineage-tree__row--${status}`}
+        disabled={!onSelectSession}
+        data-session-id={session.id}
+        title={`open session ${session.displayName}`}
+        onClick={() => onSelectSession?.(selectKey)}
+      >
+        <span className="session-lineage-tree__icon" aria-hidden="true">
+          <AgentAvatar
+            identity={identity}
+            name={session.displayName}
+            presence={status === 'active' ? 'busy' : 'online'}
+            size={20}
+          />
+        </span>
+        <span className="session-lineage-tree__content">
+          <span className="session-lineage-tree__name">
+            <MarqueeText>{session.displayName}</MarqueeText>
+          </span>
+          <span className="session-lineage-tree__meta">
+            {session.role === 'orchestrator' ? (
+              <span className="session-lineage-tree__role">orchestrator</span>
+            ) : null}
+            <span>{status}</span>
+          </span>
+        </span>
+        <span className="session-lineage-tree__action" aria-hidden="true">
+          {status === 'active' ? '⠿' : '·'}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+/** Operator-facing, one-hop hierarchy over the live session summaries. */
+function SessionLineageTree({
+  sessions,
+  onSelectSession,
+}: {
+  sessions: SessionSummary[];
+  onSelectSession?: ((id: string) => void) | undefined;
+}) {
+  const lineage = buildSessionLineage(sessions);
+  const hasOrchestrators = lineage.orchestrators.length > 0;
+  if (
+    !hasOrchestrators &&
+    lineage.standalone.length === 0 &&
+    lineage.ungrouped.length === 0
+  ) {
+    return null;
+  }
+  return (
+    <section
+      className={`session-lineage-tree${hasOrchestrators ? '' : ' session-lineage-tree--flat'}`}
+      aria-label="session lineage"
+    >
+      <div className="session-lineage-tree__header">
+        <span>session tree</span>
+        <span>{sessions.length} live</span>
+      </div>
+      {hasOrchestrators ? (
+        <ul className="session-lineage-tree__list">
+          {lineage.orchestrators.map(({ session, workers }) => (
+            <li
+              className="session-lineage-tree__branch"
+              key={scopedSessionKey(session)}
+            >
+              <ul className="session-lineage-tree__list">
+                <SessionLineageRow
+                  session={session}
+                  depth={0}
+                  onSelectSession={onSelectSession}
+                />
+              </ul>
+              {workers.length > 0 ? (
+                <ul className="session-lineage-tree__list">
+                  {workers.map((worker) => (
+                    <SessionLineageRow
+                      key={scopedSessionKey(worker)}
+                      session={worker}
+                      depth={1}
+                      onSelectSession={onSelectSession}
+                    />
+                  ))}
+                </ul>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {lineage.standalone.length > 0 ? (
+        <div className="session-lineage-tree__bucket">
+          <div className="session-lineage-tree__bucket-label">
+            {hasOrchestrators ? 'other sessions' : 'sessions'}
+          </div>
+          <ul className="session-lineage-tree__list">
+            {lineage.standalone.map((session) => (
+              <SessionLineageRow
+                key={scopedSessionKey(session)}
+                session={session}
+                depth={0}
+                onSelectSession={onSelectSession}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {lineage.ungrouped.length > 0 ? (
+        <div className="session-lineage-tree__bucket">
+          <div className="session-lineage-tree__bucket-label">
+            ungrouped/other
+          </div>
+          <ul className="session-lineage-tree__list">
+            {lineage.ungrouped.map((session) => (
+              <SessionLineageRow
+                key={scopedSessionKey(session)}
+                session={session}
+                depth={0}
+                onSelectSession={onSelectSession}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function TopicRoomSessionRow({
   session,
   onSelectSession,
@@ -970,6 +1125,7 @@ function resolveWorkspaceName(
 
 function TopicDetail({
   item,
+  sessions,
   workspaceName,
   surfacesError,
   surfacesLoading,
@@ -982,6 +1138,7 @@ function TopicDetail({
   onOpenEvidenceDashboard,
 }: {
   item: TopicNavItem;
+  sessions: SessionSummary[];
   /** Friendly workspace name for the meta strip; omitted entirely (never a raw id) when unresolved. */
   workspaceName?: string | null | undefined;
   surfacesError?: boolean | undefined;
@@ -1159,6 +1316,10 @@ function TopicDetail({
         fallback.
       </div>
 
+      <SessionLineageTree
+        sessions={sessions}
+        onSelectSession={onSelectSession}
+      />
       <ParticipantRoster item={item} onSelectSession={onSelectSession} />
     </section>
   );
@@ -1538,6 +1699,7 @@ function TopicMobileControlPanelGate({
 
 function TopicAdvancedDetailGate({
   item,
+  sessions,
   show,
   workspaceNameById,
   surfacesError,
@@ -1548,6 +1710,7 @@ function TopicAdvancedDetailGate({
   onOpenEvidenceDashboard,
 }: {
   item: TopicNavItem | undefined;
+  sessions: SessionSummary[];
   show: boolean;
   workspaceNameById: Map<string, string>;
   surfacesError: boolean;
@@ -1575,6 +1738,7 @@ function TopicAdvancedDetailGate({
     <div className="topic-shell__advanced-detail">
       <TopicDetail
         item={item}
+        sessions={sessions}
         workspaceName={resolveWorkspaceName(item, workspaceNameById)}
         surfacesError={surfacesError}
         surfacesLoading={surfacesLoading}
@@ -1891,6 +2055,7 @@ function MobileRailSection({
 
 function TopicMobileCockpit({
   tree,
+  sessions,
   unreadByChannel,
   statusByChannelAgent,
   mentionsMeByChannel,
@@ -1901,8 +2066,10 @@ function TopicMobileCockpit({
   onInterrupt,
   onCreateTaskRoom,
   onResumeLast,
+  onSelectSession,
 }: {
   tree: ChannelRailTree;
+  sessions: SessionSummary[];
   unreadByChannel: Readonly<Record<string, boolean>>;
   statusByChannelAgent: Readonly<Record<string, ChannelAgentStatus>>;
   mentionsMeByChannel: Readonly<Record<string, boolean>>;
@@ -1917,6 +2084,7 @@ function TopicMobileCockpit({
   onInterrupt: (channelId: string, agentId: string) => Promise<void>;
   onCreateTaskRoom?: (() => void) | undefined;
   onResumeLast?: (() => void) | undefined;
+  onSelectSession?: ((id: string) => void) | undefined;
 }) {
   const [collapsedGroupIds, setCollapsedGroupIds] = useState<Set<string>>(
     () => new Set()
@@ -1977,6 +2145,10 @@ function TopicMobileCockpit({
         statusTextForItem={topicLatestStatus}
         onNudge={onNudge}
         onInterrupt={onInterrupt}
+      />
+      <SessionLineageTree
+        sessions={sessions}
+        onSelectSession={onSelectSession}
       />
       <div className="topic-cockpit__all-chats-header">all chats</div>
       <div className="topic-mobile-list" aria-label="workspace-grouped chats">
@@ -2811,6 +2983,7 @@ export function TopicSidebarView({
       />
       <TopicMobileCockpit
         tree={railTree}
+        sessions={sessions}
         unreadByChannel={unreadByChannel}
         statusByChannelAgent={effectiveStatusByChannelAgent}
         mentionsMeByChannel={mentionsMeByChannel}
@@ -2819,6 +2992,7 @@ export function TopicSidebarView({
         onSelect={selectMobile}
         onNudge={postMobileNudge}
         onInterrupt={interruptMobileAgent}
+        onSelectSession={onSelectSession}
         {...(onCreateTaskRoom ? { onCreateTaskRoom: openCreateTaskRoom } : {})}
         {...(resumeLastSelectKey && onSelectSession
           ? { onResumeLast: () => onSelectSession(resumeLastSelectKey) }
@@ -2844,6 +3018,7 @@ export function TopicSidebarView({
       <GroupedTopicTree tree={railTree} renderRow={renderTopicRow} />
       <TopicAdvancedDetailGate
         item={selectedItem}
+        sessions={sessions}
         show={advancedMode && showAdvancedDetail}
         workspaceNameById={workspaceNameById}
         surfacesError={surfacesError}

--- a/frontend/src/lib/session-lineage.ts
+++ b/frontend/src/lib/session-lineage.ts
@@ -1,0 +1,100 @@
+import type { SessionSummary } from './types.js';
+import { scopedSessionKey } from './session-keys.js';
+
+export interface SessionLineageRoot {
+  session: SessionSummary;
+  workers: SessionSummary[];
+}
+
+export interface SessionLineage {
+  /** Persistent planners that own one or more directly spawned workers. */
+  orchestrators: SessionLineageRoot[];
+  /** Sessions without lineage remain ordinary, top-level session rows. */
+  standalone: SessionSummary[];
+  /** Spawned sessions whose parent is missing or not an orchestrator. */
+  ungrouped: SessionSummary[];
+}
+
+/**
+ * Order all cockpit rows independently of arrival order. Creation time gives a
+ * stable operator-friendly chronology; name and id make ties deterministic.
+ */
+function compareSessions(left: SessionSummary, right: SessionSummary): number {
+  return (
+    left.createdAt.localeCompare(right.createdAt) ||
+    left.displayName.localeCompare(right.displayName) ||
+    scopedSessionKey(left).localeCompare(scopedSessionKey(right))
+  );
+}
+
+/**
+ * Build the one-hop session lineage shown in the operator cockpit.
+ *
+ * Only orchestrators are roots. A spawned worker is nested only when its
+ * immediate parent is one of those roots; stale/missing/non-orchestrator
+ * parents remain visible in the synthetic ungrouped bucket instead of being
+ * silently lost. Sessions with no parent preserve the normal flat treatment.
+ */
+export function buildSessionLineage(
+  sessions: readonly SessionSummary[]
+): SessionLineage {
+  const orchestrators = sessions
+    .filter((session) => session.role === 'orchestrator')
+    .sort(compareSessions);
+  const rootsByScopedKey = new Map(
+    orchestrators.map((session) => [scopedSessionKey(session), session])
+  );
+  const rootsByRawId = new Map<string, SessionSummary[]>();
+  for (const root of orchestrators) {
+    const candidates = rootsByRawId.get(root.id) ?? [];
+    candidates.push(root);
+    rootsByRawId.set(root.id, candidates);
+  }
+  const workersByRootKey = new Map<string, SessionSummary[]>();
+  const standalone: SessionSummary[] = [];
+  const ungrouped: SessionSummary[] = [];
+
+  for (const session of sessions) {
+    // An orchestrator is always a visible root, even if an older record also
+    // carries a parent pointer.
+    if (session.role === 'orchestrator') continue;
+
+    if (session.spawnedBySessionId === undefined) {
+      standalone.push(session);
+      continue;
+    }
+
+    const exactRoot = rootsByScopedKey.get(session.spawnedBySessionId);
+    const rawCandidates = rootsByRawId.get(session.spawnedBySessionId) ?? [];
+    const sameNodeRoots = rawCandidates.filter(
+      (candidate) => candidate.nodeId === session.nodeId
+    );
+    const root =
+      exactRoot ??
+      (rawCandidates.length === 1
+        ? rawCandidates[0]
+        : sameNodeRoots.length === 1
+          ? sameNodeRoots[0]
+          : undefined);
+    if (!root) {
+      ungrouped.push(session);
+      continue;
+    }
+
+    const rootKey = scopedSessionKey(root);
+    const workers = workersByRootKey.get(rootKey) ?? [];
+    workers.push(session);
+    workersByRootKey.set(rootKey, workers);
+  }
+
+  return {
+    orchestrators: orchestrators.map((session) => ({
+      session,
+      workers: (workersByRootKey.get(scopedSessionKey(session)) ?? []).sort(
+        compareSessions
+      ),
+    })),
+    standalone: standalone.sort(compareSessions),
+    ungrouped: ungrouped.sort(compareSessions),
+  };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -163,6 +163,8 @@ export interface SessionSummary {
   agent: AgentType;
   /** Durable collaboration role. A hint for routing/UI, not authorization. */
   role?: AgentRole;
+  /** Session that spawned this worker, when the backend retained its lineage. */
+  spawnedBySessionId?: string;
   mode?: 'pty' | 'web' | undefined;
   repoName?: string;
   repoPath?: string;

--- a/test/session-lineage.test.ts
+++ b/test/session-lineage.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { buildSessionLineage } from '../frontend/src/lib/session-lineage.js';
+import { scopedSessionKey } from '../frontend/src/lib/session-keys.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+describe('buildSessionLineage', () => {
+  it('nests workers directly beneath their orchestrator root', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'worker-b', spawnedBySessionId: 'orch' }),
+      makeSession({ id: 'orch', role: 'orchestrator' }),
+      makeSession({ id: 'worker-a', spawnedBySessionId: 'orch' }),
+    ]);
+
+    expect(lineage.orchestrators).toHaveLength(1);
+    expect(lineage.orchestrators[0]?.session.id).toBe('orch');
+    expect(
+      lineage.orchestrators[0]?.workers.map((session) => session.id)
+    ).toEqual(['worker-a', 'worker-b']);
+  });
+
+  it('keeps workers with missing and non-orchestrator parents in ungrouped', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'plain-parent' }),
+      makeSession({ id: 'missing', spawnedBySessionId: 'gone' }),
+      makeSession({
+        id: 'non-orchestrator',
+        spawnedBySessionId: 'plain-parent',
+      }),
+    ]);
+
+    expect(lineage.orchestrators).toEqual([]);
+    expect(lineage.ungrouped.map((session) => session.id)).toEqual([
+      'missing',
+      'non-orchestrator',
+    ]);
+  });
+
+  it('preserves unparented sessions as top-level standalone rows', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'orchestrator', role: 'orchestrator' }),
+      makeSession({ id: 'standalone' }),
+    ]);
+
+    expect(lineage.standalone.map((session) => session.id)).toEqual([
+      'standalone',
+    ]);
+  });
+
+  it('attaches a raw parent id to its uniquely matching cross-node orchestrator', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'orch', nodeId: 'node-a', role: 'orchestrator' }),
+      makeSession({
+        id: 'worker',
+        nodeId: 'node-b',
+        spawnedBySessionId: 'orch',
+      }),
+    ]);
+
+    expect(
+      lineage.orchestrators[0]?.workers.map((session) => session.id)
+    ).toEqual(['worker']);
+  });
+
+  it('resolves duplicate raw parent ids to the one matching the worker node', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'orch', nodeId: 'node-a', role: 'orchestrator' }),
+      makeSession({ id: 'orch', nodeId: 'node-b', role: 'orchestrator' }),
+      makeSession({
+        id: 'worker',
+        nodeId: 'node-b',
+        spawnedBySessionId: 'orch',
+      }),
+    ]);
+
+    expect(
+      lineage.orchestrators.find((root) => root.session.nodeId === 'node-a')
+        ?.workers
+    ).toEqual([]);
+    expect(
+      lineage.orchestrators
+        .find((root) => root.session.nodeId === 'node-b')
+        ?.workers.map((session) => session.id)
+    ).toEqual(['worker']);
+  });
+
+  it('keeps an ambiguous duplicate raw parent id ungrouped', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'orch', nodeId: 'node-a', role: 'orchestrator' }),
+      makeSession({ id: 'orch', nodeId: 'node-b', role: 'orchestrator' }),
+      makeSession({
+        id: 'worker',
+        nodeId: 'node-c',
+        spawnedBySessionId: 'orch',
+      }),
+    ]);
+
+    expect(lineage.ungrouped.map((session) => session.id)).toEqual(['worker']);
+  });
+
+  it('uses an exact scoped parent key before raw-id fallback', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'orch', nodeId: 'node-a', role: 'orchestrator' }),
+      makeSession({ id: 'orch', nodeId: 'node-b', role: 'orchestrator' }),
+      makeSession({
+        id: 'worker',
+        nodeId: 'node-c',
+        spawnedBySessionId: 'node-b:orch',
+      }),
+    ]);
+
+    expect(
+      lineage.orchestrators
+        .find((root) => root.session.nodeId === 'node-b')
+        ?.workers.map((session) => session.id)
+    ).toEqual(['worker']);
+  });
+
+  it('keeps an empty parent pointer in ungrouped rather than treating it as absent', () => {
+    const lineage = buildSessionLineage([
+      makeSession({ id: 'orch', role: 'orchestrator' }),
+      makeSession({ id: 'empty-parent', spawnedBySessionId: '' }),
+    ]);
+
+    expect(lineage.standalone).toEqual([]);
+    expect(lineage.ungrouped.map((session) => session.id)).toEqual([
+      'empty-parent',
+    ]);
+  });
+
+  it('uses createdAt, displayName, then id for deterministic ordering', () => {
+    const lineage = buildSessionLineage([
+      makeSession({
+        id: 'zeta',
+        displayName: 'same',
+        createdAt: '2026-07-02T00:00:00Z',
+      }),
+      makeSession({
+        id: 'beta',
+        displayName: 'beta',
+        createdAt: '2026-07-01T00:00:00Z',
+      }),
+      makeSession({
+        id: 'alpha',
+        displayName: 'alpha',
+        createdAt: '2026-07-02T00:00:00Z',
+      }),
+      makeSession({
+        id: 'alpha-tie',
+        displayName: 'same',
+        createdAt: '2026-07-02T00:00:00Z',
+      }),
+    ]);
+
+    expect(lineage.standalone.map((session) => session.id)).toEqual([
+      'beta',
+      'alpha',
+      'alpha-tie',
+      'zeta',
+    ]);
+  });
+
+  it('uses the scoped key to break same-name, same-time duplicate raw-id ties', () => {
+    const lineage = buildSessionLineage([
+      makeSession({
+        id: 'duplicate',
+        nodeId: 'node-b',
+        displayName: 'same',
+        createdAt: '2026-07-02T00:00:00Z',
+      }),
+      makeSession({
+        id: 'duplicate',
+        nodeId: 'node-a',
+        displayName: 'same',
+        createdAt: '2026-07-02T00:00:00Z',
+      }),
+    ]);
+
+    expect(lineage.standalone.map(scopedSessionKey)).toEqual([
+      'node-a:duplicate',
+      'node-b:duplicate',
+    ]);
+  });
+});

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -418,6 +418,81 @@ describe('TopicSidebarView', () => {
     expect(onSelectSession).toHaveBeenCalledWith('global:worker');
   });
 
+  it('renders an orchestrator with nested workers and selects the exact worker session', async () => {
+    await renderView(
+      {
+        showAdvancedDetail: true,
+        sessions: [
+          makeSession({
+            id: 'orch',
+            nodeId: 'node-a',
+            displayName: 'persistent planner',
+            role: 'orchestrator',
+            idle: false,
+          }),
+          makeSession({
+            id: 'worker-a',
+            nodeId: 'node-b',
+            displayName: 'alpha worker',
+            spawnedBySessionId: 'orch',
+          }),
+          makeSession({
+            id: 'worker-b',
+            nodeId: 'node-b',
+            globalSessionId: 'global:worker-b',
+            displayName: 'beta worker',
+            spawnedBySessionId: 'orch',
+          }),
+        ],
+        surfaces: [],
+      },
+      { advancedMode: true }
+    );
+
+    const tree = container.querySelector(
+      '.topic-room .session-lineage-tree'
+    ) as HTMLElement;
+    expect(tree).not.toBeNull();
+    expect(tree.textContent).toContain('persistent planner');
+    expect(tree.textContent).toContain('orchestrator');
+    expect(tree.textContent).toContain('alpha worker');
+    expect(tree.textContent).toContain('beta worker');
+    expect(
+      container.querySelector('.topic-mobile-cockpit .session-lineage-tree')
+    ).not.toBeNull();
+    expect(
+      tree
+        .querySelector('[data-session-id="worker-a"]')
+        ?.parentElement?.style.getPropertyValue('--session-lineage-depth')
+    ).toBe('1');
+
+    const worker = tree.querySelector(
+      '[data-session-id="worker-b"]'
+    ) as HTMLButtonElement;
+    await act(async () => worker.click());
+    expect(onSelectSession).toHaveBeenCalledWith('global:worker-b');
+  });
+
+  it('keeps sessions flat when no orchestrator lineage is available', async () => {
+    await renderView(
+      {
+        showAdvancedDetail: true,
+        sessions: [
+          makeSession({ id: 'standalone', displayName: 'plain session' }),
+        ],
+        surfaces: [],
+      },
+      { advancedMode: true }
+    );
+
+    const tree = container.querySelector(
+      '.topic-room .session-lineage-tree'
+    ) as HTMLElement;
+    expect(tree.className).toContain('session-lineage-tree--flat');
+    expect(tree.textContent).toContain('plain session');
+    expect(tree.textContent).not.toContain('orchestrator');
+  });
+
   it('does not fetch WorkContext workflow runs until advanced mode is enabled', async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({ workflowRuns: [] })


### PR DESCRIPTION
#1242 **Slice 6** (final slice) — the operator-facing tree grouping a persistent orchestrator with the workers it spawned, from the `spawnedBySessionId` lineage (#1256). Closes the "flat session list, not my-workers-under-me" gap.

## What
- **`session-lineage.ts`** — pure `buildSessionLineage`: orchestrators (`role`) are roots; a spawned worker nests under its parent only when that parent is an orchestrator (scoped-key match + cross-node raw-id fallback); missing / non-orchestrator / ambiguous parents go to a **visible `ungrouped` bucket** (never silently dropped); parentless sessions stay standalone; deterministic ordering.
- **`SessionSummary.spawnedBySessionId?`** added to the frontend type (backend `/sessions` already supplies it + `role`).
- **`SessionLineageTree`** on both cockpit surfaces (desktop before `ParticipantRoster`, mobile after the attention lane); reuses `AgentAvatar` + `resolveSenderIdentity`; lowercase `orchestrator` tag; idle/active status; exact scoped session selection.

## DESIGN.md
Row grid `padding→24px icon→content→action`; child indent = **`depth × var(--icon-slot-width)`** per the alignment architecture; 0px radius; single identity/color system; no emoji. Reviewed — clean.

## Verify
`npm run check`: 0 errors. 79 tests (lineage grouping edge cases: missing/non-orchestrator/ambiguous parents, standalone, cross-node, deterministic order; + component tests for nested render, selection, both surfaces, flat fallback).

Completes the #1242 slice ladder (1, 3, 4a–c, 4/#1259, 5, 6).

Refs #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)