### PR TITLE
feat(update): auto-restart under generic systemd supervision after verified update (#1285)

### DIFF
--- a/docs/references/devbox-hub-deploy.md
+++ b/docs/references/devbox-hub-deploy.md
@@ -108,10 +108,21 @@ WantedBy=default.target
 - `NODE_OPTIONS=--max-old-space-size=4096` is the #1196 heap-leak mitigation; keep it.
 - `Restart=on-failure` restarts after a crash but not after a clean `stop`.
 - In-app updates (`POST /update`) restart under this unit even though it is not
-  the stock `relay-ide.service`: the hub detects systemd supervision from
-  `INVOCATION_ID` and exits **nonzero** on purpose, because `on-failure` only
-  restarts unclean exits (#1285). A `status=1/FAILURE` line in the journal
-  right after an update is the restart working, not a crash.
+  the stock `relay-ide.service` (#1285). The hub resolves its owning unit from
+  `/proc/self/cgroup`, reads `systemctl show --value -p Restart <unit>`, and
+  only exits when that policy is `on-failure` or `always` — the two values
+  systemd restarts a **nonzero** exit on. It then exits **nonzero** on purpose,
+  so a `status=1/FAILURE` line in the journal right after an update is the
+  restart working, not a crash. The same applies to the stock Linux unit, which
+  is also `Restart=on-failure`; only the macOS plist (`KeepAlive=true`) exits 0.
+- Units with any other policy — including systemd's default `Restart=no`, and
+  `on-abnormal`/`on-abort`/`on-watchdog`, which react to signals, timeouts and
+  watchdog misses rather than to exit status — are left running the old bytes
+  with a "restart manually" message instead of being exited into nothing. Same
+  for an unreadable policy. Set `RELAY_UPDATE_RESTART=systemd` in the unit's
+  `Environment=` to force the restart anyway (locked-down containers,
+  `systemctl` off PATH), or `RELAY_UPDATE_RESTART=never` to always restart by
+  hand. `POST /update` echoes the decision as `supervision`.
 - Enable linger once so the service runs without an active login session and comes back after reboot:
 
 ```bash

--- a/docs/references/devbox-hub-deploy.md
+++ b/docs/references/devbox-hub-deploy.md
@@ -107,6 +107,11 @@ WantedBy=default.target
 
 - `NODE_OPTIONS=--max-old-space-size=4096` is the #1196 heap-leak mitigation; keep it.
 - `Restart=on-failure` restarts after a crash but not after a clean `stop`.
+- In-app updates (`POST /update`) restart under this unit even though it is not
+  the stock `relay-ide.service`: the hub detects systemd supervision from
+  `INVOCATION_ID` and exits **nonzero** on purpose, because `on-failure` only
+  restarts unclean exits (#1285). A `status=1/FAILURE` line in the journal
+  right after an update is the restart working, not a crash.
 - Enable linger once so the service runs without an active login session and comes back after reboot:
 
 ```bash

--- a/frontend/src/components/UpdateToast.tsx
+++ b/frontend/src/components/UpdateToast.tsx
@@ -52,6 +52,12 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
   const [buttonText, setButtonText] = React.useState('Update Now');
   const [buttonDisabled, setButtonDisabled] = React.useState(false);
   const [showActions, setShowActions] = React.useState(true);
+  const [timedOut, setTimedOut] = React.useState(false);
+  // The restart wait outlives a click by up to 90s. Dismissing the toast or
+  // unmounting must stop it, or it reloads the page out from under whatever
+  // the user did next and writes state into a dead tree.
+  const waitAbortRef = React.useRef<AbortController | null>(null);
+  React.useEffect(() => () => waitAbortRef.current?.abort(), []);
 
   const triggerUpdate = React.useCallback(async () => {
     setButtonDisabled(true);
@@ -70,11 +76,22 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
       if (result.restarting) {
         setText(`${updated} Restarting server…`);
         setShowActions(false);
-        // Reload when the server actually answers again, not on a guessed
-        // timer — restart time varies with host and supervisor.
-        await reloadWhenServerReturns((timeoutText) => {
-          setText(timeoutText);
-        });
+        // Reload when the *new* server answers, not on a guessed timer —
+        // restart time varies with host and supervisor, and the outgoing
+        // process keeps answering for a moment after this response.
+        const controller = new AbortController();
+        waitAbortRef.current = controller;
+        await reloadWhenServerReturns(
+          (timeoutText) => {
+            setText(timeoutText);
+            // Dead copy with no affordance is a trap: give the reload back.
+            setTimedOut(true);
+            setButtonText('Reload');
+            setButtonDisabled(false);
+            setShowActions(true);
+          },
+          { previousBootId: result.bootId ?? null, signal: controller.signal }
+        );
       } else {
         setText(`${updated} Please restart the server manually.`);
         setShowActions(false);
@@ -87,7 +104,16 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
     }
   }, []);
 
+  const onPrimaryClick = React.useCallback(() => {
+    if (timedOut) {
+      window.location.reload();
+      return;
+    }
+    void triggerUpdate();
+  }, [timedOut, triggerUpdate]);
+
   const dismiss = React.useCallback(() => {
+    waitAbortRef.current?.abort();
     removeNotification(UPDATE_NOTIFICATION_ID);
   }, []);
 
@@ -99,7 +125,7 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
           <TuiButton
             variant="primary"
             size="sm"
-            onClick={triggerUpdate}
+            onClick={onPrimaryClick}
             disabled={buttonDisabled}
           >
             {buttonText}

--- a/frontend/src/components/UpdateToast.tsx
+++ b/frontend/src/components/UpdateToast.tsx
@@ -5,12 +5,12 @@ import {
   addNotification,
   removeNotification,
 } from '../lib/stores/notifications.js';
+import { reloadWhenServerReturns } from '../lib/server-restart.js';
 
 const UPDATE_NOTIFICATION_ID = 'update-toast';
 
 export const UpdateToast: React.FC = () => {
   const didInitRef = React.useRef(false);
-  const reloadTimerRef = React.useRef<number | null>(null);
 
   React.useEffect(() => {
     if (didInitRef.current) return;
@@ -27,7 +27,6 @@ export const UpdateToast: React.FC = () => {
             content: (
               <UpdateToastContent
                 initialText={`Update available: v${data.current} → v${data.latest}`}
-                reloadTimerRef={reloadTimerRef}
               />
             ),
             onDismiss: () => removeNotification(UPDATE_NOTIFICATION_ID),
@@ -37,12 +36,6 @@ export const UpdateToast: React.FC = () => {
         // expected: no update available or network error
       }
     })();
-
-    return () => {
-      if (reloadTimerRef.current !== null) {
-        window.clearTimeout(reloadTimerRef.current);
-      }
-    };
   }, []);
 
   return null;
@@ -50,12 +43,10 @@ export const UpdateToast: React.FC = () => {
 
 interface UpdateToastContentProps {
   initialText: string;
-  reloadTimerRef: React.RefObject<number | null>;
 }
 
 const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
   initialText,
-  reloadTimerRef,
 }) => {
   const [text, setText] = React.useState(initialText);
   const [buttonText, setButtonText] = React.useState('Update Now');
@@ -79,9 +70,11 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
       if (result.restarting) {
         setText(`${updated} Restarting server…`);
         setShowActions(false);
-        reloadTimerRef.current = window.setTimeout(() => {
-          window.location.reload();
-        }, 5000);
+        // Reload when the server actually answers again, not on a guessed
+        // timer — restart time varies with host and supervisor.
+        await reloadWhenServerReturns((timeoutText) => {
+          setText(timeoutText);
+        });
       } else {
         setText(`${updated} Please restart the server manually.`);
         setShowActions(false);
@@ -92,7 +85,7 @@ const UpdateToastContent: React.FC<UpdateToastContentProps> = ({
       setButtonText('Retry');
       setShowActions(true);
     }
-  }, [reloadTimerRef]);
+  }, []);
 
   const dismiss = React.useCallback(() => {
     removeNotification(UPDATE_NOTIFICATION_ID);

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -233,6 +233,10 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
   function SettingsDialog({ onClose }, ref) {
     const shellRef = useRef<DialogShellHandle>(null);
     const contentElRef = useRef<HTMLDivElement | null>(null);
+    // The post-update restart wait can run for up to 90s; closing the dialog
+    // must stop it rather than let it reload the page or set state later.
+    const restartWaitRef = useRef<AbortController | null>(null);
+    useEffect(() => () => restartWaitRef.current?.abort(), []);
     const [contentEl, setContentEl] = useState<HTMLDivElement | undefined>(
       undefined
     );
@@ -368,13 +372,18 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
             available: false,
           }));
           // Same shared wait-then-reload path as the update toast.
-          await reloadWhenServerReturns((timeoutText) => {
-            setVersionInfo((v) => ({
-              ...v,
-              status: timeoutText,
-              updating: false,
-            }));
-          });
+          const controller = new AbortController();
+          restartWaitRef.current = controller;
+          await reloadWhenServerReturns(
+            (timeoutText) => {
+              setVersionInfo((v) => ({
+                ...v,
+                status: timeoutText,
+                updating: false,
+              }));
+            },
+            { previousBootId: result.bootId ?? null, signal: controller.signal }
+          );
         } else
           setVersionInfo((v) => ({
             ...v,

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -36,6 +36,7 @@ import {
   setRenamerTool,
   type RenamerTool,
 } from '../../lib/api.js';
+import { reloadWhenServerReturns } from '../../lib/server-restart.js';
 import { useSessionsStore } from '../../lib/stores/sessions.js';
 import { useConfigStore } from '../../lib/stores/config.js';
 import { isFrameworkAvailable } from './CustomizeSessionDialog.js';
@@ -366,7 +367,14 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
             status: `${updated} Restarting\u2026`,
             available: false,
           }));
