### PR TITLE
fix(channels): bootstrap unread from GET /channels on sidebar mount (#1287 slice 1)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -2700,17 +2700,24 @@ export function TopicSidebarShell({
   });
   // Unread head seqs only arrive over `/ws/events` for channels that move while
   // the socket is open, so a reload would render every row as read. Seed them
-  // from the channel list once the rail mounts (#1287).
+  // from the channel list once the rail mounts (#1287). This is a cold-load
+  // bootstrap only — the live broadcast keeps head seqs current while the socket
+  // is up — so keep it lazy: the payload is a full summary (members + last
+  // message) per channel, and the rail remounts on every sidebar collapse.
   const channelsQuery = useQuery({
     queryKey: ['channels'],
     queryFn: fetchChannels,
-    staleTime: 30_000,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
   const channelRows = channelsQuery.data;
+  const channelRowsFetchedAt = channelsQuery.dataUpdatedAt;
   useEffect(() => {
     if (!channelRows) return;
-    useChannelActivityStore.getState().seedChannelActivity(channelRows);
-  }, [channelRows]);
+    useChannelActivityStore
+      .getState()
+      .seedChannelActivity(channelRows, channelRowsFetchedAt);
+  }, [channelRows, channelRowsFetchedAt]);
   const searchActive = normalizedSearchQuery.length > 0;
   const searchData = topicSearchQuery.data;
   const searchResults = useMemo(

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -37,6 +37,7 @@ import {
   fetchHubNodes,
   fetchChannelRoster,
   fetchChannelHistory,
+  fetchChannels,
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
   interruptChannelAgent,
@@ -2180,8 +2181,10 @@ export function TopicSidebarView({
       Object.fromEntries(
         model.items.map((item, index) => [
           item.id,
-          relevantActivity[index * 2] !== undefined &&
-            hasUnseenActivity(item.id, activeChannelId),
+          hasUnseenActivity(item.id, activeChannelId, {
+            latestSeq: relevantActivity[index * 2],
+            lastRead: relevantActivity[index * 2 + 1],
+          }),
         ])
       ),
     [activeChannelId, model.items, relevantActivity]
@@ -2695,6 +2698,19 @@ export function TopicSidebarShell({
     queryFn: fetchHubNodes,
     staleTime: 60_000,
   });
+  // Unread head seqs only arrive over `/ws/events` for channels that move while
+  // the socket is open, so a reload would render every row as read. Seed them
+  // from the channel list once the rail mounts (#1287).
+  const channelsQuery = useQuery({
+    queryKey: ['channels'],
+    queryFn: fetchChannels,
+    staleTime: 30_000,
+  });
+  const channelRows = channelsQuery.data;
+  useEffect(() => {
+    if (!channelRows) return;
+    useChannelActivityStore.getState().seedChannelActivity(channelRows);
+  }, [channelRows]);
   const searchActive = normalizedSearchQuery.length > 0;
   const searchData = topicSearchQuery.data;
   const searchResults = useMemo(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1733,6 +1733,12 @@ export async function fetchChannel(
  * `latestSeq`. This is the only client-side source of head seqs on a cold load:
  * the `/ws/events` `channel-activity` broadcast reports just the channels that
  * move while that socket is open.
+ *
+ * The route lists topics unfiltered, so the payload is the newest 200 by
+ * `updated_at` INCLUDING archived ones. The rail's own topic query takes a
+ * separate 200-row window whose `includeArchived` follows the archive toggle, so
+ * with enough recently-updated archived topics a rendered active row can fall
+ * outside this window and get no seed until it moves.
  */
 export async function fetchChannels(): Promise<ChannelSummaryView[]> {
   const data = await json<{ channels?: ChannelSummaryView[] }>(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1728,6 +1728,21 @@ export async function fetchChannel(
   return data.channel;
 }
 
+/**
+ * All channels (archived ones only when they hold messages) with per-channel
+ * `latestSeq`. This is the only client-side source of head seqs on a cold load:
+ * the `/ws/events` `channel-activity` broadcast reports just the channels that
+ * move while that socket is open.
+ */
+export async function fetchChannels(): Promise<ChannelSummaryView[]> {
+  const data = await json<{ channels?: ChannelSummaryView[] }>(
+    await fetch('/channels', {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  return Array.isArray(data.channels) ? data.channels : [];
+}
+
 export interface ChannelHistoryPage {
   messages: ChannelMessage[];
   hasMore: boolean;

--- a/frontend/src/lib/stores/channel-activity.ts
+++ b/frontend/src/lib/stores/channel-activity.ts
@@ -1,8 +1,10 @@
 // Coarse per-channel activity cache (#1166). Fed by the `/ws/events`
 // `channel-activity` broadcast, which carries only `{ channelId, latestSeq }` —
-// no per-user unread count, no sender info. The sidebar renders a presence-only
-// dot (not a count badge) when a channel has activity newer than the client's
-// local last-read marker and isn't the currently-open channel.
+// no per-user unread count, no sender info — and seeded on sidebar mount from
+// the channel list (#1287) because the broadcast only covers channels that move
+// while the socket is open. The sidebar renders a presence-only dot (not a count
+// badge) when a channel has activity newer than the client's local last-read
+// marker and isn't the currently-open channel.
 import { create } from 'zustand';
 
 interface ChannelActivityState {
@@ -16,6 +18,15 @@ interface ChannelActivityState {
    */
   lastReadByChannel: Record<string, number>;
   recordActivity: (channelId: string, latestSeq: number) => void;
+  /**
+   * Seed head seqs from a channel-list payload (#1287). `latestSeqByChannel` is
+   * in-memory only and the `channel-activity` broadcast reports just the channels
+   * that move while the socket is open, so without this bootstrap every reload
+   * renders the whole rail as read and the missed range is unrecoverable. Rows
+   * are applied monotonic-up, so a list response that loses the race with a live
+   * broadcast can never move a channel backwards.
+   */
+  seedChannelActivity: (rows: { id: string; latestSeq: number }[]) => void;
   /** Mark a channel read up to `seq` (monotonic up). Reactive + persistent. */
   markChannelRead: (channelId: string, seq: number) => void;
   /**
@@ -53,6 +64,22 @@ export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
           ...state.latestSeqByChannel,
           [channelId]: latestSeq,
         },
+      };
+    }),
+  seedChannelActivity: (rows) =>
+    set((state) => {
+      const seeded: Record<string, number> = {};
+      for (const row of rows) {
+        // The list view reports `latestSeq: 0` for channels with no messages;
+        // those have nothing to be unread.
+        if (!(row.latestSeq > 0)) continue;
+        const current = state.latestSeqByChannel[row.id];
+        if (current !== undefined && current >= row.latestSeq) continue;
+        seeded[row.id] = row.latestSeq;
+      }
+      if (Object.keys(seeded).length === 0) return state;
+      return {
+        latestSeqByChannel: { ...state.latestSeqByChannel, ...seeded },
       };
     }),
   markChannelRead: (channelId, seq) =>
@@ -102,28 +129,18 @@ function readPersistedLastRead(channelId: string): number {
 }
 
 /**
- * Client-local last-read seq for a channel. Prefers the reactive store value
- * (freshly written on read) and falls back to the persisted localStorage marker
- * for channels the store has not hydrated yet (e.g. first render after reload).
- */
-function readLastReadSeq(channelId: string): number {
-  const stored =
-    useChannelActivityStore.getState().lastReadByChannel[channelId];
-  if (stored !== undefined) return stored;
-  return readPersistedLastRead(channelId);
-}
-
-/**
  * True when the channel has activity newer than the client's last-read marker
  * AND isn't the currently-open channel. Presence-only signal for the sidebar.
+ * Takes the caller's already-subscribed seq pair so a rail projection recomputes
+ * whenever either seq moves, and falls back to the persisted localStorage marker
+ * for channels the store has no read marker for yet (e.g. after a reload).
  */
 export function hasUnseenActivity(
   channelId: string,
-  activeChannelId: string | null
+  activeChannelId: string | null,
+  seqs: { latestSeq: number | undefined; lastRead: number | undefined }
 ): boolean {
   if (channelId === activeChannelId) return false;
-  const latestSeq =
-    useChannelActivityStore.getState().latestSeqByChannel[channelId];
-  if (latestSeq === undefined) return false;
-  return latestSeq > readLastReadSeq(channelId);
+  if (seqs.latestSeq === undefined) return false;
+  return seqs.latestSeq > (seqs.lastRead ?? readPersistedLastRead(channelId));
 }

--- a/frontend/src/lib/stores/channel-activity.ts
+++ b/frontend/src/lib/stores/channel-activity.ts
@@ -5,6 +5,11 @@
 // while the socket is open. The sidebar renders a presence-only dot (not a count
 // badge) when a channel has activity newer than the client's local last-read
 // marker and isn't the currently-open channel.
+//
+// The read marker is client-local, so a channel with messages and no marker in
+// THIS browser reads as fully unread — a new device lights up every channel that
+// holds messages rather than only ones with new traffic. That is the accepted
+// cost of a client-only marker until server-side read state arrives.
 import { create } from 'zustand';
 
 interface ChannelActivityState {
@@ -17,16 +22,26 @@ interface ChannelActivityState {
    * keep showing a stale dot until unrelated activity arrived.
    */
   lastReadByChannel: Record<string, number>;
+  /**
+   * Wall-clock ms of the most recent applied clamp per channel. A channel-list
+   * payload fetched before that instant still carries the pre-clamp head seq, so
+   * `seedChannelActivity` refuses it (#1287).
+   */
+  clampedAtByChannel: Record<string, number>;
   recordActivity: (channelId: string, latestSeq: number) => void;
   /**
-   * Seed head seqs from a channel-list payload (#1287). `latestSeqByChannel` is
-   * in-memory only and the `channel-activity` broadcast reports just the channels
-   * that move while the socket is open, so without this bootstrap every reload
-   * renders the whole rail as read and the missed range is unrecoverable. Rows
-   * are applied monotonic-up, so a list response that loses the race with a live
-   * broadcast can never move a channel backwards.
+   * Seed head seqs from a channel-list payload fetched at `fetchedAt` (#1287).
+   * `latestSeqByChannel` is in-memory only and the `channel-activity` broadcast
+   * reports just the channels that move while the socket is open, so without this
+   * bootstrap every reload renders the whole rail as read and the missed range is
+   * unrecoverable. Rows are applied monotonic-up, so a list response that loses
+   * the race with a live broadcast can never move a channel backwards, and rows
+   * older than a clamp are skipped so a cached payload cannot undo one.
    */
-  seedChannelActivity: (rows: { id: string; latestSeq: number }[]) => void;
+  seedChannelActivity: (
+    rows: { id: string; latestSeq: number }[],
+    fetchedAt: number
+  ) => void;
   /** Mark a channel read up to `seq` (monotonic up). Reactive + persistent. */
   markChannelRead: (channelId: string, seq: number) => void;
   /**
@@ -55,6 +70,7 @@ function persistLastRead(channelId: string, seq: number): void {
 export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
   latestSeqByChannel: {},
   lastReadByChannel: {},
+  clampedAtByChannel: {},
   recordActivity: (channelId, latestSeq) =>
     set((state) => {
       const current = state.latestSeqByChannel[channelId];
@@ -66,13 +82,19 @@ export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
         },
       };
     }),
-  seedChannelActivity: (rows) =>
+  seedChannelActivity: (rows, fetchedAt) =>
     set((state) => {
       const seeded: Record<string, number> = {};
       for (const row of rows) {
         // The list view reports `latestSeq: 0` for channels with no messages;
         // those have nothing to be unread.
         if (!(row.latestSeq > 0)) continue;
+        // The rail remounts whenever the sidebar collapses and the cached list
+        // outlives that, so a payload fetched before a clamp would replay the
+        // pre-clamp head and pin the unread dot on forever (seeding is
+        // monotonic-up, so nothing would lower it again).
+        const clampedAt = state.clampedAtByChannel[row.id];
+        if (clampedAt !== undefined && clampedAt >= fetchedAt) continue;
         const current = state.latestSeqByChannel[row.id];
         if (current !== undefined && current >= row.latestSeq) continue;
         seeded[row.id] = row.latestSeq;
@@ -115,7 +137,14 @@ export const useChannelActivityStore = create<ChannelActivityState>((set) => ({
           [channelId]: headSeq,
         };
       }
-      return Object.keys(next).length > 0 ? next : state;
+      if (Object.keys(next).length === 0) return state;
+      // Fence stale channel-list payloads (#1287): every list response already in
+      // flight or cached still reports the pre-clamp head for this channel.
+      next.clampedAtByChannel = {
+        ...state.clampedAtByChannel,
+        [channelId]: Date.now(),
+      };
+      return next;
     }),
 }));
 

--- a/test/hooks/useChannelChatSocket.test.ts
+++ b/test/hooks/useChannelChatSocket.test.ts
@@ -150,6 +150,7 @@ describe('useChannelChatSocket liveness + recovery (#1178)', () => {
     useChannelActivityStore.setState({
       latestSeqByChannel: {},
       lastReadByChannel: {},
+      clampedAtByChannel: {},
     });
     try {
       localStorage.clear();

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -104,6 +104,7 @@ describe('TopicSidebarView', () => {
     useChannelActivityStore.setState({
       latestSeqByChannel: {},
       lastReadByChannel: {},
+      clampedAtByChannel: {},
     });
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -126,6 +127,7 @@ describe('TopicSidebarView', () => {
     useChannelActivityStore.setState({
       latestSeqByChannel: {},
       lastReadByChannel: {},
+      clampedAtByChannel: {},
     });
     localStorage.removeItem(channelLastReadKey('topic:alpha'));
   });
@@ -291,10 +293,13 @@ describe('TopicSidebarView', () => {
     ).toBe(false);
 
     act(() => {
-      useChannelActivityStore.getState().seedChannelActivity([
-        { id: 'topic:alpha', latestSeq: 9 },
-        { id: 'topic:empty', latestSeq: 0 },
-      ]);
+      useChannelActivityStore.getState().seedChannelActivity(
+        [
+          { id: 'topic:alpha', latestSeq: 9 },
+          { id: 'topic:empty', latestSeq: 0 },
+        ],
+        Date.now()
+      );
     });
 
     const seeded = useChannelActivityStore.getState();
@@ -313,11 +318,66 @@ describe('TopicSidebarView', () => {
       useChannelActivityStore.getState().recordActivity('topic:alpha', 12);
       useChannelActivityStore
         .getState()
-        .seedChannelActivity([{ id: 'topic:alpha', latestSeq: 9 }]);
+        .seedChannelActivity([{ id: 'topic:alpha', latestSeq: 9 }], Date.now());
     });
     expect(
       useChannelActivityStore.getState().latestSeqByChannel['topic:alpha']
     ).toBe(12);
+  });
+
+  it('refuses a channel list payload fetched before a clamp (#1287)', () => {
+    // Stale-ahead state a recreated DM leaves behind (#1178), plus the list
+    // payload the rail already cached while the head was still high.
+    act(() => {
+      useChannelActivityStore.getState().recordActivity('topic:alpha', 50);
+      useChannelActivityStore.getState().markChannelRead('topic:alpha', 40);
+    });
+    const cachedFetchedAt = Date.now() - 1;
+
+    act(() => {
+      useChannelActivityStore.getState().clampChannelStores('topic:alpha', 5);
+    });
+    const clamped = useChannelActivityStore.getState();
+    expect(clamped.latestSeqByChannel['topic:alpha']).toBe(5);
+    expect(clamped.lastReadByChannel['topic:alpha']).toBe(5);
+
+    // The rail remounts (sidebar collapse) and React Query replays the cached
+    // pre-clamp payload; re-seeding head 50 against the clamped read marker 5
+    // would pin the unread dot on for the channel's whole new lifetime.
+    act(() => {
+      useChannelActivityStore
+        .getState()
+        .seedChannelActivity(
+          [{ id: 'topic:alpha', latestSeq: 50 }],
+          cachedFetchedAt
+        );
+    });
+    const afterStaleSeed = useChannelActivityStore.getState();
+    expect(afterStaleSeed.latestSeqByChannel['topic:alpha']).toBe(5);
+    expect(
+      hasUnseenActivity('topic:alpha', null, {
+        latestSeq: afterStaleSeed.latestSeqByChannel['topic:alpha'],
+        lastRead: afterStaleSeed.lastReadByChannel['topic:alpha'],
+      })
+    ).toBe(false);
+
+    // A payload fetched after the clamp is authoritative again.
+    act(() => {
+      useChannelActivityStore
+        .getState()
+        .seedChannelActivity(
+          [{ id: 'topic:alpha', latestSeq: 7 }],
+          Date.now() + 1_000
+        );
+    });
+    const afterFreshSeed = useChannelActivityStore.getState();
+    expect(afterFreshSeed.latestSeqByChannel['topic:alpha']).toBe(7);
+    expect(
+      hasUnseenActivity('topic:alpha', null, {
+        latestSeq: afterFreshSeed.latestSeqByChannel['topic:alpha'],
+        lastRead: afterFreshSeed.lastReadByChannel['topic:alpha'],
+      })
+    ).toBe(true);
   });
 
   it('seeds unread head seqs from the channel list on shell mount (#1287)', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -19,6 +19,7 @@ import {
 import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
 import {
   channelLastReadKey,
+  hasUnseenActivity,
   useChannelActivityStore,
 } from '../frontend/src/lib/stores/channel-activity.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
@@ -275,6 +276,108 @@ describe('TopicSidebarView', () => {
       )
     ).toBeNull();
     localStorage.removeItem(channelLastReadKey('topic:alpha'));
+  });
+
+  it('reports unseen activity for a fresh store seeded from a channel list payload (#1287)', () => {
+    localStorage.setItem(channelLastReadKey('topic:alpha'), '3');
+
+    // Fresh store == every reload: `latestSeqByChannel` starts empty, so the rail
+    // has no head seq until the channel list seeds it.
+    expect(
+      hasUnseenActivity('topic:alpha', null, {
+        latestSeq: undefined,
+        lastRead: undefined,
+      })
+    ).toBe(false);
+
+    act(() => {
+      useChannelActivityStore.getState().seedChannelActivity([
+        { id: 'topic:alpha', latestSeq: 9 },
+        { id: 'topic:empty', latestSeq: 0 },
+      ]);
+    });
+
+    const seeded = useChannelActivityStore.getState();
+    expect(seeded.latestSeqByChannel['topic:alpha']).toBe(9);
+    expect(seeded.latestSeqByChannel['topic:empty']).toBeUndefined();
+    expect(
+      hasUnseenActivity('topic:alpha', null, {
+        latestSeq: seeded.latestSeqByChannel['topic:alpha'],
+        lastRead: seeded.lastReadByChannel['topic:alpha'],
+      })
+    ).toBe(true);
+
+    // Seeding is monotonic up: a list response that lands after a live
+    // `channel-activity` broadcast must not rewind the head seq.
+    act(() => {
+      useChannelActivityStore.getState().recordActivity('topic:alpha', 12);
+      useChannelActivityStore
+        .getState()
+        .seedChannelActivity([{ id: 'topic:alpha', latestSeq: 9 }]);
+    });
+    expect(
+      useChannelActivityStore.getState().latestSeqByChannel['topic:alpha']
+    ).toBe(12);
+  });
+
+  it('seeds unread head seqs from the channel list on shell mount (#1287)', async () => {
+    localStorage.setItem(channelLastReadKey('topic:alpha'), '3');
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const topicsResponse: WorkspaceTopicListResponse = {
+      topics: [makeTopic()],
+      truncated: false,
+      derived: false,
+    };
+    queryClient.setQueryData(['workspace-topics'], topicsResponse);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const body =
+        url === '/channels'
+          ? { channels: [{ id: 'topic:alpha', latestSeq: 9 }] }
+          : {};
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(TopicSidebarShell, { onSelectSession })
+        )
+      );
+      await flushQueryEffects();
+    });
+    // Drain the fetch → query-cache → seed-effect → re-render chain.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      if (
+        useChannelActivityStore.getState().latestSeqByChannel['topic:alpha'] !==
+        undefined
+      )
+        break;
+      await act(async () => {
+        await flushQueryEffects();
+      });
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith('/channels', {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    });
+    expect(
+      useChannelActivityStore.getState().latestSeqByChannel['topic:alpha']
+    ).toBe(9);
+    expect(
+      container.querySelector(
+        '[data-topic-id="topic:alpha"][data-unread="true"]'
+      )
+    ).not.toBeNull();
+    queryClient.clear();
   });
 
   it('does not commit the sidebar for unrelated channel activity', async () => {


### PR DESCRIPTION
## Defect

`latestSeqByChannel` (the unread head-seq half of the channel activity store) was
in-memory with exactly one production writer — the live `/ws/events`
`channel-activity` handler — while its sibling `lastReadByChannel` persists to
localStorage. So every page load, reload, or new tab started with **no head seqs
at all**: `hasUnseenActivity` returned false for every channel, the whole rail
rendered as read, and the range missed while the browser was closed was
unrecoverable client-side. Only channels that happened to move while that socket
was open ever showed a dot.

## Fix

`GET /channels` already returns per-channel `latestSeq`, so seed from it. No new
HTTP route, no new gateway verb.

- `fetchChannels()` in `frontend/src/lib/api.ts` — client over the existing route.
- `seedChannelActivity(rows, fetchedAt)` applies the list payload **monotonic-up**,
  so a slow list response can never rewind a live broadcast that landed first.
  Rows with `latestSeq: 0` (no messages) are skipped.
- `TopicSidebarShell` runs the query and seeds once the rail mounts.
- `hasUnseenActivity` now takes the caller's already-subscribed seq pair, which
  keeps the rail projection reactive and drops the redundant
  `relevantActivity[index * 2] !== undefined` gate at the call site.

### Review follow-up (second commit)

- **Clamp epoch fence.** `clampChannelStores` (#1178) lowers a channel's head seq
  when a full snapshot proves the stored marker is stale-ahead (a DM recreated
  under the same deterministic id restarts its seq low). The seed could undo that:
  the rail unmounts whenever the sidebar collapses (`Sidebar.tsx` renders it
  behind `!sidebarCollapsed`), nothing invalidates `['channels']`, and a remount
  inside the freshness window replays the same cached array with its pre-clamp
  `latestSeq`. Since seeding is monotonic-up, the downward correction was reversed
  and could not be re-applied until another full snapshot arrived — leaving
  `latestSeq` stale-high against a clamped-low read marker, i.e. an unread dot
  pinned on for the channel's whole new lifetime. A clamp now records
  `clampedAtByChannel[channelId]`, and the seed skips rows for channels clamped at
  or after the payload's `dataUpdatedAt`. Later refetches seed normally.
- **Query made as lazy as its use.** `staleTime` 5min, `refetchOnWindowFocus:
  false`. The list is a cold-load bootstrap only — the broadcast keeps head seqs
  current while the socket is open — and the payload is a full per-channel summary
  (members + last message) for up to 200 channels.

## Known costs (documented in code, not coded around)

- The read marker is client-local, so a channel with messages and no marker in
  *this* browser reads as fully unread: a new device/profile lights up every
  channel holding messages rather than only ones with new traffic. Accepted until
  server-side read state lands in the slice-3 hello snapshot — seeding
  `lastRead = latestSeq` on first bootstrap would instead re-suppress the genuine
  unreads this slice exists to surface.
- `GET /channels` lists the newest 200 topics by `updated_at` *including*
  archived; the rail's own 200-row window follows the archive toggle, so with
  enough recently-updated archived topics a rendered active row can fall outside
  the seeded window and keep the pre-fix behaviour until it moves.

## Verification

```
npm run check
  221 problems (0 errors, 221 warnings)   # warning count unchanged from base

npx vitest run test/topic-sidebar-shell.test.ts test/hooks/useChannelChatSocket.test.ts test/channel-hub.test.ts
  Test Files  3 passed (3)
       Tests  99 passed (99)
```

The regression test is decisive, not incidental — with the clamp fence removed:

```
npx vitest run test/topic-sidebar-shell.test.ts -t "refuses a channel list payload fetched before a clamp"
  AssertionError: expected 50 to be 5   # stale seed restores the pre-clamp head
  Tests  1 failed | 68 skipped (69)
```

Restored, the same test passes. New/updated coverage:

- `reports unseen activity for a fresh store seeded from a channel list payload (#1287)`
- `refuses a channel list payload fetched before a clamp (#1287)`
- `seeds unread head seqs from the channel list on shell mount (#1287)` — asserts
  the `/channels` fetch, the seeded head seq, and a rendered
  `[data-unread="true"]` row.

Refs #1287 (slice 1, item: unread-bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
