### PR TITLE
fix(sidebar): thread showArchived into chat search (#1287 slice 1)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -2522,11 +2522,13 @@ export function TopicSidebarShell({
       'search',
       normalizedSearchQuery,
       scopedWorkspaceId ?? 'all',
+      showArchived ? 'with-archived' : 'active-only',
     ],
     queryFn: () =>
       searchWorkspaceTopics({
         q: normalizedSearchQuery,
         limit: 20,
+        includeArchived: showArchived,
         ...(scopedWorkspaceId ? { workspaceId: scopedWorkspaceId } : {}),
       }),
     enabled: normalizedSearchQuery.length > 0,

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -70,6 +70,17 @@ function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
   };
 }
 
+/** Bypass React's instance-level value tracker so `input` events are not
+ *  deduped as no-ops when the test writes the value directly. */
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  if (setter) setter.call(input, value);
+  else input.value = value;
+}
+
 function makeSurface(
   overrides: Partial<WorkspaceSurface> = {}
 ): WorkspaceSurface {
@@ -2273,5 +2284,106 @@ describe('TopicSidebarView', () => {
       '.topic-search-result__action'
     ) as HTMLButtonElement;
     expect(action.disabled).toBe(true);
+  });
+
+  it('threads the show-older-chats toggle into chat search requests', async () => {
+    // #1287: the archived toggle used to drive only the non-search list query,
+    // so searching an archived chat title reported no matches.
+    const archivedTopic = makeTopic({
+      id: 'topic:old',
+      status: 'archived',
+      display: { title: 'Archived lane' },
+      linkedRefs: {},
+    });
+    // Parsed rather than raw URLs so param order in searchWorkspaceTopics()
+    // is free to change without breaking this regression.
+    const searchQueries: Record<string, string>[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/workspace-topics/search')) {
+        const params = new URL(url, 'http://relay.test').searchParams;
+        searchQueries.push(Object.fromEntries(params));
+        const includeArchived = params.get('includeArchived') === '1';
+        return Response.json({
+          query: 'archived',
+          results: includeArchived
+            ? [
+                {
+                  topic: archivedTopic,
+                  score: 10,
+                  freshness: 'fresh',
+                  matches: [],
+                  action: { kind: 'open-topic', topicId: archivedTopic.id },
+                },
+              ]
+            : [],
+          truncated: false,
+          derived: false,
+        });
+      }
+      return Response.json({
+        topics: [],
+        surfaces: [],
+        nodes: [],
+        workspaces: [],
+        truncated: false,
+        derived: false,
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(TopicSidebarShell, { onSelectSession })
+        )
+      );
+    });
+    await act(async () => {
+      await flushQueryEffects();
+    });
+
+    const searchInput = container.querySelector(
+      '.topic-search__input'
+    ) as HTMLInputElement;
+    await act(async () => {
+      setInputValue(searchInput, 'archived');
+      searchInput.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: 'archived',
+          inputType: 'insertText',
+        })
+      );
+    });
+    await act(async () => {
+      await flushQueryEffects();
+    });
+
+    expect(searchQueries).toEqual([{ q: 'archived', limit: '20' }]);
+    expect(container.textContent).toContain('no chat matches for');
+    expect(container.textContent).not.toContain('Archived lane');
+
+    const archivedToggle = container.querySelector(
+      '.topic-archived-toggle__btn'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      archivedToggle.click();
+      await flushQueryEffects();
+    });
+
+    expect(searchQueries).toContainEqual({
+      q: 'archived',
+      includeArchived: '1',
+      limit: '20',
+    });
+    expect(container.textContent).toContain('Archived lane');
+    expect(container.textContent).not.toContain('no chat matches for');
+    queryClient.clear();
   });
 });

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -931,6 +931,40 @@ describe('workspace topics foundation', () => {
     expect(secret.body.results).toHaveLength(0);
   });
 