-          setTimeout(() => location.reload(), 5000);
+          // Same shared wait-then-reload path as the update toast.
+          await reloadWhenServerReturns((timeoutText) => {
+            setVersionInfo((v) => ({
+              ...v,
+              status: timeoutText,
+              updating: false,
+            }));
+          });
         } else
           setVersionInfo((v) => ({
             ...v,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2767,6 +2767,10 @@ export async function triggerUpdate(): Promise<{
   /** Absent unless the server ran but could not confirm a version change. */
   verified?: boolean;
   version?: string | null;
+  /** Which supervisor the server bet on restarting it (`none` when it stays up). */
+  supervision?: string;
+  /** Boot id of the process answering this request — the one going away. */
+  bootId?: string;
   error?: string;
 }> {
   // json() throws an HttpError carrying the server's `error` string, so the
@@ -2775,6 +2779,8 @@ export async function triggerUpdate(): Promise<{
     ok: boolean;
     restarting?: boolean;
     version?: string | null;
+    supervision?: string;
+    bootId?: string;
     error?: string;
     verified?: boolean;
   }>(await fetch('/update', { method: 'POST' }));

--- a/frontend/src/lib/server-restart.ts
+++ b/frontend/src/lib/server-restart.ts
@@ -1,0 +1,96 @@
+/**
+ * Wait for a restarting server to come back, instead of reloading on a fixed
+ * timer. A fixed timer reloads into whatever is there at that instant — too
+ * early on a slow host (browser error page), needlessly late on a fast one.
+ */
+
+/** Poll cadence once the pre-exit grace window has passed. */
+export const SERVER_RESTART_POLL_INTERVAL_MS = 2000;
+
+/** Total budget, grace window included, before giving up on the reload. */
+export const SERVER_RESTART_TIMEOUT_MS = 90_000;
+
+/**
+ * The server answers `POST /update` *before* it exits: it waits ~500ms for the
+ * `server-restarting` broadcast to reach clients, then closes, with a hard
+ * fallback exit 3s later. Probing inside that window would find the outgoing
+ * process and reload straight into the shutdown.
+ */
+export const SERVER_RESTART_GRACE_MS = 4000;
+
+/** Shown when the poll budget runs out with the server still unreachable. */
+export const SERVER_RESTART_TIMEOUT_TEXT =
+  'Server is taking longer than expected — reload manually.';
+
+export interface WaitForServerRestartOptions {
+  /** Resolves true when the server answers again. Defaults to a `/healthz` probe. */
+  probe?: () => Promise<boolean>;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  graceMs?: number;
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+/**
+ * Liveness probe. Any answer from Relay's own health monitor means the process
+ * is listening again — including 503, which reports a degraded store or event
+ * loop, not a dead server. A proxy's 502/504 is not an answer from Relay, so
+ * only the two statuses the monitor itself returns count.
+ */
+async function probeHealthz(): Promise<boolean> {
+  try {
+    const res = await fetch('/healthz', { cache: 'no-store' });
+    return res.status === 200 || res.status === 503;
+  } catch {
+    return false;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Poll until the server answers or the budget is spent.
+ * Returns true when it came back (caller reloads), false on timeout.
+ */
+export async function waitForServerRestart(
+  options: WaitForServerRestartOptions = {}
+): Promise<boolean> {
+  const probe = options.probe ?? probeHealthz;
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? (() => Date.now());
+  const graceMs = options.graceMs ?? SERVER_RESTART_GRACE_MS;
+  const intervalMs = options.intervalMs ?? SERVER_RESTART_POLL_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? SERVER_RESTART_TIMEOUT_MS;
+
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  await sleep(Math.min(graceMs, timeoutMs));
+
+  // The grace window is part of the budget, so a caller passing a timeout
+  // shorter than the grace still gets exactly one probe rather than none: the
+  // deadline is only consulted after a probe has run.
+  for (;;) {
+    if (await probe()) return true;
+    if (now() >= deadline) return false;
+    await sleep(intervalMs);
+  }
+}
+
+/** Wait for the server, then reload — or hand back the timeout copy. */
+export async function reloadWhenServerReturns(
+  onTimeout: (text: string) => void,
+  options: WaitForServerRestartOptions & { reload?: () => void } = {}
+): Promise<void> {
+  const reload = options.reload ?? (() => window.location.reload());
+  const returned = await waitForServerRestart(options);
+  if (returned) {
+    reload();
+    return;
+  }
+  onTimeout(SERVER_RESTART_TIMEOUT_TEXT);
+}

--- a/frontend/src/lib/server-restart.ts
+++ b/frontend/src/lib/server-restart.ts
@@ -13,37 +13,80 @@ export const SERVER_RESTART_TIMEOUT_MS = 90_000;
 /**
  * The server answers `POST /update` *before* it exits: it waits ~500ms for the
  * `server-restarting` broadcast to reach clients, then closes, with a hard
- * fallback exit 3s later. Probing inside that window would find the outgoing
- * process and reload straight into the shutdown.
+ * fallback exit 3s later — so the outgoing process can still be listening
+ * ~3.5s after the response is written, and this clock starts later still, at
+ * response *receipt*. The margin over that budget covers timers slipping on a
+ * loaded host; boot-id identity below covers the rest.
  */
-export const SERVER_RESTART_GRACE_MS = 4000;
+export const SERVER_RESTART_GRACE_MS = 6000;
+
+/**
+ * Successful liveness probes required when the server cannot be identified by
+ * boot id. One 200 proves only "something answered", which the outgoing
+ * process still does mid-shutdown; two in a row across a poll interval do not
+ * survive it.
+ */
+export const SERVER_RESTART_LIVENESS_CONFIRMATIONS = 2;
 
 /** Shown when the poll budget runs out with the server still unreachable. */
 export const SERVER_RESTART_TIMEOUT_TEXT =
   'Server is taking longer than expected — reload manually.';
 
+/**
+ * - `new` — a different process answered (boot id changed): proof, reload now.
+ * - `alive` — something answered but could not be identified.
+ * - `down` — no answer, or the *same* process that served `POST /update`.
+ */
+export type ServerRestartProbeResult = 'new' | 'alive' | 'down';
+
 export interface WaitForServerRestartOptions {
-  /** Resolves true when the server answers again. Defaults to a `/healthz` probe. */
-  probe?: () => Promise<boolean>;
+  /** Defaults to a `/healthz` probe. */
+  probe?: () => Promise<ServerRestartProbeResult>;
+  /**
+   * `bootId` from the `POST /update` response, i.e. the process that is going
+   * away. Any other boot id is the restarted server.
+   */
+  previousBootId?: string | null;
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;
   graceMs?: number;
   intervalMs?: number;
   timeoutMs?: number;
+  /** Consecutive `alive` results accepted as a restart when no boot id is known. */
+  confirmations?: number;
+  /** Aborts the wait (component unmounted, toast dismissed). */
+  signal?: AbortSignal;
 }
 
 /**
- * Liveness probe. Any answer from Relay's own health monitor means the process
- * is listening again — including 503, which reports a degraded store or event
+ * Liveness plus identity. Any answer from Relay's own health monitor means the
+ * process is listening — including 503, which reports a degraded store or event
  * loop, not a dead server. A proxy's 502/504 is not an answer from Relay, so
  * only the two statuses the monitor itself returns count.
+ *
+ * `/healthz` also carries the per-process `bootId`, so an answer from the
+ * process that is still shutting down is reported as `down` rather than
+ * mistaken for the restarted server.
  */
-async function probeHealthz(): Promise<boolean> {
+export async function probeServerRestart(
+  previousBootId?: string | null
+): Promise<ServerRestartProbeResult> {
   try {
     const res = await fetch('/healthz', { cache: 'no-store' });
-    return res.status === 200 || res.status === 503;
+    if (res.status !== 200 && res.status !== 503) return 'down';
+    if (!previousBootId) return 'alive';
+    let bootId: string | null = null;
+    try {
+      const body = (await res.json()) as { bootId?: unknown };
+      bootId = typeof body.bootId === 'string' ? body.bootId : null;
+    } catch {
+      bootId = null;
+    }
+    // An older server without `bootId` falls back to liveness confirmations.
+    if (bootId === null) return 'alive';
+    return bootId === previousBootId ? 'down' : 'new';
   } catch {
-    return false;
+    return 'down';
   }
 }
 
@@ -55,17 +98,21 @@ function defaultSleep(ms: number): Promise<void> {
 
 /**
  * Poll until the server answers or the budget is spent.
- * Returns true when it came back (caller reloads), false on timeout.
+ * Returns true when it came back (caller reloads), false on timeout or abort.
  */
 export async function waitForServerRestart(
   options: WaitForServerRestartOptions = {}
 ): Promise<boolean> {
-  const probe = options.probe ?? probeHealthz;
+  const previousBootId = options.previousBootId ?? null;
+  const probe = options.probe ?? (() => probeServerRestart(previousBootId));
   const sleep = options.sleep ?? defaultSleep;
   const now = options.now ?? (() => Date.now());
   const graceMs = options.graceMs ?? SERVER_RESTART_GRACE_MS;
   const intervalMs = options.intervalMs ?? SERVER_RESTART_POLL_INTERVAL_MS;
   const timeoutMs = options.timeoutMs ?? SERVER_RESTART_TIMEOUT_MS;
+  const confirmations =
+    options.confirmations ?? SERVER_RESTART_LIVENESS_CONFIRMATIONS;
+  const signal = options.signal;
 
   const startedAt = now();
   const deadline = startedAt + timeoutMs;
@@ -74,8 +121,14 @@ export async function waitForServerRestart(
   // The grace window is part of the budget, so a caller passing a timeout
   // shorter than the grace still gets exactly one probe rather than none: the
   // deadline is only consulted after a probe has run.
+  let streak = 0;
   for (;;) {
-    if (await probe()) return true;
+    if (signal?.aborted) return false;
+    const result = await probe();
+    // A boot-id change is proof, not evidence: no confirmation run needed.
+    if (result === 'new') return true;
+    streak = result === 'alive' ? streak + 1 : 0;
+    if (streak >= confirmations) return true;
     if (now() >= deadline) return false;
     await sleep(intervalMs);
   }
@@ -88,6 +141,9 @@ export async function reloadWhenServerReturns(
 ): Promise<void> {
   const reload = options.reload ?? (() => window.location.reload());
   const returned = await waitForServerRestart(options);
+  // An aborted wait belongs to a dismissed toast or an unmounted dialog:
+  // neither reload the page nor write state back into a dead tree.
+  if (options.signal?.aborted) return;
   if (returned) {
     reload();
     return;

--- a/server/health.ts
+++ b/server/health.ts
@@ -1,6 +1,19 @@
+import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import type { RequestHandler } from 'express';
 import { createLogger, type Logger } from './logger.js';
+
+/**
+ * Identity of *this* process, minted once at module load.
+ *
+ * `/healthz` answers liveness, which is not enough for a client waiting out a
+ * restart: the outgoing process keeps listening for up to ~3.5s after it
+ * answers `POST /update`, and every version field it can report is read from
+ * the install root that the update just overwrote. A boot id changes only when
+ * the process does, so a client that captured the pre-update id can tell the
+ * new server from the old one instead of guessing with a timer.
+ */
+export const PROCESS_BOOT_ID = randomUUID();
 
 export const DEFAULT_EVENT_LOOP_LAG_THRESHOLD_MS = 2_000;
 export const DEFAULT_EVENT_LOOP_PROBE_INTERVAL_MS = 1_000;
@@ -41,6 +54,8 @@ export interface HealthMonitorOptions {
   logger?: Logger;
   /** Optional post-listen session-resume progress owned by server startup. */
   getResumeReadiness?: () => ResumeReadiness;
+  /** Overrides the per-process boot id reported by `/healthz` (tests). */
+  bootId?: string;
 }
 
 const healthLogger = createLogger('health');
@@ -101,6 +116,8 @@ export function createHealthMonitor(
     Math.max(0, options.getLagMs?.() ?? measuredLagMs);
   const disabledStores = options.disabledStores ?? [];
 
+  const bootId = options.bootId ?? PROCESS_BOOT_ID;
+
   const handler: RequestHandler = (_req, res) => {
     const lagMs = Math.round(getLagMs());
     const { rss } = readHealthMemorySnapshot(memoryUsage);
@@ -110,6 +127,7 @@ export function createHealthMonitor(
       status: healthy ? 'ok' : 'degraded',
       lagMs,
       rss,
+      bootId,
       ...(disabledStores.length > 0 ? { disabledStores } : {}),
       ...(resume ? { ready: resume.complete, resume } : {}),
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -61,7 +61,9 @@ import {
   buildRemedyCommand,
   buildUpdateCommand,
   detectRunningInstall,
+  detectSupervision,
   readInstalledVersion,
+  restartExitCode,
   verifyUpdateLanded,
 } from './self-update.js';
 import {
@@ -5303,7 +5305,12 @@ async function main(): Promise<void> {
         }
       }
 
-      const restarting = serviceIsInstalled();
+      // Anything that would restart this process on exit earns the automatic
+      // restart, not just the stock unit (#1285). The verified-update path
+      // above already proved new bytes are on disk, so the only question left
+      // is who starts the server again.
+      const supervision = detectSupervision({ serviceIsInstalled });
+      const restarting = supervision.supervised;
       if (restarting) {
         stopEventBatching();
         stopTelemetry();
@@ -5330,11 +5337,18 @@ async function main(): Promise<void> {
       }
       res.json({ ok: true, restarting, version: installedVersion });
       if (restarting) {
+        // Stock service: exit 0, unchanged. Foreign systemd unit: exit nonzero,
+        // because the usual hand-written policy is `Restart=on-failure`, which
+        // restarts unclean exits only — a clean exit would leave the hub down.
+        const exitCode = restartExitCode(supervision.kind);
+        logger.info(
+          `[update] restarting under ${supervision.kind} supervision (exit ${exitCode}) into v${installedVersion ?? 'unknown'}`
+        );
         // Brief delay to let the broadcast reach clients
         setTimeout(() => {
-          server.close(() => process.exit(0));
+          server.close(() => process.exit(exitCode));
           // Fallback if close hangs
-          setTimeout(() => process.exit(0), 3000);
+          setTimeout(() => process.exit(exitCode), 3000);
         }, 500);
       } else {
         updateInFlight = false;

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import { promisify } from 'node:util';
 
 import express from 'express';
 import cookieParser from 'cookie-parser';
-import { createHealthMonitor } from './health.js';
+import { createHealthMonitor, PROCESS_BOOT_ID } from './health.js';
 import { restoreSessionsAfterListen } from './startup-restore.js';
 
 import {
@@ -56,7 +56,11 @@ import {
   removeWorktreeFromDisk,
   validateWorktreeForDelete,
 } from './worktree-cleanup.js';
-import { isInstalled as serviceIsInstalled } from './service.js';
+import {
+  getPlatform as getServicePlatform,
+  isInstalled as serviceIsInstalled,
+  SERVICE_LABEL,
+} from './service.js';
 import {
   buildRemedyCommand,
   buildUpdateCommand,
@@ -5305,12 +5309,20 @@ async function main(): Promise<void> {
         }
       }
 
-      // Anything that would restart this process on exit earns the automatic
-      // restart, not just the stock unit (#1285). The verified-update path
-      // above already proved new bytes are on disk, so the only question left
-      // is who starts the server again.
-      const supervision = detectSupervision({ serviceIsInstalled });
+      // Anything that would provably restart this process on exit earns the
+      // automatic restart, not just the stock unit (#1285). The verified-update
+      // path above already proved new bytes are on disk, so the only question
+      // left is who starts the server again — and `detectSupervision` answers
+      // it from the supervisor's real policy, never from "a unit exists".
+      const supervision = detectSupervision({
+        serviceIsInstalled,
+        platform: getServicePlatform,
+        serviceLabel: SERVICE_LABEL,
+      });
       const restarting = supervision.supervised;
+      if (!restarting) {
+        logger.info(`[update] no automatic restart: ${supervision.reason}`);
+      }
       if (restarting) {
         stopEventBatching();
         stopTelemetry();
@@ -5335,14 +5347,24 @@ async function main(): Promise<void> {
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
-      res.json({ ok: true, restarting, version: installedVersion });
+      // `bootId` lets the client tell the incoming process from this one: the
+      // outgoing server keeps listening for up to ~3.5s below, and every
+      // version it can report comes from the install root the update just
+      // overwrote, so liveness and version both lie during that window.
+      res.json({
+        ok: true,
+        restarting,
+        version: installedVersion,
+        supervision: supervision.kind,
+        bootId: PROCESS_BOOT_ID,
+      });
       if (restarting) {
-        // Stock service: exit 0, unchanged. Foreign systemd unit: exit nonzero,
-        // because the usual hand-written policy is `Restart=on-failure`, which
-        // restarts unclean exits only — a clean exit would leave the hub down.
+        // launchd (KeepAlive) restarts any exit, so exit 0 keeps the log
+        // honest. systemd restarts a nonzero exit only — `on-failure`, which
+        // the stock Linux unit uses too, treats exit 0 as a successful stop.
         const exitCode = restartExitCode(supervision.kind);
         logger.info(
-          `[update] restarting under ${supervision.kind} supervision (exit ${exitCode}) into v${installedVersion ?? 'unknown'}`
+          `[update] restarting under ${supervision.kind} supervision (${supervision.reason}, exit ${exitCode}) into v${installedVersion ?? 'unknown'}`
         );
         // Brief delay to let the broadcast reach clients
         setTimeout(() => {

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -234,6 +234,82 @@ export function readInstalledVersion(
   }
 }
 
+/**
+ * How the running process is supervised, i.e. who would start it again if it
+ * exited right now.
+ *
+ * - `stock-service` — the unit/plist `relay-ide service install` writes. Its
+ *   restart semantics are proven, so it always wins.
+ * - `systemd` — some other systemd unit owns this process (a hand-written
+ *   `relay-stable-hub.service`, a distro package, a container unit).
+ * - `none` — nothing would bring the process back; the operator restarts it.
+ */
+export type SupervisionKind = 'stock-service' | 'systemd' | 'none';
+
+export interface SupervisionDetection {
+  supervised: boolean;
+  kind: SupervisionKind;
+}
+
+export interface SupervisionDeps {
+  /**
+   * The stock service check (`server/service.ts` `isInstalled`). Required —
+   * a default would silently downgrade the proven path to a guess.
+   */
+  serviceIsInstalled: () => boolean;
+  env?: NodeJS.ProcessEnv;
+  /** Defaults to `process.stdout.isTTY`; see the interactive-shell note below. */
+  stdoutIsTty?: () => boolean;
+}
+
+/**
+ * Decide whether an exit would be followed by a restart.
+ *
+ * The stock service check comes first: it identifies the exact unit Relay
+ * installs, whose restart policy is known. Everything else falls back to
+ * `INVOCATION_ID`, which systemd sets per service invocation (systemd >= 232,
+ * system and user managers alike) and no ordinary shell sets.
+ *
+ * `INVOCATION_ID` is inherited by children, so a hub launched by hand from a
+ * terminal that itself descends from a unit would look supervised. An
+ * interactive stdout (a TTY) rules that case out: systemd services get the
+ * journal, a file, or null — never a terminal — so a TTY means a human started
+ * this process and nothing will restart it.
+ */
+export function detectSupervision(deps: SupervisionDeps): SupervisionDetection {
+  let stockInstalled: boolean;
+  try {
+    stockInstalled = deps.serviceIsInstalled();
+  } catch (_) {
+    // A failed probe (permissions, exotic platform) is not evidence of a unit.
+    stockInstalled = false;
+  }
+  if (stockInstalled) return { supervised: true, kind: 'stock-service' };
+
+  const env = deps.env ?? process.env;
+  const invocationId = env.INVOCATION_ID;
+  if (typeof invocationId !== 'string' || invocationId.trim() === '') {
+    return { supervised: false, kind: 'none' };
+  }
+  const isTty = deps.stdoutIsTty ?? (() => process.stdout.isTTY === true);
+  if (isTty()) return { supervised: false, kind: 'none' };
+  return { supervised: true, kind: 'systemd' };
+}
+
+/**
+ * Exit code that makes a supervisor restart this process.
+ *
+ * The stock unit/plist restarts on any exit, and a clean exit keeps the
+ * journal honest. A foreign systemd unit is the opposite bet: the common
+ * hand-written policy is `Restart=on-failure`, which restarts *unclean* exits
+ * only — a `process.exit(0)` there would leave the hub down until an operator
+ * noticed. Exiting nonzero restarts under `on-failure`, `on-abnormal`, and
+ * `always` alike; only the rare `Restart=on-success` misses it.
+ */
+export function restartExitCode(kind: SupervisionKind): number {
+  return kind === 'systemd' ? 1 : 0;
+}
+
 export type UpdateVerification =
   | 'updated'
   | 'already-latest'

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -238,73 +239,272 @@ export function readInstalledVersion(
  * How the running process is supervised, i.e. who would start it again if it
  * exited right now.
  *
- * - `stock-service` — the unit/plist `relay-ide service install` writes. Its
- *   restart semantics are proven, so it always wins.
- * - `systemd` — some other systemd unit owns this process (a hand-written
- *   `relay-stable-hub.service`, a distro package, a container unit).
- * - `none` — nothing would bring the process back; the operator restarts it.
+ * - `launchd` — the stock `com.relay-ide` plist Relay installs on macOS. It
+ *   sets `KeepAlive=true`, which restarts the job on *any* exit.
+ * - `systemd` — a systemd unit whose `Restart=` policy was read and confirmed
+ *   to restart a nonzero exit (the stock Linux unit and hand-written ones like
+ *   `relay-daily-hub.service` alike).
+ * - `none` — nothing is known to bring the process back; the operator restarts
+ *   it. This is the fail-closed answer whenever the evidence is incomplete:
+ *   staying up on stale bytes is recoverable, exiting into nothing is not.
  */
-export type SupervisionKind = 'stock-service' | 'systemd' | 'none';
+export type SupervisionKind = 'launchd' | 'systemd' | 'none';
 
 export interface SupervisionDetection {
   supervised: boolean;
   kind: SupervisionKind;
+  /** Operator-facing explanation; logged and echoed in the `/update` response. */
+  reason: string;
+}
+
+/** The systemd unit that owns this process, plus its `Restart=` policy. */
+export interface SystemdUnitInfo {
+  /** Unit name, e.g. `relay-daily-hub.service`. */
+  unit: string;
+  /** Lowercased `Restart=` value, or `''` when it could not be read. */
+  restart: string;
 }
 
 export interface SupervisionDeps {
   /**
    * The stock service check (`server/service.ts` `isInstalled`). Required —
-   * a default would silently downgrade the proven path to a guess.
+   * a default would silently downgrade the proven path to a guess. Consulted
+   * on macOS only: launchd exposes no restart policy to read, so the stock
+   * plist is the one job whose `KeepAlive` semantics are known. On Linux the
+   * unit's own `Restart=` is authoritative, stock or not.
    */
   serviceIsInstalled: () => boolean;
+  /** `getPlatform()` from `server/service.ts`; may throw off macOS/Linux. */
+  platform?: () => 'macos' | 'linux';
+  /** launchd job label the stock plist installs (`com.relay-ide`). */
+  serviceLabel?: string;
   env?: NodeJS.ProcessEnv;
   /** Defaults to `process.stdout.isTTY`; see the interactive-shell note below. */
   stdoutIsTty?: () => boolean;
+  /** Owning unit + policy lookup; defaults to cgroup + `systemctl show`. */
+  systemdUnit?: () => SystemdUnitInfo | null;
+}
+
+/**
+ * systemd `Restart=` values that restart a process which exits *nonzero*.
+ * `on-abnormal`, `on-abort` and `on-watchdog` react to signals, timeouts and
+ * watchdog misses — never to a plain nonzero exit status — and `no` (the
+ * default) and `on-success` react to neither. See systemd.service(5).
+ */
+const RESTART_ON_NONZERO_EXIT = new Set(['always', 'on-failure']);
+
+function noSupervision(reason: string): SupervisionDetection {
+  return { supervised: false, kind: 'none', reason };
+}
+
+/**
+ * Find the systemd unit that owns this process from its cgroup path.
+ *
+ * cgroup v2 writes one `0::<path>` line; v1 writes several `<id>:<ctrl>:<path>`
+ * lines. The deepest `*.service` segment is the owning unit. A `*.scope` closer
+ * to the leaf (a login session, a `systemd-run --scope`, a container payload)
+ * means no unit owns this process directly, so nothing would restart it —
+ * that is a `null`, not a unit. `user@<uid>.service` is the per-user manager
+ * itself rather than a restartable unit, so it is skipped.
+ */
+export function parseSystemdUnitFromCgroup(
+  raw: string
+): { unit: string; user: boolean } | null {
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const cgroupPath = trimmed.split(':').slice(2).join(':');
+    if (!cgroupPath) continue;
+    const segments = cgroupPath.split('/').filter(Boolean);
+    const user = /(^|\/)user@\d+\.service(\/|$)/.test(cgroupPath);
+    for (let i = segments.length - 1; i >= 0; i -= 1) {
+      const segment = segments[i] as string;
+      if (segment.endsWith('.scope')) return null;
+      if (!segment.endsWith('.service')) continue;
+      if (/^user@\d+\.service$/.test(segment)) break;
+      return { unit: segment, user };
+    }
+  }
+  return null;
+}
+
+const SYSTEMCTL_TIMEOUT_MS = 3000;
+
+/** Default owning-unit probe: read the cgroup, then ask systemd for `Restart=`. */
+function readSystemdUnit(): SystemdUnitInfo | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync('/proc/self/cgroup', 'utf-8');
+  } catch (_) {
+    return null;
+  }
+  const owning = parseSystemdUnitFromCgroup(raw);
+  if (!owning) return null;
+  const args = owning.user
+    ? ['--user', 'show', '--value', '-p', 'Restart', owning.unit]
+    : ['show', '--value', '-p', 'Restart', owning.unit];
+  try {
+    const result = spawnSync('systemctl', args, {
+      encoding: 'utf-8',
+      timeout: SYSTEMCTL_TIMEOUT_MS,
+    });
+    if (result.error || result.status !== 0) {
+      return { unit: owning.unit, restart: '' };
+    }
+    return {
+      unit: owning.unit,
+      restart: (result.stdout ?? '').trim().toLowerCase(),
+    };
+  } catch (_) {
+    return { unit: owning.unit, restart: '' };
+  }
+}
+
+/**
+ * `INVOCATION_ID` is set once per systemd service invocation (systemd >= 232,
+ * system and user managers alike) and no ordinary shell sets it — but children
+ * inherit it, so a hub started by hand from a terminal that descends from a
+ * unit would look supervised. An interactive stdout rules that case out:
+ * services get the journal, a file, or null — never a terminal.
+ */
+function isSystemdManaged(
+  env: NodeJS.ProcessEnv,
+  isTty: () => boolean
+): boolean {
+  const invocationId = env.INVOCATION_ID;
+  if (typeof invocationId !== 'string' || invocationId.trim() === '') {
+    return false;
+  }
+  return !isTty();
+}
+
+/**
+ * launchd's equivalent evidence: it exports `XPC_SERVICE_NAME` set to the job
+ * label for jobs it started (`0` for everything else). Requiring the stock
+ * label means a hub started by hand on a Mac that merely *has* the plist
+ * installed is not mistaken for the serviced process.
+ */
+function isLaunchdManaged(
+  env: NodeJS.ProcessEnv,
+  isTty: () => boolean,
+  label: string | undefined
+): boolean {
+  if (isTty()) return false;
+  const xpcName = (env.XPC_SERVICE_NAME ?? '').trim();
+  if (xpcName === '' || xpcName === '0') return false;
+  return label ? xpcName.includes(label) : true;
 }
 
 /**
  * Decide whether an exit would be followed by a restart.
  *
- * The stock service check comes first: it identifies the exact unit Relay
- * installs, whose restart policy is known. Everything else falls back to
- * `INVOCATION_ID`, which systemd sets per service invocation (systemd >= 232,
- * system and user managers alike) and no ordinary shell sets.
+ * The bet is asymmetric: guessing "supervised" wrong takes the hub down until
+ * a human notices, while guessing "not supervised" wrong only leaves it
+ * running the old bytes with a "restart manually" toast. So every branch here
+ * demands positive evidence, and anything unreadable resolves to `none`.
  *
- * `INVOCATION_ID` is inherited by children, so a hub launched by hand from a
- * terminal that itself descends from a unit would look supervised. An
- * interactive stdout (a TTY) rules that case out: systemd services get the
- * journal, a file, or null — never a terminal — so a TTY means a human started
- * this process and nothing will restart it.
+ * On Linux that evidence is the owning unit's actual `Restart=` policy —
+ * `INVOCATION_ID` is set for *every* unit invocation regardless of policy, and
+ * `Restart=no` is systemd's default, so the variable alone proves only that
+ * systemd started the process, never that it would start it again.
+ *
+ * `RELAY_UPDATE_RESTART` overrides the whole decision: `never` keeps the
+ * process alive no matter what, `systemd` asserts a nonzero-exit-restarting
+ * supervisor for hosts where the policy cannot be read (locked-down
+ * containers, `systemctl` off PATH).
  */
 export function detectSupervision(deps: SupervisionDeps): SupervisionDetection {
-  let stockInstalled: boolean;
-  try {
-    stockInstalled = deps.serviceIsInstalled();
-  } catch (_) {
-    // A failed probe (permissions, exotic platform) is not evidence of a unit.
-    stockInstalled = false;
-  }
-  if (stockInstalled) return { supervised: true, kind: 'stock-service' };
-
   const env = deps.env ?? process.env;
-  const invocationId = env.INVOCATION_ID;
-  if (typeof invocationId !== 'string' || invocationId.trim() === '') {
-    return { supervised: false, kind: 'none' };
+  const override = (env.RELAY_UPDATE_RESTART ?? '').trim().toLowerCase();
+  if (override === 'never' || override === 'off' || override === 'manual') {
+    return noSupervision('RELAY_UPDATE_RESTART=never');
   }
+  if (override === 'systemd' || override === 'always') {
+    return {
+      supervised: true,
+      kind: 'systemd',
+      reason: `RELAY_UPDATE_RESTART=${override}`,
+    };
+  }
+
   const isTty = deps.stdoutIsTty ?? (() => process.stdout.isTTY === true);
-  if (isTty()) return { supervised: false, kind: 'none' };
-  return { supervised: true, kind: 'systemd' };
+
+  let platform: 'macos' | 'linux' | null;
+  try {
+    platform = deps.platform?.() ?? null;
+  } catch (_) {
+    // Unsupported platform: no supervisor we know how to reason about.
+    platform = null;
+  }
+
+  if (platform === 'macos') {
+    let stockInstalled: boolean;
+    try {
+      stockInstalled = deps.serviceIsInstalled();
+    } catch (_) {
+      // A failed probe (permissions, exotic platform) is not evidence.
+      stockInstalled = false;
+    }
+    if (!stockInstalled) {
+      return noSupervision('no stock launchd plist installed');
+    }
+    if (!isLaunchdManaged(env, isTty, deps.serviceLabel)) {
+      return noSupervision(
+        'stock launchd plist installed but this process was not started by it'
+      );
+    }
+    return {
+      supervised: true,
+      kind: 'launchd',
+      reason: 'stock launchd plist (KeepAlive restarts any exit)',
+    };
+  }
+
+  if (!isSystemdManaged(env, isTty)) {
+    return noSupervision('no systemd invocation owns this process');
+  }
+  const unitProbe = deps.systemdUnit ?? readSystemdUnit;
+  let info: SystemdUnitInfo | null;
+  try {
+    info = unitProbe();
+  } catch (_) {
+    info = null;
+  }
+  if (!info) {
+    return noSupervision(
+      'systemd invocation without a resolvable unit (set RELAY_UPDATE_RESTART=systemd to override)'
+    );
+  }
+  if (!info.restart) {
+    return noSupervision(
+      `could not read Restart= for ${info.unit} (set RELAY_UPDATE_RESTART=systemd to override)`
+    );
+  }
+  if (!RESTART_ON_NONZERO_EXIT.has(info.restart)) {
+    return noSupervision(
+      `${info.unit} has Restart=${info.restart}, which would not restart this process`
+    );
+  }
+  return {
+    supervised: true,
+    kind: 'systemd',
+    reason: `${info.unit} has Restart=${info.restart}`,
+  };
 }
 
 /**
  * Exit code that makes a supervisor restart this process.
  *
- * The stock unit/plist restarts on any exit, and a clean exit keeps the
- * journal honest. A foreign systemd unit is the opposite bet: the common
- * hand-written policy is `Restart=on-failure`, which restarts *unclean* exits
- * only — a `process.exit(0)` there would leave the hub down until an operator
- * noticed. Exiting nonzero restarts under `on-failure`, `on-abnormal`, and
- * `always` alike; only the rare `Restart=on-success` misses it.
+ * The two supervisors want opposite exits, so this is not a stylistic choice:
+ *
+ * - launchd with `KeepAlive=true` (the stock plist) restarts on *any* exit, so
+ *   exit 0 restarts and keeps the log honest.
+ * - systemd restarts a *nonzero* exit under `always` and `on-failure` only —
+ *   including the stock Linux unit Relay writes, which is `Restart=on-failure`
+ *   (`server/service.ts`). A clean exit there is a successful stop: the unit
+ *   goes inactive and the hub stays down. `detectSupervision` only reports
+ *   `systemd` after confirming one of those two policies, so exit 1 is always
+ *   the code that unit acts on.
  */
 export function restartExitCode(kind: SupervisionKind): number {
   return kind === 'systemd' ? 1 : 0;

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -24,10 +24,13 @@ afterEach(async () => {
   vi.useRealTimers();
 });
 
+const TEST_BOOT_ID = 'boot-id-under-test';
+
 async function serveHealthz(lagMs: number): Promise<string> {
   const monitor = createHealthMonitor({
     getLagMs: () => lagMs,
     lagThresholdMs: 100,
+    bootId: TEST_BOOT_ID,
     memoryLogIntervalMs: 60_000,
     memoryUsage: () => ({
       rss: 123_456,
@@ -55,6 +58,7 @@ describe('/healthz', () => {
     const monitor = createHealthMonitor({
       lagThresholdMs: 50,
       probeIntervalMs: 100,
+      bootId: TEST_BOOT_ID,
       memoryLogIntervalMs: 60_000,
       monotonicNow: () => monotonicMs,
       memoryUsage: () => ({
@@ -82,6 +86,7 @@ describe('/healthz', () => {
       status: 'degraded',
       lagMs: 75,
       rss: 123_456,
+      bootId: TEST_BOOT_ID,
     });
   });
 
@@ -124,6 +129,9 @@ describe('/healthz', () => {
       status: 'ok',
       lagMs: 12,
       rss: 123_456,
+      // Per-process identity: a client waiting out a restart uses it to tell
+      // the new server from the one still shutting down (#1285).
+      bootId: TEST_BOOT_ID,
     });
   });
 
@@ -136,12 +144,14 @@ describe('/healthz', () => {
       status: 'degraded',
       lagMs: 101,
       rss: 123_456,
+      bootId: TEST_BOOT_ID,
     });
   });
 
   it('returns 503 and disabled stores when persistence is explicitly degraded', () => {
     const monitor = createHealthMonitor({
       getLagMs: () => 12,
+      bootId: TEST_BOOT_ID,
       disabledStores: ['channel-messages', 'analytics'],
       memoryLogIntervalMs: 60_000,
       memoryUsage: () => ({
@@ -166,6 +176,7 @@ describe('/healthz', () => {
       status: 'degraded',
       lagMs: 12,
       rss: 123_456,
+      bootId: TEST_BOOT_ID,
       disabledStores: ['channel-messages', 'analytics'],
     });
   });

--- a/test/self-update.test.ts
+++ b/test/self-update.test.ts
@@ -1,10 +1,11 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import {
   buildRemedyCommand,
   buildUpdateCommand,
   detectInstallKind,
   detectRunningInstall,
   detectSupervision,
+  parseSystemdUnitFromCgroup,
   readInstalledVersion,
   resolveBunBinary,
   resolveDetectedScriptPath,
@@ -351,43 +352,119 @@ test('verifyUpdateLanded is unverifiable when either version is unreadable', () 
   ).toBe('unverifiable');
 });
 
-test('detectSupervision reports the stock service before anything else', () => {
-  // Stock unit wins even when the env also looks like systemd: its restart
-  // semantics (and its exit code) are the proven ones.
+const LINUX = () => 'linux' as const;
+const MACOS = () => 'macos' as const;
+
+/** Owning-unit probe stub: what `systemctl show -p Restart` would report. */
+function unitWith(restart: string, unit = 'relay-daily-hub.service') {
+  return () => ({ unit, restart });
+}
+
+test('detectSupervision restarts under a unit whose policy acts on a nonzero exit', () => {
+  for (const policy of ['on-failure', 'always']) {
+    expect(
+      detectSupervision({
+        serviceIsInstalled: () => false,
+        platform: LINUX,
+        env: { INVOCATION_ID: 'b8f0a4c1' },
+        stdoutIsTty: () => false,
+        systemdUnit: unitWith(policy),
+      })
+    ).toMatchObject({ supervised: true, kind: 'systemd' });
+  }
+});
+
+test('detectSupervision keeps the stock Linux unit on the systemd (exit 1) path', () => {
+  // The stock unit Relay writes is `Restart=on-failure`, so it needs the same
+  // nonzero exit as any hand-written unit — "stock" is not its own policy.
+  const detection = detectSupervision({
+    serviceIsInstalled: () => true,
+    platform: LINUX,
+    env: { INVOCATION_ID: 'b8f0a4c1' },
+    stdoutIsTty: () => false,
+    systemdUnit: unitWith('on-failure', 'relay-ide.service'),
+  });
+  expect(detection).toMatchObject({ supervised: true, kind: 'systemd' });
+  expect(restartExitCode(detection.kind)).toBe(1);
+});
+
+test('detectSupervision stays up under policies that would not restart it', () => {
+  // `no` is systemd's default, and `on-abnormal`/`on-abort`/`on-watchdog` react
+  // to signals and timeouts, never to a nonzero exit status. Exiting under any
+  // of them is a permanent outage.
+  for (const policy of [
+    'no',
+    'on-success',
+    'on-abnormal',
+    'on-abort',
+    'on-watchdog',
+  ]) {
+    expect(
+      detectSupervision({
+        serviceIsInstalled: () => true,
+        platform: LINUX,
+        env: { INVOCATION_ID: 'b8f0a4c1' },
+        stdoutIsTty: () => false,
+        systemdUnit: unitWith(policy),
+      })
+    ).toMatchObject({ supervised: false, kind: 'none' });
+  }
+});
+
+test('detectSupervision stays up when the restart policy cannot be read', () => {
+  // Fail closed: an unreadable policy is not evidence of a supervisor.
   expect(
     detectSupervision({
       serviceIsInstalled: () => true,
+      platform: LINUX,
       env: { INVOCATION_ID: 'b8f0a4c1' },
       stdoutIsTty: () => false,
+      systemdUnit: unitWith(''),
     })
-  ).toEqual({ supervised: true, kind: 'stock-service' });
-});
-
-test('detectSupervision treats INVOCATION_ID as a custom systemd unit', () => {
+  ).toMatchObject({ supervised: false, kind: 'none' });
   expect(
     detectSupervision({
-      serviceIsInstalled: () => false,
+      serviceIsInstalled: () => true,
+      platform: LINUX,
       env: { INVOCATION_ID: 'b8f0a4c1' },
       stdoutIsTty: () => false,
+      systemdUnit: () => null,
     })
-  ).toEqual({ supervised: true, kind: 'systemd' });
+  ).toMatchObject({ supervised: false, kind: 'none' });
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => true,
+      platform: LINUX,
+      env: { INVOCATION_ID: 'b8f0a4c1' },
+      stdoutIsTty: () => false,
+      systemdUnit: () => {
+        throw new Error('EACCES');
+      },
+    })
+  ).toMatchObject({ supervised: false, kind: 'none' });
 });
 
 test('detectSupervision reports none without INVOCATION_ID', () => {
+  const unit = vi.fn(unitWith('always'));
   expect(
     detectSupervision({
-      serviceIsInstalled: () => false,
+      serviceIsInstalled: () => true,
+      platform: LINUX,
       env: {},
       stdoutIsTty: () => false,
+      systemdUnit: unit,
     })
-  ).toEqual({ supervised: false, kind: 'none' });
+  ).toMatchObject({ supervised: false, kind: 'none' });
   expect(
     detectSupervision({
-      serviceIsInstalled: () => false,
+      serviceIsInstalled: () => true,
+      platform: LINUX,
       env: { INVOCATION_ID: '   ' },
       stdoutIsTty: () => false,
+      systemdUnit: unit,
     })
-  ).toEqual({ supervised: false, kind: 'none' });
+  ).toMatchObject({ supervised: false, kind: 'none' });
+  expect(unit).not.toHaveBeenCalled();
 });
 
 test('detectSupervision ignores an INVOCATION_ID inherited by an interactive shell', () => {
@@ -396,11 +473,47 @@ test('detectSupervision ignores an INVOCATION_ID inherited by an interactive she
   // TTY on stdout, so a TTY rules the unit out.
   expect(
     detectSupervision({
-      serviceIsInstalled: () => false,
+      serviceIsInstalled: () => true,
+      platform: LINUX,
       env: { INVOCATION_ID: 'b8f0a4c1' },
       stdoutIsTty: () => true,
+      systemdUnit: unitWith('always'),
     })
-  ).toEqual({ supervised: false, kind: 'none' });
+  ).toMatchObject({ supervised: false, kind: 'none' });
+});
+
+test('detectSupervision claims launchd only for the stock plist that started it', () => {
+  const base = {
+    serviceIsInstalled: () => true,
+    platform: MACOS,
+    serviceLabel: 'com.relay-ide',
+    stdoutIsTty: () => false,
+  };
+  expect(
+    detectSupervision({ ...base, env: { XPC_SERVICE_NAME: 'com.relay-ide' } })
+  ).toMatchObject({ supervised: true, kind: 'launchd' });
+  // `0` is what launchd exports for processes it did not start, and a hub run
+  // by hand on a Mac that merely has the plist installed is not that job.
+  expect(
+    detectSupervision({ ...base, env: { XPC_SERVICE_NAME: '0' } })
+  ).toMatchObject({ supervised: false, kind: 'none' });
+  expect(detectSupervision({ ...base, env: {} })).toMatchObject({
+    supervised: false,
+    kind: 'none',
+  });
+  expect(
+    detectSupervision({
+      ...base,
+      env: { XPC_SERVICE_NAME: 'com.other.job' },
+    })
+  ).toMatchObject({ supervised: false, kind: 'none' });
+  expect(
+    detectSupervision({
+      ...base,
+      serviceIsInstalled: () => false,
+      env: { XPC_SERVICE_NAME: 'com.relay-ide' },
+    })
+  ).toMatchObject({ supervised: false, kind: 'none' });
 });
 
 test('detectSupervision survives a throwing stock service probe', () => {
@@ -409,16 +522,92 @@ test('detectSupervision survives a throwing stock service probe', () => {
       serviceIsInstalled: () => {
         throw new Error('EACCES');
       },
-      env: { INVOCATION_ID: 'b8f0a4c1' },
+      platform: MACOS,
+      serviceLabel: 'com.relay-ide',
+      env: { XPC_SERVICE_NAME: 'com.relay-ide' },
       stdoutIsTty: () => false,
     })
-  ).toEqual({ supervised: true, kind: 'systemd' });
+  ).toMatchObject({ supervised: false, kind: 'none' });
 });
 
-test('restartExitCode exits clean for the stock service and unclean under systemd', () => {
-  // Restart=on-failure only restarts unclean exits, so a foreign unit needs a
-  // nonzero code to come back.
-  expect(restartExitCode('stock-service')).toBe(0);
+test('detectSupervision honours the RELAY_UPDATE_RESTART override both ways', () => {
+  const supervisedDeps = {
+    serviceIsInstalled: () => false,
+    platform: LINUX,
+    stdoutIsTty: () => false,
+    systemdUnit: unitWith('always'),
+  };
+  expect(
+    detectSupervision({
+      ...supervisedDeps,
+      env: { INVOCATION_ID: 'b8f0a4c1', RELAY_UPDATE_RESTART: 'never' },
+    })
+  ).toMatchObject({ supervised: false, kind: 'none' });
+  // Escape hatch for hosts where the policy is unreadable (locked-down
+  // containers, systemctl off PATH) but the operator knows it restarts.
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => false,
+      platform: LINUX,
+      stdoutIsTty: () => true,
+      systemdUnit: () => null,
+      env: { RELAY_UPDATE_RESTART: 'systemd' },
+    })
+  ).toMatchObject({ supervised: true, kind: 'systemd' });
+});
+
+test('detectSupervision stays up on platforms with no supervisor model', () => {
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => true,
+      platform: () => {
+        throw new Error('Unsupported platform: win32');
+      },
+      env: {},
+      stdoutIsTty: () => false,
+    })
+  ).toMatchObject({ supervised: false, kind: 'none' });
+});
+
+test('parseSystemdUnitFromCgroup finds the owning unit and its manager', () => {
+  expect(
+    parseSystemdUnitFromCgroup(
+      '0::/user.slice/user-1000.slice/user@1000.service/app.slice/relay-daily-hub.service\n'
+    )
+  ).toEqual({ unit: 'relay-daily-hub.service', user: true });
+  expect(
+    parseSystemdUnitFromCgroup('0::/system.slice/relay-ide.service\n')
+  ).toEqual({ unit: 'relay-ide.service', user: false });
+  // cgroup v1 writes one line per controller.
+  expect(
+    parseSystemdUnitFromCgroup(
+      '3:cpu,cpuacct:/system.slice/relay-ide.service\n1:name=systemd:/system.slice/relay-ide.service\n'
+    )
+  ).toEqual({ unit: 'relay-ide.service', user: false });
+});
+
+test('parseSystemdUnitFromCgroup rejects scopes and bare manager cgroups', () => {
+  // A login session or `systemd-run --scope` is not a restartable unit, even
+  // though it sits under the user manager's `.service` cgroup.
+  expect(
+    parseSystemdUnitFromCgroup(
+      '0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-tmux.scope\n'
+    )
+  ).toBeNull();
+  expect(
+    parseSystemdUnitFromCgroup(
+      '0::/user.slice/user-1000.slice/user@1000.service\n'
+    )
+  ).toBeNull();
+  expect(parseSystemdUnitFromCgroup('0::/\n')).toBeNull();
+  expect(parseSystemdUnitFromCgroup('')).toBeNull();
+});
+
+test('restartExitCode matches each supervisor\'s real restart semantics', () => {
+  // launchd `KeepAlive=true` restarts any exit, so exit 0 keeps the log honest.
+  expect(restartExitCode('launchd')).toBe(0);
+  // systemd restarts a nonzero exit under `always`/`on-failure` only — exit 0
+  // is a successful stop and leaves the unit inactive.
   expect(restartExitCode('systemd')).toBe(1);
   expect(restartExitCode('none')).toBe(0);
 });

--- a/test/self-update.test.ts
+++ b/test/self-update.test.ts
@@ -4,9 +4,11 @@ import {
   buildUpdateCommand,
   detectInstallKind,
   detectRunningInstall,
+  detectSupervision,
   readInstalledVersion,
   resolveBunBinary,
   resolveDetectedScriptPath,
+  restartExitCode,
   verifyUpdateLanded,
 } from '../server/self-update.js';
 
@@ -347,4 +349,76 @@ test('verifyUpdateLanded is unverifiable when either version is unreadable', () 
       latest: null,
     })
   ).toBe('unverifiable');
+});
+
+test('detectSupervision reports the stock service before anything else', () => {
+  // Stock unit wins even when the env also looks like systemd: its restart
+  // semantics (and its exit code) are the proven ones.
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => true,
+      env: { INVOCATION_ID: 'b8f0a4c1' },
+      stdoutIsTty: () => false,
+    })
+  ).toEqual({ supervised: true, kind: 'stock-service' });
+});
+
+test('detectSupervision treats INVOCATION_ID as a custom systemd unit', () => {
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => false,
+      env: { INVOCATION_ID: 'b8f0a4c1' },
+      stdoutIsTty: () => false,
+    })
+  ).toEqual({ supervised: true, kind: 'systemd' });
+});
+
+test('detectSupervision reports none without INVOCATION_ID', () => {
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => false,
+      env: {},
+      stdoutIsTty: () => false,
+    })
+  ).toEqual({ supervised: false, kind: 'none' });
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => false,
+      env: { INVOCATION_ID: '   ' },
+      stdoutIsTty: () => false,
+    })
+  ).toEqual({ supervised: false, kind: 'none' });
+});
+
+test('detectSupervision ignores an INVOCATION_ID inherited by an interactive shell', () => {
+  // A hub started by hand from a terminal that descends from a unit inherits
+  // INVOCATION_ID, but nothing would restart it. Systemd services never get a
+  // TTY on stdout, so a TTY rules the unit out.
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => false,
+      env: { INVOCATION_ID: 'b8f0a4c1' },
+      stdoutIsTty: () => true,
+    })
+  ).toEqual({ supervised: false, kind: 'none' });
+});
+
+test('detectSupervision survives a throwing stock service probe', () => {
+  expect(
+    detectSupervision({
+      serviceIsInstalled: () => {
+        throw new Error('EACCES');
+      },
+      env: { INVOCATION_ID: 'b8f0a4c1' },
+      stdoutIsTty: () => false,
+    })
+  ).toEqual({ supervised: true, kind: 'systemd' });
+});
+
+test('restartExitCode exits clean for the stock service and unclean under systemd', () => {
+  // Restart=on-failure only restarts unclean exits, so a foreign unit needs a
+  // nonzero code to come back.
+  expect(restartExitCode('stock-service')).toBe(0);
+  expect(restartExitCode('systemd')).toBe(1);
+  expect(restartExitCode('none')).toBe(0);
 });

--- a/test/server-restart-poll.test.ts
+++ b/test/server-restart-poll.test.ts
@@ -1,0 +1,135 @@
+import { expect, test, vi } from 'vitest';
+import {
+  SERVER_RESTART_GRACE_MS,
+  SERVER_RESTART_POLL_INTERVAL_MS,
+  SERVER_RESTART_TIMEOUT_MS,
+  SERVER_RESTART_TIMEOUT_TEXT,
+  reloadWhenServerReturns,
+  waitForServerRestart,
+} from '../frontend/src/lib/server-restart.js';
+
+/**
+ * Virtual clock: `sleep` advances it instead of waiting, so a 90s poll budget
+ * runs in microseconds and every assertion is about the schedule, not timing
+ * luck.
+ */
+function fakeClock() {
+  let current = 0;
+  const sleeps: number[] = [];
+  return {
+    now: () => current,
+    sleeps,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      current += ms;
+    },
+  };
+}
+
+test('waitForServerRestart waits out the pre-exit grace before the first probe', async () => {
+  const clock = fakeClock();
+  const probedAt: number[] = [];
+  const probe = vi.fn(async () => {
+    probedAt.push(clock.now());
+    return true;
+  });
+
+  await expect(
+    waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
+  ).resolves.toBe(true);
+
+  // Probing immediately would hit the server still finishing its shutdown and
+  // reload the page into the outgoing process.
+  expect(probedAt).toEqual([SERVER_RESTART_GRACE_MS]);
+  expect(probe).toHaveBeenCalledTimes(1);
+});
+
+test('waitForServerRestart polls on the interval until the server answers', async () => {
+  const clock = fakeClock();
+  const probedAt: number[] = [];
+  const probe = vi.fn(async () => {
+    probedAt.push(clock.now());
+    return probedAt.length === 4;
+  });
+
+  await expect(
+    waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
+  ).resolves.toBe(true);
+
+  expect(probedAt).toEqual([
+    SERVER_RESTART_GRACE_MS,
+    SERVER_RESTART_GRACE_MS + SERVER_RESTART_POLL_INTERVAL_MS,
+    SERVER_RESTART_GRACE_MS + SERVER_RESTART_POLL_INTERVAL_MS * 2,
+    SERVER_RESTART_GRACE_MS + SERVER_RESTART_POLL_INTERVAL_MS * 3,
+  ]);
+});
+
+test('waitForServerRestart gives up at the timeout instead of polling forever', async () => {
+  const clock = fakeClock();
+  const probe = vi.fn(async () => false);
+
+  await expect(
+    waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
+  ).resolves.toBe(false);
+
+  expect(clock.now()).toBeGreaterThanOrEqual(SERVER_RESTART_TIMEOUT_MS);
+  const expectedProbes =
+    1 +
+    Math.ceil(
+      (SERVER_RESTART_TIMEOUT_MS - SERVER_RESTART_GRACE_MS) /
+        SERVER_RESTART_POLL_INTERVAL_MS
+    );
+  expect(probe).toHaveBeenCalledTimes(expectedProbes);
+});
+
+test('waitForServerRestart still probes once when the budget is shorter than the grace', async () => {
+  const clock = fakeClock();
+  const probe = vi.fn(async () => false);
+
+  await expect(
+    waitForServerRestart({
+      probe,
+      sleep: clock.sleep,
+      now: clock.now,
+      timeoutMs: 1000,
+    })
+  ).resolves.toBe(false);
+
+  expect(probe).toHaveBeenCalledTimes(1);
+  expect(clock.sleeps).toEqual([1000]);
+});
+
+test('reloadWhenServerReturns reloads once the server answers', async () => {
+  const clock = fakeClock();
+  const reload = vi.fn();
+  const onTimeout = vi.fn();
+
+  await reloadWhenServerReturns(onTimeout, {
+    probe: async () => true,
+    sleep: clock.sleep,
+    now: clock.now,
+    reload,
+  });
+
+  expect(reload).toHaveBeenCalledTimes(1);
+  expect(onTimeout).not.toHaveBeenCalled();
+});
+
+test('reloadWhenServerReturns hands back the manual-reload copy on timeout', async () => {
+  const clock = fakeClock();
+  const reload = vi.fn();
+  const onTimeout = vi.fn();
+
+  await reloadWhenServerReturns(onTimeout, {
+    probe: async () => false,
+    sleep: clock.sleep,
+    now: clock.now,
+    reload,
+  });
+
+  expect(reload).not.toHaveBeenCalled();
+  expect(onTimeout).toHaveBeenCalledWith(SERVER_RESTART_TIMEOUT_TEXT);
+  expect(SERVER_RESTART_TIMEOUT_TEXT).toBe(
+    'Server is taking longer than expected — reload manually.'
+  );
+});

