### PR TITLE
feat(profiles): per-profile config editor + CRUD route + vendor gallery (#1232 slice 7)

### DIFF
--- a/frontend/src/components/SearchableSelect.css
+++ b/frontend/src/components/SearchableSelect.css
@@ -74,3 +74,8 @@
   color: var(--text-muted);
   font-style: italic;
 }
+
+.ss-active .fzf-cursor {
+  transform: translateX(0);
+  opacity: 1;
+}

--- a/frontend/src/components/SearchableSelect.tsx
+++ b/frontend/src/components/SearchableSelect.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -20,6 +21,7 @@ export interface SearchableSelectProps {
   value?: string;
   placeholder?: string;
   onchange?: (value: string) => void;
+  disabled?: boolean;
 }
 
 export function SearchableSelect({
@@ -27,11 +29,14 @@ export function SearchableSelect({
   value = '',
   placeholder = 'Select...',
   onchange,
+  disabled = false,
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
 
   const selectedLabel = useMemo(
     () => options.find((o) => o.value === value)?.label ?? '',
@@ -43,6 +48,16 @@ export function SearchableSelect({
     const lower = searchText.toLowerCase();
     return options.filter((o) => o.label.toLowerCase().includes(lower));
   }, [options, searchText]);
+  const selectableOptions = useMemo(
+    () => [{ value: '', label: placeholder }, ...filteredOptions],
+    [filteredOptions, placeholder]
+  );
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      Math.min(current, selectableOptions.length - 1)
+    );
+  }, [selectableOptions.length]);
 
   useEffect(() => {
     if (!open) return;
@@ -56,8 +71,11 @@ export function SearchableSelect({
   useClickOutside(wrapperRef, handleClickOutside, open);
 
   function openDropdown() {
+    if (disabled) return;
     setOpen(true);
     setSearchText('');
+    const selected = options.findIndex((option) => option.value === value);
+    setActiveIndex(selected >= 0 ? selected + 1 : 0);
   }
 
   function close() {
@@ -71,9 +89,38 @@ export function SearchableSelect({
   }
 
   function onKeydown(e: React.KeyboardEvent) {
-    if (e.key === 'Escape' && open) {
+    if (e.key === 'Escape') {
       close();
       e.stopPropagation();
+      return;
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const delta = e.key === 'ArrowDown' ? 1 : -1;
+      setActiveIndex(
+        (current) =>
+          (current + delta + selectableOptions.length) %
+          selectableOptions.length
+      );
+      return;
+    }
+    if (e.key === 'Enter' && open) {
+      e.preventDefault();
+      const option = selectableOptions[activeIndex];
+      if (option) select(option.value);
+    }
+  }
+
+  function onTriggerKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (disabled) return;
+    if (
+      e.key === 'ArrowDown' ||
+      e.key === 'ArrowUp' ||
+      e.key === 'Enter' ||
+      e.key === ' '
+    ) {
+      e.preventDefault();
+      openDropdown();
     }
   }
 
@@ -87,33 +134,37 @@ export function SearchableSelect({
             className="ss-input"
             placeholder={selectedLabel || placeholder}
             value={searchText}
-            onChange={(e) => setSearchText(e.currentTarget.value)}
+            onChange={(e) => {
+              setSearchText(e.currentTarget.value);
+              setActiveIndex(0);
+            }}
             onKeyDown={onKeydown}
+            role="combobox"
+            aria-expanded="true"
+            aria-controls={listboxId}
+            aria-activedescendant={`${listboxId}-option-${activeIndex}`}
+            aria-autocomplete="list"
           />
-          <div className="ss-dropdown" role="listbox">
+          <div className="ss-dropdown" id={listboxId} role="listbox">
             <TuiMenuPanel>
-              <TuiMenuItem
-                role="option"
-                ariaSelected={!value}
-                onmousedown={() => select('')}
-              >
-                <span
-                  className={['ss-option--reset', !value && 'ss-selected']
-                    .filter(Boolean)
-                    .join(' ')}
-                >
-                  {placeholder}
-                </span>
-              </TuiMenuItem>
-              {filteredOptions.map((opt) => (
+              {selectableOptions.map((opt, index) => (
                 <TuiMenuItem
                   key={opt.value}
+                  id={`${listboxId}-option-${index}`}
                   role="option"
                   ariaSelected={opt.value === value}
+                  tabIndex={-1}
                   onmousedown={() => select(opt.value)}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={index === activeIndex ? 'ss-active' : ''}
                 >
                   <span
-                    className={opt.value === value ? 'ss-selected' : undefined}
+                    className={[
+                      opt.value === '' && 'ss-option--reset',
+                      opt.value === value && 'ss-selected',
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
                   >
                     {opt.label}
                   </span>
@@ -128,7 +179,17 @@ export function SearchableSelect({
           </div>
         </>
       ) : (
-        <button type="button" className="ss-trigger" onClick={openDropdown}>
+        <button
+          type="button"
+          className="ss-trigger"
+          onClick={openDropdown}
+          onKeyDown={onTriggerKeyDown}
+          disabled={disabled}
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded="false"
+          aria-controls={listboxId}
+        >
           <span
             className={['ss-trigger-text', !value && 'ss-placeholder']
               .filter(Boolean)

--- a/frontend/src/components/dialogs/SettingsAgentProfilesSection.css
+++ b/frontend/src/components/dialogs/SettingsAgentProfilesSection.css
@@ -1,0 +1,267 @@
+.agent-profiles-section,
+.agent-profiles-group,
+.agent-profiles-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agent-profiles-section__intro,
+.agent-profiles-card,
+.agent-profiles-editor,
+.agent-profiles-section__state {
+  border: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.agent-profiles-section__intro {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+}
+
+.agent-profiles-section__intro p,
+.agent-profiles-editor p,
+.agent-profiles-card__restriction,
+.agent-profiles-section__state {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.agent-profiles-group > h4,
+.agent-profiles-editor h4 {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  font-weight: normal;
+}
+
+.agent-profiles-group > h4 {
+  text-transform: lowercase;
+}
+
+.agent-profiles-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.agent-profiles-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.agent-profiles-card__identity,
+.agent-profiles-card__actions,
+.agent-profiles-editor__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.agent-profiles-card__identity {
+  display: grid;
+  grid-template-columns: var(--icon-slot-width) 24px minmax(0, 1fr) auto;
+}
+
+.agent-profiles-card__icon-slot {
+  width: var(--icon-slot-width);
+  display: inline-flex;
+  justify-content: center;
+}
+
+.agent-profiles-card__icon-slot .agent-badge {
+  width: 16px;
+  height: 16px;
+}
+
+.agent-profiles-card__name {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agent-profiles-card__name strong,
+.agent-profiles-card__name span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-profiles-card__name strong {
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  font-weight: normal;
+}
+
+.agent-profiles-card__name span,
+.agent-profiles-card__default {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.agent-profiles-card__default {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 2px 4px;
+  white-space: nowrap;
+}
+
+.agent-profiles-card__restriction {
+  border-left: 1px solid var(--border);
+  padding-left: 8px;
+  grid-column: 1 / -1;
+}
+
+.agent-profiles-card__actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.agent-profiles-editor {
+  padding: 12px;
+}
+
+.agent-profiles-editor__heading {
+  display: grid;
+  gap: 4px;
+}
+
+.agent-profiles-editor label,
+.agent-profiles-editor__env {
+  display: grid;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.agent-profiles-editor textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  outline: none;
+  padding: 8px;
+}
+
+.agent-profiles-editor textarea {
+  caret-color: transparent;
+  resize: vertical;
+}
+
+.agent-profiles-textarea {
+  position: relative;
+}
+
+.agent-profiles-textarea textarea {
+  line-height: 18px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.agent-profiles-textarea__mirror {
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  visibility: hidden;
+  overflow: hidden;
+  border: 1px solid transparent;
+  padding: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  line-height: 18px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.agent-profiles-textarea__marker {
+  display: inline-block;
+  width: 0;
+  overflow: visible;
+}
+
+.agent-profiles-textarea__cursor {
+  position: absolute;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  line-height: 18px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.agent-profiles-textarea__cursor.is-idle {
+  animation: agent-profiles-cursor-blink 1s step-end infinite;
+}
+
+@keyframes agent-profiles-cursor-blink {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+.agent-profiles-editor textarea:focus {
+  border-color: var(--accent);
+}
+
+/* Catalog labels remain live data; this settings control renders them in the
+   terminal UI's lowercase presentation without copying or normalizing data. */
+.agent-profiles-editor .ss-trigger,
+.agent-profiles-editor .ss-input,
+.agent-profiles-editor .tui-menu-item {
+  text-transform: lowercase;
+}
+
+.agent-profiles-editor__two-up {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.agent-profiles-editor__env {
+  border: 1px dashed var(--border);
+  padding: 10px;
+}
+
+.agent-profiles-editor__env legend {
+  padding: 0 4px;
+}
+
+.agent-profiles-editor__env-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 6px;
+}
+
+.agent-profiles-section__state {
+  padding: 12px;
+}
+
+.agent-profiles-section__state--error {
+  color: var(--status-error);
+}
+
+@media (max-width: 520px) {
+  .agent-profiles-editor__two-up,
+  .agent-profiles-editor__env-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/dialogs/SettingsAgentProfilesSection.tsx
+++ b/frontend/src/components/dialogs/SettingsAgentProfilesSection.tsx
@@ -1,0 +1,742 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  AgentProfile,
+  AgentProfileRespondTo,
+} from '../../../../shared/agent-profile.js';
+import type { FrameworkInfo } from '../../lib/types.js';
+import {
+  createAgentProfile,
+  deleteAgentProfile,
+  fetchAgentProfiles,
+  setDefaultAgentProfile,
+  updateAgentProfile,
+  type AgentProfileWriteInput,
+} from '../../lib/api.js';
+import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { useConfigStore } from '../../lib/stores/config.js';
+import AgentBadge from '../AgentBadge.js';
+import SearchableSelect from '../SearchableSelect.js';
+import TuiButton from '../TuiButton.js';
+import TuiInput from '../TuiInput.js';
+import { AgentAvatar } from '../chat/AgentAvatar.js';
+import './SettingsAgentProfilesSection.css';
+
+const AGENT_PROFILE_QUERY = ['agent-profiles'] as const;
+const SEARCH_TERMS = [
+  'agent',
+  'agents',
+  'profile',
+  'profiles',
+  'system prompt',
+  'model',
+  'effort',
+  'environment',
+  'respond to',
+  'allowlist',
+];
+
+export interface AgentProfileDraft {
+  providerId: string;
+  displayName: string;
+  systemPrompt: string;
+  model: string;
+  effort: string;
+  envVars: EnvVarRow[];
+  namePool: string;
+  respondTo: AgentProfileRespondTo;
+  respondToAllowlist: string;
+}
+
+export interface EnvVarRow {
+  key: string;
+  value: string;
+}
+
+export interface AgentProfileGroup {
+  providerId: string;
+  label: string;
+  profiles: AgentProfile[];
+}
+
+function optionalText(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function splitLines(value: string): string[] | undefined {
+  const entries = value
+    .split(/[,\n]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return entries.length > 0 ? entries : undefined;
+}
+
+function envRecord(
+  rows: readonly EnvVarRow[]
+): Record<string, string> | undefined {
+  const entries = rows
+    .map(({ key, value }) => [key.trim(), value] as const)
+    .filter(([key]) => key !== '');
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+export function profileDraftFrom(profile?: AgentProfile): AgentProfileDraft {
+  return {
+    providerId: profile?.providerId ?? '',
+    displayName: profile?.displayName ?? '',
+    systemPrompt: profile?.systemPrompt ?? '',
+    model: profile?.model ?? '',
+    effort: profile?.effort ?? '',
+    envVars: Object.entries(profile?.envVars ?? {}).map(([key, value]) => ({
+      key,
+      value,
+    })),
+    namePool: (profile?.namePool ?? []).join('\n'),
+    respondTo: profile?.respondTo ?? 'anyone',
+    respondToAllowlist: (profile?.respondToAllowlist ?? []).join('\n'),
+  };
+}
+
+/** Provider-owned model and effort values cannot follow a provider change. */
+export function withProfileProvider(
+  draft: AgentProfileDraft,
+  providerId: string
+): AgentProfileDraft {
+  return { ...draft, providerId, model: '', effort: '' };
+}
+
+export function profileSubmitInput(
+  draft: AgentProfileDraft,
+  options: { clearEmpty?: boolean } = {}
+): AgentProfileWriteInput {
+  const displayName = optionalText(draft.displayName);
+  const systemPrompt = optionalText(draft.systemPrompt);
+  const model = optionalText(draft.model);
+  const effort = optionalText(draft.effort);
+  const envVars = envRecord(draft.envVars);
+  const namePool = splitLines(draft.namePool);
+  const respondToAllowlist =
+    draft.respondTo === 'allowlist'
+      ? splitLines(draft.respondToAllowlist)
+      : undefined;
+  return {
+    providerId: draft.providerId,
+    ...(displayName
+      ? { displayName }
+      : options.clearEmpty
+        ? { displayName: '' }
+        : {}),
+    ...(systemPrompt || options.clearEmpty
+      ? { systemPrompt: systemPrompt ?? null }
+      : {}),
+    ...(model || options.clearEmpty ? { model: model ?? null } : {}),
+    ...(effort || options.clearEmpty ? { effort: effort ?? null } : {}),
+    ...(envVars || options.clearEmpty ? { envVars: envVars ?? null } : {}),
+    ...(namePool || options.clearEmpty ? { namePool: namePool ?? null } : {}),
+    respondTo: draft.respondTo,
+    ...(respondToAllowlist || options.clearEmpty
+      ? { respondToAllowlist: respondToAllowlist ?? null }
+      : {}),
+  };
+}
+
+/** Group by the live configured framework catalog; never copy vendor metadata. */
+export function groupAgentProfiles(
+  profiles: readonly AgentProfile[],
+  frameworks: readonly FrameworkInfo[]
+): AgentProfileGroup[] {
+  const labels = new Map(
+    frameworks.map((framework) => [framework.id, framework.displayName])
+  );
+  const ids = [
+    ...frameworks.map((framework) => framework.id),
+    ...profiles
+      .map((profile) => profile.providerId)
+      .filter((providerId) => !labels.has(providerId))
+      .sort(),
+  ];
+  return [...new Set(ids)]
+    .map((providerId) => ({
+      providerId,
+      label: labels.get(providerId) ?? providerId,
+      profiles: profiles.filter((profile) => profile.providerId === providerId),
+    }))
+    .filter((group) => group.profiles.length > 0);
+}
+
+function matchesSearch(searchQuery: string): boolean {
+  const query = searchQuery.trim().toLowerCase();
+  return (
+    !query ||
+    SEARCH_TERMS.some((term) => term.includes(query) || query.includes(term))
+  );
+}
+
+function displayName(profile: AgentProfile, framework?: FrameworkInfo): string {
+  return profile.displayName || framework?.displayName || profile.providerId;
+}
+
+/** Compact multiline counterpart to TuiInput's terminal block cursor. */
+function AgentProfileTextarea({
+  value,
+  onChange,
+  placeholder,
+  rows,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  rows: number;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const markerRef = useRef<HTMLSpanElement>(null);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const [focused, setFocused] = useState(false);
+  const [idle, setIdle] = useState(true);
+  const [cursorMeasure, setCursorMeasure] = useState({
+    prefix: '',
+    scrollLeft: 0,
+    scrollTop: 0,
+  });
+  const [cursor, setCursor] = useState({ left: 0, top: 0, height: 18 });
+
+  const updateCursor = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    setCursorMeasure({
+      prefix: textarea.value.slice(0, textarea.selectionStart ?? 0),
+      scrollLeft: textarea.scrollLeft,
+      scrollTop: textarea.scrollTop,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    const marker = markerRef.current;
+    if (!textarea || !marker) return;
+    const style = window.getComputedStyle(textarea);
+    const lineHeight = Number.parseFloat(style.lineHeight) || 18;
+    setCursor({
+      left: marker.offsetLeft - cursorMeasure.scrollLeft,
+      top: marker.offsetTop - cursorMeasure.scrollTop,
+      height: lineHeight,
+    });
+  }, [cursorMeasure]);
+
+  const markTyping = () => {
+    setIdle(false);
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = setTimeout(() => setIdle(true), 530);
+  };
+
+  useEffect(
+    () => () => {
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    },
+    []
+  );
+
+  return (
+    <div className="agent-profiles-textarea">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onInput={(event) => {
+          onChange(event.currentTarget.value);
+          markTyping();
+          requestAnimationFrame(updateCursor);
+        }}
+        onFocus={() => {
+          setFocused(true);
+          updateCursor();
+        }}
+        onBlur={() => {
+          setFocused(false);
+          setIdle(true);
+        }}
+        onClick={() => requestAnimationFrame(updateCursor)}
+        onKeyDown={() => {
+          markTyping();
+          requestAnimationFrame(updateCursor);
+        }}
+        onScroll={updateCursor}
+        placeholder={placeholder}
+        rows={rows}
+      />
+      <div className="agent-profiles-textarea__mirror" aria-hidden="true">
+        {cursorMeasure.prefix}
+        <span ref={markerRef} className="agent-profiles-textarea__marker">
+          █
+        </span>
+      </div>
+      {focused ? (
+        <span
+          className={['agent-profiles-textarea__cursor', idle ? 'is-idle' : '']
+            .filter(Boolean)
+            .join(' ')}
+          style={{ left: cursor.left, top: cursor.top, height: cursor.height }}
+          aria-hidden="true"
+        >
+          █
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function ProfileCard({
+  profile,
+  framework,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  onSetDefault,
+}: {
+  profile: AgentProfile;
+  framework?: FrameworkInfo;
+  onEdit: (profile: AgentProfile) => void;
+  onDuplicate: (profile: AgentProfile) => void;
+  onDelete: (profile: AgentProfile) => void;
+  onSetDefault: (profile: AgentProfile) => void;
+}) {
+  const name = displayName(profile, framework);
+  const identity = resolveSenderIdentity({
+    kind: 'agent',
+    id: profile.id,
+    providerId: profile.providerId,
+    displayName: name,
+  });
+  const builtIn = profile.isBuiltIn;
+  return (
+    <article className="agent-profiles-card" data-profile-id={profile.id}>
+      <div className="agent-profiles-card__identity">
+        <span className="agent-profiles-card__icon-slot" aria-hidden="true">
+          <AgentBadge agent={identity.glyph ?? profile.providerId} />
+        </span>
+        <AgentAvatar identity={identity} name={name} size={24} />
+        <div className="agent-profiles-card__name">
+          <strong>{name}</strong>
+          <span>{profile.providerId}</span>
+        </div>
+        {profile.isDefault ? (
+          <span className="agent-profiles-card__default">default</span>
+        ) : null}
+      </div>
+      {builtIn ? (
+        <p className="agent-profiles-card__restriction">
+          {profile.isDefault
+            ? 'built-in default; vendor settings stay in the configured framework.'
+            : 'built-in profile; provider identity is managed by the configured framework.'}
+        </p>
+      ) : null}
+      <div className="agent-profiles-card__actions">
+        <TuiButton variant="ghost" size="sm" onClick={() => onEdit(profile)}>
+          edit
+        </TuiButton>
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          onClick={() => onDuplicate(profile)}
+        >
+          duplicate
+        </TuiButton>
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          onClick={() => onSetDefault(profile)}
+          disabled={profile.isDefault}
+        >
+          set default
+        </TuiButton>
+        <TuiButton
+          variant="danger"
+          size="sm"
+          onClick={() => onDelete(profile)}
+          disabled={profile.isDefault}
+        >
+          delete
+        </TuiButton>
+      </div>
+    </article>
+  );
+}
+
+export function AgentProfileEditor({
+  profile,
+  frameworks,
+  onCancel,
+  onSubmit,
+  submitting = false,
+}: {
+  profile?: AgentProfile;
+  frameworks: readonly FrameworkInfo[];
+  onCancel: () => void;
+  onSubmit: (input: AgentProfileWriteInput) => void;
+  submitting?: boolean;
+}) {
+  const [draft, setDraft] = useState(() => profileDraftFrom(profile));
+  const isEdit = Boolean(profile?.id);
+  const set = <K extends keyof AgentProfileDraft>(
+    key: K,
+    value: AgentProfileDraft[K]
+  ) => setDraft((current) => ({ ...current, [key]: value }));
+  const setEnv = (index: number, field: keyof EnvVarRow, value: string) =>
+    setDraft((current) => ({
+      ...current,
+      envVars: current.envVars.map((row, rowIndex) =>
+        rowIndex === index ? { ...row, [field]: value } : row
+      ),
+    }));
+
+  return (
+    <form
+      className="agent-profiles-editor"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!draft.providerId) return;
+        onSubmit(profileSubmitInput(draft, { clearEmpty: isEdit }));
+      }}
+    >
+      <div className="agent-profiles-editor__heading">
+        <h4>{isEdit ? 'edit profile' : 'new profile'}</h4>
+        <p>
+          avatar upload is deferred; initials and vendor glyph are used here.
+        </p>
+      </div>
+      <label>
+        configured framework
+        <SearchableSelect
+          value={draft.providerId}
+          placeholder="select framework"
+          options={frameworks.map((framework) => ({
+            value: framework.id,
+            label: framework.displayName,
+          }))}
+          onchange={(providerId) =>
+            setDraft(withProfileProvider(draft, providerId))
+          }
+          {...(profile?.isBuiltIn ? { disabled: true } : {})}
+        />
+      </label>
+      <label>
+        display name
+        <TuiInput
+          value={draft.displayName}
+          onChange={(value) => set('displayName', value)}
+          placeholder="e.g. reviewer codex"
+        />
+      </label>
+      <label>
+        system prompt
+        <AgentProfileTextarea
+          value={draft.systemPrompt}
+          onChange={(value) => set('systemPrompt', value)}
+          placeholder="optional launch-time instruction"
+          rows={3}
+        />
+      </label>
+      <div className="agent-profiles-editor__two-up">
+        <label>
+          model
+          <TuiInput
+            value={draft.model}
+            onChange={(value) => set('model', value)}
+            placeholder="provider-defined"
+          />
+        </label>
+        <label>
+          effort
+          <TuiInput
+            value={draft.effort}
+            onChange={(value) => set('effort', value)}
+            placeholder="provider-defined"
+          />
+        </label>
+      </div>
+      <fieldset className="agent-profiles-editor__env">
+        <legend>environment variables</legend>
+        {draft.envVars.map((row, index) => (
+          <div className="agent-profiles-editor__env-row" key={index}>
+            <TuiInput
+              value={row.key}
+              onChange={(value) => setEnv(index, 'key', value)}
+              placeholder="key"
+              aria-label={`environment variable ${index + 1} key`}
+            />
+            <TuiInput
+              value={row.value}
+              onChange={(value) => setEnv(index, 'value', value)}
+              placeholder="value"
+              aria-label={`environment variable ${index + 1} value`}
+            />
+            <TuiButton
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                set(
+                  'envVars',
+                  draft.envVars.filter((_, rowIndex) => rowIndex !== index)
+                )
+              }
+            >
+              remove
+            </TuiButton>
+          </div>
+        ))}
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            set('envVars', [...draft.envVars, { key: '', value: '' }])
+          }
+        >
+          add variable
+        </TuiButton>
+      </fieldset>
+      <label>
+        name pool
+        <AgentProfileTextarea
+          value={draft.namePool}
+          onChange={(value) => set('namePool', value)}
+          placeholder="one alternate name per line"
+          rows={2}
+        />
+      </label>
+      <label>
+        respond to
+        <SearchableSelect
+          value={draft.respondTo}
+          options={[
+            { value: 'anyone', label: 'anyone' },
+            { value: 'owner-only', label: 'owner only' },
+            { value: 'allowlist', label: 'allowlist' },
+          ]}
+          onchange={(respondTo) =>
+            set('respondTo', respondTo as AgentProfileRespondTo)
+          }
+        />
+      </label>
+      {draft.respondTo === 'allowlist' ? (
+        <label>
+          allowlist
+          <AgentProfileTextarea
+            value={draft.respondToAllowlist}
+            onChange={(value) => set('respondToAllowlist', value)}
+            placeholder="one actor id per line"
+            rows={2}
+          />
+        </label>
+      ) : null}
+      <div className="agent-profiles-editor__actions">
+        <TuiButton
+          variant="primary"
+          type="submit"
+          disabled={
+            submitting ||
+            !draft.providerId ||
+            (!isEdit && !draft.displayName.trim())
+          }
+        >
+          {submitting ? 'saving…' : isEdit ? 'save profile' : 'create profile'}
+        </TuiButton>
+        <TuiButton variant="ghost" onClick={onCancel} disabled={submitting}>
+          cancel
+        </TuiButton>
+      </div>
+    </form>
+  );
+}
+
+export function AgentProfileGallery({
+  profiles,
+  frameworks,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  onSetDefault,
+}: {
+  profiles: readonly AgentProfile[];
+  frameworks: readonly FrameworkInfo[];
+  onEdit: (profile: AgentProfile) => void;
+  onDuplicate: (profile: AgentProfile) => void;
+  onDelete: (profile: AgentProfile) => void;
+  onSetDefault: (profile: AgentProfile) => void;
+}) {
+  const groups = groupAgentProfiles(profiles, frameworks);
+  return (
+    <>
+      {groups.map((group) => {
+        const framework = frameworks.find(
+          (item) => item.id === group.providerId
+        );
+        return (
+          <div className="agent-profiles-group" key={group.providerId}>
+            <h4>{group.label}</h4>
+            <div className="agent-profiles-grid">
+              {group.profiles.map((profile) => (
+                <ProfileCard
+                  key={profile.id}
+                  profile={profile}
+                  {...(framework ? { framework } : {})}
+                  onEdit={onEdit}
+                  onDuplicate={onDuplicate}
+                  onDelete={onDelete}
+                  onSetDefault={onSetDefault}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+export function SettingsAgentProfilesSection({
+  searchQuery,
+}: {
+  searchQuery: string;
+}) {
+  const queryClient = useQueryClient();
+  const frameworks = useConfigStore((state) => state.frameworks);
+  const [editing, setEditing] = useState<AgentProfile | null | undefined>(
+    undefined
+  );
+  const profilesQuery = useQuery({
+    queryKey: AGENT_PROFILE_QUERY,
+    queryFn: fetchAgentProfiles,
+  });
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: AGENT_PROFILE_QUERY });
+  const createMutation = useMutation({
+    mutationFn: createAgentProfile,
+    onSuccess: () => {
+      setEditing(undefined);
+      void invalidate();
+    },
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({
+      id,
+      input,
+    }: {
+      id: string;
+      input: AgentProfileWriteInput;
+    }) => updateAgentProfile(id, input),
+    onSuccess: () => {
+      setEditing(undefined);
+      void invalidate();
+    },
+  });
+  const deleteMutation = useMutation({
+    mutationFn: deleteAgentProfile,
+    onSuccess: () => void invalidate(),
+  });
+  const defaultMutation = useMutation({
+    mutationFn: setDefaultAgentProfile,
+    onSuccess: () => void invalidate(),
+  });
+  const groups = useMemo(
+    () => groupAgentProfiles(profilesQuery.data ?? [], frameworks),
+    [frameworks, profilesQuery.data]
+  );
+
+  return (
+    <section
+      id="section-agent-profiles"
+      className={[
+        'settings-dialog-section',
+        !matchesSearch(searchQuery) ? 'dimmed' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <h3 className="settings-dialog-section-heading">agent profiles</h3>
+      <div className="agent-profiles-section">
+        <div className="agent-profiles-section__intro">
+          <p>profiles are local overlays on configured frameworks.</p>
+          {editing === undefined ? (
+            <TuiButton
+              variant="primary"
+              size="sm"
+              onClick={() => setEditing(null)}
+            >
+              add profile
+            </TuiButton>
+          ) : null}
+        </div>
+        {editing !== undefined ? (
+          <AgentProfileEditor
+            {...(editing ? { profile: editing } : {})}
+            frameworks={frameworks}
+            submitting={createMutation.isPending || updateMutation.isPending}
+            onCancel={() => setEditing(undefined)}
+            onSubmit={(input) => {
+              if (editing?.id) updateMutation.mutate({ id: editing.id, input });
+              else createMutation.mutate(input);
+            }}
+          />
+        ) : null}
+        {profilesQuery.isPending ? (
+          <p className="agent-profiles-section__state">loading profiles…</p>
+        ) : profilesQuery.isError ? (
+          <p className="agent-profiles-section__state agent-profiles-section__state--error">
+            unable to load profiles; retry from settings.
+          </p>
+        ) : groups.length === 0 ? (
+          <p className="agent-profiles-section__state">
+            no configured profiles.
+          </p>
+        ) : (
+          <AgentProfileGallery
+            profiles={profilesQuery.data ?? []}
+            frameworks={frameworks}
+            onEdit={setEditing}
+            onDuplicate={(source) => {
+              setEditing({
+                ...source,
+                id: '',
+                isDefault: false,
+                isBuiltIn: false,
+                displayName: source.displayName
+                  ? `${source.displayName} copy`
+                  : '',
+              });
+            }}
+            onDelete={(source) => {
+              if (
+                !window.confirm(
+                  `delete ${displayName(source)}? this cannot be undone.`
+                )
+              ) {
+                return;
+              }
+              deleteMutation.mutate(source.id);
+            }}
+            onSetDefault={(source) => defaultMutation.mutate(source.id)}
+          />
+        )}
+        {createMutation.error ||
+        updateMutation.error ||
+        deleteMutation.error ||
+        defaultMutation.error ? (
+          <p className="agent-profiles-section__state agent-profiles-section__state--error">
+            profile change failed; no local profile data was discarded.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export default SettingsAgentProfilesSection;

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import GitHubIntegration from './integrations/GitHubIntegration.js';
 import WebhookIntegration from './integrations/WebhookIntegration.js';
 import JiraIntegration from './integrations/JiraIntegration.js';
 import SettingsNodesSection from './SettingsNodesSection.js';
+import SettingsAgentProfilesSection from './SettingsAgentProfilesSection.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import {
   setDefaultAgent,
@@ -77,7 +78,10 @@ const TOC_SECTIONS = [
   {
     id: 'section-agents',
     label: 'agents',
-    children: [{ id: 'agent-claude-code', label: 'Claude Code' }],
+    children: [
+      { id: 'agent-claude-code', label: 'Claude Code' },
+      { id: 'section-agent-profiles', label: 'profiles' },
+    ],
   },
   {
     id: 'section-integrations',
@@ -104,7 +108,7 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
     'branch name',
     'session name',
   ],
-  agents: ['claude', 'claude code', 'fullscreen', 'no flicker'],
+  agents: ['claude', 'claude code', 'fullscreen', 'no flicker', 'profiles'],
   integrations: [
     'github',
     'webhooks',
@@ -481,6 +485,7 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
               searchQuery={searchQuery}
               handlers={configHandlers}
             />
+            <SettingsAgentProfilesSection searchQuery={searchQuery} />
             <IntegrationsSection
               searchQuery={searchQuery}
               githubConnected={githubConnected}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,6 +56,10 @@ import type {
   PipelineHandoffStageName,
 } from '../../../shared/pipeline-handoff-artifact.js';
 import type { ViewArtifactPackage } from '../../../shared/agent-view-artifact.js';
+import type {
+  AgentProfile,
+  AgentProfileRespondTo,
+} from '../../../shared/agent-profile.js';
 import type { TaskRef, WorkContext } from '../../../shared/work-context.js';
 import type {
   PipelineHandoffArtifactEnvelope,
@@ -3556,6 +3560,82 @@ export async function fetchFrameworks(): Promise<FrameworkInfo[]> {
     await fetch('/api/frameworks')
   );
   return data.frameworks;
+}
+
+// ── Agent profiles ──────────────────────────────────────────────────────────
+
+/**
+ * The editable, vendor-neutral overlay fields for an AgentProfile. Framework
+ * facts remain in `/api/frameworks`, keyed by `providerId`.
+ */
+export interface AgentProfileWriteInput {
+  providerId: string;
+  displayName?: string;
+  systemPrompt?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  effort?: string | null;
+  envVars?: Record<string, string> | null;
+  namePool?: string[] | null;
+  respondTo?: AgentProfileRespondTo;
+  respondToAllowlist?: string[] | null;
+}
+
+const AGENT_PROFILES_PATH = '/agent-profiles';
+
+export async function fetchAgentProfiles(): Promise<AgentProfile[]> {
+  const data = await json<{ profiles?: AgentProfile[] }>(
+    await fetch(AGENT_PROFILES_PATH)
+  );
+  return Array.isArray(data.profiles) ? data.profiles : [];
+}
+
+export async function createAgentProfile(
+  input: AgentProfileWriteInput
+): Promise<AgentProfile> {
+  const data = await json<{ profile: AgentProfile }>(
+    await fetch(AGENT_PROFILES_PATH, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+  );
+  return data.profile;
+}
+
+export async function updateAgentProfile(
+  id: string,
+  input: AgentProfileWriteInput
+): Promise<AgentProfile> {
+  const data = await json<{ profile: AgentProfile }>(
+    await fetch(`${AGENT_PROFILES_PATH}/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+  );
+  return data.profile;
+}
+
+export async function deleteAgentProfile(id: string): Promise<void> {
+  const response = await fetch(
+    `${AGENT_PROFILES_PATH}/${encodeURIComponent(id)}`,
+    {
+      method: 'DELETE',
+    }
+  );
+  if (!response.ok) throw await httpErrorFromResponse(response);
+}
+
+export async function setDefaultAgentProfile(
+  id: string
+): Promise<AgentProfile> {
+  const data = await json<{ profile: AgentProfile }>(
+    await fetch(`${AGENT_PROFILES_PATH}/${encodeURIComponent(id)}/default`, {
+      method: 'POST',
+    })
+  );
+  return data.profile;
 }
 
 // ── Workspace branch operations ───────────────────────────────────────────────

--- a/server/agent-profile-router.ts
+++ b/server/agent-profile-router.ts
@@ -1,0 +1,553 @@
+import { Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+
+import type {
+  AgentProfileAvatarRef,
+  AgentProfileRespondTo,
+} from '../shared/agent-profile.js';
+import {
+  AgentProfileStoreError,
+  type AgentProfileCreateInput,
+  type AgentProfileStore,
+  type AgentProfileUpdateInput,
+  type SeedFramework,
+} from './agent-profile-store.js';
+
+/** Browser/operator CRUD for the local AgentProfile overlay (#1232 slice 7). */
+export interface AgentProfileRouterDeps {
+  store: AgentProfileStore | null;
+  /** The live framework catalog, already resolved from the current config. */
+  listConfiguredFrameworks: () => readonly SeedFramework[];
+  requireAuth?: RequestHandler;
+}
+
+const RESPOND_TO_VALUES: readonly AgentProfileRespondTo[] = [
+  'owner-only',
+  'allowlist',
+  'anyone',
+];
+const PATCH_FIELDS = new Set([
+  'providerId',
+  'displayName',
+  'avatar',
+  'systemPrompt',
+  'model',
+  'provider',
+  'effort',
+  'envVars',
+  'namePool',
+  'respondTo',
+  'respondToAllowlist',
+  'isDefault',
+]);
+
+function bodyRecord(req: Request): Record<string, unknown> | null {
+  return req.body && typeof req.body === 'object' && !Array.isArray(req.body)
+    ? (req.body as Record<string, unknown>)
+    : null;
+}
+
+function hasOwn(record: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function trimString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  reasonCode: string,
+  message: string,
+  details?: Record<string, unknown>
+): void {
+  res.status(status).json({
+    error: {
+      code:
+        status === 404
+          ? 'NOT_FOUND'
+          : status === 409
+            ? 'SESSION_CONFLICT'
+            : status >= 500
+              ? 'SERVER_UNAVAILABLE'
+              : 'INVALID_ARGUMENT',
+      message,
+      retryable: status >= 500,
+      details: { reasonCode, ...(details ?? {}) },
+    },
+  });
+}
+
+function storeOr503(
+  res: Response,
+  store: AgentProfileStore | null
+): AgentProfileStore | null {
+  if (store) return store;
+  sendError(
+    res,
+    503,
+    'AGENT_PROFILE_STORE_UNAVAILABLE',
+    'agent profile store is unavailable'
+  );
+  return null;
+}
+
+function configuredFrameworksOr503(
+  res: Response,
+  listConfiguredFrameworks: () => readonly SeedFramework[]
+): readonly SeedFramework[] | null {
+  try {
+    return listConfiguredFrameworks();
+  } catch {
+    // Custom framework resolution can throw for hand-edited, malformed config.
+    // Keep that startup/catalog failure out of Express's generic error path.
+    sendError(
+      res,
+      503,
+      'AGENT_PROFILE_FRAMEWORK_CATALOG_UNAVAILABLE',
+      'configured framework catalog is unavailable'
+    );
+    return null;
+  }
+}
+
+/**
+ * A framework can be added to live config after the store's boot seed. Before
+ * exposing or accepting that framework, repair its required built-in default
+ * so no browser operation can introduce a zero-default provider.
+ */
+function configuredAndSeededFrameworksOr503(
+  res: Response,
+  store: AgentProfileStore,
+  listConfiguredFrameworks: () => readonly SeedFramework[]
+): readonly SeedFramework[] | null {
+  const frameworks = configuredFrameworksOr503(res, listConfiguredFrameworks);
+  if (!frameworks) return null;
+  try {
+    store.seedBuiltIns(frameworks);
+    return frameworks;
+  } catch {
+    sendError(
+      res,
+      503,
+      'AGENT_PROFILE_BUILT_IN_SEED_FAILED',
+      'agent profile built-in defaults could not be initialized'
+    );
+    return null;
+  }
+}
+
+function requireConfiguredProvider(
+  res: Response,
+  providerId: unknown,
+  frameworks: readonly SeedFramework[]
+): string | null {
+  const value = trimString(providerId);
+  if (!value) {
+    sendError(
+      res,
+      400,
+      'AGENT_PROFILE_PROVIDER_ID_REQUIRED',
+      'providerId is required',
+      { field: 'providerId' }
+    );
+    return null;
+  }
+  if (!frameworks.some((framework) => framework.id === value)) {
+    sendError(
+      res,
+      400,
+      'AGENT_PROFILE_PROVIDER_NOT_CONFIGURED',
+      'providerId must name a configured framework',
+      { field: 'providerId' }
+    );
+    return null;
+  }
+  return value;
+}
+
+function validateAvatar(
+  value: unknown
+): AgentProfileAvatarRef | null | undefined {
+  if (value === null) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    return undefined;
+  const record = value as Record<string, unknown>;
+  const id = trimString(record['id']);
+  if (!id) return undefined;
+  const avatar: AgentProfileAvatarRef = { id };
+  if (typeof record['sha256'] === 'string') avatar.sha256 = record['sha256'];
+  if (typeof record['mediaType'] === 'string')
+    avatar.mediaType = record['mediaType'];
+  if (typeof record['byteCount'] === 'number')
+    avatar.byteCount = record['byteCount'];
+  return avatar;
+}
+
+function validateStringRecord(
+  value: unknown
+): Record<string, string> | null | undefined {
+  if (value === null) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    return undefined;
+  const record = value as Record<string, unknown>;
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (typeof entry !== 'string') return undefined;
+    result[key] = entry;
+  }
+  return result;
+}
+
+function validateStringList(value: unknown): string[] | null | undefined {
+  if (value === null) return null;
+  if (!Array.isArray(value) || value.some((entry) => !trimString(entry))) {
+    return undefined;
+  }
+  return value.map((entry) => (entry as string).trim());
+}
+
+function validateOptionalString(value: unknown): string | null | undefined {
+  return value === null || typeof value === 'string' ? value : undefined;
+}
+
+function invalidField(
+  res: Response,
+  field: string,
+  message = 'invalid agent profile field'
+): null {
+  sendError(res, 400, 'AGENT_PROFILE_INVALID_FIELD', message, { field });
+  return null;
+}
+
+/**
+ * Converts a browser PATCH body into a typed store patch. Explicit `null`
+ * clears optional overlays; an empty `displayName` restores the catalog-label
+ * inheritance sentinel; omitted fields are never inspected or changed.
+ */
+function parsePatch(
+  res: Response,
+  body: Record<string, unknown>,
+  frameworks: readonly SeedFramework[]
+): AgentProfileUpdateInput | null {
+  for (const field of Object.keys(body)) {
+    if (field === 'isBuiltIn') {
+      sendError(
+        res,
+        400,
+        'AGENT_PROFILE_IS_BUILT_IN_MANAGED',
+        'isBuiltIn is managed by the server',
+        { field }
+      );
+      return null;
+    }
+    if (!PATCH_FIELDS.has(field)) {
+      sendError(
+        res,
+        400,
+        'AGENT_PROFILE_PATCH_FIELD_UNSUPPORTED',
+        'unsupported agent profile patch field',
+        { field }
+      );
+      return null;
+    }
+  }
+  if (Object.keys(body).length === 0) {
+    sendError(res, 400, 'AGENT_PROFILE_PATCH_EMPTY', 'patch body is empty');
+    return null;
+  }
+  const patch: AgentProfileUpdateInput = {};
+  if (hasOwn(body, 'providerId')) {
+    const providerId = requireConfiguredProvider(
+      res,
+      body['providerId'],
+      frameworks
+    );
+    if (!providerId) return null;
+    patch.providerId = providerId;
+  }
+  if (hasOwn(body, 'displayName')) {
+    if (typeof body['displayName'] !== 'string') {
+      return invalidField(res, 'displayName');
+    }
+    patch.displayName = body['displayName'].trim();
+  }
+  if (hasOwn(body, 'avatar')) {
+    const avatar = validateAvatar(body['avatar']);
+    if (avatar === undefined) return invalidField(res, 'avatar');
+    patch.avatar = avatar;
+  }
+  for (const field of [
+    'systemPrompt',
+    'model',
+    'provider',
+    'effort',
+  ] as const) {
+    if (!hasOwn(body, field)) continue;
+    const value = validateOptionalString(body[field]);
+    if (value === undefined) return invalidField(res, field);
+    patch[field] = value;
+  }
+  if (hasOwn(body, 'envVars')) {
+    const envVars = validateStringRecord(body['envVars']);
+    if (envVars === undefined) return invalidField(res, 'envVars');
+    patch.envVars = envVars;
+  }
+  if (hasOwn(body, 'namePool')) {
+    const namePool = validateStringList(body['namePool']);
+    if (namePool === undefined) return invalidField(res, 'namePool');
+    patch.namePool = namePool;
+  }
+  if (hasOwn(body, 'respondTo')) {
+    const respondTo = body['respondTo'];
+    if (
+      respondTo !== null &&
+      (typeof respondTo !== 'string' ||
+        !RESPOND_TO_VALUES.includes(respondTo as AgentProfileRespondTo))
+    ) {
+      return invalidField(res, 'respondTo');
+    }
+    patch.respondTo = respondTo as AgentProfileRespondTo | null;
+  }
+  if (hasOwn(body, 'respondToAllowlist')) {
+    const allowlist = validateStringList(body['respondToAllowlist']);
+    if (allowlist === undefined) return invalidField(res, 'respondToAllowlist');
+    patch.respondToAllowlist = allowlist;
+  }
+  if (hasOwn(body, 'isDefault')) {
+    if (typeof body['isDefault'] !== 'boolean')
+      return invalidField(res, 'isDefault');
+    patch.isDefault = body['isDefault'];
+  }
+  return patch;
+}
+
+function mapStoreError(res: Response, error: unknown): void {
+  if (error instanceof AgentProfileStoreError) {
+    sendError(res, error.status, error.code.toUpperCase(), error.message);
+    return;
+  }
+  sendError(
+    res,
+    500,
+    'AGENT_PROFILE_OPERATION_FAILED',
+    'agent profile operation failed'
+  );
+}
+
+function createInputFromPatch(
+  providerId: string,
+  displayName: string,
+  patch: AgentProfileUpdateInput
+): AgentProfileCreateInput {
+  const input: AgentProfileCreateInput = {
+    providerId,
+    displayName,
+    isDefault: patch.isDefault ?? false,
+  };
+  if (patch.avatar !== undefined) input.avatar = patch.avatar;
+  if (typeof patch.systemPrompt === 'string')
+    input.systemPrompt = patch.systemPrompt;
+  if (typeof patch.model === 'string') input.model = patch.model;
+  if (typeof patch.provider === 'string') input.provider = patch.provider;
+  if (typeof patch.effort === 'string') input.effort = patch.effort;
+  if (patch.envVars) input.envVars = patch.envVars;
+  if (patch.namePool) input.namePool = patch.namePool;
+  if (patch.respondTo) input.respondTo = patch.respondTo;
+  if (patch.respondToAllowlist)
+    input.respondToAllowlist = patch.respondToAllowlist;
+  return input;
+}
+
+export function createAgentProfileRouter(deps: AgentProfileRouterDeps): Router {
+  const router = Router();
+  const auth =
+    deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
+
+  router.get('/agent-profiles', auth, (_req, res) => {
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    if (
+      !configuredAndSeededFrameworksOr503(
+        res,
+        store,
+        deps.listConfiguredFrameworks
+      )
+    )
+      return;
+    res.json({ profiles: store.list() });
+  });
+
+  router.post('/agent-profiles', auth, (req, res) => {
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const body = bodyRecord(req);
+    if (!body)
+      return void sendError(
+        res,
+        400,
+        'AGENT_PROFILE_BODY_REQUIRED',
+        'request body must be an object'
+      );
+    if (hasOwn(body, 'isBuiltIn')) {
+      return void sendError(
+        res,
+        400,
+        'AGENT_PROFILE_IS_BUILT_IN_MANAGED',
+        'isBuiltIn is managed by the server',
+        { field: 'isBuiltIn' }
+      );
+    }
+    const frameworks = configuredAndSeededFrameworksOr503(
+      res,
+      store,
+      deps.listConfiguredFrameworks
+    );
+    if (!frameworks) return;
+    const providerId = requireConfiguredProvider(
+      res,
+      body['providerId'],
+      frameworks
+    );
+    if (!providerId) return;
+    const displayName = trimString(body['displayName']);
+    if (!displayName) {
+      return void sendError(
+        res,
+        400,
+        'AGENT_PROFILE_DISPLAY_NAME_REQUIRED',
+        'displayName is required',
+        { field: 'displayName' }
+      );
+    }
+    const patch = parsePatch(res, body, frameworks);
+    if (!patch) return;
+    try {
+      const profile = store.create(
+        createInputFromPatch(providerId, displayName, patch)
+      );
+      res.status(201).json({ profile });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  router.patch('/agent-profiles/:id', auth, (req, res) => {
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const body = bodyRecord(req);
+    if (!body)
+      return void sendError(
+        res,
+        400,
+        'AGENT_PROFILE_BODY_REQUIRED',
+        'request body must be an object'
+      );
+    const existing = store.get(req.params['id'] ?? '');
+    if (!existing)
+      return void sendError(
+        res,
+        404,
+        'AGENT_PROFILE_NOT_FOUND',
+        'agent profile not found'
+      );
+    const frameworks = configuredAndSeededFrameworksOr503(
+      res,
+      store,
+      deps.listConfiguredFrameworks
+    );
+    if (!frameworks) return;
+    const patch = parsePatch(res, body, frameworks);
+    if (!patch) return;
+    if (
+      existing.isBuiltIn &&
+      hasOwn(patch, 'providerId') &&
+      patch.providerId !== existing.providerId
+    ) {
+      return void sendError(
+        res,
+        400,
+        'AGENT_PROFILE_BUILT_IN_PROVIDER_CHANGE_FORBIDDEN',
+        'built-in profiles cannot change providerId',
+        { field: 'providerId' }
+      );
+    }
+    if (existing.isDefault && patch.isDefault === false) {
+      return void sendError(
+        res,
+        409,
+        'AGENT_PROFILE_LAST_DEFAULT',
+        'a provider must retain a default profile',
+        { field: 'isDefault' }
+      );
+    }
+    if (
+      existing.isDefault &&
+      patch.providerId &&
+      patch.providerId !== existing.providerId
+    ) {
+      return void sendError(
+        res,
+        409,
+        'AGENT_PROFILE_DEFAULT_PROVIDER_CHANGE_FORBIDDEN',
+        'move a non-default profile, or set another default first.',
+        { field: 'providerId' }
+      );
+    }
+    if (patch.providerId && patch.providerId !== existing.providerId) {
+      // Model and effort semantics belong to the selected vendor. Never carry
+      // those vendor-dependent overrides across a provider change.
+      patch.model = null;
+      patch.effort = null;
+    }
+    try {
+      res.json({ profile: store.update(existing.id, patch) });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  router.delete('/agent-profiles/:id', auth, (req, res) => {
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const profile = store.get(req.params['id'] ?? '');
+    if (!profile)
+      return void sendError(
+        res,
+        404,
+        'AGENT_PROFILE_NOT_FOUND',
+        'agent profile not found'
+      );
+    if (profile.isBuiltIn && profile.isDefault) {
+      return void sendError(
+        res,
+        409,
+        'AGENT_PROFILE_BUILT_IN_DEFAULT_DELETE_FORBIDDEN',
+        'the built-in default profile cannot be deleted'
+      );
+    }
+    if (profile.isDefault) {
+      return void sendError(
+        res,
+        409,
+        'AGENT_PROFILE_LAST_DEFAULT_DELETE_FORBIDDEN',
+        'a provider must retain a default profile'
+      );
+    }
+    store.delete(profile.id);
+    res.status(204).end();
+  });
+
+  router.post('/agent-profiles/:id/default', auth, (req, res) => {
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    try {
+      res.json({ profile: store.setDefault(req.params['id'] ?? '') });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  return router;
+}

--- a/server/agent-profile-store.ts
+++ b/server/agent-profile-store.ts
@@ -96,6 +96,27 @@ export interface AgentProfileCreateInput {
   isBuiltIn?: boolean;
 }
 
+/**
+ * Mutable overlay fields for an existing profile. Every field is optional so
+ * callers can make a true PATCH; `null` clears optional vendor-dependent
+ * overlays. `isBuiltIn` is store-managed and may not be changed.
+ */
+export interface AgentProfileUpdateInput {
+  providerId?: string;
+  displayName?: string;
+  avatar?: AgentProfileAvatarRef | null;
+  systemPrompt?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  effort?: string | null;
+  envVars?: Record<string, string> | null;
+  namePool?: string[] | null;
+  respondTo?: AgentProfileRespondTo | null;
+  respondToAllowlist?: string[] | null;
+  isDefault?: boolean;
+  isBuiltIn?: boolean;
+}
+
 export interface AgentProfileStore {
   close(): void;
   /**
@@ -104,6 +125,12 @@ export interface AgentProfileStore {
    * profile is default.
    */
   create(input: AgentProfileCreateInput): AgentProfile;
+  /**
+   * Update a profile atomically while keeping the JSON blob and denormalized
+   * identity/default columns in lockstep. A default cannot be cleared or moved
+   * to another provider because that would leave its old provider defaultless.
+   */
+  update(id: string, patch: AgentProfileUpdateInput): AgentProfile;
   get(id: string): AgentProfile | null;
   list(filter?: { providerId?: string }): AgentProfile[];
   getDefaultForProvider(providerId: string): AgentProfile | null;
@@ -166,6 +193,15 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
   const setDefaultRow = db.prepare(
     `UPDATE agent_profiles SET is_default = 1, profile_json = ?, updated_at = ?
      WHERE id = ?`
+  );
+  const updateRow = db.prepare(
+    `UPDATE agent_profiles
+       SET provider_id = @providerId,
+           is_default = @isDefault,
+           is_built_in = @isBuiltIn,
+           profile_json = @profileJson,
+           updated_at = @updatedAt
+     WHERE id = @id`
   );
   // Self-heal a zero-default vendor: force a survivor at the stable built-in PK
   // to be the built-in default. Sets is_built_in = 1 (not just is_default) so a
@@ -241,6 +277,99 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
         createdAt: nowIso,
         updatedAt: nowIso,
       });
+      const written = getById(id);
+      if (!written) {
+        throw new AgentProfileStoreError(500, 'agent_profile_write_failed');
+      }
+      return written;
+    },
+
+    update(id: string, patch: AgentProfileUpdateInput): AgentProfile {
+      const current = getById(id);
+      if (!current) {
+        throw new AgentProfileStoreError(404, 'agent_profile_not_found');
+      }
+      if (
+        hasOwn(patch, 'isBuiltIn') &&
+        patch.isBuiltIn !== undefined &&
+        patch.isBuiltIn !== current.isBuiltIn
+      ) {
+        throw new AgentProfileStoreError(
+          400,
+          'agent_profile_is_built_in_immutable',
+          'isBuiltIn is managed by the store and cannot be changed.'
+        );
+      }
+
+      const providerId = hasOwn(patch, 'providerId')
+        ? requireNonEmpty(patch.providerId, 'providerId')
+        : current.providerId;
+      if (current.isBuiltIn && providerId !== current.providerId) {
+        throw new AgentProfileStoreError(
+          400,
+          'agent_profile_builtin_provider_change_forbidden',
+          'Built-in profiles cannot change providerId.'
+        );
+      }
+      const isDefault = hasOwn(patch, 'isDefault')
+        ? patch.isDefault
+        : current.isDefault;
+      if (typeof isDefault !== 'boolean') {
+        throw new AgentProfileStoreError(400, 'agent_profile_invalid');
+      }
+      if (current.isDefault && !isDefault) {
+        throw new AgentProfileStoreError(
+          409,
+          'agent_profile_last_default',
+          'A provider must retain a default profile.'
+        );
+      }
+      if (current.isDefault && providerId !== current.providerId) {
+        throw new AgentProfileStoreError(
+          409,
+          'agent_profile_default_provider_change_forbidden',
+          'Move a non-default profile, or set another default first.'
+        );
+      }
+
+      const profile = applyProfilePatch(current, patch, providerId, isDefault);
+      if (!isAgentProfile(profile)) {
+        throw new AgentProfileStoreError(400, 'agent_profile_invalid');
+      }
+      const nowIso = new Date().toISOString();
+      const write = db.transaction(() => {
+        // A false→true flip is the one sanctioned way update() changes a
+        // provider's default. Clear its current default first, then write the
+        // target row, so JSON and denormalized flags agree at every commit.
+        if (profile.isDefault && !current.isDefault) {
+          const previous = selectDefaultForProvider.get(profile.providerId) as
+            | AgentProfileRow
+            | undefined;
+          if (previous && previous.id !== id) {
+            const previousProfile = rowToProfileSafe(previous);
+            if (previousProfile) {
+              clearDefault.run(
+                JSON.stringify({ ...previousProfile, isDefault: false }),
+                nowIso,
+                previous.id
+              );
+            }
+          }
+        }
+        try {
+          updateRow.run({
+            id,
+            providerId: profile.providerId,
+            isDefault: profile.isDefault ? 1 : 0,
+            isBuiltIn: profile.isBuiltIn ? 1 : 0,
+            profileJson: JSON.stringify(profile),
+            updatedAt: nowIso,
+          });
+        } catch (err) {
+          rethrowConstraint(err, profile.providerId);
+        }
+      });
+      write();
       const written = getById(id);
       if (!written) {
         throw new AgentProfileStoreError(500, 'agent_profile_write_failed');
@@ -405,6 +534,91 @@ function requireNonEmpty(value: unknown, field: string): string {
 
 function readTrimmed(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function hasOwn(record: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function optionalString(value: string | null | undefined): string | undefined {
+  return readTrimmed(value);
+}
+
+function stringRecord(
+  value: Record<string, string> | null | undefined
+): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string') result[key] = entry;
+  }
+  return Object.keys(result).length ? result : undefined;
+}
+
+function stringList(value: string[] | null | undefined): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const result = value.filter(
+    (entry): entry is string =>
+      typeof entry === 'string' && entry.trim().length > 0
+  );
+  return result.length ? result : undefined;
+}
+
+/** Apply only fields explicitly present in the PATCH, preserving every other overlay. */
+function applyProfilePatch(
+  current: AgentProfile,
+  patch: AgentProfileUpdateInput,
+  providerId: string,
+  isDefault: boolean
+): AgentProfile {
+  const profile: AgentProfile = {
+    ...current,
+    providerId,
+    isDefault,
+  };
+  if (hasOwn(patch, 'displayName')) {
+    profile.displayName =
+      typeof patch.displayName === 'string' ? patch.displayName : '';
+  }
+  if (hasOwn(patch, 'avatar')) profile.avatar = patch.avatar ?? null;
+
+  const optionalFields: Array<
+    readonly [
+      'systemPrompt' | 'model' | 'provider' | 'effort',
+      string | null | undefined,
+    ]
+  > = [
+    ['systemPrompt', patch.systemPrompt],
+    ['model', patch.model],
+    ['provider', patch.provider],
+    ['effort', patch.effort],
+  ];
+  for (const [field, value] of optionalFields) {
+    if (!hasOwn(patch, field)) continue;
+    const normalized = optionalString(value);
+    if (normalized) profile[field] = normalized;
+    else delete profile[field];
+  }
+  if (hasOwn(patch, 'envVars')) {
+    const normalized = stringRecord(patch.envVars);
+    if (normalized) profile.envVars = normalized;
+    else delete profile.envVars;
+  }
+  if (hasOwn(patch, 'namePool')) {
+    const normalized = stringList(patch.namePool);
+    if (normalized) profile.namePool = normalized;
+    else delete profile.namePool;
+  }
+  if (hasOwn(patch, 'respondTo')) {
+    if (patch.respondTo) profile.respondTo = patch.respondTo;
+    else delete profile.respondTo;
+  }
+  if (hasOwn(patch, 'respondToAllowlist')) {
+    const normalized = stringList(patch.respondToAllowlist);
+    if (normalized) profile.respondToAllowlist = normalized;
+    else delete profile.respondToAllowlist;
+  }
+  return profile;
 }
 
 function generateProfileId(providerId: string, isDefault: boolean): string {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -61,6 +61,7 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
       '/api/analytics/*',
       '/telemetry/*',
       '/work-contexts/*',
+      '/agent-profiles/*',
     ],
     acceptedLanes: ['browser-session'],
     middleware: 'requireAuth',

--- a/server/index.ts
+++ b/server/index.ts
@@ -233,6 +233,7 @@ import { createWorkflowRunRouter } from './features/workflow-run-router.js';
 import { createAutomationRunRouter } from './features/automation-run-router.js';
 import { createPrOverseerRouter } from './features/pr-overseer-router.js';
 import { createAgentRosterRouter } from './features/agent-roster-router.js';
+import { createAgentProfileRouter } from './agent-profile-router.js';
 import {
   AGENT_ROLES,
   buildAttentionEventInput,
@@ -3164,6 +3165,17 @@ async function main(): Promise<void> {
   // non-destructive). Consumes the `iaStore` handle wired above; degrades to
   // 503 if the store failed to init.
   app.use(createIaWorkspaceRouter({ requireAuth, iaStore }));
+  // AgentProfile CRUD (#1232): local browser/operator configuration only. The
+  // router resolves provider ids through the live configured framework catalog;
+  // it never receives or logs framework environment-variable values.
+  app.use(
+    createAgentProfileRouter({
+      store: agentProfileStore,
+      listConfiguredFrameworks: () =>
+        listConfiguredFrameworks(getConfig().frameworks),
+      requireAuth,
+    })
+  );
   app.use(
     createWorkspaceEvidenceRouter({
       requireAuth,

--- a/test/agent-profile-router.test.ts
+++ b/test/agent-profile-router.test.ts
@@ -1,0 +1,246 @@
+import express from 'express';
+import http from 'node:http';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createAgentProfileRouter } from '../server/agent-profile-router.js';
+import {
+  createAgentProfileStore,
+  type AgentProfileStore,
+} from '../server/agent-profile-store.js';
+
+let server: http.Server | undefined;
+let baseUrl = '';
+let store: AgentProfileStore;
+let configuredFrameworkIds: string[];
+
+async function mount(): Promise<void> {
+  store = createAgentProfileStore(':memory:');
+  configuredFrameworkIds = ['claude', 'codex'];
+  store.seedBuiltIns(configuredFrameworkIds.map((id) => ({ id })));
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createAgentProfileRouter({
+      store,
+      listConfiguredFrameworks: () =>
+        configuredFrameworkIds.map((id) => ({ id })),
+      requireAuth: (_req, _res, next) => next(),
+    })
+  );
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('missing server address');
+      }
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+}
+
+async function request(
+  method: string,
+  route: string,
+  body?: unknown
+): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${baseUrl}${route}`, {
+    method,
+    headers:
+      body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : {} };
+}
+
+beforeEach(mount);
+
+afterEach(async () => {
+  await new Promise<void>((resolve) =>
+    server ? server.close(() => resolve()) : resolve()
+  );
+  server = undefined;
+  store.close();
+});
+
+describe('agent profile router', () => {
+  it('creates only profiles for configured providers with a non-empty name', async () => {
+    const unconfigured = await request('POST', '/agent-profiles', {
+      providerId: 'unknown',
+      displayName: 'Unknown',
+    });
+    expect(unconfigured.status).toBe(400);
+    expect(unconfigured.body.error.details.reasonCode).toBe(
+      'AGENT_PROFILE_PROVIDER_NOT_CONFIGURED'
+    );
+
+    const blankName = await request('POST', '/agent-profiles', {
+      providerId: 'claude',
+      displayName: ' ',
+    });
+    expect(blankName.status).toBe(400);
+    expect(blankName.body.error.details.reasonCode).toBe(
+      'AGENT_PROFILE_DISPLAY_NAME_REQUIRED'
+    );
+
+    const created = await request('POST', '/agent-profiles', {
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+      envVars: { FAST: '1' },
+    });
+    expect(created.status).toBe(201);
+    expect(created.body.profile).toMatchObject({
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+      isBuiltIn: false,
+      isDefault: false,
+    });
+  });
+
+  it('rejects malformed patch envVars/list values and only validates present fields', async () => {
+    const created = await request('POST', '/agent-profiles', {
+      providerId: 'claude',
+      displayName: 'Backend Claude',
+      systemPrompt: 'keep this',
+    });
+    const id = created.body.profile.id;
+
+    const malformedEnv = await request('PATCH', `/agent-profiles/${id}`, {
+      envVars: { FAST: 1 },
+    });
+    expect(malformedEnv.status).toBe(400);
+    expect(malformedEnv.body.error.details).toMatchObject({
+      reasonCode: 'AGENT_PROFILE_INVALID_FIELD',
+      field: 'envVars',
+    });
+
+    const malformedList = await request('PATCH', `/agent-profiles/${id}`, {
+      namePool: ['valid', ''],
+    });
+    expect(malformedList.status).toBe(400);
+    expect(malformedList.body.error.details).toMatchObject({
+      reasonCode: 'AGENT_PROFILE_INVALID_FIELD',
+      field: 'namePool',
+    });
+
+    const updated = await request('PATCH', `/agent-profiles/${id}`, {
+      displayName: 'Renamed Claude',
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.body.profile).toMatchObject({
+      displayName: 'Renamed Claude',
+      systemPrompt: 'keep this',
+    });
+  });
+
+  it('resets vendor-dependent model and effort when a non-default changes provider', async () => {
+    const created = await request('POST', '/agent-profiles', {
+      providerId: 'claude',
+      displayName: 'Portable Reviewer',
+      model: 'claude-model',
+      effort: 'high',
+    });
+    const moved = await request(
+      'PATCH',
+      `/agent-profiles/${created.body.profile.id}`,
+      { providerId: 'codex' }
+    );
+    expect(moved.status).toBe(200);
+    expect(moved.body.profile).toMatchObject({
+      providerId: 'codex',
+      displayName: 'Portable Reviewer',
+    });
+    expect(moved.body.profile.model).toBeUndefined();
+    expect(moved.body.profile.effort).toBeUndefined();
+  });
+
+  it('does not delete a built-in default and flips defaults atomically', async () => {
+    const builtIn = store.getDefaultForProvider('claude')!;
+    const blocked = await request('DELETE', `/agent-profiles/${builtIn.id}`);
+    expect(blocked.status).toBe(409);
+    expect(blocked.body.error.details.reasonCode).toBe(
+      'AGENT_PROFILE_BUILT_IN_DEFAULT_DELETE_FORBIDDEN'
+    );
+
+    const created = await request('POST', '/agent-profiles', {
+      providerId: 'claude',
+      displayName: 'Reviewer Claude',
+    });
+    const selected = await request(
+      'POST',
+      `/agent-profiles/${created.body.profile.id}/default`
+    );
+    expect(selected.status).toBe(200);
+    expect(selected.body.profile.isDefault).toBe(true);
+    expect(store.get(builtIn.id)?.isDefault).toBe(false);
+    expect(
+      store
+        .list({ providerId: 'claude' })
+        .filter((profile) => profile.isDefault)
+    ).toHaveLength(1);
+  });
+
+  it('allows a built-in display name to reset to the catalog-label sentinel', async () => {
+    const builtIn = store.getDefaultForProvider('claude')!;
+    const renamed = await request('PATCH', `/agent-profiles/${builtIn.id}`, {
+      displayName: 'Claude Operator',
+    });
+    expect(renamed.status).toBe(200);
+    expect(renamed.body.profile).toMatchObject({
+      displayName: 'Claude Operator',
+      isBuiltIn: true,
+    });
+
+    const reset = await request('PATCH', `/agent-profiles/${builtIn.id}`, {
+      displayName: '',
+    });
+    expect(reset.status).toBe(200);
+    expect(reset.body.profile).toMatchObject({
+      displayName: '',
+      isBuiltIn: true,
+      isDefault: true,
+    });
+  });
+
+  it('seeds a runtime-added framework before exposing or mutating its profiles', async () => {
+    configuredFrameworkIds.push('runtime');
+    const listed = await request('GET', '/agent-profiles');
+    expect(listed.status).toBe(200);
+    expect(listed.body.profiles).toContainEqual(
+      expect.objectContaining({
+        providerId: 'runtime',
+        isBuiltIn: true,
+        isDefault: true,
+      })
+    );
+
+    const created = await request('POST', '/agent-profiles', {
+      providerId: 'runtime',
+      displayName: 'Runtime Reviewer',
+    });
+    expect(created.status).toBe(201);
+    expect(
+      store
+        .list({ providerId: 'runtime' })
+        .filter((profile) => profile.isDefault)
+    ).toHaveLength(1);
+
+    const claudeCustom = await request('POST', '/agent-profiles', {
+      providerId: 'claude',
+      displayName: 'Portable Reviewer',
+    });
+    const moved = await request(
+      'PATCH',
+      `/agent-profiles/${claudeCustom.body.profile.id}`,
+      { providerId: 'runtime' }
+    );
+    expect(moved.status).toBe(200);
+    expect(
+      store
+        .list({ providerId: 'runtime' })
+        .filter((profile) => profile.isDefault)
+    ).toHaveLength(1);
+  });
+});

--- a/test/agent-profile-store.test.ts
+++ b/test/agent-profile-store.test.ts
@@ -359,6 +359,90 @@ describe('one-default-per-provider invariant (enforcement CHOICE: reject)', () =
   });
 });
 
+describe('update — profile JSON and denormalized invariant stay in lockstep', () => {
+  it('patches explicit fields while preserving omitted overlay fields', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'codex' }]);
+    const created = store.create({
+      providerId: 'codex',
+      displayName: 'Fast Codex',
+      systemPrompt: 'be concise',
+      model: 'gpt-x',
+      effort: 'high',
+      envVars: { FAST: '1' },
+    });
+
+    const updated = store.update(created.id, {
+      displayName: 'Careful Codex',
+      effort: null,
+    });
+    expect(updated).toMatchObject({
+      id: created.id,
+      providerId: 'codex',
+      displayName: 'Careful Codex',
+      systemPrompt: 'be concise',
+      model: 'gpt-x',
+      envVars: { FAST: '1' },
+      isDefault: false,
+      isBuiltIn: false,
+    });
+    expect(updated.effort).toBeUndefined();
+    expect(store.get(created.id)).toEqual(updated);
+  });
+
+  it('rejects provider changes for built-in profiles and isBuiltIn edits', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const builtInId = builtInAgentProfileId('claude');
+
+    try {
+      store.update(builtInId, { providerId: 'codex' });
+      throw new Error('expected provider change to fail');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'agent_profile_builtin_provider_change_forbidden',
+        status: 400,
+      });
+    }
+    try {
+      store.update(builtInId, { isBuiltIn: false });
+      throw new Error('expected isBuiltIn edit to fail');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'agent_profile_is_built_in_immutable',
+        status: 400,
+      });
+    }
+  });
+
+  it('keeps exactly one default when an update promotes a profile', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const custom = store.create({
+      providerId: 'claude',
+      displayName: 'Reviewer Claude',
+    });
+
+    const updated = store.update(custom.id, { isDefault: true });
+    expect(updated.isDefault).toBe(true);
+    expect(store.get(builtInAgentProfileId('claude'))?.isDefault).toBe(false);
+    expect(
+      store
+        .list({ providerId: 'claude' })
+        .filter((profile) => profile.isDefault)
+    ).toHaveLength(1);
+    try {
+      store.update(custom.id, { isDefault: false });
+      throw new Error('expected default clearing to fail');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'agent_profile_last_default',
+        status: 409,
+      });
+    }
+  });
+});
+
 describe('read-time shim over the store', () => {
   it('maps agent:<framework> to the seeded default profile id', () => {
     const store = makeStore();

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -241,6 +241,7 @@ const expectedInventoryCoverage = [
       '/api/analytics/*',
       '/telemetry/*',
       '/work-contexts/*',
+      '/agent-profiles/*',
     ],
   },
   {

--- a/test/components/SettingsAgentProfilesSection.test.ts
+++ b/test/components/SettingsAgentProfilesSection.test.ts
@@ -1,0 +1,326 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { AgentProfile } from '../../shared/agent-profile.js';
+import { deleteAgentProfile } from '../../frontend/src/lib/api.js';
+import type { FrameworkInfo } from '../../frontend/src/lib/types.js';
+import { SearchableSelect } from '../../frontend/src/components/SearchableSelect.js';
+import {
+  AgentProfileEditor,
+  AgentProfileGallery,
+  groupAgentProfiles,
+  profileDraftFrom,
+  profileSubmitInput,
+} from '../../frontend/src/components/dialogs/SettingsAgentProfilesSection.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const matchMedia = () =>
+  ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as MediaQueryList;
+
+const frameworks: FrameworkInfo[] = [
+  {
+    id: 'claude',
+    displayName: 'Claude Code',
+    command: 'claude',
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: true,
+    },
+    eventSource: 'hooks',
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex',
+    command: 'codex',
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: true,
+    },
+    eventSource: 'hooks',
+  },
+];
+
+function profile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    id: 'agent-profile:claude:reviewer',
+    providerId: 'claude',
+    displayName: 'reviewer claude',
+    avatar: null,
+    model: 'sonnet',
+    effort: 'high',
+    isDefault: false,
+    isBuiltIn: false,
+    ...overrides,
+  };
+}
+
+function setInput(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function selectFramework(
+  host: HTMLElement,
+  label: string
+): Promise<void> {
+  const trigger = host.querySelector<HTMLButtonElement>('.ss-trigger');
+  await act(async () => trigger?.click());
+  const option = Array.from(
+    host.querySelectorAll<HTMLElement>('[role="option"]')
+  ).find(
+    (item) =>
+      item.querySelector('.tui-menu-item__content')?.textContent?.trim() ===
+      label
+  );
+  await act(async () =>
+    option?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+  );
+}
+
+describe('AgentProfileEditor', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', matchMedia);
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('submits a create profile draft from the configured provider catalog', async () => {
+    const onSubmit = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(AgentProfileEditor, {
+          key: 'create-submit',
+          frameworks,
+          onCancel: vi.fn(),
+          onSubmit,
+        })
+      );
+    });
+    await act(async () => {
+      setInput(
+        host.querySelector(
+          'input[placeholder="e.g. reviewer codex"]'
+        ) as HTMLInputElement,
+        'review codex'
+      );
+    });
+    await selectFramework(host, 'Codex');
+    await act(async () => {
+      (host.querySelector('form') as HTMLFormElement).dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'codex',
+        displayName: 'review codex',
+      })
+    );
+  });
+
+  it('clears provider-owned model and effort when a create draft changes provider', async () => {
+    const onSubmit = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(AgentProfileEditor, {
+          key: 'create-reset',
+          frameworks,
+          onCancel: vi.fn(),
+          onSubmit,
+        })
+      );
+    });
+    const fields = Array.from(host.querySelectorAll('input'));
+    await act(async () => {
+      setInput(fields[1] as HTMLInputElement, 'gpt-5');
+      setInput(fields[2] as HTMLInputElement, 'high');
+    });
+    await selectFramework(host, 'Codex');
+    expect(
+      Array.from(host.querySelectorAll('input')).map((input) => input.value)
+    ).not.toContain('gpt-5');
+    expect(
+      Array.from(host.querySelectorAll('input')).map((input) => input.value)
+    ).not.toContain('high');
+  });
+
+  it('submits an update profile draft', async () => {
+    const onSubmit = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(AgentProfileEditor, {
+          key: 'update-submit',
+          profile: profile({ displayName: 'updated reviewer' }),
+          frameworks,
+          onCancel: vi.fn(),
+          onSubmit,
+        })
+      );
+    });
+    await act(async () => {
+      (host.querySelector('form') as HTMLFormElement).dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        providerId: 'claude',
+        displayName: 'updated reviewer',
+      })
+    );
+  });
+
+  it('serializes blank optional fields as clear patches for an existing profile', () => {
+    expect(
+      profileSubmitInput(profileDraftFrom(profile()), { clearEmpty: true })
+    ).toEqual(
+      expect.objectContaining({
+        systemPrompt: null,
+        envVars: null,
+        namePool: null,
+        respondToAllowlist: null,
+      })
+    );
+  });
+
+  it('keeps an explicit blank display name when an edit resets to catalog inheritance', () => {
+    expect(
+      profileSubmitInput(
+        { ...profileDraftFrom(profile()), displayName: '' },
+        { clearEmpty: true }
+      )
+    ).toEqual(expect.objectContaining({ displayName: '' }));
+  });
+});
+
+describe('AgentProfileGallery', () => {
+  it('groups cards by configured vendor and marks the provider default', () => {
+    const profiles = [
+      profile({
+        id: 'agent-profile:claude:default',
+        displayName: '',
+        isDefault: true,
+        isBuiltIn: true,
+      }),
+      profile({
+        id: 'agent-profile:codex:reviewer',
+        providerId: 'codex',
+        displayName: 'review codex',
+      }),
+    ];
+    expect(
+      groupAgentProfiles(profiles, frameworks).map((group) => group.label)
+    ).toEqual(['Claude Code', 'Codex']);
+    const html = renderToStaticMarkup(
+      React.createElement(AgentProfileGallery, {
+        profiles,
+        frameworks,
+        onEdit: vi.fn(),
+        onDuplicate: vi.fn(),
+        onDelete: vi.fn(),
+        onSetDefault: vi.fn(),
+      })
+    );
+    expect(html).toContain('Claude Code');
+    expect(html).toContain('Codex');
+    expect(html).toContain('default');
+    expect(html).toContain('built-in default');
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>delete<\/button>/);
+  });
+});
+
+describe('SearchableSelect keyboard and ARIA', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('opens as a combobox and selects the roved option with ArrowDown and Enter', async () => {
+    const onchange = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(SearchableSelect, {
+          options: frameworks.map(({ id, displayName }) => ({
+            value: id,
+            label: displayName,
+          })),
+          placeholder: 'select framework',
+          onchange,
+        })
+      );
+    });
+    const trigger = host.querySelector<HTMLButtonElement>('.ss-trigger');
+    await act(async () =>
+      trigger?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+      )
+    );
+    const input = host.querySelector<HTMLInputElement>('[role="combobox"]');
+    expect(input?.getAttribute('aria-expanded')).toBe('true');
+    expect(input?.getAttribute('aria-controls')).toBeTruthy();
+    expect(input?.getAttribute('aria-activedescendant')).toContain('option-0');
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+      );
+    });
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+    expect(onchange).toHaveBeenCalledWith('claude');
+  });
+});
+
+describe('deleteAgentProfile', () => {
+  it("accepts the router's empty 204 delete response", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(
+      deleteAgentProfile('agent-profile:claude:reviewer')
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/agent-profiles/agent-profile%3Aclaude%3Areviewer',
+      { method: 'DELETE' }
+    );
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
#1232 **Slice 7** — makes AgentProfiles (#1233) operator-manageable. The store was **seed-only** (no route, no UI); this wires a CRUD route + config editor + vendor gallery. **Additive — no binding re-key or migration** (that's slice 5, next; sequenced after this to de-risk with real profiles to test against).

## Backend
- `agent-profile-store`: `update(id, patch)` with atomic one-default-per-provider + built-in immutability.
- `agent-profile-router` (authenticated): `GET` list · `POST` create (201) · `PATCH` · `DELETE` (204) · `POST :id/default`. Validation: `providerId` must name a configured framework; `isBuiltIn` server-managed; built-in `providerId` immutable; provider change resets model/effort; **delete blocks the built-in default AND the last default** (409). Named `reasonCode`s; `envVars` never logged.

## Frontend
- api client (5 ops); **Settings → Agents → Profiles**: per-profile editor (displayName, framework, systemPrompt, model, effort, envVars, namePool, respondTo + allowlist; framework change resets dependents) + vendor-grouped gallery (identity via AgentAvatar/AgentBadge, default badge, edit/duplicate/delete/set-default). `SearchableSelect` gains disabled state + `>` cursor + arrow/enter nav + combobox ARIA.

## DESIGN.md
0px radius, pure-black inline surfaces, outline TUI actions, fixed icon column, block-cursor inputs, no emoji/Radix, lowercase copy. Reviewed — clean.

## Deferred (noted)
Avatar upload; drift/staleness markers (depend on Slice 4b).

## Verify
`npm run check`: 0 errors. 31 tests (store invariants + router validation incl. built-in/default guards + editor create/update/reset).

Refs #1232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Agent Profiles management in Settings.
  - Create, edit, duplicate, delete, search, and set default profiles.
  - Configure frameworks, models, effort levels, environment variables, prompts, and response permissions.
  - Added responsive profile cards and editor layouts with clear validation and error states.
- **Accessibility**
  - Improved searchable select keyboard navigation and ARIA support.
  - Added disabled-state behavior for selection controls.
- **Bug Fixes**
  - Preserved profile settings during partial edits and safely reset provider-specific options when changing frameworks.
  - Prevented invalid default-profile changes and protected built-in defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->