+  it('includes archived topics in search only when the caller asks for them', async () => {
+    const store = topicStore();
+    store.create({
+      id: 'topic:active-lane',
+      workspaceId: 'ws-search',
+      title: 'Apollo active lane',
+    });
+    store.create({
+      id: 'topic:archived-lane',
+      workspaceId: 'ws-search',
+      title: 'Apollo archived lane',
+    });
+    store.archive('topic:archived-lane');
+    const { port } = await listen({ store });
+
+    const active = await getJson<WorkspaceTopicSearchResponse>(
+      port,
+      '/workspace-topics/search?q=apollo&workspaceId=ws-search'
+    );
+    expect(active.status).toBe(200);
+    expect(active.body.results.map((result) => result.topic.id)).toEqual([
+      'topic:active-lane',
+    ]);
+
+    const withArchived = await getJson<WorkspaceTopicSearchResponse>(
+      port,
+      '/workspace-topics/search?q=apollo&workspaceId=ws-search&includeArchived=1'
+    );
+    expect(withArchived.status).toBe(200);
+    expect(
+      withArchived.body.results.map((result) => result.topic.id).sort()
+    ).toEqual(['topic:active-lane', 'topic:archived-lane']);
+  });
+
   it('bounds search results and scopes actor reads by requested WorkContext', async () => {
     const store = topicStore();
     for (let i = 0; i < 3; i += 1) {


### PR DESCRIPTION
## Defect

Searching the chat sidebar for an archived chat title reported `no chat matches for "..."` even though the chat existed, and the `show older chats` toggle sitting right below the search box had no effect on the result.

`topicSearchQuery` (`frontend/src/components/TopicSidebarShell.tsx`) omitted `includeArchived` from both the request args and its `queryKey`:

- No arg → `searchWorkspaceTopics()` never set `includeArchived=1`, so the server applied its default (`false`) and filtered archived rows out of `/workspace-topics/search`.
- No `queryKey` entry → even once the arg was added, flipping the toggle would not refetch; TanStack Query (`staleTime: 10_000`) would serve the cached active-only result.

The toggle only ever drove the non-search list/tree query, whose data is discarded while search is active — hence a live-looking control with no effect on the visible result set.

## Fix

Two lines in `TopicSidebarShell.tsx`: thread the existing `showArchived` state into `searchWorkspaceTopics({ includeArchived: showArchived })` and add `showArchived ? 'with-archived' : 'active-only'` to the search `queryKey`.

No new HTTP routes and no new gateway verbs — `/workspace-topics/search` already accepted `includeArchived`; only the client failed to send it. Default (toggle off) request shape is byte-identical to `nightly`. No UI/copy changes, so no `DESIGN.md` surface is touched.

## Verification

```
npm run check
  ✖ 250 problems (0 errors, 250 warnings)     # 0 errors; warnings are pre-existing repo-wide

npx vitest run test/topic-sidebar-shell.test.ts test/workspace-topics.test.ts
  Test Files  2 passed (2)
       Tests  85 passed (85)
```

Mutation-checked that the regression pins **both** production lines, not just one:

```
drop `includeArchived: showArchived` (arg only):
  AssertionError: expected [ Array(2) ] to deep equally contain { q: 'archived', …(2) }
  Tests  1 failed | 67 skipped (68)

drop `showArchived ? 'with-archived' : 'active-only'` (queryKey only):
  AssertionError: expected [ { q: 'archived', limit: '20' } ] to deep equally contain { q: 'archived', …(2) }
  Tests  1 failed | 67 skipped (68)
```

The queryKey mutation is the interesting one: only **one** request is ever issued because the cached active-only result is served, so the second (`includeArchived=1`) entry never appears.

Coverage added:

- `test/topic-sidebar-shell.test.ts` — shell-level regression: search request omits `includeArchived` by default (empty state), then sends `includeArchived=1` and renders the archived topic after the toggle click.
- `test/workspace-topics.test.ts` — server contract: `/workspace-topics/search` returns archived rows only when `includeArchived=1` is requested.

## Review findings applied

Review verdict was **approve** with three P3 findings.

- **Applied** (`test/topic-sidebar-shell.test.ts`): the regression asserted exact URL strings, which made `URLSearchParams` append order inside `searchWorkspaceTopics` (`frontend/src/lib/api.ts`) silently load-bearing — an unrelated param reorder would have failed with a diff pointing at the sidebar. Now asserts on parsed params (`Object.fromEntries(new URL(url, ...).searchParams)`), keeping the negative case (no `includeArchived` key when the toggle is off). Confirmed by swapping `limit`/`includeArchived` order in `api.ts`: `Tests 1 passed` under the new assertion, where the old raw-string assertion would have broken.
- **Deferred, follow-up on #1287** (`server/workspace-topics.ts`): search candidates are capped at 201 rows ordered `updated_at DESC` while the store retains 500, and `archiveWorkspaceTopicRecord` bumps `updatedAt` so freshly archived rows sort to the top. In a scope with >200 topics, enabling `show older chats` can therefore evict an older *active* match from the candidate window. Inherited structural limit that the tree/list path already had — surfaced on a new path, not introduced here — and the toggle-off default path is unchanged. Fix belongs in a separate slice (widen the search-path window, or merge two capped active/archived queries).
- **Deferred, follow-up on #1287** (`TopicSidebarShell.tsx`): with the toggle off, the empty state gives no hint that archived chats were excluded, so the symptom is only fixed for users who find the toggle. Adding that affordance means restructuring the search empty state, which this slice's spec explicitly excludes.

Refs #1287 (slice 1, item: archived-search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Topic search now correctly respects the “show archived” setting.
  * Archived topics are excluded by default and included when the archived-content option is enabled.
  * Search results and displayed topic content now stay in sync with the selected filter.

* **Tests**
  * Added coverage for active-only and archived topic search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->