### PR TITLE
fix(channels): route DM messages to the DM profile without requiring a literal mention

### DIFF
--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -115,10 +115,35 @@ conversation.
 
 1. subscribe to newly posted channel messages;
 2. resolve mentions against agent profiles;
-3. start or reuse one private runtime per `(channel, profileActorId)`;
-4. build a bounded context packet from durable channel history;
-5. queue and deliver the turn to the provider adapter;
-6. mirror the provider response into the originating channel or thread.
+3. fall back to implicit DM routing when a human message resolves none;
+4. start or reuse one private runtime per `(channel, profileActorId)`;
+5. build a bounded context packet from durable channel history;
+6. queue and deliver the turn to the provider adapter;
+7. mirror the provider response into the originating channel or thread.
+
+Implicit DM routing (step 3) is the routing half of "a DM is a channel with one
+agent". A message with zero resolved mentions is routed as follows:
+
+- DM channel, human sender → the default profile for the DM's provider, exactly
+  as if the provider had been mentioned. Threads included: a thread reply in a
+  DM routes implicitly too. Both DM composers therefore drop the `@ to mention`
+  hint.
+- DM channel, agent sender → nothing. An agent's own DM post cannot re-trigger
+  the DM's agent; the mention self-filter cannot see a message with no mentions.
+- Multi-party channel → nothing, silently (debug log only). Humans chat there
+  without addressing an agent, so a system row would be spam.
+
+A DM whose provider cannot be resolved at all posts one `nothing was routed`
+system row per five-minute dedupe window, because in a DM there is nobody else
+to answer and silence reads as the product being broken. That row is gated on
+the trigger's sender kind, so an agent's own unroutable `@mention` never stamps
+a failure under the human message that did route.
+
+DM-ness itself is derived, not stored: `shared/dm-channels.ts` recomputes the
+deterministic per-`(workspace, provider)` DM id and compares it to the topic's
+own id, so both halves — the UI's DM affordances and the binder's routing —
+read one pure derivation. A DM's agent is that provider's default profile,
+matching the DM-per-provider id formula.
 
 `server/channel-agent-runtime.ts` owns the private execution handle. A channel
 agent runtime is intentionally absent from public session lists, terminal

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -17,9 +17,23 @@ import { ChannelMessageRow } from './ChannelMessageRow.js';
 import { useFollowingScroll } from './useFollowingScroll.js';
 import { useLiveReplyGrowth } from './useLiveReplyGrowth.js';
 
+/** Default thread copy: `@` is required to reach an agent in a group channel. */
+const THREAD_PLACEHOLDER =
+  'reply in thread…  ·  @ to mention · shift+enter for newline';
+/**
+ * DM thread copy. `handleMessagePosted` has no `threadId` gate, so an
+ * unmentioned reply inside a DM thread routes implicitly exactly like a
+ * top-level DM message — the composer must not ask for the `@` it does not
+ * need. Kept name-free (unlike the channel composer) because the thread header
+ * already says "thread" and the DM header already names the agent.
+ */
+const DM_THREAD_PLACEHOLDER = 'reply in thread…  ·  shift+enter for newline';
+
 interface ChannelThreadPanelProps {
   channelId: string;
   channelTitle: string;
+  /** True when the channel is a DM (one agent, implicit routing). */
+  isDm?: boolean;
   rootId: ChannelMessageId;
   liveMessages: ChannelMessage[];
   onClose: () => void;
@@ -39,6 +53,7 @@ interface ChannelThreadPanelProps {
 export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
   channelId,
   channelTitle,
+  isDm = false,
   rootId,
   liveMessages,
   onClose,
@@ -217,7 +232,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
       <ChannelComposer
         channelId={channelId}
         channelTitle={channelTitle}
-        placeholder="reply in thread…  ·  @ to mention · shift+enter for newline"
+        placeholder={isDm ? DM_THREAD_PLACEHOLDER : THREAD_PLACEHOLDER}
         onSend={onSend}
         postPending={postPending}
         storeDown={storeDown}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -628,6 +628,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             key={activeThreadRootId}
             channelId={channelId}
             channelTitle={title}
+            isDm={isDm}
             rootId={activeThreadRootId}
             liveMessages={reducer.messages}
             onClose={() => setActiveThreadRootId(null)}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -107,6 +107,14 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       })
     : null;
 
+  // A DM addresses its one agent implicitly — the binder routes an unmentioned
+  // message to it — so the composer must not tell you to type `@` at the very
+  // agent the header already says you are talking to.
+  const dmPlaceholder =
+    isDm && dmIdentity
+      ? `message @${dmIdentity.label}…  ·  shift+enter for newline`
+      : null;
+
   const title = channel?.title ?? topicQuery.data?.display.title ?? channelId;
 
   // Unread line: captured once on mount (per channelId, since ChatHome keys this
@@ -604,6 +612,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
           <ChannelComposer
             channelId={channelId}
             channelTitle={title}
+            {...(dmPlaceholder ? { placeholder: dmPlaceholder } : {})}
             {...(channel?.members ? { members: channel.members } : {})}
             onSend={handleSend}
             postPending={postPending}

--- a/frontend/src/lib/dm-channels.ts
+++ b/frontend/src/lib/dm-channels.ts
@@ -1,117 +1,13 @@
-// DM-as-channel derivation (#1166, epic #1163). A "direct message" is not a
-// distinct backend entity — it is a regular `workspace_topics` channel whose id
-// follows a deterministic per-(workspace, framework) formula. DM-ness is a pure
-// client-side derivation from the topic's id + `routingDefaults.providerId`, so
-// no `WorkspaceTopicChannelKind` enum extension or server marker is required.
+// DM-as-channel derivation (#1166, epic #1163) — now owned by `shared/` so the
+// server's channel binder can route an unmentioned DM message to that channel's
+// one agent from the SAME pure derivation the UI renders from. The routing half
+// of the DM contract was originally client-only, which is why a DM message with
+// no literal @mention used to route to nobody, silently.
 //
