### PR TITLE
fix(palette): channel selection opens the channel (#1287 slice 1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,9 +32,9 @@ import {
   resubscribeIfNeeded,
 } from './lib/notifications.js';
 import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
-import { resolveTopicActiveContext } from '../../shared/workspace-topics.js';
 import { estimateTerminalDimensions } from './lib/utils.js';
 import { openTopicTaskRoom } from './lib/topic-task-room.js';
+import { openTopicSelectionFromPalette } from './lib/topic-selection.js';
 import { createSessionWithoutActivation } from './lib/session-utils.js';
 import {
   resolveSessionByKey,
@@ -1448,13 +1448,7 @@ export default function App() {
           closeSidebar();
         }}
         onSelectSession={(id) => handleSelectSession(id)}
-        onSelectTopic={(topic) => {
-          const context = resolveTopicActiveContext(topic);
-          const ui = useUiStore.getState();
-          ui.setActiveWorkspaceId(context.workspaceId);
-          if (context.repoPath) ui.setActiveRepoPath(context.repoPath);
-          closeSidebar();
-        }}
+        onSelectTopic={openTopicSelectionFromPalette}
         onSelectPr={handlePaletteSelectPr}
         onOpenSettings={(sectionId) => {
           setSpotlightOpen(false);

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   Repo,
   SessionSummary,
@@ -35,12 +35,10 @@ import {
   type ArtifactPaletteResult,
 } from '../lib/command-palette-artifact-results.js';
 import type { PipelineHandoffArtifactEnvelope } from '../lib/pipeline-handoff-timeline.js';
-import type {
-  WorkspaceTopic,
-  WorkspaceTopicListResponse,
-} from '../../../shared/workspace-topics.js';
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
 import {
   executeCommandCenterAssistantCommand,
+  fetchWorkspaceTopics,
   resolveCommandCenterAssistantIntent,
 } from '../lib/api.js';
 import {
@@ -68,6 +66,9 @@ const TABS = [
   'settings',
 ] as const;
 type Tab = (typeof TABS)[number];
+
+/** Stable identity so the topic-derived memos/effects do not refire per render. */
+const EMPTY_TOPICS: WorkspaceTopic[] = [];
 
 const SEC_GENERAL = 'section-general';
 const SEC_INTEGRATIONS = 'section-integrations';
@@ -328,12 +329,19 @@ function useCachedData(open: boolean) {
       [],
     [queryClient, open]
   );
-  const cachedTopics = useMemo<WorkspaceTopic[]>(
-    () =>
-      queryClient.getQueryData<WorkspaceTopicListResponse>(['workspace-topics'])
-        ?.topics ?? [],
-    [queryClient, open]
-  );
+  // #1287: the sidebar shell is the only other producer of this cache entry and
+  // it never mounts while the sidebar is collapsed, so a collapsed-sidebar user
+  // would otherwise have no topics in the palette at all. Observe the canonical
+  // key itself (shared with the sidebar) rather than snapshotting it: staying an
+  // active observer while open is what lets topic create/restore invalidations,
+  // which default to `refetchType: 'active'`, refresh a palette-only corpus.
+  const topicsQuery = useQuery({
+    queryKey: ['workspace-topics'],
+    queryFn: () => fetchWorkspaceTopics(),
+    enabled: open,
+    staleTime: 30_000,
+  });
+  const cachedTopics = topicsQuery.data?.topics ?? EMPTY_TOPICS;
   const cachedActiveWork = useMemo<WorkContextActiveGroup[]>(
     () =>
       queryClient.getQueryData<WorkContextActiveGroup[]>(['active-work']) ?? [],

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -49,6 +49,10 @@ import {
 } from '../lib/stores/channel-activity.js';
 import { AgentBadge } from './AgentBadge.js';
 import { openTopicTaskRoom } from '../lib/topic-task-room.js';
+import {
+  applyTopicActiveContext,
+  openTopicSelection,
+} from '../lib/topic-selection.js';
 import type { SessionSummary } from '../lib/types.js';
 import { formatRelativeTimeCompact } from '../lib/utils.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
@@ -2119,14 +2123,6 @@ function GroupedTopicTree({
   );
 }
 
-function applyTopicActiveContext(topic: WorkspaceTopic | undefined): void {
-  if (!topic) return;
-  const context = resolveTopicActiveContext(topic);
-  const ui = useUiStore.getState();
-  ui.setActiveWorkspaceId(context.workspaceId);
-  if (context.repoPath) ui.setActiveRepoPath(context.repoPath);
-}
-
 function TopicShellHeader({
   derived,
   onCreateTaskRoom,
@@ -2303,13 +2299,7 @@ export function TopicSidebarView({
     (id: string) => {
       setSelectedId(id);
       setMobileControlTopicId(null);
-      const topic = topicsById.get(id);
-      applyTopicActiveContext(topic);
-      if (topic?.source === 'persisted') {
-        const ui = useUiStore.getState();
-        ui.setActiveChannelId(id);
-        ui.setTopicComposerOpen(false);
-      }
+      openTopicSelection(topicsById.get(id));
     },
     [topicsById]
   );

--- a/frontend/src/lib/topic-selection.ts
+++ b/frontend/src/lib/topic-selection.ts
@@ -1,0 +1,50 @@
+import {
+  resolveTopicActiveContext,
+  type WorkspaceTopic,
+} from '../../../shared/workspace-topics.js';
+import { useUiStore } from './stores/ui.js';
+
+/**
+ * Establish the active workspace/repo context a topic selection implies so
+ * terminals, agents, and the workspace pane operate in the topic's repo. A
+ * pure-thread topic resolves no repo path and leaves the current one untouched.
+ */
+export function applyTopicActiveContext(
+  topic: WorkspaceTopic | undefined
+): void {
+  if (!topic) return;
+  const context = resolveTopicActiveContext(topic);
+  const ui = useUiStore.getState();
+  ui.setActiveWorkspaceId(context.workspaceId);
+  if (context.repoPath) ui.setActiveRepoPath(context.repoPath);
+}
+
+/**
+ * Route an explicit user selection of a topic: apply its workspace/repo context
+ * and, for a persisted topic, open its channel in the main pane and close the
+ * composer (#1166). Only persisted topics are backed by a channel — derived
+ * topics have none, so they move workspace/repo context only.
+ *
+ * Shared by the sidebar row and the command palette (#1287) so both entry
+ * points land the user on the same surface and the gate cannot drift.
+ */
+export function openTopicSelection(topic: WorkspaceTopic | undefined): void {
+  applyTopicActiveContext(topic);
+  if (topic?.source !== 'persisted') return;
+  const ui = useUiStore.getState();
+  ui.setActiveChannelId(topic.id);
+  ui.setTopicComposerOpen(false);
+}
+
+/**
+ * Command-palette selection (#1287): the same routing plus dismissing the mobile
+ * sidebar drawer the palette may have been opened over. Named rather than an
+ * inline arrow in App.tsx so the wired behaviour is what the regression test
+ * exercises — App passes this by reference.
+ */
+export function openTopicSelectionFromPalette(
+  topic: WorkspaceTopic | undefined
+): void {
+  openTopicSelection(topic);
+  useUiStore.getState().closeSidebar();
+}

--- a/test/command-center-assistant-shell.test.ts
+++ b/test/command-center-assistant-shell.test.ts
@@ -20,6 +20,7 @@ import type {
   ActionContext,
 } from '../frontend/src/lib/actions/types.js';
 import type { CommandCenterExecutionResult } from '../shared/command-center-execution.js';
+import type { WorkspaceTopicListResponse } from '../shared/workspace-topics.js';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -136,6 +137,37 @@ function executionSuccess(): CommandCenterExecutionResult {
   };
 }
 
+/**
+ * The palette observes ['workspace-topics'] the whole time it is open (#1287), so
+ * this shell test has to answer that request itself — unstubbed, happy-dom would
+ * resolve the relative URL against its default origin and open a real socket.
+ * Anything else is a hard failure so a future always-on query cannot silently add
+ * network I/O here.
+ */
+function stubPaletteFetch(): void {
+  const topics: WorkspaceTopicListResponse = {
+    topics: [],
+    truncated: false,
+    derived: false,
+  };
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (!url.includes('/workspace-topics')) {
+      throw new Error(`unstubbed fetch in unit test: ${url}`);
+    }
+    return new Response(JSON.stringify(topics), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+}
+
 function setInputValue(input: HTMLInputElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(
     HTMLInputElement.prototype,
@@ -210,16 +242,20 @@ describe('<CommandPalette /> assistant shell', () => {
 
   beforeEach(() => {
     _resetForTesting();
+    stubPaletteFetch();
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
-    queryClient = new QueryClient();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
   });
 
   afterEach(() => {
     act(() => root.unmount());
     queryClient.clear();
     container.remove();
+    vi.unstubAllGlobals();
     _resetForTesting();
   });
 

--- a/test/command-palette-topic-open.test.ts
+++ b/test/command-palette-topic-open.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CommandPalette from '../frontend/src/components/CommandPalette.js';
+import { openTopicSelectionFromPalette } from '../frontend/src/lib/topic-selection.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import { _resetForTesting } from '../frontend/src/lib/actions/registry.js';
+import type { ActionContext } from '../frontend/src/lib/actions/types.js';
+import type {
+  WorkspaceTopic,
+  WorkspaceTopicListResponse,
+} from '../shared/workspace-topics.js';
+import { createMockFetch } from './helpers/mock-fetch.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NOW = '2026-07-27T00:00:00Z';
+
+const actionContext: ActionContext = {
+  view: 'session',
+  workspacePath: '/repo',
+  cwd: '/repo',
+  isMobile: false,
+};
+
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:alpha',
+    workspaceId: 'workspace:alpha',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Palette lane', description: 'palette open target' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: { nodeId: 'devbox', repoPath: '/repo/relay' },
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function listResponse(topics: WorkspaceTopic[]): WorkspaceTopicListResponse {
+  return { topics, truncated: false, derived: false };
+}
+
+async function flushQueryEffects() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+describe('<CommandPalette /> topic selection', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    _resetForTesting();
+    useUiStore.setState({
+      activeChannelId: null,
+      topicComposerOpen: true,
+      sidebarOpen: true,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    useUiStore.setState({
+      activeChannelId: null,
+      topicComposerOpen: false,
+      sidebarOpen: false,
+    });
+    useUiStore.getState().setActiveRepoPath(null);
+    useUiStore.getState().setActiveWorkspaceId(null);
+    _resetForTesting();
+  });
+
+  async function renderPalette(open = true) {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(CommandPalette, {
+            open,
+            workspaces: [],
+            sessions: [],
+            actionContext,
+            onClose: vi.fn(),
+            onSelectWorkspace: vi.fn(),
+            onSelectSession: vi.fn(),
+            // The exact reference App.tsx wires into the palette.
+            onSelectTopic: openTopicSelectionFromPalette,
+            onSelectPr: vi.fn(),
+          })
+        )
+      );
+      await flushQueryEffects();
+    });
+  }
+
+  function topicItem(title: string): HTMLElement {
+    const item = [...container.querySelectorAll('.palette-item')].find(
+      (el) => el.querySelector('.item-label')?.textContent === title
+    );
+    if (!item) throw new Error(`palette item not found: ${title}`);
+    return item as HTMLElement;
+  }
+
+  it('opens the channel when a persisted topic is selected', async () => {
+    queryClient.setQueryData(['workspace-topics'], listResponse([makeTopic()]));
+    await renderPalette();
+
+    await act(async () => topicItem('Palette lane').click());
+
+    expect(useUiStore.getState().activeChannelId).toBe('topic:alpha');
+    expect(useUiStore.getState().topicComposerOpen).toBe(false);
+    expect(useUiStore.getState().activeWorkspaceId).toBe('workspace:alpha');
+    expect(useUiStore.getState().activeRepoPath).toBe('/repo/relay');
+    // The palette floats over the mobile drawer, which must not stay open.
+    expect(useUiStore.getState().sidebarOpen).toBe(false);
+  });
+
+  it('leaves the channel closed for a derived topic', async () => {
+    queryClient.setQueryData(
+      ['workspace-topics'],
+      listResponse([
+        makeTopic({
+          id: 'topic:derived',
+          source: 'derived',
+          display: { title: 'Derived lane' },
+        }),
+      ])
+    );
+    await renderPalette();
+
+    await act(async () => topicItem('Derived lane').click());
+
+    expect(useUiStore.getState().activeChannelId).toBeNull();
+    expect(useUiStore.getState().activeWorkspaceId).toBe('workspace:alpha');
+    expect(useUiStore.getState().activeRepoPath).toBe('/repo/relay');
+  });
+
+  it('fetches topics itself when the sidebar never mounted to fill the cache', async () => {
+    // Collapsed-sidebar users never mount TopicSidebarShell, so the shared
+    // ['workspace-topics'] cache entry stays empty (#1287).
+    const fetchMock = vi.fn(
+      createMockFetch({
+        '/workspace-topics': [{ json: listResponse([makeTopic()]) }],
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await renderPalette();
+    await act(async () => {
+      await flushQueryEffects();
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(
+      queryClient.getQueryData<WorkspaceTopicListResponse>(['workspace-topics'])
+        ?.topics
+    ).toHaveLength(1);
+    await act(async () => topicItem('Palette lane').click());
+    expect(useUiStore.getState().activeChannelId).toBe('topic:alpha');
+  });
+
+  it('picks up a topic invalidated while the palette was closed', async () => {
+    // A topic created elsewhere invalidates ['workspace-topics'] with the default
+    // `refetchType: 'active'`, so the palette has to stay an observer of the key
+    // to ever see it — otherwise its corpus freezes at the first snapshot for the
+    // rest of the session (#1287).
+    const fetchMock = vi.fn(
+      createMockFetch({
+        '/workspace-topics': [
+          { json: listResponse([makeTopic()]) },
+          {
+            json: listResponse([
+              makeTopic(),
+              makeTopic({
+                id: 'topic:beta',
+                display: { title: 'Later lane' },
+              }),
+            ]),
+          },
+        ],
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await renderPalette();
+    await act(async () => {
+      await flushQueryEffects();
+    });
+    expect(topicItem('Palette lane')).toBeTruthy();
+
+    await renderPalette(false);
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ['workspace-topics'] });
+      await flushQueryEffects();
+    });
+    await renderPalette();
+    await act(async () => {
+      await flushQueryEffects();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await act(async () => topicItem('Later lane').click());
+    expect(useUiStore.getState().activeChannelId).toBe('topic:beta');
+  });
+});


### PR DESCRIPTION
## Defect

Cmd+K → a channel row did nothing useful. `onSelectTopic` in `App.tsx` only
resolved workspace/repo context (`setActiveWorkspaceId` / `setActiveRepoPath`)
and never set `activeChannelId`, so with a live session the selection was a
silent no-op, and with no session it set `activeRepoPath` and landed the user on
the legacy RepoDashboard instead of the chosen channel. The sidebar row already
opened the channel — the two entry points had drifted.

Second defect in the same path: the palette's topic corpus was read only from the
`['workspace-topics']` cache, whose sole producer was `TopicSidebarShell`. That
shell never mounts while the sidebar is collapsed, so a collapsed-sidebar user
had zero topics in the palette for the whole session.

## Fix

- `frontend/src/lib/topic-selection.ts` (new): `applyTopicActiveContext` +
  `openTopicSelection` (persisted topic → open channel + close composer; derived
  topic → context only), lifted out of `TopicSidebarShell` so the sidebar row and
  the palette share one gate. `openTopicSelectionFromPalette` composes selection
  with `closeSidebar()` and `App.tsx` passes it **by reference**, so the wiring —
  not just the helper — is what the regression test exercises.
- `CommandPalette.tsx` now observes `['workspace-topics']` with `useQuery` while
  open instead of snapshotting the cache. `enabled: open` (not
  `open && snapshot.length === 0`) matters: a snapshot-gated query self-disables
  after its first success, and `invalidateQueries` defaults to
  `refetchType: 'active'`, which never refetches a query whose only observer is
  disabled — the corpus would have frozen at the first snapshot ("permanently
  empty" traded for "permanently stale"). Same key, same `queryFn` args, same
  `staleTime` as the sidebar, so the cache entry stays shared.
- `test/command-center-assistant-shell.test.ts`: the always-mounted query made
  that pre-existing unit test perform real network I/O (happy-dom resolved
  `/workspace-topics` against its default origin, 4 attempts with default
  retries). It now stubs `fetch` — failing loudly on any other URL — and builds
  its `QueryClient` with `retry: false`.

## Verification

```
npm run check
✖ 249 problems (0 errors, 249 warnings)   # exit 0, warnings are the repo baseline

npx vitest run test/command-palette-topic-open.test.ts \
  test/command-center-assistant-shell.test.ts test/topic-sidebar-shell.test.ts \
  test/topic-nav.test.ts test/command-palette-topic-results.test.ts \
  test/command-palette-artifact-results.test.ts \
  test/command-palette-session-fields.test.ts test/sidebar-items.test.ts
 Test Files  8 passed (8)
      Tests  126 passed (126)
```

`test/command-palette-topic-open.test.ts` renders the real `CommandPalette` with
the exact handler `App.tsx` passes and asserts, per case:

1. persisted topic → `activeChannelId`, composer closed, workspace/repo context,
   sidebar closed;
2. derived topic → `activeChannelId` stays `null`, context still applied;
3. empty cache (collapsed sidebar) → palette fetches `/workspace-topics` itself
   and the row opens its channel;
4. topic invalidated while the palette was closed → reopening refetches and the
   new row opens (`fetchMock` called twice).

Both new guards were mutation-checked against the defective behaviour:
re-gating the query on the cache snapshot fails case 4
(`expected "vi.fn()" to be called 2 times, but got 1 times`), and reverting the
palette handler to the context-only body fails cases 1, 3 and 4
(`expected null to be 'topic:alpha'`). The assistant-shell test emits no
`localhost:3000` requests any more.

## Residual (not fixed here, mirrors sidebar semantics)

- Selecting a channel while an analytics view is open still changes nothing
  visible: `resolveAppViewMode` returns `analytics` before `hasActiveChannel`.
  The sidebar's own navigation helper clears `analyticsView`; `openTopicSelection`
  deliberately does not, so this stays a shared, pre-existing gap.
- `applyTopicActiveContext` still sets `activeRepoPath` from `routingDefaults`,
  so dismissing a channel with no active session falls through to
  `dashboard` (RepoDashboard) rather than the chat landing.

Both are shared with the sidebar path and out of this slice's scope — logged here
so they are not read as fixed.

Refs #1287 (slice 1, item: palette-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
