### PR TITLE
feat(channels): re-key channel binding to AgentProfile actor id (#1232 slice 5)

### DIFF
--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -44,14 +44,14 @@ wiring over it. Verified 2026-07-17 against source:
 | Workspace       | `ia_workspaces` (`server/ia-store.ts`, epic #1021)                                  | Rail entries: `status`, `pinned`, `color`, `icon`, `default_repo_path`, `default_node_id`.                                                                                                                                                                 |
 | Channel         | `workspace_topics` (`server/workspace-topics.ts`)                                   | Record carries `routingDefaults`, `promptDefaults`, and channel `kind` = repo/product-area/journal/ops/research/topic. Channel identity = topic id.                                                                                                        |
 | Message store   | `channel_messages` (`server/channel-message-store.ts`, #1165 SHIPPED)               | New durable `channel-chat.db`: per-channel gap-free `seq`, streaming lifecycle, `sender_kind`/`sender_id`, `thread_id`/`parent_message_id`, `source_*` bridge provenance. `work_context_messages` is agent-mail (#945), a deliberately separate substrate. |
-| Mention targets | Agent roster (`shared/agent-roster.ts`, #952/#953)                                  | `RosterEntry.provider` = framework id (`claude`/`codex`/`hermes`); derived per live session.                                                                                                                                                               |
+| Mention targets | Channel AgentProfile roster (`server/channel-agent-binder.ts`, #1232)               | `entry.id` is the durable `AgentProfile` Actor identity; `entry.providerId` is the vendor selector (`claude`/`codex`/`hermes`). Profiles also carry `isDefault`, `isBuiltIn`, and collaboration `role`.                                                |
 | Agent transport | `ProtocolAdapterV2` (`server/protocol-adapter-v2.ts`, `protocol-adapters/index.ts`) | v2 registry: `mock`, `claude`, `codex` (native), `opencode`/`hermes` via legacy bridge.                                                                                                                                                                    |
 
-**Verification nuance:** the roster is _derived from live sessions_ and keyed by
-`sessionId` + `provider`, not a persistent per-agent handle registry. So
-`@claude` resolves to a framework/provider id, and spawn-on-first-mention must
-bind `(channel, agent-framework)` and create the session — it cannot assume a
-roster row already exists. This is new wiring, not a contradiction.
+**Verification nuance:** the channel roster is derived per request from durable
+`AgentProfile` rows plus current framework availability and live binding status;
+its identity is the profile Actor id, not `sessionId` + provider. Mention
+`@<providerId>` or `@<profileName>`, never `@<id>`; spawn-on-first-mention binds
+`(channel, profileActorId)` and creates that profile's session when needed.
 
 ## Claude integration decision (HARD — do not soften)
 
@@ -115,15 +115,15 @@ agent mail, and every adapter are untouched):
   `complete`), and an optional `onAssistantMessageFinalized` hook fires on cleanly
   completed rows to drive agent-to-agent mentions.
 - **@-mention routing (#1167)** `server/channel-agent-binder.ts`: one module owns
-  the loop — subscribe `hub.onMessagePosted` → resolve mentions (`providerId` only)
-  → single-flight ensure a `(channel, framework)` web session (spawn | reuse |
+  the loop — subscribe `hub.onMessagePosted` → resolve provider/profile-name mentions
+  → single-flight ensure a `(channel, profileActorId)` web session (spawn | reuse |
   rebind) → wire the bridge → build a context packet (`server/channel-context-packet.ts`,
   pure) → `adapter.sendMessage`. Browser posts and CLI-gateway-actor posts route
   identically. Spawns default to **yolo/permission-bypass** (MVP constant
   `CHANNEL_BINDING_YOLO_DEFAULT`) so routing never wedges on an approval; the
   approval-render path stays wired. Per-binding FIFO turn queue (cap 8), a per-turn
   watchdog that pauses on `waitingOn` (never force-drains a human approval), a
-  single-node cross-node guard, deterministic `turnId = chturn-<messageId>-<framework>`
+  single-node cross-node guard, deterministic `turnId = chturn-<messageId>-<profileActorId>`
   (retry reuses it), an at-least-once delivery cursor
   (`binding.providerSession.lastDeliveredSeq`, advanced only on send acceptance),
   and a per-channel **consecutive-agent-turn brake** (`MAX_CONSECUTIVE_AGENT_TURNS=4`,
@@ -139,6 +139,11 @@ agent mail, and every adapter are untouched):
     (`channels.interrupt`) and `POST .../approvals` (`channels.respond-approval`),
     both `context:write`. Status transitions ride `/ws/events` as
     `channel-agent-status`.
+  - **Roster identity:** `entry.id` is the durable `AgentProfile` Actor id and
+    unique identity; `entry.providerId` is the vendor / mention selector. Mention
+    `@<providerId>` or `@<profileName>`, never `@<id>`; `isDefault` identifies a
+    provider default, `isBuiltIn` a catalog-seeded profile, and `role` a
+    collaboration hint.
 
 **Privacy note:** channel message bodies are stored **raw**, with no redaction
 pipeline (unlike the `work_context_messages` sanitizer,

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -313,17 +313,17 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     return () => clearChannel(channelId);
   }, [channelId]);
 
-  const streamingProviderIds = useMemo(() => {
-    const ids = new Set<string>();
+  const streamingProfileProviders = useMemo(() => {
+    const providers = new Map<string, string | undefined>();
     for (const message of reducer.messages) {
       if (message.status !== 'streaming' || message.sender.kind !== 'agent')
         continue;
-      // providerId is authoritative from the explicit field — the id is now a
-      // profile Actor id, not `agent:<framework>`, so never strip it (#1234).
-      const providerId = message.sender.providerId;
-      if (providerId) ids.add(providerId);
+      // Agent sender ids are profile Actor ids. Keep stream state in the same
+      // identity namespace as roster/status rather than collapsing profiles by
+      // provider.
+      providers.set(message.sender.id, message.sender.providerId);
     }
-    return ids;
+    return providers;
   }, [reducer.messages]);
 
   const rosterUpdatedAt = rosterChipsQuery.dataUpdatedAt;
@@ -338,7 +338,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     for (const key of Object.keys(statusMap)) {
       if (key.startsWith(prefix)) candidateIds.add(key.slice(prefix.length));
     }
-    for (const providerId of streamingProviderIds) candidateIds.add(providerId);
+    for (const profileId of streamingProfileProviders.keys())
+      candidateIds.add(profileId);
 
     const chips: Array<{
       agentId: string;
@@ -349,7 +350,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     for (const agentId of candidateIds) {
       const entry = rosterById.get(agentId);
       const key = channelAgentStatusKey(channelId, agentId);
-      const streaming = streamingProviderIds.has(agentId);
+      const streaming = streamingProfileProviders.has(agentId);
       const status = resolveEffectiveAgentStatus({
         socketStatus: statusMap[key],
         socketUpdatedAt: statusUpdatedAtMap[key],
@@ -361,12 +362,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       // active/streaming — but drop an unbound agent whose only signal is a stale
       // socket status the roster has since superseded to idle.
       if (entry?.binding == null && status === 'idle' && !streaming) continue;
+      const providerId =
+        entry?.providerId ?? streamingProfileProviders.get(agentId);
       const identity = resolveSenderIdentity({
         kind: 'agent',
-        // Roster/presence chips represent a vendor's DEFAULT profile — key on the
-        // profile Actor id so the chip keeps the curated vendor token (#1234).
-        id: builtInAgentProfileId(agentId),
-        providerId: agentId,
+        id: agentId,
+        ...(providerId ? { providerId } : {}),
         ...(entry?.displayName ? { displayName: entry.displayName } : {}),
       });
       chips.push({
@@ -382,7 +383,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     rosterUpdatedAt,
     statusMap,
     statusUpdatedAtMap,
-    streamingProviderIds,
+    streamingProfileProviders,
     channelId,
   ]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1901,7 +1901,7 @@ export async function fetchChannelAttachmentBlob(
 // The roster lists the frameworks that can be @-mentioned in a channel, with
 // their live binding/status. Interrupt + approval are per-agent control writes.
 
-/** Live agent status within a channel (framework-id keyed). */
+/** Live agent status within a channel (profile-actor-id keyed). */
 export type ChannelAgentStatus =
   | 'spawning'
   | 'thinking'
@@ -1911,9 +1911,13 @@ export type ChannelAgentStatus =
 
 /** One row of the channel @-mention roster (GET /channels/:id/roster). */
 export interface RosterEntry {
-  /** Framework id (e.g. `claude`, `codex`, `mock`) — what a mention resolves to. */
+  /** Durable AgentProfile actor id — what a mention resolves to. */
   id: string;
   displayName: string;
+  /** Provider/framework spawn selector for this profile. */
+  providerId: string;
+  isDefault: boolean;
+  isBuiltIn: boolean;
   kind: 'framework';
   /** False when the framework cannot currently be routed to (see `reason`). */
   available: boolean;

--- a/frontend/src/lib/chat/mention-contacts.ts
+++ b/frontend/src/lib/chat/mention-contacts.ts
@@ -1,14 +1,7 @@
 // Build the @mention palette's contact set (#1236, slice 4).
 //
-// v1 SOURCE = CLIENT-SIDE SYNTHESIS, no new server endpoint. Agent contacts are
-// the vendor DEFAULT profiles synthesized from the channel roster the composer
-// already fetches (`GET /channels/:id/roster`), each keyed on
-// `builtInAgentProfileId(vendor)`. Human contacts come from the channel members
-// the composer already receives. When a later slice adds custom-profile
-// creation those rows slot in as `kind: 'profile'` with their own ids — this
-// builder is the only place that changes.
-
-import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
+// Agent contacts arrive as durable profile rows from the channel roster; human
+// contacts come from the channel members the composer already receives.
 import {
   annotateMentionCollisions,
   type MentionContact,
@@ -17,8 +10,8 @@ import type { ChannelMemberRef } from '../../../../shared/channel-chat-protocol.
 import type { RosterEntry } from '../api.js';
 
 /**
- * Synthesize the palette contact set from the framework roster (vendor defaults)
- * plus human channel members, then annotate same-name collisions with a stable
+ * Build the palette contact set from the profile roster plus human channel
+ * members, then annotate same-name collisions with a stable
  * local id token. Ordering: agents first (roster order), then humans.
  */
 export function buildMentionContacts(
@@ -26,18 +19,19 @@ export function buildMentionContacts(
   members: readonly ChannelMemberRef[] = []
 ): MentionContact[] {
   const contacts: MentionContact[] = [];
-  for (const framework of roster) {
+  for (const profile of roster) {
     contacts.push({
-      id: builtInAgentProfileId(framework.id),
-      providerId: framework.id,
-      displayName: framework.displayName,
-      kind: 'vendor-default',
-      owner: 'system',
-      available: framework.available,
-      reason: framework.reason,
+      id: profile.id,
+      providerId: profile.providerId,
+      displayName: profile.displayName,
+      kind:
+        profile.isDefault && profile.isBuiltIn ? 'vendor-default' : 'profile',
+      owner: profile.isBuiltIn ? 'system' : 'user',
+      available: profile.available,
+      reason: profile.reason,
       inChannel: true,
-      isDefault: true,
-      isBuiltIn: true,
+      isDefault: profile.isDefault,
+      isBuiltIn: profile.isBuiltIn,
     });
   }
   const seenHumans = new Set<string>();

--- a/server/agent-profile-store.ts
+++ b/server/agent-profile-store.ts
@@ -136,6 +136,7 @@ export interface AgentProfileStore {
   getDefaultForProvider(providerId: string): AgentProfile | null;
   /** Atomically make `profileId` the sole default for its providerId. */
   setDefault(profileId: string): AgentProfile;
+  /** Refuses to delete the built-in default profile for a provider (409). */
   delete(id: string): boolean;
   /**
    * Seed/repair exactly one `isBuiltIn`+`isDefault` profile per configured
@@ -442,6 +443,14 @@ export function createAgentProfileStore(dbPath: string): AgentProfileStore {
     },
 
     delete(id: string): boolean {
+      const profile = getById(id);
+      if (profile?.isBuiltIn && profile.isDefault) {
+        throw new AgentProfileStoreError(
+          409,
+          'agent_profile_builtin_default_delete_forbidden',
+          'The built-in default profile cannot be deleted.'
+        );
+      }
       return deleteById.run(id).changes > 0;
     },
 

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -19,8 +19,13 @@ import type { Attachment, ProtocolAdapterV2 } from './protocol-adapter-v2.js';
 import type { CreateWebParams } from './web-session-handler.js';
 import type { Session, WebSession } from './types.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
+import type { AgentProfileStore } from './agent-profile-store.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
-import { builtInAgentProfileId } from '../shared/agent-profile.js';
+import {
+  builtInAgentProfileId,
+  resolveProfileForMention,
+  type AgentProfile,
+} from '../shared/agent-profile.js';
 import {
   parseMentions,
   type ChannelMention,
@@ -91,6 +96,9 @@ export interface MentionTarget {
 export interface ChannelAgentRosterEntry {
   id: string;
   displayName: string;
+  providerId: string;
+  isDefault: boolean;
+  isBuiltIn: boolean;
   kind: 'framework';
   available: boolean;
   reason: string | null;
@@ -118,6 +126,8 @@ export interface ChannelAgentBinderDeps {
   attachmentStore?: ChannelAttachmentStore | null;
   hub: ChannelHub;
   topicStore: WorkspaceTopicStore | null;
+  /** Durable local AgentProfile catalog; null keeps the legacy default-profile fallback. */
+  agentProfileStore?: AgentProfileStore | null;
   sessions: BinderSessions;
   /** Resolve the current routable frameworks (builtin/configured + mock in tests). */
   mentionTargets: () => Promise<MentionTarget[]>;
@@ -140,7 +150,8 @@ export interface ChannelAgentBinder {
   /** Designate or resume the one orchestrator bound to a product channel. */
   ensureOrchestrator(
     channelId: string,
-    framework?: string
+    framework?: string,
+    profileActorId?: string
   ): Promise<LiveBinding>;
   interrupt(channelId: string, agentId: string): Promise<void>;
   respondToApproval(
@@ -162,7 +173,10 @@ interface QueuedTurn {
 
 export interface LiveBinding {
   channelId: string;
+  /** Actor id, not provider id: one profile owns one live binding/session. */
+  profileActorId: string;
   framework: string;
+  /** Bare profile label for user-facing channel rows, never the session title. */
   displayName: string;
   sessionId: string | null;
   adapter: ProtocolAdapterV2 | null;
@@ -241,8 +255,8 @@ class BinderClosedError extends Error {
 
 const SYSTEM_SENDER = { kind: 'system', id: 'system' } as const;
 
-function bindingKey(channelId: string, framework: string): string {
-  return `${channelId}\u0000${framework}`;
+function bindingKey(channelId: string, profileActorId: string): string {
+  return `${channelId}\u0000${profileActorId}`;
 }
 
 export function createChannelAgentBinder(
@@ -302,11 +316,11 @@ export function createChannelAgentBinder(
 
   function postUnavailableRow(
     channelId: string,
-    framework: string,
+    profileActorId: string,
     text: string,
     parentMessageId?: string
   ): void {
-    const key = `${bindingKey(channelId, framework)}\u0000${text}\u0000${parentMessageId ?? ''}`;
+    const key = `${bindingKey(channelId, profileActorId)}\u0000${text}\u0000${parentMessageId ?? ''}`;
     const last = unavailableRowAt.get(key);
     if (last !== undefined && now() - last < UNAVAILABLE_ROW_TTL_MS) return;
     unavailableRowAt.set(key, now());
@@ -383,6 +397,49 @@ export function createChannelAgentBinder(
     }
   }
 
+  /**
+   * The profile store is intentionally the only named-profile resolver. When it
+   * is unavailable during boot/failure, retain legacy `@provider` behavior by
+   * synthesizing just that provider's built-in actor identity.
+   */
+  function defaultProfileForProvider(providerId: string): AgentProfile {
+    const stored = deps.agentProfileStore?.getDefaultForProvider(providerId);
+    if (stored) return stored;
+    return {
+      id: builtInAgentProfileId(providerId),
+      providerId,
+      displayName: '',
+      avatar: null,
+      isDefault: true,
+      isBuiltIn: true,
+    };
+  }
+
+  function resolveProfileMention(
+    mention: ChannelMention
+  ): AgentProfile | null {
+    const profiles = deps.agentProfileStore?.list() ?? [];
+    if (mention.profileId) {
+      const pinned = profiles.find((profile) => profile.id === mention.profileId);
+      if (pinned) return pinned;
+      // A persisted, collision-disambiguated profile id must never silently
+      // become a different named profile after a catalog edit.
+      return null;
+    }
+    // Keep mention identity deterministic even if an older caller did not
+    // persist `profileId`: all profile matching delegates to the shared
+    // vendor-alias/longest-name resolver.
+    const resolved = resolveProfileForMention(mention.raw, profiles);
+    if (resolved) return resolved;
+    return mention.providerId
+      ? defaultProfileForProvider(mention.providerId)
+      : null;
+  }
+
+  async function rosterDisplayName(profile: AgentProfile): Promise<string> {
+    return profile.displayName || (await senderLabelFor(profile.providerId));
+  }
+
   // ── status ──────────────────────────────────────────────────────────────────
 
   function setStatus(binding: LiveBinding, status: ChannelAgentStatus): void {
@@ -390,7 +447,7 @@ export function createChannelAgentBinder(
     binding.status = status;
     statusBroadcaster?.('channel-agent-status', {
       channelId: binding.channelId,
-      agentId: binding.framework,
+      agentId: binding.profileActorId,
       status,
       sessionId: binding.sessionId ?? null,
     });
@@ -426,11 +483,13 @@ export function createChannelAgentBinder(
 
   function newLiveBinding(
     channelId: string,
+    profileActorId: string,
     framework: string,
     displayName: string
   ): LiveBinding {
     return {
       channelId,
+      profileActorId,
       framework,
       displayName,
       sessionId: null,
@@ -454,12 +513,12 @@ export function createChannelAgentBinder(
 
   function attachSession(
     channelId: string,
+    profileActorId: string,
     framework: string,
-    displayName: string,
     senderDisplayName: string,
     session: { id: string; adapterV2: ProtocolAdapterV2 }
   ): LiveBinding {
-    const key = bindingKey(channelId, framework);
+    const key = bindingKey(channelId, profileActorId);
     const existing = live.get(key);
     // Tear down any prior wiring before re-binding a fresh adapter.
     existing?.unbind?.();
@@ -478,8 +537,10 @@ export function createChannelAgentBinder(
       existing.turnZeroFallbackUnsafe = false;
     }
     const binding =
-      existing ?? newLiveBinding(channelId, framework, displayName);
-    binding.displayName = displayName;
+      existing ??
+      newLiveBinding(channelId, profileActorId, framework, senderDisplayName);
+    binding.profileActorId = profileActorId;
+    binding.displayName = senderDisplayName;
     binding.sessionId = session.id;
     binding.adapter = session.adapterV2;
     binding.unbind = bindSessionToChannel({
@@ -492,9 +553,9 @@ export function createChannelAgentBinder(
         : {}),
       hub,
       // Sender attribution (#1234): the durable ChannelSenderRef carries the
-      // vendor DEFAULT profile Actor id + the vendor catalog label, NOT the
-      // session/tab composite (`binding.displayName`). One session == one profile.
-      profileActorId: builtInAgentProfileId(framework),
+      // vendor DEFAULT profile Actor id + its catalog label. One session == one
+      // profile, and the composite session title remains createWeb-only.
+      profileActorId,
       displayName: senderDisplayName,
       parentMessageIdForTurn: (turnId) => parentForTurn(binding, turnId),
       onAssistantMessageFinalized: (message) =>
@@ -509,7 +570,8 @@ export function createChannelAgentBinder(
 
   function healthySession(
     sessionId: string | null,
-    framework: string
+    framework: string,
+    profileActorId: string
   ): (Session & { adapterV2: ProtocolAdapterV2 }) | null {
     if (!sessionId) return null;
     const session = deps.sessions.get(sessionId);
@@ -517,6 +579,9 @@ export function createChannelAgentBinder(
       session &&
       session.mode === 'web' &&
       session.agent === framework &&
+      (session.profileId === profileActorId ||
+        (session.profileId === undefined &&
+          profileActorId === builtInAgentProfileId(framework))) &&
       session.adapterV2
     ) {
       return session as Session & { adapterV2: ProtocolAdapterV2 };
@@ -524,24 +589,34 @@ export function createChannelAgentBinder(
     return null;
   }
 
-  function displayNameFor(channelId: string, framework: string): string {
+  function displayNameFor(
+    channelId: string,
+    framework: string,
+    profile: AgentProfile
+  ): string {
     const topic = topicStore?.get(channelId);
-    return `#${topic?.display.title ?? channelId} · ${framework}`;
+    return `#${topic?.display.title ?? channelId} · ${profile.displayName || framework}`;
   }
 
   async function doEnsureBinding(
     channelId: string,
-    framework: string,
+    profile: AgentProfile,
     requiredRole?: 'orchestrator'
   ): Promise<LiveBinding> {
     if (closed) throw new BinderClosedError();
-    const key = bindingKey(channelId, framework);
-    const displayName = displayNameFor(channelId, framework);
+    const framework = profile.providerId;
+    const profileActorId = profile.id;
+    const key = bindingKey(channelId, profileActorId);
+    const sessionDisplayName = displayNameFor(channelId, framework, profile);
 
     // 2. Reuse a live entry whose session is still healthy.
     const existing = live.get(key);
     if (existing?.adapter && existing.sessionId) {
-      const session = healthySession(existing.sessionId, framework);
+      const session = healthySession(
+        existing.sessionId,
+        framework,
+        profileActorId
+      );
       if (session && session.adapterV2 === existing.adapter) {
         if (requiredRole && session.role !== requiredRole) {
           throw new ChannelAgentRoleConflictError(
@@ -559,11 +634,15 @@ export function createChannelAgentBinder(
     // framework catalog label (built-in default profiles carry an empty stored
     // displayName). Resolved past the reuse fast-path so a hot rebind pays no
     // availability probe; failures fall back to the raw framework id.
-    const senderDisplayName = await senderLabelFor(framework);
+    const senderDisplayName = await rosterDisplayName(profile);
 
     // 3. Rebind a restored session that survived a live reconnect / restart.
-    const row = store.getBinding(channelId, framework);
-    const restored = healthySession(row?.sessionId ?? null, framework);
+    const row = store.getBinding(channelId, profileActorId);
+    const restored = healthySession(
+      row?.sessionId ?? null,
+      framework,
+      profileActorId
+    );
     if (restored) {
       if (requiredRole && restored.role !== requiredRole) {
         throw new ChannelAgentRoleConflictError(
@@ -575,8 +654,8 @@ export function createChannelAgentBinder(
       }
       return attachSession(
         channelId,
+        profileActorId,
         framework,
-        displayName,
         senderDisplayName,
         restored
       );
@@ -599,27 +678,44 @@ export function createChannelAgentBinder(
     const cwd =
       routing.cwd ?? routing.worktreePath ?? routing.repoPath ?? os.homedir();
     const provisional =
-      existing ?? newLiveBinding(channelId, framework, displayName);
+      existing ??
+      newLiveBinding(channelId, profileActorId, framework, senderDisplayName);
     live.set(key, provisional);
     setStatus(provisional, 'spawning');
     let created: { session: WebSession };
     try {
       created = await deps.sessions.createWeb({
         agentType: framework,
+        profileId: profileActorId,
         cwd,
-        displayName,
+        displayName: sessionDisplayName,
         port: deps.port,
         configDir: deps.configDir,
         ...(requiredRole ? { role: requiredRole } : {}),
         ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
         ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
         ...(yolo ? { permissionMode: YOLO_PERMISSION_MODE } : {}),
+        ...(profile.model !== undefined ? { model: profile.model } : {}),
+        ...(profile.envVars !== undefined ? { processEnv: profile.envVars } : {}),
+        ...(profile.systemPrompt !== undefined
+          ? { systemPrompt: profile.systemPrompt }
+          : {}),
+        ...(profile.provider !== undefined || profile.effort !== undefined
+          ? {
+              extra: {
+                ...(profile.provider !== undefined
+                  ? { provider: profile.provider }
+                  : {}),
+                ...(profile.effort !== undefined ? { effort: profile.effort } : {}),
+              },
+            }
+          : {}),
       });
     } catch (err) {
       setStatus(provisional, 'idle');
       throw new ChannelBindingError(
-        `spawn failed for @${framework}: ${errText(err)}`,
-        `@${framework} failed to start: ${errText(err)}`
+        `spawn failed for @${senderDisplayName}: ${errText(err)}`,
+        `@${senderDisplayName} failed to start: ${errText(err)}`
       );
     }
     // close() may have raced the spawn await: abort before we attach a bridge,
@@ -627,13 +723,14 @@ export function createChannelAgentBinder(
     if (closed) throw new BinderClosedError();
     const binding = attachSession(
       channelId,
+      profileActorId,
       framework,
-      displayName,
       senderDisplayName,
       created.session
     );
     store.upsertBinding({
       channelId,
+      profileActorId,
       agentFramework: framework,
       sessionId: created.session.id,
     });
@@ -645,12 +742,19 @@ export function createChannelAgentBinder(
     channelId: string,
     framework: string
   ): Promise<LiveBinding> {
-    const key = bindingKey(channelId, framework);
+    return ensureProfileBinding(channelId, defaultProfileForProvider(framework));
+  }
+
+  function ensureProfileBinding(
+    channelId: string,
+    profile: AgentProfile,
+    requiredRole?: 'orchestrator'
+  ): Promise<LiveBinding> {
+    const key = bindingKey(channelId, profile.id);
     const pending = inflight.get(key);
     if (pending) return pending;
-    // Store the promise BEFORE any await so two concurrent mentions of the same
-    // framework in one channel single-flight to exactly one spawn.
-    const promise = doEnsureBinding(channelId, framework).finally(() => {
+    // Store before awaiting so concurrent mentions of one profile single-flight.
+    const promise = doEnsureBinding(channelId, profile, requiredRole).finally(() => {
       inflight.delete(key);
     });
     inflight.set(key, promise);
@@ -659,14 +763,24 @@ export function createChannelAgentBinder(
 
   async function ensureOrchestrator(
     channelId: string,
-    framework = 'claude'
+    framework = 'claude',
+    profileActorId?: string
   ): Promise<LiveBinding> {
-    const key = bindingKey(channelId, framework);
+    const profile = profileActorId
+      ? deps.agentProfileStore?.get(profileActorId) ?? null
+      : defaultProfileForProvider(framework);
+    if (!profile) {
+      throw new ChannelBindingError(
+        `agent profile ${profileActorId} was not found`,
+        'The requested agent profile no longer exists.'
+      );
+    }
+    const key = bindingKey(channelId, profile.id);
     const pending = inflight.get(key);
     if (pending) {
       const binding = await pending;
       const session = binding.sessionId
-        ? healthySession(binding.sessionId, framework)
+        ? healthySession(binding.sessionId, profile.providerId, profile.id)
         : null;
       if (!session || session.role !== 'orchestrator') {
         throw new ChannelAgentRoleConflictError(
@@ -678,11 +792,7 @@ export function createChannelAgentBinder(
       }
       return binding;
     }
-    const promise = doEnsureBinding(
-      channelId,
-      framework,
-      'orchestrator'
-    ).finally(() => {
+    const promise = doEnsureBinding(channelId, profile, 'orchestrator').finally(() => {
       inflight.delete(key);
     });
     inflight.set(key, promise);
@@ -695,7 +805,7 @@ export function createChannelAgentBinder(
     if (binding.queue.length >= QUEUE_CAP) {
       postSystemRow(
         binding.channelId,
-        `@${binding.framework} has ${QUEUE_CAP} turns queued — message dropped`,
+        `@${binding.displayName} has ${QUEUE_CAP} turns queued — message dropped`,
         { parentMessageId: parentForTrigger(trigger) }
       );
       return;
@@ -718,7 +828,7 @@ export function createChannelAgentBinder(
   ): ResolvedMentionContextPacket {
     const topic = topicStore?.get(binding.channelId);
     const title = topic?.display.title ?? binding.channelId;
-    const row = store.getBinding(binding.channelId, binding.framework);
+    const row = store.getBinding(binding.channelId, binding.profileActorId);
     const lastDeliveredSeq =
       typeof row?.providerSession['lastDeliveredSeq'] === 'number'
         ? (row.providerSession['lastDeliveredSeq'] as number)
@@ -760,7 +870,7 @@ export function createChannelAgentBinder(
   function sendTurn(binding: LiveBinding, trigger: ChannelMessage): void {
     const adapter = binding.adapter;
     if (!adapter) return;
-    const turnId = `chturn-${trigger.id}-${binding.framework}`;
+    const turnId = `chturn-${trigger.id}-${binding.profileActorId}`;
     // Build the packet BEFORE mutating any binding state: buildPacket does
     // synchronous SQLite work (getBinding/history) that can throw. If it did so
     // AFTER activeTurnId was set (and before the watchdog armed), the binding
@@ -773,7 +883,7 @@ export function createChannelAgentBinder(
       logger.warn('channel binder packet build failed:', err);
       postSystemRow(
         binding.channelId,
-        `@${binding.framework} could not build the message context: ${errText(err)}`,
+        `@${binding.displayName} could not build the message context: ${errText(err)}`,
         { parentMessageId: parentForTrigger(trigger) }
       );
       pump(binding); // activeTurnId is still null — keep the queue draining
@@ -819,7 +929,7 @@ export function createChannelAgentBinder(
         // Deterministic per routed (message, framework) turn (Amendment 3): a
         // retry reuses the same turn identity. `clientMessageId` is forward-compat
         // only — no adapter dedupes on it today.
-        clientMessageId: `${trigger.id}:${binding.framework}`,
+        clientMessageId: `${trigger.id}:${binding.profileActorId}`,
       })
       .then(() => advanceCursor(binding, trigger))
       .catch((err) => handleSendFailure(binding, trigger, turnId, err));
@@ -834,7 +944,7 @@ export function createChannelAgentBinder(
     // Cursor advances only on send acceptance (§4): a failed send re-offers the
     // rows next mention (at-least-once). Never lower the cursor.
     try {
-      const row = store.getBinding(binding.channelId, binding.framework);
+      const row = store.getBinding(binding.channelId, binding.profileActorId);
       const prev = row?.providerSession ?? {};
       const current =
         typeof prev['lastDeliveredSeq'] === 'number'
@@ -843,6 +953,7 @@ export function createChannelAgentBinder(
       if (triggerSeq <= current) return;
       store.upsertBinding({
         channelId: binding.channelId,
+        profileActorId: binding.profileActorId,
         agentFramework: binding.framework,
         providerSession: { ...prev, lastDeliveredSeq: triggerSeq },
       });
@@ -863,10 +974,16 @@ export function createChannelAgentBinder(
     if (!binding.retriedTurns.has(turnId)) {
       binding.retriedTurns.add(turnId);
       try {
-        const rebound = await ensureBinding(
-          binding.channelId,
-          binding.framework
-        );
+        const profile = deps.agentProfileStore
+          ? deps.agentProfileStore.get(binding.profileActorId)
+          : defaultProfileForProvider(binding.framework);
+        if (!profile) {
+          throw new ChannelBindingError(
+            `agent profile ${binding.profileActorId} no longer exists`,
+            `@${binding.displayName} could not receive the message: its profile no longer exists.`
+          );
+        }
+        const rebound = await ensureProfileBinding(binding.channelId, profile);
         if (closed) return;
         if (rebound.adapter && rebound.activeTurnId === turnId) {
           // Same binding still owns this turn — redeliver identical content.
@@ -889,7 +1006,7 @@ export function createChannelAgentBinder(
     }
     postSystemRow(
       binding.channelId,
-      `@${binding.framework} could not receive the message: ${errText(err)}`,
+      `@${binding.displayName} could not receive the message: ${errText(err)}`,
       { parentMessageId: parentForTrigger(trigger) }
     );
     releaseTurnParent(binding, turnId);
@@ -1027,7 +1144,7 @@ export function createChannelAgentBinder(
             if (!binding.sawStream) {
               postSystemRow(
                 binding.channelId,
-                `@${binding.framework} errored: ${patch.message}`,
+                `@${binding.displayName} errored: ${patch.message}`,
                 {
                   parentMessageId:
                     activeTurnId === null
@@ -1073,7 +1190,7 @@ export function createChannelAgentBinder(
     binding.announcedApprovals.add(item.requestId);
     postSystemRow(
       binding.channelId,
-      `@${binding.framework} requests approval: ${item.description} (${item.target})`,
+      `@${binding.displayName} requests approval: ${item.description} (${item.target})`,
       {
         parentMessageId:
           binding.activeTurnId === null
@@ -1081,7 +1198,7 @@ export function createChannelAgentBinder(
             : parentForTurn(binding, binding.activeTurnId),
         meta: {
           approvalRequestId: item.requestId,
-          agentId: binding.framework,
+          agentId: binding.profileActorId,
           sessionId: binding.sessionId,
         },
       }
@@ -1095,7 +1212,7 @@ export function createChannelAgentBinder(
     if (!binding.announcedApprovals.has(item.requestId)) return;
     binding.announcedApprovals.delete(item.requestId);
     const kind = item.decision?.kind ?? 'resolved';
-    postSystemRow(binding.channelId, `@${binding.framework} approval ${kind}`, {
+    postSystemRow(binding.channelId, `@${binding.displayName} approval ${kind}`, {
       parentMessageId:
         binding.activeTurnId === null
           ? undefined
@@ -1105,31 +1222,34 @@ export function createChannelAgentBinder(
 
   // ── routing ─────────────────────────────────────────────────────────────────
 
-  function routeOne(trigger: ChannelMessage, framework: string): void {
+  function routeOne(trigger: ChannelMessage, profile: AgentProfile): void {
     void (async () => {
       try {
+        const framework = profile.providerId;
         const target = await resolveTarget(framework);
         if (closed) return; // close() raced the availability probe
         if (!target) return; // not a known framework — ignore silently
         if (!target.available) {
+          const senderDisplayName =
+            profile.displayName || target.displayName || framework;
           postUnavailableRow(
             trigger.channelId,
-            framework,
-            `@${framework} is not available in channels yet — ${target.reason ?? 'web sessions unavailable.'}`,
+            profile.id,
+            `@${senderDisplayName} is not available in channels yet — ${target.reason ?? 'web sessions unavailable.'}`,
             parentForTrigger(trigger)
           );
           return;
         }
         let binding: LiveBinding;
         try {
-          binding = await ensureBinding(trigger.channelId, framework);
+          binding = await ensureProfileBinding(trigger.channelId, profile);
         } catch (err) {
           if (err instanceof BinderClosedError) return; // shutdown — silent
           if (err instanceof ChannelBindingError) {
             if (err.unavailable) {
               postUnavailableRow(
                 trigger.channelId,
-                framework,
+                profile.id,
                 err.systemMessage,
                 parentForTrigger(trigger)
               );
@@ -1151,20 +1271,71 @@ export function createChannelAgentBinder(
     })();
   }
 
-  /** Eligible (providerId-resolved, non-self) mentions in routing order. */
-  function eligibleFrameworks(
+  /** Eligible profile-resolved, non-self mentions in routing order. */
+  function eligibleProfiles(
     message: ChannelMessage,
     mentions: ChannelMention[]
-  ): string[] {
+  ): AgentProfile[] {
     const seen = new Set<string>();
-    const out: string[] = [];
+    const out: AgentProfile[] = [];
     for (const mention of mentions) {
-      const framework = mention.providerId;
-      if (!framework) continue; // unknown @name never routes (§1)
-      if (framework === message.sender.providerId) continue; // self-mention
-      if (seen.has(framework)) continue;
-      seen.add(framework);
-      out.push(framework);
+      const profile = resolveProfileMention(mention);
+      if (!profile) continue; // unknown @name never routes (§1)
+      // Bound-session replies carry the exact profile Actor id. Gateway posts
+      // may instead use a provider-owned agent id (for example `agent:claude`),
+      // so a provider's default profile must also be treated as self.
+      if (
+        profile.id === message.sender.id ||
+        (profile.providerId === message.sender.providerId &&
+          (profile.isDefault || profile.id === message.sender.id))
+      ) {
+        continue;
+      }
+      if (seen.has(profile.id)) continue;
+      seen.add(profile.id);
+      out.push(profile);
+    }
+    return out;
+  }
+
+  function currentProfileMentions(
+    message: ChannelMessage,
+    supplied: ChannelMention[]
+  ): ChannelMention[] {
+    if (!deps.agentProfileStore) return supplied;
+    const reparsed = parseMentions(
+      message.body.text,
+      deps.knownProviderIds,
+      deps.agentProfileStore.list()
+    );
+    const reparsedByRaw = new Map(
+      reparsed.map((mention) => [mention.raw.toLowerCase(), mention])
+    );
+    const seen = new Set<string>();
+    const out: ChannelMention[] = [];
+    const pinnedRaw = new Set(
+      supplied
+        .filter((mention) => mention.profileId)
+        .map((mention) => mention.raw.toLowerCase())
+    );
+    const append = (mention: ChannelMention) => {
+      const key = mention.profileId ?? mention.raw.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push(mention);
+    };
+    // Persisted profile pins are authoritative through renames/collisions. Only
+    // unpinned legacy tokens are refreshed from the current contact catalog.
+    for (const mention of supplied) {
+      append(
+        mention.profileId
+          ? mention
+          : (reparsedByRaw.get(mention.raw.toLowerCase()) ?? mention)
+      );
+    }
+    for (const mention of reparsed) {
+      if (pinnedRaw.has(mention.raw.toLowerCase())) continue;
+      append(mention);
     }
     return out;
   }
@@ -1186,8 +1357,8 @@ export function createChannelAgentBinder(
    * AND gateway-agent posts so neither can escape the token-spend guard between
    * human turns.
    */
-  function routeWithBrake(message: ChannelMessage, frameworks: string[]): void {
-    if (frameworks.length === 0) return;
+  function routeWithBrake(message: ChannelMessage, profiles: AgentProfile[]): void {
+    if (profiles.length === 0) return;
     const sourceSession = message.source?.sessionId
       ? deps.sessions.get(message.source.sessionId)
       : undefined;
@@ -1196,8 +1367,8 @@ export function createChannelAgentBinder(
       // participant. It must keep coordinating even after worker traffic trips
       // the brake, and its turns must not consume the worker-turn allowance.
       // Human posts still reset the ordinary brake state below.
-      for (const framework of frameworks) {
-        routeOne(message, framework);
+      for (const profile of profiles) {
+        routeOne(message, profile);
       }
       return;
     }
@@ -1226,8 +1397,8 @@ export function createChannelAgentBinder(
       state.allowedTurnKeys.add(turnKey);
       state.count += 1;
     }
-    for (const framework of frameworks) {
-      routeOne(message, framework);
+    for (const profile of profiles) {
+      routeOne(message, profile);
     }
   }
 
@@ -1249,21 +1420,26 @@ export function createChannelAgentBinder(
     // Without this a bound agent posting via `relay-ide v1 channels.post` would
     // both bypass the increment AND reset the brake, defeating the sole
     // token-spend guard between human turns (#1167 P1).
-    const frameworks = eligibleFrameworks(message, mentions);
+    const routingMentions = currentProfileMentions(message, mentions);
+    const profiles = eligibleProfiles(message, routingMentions);
     if (message.sender.kind === 'agent') {
-      routeWithBrake(message, frameworks);
+      routeWithBrake(message, profiles);
       return;
     }
     consecutiveAgentTurns.delete(message.channelId);
-    for (const framework of frameworks) {
-      routeOne(message, framework);
+    for (const profile of profiles) {
+      routeOne(message, profile);
     }
   }
 
   function handleAssistantFinalized(message: ChannelMessage): void {
     if (closed) return;
-    const mentions = parseMentions(message.body.text, deps.knownProviderIds);
-    routeWithBrake(message, eligibleFrameworks(message, mentions));
+    const mentions = parseMentions(
+      message.body.text,
+      deps.knownProviderIds,
+      deps.agentProfileStore?.list()
+    );
+    routeWithBrake(message, eligibleProfiles(message, mentions));
   }
 
   // ── session death ───────────────────────────────────────────────────────────
@@ -1277,7 +1453,7 @@ export function createChannelAgentBinder(
       for (const queued of binding.queue) {
         postSystemRow(
           binding.channelId,
-          `@${binding.framework} session ended before delivering a queued message.`,
+          `@${binding.displayName} session ended before delivering a queued message.`,
           { parentMessageId: parentForTrigger(queued.trigger) }
         );
       }
@@ -1296,6 +1472,7 @@ export function createChannelAgentBinder(
       try {
         store.upsertBinding({
           channelId: binding.channelId,
+          profileActorId: binding.profileActorId,
           agentFramework: binding.framework,
           sessionId: null,
         });
@@ -1308,7 +1485,9 @@ export function createChannelAgentBinder(
   // ── control verbs ───────────────────────────────────────────────────────────
 
   async function interrupt(channelId: string, agentId: string): Promise<void> {
-    const binding = live.get(bindingKey(channelId, agentId));
+    const binding =
+      live.get(bindingKey(channelId, agentId)) ??
+      live.get(bindingKey(channelId, builtInAgentProfileId(agentId)));
     if (!binding || !binding.adapter) throw new ChannelAgentNotFoundError();
     if (binding.activeTurnId === null)
       throw new ChannelAgentNoActiveTurnError();
@@ -1321,7 +1500,9 @@ export function createChannelAgentBinder(
     requestId: string,
     decision: AgentApprovalDecisionV2
   ): Promise<void> {
-    const binding = live.get(bindingKey(channelId, agentId));
+    const binding =
+      live.get(bindingKey(channelId, agentId)) ??
+      live.get(bindingKey(channelId, builtInAgentProfileId(agentId)));
     if (!binding || !binding.adapter) throw new ChannelAgentNotFoundError();
     await binding.adapter.respondToApproval({ requestId, decision });
   }
@@ -1330,23 +1511,42 @@ export function createChannelAgentBinder(
     channelId: string
   ): Promise<ChannelAgentRosterEntry[]> {
     const targets = await getTargets();
-    return targets.map((target) => {
-      const binding = live.get(bindingKey(channelId, target.id));
-      const row = store.getBinding(channelId, target.id);
+    const targetByProvider = new Map(targets.map((target) => [target.id, target]));
+    const storedProfiles = deps.agentProfileStore?.list();
+    const profiles = storedProfiles
+      ? [
+          ...storedProfiles,
+          ...targets
+            .filter(
+              (target) =>
+                !storedProfiles.some(
+                  (profile) => profile.providerId === target.id
+                )
+            )
+            .map((target) => defaultProfileForProvider(target.id)),
+        ]
+      : targets.map((target) => defaultProfileForProvider(target.id));
+    return Promise.all(profiles.map(async (profile) => {
+      const target = targetByProvider.get(profile.providerId);
+      const binding = live.get(bindingKey(channelId, profile.id));
+      const row = store.getBinding(channelId, profile.id);
       const sessionId = binding?.sessionId ?? row?.sessionId ?? null;
       const session = sessionId ? deps.sessions.get(sessionId) : undefined;
       return {
-        id: target.id,
-        displayName: target.displayName,
+        id: profile.id,
+        displayName: await rosterDisplayName(profile),
+        providerId: profile.providerId,
+        isDefault: profile.isDefault,
+        isBuiltIn: profile.isBuiltIn,
         kind: 'framework',
-        available: target.available,
-        reason: target.reason,
+        available: target?.available ?? false,
+        reason: target?.reason ?? 'framework unavailable',
         ...(session?.role !== undefined ? { role: session.role } : {}),
         binding: sessionId
           ? { sessionId, status: binding?.status ?? 'idle' }
           : null,
       };
-    });
+    }));
   }
 
   return {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import Database from 'better-sqlite3';
 
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import { createLogger } from './logger.js';
 
 import {
@@ -41,7 +42,7 @@ import {
 //    row deletion — that would break gap-free seq. Future mutation lands as new
 //    events over retained rows.
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -135,12 +136,13 @@ CREATE TABLE IF NOT EXISTS channel_members (
 
 CREATE TABLE IF NOT EXISTS channel_agent_bindings (
   channel_id            TEXT NOT NULL,
+  profile_actor_id      TEXT NOT NULL,
   agent_framework       TEXT NOT NULL,
   session_id            TEXT,
   provider_session_json TEXT NOT NULL DEFAULT '{}',
   created_at            TEXT NOT NULL,
   updated_at            TEXT NOT NULL,
-  PRIMARY KEY (channel_id, agent_framework)
+  PRIMARY KEY (channel_id, profile_actor_id)
 );
 `;
 
@@ -178,6 +180,7 @@ interface MemberRow {
 
 interface BindingRow {
   channel_id: string;
+  profile_actor_id: string;
   agent_framework: string;
   session_id: string | null;
   provider_session_json: string;
@@ -268,6 +271,9 @@ export interface ChannelHistoryFilter {
 
 export interface ChannelBinding {
   channelId: string;
+  /** Durable AgentProfile actor identity; binding/session ownership key. */
+  profileActorId: string;
+  /** Provider/framework spawn selector retained independently of the profile. */
   agentFramework: string;
   sessionId: string | null;
   providerSession: Record<string, unknown>;
@@ -346,7 +352,7 @@ export interface ChannelMessageStore {
   }): ChannelMemberRef;
   listMembers(channelId: string): ChannelMemberRef[];
   findDmChannel(memberIdA: string, memberIdB: string): string | null;
-  getBinding(channelId: string, agentFramework: string): ChannelBinding | null;
+  getBinding(channelId: string, profileActorId: string): ChannelBinding | null;
   /**
    * Distinct non-null `session_id`s across every channel binding. Feeds the
    * relay-state-db age-reaper's protection set (#1248) so a web_session still
@@ -356,6 +362,8 @@ export interface ChannelMessageStore {
   listBoundSessionIds(): string[];
   upsertBinding(input: {
     channelId: string;
+    /** Omit only for legacy callers; normalizes to the provider's built-in profile. */
+    profileActorId?: string;
     agentFramework: string;
     sessionId?: string | null;
     providerSession?: Record<string, unknown>;
@@ -824,6 +832,41 @@ function runMigrations(db: Database.Database): void {
       );
     }
   }
+  if (current < 3) {
+    db.transaction(() => {
+      // Bindings used to be keyed by framework, which made two profiles of one
+      // provider overwrite and reuse one another. Rebuild the small table so the
+      // durable Actor id is the primary key. Every legacy row is deterministically
+      // backfilled to that provider's built-in/default profile; the transaction
+      // makes this fail-safe and an already-complete v3 reopen a no-op.
+      db.exec(`
+        CREATE TABLE channel_agent_bindings_v3 (
+          channel_id            TEXT NOT NULL,
+          profile_actor_id      TEXT NOT NULL,
+          agent_framework       TEXT NOT NULL,
+          session_id            TEXT,
+          provider_session_json TEXT NOT NULL DEFAULT '{}',
+          created_at            TEXT NOT NULL,
+          updated_at            TEXT NOT NULL,
+          PRIMARY KEY (channel_id, profile_actor_id)
+        );
+        INSERT INTO channel_agent_bindings_v3
+          (channel_id, profile_actor_id, agent_framework, session_id,
+           provider_session_json, created_at, updated_at)
+        SELECT channel_id,
+               'agent-profile:' || agent_framework || ':default',
+               agent_framework,
+               session_id,
+               provider_session_json,
+               created_at,
+               updated_at
+          FROM channel_agent_bindings;
+        DROP TABLE channel_agent_bindings;
+        ALTER TABLE channel_agent_bindings_v3 RENAME TO channel_agent_bindings;
+      `);
+      db.prepare('UPDATE schema_version SET version = 3').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
@@ -1035,14 +1078,21 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
 
   function getBindingImpl(
     channelId: string,
-    agentFramework: string
+    profileActorId: string
   ): ChannelBinding | null {
-    const row = db
+    const select = db
       .prepare(
-        'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND agent_framework = ?'
-      )
-      .get(channelId, agentFramework) as BindingRow | undefined;
-    return row ? bindingRowToRecord(row) : null;
+        'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND profile_actor_id = ?'
+      );
+    const row = select.get(channelId, profileActorId) as BindingRow | undefined;
+    if (row) return bindingRowToRecord(row);
+    // Compatibility only after an exact Actor lookup misses: older callers sent
+    // bare provider ids, whose durable binding migrated to the built-in profile.
+    const legacy = select.get(
+      channelId,
+      builtInAgentProfileId(profileActorId)
+    ) as BindingRow | undefined;
+    return legacy ? bindingRowToRecord(legacy) : null;
   }
 
   return {
@@ -1466,8 +1516,8 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       return row?.channel_id ?? null;
     },
 
-    getBinding(channelId, agentFramework) {
-      return getBindingImpl(channelId, agentFramework);
+    getBinding(channelId, profileActorId) {
+      return getBindingImpl(channelId, profileActorId);
     },
 
     listBoundSessionIds() {
@@ -1481,25 +1531,29 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
 
     upsertBinding(input) {
       const now = nowIso();
+      const profileActorId =
+        input.profileActorId ?? builtInAgentProfileId(input.agentFramework);
       const existing = db
         .prepare(
-          'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND agent_framework = ?'
+          'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND profile_actor_id = ?'
         )
-        .get(input.channelId, input.agentFramework) as BindingRow | undefined;
+        .get(input.channelId, profileActorId) as BindingRow | undefined;
       const providerSessionJson = JSON.stringify(
         input.providerSession ??
           (existing ? JSON.parse(existing.provider_session_json) : {})
       );
       db.prepare(
         `INSERT INTO channel_agent_bindings
-           (channel_id, agent_framework, session_id, provider_session_json, created_at, updated_at)
-         VALUES (@channelId, @agentFramework, @sessionId, @providerSessionJson, @createdAt, @updatedAt)
-         ON CONFLICT(channel_id, agent_framework) DO UPDATE SET
+           (channel_id, profile_actor_id, agent_framework, session_id, provider_session_json, created_at, updated_at)
+         VALUES (@channelId, @profileActorId, @agentFramework, @sessionId, @providerSessionJson, @createdAt, @updatedAt)
+         ON CONFLICT(channel_id, profile_actor_id) DO UPDATE SET
+           agent_framework = excluded.agent_framework,
            session_id = excluded.session_id,
            provider_session_json = excluded.provider_session_json,
            updated_at = excluded.updated_at`
       ).run({
         channelId: input.channelId,
+        profileActorId,
         agentFramework: input.agentFramework,
         sessionId:
           input.sessionId !== undefined
@@ -1509,7 +1563,7 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         createdAt: existing?.created_at ?? now,
         updatedAt: now,
       });
-      return getBindingImpl(input.channelId, input.agentFramework)!;
+      return getBindingImpl(input.channelId, profileActorId)!;
     },
 
     sweepStaleStreaming() {
@@ -1644,6 +1698,7 @@ function bindingRowToRecord(row: BindingRow): ChannelBinding {
   }
   return {
     channelId: row.channel_id,
+    profileActorId: row.profile_actor_id,
     agentFramework: row.agent_framework,
     sessionId: row.session_id,
     providerSession,

--- a/server/index.ts
+++ b/server/index.ts
@@ -2162,6 +2162,7 @@ async function main(): Promise<void> {
         attachmentStore: channelAttachmentStore,
         hub: channelHub,
         topicStore: workspaceTopicStore,
+        agentProfileStore,
         sessions: {
           createWeb: sessions.createWeb,
           get: sessions.get,

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -110,6 +110,7 @@ ON CONFLICT(id) DO UPDATE SET
 export interface WebSessionMeta {
   type: string;
   agent: string;
+  profileId?: string;
   role?: AgentRole;
   spawnedBySessionId?: string;
   repoName?: string;
@@ -451,6 +452,7 @@ function writeUpsert(session: WebSession): void {
   const meta: WebSessionMeta = {
     type: session.type,
     agent: session.agent,
+    ...(session.profileId !== undefined ? { profileId: session.profileId } : {}),
     ...(session.role !== undefined ? { role: session.role } : {}),
     ...(session.spawnedBySessionId !== undefined
       ? { spawnedBySessionId: session.spawnedBySessionId }

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -1214,6 +1214,9 @@ function list(): SessionSummary[] {
         agent: s.agent,
         ...(s.role !== undefined ? { role: s.role } : {}),
         mode: s.mode,
+        ...(s.mode === 'web' && s.profileId !== undefined
+          ? { profileId: s.profileId }
+          : {}),
         ...(s.repoPath ? { repoPath: s.repoPath } : {}),
         ...(s.worktreePath !== undefined
           ? { worktreePath: s.worktreePath }
@@ -2218,6 +2221,7 @@ async function restoreWebSessionFromDb(
       ? { spawnedBySessionId: row.meta.spawnedBySessionId }
       : {}),
     agentType: row.meta.adapterType,
+    ...(row.meta.profileId !== undefined ? { profileId: row.meta.profileId } : {}),
     ...(row.meta.role !== undefined ? { role: row.meta.role } : {}),
     cwd: row.cwd,
     ...(restoredRepoPath !== undefined

--- a/server/types.ts
+++ b/server/types.ts
@@ -429,6 +429,8 @@ export interface PtySession extends BaseSession {
 
 export interface WebSession extends BaseSession {
   mode: 'web';
+  /** Durable AgentProfile actor that selected this runtime, when profile-bound. */
+  profileId?: string;
   /** Native v2 protocol adapter for web-chat sessions. */
   adapterV2: ProtocolAdapterV2;
   /** Canonical v2 web-chat state. */
@@ -465,6 +467,8 @@ export interface SessionSummary {
   /** Durable collaboration role. A hint for routing/UI, not authorization. */
   role?: AgentRole;
   mode: SessionMode;
+  /** Durable AgentProfile actor that selected this web runtime, when profile-bound. */
+  profileId?: string;
   /**
    * Filesystem path of the repo this session is bound to. Optional so
    * non-repo (node-only / raw-shell) routed sessions can flow through

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -84,6 +84,8 @@ export interface CreateWebParams {
   id?: string;
   spawnedBySessionId?: string;
   agentType: string;
+  /** Durable AgentProfile actor identity for profile-bound web runtimes. */
+  profileId?: string;
   role?: AgentRole;
   roleOverrides?: Readonly<Record<string, AgentRole>>;
   cwd: string;
@@ -96,6 +98,8 @@ export interface CreateWebParams {
   configDir: string;
   permissionMode?: string;
   model?: string;
+  /** Profile-authored prompt appended after Relay's collaboration instructions. */
+  systemPrompt?: string;
   /** Runtime-only subprocess env; never copied into persisted provider options. */
   processEnv?: Record<string, string>;
   sessionLane?: SessionLane | undefined;
@@ -139,6 +143,7 @@ export async function createWebSession(
     nodeId: DEFAULT_LOCAL_NODE_ID,
     type: 'agent',
     agent: params.agentType as AgentType,
+    ...(params.profileId !== undefined ? { profileId: params.profileId } : {}),
     ...(params.role !== undefined ? { role: params.role } : {}),
     ...(params.repoPath ? { repoPath: params.repoPath } : {}),
     ...(params.repoPath ? { worktreePath: params.worktreePath ?? null } : {}),
@@ -219,10 +224,15 @@ export async function createWebSession(
     sessionId: id,
     hookToken,
     configDir: params.configDir,
-    systemPromptAppendix: collaborationPromptAppendix({
-      provider: params.agentType,
-      role: displayRole,
-    }),
+    systemPromptAppendix: [
+      collaborationPromptAppendix({
+        provider: params.agentType,
+        role: displayRole,
+      }),
+      params.systemPrompt,
+    ]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join('\n\n'),
     ...(params.processEnv !== undefined
       ? { processEnv: { ...params.processEnv } }
       : {}),

--- a/test/agent-profile-store.test.ts
+++ b/test/agent-profile-store.test.ts
@@ -212,6 +212,26 @@ describe('best-effort init survives a malformed custom framework (#1241 FIX 1)',
 });
 
 describe('one-default-per-provider invariant (enforcement CHOICE: reject)', () => {
+  it('refuses to delete a built-in default profile', () => {
+    const store = makeStore();
+    store.seedBuiltIns([{ id: 'claude' }]);
+    const builtInId = builtInAgentProfileId('claude');
+
+    try {
+      store.delete(builtInId);
+      throw new Error('expected built-in default delete to fail');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'agent_profile_builtin_default_delete_forbidden',
+        status: 409,
+      });
+    }
+    expect(store.get(builtInId)).toMatchObject({
+      isBuiltIn: true,
+      isDefault: true,
+    });
+  });
+
   it('rejects creating a second default for the same provider', () => {
     const store = makeStore();
     store.seedBuiltIns([{ id: 'claude' }]);

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -16,6 +16,11 @@ import {
 } from '../server/protocol-adapter-v2.js';
 import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
+import {
+  createAgentProfileStore,
+  type AgentProfileStore,
+} from '../server/agent-profile-store.js';
 import {
   createChannelMessageStore,
   type ChannelMessageStore,
@@ -777,7 +782,8 @@ interface SessionsHarness {
   registerRestoredWebSession: (
     sessionId: string,
     agentType: string,
-    role: AgentRole
+    role: AgentRole,
+    profileId?: string
   ) => Promise<void>;
   lastCreateParams: () => CreateWebParams | undefined;
 }
@@ -812,6 +818,7 @@ function makeSessions(
         id,
         mode: 'web',
         agent: params.agentType,
+        ...(params.profileId !== undefined ? { profileId: params.profileId } : {}),
         ...(params.role !== undefined ? { role: params.role } : {}),
         adapterV2: adapter,
         cwd: params.cwd,
@@ -848,7 +855,7 @@ function makeSessions(
         session: { id, role } as unknown as WebSession,
       });
     },
-    registerRestoredWebSession: async (id, agentType, role) => {
+    registerRestoredWebSession: async (id, agentType, role, profileId) => {
       const adapter = build(agentType);
       await adapter.connect({
         cwd: '/tmp',
@@ -862,6 +869,7 @@ function makeSessions(
           id,
           mode: 'web',
           agent: agentType,
+          ...(profileId !== undefined ? { profileId } : {}),
           role,
           adapterV2: adapter,
           cwd: '/tmp',
@@ -892,6 +900,7 @@ function makeBinder(cfg: {
   yolo?: boolean;
   gate?: Promise<void>;
   attachmentStore?: ChannelAttachmentStore;
+  agentProfileStore?: AgentProfileStore | null;
 }): {
   binder: ChannelAgentBinder;
   store: ChannelMessageStore;
@@ -908,6 +917,9 @@ function makeBinder(cfg: {
     ...(cfg.attachmentStore ? { attachmentStore: cfg.attachmentStore } : {}),
     hub,
     topicStore: cfg.topicStore ?? null,
+    ...(cfg.agentProfileStore !== undefined
+      ? { agentProfileStore: cfg.agentProfileStore }
+      : {}),
     sessions: sessions.sessions,
     knownProviderIds: cfg.knownProviderIds,
     mentionTargets: async () => cfg.targets,
@@ -923,6 +935,146 @@ function makeBinder(cfg: {
 // ── tests ────────────────────────────────────────────────────────────────────
 
 describe('channel-agent-binder — lifecycle', () => {
+  it('keeps same-provider profiles isolated: bindings, sessions, replies, roster, and status all use profile actor ids', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const backend = profiles.create({
+      id: 'agent-profile:mock:backend',
+      providerId: 'mock',
+      displayName: 'Backend',
+      model: 'mock-model',
+      provider: 'mock-provider',
+      effort: 'high',
+      envVars: { PROFILE_TEST_FLAG: '1' },
+      systemPrompt: 'Review the backend boundary.',
+    });
+    const reviewer = profiles.create({
+      id: 'agent-profile:mock:reviewer',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+    const statusAgentIds = new Set<string>();
+    binder.setStatusBroadcaster((_type, data) => {
+      if (typeof data['agentId'] === 'string') statusAgentIds.add(data['agentId']);
+    });
+
+    post(store, binder, '@Backend one', ['mock']);
+    await waitFor(() => sessions.spawns() === 1);
+    expect(sessions.lastCreateParams()).toMatchObject({
+      agentType: 'mock',
+      profileId: backend.id,
+      model: 'mock-model',
+      processEnv: { PROFILE_TEST_FLAG: '1' },
+      systemPrompt: 'Review the backend boundary.',
+      extra: { provider: 'mock-provider', effort: 'high' },
+    });
+    post(store, binder, '@Reviewer two', ['mock']);
+    await waitFor(() => sessions.spawns() === 2);
+    expect(store.getBinding(CH, backend.id)?.sessionId).toBeTruthy();
+    expect(store.getBinding(CH, reviewer.id)?.sessionId).toBeTruthy();
+
+    // A second mention of Backend reuses only Backend's pinned profile session.
+    post(store, binder, '@Backend again', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 3);
+    expect(sessions.spawns()).toBe(2);
+    expect(agentReplies(store, 'mock').map((reply) => reply.sender.id)).toEqual(
+      expect.arrayContaining([backend.id, reviewer.id])
+    );
+    const roster = await binder.rosterForChannel(CH);
+    expect(roster.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining([backend.id, reviewer.id])
+    );
+    expect(statusAgentIds.has(backend.id)).toBe(true);
+    expect(statusAgentIds.has(reviewer.id)).toBe(true);
+  });
+
+  it('keeps the default-only provider path on one reusable built-in profile identity', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const defaultId = builtInAgentProfileId('mock');
+    const statusIds = new Set<string>();
+    binder.setStatusBroadcaster((_type, data) => {
+      if (typeof data['agentId'] === 'string') statusIds.add(data['agentId']);
+    });
+    post(store, binder, '@mock first', ['mock']);
+    post(store, binder, '@mock second', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(sessions.spawns()).toBe(1);
+    expect(store.getBinding(CH, defaultId)?.sessionId).toBeTruthy();
+    expect(agentReplies(store, 'mock').every((row) => row.sender.id === defaultId)).toBe(true);
+    expect((await binder.rosterForChannel(CH)).find((row) => row.id === defaultId)?.binding).not.toBeNull();
+    expect(statusIds.has(defaultId)).toBe(true);
+  });
+
+  it('routes a named profile mention from the assistant-finalized contacts parser path', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    profiles.create({
+      id: 'agent-profile:mock:backend-finalizer',
+      providerId: 'mock',
+      displayName: 'Backend',
+    });
+    const reviewer = profiles.create({
+      id: 'agent-profile:mock:reviewer-finalizer',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) =>
+        new ScriptedAdapter(agentType, { mode: 'reply', text: '@Reviewer take this.' }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+
+    post(store, binder, '@Backend begin', ['mock']);
+    await waitFor(() => sessions.spawns() === 2);
+    expect(store.getBinding(CH, reviewer.id)?.sessionId).toBeTruthy();
+  });
+
+  it('keeps a persisted profile mention pinned across a rename/collision reparse', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const pinned = profiles.create({
+      id: 'agent-profile:mock:renamed',
+      providerId: 'mock',
+      displayName: 'Backend',
+    });
+    profiles.create({
+      id: 'agent-profile:mock:current-reviewer',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+    const message = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@Reviewer please inspect',
+      mentions: [{ raw: '@Reviewer', providerId: 'mock', profileId: pinned.id }],
+    });
+    binder.handleMessagePosted(message, message.mentions ?? []);
+    await waitFor(() => sessions.spawns() === 1);
+    expect(store.getBinding(CH, pinned.id)?.sessionId).toBeTruthy();
+    expect(store.getBinding(CH, 'agent-profile:mock:current-reviewer')).toBeNull();
+  });
+
   it('designates an orchestrator without submitting a turn', async () => {
     const { binder, store, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
@@ -962,6 +1114,114 @@ describe('channel-agent-binder — lifecycle', () => {
 
     expect(binding.sessionId).toBe(sessionId);
     expect(sessions.spawns()).toBe(0);
+  });
+
+  it('reuses an explicitly selected profile-pinned restored orchestrator', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const reviewer = profiles.create({
+      id: 'reviewer',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+    const sessionId = 'session:restored-profile';
+    await sessions.registerRestoredWebSession(
+      sessionId,
+      'mock',
+      'orchestrator',
+      reviewer.id
+    );
+    store.upsertBinding({
+      channelId: CH,
+      profileActorId: reviewer.id,
+      agentFramework: 'mock',
+      sessionId,
+    });
+
+    expect((await binder.ensureOrchestrator(CH, 'mock', reviewer.id)).sessionId).toBe(sessionId);
+    expect(sessions.spawns()).toBe(0);
+    // Exact custom actor ids are accepted by the control lookup; a legacy
+    // prefix rewrite would miss this live binding as "not found".
+    await expect(binder.interrupt(CH, reviewer.id)).rejects.toThrow(
+      /no active turn/
+    );
+  });
+
+  it('does not reuse an unpinned legacy session for a custom profile', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const reviewer = profiles.create({
+      id: 'reviewer',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+    await sessions.registerRestoredWebSession('session:legacy', 'mock', 'orchestrator');
+    store.upsertBinding({
+      channelId: CH,
+      profileActorId: reviewer.id,
+      agentFramework: 'mock',
+      sessionId: 'session:legacy',
+    });
+
+    expect((await binder.ensureOrchestrator(CH, 'mock', reviewer.id)).sessionId).not.toBe('session:legacy');
+    expect(sessions.spawns()).toBe(1);
+  });
+
+  it('does not reuse a different custom profile restored session for the same provider', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const profileA = profiles.create({
+      id: 'profile-a',
+      providerId: 'mock',
+      displayName: 'Reviewer A',
+    });
+    const profileB = profiles.create({
+      id: 'profile-b',
+      providerId: 'mock',
+      displayName: 'Reviewer B',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+    await sessions.registerRestoredWebSession(
+      'session:profile-a',
+      'mock',
+      'orchestrator',
+      profileA.id
+    );
+    store.upsertBinding({
+      channelId: CH,
+      profileActorId: profileB.id,
+      agentFramework: 'mock',
+      sessionId: 'session:profile-a',
+    });
+
+    const binding = await binder.ensureOrchestrator(CH, 'mock', profileB.id);
+    expect(binding.sessionId).not.toBe('session:profile-a');
+    expect(sessions.spawns()).toBe(1);
+    expect(sessions.lastCreateParams()).toMatchObject({ profileId: profileB.id });
+    expect(store.getBinding(CH, profileB.id)).toMatchObject({
+      profileActorId: profileB.id,
+      sessionId: binding.sessionId,
+    });
   });
 
   it('rejects a restored healthy non-orchestrator binding', async () => {
@@ -1270,13 +1530,23 @@ describe('channel-agent-binder — lifecycle', () => {
   });
 
   it('surfaces an agent error received while the binding is idle', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    profiles.create({
+      id: 'agent-profile:mock:backend-error',
+      providerId: 'mock',
+      displayName: 'Backend',
+    });
     const { binder, store, sessions } = makeBinder({
       build: (agentType) => new ManualBareIdleAdapter(agentType),
       targets: MOCK_TARGETS,
       knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
     });
-    post(store, binder, '@mock idle', ['mock']);
+    post(store, binder, '@Backend idle', ['mock']);
     await waitFor(() => sessions.spawns() === 1);
+    expect(sessions.lastCreateParams()?.displayName).toBe(`#${CH} · Backend`);
     const adapter = sessions.adapterFor(
       sessions.firstSessionId()
     ) as ManualBareIdleAdapter;
@@ -1284,7 +1554,7 @@ describe('channel-agent-binder — lifecycle', () => {
     adapter.emitError('idle failure');
     await waitFor(() =>
       systemRows(store).some((row) =>
-        row.body.text.includes('@mock errored: idle failure')
+        row.body.text === '@Backend errored: idle failure'
       )
     );
   });
@@ -1559,7 +1829,7 @@ describe('channel-agent-binder — delivery + idempotency', () => {
       sessions.firstSessionId()
     ) as ScriptedAdapter;
     expect(adapter.sendCalls).toHaveLength(2); // rejected once, then retried
-    const expected = `chturn-${trigger.id}-x`;
+    const expected = `chturn-${trigger.id}-${builtInAgentProfileId('x')}`;
     expect(adapter.sendCalls[0]).toBe(expected);
     expect(adapter.sendCalls[1]).toBe(expected); // retry reuses the SAME turnId
     expect(sessions.spawns()).toBe(1);
@@ -2008,6 +2278,37 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
 });
 
 describe('channel-agent-binder — roster + availability', () => {
+  it('includes the default profile for an unseeded target provider without duplicating stored providers', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const { binder } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        ...MOCK_TARGETS,
+        {
+          id: 'worker',
+          displayName: 'Worker',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['mock', 'worker'],
+      agentProfileStore: profiles,
+    });
+
+    const roster = await binder.rosterForChannel(CH);
+    expect(roster.filter((entry) => entry.providerId === 'mock')).toHaveLength(1);
+    expect(roster).toContainEqual(
+      expect.objectContaining({
+        id: builtInAgentProfileId('worker'),
+        providerId: 'worker',
+        isDefault: true,
+      })
+    );
+  });
+
   it('surfaces bound session roles in the channel roster', async () => {
     const { binder, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
@@ -2028,10 +2329,10 @@ describe('channel-agent-binder — roster + availability', () => {
     await binder.ensureBinding(CH, 'worker');
 
     const roster = await binder.rosterForChannel(CH);
-    expect(roster.find((entry) => entry.id === 'mock')?.role).toBe(
+    expect(roster.find((entry) => entry.id === builtInAgentProfileId('mock'))?.role).toBe(
       'orchestrator'
     );
-    expect(roster.find((entry) => entry.id === 'worker')?.role).toBeUndefined();
+    expect(roster.find((entry) => entry.id === builtInAgentProfileId('worker'))?.role).toBeUndefined();
     expect(sessions.spawns()).toBe(2);
   });
 
@@ -2052,16 +2353,16 @@ describe('channel-agent-binder — roster + availability', () => {
       knownProviderIds: ['mock', 'codex'],
     });
     let roster = await binder.rosterForChannel(CH);
-    const codex = roster.find((r) => r.id === 'codex')!;
+    const codex = roster.find((r) => r.id === builtInAgentProfileId('codex'))!;
     expect(codex.available).toBe(false);
     expect(codex.reason).toContain('#301');
-    expect(roster.find((r) => r.id === 'mock')!.binding).toBeNull();
+    expect(roster.find((r) => r.id === builtInAgentProfileId('mock'))!.binding).toBeNull();
 
     post(store, binder, '@mock hi', ['mock', 'codex']);
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     roster = await binder.rosterForChannel(CH);
-    expect(roster.find((r) => r.id === 'mock')!.binding).not.toBeNull();
-    expect(roster.find((r) => r.id === 'mock')!.binding?.status).toBe('idle');
+    expect(roster.find((r) => r.id === builtInAgentProfileId('mock'))!.binding).not.toBeNull();
+    expect(roster.find((r) => r.id === builtInAgentProfileId('mock'))!.binding?.status).toBe('idle');
   });
 
   it('clears presence to idle when a turn finalizes with an idle live-state and no turn-completed (#1181)', async () => {
@@ -2080,7 +2381,7 @@ describe('channel-agent-binder — roster + availability', () => {
     });
     const statuses: string[] = [];
     binder.setStatusBroadcaster((_type, data) => {
-      if (data['agentId'] === 'hermes') statuses.push(String(data['status']));
+      if (data['agentId'] === builtInAgentProfileId('hermes')) statuses.push(String(data['status']));
     });
     post(store, binder, '@hermes hi', ['hermes']);
     // The turn must reach 'thinking' (proving it was delivered) and then settle
@@ -2094,7 +2395,15 @@ describe('channel-agent-binder — roster + availability', () => {
     expect(statuses.at(-1)).toBe('idle');
   });
 
-  it('an unavailable framework posts a de-advertise row, rate-limited', async () => {
+  it('an unavailable named profile posts a de-advertise row, rate-limited', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'codex' }]);
+    profiles.create({
+      id: 'agent-profile:codex:backend-unavailable',
+      providerId: 'codex',
+      displayName: 'Backend',
+    });
     const { binder, store, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2(),
       targets: [
@@ -2108,6 +2417,7 @@ describe('channel-agent-binder — roster + availability', () => {
         },
       ],
       knownProviderIds: ['codex'],
+      agentProfileStore: profiles,
     });
     const root = store.appendComplete({
       channelId: CH,
@@ -2117,7 +2427,7 @@ describe('channel-agent-binder — roster + availability', () => {
     const trigger = post(
       store,
       binder,
-      '@codex fix it',
+      '@Backend fix it',
       ['codex'],
       OPERATOR,
       root.id
@@ -2128,7 +2438,7 @@ describe('channel-agent-binder — roster + availability', () => {
     const secondTrigger = post(
       store,
       binder,
-      '@codex fix it again',
+      '@Backend fix it again',
       ['codex'],
       OPERATOR,
       root.id
@@ -2143,6 +2453,9 @@ describe('channel-agent-binder — roster + availability', () => {
         m.body.text.includes('not available') &&
         m.parentMessageId === trigger.id
     )!;
+    expect(unavailable.body.text).toBe(
+      '@Backend is not available in channels yet — Codex web sessions do not yet stream chat responses (see issue #301).'
+    );
     expect(unavailable.threadId).toBe(root.id);
     expect(unavailable.parentMessageId).toBe(trigger.id);
     expect(
@@ -2248,6 +2561,35 @@ describe('channel-agent-binder — watchdog + cross-node + interrupt', () => {
 // ── #1180 review findings ─────────────────────────────────────────────────────
 
 describe('channel-agent-binder — gateway agent-sender loop brake (P1 #1180)', () => {
+  it('does not route a provider-default gateway self mention', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        {
+          id: 'claude',
+          displayName: 'Claude',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['claude'],
+    });
+
+    const gatewayPost = post(store, binder, '@claude', ['claude'], {
+      kind: 'agent',
+      id: 'agent:claude',
+      providerId: 'claude',
+      displayName: 'Claude',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(sessions.spawns()).toBe(0);
+    expect(
+      agentReplies(store, 'claude').filter((message) => message.id !== gatewayPost.id)
+    ).toHaveLength(0);
+  });
+
   it('agent-sender posts count toward the cap and pause; a human post resets', async () => {
     const { binder, store } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
@@ -2413,7 +2755,7 @@ describe('channel-agent-binder — send-failure rebind clobber guard (P2 #1180)'
     const m1 = post(store, binder, '@mock one', ['mock']);
     await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
     const a1 = built[0]!;
-    const t1 = `chturn-${m1.id}-mock`;
+    const t1 = `chturn-${m1.id}-${builtInAgentProfileId('mock')}`;
     expect(a1.sendCalls).toEqual([t1]);
     const sid1 = sessions.firstSessionId();
 
@@ -2424,7 +2766,7 @@ describe('channel-agent-binder — send-failure rebind clobber guard (P2 #1180)'
     const m2 = post(store, binder, '@mock two', ['mock']);
     await waitFor(() => built.length === 2 && built[1]!.sendCalls.length === 1);
     const a2 = built[1]!;
-    const t2 = `chturn-${m2.id}-mock`;
+    const t2 = `chturn-${m2.id}-${builtInAgentProfileId('mock')}`;
     expect(a2.sendCalls).toEqual([t2]);
 
     // Reject T1's original send: handleSendFailure rebinds → binding with T2
@@ -2559,14 +2901,14 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     await waitFor(() =>
       systemRows(store).some((m) => m.body.text.includes('requests approval'))
     );
-    const turnId = `chturn-${trigger.id}-mock`;
+    const turnId = `chturn-${trigger.id}-${builtInAgentProfileId('mock')}`;
     const requestId = `appr-${turnId}`;
     const approvalRow = systemRows(store).find((m) =>
       m.body.text.includes('requests approval')
     )!;
     expect(approvalRow.meta).toMatchObject({
       approvalRequestId: requestId,
-      agentId: 'mock',
+      agentId: builtInAgentProfileId('mock'),
     });
     expect(approvalRow.meta?.['sessionId']).toBe(sessions.firstSessionId());
     expect(approvalRow.threadId).toBe(root.id);
@@ -2616,7 +2958,7 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     await new Promise((r) => setTimeout(r, 90));
     expect(a.sendCalls).toHaveLength(1); // PAUSED: T2 not pumped
 
-    const requestId = `appr-chturn-${t1msg.id}-mock`;
+    const requestId = `appr-chturn-${t1msg.id}-${builtInAgentProfileId('mock')}`;
     await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
     await waitFor(() => a.sendCalls.length === 2, 4000); // resumes → T2 drains
     expect(a.sendCalls).toHaveLength(2);
@@ -2679,12 +3021,12 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     expect(a.sendCalls).toHaveLength(1); // T2 NOT pumped — turn stayed parked
     // Presence stayed 'waiting' — never flipped to idle/thinking mid-approval.
     expect(
-      (await binder.rosterForChannel(CH)).find((r) => r.id === 'mock')!.binding
+      (await binder.rosterForChannel(CH)).find((r) => r.id === builtInAgentProfileId('mock'))!.binding
         ?.status
     ).toBe('waiting');
 
     // Resolving the approval resumes the turn: it completes normally, then T2 drains.
-    const requestId = `appr-chturn-${t1.id}-mock`;
+    const requestId = `appr-chturn-${t1.id}-${builtInAgentProfileId('mock')}`;
     await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
     await waitFor(() => agentReplies(store, 'mock').length === 1, 4000);
     expect(agentReplies(store, 'mock')[0]!.body.text).toBe('approved and done');

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -550,16 +550,23 @@ describe('mention routing — end-to-end via the router', () => {
   it('the roster verb reports availability + reasons', async () => {
     const h = await harness();
     const res = await req<{
-      roster: Array<{ id: string; available: boolean; reason: string | null }>;
+      roster: Array<{
+        id: string;
+        providerId: string;
+        available: boolean;
+        reason: string | null;
+      }>;
     }>({
       port: h.port,
       method: 'GET',
       url: `/channels/${encodeURIComponent(h.channelId)}/roster`,
     });
     expect(res.status).toBe(200);
-    const mock = res.body.roster.find((r) => r.id === 'mock')!;
+    // #1232 slice 5: roster entries are keyed by profile actor id; the vendor is
+    // carried on the explicit providerId field (never derived from id).
+    const mock = res.body.roster.find((r) => r.providerId === 'mock')!;
     expect(mock.available).toBe(true);
-    const codex = res.body.roster.find((r) => r.id === 'codex')!;
+    const codex = res.body.roster.find((r) => r.providerId === 'codex')!;
     expect(codex.available).toBe(false);
     expect(codex.reason).toContain('#301');
   });

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -12,6 +12,7 @@ import {
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import type { ChannelSenderRef } from '../shared/channel-chat-protocol.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -39,7 +40,74 @@ const AGENT: ChannelSenderRef = {
 };
 
 describe('channel-message-store schema migration', () => {
-  it('widens v1 status safely and preserves durable rows', () => {
+  it('migrates a v2 binding to its built-in profile without changing durable fields on reopen', () => {
+    const file = dbPath();
+    const legacy = new Database(file);
+    legacy.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version VALUES (2);
+      CREATE TABLE channel_messages (
+        id TEXT PRIMARY KEY, channel_id TEXT NOT NULL, seq INTEGER NOT NULL,
+        kind TEXT NOT NULL, status TEXT NOT NULL, sender_kind TEXT NOT NULL,
+        sender_id TEXT NOT NULL, sender_display TEXT, thread_id TEXT,
+        parent_message_id TEXT, body_text TEXT NOT NULL, body_format TEXT NOT NULL,
+        meta_json TEXT, source_session_id TEXT, source_turn_id TEXT,
+        source_item_id TEXT, client_message_id TEXT, created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL, completed_at TEXT, UNIQUE(channel_id, seq)
+      );
+      CREATE TABLE channel_members (
+        channel_id TEXT NOT NULL, member_kind TEXT NOT NULL, member_id TEXT NOT NULL,
+        joined_at TEXT NOT NULL, metadata_json TEXT NOT NULL DEFAULT '{}',
+        PRIMARY KEY(channel_id, member_kind, member_id)
+      );
+      CREATE UNIQUE INDEX idx_chm_source_dedupe
+        ON channel_messages(source_session_id, source_turn_id, source_item_id)
+        WHERE source_session_id IS NOT NULL
+          AND source_turn_id IS NOT NULL
+          AND source_item_id IS NOT NULL;
+      CREATE UNIQUE INDEX idx_chm_client_dedupe
+        ON channel_messages(channel_id, sender_id, client_message_id)
+        WHERE client_message_id IS NOT NULL;
+      CREATE TABLE channel_agent_bindings (
+        channel_id TEXT NOT NULL, agent_framework TEXT NOT NULL,
+        session_id TEXT, provider_session_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        PRIMARY KEY (channel_id, agent_framework)
+      );
+      INSERT INTO channel_agent_bindings VALUES (
+        'topic:v2', 'claude', 'sess-v2', '{"lastDeliveredSeq":7}',
+        '2026-07-01T00:00:00.000Z', '2026-07-02T00:00:00.000Z'
+      );
+    `);
+    legacy.close();
+
+    const migrated = store(file);
+    const profileId = builtInAgentProfileId('claude');
+    expect(migrated.getBinding('topic:v2', profileId)).toMatchObject({
+      profileActorId: profileId,
+      agentFramework: 'claude',
+      sessionId: 'sess-v2',
+      providerSession: { lastDeliveredSeq: 7 },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-02T00:00:00.000Z',
+    });
+    const reopened = store(file);
+    expect(reopened.getBinding('topic:v2', profileId)).toMatchObject({
+      sessionId: 'sess-v2',
+      providerSession: { lastDeliveredSeq: 7 },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-02T00:00:00.000Z',
+    });
+    const inspect = new Database(file, { readonly: true });
+    cleanup.push(() => inspect.close());
+    expect(
+      inspect
+        .prepare('SELECT COUNT(*) AS count FROM channel_agent_bindings')
+        .get()
+    ).toEqual({ count: 1 });
+  });
+
+  it('widens v1 status, heals its known aliases, and preserves durable rows through v3', () => {
     const file = dbPath();
     const legacy = new Database(file);
     legacy.exec(`
@@ -193,10 +261,15 @@ describe('channel-message-store schema migration', () => {
     ).toHaveLength(2);
     expect(migrated.getMessage('chm:claude-live-keeper')?.replyCount).toBe(1);
     expect(
-      migrated.getBinding('topic:live-heal', 'claude')?.providerSession[
+      migrated.getBinding('topic:live-heal', builtInAgentProfileId('claude'))?.providerSession[
         'lastDeliveredSeq'
       ]
     ).toBe(2);
+    expect(migrated.getBinding('topic:live-heal', builtInAgentProfileId('claude'))).toMatchObject({
+      profileActorId: builtInAgentProfileId('claude'),
+      agentFramework: 'claude',
+      sessionId: 'session-live',
+    });
     expect(migrated.latestSeq('topic:live-heal')).toBe(3);
     expect(
       migrated
@@ -216,7 +289,7 @@ describe('channel-message-store schema migration', () => {
       }).seq
     ).toBe(4);
 
-    // Reopening a v2 database is an idempotent no-op: the healed row set,
+    // Reopening the v3 database is an idempotent no-op: the healed row set,
     // references, gap-free sequence, and translated delivery cursor survive.
     const reopened = store(file);
     expect(
@@ -230,7 +303,7 @@ describe('channel-message-store schema migration', () => {
       [expect.any(String), 4],
     ]);
     expect(
-      reopened.getBinding('topic:live-heal', 'claude')?.providerSession[
+      reopened.getBinding('topic:live-heal', builtInAgentProfileId('claude'))?.providerSession[
         'lastDeliveredSeq'
       ]
     ).toBe(2);
@@ -243,7 +316,30 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(2);
+    ).toBe(3);
+
+    // The v3 conversion is reopen-idempotent: exactly one legacy binding is
+    // backfilled, with its session and provider cursor byte-for-byte intact.
+    const bindingRows = (
+      inspect
+        .prepare(
+          'SELECT profile_actor_id, agent_framework, session_id, provider_session_json FROM channel_agent_bindings'
+        )
+        .all() as Array<{
+        profile_actor_id: string;
+        agent_framework: string;
+        session_id: string | null;
+        provider_session_json: string;
+      }>
+    );
+    expect(bindingRows).toEqual([
+      {
+        profile_actor_id: builtInAgentProfileId('claude'),
+        agent_framework: 'claude',
+        session_id: 'session-live',
+        provider_session_json: '{"claudeSessionId":"session-live","lastDeliveredSeq":2}',
+      },
+    ]);
   });
 });
 
@@ -961,6 +1057,21 @@ describe('channel-message-store members and bindings', () => {
     });
     expect(updated.sessionId).toBe('sess-9');
     expect(updated.providerSession).toEqual({ claudeSessionId: 'abc' });
+
+    // Arbitrary profile ids are real actor ids, never rewritten by a prefix
+    // heuristic or legacy provider fallback.
+    s.upsertBinding({
+      channelId: 'topic:c',
+      profileActorId: 'reviewer',
+      agentFramework: 'claude',
+      sessionId: 'sess-reviewer',
+      providerSession: { lastDeliveredSeq: 9 },
+    });
+    expect(s.getBinding('topic:c', 'reviewer')).toMatchObject({
+      profileActorId: 'reviewer',
+      sessionId: 'sess-reviewer',
+      providerSession: { lastDeliveredSeq: 9 },
+    });
   });
 
   it('lists distinct non-null bound session ids (reaper protection) (#1248)', () => {

--- a/test/components/mention-palette.test.ts
+++ b/test/components/mention-palette.test.ts
@@ -8,9 +8,11 @@ import { buildMentionContacts } from '../../frontend/src/lib/chat/mention-contac
 import {
   annotateMentionCollisions,
   filterMentionContacts,
+  mentionInsertText,
   type MentionContact,
 } from '../../shared/mention-contacts.js';
 import { builtInAgentProfileId } from '../../shared/agent-profile.js';
+import { parseMentions } from '../../shared/channel-chat-protocol.js';
 import type { RosterEntry } from '../../frontend/src/lib/api.js';
 
 (
@@ -19,7 +21,10 @@ import type { RosterEntry } from '../../frontend/src/lib/api.js';
 
 const roster: RosterEntry[] = [
   {
-    id: 'claude',
+    id: builtInAgentProfileId('claude'),
+    providerId: 'claude',
+    isDefault: true,
+    isBuiltIn: true,
     displayName: 'Claude',
     kind: 'framework',
     available: true,
@@ -27,7 +32,10 @@ const roster: RosterEntry[] = [
     binding: null,
   },
   {
-    id: 'codex',
+    id: builtInAgentProfileId('codex'),
+    providerId: 'codex',
+    isDefault: true,
+    isBuiltIn: true,
     displayName: 'Codex',
     kind: 'framework',
     available: false,
@@ -35,7 +43,10 @@ const roster: RosterEntry[] = [
     binding: null,
   },
   {
-    id: 'hermes',
+    id: builtInAgentProfileId('hermes'),
+    providerId: 'hermes',
+    isDefault: true,
+    isBuiltIn: true,
     displayName: 'Hermes',
     kind: 'framework',
     available: true,
@@ -45,7 +56,7 @@ const roster: RosterEntry[] = [
 ];
 
 describe('buildMentionContacts', () => {
-  it('synthesizes a vendor-default profile per framework, keyed on the built-in id', () => {
+  it('keeps roster-provided built-in profile identities intact', () => {
     const contacts = buildMentionContacts(roster);
     expect(contacts.map((c) => c.id)).toEqual([
       builtInAgentProfileId('claude'),
@@ -75,6 +86,39 @@ describe('buildMentionContacts', () => {
     expect(human.providerId).toBe('human');
     // agent members are not folded in as humans.
     expect(contacts.filter((c) => c.kind === 'human')).toHaveLength(1);
+  });
+
+  it('preserves same-provider custom profile ids and insert-text round trips', () => {
+    const customId = 'agent-profile:claude:reviewer';
+    const contacts = buildMentionContacts([
+      ...roster,
+      {
+        id: customId,
+        providerId: 'claude',
+        displayName: 'Reviewer',
+        isDefault: false,
+        isBuiltIn: false,
+        kind: 'framework',
+        available: true,
+        reason: null,
+        binding: null,
+      },
+    ]);
+    const custom = contacts.find((contact) => contact.id === customId)!;
+    expect(custom).toMatchObject({
+      providerId: 'claude',
+      kind: 'profile',
+      owner: 'user',
+      isDefault: false,
+      isBuiltIn: false,
+    });
+    expect(
+      parseMentions(
+        mentionInsertText(custom),
+        ['claude'],
+        contacts
+      )[0]?.profileId
+    ).toBe(customId);
   });
 });
 


### PR DESCRIPTION
#1232 **Slice 5** — the mechanic that lets **multiple profiles of one vendor run as distinct live sessions in one channel**. Previously the whole mention→provision→binding→roster path was framework-keyed and profile identity was dropped. Sequenced after Slice 7 (config editor) to de-risk with real profiles.

## What
- **Binder re-key** framework → `profileActorId`: live/inflight maps, sender attribution, roster, status broadcast, interrupt/approval, brake, turnId; server-side mention resolution via `agentProfileStore.list()` + `resolveProfileForMention` (custom profile ids preserved).
- **Durable schema-v3 migration** (`channel_agent_bindings`): PK `(channel_id, profile_actor_id)`, `agent_framework` retained for CLI selection, legacy rows backfilled to `agent-profile:<framework>:default`. Transactional, idempotent, empty/v1/v2-safe, no durable-field loss.
- **Profile spawn config**: a custom profile's `model/effort/envVars/systemPrompt/provider` reach `CreateWebParams` (default profiles unchanged).
- **Session `profileId` pin** + drift-aware smart reuse (same-profile only; legacy unpinned reusable for the vendor default only). `ensureOrchestrator` keeps default-profile behavior.
- **Roster** entry gains `providerId`/`isDefault`/`isBuiltIn` (`id` = profile actor id, `providerId` = vendor mention-selector); unions unseeded target providers.

## Review + verification
- **Adversarial review**: migration + smart-reuse audited **CLEAN**; P2/P3 edges fixed (gateway provider-default self-mention exclusion, roster union, turnId symmetry, system-row display names, store built-in-default delete guard). `docs/CHANNEL_CHAT.md` roster shape updated.
- **Live migration proof**: booted on a real **v2** dev DB with an existing binding → migrated to **v3** clean (0 errors); the binding preserved with `profile_actor_id=agent-profile:claude:default` backfilled, `agent_framework`/`session_id` intact.
- `npm run check`: 0 errors. 131 focused tests (two-same-vendor-profile routing, migration v1/v2→v3 + idempotency, reuse-isolation) + full changed-set 1698 pass.

Refs #1232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mentions now target named agent profiles, allowing multiple profiles using the same provider to operate independently.
  * Agent rosters now show profile identity, provider, availability, and default or built-in status.
  * Profile-specific settings, prompts, and session associations are preserved across restored conversations.

* **Bug Fixes**
  * Prevented deletion of built-in default agent profiles.
  * Improved routing, streaming indicators, approvals, retries, and unavailable-profile messaging for profile-based conversations.

* **Documentation**
  * Updated channel chat documentation to describe profile-based mentions and routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->