### PR TITLE
fix(startup): yield event loop during session resume so HTTP is served (#1185)

### DIFF
--- a/server/health.ts
+++ b/server/health.ts
@@ -12,6 +12,17 @@ export interface HealthMemorySnapshot {
   external: number;
 }
 
+/**
+ * Progress for work that begins only after the HTTP listener is available.
+ * Health reports this informationally; it never changes the health status.
+ */
+export interface ResumeReadiness {
+  inProgress: boolean;
+  complete: boolean;
+  restored: number;
+  failed: boolean;
+}
+
 export interface HealthMonitor {
   handler: RequestHandler;
   getLagMs(): number;
@@ -28,6 +39,8 @@ export interface HealthMonitorOptions {
   memoryUsage?: () => NodeJS.MemoryUsage;
   monotonicNow?: () => number;
   logger?: Logger;
+  /** Optional post-listen session-resume progress owned by server startup. */
+  getResumeReadiness?: () => ResumeReadiness;
 }
 
 const healthLogger = createLogger('health');
@@ -92,11 +105,13 @@ export function createHealthMonitor(
     const lagMs = Math.round(getLagMs());
     const { rss } = readHealthMemorySnapshot(memoryUsage);
     const healthy = lagMs <= lagThresholdMs && disabledStores.length === 0;
+    const resume = options.getResumeReadiness?.();
     res.status(healthy ? 200 : 503).json({
       status: healthy ? 'ok' : 'degraded',
       lagMs,
       rss,
       ...(disabledStores.length > 0 ? { disabledStores } : {}),
+      ...(resume ? { ready: resume.complete, resume } : {}),
     });
   };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -2127,8 +2127,17 @@ async function main(): Promise<void> {
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
   });
+  // Session resume starts after the listener is bound. Keep this separate from
+  // health status: callers can observe readiness without making /healthz wait.
+  const startupResume = {
+    inProgress: false,
+    complete: false,
+    restored: 0,
+    failed: false,
+  };
   const healthMonitor = createHealthMonitor({
     disabledStores: persistenceState.disabledStores,
+    getResumeReadiness: () => startupResume,
   });
   app.get('/healthz', healthMonitor.handler);
 
@@ -6437,6 +6446,7 @@ async function main(): Promise<void> {
       ? (positiveIntegerEnv('RELAY_IDE_TEST_STARTUP_RESTORE_HOLD_MS') ?? 0)
       : 0;
   async function restoreStartupSessions(): Promise<number> {
+    startupResume.inProgress = true;
     if (testStartupRestoreHoldMs > 0) {
       await new Promise<void>((resolve) =>
         setTimeout(resolve, testStartupRestoreHoldMs)
@@ -6456,6 +6466,9 @@ async function main(): Promise<void> {
     restoreStartupSessions,
     {
       restored: (restoredCount) => {
+        startupResume.inProgress = false;
+        startupResume.complete = true;
+        startupResume.restored = restoredCount;
         if (restoredCount === 0) return;
         logger.info(
           `Restored ${restoredCount} session(s) from previous update.`
@@ -6465,6 +6478,9 @@ async function main(): Promise<void> {
         }
       },
       failed: (err) => {
+        startupResume.inProgress = false;
+        startupResume.complete = true;
+        startupResume.failed = true;
         logger.error(
           'Background session restore failed:',
           err instanceof Error ? err.message : String(err)

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -18,7 +18,8 @@ let db: Database.Database | null = null;
 let upsertWebStmt: Database.Statement | null = null;
 let deleteWebStmt: Database.Statement | null = null;
 let markStatusStmt: Database.Statement | null = null;
-let loadAllWebStmt: Database.Statement | null = null;
+let loadWebSessionIdsStmt: Database.Statement | null = null;
+let loadWebSessionByIdStmt: Database.Statement | null = null;
 let reapCandidatesStmt: Database.Statement | null = null;
 let maintenanceTimer: NodeJS.Timeout | null = null;
 /**
@@ -140,6 +141,23 @@ export interface LoadedWebSessionRow {
   status: 'active' | 'disconnected' | 'archived';
 }
 
+interface StoredWebSessionRow {
+  id: string;
+  vendor: string;
+  vendor_session_id: string | null;
+  cwd: string;
+  repo_path: string | null;
+  worktree_path: string | null;
+  branch_name: string | null;
+  display_name: string | null;
+  workspace_id: string | null;
+  agent_session_v2_json: string;
+  meta_json: string;
+  created_at: number;
+  last_activity: number;
+  status: 'active' | 'disconnected' | 'archived';
+}
+
 export function initRelayStateDb(configDir: string): void {
   if (db) closeRelayStateDb();
 
@@ -202,13 +220,18 @@ export function initRelayStateDb(configDir: string): void {
   // with a new providerSession) and orphaned direct sessions past the cap. The
   // per-session transcript cap already bounds each row's memory; total row count
   // is bounded instead by the age-reaper below.
-  loadAllWebStmt = db.prepare(
+  loadWebSessionIdsStmt = db.prepare(
+    `SELECT id
+     FROM web_sessions
+     WHERE status != 'archived'
+     ORDER BY last_activity ASC`
+  );
+  loadWebSessionByIdStmt = db.prepare(
     `SELECT id, vendor, vendor_session_id, cwd, repo_path, worktree_path,
             branch_name, display_name, workspace_id, agent_session_v2_json,
             meta_json, created_at, last_activity, status
      FROM web_sessions
-     WHERE status != 'archived'
-     ORDER BY last_activity ASC`
+     WHERE id = ? AND status != 'archived'`
   );
   reapCandidatesStmt = db.prepare(
     `SELECT id FROM web_sessions
@@ -335,7 +358,8 @@ export function closeRelayStateDb(): void {
     upsertWebStmt = null;
     deleteWebStmt = null;
     markStatusStmt = null;
-    loadAllWebStmt = null;
+    loadWebSessionIdsStmt = null;
+    loadWebSessionByIdStmt = null;
     reapCandidatesStmt = null;
   }
 }
@@ -532,28 +556,22 @@ export function markWebSessionStatus(
   }
 }
 
-export function loadAllWebSessions(): LoadedWebSessionRow[] {
-  if (!db || !loadAllWebStmt) return [];
+/**
+ * Snapshot the established restore order as lightweight IDs, then load and
+ * deserialize each full row separately. The individual SELECT completes before
+ * yielding, so resume may persist a row or close the DB between sessions.
+ */
+export function* iterateWebSessions(): IterableIterator<LoadedWebSessionRow> {
+  if (!db || !loadWebSessionIdsStmt) return;
 
-  const rows = loadAllWebStmt.all() as Array<{
-    id: string;
-    vendor: string;
-    vendor_session_id: string | null;
-    cwd: string;
-    repo_path: string | null;
-    worktree_path: string | null;
-    branch_name: string | null;
-    display_name: string | null;
-    workspace_id: string | null;
-    agent_session_v2_json: string;
-    meta_json: string;
-    created_at: number;
-    last_activity: number;
-    status: 'active' | 'disconnected' | 'archived';
-  }>;
-
-  const out: LoadedWebSessionRow[] = [];
-  for (const row of rows) {
+  const ids = loadWebSessionIdsStmt.all() as Array<{ id: string }>;
+  for (const { id } of ids) {
+    // The generator can be paused after yielding a row. Do not use a prepared
+    // statement after a shutdown has cleared it.
+    const row = loadWebSessionByIdStmt?.get(id) as
+      | StoredWebSessionRow
+      | undefined;
+    if (!row) continue;
     try {
       // Cap the parsed blob before it is cloned into the live session (#1243).
       // A row persisted before this fix landed can still be the observed 14.9MB
@@ -564,7 +582,7 @@ export function loadAllWebSessions(): LoadedWebSessionRow[] {
         JSON.parse(row.agent_session_v2_json) as AgentSessionV2
       );
       const meta = JSON.parse(row.meta_json) as WebSessionMeta;
-      out.push({
+      yield {
         id: row.id,
         vendor: row.vendor,
         vendorSessionId: row.vendor_session_id,
@@ -579,12 +597,15 @@ export function loadAllWebSessions(): LoadedWebSessionRow[] {
         createdAt: row.created_at,
         lastActivity: row.last_activity,
         status: row.status,
-      });
+      };
     } catch (err) {
       logger.warn('failed to parse row %s: %s', row.id, err);
     }
   }
-  return out;
+}
+
+export function loadAllWebSessions(): LoadedWebSessionRow[] {
+  return Array.from(iterateWebSessions());
 }
 
 function pickVendorSessionId(session: AgentSessionV2): string | null {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -33,7 +33,7 @@ import {
   type CreateWebParams,
 } from './web-session-handler.js';
 import {
-  loadAllWebSessions,
+  iterateWebSessions,
   deleteWebSession,
   upsertWebSessionNow,
 } from './relay-state-db.js';
@@ -120,6 +120,11 @@ import {
 } from './orchestrator-credential-lifecycle.js';
 
 const logger = createLogger('sessions');
+
+/** Let pending HTTP, socket, and I/O callbacks run between cold-resume units. */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 // ── Global scrollback cap ──────────────────────────────────────────────────────
 
@@ -1958,10 +1963,10 @@ function readPendingSessionsFile(
   }
 }
 
-function migrateV2ToV3(
+async function migrateV2ToV3(
   sessions: SerializedPtySession[],
   workspaces: string[]
-): void {
+): Promise<void> {
   for (const s of sessions) {
     const raw = s as unknown as RawV2Session;
     // In v2 format, the field was called "repoPath" and stored the CWD
@@ -1994,10 +1999,13 @@ function migrateV2ToV3(
     // Clean up legacy fields (repoPath is now kept as it's our real field)
     delete raw.root;
     delete raw.worktreeName;
+    await yieldToEventLoop();
   }
 }
 
-function migrateV3ToV4(sessions: SerializedPtySession[]): void {
+async function migrateV3ToV4(
+  sessions: SerializedPtySession[]
+): Promise<void> {
   // v3 → v4 migration: workspacePath → repoPath
   // NOTE: This block also fires for v1/v2 files, but is a no-op for them because
   // the v2→v3 block above already sets `repoPath`, so the `!('repoPath' in s)`
@@ -2008,6 +2016,7 @@ function migrateV3ToV4(sessions: SerializedPtySession[]): void {
       (legacy as unknown as RawV2Session).repoPath = legacy.workspacePath;
       delete legacy.workspacePath;
     }
+    await yieldToEventLoop();
   }
 }
 
@@ -2623,12 +2632,13 @@ function withPendingSince(
   };
 }
 
-function migratePendingSessionsFile(
+async function migratePendingSessionsFile(
   pending: PendingSessionsFile,
   workspaces?: string[]
-): void {
-  if (pending.version <= 2) migrateV2ToV3(pending.sessions, workspaces ?? []);
-  if (pending.version <= 3) migrateV3ToV4(pending.sessions);
+): Promise<void> {
+  if (pending.version <= 2)
+    await migrateV2ToV3(pending.sessions, workspaces ?? []);
+  if (pending.version <= 3) await migrateV3ToV4(pending.sessions);
 }
 
 async function tryRestorePtySession(
@@ -2677,13 +2687,17 @@ async function restoreFreshPendingSessions(
   workspaces?: string[],
   frameworks?: Record<string, Partial<AgentFramework>>
 ): Promise<number> {
-  migratePendingSessionsFile(pending, workspaces);
+  await migratePendingSessionsFile(pending, workspaces);
   const failedSessions: SerializedPtySession[] = [];
   const scrollbackDirPath = scrollbackDir(configDir);
   let restored = 0;
   const unsupportedTmuxSessions: SerializedPtySession[] = [];
 
   for (const s of pending.sessions) {
+    // Yield before each restore unit rather than after it. This gives HTTP/I/O
+    // a turn between sessions without delaying restoreFromDisk's result after
+    // the final child has been created.
+    await yieldToEventLoop();
     const removedTmuxReason = removedTmuxBackendReason(s, pending.version);
     if (removedTmuxReason) {
       logger.warn(
@@ -2748,9 +2762,13 @@ async function restorePendingSessionsFromDisk(
     configDir
   );
 
-  const freshSessions = pending.sessions
-    .filter((session) => !isPendingSessionStale(pending, session))
-    .map((session) => withPendingSince(pending, session));
+  const freshSessions: SerializedPtySession[] = [];
+  for (const session of pending.sessions) {
+    if (!isPendingSessionStale(pending, session)) {
+      freshSessions.push(withPendingSince(pending, session));
+    }
+    await yieldToEventLoop();
+  }
   const staleSessionCount = pending.sessions.length - freshSessions.length;
   if (freshSessions.length === 0) {
     logger.warn(
@@ -2792,11 +2810,15 @@ async function restoreWebSessionsFromDb(
   // Web sessions live in relay-state.db. Rows persist until the user archives or
   // closes the session, OR until the relay-state-db age-reaper (#1248) evicts a
   // row idle past its retention window — but never one that is live in-memory or
-  // still bound to an open channel, so resume anchors survive. loadAllWebSessions
+  // still bound to an open channel, so resume anchors survive. iterateWebSessions
   // restores ALL non-archived rows (no restore cap); the reaper bounds count.
-  for (const row of loadAllWebSessions()) {
-    if (webSessionRestoreShutdown) break;
+  for (const row of iterateWebSessions()) {
+    // Rows are parsed one at a time. Yield before their synchronous
+    // materialization, but never after the final row so a just-restored child
+    // remains observable when the restore promise resolves.
+    await yieldToEventLoop();
     try {
+      if (webSessionRestoreShutdown) break;
       await restoreWebSessionFromDb(row, reattachTimeoutMs);
       restored++;
     } catch (err) {
@@ -2816,6 +2838,10 @@ async function restoreFromDisk(
   options: RestoreFromDiskOptions = {}
 ): Promise<number> {
   webSessionRestoreShutdown = false;
+  // Startup restore is detached after `listening`, but an async function still
+  // executes synchronously until its first await. Yield before manifest/DB work
+  // so the listener can return to the event loop before any cold-resume burst.
+  await yieldToEventLoop();
   const restoredPty = await restorePendingSessionsFromDisk(
     configDir,
     workspaces,

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -111,9 +111,16 @@ let root: Root;
 let queryClient: QueryClient;
 
 async function flush(): Promise<void> {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
+  // Drain several macrotasks per flush: resolving a mocked query promise takes
+  // a microtask to settle, then TanStack Query flips isSuccess and schedules a
+  // re-render on a later tick — a single setTimeout(0) intermittently observed
+  // the DOM before the designate control re-rendered (flaky "expected null not
+  // to be null"). A few ticks reliably drains the resolve → re-render chain.
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
 }
 
 async function render(): Promise<void> {

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -294,6 +294,13 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
       status: 'ok',
       lagMs: expect.any(Number),
       rss: expect.any(Number),
+      ready: expect.any(Boolean),
+      resume: {
+        inProgress: expect.any(Boolean),
+        complete: expect.any(Boolean),
+        restored: expect.any(Number),
+        failed: expect.any(Boolean),
+      },
     });
 
     // Hit GET /auth/status — should work without auth
@@ -411,7 +418,16 @@ test('real server listens before a hanging serialized-session restore', async ()
       fetch(`${baseUrl}/auth/status`),
     ]);
     expect(health.status).toBe(200);
-    await expect(health.json()).resolves.toMatchObject({ status: 'ok' });
+    await expect(health.json()).resolves.toMatchObject({
+      status: 'ok',
+      ready: false,
+      resume: {
+        inProgress: true,
+        complete: false,
+        restored: 0,
+        failed: false,
+      },
+    });
     expect(authStatus.status).toBe(200);
     await expect(authStatus.json()).resolves.toEqual({ hasPIN: true });
     // The real startup restore function is still held. This proves both public
@@ -449,6 +465,18 @@ test('real server listens before a hanging serialized-session restore', async ()
         'Restored 1 session(s) from previous update.'
       )
     );
+    const resumedHealth = await fetch(`${baseUrl}/healthz`);
+    expect(resumedHealth.status).toBe(200);
+    await expect(resumedHealth.json()).resolves.toMatchObject({
+      status: 'ok',
+      ready: true,
+      resume: {
+        inProgress: false,
+        complete: true,
+        restored: 1,
+        failed: false,
+      },
+    });
     const listeningAt = output
       .stdout()
       .indexOf('relay-ide listening on 127.0.0.1:');

--- a/test/server/relay-state-db.test.ts
+++ b/test/server/relay-state-db.test.ts
@@ -9,6 +9,7 @@ import {
   upsertWebSessionNow,
   scheduleWebSessionUpsert,
   flushAllPendingWrites,
+  iterateWebSessions,
   loadAllWebSessions,
   deleteWebSession,
   markWebSessionStatus,
@@ -117,6 +118,46 @@ describe('relay-state-db', () => {
     const rows = loadAllWebSessions();
     expect(rows).toHaveLength(1);
     expect(rows[0]!.displayName).toBe('Renamed');
+  });
+
+  it('snapshots restore IDs without holding a SQLite cursor between rows', () => {
+    for (let i = 0; i < 3; i++) {
+      upsertWebSessionNow(
+        fakeWebSession({
+          id: `iter-${i}`,
+          displayName: `Before ${i}`,
+          lastActivity: new Date(
+            Date.parse('2026-04-29T00:00:00Z') + i * 1000
+          ).toISOString(),
+        })
+      );
+    }
+
+    const iterator = iterateWebSessions();
+    const first = iterator.next();
+    expect(first.value?.id).toBe('iter-0');
+
+    // A write must complete while the iterator is paused; the remaining row is
+    // fetched by ID only after the write, not from a long-lived SQLite cursor.
+    upsertWebSessionNow(
+      fakeWebSession({
+        id: 'iter-1',
+        displayName: 'Updated between rows',
+        lastActivity: new Date('2026-04-29T00:00:01Z').toISOString(),
+      })
+    );
+    const remaining = Array.from(iterator);
+    expect([first.value, ...remaining].map((row) => row!.id)).toEqual([
+      'iter-0',
+      'iter-1',
+      'iter-2',
+    ]);
+    expect(remaining[0]!.displayName).toBe('Updated between rows');
+
+    const closeIterator = iterateWebSessions();
+    expect(closeIterator.next().value?.id).toBe('iter-0');
+    expect(() => closeRelayStateDb()).not.toThrow();
+    expect(closeIterator.next().done).toBe(true);
   });
 
   it('debounces scheduled upserts and flushes on demand', async () => {

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
@@ -57,6 +58,10 @@ const refreshRuntimeEnv = vi.fn();
 let supportsRuntimeEnvRefresh = true;
 let emitBlankSnapshotOnConnect = false;
 let emitPatchOnDisconnect: AgentPatchV2 | undefined;
+let syncRestoreHoldMs = 0;
+let onAdapterCreated: (() => void) | undefined;
+const restoreHoldSignal = new Int32Array(new SharedArrayBuffer(4));
+const servers: http.Server[] = [];
 
 class RestoreFailureAdapter implements ProtocolAdapterV2 {
   readonly agentType = 'claude';
@@ -130,6 +135,9 @@ const createdAdapters: RestoreFailureAdapter[] = [];
 
 vi.mock('../server/relay-state-db.js', () => ({
   loadAllWebSessions,
+  iterateWebSessions: function* () {
+    yield* loadAllWebSessions();
+  },
   upsertWebSessionNow,
   deleteWebSession,
   scheduleWebSessionUpsert,
@@ -139,6 +147,10 @@ vi.mock('../server/protocol-adapters/index.js', () => ({
   createAdapterV2: () => {
     latestAdapter = new RestoreFailureAdapter();
     createdAdapters.push(latestAdapter);
+    onAdapterCreated?.();
+    if (syncRestoreHoldMs > 0) {
+      Atomics.wait(restoreHoldSignal, 0, 0, syncRestoreHoldMs);
+    }
     return latestAdapter;
   },
 }));
@@ -170,6 +182,38 @@ function restoredOrchestratorCredential(
   };
 }
 
+function restoredWebRow(id: string, configDir: string): LoadedWebSessionRow {
+  return {
+    id,
+    vendor: 'claude',
+    vendorSessionId: `provider-${id}`,
+    cwd: configDir,
+    repoPath: configDir,
+    worktreePath: null,
+    branchName: 'feature/resume-yield',
+    displayName: `Restored ${id}`,
+    workspaceId: null,
+    agentSessionV2: emptyAgentSessionV2({
+      id,
+      provider: 'claude',
+      cwd: configDir,
+      capabilities,
+      providerSession: { claudeSessionId: `provider-${id}` },
+    }),
+    meta: {
+      type: 'agent',
+      agent: 'claude',
+      customCommand: null,
+      runtimeOwnership: 'attached',
+      hookToken: `hook-${id}`,
+      adapterType: 'claude',
+    },
+    createdAt: Date.now() - 10_000,
+    lastActivity: Date.now() - 5_000,
+    status: 'active',
+  };
+}
+
 describe('web session restore failure recovery', () => {
   let configDir: string;
 
@@ -191,6 +235,8 @@ describe('web session restore failure recovery', () => {
     createdAdapters.length = 0;
     emitBlankSnapshotOnConnect = false;
     emitPatchOnDisconnect = undefined;
+    syncRestoreHoldMs = 0;
+    onAdapterCreated = undefined;
   });
 
   afterEach(async () => {
@@ -202,7 +248,82 @@ describe('web session restore failure recovery', () => {
         /* ignore */
       }
     }
+    await Promise.all(
+      servers.splice(0).map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve()))
+      )
+    );
     fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('serves HTTP between slow restored web sessions', async () => {
+    loadAllWebSessions.mockReturnValueOnce(
+      ['resume-yield-1', 'resume-yield-2', 'resume-yield-3'].map((id) =>
+        restoredWebRow(id, configDir)
+      )
+    );
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+
+    let complete = false;
+    let resolveFirstResponse:
+      | ((value: { status: number; ready: boolean }) => void)
+      | undefined;
+    let rejectFirstResponse: ((reason: unknown) => void) | undefined;
+    const firstResponse = new Promise<{ status: number; ready: boolean }>(
+      (resolve, reject) => {
+        resolveFirstResponse = resolve;
+        rejectFirstResponse = reject;
+      }
+    );
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ ready: complete }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('test server did not bind an address');
+    }
+
+    syncRestoreHoldMs = 25;
+    onAdapterCreated = () => {
+      if (createdAdapters.length !== 1) return;
+      void fetch(`http://127.0.0.1:${String(address.port)}/healthz`)
+        .then(async (response) => {
+          resolveFirstResponse?.({
+            status: response.status,
+            ready: (await response.json() as { ready: boolean }).ready,
+          });
+        })
+        .catch(rejectFirstResponse);
+    };
+    const restoring = sessions.restoreFromDisk(configDir).then((restored) => {
+      complete = true;
+      return restored;
+    });
+
+    const response = await firstResponse;
+    expect(response.status).toBe(200);
+    // The server handler ran while restore was still in flight and reported
+    // ready:false — the deterministic proof that resume did not starve the event
+    // loop. (We intentionally do NOT assert `complete===false` here: resume may
+    // legitimately finish while the response is still in transit back to the
+    // client, so that check races resume completion without adding coverage —
+    // response.ready captured the in-flight state at handler time.)
+    expect(response.ready).toBe(false);
+    await expect(restoring).resolves.toBe(3);
+    expect(createdAdapters).toHaveLength(3);
+
+    const completedResponse = await fetch(
+      `http://127.0.0.1:${String(address.port)}/healthz`
+    );
+    await expect(completedResponse.json()).resolves.toEqual({ ready: true });
   });
 
   it('restores persisted web metadata and surfaces resume failure as recoverable session state', async () => {


### PR DESCRIPTION
Closes #1185.

After a restart with resumable sessions the hub logged `listening` but hung connections for ~60-70s while `restoreFromDisk` ran the per-session restore loop synchronously, **starving the single event loop** until it finished (worse with more sessions). Resume already ran post-listen + detached, but the loop itself was blocked.

## Fix
- **`restoreFromDisk`** yields via `setImmediate` before startup work and before each PTY/web restore unit — HTTP handlers interleave between units.
- **`iterateWebSessions`** snapshots ordered ids then loads one row per unit — no SQLite cursor held across yields/upserts/shutdown.
- **`/healthz`** reports `ready` + `resume:{inProgress,complete,restored,failed}` and never waits for resume; existing status codes unchanged.
- Preserves the post-listen invariant + `RELAY_IDE_TEST_STARTUP_RESTORE_HOLD_MS`.

## Verify
`npm run check` 0 errors. 44 tests — interleave proof (`/healthz` handler runs mid-resume, `response.ready===false`, 8/8 stable), cursor-snapshot, listens-before-hanging-restore readiness. (The delegated worker couldn't run the socket-bound tests under sandbox EPERM; verified locally + corrected a redundant/racy `complete===false` assertion it shipped.)

Also carries a small **de-flake** of `channel-view-orchestrator.test.ts` (drain re-render ticks) that was reddening CI on every PR (`expected null not to be null`, ~2/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-resume readiness details to health responses, including progress, completion, restored count, and failure status.
  * Health endpoints now indicate when startup session restoration is complete.

* **Performance**
  * Improved server responsiveness during startup by allowing HTTP requests to be handled between restoration tasks.
  * Enhanced session restoration to process data incrementally and skip invalid records safely.

* **Bug Fixes**
  * Improved reliability of session restoration while data changes or the database closes during processing.

* **Tests**
  * Added coverage for readiness transitions, responsive health checks, and incremental session restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->