### PR TITLE
docs: nav-spine model rule + #1287 audit learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ need Vite HMR or a fresh build before package-mode verification.
   Custom frameworks and profiles must use the same channel contract.
 - The hub owns channel persistence, mention routing, auth, policy, and
   federation. Nodes own local execution and paths.
+- Sidebar/navigation surfaces read the channel-workspace model
+  (`workspace_topics` + `ia_workspaces` + channel summaries), never
+  `config.repos`. Any add/create surface must write the store its reading
+  surface renders. Verified findings ladder: epic #1287; traps in
+  `docs/LEARNINGS.md` § navigation spine.
 - Interactive terminals use `relay-pty`/libghostty-vt only. xterm.js is the
   browser renderer. Relay server restart is cold resume, not child-process
   supervision.

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -548,3 +548,13 @@ current are:
   and terminal bytes stay on the source system.
 
 ---
+
+## July 2026 — channel-workspace navigation spine (epic #1287 audit)
+
+Consolidated from the 2026-07-29 46-agent architecture audit (5 mappers, 3 hunters, per-finding adversarial verification: 37 raw findings, 27 confirmed, 10 refuted) and the Slice 1 PRs #1288–#1291. Full verified ladder lives in epic #1287.
+
+- L-20260729-disjoint-workspace-stores: `+ add project` (`POST /workspaces/bulk`) writes `config.repos` only, the duplicate check reads `config.repos`, and the sidebar renders `workspace_topics` + `ia_workspaces` — so "already exists" and "not in the sidebar" can both be permanently true. Before wiring any add/create surface, trace which store the reading surface renders and write that store. A one-shot boot migration is not a create path.
+- L-20260729-workspace-sentinel-ids: channels minted with the literal `workspace:local` / `ws:derived` sentinels can never match real IA workspace ids (`ws:<localId>`), so 100% of channels land in the orphan lane and empty workspace groups are dropped from the tree. Validate cross-store reference id grammar at the create boundary; a sentinel that parses as "some id" poisons grouping silently downstream.
+- L-20260729-topic-id-title-slug: topic/channel id is `slug(workspaceId + '-' + title)`. Never recompute the id on rename — `channel_messages.channel_id` keys the history and boot `sweepOrphans(listAllTopicIds())` would permanently delete the re-keyed channel's messages. Decoupling identity from title requires opaque ids plus a migration plan (epic #1287 Slice 4), not a rename-time re-slug.
+- L-20260729-client-derived-unread: unread state is client-derived: persisted `lastRead` (localStorage) vs live `latestSeq` (in-memory). Any in-memory half must be seeded from a list payload on mount or every page reload renders fully read. Seeding races with mark-as-read: guard stale refetch payloads with a per-channel clamp-epoch fence compared against the query's `dataUpdatedAt` (PR #1290).
+- L-20260729-audit-refuter-pass: of 37 plausible audit findings with file:line evidence, 10 (~27%) were refuted by independent adversarial verification. Never file audit findings as issues without a refuter pass; record the refuted ones as no-defect notes so the next audit does not rediscover them.


### PR DESCRIPTION
Adds the channel-workspace read-model rule to AGENTS.md §Product and architecture rules, and a § July 2026 navigation-spine block to docs/LEARNINGS.md with five durable learnings from the #1287 audit (disjoint stores, sentinel ids, title-slug identity, unread seeding + clamp fence, 27% refuter hit rate).

Docs-only. Refs #1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)