### PR TITLE
fix(nav): cockpit escape hatches clear activeChannelId (#1287 slice 1)

### DIFF
--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -111,7 +111,7 @@ import {
 } from '../lib/actions/definitions/navigation.js';
 import { cliGatewayCommandActions } from '../lib/actions/definitions/cli-gateway.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
-import { useUiStore } from '../lib/stores/ui.js';
+import { useUiStore, type OrgDashboardTab } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { useToastStore } from '../lib/stores/toasts.js';
 import {
@@ -171,6 +171,24 @@ function openSettingsNodes(): void {
   useUiStore
     .getState()
     .setActiveModal({ modal: 'settings', scrollToId: SECTION_NODES });
+}
+
+/**
+ * #1058/#1287: escape hatch out of the chat spine into the legacy WorkContext
+ * cockpit. Every chat-shell surface that outranks `forceOrgCockpit` in
+ * `resolveAppViewMode` must be cleared here — an open channel or composer wins
+ * over the flag, so leaving one set makes the action a silent no-op that later
+ * fires as a surprise navigation when the operator closes the channel.
+ */
+function enterWorkCockpit(tab?: OrgDashboardTab): void {
+  const ui = useUiStore.getState();
+  ui.setAnalyticsView(null);
+  ui.setActiveChannelId(null);
+  ui.setTopicComposerOpen(false);
+  useSessionsStore.getState().setActiveSessionId(null);
+  ui.setActiveRepoPath(null);
+  if (tab) ui.setOrgDashboardTab(tab);
+  ui.setForceOrgCockpit(true);
 }
 
 async function copyText(text: string): Promise<void> {
@@ -700,18 +718,9 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       {
         // #1058: the chat/topic spine is the default no-session/no-repo
         // landing; this is the escape hatch back to the legacy WorkContext
-        // cockpit. Clears the active session/repo/analytics view so
-        // resolveAppViewMode's no-session/no-repo branch is reached, then
-        // sets forceOrgCockpit so it resolves to 'org' instead of 'chat'.
+        // cockpit (see enterWorkCockpit).
         ...navOpenWorkCockpit,
-        handler: () => {
-          const sessions = useSessionsStore.getState();
-          const ui = useUiStore.getState();
-          ui.setAnalyticsView(null);
-          sessions.setActiveSessionId(null);
-          ui.setActiveRepoPath(null);
-          ui.setForceOrgCockpit(true);
-        },
+        handler: () => enterWorkCockpit(),
       },
       {
         // #1058: one-off escape hatch — opens the work cockpit's nodes tab
@@ -719,29 +728,13 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
         // strip stays hidden on the next visit unless the user opts in via
         // Settings.
         ...navOpenNodesDashboard,
-        handler: () => {
-          const sessions = useSessionsStore.getState();
-          const ui = useUiStore.getState();
-          ui.setAnalyticsView(null);
-          sessions.setActiveSessionId(null);
-          ui.setActiveRepoPath(null);
-          ui.setOrgDashboardTab('nodes');
-          ui.setForceOrgCockpit(true);
-        },
+        handler: () => enterWorkCockpit('nodes'),
       },
       {
         // #1058: one-off escape hatch — opens the work cockpit's active-work
         // tab without flipping the persistent advancedMode flag.
         ...navOpenActiveWork,
-        handler: () => {
-          const sessions = useSessionsStore.getState();
-          const ui = useUiStore.getState();
-          ui.setAnalyticsView(null);
-          sessions.setActiveSessionId(null);
-          ui.setActiveRepoPath(null);
-          ui.setOrgDashboardTab('active-work');
-          ui.setForceOrgCockpit(true);
-        },
+        handler: () => enterWorkCockpit('active-work'),
       },
       {
         // #1058: one-off escape hatch — opens the analytics dashboard

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -1114,7 +1114,15 @@ export const useUiStore = create<UiState>()((set, get) => ({
   setForceOrgCockpit: (v) => set({ forceOrgCockpit: v }),
   setTopicComposerOpen: (v) => set({ topicComposerOpen: v }),
   setActiveChannelId: (v) =>
-    set({ activeChannelId: v, activeThreadRootId: null }),
+    set({
+      activeChannelId: v,
+      activeThreadRootId: null,
+      // #1287: an open channel outranks `forceOrgCockpit` in resolveAppViewMode,
+      // so a channel activation must also drop the one-off cockpit escape hatch
+      // (as sessions.setActiveSessionId does) — otherwise a latched flag fires
+      // as a surprise cockpit navigation when the channel is later closed.
+      ...(v !== null ? { forceOrgCockpit: false } : {}),
+    }),
   setActiveThreadRootId: (v) => set({ activeThreadRootId: v }),
   setActiveModal: (v) => set({ activeModal: v }),
 

--- a/test/app-view-mode.test.ts
+++ b/test/app-view-mode.test.ts
@@ -108,6 +108,43 @@ describe('resolveAppViewMode', () => {
     ).toBe('dashboard');
   });
 
+  it('keeps an open channel ahead of forceOrgCockpit, so cockpit escape hatches must clear the channel (#1287)', () => {
+    // The flag alone cannot escape a channel — any surface that latches
+    // forceOrgCockpit without clearing activeChannelId is a silent no-op that
+    // fires later as a surprise navigation when the channel is closed.
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        activeRepoPath: null,
+        hasActiveChannel: true,
+        forceOrgCockpit: true,
+      })
+    ).toBe('chat');
+
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: true,
+        activeRepoPath: '/repo/relay-ide',
+        activeSessionMode: 'pty',
+        hasActiveChannel: true,
+        forceOrgCockpit: true,
+      })
+    ).toBe('chat');
+
+    // Clearing the channel (what the escape hatches now do) reaches the cockpit.
+    expect(
+      resolveAppViewMode({
+        analyticsView: null,
+        hasActiveSession: false,
+        activeRepoPath: null,
+        hasActiveChannel: false,
+        forceOrgCockpit: true,
+      })
+    ).toBe('org');
+  });
+
   it('routes an active PTY agent/terminal session to the terminal view (#1058)', () => {
     // A live PTY session (Claude/Codex/Hermes TUI) must surface its terminal.
     expect(

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -156,6 +156,7 @@ describe('session lifecycle handlers', () => {
       analyticsView: null,
       forceOrgCockpit: false,
       topicComposerOpen: false,
+      activeChannelId: null,
       sidebarOpen: false,
     });
     window.history.replaceState(null, '', '/');
@@ -188,6 +189,7 @@ describe('session lifecycle handlers', () => {
       analyticsView: null,
       forceOrgCockpit: false,
       topicComposerOpen: false,
+      activeChannelId: null,
       sidebarOpen: false,
     });
     vi.unstubAllGlobals();
@@ -649,6 +651,70 @@ describe('session lifecycle handlers', () => {
         activeSessionMode: 'web',
       })
     ).toBe('chat');
+  });
+
+  // #1287: an open channel outranks forceOrgCockpit in resolveAppViewMode, so
+  // every cockpit escape hatch has to clear activeChannelId — otherwise the
+  // action looks inert and its latched flag fires later as a surprise
+  // navigation when the operator closes the channel.
+  async function invokeCockpitEscapeHatch(actionId: string): Promise<void> {
+    useSessionsStore.setState({ activeSessionId: 'channel-session-1' });
+    useUiStore.setState({
+      activeRepoPath: '/repo/relay-ide',
+      analyticsView: null,
+      forceOrgCockpit: false,
+      topicComposerOpen: true,
+      activeChannelId: 'channel-1',
+      orgDashboardTab: 'prs',
+    });
+
+    await act(async () => {
+      root!.render(React.createElement(ActionRegistryHarness));
+    });
+    await flushPromises();
+
+    const action = getAction(actionId);
+    expect(action).toBeDefined();
+    await act(async () => {
+      await action!.handler({ view: 'session' });
+    });
+    await flushPromises();
+  }
+
+  function expectCockpitReached(): void {
+    const ui = useUiStore.getState();
+    expect(ui.activeChannelId).toBe(null);
+    expect(ui.topicComposerOpen).toBe(false);
+    expect(ui.forceOrgCockpit).toBe(true);
+    expect(ui.activeRepoPath).toBe(null);
+    expect(useSessionsStore.getState().activeSessionId).toBe(null);
+    expect(
+      resolveAppViewMode({
+        analyticsView: ui.analyticsView,
+        hasActiveSession: false,
+        activeRepoPath: ui.activeRepoPath,
+        forceOrgCockpit: ui.forceOrgCockpit,
+        topicComposerOpen: ui.topicComposerOpen,
+        hasActiveChannel: ui.activeChannelId !== null,
+      })
+    ).toBe('org');
+  }
+
+  it('clears an open channel when opening the work cockpit (#1287)', async () => {
+    await invokeCockpitEscapeHatch('navigation.open-work-cockpit');
+    expectCockpitReached();
+  });
+
+  it('clears an open channel when opening the nodes dashboard (#1287)', async () => {
+    await invokeCockpitEscapeHatch('navigation.open-nodes-dashboard');
+    expectCockpitReached();
+    expect(useUiStore.getState().orgDashboardTab).toBe('nodes');
+  });
+
+  it('clears an open channel when opening active work detail (#1287)', async () => {
+    await invokeCockpitEscapeHatch('navigation.open-active-work');
+    expectCockpitReached();
+    expect(useUiStore.getState().orgDashboardTab).toBe('active-work');
   });
 
   it('routes command-palette kill for remote sessions through the owning node', async () => {

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -157,6 +157,7 @@ describe('session lifecycle handlers', () => {
       forceOrgCockpit: false,
       topicComposerOpen: false,
       activeChannelId: null,
+      orgDashboardTab: 'active-work',
       sidebarOpen: false,
     });
     window.history.replaceState(null, '', '/');
@@ -190,6 +191,7 @@ describe('session lifecycle handlers', () => {
       forceOrgCockpit: false,
       topicComposerOpen: false,
       activeChannelId: null,
+      orgDashboardTab: 'active-work',
       sidebarOpen: false,
     });
     vi.unstubAllGlobals();

--- a/test/stores/channel-thread-ui-state.test.ts
+++ b/test/stores/channel-thread-ui-state.test.ts
@@ -9,6 +9,7 @@ describe('channel thread transient UI state', () => {
     useUiStore.setState({
       activeChannelId: null,
       activeThreadRootId: null,
+      forceOrgCockpit: false,
     });
   });
 
@@ -20,5 +21,23 @@ describe('channel thread transient UI state', () => {
     useUiStore.getState().setActiveChannelId('topic:next');
     expect(useUiStore.getState().activeChannelId).toBe('topic:next');
     expect(useUiStore.getState().activeThreadRootId).toBeNull();
+  });
+
+  // #1287: forceOrgCockpit is a one-off escape hatch an open channel outranks,
+  // so opening a channel must drop it — a latched flag would otherwise fire as
+  // a surprise cockpit navigation the moment the channel is closed again.
+  it('drops a latched cockpit escape hatch when a channel is opened', () => {
+    useUiStore.getState().setForceOrgCockpit(true);
+
+    useUiStore.getState().setActiveChannelId('topic:next');
+    expect(useUiStore.getState().forceOrgCockpit).toBe(false);
+  });
+
+  it('keeps the cockpit escape hatch when a channel is closed', () => {
+    useUiStore.getState().setActiveChannelId('topic:next');
+    useUiStore.getState().setForceOrgCockpit(true);
+
+    useUiStore.getState().setActiveChannelId(null);
+    expect(useUiStore.getState().forceOrgCockpit).toBe(true);
   });
 });