-// See channel-ui-spec §0.2/§0.3 and §3.1.
-import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
-import type { WorkspaceTopicCreateInput } from '../../../shared/workspace-topics.js';
-import {
-  isLocalWorkspaceRef,
-  normalizeWorkspaceId,
-} from '../../../shared/workspace.js';
-
-/**
- * Slug segment a DM id uses for the local workspace. This is the LEGACY
- * `workspace:local` sentinel slug, deliberately frozen (#1287 slice 2): the DM
- * id is the `workspace_topics` id, and `channel_messages.channel_id` keys
- * transcript history off it. Re-deriving local DM ids to `ws-local` would mint
- * new channels and strand every existing DM's history behind the boot
- * `sweepOrphans` pass. The row's `workspaceId` COLUMN moves to the real seeded
- * workspace; the id does not.
- */
-const DM_LOCAL_WORKSPACE_SEGMENT = 'workspace-local';
-
-// A DM id is namespaced with `~` separators. No other id-minting path can emit
-// a `~`, though `~` is legal per the topic-id grammar
-// (`/^topic:[A-Za-z0-9._~%-]+$/`): `createWorkspaceTopicId` (deterministic
-// derived rows, plus every grandfathered title-slugged row) slugs down to
-// `[a-z0-9._-]`, and `mintWorkspaceTopicId` (#1287 slice 4, every new free-
-// titled chat) emits lowercase Crockford base32 only. Building the DM id
-// directly with `~` therefore puts it in an id sub-namespace nothing else can
-// collide with (a legacy topic titled "dm claude" would otherwise have minted
-// `topic:...-dm-claude`, the exact old DM id).
-const DM_ID_MARKER = 'dm~';
-
-/**
- * Length budget for one `~`-separated segment of a DM id.
- *
- * TRUNCATION IS LOSSY, SO THE INPUTS MUST BE BOUNDED. Two workspace ids that
- * share the first `DM_SEGMENT_MAX` slug characters derive the SAME DM id, and
- * `getOrCreateDmChannel` fetches by that id before creating — so a collision
- * silently reuses another workspace's DM row and files the conversation in the
- * wrong lane. The id cannot simply be re-derived to fix that later: it IS the
- * `workspace_topics` id and `channel_messages.channel_id` keys transcript
- * history off it (`docs/LEARNINGS.md` L-20260729-topic-id-title-slug).
- *
- * Every id-minting helper therefore keeps its output inside this budget:
- * `local` (frozen segment below), `createWorkspaceId(randomUUID())` (39 slug
- * chars), and `projectWorkspaceId` (29 — it digests the path precisely so it
- * fits; see `server/project-workspace.ts`). The one legacy shape that exceeds
- * it, `ws:migrated%3A<uuid>` at 50, still retains 34 characters of a v4 UUID
- * after truncation and so cannot collide either.
- */
-const DM_SEGMENT_MAX = 48;
-
-/** Slug a provider/workspace segment to the title-id charset (no `~`, no `%`). */
-function slugifyDmSegment(part: string): string {
-  return part
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, DM_SEGMENT_MAX);
-}
-
-/**
- * Deterministic per-(workspace, framework) DM channel id. Pure, no I/O.
- *
- * Every reference to the local workspace — `null`, the retired
- * `workspace:local`/`ws:derived` sentinels, and the new `ws:local` — collapses
- * onto ONE segment, so an existing local DM keeps its exact id (and therefore
- * its history) after the workspace-id migration. Named workspaces slug their
- * own id exactly as before.
- */
-export function dmChannelTopicId(
-  providerId: string,
-  workspaceId: string | null
-): string {
-  const provider = slugifyDmSegment(providerId) || 'agent';
-  const workspace = isLocalWorkspaceRef(workspaceId)
-    ? DM_LOCAL_WORKSPACE_SEGMENT
-    : slugifyDmSegment(workspaceId ?? '') || DM_LOCAL_WORKSPACE_SEGMENT;
-  return `topic:${DM_ID_MARKER}${provider}~${workspace}`;
-}
-
-/**
- * A topic is a DM iff its id matches the deterministic formula for its OWN
- * `routingDefaults.providerId`. Recomputes the id — no string-prefix guessing,
- * no server-side marker needed. Returns the provider id when true, else null.
- */
-export function isDmChannel(
-  topic: Pick<WorkspaceTopic, 'id' | 'workspaceId' | 'routingDefaults'>
-): string | null {
-  const providerId = topic.routingDefaults?.providerId;
-  if (!providerId) return null;
-  return topic.id === dmChannelTopicId(providerId, topic.workspaceId)
-    ? providerId
-    : null;
-}
-
-/** Build the POST /workspace-topics body for a new DM channel. */
-export function dmChannelCreateInput(input: {
-  providerId: string;
-  providerDisplayName: string;
-  workspaceId: string | null;
-}): WorkspaceTopicCreateInput {
-  // The id keeps the caller's raw reference (stable across the sentinel
-  // retirement); the persisted pointer is the real workspace id.
-  return {
-    id: dmChannelTopicId(input.providerId, input.workspaceId),
-    workspaceId: normalizeWorkspaceId(input.workspaceId),
-    title: input.providerDisplayName,
-    visibility: 'default',
-    routingDefaults: { providerId: input.providerId },
-  };
-}
+// This module stays put as the frontend's import site so every existing
+// `lib/dm-channels.js` import keeps working unchanged.
+export {
+  dmChannelCreateInput,
+  dmChannelTopicId,
+  isDmChannel,
+} from '../../../shared/dm-channels.js';

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -35,6 +35,7 @@ import {
 } from '../shared/channel-chat-protocol.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
+import { isDmChannel } from '../shared/dm-channels.js';
 import { workspaceTopicAgentRuntimeLinkPatch } from '../shared/workspace-topics.js';
 
 // @-mention routing binder (#1167, slice 4). One module owns the whole loop:
