### PR TITLE
fix(channels): lazy-load sharp — stop the CLI eagerly loading its native binding (#1263)

### DIFF
--- a/server/channel-attachments.ts
+++ b/server/channel-attachments.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import Database from 'better-sqlite3';
-import sharp, { type Sharp } from 'sharp';
+import type { Sharp } from 'sharp';
 
 import {
   CHANNEL_IMAGE_ALT_MAX_LENGTH,
@@ -165,6 +165,11 @@ async function sanitizeImage(input: ChannelAttachmentIngestInput): Promise<{
 
   let format: keyof typeof MIME_BY_FORMAT;
   let animated: boolean;
+  // Lazy-load sharp's native binding only when actually decoding an image, so
+  // importing this module (transitively reached from the CLI via local-node)
+  // never eagerly loads the native addon at module-eval — that eager load raced
+  // under parallel CLI spawns and intermittently threw during ESM load (#1263).
+  const sharp = (await import('sharp')).default;
   try {
     const metadata = await sharp(input.bytes, {
       animated: true,


### PR DESCRIPTION
Closes #1263.

**Root cause (confirmed):** `server/channel-attachments.ts` imported `sharp` at module top level. The CLI (`dist/bin/relay-ide.js`) transitively reaches this module via `local-node`, so every `relay-ide v1 …` spawn eagerly loaded sharp's native addon during ESM-eval. Under the test suite's parallel CLI spawns that native load raced and intermittently threw during module loading → non-empty stderr → ~1/12 subprocess tests reddened otherwise-green CI, forcing re-runs.

**Fix:** `import type { Sharp }` (erased at runtime) + `const sharp = (await import('sharp')).default` inside `sanitizeImage`, so the native binding loads **only when an image is actually decoded** — never at module-eval (CLI startup, hub boot).

**Verified:**
- Importing the CLI's server graph (`local-node`) loads **NONE** sharp modules (was loading them before).
- Compiled `channel-attachments.js` retains only the dynamic `await import('sharp')` — no static import.
- Image sanitizer tests pass (lazy load works end-to-end).
- `cli-gateway-sessions-wait` 12/12 ×3 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)