### PR TITLE
feat(sidebar): channel-summary row hydration + cache coherence (#1287 slice 3)

### DIFF
--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -233,11 +233,38 @@
   stroke-width: 2;
 }
 
+/* #1287: two-line Slack-style row — title over the hydrated last-message
+   snippet. Rows without a channel summary keep the single title line. */
+.topic-row__lines {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
 .topic-row__title {
   min-width: 0;
   overflow: hidden;
   color: inherit;
   font-weight: 560;
+  white-space: nowrap;
+}
+
+.topic-row__preview {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 0.66rem;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-row__time {
+  flex: 0 0 auto;
+  margin-right: 5px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
@@ -1263,6 +1290,14 @@
     max-width: 78px;
     color: var(--accent);
     font-size: var(--font-size-xs);
+  }
+
+  /* #1287: last-message stamp for the hydrated cockpit row. */
+  .topic-mobile-row__time {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
   }
 
   .topic-mobile-detail {

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1539,18 +1539,3 @@
 .topic-row.archived {
   opacity: 0.55;
 }
-
-.topic-detail__restore {
-  background: transparent;
-  border: 1px solid var(--accent);
-  color: var(--accent);
-  font-family: var(--font-mono);
-  font-size: var(--font-size-xs);
-  padding: 1px 8px;
-  cursor: pointer;
-}
-
-.topic-detail__restore:disabled {
-  opacity: 0.55;
-  cursor: default;
-}

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -23,10 +23,7 @@ import {
   TriangleAlert,
 } from 'lucide-react';
 import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
-import {
-  parseMentions,
-  type ChannelMessage,
-} from '../../../shared/channel-chat-protocol.js';
+import { parseMentions } from '../../../shared/channel-chat-protocol.js';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import {
   resolveTopicActiveContext,
@@ -36,7 +33,6 @@ import {
 import {
   fetchHubNodes,
   fetchChannelRoster,
-  fetchChannelHistory,
   fetchChannels,
   fetchWorkspaceSurfaces,
   fetchWorkspaceTopics,
@@ -76,9 +72,11 @@ import { durabilityDisabledReason } from '../lib/session-durability.js';
 import {
   buildTopicNavModel,
   formatTaskRefLabel,
+  indexChannelSummaries,
   selectChannelRailTree,
   type ChannelRailNode,
   type ChannelRailSection,
+  type ChannelRailSummary,
   type ChannelRailTree,
   type TopicNavItem,
   type TopicNavModel,
@@ -128,6 +126,8 @@ const DISCONNECTED_SESSION_CONTROL_REASON =
   'session offline/disconnected — controls unavailable until reconnect';
 const TOPIC_LATEST_STATUS_MAX_LENGTH = 96;
 const MOBILE_COCKPIT_ROSTER_BATCH_SIZE = 12;
+/** Trailing-edge window for the channel-list refresh a live activity burst triggers. */
+const CHANNEL_SUMMARY_REFRESH_THROTTLE_MS = 2_000;
 const CURRENT_OPERATOR_SENDER_ID = 'human:operator';
 const CURRENT_OPERATOR_MENTION_NAME = 'operator';
 
@@ -148,17 +148,64 @@ function useMobileCockpitViewport(): boolean {
   return matches;
 }
 
-function messageMentionsCurrentOperator(message: ChannelMessage): boolean {
-  if (message.sender.id === CURRENT_OPERATOR_SENDER_ID) return false;
+/**
+ * Mention signal read off the channel-list summary (#1287). Replaces a limit-1
+ * `channel-history` fetch per unread channel: the list payload already carries
+ * the newest prose row's sender + preview, so one call covers the whole rail.
+ * The summary preview is the newest row that carries prose (detail cards persist
+ * an empty body), which is exactly the row an operator would read as "the last
+ * message".
+ */
+function summaryMentionsCurrentOperator(
+  summary: ChannelRailSummary | null
+): boolean {
+  const last = summary?.lastMessage;
+  if (!last) return false;
+  if (last.senderId === CURRENT_OPERATOR_SENDER_ID) return false;
   // Browser-authored channel posts are canonically `human:operator` with the
-  // display name `Operator` (channel-chat-router deriveSender). Persisted
-  // mentions come from this same parser; parse older rows when metadata is
-  // absent rather than introducing a cockpit-only regex/tokenizer.
-  const mentions = message.mentions ?? parseMentions(message.body.text);
-  return mentions.some(
+  // display name `Operator` (channel-chat-router deriveSender). The summary
+  // carries preview text only, so parse it with the shared parser rather than
+  // introducing a cockpit-only regex/tokenizer.
+  return parseMentions(last.preview).some(
     (mention) =>
       mention.raw.slice(1).toLowerCase() === CURRENT_OPERATOR_MENTION_NAME
   );
+}
+
+/**
+ * Slack-style row snippet: `sender: text` for the newest message, bounded to the
+ * same length cap the status line uses. Null when the row has no summary yet or
+ * the channel holds no messages — callers fall back to the topic status line.
+ */
+function channelRowPreview(summary: ChannelRailSummary | null): string | null {
+  const last = summary?.lastMessage;
+  if (!last) return null;
+  const text = last.preview.replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+  const sender = channelRowSenderLabel(last.senderId);
+  return boundedTopicLatestStatus(sender ? `${sender}: ${text}` : text);
+}
+
+/**
+ * Short sender label for a row snippet. Sender ids are `<kind>:<name>` refs
+ * (`human:operator`, `agent:claude`); render the name half only, never the raw
+ * routing id shape.
+ */
+function channelRowSenderLabel(senderId: string): string {
+  const name = senderId.includes(':')
+    ? (senderId.split(':').pop() ?? senderId)
+    : senderId;
+  return name === 'operator' ? 'you' : name;
+}
+
+/** Compact last-activity stamp for a hydrated row; null without a summary. */
+function channelRowTimestamp(
+  summary: ChannelRailSummary | null
+): string | null {
+  const createdAt = summary?.lastMessage?.createdAt;
+  if (!createdAt) return null;
+  const label = formatRelativeTimeCompact(createdAt);
+  return label || null;
 }
 
 function boundedTopicLatestStatus(value: string): string {
@@ -983,9 +1030,13 @@ function TopicMobileAttentionRow({
   selected: boolean;
   onSelect: (id: string) => void;
 }) {
-  const { item, unread } = node;
+  const { item, unread, summary } = node;
   const action = topicPrimaryAction(item);
   const session = topicPrimarySession(item);
+  // Same hydrated row payload as the desktop rail (#1287); the live session
+  // status line remains the fallback for rows the channel list does not cover.
+  const preview = channelRowPreview(summary);
+  const timestamp = channelRowTimestamp(summary);
   const resumeDisabledReason = sessionAttachDisabledReason(session);
   const resumesDerivedSession = Boolean(
     item.source === 'derived' &&
@@ -1020,7 +1071,7 @@ function TopicMobileAttentionRow({
         <span className="topic-mobile-row__main">
           <span className="topic-mobile-row__title">{item.title}</span>
           <span className="topic-mobile-row__status">
-            {topicLatestStatus(item)}
+            {preview ?? topicLatestStatus(item)}
           </span>
         </span>
         <span className="topic-mobile-row__cta">
@@ -1031,6 +1082,9 @@ function TopicMobileAttentionRow({
               : action.label}
         </span>
         <span className="topic-mobile-row__trail">
+          {timestamp ? (
+            <span className="topic-mobile-row__time">{timestamp}</span>
+          ) : null}
           {unread ? (
             <span
               className="topic-row__activity-dot"
@@ -1388,10 +1442,15 @@ function TopicRow({
   onSelect: (id: string) => void;
   onSelectSession?: ((id: string) => void) | undefined;
 }) {
-  const { item, unread, children } = node;
+  const { item, unread, summary, children } = node;
   const hasNested = children.length > 0 || item.participants.length > 0;
   const expanded = expandedIds.has(item.id);
   const selected = selectedId === item.id;
+  // Slack-browser row payload (#1287): last message + stamp, hydrated from the
+  // channel list the rail already fetches. Rows the list does not cover (derived
+  // topics) keep the bare title.
+  const preview = channelRowPreview(summary);
+  const timestamp = channelRowTimestamp(summary);
 
   const activate = () => {
     onSelect(item.id);
@@ -1436,11 +1495,21 @@ function TopicRow({
           }}
         >
           <TopicBadge item={item} />
-          <span className="topic-row__title">
-            <MarqueeText>{item.title}</MarqueeText>
+          <span className="topic-row__lines">
+            <span className="topic-row__title">
+              <MarqueeText>{item.title}</MarqueeText>
+            </span>
+            {preview ? (
+              <span className="topic-row__preview" title={preview}>
+                {preview}
+              </span>
+            ) : null}
           </span>
         </button>
         <span className="topic-row__trail" aria-label={item.statusLabel}>
+          {timestamp ? (
+            <span className="topic-row__time">{timestamp}</span>
+          ) : null}
           {unread ? (
             <span
               className="topic-row__activity-dot"
@@ -1960,6 +2029,7 @@ const EMPTY_TOPICS: WorkspaceTopic[] = [];
 const EMPTY_SURFACES: WorkspaceSurface[] = [];
 const EMPTY_SEARCH_RESULTS: WorkspaceTopicSearchResult[] = [];
 const EMPTY_WORKSPACES: TopicNavWorkspace[] = [];
+const EMPTY_CHANNEL_SUMMARIES: ChannelRailSummary[] = [];
 
 /** Show/hide older chats toggle; renders nothing without a handler. */
 function ArchivedToggle({
@@ -2164,6 +2234,7 @@ export function TopicSidebarView({
   onCreateTaskRoom,
   workspaces = EMPTY_WORKSPACES,
   nodes,
+  channelSummaries = EMPTY_CHANNEL_SUMMARIES,
   activeWorkspaceId = null,
   searchScope = 'all',
   onToggleSearchScope,
@@ -2179,6 +2250,12 @@ export function TopicSidebarView({
   workspaces?: TopicNavWorkspace[];
   /** Known node roster; resolves raw routing node ids to friendly names. */
   nodes?: TopicNavNode[];
+  /**
+   * `GET /channels` rows (#1287). Joined onto topic rows by id to hydrate the
+   * last-message snippet, stamp, and mention signal. Optional: the rail renders
+   * from topics alone until it lands, and derived topics never appear here.
+   */
+  channelSummaries?: ChannelRailSummary[];
   activeWorkspaceId?: string | null;
   searchScope?: 'all' | 'workspace';
   onToggleSearchScope?: (() => void) | undefined;
@@ -2255,15 +2332,12 @@ export function TopicSidebarView({
       ),
     [activeChannelId, model.items, relevantActivity]
   );
-  const latestSeqByChannel = useMemo(
-    () =>
-      Object.fromEntries(
-        activityIds.flatMap((id, index) => {
-          const latestSeq = relevantActivity[index * 2];
-          return typeof latestSeq === 'number' ? [[id, latestSeq]] : [];
-        })
-      ),
-    [activityIds, relevantActivity]
+  // One channel-list payload hydrates every row (#1287): last message, stamp,
+  // members, and the mention signal the cockpit used to fan out limit-1 history
+  // fetches for. Unread stays owned by the clamp-fenced activity store above.
+  const summaryByChannel = useMemo(
+    () => indexChannelSummaries(channelSummaries),
+    [channelSummaries]
   );
   // The channel roster endpoint is per-channel, so reconcile only while the
   // mobile cockpit is actually open. High-signal rows lead rolling batches;
@@ -2332,47 +2406,6 @@ export function TopicSidebarView({
     rosterQueries
       .slice(currentRosterBatchStart, activeRosterBatchEnd)
       .every((query) => !query.isPending && !query.isFetching);
-  const latestUnreadTargets = useMemo(
-    () =>
-      rosterChannelIds.flatMap((channelId, index) => {
-        const rosterQuery = rosterQueries[index];
-        const latestSeq = latestSeqByChannel[channelId];
-        return unreadByChannel[channelId] &&
-          typeof latestSeq === 'number' &&
-          rosterQuery &&
-          !rosterQuery.isPending &&
-          !rosterQuery.isFetching
-          ? [{ channelId, latestSeq }]
-          : [];
-      }),
-    [latestSeqByChannel, rosterChannelIds, rosterQueries, unreadByChannel]
-  );
-  const latestUnreadQueries = useQueries({
-    queries: latestUnreadTargets.map(({ channelId, latestSeq }) => ({
-      queryKey: ['channel-history', channelId, 'latest-unread', latestSeq],
-      queryFn: () => fetchChannelHistory(channelId, { limit: 1 }),
-      staleTime: Number.POSITIVE_INFINITY,
-      gcTime: 60_000,
-      retry: false,
-    })),
-  });
-  const currentRosterBatchIds = rosterChannelIds.slice(
-    currentRosterBatchStart,
-    activeRosterBatchEnd
-  );
-  const latestUnreadQueryByChannel = new Map(
-    latestUnreadTargets.map((target, index) => [
-      target.channelId,
-      latestUnreadQueries[index],
-    ])
-  );
-  const currentMentionBatchSettled = currentRosterBatchIds.every(
-    (channelId) => {
-      if (!unreadByChannel[channelId]) return true;
-      const query = latestUnreadQueryByChannel.get(channelId);
-      return Boolean(query && !query.isPending && !query.isFetching);
-    }
-  );
   useEffect(() => {
     if (rosterBatch.scope !== rosterBatchScope) {
       setRosterBatch({
@@ -2383,7 +2416,6 @@ export function TopicSidebarView({
     }
     if (
       currentRosterBatchSettled &&
-      currentMentionBatchSettled &&
       rosterBatch.end < allRosterChannelIds.length
     ) {
       setRosterBatch((current) => ({
@@ -2396,26 +2428,23 @@ export function TopicSidebarView({
     }
   }, [
     allRosterChannelIds.length,
-    currentMentionBatchSettled,
     currentRosterBatchSettled,
     rosterBatch.end,
     rosterBatch.scope,
     rosterBatchScope,
   ]);
+  // #1287: derived from the one channel-list payload the rail already holds.
+  // This replaced a limit-1 `channel-history` fetch per unread channel — the
+  // list summary carries the same newest-prose sender + text. Still gated on
+  // unread so a read channel never keeps its mention bonus in the lane.
   const mentionsMeByChannel = useMemo(() => {
     const mentioned: Record<string, boolean> = {};
-    latestUnreadTargets.forEach((target, index) => {
-      const message = latestUnreadQueries[index]?.data?.messages.at(-1);
-      if (
-        message &&
-        message.seq === target.latestSeq &&
-        messageMentionsCurrentOperator(message)
-      ) {
-        mentioned[target.channelId] = true;
-      }
-    });
+    for (const [channelId, summary] of Object.entries(summaryByChannel)) {
+      if (!unreadByChannel[channelId]) continue;
+      if (summaryMentionsCurrentOperator(summary)) mentioned[channelId] = true;
+    }
     return mentioned;
-  }, [latestUnreadQueries, latestUnreadTargets]);
+  }, [summaryByChannel, unreadByChannel]);
   const effectiveStatusByChannelAgent = useMemo(() => {
     const effective: Record<string, ChannelAgentStatus> = {
       ...statusByChannelAgent,
@@ -2456,8 +2485,12 @@ export function TopicSidebarView({
   const rosterAttentionBySessionKey: Record<string, CockpitRosterAttention> =
     {};
   const railTree = useMemo(
-    () => selectChannelRailTree(model, workspaces, { unreadByChannel }),
-    [model, unreadByChannel, workspaces]
+    () =>
+      selectChannelRailTree(model, workspaces, {
+        unreadByChannel,
+        summaryByChannel,
+      }),
+    [model, summaryByChannel, unreadByChannel, workspaces]
   );
   const firstId = model.rootIds[0] ?? model.items[0]?.id ?? null;
   const [selectedId, setSelectedId] = useState<string | null>(firstId);
@@ -2791,10 +2824,10 @@ export function TopicSidebarShell({
   });
   // Unread head seqs only arrive over `/ws/events` for channels that move while
   // the socket is open, so a reload would render every row as read. Seed them
-  // from the channel list once the rail mounts (#1287). This is a cold-load
-  // bootstrap only — the live broadcast keeps head seqs current while the socket
-  // is up — so keep it lazy: the payload is a full summary (members + last
-  // message) per channel, and the rail remounts on every sidebar collapse.
+  // from the channel list once the rail mounts (#1287). The same payload is a
+  // full summary (members + last message) per channel, so it also hydrates every
+  // sidebar row — one list call in place of the per-channel fan-out the mobile
+  // cockpit used to run.
   const channelsQuery = useQuery({
     queryKey: ['channels'],
     queryFn: fetchChannels,
@@ -2809,6 +2842,26 @@ export function TopicSidebarShell({
       .getState()
       .seedChannelActivity(channelRows, channelRowsFetchedAt);
   }, [channelRows, channelRowsFetchedAt]);
+  // Row snippets/stamps would otherwise freeze at the mount payload, so refresh
+  // the list when channels move. Subscribed imperatively (never as a selector)
+  // because the rail must not re-render on unrelated channel activity, and
+  // trailing-edge throttled so a busy agent turn costs one refetch per window
+  // instead of the removed per-channel history fetches.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = useChannelActivityStore.subscribe((state, previous) => {
+      if (state.latestSeqByChannel === previous.latestSeqByChannel) return;
+      if (timer !== undefined) return;
+      timer = setTimeout(() => {
+        timer = undefined;
+        void queryClient.invalidateQueries({ queryKey: ['channels'] });
+      }, CHANNEL_SUMMARY_REFRESH_THROTTLE_MS);
+    });
+    return () => {
+      unsubscribe();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [queryClient]);
   const searchActive = normalizedSearchQuery.length > 0;
   const searchData = topicSearchQuery.data;
   const searchResults = useMemo(
@@ -2843,6 +2896,7 @@ export function TopicSidebarShell({
       surfaces={viewSurfaces}
       workspaces={viewWorkspaces}
       nodes={viewNodes}
+      channelSummaries={channelRows ?? EMPTY_CHANNEL_SUMMARIES}
       activeWorkspaceId={activeWorkspaceId}
       searchScope={searchScope}
       onToggleSearchScope={() =>

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -17,7 +17,10 @@ import {
   MessageSquare,
   TriangleAlert,
 } from 'lucide-react';
-import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
+import {
+  builtInAgentProfileId,
+  parseAgentProfileProviderId,
+} from '../../../shared/agent-profile.js';
 import { parseMentions } from '../../../shared/channel-chat-protocol.js';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import {
@@ -119,8 +122,17 @@ const DISCONNECTED_SESSION_CONTROL_REASON =
   'session offline/disconnected — controls unavailable until reconnect';
 const TOPIC_LATEST_STATUS_MAX_LENGTH = 96;
 const MOBILE_COCKPIT_ROSTER_BATCH_SIZE = 12;
-/** Trailing-edge window for the channel-list refresh a live activity burst triggers. */
-const CHANNEL_SUMMARY_REFRESH_THROTTLE_MS = 2_000;
+/**
+ * Trailing-edge window for the channel-list refresh a live activity burst
+ * triggers. `GET /channels` costs a per-channel summary + member read on the
+ * hub, and a streaming agent turn emits a badge per message create / stream
+ * open / stream complete, so the window is sized for "the rail's snippets stay
+ * roughly current" rather than per-message freshness: unread state already
+ * arrives live over the socket, and the open channel renders from its own
+ * timeline. Paired with the hidden-tab gate below, an unwatched turn costs zero
+ * refetches.
+ */
+const CHANNEL_SUMMARY_REFRESH_THROTTLE_MS = 10_000;
 const CURRENT_OPERATOR_SENDER_ID = 'human:operator';
 const CURRENT_OPERATOR_MENTION_NAME = 'operator';
 
@@ -144,10 +156,15 @@ function useMobileCockpitViewport(): boolean {
 /**
  * Mention signal read off the channel-list summary (#1287). Replaces a limit-1
  * `channel-history` fetch per unread channel: the list payload already carries
- * the newest prose row's sender + preview, so one call covers the whole rail.
- * The summary preview is the newest row that carries prose (detail cards persist
- * an empty body), which is exactly the row an operator would read as "the last
- * message".
+ * the newest prose row's sender + mention refs, so one call covers the whole
+ * rail. The summary preview is the newest row that carries prose (detail cards
+ * persist an empty body), which is exactly the row an operator would read as
+ * "the last message".
+ *
+ * `lastMessage.mentions` is authoritative: the server computes it over the FULL
+ * body (persisted mentions when the write path resolved them), so a mention past
+ * the 200-char preview cut-off still counts. The preview parse below is only the
+ * fallback for a payload predating that field.
  */
 function summaryMentionsCurrentOperator(
   summary: ChannelRailSummary | null
@@ -156,10 +173,13 @@ function summaryMentionsCurrentOperator(
   if (!last) return false;
   if (last.senderId === CURRENT_OPERATOR_SENDER_ID) return false;
   // Browser-authored channel posts are canonically `human:operator` with the
-  // display name `Operator` (channel-chat-router deriveSender). The summary
-  // carries preview text only, so parse it with the shared parser rather than
-  // introducing a cockpit-only regex/tokenizer.
-  return parseMentions(last.preview).some(
+  // display name `Operator` (channel-chat-router deriveSender).
+  const mentions =
+    last.mentions ??
+    // Legacy payload without the field: parse the truncated preview with the
+    // shared parser rather than introducing a cockpit-only tokenizer.
+    parseMentions(last.preview);
+  return mentions.some(
     (mention) =>
       mention.raw.slice(1).toLowerCase() === CURRENT_OPERATOR_MENTION_NAME
   );
@@ -175,20 +195,45 @@ function channelRowPreview(summary: ChannelRailSummary | null): string | null {
   if (!last) return null;
   const text = last.preview.replace(/\s+/g, ' ').trim();
   if (!text) return null;
-  const sender = channelRowSenderLabel(last.senderId);
+  const sender = channelRowSenderLabel(last);
   return boundedTopicLatestStatus(sender ? `${sender}: ${text}` : text);
 }
 
 /**
- * Short sender label for a row snippet. Sender ids are `<kind>:<name>` refs
- * (`human:operator`, `agent:claude`); render the name half only, never the raw
- * routing id shape.
+ * Short sender label for a row snippet. NEVER derived by splitting `senderId`:
+ * an agent's id is its profile Actor id (`agent-profile:<vendor>:default`, or
+ * `agent-profile:<vendor>:<uuid>` for a custom profile), so the trailing segment
+ * is `default`/a uuid, not a name (#1234, `shared/channel-chat-protocol.ts`).
+ * Read the server-resolved `senderDisplayName`, then `providerId`, and only then
+ * fall back to the vendor segment of a profile id / the name half of a
+ * `human:<actorId>` ref.
  */
-function channelRowSenderLabel(senderId: string): string {
-  const name = senderId.includes(':')
-    ? (senderId.split(':').pop() ?? senderId)
+function channelRowSenderLabel(
+  last: NonNullable<ChannelRailSummary['lastMessage']>
+): string {
+  if (last.senderId === CURRENT_OPERATOR_SENDER_ID) return 'you';
+  const label =
+    last.senderDisplayName?.trim() ||
+    last.providerId?.trim() ||
+    senderLabelFromId(last.senderId);
+  return label === 'operator' ? 'you' : label;
+}
+
+/** Last-resort label for a sender id with no server-resolved name/vendor. */
+function senderLabelFromId(senderId: string): string {
+  // CLI-gateway actor rows are `agent:<actorId>` where the actor id may itself
+  // be a profile id (`deriveSender`), so unwrap that prefix first.
+  const withoutAgentPrefix = senderId.startsWith('agent:')
+    ? senderId.slice('agent:'.length)
     : senderId;
-  return name === 'operator' ? 'you' : name;
+  // `agent-profile:<vendor>:<rest>` — the VENDOR segment names the sender; the
+  // trailing segment is `default` or a uuid.
+  const vendor = parseAgentProfileProviderId(withoutAgentPrefix);
+  if (vendor) return vendor;
+  const separator = withoutAgentPrefix.indexOf(':');
+  return separator === -1
+    ? withoutAgentPrefix
+    : withoutAgentPrefix.slice(separator + 1);
 }
 
 /** Compact last-activity stamp for a hydrated row; null without a summary. */
@@ -2805,18 +2850,47 @@ export function TopicSidebarShell({
   // because the rail must not re-render on unrelated channel activity, and
   // trailing-edge throttled so a busy agent turn costs one refetch per window
   // instead of the removed per-channel history fetches.
+  //
+  // `GET /channels` is O(channels) server-side, so this lane is deliberately
+  // BACKGROUND-SILENT: a hidden tab records the pending refresh and fires it
+  // once on the way back to visible, instead of holding the hub at a steady
+  // refetch cadence for the whole length of an agent turn nobody is watching.
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const unsubscribe = useChannelActivityStore.subscribe((state, previous) => {
-      if (state.latestSeqByChannel === previous.latestSeqByChannel) return;
+    let pendingWhileHidden = false;
+    const documentRef = typeof document === 'undefined' ? null : document;
+    const refresh = () => {
+      void queryClient.invalidateQueries({ queryKey: ['channels'] });
+    };
+    const schedule = () => {
+      if (documentRef?.hidden) {
+        // Nothing is rendering these rows: remember the debt and arm no timer.
+        pendingWhileHidden = true;
+        return;
+      }
       if (timer !== undefined) return;
       timer = setTimeout(() => {
         timer = undefined;
-        void queryClient.invalidateQueries({ queryKey: ['channels'] });
+        if (documentRef?.hidden) {
+          pendingWhileHidden = true;
+          return;
+        }
+        refresh();
       }, CHANNEL_SUMMARY_REFRESH_THROTTLE_MS);
+    };
+    const onVisibilityChange = () => {
+      if (documentRef?.hidden || !pendingWhileHidden) return;
+      pendingWhileHidden = false;
+      refresh();
+    };
+    documentRef?.addEventListener('visibilitychange', onVisibilityChange);
+    const unsubscribe = useChannelActivityStore.subscribe((state, previous) => {
+      if (state.latestSeqByChannel === previous.latestSeqByChannel) return;
+      schedule();
     });
     return () => {
       unsubscribe();
+      documentRef?.removeEventListener('visibilitychange', onVisibilityChange);
       if (timer !== undefined) clearTimeout(timer);
     };
   }, [queryClient]);

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -7,12 +7,7 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react';
-import {
-  useMutation,
-  useQueries,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useShallow } from 'zustand/react/shallow';
 import {
   CircleAlert,
@@ -38,7 +33,6 @@ import {
   fetchWorkspaceTopics,
   interruptChannelAgent,
   postChannelMessage,
-  restoreWorkspaceTopic,
   searchWorkspaceTopics,
   sendSessionInput,
   type ChannelAgentStatus,
@@ -61,7 +55,6 @@ import type { SessionSummary } from '../lib/types.js';
 import { formatRelativeTimeCompact } from '../lib/utils.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
-import { useToastStore } from '../lib/stores/toasts.js';
 import {
   channelAgentStatusKey,
   resolveEffectiveAgentStatus,
@@ -837,8 +830,6 @@ function TopicDetail({
   surfacesError,
   surfacesLoading,
   onSelectSession,
-  onRestoreTopic,
-  restoringTopicId,
   onOpenEvidenceDashboard,
 }: {
   item: TopicNavItem;
@@ -848,8 +839,6 @@ function TopicDetail({
   surfacesError?: boolean | undefined;
   surfacesLoading?: boolean | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
-  onRestoreTopic?: ((topicId: string) => void) | undefined;
-  restoringTopicId?: string | undefined;
   onOpenEvidenceDashboard?: (() => void) | undefined;
 }) {
   const action = topicPrimaryAction(item);
@@ -883,16 +872,10 @@ function TopicDetail({
         <span>{topicRoomFreshnessLabel(item)}</span>
         <span>{topicRoomAnchorLabel(item)}</span>
         <span>updated {item.updatedAt}</span>
-        {item.lifecycleLabel === 'archived' && onRestoreTopic ? (
-          <button
-            type="button"
-            className="topic-detail__restore"
-            disabled={restoringTopicId === item.id}
-            onClick={() => onRestoreTopic(item.id)}
-          >
-            {restoringTopicId === item.id ? 'restoring…' : 'restore'}
-          </button>
-        ) : null}
+        {/* #1287: no restore button here. This panel only exists under advanced
+            mode, while opening the archived row puts the ungated composer
+            restore bar in front of the operator at every breakpoint — one
+            affordance, one shared mutation (`useRestoreTopicMutation`). */}
       </div>
 
       <div className="topic-room__action-band">
@@ -1392,8 +1375,6 @@ function TopicAdvancedDetailGate({
   surfacesError,
   surfacesLoading,
   onSelectSession,
-  onRestoreTopic,
-  restoringTopicId,
   onOpenEvidenceDashboard,
 }: {
   item: TopicNavItem | undefined;
@@ -1403,8 +1384,6 @@ function TopicAdvancedDetailGate({
   surfacesError: boolean;
   surfacesLoading: boolean;
   onSelectSession?: ((id: string) => void) | undefined;
-  onRestoreTopic?: ((topicId: string) => void) | undefined;
-  restoringTopicId?: string | undefined;
   onOpenEvidenceDashboard?: (() => void) | undefined;
 }) {
   if (!item || !show) return null;
@@ -1417,8 +1396,6 @@ function TopicAdvancedDetailGate({
         surfacesError={surfacesError}
         surfacesLoading={surfacesLoading}
         onSelectSession={onSelectSession}
-        onRestoreTopic={onRestoreTopic}
-        restoringTopicId={restoringTopicId}
         onOpenEvidenceDashboard={onOpenEvidenceDashboard}
       />
     </div>
@@ -2240,8 +2217,6 @@ export function TopicSidebarView({
   onToggleSearchScope,
   showArchived = false,
   onToggleArchived,
-  onRestoreTopic,
-  restoringTopicId,
   showAdvancedDetail = false,
 }: {
   topics: WorkspaceTopic[];
@@ -2261,8 +2236,6 @@ export function TopicSidebarView({
   onToggleSearchScope?: (() => void) | undefined;
   showArchived?: boolean;
   onToggleArchived?: (() => void) | undefined;
-  onRestoreTopic?: ((topicId: string) => void) | undefined;
-  restoringTopicId?: string | undefined;
   loading?: boolean;
   error?: boolean;
   derived?: boolean;
@@ -2735,8 +2708,6 @@ export function TopicSidebarView({
         surfacesError={surfacesError}
         surfacesLoading={surfacesLoading}
         onSelectSession={onSelectSession}
-        onRestoreTopic={onRestoreTopic}
-        restoringTopicId={restoringTopicId}
         {...(selectedRepoPath
           ? { onOpenEvidenceDashboard: openEvidenceDashboard }
           : {})}
@@ -2775,19 +2746,6 @@ export function TopicSidebarShell({
       : ['workspace-topics'],
     queryFn: () => fetchWorkspaceTopics({ includeArchived: showArchived }),
     staleTime: 30_000,
-  });
-  const restoreTopicMutation = useMutation({
-    mutationFn: (topicId: string) => restoreWorkspaceTopic(topicId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['workspace-topics'] });
-    },
-    onError: (err: unknown) => {
-      useToastStore
-        .getState()
-        .showToast(
-          err instanceof Error ? err.message : 'failed to restore topic'
-        );
-    },
   });
   const workspacesQuery = useIaWorkspacesQuery();
   const viewWorkspaces = useMemo<TopicNavWorkspace[]>(
@@ -2904,12 +2862,6 @@ export function TopicSidebarShell({
       }
       showArchived={showArchived}
       onToggleArchived={() => setShowArchived((prev) => !prev)}
-      onRestoreTopic={(topicId) => restoreTopicMutation.mutate(topicId)}
-      restoringTopicId={
-        restoreTopicMutation.isPending
-          ? restoreTopicMutation.variables
-          : undefined
-      }
       loading={!searchActive && topicsQuery.isLoading && !topicsQuery.data}
       error={topicsQuery.isError && !topicsQuery.data && !searchActive}
       surfacesLoading={surfacesQuery.isLoading && !surfacesQuery.data}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -13,13 +13,13 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useChannelChatSocket } from '../../hooks/useChannelChatSocket.js';
 import {
   fetchWorkspaceTopic,
-  restoreWorkspaceTopic,
   fetchChannelRoster,
   designateChannelOrchestrator,
   interruptChannelAgent,
   HttpError,
   type ChannelAgentStatus,
 } from '../../lib/api.js';
+import { useRestoreTopicMutation } from '../../lib/hooks/use-restore-topic.js';
 import { isDmChannel } from '../../lib/dm-channels.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import {
@@ -141,21 +141,14 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     (postError instanceof HttpError && postError.status === 409);
   const storeDown = postError instanceof HttpError && postError.status === 503;
 
-  const [restorePending, setRestorePending] = useState(false);
-  const handleRestore = useCallback(async () => {
-    setRestorePending(true);
-    try {
-      await restoreWorkspaceTopic(channelId);
-      await queryClient.invalidateQueries({ queryKey: ['channel', channelId] });
-      await queryClient.invalidateQueries({
-        queryKey: ['workspace-topic', channelId],
-      });
-    } catch {
-      /* leave the archived bar in place; the user can retry */
-    } finally {
-      setRestorePending(false);
-    }
-  }, [channelId, queryClient]);
+  // Shared with every other restore affordance (#1287) so one restore refreshes
+  // the channel, its topic, and every topic list — and a failure toasts instead
+  // of leaving the archived bar sitting there with no explanation.
+  const { mutate: restoreChannel, isPending: restorePending } =
+    useRestoreTopicMutation();
+  const handleRestore = useCallback(() => {
+    restoreChannel(channelId);
+  }, [channelId, restoreChannel]);
 
   const [designatePending, setDesignatePending] = useState(false);
 

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -175,11 +175,29 @@ function invalidateReconnectQueries(queryClient: QueryClient): void {
  */
 const UNKNOWN_CHANNEL_LIST_REFRESH_MS = 750;
 /**
+ * Back-off before a channel a completed refresh FAILED to materialize is allowed
+ * to schedule another one. `GET /channels` and `/workspace-topics` are both
+ * capped list windows, so a channel outside that window can never be pulled in
+ * by refetching — without this the lane would re-fire on every subsequent badge
+ * (one per message create / stream open / stream complete) for the whole turn,
+ * on every open client, and still never render the row.
+ */
+const UNKNOWN_CHANNEL_REFRESH_BACKOFF_MS = 60_000;
+/** Hard cap on remembered unresolved channels so the map cannot grow unbounded. */
+const UNKNOWN_CHANNEL_BACKOFF_MAX_ENTRIES = 256;
+/**
  * Trailing-edge window for per-channel roster refetches. An agent turn walks
  * spawning → thinking → streaming → waiting → idle, so debouncing collapses a
  * whole turn into the single refetch that matters: the one after it settles.
  */
 const AGENT_STATUS_ROSTER_REFRESH_MS = 750;
+/**
+ * Ceiling on how long a continuous status burst may keep pushing the roster
+ * debounce out. Without it a turn that emits a transition faster than the window
+ * would starve the refetch forever; with it the roster lands at least this often
+ * mid-burst and once more after it settles.
+ */
+const AGENT_STATUS_ROSTER_MAX_WAIT_MS = 5_000;
 
 /** Topic-list caches the sidebar renders rows from (active + archived views). */
 const TOPIC_LIST_QUERY_KEYS: string[][] = [
@@ -294,9 +312,14 @@ export function useEventSocket({
     let pollInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
     let channelListRefreshTimer: ReturnType<typeof setTimeout> | null = null;
     let rosterInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
+    let rosterBurstStartedAt = 0;
     let eventSocketOpened = false;
     const pendingWebhookRepos = new Set<string>();
     const pendingRosterChannels = new Set<string>();
+    /** Channels the pending refresh is expected to materialize. */
+    const pendingUnknownChannels = new Set<string>();
+    /** Channel id → timestamp of the last refresh that failed to produce its row. */
+    const unresolvedChannelAttempts = new Map<string, number>();
 
     function invalidateScopedPrData(
       repoPaths: string[],
@@ -336,19 +359,77 @@ export function useEventSocket({
      * effect, so the per-channel clamp-epoch fence (#1287 Slice 1) still gates
      * every head seq. This lane never touches `latestSeqByChannel` itself.
      */
-    function scheduleChannelListRefresh(): void {
+    function scheduleChannelListRefresh(channelId: string): void {
+      const now = Date.now();
+      // A previous refresh already ran for this channel and the row still is not
+      // cached — the channel sits outside the list windows, so retrying now
+      // would burn the same O(channels) query for the same empty result.
+      const lastAttempt = unresolvedChannelAttempts.get(channelId);
+      if (
+        lastAttempt !== undefined &&
+        now - lastAttempt < UNKNOWN_CHANNEL_REFRESH_BACKOFF_MS
+      ) {
+        return;
+      }
+      pendingUnknownChannels.add(channelId);
       if (channelListRefreshTimer) return;
       channelListRefreshTimer = setTimeout(() => {
         channelListRefreshTimer = null;
+        const attemptedAt = Date.now();
+        for (const attemptedChannelId of pendingUnknownChannels) {
+          unresolvedChannelAttempts.set(attemptedChannelId, attemptedAt);
+        }
+        pendingUnknownChannels.clear();
+        pruneUnresolvedChannelAttempts(attemptedAt);
         queryClient.invalidateQueries({ queryKey: ['workspace-topics'] });
         queryClient.invalidateQueries({ queryKey: ['channels'] });
       }, UNKNOWN_CHANNEL_LIST_REFRESH_MS);
     }
 
-    /** Debounced per-channel roster refetch, batched across a status burst. */
+    /**
+     * Drop expired back-off marks, then oldest-first down to the cap. A channel
+     * whose row DID materialize never reaches the map lookup again anyway
+     * (`hasCachedChannelRow` short-circuits), so eviction only costs one extra
+     * refresh in the worst case.
+     */
+    function pruneUnresolvedChannelAttempts(now: number): void {
+      for (const [channelId, attemptedAt] of unresolvedChannelAttempts) {
+        if (now - attemptedAt >= UNKNOWN_CHANNEL_REFRESH_BACKOFF_MS) {
+          unresolvedChannelAttempts.delete(channelId);
+        }
+      }
+      while (
+        unresolvedChannelAttempts.size > UNKNOWN_CHANNEL_BACKOFF_MAX_ENTRIES
+      ) {
+        const oldest = unresolvedChannelAttempts.keys().next();
+        if (oldest.done) break;
+        unresolvedChannelAttempts.delete(oldest.value);
+      }
+    }
+
+    /**
+     * Debounced per-channel roster refetch, batched across a status burst. Only
+     * channels the client already holds a roster for are scheduled: a status
+     * event for a channel no surface has queried has nothing to refresh. The
+     * debounce RESETS on each status so a walking turn lands one refetch after
+     * it settles, capped by `AGENT_STATUS_ROSTER_MAX_WAIT_MS` so a continuous
+     * burst cannot starve it.
+     */
     function scheduleRosterRefresh(channelId: string): void {
+      if (
+        queryClient.getQueryData(['channel-roster', channelId]) === undefined
+      ) {
+        return;
+      }
       pendingRosterChannels.add(channelId);
-      if (rosterInvalidateTimer) return;
+      const now = Date.now();
+      if (!rosterInvalidateTimer) rosterBurstStartedAt = now;
+      else if (now - rosterBurstStartedAt >= AGENT_STATUS_ROSTER_MAX_WAIT_MS) {
+        // Burst has run past the max wait — let the armed timer fire.
+        return;
+      } else {
+        clearTimeout(rosterInvalidateTimer);
+      }
       rosterInvalidateTimer = setTimeout(() => {
         rosterInvalidateTimer = null;
         const channelIds = Array.from(pendingRosterChannels);
@@ -502,7 +583,7 @@ export function useEventSocket({
         // the lists only refetch on blur/refocus — never on a tab left focused.
         // Pull the new row in instead of waiting for a window event.
         if (!hasCachedChannelRow(queryClient, msg.channelId)) {
-          scheduleChannelListRefresh();
+          scheduleChannelListRefresh(msg.channelId);
         }
       },
       'channel-agent-status': (msg) => {
@@ -570,6 +651,8 @@ export function useEventSocket({
     return () => {
       pendingWebhookRepos.clear();
       pendingRosterChannels.clear();
+      pendingUnknownChannels.clear();
+      unresolvedChannelAttempts.clear();
       if (pollInvalidateTimer) {
         clearTimeout(pollInvalidateTimer);
         pollInvalidateTimer = null;

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -167,6 +167,54 @@ function invalidateReconnectQueries(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ['fileDiff'] });
 }
 
+/**
+ * Trailing-edge window for the nav-spine refetch triggered by activity on a
+ * channel the client holds no row for. Agent-created implementation channels
+ * (#1242) arrive in bursts as the orchestrator fans work out, and one refetch
+ * per burst is enough to materialize every new row.
+ */
+const UNKNOWN_CHANNEL_LIST_REFRESH_MS = 750;
+/**
+ * Trailing-edge window for per-channel roster refetches. An agent turn walks
+ * spawning → thinking → streaming → waiting → idle, so debouncing collapses a
+ * whole turn into the single refetch that matters: the one after it settles.
+ */
+const AGENT_STATUS_ROSTER_REFRESH_MS = 750;
+
+/** Topic-list caches the sidebar renders rows from (active + archived views). */
+const TOPIC_LIST_QUERY_KEYS: string[][] = [
+  ['workspace-topics'],
+  ['workspace-topics', 'with-archived'],
+];
+
+/**
+ * True when a rendered list already covers this channel. Reads the two caches
+ * the rail joins its rows from — the `/channels` summary list (#1287 Slice 1)
+ * and `/workspace-topics` — without fetching. When neither has loaded there is
+ * no rail to be missing a row, so the channel counts as known and no refetch is
+ * scheduled.
+ */
+function hasCachedChannelRow(
+  queryClient: QueryClient,
+  channelId: string
+): boolean {
+  let sawCachedList = false;
+  const channels = queryClient.getQueryData<{ id: string }[]>(['channels']);
+  if (Array.isArray(channels)) {
+    sawCachedList = true;
+    if (channels.some((row) => row.id === channelId)) return true;
+  }
+  for (const queryKey of TOPIC_LIST_QUERY_KEYS) {
+    const topics = queryClient.getQueryData<{ topics?: { id: string }[] }>(
+      queryKey
+    );
+    if (!Array.isArray(topics?.topics)) continue;
+    sawCachedList = true;
+    if (topics.topics.some((topic) => topic.id === channelId)) return true;
+  }
+  return !sawCachedList;
+}
+
 const HUB_NODE_REVERSE_LINK_ROUTE = 'reverse-link';
 
 function hubNodeConnectionSummary(
@@ -244,8 +292,11 @@ export function useEventSocket({
     if (!authAuthenticated) return;
 
     let pollInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
+    let channelListRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+    let rosterInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
     let eventSocketOpened = false;
     const pendingWebhookRepos = new Set<string>();
+    const pendingRosterChannels = new Set<string>();
 
     function invalidateScopedPrData(
       repoPaths: string[],
@@ -276,6 +327,38 @@ export function useEventSocket({
         pendingWebhookRepos.clear();
         invalidateScopedPrData(repos, 'webhook');
       }, 500);
+    }
+
+    /**
+     * Refetch the lists the sidebar builds rows from. Deliberately an
+     * invalidation and not a store write: the refreshed `/channels` payload
+     * re-enters the activity store through the rail's `seedChannelActivity`
+     * effect, so the per-channel clamp-epoch fence (#1287 Slice 1) still gates
+     * every head seq. This lane never touches `latestSeqByChannel` itself.
+     */
+    function scheduleChannelListRefresh(): void {
+      if (channelListRefreshTimer) return;
+      channelListRefreshTimer = setTimeout(() => {
+        channelListRefreshTimer = null;
+        queryClient.invalidateQueries({ queryKey: ['workspace-topics'] });
+        queryClient.invalidateQueries({ queryKey: ['channels'] });
+      }, UNKNOWN_CHANNEL_LIST_REFRESH_MS);
+    }
+
+    /** Debounced per-channel roster refetch, batched across a status burst. */
+    function scheduleRosterRefresh(channelId: string): void {
+      pendingRosterChannels.add(channelId);
+      if (rosterInvalidateTimer) return;
+      rosterInvalidateTimer = setTimeout(() => {
+        rosterInvalidateTimer = null;
+        const channelIds = Array.from(pendingRosterChannels);
+        pendingRosterChannels.clear();
+        for (const pendingChannelId of channelIds) {
+          queryClient.invalidateQueries({
+            queryKey: ['channel-roster', pendingChannelId],
+          });
+        }
+      }, AGENT_STATUS_ROSTER_REFRESH_MS);
     }
 
     const handlers: {
@@ -414,11 +497,24 @@ export function useEventSocket({
         useChannelActivityStore
           .getState()
           .recordActivity(msg.channelId, msg.latestSeq);
+        // An agent- or orchestrator-created channel (#1242) has no row in any
+        // cached list, so the seq just recorded is inert: nothing renders it and
+        // the lists only refetch on blur/refocus — never on a tab left focused.
+        // Pull the new row in instead of waiting for a window event.
+        if (!hasCachedChannelRow(queryClient, msg.channelId)) {
+          scheduleChannelListRefresh();
+        }
       },
       'channel-agent-status': (msg) => {
         useChannelAgentStatusStore
           .getState()
           .recordStatus(msg.channelId, msg.agentId, msg.status, msg.runtimeId);
+        // The status store alone cannot carry a binding: a newly bound agent's
+        // chip is dropped the moment it goes idle (the header keeps a chip for
+        // an unbound agent only while it is busy), and a remotely-designated
+        // orchestrator leaves a stale "designate orchestrator" button. Both read
+        // the roster snapshot, so refetch it.
+        scheduleRosterRefresh(msg.channelId);
       },
       'browser-tab-opened': (msg) => {
         useUiStore.getState().openHtmlTab(msg.filePath, msg.token);
@@ -473,9 +569,18 @@ export function useEventSocket({
 
     return () => {
       pendingWebhookRepos.clear();
+      pendingRosterChannels.clear();
       if (pollInvalidateTimer) {
         clearTimeout(pollInvalidateTimer);
         pollInvalidateTimer = null;
+      }
+      if (channelListRefreshTimer) {
+        clearTimeout(channelListRefreshTimer);
+        channelListRefreshTimer = null;
+      }
+      if (rosterInvalidateTimer) {
+        clearTimeout(rosterInvalidateTimer);
+        rosterInvalidateTimer = null;
       }
     };
   }, [authAuthenticated]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,6 +43,7 @@ import type {
 } from '../../../shared/workspace-topics.js';
 import type {
   ChannelImagePart,
+  ChannelMention,
   ChannelMessage,
   ChannelMessageId,
   ChannelMessagePart,
@@ -1728,6 +1729,15 @@ export interface ChannelSummaryView {
     preview: string;
     senderId: string;
     senderKind: 'human' | 'agent' | 'system';
+    /**
+     * Server-resolved sender label + vendor. `senderId` is a profile Actor id
+     * (`agent-profile:<vendor>:default`), so these are the ONLY safe sources for
+     * a display label — never strip segments off the id (#1234).
+     */
+    senderDisplayName?: string;
+    providerId?: string;
+    /** Mention refs for this row, computed over the full body server-side. */
+    mentions?: ChannelMention[];
     status: string;
     createdAt: string;
   } | null;

--- a/frontend/src/lib/hooks/use-restore-topic.ts
+++ b/frontend/src/lib/hooks/use-restore-topic.ts
@@ -1,0 +1,57 @@
+// #1287: ONE restore path for an archived channel/topic. Two surfaces used to
+// restore with disjoint cache invalidations — the in-channel composer bar
+// refreshed `['channel', id]` + `['workspace-topic', id]` while the sidebar
+// refreshed `['workspace-topics']` — so whichever surface ran the restore left
+// the other rendering stale archived state, and the composer swallowed the
+// failure while the sidebar toasted it. This hook owns the whole contract:
+// every reader key, plus the toast, for every caller.
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { restoreWorkspaceTopic } from '../api.js';
+import { useToastStore } from '../stores/toasts.js';
+
+/**
+ * Every query key that renders a topic's archived state.
+ *
+ * `['workspace-topics']` is a PREFIX, not an exact key: TanStack matches it
+ * against the sidebar's `['workspace-topics', 'with-archived']` view and its
+ * `['workspace-topics', 'search', …]` results too, so the three entries here
+ * cover all five readers.
+ */
+export function restoreTopicQueryKeys(topicId: string): string[][] {
+  return [
+    ['channel', topicId],
+    ['workspace-topic', topicId],
+    ['workspace-topics'],
+  ];
+}
+
+/**
+ * Shared restore mutation. `mutate(topicId)` is a stable reference, so callers
+ * can hand it straight to a `useCallback` dependency list.
+ *
+ * Stays pending until the invalidated reads settle — the restore affordance
+ * must not flip back to "restore" while its own channel row is still archived.
+ */
+export function useRestoreTopicMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (topicId: string) => restoreWorkspaceTopic(topicId),
+    onSuccess: async (_topic, topicId) => {
+      await Promise.all(
+        restoreTopicQueryKeys(topicId).map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey })
+        )
+      );
+    },
+    onError: (err: unknown) => {
+      // Never silent: an archived channel that refuses to reopen is exactly the
+      // case an operator needs told about.
+      useToastStore
+        .getState()
+        .showToast(
+          err instanceof Error ? err.message : 'failed to restore topic'
+        );
+    },
+  });
+}

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -1,8 +1,9 @@
 import type { WorkspaceSurface } from '../../../../shared/workspace-surfaces.js';
-import type {
-  WorkspaceTopic,
-  WorkspaceTopicChannelKind,
-  WorkspaceTopicId,
+import {
+  workspaceTopicHasExplicitParticipantLinks,
+  type WorkspaceTopic,
+  type WorkspaceTopicChannelKind,
+  type WorkspaceTopicId,
 } from '../../../../shared/workspace-topics.js';
 import type { SessionSummary } from '../types.js';
 import { isAttentionState, type DisplayState } from './display-state.js';
@@ -358,10 +359,25 @@ export function sessionMatchesTopic(
   ) {
     return true;
   }
-  if ((linked.sessionIds?.length ?? 0) > 0) return false;
-  if ((linked.workContextIds?.length ?? 0) > 0) return false;
+  // Explicitly linked topics answer for themselves. `agentRuntimeIds` counts
+  // even though a channel agent runtime never resolves to a session row: its
+  // presence proves the binder recorded this topic's participants, so an
+  // unmatched session here is genuinely NOT a participant (#1287).
+  if (workspaceTopicHasExplicitParticipantLinks(topic)) return false;
 
+  // DEPRECATED legacy lane (#1287): topics with NO explicit refs at all — rows
+  // written before the binder linked its runtimes, plus raw
+  // `POST /workspace-topics` and CLI-gateway `workspace-topics.create` callers
+  // that never pass `linkedRefs`. Path matching is a display-only guess that
+  // can adopt an unrelated terminal into a channel's participant list. Every
+  // writer that links explicitly skips this branch; delete it once none are
+  // left.
   const routing = topic.routingDefaults;
+  // Never guess across machines: the same path on another node is a different
+  // checkout, not this topic's work.
+  if (routing.nodeId && session.nodeId && session.nodeId !== routing.nodeId) {
+    return false;
+  }
   if (routing.worktreePath && session.worktreePath === routing.worktreePath)
     return true;
   if (routing.repoPath && session.repoPath === routing.repoPath) return true;

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -153,6 +153,18 @@ export interface ChannelRailSummary {
     preview: string;
     senderId: string;
     senderKind: 'human' | 'agent' | 'system';
+    /**
+     * Server-resolved label + vendor for the sender. The rail labels snippets
+     * from these; `senderId` is a profile Actor id and must never be split for
+     * a name (#1234).
+     */
+    senderDisplayName?: string;
+    providerId?: string;
+    /**
+     * Mention refs the server computed over the FULL body (not the truncated
+     * preview), so the cockpit's mention lane is not capped at 200 chars.
+     */
+    mentions?: { raw: string }[];
     createdAt: string;
   } | null;
 }

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -136,9 +136,35 @@ export interface TopicNavNode {
   displayName: string | null | undefined;
 }
 
+/**
+ * Per-row channel payload hydrated from `GET /channels` (#1287). Structural
+ * subset of the route's `channelSummaryView` — last message, member roster, and
+ * counts — so `ChannelSummaryView` from the API client assigns directly without
+ * the rail projection depending on the fetch layer.
+ */
+export interface ChannelRailSummary {
+  id: string;
+  latestSeq: number;
+  messageCount: number;
+  members: { kind: 'human' | 'agent'; id: string; joinedAt: string }[];
+  lastMessage: {
+    seq: number;
+    preview: string;
+    senderId: string;
+    senderKind: 'human' | 'agent' | 'system';
+    createdAt: string;
+  } | null;
+}
+
 export interface ChannelRailNode {
   item: TopicNavItem;
   unread: boolean;
+  /**
+   * Channel summary joined by id, or null for a row the channel list does not
+   * cover (derived/fallback topics, and persisted rows outside the list's own
+   * 200-row window). Renderers must degrade to the topic record alone.
+   */
+  summary: ChannelRailSummary | null;
   children: ChannelRailNode[];
 }
 
@@ -170,6 +196,21 @@ export interface ChannelRailTree {
 
 export interface ChannelRailActivitySnapshot {
   unreadByChannel: Readonly<Record<string, boolean>>;
+  /**
+   * Channel summaries keyed by channel id (#1287). Optional: the rail renders
+   * from the topic list alone before the summaries land, and derived topics
+   * never get one.
+   */
+  summaryByChannel?: Readonly<Record<string, ChannelRailSummary>>;
+}
+
+/** Key a `GET /channels` payload by channel id for the rail join (#1287). */
+export function indexChannelSummaries(
+  rows: readonly ChannelRailSummary[]
+): Record<string, ChannelRailSummary> {
+  const byId: Record<string, ChannelRailSummary> = {};
+  for (const row of rows) byId[row.id] = row;
+  return byId;
 }
 
 /**
@@ -178,7 +219,8 @@ export interface ChannelRailActivitySnapshot {
  * topic model's order and split into regular-channel and direct-message
  * sections. Descendants stay nested under their canonical root instead of being
  * flattened into workspace peers. Unread is computed once from the same
- * activity snapshot for both consumers.
+ * activity snapshot for both consumers, and each row carries the channel
+ * summary joined by id (#1287) so neither renderer needs a per-channel fetch.
  *
  * EVERY known workspace becomes a lane, including one holding zero channels
  * (#1287). Dropping an empty bucket made a freshly added workspace invisible
@@ -199,6 +241,7 @@ export function selectChannelRailTree(
     return {
       item,
       unread: activity.unreadByChannel[item.id] ?? false,
+      summary: activity.summaryByChannel?.[item.id] ?? null,
       children,
     };
   };

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -35,6 +35,7 @@ import {
 } from '../shared/channel-chat-protocol.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
+import { workspaceTopicAgentRuntimeLinkPatch } from '../shared/workspace-topics.js';
 
 // @-mention routing binder (#1167, slice 4). One module owns the whole loop:
 // subscribe to hub.onMessagePosted → resolve mentions → ensure a (channel,
@@ -512,6 +513,29 @@ export function createChannelAgentBinder(
     };
   }
 
+  /**
+   * Record a binder-owned runtime on its channel topic (#1287). Navigation used
+   * to GUESS a channel's participants from `routingDefaults.cwd/repoPath`
+   * whenever `linkedRefs` was empty, which pulled unrelated same-path sessions
+   * into a channel's participant list. Linking here means every channel the
+   * binder ever bound states its participants explicitly instead.
+   *
+   * Best effort and idempotent: no topic store, no topic row, or a failed store
+   * write must never fail the mention turn that triggered the bind.
+   */
+  function linkRuntimeToTopic(channelId: string, runtimeId: string): void {
+    if (!topicStore) return;
+    try {
+      const topic = topicStore.get(channelId);
+      if (!topic) return;
+      const patch = workspaceTopicAgentRuntimeLinkPatch({ topic, runtimeId });
+      if (!patch) return;
+      topicStore.update(topic.id, patch);
+    } catch (err) {
+      logger.warn('channel binder topic runtime link failed:', errText(err));
+    }
+  }
+
   function attachRuntime(
     channelId: string,
     profileActorId: string,
@@ -565,6 +589,8 @@ export function createChannelAgentBinder(
       handleBindingPatch(binding, patch)
     );
     live.set(key, binding);
+    // Single funnel for both fresh spawns and restored-runtime rebinds.
+    linkRuntimeToTopic(channelId, runtime.id);
     return binding;
   }
 
@@ -624,6 +650,11 @@ export function createChannelAgentBinder(
             runtime.role ?? 'unknown'
           );
         }
+        // Reuse still links: a topic row created (or re-created) after this
+        // runtime was attached would otherwise never learn its participant.
+        // The patch helper returns undefined when already linked, so a hot
+        // rebind pays one indexed topic read and no write.
+        linkRuntimeToTopic(channelId, runtime.id);
         return existing;
       }
     }

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -12,6 +12,7 @@ import {
   CHANNEL_MESSAGE_MAX_IMAGE_PARTS,
   isChannelMessagePart,
   isChannelAgentDetail,
+  parseMentions,
   type ChannelAgentDetail,
   type ChannelBodyFormat,
   type ChannelMemberRef,
@@ -46,6 +47,15 @@ const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
 const CHANNEL_SUMMARY_PREVIEW_MAX_CHARS = 200;
+/**
+ * Body window scanned for the summary's mention signal when the row carries no
+ * persisted `meta.mentions` (bridge-authored agent rows never do — the binder
+ * parses mentions for fan-out without writing them back). Deliberately far
+ * beyond `CHANNEL_SUMMARY_PREVIEW_MAX_CHARS` so a long agent status update that
+ * ends in `@operator` still lights the mention lane, and still bounded so the
+ * list route never regex-scans 200 × 256KB of body text.
+ */
+const CHANNEL_SUMMARY_MENTION_SCAN_MAX_CHARS = 8_000;
 
 export type ChannelThreadHistoryQueryMode = 'default' | 'after' | 'before';
 
@@ -254,6 +264,21 @@ export interface ChannelSummary {
     preview: string;
     senderId: string;
     senderKind: ChannelSenderKindLoose;
+    /**
+     * Persisted `sender_display`. Sidebar/rail snippets label the sender from
+     * this (falling back to `providerId`) — NEVER by stripping `senderId`, which
+     * is a profile Actor id (`agent-profile:<vendor>:default`), not a name.
+     */
+    senderDisplayName?: string;
+    /** Vendor framework id for agent rows; the authoritative label fallback. */
+    providerId?: string;
+    /**
+     * Mention refs for the previewed row. Persisted `meta.mentions` when the
+     * write path resolved them (#1236 contact-set resolution included);
+     * otherwise parsed server-side from a bounded window of the FULL body, so a
+     * mention past the 200-char preview cut-off is still visible to clients.
+     */
+    mentions?: ChannelMention[];
     status: ChannelMessageStatus;
     createdAt: string;
   } | null;
@@ -1658,6 +1683,12 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
     previewRow: ChannelMessageRow,
     messageCount: number
   ): ChannelSummary {
+    const meta = parseMeta(previewRow.meta_json);
+    const providerId =
+      typeof meta?.['providerId'] === 'string'
+        ? (meta['providerId'] as string)
+        : undefined;
+    const mentions = summaryMentions(previewRow, meta);
     return {
       channelId: previewRow.channel_id,
       latestSeq,
@@ -1671,10 +1702,35 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         ),
         senderId: previewRow.sender_id,
         senderKind: previewRow.sender_kind as ChannelSenderRef['kind'],
+        ...(previewRow.sender_display
+          ? { senderDisplayName: previewRow.sender_display }
+          : {}),
+        ...(providerId ? { providerId } : {}),
+        ...(mentions.length > 0 ? { mentions } : {}),
         status: previewRow.status as ChannelMessageStatus,
         createdAt: previewRow.created_at,
       },
     };
+  }
+
+  /**
+   * Mention refs for a summary row. Persisted mentions win — they are the
+   * server-resolved set (contact-set resolution a plain re-parse cannot
+   * reproduce). Rows written without them (every bridge-authored agent row) get
+   * a bounded parse of the full body so a mention past the preview cut-off is
+   * not silently lost.
+   */
+  function summaryMentions(
+    previewRow: ChannelMessageRow,
+    meta: ChannelMessageMeta | undefined
+  ): ChannelMention[] {
+    if (Array.isArray(meta?.mentions) && meta.mentions.length > 0) {
+      return meta.mentions;
+    }
+    if (!previewRow.body_text.includes('@')) return [];
+    return parseMentions(
+      previewRow.body_text.slice(0, CHANNEL_SUMMARY_MENTION_SCAN_MAX_CHARS)
+    );
   }
 }
 

--- a/shared/agent-profile.ts
+++ b/shared/agent-profile.ts
@@ -89,9 +89,30 @@ export type AgentProfileContact = Pick<
   'id' | 'providerId' | 'displayName' | 'isDefault' | 'isBuiltIn'
 >;
 
+/** Namespace prefix every profile Actor id carries. */
+export const AGENT_PROFILE_ID_PREFIX = 'agent-profile:';
+
 /** Stable id for the built-in default profile of a vendor. Distinct from `<vendor>`. */
 export function builtInAgentProfileId(providerId: string): string {
-  return `agent-profile:${providerId}:default`;
+  return `${AGENT_PROFILE_ID_PREFIX}${providerId}:default`;
+}
+
+/**
+ * Vendor framework id embedded in a profile Actor id
+ * (`agent-profile:<vendor>:default` | `agent-profile:<vendor>:<uuid>`), or
+ * `null` for anything else. LAST-RESORT display fallback only: the authoritative
+ * vendor is `ChannelSenderRef.providerId` / `AgentProfile.providerId`, and no
+ * render path may derive a NAME from a profile id — the trailing segment is
+ * `default` or a uuid, never a label (#1234).
+ */
+export function parseAgentProfileProviderId(
+  profileActorId: string
+): string | null {
+  if (!profileActorId.startsWith(AGENT_PROFILE_ID_PREFIX)) return null;
+  const vendor = profileActorId
+    .slice(AGENT_PROFILE_ID_PREFIX.length)
+    .split(':')[0];
+  return vendor ? vendor : null;
 }
 
 /**

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -385,6 +385,7 @@ const workspaceTopicSchema: RelayJsonSchema = {
         },
         artifactIds: { type: 'array', items: stringSchema },
         workspaceSurfaceIds: { type: 'array', items: stringSchema },
+        agentRuntimeIds: { type: 'array', items: stringSchema },
       },
     },
     state: { type: 'object', additionalProperties: true },

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -118,6 +118,15 @@ export interface WorkspaceTopicLinkedRefs {
   artifactIds?: ArtifactId[];
   /** WorkspaceSurface ids from shared/workspace-surfaces.ts. No duplicated surface fields. */
   workspaceSurfaceIds?: string[];
+  /**
+   * Private channel agent runtimes the binder bound to this topic (#1287).
+   * These are deliberately NOT Relay sessions — `ChannelAgentRuntime` is absent
+   * from session lists — so they never resolve to a session row and MUST NOT be
+   * written into `sessionIds`. They exist so a channel that has ever bound an
+   * agent counts as explicitly linked and stops guessing its participants from
+   * `routingDefaults` paths.
+   */
+  agentRuntimeIds?: string[];
 }
 
 export interface WorkspaceTopicState {
@@ -828,6 +837,11 @@ function parseLinkedRefs(
     'linkedRefs.artifactIds'
   );
   if (artifactIds) out.artifactIds = artifactIds;
+  const agentRuntimeIds = readStringList(
+    record['agentRuntimeIds'],
+    'linkedRefs.agentRuntimeIds'
+  );
+  if (agentRuntimeIds) out.agentRuntimeIds = agentRuntimeIds;
   const workspaceSurfaceIds = readStringList(
     record['workspaceSurfaceIds'],
     'linkedRefs.workspaceSurfaceIds'
@@ -1249,6 +1263,54 @@ export function workspaceTopicSessionLinkPatch(input: {
     return undefined;
   }
   return { linkedRefs };
+}
+
+/**
+ * Newest binder runtime links retained per topic. A channel rebinds a fresh
+ * runtime on every cold start, so the list is trimmed FIFO — it is a "this
+ * topic links explicitly" marker plus a short recency tail, never an audit log,
+ * and it must never grow into `WORKSPACE_TOPIC_MAX_REFS` territory.
+ */
+export const WORKSPACE_TOPIC_MAX_AGENT_RUNTIME_REFS = 16;
+
+/**
+ * Patch that records a binder-owned channel agent runtime on its topic (#1287).
+ * Returns `undefined` when the runtime is already linked so callers skip a
+ * no-op store write (and the `updatedAt` churn it would cause).
+ */
+export function workspaceTopicAgentRuntimeLinkPatch(input: {
+  topic: WorkspaceTopic;
+  runtimeId: string;
+}): WorkspaceTopicUpdateInput | undefined {
+  const runtimeId = input.runtimeId.trim();
+  if (!runtimeId) return undefined;
+  const current = input.topic.linkedRefs.agentRuntimeIds ?? [];
+  if (current.includes(runtimeId)) return undefined;
+  return {
+    linkedRefs: {
+      ...input.topic.linkedRefs,
+      agentRuntimeIds: [...current, runtimeId].slice(
+        -WORKSPACE_TOPIC_MAX_AGENT_RUNTIME_REFS
+      ),
+    },
+  };
+}
+
+/**
+ * True when a topic states who its participants are instead of leaving them to
+ * be inferred. Any linked session, WorkContext, or channel agent runtime counts:
+ * navigation surfaces use this to decide whether the legacy cwd/repoPath
+ * fallback is allowed to run at all (#1287).
+ */
+export function workspaceTopicHasExplicitParticipantLinks(
+  topic: WorkspaceTopic
+): boolean {
+  const linked = topic.linkedRefs;
+  return (
+    (linked.sessionIds?.length ?? 0) > 0 ||
+    (linked.workContextIds?.length ?? 0) > 0 ||
+    (linked.agentRuntimeIds?.length ?? 0) > 0
+  );
 }
 
 export function buildWorkspaceTopicRecord(input: {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -39,7 +39,10 @@ import type {
   ChannelAgentRuntime,
   CreateChannelAgentRuntimeParams,
 } from '../server/channel-agent-runtime.js';
-import type { WorkspaceTopicStore } from '../server/workspace-topics.js';
+import {
+  createWorkspaceTopicStore,
+  type WorkspaceTopicStore,
+} from '../server/workspace-topics.js';
 import {
   parseMentions,
   type ChannelImagePart,
@@ -3039,5 +3042,68 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     expect(agentReplies(store, 'mock')[0]!.body.text).toBe('approved and done');
     await waitFor(() => a.sendCalls.length === 2, 4000); // queued turn drained
     expect(a.sendCalls).toHaveLength(2);
+  });
+});
+
+// ── #1287: channels state their participants instead of being guessed ────────
+
+describe('channel-agent-binder — topic participant links', () => {
+  function makeTopicStore(): WorkspaceTopicStore {
+    const topicStore = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topicStore.close());
+    return topicStore;
+  }
+
+  it('links its spawned runtime into the topic and never relinks on reuse', async () => {
+    const topicStore = makeTopicStore();
+    topicStore.create({
+      id: CH,
+      workspaceId: 'ws:local',
+      title: 'general',
+      routingDefaults: { repoPath: '/repo/relay', cwd: '/repo/relay' },
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      topicStore,
+    });
+
+    post(store, binder, '@mock hi', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    const runtimeId = sessions.firstSessionId();
+    const linked = topicStore.get(CH)!;
+    expect(linked.linkedRefs.agentRuntimeIds).toEqual([runtimeId]);
+    // The runtime is NOT a Relay session and must never be filed as one.
+    expect(linked.linkedRefs.sessionIds).toBeUndefined();
+
+    // Reuse: same runtime, so the topic keeps one entry and takes no write.
+    post(store, binder, '@mock again', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(sessions.spawns()).toBe(1);
+    expect(topicStore.get(CH)?.linkedRefs.agentRuntimeIds).toEqual([runtimeId]);
+    expect(topicStore.get(CH)?.updatedAt).toBe(linked.updatedAt);
+  });
+
+  it('links on reuse when the topic row only appears after the bind', async () => {
+    const topicStore = makeTopicStore();
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      topicStore,
+    });
+
+    post(store, binder, '@mock hi', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    expect(topicStore.get(CH)).toBeNull();
+
+    topicStore.create({ id: CH, workspaceId: 'ws:local', title: 'general' });
+    post(store, binder, '@mock again', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(sessions.spawns()).toBe(1);
+    expect(topicStore.get(CH)?.linkedRefs.agentRuntimeIds).toEqual([
+      sessions.firstSessionId(),
+    ]);
   });
 });

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -979,6 +979,69 @@ describe('channel-message-store posts, threads, idempotency', () => {
     expect(c?.lastMessage?.preview).toBe('second');
   });
 
+  // A summary sender id is a profile Actor id, so clients cannot label a row
+  // from it (#1234) — and the 200-char preview cannot answer "was I mentioned?"
+  // for a long agent status update. Both signals ride the payload instead.
+  it('carries the resolved sender identity and full-body mentions on a summary', () => {
+    const s = store();
+    const longStatus = `${'status update. '.repeat(40)}@operator please confirm`;
+    s.appendComplete({
+      channelId: 'topic:e',
+      sender: {
+        kind: 'agent',
+        id: builtInAgentProfileId('claude'),
+        providerId: 'claude',
+        displayName: 'Reviewer Claude',
+      },
+      text: longStatus,
+    });
+
+    const summary = s.getChannelSummary('topic:e');
+    expect(summary?.lastMessage?.senderId).toBe(
+      builtInAgentProfileId('claude')
+    );
+    expect(summary?.lastMessage?.senderDisplayName).toBe('Reviewer Claude');
+    expect(summary?.lastMessage?.providerId).toBe('claude');
+    // The mention sits well past the truncated preview...
+    expect(summary?.lastMessage?.preview).not.toContain('@operator');
+    // ...but is still visible to the rail.
+    expect(summary?.lastMessage?.mentions?.map((m) => m.raw)).toEqual([
+      '@operator',
+    ]);
+    const viaList = s
+      .listChannelSummaries()
+      .find((x) => x.channelId === 'topic:e');
+    expect(viaList?.lastMessage?.mentions?.map((m) => m.raw)).toEqual([
+      '@operator',
+    ]);
+  });
+
+  it('prefers persisted mentions over a re-parse of the body', () => {
+    const s = store();
+    s.appendComplete({
+      channelId: 'topic:f',
+      sender: HUMAN,
+      text: '@Reviewer Claude take a look',
+      mentions: [
+        {
+          raw: '@Reviewer Claude',
+          providerId: 'claude',
+          profileId: 'agent-profile:claude:reviewer',
+        },
+      ],
+    });
+
+    // Server-resolved contact-set mentions (#1236) survive verbatim — a plain
+    // re-parse of the body could not reproduce the multi-word name or profileId.
+    expect(s.getChannelSummary('topic:f')?.lastMessage?.mentions).toEqual([
+      {
+        raw: '@Reviewer Claude',
+        providerId: 'claude',
+        profileId: 'agent-profile:claude:reviewer',
+      },
+    ]);
+  });
+
   it('previews the newest prose row when a turn ends on a detail card', () => {
     const s = store();
     s.appendComplete({

--- a/test/components/channel-restore-mutation.test.ts
+++ b/test/components/channel-restore-mutation.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment happy-dom
+//
+// #1287 ITEM 14: restore used to be two mutations with disjoint invalidations —
+// the in-channel composer bar refreshed `['channel']` + `['workspace-topic']`
+// and swallowed errors, while the sidebar refreshed `['workspace-topics']` and
+// toasted them. Both surfaces mount at once, so one restore always left the
+// other rendering stale archived state. These tests pin the single shared
+// mutation: three keys every time, and a failure that reaches the operator.
+
+import React, { act, useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  restoreWorkspaceTopic: vi.fn(),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+    restoreWorkspaceTopic: mocks.restoreWorkspaceTopic,
+  };
+});
+
+const CHANNEL_ID = 'topic:archived-lane';
+
+// Archived channel: the composer renders its restore bar instead of the input.
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: CHANNEL_ID,
+      title: 'archived lane',
+      visibility: 'default',
+      archived: true,
+      latestSeq: 0,
+      messageCount: 0,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: CHANNEL_ID,
+      messages: [],
+      lastSeq: 0,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    fullSnapshotRevision: 0,
+    post: vi.fn(),
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+vi.mock('../../frontend/src/components/chat/ChannelTimeline.js', () => ({
+  ChannelTimeline: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
+  ChannelThreadPanel: () => null,
+}));
+
+const { ChannelView } = await import(
+  '../../frontend/src/components/chat/ChannelView.js'
+);
+const { restoreTopicQueryKeys, useRestoreTopicMutation } = await import(
+  '../../frontend/src/lib/hooks/use-restore-topic.js'
+);
+const { useToastStore } = await import(
+  '../../frontend/src/lib/stores/toasts.js'
+);
+
+function topicFixture(status: 'active' | 'archived' = 'archived') {
+  return {
+    id: CHANNEL_ID,
+    workspaceId: 'ws:local',
+    status,
+    display: { title: 'archived lane' },
+    routingDefaults: {},
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let queryClient: QueryClient;
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+/** Seed the readers that must not keep rendering the archived state. */
+function seedTopicCaches(): void {
+  queryClient.setQueryData(['channel', CHANNEL_ID], { archived: true });
+  queryClient.setQueryData(['workspace-topics'], { topics: [] });
+  queryClient.setQueryData(['workspace-topics', 'with-archived'], {
+    topics: [],
+  });
+  queryClient.setQueryData(
+    ['workspace-topics', 'search', 'lane', 'all', 'with-archived'],
+    { results: [] }
+  );
+}
+
+beforeEach(() => {
+  mocks.fetchWorkspaceTopic.mockReset();
+  mocks.fetchChannelRoster.mockReset();
+  mocks.restoreWorkspaceTopic.mockReset();
+  mocks.fetchWorkspaceTopic.mockResolvedValue(topicFixture());
+  mocks.fetchChannelRoster.mockResolvedValue([]);
+  mocks.restoreWorkspaceTopic.mockResolvedValue(topicFixture('active'));
+  useToastStore.setState({ toasts: [] });
+  vi.stubGlobal('matchMedia', () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  queryClient.clear();
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('shared restore mutation (#1287)', () => {
+  it('names every reader of a topic archived state, list keys by prefix', () => {
+    expect(restoreTopicQueryKeys(CHANNEL_ID)).toEqual([
+      ['channel', CHANNEL_ID],
+      ['workspace-topic', CHANNEL_ID],
+      ['workspace-topics'],
+    ]);
+  });
+
+  it('invalidates all three key sets from any caller, prefix included', async () => {
+    seedTopicCaches();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    function Probe(): null {
+      const { mutate } = useRestoreTopicMutation();
+      useEffect(() => {
+        mutate(CHANNEL_ID);
+      }, [mutate]);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Probe)
+        )
+      );
+    });
+    await flush();
+
+    expect(mocks.restoreWorkspaceTopic).toHaveBeenCalledWith(CHANNEL_ID);
+    for (const queryKey of restoreTopicQueryKeys(CHANNEL_ID)) {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey });
+    }
+    // The `['workspace-topics']` entry is a PREFIX: the archived-inclusive view
+    // and the search results must fall in with it, or the sidebar keeps the
+    // restored row greyed out.
+    for (const queryKey of [
+      ['channel', CHANNEL_ID],
+      ['workspace-topics'],
+      ['workspace-topics', 'with-archived'],
+      ['workspace-topics', 'search', 'lane', 'all', 'with-archived'],
+    ]) {
+      expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    }
+  });
+
+  it('surfaces a restore failure as a toast instead of swallowing it', async () => {
+    mocks.restoreWorkspaceTopic.mockRejectedValue(new Error('restore refused'));
+
+    function Probe(): null {
+      const { mutate } = useRestoreTopicMutation();
+      useEffect(() => {
+        mutate(CHANNEL_ID);
+      }, [mutate]);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Probe)
+        )
+      );
+    });
+    await flush();
+
+    expect(useToastStore.getState().toasts.map((t) => t.message)).toContain(
+      'restore refused'
+    );
+  });
+});
+
+describe('ChannelView restore bar call site (#1287)', () => {
+  async function renderChannel(): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChannelView, { channelId: CHANNEL_ID })
+        )
+      );
+    });
+    await flush();
+  }
+
+  it('drives the shared mutation from the ungated composer restore bar', async () => {
+    seedTopicCaches();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    await renderChannel();
+
+    const restore = container.querySelector<HTMLButtonElement>(
+      '.ch-composer__restore'
+    );
+    expect(restore).not.toBeNull();
+
+    await act(async () => restore?.click());
+    await flush();
+
+    expect(mocks.restoreWorkspaceTopic).toHaveBeenCalledWith(CHANNEL_ID);
+    for (const queryKey of restoreTopicQueryKeys(CHANNEL_ID)) {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey });
+    }
+  });
+
+  it('holds the bar in its pending state until the restore settles', async () => {
+    let settle: (() => void) | null = null;
+    mocks.restoreWorkspaceTopic.mockReturnValue(
+      new Promise<void>((resolve) => {
+        settle = resolve;
+      })
+    );
+    await renderChannel();
+
+    const restore = container.querySelector<HTMLButtonElement>(
+      '.ch-composer__restore'
+    );
+    act(() => {
+      restore?.click();
+    });
+    await flush();
+
+    expect(restore?.disabled).toBe(true);
+    expect(restore?.textContent).toContain('restoring');
+
+    settle?.();
+    await flush();
+  });
+
+  it('toasts a failed in-channel restore rather than failing silently', async () => {
+    mocks.restoreWorkspaceTopic.mockRejectedValue(
+      new Error('channel store unavailable')
+    );
+    await renderChannel();
+
+    const restore = container.querySelector<HTMLButtonElement>(
+      '.ch-composer__restore'
+    );
+    await act(async () => restore?.click());
+    await flush();
+
+    expect(useToastStore.getState().toasts.map((t) => t.message)).toContain(
+      'channel store unavailable'
+    );
+    // Retryable: the bar comes back out of its pending state.
+    expect(restore?.disabled).toBe(false);
+  });
+});

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -136,7 +136,9 @@ describe('useEventSocket repo-scoped refresh', () => {
         nodes = typeof updater === 'function' ? updater(nodes) : updater;
       }),
       getQueryData: vi.fn((queryKey: unknown[]) =>
-        queryKey[0] === 'hub-nodes' ? nodes : seedCache[JSON.stringify(queryKey)]
+        queryKey[0] === 'hub-nodes'
+          ? nodes
+          : seedCache[JSON.stringify(queryKey)]
       ),
       get nodes() {
         return nodes;
@@ -454,6 +456,17 @@ describe('useEventSocket repo-scoped refresh', () => {
       };
     }
 
+    /** Lists plus a held roster per channel, as an open cockpit would have. */
+    function seededListsWithRosters(
+      ...channelIds: string[]
+    ): Record<string, unknown> {
+      const seeded = seededLists();
+      for (const channelId of channelIds) {
+        seeded[JSON.stringify(['channel-roster', channelId])] = [];
+      }
+      return seeded;
+    }
+
     beforeEach(() => {
       useChannelActivityStore.setState({
         latestSeqByChannel: {},
@@ -533,9 +546,71 @@ describe('useEventSocket repo-scoped refresh', () => {
 
       const channelListInvalidations =
         queryClient.invalidateQueries.mock.calls.filter(
-          (call: [{ queryKey: unknown[] }]) => call[0].queryKey[0] === 'channels'
+          (call: [{ queryKey: unknown[] }]) =>
+            call[0].queryKey[0] === 'channels'
         );
       expect(channelListInvalidations).toHaveLength(1);
+    });
+
+    // A channel outside the capped `/channels` + `/workspace-topics` windows can
+    // never be materialized by refetching, and posting to it does not bump its
+    // topic `updated_at`, so an unbounded lane would refetch two O(channels)
+    // endpoints once per badge for the whole turn and still render nothing.
+    it('stops refetching for an unknown channel a completed refresh never materialized', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      for (let burst = 0; burst < 8; burst += 1) {
+        wsMock.onMessage?.({
+          type: 'channel-activity',
+          channelId: NEW_CHANNEL,
+          latestSeq: burst + 1,
+        });
+        vi.advanceTimersByTime(750);
+      }
+
+      const listInvalidations = () =>
+        queryClient.invalidateQueries.mock.calls.filter(
+          (call: [{ queryKey: unknown[] }]) =>
+            call[0].queryKey[0] === 'channels'
+        ).length;
+      expect(listInvalidations()).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+
+      // A second, still-unknown channel is unaffected by the first one's mark.
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: 'topic:another-new',
+        latestSeq: 1,
+      });
+      vi.advanceTimersByTime(750);
+      expect(listInvalidations()).toBe(2);
+    });
+
+    it('retries an unknown channel once the back-off window has passed', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: NEW_CHANNEL,
+        latestSeq: 1,
+      });
+      vi.advanceTimersByTime(750);
+      vi.advanceTimersByTime(60_000);
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: NEW_CHANNEL,
+        latestSeq: 2,
+      });
+      vi.advanceTimersByTime(750);
+
+      expect(
+        queryClient.invalidateQueries.mock.calls.filter(
+          (call: [{ queryKey: unknown[] }]) =>
+            call[0].queryKey[0] === 'channels'
+        )
+      ).toHaveLength(2);
     });
 
     it('routes new head seqs through the clamp-fenced seed path, never a direct store write', () => {
@@ -559,7 +634,10 @@ describe('useEventSocket repo-scoped refresh', () => {
     });
 
     it('refreshes the roster of every channel an agent status event touched', () => {
-      const queryClient = makeQueryClient(undefined, seededLists());
+      const queryClient = makeQueryClient(
+        undefined,
+        seededListsWithRosters('ch-a', 'ch-b')
+      );
       mount(queryClient);
 
       wsMock.onMessage?.({
@@ -596,8 +674,68 @@ describe('useEventSocket repo-scoped refresh', () => {
       ]);
     });
 
-    it('cleanup cancels pending list and roster timers', () => {
+    it('ignores agent status for a channel the client holds no roster for', () => {
       const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-agent-status',
+        channelId: 'ch-unwatched',
+        agentId: 'agent:claude',
+        status: 'thinking',
+        runtimeId: 'rt-1',
+      });
+
+      expect(vi.getTimerCount()).toBe(0);
+      // The status store still records it — only the refetch is suppressed.
+      expect(
+        useChannelAgentStatusStore.getState().statusByChannelAgent[
+          'ch-unwatched agent:claude'
+        ]
+      ).toBe('thinking');
+    });
+
+    // A turn walks spawning → thinking → streaming → waiting → idle over minutes.
+    // The debounce must land AFTER the burst, not once per transition through it.
+    it('collapses a walking status burst into one roster refetch', () => {
+      const queryClient = makeQueryClient(
+        undefined,
+        seededListsWithRosters('ch-a')
+      );
+      mount(queryClient);
+
+      for (const status of [
+        'spawning',
+        'thinking',
+        'streaming',
+        'waiting',
+        'idle',
+      ] as const) {
+        wsMock.onMessage?.({
+          type: 'channel-agent-status',
+          channelId: 'ch-a',
+          agentId: 'agent:claude',
+          status,
+          runtimeId: 'rt-1',
+        });
+        // Each transition lands inside the debounce window.
+        vi.advanceTimersByTime(600);
+      }
+      vi.advanceTimersByTime(750);
+
+      expect(
+        queryClient.invalidateQueries.mock.calls.filter(
+          (call: [{ queryKey: unknown[] }]) =>
+            call[0].queryKey[0] === 'channel-roster'
+        )
+      ).toHaveLength(1);
+    });
+
+    it('cleanup cancels pending list and roster timers', () => {
+      const queryClient = makeQueryClient(
+        undefined,
+        seededListsWithRosters('ch-a')
+      );
       mount(queryClient);
 
       wsMock.onMessage?.({

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -107,6 +107,8 @@ vi.mock('../../frontend/src/lib/stores/ui.js', () => ({
 }));
 
 import { useEventSocket } from '../../frontend/src/hooks/useEventSocket.js';
+import { useChannelActivityStore } from '../../frontend/src/lib/stores/channel-activity.js';
+import { useChannelAgentStatusStore } from '../../frontend/src/lib/stores/channel-agent-status.js';
 
 describe('useEventSocket repo-scoped refresh', () => {
   beforeEach(() => {
@@ -123,13 +125,19 @@ describe('useEventSocket repo-scoped refresh', () => {
     apiMock.fetchHubNodes.mockResolvedValue([]);
   });
 
-  function makeQueryClient(cachedNodes?: unknown[]): any {
+  function makeQueryClient(
+    cachedNodes?: unknown[],
+    seedCache: Record<string, unknown> = {}
+  ): any {
     let nodes = cachedNodes;
     return {
       invalidateQueries: vi.fn(),
       setQueryData: vi.fn((_queryKey, updater) => {
         nodes = typeof updater === 'function' ? updater(nodes) : updater;
       }),
+      getQueryData: vi.fn((queryKey: unknown[]) =>
+        queryKey[0] === 'hub-nodes' ? nodes : seedCache[JSON.stringify(queryKey)]
+      ),
       get nodes() {
         return nodes;
       },
@@ -429,5 +437,186 @@ describe('useEventSocket repo-scoped refresh', () => {
     if (effectState.cleanup) effectState.cleanup();
 
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // #1287 Slice 3 item 15: channel-activity / channel-agent-status broadcasts
+  // carry no row payload, so an agent-created channel (#1242) and a newly bound
+  // agent were both invisible until an unrelated refetch happened to run.
+  describe('channel list + roster invalidation', () => {
+    const LISTED_CHANNEL = 'topic-listed';
+    const NEW_CHANNEL = 'topic-agent-created';
+
+    /** Caches shaped like a rail that has loaded both of its list queries. */
+    function seededLists(): Record<string, unknown> {
+      return {
+        '["channels"]': [{ id: LISTED_CHANNEL, latestSeq: 4 }],
+        '["workspace-topics"]': { topics: [{ id: LISTED_CHANNEL }] },
+      };
+    }
+
+    beforeEach(() => {
+      useChannelActivityStore.setState({
+        latestSeqByChannel: {},
+        lastReadByChannel: {},
+        clampedAtByChannel: {},
+      });
+      useChannelAgentStatusStore.setState({
+        statusByChannelAgent: {},
+        runtimeByChannelAgent: {},
+        updatedAtByChannelAgent: {},
+      });
+    });
+
+    it('refetches the topic and channel lists when activity names a channel no cached list holds', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: NEW_CHANNEL,
+        latestSeq: 1,
+      });
+      vi.advanceTimersByTime(750);
+
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['workspace-topics'],
+      });
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['channels'],
+      });
+      expect(
+        useChannelActivityStore.getState().latestSeqByChannel[NEW_CHANNEL]
+      ).toBe(1);
+    });
+
+    it('leaves the lists alone when the channel already has a cached row', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: LISTED_CHANNEL,
+        latestSeq: 9,
+      });
+
+      expect(vi.getTimerCount()).toBe(0);
+      expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: ['channels'],
+      });
+    });
+
+    it('skips the refetch entirely when no list has loaded yet', () => {
+      const queryClient = makeQueryClient();
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: NEW_CHANNEL,
+        latestSeq: 1,
+      });
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('debounces an unknown-channel burst into a single list refetch', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      for (const latestSeq of [1, 2, 3]) {
+        wsMock.onMessage?.({
+          type: 'channel-activity',
+          channelId: NEW_CHANNEL,
+          latestSeq,
+        });
+      }
+      vi.advanceTimersByTime(750);
+
+      const channelListInvalidations =
+        queryClient.invalidateQueries.mock.calls.filter(
+          (call: [{ queryKey: unknown[] }]) => call[0].queryKey[0] === 'channels'
+        );
+      expect(channelListInvalidations).toHaveLength(1);
+    });
+
+    it('routes new head seqs through the clamp-fenced seed path, never a direct store write', () => {
+      const seedSpy = vi.spyOn(
+        useChannelActivityStore.getState(),
+        'seedChannelActivity'
+      );
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: NEW_CHANNEL,
+        latestSeq: 1,
+      });
+      vi.advanceTimersByTime(750);
+
+      expect(seedSpy).not.toHaveBeenCalled();
+      expect(useChannelActivityStore.getState().clampedAtByChannel).toEqual({});
+      seedSpy.mockRestore();
+    });
+
+    it('refreshes the roster of every channel an agent status event touched', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-agent-status',
+        channelId: 'ch-a',
+        agentId: 'agent:claude',
+        status: 'spawning',
+        runtimeId: 'rt-1',
+      });
+      wsMock.onMessage?.({
+        type: 'channel-agent-status',
+        channelId: 'ch-a',
+        agentId: 'agent:claude',
+        status: 'idle',
+        runtimeId: 'rt-1',
+      });
+      wsMock.onMessage?.({
+        type: 'channel-agent-status',
+        channelId: 'ch-b',
+        agentId: 'agent:codex',
+        status: 'thinking',
+        runtimeId: 'rt-2',
+      });
+      vi.advanceTimersByTime(750);
+
+      const rosterInvalidations =
+        queryClient.invalidateQueries.mock.calls.filter(
+          (call: [{ queryKey: unknown[] }]) =>
+            call[0].queryKey[0] === 'channel-roster'
+        );
+      expect(rosterInvalidations.map((call: any) => call[0].queryKey)).toEqual([
+        ['channel-roster', 'ch-a'],
+        ['channel-roster', 'ch-b'],
+      ]);
+    });
+
+    it('cleanup cancels pending list and roster timers', () => {
+      const queryClient = makeQueryClient(undefined, seededLists());
+      mount(queryClient);
+
+      wsMock.onMessage?.({
+        type: 'channel-activity',
+        channelId: NEW_CHANNEL,
+        latestSeq: 1,
+      });
+      wsMock.onMessage?.({
+        type: 'channel-agent-status',
+        channelId: 'ch-a',
+        agentId: 'agent:claude',
+        status: 'thinking',
+        runtimeId: 'rt-1',
+      });
+      expect(vi.getTimerCount()).toBe(2);
+
+      if (effectState.cleanup) effectState.cleanup();
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 });

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -178,6 +178,73 @@ describe('buildTopicNavModel', () => {
     ]);
   });
 
+  it('stops path-matching once a channel links its bound agent runtime', () => {
+    // Same routing paths, same stray terminal: only the row that never linked
+    // anything is still allowed to guess (#1287).
+    const channel = makeTopic({
+      id: 'topic:channel',
+      display: { title: 'Channel' },
+      routingDefaults: { repoPath: '/repo/relay', cwd: '/repo/relay' },
+      linkedRefs: { agentRuntimeIds: ['a1b2c3d4e5f60718'] },
+    });
+    const legacy = makeTopic({
+      id: 'topic:legacy',
+      display: { title: 'Legacy' },
+      routingDefaults: { repoPath: '/repo/relay', cwd: '/repo/relay' },
+    });
+
+    const model = buildTopicNavModel({
+      topics: [channel, legacy],
+      sessions: [
+        makeSession({
+          id: 'stray-terminal',
+          displayName: 'stray terminal',
+          repoPath: '/repo/relay',
+          worktreePath: '/repo/relay',
+          cwd: '/repo/relay',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    expect(model.byId.get('topic:channel')?.sessions).toEqual([]);
+    expect(model.byId.get('topic:channel')?.participants).toEqual([]);
+    expect(model.byId.get('topic:legacy')?.sessions).toMatchObject([
+      { id: 'stray-terminal' },
+    ]);
+  });
+
+  it('never path-matches a same-path session from another node', () => {
+    const topic = makeTopic({
+      routingDefaults: { nodeId: 'devbox', cwd: '/repo/relay' },
+    });
+
+    const model = buildTopicNavModel({
+      topics: [topic],
+      sessions: [
+        makeSession({
+          id: 'laptop-copy',
+          displayName: 'laptop copy',
+          cwd: '/repo/relay',
+          worktreePath: '/repo/relay',
+          nodeId: 'laptop',
+        }),
+        makeSession({
+          id: 'devbox-copy',
+          displayName: 'devbox copy',
+          cwd: '/repo/relay',
+          worktreePath: '/repo/relay',
+          nodeId: 'devbox',
+        }),
+      ],
+      surfaces: [],
+    });
+
+    expect(model.byId.get('topic:alpha')?.sessions).toMatchObject([
+      { id: 'devbox-copy' },
+    ]);
+  });
+
   it('links surfaces by workspace id without fabricating sessions', () => {
     const topic = makeTopic({ workspaceId: 'workspace:alpha' });
     const model = buildTopicNavModel({

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -4,7 +4,9 @@ import type { WorkspaceTopic } from '../shared/workspace-topics.js';
 import {
   buildTopicNavModel,
   formatTaskRefLabel,
+  indexChannelSummaries,
   selectChannelRailTree,
+  type ChannelRailSummary,
   type TopicNavWorkspace,
 } from '../frontend/src/lib/state/topic-nav.js';
 import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
@@ -733,6 +735,58 @@ describe('selectChannelRailTree', () => {
       dmA,
       dmOrphan,
     ]);
+  });
+
+  // #1287 item 6: the rail joins GET /channels summaries onto topic rows so a
+  // row's last message/members come from the one list call, not a per-channel
+  // fan-out. Topics the list does not cover must still project.
+  it('joins channel summaries onto rows by id and leaves uncovered rows null', () => {
+    const summary = (
+      overrides: Partial<ChannelRailSummary> & { id: string }
+    ): ChannelRailSummary => ({
+      latestSeq: 4,
+      messageCount: 12,
+      members: [{ kind: 'agent', id: 'agent:claude', joinedAt: NOW }],
+      lastMessage: {
+        seq: 4,
+        preview: 'shipped the rail join',
+        senderId: 'agent:claude',
+        senderKind: 'agent',
+        createdAt: NOW,
+      },
+      ...overrides,
+    });
+    const tree = selectChannelRailTree(
+      model(),
+      [makeWorkspace({ id: 'ws:a' })],
+      {
+        unreadByChannel: {},
+        summaryByChannel: indexChannelSummaries([
+          summary({ id: 'topic:a1' }),
+          summary({ id: 'topic:a-child', messageCount: 0, lastMessage: null }),
+        ]),
+      }
+    );
+    const groupA = tree.groups.find((group) => group.id === 'ws:a');
+    expect(groupA?.channels[0]?.summary?.messageCount).toBe(12);
+    expect(groupA?.channels[0]?.summary?.lastMessage?.preview).toBe(
+      'shipped the rail join'
+    );
+    expect(groupA?.channels[0]?.summary?.members).toHaveLength(1);
+    // Covered but empty: a summary with no messages still hydrates the row.
+    expect(groupA?.channels[0]?.children[0]?.summary?.lastMessage).toBeNull();
+    // Uncovered (derived/fallback) rows carry no summary at all.
+    expect(groupA?.directMessages[0]?.summary).toBeNull();
+    expect(tree.orphans.channels[0]?.summary).toBeNull();
+  });
+
+  it('projects rows with no summary snapshot at all', () => {
+    const tree = selectChannelRailTree(
+      model(),
+      [makeWorkspace({ id: 'ws:a' })],
+      { unreadByChannel: {} }
+    );
+    expect(tree.groups[0]?.channels[0]?.summary).toBeNull();
   });
 
   it('orders an empty lane among populated ones and flags only the empty one', () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -1368,8 +1368,12 @@ describe('TopicSidebarView', () => {
     expect(onToggleArchived).toHaveBeenCalled();
   });
 
-  it('restores an archived topic from its detail panel', async () => {
-    const onRestoreTopic = vi.fn();
+  // #1287: the sidebar no longer owns a restore affordance. Its only one lived
+  // in the advanced-mode detail panel and invalidated a different key set than
+  // the in-channel bar, so archived rows went stale on whichever surface did not
+  // run the restore. Opening the archived row shows the ungated composer restore
+  // bar at every breakpoint, and that bar drives the one shared mutation.
+  it('renders an archived topic without a sidebar restore button', async () => {
     await renderView({
       showAdvancedDetail: true,
       topics: [
@@ -1383,42 +1387,15 @@ describe('TopicSidebarView', () => {
       ],
       sessions: [],
       surfaces: [],
-      onRestoreTopic,
     });
     expect(container.querySelector('.topic-row.archived')).not.toBeNull();
-    const restore = container.querySelector(
-      '.topic-detail__restore'
-    ) as HTMLButtonElement;
-    expect(restore).not.toBeNull();
-    await act(async () => restore.click());
-    expect(onRestoreTopic).toHaveBeenCalledWith('topic:old');
-  });
-
-  it('disables the restore button while its restore is in flight', async () => {
-    const onRestoreTopic = vi.fn();
-    await renderView({
-      showAdvancedDetail: true,
-      topics: [
-        makeTopic({
-          id: 'topic:old',
-          workspaceId: 'ws:a',
-          status: 'archived',
-          display: { title: 'Archived lane' },
-          linkedRefs: {},
-        }),
-      ],
-      sessions: [],
-      surfaces: [],
-      onRestoreTopic,
-      restoringTopicId: 'topic:old',
-    });
-    const restore = container.querySelector(
-      '.topic-detail__restore'
-    ) as HTMLButtonElement;
-    expect(restore.disabled).toBe(true);
-    expect(restore.textContent).toContain('restoring');
-    await act(async () => restore.click());
-    expect(onRestoreTopic).not.toHaveBeenCalled();
+    expect(container.querySelector('.topic-detail')).not.toBeNull();
+    expect(container.querySelector('.topic-detail__restore')).toBeNull();
+    expect(
+      [...container.querySelectorAll('button')].some((btn) =>
+        (btn.textContent ?? '').includes('restore')
+      )
+    ).toBe(false);
   });
 
   it('selects linked sessions using the existing sidebar callback', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -16,10 +16,7 @@ import {
   TopicSidebarShell,
   TopicSidebarView,
 } from '../frontend/src/components/TopicSidebarShell.js';
-import {
-  createWorkspaceId,
-  LOCAL_WORKSPACE_ID,
-} from '../shared/workspace.js';
+import { createWorkspaceId, LOCAL_WORKSPACE_ID } from '../shared/workspace.js';
 import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
 import {
   buildTopicRoomCreateInput,
@@ -30,6 +27,7 @@ import {
   hasUnseenActivity,
   useChannelActivityStore,
 } from '../frontend/src/lib/stores/channel-activity.js';
+import type { ChannelRailSummary } from '../frontend/src/lib/state/topic-nav.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
 import { makeSession } from './helpers/frontend-factories.js';
@@ -74,6 +72,25 @@ function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
     },
     createdAt: NOW,
     updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+/** A `GET /channels` row as the rail consumes it (#1287). */
+function makeChannelSummary(
+  overrides: Partial<ChannelRailSummary> & { id: string }
+): ChannelRailSummary {
+  return {
+    latestSeq: 3,
+    messageCount: 3,
+    members: [{ kind: 'agent', id: 'agent:claude', joinedAt: NOW }],
+    lastMessage: {
+      seq: 3,
+      preview: 'latest channel message',
+      senderId: 'agent:claude',
+      senderKind: 'agent',
+      createdAt: NOW,
+    },
     ...overrides,
   };
 }
@@ -456,6 +473,177 @@ describe('TopicSidebarView', () => {
         '[data-topic-id="topic:alpha"][data-unread="true"]'
       )
     ).not.toBeNull();
+    queryClient.clear();
+  });
+
+  // #1287 item 6: the rail listed bare topic records while GET /channels already
+  // returned the per-row payload the Slack-style UX needs. Rows now join that
+  // summary by id.
+  it('hydrates rail rows with the channel summary last message and stamp (#1287)', async () => {
+    await renderView({
+      topics: [makeTopic()],
+      channelSummaries: [
+        makeChannelSummary({
+          id: 'topic:alpha',
+          lastMessage: {
+            seq: 7,
+            preview: 'pushed the row payload join',
+            senderId: 'agent:claude',
+            senderKind: 'agent',
+            createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+          },
+        }),
+      ],
+    });
+
+    const preview = container.querySelector('.topic-row__preview');
+    expect(preview?.textContent).toBe('claude: pushed the row payload join');
+    expect(container.querySelector('.topic-row__time')?.textContent).toBe('5m');
+    // Title still renders alongside the snippet — hydration is additive.
+    expect(container.querySelector('.topic-row__title')?.textContent).toContain(
+      'Build UI shell'
+    );
+  });
+
+  it('renders rows with no channel summary (derived/fallback topics) unchanged (#1287)', async () => {
+    await renderView({
+      topics: [makeTopic({ source: 'derived' })],
+      derived: true,
+      channelSummaries: [],
+    });
+
+    expect(container.querySelector('.topic-row')).not.toBeNull();
+    expect(container.querySelector('.topic-row__title')?.textContent).toContain(
+      'Build UI shell'
+    );
+    expect(container.querySelector('.topic-row__preview')).toBeNull();
+    expect(container.querySelector('.topic-row__time')).toBeNull();
+  });
+
+  it('labels the operator as the snippet sender and skips message-less channels (#1287)', async () => {
+    await renderView({
+      topics: [
+        makeTopic({ id: 'topic:alpha', display: { title: 'alpha' } }),
+        makeTopic({
+          id: 'topic:quiet',
+          display: { title: 'quiet' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      channelSummaries: [
+        makeChannelSummary({
+          id: 'topic:alpha',
+          lastMessage: {
+            seq: 2,
+            preview: 'ack',
+            senderId: 'human:operator',
+            senderKind: 'human',
+            createdAt: NOW,
+          },
+        }),
+        makeChannelSummary({
+          id: 'topic:quiet',
+          latestSeq: 0,
+          messageCount: 0,
+          lastMessage: null,
+        }),
+      ],
+    });
+
+    const previews = [...container.querySelectorAll('.topic-row__preview')].map(
+      (node) => node.textContent
+    );
+    expect(previews).toEqual(['you: ack']);
+  });
+
+  // #1287 item 6: the mobile cockpit used to fan out a limit-1 `channel-history`
+  // request per unread channel just to learn whether the newest message
+  // mentioned the operator. The channel list already carries that row, so the
+  // per-channel history calls must be gone.
+  it('drops the per-unread-channel history fan-out in the mobile cockpit (#1287)', async () => {
+    localStorage.setItem(channelLastReadKey('topic:alpha'), '3');
+    useUiStore.setState({ sidebarOpen: true });
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: query === '(max-width: 600px)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const topicsResponse: WorkspaceTopicListResponse = {
+      topics: [makeTopic()],
+      truncated: false,
+      derived: false,
+    };
+    queryClient.setQueryData(['workspace-topics'], topicsResponse);
+    const requested: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      const body =
+        url === '/channels'
+          ? {
+              channels: [
+                makeChannelSummary({
+                  id: 'topic:alpha',
+                  latestSeq: 9,
+                  lastMessage: {
+                    seq: 9,
+                    preview: '@operator please review',
+                    senderId: 'agent:claude',
+                    senderKind: 'agent',
+                    createdAt: NOW,
+                  },
+                }),
+              ],
+            }
+          : url.endsWith('/roster')
+            ? { roster: [] }
+            : {};
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(TopicSidebarShell, { onSelectSession })
+        )
+      );
+      await flushQueryEffects();
+    });
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (
+        requested.some((url) => url.endsWith('/roster')) &&
+        useChannelActivityStore.getState().latestSeqByChannel['topic:alpha'] !==
+          undefined
+      ) {
+        break;
+      }
+      await act(async () => {
+        await flushQueryEffects();
+      });
+    }
+
+    // The cockpit reconcile path really ran (roster is per-channel and stays)...
+    expect(requested).toContain('/channels/topic%3Aalpha/roster');
+    // ...and the row is unread, which is exactly what used to trigger the
+    // limit-1 history fetch.
+    expect(
+      useChannelActivityStore.getState().latestSeqByChannel['topic:alpha']
+    ).toBe(9);
+    // One list call, and no per-channel message reads at all.
+    expect(requested.filter((url) => url === '/channels')).toHaveLength(1);
+    expect(requested.filter((url) => url.includes('/messages'))).toEqual([]);
     queryClient.clear();
   });
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -16,6 +16,7 @@ import {
   TopicSidebarShell,
   TopicSidebarView,
 } from '../frontend/src/components/TopicSidebarShell.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import { createWorkspaceId, LOCAL_WORKSPACE_ID } from '../shared/workspace.js';
 import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
 import {
@@ -76,19 +77,27 @@ function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
   };
 }
 
-/** A `GET /channels` row as the rail consumes it (#1287). */
+/**
+ * A `GET /channels` row as the rail consumes it (#1287). Agent senders carry the
+ * REAL post-#1234 shape: the sender id is the profile Actor id and the vendor
+ * rides `providerId` — the legacy `agent:<vendor>` id is the one form whose
+ * trailing segment happens to read like a name, so fixtures must not use it.
+ */
 function makeChannelSummary(
   overrides: Partial<ChannelRailSummary> & { id: string }
 ): ChannelRailSummary {
   return {
     latestSeq: 3,
     messageCount: 3,
-    members: [{ kind: 'agent', id: 'agent:claude', joinedAt: NOW }],
+    members: [
+      { kind: 'agent', id: builtInAgentProfileId('claude'), joinedAt: NOW },
+    ],
     lastMessage: {
       seq: 3,
       preview: 'latest channel message',
-      senderId: 'agent:claude',
+      senderId: builtInAgentProfileId('claude'),
       senderKind: 'agent',
+      providerId: 'claude',
       createdAt: NOW,
     },
     ...overrides,
@@ -476,6 +485,78 @@ describe('TopicSidebarView', () => {
     queryClient.clear();
   });
 
+  // `GET /channels` is O(channels) on the hub, and a streaming turn emits a
+  // badge per message create / stream open / stream complete. The rail's refresh
+  // lane must therefore stay throttled AND silent while the tab is hidden,
+  // deferring one refresh to the moment the operator comes back.
+  it('defers the throttled channel-list refresh while the tab is hidden (#1287)', async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      queryClient.setQueryData(['workspace-topics'], {
+        topics: [makeTopic()],
+        truncated: false,
+        derived: false,
+      } satisfies WorkspaceTopicListResponse);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify({ channels: [] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+        ) as unknown as typeof fetch
+      );
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const channelListRefreshes = () =>
+        invalidateSpy.mock.calls.filter(
+          (call) =>
+            Array.isArray(call[0]?.queryKey) &&
+            call[0].queryKey[0] === 'channels'
+        ).length;
+
+      act(() => {
+        root.render(
+          React.createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            React.createElement(TopicSidebarShell, { onSelectSession })
+          )
+        );
+      });
+
+      // Visible tab: one refresh per throttle window, not per activity event.
+      act(() => {
+        useChannelActivityStore.getState().recordActivity('topic:alpha', 5);
+        useChannelActivityStore.getState().recordActivity('topic:alpha', 6);
+        vi.advanceTimersByTime(10_000);
+      });
+      expect(channelListRefreshes()).toBe(1);
+
+      // Hidden tab: the window elapses without touching the hub.
+      const hidden = vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+      act(() => {
+        useChannelActivityStore.getState().recordActivity('topic:alpha', 7);
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(channelListRefreshes()).toBe(1);
+
+      // Coming back to the foreground settles the deferred refresh exactly once.
+      hidden.mockReturnValue(false);
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+      expect(channelListRefreshes()).toBe(2);
+      hidden.mockRestore();
+      queryClient.clear();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // #1287 item 6: the rail listed bare topic records while GET /channels already
   // returned the per-row payload the Slack-style UX needs. Rows now join that
   // summary by id.
@@ -488,8 +569,9 @@ describe('TopicSidebarView', () => {
           lastMessage: {
             seq: 7,
             preview: 'pushed the row payload join',
-            senderId: 'agent:claude',
+            senderId: builtInAgentProfileId('claude'),
             senderKind: 'agent',
+            providerId: 'claude',
             createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
           },
         }),
@@ -556,6 +638,136 @@ describe('TopicSidebarView', () => {
       (node) => node.textContent
     );
     expect(previews).toEqual(['you: ack']);
+  });
+
+  // Sender ids are profile Actor ids (#1234): `agent-profile:<vendor>:default`
+  // and `agent-profile:<vendor>:<uuid>`. Splitting one for a label renders
+  // "default:" / "<uuid>:", so the label must come from the server-resolved
+  // display name or providerId, with the VENDOR segment as the only fallback.
+  it('labels agent snippets from the resolved identity, never the profile id tail (#1234)', async () => {
+    const customProfileId = 'agent-profile:claude:9f3ac1de-42b7-4d1a-8f00-1e2b';
+    await renderView({
+      topics: [
+        makeTopic({ id: 'topic:alpha', display: { title: 'alpha' } }),
+        makeTopic({ id: 'topic:beta', display: { title: 'beta' } }),
+        makeTopic({ id: 'topic:gamma', display: { title: 'gamma' } }),
+      ],
+      sessions: [],
+      surfaces: [],
+      channelSummaries: [
+        // Built-in default profile: no stored display name, vendor on providerId.
+        makeChannelSummary({
+          id: 'topic:alpha',
+          lastMessage: {
+            seq: 3,
+            preview: 'built-in default reply',
+            senderId: builtInAgentProfileId('codex'),
+            senderKind: 'agent',
+            providerId: 'codex',
+            createdAt: NOW,
+          },
+        }),
+        // Custom profile: the authored name wins over the vendor.
+        makeChannelSummary({
+          id: 'topic:beta',
+          lastMessage: {
+            seq: 3,
+            preview: 'custom profile reply',
+            senderId: customProfileId,
+            senderKind: 'agent',
+            senderDisplayName: 'Reviewer Claude',
+            providerId: 'claude',
+            createdAt: NOW,
+          },
+        }),
+        // Neither field resolved (older row): fall back to the VENDOR segment.
+        makeChannelSummary({
+          id: 'topic:gamma',
+          lastMessage: {
+            seq: 3,
+            preview: 'unresolved reply',
+            senderId: customProfileId,
+            senderKind: 'agent',
+            createdAt: NOW,
+          },
+        }),
+      ],
+    });
+
+    const previews = [...container.querySelectorAll('.topic-row__preview')].map(
+      (node) => node.textContent
+    );
+    expect(previews).toEqual([
+      'codex: built-in default reply',
+      'Reviewer Claude: custom profile reply',
+      'claude: unresolved reply',
+    ]);
+    expect(previews.some((text) => text?.startsWith('default:'))).toBe(false);
+  });
+
+  // The summary preview is truncated server-side, so re-deriving the mention
+  // signal from it drops any `@operator` past the cut-off — exactly the long
+  // agent status update the attention lane exists for. The payload carries
+  // server-computed mention refs over the FULL body instead.
+  it('keeps the mention bonus when the mention sits past the preview cut-off', async () => {
+    useChannelActivityStore.setState({
+      latestSeqByChannel: { 'topic:alpha': 9, 'topic:beta': 9 },
+      lastReadByChannel: { 'topic:alpha': 3, 'topic:beta': 3 },
+      clampedAtByChannel: {},
+    });
+    const longStatus = `${'status update. '.repeat(40)}@operator please confirm`;
+    const truncatedPreview = longStatus.slice(0, 200);
+    expect(truncatedPreview).not.toContain('@operator');
+
+    await renderView({
+      topics: [
+        makeTopic({
+          id: 'topic:alpha',
+          display: { title: 'alpha' },
+          linkedRefs: {},
+        }),
+        makeTopic({
+          id: 'topic:beta',
+          display: { title: 'beta' },
+          linkedRefs: {},
+        }),
+      ],
+      sessions: [],
+      surfaces: [],
+      channelSummaries: [
+        makeChannelSummary({
+          id: 'topic:alpha',
+          latestSeq: 9,
+          lastMessage: {
+            seq: 9,
+            preview: 'no mention here',
+            senderId: builtInAgentProfileId('claude'),
+            senderKind: 'agent',
+            providerId: 'claude',
+            createdAt: NOW,
+          },
+        }),
+        makeChannelSummary({
+          id: 'topic:beta',
+          latestSeq: 9,
+          lastMessage: {
+            seq: 9,
+            preview: truncatedPreview,
+            senderId: builtInAgentProfileId('claude'),
+            senderKind: 'agent',
+            providerId: 'claude',
+            mentions: [{ raw: '@operator' }],
+            createdAt: NOW,
+          },
+        }),
+      ],
+    });
+
+    const attentionTitles = [
+      ...container.querySelectorAll('.topic-cockpit__attention-title'),
+    ].map((node) => node.textContent);
+    // Without the mention bonus these tie and sort alphabetically.
+    expect(attentionTitles).toEqual(['#beta', '#alpha']);
   });
 
   // #1287 item 6: the mobile cockpit used to fan out a limit-1 `channel-history`

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -29,11 +29,14 @@ import type {
 import type { WorkContext } from '../shared/work-context.js';
 import {
   WORKSPACE_TOPICS_MAX_LIST_ENTRIES,
+  WORKSPACE_TOPIC_MAX_AGENT_RUNTIME_REFS,
   buildWorkspaceTopicLaunchPreview,
   buildWorkspaceTopicSessionCreateBody,
   buildWorkspaceTopicRecord,
   parseWorkspaceTopicCreateInput,
   resolveWorkspaceTopicRoutingDefaults,
+  workspaceTopicAgentRuntimeLinkPatch,
+  workspaceTopicHasExplicitParticipantLinks,
   workspaceTopicSessionLinkPatch,
   type WorkspaceTopic,
   type WorkspaceTopicListResponse,
@@ -307,6 +310,55 @@ describe('workspace topics foundation', () => {
         sessionIds: ['session-topic'],
       },
     });
+  });
+
+  it('links channel agent runtimes without pretending they are sessions', () => {
+    const topic = buildWorkspaceTopicRecord({
+      create: { workspaceId: 'ws:local', title: 'general' },
+      now: '2026-06-26T00:00:00.000Z',
+    });
+    expect(workspaceTopicHasExplicitParticipantLinks(topic)).toBe(false);
+
+    const patch = workspaceTopicAgentRuntimeLinkPatch({
+      topic,
+      runtimeId: 'rt-one',
+    });
+    expect(patch).toEqual({ linkedRefs: { agentRuntimeIds: ['rt-one'] } });
+    const linked: WorkspaceTopic = {
+      ...topic,
+      linkedRefs: patch!.linkedRefs!,
+    };
+    // A runtime link proves the topic states its participants, but it is never
+    // a session ref — nothing may resolve it against the session list.
+    expect(workspaceTopicHasExplicitParticipantLinks(linked)).toBe(true);
+    expect(linked.linkedRefs.sessionIds).toBeUndefined();
+
+    // Idempotent: relinking the same runtime skips the store write entirely.
+    expect(
+      workspaceTopicAgentRuntimeLinkPatch({ topic: linked, runtimeId: 'rt-one' })
+    ).toBeUndefined();
+    expect(
+      workspaceTopicAgentRuntimeLinkPatch({ topic: linked, runtimeId: '  ' })
+    ).toBeUndefined();
+
+    // Bounded: cold starts rebind forever, so the tail trims FIFO instead of
+    // growing toward the shared per-list ref cap.
+    const saturated: WorkspaceTopic = {
+      ...topic,
+      linkedRefs: {
+        agentRuntimeIds: Array.from(
+          { length: WORKSPACE_TOPIC_MAX_AGENT_RUNTIME_REFS },
+          (_, index) => `rt-${index}`
+        ),
+      },
+    };
+    const trimmed = workspaceTopicAgentRuntimeLinkPatch({
+      topic: saturated,
+      runtimeId: 'rt-next',
+    })?.linkedRefs?.agentRuntimeIds;
+    expect(trimmed).toHaveLength(WORKSPACE_TOPIC_MAX_AGENT_RUNTIME_REFS);
+    expect(trimmed?.[0]).toBe('rt-1');
+    expect(trimmed?.at(-1)).toBe('rt-next');
   });
 
   it('previews create-only and create+launch side effects from topic defaults', () => {


### PR DESCRIPTION
Slice 3 of #1287 makes the channel rail render the payload `GET /channels` already returns, and keeps every cache that feeds it coherent. Builds on Slice 1 (`channelsQuery` + clamp-epoch activity fence) and Slice 2 (real workspace ids) — both reused, neither duplicated.

## What landed

- **Row hydration** (`2c71761c`) — join `GET /channels` summaries onto `/workspace-topics` rows by id so desktop and mobile rails render the last-message snippet + compact stamp; drops the mobile cockpit's per-unread-channel `limit=1` history fetch, additive so uncovered rows keep title + live status.
- **Nav/roster cache coherence** (`2492d395`) — `channel-activity` for a channel neither cached list holds now debounce-invalidates `['workspace-topics']` + `['channels']` (invalidation, not a store write, so the Slice 1 clamp-epoch fence still gates every head seq); `channel-agent-status` invalidates that channel's roster so a newly bound agent's chip and a remote designate survive going idle.
- **One shared restore mutation** (`671b79fe`) — `useRestoreTopicMutation` owns `['channel', id]` + `['workspace-topic', id]` + the `['workspace-topics']` prefix for both the in-channel bar and the sidebar, always toasts failures, and retires the redundant advanced-gated `topic-detail__restore` button.
- **Binder links runtimes to topics** (`274ccc96`) — `attachRuntime` records spawned/rebound runtimes in `linkedRefs.agentRuntimeIds` (best-effort, idempotent, FIFO-trimmed at 16) so participants stop being guessed from `routingDefaults` paths; the path fallback is narrowed, node-scoped, and marked deprecated.

## Review trail

Adversarial review → one batched fix pass (`b206f568`): P1 rail labels now read server-resolved `senderDisplayName`/`providerId` off the persisted row instead of splitting a profile Actor id; P1 unknown-channel refetch loop bounded by a 60s per-channel back-off with a capped attempt map; P2 `['channels']` throttle 2s → 10s and skipped while the tab is hidden; P3 mentions computed server-side over the full body; P3 roster refetch only when the client holds that roster. Re-review verdict: **approve**, no P0/P1 outstanding.

Deferred as follow-ups (both P3):

- `frontend/src/hooks/useEventSocket.ts` — the unknown-channel back-off marks on debounce-timer fire rather than on refetch settle, so an errored/aborted refresh (e.g. a hub restart) is indistinguishable from one that legitimately came back empty and suppresses the row for 60s. Fix: await the invalidations, re-check `hasCachedChannelRow`, mark only the still-missing ids.
- `frontend/src/components/TopicSidebarShell.tsx` — `channelRowSenderLabel`'s `providerId` fallback renders the value verbatim, but `deriveSender` can set `providerId` to a profile Actor id when no scoped runtime resolves. Fix: normalize it through `parseAgentProfileProviderId` the way the id fallback already does.

No new HTTP routes and no new gateway verbs (only an additive `agentRuntimeIds` field on the existing workspace-topic schema), so the auth-inventory and command-manifest drift guards are untouched.

## Verification

- `npm run check` — 0 errors (219 pre-existing sonarjs warnings), node 24.16.0.
- `npx vitest run test/channel-agent-binder.test.ts test/channel-message-store.test.ts test/components/channel-restore-mutation.test.ts test/hooks/useEventSocket.test.ts test/topic-nav.test.ts test/topic-sidebar-shell.test.ts test/workspace-topics.test.ts` — **246 passed / 0 failed** (node 22.22.3; the local `better-sqlite3` binding is ABI-built for 22).
- Pure-frontend subset re-run on node 24.16.0 (`channel-restore-mutation`, `useEventSocket`, `topic-nav`, `topic-sidebar-shell`) — **137 passed / 0 failed**.

Refs #1287 (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topic sidebars now show latest-message previews, sender names, timestamps, and mention indicators.
  * Sidebar activity updates automatically, with efficient refresh behavior when returning to an active view.
  * Agent-linked topics are matched more accurately across navigation and channel views.

* **Bug Fixes**
  * Improved topic routing to prevent messages from appearing under unrelated topics.
  * Restoring archived topics now uses a shared flow with consistent loading, cache updates, and error feedback.
  * Topic summaries preserve full mention information, including mentions beyond truncated previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->