### PR TITLE
fix(channels): prioritize fresh rows over resync in WS catch-up budget (#1177)

### DIFF
--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -271,21 +271,29 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
    * Assemble rows under the byte budget. `keepEnd` chooses which side to keep
    * when the candidate set overflows: `'tail'` keeps the newest rows (full
    * snapshot — older rows scroll back), `'head'` keeps the oldest-first rows
-   * (catch-up — forward pagination fills the remainder). Always keeps ≥1 row
-   * (a single row is ≤256KB < 4MB), returning `truncated` when it stopped early.
+   * (catch-up — forward pagination fills the remainder). The normal snapshot
+   * mode keeps ≥1 row (a single row is ≤256KB < 4MB); an optional remainder
+   * mode may keep zero rows so a secondary allocation cannot exceed the shared
+   * cap. Returns `truncated` when it stopped early.
    */
   function assembleWithBudget(
     candidate: ChannelMessage[],
-    keepEnd: 'head' | 'tail'
-  ): { rows: ChannelMessage[]; truncated: boolean } {
-    if (candidate.length === 0) return { rows: [], truncated: false };
+    keepEnd: 'head' | 'tail',
+    maxBytes = snapshotMaxBytes,
+    keepFirstOverBudget = true
+  ): { rows: ChannelMessage[]; truncated: boolean; bytes: number } {
+    if (candidate.length === 0)
+      return { rows: [], truncated: false, bytes: 0 };
     const order = keepEnd === 'tail' ? [...candidate].reverse() : candidate;
     const kept: ChannelMessage[] = [];
     let bytes = 0;
     let truncated = false;
     for (const row of order) {
       const size = Buffer.byteLength(JSON.stringify(row), 'utf8') + 1;
-      if (kept.length > 0 && bytes + size > snapshotMaxBytes) {
+      if (
+        bytes + size > maxBytes &&
+        (kept.length > 0 || !keepFirstOverBudget)
+      ) {
         truncated = true;
         break;
       }
@@ -293,7 +301,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       kept.push(row);
     }
     if (keepEnd === 'tail') kept.reverse();
-    return { rows: kept, truncated };
+    return { rows: kept, truncated, bytes };
   }
 
   function buildSnapshot(
@@ -352,9 +360,26 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         cursor = page[page.length - 1]!.seq;
         if (page.length < 200) break;
       }
-      assembled = assembleWithBudget([...resync, ...fresh], 'head');
-      if (assembled.truncated && assembled.rows.length > 0) {
-        snapshotLatestSeq = assembled.rows[assembled.rows.length - 1]!.seq;
+      // Fresh rows must consume the shared budget first: skipping a fresh seq
+      // would strand the reconnect cursor behind it. Resync rows only replace
+      // known messages, so use any remainder for the rows nearest the cursor.
+      const freshAssembled = assembleWithBudget(fresh, 'head');
+      const remainingBytes = snapshotMaxBytes - freshAssembled.bytes;
+      const resyncAssembled =
+        remainingBytes > 0
+          ? assembleWithBudget(resync, 'tail', remainingBytes, false)
+          : { rows: [], truncated: resync.length > 0, bytes: 0 };
+      assembled = {
+        rows: [...resyncAssembled.rows, ...freshAssembled.rows].sort(
+          (a, b) => a.seq - b.seq
+        ),
+        truncated: freshAssembled.truncated || resyncAssembled.truncated,
+      };
+      // Only a fresh-row truncation leaves an undelivered seq above the cursor.
+      // Partial resync merely omits stale replacements and must not pull the
+      // cursor back from an otherwise complete fresh catch-up.
+      if (freshAssembled.truncated && freshAssembled.rows.length > 0) {
+        snapshotLatestSeq = freshAssembled.rows[freshAssembled.rows.length - 1]!.seq;
       }
     }
 

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -474,6 +474,191 @@ describe('channel-hub snapshot correctness', () => {
     expect(state.needsCatchup).toBe(false);
   });
 
+  it('prioritizes a fresh row over resync rows that exceed the default 4MB catch-up budget', () => {
+    const s = store();
+    const resyncText = 'r'.repeat(10 * 1024);
+    for (let index = 0; index < 500; index++) {
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: AGENT,
+        source: { sessionId: `resync-${index}` },
+        text: resyncText,
+      });
+    }
+    const sinceSeq = s.latestSeq('topic:c');
+    const fresh = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'fresh after reconnect',
+    });
+    expect(
+      Buffer.byteLength(
+        JSON.stringify(s.listResyncRows('topic:c', sinceSeq, 500)),
+        'utf8'
+      )
+    ).toBeGreaterThan(4 * 1024 * 1024);
+
+    const hub = hubWith(s); // default 4MB budget
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+
+    expect(snap.truncated).toBe(true);
+    expect(snap.messages.some((message) => message.id === fresh.id)).toBe(true);
+    expect(snap.latestSeq).toBe(fresh.seq);
+    expect(
+      snap.messages.reduce(
+        (total, message) =>
+          total + Buffer.byteLength(JSON.stringify(message), 'utf8') + 1,
+        0
+      )
+    ).toBeLessThanOrEqual(4 * 1024 * 1024);
+    let state = {
+      ...initialChannelReducerState('topic:c'),
+      lastSeq: sinceSeq,
+    };
+    state = applyChannelEventV1(state, snap);
+    expect(state.lastSeq).toBe(fresh.seq);
+    expect(state.needsCatchup).toBe(false);
+  });
+
+  it('trims resync rows nearest the cursor while emitting them in ascending sequence order', () => {
+    const s = store();
+    for (let index = 0; index < 4; index++) {
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: AGENT,
+        source: { sessionId: `resync-${index}` },
+        text: 'r'.repeat(1_000),
+      });
+    }
+    const sinceSeq = s.latestSeq('topic:c');
+    const resync = s.listResyncRows('topic:c', sinceSeq, 500);
+    const snapshotMaxBytes = resync.slice(-2).reduce(
+      (total, message) =>
+        total + Buffer.byteLength(JSON.stringify(message), 'utf8') + 1,
+      0
+    );
+    const hub = hubWith(s, { snapshotMaxBytes });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+
+    expect(snap.truncated).toBe(true);
+    expect(snap.messages.map((message) => message.seq)).toEqual([3, 4]);
+    expect(snap.latestSeq).toBe(4);
+  });
+
+  it('keeps a contiguous fresh prefix and cursor at its end when fresh rows overflow the budget', () => {
+    const s = store();
+    s.appendComplete({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'resync' },
+      text: 'resync',
+    });
+    const sinceSeq = s.latestSeq('topic:c');
+    const fresh = [0, 1, 2].map((index) =>
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: HUMAN,
+        text: `fresh-${index}-${'f'.repeat(1_000)}`,
+      })
+    );
+    const snapshotMaxBytes = fresh.slice(0, 2).reduce(
+      (total, message) =>
+        total + Buffer.byteLength(JSON.stringify(message), 'utf8') + 1,
+      0
+    );
+    const hub = hubWith(s, { snapshotMaxBytes });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+
+    expect(snap.truncated).toBe(true);
+    expect(snap.messages.map((message) => message.seq)).toEqual(
+      fresh.slice(0, 2).map((message) => message.seq)
+    );
+    expect(snap.latestSeq).toBe(fresh[1]!.seq);
+    let state = {
+      ...initialChannelReducerState('topic:c'),
+      lastSeq: sinceSeq,
+    };
+    state = applyChannelEventV1(state, snap);
+    expect(state.lastSeq).toBe(fresh[1]!.seq);
+    expect(state.needsCatchup).toBe(false);
+  });
+
+  it('keeps only fresh rows when one exactly fills the catch-up budget remainder', () => {
+    const s = store();
+    s.appendComplete({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { sessionId: 'resync' },
+      text: 'resync',
+    });
+    const sinceSeq = s.latestSeq('topic:c');
+    const fresh = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'fresh',
+    });
+    const snapshotMaxBytes =
+      Buffer.byteLength(JSON.stringify(fresh), 'utf8') + 1;
+    const hub = hubWith(s, { snapshotMaxBytes });
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+
+    expect(snap.truncated).toBe(true);
+    expect(snap.messages.map((message) => message.id)).toEqual([fresh.id]);
+    expect(
+      snap.messages.reduce(
+        (total, message) =>
+          total + Buffer.byteLength(JSON.stringify(message), 'utf8') + 1,
+        0
+      )
+    ).toBeLessThanOrEqual(snapshotMaxBytes);
+  });
+
+  it('keeps an under-budget resync plus fresh catch-up complete and ascending', () => {
+    const s = store();
+    for (let index = 0; index < 2; index++) {
+      s.appendComplete({
+        channelId: 'topic:c',
+        sender: AGENT,
+        source: { sessionId: `resync-${index}` },
+        text: `resync-${index}`,
+      });
+    }
+    const sinceSeq = s.latestSeq('topic:c');
+    s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'fresh-1' });
+    const fresh = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'fresh-2',
+    });
+    const hub = hubWith(s);
+    const sock = fakeSocket();
+    hub.handleConnection(sock, { channelId: 'topic:c', sinceSeq });
+    const snap = sock.sent[0];
+    if (snap?.type !== 'channel-snapshot-v1')
+      throw new Error('expected snapshot');
+
+    expect(snap.mode).toBe('catchup');
+    expect(snap.truncated).toBe(false);
+    expect(snap.latestSeq).toBe(fresh.seq);
+    expect(snap.messages.map((message) => message.seq)).toEqual([1, 2, 3, 4]);
+  });
+
   it('forces a full snapshot (client reset) when the cursor is ahead of the server head', () => {
     const s = store();
     for (let i = 1; i <= 3; i++) {

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -111,9 +111,16 @@ let root: Root;
 let queryClient: QueryClient;
 
 async function flush(): Promise<void> {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
+  // Drain several macrotasks per flush: resolving a mocked query promise takes
+  // a microtask to settle, then TanStack Query flips isSuccess and schedules a
+  // re-render on a later tick — a single setTimeout(0) intermittently observed
+  // the DOM before the designate control re-rendered (flaky "expected null not
+  // to be null"). A few ticks reliably drains the resolve → re-render chain.
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
 }
 
 async function render(): Promise<void> {


### PR DESCRIPTION
Closes #1177.

WS catch-up assembled `[...resync, ...fresh]` into the shared 4MB budget with `keepEnd:'head'`, so on a transcript-heavy channel where resync rows alone exceed the budget, a truncated catch-up delivered only already-known rows: `snapshotLatestSeq <= sinceSeq`, `lastSeq` never advanced, `needsCatchup` stayed false — a WS-reconnect client looped without receiving fresh rows.

**Fix** (`channel-hub` `buildSnapshot`/`assembleWithBudget`): fresh rows (`seq > sinceSeq`) consume the budget **first** so `lastSeq` always advances; resync retains the **nearest-cursor** rows from the remainder; output stays sequence-ascending.

**Verify:** `npm run check` 0 errors; 5 new starvation/trim tests + 51 channel-hub/store tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)