### PR DESCRIPTION
## Defect

`resolveAppViewMode` returns `'chat'` on `hasActiveChannel` **before** `forceOrgCockpit` is read (`frontend/src/lib/state/app-view-mode.ts:72`). The three palette cockpit escape hatches — `navigation.open-work-cockpit`, `navigation.open-nodes-dashboard`, `navigation.open-active-work` — cleared session/repo/analytics but never the active channel, so with a channel open they were silent no-ops: nothing changed on screen, yet `forceOrgCockpit` stayed latched and fired as a surprise navigation into the legacy WorkContext cockpit the moment the operator closed the channel.

The same latch also survived a sidebar channel selection, so after one cockpit command a later channel close via ChannelView's `back to chat` button (its only close affordance) landed in the cockpit, contradicting the button copy.

## Fix

- `frontend/src/hooks/useActionRegistry.ts` — all three handlers route through one `enterWorkCockpit(tab?)` helper that clears every chat-shell surface outranking the flag (`activeChannelId`, `topicComposerOpen`, analytics view, session, repo) before latching it — the pattern `TopicSidebarShell.openEvidenceDashboard` already used. 30 duplicated lines collapse to 3 call sites.
- `frontend/src/lib/stores/ui.ts` — the invariant is now structural, not per-call-site: `setActiveChannelId` drops `forceOrgCockpit` on any non-null channel activation, mirroring `sessions.setActiveSessionId`. `enterWorkCockpit` is unaffected because it clears the channel (`null`) before latching. Closing a channel keeps the flag, so the ordering inside the helper still works.
- `test/session-lifecycle-handlers.test.ts` — setup/teardown reset blocks now also reset `activeChannelId` and `orgDashboardTab`, so the new cockpit tests cannot leak tab state into later tests in the file.

No new HTTP routes, no new gateway verbs, no UI copy or visual change.

## Verification

```
npm run check
  0 errors, 250 warnings          # pre-existing sonarjs warnings only

npx vitest run <29 suites importing stores/ui.js or useActionRegistry> test/app-view-mode.test.ts
  Test Files  30 passed (30)
       Tests  299 passed (299)
```

Regression coverage added by this branch:

- `test/app-view-mode.test.ts` — an open channel resolves to `'chat'` even with `forceOrgCockpit: true` (both the no-session and the session+repo shapes); clearing the channel reaches `'org'`.
- `test/session-lifecycle-handlers.test.ts` — each of the three palette actions, invoked through the real registry with a channel + composer + session + repo live, clears the channel and lands `resolveAppViewMode` on `'org'`, with the expected `orgDashboardTab` (`nodes` / `active-work`).
- `test/stores/channel-thread-ui-state.test.ts` — opening a channel drops a latched `forceOrgCockpit`; closing a channel keeps it.

Refs #1287 (slice 1, item: cockpit-escape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
