### PR TITLE
fix(startup): fail fast when persistence can't initialize instead of booting amnesiac (#1187)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -141,7 +141,8 @@ if (args.includes('--help') || args.includes('-h')) {
 Commands:
   dev [--self-host]  Run backend + Vite frontend with HMR (source checkout)
   update             Update this single relay-ide package from npm
-  hub                Run the Relay hub web server (same as bare relay-ide)
+  hub [--allow-degraded]
+                     Run the Relay hub web server (same as bare relay-ide)
     install                           Install/start the hub background service
     uninstall                         Stop and remove the hub background service
     status                            Show hub service status
@@ -198,6 +199,7 @@ Options:
   --config <path>    Path to config.json (default: ~/.config/relay-ide/config.json)
   --compact          With 'manifest': print compact JSON
   --debug-log        Enable SDK event debug logging to ~/.config/relay-ide/debug/
+  --allow-degraded   Permit the hub to start with failed persistence stores (unsafe; health reports degraded)
   --yolo             With 'worktree add': pass --dangerously-skip-permissions to Claude
   --version, -v      Show version
   --help, -h         Show this help`);
@@ -6220,6 +6222,7 @@ type HubDoctorReason =
   | 'AUTH_TOKEN_MISSING'
   | 'HUB_UNREACHABLE'
   | 'HUB_HTTP_ERROR'
+  | 'PERSISTENCE_DEGRADED'
   | 'UNAUTHORIZED'
   | 'NODE_REGISTRY_INVALID'
   | 'NODE_OFFLINE'
@@ -6275,7 +6278,8 @@ function isAbortError(error: unknown): boolean {
 
 async function hubFetchJson(
   pathName: string,
-  capabilities: readonly string[] = []
+  capabilities: readonly string[] = [],
+  unauthenticated = false
 ): Promise<
   | { ok: true; status: number; body: unknown }
   | {
@@ -6286,7 +6290,7 @@ async function hubFetchJson(
       body?: unknown;
     }
 > {
-  const token = hubCliToken();
+  const token = unauthenticated ? '' : hubCliToken();
   const headers: Record<string, string> = { 'x-relay-cli-gateway': 'v1' };
   if (token) headers['Authorization'] = `Bearer ${token}`;
   if (capabilities.length)
@@ -6625,6 +6629,53 @@ async function runHubDoctor(commandArgs: string[]): Promise<void> {
           message: reachable.message,
         }
   );
+  if (hubReachable) {
+    const health = await hubFetchJson('/healthz', [], true);
+    const body =
+      typeof health.body === 'object' && health.body !== null
+        ? (health.body as Record<string, unknown>)
+        : {};
+    const rawDisabledStores = body['disabledStores'];
+    const disabledStores =
+      Array.isArray(rawDisabledStores) &&
+      rawDisabledStores.length > 0 &&
+      rawDisabledStores.every(
+        (store): store is string =>
+          typeof store === 'string' && store.length > 0
+      )
+        ? rawDisabledStores
+        : undefined;
+    if (disabledStores) {
+      checks.push({
+        name: 'persistence.health',
+        status: 'fail',
+        reason: 'PERSISTENCE_DEGRADED',
+        message: `hub persistence is degraded: ${disabledStores.join(', ')}.`,
+        details: { status: body['status'], disabledStores },
+      });
+    } else if ('reason' in health) {
+      checks.push({
+        name: 'hub.health',
+        status: 'fail',
+        reason: health.reason,
+        message: health.message,
+        details: { status: health.status, body: health.body },
+      });
+    } else {
+      checks.push({
+        name: 'hub.health',
+        status: 'pass',
+        message: `hub /healthz reports ${typeof body['status'] === 'string' ? body['status'] : 'healthy'}.`,
+      });
+    }
+  } else {
+    checks.push({
+      name: 'hub.health',
+      status: 'skip',
+      reason: 'CHECK_SKIPPED',
+      message: 'unauthenticated health check skipped because hub reachability failed.',
+    });
+  }
   let nodes: HubNodeSummary[] = [];
   if (hubCliToken() && hubReachable) {
     const fetched = await fetchHubNodes();
@@ -8453,7 +8504,7 @@ if (command === 'hub') {
     // an alias preserves bare `relay-ide` while making the runtime role explicit.
   } else {
     logger.error(
-      'Usage: relay-ide hub [install|uninstall|status|logs|nodes|doctor|node-logs] [--port <port>] [--host <host>] [--config <path>]'
+      'Usage: relay-ide hub [install|uninstall|status|logs|nodes|doctor|node-logs] [--allow-degraded] [--port <port>] [--host <host>] [--config <path>]'
     );
     process.exit(1);
   }
@@ -9009,5 +9060,8 @@ if (portArg !== undefined) process.env['RELAY_IDE_PORT'] = portArg;
 const hostArg = getArg('--host');
 if (hostArg !== undefined) process.env['RELAY_IDE_HOST'] = hostArg;
 if (args.includes('--debug-log')) process.env['RELAY_IDE_DEBUG_LOG'] = '1';
+if (args.includes('--allow-degraded')) {
+  process.env['RELAY_IDE_ALLOW_DEGRADED'] = '1';
+}
 
 await import('../server/index.js');

--- a/server/health.ts
+++ b/server/health.ts
@@ -19,6 +19,8 @@ export interface HealthMonitor {
 }
 
 export interface HealthMonitorOptions {
+  /** Finalized disabled persistence stores for this hub process, if any. */
+  disabledStores?: readonly string[];
   lagThresholdMs?: number;
   probeIntervalMs?: number;
   memoryLogIntervalMs?: number;
@@ -84,15 +86,17 @@ export function createHealthMonitor(
 
   const getLagMs = (): number =>
     Math.max(0, options.getLagMs?.() ?? measuredLagMs);
+  const disabledStores = options.disabledStores ?? [];
 
   const handler: RequestHandler = (_req, res) => {
     const lagMs = Math.round(getLagMs());
     const { rss } = readHealthMemorySnapshot(memoryUsage);
-    const healthy = lagMs <= lagThresholdMs;
+    const healthy = lagMs <= lagThresholdMs && disabledStores.length === 0;
     res.status(healthy ? 200 : 503).json({
       status: healthy ? 'ok' : 'degraded',
       lagMs,
       rss,
+      ...(disabledStores.length > 0 ? { disabledStores } : {}),
     });
   };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,7 +94,8 @@ import {
 } from './relay-state-db.js';
 import {
   createWorkContextRouter,
-  initWorkContextStoreBestEffort,
+  createUnavailableWorkContextStore,
+  initWorkContextStore,
   type WorkContextStore,
 } from './work-contexts.js';
 import { initIaStore, type IaStore } from './ia-store.js';
@@ -325,6 +326,13 @@ import {
 } from './browser-content.js';
 import { sessionEnvelopeRegistry } from './session-envelope-registry.js';
 import { createLogger, initFileLogging } from './logger.js';
+import {
+  initializePersistenceStores,
+  isAllowDegradedPersistence,
+  persistenceFailureInjectorFromTestEnvironment,
+  PersistenceStartupError,
+  type PersistenceStartupState,
+} from './persistence-startup.js';
 import { createSecurityAuditLog } from './security-audit-log.js';
 import {
   getDefaultAllocator,
@@ -1628,39 +1636,6 @@ function deriveContextInboxStore(
   return store ? createContextInboxStoreAdapter(store) : null;
 }
 
-function initWorkContextArtifactStoreBestEffort(
-  configDir: string
-): WorkContextArtifactStore | null {
-  try {
-    return initWorkContextArtifactStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'WorkContext artifact store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-/**
- * Boot the #964 explicit agent presence store, or `null` when init fails (the
- * roster then degrades to its derived projection and presence writes 503).
- * Extracted from `main()` to keep that boot function under the complexity gate.
- */
-function initAgentPresenceStoreBestEffort(
-  configDir: string
-): AgentPresenceStore | null {
-  try {
-    return initAgentPresenceStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Agent presence store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
 /**
  * Audit-attributed actor id for an explicit-presence (#964) write, sourced from
  * the authenticated CLI-gateway actor credential. Module-scoped so `main()`
@@ -1671,143 +1646,116 @@ function presenceActorIdFromRequest(req: express.Request): string | undefined {
 }
 
 /**
- * Boot the #1233 AgentProfile store and seed one built-in default profile per
- * CONFIGURED framework, or `null` when init fails (agent-profile identity then
- * simply has no rows this boot). Seeding is idempotent — safe every startup.
- * Extracted from `main()` to keep that boot function under the complexity gate.
+ * Initialize every SQLite-backed boot store through one collector. A hub may
+ * use disabled stores only when the operator explicitly opts into degraded
+ * mode; the collector otherwise throws before Express or server.listen exist.
  */
-function initAgentProfileStoreBestEffort(
+function initializeHubPersistence(
   configDir: string,
   config: Config
-): AgentProfileStore | null {
-  try {
-    const store = initAgentProfileStore(configDir);
-    // Enumerate configured frameworks INSIDE the guard: resolveFramework throws
-    // for a malformed fully-custom framework entry (missing command/args/parser/
-    // capabilities) that config loading does not validate. Keeping it here lets
-    // that resolution throw degrade to "no profile rows" instead of escaping the
-    // best-effort guard and crashing hub boot.
-    store.seedBuiltIns(listConfiguredFrameworks(config.frameworks));
-    return store;
-  } catch (err) {
-    logger.warn(
-      'Agent profile store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initWorkflowRunStoreBestEffort(
-  configDir: string
-): WorkflowRunStore | null {
-  try {
-    return initWorkflowRunStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Workflow run store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initAutomationRunStoreBestEffort(
-  configDir: string
-): AutomationRunStore | null {
-  try {
-    return initAutomationRunStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Automation run store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initWorkspaceSurfaceStoreBestEffort(
-  configDir: string
-): WorkspaceSurfaceStore | null {
-  try {
-    return initWorkspaceSurfaceStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Workspace surface store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initWorkspaceTopicStoreBestEffort(
-  configDir: string
-): WorkspaceTopicStore | null {
-  try {
-    return initWorkspaceTopicStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Workspace topic store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initPrOverseerStoreBestEffort(
-  configDir: string
-): PrOverseerStore | null {
-  try {
-    return initPrOverseerStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'PR overseer store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initWorkContextMessageStoreBestEffort(
-  configDir: string
-): WorkContextMessageStore | null {
-  try {
-    return initWorkContextMessageStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'WorkContext message store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initChannelMessageStoreBestEffort(
-  configDir: string
-): ChannelMessageStore | null {
-  try {
-    return initChannelMessageStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Channel message store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
-}
-
-function initChannelAttachmentStoreBestEffort(
-  configDir: string
-): ChannelAttachmentStore | null {
-  try {
-    return initChannelAttachmentStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Channel attachment store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-    return null;
-  }
+): PersistenceStartupState {
+  const failureInjector = persistenceFailureInjectorFromTestEnvironment();
+  return initializePersistenceStores(
+    [
+      {
+        name: 'security-audit',
+        criticality: 'core',
+        initialize: () =>
+          createSecurityAuditLog(path.join(configDir, 'security-audit.db')),
+      },
+      {
+        name: 'relay-state',
+        criticality: 'core',
+        initialize: () => initRelayStateDb(configDir),
+      },
+      {
+        name: 'work-contexts',
+        criticality: 'core',
+        initialize: () => initWorkContextStore(configDir),
+        unavailable: (cause) => createUnavailableWorkContextStore(cause),
+      },
+      { name: 'ia', criticality: 'core', initialize: () => initIaStore(configDir) },
+      {
+        name: 'context-packets',
+        criticality: 'core',
+        initialize: () => initContextPacketStore(configDir),
+      },
+      {
+        name: 'agent-presence',
+        criticality: 'core',
+        initialize: () => initAgentPresenceStore(configDir),
+      },
+      {
+        name: 'agent-profiles',
+        criticality: 'core',
+        initialize: () => {
+          const store = initAgentProfileStore(configDir);
+          store.seedBuiltIns(listConfiguredFrameworks(config.frameworks));
+          return store;
+        },
+      },
+      {
+        name: 'work-context-artifacts',
+        criticality: 'core',
+        initialize: () => initWorkContextArtifactStore(configDir),
+      },
+      {
+        name: 'workspace-topics',
+        criticality: 'core',
+        initialize: () => initWorkspaceTopicStore(configDir),
+      },
+      {
+        name: 'work-context-messages',
+        criticality: 'core',
+        initialize: () => initWorkContextMessageStore(configDir),
+      },
+      {
+        name: 'channel-attachments',
+        criticality: 'core',
+        initialize: () => initChannelAttachmentStore(configDir),
+      },
+      {
+        name: 'channel-messages',
+        criticality: 'core',
+        initialize: () => initChannelMessageStore(configDir),
+      },
+      {
+        name: 'intervention-log',
+        criticality: 'core',
+        initialize: () => initInterventionLog(configDir),
+      },
+      {
+        name: 'analytics',
+        criticality: 'optional',
+        initialize: () => initAnalytics(configDir),
+      },
+      {
+        name: 'workflow-runs',
+        criticality: 'optional',
+        initialize: () => initWorkflowRunStore(configDir),
+      },
+      {
+        name: 'automation-runs',
+        criticality: 'optional',
+        initialize: () => initAutomationRunStore(configDir),
+      },
+      {
+        name: 'workspace-surfaces',
+        criticality: 'optional',
+        initialize: () => initWorkspaceSurfaceStore(configDir),
+      },
+      {
+        name: 'pr-overseer',
+        criticality: 'optional',
+        initialize: () => initPrOverseerStore(configDir),
+      },
+    ],
+    {
+      allowDegraded: isAllowDegradedPersistence(),
+      logger,
+      ...(failureInjector ? { failureInjector } : {}),
+    }
+  );
 }
 
 /**
@@ -1986,17 +1934,42 @@ async function main(): Promise<void> {
 
   const configDir = getConfigDir(CONFIG_PATH);
   initializeRuntimeDirectories(configDir);
-  let securityAuditLog: ReturnType<typeof createSecurityAuditLog> | undefined;
-  try {
-    securityAuditLog = createSecurityAuditLog(
-      path.join(configDir, 'security-audit.db')
-    );
-  } catch (err) {
-    logger.warn(
-      'Security audit log disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
+  // Finalize all SQLite persistence before building long-lived services. A
+  // failed store throws here by default, before a scheduler or listener can
+  // leave an amnesiac hub running.
+  const persistenceState = initializeHubPersistence(configDir, getConfig());
+  const securityAuditLog =
+    persistenceState.get<ReturnType<typeof createSecurityAuditLog>>(
+      'security-audit'
+    ) ?? undefined;
+  const workContextStore =
+    persistenceState.get<WorkContextStore>('work-contexts') ??
+    createUnavailableWorkContextStore('work-contexts missing from startup');
+  const iaStore = persistenceState.get<IaStore>('ia');
+  const contextPacketStore =
+    persistenceState.get<ContextPacketStore>('context-packets');
+  const agentPresenceStore =
+    persistenceState.get<AgentPresenceStore>('agent-presence');
+  const agentProfileStore =
+    persistenceState.get<AgentProfileStore>('agent-profiles');
+  const workContextArtifactStore =
+    persistenceState.get<WorkContextArtifactStore>('work-context-artifacts');
+  const workflowRunStore =
+    persistenceState.get<WorkflowRunStore>('workflow-runs');
+  const automationRunStore =
+    persistenceState.get<AutomationRunStore>('automation-runs');
+  const workspaceSurfaceStore =
+    persistenceState.get<WorkspaceSurfaceStore>('workspace-surfaces');
+  const workspaceTopicStore =
+    persistenceState.get<WorkspaceTopicStore>('workspace-topics');
+  const prOverseerStore =
+    persistenceState.get<PrOverseerStore>('pr-overseer');
+  const workContextMessageStore =
+    persistenceState.get<WorkContextMessageStore>('work-context-messages');
+  const channelAttachmentStore =
+    persistenceState.get<ChannelAttachmentStore>('channel-attachments');
+  const channelMessageStore =
+    persistenceState.get<ChannelMessageStore>('channel-messages');
   const hubNodeRegistry = createAuditedHubNodeRegistry(
     configDir,
     securityAuditLog
@@ -2037,31 +2010,6 @@ async function main(): Promise<void> {
     reconcilePortsForAllRepos
   );
 
-  try {
-    initRelayStateDb(configDir);
-  } catch (err) {
-    logger.warn(
-      'Relay state DB disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
-
-  const workContextStore = initWorkContextStoreBestEffort(configDir);
-
-  // IA persistence substrate (#737): Workspace grouping + Bench overlays. Own
-  // SQLite file; new tables only, non-destructive. Routes that consume it
-  // (#733/#735) land in follow-ups. Guarded so a DB error degrades to "no IA
-  // persistence" rather than failing boot.
-  let iaStore: IaStore | null = null;
-  try {
-    iaStore = initIaStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'IA store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
-
   // #736: one-time, idempotent boot migration of legacy `config.workspaces`
   // groupings → persisted IA Workspaces (`ia.db`). NON-DESTRUCTIVE: reads
   // `config.workspaces` + the local repo inventory, writes ONLY to `ia.db`.
@@ -2078,56 +2026,6 @@ async function main(): Promise<void> {
         configPath: CONFIG_PATH,
       }),
   });
-
-  // Context-packet + session-inbox store (#758, ADR-019). Own SQLite file
-  // (`context-packets.db`); new tables only, non-destructive. CLI verbs/routes
-  // that consume it (#765) and anchor resolution (#766) land in follow-ups.
-  // Guarded so a DB error degrades to "no context-packet persistence" rather
-  // than failing boot.
-  let contextPacketStore: ContextPacketStore | null = null;
-  try {
-    contextPacketStore = initContextPacketStore(configDir);
-  } catch (err) {
-    logger.warn(
-      'Context-packet store disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
-
-  // Explicit agent presence store (#964, child of #953). Own SQLite file
-  // (`agent-presence.db`); new table only, non-destructive. Backs
-  // roster.register / roster.updateSelf and the roster.list self-declared
-  // overlay. Guarded so a DB error degrades to "no explicit presence" (the
-  // roster falls back to the derived projection) rather than failing boot.
-  const agentPresenceStore = initAgentPresenceStoreBestEffort(configDir);
-
-  // AgentProfile store (#1233, epic #1232). Own SQLite file (`agent-profiles.db`);
-  // new table only, non-destructive. Seeds one built-in default profile per
-  // configured framework at boot (idempotent). Guarded so a DB error degrades to
-  // "no profile rows" rather than failing boot. NO live-row re-key ships here.
-  const agentProfileStore = initAgentProfileStoreBestEffort(
-    configDir,
-    getConfig()
-  );
-
-  // WorkContext artifact store (#889/#890). Own SQLite/payload files; routes
-  // degrade to typed 503 when initialization fails so hub startup stays useful.
-  const workContextArtifactStore =
-    initWorkContextArtifactStoreBestEffort(configDir);
-  const workflowRunStore = initWorkflowRunStoreBestEffort(configDir);
-  const automationRunStore = initAutomationRunStoreBestEffort(configDir);
-  const workspaceSurfaceStore = initWorkspaceSurfaceStoreBestEffort(configDir);
-  const workspaceTopicStore = initWorkspaceTopicStoreBestEffort(configDir);
-  const prOverseerStore = initPrOverseerStoreBestEffort(configDir);
-  const workContextMessageStore =
-    initWorkContextMessageStoreBestEffort(configDir);
-  const channelAttachmentStore =
-    initChannelAttachmentStoreBestEffort(configDir);
-  // Channel conversation core (#1165). Own SQLite (`channel-chat.db`); routes and
-  // the /ws/channels lane degrade when init fails — a failed channel store never
-  // takes down the hub or the untouched /ws/:sessionId lane. Boot order: init →
-  // sweep stale streaming → sweep orphans → hub → mount router → wire ws.
-  const channelMessageStore = initChannelMessageStoreBestEffort(configDir);
   if (channelMessageStore) {
     try {
       channelMessageStore.sweepStaleStreaming();
@@ -2197,24 +2095,6 @@ async function main(): Promise<void> {
   });
   const cliGatewayEventBus = createCliGatewayEventBus();
 
-  try {
-    initInterventionLog(configDir);
-  } catch (err) {
-    logger.warn(
-      'Intervention log disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
-
-  try {
-    initAnalytics(configDir);
-  } catch (err) {
-    logger.warn(
-      'Analytics disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
-
   await initializePinConfig(startupConfig);
 
   const authenticatedTokens = new Set<string>();
@@ -2247,7 +2127,9 @@ async function main(): Promise<void> {
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
   });
-  const healthMonitor = createHealthMonitor();
+  const healthMonitor = createHealthMonitor({
+    disabledStores: persistenceState.disabledStores,
+  });
   app.get('/healthz', healthMonitor.handler);
 
   function authenticatedBrowserSession(req: express.Request): boolean {
@@ -4732,7 +4614,15 @@ async function main(): Promise<void> {
   // GET /auth/status — no auth required, tells frontend if PIN is configured
   app.get('/auth/status', (_req, res) => {
     const config = getConfig();
-    res.json({ hasPIN: auth.isPinConfigured(config.pinHash) });
+    res.json({
+      hasPIN: auth.isPinConfigured(config.pinHash),
+      ...(persistenceState.isDegraded
+        ? {
+            status: 'degraded',
+            disabledStores: persistenceState.disabledStores,
+          }
+        : {}),
+    });
   });
 
   // POST /auth/setup — set initial PIN (only works when no PIN is configured)
@@ -6615,6 +6505,10 @@ function positiveIntegerEnv(name: string): number | undefined {
 }
 
 main().catch((err) => {
-  logger.error('Unhandled fatal error:', err);
+  if (err instanceof PersistenceStartupError) {
+    logger.error(err.message);
+  } else {
+    logger.error('Unhandled fatal error:', err);
+  }
   process.exitCode = 1;
 });

--- a/server/persistence-startup.ts
+++ b/server/persistence-startup.ts
@@ -1,0 +1,196 @@
+import type { Logger } from './logger.js';
+
+export type PersistenceStoreCriticality = 'core' | 'optional';
+
+export interface PersistenceStoreDescriptor<T> {
+  /** Stable operator-facing identifier; also used by test-only failure injection. */
+  name: string;
+  criticality: PersistenceStoreCriticality;
+  initialize: () => T;
+  /**
+   * Some legacy routes require a callable unavailable-store object rather than
+   * null. The persistence state remains disabled even when this fallback is
+   * supplied.
+   */
+  unavailable?: (cause: unknown) => T;
+}
+
+export interface PersistenceStoreFailure {
+  name: string;
+  criticality: PersistenceStoreCriticality;
+  cause: string;
+}
+
+export interface PersistenceFailureInjector {
+  (descriptor: Pick<PersistenceStoreDescriptor<unknown>, 'name'>):
+    | Error
+    | undefined;
+}
+
+export interface PersistenceStartupOptions {
+  allowDegraded?: boolean;
+  logger: Pick<Logger, 'warn'>;
+  failureInjector?: PersistenceFailureInjector;
+}
+
+/**
+ * The finalized persistence state is immutable for the lifetime of one hub
+ * process. It is deliberately small so health/auth can report the truth
+ * without coupling to every store implementation.
+ */
+export class PersistenceStartupState {
+  readonly disabledStores: readonly string[];
+  readonly failures: readonly PersistenceStoreFailure[];
+  readonly coreFailures: readonly PersistenceStoreFailure[];
+  readonly totalStores: number;
+  private readonly values: ReadonlyMap<string, unknown>;
+
+  constructor(input: {
+    values: ReadonlyMap<string, unknown>;
+    failures: readonly PersistenceStoreFailure[];
+    totalStores: number;
+  }) {
+    this.values = input.values;
+    this.failures = input.failures;
+    this.disabledStores = input.failures.map((failure) => failure.name);
+    this.coreFailures = input.failures.filter(
+      (failure) => failure.criticality === 'core'
+    );
+    this.totalStores = input.totalStores;
+  }
+
+  get isDegraded(): boolean {
+    return this.disabledStores.length > 0;
+  }
+
+  get<T>(name: string): T | null {
+    if (!this.values.has(name)) return null;
+    return this.values.get(name) as T;
+  }
+}
+
+/** Error intentionally formatted for one concise fatal startup log line. */
+export class PersistenceStartupError extends Error {
+  constructor(
+    readonly state: PersistenceStartupState
+  ) {
+    super(
+      `persistence initialization failed before listening: ${formatPersistenceFailureSummary(
+        state.failures,
+        state.totalStores
+      )}. Rebuild the persistence layer or start explicitly degraded with --allow-degraded (RELAY_IDE_ALLOW_DEGRADED=1).`
+    );
+    this.name = 'PersistenceStartupError';
+  }
+}
+
+export function isAllowDegradedPersistence(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: readonly string[] = process.argv
+): boolean {
+  return (
+    env['RELAY_IDE_ALLOW_DEGRADED'] === '1' ||
+    argv.includes('--allow-degraded')
+  );
+}
+
+/**
+ * Child startup tests can fail named factories without corrupting a database.
+ * This is deliberately inert outside NODE_ENV=test.
+ */
+export function persistenceFailureInjectorFromTestEnvironment(
+  env: NodeJS.ProcessEnv = process.env
+): PersistenceFailureInjector | undefined {
+  if (env['NODE_ENV'] !== 'test') return undefined;
+  const names = new Set(
+    (env['RELAY_IDE_TEST_FAIL_PERSISTENCE_STORES'] ?? '')
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean)
+  );
+  if (names.size === 0) return undefined;
+  return (descriptor) =>
+    names.has(descriptor.name)
+      ? new Error(`test persistence factory failure for ${descriptor.name}`)
+      : undefined;
+}
+
+/**
+ * Runs every synchronous boot-time SQLite factory exactly once, records all
+ * failures, and emits at most one warning only for explicitly allowed
+ * degraded boot. Core marks the amnesiac-hub boundary for operators, but the
+ * strict default applies to every SQLite store: without opt-in, no caller
+ * receives a state and thus no listener can be started with disabled
+ * persistence.
+ */
+export function initializePersistenceStores(
+  descriptors: readonly PersistenceStoreDescriptor<unknown>[],
+  options: PersistenceStartupOptions
+): PersistenceStartupState {
+  const values = new Map<string, unknown>();
+  const failures: PersistenceStoreFailure[] = [];
+
+  for (const descriptor of descriptors) {
+    try {
+      const injected = options.failureInjector?.(descriptor);
+      if (injected) throw injected;
+      values.set(descriptor.name, descriptor.initialize());
+    } catch (err) {
+      failures.push({
+        name: descriptor.name,
+        criticality: descriptor.criticality,
+        cause: normalizeFailureCause(err),
+      });
+      values.set(
+        descriptor.name,
+        descriptor.unavailable ? descriptor.unavailable(err) : null
+      );
+    }
+  }
+
+  const state = new PersistenceStartupState({
+    values,
+    failures,
+    totalStores: descriptors.length,
+  });
+  if (!state.isDegraded) return state;
+
+  if (!options.allowDegraded) {
+    throw new PersistenceStartupError(state);
+  }
+
+  options.logger.warn(
+    formatPersistenceFailureSummary(state.failures, state.totalStores)
+  );
+  return state;
+}
+
+export function formatPersistenceFailureSummary(
+  failures: readonly PersistenceStoreFailure[],
+  totalStores: number
+): string {
+  const names = failures.map((failure) => failure.name).join(', ');
+  return `persistence degraded: ${failures.length}/${totalStores} stores failed to init: [${names}] — ${summarizeFailureCauses(failures)}`;
+}
+
+function summarizeFailureCauses(
+  failures: readonly PersistenceStoreFailure[]
+): string {
+  const causes = Array.from(new Set(failures.map((failure) => failure.cause)));
+  const joined = causes.join('; ');
+  if (
+    causes.some((cause) =>
+      /NODE_MODULE_VERSION|was compiled against a different Node\.js version|better-sqlite3.*(?:module|version)/i.test(
+        cause
+      )
+    )
+  ) {
+    return `better-sqlite3 native module ABI mismatch (running Node ${process.version}); run npm rebuild better-sqlite3. ${joined}`;
+  }
+  return joined;
+}
+
+function normalizeFailureCause(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw.replace(/\s+/g, ' ').trim() || 'unknown initialization failure';
+}

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -139,6 +139,37 @@ describe('/healthz', () => {
     });
   });
 
+  it('returns 503 and disabled stores when persistence is explicitly degraded', () => {
+    const monitor = createHealthMonitor({
+      getLagMs: () => 12,
+      disabledStores: ['channel-messages', 'analytics'],
+      memoryLogIntervalMs: 60_000,
+      memoryUsage: () => ({
+        rss: 123_456,
+        heapTotal: 80_000,
+        heapUsed: 40_000,
+        external: 2_000,
+        arrayBuffers: 1_000,
+      }),
+    });
+    monitors.push(monitor);
+    const json = vi.fn();
+    const response = {
+      status: vi.fn().mockReturnThis(),
+      json,
+    };
+
+    monitor.handler({} as never, response as never, vi.fn());
+
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(json).toHaveBeenCalledWith({
+      status: 'degraded',
+      lagMs: 12,
+      rss: 123_456,
+      disabledStores: ['channel-messages', 'analytics'],
+    });
+  });
+
   it('formats one memory line with rss, heapUsed, and external', () => {
     const info = vi.fn();
     const snapshot = logHealthMemorySnapshot(

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -33,6 +33,10 @@ const loggerMocks = vi.hoisted(() => ({
   error: vi.fn(),
 }));
 
+const serverStartMocks = vi.hoisted(() => ({
+  imported: vi.fn(),
+}));
+
 vi.mock('../server/service.js', () => ({
   CONFIG_DIR: '/tmp/relay-ide-test-config',
   install: serviceMocks.install,
@@ -44,6 +48,11 @@ vi.mock('../server/service.js', () => ({
 vi.mock('../server/logger.js', () => ({
   createLogger: () => loggerMocks,
 }));
+
+vi.mock('../server/index.js', () => {
+  serverStartMocks.imported();
+  return {};
+});
 
 type CliExitError = Error & { code: number; relayCliExit: true };
 
@@ -66,6 +75,7 @@ async function runCli(
   serviceMocks.status.mockClear();
   loggerMocks.info.mockClear();
   loggerMocks.error.mockClear();
+  serverStartMocks.imported.mockClear();
 
   const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
     code?: number | string | null
@@ -244,13 +254,62 @@ describe('hub/node packaging decision', () => {
     }
 
     expect(cliSource).toContain(
-      'hub                Run the Relay hub web server'
+      'Run the Relay hub web server (same as bare relay-ide)'
     );
     expect(cliSource).toContain(
       'node               Manage relay-node pairing and diagnostics'
     );
+    expect(cliSource).toContain('--allow-degraded');
     expect(bootstrapDoc).toContain('run the web server as `relay-ide hub`');
     expect(bootstrapDoc).toContain('relay-ide node install');
+  });
+
+  it('documents and forwards --allow-degraded before hub startup', async () => {
+    const previous = process.env['RELAY_IDE_ALLOW_DEGRADED'];
+    const cliSource = readRepoFile('bin/relay-ide.ts');
+    const configPath = writeHubConfig();
+    delete process.env['RELAY_IDE_ALLOW_DEGRADED'];
+
+    try {
+      const bareResult = await runCli([
+        '--allow-degraded',
+        '--config',
+        configPath,
+      ]);
+      expect(bareResult.exitCode).toBeUndefined();
+      expect(process.env['RELAY_IDE_ALLOW_DEGRADED']).toBe('1');
+      expect(serverStartMocks.imported).toHaveBeenCalledTimes(1);
+
+      delete process.env['RELAY_IDE_ALLOW_DEGRADED'];
+      const hubResult = await runCli([
+        'hub',
+        '--allow-degraded',
+        '--config',
+        configPath,
+      ]);
+      expect(hubResult.exitCode).toBeUndefined();
+      expect(process.env['RELAY_IDE_ALLOW_DEGRADED']).toBe('1');
+      expect(
+        cliSource.indexOf("process.env['RELAY_IDE_ALLOW_DEGRADED'] = '1'")
+      ).toBeLessThan(cliSource.indexOf("await import('../server/index.js')"));
+
+      process.env['RELAY_IDE_ALLOW_DEGRADED'] = 'already-set';
+      const envOptInResult = await runCli(['--config', configPath]);
+      expect(envOptInResult.exitCode).toBeUndefined();
+      expect(process.env['RELAY_IDE_ALLOW_DEGRADED']).toBe('already-set');
+
+      const helpResult = await runCli(['--help']);
+      expect(helpResult.exitCode).toBe(0);
+      expect(loggerMocks.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '--allow-degraded   Permit the hub to start with failed persistence stores'
+        )
+      );
+    } finally {
+      resetCliLogDir();
+      if (previous === undefined) delete process.env['RELAY_IDE_ALLOW_DEGRADED'];
+      else process.env['RELAY_IDE_ALLOW_DEGRADED'] = previous;
+    }
   });
 
   it('keeps explicit hub subcommands ahead of the --bg shorthand fallback', () => {
@@ -504,6 +563,151 @@ describe('hub/node packaging decision', () => {
     }
   });
 
+  it('reports unauthenticated degraded persistence health as a typed hub doctor failure', async () => {
+    resetCliLogDir();
+    const configPath = writeHubConfig();
+    const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
+    process.env['RELAY_IDE_BROWSER_TOKEN'] = 'browser-secret-token';
+    const fetchMock = vi.fn(async (input: URL | RequestInfo) => {
+      const pathname = new URL(String(input)).pathname;
+      if (pathname === '/version') {
+        return new Response(JSON.stringify({ version: '0.1.0' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (pathname === '/healthz') {
+        return new Response(
+          JSON.stringify({
+            status: 'degraded',
+            lagMs: 3,
+            rss: 1024,
+            disabledStores: ['channelMessages', 'workContexts'],
+          }),
+          {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          }
+        );
+      }
+      return new Response(JSON.stringify({ nodes: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(globalThis.console, 'log')
+      .mockImplementation((message?: unknown) => {
+        stdout += `${String(message ?? '')}\n`;
+      });
+
+    try {
+      const result = await runCli([
+        'hub',
+        'doctor',
+        '--json',
+        '--config',
+        configPath,
+      ]);
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(stdout) as {
+        ok: boolean;
+        checks: Array<{
+          name: string;
+          reason?: string;
+          details?: { status?: string; disabledStores?: string[] };
+        }>;
+      };
+      const persistence = payload.checks.find(
+        (check) => check.name === 'persistence.health'
+      );
+      expect(payload.ok).toBe(false);
+      expect(persistence).toMatchObject({
+        reason: 'PERSISTENCE_DEGRADED',
+        details: {
+          status: 'degraded',
+          disabledStores: ['channelMessages', 'workContexts'],
+        },
+      });
+      const healthCall = fetchMock.mock.calls.find(
+        ([input]) => new URL(String(input)).pathname === '/healthz'
+      );
+      expect(healthCall?.[1]).toMatchObject({
+        headers: { 'x-relay-cli-gateway': 'v1' },
+      });
+      expect((healthCall?.[1] as RequestInit | undefined)?.headers).not.toHaveProperty(
+        'Authorization'
+      );
+    } finally {
+      stdoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+      resetCliLogDir();
+      if (oldToken === undefined) delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+      else process.env['RELAY_IDE_BROWSER_TOKEN'] = oldToken;
+    }
+  });
+
+  it('keeps lag-only health degradation as a hub health failure', async () => {
+    resetCliLogDir();
+    const configPath = writeHubConfig();
+    const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
+    process.env['RELAY_IDE_BROWSER_TOKEN'] = 'browser-secret-token';
+    stubHubFetch([
+      { pathName: '/version', body: { version: '0.1.0' } },
+      {
+        pathName: '/healthz',
+        status: 503,
+        body: { status: 'degraded', lagMs: 125, rss: 2048 },
+      },
+      { pathName: '/nodes', body: { nodes: [] } },
+    ]);
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(globalThis.console, 'log')
+      .mockImplementation((message?: unknown) => {
+        stdout += `${String(message ?? '')}\n`;
+      });
+
+    try {
+      const result = await runCli([
+        'hub',
+        'doctor',
+        '--json',
+        '--config',
+        configPath,
+      ]);
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(stdout) as {
+        checks: Array<{
+          name: string;
+          reason?: string;
+          details?: { status?: number; body?: Record<string, unknown> };
+        }>;
+      };
+      expect(
+        payload.checks.find((check) => check.name === 'persistence.health')
+      ).toBeUndefined();
+      expect(
+        payload.checks.find((check) => check.name === 'hub.health')
+      ).toMatchObject({
+        status: 'fail',
+        reason: 'HUB_HTTP_ERROR',
+        details: {
+          status: 503,
+          body: { status: 'degraded', lagMs: 125, rss: 2048 },
+        },
+      });
+    } finally {
+      stdoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+      resetCliLogDir();
+      if (oldToken === undefined) delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+      else process.env['RELAY_IDE_BROWSER_TOKEN'] = oldToken;
+    }
+  });
+
   it('reports node availability, version, capability, and log support diagnostics', async () => {
     resetCliLogDir();
     const configPath = writeHubConfig();
@@ -539,6 +743,7 @@ describe('hub/node packaging decision', () => {
     ];
     stubHubFetch([
       { pathName: '/version', body: { version: '0.1.0' } },
+      { pathName: '/healthz', body: { status: 'ok', lagMs: 0, rss: 0 } },
       { pathName: '/nodes', body: { nodes } },
       {
         pathName: '/hub/nodes/node_no_relay_pty/logs?lines=0',

--- a/test/persistence-startup.test.ts
+++ b/test/persistence-startup.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PersistenceStartupError,
+  initializePersistenceStores,
+  type PersistenceStoreDescriptor,
+} from '../server/persistence-startup.js';
+
+function descriptors(): PersistenceStoreDescriptor<unknown>[] {
+  return [
+    {
+      name: 'relay-state',
+      criticality: 'core',
+      initialize: () => ({ ready: true }),
+    },
+    {
+      name: 'analytics',
+      criticality: 'optional',
+      initialize: () => ({ ready: true }),
+    },
+  ];
+}
+
+describe('persistence startup collector', () => {
+  it('fails boot before listening by default when an injected core factory throws', () => {
+    const warn = vi.fn();
+
+    expect(() =>
+      initializePersistenceStores(descriptors(), {
+        logger: { warn },
+        failureInjector: (descriptor) =>
+          descriptor.name === 'relay-state'
+            ? new Error('test persistence factory failure')
+            : undefined,
+      })
+    ).toThrow(PersistenceStartupError);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('also fails by default when only an optional SQLite store is disabled', () => {
+    const warn = vi.fn();
+
+    expect(() =>
+      initializePersistenceStores(descriptors(), {
+        logger: { warn },
+        failureInjector: (descriptor) =>
+          descriptor.name === 'analytics'
+            ? new Error('test optional persistence factory failure')
+            : undefined,
+      })
+    ).toThrow(PersistenceStartupError);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('collapses multiple degraded store failures into one warning summary', () => {
+    const warn = vi.fn();
+    const state = initializePersistenceStores(descriptors(), {
+      allowDegraded: true,
+      logger: { warn },
+      failureInjector: () => new Error('Module did not self-register'),
+    });
+
+    expect(state.isDegraded).toBe(true);
+    expect(state.disabledStores).toEqual(['relay-state', 'analytics']);
+    expect(state.coreFailures.map((failure) => failure.name)).toEqual([
+      'relay-state',
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'persistence degraded: 2/2 stores failed to init: [relay-state, analytics] — Module did not self-register'
+    );
+  });
+
+  it('summarizes a better-sqlite3 ABI failure with running Node and rebuild guidance', () => {
+    const warn = vi.fn();
+    initializePersistenceStores(descriptors(), {
+      allowDegraded: true,
+      logger: { warn },
+      failureInjector: () =>
+        new Error(
+          'The module was compiled against a different Node.js version using NODE_MODULE_VERSION 127.'
+        ),
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`running Node ${process.version}`)
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('npm rebuild better-sqlite3')
+    );
+  });
+
+  it('keeps normal persistence startup healthy without a warning', () => {
+    const warn = vi.fn();
+    const state = initializePersistenceStores(descriptors(), {
+      logger: { warn },
+    });
+
+    expect(state.isDegraded).toBe(false);
+    expect(state.disabledStores).toEqual([]);
+    expect(state.get<{ ready: boolean }>('relay-state')).toEqual({
+      ready: true,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -115,6 +115,24 @@ function captureOutput(child: ChildProcess): {
   };
 }
 
+async function waitForChildExit(
+  child: ChildProcess,
+  timeoutMs = 10_000
+): Promise<number | null> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return child.exitCode;
+  }
+  return new Promise<number | null>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Server did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once('exit', (code) => {
+      clearTimeout(timeout);
+      resolve(code);
+    });
+  });
+}
+
 function seedHangingCodexSession(configDir: string): void {
   const id = 'startup-hanging-codex';
   const now = new Date().toISOString();
@@ -272,7 +290,7 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
 
     const health = await fetch(`http://127.0.0.1:${port}/healthz`);
     expect(health.status).toBe(200);
