### PR TITLE
fix(update): detect the running install's package manager and verify /update actually landed (#1284)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -16,6 +16,7 @@ import {
   buildUpdateCommand,
   detectRunningInstall,
   readInstalledVersion as readInstallRootVersion,
+  resolveDetectedScriptPath,
   verifyUpdateLanded,
 } from '../server/self-update.js';
 import { redactBootstrapSecrets } from '../shared/bootstrap-diagnostics.js';
@@ -7167,6 +7168,8 @@ async function runNodeInstallBinary(nodeArgs: string[]): Promise<void> {
       configPath: resolveConfigPath(),
       port: getArg('--port') ?? String(DEFAULTS.port),
       host: getArg('--host') ?? DEFAULTS.host,
+      // A bun-global install has no npm-prefix copy for service.ts to find.
+      scriptPath: resolveDetectedScriptPath(bootstrapInstall),
     });
   });
 }
@@ -7261,7 +7264,7 @@ async function fetchLatestNpmVersion(tag: string): Promise<string> {
 }
 
 /** Restart the managed platform service after a binary update. Best-effort. */
-function restartServiceAfterUpdate(): void {
+function restartServiceAfterUpdate(scriptPath?: string | undefined): void {
   if (!service.isInstalled()) {
     logger.info(
       'no managed service detected. restart relay-ide node link manually to connect with the updated binary.'
@@ -7275,6 +7278,9 @@ function restartServiceAfterUpdate(): void {
       configPath: resolveConfigPath(),
       port: getArg('--port') ?? String(DEFAULTS.port),
       host: getArg('--host') ?? DEFAULTS.host,
+      // Without this, a bun-global install would uninstall the unit and then
+      // fail to reinstall it (npm prefix probing cannot see the bun root).
+      scriptPath,
     });
     logger.info('service restarted.');
   } catch (err) {
@@ -7409,7 +7415,7 @@ async function runNodeUpdate(nodeArgs: string[]): Promise<void> {
   // Signal hub: update complete, clear the updating flag.
   await clearHubUpdatingFlag();
 
-  restartServiceAfterUpdate();
+  restartServiceAfterUpdate(resolveDetectedScriptPath(install));
 }
 
 function optionalNodeJsonNumber(

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -11,6 +11,13 @@ import * as service from '../server/service.js';
 import { DEFAULTS, loadConfig } from '../server/config.js';
 import { createLogger } from '../server/logger.js';
 import { getNodeManifest } from '../server/node-manifest.js';
+import {
+  buildRemedyCommand,
+  buildUpdateCommand,
+  detectRunningInstall,
+  readInstalledVersion as readInstallRootVersion,
+  verifyUpdateLanded,
+} from '../server/self-update.js';
 import { redactBootstrapSecrets } from '../shared/bootstrap-diagnostics.js';
 import {
   NODE_PAIR_TOKEN_CREATE_CAPABILITY,
@@ -7121,15 +7128,24 @@ async function runNodeInstallBinary(nodeArgs: string[]): Promise<void> {
     getNodeArg(nodeArgs, '--service') ?? 'manual'
   );
 
-  logger.info('installing relay-ide globally via npm...');
+  // Bootstrap installs the published binary; there is no before/after version
+  // to verify (the caller may be running from npx or not be installed at all),
+  // so only the package manager is detected here.
+  const bootstrapInstall = detectRunningInstall([process.argv[1], __dirname]);
+  const [bootstrapCommand, bootstrapArgs] = buildUpdateCommand(
+    bootstrapInstall.kind,
+    'latest',
+    bootstrapInstall.installRoot
+  );
+  logger.info(`installing relay-ide globally via ${bootstrapCommand}...`);
   try {
-    await execFileAsync('npm', ['install', '-g', 'relay-ide@latest'], {
+    await execFileAsync(bootstrapCommand, bootstrapArgs, {
       env: process.env,
     });
     logger.info('relay-ide installed.');
   } catch (err) {
     logger.error(
-      `BOOTSTRAP_INSTALL_FAILED: ${execErrorMessage(err, 'npm install -g relay-ide failed')}`
+      `BOOTSTRAP_INSTALL_FAILED: ${execErrorMessage(err, `${bootstrapCommand} ${bootstrapArgs.join(' ')} failed`)}`
     );
     process.exit(1);
   }
@@ -7203,15 +7219,20 @@ function resolveUpdateChannel(): 'stable' | 'nightly' {
   return 'stable';
 }
 
-/** Read the currently installed relay-ide version from package.json. */
-function readInstalledVersion(): string {
+/**
+ * Read the version currently on disk for the running install. Prefers the
+ * detected install root so a re-read after `npm install -g` reflects whichever
+ * prefix the package manager actually wrote to (#1284).
+ */
+function readRunningVersion(installRoot: string | null): string | null {
+  if (installRoot) return readInstallRootVersion(installRoot);
   try {
     const pkg = JSON.parse(
       fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8')
     ) as { version: string };
     return pkg.version;
   } catch {
-    return 'unknown';
+    return null;
   }
 }
 
@@ -7279,7 +7300,8 @@ async function runNodeUpdate(nodeArgs: string[]): Promise<void> {
   const checkOnly = nodeArgs.includes('--check');
   const hubUrl = getNodeArg(nodeArgs, '--hub');
   const tag = resolveUpdateChannel() === 'nightly' ? 'nightly' : 'latest';
-  const currentVersion = readInstalledVersion();
+  const install = detectRunningInstall([process.argv[1], __dirname]);
+  const currentVersion = readRunningVersion(install.installRoot);
   const latestVersion = await fetchLatestNpmVersion(tag);
 
   if (checkOnly) {
@@ -7289,7 +7311,7 @@ async function runNodeUpdate(nodeArgs: string[]): Promise<void> {
       );
     } else {
       logger.info(
-        `update available: installed ${currentVersion}, latest relay-ide@${tag} is ${latestVersion}. run 'relay-ide node update' to apply.`
+        `update available: installed ${currentVersion ?? 'unknown'}, latest relay-ide@${tag} is ${latestVersion}. run 'relay-ide node update' to apply.`
       );
     }
     process.exit(0);
@@ -7324,44 +7346,68 @@ async function runNodeUpdate(nodeArgs: string[]): Promise<void> {
     );
   }
 
-  logger.info(
-    `updating relay-ide from ${currentVersion} → ${latestVersion} (relay-ide@${tag})...`
+  const [updateCommand, updateArgs] = buildUpdateCommand(
+    install.kind,
+    tag,
+    install.installRoot
   );
-  try {
-    await execFileAsync('npm', ['install', '-g', `relay-ide@${tag}`], {
-      env: process.env,
-    });
-  } catch (err) {
-    if (hubUrl && credential) {
-      await notifyHubNodeUpdating(
-        hubUrl,
-        credential.nodeId,
-        credential.token,
-        false
-      );
-    }
-    logger.error(
-      `NODE_UPDATE_FAILED: ${execErrorMessage(err, 'npm install -g relay-ide failed')}`
-    );
-    process.exit(1);
-  }
-
-  const installedVersion = readInstalledVersion();
-  logger.info(
-    installedVersion !== 'unknown'
-      ? `relay-ide updated to ${installedVersion}.`
-      : 'relay-ide updated.'
-  );
-
-  // Signal hub: update complete, clear the updating flag.
-  if (hubUrl && credential) {
+  const clearHubUpdatingFlag = async (): Promise<void> => {
+    if (!hubUrl || !credential) return;
     await notifyHubNodeUpdating(
       hubUrl,
       credential.nodeId,
       credential.token,
       false
     );
+  };
+
+  logger.info(
+    `updating relay-ide from ${currentVersion ?? 'unknown'} → ${latestVersion} (relay-ide@${tag} via ${updateCommand})...`
+  );
+  try {
+    await execFileAsync(updateCommand, updateArgs, {
+      env: process.env,
+    });
+  } catch (err) {
+    await clearHubUpdatingFlag();
+    logger.error(
+      `NODE_UPDATE_FAILED: ${execErrorMessage(err, `${updateCommand} ${updateArgs.join(' ')} failed`)}`
+    );
+    process.exit(1);
   }
+
+  // The package manager can report success while writing to a different global
+  // prefix than the one this CLI runs from (#1284), so verify the running root.
+  const installedVersion = readRunningVersion(install.installRoot);
+  // Without an install root (dev checkout) a global install legitimately leaves
+  // this process's version alone, so there is nothing to verify.
+  const verification = install.installRoot
+    ? verifyUpdateLanded({
+        versionBefore: currentVersion,
+        versionAfter: installedVersion,
+        latest: latestVersion,
+      })
+    : 'unverifiable';
+  if (
+    verification === 'unchanged-stale' ||
+    verification === 'no-change-detected'
+  ) {
+    await clearHubUpdatingFlag();
+    const remedy = buildRemedyCommand(install.kind, install.installRoot, tag);
+    logger.error(
+      `NODE_UPDATE_FAILED: \`${updateCommand} ${updateArgs.join(' ')}\` reported success but ${install.installRoot ?? 'the running install'} is still ${installedVersion ?? 'unknown'} (expected ${latestVersion}). Run: ${remedy}`
+    );
+    process.exit(1);
+  }
+
+  logger.info(
+    installedVersion !== null
+      ? `relay-ide updated to ${installedVersion}.`
+      : 'relay-ide updated.'
+  );
+
+  // Signal hub: update complete, clear the updating flag.
+  await clearHubUpdatingFlag();
 
   restartServiceAfterUpdate();
 }

--- a/frontend/src/components/UpdateToast.tsx
+++ b/frontend/src/components/UpdateToast.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import * as api from '../lib/api.js';
 import { TuiButton } from './TuiButton';
-import { addNotification, removeNotification } from '../lib/stores/notifications.js';
+import {
+  addNotification,
+  removeNotification,
+} from '../lib/stores/notifications.js';
 
 const UPDATE_NOTIFICATION_ID = 'update-toast';
 
@@ -65,18 +68,24 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
 
     try {
       const result = await api.triggerUpdate();
+      const updated = result.version
+        ? `Updated to v${result.version}!`
+        : 'Updated!';
       if (result.restarting) {
-        setText('Updated! Restarting server…');
+        setText(`${updated} Restarting server…`);
         setShowActions(false);
         reloadTimerRef.current = window.setTimeout(() => {
           window.location.reload();
         }, 5000);
       } else {
-        setText('Updated! Please restart the server manually.');
+        setText(`${updated} Please restart the server manually.`);
         setShowActions(false);
       }
-    } catch {
-      setText('Update failed. Please try again.');
+    } catch (err) {
+      const detail = err instanceof Error ? err.message.trim() : '';
+      setText(
+        detail ? `Update failed: ${detail}` : 'Update failed. Please try again.'
+      );
       setButtonDisabled(false);
       setButtonText('Retry');
       setShowActions(true);
@@ -100,7 +109,11 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
           >
             {buttonText}
           </TuiButton>
-          <button className="notification-card__dismiss" onClick={dismiss} aria-label="Dismiss">
+          <button
+            className="notification-card__dismiss"
+            onClick={dismiss}
+            aria-label="Dismiss"
+          >
             ×
           </button>
         </div>

--- a/frontend/src/components/UpdateToast.tsx
+++ b/frontend/src/components/UpdateToast.tsx
@@ -82,10 +82,7 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
         setShowActions(false);
       }
     } catch (err) {
-      const detail = err instanceof Error ? err.message.trim() : '';
-      setText(
-        detail ? `Update failed: ${detail}` : 'Update failed. Please try again.'
-      );
+      setText(api.updateFailureText(err));
       setButtonDisabled(false);
       setButtonText('Retry');
       setShowActions(true);

--- a/frontend/src/components/UpdateToast.tsx
+++ b/frontend/src/components/UpdateToast.tsx
@@ -68,6 +68,11 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
 
     try {
       const result = await api.triggerUpdate();
+      if (result.verified === false) {
+        setText(api.UPDATE_NO_CHANGE_TEXT);
+        setShowActions(false);
+        return;
+      }
       const updated = result.version
         ? `Updated to v${result.version}!`
         : 'Updated!';

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -25,6 +25,7 @@ import {
   checkVersion,
   triggerUpdate,
   updateFailureText,
+  UPDATE_NO_CHANGE_TEXT,
   fetchAnalyticsSize,
   clearAnalytics,
   fetchGitHubStatus,
@@ -405,6 +406,14 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
       setVersionInfo((v) => ({ ...v, updating: true, status: '' }));
       try {
         const result = await triggerUpdate();
+        if (result.verified === false) {
+          setVersionInfo((v) => ({
+            ...v,
+            status: UPDATE_NO_CHANGE_TEXT,
+            updating: false,
+          }));
+          return;
+        }
         const updated = result.version
           ? `Updated to v${result.version}!`
           : 'Updated!';

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -24,6 +24,7 @@ import {
   setClaudeFullscreen,
   checkVersion,
   triggerUpdate,
+  updateFailureText,
   fetchAnalyticsSize,
   clearAnalytics,
   fetchGitHubStatus,
@@ -404,23 +405,26 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
       setVersionInfo((v) => ({ ...v, updating: true, status: '' }));
       try {
         const result = await triggerUpdate();
+        const updated = result.version
+          ? `Updated to v${result.version}!`
+          : 'Updated!';
         if (result.restarting) {
           setVersionInfo((v) => ({
             ...v,
-            status: 'Updated! Restarting\u2026',
+            status: `${updated} Restarting\u2026`,
             available: false,
           }));
           setTimeout(() => location.reload(), 5000);
         } else
           setVersionInfo((v) => ({
             ...v,
-            status: 'Updated! Please restart the server manually.',
+            status: `${updated} Please restart the server manually.`,
             available: false,
           }));
-      } catch {
+      } catch (err) {
         setVersionInfo((v) => ({
           ...v,
-          status: 'Update failed. Please try again.',
+          status: updateFailureText(err),
           updating: false,
         }));
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2638,6 +2638,8 @@ export async function checkVersion(): Promise<{
 export async function triggerUpdate(): Promise<{
   ok: boolean;
   restarting?: boolean;
+  /** Absent unless the server ran but could not confirm a version change. */
+  verified?: boolean;
   version?: string | null;
   error?: string;
 }> {
@@ -2648,8 +2650,12 @@ export async function triggerUpdate(): Promise<{
     restarting?: boolean;
     version?: string | null;
     error?: string;
+    verified?: boolean;
   }>(await fetch('/update', { method: 'POST' }));
 }
+
+/** Neutral copy for an install that ran without changing the install root. */
+export const UPDATE_NO_CHANGE_TEXT = 'No version change detected.';
 
 /**
  * Failure text for an update attempt. Only an HttpError carries the server's

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2638,11 +2638,17 @@ export async function checkVersion(): Promise<{
 export async function triggerUpdate(): Promise<{
   ok: boolean;
   restarting?: boolean;
+  version?: string | null;
   error?: string;
 }> {
-  return json<{ ok: boolean; restarting?: boolean; error?: string }>(
-    await fetch('/update', { method: 'POST' })
-  );
+  // json() throws an HttpError carrying the server's `error` string, so the
+  // caller can show why the update failed instead of a generic message.
+  return json<{
+    ok: boolean;
+    restarting?: boolean;
+    version?: string | null;
+    error?: string;
+  }>(await fetch('/update', { method: 'POST' }));
 }
 
 export async function fetchUpdateChannel(): Promise<'stable' | 'nightly'> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2651,6 +2651,18 @@ export async function triggerUpdate(): Promise<{
   }>(await fetch('/update', { method: 'POST' }));
 }
 
+/**
+ * Failure text for an update attempt. Only an HttpError carries the server's
+ * explanation; a transport failure can also mean the server exited mid-request
+ * after a successful install, so those stay generic.
+ */
+export function updateFailureText(err: unknown): string {
+  const detail = err instanceof HttpError ? err.message.trim() : '';
+  return detail
+    ? `Update failed: ${detail}`
+    : 'Update failed. Please try again.';
+}
+
 export async function fetchUpdateChannel(): Promise<'stable' | 'nightly'> {
   const data = await json<{ channel: 'stable' | 'nightly' }>(
     await fetch('/update-channel')

--- a/server/index.ts
+++ b/server/index.ts
@@ -64,10 +64,11 @@ import {
 } from './worktree-cleanup.js';
 import { isInstalled as serviceIsInstalled } from './service.js';
 import {
+  buildRemedyCommand,
   buildUpdateCommand,
-  detectInstallKind,
+  detectRunningInstall,
   readInstalledVersion,
-  type InstallDetection,
+  verifyUpdateLanded,
 } from './self-update.js';
 import {
   ingressSessionImage,
@@ -496,15 +497,14 @@ function getCurrentVersion(): string {
   return pkg.version;
 }
 
-function detectRunningInstall(): InstallDetection {
-  // argv[1] is the (usually symlinked) global bin entry; __filename is the
-  // fallback when the process was started some other way.
-  for (const candidate of [process.argv[1], __filename]) {
-    if (!candidate) continue;
-    const detection = detectInstallKind(candidate);
-    if (detection.kind !== 'unknown') return detection;
-  }
-  return { kind: 'unknown', installRoot: null };
+const UPDATE_COMMAND_TIMEOUT_MS = 5 * 60_000;
+const UPDATE_COMMAND_MAX_BUFFER = 8 * 1024 * 1024;
+
+/** execFile kills the child on timeout, surfacing as `killed` on the error. */
+function isKilledByTimeout(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { killed?: boolean; code?: unknown; signal?: unknown };
+  return e.killed === true || e.code === 'ETIMEDOUT';
 }
 
 async function getLatestVersion(
@@ -5883,14 +5883,32 @@ async function main(): Promise<void> {
     try {
       const channel = startupConfig.updateChannel ?? 'stable';
       const tag = channel === 'nightly' ? 'nightly' : 'latest';
-      const install = detectRunningInstall();
-      const [updateCommand, updateArgs] = buildUpdateCommand(install.kind, tag);
+      // argv[1] is the (usually symlinked) global bin entry; __filename is the
+      // fallback when the process was started some other way.
+      const install = detectRunningInstall([process.argv[1], __filename]);
+      const [updateCommand, updateArgs] = buildUpdateCommand(
+        install.kind,
+        tag,
+        install.installRoot
+      );
       const versionBefore = install.installRoot
         ? readInstalledVersion(install.installRoot)
         : null;
-      await execFileAsync(updateCommand, updateArgs, {
-        env: { ...process.env, RELAY_IDE_SKIP_SERVICE_RESTART: '1' },
-      });
+      try {
+        await execFileAsync(updateCommand, updateArgs, {
+          env: { ...process.env, RELAY_IDE_SKIP_SERVICE_RESTART: '1' },
+          timeout: UPDATE_COMMAND_TIMEOUT_MS,
+          maxBuffer: UPDATE_COMMAND_MAX_BUFFER,
+        });
+      } catch (err) {
+        if (isKilledByTimeout(err)) {
+          throw new Error(
+            `Update command timed out after ${UPDATE_COMMAND_TIMEOUT_MS / 60_000}m.`,
+            { cause: err }
+          );
+        }
+        throw err;
+      }
 
       // A package manager can report success while installing into a different
       // global prefix than the one this process runs from (#1284). Only claim
@@ -5899,20 +5917,30 @@ async function main(): Promise<void> {
       if (install.installRoot) {
         installedVersion = readInstalledVersion(install.installRoot);
         const latest = await getLatestVersion(channel);
-        // An unreadable version on either side means we cannot prove anything;
-        // fall through to the legacy behavior rather than fail a real update.
+        const verification = verifyUpdateLanded({
+          versionBefore,
+          versionAfter: installedVersion,
+          latest,
+        });
         if (
-          installedVersion !== null &&
-          installedVersion === versionBefore &&
-          latest !== null &&
-          installedVersion !== latest
+          verification === 'unchanged-stale' ||
+          verification === 'no-change-detected'
         ) {
           updateInFlight = false;
+          const remedy = buildRemedyCommand(
+            install.kind,
+            install.installRoot,
+            tag
+          );
+          logger.warn(
+            `[update] ${verification}: ran \`${updateCommand} ${updateArgs.join(' ')}\` (kind=${install.kind}) but ${install.installRoot} stayed at ${versionBefore ?? 'unknown'} (after=${installedVersion ?? 'unknown'}, latest=${latest ?? 'unknown'}). Remedy: ${remedy}`
+          );
           res.status(500).json({
             ok: false,
             error:
-              `\`${updateCommand} ${updateArgs.join(' ')}\` reported success but the running install at ${install.installRoot} is still v${installedVersion} (expected v${latest}). ` +
-              'The update landed in a different global prefix — update that install root directly.',
+              verification === 'unchanged-stale'
+                ? `Update installed elsewhere — this server still runs v${installedVersion} from ${install.installRoot}. Run: ${remedy}`
+                : `Update ran but the version at ${install.installRoot} did not change and the latest version is unknown. Run: ${remedy}`,
           });
           return;
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -5935,12 +5935,21 @@ async function main(): Promise<void> {
           logger.warn(
             `[update] ${verification}: ran \`${updateCommand} ${updateArgs.join(' ')}\` (kind=${install.kind}) but ${install.installRoot} stayed at ${versionBefore ?? 'unknown'} (after=${installedVersion ?? 'unknown'}, latest=${latest ?? 'unknown'}). Remedy: ${remedy}`
           );
+          if (verification === 'no-change-detected') {
+            // Latest is unknown (offline host, private registry), so a no-op
+            // install is most likely already-current: advisory, not a failure.
+            // Nothing changed on disk, so there is nothing to restart into.
+            res.json({
+              ok: true,
+              verified: false,
+              restarting: false,
+              version: installedVersion,
+            });
+            return;
+          }
           res.status(500).json({
             ok: false,
-            error:
-              verification === 'unchanged-stale'
-                ? `Update installed elsewhere — this server still runs v${installedVersion} from ${install.installRoot}. Run: ${remedy}`
-                : `Update ran but the version at ${install.installRoot} did not change and the latest version is unknown. Run: ${remedy}`,
+            error: `Update installed elsewhere — this server still runs v${installedVersion} from ${install.installRoot}. Run: ${remedy}`,
           });
           return;
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -64,6 +64,12 @@ import {
 } from './worktree-cleanup.js';
 import { isInstalled as serviceIsInstalled } from './service.js';
 import {
+  buildUpdateCommand,
+  detectInstallKind,
+  readInstalledVersion,
+  type InstallDetection,
+} from './self-update.js';
+import {
   ingressSessionImage,
   parseSessionImagePayload,
   SessionImageIngressError,
@@ -488,6 +494,17 @@ function getCurrentVersion(): string {
     version: string;
   };
   return pkg.version;
+}
+
+function detectRunningInstall(): InstallDetection {
+  // argv[1] is the (usually symlinked) global bin entry; __filename is the
+  // fallback when the process was started some other way.
+  for (const candidate of [process.argv[1], __filename]) {
+    if (!candidate) continue;
+    const detection = detectInstallKind(candidate);
+    if (detection.kind !== 'unknown') return detection;
+  }
+  return { kind: 'unknown', installRoot: null };
 }
 
 async function getLatestVersion(
@@ -5866,9 +5883,41 @@ async function main(): Promise<void> {
     try {
       const channel = startupConfig.updateChannel ?? 'stable';
       const tag = channel === 'nightly' ? 'nightly' : 'latest';
-      await execFileAsync('npm', ['install', '-g', `relay-ide@${tag}`], {
+      const install = detectRunningInstall();
+      const [updateCommand, updateArgs] = buildUpdateCommand(install.kind, tag);
+      const versionBefore = install.installRoot
+        ? readInstalledVersion(install.installRoot)
+        : null;
+      await execFileAsync(updateCommand, updateArgs, {
         env: { ...process.env, RELAY_IDE_SKIP_SERVICE_RESTART: '1' },
       });
+
+      // A package manager can report success while installing into a different
+      // global prefix than the one this process runs from (#1284). Only claim
+      // success once the running install root actually changed.
+      let installedVersion: string | null = null;
+      if (install.installRoot) {
+        installedVersion = readInstalledVersion(install.installRoot);
+        const latest = await getLatestVersion(channel);
+        // An unreadable version on either side means we cannot prove anything;
+        // fall through to the legacy behavior rather than fail a real update.
+        if (
+          installedVersion !== null &&
+          installedVersion === versionBefore &&
+          latest !== null &&
+          installedVersion !== latest
+        ) {
+          updateInFlight = false;
+          res.status(500).json({
+            ok: false,
+            error:
+              `\`${updateCommand} ${updateArgs.join(' ')}\` reported success but the running install at ${install.installRoot} is still v${installedVersion} (expected v${latest}). ` +
+              'The update landed in a different global prefix — update that install root directly.',
+          });
+          return;
+        }
+      }
+
       const restarting = serviceIsInstalled();
       if (restarting) {
         stopEventBatching();
@@ -5894,7 +5943,7 @@ async function main(): Promise<void> {
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
-      res.json({ ok: true, restarting });
+      res.json({ ok: true, restarting, version: installedVersion });
       if (restarting) {
         // Brief delay to let the broadcast reach clients
         setTimeout(() => {

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Self-update install detection.
+ *
+ * `POST /update` used to always shell out to `npm install -g relay-ide`, which
+ * silently no-ops when the running server was installed with `bun add -g`: npm
+ * writes into npm's own global prefix while the running install root stays on
+ * the old version. Detect the package manager that owns the running install
+ * root so the update lands where the server actually runs from.
+ */
+
+export type InstallKind = 'bun' | 'npm' | 'unknown';
+
+export interface InstallDetection {
+  kind: InstallKind;
+  /** Directory the running server was installed into, or null when unknown. */
+  installRoot: string | null;
+}
+
+export interface SelfUpdateDeps {
+  env?: NodeJS.ProcessEnv;
+  fsRealpathSync?: (p: string) => string;
+  fsReadFileSync?: (p: string, encoding: BufferEncoding) => string;
+}
+
+/** Matches the deepest `<prefix>/node_modules/relay-ide` in a path. */
+const INSTALL_ROOT_RE = /^(.*)[\\/]node_modules[\\/]relay-ide(?=[\\/]|$)/;
+
+function normalizePath(p: string): string {
+  return p.replace(/[\\/]+/g, '/').replace(/\/+$/, '');
+}
+
+function resolveEntry(entryPath: string, deps: SelfUpdateDeps): string {
+  const realpath = deps.fsRealpathSync ?? fs.realpathSync;
+  try {
+    // Global bin entries are symlinks (e.g. ~/.bun/bin/relay-ide), so the
+    // install root only shows up after resolving them.
+    return realpath(entryPath);
+  } catch (_) {
+    return entryPath;
+  }
+}
+
+/**
+ * Classify the install root the running server was launched from.
+ * Dev checkouts and worktrees have no `node_modules/relay-ide` ancestor and
+ * come back as `unknown` with a null root, which keeps callers on the legacy
+ * npm behavior instead of guessing.
+ */
+export function detectInstallKind(
+  entryPath: string,
+  deps: SelfUpdateDeps = {}
+): InstallDetection {
+  if (!entryPath) return { kind: 'unknown', installRoot: null };
+  const env = deps.env ?? process.env;
+  const resolved = resolveEntry(entryPath, deps);
+  const match = INSTALL_ROOT_RE.exec(resolved);
+  if (!match) return { kind: 'unknown', installRoot: null };
+
+  const installRoot = match[0];
+  const prefix = normalizePath(match[1] ?? '');
+
+  const bunInstall = env.BUN_INSTALL ? normalizePath(env.BUN_INSTALL) : null;
+  const bunGlobalDir = env.BUN_INSTALL_GLOBAL_DIR
+    ? normalizePath(env.BUN_INSTALL_GLOBAL_DIR)
+    : null;
+  const isBun =
+    prefix.endsWith('/.bun/install/global') ||
+    prefix === '.bun/install/global' ||
+    (bunInstall !== null && prefix === `${bunInstall}/install/global`) ||
+    (bunGlobalDir !== null && prefix === bunGlobalDir);
+  if (isBun) return { kind: 'bun', installRoot };
+
+  const npmPrefix = env.npm_config_prefix
+    ? normalizePath(env.npm_config_prefix)
+    : null;
+  const prefixSegments = prefix.split('/').filter(Boolean);
+  const lastSegment = prefixSegments[prefixSegments.length - 1] ?? '';
+  // Unix global installs live under `<prefix>/lib/node_modules`; the Windows
+  // npm prefix is `%AppData%\npm` with no `lib` level.
+  const isNpm =
+    lastSegment === 'lib' ||
+    lastSegment === 'npm' ||
+    (npmPrefix !== null && prefix === npmPrefix);
+  if (isNpm) return { kind: 'npm', installRoot };
+
+  return { kind: 'unknown', installRoot: null };
+}
+
+/** Build the global-install command for the detected package manager. */
+export function buildUpdateCommand(
+  kind: InstallKind,
+  tag: string
+): [command: string, args: string[]] {
+  if (kind === 'bun') return ['bun', ['add', '-g', `relay-ide@${tag}`]];
+  return ['npm', ['install', '-g', `relay-ide@${tag}`]];
+}
+
+/** Read the version currently on disk in an install root. */
+export function readInstalledVersion(
+  installRoot: string,
+  deps: SelfUpdateDeps = {}
+): string | null {
+  const readFile = deps.fsReadFileSync ?? fs.readFileSync;
+  try {
+    const raw = readFile(path.join(installRoot, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(raw) as { version?: unknown };
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch (_) {
+    return null;
+  }
+}

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -8,25 +8,35 @@ import path from 'node:path';
  * silently no-ops when the running server was installed with `bun add -g`: npm
  * writes into npm's own global prefix while the running install root stays on
  * the old version. Detect the package manager that owns the running install
- * root so the update lands where the server actually runs from.
+ * root so the update lands where the server actually runs from, and verify the
+ * root afterwards so an install into some other prefix cannot report success.
  */
 
 export type InstallKind = 'bun' | 'npm' | 'unknown';
 
 export interface InstallDetection {
   kind: InstallKind;
-  /** Directory the running server was installed into, or null when unknown. */
+  /**
+   * Directory the running server was installed into. Non-null whenever the
+   * running path has a `node_modules/relay-ide` ancestor — including `unknown`
+   * kinds (pnpm/yarn/deno globals), so callers can still verify that an update
+   * landed here. Null only for dev checkouts and worktrees.
+   */
   installRoot: string | null;
 }
 
 export interface SelfUpdateDeps {
   env?: NodeJS.ProcessEnv;
+  execPath?: string;
   fsRealpathSync?: (p: string) => string;
   fsReadFileSync?: (p: string, encoding: BufferEncoding) => string;
+  fsExistsSync?: (p: string) => boolean;
 }
 
 /** Matches the deepest `<prefix>/node_modules/relay-ide` in a path. */
 const INSTALL_ROOT_RE = /^(.*)[\\/]node_modules[\\/]relay-ide(?=[\\/]|$)/;
+
+const BUN_GLOBAL_SUFFIX = '/install/global';
 
 function normalizePath(p: string): string {
   return p.replace(/[\\/]+/g, '/').replace(/\/+$/, '');
@@ -43,11 +53,52 @@ function resolveEntry(entryPath: string, deps: SelfUpdateDeps): string {
   }
 }
 
+/** `<prefix>/bin/node` → `<prefix>`, matching npm's global prefix layout. */
+function nodePrefixOf(execPath: string): string {
+  const normalized = normalizePath(execPath);
+  return normalizePath(path.dirname(path.dirname(normalized)));
+}
+
+function isBunPrefix(prefix: string, env: NodeJS.ProcessEnv): boolean {
+  if (prefix.endsWith(`/.bun${BUN_GLOBAL_SUFFIX}`)) return true;
+  if (prefix === `.bun${BUN_GLOBAL_SUFFIX}`) return true;
+  const bunInstall = env.BUN_INSTALL ? normalizePath(env.BUN_INSTALL) : null;
+  if (bunInstall !== null && prefix === `${bunInstall}${BUN_GLOBAL_SUFFIX}`) {
+    return true;
+  }
+  const bunGlobalDir = env.BUN_INSTALL_GLOBAL_DIR
+    ? normalizePath(env.BUN_INSTALL_GLOBAL_DIR)
+    : null;
+  return bunGlobalDir !== null && prefix === bunGlobalDir;
+}
+
+function isNpmPrefix(
+  prefix: string,
+  env: NodeJS.ProcessEnv,
+  execPath: string
+): boolean {
+  const segments = prefix.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1] ?? '';
+  // Unix global installs live under `<prefix>/lib/node_modules`; the Windows
+  // npm prefix is `%AppData%\npm` with no `lib` level.
+  if (lastSegment !== 'lib' && lastSegment !== 'npm') return false;
+  // Shape alone is ambiguous — any `/srv/lib/node_modules/relay-ide` matches —
+  // so require a real npm prefix to corroborate it.
+  const configured = env.npm_config_prefix ?? env.NPM_CONFIG_PREFIX;
+  const candidates = [nodePrefixOf(execPath)];
+  if (configured) candidates.push(normalizePath(configured));
+  return candidates.some(
+    (candidate) =>
+      candidate.length > 0 &&
+      (prefix === candidate || prefix === `${candidate}/lib`)
+  );
+}
+
 /**
  * Classify the install root the running server was launched from.
  * Dev checkouts and worktrees have no `node_modules/relay-ide` ancestor and
- * come back as `unknown` with a null root, which keeps callers on the legacy
- * npm behavior instead of guessing.
+ * come back as `unknown` with a null root; other unrecognized package managers
+ * come back as `unknown` with a usable root so update verification still runs.
  */
 export function detectInstallKind(
   entryPath: string,
@@ -55,6 +106,7 @@ export function detectInstallKind(
 ): InstallDetection {
   if (!entryPath) return { kind: 'unknown', installRoot: null };
   const env = deps.env ?? process.env;
+  const execPath = deps.execPath ?? process.execPath;
   const resolved = resolveEntry(entryPath, deps);
   const match = INSTALL_ROOT_RE.exec(resolved);
   if (!match) return { kind: 'unknown', installRoot: null };
@@ -62,40 +114,82 @@ export function detectInstallKind(
   const installRoot = match[0];
   const prefix = normalizePath(match[1] ?? '');
 
-  const bunInstall = env.BUN_INSTALL ? normalizePath(env.BUN_INSTALL) : null;
-  const bunGlobalDir = env.BUN_INSTALL_GLOBAL_DIR
-    ? normalizePath(env.BUN_INSTALL_GLOBAL_DIR)
-    : null;
-  const isBun =
-    prefix.endsWith('/.bun/install/global') ||
-    prefix === '.bun/install/global' ||
-    (bunInstall !== null && prefix === `${bunInstall}/install/global`) ||
-    (bunGlobalDir !== null && prefix === bunGlobalDir);
-  if (isBun) return { kind: 'bun', installRoot };
+  if (isBunPrefix(prefix, env)) return { kind: 'bun', installRoot };
+  if (isNpmPrefix(prefix, env, execPath)) return { kind: 'npm', installRoot };
+  return { kind: 'unknown', installRoot };
+}
 
-  const npmPrefix = env.npm_config_prefix
-    ? normalizePath(env.npm_config_prefix)
-    : null;
-  const prefixSegments = prefix.split('/').filter(Boolean);
-  const lastSegment = prefixSegments[prefixSegments.length - 1] ?? '';
-  // Unix global installs live under `<prefix>/lib/node_modules`; the Windows
-  // npm prefix is `%AppData%\npm` with no `lib` level.
-  const isNpm =
-    lastSegment === 'lib' ||
-    lastSegment === 'npm' ||
-    (npmPrefix !== null && prefix === npmPrefix);
-  if (isNpm) return { kind: 'npm', installRoot };
+/**
+ * Classify the running install from candidate entry paths (argv[1] first, then
+ * the module path). A classified hit wins; otherwise the first candidate that
+ * still yields an install root is kept so verification can run.
+ */
+export function detectRunningInstall(
+  candidates: Array<string | undefined>,
+  deps: SelfUpdateDeps = {}
+): InstallDetection {
+  let fallback: InstallDetection = { kind: 'unknown', installRoot: null };
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const detection = detectInstallKind(candidate, deps);
+    if (detection.kind !== 'unknown') return detection;
+    if (detection.installRoot && !fallback.installRoot) fallback = detection;
+  }
+  return fallback;
+}
 
-  return { kind: 'unknown', installRoot: null };
+/**
+ * Resolve the bun binary that owns an install root. Service units frequently
+ * run with a PATH that lacks `~/.bun/bin`, so prefer the absolute path.
+ */
+export function resolveBunBinary(
+  installRoot: string | null,
+  deps: SelfUpdateDeps = {}
+): string {
+  if (!installRoot) return 'bun';
+  const exists = deps.fsExistsSync ?? fs.existsSync;
+  const normalized = normalizePath(installRoot);
+  const suffix = `${BUN_GLOBAL_SUFFIX}/node_modules/relay-ide`;
+  if (!normalized.endsWith(suffix)) return 'bun';
+  const bunHome = normalized.slice(0, normalized.length - suffix.length);
+  if (!bunHome) return 'bun';
+  const binary = `${bunHome}/bin/bun`;
+  return exists(binary) ? binary : 'bun';
 }
 
 /** Build the global-install command for the detected package manager. */
 export function buildUpdateCommand(
   kind: InstallKind,
-  tag: string
+  tag: string,
+  installRoot: string | null = null,
+  deps: SelfUpdateDeps = {}
 ): [command: string, args: string[]] {
-  if (kind === 'bun') return ['bun', ['add', '-g', `relay-ide@${tag}`]];
+  if (kind === 'bun') {
+    return [
+      resolveBunBinary(installRoot, deps),
+      ['add', '-g', `relay-ide@${tag}`],
+    ];
+  }
   return ['npm', ['install', '-g', `relay-ide@${tag}`]];
+}
+
+/** Operator-facing command that installs into a specific install root. */
+export function buildRemedyCommand(
+  kind: InstallKind,
+  installRoot: string | null,
+  tag: string
+): string {
+  if (kind === 'bun') return `bun add -g relay-ide@${tag}`;
+  if (kind === 'npm' && installRoot) {
+    const prefix = normalizePath(installRoot)
+      .replace(/\/node_modules\/relay-ide$/, '')
+      .replace(/\/lib$/, '');
+    return `npm install -g --prefix ${prefix} relay-ide@${tag}`;
+  }
+  if (installRoot) {
+    return `reinstall relay-ide@${tag} into ${installRoot} with the package manager that owns it`;
+  }
+  return `npm install -g relay-ide@${tag}`;
 }
 
 /** Read the version currently on disk in an install root. */
@@ -111,4 +205,30 @@ export function readInstalledVersion(
   } catch (_) {
     return null;
   }
+}
+
+export type UpdateVerification =
+  | 'updated'
+  | 'already-latest'
+  | 'unchanged-stale'
+  | 'no-change-detected'
+  | 'unverifiable';
+
+/**
+ * Decide whether an install actually landed in the running install root.
+ * `unverifiable` means the root's version could not be read on one side, so the
+ * caller has no evidence either way and should keep its legacy behavior.
+ */
+export function verifyUpdateLanded(input: {
+  versionBefore: string | null;
+  versionAfter: string | null;
+  latest: string | null;
+}): UpdateVerification {
+  const { versionBefore, versionAfter, latest } = input;
+  if (versionBefore === null || versionAfter === null) return 'unverifiable';
+  // Any change counts as landed, including an intentional downgrade.
+  if (versionAfter !== versionBefore) return 'updated';
+  if (latest !== null && versionAfter === latest) return 'already-latest';
+  if (latest !== null) return 'unchanged-stale';
+  return 'no-change-detected';
 }

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -157,6 +157,27 @@ export function resolveBunBinary(
   return exists(binary) ? binary : 'bun';
 }
 
+/**
+ * Script path a platform service should point at, for install roots npm prefix
+ * probing cannot find (a `bun add -g` install has no npm-global copy). Only
+ * classified global installs qualify — never a dev checkout, and never an
+ * unclassified root such as an npx cache directory.
+ */
+export function resolveDetectedScriptPath(
+  detection: InstallDetection,
+  deps: SelfUpdateDeps = {}
+): string | undefined {
+  if (detection.kind === 'unknown' || !detection.installRoot) return undefined;
+  const exists = deps.fsExistsSync ?? fs.existsSync;
+  const script = path.join(
+    detection.installRoot,
+    'dist',
+    'bin',
+    'relay-ide.js'
+  );
+  return exists(script) ? script : undefined;
+}
+
 /** Build the global-install command for the detected package manager. */
 export function buildUpdateCommand(
   kind: InstallKind,
@@ -180,11 +201,17 @@ export function buildRemedyCommand(
   tag: string
 ): string {
   if (kind === 'bun') return `bun add -g relay-ide@${tag}`;
-  if (kind === 'npm' && installRoot) {
-    const prefix = normalizePath(installRoot)
+  const normalized = installRoot ? normalizePath(installRoot) : '';
+  // An npm-shaped root deserves the precise command even when classification
+  // fell back to `unknown` (e.g. a node prefix this process is not running).
+  if (
+    installRoot &&
+    (kind === 'npm' || normalized.endsWith('/lib/node_modules/relay-ide'))
+  ) {
+    const prefix = normalized
       .replace(/\/node_modules\/relay-ide$/, '')
       .replace(/\/lib$/, '');
-    return `npm install -g --prefix ${prefix} relay-ide@${tag}`;
+    return `npm install -g --prefix "${prefix}" relay-ide@${tag}`;
   }
   if (installRoot) {
     return `reinstall relay-ide@${tag} into ${installRoot} with the package manager that owns it`;

--- a/server/service.ts
+++ b/server/service.ts
@@ -58,10 +58,18 @@ function isGlobalInstall(): boolean {
 
 /**
  * Resolve the script path for the service file.
- * Always uses the global npm binary to prevent worktrees/dev builds from
- * hijacking the production service. Returns null if no global install found.
+ * Always uses a global install to prevent worktrees/dev builds from hijacking
+ * the production service. Returns null if no global install found.
+ *
+ * `preferred` is an already-detected global script path (bun globals never show
+ * up under an npm prefix); callers must derive it from a detected install root,
+ * and the worktree guard in `install()` still applies to it.
  */
-function resolveGlobalScriptPath(): string | null {
+function resolveGlobalScriptPath(
+  preferred?: string | undefined
+): string | null {
+  if (preferred && fs.existsSync(preferred)) return preferred;
+
   // Try to find the global relay-ide binary via node's prefix
   const nodePrefix = path.resolve(process.execPath, '..', '..');
   const globalScript = path.join(
@@ -519,8 +527,8 @@ function install(opts: InstallOpts): void {
   }
 
   // Resolve the global binary path once and validate it.
-  // The service plist/unit must always point to the global npm binary.
-  const scriptPath = resolveGlobalScriptPath();
+  // The service plist/unit must always point to a global install.
+  const scriptPath = resolveGlobalScriptPath(opts.scriptPath);
   if (!scriptPath) {
     throw new Error(
       'Cannot install service: no global relay-ide installation found. ' +

--- a/server/types.ts
+++ b/server/types.ts
@@ -998,6 +998,12 @@ export interface InstallOpts {
   configPath?: string | undefined;
   port?: string | undefined;
   host?: string | undefined;
+  /**
+   * Known-good global script path (`<installRoot>/dist/bin/relay-ide.js`) for
+   * installs that npm prefix probing cannot find, e.g. a `bun add -g` install.
+   * Must come from a detected global install root, never a bare checkout.
+   */
+  scriptPath?: string | undefined;
 }
 
 // Changed file status from git status/diff

--- a/test/self-update.test.ts
+++ b/test/self-update.test.ts
@@ -1,0 +1,132 @@
+import { test, expect } from 'vitest';
+import {
+  buildUpdateCommand,
+  detectInstallKind,
+  readInstalledVersion,
+} from '../server/self-update.js';
+
+const BUN_ROOT = '/home/relay/.bun/install/global/node_modules/relay-ide';
+const NPM_ROOT = '/usr/local/lib/node_modules/relay-ide';
+
+function fakeReadFile(files: Record<string, string>) {
+  return (p: string) => {
+    const content = files[p];
+    if (content === undefined) throw new Error(`ENOENT: ${p}`);
+    return content;
+  };
+}
+
+test('detectInstallKind classifies a bun global install root', () => {
+  const detection = detectInstallKind(`${BUN_ROOT}/dist/server/index.js`, {
+    env: {},
+    fsRealpathSync: (p) => p,
+  });
+  expect(detection).toEqual({ kind: 'bun', installRoot: BUN_ROOT });
+});
+
+test('detectInstallKind classifies a bun install rooted at $BUN_INSTALL', () => {
+  const root = '/opt/bun-home/install/global/node_modules/relay-ide';
+  const detection = detectInstallKind(`${root}/dist/bin/relay-ide.js`, {
+    env: { BUN_INSTALL: '/opt/bun-home' },
+    fsRealpathSync: (p) => p,
+  });
+  expect(detection).toEqual({ kind: 'bun', installRoot: root });
+});
+
+test('detectInstallKind classifies an npm lib/node_modules install root', () => {
+  const detection = detectInstallKind(`${NPM_ROOT}/dist/server/index.js`, {
+    env: {},
+    fsRealpathSync: (p) => p,
+  });
+  expect(detection).toEqual({ kind: 'npm', installRoot: NPM_ROOT });
+});
+
+test('detectInstallKind classifies a Windows npm prefix install root', () => {
+  const root =
+    'C:\\Users\\relay\\AppData\\Roaming\\npm\\node_modules\\relay-ide';
+  const detection = detectInstallKind(`${root}\\dist\\server\\index.js`, {
+    env: {},
+    fsRealpathSync: (p) => p,
+  });
+  expect(detection).toEqual({ kind: 'npm', installRoot: root });
+});
+
+test('detectInstallKind returns unknown for a worktree/dev checkout', () => {
+  const detection = detectInstallKind(
+    '/home/relay/Documents/relay-ide/.worktrees/1284-fix/dist/server/index.js',
+    { env: {}, fsRealpathSync: (p) => p }
+  );
+  expect(detection).toEqual({ kind: 'unknown', installRoot: null });
+});
+
+test('detectInstallKind resolves a symlinked bin entry into the bun root', () => {
+  const detection = detectInstallKind('/home/relay/.bun/bin/relay-ide', {
+    env: {},
+    fsRealpathSync: (p) =>
+      p === '/home/relay/.bun/bin/relay-ide'
+        ? `${BUN_ROOT}/dist/bin/relay-ide.js`
+        : p,
+  });
+  expect(detection).toEqual({ kind: 'bun', installRoot: BUN_ROOT });
+});
+
+test('detectInstallKind falls back to the raw path when realpath fails', () => {
+  const detection = detectInstallKind(`${NPM_ROOT}/dist/server/index.js`, {
+    env: {},
+    fsRealpathSync: () => {
+      throw new Error('ENOENT');
+    },
+  });
+  expect(detection.kind).toBe('npm');
+});
+
+test('buildUpdateCommand uses bun for bun installs and npm otherwise', () => {
+  expect(buildUpdateCommand('bun', 'nightly')).toEqual([
+    'bun',
+    ['add', '-g', 'relay-ide@nightly'],
+  ]);
+  expect(buildUpdateCommand('npm', 'latest')).toEqual([
+    'npm',
+    ['install', '-g', 'relay-ide@latest'],
+  ]);
+  expect(buildUpdateCommand('unknown', 'latest')).toEqual([
+    'npm',
+    ['install', '-g', 'relay-ide@latest'],
+  ]);
+});
+
+test('readInstalledVersion sees a changed version after a successful install', () => {
+  const pkgPath = `${BUN_ROOT}/package.json`;
+  const before = readInstalledVersion(BUN_ROOT, {
+    fsReadFileSync: fakeReadFile({ [pkgPath]: '{"version":"1.2.3"}' }),
+  });
+  const after = readInstalledVersion(BUN_ROOT, {
+    fsReadFileSync: fakeReadFile({ [pkgPath]: '{"version":"1.2.4"}' }),
+  });
+  expect(before).toBe('1.2.3');
+  expect(after).toBe('1.2.4');
+});
+
+test('readInstalledVersion reports the same version when the root is untouched', () => {
+  const pkgPath = `${NPM_ROOT}/package.json`;
+  const read = fakeReadFile({ [pkgPath]: '{"version":"1.2.3"}' });
+  expect(readInstalledVersion(NPM_ROOT, { fsReadFileSync: read })).toBe(
+    '1.2.3'
+  );
+  expect(readInstalledVersion(NPM_ROOT, { fsReadFileSync: read })).toBe(
+    '1.2.3'
+  );
+});
+
+test('readInstalledVersion returns null for a missing or invalid package.json', () => {
+  expect(
+    readInstalledVersion(NPM_ROOT, { fsReadFileSync: fakeReadFile({}) })
+  ).toBe(null);
+  expect(
+    readInstalledVersion(NPM_ROOT, {
+      fsReadFileSync: fakeReadFile({
+        [`${NPM_ROOT}/package.json`]: 'not json',
+      }),
+    })
+  ).toBe(null);
+});

--- a/test/self-update.test.ts
+++ b/test/self-update.test.ts
@@ -1,12 +1,17 @@
 import { test, expect } from 'vitest';
 import {
+  buildRemedyCommand,
   buildUpdateCommand,
   detectInstallKind,
+  detectRunningInstall,
   readInstalledVersion,
+  resolveBunBinary,
+  verifyUpdateLanded,
 } from '../server/self-update.js';
 
 const BUN_ROOT = '/home/relay/.bun/install/global/node_modules/relay-ide';
 const NPM_ROOT = '/usr/local/lib/node_modules/relay-ide';
+const NPM_EXEC_PATH = '/usr/local/bin/node';
 
 function fakeReadFile(files: Record<string, string>) {
   return (p: string) => {
@@ -16,10 +21,13 @@ function fakeReadFile(files: Record<string, string>) {
   };
 }
 
+const identityRealpath = (p: string) => p;
+
 test('detectInstallKind classifies a bun global install root', () => {
   const detection = detectInstallKind(`${BUN_ROOT}/dist/server/index.js`, {
     env: {},
-    fsRealpathSync: (p) => p,
+    execPath: NPM_EXEC_PATH,
+    fsRealpathSync: identityRealpath,
   });
   expect(detection).toEqual({ kind: 'bun', installRoot: BUN_ROOT });
 });
@@ -28,33 +36,67 @@ test('detectInstallKind classifies a bun install rooted at $BUN_INSTALL', () => 
   const root = '/opt/bun-home/install/global/node_modules/relay-ide';
   const detection = detectInstallKind(`${root}/dist/bin/relay-ide.js`, {
     env: { BUN_INSTALL: '/opt/bun-home' },
-    fsRealpathSync: (p) => p,
+    execPath: NPM_EXEC_PATH,
+    fsRealpathSync: identityRealpath,
   });
   expect(detection).toEqual({ kind: 'bun', installRoot: root });
 });
 
-test('detectInstallKind classifies an npm lib/node_modules install root', () => {
+test('detectInstallKind classifies an npm install corroborated by execPath', () => {
   const detection = detectInstallKind(`${NPM_ROOT}/dist/server/index.js`, {
     env: {},
-    fsRealpathSync: (p) => p,
+    execPath: NPM_EXEC_PATH,
+    fsRealpathSync: identityRealpath,
   });
   expect(detection).toEqual({ kind: 'npm', installRoot: NPM_ROOT });
+});
+
+test('detectInstallKind accepts an uppercase NPM_CONFIG_PREFIX', () => {
+  const root = '/home/relay/.npm-global/lib/node_modules/relay-ide';
+  const detection = detectInstallKind(`${root}/dist/server/index.js`, {
+    env: { NPM_CONFIG_PREFIX: '/home/relay/.npm-global' },
+    execPath: NPM_EXEC_PATH,
+    fsRealpathSync: identityRealpath,
+  });
+  expect(detection).toEqual({ kind: 'npm', installRoot: root });
 });
 
 test('detectInstallKind classifies a Windows npm prefix install root', () => {
   const root =
     'C:\\Users\\relay\\AppData\\Roaming\\npm\\node_modules\\relay-ide';
   const detection = detectInstallKind(`${root}\\dist\\server\\index.js`, {
-    env: {},
-    fsRealpathSync: (p) => p,
+    env: { npm_config_prefix: 'C:\\Users\\relay\\AppData\\Roaming\\npm' },
+    execPath: 'C:\\Program Files\\nodejs\\node.exe',
+    fsRealpathSync: identityRealpath,
   });
   expect(detection).toEqual({ kind: 'npm', installRoot: root });
 });
 
-test('detectInstallKind returns unknown for a worktree/dev checkout', () => {
+test('detectInstallKind does not call an uncorroborated lib path npm', () => {
+  const root = '/srv/lib/node_modules/relay-ide';
+  const detection = detectInstallKind(`${root}/dist/server/index.js`, {
+    env: {},
+    execPath: NPM_EXEC_PATH,
+    fsRealpathSync: identityRealpath,
+  });
+  // Still carries the root so the caller can verify the update landed here.
+  expect(detection).toEqual({ kind: 'unknown', installRoot: root });
+});
+
+test('detectInstallKind keeps the root for other global package managers', () => {
+  const root = '/home/relay/.local/share/pnpm/global/5/node_modules/relay-ide';
+  const detection = detectInstallKind(`${root}/dist/server/index.js`, {
+    env: {},
+    execPath: NPM_EXEC_PATH,
+    fsRealpathSync: identityRealpath,
+  });
+  expect(detection).toEqual({ kind: 'unknown', installRoot: root });
+});
+
+test('detectInstallKind returns a null root for a worktree/dev checkout', () => {
   const detection = detectInstallKind(
     '/home/relay/Documents/relay-ide/.worktrees/1284-fix/dist/server/index.js',
-    { env: {}, fsRealpathSync: (p) => p }
+    { env: {}, execPath: NPM_EXEC_PATH, fsRealpathSync: identityRealpath }
   );
   expect(detection).toEqual({ kind: 'unknown', installRoot: null });
 });
@@ -62,6 +104,7 @@ test('detectInstallKind returns unknown for a worktree/dev checkout', () => {
 test('detectInstallKind resolves a symlinked bin entry into the bun root', () => {
   const detection = detectInstallKind('/home/relay/.bun/bin/relay-ide', {
     env: {},
+    execPath: NPM_EXEC_PATH,
     fsRealpathSync: (p) =>
       p === '/home/relay/.bun/bin/relay-ide'
         ? `${BUN_ROOT}/dist/bin/relay-ide.js`
@@ -73,11 +116,38 @@ test('detectInstallKind resolves a symlinked bin entry into the bun root', () =>
 test('detectInstallKind falls back to the raw path when realpath fails', () => {
   const detection = detectInstallKind(`${NPM_ROOT}/dist/server/index.js`, {
     env: {},
+    execPath: NPM_EXEC_PATH,
     fsRealpathSync: () => {
       throw new Error('ENOENT');
     },
   });
   expect(detection.kind).toBe('npm');
+});
+
+test('detectRunningInstall prefers a classified candidate over an unknown root', () => {
+  const detection = detectRunningInstall(
+    [
+      undefined,
+      '/srv/lib/node_modules/relay-ide/dist/bin/relay-ide.js',
+      `${BUN_ROOT}/dist/server/index.js`,
+    ],
+    { env: {}, execPath: NPM_EXEC_PATH, fsRealpathSync: identityRealpath }
+  );
+  expect(detection).toEqual({ kind: 'bun', installRoot: BUN_ROOT });
+});
+
+test('detectRunningInstall keeps an unknown root when nothing classifies', () => {
+  const detection = detectRunningInstall(
+    [
+      '/srv/lib/node_modules/relay-ide/dist/bin/relay-ide.js',
+      '/home/relay/checkout/dist/server/index.js',
+    ],
+    { env: {}, execPath: NPM_EXEC_PATH, fsRealpathSync: identityRealpath }
+  );
+  expect(detection).toEqual({
+    kind: 'unknown',
+    installRoot: '/srv/lib/node_modules/relay-ide',
+  });
 });
 
 test('buildUpdateCommand uses bun for bun installs and npm otherwise', () => {
@@ -93,6 +163,35 @@ test('buildUpdateCommand uses bun for bun installs and npm otherwise', () => {
     'npm',
     ['install', '-g', 'relay-ide@latest'],
   ]);
+});
+
+test('buildUpdateCommand uses the absolute bun binary when it exists', () => {
+  expect(
+    buildUpdateCommand('bun', 'nightly', BUN_ROOT, {
+      fsExistsSync: (p) => p === '/home/relay/.bun/bin/bun',
+    })
+  ).toEqual(['/home/relay/.bun/bin/bun', ['add', '-g', 'relay-ide@nightly']]);
+});
+
+test('resolveBunBinary falls back to bare bun when the binary is missing', () => {
+  expect(resolveBunBinary(BUN_ROOT, { fsExistsSync: () => false })).toBe('bun');
+  expect(resolveBunBinary(NPM_ROOT, { fsExistsSync: () => true })).toBe('bun');
+  expect(resolveBunBinary(null)).toBe('bun');
+});
+
+test('buildRemedyCommand targets the detected prefix', () => {
+  expect(buildRemedyCommand('bun', BUN_ROOT, 'nightly')).toBe(
+    'bun add -g relay-ide@nightly'
+  );
+  expect(buildRemedyCommand('npm', NPM_ROOT, 'latest')).toBe(
+    'npm install -g --prefix /usr/local relay-ide@latest'
+  );
+  expect(
+    buildRemedyCommand('unknown', '/srv/lib/node_modules/relay-ide', 'latest')
+  ).toContain('/srv/lib/node_modules/relay-ide');
+  expect(buildRemedyCommand('unknown', null, 'latest')).toBe(
+    'npm install -g relay-ide@latest'
+  );
 });
 
 test('readInstalledVersion sees a changed version after a successful install', () => {
@@ -129,4 +228,76 @@ test('readInstalledVersion returns null for a missing or invalid package.json', 
       }),
     })
   ).toBe(null);
+});
+
+test('verifyUpdateLanded flags an unchanged root that is behind latest', () => {
+  expect(
+    verifyUpdateLanded({
+      versionBefore: '1.2.3',
+      versionAfter: '1.2.3',
+      latest: '1.2.4',
+    })
+  ).toBe('unchanged-stale');
+});
+
+test('verifyUpdateLanded flags an unchanged root when latest is unknown', () => {
+  expect(
+    verifyUpdateLanded({
+      versionBefore: '1.2.3',
+      versionAfter: '1.2.3',
+      latest: null,
+    })
+  ).toBe('no-change-detected');
+});
+
+test('verifyUpdateLanded accepts an unchanged root that is already at latest', () => {
+  expect(
+    verifyUpdateLanded({
+      versionBefore: '1.2.4',
+      versionAfter: '1.2.4',
+      latest: '1.2.4',
+    })
+  ).toBe('already-latest');
+});
+
+test('verifyUpdateLanded counts any version change as landed', () => {
+  expect(
+    verifyUpdateLanded({
+      versionBefore: '1.2.3',
+      versionAfter: '1.2.4',
+      latest: '1.2.4',
+    })
+  ).toBe('updated');
+  // A downgrade still means the install root was rewritten.
+  expect(
+    verifyUpdateLanded({
+      versionBefore: '1.2.4',
+      versionAfter: '1.2.3',
+      latest: '1.2.4',
+    })
+  ).toBe('updated');
+});
+
+test('verifyUpdateLanded is unverifiable when either version is unreadable', () => {
+  expect(
+    verifyUpdateLanded({
+      versionBefore: null,
+      versionAfter: '1.2.4',
+      latest: '1.2.4',
+    })
+  ).toBe('unverifiable');
+  expect(
+    verifyUpdateLanded({
+      versionBefore: '1.2.3',
+      versionAfter: null,
+      latest: '1.2.4',
+    })
+  ).toBe('unverifiable');
+  expect(
+    verifyUpdateLanded({
+      versionBefore: null,
+      versionAfter: null,
+      latest: null,
+    })
+  ).toBe('unverifiable');
 });

--- a/test/self-update.test.ts
+++ b/test/self-update.test.ts
@@ -6,6 +6,7 @@ import {
   detectRunningInstall,
   readInstalledVersion,
   resolveBunBinary,
+  resolveDetectedScriptPath,
   verifyUpdateLanded,
 } from '../server/self-update.js';
 
@@ -184,14 +185,60 @@ test('buildRemedyCommand targets the detected prefix', () => {
     'bun add -g relay-ide@nightly'
   );
   expect(buildRemedyCommand('npm', NPM_ROOT, 'latest')).toBe(
-    'npm install -g --prefix /usr/local relay-ide@latest'
+    'npm install -g --prefix "/usr/local" relay-ide@latest'
   );
+  // Unclassified but npm-shaped roots still get the precise command.
   expect(
     buildRemedyCommand('unknown', '/srv/lib/node_modules/relay-ide', 'latest')
-  ).toContain('/srv/lib/node_modules/relay-ide');
+  ).toBe('npm install -g --prefix "/srv" relay-ide@latest');
   expect(buildRemedyCommand('unknown', null, 'latest')).toBe(
     'npm install -g relay-ide@latest'
   );
+});
+
+test('buildRemedyCommand quotes prefixes containing spaces', () => {
+  expect(
+    buildRemedyCommand(
+      'npm',
+      '/opt/relay nodes/lib/node_modules/relay-ide',
+      'latest'
+    )
+  ).toBe('npm install -g --prefix "/opt/relay nodes" relay-ide@latest');
+});
+
+test('buildRemedyCommand falls back for non-npm-shaped unknown roots', () => {
+  const pnpmRoot =
+    '/home/relay/.local/share/pnpm/global/5/node_modules/relay-ide';
+  expect(buildRemedyCommand('unknown', pnpmRoot, 'latest')).toContain(pnpmRoot);
+});
+
+test('resolveDetectedScriptPath only trusts classified global roots', () => {
+  const exists = () => true;
+  expect(
+    resolveDetectedScriptPath(
+      { kind: 'bun', installRoot: BUN_ROOT },
+      { fsExistsSync: exists }
+    )
+  ).toBe(`${BUN_ROOT}/dist/bin/relay-ide.js`);
+  // npx caches and other unclassified roots must not become service targets.
+  expect(
+    resolveDetectedScriptPath(
+      { kind: 'unknown', installRoot: '/tmp/npx-cache/node_modules/relay-ide' },
+      { fsExistsSync: exists }
+    )
+  ).toBeUndefined();
+  expect(
+    resolveDetectedScriptPath(
+      { kind: 'npm', installRoot: NPM_ROOT },
+      { fsExistsSync: () => false }
+    )
+  ).toBeUndefined();
+  expect(
+    resolveDetectedScriptPath(
+      { kind: 'npm', installRoot: null },
+      { fsExistsSync: exists }
+    )
+  ).toBeUndefined();
 });
 
 test('readInstalledVersion sees a changed version after a successful install', () => {

--- a/test/server-shutdown-contract.test.ts
+++ b/test/server-shutdown-contract.test.ts
@@ -38,7 +38,7 @@ describe('server shutdown store closing contract', () => {
   it('keeps the existing update-restart artifact store close path', () => {
     const updateRestartStart = serverSource.indexOf('if (restarting) {');
     const updateResponseStart = serverSource.indexOf(
-      'res.json({ ok: true, restarting });'
+      'res.json({ ok: true, restarting, version: installedVersion });'
     );
     const updateRestartSource = serverSource.slice(
       updateRestartStart,


### PR DESCRIPTION
Closes #1284. Residual (custom-unit restart detection) tracked in #1285.

## Problem

On a bun-global install, the update toast claimed success forever while never updating the running server: `POST /update` always ran `npm install -g relay-ide@<tag>`, which wrote into npm's global prefix while the running install root (`~/.bun/install/global/...`) stayed old, and success was reported on the npm exit code alone. Observed live on the :3456 stable hub (`.772 → .774` toast loop).

## Changes

- **`server/self-update.ts` (new, deps-injected + unit-tested)** — classifies the running install root from the realpath-resolved entry path (`bun` / `npm` / `unknown`, with the matched root retained even for unknown so verification still applies to pnpm/yarn/deno layouts); builds the matching global-install command (absolute `<bunHome>/bin/bun` when present, so service units without `~/.bun/bin` on PATH still work); pure `verifyUpdateLanded()` outcome matrix; remedy-command builder (precise quoted `npm install -g --prefix "<prefix>"` form for npm-shaped roots regardless of classification).
- **`POST /update`** — runs the detected package manager, then re-reads the running root's version: `unchanged-stale` → 500 with a short error + remedy command (full detail to server log); `no-change-detected` (already current, registry unreachable) → 200 `{ ok: true, verified: false }` benign no-op; success payload carries the verified version. Added 5m timeout / 8MB maxBuffer with a distinct timeout error. npm classification corroborates against the node exec prefix or `npm_config_prefix`/`NPM_CONFIG_PREFIX` so a local `/srv/lib/node_modules` install can't be misclassified as npm-global.
- **CLI `relay-ide node install|update`** — same detection + before/after verification; on a no-op it exits nonzero without printing "updated" and without restarting the service, while still clearing the hub's `updating` flag. Bootstrap install routes through the detected PM (no verification — there is no before-state, and npx-cache roots would false-positive).
- **`service.install()`** — accepts a script path derived from a *classified* detected install root (bun globals have no npm-prefix copy to probe), so `node install --service systemd|launchd` keeps working on bun hosts; worktree anti-hijack guard unchanged, npx-cache/unknown roots never qualify.
- **Frontend (`UpdateToast`, `SettingsDialog`)** — server error surfaced only for `HttpError` (transport failures keep the generic copy — a mid-restart drop may follow a successful update); `verified: false` renders neutral "No version change detected."; success shows the verified version.

## Review

Adversarial review (Opus) + focused re-review of remediation hunks: final verdict Approve, no P0/P1 outstanding. Live-host proofs on the affected bun-global layout, an npm/hermes prefix, and pnpm/yarn/npx/nvm/Volta shapes.

## Evidence

- `npm run check` → 0 errors (250 pre-existing warnings)
- `vitest run test/self-update.test.ts test/service.test.ts test/auth.test.ts test/node-device-pair-cli.test.ts` → 74/74 passed (auth route-inventory drift guard green — no route shape changes)
- `npm run build:server` → ok; CLI smoke from built `dist/bin/relay-ide.js` (`node update --check`) → ok
- Live detection proof on the reporting host: `~/.bun/bin/relay-ide` → `{kind:'bun', root:~/.bun/install/global/node_modules/relay-ide}` → `["/home/…/.bun/bin/bun", ["add","-g","relay-ide@nightly"]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved self-update support across npm and Bun installations.
  * Added update verification to confirm whether a new version was installed.
  * Added clearer guidance when an update cannot be verified or produces no change.
  * Service restarts now better support installations in different environments.

* **Bug Fixes**
  * Fixed update failures caused by assuming npm-only global installations.
  * Improved update status messages, including version details and restart notifications.
  * Added automatic page reloads after updates that restart the service.

* **Tests**
  * Added comprehensive coverage for installation detection, update commands, verification, and service path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->