@@ -1307,13 +1308,41 @@ export function createChannelAgentBinder(
 
   // ── routing ─────────────────────────────────────────────────────────────────
 
+  /**
+   * Provider id of the single agent a DM channel belongs to, else null.
+   *
+   * A DM is not a distinct backend entity — it is a topic whose id equals the
+   * deterministic formula for its own `routingDefaults.providerId` (shared
+   * derivation, `shared/dm-channels.ts`). Without a topic store — or before the
+   * topic row exists — the binder cannot tell a DM from a group channel, so it
+   * fails closed to "not a DM" and keeps the multi-party silence rule.
+   */
+  function dmProviderIdFor(channelId: string): string | null {
+    const topic = topicStore?.get(channelId);
+    if (!topic) return null;
+    return isDmChannel(topic);
+  }
+
   function routeOne(trigger: ChannelMessage, profile: AgentProfile): void {
     void (async () => {
       try {
         const framework = profile.providerId;
         const target = await resolveTarget(framework);
         if (closed) return; // close() raced the availability probe
-        if (!target) return; // not a known framework — ignore silently
+        if (!target) {
+          // Not a known framework. In a multi-party channel an unroutable
+          // @name stays silent (§1). In a DM there is nobody ELSE to answer,
+          // so silence reads as the product being broken — say so instead.
+          if (dmProviderIdFor(trigger.channelId) !== null) {
+            postUnavailableRow(
+              trigger.channelId,
+              profile.id,
+              `nothing was routed — ${profile.displayName || framework} is unavailable.`,
+              parentForTrigger(trigger)
+            );
+          }
+          return;
+        }
         if (!target.available) {
           const senderDisplayName =
             profile.displayName || target.displayName || framework;
@@ -1515,9 +1544,41 @@ export function createChannelAgentBinder(
       return;
     }
     consecutiveAgentTurns.delete(message.channelId);
+    if (profiles.length === 0) {
+      routeImplicitDm(message);
+      return;
+    }
     for (const profile of profiles) {
       routeOne(message, profile);
     }
+  }
+
+  /**
+   * DM implicit routing. A DM is "a channel with one agent" (ADR-020,
+   * `docs/CHANNEL_CHAT.md`), so addressing it IS the mention — a human message
+   * in a DM must reach that agent with no literal `@name` typed.
+   *
+   * Only reached when the explicit-mention resolver produced ZERO routable
+   * profiles, so an explicit `@name` can never be double-routed, and only from
+   * the human branch of `handleMessagePosted`, so an agent's own DM post can
+   * never re-trigger itself (`eligibleProfiles`' self-filter does not cover a
+   * message with no mentions at all).
+   */
+  function routeImplicitDm(message: ChannelMessage): void {
+    const providerId = dmProviderIdFor(message.channelId);
+    if (providerId === null) {
+      // Legitimate in a multi-party channel: humans chat without addressing an
+      // agent. Logged, never announced — a system row here would spam #general.
+      logger.debug(
+        `message posted, 0 profiles routed, channel=${message.channelId} message=${message.id}`
+      );
+      return;
+    }
+    const profile = defaultProfileForProvider(providerId);
+    logger.debug(
+      `dm implicit route, channel=${message.channelId} provider=${providerId} profile=${profile.id}`
+    );
+    routeOne(message, profile);
   }
 
   function handleAssistantFinalized(message: ChannelMessage): void {

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -1331,9 +1331,21 @@ export function createChannelAgentBinder(
         if (closed) return; // close() raced the availability probe
         if (!target) {
           // Not a known framework. In a multi-party channel an unroutable
-          // @name stays silent (§1). In a DM there is nobody ELSE to answer,
-          // so silence reads as the product being broken — say so instead.
-          if (dmProviderIdFor(trigger.channelId) !== null) {
+          // @name stays silent (§1). In a DM there is nobody ELSE to answer the
+          // HUMAN, so silence reads as the product being broken — say so.
+          //
+          // Gated on the trigger's server-derived sender kind, not only on
+          // DM-ness: `routeOne` is shared with the agent lanes
+          // (handleAssistantFinalized → routeWithBrake, and gateway agent
+          // posts). `knownProviderIds` (every built-in adapter) is a superset of
+          // `mentionTargets` (the configured frameworks), so a DM agent's own
+          // reply text mentioning a known-but-de-configured provider would
+          // otherwise stamp "nothing was routed" under the human's message —
+          // while the human's message did route and was answered.
+          if (
+            trigger.sender.kind !== 'agent' &&
+            dmProviderIdFor(trigger.channelId) !== null
+          ) {
             postUnavailableRow(
               trigger.channelId,
               profile.id,

--- a/shared/dm-channels.ts
+++ b/shared/dm-channels.ts
@@ -1,0 +1,123 @@
+// DM-as-channel derivation (#1166, epic #1163). A "direct message" is not a
+// distinct backend entity — it is a regular `workspace_topics` channel whose id
+// follows a deterministic per-(workspace, framework) formula. DM-ness is a pure
+// derivation from the topic's id + `routingDefaults.providerId`, so no
+// `WorkspaceTopicChannelKind` enum extension or server marker is required.
+//
+// This lives in `shared/` because BOTH halves of the DM contract need it: the
+// client renders DM affordances from it, and the server's channel binder routes
+// an unmentioned DM message to that channel's one agent from it. It is pure (no
+// browser and no node built-ins) so either side may import it;
+// `frontend/src/lib/dm-channels.ts` re-exports it verbatim.
+//
+// See channel-ui-spec §0.2/§0.3 and §3.1, and `docs/CHANNEL_CHAT.md`.
+import type { WorkspaceTopic } from './workspace-topics.js';
+import type { WorkspaceTopicCreateInput } from './workspace-topics.js';
+import {
+  isLocalWorkspaceRef,
+  normalizeWorkspaceId,
+} from './workspace.js';
+
+/**
+ * Slug segment a DM id uses for the local workspace. This is the LEGACY
+ * `workspace:local` sentinel slug, deliberately frozen (#1287 slice 2): the DM
+ * id is the `workspace_topics` id, and `channel_messages.channel_id` keys
+ * transcript history off it. Re-deriving local DM ids to `ws-local` would mint
+ * new channels and strand every existing DM's history behind the boot
+ * `sweepOrphans` pass. The row's `workspaceId` COLUMN moves to the real seeded
+ * workspace; the id does not.
+ */
+const DM_LOCAL_WORKSPACE_SEGMENT = 'workspace-local';
+
+// A DM id is namespaced with `~` separators. No other id-minting path can emit
+// a `~`, though `~` is legal per the topic-id grammar
+// (`/^topic:[A-Za-z0-9._~%-]+$/`): `createWorkspaceTopicId` (deterministic
+// derived rows, plus every grandfathered title-slugged row) slugs down to
+// `[a-z0-9._-]`, and `mintWorkspaceTopicId` (#1287 slice 4, every new free-
+// titled chat) emits lowercase Crockford base32 only. Building the DM id
+// directly with `~` therefore puts it in an id sub-namespace nothing else can
+// collide with (a legacy topic titled "dm claude" would otherwise have minted
+// `topic:...-dm-claude`, the exact old DM id).
+const DM_ID_MARKER = 'dm~';
+
+/**
+ * Length budget for one `~`-separated segment of a DM id.
+ *
+ * TRUNCATION IS LOSSY, SO THE INPUTS MUST BE BOUNDED. Two workspace ids that
+ * share the first `DM_SEGMENT_MAX` slug characters derive the SAME DM id, and
+ * `getOrCreateDmChannel` fetches by that id before creating — so a collision
+ * silently reuses another workspace's DM row and files the conversation in the
+ * wrong lane. The id cannot simply be re-derived to fix that later: it IS the
+ * `workspace_topics` id and `channel_messages.channel_id` keys transcript
+ * history off it (`docs/LEARNINGS.md` L-20260729-topic-id-title-slug).
+ *
+ * Every id-minting helper therefore keeps its output inside this budget:
+ * `local` (frozen segment below), `createWorkspaceId(randomUUID())` (39 slug
+ * chars), and `projectWorkspaceId` (29 — it digests the path precisely so it
+ * fits; see `server/project-workspace.ts`). The one legacy shape that exceeds
+ * it, `ws:migrated%3A<uuid>` at 50, still retains 34 characters of a v4 UUID
+ * after truncation and so cannot collide either.
+ */
+const DM_SEGMENT_MAX = 48;
+
+/** Slug a provider/workspace segment to the title-id charset (no `~`, no `%`). */
+function slugifyDmSegment(part: string): string {
+  return part
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, DM_SEGMENT_MAX);
+}
+
+/**
+ * Deterministic per-(workspace, framework) DM channel id. Pure, no I/O.
+ *
+ * Every reference to the local workspace — `null`, the retired
+ * `workspace:local`/`ws:derived` sentinels, and the new `ws:local` — collapses
+ * onto ONE segment, so an existing local DM keeps its exact id (and therefore
+ * its history) after the workspace-id migration. Named workspaces slug their
+ * own id exactly as before.
+ */
+export function dmChannelTopicId(
+  providerId: string,
+  workspaceId: string | null
+): string {
+  const provider = slugifyDmSegment(providerId) || 'agent';
+  const workspace = isLocalWorkspaceRef(workspaceId)
+    ? DM_LOCAL_WORKSPACE_SEGMENT
+    : slugifyDmSegment(workspaceId ?? '') || DM_LOCAL_WORKSPACE_SEGMENT;
+  return `topic:${DM_ID_MARKER}${provider}~${workspace}`;
+}
+
+/**
+ * A topic is a DM iff its id matches the deterministic formula for its OWN
+ * `routingDefaults.providerId`. Recomputes the id — no string-prefix guessing,
+ * no server-side marker needed. Returns the provider id when true, else null.
+ */
+export function isDmChannel(
+  topic: Pick<WorkspaceTopic, 'id' | 'workspaceId' | 'routingDefaults'>
+): string | null {
+  const providerId = topic.routingDefaults?.providerId;
+  if (!providerId) return null;
+  return topic.id === dmChannelTopicId(providerId, topic.workspaceId)
+    ? providerId
+    : null;
+}
+
+/** Build the POST /workspace-topics body for a new DM channel. */
+export function dmChannelCreateInput(input: {
+  providerId: string;
+  providerDisplayName: string;
+  workspaceId: string | null;
+}): WorkspaceTopicCreateInput {
+  // The id keeps the caller's raw reference (stable across the sentinel
+  // retirement); the persisted pointer is the real workspace id.
+  return {
+    id: dmChannelTopicId(input.providerId, input.workspaceId),
+    workspaceId: normalizeWorkspaceId(input.workspaceId),
+    title: input.providerDisplayName,
+    visibility: 'default',
+    routingDefaults: { providerId: input.providerId },
+  };
+}

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -18,6 +18,10 @@ import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
 import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import {
+  dmChannelCreateInput,
+  dmChannelTopicId,
+} from '../shared/dm-channels.js';
+import {
   createAgentProfileStore,
   type AgentProfileStore,
 } from '../server/agent-profile-store.js';
@@ -3105,5 +3109,208 @@ describe('channel-agent-binder — topic participant links', () => {
     expect(topicStore.get(CH)?.linkedRefs.agentRuntimeIds).toEqual([
       sessions.firstSessionId(),
     ]);
+  });
+});
+
+// ── #1166 routing half: a DM is "a channel with one agent", so addressing the
+// channel IS the mention. Before this lane a DM message with no literal @name
+// resolved zero profiles and returned with zero rows and zero logs — the agent
+// never heard you and nothing said so.
+
+describe('channel-agent-binder — DM implicit routing', () => {
+  const DM_WORKSPACE = 'ws:local';
+  const DM_CH = dmChannelTopicId('hermes', DM_WORKSPACE);
+  const HERMES_TARGETS: MentionTarget[] = [
+    {
+      id: 'hermes',
+      displayName: 'Hermes',
+      kind: 'framework',
+      available: true,
+      reason: null,
+    },
+  ];
+  /** A bound hermes reply posting back into its own DM (self-trigger bait). */
+  const HERMES_AGENT_SENDER: ChannelSenderRef = {
+    kind: 'agent',
+    id: builtInAgentProfileId('hermes'),
+    providerId: 'hermes',
+    displayName: 'Hermes',
+  };
+
+  function makeTopics(): WorkspaceTopicStore {
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    return topics;
+  }
+
+  function createDmTopic(topics: WorkspaceTopicStore): void {
+    topics.create(
+      dmChannelCreateInput({
+        providerId: 'hermes',
+        providerDisplayName: 'Hermes',
+        workspaceId: DM_WORKSPACE,
+      })
+    );
+  }
+
+  function postTo(
+    store: ChannelMessageStore,
+    binder: ChannelAgentBinder,
+    channelId: string,
+    text: string,
+    sender: ChannelSenderRef = OPERATOR
+  ): ChannelMessage {
+    const mentions = parseMentions(text, ['hermes']);
+    const message = store.appendComplete({
+      channelId,
+      sender,
+      text,
+      ...(mentions.length ? { mentions } : {}),
+    });
+    binder.handleMessagePosted(message, message.mentions ?? []);
+    return message;
+  }
+
+  function repliesIn(store: ChannelMessageStore, channelId: string) {
+    return store
+      .history(channelId, { limit: 200 })
+      .filter(
+        (m) =>
+          m.sender.kind === 'agent' && m.status === 'complete' && !m.agentDetail
+      );
+  }
+
+  function systemRowsIn(store: ChannelMessageStore, channelId: string) {
+    return store
+      .history(channelId, { limit: 200 })
+      .filter((m) => m.kind === 'system');
+  }
+
+  /** Let every queued microtask + availability probe drain before asserting a negative. */
+  const settle = () => new Promise((r) => setTimeout(r, 60));
+
+  it('routes an unmentioned human DM message to the channel agent', async () => {
+    const topics = makeTopics();
+    createDmTopic(topics);
+    const adapter = new ScriptedAdapter('hermes', {
+      mode: 'reply',
+      text: 'on it',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => adapter,
+      targets: HERMES_TARGETS,
+      knownProviderIds: ['hermes'],
+      topicStore: topics,
+    });
+
+    postTo(store, binder, DM_CH, 'what is the state of the build?');
+
+    await waitFor(() => repliesIn(store, DM_CH).length === 1);
+    expect(repliesIn(store, DM_CH)[0]!.body.text).toBe('on it');
+    expect(adapter.sendCalls).toHaveLength(1);
+    // The DM's single agent is that provider's DEFAULT profile actor.
+    expect(sessions.lastCreateParams()).toMatchObject({
+      providerId: 'hermes',
+      profileActorId: builtInAgentProfileId('hermes'),
+    });
+  });
+
+  it('does not double-route an explicit @mention in a DM', async () => {
+    const topics = makeTopics();
+    createDmTopic(topics);
+    const adapter = new ScriptedAdapter('hermes', {
+      mode: 'reply',
+      text: 'ack',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => adapter,
+      targets: HERMES_TARGETS,
+      knownProviderIds: ['hermes'],
+      topicStore: topics,
+    });
+
+    postTo(store, binder, DM_CH, '@hermes ship it');
+
+    await waitFor(() => repliesIn(store, DM_CH).length === 1);
+    await settle();
+    // Exactly ONE turn: the explicit mention resolved, so the implicit DM path
+    // must not fire a second copy of the same message.
+    expect(adapter.sendCalls).toHaveLength(1);
+    expect(repliesIn(store, DM_CH)).toHaveLength(1);
+    expect(sessions.spawns()).toBe(1);
+  });
+
+  it('never self-routes an agent-authored DM post', async () => {
+    const topics = makeTopics();
+    createDmTopic(topics);
+    const adapter = new ScriptedAdapter('hermes', {
+      mode: 'reply',
+      text: 'loop',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => adapter,
+      targets: HERMES_TARGETS,
+      knownProviderIds: ['hermes'],
+      topicStore: topics,
+    });
+
+    // An unmentioned post from the DM's OWN agent. `eligibleProfiles`' self
+    // filter cannot catch this — there are no mentions to filter — so the
+    // implicit path must be gated on sender kind instead.
+    postTo(store, binder, DM_CH, 'still working on it', HERMES_AGENT_SENDER);
+
+    await settle();
+    expect(adapter.sendCalls).toHaveLength(0);
+    expect(sessions.spawns()).toBe(0);
+    expect(systemRowsIn(store, DM_CH)).toHaveLength(0);
+  });
+
+  it('says so out loud when a DM agent is not routable', async () => {
+    const topics = makeTopics();
+    createDmTopic(topics);
+    const adapter = new ScriptedAdapter('hermes', {
+      mode: 'reply',
+      text: 'never',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => adapter,
+      targets: [], // hermes is not a known framework on this hub
+      knownProviderIds: ['hermes'],
+      topicStore: topics,
+    });
+
+    postTo(store, binder, DM_CH, 'are you there?');
+
+    await waitFor(() => systemRowsIn(store, DM_CH).length === 1);
+    expect(systemRowsIn(store, DM_CH)[0]!.body.text).toContain(
+      'nothing was routed'
+    );
+    expect(sessions.spawns()).toBe(0);
+    expect(adapter.sendCalls).toHaveLength(0);
+  });
+
+  it('stays silent in a multi-party channel with no mentions', async () => {
+    const topics = makeTopics();
+    createDmTopic(topics); // the DM exists; this post just is not in it
+    topics.create({ id: CH, workspaceId: DM_WORKSPACE, title: 'general' });
+    const adapter = new ScriptedAdapter('hermes', {
+      mode: 'reply',
+      text: 'never',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => adapter,
+      targets: HERMES_TARGETS,
+      knownProviderIds: ['hermes'],
+      topicStore: topics,
+    });
+
+    postTo(store, binder, CH, 'morning everyone');
+
+    await settle();
+    expect(adapter.sendCalls).toHaveLength(0);
+    expect(sessions.spawns()).toBe(0);
+    // Humans chat without addressing an agent — a system row here is spam.
+    expect(systemRowsIn(store, CH)).toHaveLength(0);
+    expect(repliesIn(store, CH)).toHaveLength(0);
   });
 });

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -3158,9 +3158,10 @@ describe('channel-agent-binder — DM implicit routing', () => {
     binder: ChannelAgentBinder,
     channelId: string,
     text: string,
-    sender: ChannelSenderRef = OPERATOR
+    sender: ChannelSenderRef = OPERATOR,
+    providers: string[] = ['hermes']
   ): ChannelMessage {
-    const mentions = parseMentions(text, ['hermes']);
+    const mentions = parseMentions(text, providers);
     const message = store.appendComplete({
       channelId,
       sender,
@@ -3263,6 +3264,49 @@ describe('channel-agent-binder — DM implicit routing', () => {
     expect(adapter.sendCalls).toHaveLength(0);
     expect(sessions.spawns()).toBe(0);
     expect(systemRowsIn(store, DM_CH)).toHaveLength(0);
+  });
+
+  it('never blames the human for an AGENT-authored unroutable mention in a DM', async () => {
+    const topics = makeTopics();
+    createDmTopic(topics);
+    // The DM agent's own reply mentions a provider that is MENTIONABLE
+    // (`knownProviderIds` = every built-in adapter) but not a configured
+    // routing target (`mentionTargets` = the configured frameworks).
+    const adapter = new ScriptedAdapter('hermes', {
+      mode: 'reply',
+      text: 'looking now — @codex can you diff the branch?',
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => adapter,
+      targets: HERMES_TARGETS, // codex resolves, but is not a target
+      knownProviderIds: ['hermes', 'codex'],
+      topicStore: topics,
+    });
+
+    postTo(store, binder, DM_CH, 'what is the state of the build?');
+
+    await waitFor(() => repliesIn(store, DM_CH).length === 1);
+    await settle();
+    // The human's message routed and WAS answered. `routeOne` is shared with
+    // the agent lanes, so the DM "nothing was routed" row must be gated on the
+    // trigger's sender kind, not on DM-ness alone: otherwise the agent's own
+    // dead @mention stamps a failure row under the human's trigger claiming
+    // nothing was routed, while the human was in fact answered.
+    expect(systemRowsIn(store, DM_CH)).toHaveLength(0);
+    expect(sessions.spawns()).toBe(1);
+
+    // Same gate for the other agent lane: a gateway agent post in the DM.
+    postTo(
+      store,
+      binder,
+      DM_CH,
+      '@codex following up',
+      HERMES_AGENT_SENDER,
+      ['hermes', 'codex']
+    );
+    await settle();
+    expect(systemRowsIn(store, DM_CH)).toHaveLength(0);
+    expect(sessions.spawns()).toBe(1);
   });
 
   it('says so out loud when a DM agent is not routable', async () => {

--- a/test/components/channel-view-dm-composer.test.ts
+++ b/test/components/channel-view-dm-composer.test.ts
@@ -2,13 +2,17 @@
 //
 // #1166 routing half, composer copy. A DM routes an unmentioned message to its
 // one agent implicitly, so the composer must stop telling you to type `@` at
-// the very agent the header already says you are talking to.
+// the very agent the header already says you are talking to. Covers BOTH
+// composers a DM exposes: the channel composer and the thread composer —
+// `handleMessagePosted` has no `threadId` gate, so a thread reply in a DM
+// routes implicitly too.
 
 import React, { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import type { ChannelMessageId } from '../../shared/channel-chat-protocol.js';
 import { dmChannelTopicId } from '../../shared/dm-channels.js';
 
 (
@@ -73,8 +77,20 @@ vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
 vi.mock('../../frontend/src/components/chat/ChannelTimeline.js', () => ({
   ChannelTimeline: () => null,
 }));
-vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
-  ChannelThreadPanel: () => null,
+// ChannelThreadPanel is deliberately REAL here: its composer copy is the thing
+// under test, and only the live ChannelView → panel wiring proves a DM thread
+// actually gets the DM copy. Only its data hook is stubbed.
+vi.mock('../../frontend/src/hooks/useChannelThread.js', () => ({
+  useChannelThread: () => ({
+    root: null,
+    replies: [],
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    loading: false,
+    error: null,
+    rootFloorRevision: 0,
+  }),
 }));
 vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
   ChannelComposer: (props: Record<string, unknown>) => {
@@ -86,6 +102,9 @@ vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
 const { ChannelView } = await import(
   '../../frontend/src/components/chat/ChannelView.js'
 );
+const { useUiStore } = await import('../../frontend/src/lib/stores/ui.js');
+
+const THREAD_ROOT_ID = 'chm:root-1' as ChannelMessageId;
 
 let container: HTMLDivElement;
 let root: Root;
@@ -116,6 +135,21 @@ function latestPlaceholder(): unknown {
   return mocks.composerProps.at(-1)?.['placeholder'];
 }
 
+/** Every placeholder any composer has been handed this render pass. */
+function placeholders(): string[] {
+  return mocks.composerProps
+    .map((props) => props['placeholder'])
+    .filter((value): value is string => typeof value === 'string');
+}
+
+/** Open the thread panel on the channel already on screen. */
+async function openThread(channelId: string): Promise<void> {
+  await act(async () => {
+    useUiStore.getState().requestChannelThread(channelId, THREAD_ROOT_ID);
+  });
+  await flush();
+}
+
 beforeEach(() => {
   mocks.fetchWorkspaceTopic.mockReset();
   mocks.fetchChannelRoster.mockReset();
@@ -126,6 +160,11 @@ beforeEach(() => {
     addEventListener: () => {},
     removeEventListener: () => {},
   }));
+  useUiStore.setState({
+    activeChannelId: null,
+    activeThreadRootId: null,
+    pendingChannelThread: null,
+  });
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 0 } },
   });
@@ -140,6 +179,11 @@ afterEach(async () => {
   container.remove();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  useUiStore.setState({
+    activeChannelId: null,
+    activeThreadRootId: null,
+    pendingChannelThread: null,
+  });
 });
 
 describe('ChannelView composer copy', () => {
@@ -178,5 +222,49 @@ describe('ChannelView composer copy', () => {
     // No override: ChannelComposer keeps its own `#channel… · @ to mention`
     // default, which is still the right instruction where @ is required.
     expect(latestPlaceholder()).toBeUndefined();
+  });
+
+  it('drops the mention hint from a DM thread composer too', async () => {
+    mocks.channelId = DM_CHANNEL_ID;
+    mocks.channelTitle = 'Claude Code';
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: DM_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'Claude Code' },
+      routingDefaults: { providerId: 'claude' },
+    });
+
+    await render(DM_CHANNEL_ID);
+    mocks.composerProps.length = 0;
+    await openThread(DM_CHANNEL_ID);
+
+    // A thread reply in a DM routes implicitly exactly like a top-level one
+    // (no `threadId` gate in the binder), so neither composer may ask for `@`.
+    expect(placeholders()).toContain(
+      'reply in thread…  ·  shift+enter for newline'
+    );
+    expect(placeholders().some((copy) => copy.includes('to mention'))).toBe(
+      false
+    );
+  });
+
+  it('keeps the mention hint on a multi-party thread composer', async () => {
+    mocks.channelId = GROUP_CHANNEL_ID;
+    mocks.channelTitle = 'general';
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: GROUP_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'general' },
+      routingDefaults: {},
+    });
+
+    await render(GROUP_CHANNEL_ID);
+    mocks.composerProps.length = 0;
+    await openThread(GROUP_CHANNEL_ID);
+
+    // Nothing implicit here — `@` is still the only way to reach an agent.
+    expect(placeholders()).toContain(
+      'reply in thread…  ·  @ to mention · shift+enter for newline'
+    );
   });
 });

--- a/test/components/channel-view-dm-composer.test.ts
+++ b/test/components/channel-view-dm-composer.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+//
+// #1166 routing half, composer copy. A DM routes an unmentioned message to its
+// one agent implicitly, so the composer must stop telling you to type `@` at
+// the very agent the header already says you are talking to.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { dmChannelTopicId } from '../../shared/dm-channels.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const DM_CHANNEL_ID = dmChannelTopicId('claude', 'ws:local');
+const GROUP_CHANNEL_ID = 'topic:general';
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  composerProps: [] as Record<string, unknown>[],
+  channelId: 'topic:unset',
+  channelTitle: 'unset',
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+  };
+});
+
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: mocks.channelId,
+      title: mocks.channelTitle,
+      visibility: 'default',
+      archived: false,
+      latestSeq: 0,
+      messageCount: 0,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: mocks.channelId,
+      messages: [],
+      lastSeq: 0,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    fullSnapshotRevision: 0,
+    post: vi.fn(),
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+vi.mock('../../frontend/src/components/chat/ChannelTimeline.js', () => ({
+  ChannelTimeline: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
+  ChannelThreadPanel: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
+  ChannelComposer: (props: Record<string, unknown>) => {
+    mocks.composerProps.push(props);
+    return null;
+  },
+}));
+
+const { ChannelView } = await import(
+  '../../frontend/src/components/chat/ChannelView.js'
+);
+
+let container: HTMLDivElement;
+let root: Root;
+let queryClient: QueryClient;
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+async function render(channelId: string): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(ChannelView, { channelId })
+      )
+    );
+  });
+  await flush();
+}
+
+function latestPlaceholder(): unknown {
+  return mocks.composerProps.at(-1)?.['placeholder'];
+}
+
+beforeEach(() => {
+  mocks.fetchWorkspaceTopic.mockReset();
+  mocks.fetchChannelRoster.mockReset();
+  mocks.fetchChannelRoster.mockResolvedValue([]);
+  mocks.composerProps.length = 0;
+  vi.stubGlobal('matchMedia', () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  queryClient.clear();
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('ChannelView composer copy', () => {
+  it('addresses the agent and drops the mention hint inside a DM', async () => {
+    mocks.channelId = DM_CHANNEL_ID;
+    mocks.channelTitle = 'Claude Code';
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: DM_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'Claude Code' },
+      routingDefaults: { providerId: 'claude' },
+    });
+
+    await render(DM_CHANNEL_ID);
+
+    const placeholder = latestPlaceholder();
+    expect(typeof placeholder).toBe('string');
+    expect(placeholder as string).toMatch(/^message @/);
+    // The DM routes implicitly — never prompt for the `@` it does not need.
+    expect(placeholder as string).not.toContain('to mention');
+    expect(placeholder as string).not.toContain('#');
+  });
+
+  it('leaves a multi-party channel on the default `#channel` copy', async () => {
+    mocks.channelId = GROUP_CHANNEL_ID;
+    mocks.channelTitle = 'general';
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: GROUP_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'general' },
+      routingDefaults: {},
+    });
+
+    await render(GROUP_CHANNEL_ID);
+
+    // No override: ChannelComposer keeps its own `#channel… · @ to mention`
+    // default, which is still the right instruction where @ is required.
+    expect(latestPlaceholder()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Root cause — the routing half of the DM design was never built

`docs/CHANNEL_CHAT.md` and ADR-020 both state the contract plainly: **a DM is a
channel with one agent profile**. Only the *rendering* half of that contract was
ever implemented.

`dmChannelTopicId` / `isDmChannel` lived in `frontend/src/lib/dm-channels.ts` —
frontend-only. The server read a topic's `routingDefaults.providerId` for mention
*vocabulary* and validation, but never for *routing*. Nothing on the server could
tell a DM from a group channel, so a DM inherited the multi-party rule verbatim:
**no `@mention` → no route.**

### The silent zero-route trace

A human posts `what is the state of the build?` in the hermes DM:

1. `channel-chat-router` persists the row, `hub.onMessagePosted` fires.
2. `handleMessagePosted` → `currentProfileMentions` → `parseMentions` → `[]`.
3. `eligibleProfiles([])` → `[]`.
4. `for (const profile of profiles)` iterates zero times.
5. Return.

Zero rows written. Zero log lines. No binding, no spawn, no error, no system row.
The agent never heard you and **nothing said so** — the worst shape a bug can
take in a chat product, because the surface is indistinguishable from an agent
that is merely slow.

## Fix

- **`shared/dm-channels.ts`** — move the pure DM derivation out of the frontend so
  both halves read one source. No browser and no node built-ins, so either side may
  import it. `frontend/src/lib/dm-channels.ts` stays put as a verbatim re-export, so
  every existing import site is untouched.
- **`server/channel-agent-binder.ts`** — when a **human** post resolves zero routable
  profiles and the topic derives as a DM, route it to that provider's default profile,
  exactly as if the provider had been mentioned.

### Guards

| Guard | Why |
| --- | --- |
| Only when `profiles.length === 0` | An explicit `@name` can never be double-routed. |
| Only on the non-agent branch | An agent's own DM post cannot self-trigger. `eligibleProfiles`' self-filter is a *mention* filter — it cannot see a message with **no mentions at all**. |
| `dmProviderIdFor` fails closed | No topic store, or no topic row yet → "not a DM" → multi-party silence rule holds. |
| Multi-party stays silent | Humans chat in `#general` without addressing an agent. Debug log only; a system row there would be spam. |

### Silence-row behavior

A DM whose provider cannot be resolved at all now posts one
`nothing was routed — <name> is unavailable.` system row (deduped per 5-minute TTL)
instead of returning quietly. In a group channel an unroutable `@name` stays silent
because somebody else can still answer; in a DM there is nobody else, so silence
reads as the product being broken.

That row is gated on **the trigger's server-derived sender kind**, not on DM-ness
alone — see the review trail below.

### Composer copy

A DM composer reads `message @<name>…  ·  shift+enter for newline`. It used to
instruct `@ to mention`: the exact keystroke the channel no longer needs, at the
very agent the header already says you are talking to. Both DM composers are
covered — `handleMessagePosted` has no `threadId` gate, so a thread reply inside a
DM routes implicitly too, and `ChannelThreadPanel` now takes `isDm` and drops the
hint to match.

## Review trail

One adversarial review ran before this PR (verdict: *concern*). All findings batched
into one fix pass:

- **P2 — the unroutable row was not structurally gated to humans.** `routeOne` is shared
  by the human path **and** both agent paths (`handleAssistantFinalized` → `routeWithBrake`,
  and gateway agent posts); the only gate was DM-ness. Reachable because
  `knownProviderIds` (every built-in adapter) is a **superset** of `mentionTargets` (the
  configured frameworks): in a hermes DM, a hermes reply containing `@codex` with codex
  de-configured stamped `nothing was routed — codex is unavailable.` under the *human's*
  trigger via `parentForTrigger` — while the human's message had in fact routed and been
  answered. Actively misleading copy. **Fixed**: gated on `trigger.sender.kind !== 'agent'`
  as well, with a binder test covering both agent lanes.
- **P3 — DM thread composer kept the `@ to mention` copy.** The exact bug the ChannelView
  change fixed, left in place one component over. **Fixed**: `isDm` threaded through;
  the test now renders the *real* `ChannelThreadPanel` (only its data hook stubbed) so
  the wiring is proven rather than mocked away.
- **P3 — routing-contract change landed without its doc.** **Fixed**: `docs/CHANNEL_CHAT.md`
  § *Mentions and private runtimes* now documents the human/agent/multi-party matrix, the
  DM silence break and its sender-kind gate, and the shared derivation.
- **P3 (follow-up, not in this PR) — DM label source.** `ChannelView` derives the DM label
  from `builtInAgentProfileId(providerId)` (the vendor's built-in default), while the binder
  routes through `agentProfileStore.getDefaultForProvider(providerId)`, which can be a
  user-created custom default. With a custom default named e.g. "Ares" for hermes, the
  composer would read `message @hermes…` while the reply arrives from "Ares". Pre-existing
  header mismatch that the new placeholder makes load-bearing; the fix needs a decision on
  reading the roster's `isDefault` row instead of the built-in id, so it is deliberately
  scoped out.

## Verification

- `npm run check` — **0 errors** (218 pre-existing `sonarjs` warnings, unchanged).
- `npm test` — **442 files / 5497 tests passed, 0 failed** at this head.
- New binder tests (`test/channel-agent-binder.test.ts`, `DM implicit routing`):
  routes an unmentioned human DM message to the channel agent (asserting the spawn
  uses `profileActorId: builtInAgentProfileId('hermes')`); does not double-route an
  explicit `@mention`; never self-routes an agent-authored DM post; never blames the
  human for an agent-authored unroutable mention (both agent lanes); says so out loud
  when a DM agent is not routable; stays silent in a multi-party channel.
- New component tests (`test/components/channel-view-dm-composer.test.ts`): DM and
  group copy for the channel composer and the thread composer.

### Anti-vacuity

Each guard was reverted individually and the corresponding test confirmed red:

- revert the implicit-route hunk → `routes an unmentioned human DM message` red.
- revert the sender-kind gate → `never blames the human for an AGENT-authored
  unroutable mention in a DM` red (`expected 0 system rows, received 1`).
- revert the thread placeholder branch → `drops the mention hint from a DM thread
  composer too` red.

Found via dogfood on the :3456 prod hub (hermes DM no-reply). Refs #1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct messages now automatically route unaddressed human messages to the default agent.
  * Direct-message threads use clearer composer prompts without mention instructions.
  * Unavailable direct-message agents display a deduplicated system notification.
  * Group channels continue requiring explicit mentions and ignore unaddressed messages.

* **Bug Fixes**
  * Prevented agent-authored messages from triggering responses to themselves.
  * Avoided duplicate routing when an agent is explicitly mentioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->