-    await expect(health.json()).resolves.toMatchObject({
+    await expect(health.json()).resolves.toEqual({
       status: 'ok',
       lagMs: expect.any(Number),
       rss: expect.any(Number),
@@ -282,7 +300,73 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
     const res = await fetch(`http://127.0.0.1:${port}/auth/status`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { hasPIN: boolean };
-    expect(body.hasPIN).toBe(false);
+    expect(body).toEqual({ hasPIN: false });
+  } finally {
+    await killAndWait(child);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('fatal persistence failure exits before listening without degraded opt-in', async () => {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-persistence-fatal-')
+  );
+  const configPath = path.join(tmpDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ port: 0, host: '127.0.0.1' }));
+  const child = startServer({
+    env: {
+      RELAY_IDE_CONFIG: configPath,
+      RELAY_IDE_PORT: '0',
+      NODE_ENV: 'test',
+      RELAY_IDE_TEST_FAIL_PERSISTENCE_STORES: 'channel-messages',
+    },
+  });
+
+  try {
+    await expect(waitForChildExit(child, 1_000)).resolves.toBe(1);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      await killAndWait(child);
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('allow-degraded boot reports disabled persistence through health and auth', async () => {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-persistence-degraded-')
+  );
+  const configPath = path.join(tmpDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ port: 0, host: '127.0.0.1' }));
+  const child = startServer({
+    env: {
+      RELAY_IDE_CONFIG: configPath,
+      RELAY_IDE_PORT: '0',
+      NODE_ENV: 'test',
+      RELAY_IDE_ALLOW_DEGRADED: '1',
+      RELAY_IDE_TEST_FAIL_PERSISTENCE_STORES: 'channel-messages,analytics',
+    },
+  });
+
+  try {
+    const port = await waitForListeningPort(child);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+    const [health, authStatus] = await Promise.all([
+      fetch(`${baseUrl}/healthz`),
+      fetch(`${baseUrl}/auth/status`),
+    ]);
+
+    expect(health.status).toBe(503);
+    await expect(health.json()).resolves.toMatchObject({
+      status: 'degraded',
+      disabledStores: ['channel-messages', 'analytics'],
+    });
+    expect(authStatus.status).toBe(200);
+    await expect(authStatus.json()).resolves.toEqual({
+      hasPIN: false,
+      status: 'degraded',
+      disabledStores: ['channel-messages', 'analytics'],
+    });
   } finally {
     await killAndWait(child);
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #1187.

A hub whose SQLite stores all failed to init (e.g. a better-sqlite3 ABI mismatch) used to log each store `disabled: failed to initialize` as a warning, then log `listening` and serve HTTP 200 **as if healthy** — running amnesiac (no channels/messages), failing confusingly, while the per-store warning spam rolled `logs/relay-ide.jsonl` and destroyed history.

## Fix
- **`persistence-startup.ts`** centralizes all 18 SQLite initializers. Any failure now **exits non-zero before listening**, unless `--allow-degraded` / `RELAY_IDE_ALLOW_DEGRADED=1`.
- Fatal output is **one** actionable line naming the failed stores + cause; ABI errors include the running Node version + `npm rebuild better-sqlite3` guidance.
- Degraded boot (opt-in) emits **one** aggregated warning, not per-store spam.
- Honest health: `/healthz` → **503** `{status:"degraded", disabledStores:[...]}`; `/auth/status` adds the same degraded fields (healthy shapes unchanged); `hub doctor` reports `persistence.health / PERSISTENCE_DEGRADED`.
- **core** (work/conversation/session/audit state) vs **optional** (telemetry/projection) stores classified; even optional failures require the explicit opt-in.

Distinct from #1185 (resume readiness stall) — this is about lying about persistence health, not startup latency.

## Verify
`npm run check`: 0 errors. 37 tests incl. fatal-before-listen + degraded `/healthz` 503 + `/auth/status` degraded + doctor (the socket-based ones the delegated worker couldn't run under sandbox EPERM, verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added degraded-startup support through the `--allow-degraded` hub option.
  * Hub health reporting now identifies disabled persistence stores and reports degraded status.
  * Health and authentication status responses include affected persistence stores.

* **Bug Fixes**
  * Persistence startup failures now provide clearer diagnostics and actionable recovery guidance.
  * Core persistence failures prevent startup unless degraded mode is enabled.

* **Tests**
  * Expanded coverage for degraded health reporting, startup failures, CLI behavior, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->