--- a/test/server-restart-poll.test.ts
+++ b/test/server-restart-poll.test.ts
@@ -1,11 +1,14 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import {
   SERVER_RESTART_GRACE_MS,
+  SERVER_RESTART_LIVENESS_CONFIRMATIONS,
   SERVER_RESTART_POLL_INTERVAL_MS,
   SERVER_RESTART_TIMEOUT_MS,
   SERVER_RESTART_TIMEOUT_TEXT,
+  probeServerRestart,
   reloadWhenServerReturns,
   waitForServerRestart,
+  type ServerRestartProbeResult,
 } from '../frontend/src/lib/server-restart.js';
 
 /**
@@ -26,12 +29,26 @@ function fakeClock() {
   };
 }
 
+/** A probe that walks a scripted sequence, repeating its last result. */
+function scriptedProbe(results: ServerRestartProbeResult[]) {
+  let index = 0;
+  return vi.fn(async () => {
+    const result = results[Math.min(index, results.length - 1)];
+    index += 1;
+    return result as ServerRestartProbeResult;
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 test('waitForServerRestart waits out the pre-exit grace before the first probe', async () => {
   const clock = fakeClock();
   const probedAt: number[] = [];
-  const probe = vi.fn(async () => {
+  const probe = vi.fn(async (): Promise<ServerRestartProbeResult> => {
     probedAt.push(clock.now());
-    return true;
+    return 'new';
   });
 
   await expect(
@@ -44,12 +61,49 @@ test('waitForServerRestart waits out the pre-exit grace before the first probe',
   expect(probe).toHaveBeenCalledTimes(1);
 });
 
+test('waitForServerRestart accepts a boot-id change as proof on the first probe', async () => {
+  const clock = fakeClock();
+  const probe = scriptedProbe(['down', 'new']);
+
+  await expect(
+    waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
+  ).resolves.toBe(true);
+
+  // `new` is identity, not evidence: no confirmation round is required.
+  expect(probe).toHaveBeenCalledTimes(2);
+});
+
+test('waitForServerRestart needs consecutive liveness answers without a boot id', async () => {
+  const clock = fakeClock();
+  const probe = scriptedProbe(['alive', 'alive']);
+
+  await expect(
+    waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
+  ).resolves.toBe(true);
+
+  expect(SERVER_RESTART_LIVENESS_CONFIRMATIONS).toBe(2);
+  expect(probe).toHaveBeenCalledTimes(2);
+});
+
+test('waitForServerRestart restarts the confirmation streak when the server drops', async () => {
+  const clock = fakeClock();
+  // The outgoing process answering once, then dying, must not read as a
+  // restart — one 200 is not evidence the new server is up.
+  const probe = scriptedProbe(['alive', 'down', 'alive', 'alive']);
+
+  await expect(
+    waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
+  ).resolves.toBe(true);
+
+  expect(probe).toHaveBeenCalledTimes(4);
+});
+
 test('waitForServerRestart polls on the interval until the server answers', async () => {
   const clock = fakeClock();
   const probedAt: number[] = [];
-  const probe = vi.fn(async () => {
+  const probe = vi.fn(async (): Promise<ServerRestartProbeResult> => {
     probedAt.push(clock.now());
-    return probedAt.length === 4;
+    return probedAt.length === 4 ? 'new' : 'down';
   });
 
   await expect(
@@ -64,9 +118,15 @@ test('waitForServerRestart polls on the interval until the server answers', asyn
   ]);
 });
 
+test('the grace window outlasts the server exit budget it covers', () => {
+  // server/index.ts: 500ms broadcast delay, then close, with a hard 3000ms
+  // fallback exit — and this clock starts at response receipt, later still.
+  expect(SERVER_RESTART_GRACE_MS).toBeGreaterThan(500 + 3000);
+});
+
 test('waitForServerRestart gives up at the timeout instead of polling forever', async () => {
   const clock = fakeClock();
-  const probe = vi.fn(async () => false);
+  const probe = scriptedProbe(['down']);
 
   await expect(
     waitForServerRestart({ probe, sleep: clock.sleep, now: clock.now })
@@ -84,7 +144,7 @@ test('waitForServerRestart gives up at the timeout instead of polling forever', 
 
 test('waitForServerRestart still probes once when the budget is shorter than the grace', async () => {
   const clock = fakeClock();
-  const probe = vi.fn(async () => false);
+  const probe = scriptedProbe(['down']);
 
   await expect(
     waitForServerRestart({
@@ -99,13 +159,34 @@ test('waitForServerRestart still probes once when the budget is shorter than the
   expect(clock.sleeps).toEqual([1000]);
 });
 
+test('waitForServerRestart stops when the caller aborts', async () => {
+  const clock = fakeClock();
+  const controller = new AbortController();
+  const probe = vi.fn(async (): Promise<ServerRestartProbeResult> => {
+    controller.abort();
+    return 'down';
+  });
+
+  await expect(
+    waitForServerRestart({
+      probe,
+      sleep: clock.sleep,
+      now: clock.now,
+      signal: controller.signal,
+    })
+  ).resolves.toBe(false);
+
+  // One probe ran, then the abort ended the wait instead of burning the budget.
+  expect(probe).toHaveBeenCalledTimes(1);
+});
+
 test('reloadWhenServerReturns reloads once the server answers', async () => {
   const clock = fakeClock();
   const reload = vi.fn();
   const onTimeout = vi.fn();
 
   await reloadWhenServerReturns(onTimeout, {
-    probe: async () => true,
+    probe: async () => 'new',
     sleep: clock.sleep,
     now: clock.now,
     reload,
@@ -121,7 +202,7 @@ test('reloadWhenServerReturns hands back the manual-reload copy on timeout', asy
   const onTimeout = vi.fn();
 
   await reloadWhenServerReturns(onTimeout, {
-    probe: async () => false,
+    probe: async () => 'down',
     sleep: clock.sleep,
     now: clock.now,
     reload,
@@ -132,4 +213,67 @@ test('reloadWhenServerReturns hands back the manual-reload copy on timeout', asy
   expect(SERVER_RESTART_TIMEOUT_TEXT).toBe(
     'Server is taking longer than expected — reload manually.'
   );
+});
+
+test('reloadWhenServerReturns neither reloads nor reports after an abort', async () => {
+  const clock = fakeClock();
+  const reload = vi.fn();
+  const onTimeout = vi.fn();
+  const controller = new AbortController();
+
+  await reloadWhenServerReturns(onTimeout, {
+    probe: async () => {
+      controller.abort();
+      return 'new';
+    },
+    sleep: clock.sleep,
+    now: clock.now,
+    reload,
+    signal: controller.signal,
+  });
+
+  // A dismissed toast must not navigate the page or set state on a dead tree.
+  expect(reload).not.toHaveBeenCalled();
+  expect(onTimeout).not.toHaveBeenCalled();
+});
+
+function stubHealthz(status: number, body: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      status,
+      json: async () => body,
+    }))
+  );
+}
+
+test('probeServerRestart reports the outgoing process as down, not alive', async () => {
+  stubHealthz(200, { status: 'ok', bootId: 'boot-old' });
+  await expect(probeServerRestart('boot-old')).resolves.toBe('down');
+
+  stubHealthz(200, { status: 'ok', bootId: 'boot-new' });
+  await expect(probeServerRestart('boot-old')).resolves.toBe('new');
+});
+
+test('probeServerRestart falls back to liveness without a comparable boot id', async () => {
+  stubHealthz(200, { status: 'ok', bootId: 'boot-new' });
+  await expect(probeServerRestart(null)).resolves.toBe('alive');
+
+  // A server old enough to lack `bootId` still counts as alive, and 503 is a
+  // degraded store or event loop — an answer from Relay either way.
+  stubHealthz(503, { status: 'degraded' });
+  await expect(probeServerRestart('boot-old')).resolves.toBe('alive');
+});
+
+test('probeServerRestart treats proxy errors and transport failures as down', async () => {
+  stubHealthz(502, 'Bad Gateway');
+  await expect(probeServerRestart('boot-old')).resolves.toBe('down');
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    })
+  );
+  await expect(probeServerRestart('boot-old')).resolves.toBe('down');
 });

--- a/test/server-shutdown-contract.test.ts
+++ b/test/server-shutdown-contract.test.ts
@@ -39,9 +39,15 @@ describe('server shutdown store closing contract', () => {
   });
 
   it('keeps the existing update-restart artifact store close path', () => {
+    // First `if (restarting)` is the store-close branch; the second one below
+    // the response only schedules the exit.
     const updateRestartStart = serverSource.indexOf('if (restarting) {');
+    // Bound the slice on the shape of the /update response, not on its fields:
+    // the payload keeps growing (#1285 added supervision + bootId) while the
+    // store-close sequence inside the restart branch is what this test pins.
     const updateResponseStart = serverSource.indexOf(
-      'res.json({ ok: true, restarting, version: installedVersion });'
+      'res.json({',
+      updateRestartStart
     );
     const updateRestartSource = serverSource.slice(
       updateRestartStart,
@@ -50,6 +56,11 @@ describe('server shutdown store closing contract', () => {
 
     expect(updateRestartStart).toBeGreaterThanOrEqual(0);
     expect(updateResponseStart).toBeGreaterThan(updateRestartStart);
+    // Guard the anchor: it must be the /update success response, not some
+    // other `res.json({` that drifted into the restart branch.
+    expect(
+      serverSource.slice(updateResponseStart, updateResponseStart + 200)
+    ).toContain('restarting,');
     expect(updateRestartSource).toContain('agentProfileStore?.close();');
     expect(updateRestartSource).toContain('workContextArtifactStore?.close();');
     expect(updateRestartSource).toContain('workContextMessageStore?.close();');

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -187,6 +187,8 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
       status: 'ok',
       lagMs: expect.any(Number),
       rss: expect.any(Number),
+      // Per-process identity a restart-waiting client compares against (#1285).
+      bootId: expect.any(String),
       ready: expect.any(Boolean),
       resume: {
         inProgress: expect.any(Boolean),


### PR DESCRIPTION
`POST /update` only offered an automatic restart when `serviceIsInstalled()` found the stock `relay-ide.service` / `com.relay-ide` unit, so hubs running under hand-written units (`relay-stable-hub.service`, `relay-daily-hub.service`) got `restarting: false` and a "restart manually" toast even though the supervisor would have brought them straight back. This makes the restart decision from the supervisor's *actual* restart policy, in both directions.

## Mechanism

`detectSupervision()` in `server/self-update.ts` answers one question — would anything start this process again? — and demands positive evidence for every "yes", because the bet is asymmetric: guessing supervised wrong takes the hub down until a human notices, guessing unsupervised wrong only leaves it running old bytes with a manual-restart message.

- **Managed-process evidence first.** systemd's `INVOCATION_ID` (set per unit invocation, system and user managers alike) with a non-TTY stdout, since the variable is inherited and a hub started by hand from a terminal descending from a unit would otherwise look supervised. On macOS the equivalent is launchd's `XPC_SERVICE_NAME` naming the stock job, so a hand-run hub on a Mac that merely *has* the plist installed is not mistaken for the serviced process.
- **Then the real policy.** `INVOCATION_ID` proves systemd *started* the process, never that it would start it again — `Restart=no` is systemd's default. The owning unit is resolved from `/proc/self/cgroup` (`.scope` leaves and the bare `user@<uid>.service` manager cgroup are not units) and its policy read with `systemctl show --value -p Restart <unit>` (`--user` when the cgroup sits under the user manager). Only `always` and `on-failure` count.
- **Exit code follows the supervisor, not stock-vs-foreign.** systemd restarts a *nonzero* exit under `always`/`on-failure` only — including the stock Linux unit Relay writes, which is `Restart=on-failure` (`server/service.ts`), where `process.exit(0)` is a successful stop that leaves the unit inactive. launchd's stock plist is `KeepAlive=true` and restarts *any* exit, so it exits 0 and keeps the log honest. `on-abnormal`/`on-abort`/`on-watchdog` react to signals, timeouts and watchdog misses rather than exit status, so they are treated as "would not restart".
- **Fail closed and escapable.** An unreadable policy, an unresolvable unit, or any non-restarting policy keeps the server up with `restarting: false` and a logged reason. `RELAY_UPDATE_RESTART=never` forces manual restarts; `RELAY_UPDATE_RESTART=systemd` forces the restart where the policy cannot be read (locked-down containers, `systemctl` off PATH). `POST /update` echoes the decision as `supervision`.

**The stock path is unchanged in behaviour where it was already correct**: the macOS stock plist still exits 0, and the `/update` response shape, `updateInFlight` semantics, and graceful shutdown sequence are identical. The stock Linux unit moves from exit 0 (which never restarted it) to exit 1 (which does) — a `status=1/FAILURE` journal line right after an update is the restart working.

## Reload path

The frontend restarting path (update toast and settings dialog share `frontend/src/lib/server-restart.ts`) polls `/healthz` every 2s for up to 90s instead of reloading blind on a fixed 5s timer.

The outgoing process keeps listening for up to ~3.5s after it answers `POST /update` (500ms broadcast delay + 3s hard close fallback), and every version it can report is read from the install root the update just overwrote — so both liveness and version lie during that window. `/healthz` now carries a per-process `bootId` and `POST /update` returns the id of the process that is going away, so the client accepts a *changed* boot id as proof rather than reloading into the shutdown. Without a comparable id it falls back to two consecutive liveness answers, behind a 6s grace window. On timeout it shows "Server is taking longer than expected — reload manually." **with a working Reload action**, and both callers abort the wait on unmount/dismiss so a dismissed toast never reloads the page or writes state into a dead tree.

No new HTTP routes: `/update` and `/healthz` gained additive response fields only.

## Review trail

Adversarial review returned `block`; all six findings are applied in `6da38e20`:

| Sev | Finding | Applied |
| --- | --- | --- |
| P0 | `restartExitCode('stock-service')` returned 0, but the stock Linux unit is `Restart=on-failure` — the most common install was exactly the failure mode this PR exists to fix | Exit code is now a function of the supervisor: launchd 0, systemd 1 |
| P0 | Any `INVOCATION_ID` was treated as supervised, so a `Restart=no` unit (systemd's default) would be exited into a permanent outage | Owning unit + `Restart=` policy are read before the process bets on them; fail closed; `RELAY_UPDATE_RESTART` opt-out; `supervision` in the response |
| P2 | 4000ms grace left only a 500ms margin over the server's own exit budget, and the probe could not tell old process from new | `bootId` identity proof, two-confirmation liveness fallback, 6s grace |
| P2 | The stock branch bypassed the TTY/managed guard, so a hand-run hub on a box with the unit installed would exit into nothing | macOS branch requires launchd to name the stock job; Linux goes through the policy read |
| P3 | The awaited restart wait had no cancellation and the timeout path rendered dead copy | `AbortSignal` threaded through both callers; Reload action restored on timeout |
| P3 | Doc comment and deploy doc were factually wrong about `on-abnormal` and the `Restart=no` default | Corrected in `server/self-update.ts` and `docs/references/devbox-hub-deploy.md` |

## Verification

- `npm run check` — 0 errors (218 pre-existing sonarjs warnings)
- `npx vitest run test/self-update.test.ts test/server-restart-poll.test.ts test/health.test.ts test/startup-restore.test.ts test/server-startup.test.ts test/hub-node-packaging.test.ts test/auth.test.ts` — 104 passed, 0 failed

New coverage: the `Restart=` policy matrix (restarting vs non-restarting vs unreadable), the cgroup unit parser (v1/v2, user vs system, scopes and manager cgroups), the launchd stock-job guard, the `RELAY_UPDATE_RESTART` overrides, boot-id discrimination of the outgoing process, the liveness confirmation streak, and the abort path.

Closes #1285. Refs #1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updates now detect supervision settings and restart using the appropriate behavior.
  - Update responses include restart status and process identity for reliable recovery.
  - The interface waits for the server to return before reloading, with timeout messaging and a manual **Reload** option.
  - Settings updates use the same restart recovery flow and handle cancellation cleanly.

- **Documentation**
  - Expanded the deployment runbook with restart behavior and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->