### PR TITLE
feat(chat): in-timeline agent presence row (X is thinking…) + opencode streaming flag

### DIFF
--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -9,6 +9,12 @@ import {
   formatDayLabel,
   selectTopLevel,
 } from '../../lib/chat/channel-timeline-layout.js';
+import {
+  channelPresenceCopy,
+  type ChannelAgentPresence,
+} from '../../lib/chat/channel-agent-presence.js';
+import { AgentBadge } from '../AgentBadge.js';
+import { TuiProgress } from '../TuiProgress.js';
 import { ChannelMessageGroup } from './ChannelMessageGroup.js';
 import { ChannelMessageRow } from './ChannelMessageRow.js';
 import { useFollowingScroll } from './useFollowingScroll.js';
@@ -31,6 +37,12 @@ interface ChannelTimelineProps {
   replyOnlyBackfillPaused?: boolean;
   onContinueHistory?: () => void;
   onOpenThread?: (rootId: ChannelMessageId) => void;
+  /**
+   * Busy agents with no live streaming row of their own (#1277). Already
+   * filtered by `selectChannelAgentPresence` — the timeline renders what it is
+   * given and owns no presence policy.
+   */
+  agentPresence?: readonly ChannelAgentPresence[];
 }
 
 export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
@@ -47,6 +59,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   replyOnlyBackfillPaused = false,
   onContinueHistory,
   onOpenThread,
+  agentPresence = [],
 }) => {
   const [showResyncButton, setShowResyncButton] = useState(false);
 
@@ -185,6 +198,41 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
               />
             );
           })}
+          {agentPresence.length > 0 ? (
+            // Lives INSIDE `.ch-tl-content` on purpose: `useFollowingScroll`
+            // observes that element, so the row appearing/disappearing is a
+            // content resize the follow model already bottom-anchors. It carries
+            // no `data-channel-message-seq`, so it can never become a reader
+            // anchor, and it changes no message seq, so the "n new messages"
+            // pill cannot be inflated by presence.
+            <div className="ch-presence" aria-label="agent presence">
+              {agentPresence.map((presence) => (
+                <div
+                  key={presence.agentId}
+                  className={`ch-presence__row ch-presence__row--${presence.status}`}
+                  data-channel-presence-agent={presence.agentId}
+                  data-channel-presence-status={presence.status}
+                >
+                  {presence.glyph ? (
+                    <span
+                      className="ch-presence__glyph"
+                      style={{ color: presence.colorVar }}
+                      aria-hidden="true"
+                    >
+                      <AgentBadge agent={presence.glyph} />
+                    </span>
+                  ) : null}
+                  <TuiProgress
+                    variant="braille"
+                    className="ch-presence__spinner"
+                  />
+                  <span className="ch-presence__label">
+                    {channelPresenceCopy(presence)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
       {newMessageCount > 0 ? (

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -147,7 +147,18 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
         ) : loadingOlder ? (
           <div className="ch-loading-older">loading older messages…</div>
         ) : null}
-        <div ref={contentRef} className="ch-tl-content">
+        <div
+          ref={contentRef}
+          className={
+            // With zero history the presence row is the only content, and `.ch-tl`
+            // is a top-anchored flex column — the row would otherwise sit alone in
+            // the top-left corner of a full-height blank pane. Bottom-anchor only
+            // in that case so the normal scroll model is untouched (#1277 review).
+            nodes.length === 0 && agentPresence.length > 0
+              ? 'ch-tl-content ch-tl-content--presence-only'
+              : 'ch-tl-content'
+          }
+        >
           {nodes.map((node, index) => {
             if (node.kind === 'day-divider') {
               return (
@@ -205,7 +216,17 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
             // no `data-channel-message-seq`, so it can never become a reader
             // anchor, and it changes no message seq, so the "n new messages"
             // pill cannot be inflated by presence.
-            <div className="ch-presence" aria-label="agent presence">
+            // `role="status"` (implicit polite) makes this the innermost live
+            // region, so a transition is announced ONCE here instead of by the
+            // enclosing `role="log"`. The spinner is `aria-hidden`: its text
+            // mutates every 80ms and is pure decoration — without that, a nested
+            // live region would announce ~12x/second per busy agent.
+            <div
+              className="ch-presence"
+              role="status"
+              aria-live="polite"
+              aria-label="agent presence"
+            >
               {agentPresence.map((presence) => (
                 <div
                   key={presence.agentId}
@@ -225,6 +246,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                   <TuiProgress
                     variant="braille"
                     className="ch-presence__spinner"
+                    aria-hidden="true"
                   />
                   <span className="ch-presence__label">
                     {channelPresenceCopy(presence)}

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -263,6 +263,14 @@
   min-width: 0;
 }
 
+/* Presence row with no history behind it: push it to the foot of the pane next
+   to the composer instead of stranding it in the top-left corner. `margin-top`
+   auto resolves to 0 once content overflows, so the scroll model is unchanged
+   and this class is only applied when the timeline holds no message nodes. */
+.ch-tl-content--presence-only {
+  margin-top: auto;
+}
+
 /* Square, outline-only floating affordance per DESIGN.md. Info matches the
    unread-divider semantics. */
 .ch-new-messages {
@@ -362,6 +370,14 @@
   flex-shrink: 0;
   width: 12px;
   height: 12px;
+}
+
+/* AgentBadge declares `color: var(--text-muted)` on the svg itself, which beats
+   the wrapper's inherited color. Opt back into the per-agent tint the wrapper's
+   inline `colorVar` sets, otherwise every presence glyph paints muted. */
+.ch-presence__glyph .agent-badge,
+.ch-presence__glyph .agent-badge--fallback {
+  color: currentColor;
 }
 
 .ch-presence__spinner {

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -333,6 +333,49 @@
   white-space: nowrap;
 }
 
+/* in-timeline agent presence (#1277) — "hermes is thinking…" at the foot of the
+   conversation. Dim secondary text, zero radius, shared braille spinner as the
+   only motion. No shimmer, no particles, no emoji (DESIGN.md §6 / motion rules);
+   TuiProgress already freezes on prefers-reduced-motion. */
+.ch-presence {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ch-presence__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  border-radius: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.ch-presence__glyph {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+}
+
+.ch-presence__spinner {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.ch-presence__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* system message — full-width centered muted, own row (never in a group) */
 .ch-system-msg {
   display: flex;

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -24,6 +24,7 @@ import { useRestoreTopicMutation } from '../../lib/hooks/use-restore-topic.js';
 import { isDmChannel } from '../../lib/dm-channels.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { selectChannelAgentPresence } from '../../lib/chat/channel-agent-presence.js';
+import { useStreamingPresenceHold } from './useStreamingPresenceHold.js';
 import {
   channelLastReadKey,
   useChannelActivityStore,
@@ -344,6 +345,21 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     return providers;
   }, [reducer.messages]);
 
+  // Presence suppression keys on MAIN-LANE streaming rows only. `ChannelTimeline`
+  // renders `selectTopLevel(messages)`, so an agent streaming a reply inside a
+  // thread draws its block cursor in the thread panel — the main lane shows
+  // nothing and must still announce "X is responding…" (#1277 review).
+  const topLevelStreamingAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const message of reducer.messages) {
+      if (message.status !== 'streaming' || message.sender.kind !== 'agent')
+        continue;
+      if (message.threadId !== null) continue;
+      ids.add(message.sender.id);
+    }
+    return ids;
+  }, [reducer.messages]);
+
   const rosterUpdatedAt = rosterChipsQuery.dataUpdatedAt;
   const agentChips = useMemo(() => {
     const roster = rosterChipsQuery.data ?? [];
@@ -406,12 +422,16 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   ]);
 
   // In-timeline presence rows (#1277). Same chip signal, so a reload rebuilds
-  // the rows from `resolveEffectiveAgentStatus` for free — no new WS event.
-  // `streamingProfileProviders` is the suppression set: an agent already drawing
-  // a live streaming row must not also be announced as thinking/responding.
+  // the rows from `resolveEffectiveAgentStatus` for free — no new WS event. The
+  // suppression set is "owns a live main-lane streaming row", plus a trailing
+  // hold so the gap between two assistant items of one turn does not strobe the
+  // row in and out.
+  const presenceSuppression = useStreamingPresenceHold(
+    topLevelStreamingAgentIds
+  );
   const agentPresence = useMemo(
-    () => selectChannelAgentPresence(agentChips, streamingProfileProviders),
-    [agentChips, streamingProfileProviders]
+    () => selectChannelAgentPresence(agentChips, presenceSuppression),
+    [agentChips, presenceSuppression]
   );
 
   const handleInterruptAgent = useCallback(

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -23,6 +23,7 @@ import { isArchivedChannelPostError } from '../../lib/agent-channels.js';
 import { useRestoreTopicMutation } from '../../lib/hooks/use-restore-topic.js';
 import { isDmChannel } from '../../lib/dm-channels.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { selectChannelAgentPresence } from '../../lib/chat/channel-agent-presence.js';
 import {
   channelLastReadKey,
   useChannelActivityStore,
@@ -404,6 +405,15 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     channelId,
   ]);
 
+  // In-timeline presence rows (#1277). Same chip signal, so a reload rebuilds
+  // the rows from `resolveEffectiveAgentStatus` for free — no new WS event.
+  // `streamingProfileProviders` is the suppression set: an agent already drawing
+  // a live streaming row must not also be announced as thinking/responding.
+  const agentPresence = useMemo(
+    () => selectChannelAgentPresence(agentChips, streamingProfileProviders),
+    [agentChips, streamingProfileProviders]
+  );
+
   const handleInterruptAgent = useCallback(
     (agentId: string) => {
       // 404 (no live binding) / 409 (NO_ACTIVE_TURN) both mean "already idle" —
@@ -459,8 +469,15 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     );
   }
 
+  // Live presence mounts the timeline even with zero history so a DM's very
+  // first turn shows "<agent> is thinking…" instead of the static empty state
+  // (#1277). Smaller diff than duplicating the row inside `.ch-empty`, and the
+  // empty copy comes back the moment every agent goes idle again.
   const hasHistory =
-    reducer.messages.length > 0 || hasMoreOlder || loadingOlder;
+    reducer.messages.length > 0 ||
+    hasMoreOlder ||
+    loadingOlder ||
+    agentPresence.length > 0;
 
   return (
     <div className="ch-view" role="main" aria-label="channel">
@@ -602,6 +619,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               replyOnlyBackfillPaused={replyOnlyBackfillPaused}
               onContinueHistory={continueReplyOnlyBackfill}
               onOpenThread={setActiveThreadRootId}
+              agentPresence={agentPresence}
             />
           ) : (
             <div className="ch-empty">

--- a/frontend/src/components/chat/useStreamingPresenceHold.ts
+++ b/frontend/src/components/chat/useStreamingPresenceHold.ts
@@ -1,0 +1,73 @@
+// Trailing-hold driver for the in-timeline presence rows (#1277).
+//
+// `ChannelView` derives "which agents own a live streaming row in the main
+// lane" from the reducer on every render. That set drops to empty in the gap
+// between two assistant items of the SAME turn, which would strobe the presence
+// row at the foot of the timeline. This hook wraps the pure hold state machine
+// in `channel-agent-presence.ts` and re-renders exactly once when the hold
+// lapses, so the row returns only after a real quiet window.
+import { useEffect, useMemo, useState } from 'react';
+import {
+  advanceStreamingHold,
+  nextStreamingHoldExpiry,
+  sameStreamingHold,
+  PRESENCE_STREAM_HOLD_MS,
+  type AgentIdMembership,
+} from '../../lib/chat/channel-agent-presence.js';
+
+/**
+ * Membership probe that answers "is this agent suppressed?" — true while it owns
+ * a live streaming row, and for `holdMs` after that row closes.
+ */
+export function useStreamingPresenceHold(
+  liveStreamingAgentIds: ReadonlySet<string>,
+  holdMs: number = PRESENCE_STREAM_HOLD_MS
+): AgentIdMembership {
+  const [hold, setHold] = useState<ReadonlyMap<string, number>>(
+    () => new Map<string, number>()
+  );
+
+  useEffect(() => {
+    setHold((previous) => {
+      const next = advanceStreamingHold(
+        previous,
+        liveStreamingAgentIds,
+        Date.now(),
+        holdMs
+      );
+      return sameStreamingHold(previous, next) ? previous : next;
+    });
+  }, [liveStreamingAgentIds, holdMs]);
+
+  useEffect(() => {
+    const expiry = nextStreamingHoldExpiry(hold);
+    if (expiry === null) return;
+    const timer = setTimeout(
+      () =>
+        setHold((previous) => {
+          const next = advanceStreamingHold(
+            previous,
+            liveStreamingAgentIds,
+            Date.now(),
+            holdMs
+          );
+          return sameStreamingHold(previous, next) ? previous : next;
+        }),
+      Math.max(0, expiry - Date.now()) + 1
+    );
+    return () => clearTimeout(timer);
+  }, [hold, liveStreamingAgentIds, holdMs]);
+
+  // Union the live set in at render time: a row that opened this very render is
+  // suppressed immediately rather than after the effect commits, so the presence
+  // row never double-renders with a fresh block cursor for one frame.
+  return useMemo(
+    () => ({
+      has: (agentId: string) =>
+        liveStreamingAgentIds.has(agentId) || hold.has(agentId),
+    }),
+    [liveStreamingAgentIds, hold]
+  );
+}
+
+export default useStreamingPresenceHold;

--- a/frontend/src/lib/chat/channel-agent-presence.ts
+++ b/frontend/src/lib/chat/channel-agent-presence.ts
@@ -1,0 +1,77 @@
+// In-timeline agent presence rows (#1277 slice 13). Slack renders "X is
+// typing…" at the foot of the conversation; Relay renders "hermes is thinking…"
+// there for every agent that is busy but has NOT yet opened a streaming row.
+//
+// No new transport: this is a pure projection of the header presence chips
+// (`ChannelView` `agentChips`, itself `resolveEffectiveAgentStatus` over the
+// roster query + the `channel-agent-status` socket store), so the row survives
+// reload exactly as the chips do.
+//
+// The suppression rule is the load-bearing part. Once the bridge opens a
+// streaming message row, `ChannelMessageRow` already draws the live block-cursor
+// (DESIGN.md motion effect 4) — a presence row on top of it would double-render
+// the same agent. Suppression therefore keys on "does a streaming ROW exist for
+// this agent", not on "is the agent's status streaming": a provider whose status
+// flipped to `streaming` before its first row lands still earns a row, and a
+// non-streaming provider (Hermes) keeps the row for its whole thinking window,
+// which is the entire point of the feature.
+import type { ChannelAgentStatus } from '../api.js';
+import type { KnownAgentGlyph } from './sender-identity.js';
+
+/** Busy statuses that earn a presence row (`idle` never does). */
+export type ChannelPresenceStatus = Exclude<ChannelAgentStatus, 'idle'>;
+
+export interface ChannelAgentPresence {
+  /** AgentProfile actor id — the same identity namespace as roster/status. */
+  agentId: string;
+  status: ChannelPresenceStatus;
+  label: string;
+  /** `var(--sender-*)` token or hash-derived hex from `resolveSenderIdentity`. */
+  colorVar: string;
+  glyph: KnownAgentGlyph | null;
+}
+
+/** Minimal shape of the header chips this projection consumes. */
+export interface ChannelPresenceChip {
+  agentId: string;
+  status: ChannelAgentStatus;
+  identity: { label: string; colorVar: string; glyph: KnownAgentGlyph | null };
+}
+
+/** Membership probe — satisfied by both `Set` and `Map` of agent ids. */
+export interface AgentIdMembership {
+  has(agentId: string): boolean;
+}
+
+/**
+ * Project header chips to presence rows: drop idle agents, drop any agent that
+ * already owns a live streaming row in the timeline.
+ */
+export function selectChannelAgentPresence(
+  chips: readonly ChannelPresenceChip[],
+  streamingRowAgentIds: AgentIdMembership
+): ChannelAgentPresence[] {
+  const rows: ChannelAgentPresence[] = [];
+  for (const chip of chips) {
+    if (chip.status === 'idle') continue;
+    if (streamingRowAgentIds.has(chip.agentId)) continue;
+    rows.push({
+      agentId: chip.agentId,
+      status: chip.status,
+      label: chip.identity.label,
+      colorVar: chip.identity.colorVar,
+      glyph: chip.identity.glyph,
+    });
+  }
+  return rows;
+}
+
+/** Lowercase presence copy per DESIGN.md — dim secondary text, no emoji. */
+export function channelPresenceCopy(presence: ChannelAgentPresence): string {
+  if (presence.status === 'streaming') return `${presence.label} is responding…`;
+  if (presence.status === 'waiting')
+    return `${presence.label} is waiting for input`;
+  // spawning and thinking read the same to an operator: the agent has the turn
+  // and nothing has come back yet.
+  return `${presence.label} is thinking…`;
+}

--- a/frontend/src/lib/chat/channel-agent-presence.ts
+++ b/frontend/src/lib/chat/channel-agent-presence.ts
@@ -15,6 +15,16 @@
 // flipped to `streaming` before its first row lands still earns a row, and a
 // non-streaming provider (Hermes) keeps the row for its whole thinking window,
 // which is the entire point of the feature.
+//
+// Suppression also needs a TRAILING HOLD. The bridge finalizes every assistant
+// item independently (`finalize(stream, 'complete', …)` per terminal
+// `agent-item-updated-v2`), while the binder keeps the binding `streaming` for
+// the whole turn. So a normal Claude turn (text → tool → text → tool → text) has
+// gaps between item N closing and item N+1 opening in which no row is streaming.
+// Without a hold the presence row would flash in and out at every one of those
+// boundaries, each toggle growing/shrinking the timeline foot and re-firing the
+// follow-scroll ResizeObserver. `advanceStreamingHold` keeps a just-closed row
+// suppressing for `PRESENCE_STREAM_HOLD_MS` so an intra-turn gap stays silent.
 import type { ChannelAgentStatus } from '../api.js';
 import type { KnownAgentGlyph } from './sender-identity.js';
 
@@ -64,6 +74,70 @@ export function selectChannelAgentPresence(
     });
   }
   return rows;
+}
+
+/**
+ * How long a closed streaming row keeps suppressing its agent's presence row.
+ * Long enough to swallow the bridge's item→item gap inside one turn, short
+ * enough that a genuinely finished turn re-announces promptly if the binder is
+ * still busy (e.g. a follow-up tool phase that produces no text).
+ */
+export const PRESENCE_STREAM_HOLD_MS = 600;
+
+/**
+ * Advance the trailing-hold map one step.
+ *
+ * Live streaming agents map to `Infinity` (suppressed for as long as the row is
+ * open). The step an agent leaves the live set, its entry becomes a finite
+ * `now + holdMs` deadline; entries past their deadline are dropped. Pure so the
+ * timing rule is testable without a component or fake DOM.
+ */
+export function advanceStreamingHold(
+  previousHold: ReadonlyMap<string, number>,
+  liveStreamingAgentIds: Iterable<string>,
+  now: number,
+  holdMs: number = PRESENCE_STREAM_HOLD_MS
+): Map<string, number> {
+  const live = new Set(liveStreamingAgentIds);
+  const next = new Map<string, number>();
+  for (const [agentId, expiresAt] of previousHold) {
+    if (live.has(agentId)) continue; // re-added as live below
+    if (expiresAt === Number.POSITIVE_INFINITY) {
+      next.set(agentId, now + holdMs); // row just closed — start the hold
+    } else if (expiresAt > now) {
+      next.set(agentId, expiresAt); // hold still running
+    }
+    // otherwise the hold lapsed: drop it and let the row come back
+  }
+  for (const agentId of live) next.set(agentId, Number.POSITIVE_INFINITY);
+  return next;
+}
+
+/**
+ * Earliest finite hold deadline, or `null` when nothing is pending. Callers use
+ * it to schedule exactly one wake-up instead of polling.
+ */
+export function nextStreamingHoldExpiry(
+  hold: ReadonlyMap<string, number>
+): number | null {
+  let earliest: number | null = null;
+  for (const expiresAt of hold.values()) {
+    if (!Number.isFinite(expiresAt)) continue;
+    if (earliest === null || expiresAt < earliest) earliest = expiresAt;
+  }
+  return earliest;
+}
+
+/** Entry-wise equality so an unchanged step can reuse the previous map. */
+export function sameStreamingHold(
+  a: ReadonlyMap<string, number>,
+  b: ReadonlyMap<string, number>
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [agentId, expiresAt] of a) {
+    if (b.get(agentId) !== expiresAt) return false;
+  }
+  return true;
 }
 
 /** Lowercase presence copy per DESIGN.md — dim secondary text, no emoji. */

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -25,6 +25,13 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       cancelQueued: false,
       resume: false,
       telemetry: true,
+      // `OpenCodeProtocolAdapter.handleMessagePartUpdated` fires
+      // `chat:text-delta` per `message.part.updated`, and
+      // `mapChatEventToAgentPatchV2` DOES have a case for it, so the bridge
+      // really does surface `agent-item-delta-v2` token-by-token. Unlike the
+      // hermes `telemetry` gap below, the compat mapping exists — the flag was
+      // just never set.
+      streaming: true,
     }),
   'opencode-attached': () =>
     new LegacyProtocolAdapterV2Bridge(new OpenCodeAttachedAdapter(), {
@@ -40,6 +47,10 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       cancelQueued: false,
       resume: false,
       telemetry: true,
+      // Same as `opencode`: the attached adapter's `message.part.updated`
+      // handler fires `chat:text-delta` whenever the event carries a string
+      // delta.
+      streaming: true,
     }),
   hermes: () =>
     new LegacyProtocolAdapterV2Bridge(new HermesProtocolAdapter(), {

--- a/test/components/channel-timeline-presence.test.ts
+++ b/test/components/channel-timeline-presence.test.ts
@@ -5,6 +5,7 @@
 // interaction. `ChannelView`-level suppression/empty-channel behaviour lives in
 // `channel-view-presence.test.ts`.
 
+import fs from 'node:fs';
 import React, { act } from 'react';
 import {
   afterAll,
@@ -18,9 +19,14 @@ import {
 } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import { useStreamingPresenceHold } from '../../frontend/src/components/chat/useStreamingPresenceHold.js';
 import {
+  advanceStreamingHold,
   channelPresenceCopy,
+  nextStreamingHoldExpiry,
+  sameStreamingHold,
   selectChannelAgentPresence,
+  PRESENCE_STREAM_HOLD_MS,
   type ChannelAgentPresence,
   type ChannelPresenceChip,
 } from '../../frontend/src/lib/chat/channel-agent-presence.js';
@@ -147,6 +153,79 @@ describe('selectChannelAgentPresence (#1277)', () => {
     expect(channelPresenceCopy(presence(HERMES_ID, 'waiting', 'hermes'))).toBe(
       'hermes is waiting for input'
     );
+  });
+});
+
+describe('advanceStreamingHold (#1277 intra-turn gap)', () => {
+  it('holds a just-closed streaming row instead of releasing it immediately', () => {
+    const live = advanceStreamingHold(new Map(), [CLAUDE_ID], 1_000);
+    expect(live.get(CLAUDE_ID)).toBe(Number.POSITIVE_INFINITY);
+
+    // Item N finalized; item N+1 has not opened yet. Suppression must survive.
+    const gap = advanceStreamingHold(live, [], 1_000);
+    expect(gap.has(CLAUDE_ID)).toBe(true);
+    expect(gap.get(CLAUDE_ID)).toBe(1_000 + PRESENCE_STREAM_HOLD_MS);
+
+    // Still inside the hold window a step later.
+    const stillHeld = advanceStreamingHold(gap, [], 1_100);
+    expect(stillHeld.get(CLAUDE_ID)).toBe(1_000 + PRESENCE_STREAM_HOLD_MS);
+
+    // Item N+1 opens: back to a live row, deadline discarded.
+    const resumed = advanceStreamingHold(stillHeld, [CLAUDE_ID], 1_200);
+    expect(resumed.get(CLAUDE_ID)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('releases the agent once the hold lapses so a finished turn re-announces', () => {
+    const live = advanceStreamingHold(new Map(), [CLAUDE_ID], 1_000);
+    const gap = advanceStreamingHold(live, [], 1_000);
+    const lapsed = advanceStreamingHold(
+      gap,
+      [],
+      1_000 + PRESENCE_STREAM_HOLD_MS + 1
+    );
+    expect(lapsed.has(CLAUDE_ID)).toBe(false);
+
+    // Which is what lets a still-busy chip earn a row again.
+    expect(
+      selectChannelAgentPresence(
+        [chip(CLAUDE_ID, 'thinking', 'claude')],
+        lapsed
+      ).map((row) => row.agentId)
+    ).toEqual([CLAUDE_ID]);
+  });
+
+  it('holds each agent independently', () => {
+    const live = advanceStreamingHold(new Map(), [CLAUDE_ID, HERMES_ID], 1_000);
+    const claudeClosed = advanceStreamingHold(live, [HERMES_ID], 1_000);
+    expect(claudeClosed.get(CLAUDE_ID)).toBe(1_000 + PRESENCE_STREAM_HOLD_MS);
+    expect(claudeClosed.get(HERMES_ID)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('reports the earliest pending deadline and ignores live rows', () => {
+    expect(nextStreamingHoldExpiry(new Map())).toBeNull();
+    expect(
+      nextStreamingHoldExpiry(
+        new Map([[CLAUDE_ID, Number.POSITIVE_INFINITY]])
+      )
+    ).toBeNull();
+    expect(
+      nextStreamingHoldExpiry(
+        new Map([
+          [CLAUDE_ID, 2_000],
+          [HERMES_ID, 1_500],
+        ])
+      )
+    ).toBe(1_500);
+  });
+
+  it('compares hold maps entry-wise so an unchanged step can reuse the previous map', () => {
+    expect(
+      sameStreamingHold(new Map([[CLAUDE_ID, 1]]), new Map([[CLAUDE_ID, 1]]))
+    ).toBe(true);
+    expect(
+      sameStreamingHold(new Map([[CLAUDE_ID, 1]]), new Map([[CLAUDE_ID, 2]]))
+    ).toBe(false);
+    expect(sameStreamingHold(new Map([[CLAUDE_ID, 1]]), new Map())).toBe(false);
   });
 });
 
@@ -311,8 +390,66 @@ describe('ChannelTimeline presence row (#1277)', () => {
     await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
     const spinner = host.querySelector('.ch-presence__spinner');
     expect(spinner).not.toBeNull();
-    expect(spinner?.getAttribute('role')).toBe('status');
     expect(spinner?.classList.contains('tui-progress')).toBe(true);
+  });
+
+  it('hides the spinner from assistive tech and announces once per transition', async () => {
+    await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
+
+    // TuiProgress rewrites its own text every 80ms and hard-codes
+    // `role="status"`. Inside a live region that is a ~12x/second announcement
+    // flood, so the presence row must hide it: the label already carries the
+    // meaning.
+    const spinner = host.querySelector('.ch-presence__spinner');
+    expect(spinner?.getAttribute('aria-hidden')).toBe('true');
+
+    // Exactly one announcing region for presence — the innermost live region
+    // wins, so the enclosing `role="log"` does not also read the row out.
+    const region = host.querySelector('.ch-presence');
+    expect(region?.getAttribute('role')).toBe('status');
+    expect(region?.getAttribute('aria-live')).toBe('polite');
+    expect(region?.getAttribute('aria-label')).toBe('agent presence');
+  });
+
+  it('tints the glyph with the per-agent color instead of the muted default', async () => {
+    await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
+    const glyph = host.querySelector<HTMLElement>('.ch-presence__glyph');
+    expect(glyph?.style.color).toBe('var(--sender-hermes)');
+
+    // `.agent-badge` declares `color: var(--text-muted)` on the svg itself, so
+    // the wrapper's inline color only lands if the sheet opts back in. happy-dom
+    // does not resolve component stylesheets, so assert the rule directly.
+    const css = fs.readFileSync(
+      'frontend/src/components/chat/ChannelView.css',
+      'utf8'
+    );
+    expect(css).toMatch(
+      /\.ch-presence__glyph \.agent-badge[\s\S]*?{[^}]*color:\s*currentColor/
+    );
+  });
+
+  it('bottom-anchors the row when it is the only timeline content', async () => {
+    await render([], [presence(HERMES_ID, 'thinking', 'hermes')]);
+    const content = host.querySelector('.ch-tl-content');
+    expect(content?.classList.contains('ch-tl-content--presence-only')).toBe(
+      true
+    );
+
+    const css = fs.readFileSync(
+      'frontend/src/components/chat/ChannelView.css',
+      'utf8'
+    );
+    expect(css).toMatch(
+      /\.ch-tl-content--presence-only\s*{[^}]*margin-top:\s*auto/
+    );
+
+    // Anti-vacuity: with history behind it the normal top-anchored model stays.
+    await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
+    expect(
+      host
+        .querySelector('.ch-tl-content')
+        ?.classList.contains('ch-tl-content--presence-only')
+    ).toBe(false);
   });
 
   it('still renders under prefers-reduced-motion', async () => {
@@ -370,5 +507,81 @@ describe('ChannelTimeline presence row (#1277)', () => {
     await render([message(1), message(2)], []);
     await act(async () => resizeCallback?.([], {} as ResizeObserver));
     expect(timeline().scrollTop).toBe(1_000);
+  });
+});
+
+describe('useStreamingPresenceHold (#1277)', () => {
+  let hookHost: HTMLDivElement;
+  let hookRoot: Root;
+
+  function Probe({
+    live,
+  }: {
+    live: ReadonlySet<string>;
+  }): React.ReactElement {
+    const membership = useStreamingPresenceHold(live, 200);
+    return React.createElement('span', {
+      'data-suppressed': membership.has(CLAUDE_ID) ? 'yes' : 'no',
+    });
+  }
+
+  async function renderProbe(live: ReadonlySet<string>): Promise<void> {
+    await act(async () => {
+      hookRoot.render(React.createElement(Probe, { live }));
+    });
+  }
+
+  function suppressed(): string | null {
+    return hookHost
+      .querySelector('span')
+      ?.getAttribute('data-suppressed') ?? null;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    hookHost = document.createElement('div');
+    document.body.appendChild(hookHost);
+    hookRoot = createRoot(hookHost);
+  });
+
+  afterEach(() => {
+    act(() => hookRoot.unmount());
+    hookHost.remove();
+    vi.useRealTimers();
+  });
+
+  it('keeps suppressing across the gap, then releases once the hold lapses', async () => {
+    await renderProbe(new Set([CLAUDE_ID]));
+    expect(suppressed()).toBe('yes');
+
+    // Streaming row closed — suppression must survive the intra-turn gap.
+    await renderProbe(new Set<string>());
+    expect(suppressed()).toBe('yes');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(suppressed()).toBe('yes');
+
+    // Nothing re-opened inside the window: the row is allowed back.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(suppressed()).toBe('no');
+  });
+
+  it('re-arms the hold when a new row opens inside the window', async () => {
+    await renderProbe(new Set([CLAUDE_ID]));
+    await renderProbe(new Set<string>());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    // Item N+1 opens before the deadline.
+    await renderProbe(new Set([CLAUDE_ID]));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(suppressed()).toBe('yes');
   });
 });

--- a/test/components/channel-timeline-presence.test.ts
+++ b/test/components/channel-timeline-presence.test.ts
@@ -1,0 +1,374 @@
+// @vitest-environment happy-dom
+//
+// #1277 slice 13 — in-timeline agent presence row ("hermes is thinking…").
+// Covers the pure projection, the timeline render, and the follow-scroll
+// interaction. `ChannelView`-level suppression/empty-channel behaviour lives in
+// `channel-view-presence.test.ts`.
+
+import React, { act } from 'react';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import {
+  channelPresenceCopy,
+  selectChannelAgentPresence,
+  type ChannelAgentPresence,
+  type ChannelPresenceChip,
+} from '../../frontend/src/lib/chat/channel-agent-presence.js';
+import type { ChannelAgentStatus } from '../../frontend/src/lib/api.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const HERMES_ID = 'agent-profile:hermes:default';
+const CLAUDE_ID = 'agent-profile:claude:default';
+
+function chip(
+  agentId: string,
+  status: ChannelAgentStatus,
+  label: string
+): ChannelPresenceChip {
+  return {
+    agentId,
+    status,
+    identity: { label, colorVar: 'var(--sender-hermes)', glyph: 'hermes' },
+  };
+}
+
+function presence(
+  agentId: string,
+  status: ChannelAgentPresence['status'],
+  label: string
+): ChannelAgentPresence {
+  return {
+    agentId,
+    status,
+    label,
+    colorVar: 'var(--sender-hermes)',
+    glyph: 'hermes',
+  };
+}
+
+function message(seq: number, own = false): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: 'topic:general',
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: own
+      ? { kind: 'human', id: 'human:operator' }
+      : { kind: 'agent', id: HERMES_ID, providerId: 'hermes' },
+    body: { text: `message ${seq}`, format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+    updatedAt: `2026-07-18T10:${String(seq).padStart(2, '0')}:00.000Z`,
+  };
+}
+
+describe('selectChannelAgentPresence (#1277)', () => {
+  it('keeps every busy agent and drops idle ones', () => {
+    const rows = selectChannelAgentPresence(
+      [
+        chip(HERMES_ID, 'thinking', 'hermes'),
+        chip(CLAUDE_ID, 'idle', 'claude'),
+      ],
+      new Set<string>()
+    );
+    expect(rows.map((row) => row.agentId)).toEqual([HERMES_ID]);
+    expect(rows[0]?.status).toBe('thinking');
+  });
+
+  it('suppresses only the agents that already own a live streaming row', () => {
+    const chips = [
+      chip(HERMES_ID, 'thinking', 'hermes'),
+      chip(CLAUDE_ID, 'streaming', 'claude'),
+    ];
+    // Anti-vacuity: with an empty suppression set BOTH rows survive, so the
+    // single-row result below is caused by the suppression input and nothing
+    // else about these chips.
+    expect(
+      selectChannelAgentPresence(chips, new Set<string>()).map((r) => r.agentId)
+    ).toEqual([HERMES_ID, CLAUDE_ID]);
+
+    expect(
+      selectChannelAgentPresence(chips, new Set([CLAUDE_ID])).map(
+        (r) => r.agentId
+      )
+    ).toEqual([HERMES_ID]);
+  });
+
+  it('suppresses on streaming-row membership, not on streaming status', () => {
+    // Status flipped to `streaming` before the bridge opened a row: nothing is
+    // drawing a block cursor yet, so the presence row must still announce it.
+    const rows = selectChannelAgentPresence(
+      [chip(CLAUDE_ID, 'streaming', 'claude')],
+      new Set<string>()
+    );
+    expect(rows).toHaveLength(1);
+    expect(channelPresenceCopy(rows[0]!)).toBe('claude is responding…');
+  });
+
+  it('accepts a Map (the reducer-derived streaming provider index) as the suppression set', () => {
+    const streaming = new Map<string, string | undefined>([
+      [CLAUDE_ID, 'claude'],
+    ]);
+    expect(
+      selectChannelAgentPresence(
+        [chip(CLAUDE_ID, 'streaming', 'claude')],
+        streaming
+      )
+    ).toEqual([]);
+  });
+
+  it('reads spawning and thinking as one operator-facing verb', () => {
+    expect(channelPresenceCopy(presence(HERMES_ID, 'spawning', 'hermes'))).toBe(
+      'hermes is thinking…'
+    );
+    expect(channelPresenceCopy(presence(HERMES_ID, 'thinking', 'hermes'))).toBe(
+      'hermes is thinking…'
+    );
+    expect(channelPresenceCopy(presence(HERMES_ID, 'waiting', 'hermes'))).toBe(
+      'hermes is waiting for input'
+    );
+  });
+});
+
+let host: HTMLDivElement;
+let root: Root;
+let timelineScrollHeight = 1_000;
+let timelineClientHeight = 300;
+let resizeCallback: ResizeObserverCallback | null = null;
+
+const originalScrollHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'scrollHeight'
+);
+const originalClientHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'clientHeight'
+);
+const OriginalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).classList.contains('ch-tl')
+        ? timelineScrollHeight
+        : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).classList.contains('ch-tl')
+        ? timelineClientHeight
+        : 0;
+    },
+  });
+  globalThis.ResizeObserver = class ResizeObserverMock {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {
+      resizeCallback = null;
+    }
+  };
+});
+
+afterAll(() => {
+  if (originalScrollHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'scrollHeight',
+      originalScrollHeight
+    );
+  }
+  if (originalClientHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'clientHeight',
+      originalClientHeight
+    );
+  }
+  globalThis.ResizeObserver = OriginalResizeObserver;
+});
+
+async function render(
+  messages: ChannelMessage[],
+  agentPresence: ChannelAgentPresence[]
+): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(ChannelTimeline, {
+        messages,
+        lastReadSeq: null,
+        channelId: 'topic:general',
+        channelTitle: 'general',
+        hasMoreOlder: false,
+        loadingOlder: false,
+        loadOlder: async () => {},
+        fullSnapshotRevision: 0,
+        needsCatchup: false,
+        onResync: () => {},
+        agentPresence,
+      })
+    );
+  });
+}
+
+function timeline(): HTMLDivElement {
+  const element = host.querySelector<HTMLDivElement>('.ch-tl');
+  if (!element) throw new Error('timeline not rendered');
+  return element;
+}
+
+async function userScroll(scrollTop: number): Promise<void> {
+  const element = timeline();
+  element.scrollTop = scrollTop;
+  await act(async () => {
+    element.dispatchEvent(new Event('scroll'));
+  });
+}
+
+describe('ChannelTimeline presence row (#1277)', () => {
+  beforeEach(() => {
+    timelineScrollHeight = 1_000;
+    timelineClientHeight = 300;
+    resizeCallback = null;
+    vi.stubGlobal('matchMedia', () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders one row per busy agent at the foot of the timeline content', async () => {
+    await render(
+      [message(1)],
+      [
+        presence(HERMES_ID, 'thinking', 'hermes'),
+        presence(CLAUDE_ID, 'waiting', 'claude'),
+      ]
+    );
+
+    const rows = host.querySelectorAll('.ch-presence__row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain('hermes is thinking…');
+    expect(rows[1]?.textContent).toContain('claude is waiting for input');
+
+    // Foot of the conversation, inside the observed content element.
+    const content = host.querySelector('.ch-tl-content');
+    expect(content?.lastElementChild?.classList.contains('ch-presence')).toBe(
+      true
+    );
+  });
+
+  it('renders nothing when no agent is busy', async () => {
+    await render([message(1)], []);
+    expect(host.querySelector('.ch-presence')).toBeNull();
+  });
+
+  it('carries no message seq, so it can never become a scroll anchor', async () => {
+    await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
+    const row = host.querySelector('.ch-presence__row');
+    expect(row).not.toBeNull();
+    expect(row?.hasAttribute('data-channel-message-seq')).toBe(false);
+    expect(
+      host.querySelectorAll('[data-channel-message-seq]')
+    ).toHaveLength(1);
+  });
+
+  it('uses the shared braille spinner as its only motion', async () => {
+    await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
+    const spinner = host.querySelector('.ch-presence__spinner');
+    expect(spinner).not.toBeNull();
+    expect(spinner?.getAttribute('role')).toBe('status');
+    expect(spinner?.classList.contains('tui-progress')).toBe(true);
+  });
+
+  it('still renders under prefers-reduced-motion', async () => {
+    vi.stubGlobal('matchMedia', () => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+    await render([message(1)], [presence(HERMES_ID, 'thinking', 'hermes')]);
+
+    const row = host.querySelector('.ch-presence__row');
+    expect(row?.textContent).toContain('hermes is thinking…');
+    // TuiProgress freezes on frame 0 rather than disappearing.
+    expect(host.querySelector('.ch-presence__spinner')?.textContent).toBe(
+      '⠋'
+    );
+  });
+
+  it('does not inflate the new-message pill when the row appears or clears', async () => {
+    await render([message(1), message(2)], []);
+    await userScroll(200);
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+
+    // Row appears (agent started thinking) — no message seq changed.
+    timelineScrollHeight = 1_100;
+    await render(
+      [message(1), message(2)],
+      [presence(HERMES_ID, 'thinking', 'hermes')]
+    );
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+    expect(timeline().scrollTop).toBe(200);
+
+    // Row clears again — still no pill, reader still parked.
+    timelineScrollHeight = 1_000;
+    await render([message(1), message(2)], []);
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(host.querySelector('.ch-new-messages')).toBeNull();
+    expect(timeline().scrollTop).toBe(200);
+  });
+
+  it('keeps a follower stuck to the bottom across presence growth and shrink', async () => {
+    await render([message(1), message(2)], []);
+    expect(timeline().scrollTop).toBe(1_000);
+
+    timelineScrollHeight = 1_100;
+    await render(
+      [message(1), message(2)],
+      [presence(HERMES_ID, 'thinking', 'hermes')]
+    );
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(timeline().scrollTop).toBe(1_100);
+
+    timelineScrollHeight = 1_000;
+    await render([message(1), message(2)], []);
+    await act(async () => resizeCallback?.([], {} as ResizeObserver));
+    expect(timeline().scrollTop).toBe(1_000);
+  });
+});

--- a/test/components/channel-view-presence.test.ts
+++ b/test/components/channel-view-presence.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment happy-dom
+//
+// #1277 slice 13 — `ChannelView` wiring for the in-timeline presence row. The
+// real `ChannelTimeline`/`ChannelMessageRow` are rendered here on purpose: the
+// dedupe rule (a streaming row already draws the live block cursor) is only
+// provable against the actual DOM both paths produce.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+import type { ChannelAgentStatus } from '../../frontend/src/lib/api.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+const CLAUDE_ID = 'agent-profile:claude:default';
+const HERMES_ID = 'agent-profile:hermes:default';
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  messages: [] as unknown[],
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+  };
+});
+
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: CHANNEL_ID,
+      title: 'operator lane',
+      visibility: 'default',
+      archived: false,
+      latestSeq: 0,
+      messageCount: mocks.messages.length,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: CHANNEL_ID,
+      messages: mocks.messages,
+      lastSeq: mocks.messages.length,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    fullSnapshotRevision: 0,
+    post: vi.fn(),
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
+  ChannelComposer: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
+  ChannelThreadPanel: () => null,
+}));
+
+const { ChannelView } = await import(
+  '../../frontend/src/components/chat/ChannelView.js'
+);
+
+function topicFixture() {
+  return {
+    id: CHANNEL_ID,
+    workspaceId: 'workspace:local',
+    display: { title: 'operator lane' },
+    routingDefaults: {},
+  };
+}
+
+function rosterEntry(
+  id: string,
+  providerId: string,
+  status: ChannelAgentStatus
+) {
+  return {
+    id,
+    displayName: providerId,
+    providerId,
+    isDefault: true,
+    isBuiltIn: true,
+    kind: 'framework' as const,
+    available: true,
+    reason: null,
+    binding: { runtimeId: `runtime:${providerId}-1`, status },
+  };
+}
+
+function agentMessage(
+  seq: number,
+  agentId: string,
+  providerId: string,
+  status: ChannelMessage['status']
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: CHANNEL_ID,
+    seq,
+    kind: 'message',
+    status,
+    sender: { kind: 'agent', id: agentId, providerId },
+    body: { text: 'partial answer', format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-07-18T10:00:00.000Z',
+    updatedAt: '2026-07-18T10:00:00.000Z',
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let queryClient: QueryClient;
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+async function render(): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(ChannelView, { channelId: CHANNEL_ID })
+      )
+    );
+  });
+  await flush();
+}
+
+function presenceLabels(): string[] {
+  return [...container.querySelectorAll('.ch-presence__label')].map(
+    (label) => label.textContent ?? ''
+  );
+}
+
+beforeEach(() => {
+  mocks.fetchWorkspaceTopic.mockReset();
+  mocks.fetchChannelRoster.mockReset();
+  mocks.messages = [];
+  mocks.fetchWorkspaceTopic.mockResolvedValue(topicFixture());
+  vi.stubGlobal('matchMedia', () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  queryClient.clear();
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('ChannelView in-timeline presence (#1277)', () => {
+  it('announces a non-streaming agent for its whole thinking window', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(HERMES_ID, 'hermes', 'thinking'),
+    ]);
+    mocks.messages = [agentMessage(1, HERMES_ID, 'hermes', 'complete')];
+
+    await render();
+
+    expect(presenceLabels()).toEqual(['hermes is thinking…']);
+  });
+
+  it('does not announce an idle agent', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(HERMES_ID, 'hermes', 'idle'),
+    ]);
+    mocks.messages = [agentMessage(1, HERMES_ID, 'hermes', 'complete')];
+
+    await render();
+
+    // The header chip still exists (the agent is bound) — only the timeline
+    // presence row is suppressed, which is what distinguishes idle from busy.
+    expect(container.querySelector('.ch-agent-chip')).not.toBeNull();
+    expect(container.querySelector('.ch-presence')).toBeNull();
+  });
+
+  it('suppresses the row for a provider that already owns a live streaming row', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(CLAUDE_ID, 'claude', 'streaming'),
+    ]);
+    mocks.messages = [agentMessage(1, CLAUDE_ID, 'claude', 'streaming')];
+
+    await render();
+
+    // The streaming row IS rendering its live block cursor…
+    expect(container.querySelector('.ch-msg__cursor')).not.toBeNull();
+    // …so claude must not also be announced below it.
+    expect(container.querySelector('.ch-presence')).toBeNull();
+  });
+
+  it('anti-vacuity: the same streaming-status chip DOES announce once its row completes', async () => {
+    // Identical roster/status to the suppression case above; the ONLY change is
+    // that no message is in `streaming` state, so nothing draws a block cursor.
+    // A presence row appearing here proves the previous assertion measured the
+    // dedupe rule rather than a chip that was never there.
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(CLAUDE_ID, 'claude', 'streaming'),
+    ]);
+    mocks.messages = [agentMessage(1, CLAUDE_ID, 'claude', 'complete')];
+
+    await render();
+
+    expect(container.querySelector('.ch-msg__cursor')).toBeNull();
+    expect(presenceLabels()).toEqual(['claude is responding…']);
+  });
+
+  it('suppresses only the streaming provider when another agent is thinking', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(CLAUDE_ID, 'claude', 'streaming'),
+      rosterEntry(HERMES_ID, 'hermes', 'thinking'),
+    ]);
+    mocks.messages = [agentMessage(1, CLAUDE_ID, 'claude', 'streaming')];
+
+    await render();
+
+    expect(container.querySelector('.ch-msg__cursor')).not.toBeNull();
+    expect(presenceLabels()).toEqual(['hermes is thinking…']);
+    expect(
+      container
+        .querySelector('.ch-presence__row')
+        ?.getAttribute('data-channel-presence-agent')
+    ).toBe(HERMES_ID);
+  });
+
+  it('mounts the timeline on an empty channel so a first DM turn shows presence', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(HERMES_ID, 'hermes', 'thinking'),
+    ]);
+    mocks.messages = [];
+
+    await render();
+
+    expect(container.querySelector('.ch-empty')).toBeNull();
+    expect(container.querySelector('.ch-tl')).not.toBeNull();
+    expect(presenceLabels()).toEqual(['hermes is thinking…']);
+  });
+
+  it('keeps the static empty state when an empty channel has no busy agent', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(HERMES_ID, 'hermes', 'idle'),
+    ]);
+    mocks.messages = [];
+
+    await render();
+
+    expect(container.querySelector('.ch-empty')).not.toBeNull();
+    expect(container.querySelector('.ch-presence')).toBeNull();
+  });
+
+  it('rebuilds the row from the roster snapshot alone (reload path, no socket event)', async () => {
+    // A cold mount clears this channel's socket statuses, so the only signal is
+    // the roster query — exactly the state after a browser reload mid-turn.
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(HERMES_ID, 'hermes', 'spawning'),
+    ]);
+    mocks.messages = [];
+
+    await render();
+
+    expect(presenceLabels()).toEqual(['hermes is thinking…']);
+  });
+});

--- a/test/components/channel-view-presence.test.ts
+++ b/test/components/channel-view-presence.test.ts
@@ -289,6 +289,57 @@ describe('ChannelView in-timeline presence (#1277)', () => {
     expect(container.querySelector('.ch-presence')).toBeNull();
   });
 
+  it('does not flash the row in the gap between two items of one turn', async () => {
+    // The binder holds the binding `streaming` for the whole turn, but the
+    // bridge finalizes each assistant item independently. Between item N closing
+    // and item N+1 opening no row is streaming — without a trailing hold the
+    // presence row would appear and vanish at every tool boundary, growing and
+    // shrinking the timeline foot each time.
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(CLAUDE_ID, 'claude', 'streaming'),
+    ]);
+    mocks.messages = [agentMessage(1, CLAUDE_ID, 'claude', 'streaming')];
+    await render();
+    expect(container.querySelector('.ch-presence')).toBeNull();
+
+    // Item 1 finalizes; item 2 has not opened yet.
+    mocks.messages = [agentMessage(1, CLAUDE_ID, 'claude', 'complete')];
+    await render();
+    expect(container.querySelector('.ch-msg__cursor')).toBeNull();
+    expect(container.querySelector('.ch-presence')).toBeNull();
+
+    // Item 2 opens: still no presence row, and no toggle happened in between.
+    mocks.messages = [
+      agentMessage(1, CLAUDE_ID, 'claude', 'complete'),
+      agentMessage(2, CLAUDE_ID, 'claude', 'streaming'),
+    ];
+    await render();
+    expect(container.querySelector('.ch-presence')).toBeNull();
+    // Anti-vacuity: a cold mount with the identical complete-message state DOES
+    // announce (see the anti-vacuity case above), so the silence here is the
+    // hold and not a missing chip.
+  });
+
+  it('keeps the main-lane row while the agent streams inside a thread', async () => {
+    // Thread replies never render in the main timeline (`selectTopLevel`), so a
+    // thread-only stream draws no block cursor here — the channel would look
+    // idle while the agent is working.
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry(CLAUDE_ID, 'claude', 'streaming'),
+    ]);
+    const root = agentMessage(1, CLAUDE_ID, 'claude', 'complete');
+    const reply = agentMessage(2, CLAUDE_ID, 'claude', 'streaming');
+    mocks.messages = [
+      root,
+      { ...reply, threadId: root.id, parentMessageId: root.id },
+    ];
+
+    await render();
+
+    expect(container.querySelector('.ch-msg__cursor')).toBeNull();
+    expect(presenceLabels()).toEqual(['claude is responding…']);
+  });
+
   it('rebuilds the row from the roster snapshot alone (reload path, no socket event)', async () => {
     // A cold mount clears this channel's socket statuses, so the only signal is
     // the roster query — exactly the state after a browser reload mid-turn.

--- a/test/server/protocol-adapters/opencode-adapter.test.ts
+++ b/test/server/protocol-adapters/opencode-adapter.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it } from 'vitest';
 import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
+import { OpenCodeProtocolAdapter } from '../../../server/protocol-adapters/opencode-adapter.js';
+import { OpenCodeAttachedAdapter } from '../../../server/protocol-adapters/opencode-attached-adapter.js';
+import { mapChatEventToAgentPatchV2 } from '../../../shared/agent-chat-v1-compat.js';
+import type { ChatEvent } from '../../../shared/agent-chat-protocol.js';
+
+interface OpenCodeEventLike {
+  type: string;
+  properties?: Record<string, unknown>;
+}
+
+/** Drive the adapter's real SSE event dispatcher and collect what it fires. */
+function driveOpenCodeEvent(
+  adapter: OpenCodeProtocolAdapter | OpenCodeAttachedAdapter,
+  event: OpenCodeEventLike
+): ChatEvent[] {
+  const seen: ChatEvent[] = [];
+  const off = adapter.on((chatEvent) => {
+    seen.push(chatEvent);
+  });
+  (
+    adapter as unknown as { mapOpenCodeEvent(event: OpenCodeEventLike): void }
+  ).mapOpenCodeEvent(event);
+  off();
+  return seen;
+}
 
 describe('OpenCode V2 web adapter registration', () => {
   it('registers opencode as a ProtocolAdapterV2 bridge while native mapping is ported', () => {
@@ -15,6 +40,7 @@ describe('OpenCode V2 web adapter registration', () => {
       approvals: true,
       interrupt: true,
       telemetry: true,
+      streaming: true,
     });
   });
 
@@ -23,5 +49,47 @@ describe('OpenCode V2 web adapter registration', () => {
 
     expect(adapter).toBeInstanceOf(LegacyProtocolAdapterV2Bridge);
     expect(adapter.agentType).toBe('opencode');
+    expect(adapter.capabilities).toMatchObject({ streaming: true });
+  });
+});
+
+// The `streaming` bit means "this adapter emits live `agent-item-delta-v2`
+// patches". Advertising it without the emission would repeat the hermes
+// `telemetry` trap (event fired, no compat mapping, silently dropped), so both
+// halves are asserted against the real code path rather than the literal.
+describe('OpenCode streaming capability is backed by real deltas', () => {
+  it('fires chat:text-delta from the web adapter and maps it to a V2 delta patch', () => {
+    const adapter = new OpenCodeProtocolAdapter();
+    const events = driveOpenCodeEvent(adapter, {
+      type: 'message.part.updated',
+      properties: {
+        part: { type: 'text', id: 'part-1', messageID: 'msg-1', text: 'hel' },
+        delta: 'hel',
+      },
+    });
+
+    const delta = events.find((event) => event.type === 'chat:text-delta');
+    expect(delta).toMatchObject({ type: 'chat:text-delta', delta: 'hel' });
+
+    const patches = mapChatEventToAgentPatchV2(delta!);
+    expect(patches.map((patch) => patch.type)).toContain(
+      'agent-item-delta-v2'
+    );
+  });
+
+  it('fires chat:text-delta from the attached adapter and maps it to a V2 delta patch', () => {
+    const adapter = new OpenCodeAttachedAdapter();
+    const events = driveOpenCodeEvent(adapter, {
+      type: 'message.part.updated',
+      properties: { delta: 'lo world' },
+    });
+
+    const delta = events.find((event) => event.type === 'chat:text-delta');
+    expect(delta).toMatchObject({ type: 'chat:text-delta', delta: 'lo world' });
+
+    const patches = mapChatEventToAgentPatchV2(delta!);
+    expect(patches.map((patch) => patch.type)).toContain(
+      'agent-item-delta-v2'
+    );
   });
 });


### PR DESCRIPTION
## What

Slack-style **"`<agent>` is thinking…"** at the foot of the channel timeline, for
every agent that holds the turn but has not opened a streaming row yet — plus the
`streaming` capability bit both opencode adapters were always entitled to.

```
  ⠹  hermes is thinking…
  ⠼  claude is waiting for input
```

One row per busy agent (they are few), each keeping its vendor glyph and resolved
sender color. Copy is lowercase dim secondary text; motion is the shared braille
`TuiProgress` and nothing else (no shimmer, no particles, no emoji), and
`TuiProgress` already freezes under `prefers-reduced-motion`.

**No new transport.** The rows are a pure projection of the presence chips
`ChannelView` already computes — the `channel-roster` query reconciled with the
`channel-agent-status` socket store by `resolveEffectiveAgentStatus` — pushed
through `selectChannelAgentPresence` into a new optional `ChannelTimeline` prop.
No route, no gateway verb, no WS event. The row survives a reload for exactly the
reason the header chip does.

## Why this matters most for non-streaming providers

For Claude the turn is already legible: the bridge opens a streaming row and
`ChannelMessageRow` draws a live block cursor within a beat of you hitting enter.

For **Hermes there is nothing at all**. `hermes` is registered in `v2Adapters`
without a `streaming` bit, because `HermesProtocolAdapter` returns a completed
reply rather than token deltas (the upstream gap tracked in **#1181**). Between
"operator sends" and "reply lands" the channel is visually identical to an idle
channel — a 6px chip dot in the header is the only tell, and on mobile the header
is often the part you are not looking at. Long Hermes turns read as "Relay
dropped my message".

The presence row closes that gap without waiting on #1181: the roster/status
signal already knows the binding is `thinking`, so the timeline can say so. When
#1181 lands and Hermes does stream, the same suppression rule silently hands the
job back to the block cursor with no change here.

## Dedupe vs the streaming row

This is the load-bearing design decision. Once the bridge opens a streaming row,
the timeline is already animating for that agent — a presence row underneath
would double-render the same agent.

Suppression therefore keys on **"does this agent own a live streaming ROW"**, not
on **"is this agent's STATUS streaming"**. The two come apart in both directions,
and both directions are the point:

- status flips to `streaming` before the first row lands → **row still shows**
  (otherwise the gap is silent again)
- a non-streaming provider is `thinking` with no row for the whole turn → **row
  shows the whole time**, which is the entire feature

Three refinements over the naive rule, all from review:

- **Main lane only.** `ChannelTimeline` renders `selectTopLevel(messages)`, so an
  agent streaming a reply inside a *thread* draws its cursor in the thread panel
  and nothing in the main lane. Suppression is built from `threadId === null`
  streaming rows so the main lane still announces it.
- **Trailing hold.** The binder holds a binding `streaming` for the whole turn,
  but the bridge finalizes each assistant item independently. A normal
  text→tool→text→tool→text turn therefore has gaps where *no* row is streaming.
  Without a hold the presence row flashes in and out at every tool boundary,
  each toggle growing/shrinking the timeline foot and re-firing the follow-scroll
  `ResizeObserver`. `advanceStreamingHold` keeps a just-closed row suppressing for
  `PRESENCE_STREAM_HOLD_MS` (600ms); `useStreamingPresenceHold` schedules exactly
  one wake-up when the hold lapses instead of polling.
- **Empty channels.** Live presence mounts the timeline with zero history so a
  DM's very first turn shows the row instead of the static empty state, and
  `.ch-tl-content--presence-only` bottom-anchors it next to the composer rather
  than stranding it in the top-left of a blank pane. The empty copy returns the
  moment every agent goes idle.

Scroll safety: the row lives inside `.ch-tl-content` (the element
`useFollowingScroll` already observes, so its appearance is a resize the follow
model bottom-anchors) and carries no `data-channel-message-seq` — it can neither
become a reader anchor nor inflate the "n new messages" pill.

## opencode `streaming` flag

`OpenCodeProtocolAdapter.handleMessagePartUpdated` and the attached adapter's
`message.part.updated` handler both fire `chat:text-delta`, and
`mapChatEventToAgentPatchV2` **does** have a case for it — so
`LegacyProtocolAdapterV2Bridge` really has been surfacing `agent-item-delta-v2`
token-by-token. The capability bit was simply never set, understating both
adapters against claude.

Verified, not asserted from the literal: the new tests drive each adapter's real
SSE dispatcher, assert the `chat:text-delta` it emits, then push that event
through `mapChatEventToAgentPatchV2` and assert an `agent-item-delta-v2` patch
comes out. This deliberately avoids repeating the hermes `telemetry` trap
directly below it in the registry (event fired, compat mapping missing, silently
dropped) — that bit stays `false` on purpose, and the comment now says why.

## Review trail

One adversarial review returned `concern`; all findings batched into one fix
pass (`b063038`):

| Sev | Finding | Disposition |
| --- | --- | --- |
| P2 | Screen-reader flood — `TuiProgress` hard-codes `role="status"` and rewrites its text every 80ms inside `.ch-tl`'s `role="log" aria-live="polite"`; `aria-label` on the role-less `.ch-presence` div was a no-op | **Fixed** — spinner `aria-hidden` (decoration; the label carries the meaning), `.ch-presence` promoted to an explicit `role="status"` region so exactly one region announces once per transition |
| P2 | Presence row strobes at every assistant-item boundary inside one turn | **Fixed** — 600ms trailing hold (`advanceStreamingHold` + `useStreamingPresenceHold`) |
| P3 | Empty channel: row pinned to the top-left of a blank full-height pane | **Fixed** — `.ch-tl-content--presence-only { margin-top: auto }`, applied only when the timeline holds no message nodes so the scroll model is untouched |
| P3 | Per-agent tint never rendered — `.agent-badge { color: var(--text-muted) }` on the svg beat the wrapper's inherited inline `colorVar` | **Fixed** — `.ch-presence__glyph .agent-badge { color: currentColor }` |
| P3 | Thread-only stream suppressed the main-lane row | **Fixed** — suppression built from top-level streaming rows only |
| P3 | Stale-status amplification: a wedged non-idle binding pins an animated row with no client-side path back to idle | **Deferred, noted** — pre-existing (it already pinned a pulsing header chip); server watchdog bounds it at 5min except for `waiting` bindings, where the copy is correct. A client-side staleness cutoff risks hiding legitimately long turns, so it wants its own issue alongside the roster-refetch question rather than a guess here |

The two P2s and the thread P3 were the only findings with behavioral bite; the
a11y one had the sharpest observation — the original tests asserted
`spinner.getAttribute('role') === 'status'`, i.e. they *pinned* the defect rather
than guarding against it. That assertion is now inverted to `aria-hidden`.

## Verification

- `npm run check` → **0 errors** (218 pre-existing `sonarjs` warnings, none in
  touched files)
- `npm test` → **444 files / 5531 tests passed**, exit 0
- New/changed coverage: `test/components/channel-timeline-presence.test.ts`
  (projection, hold state machine, hook timing under fake timers, render,
  follow-scroll, a11y, tint, anchoring),
  `test/components/channel-view-presence.test.ts` (live `ChannelView` +
  real `ChannelTimeline`/`ChannelMessageRow` — dedupe, intra-turn gap, thread
  lane, empty channel, reload path),
  `test/server/protocol-adapters/opencode-adapter.test.ts` (real dispatcher →
  `chat:text-delta` → V2 patch)
- **Anti-vacuity, measured:** reverting only the suppression wiring in
  `ChannelView` (back to the full-lane, hold-less set) fails exactly the two new
  `ChannelView` cases — "does not flash the row in the gap between two items of
  one turn" and "keeps the main-lane row while the agent streams inside a
  thread" — while the other 8 pass. Restored and re-verified green.
- Several assertions are anti-vacuity pairs by construction: the dedupe case is
  paired with an identical-roster case whose only difference is that no message
  is `streaming`, and the anchoring case asserts the modifier class is *absent*
  once history exists.
- CSS rules that happy-dom cannot resolve (the `currentColor` override, the
  `margin-top: auto` anchor) are asserted against the stylesheet source, matching
  the existing precedent in `test/topic-sidebar-shell.test.ts`.

Refs #1277 (slice 13 first half). Refs #1181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-channel agent presence indicators showing when agents are thinking, responding, or otherwise active.
  * Presence indicators now appear in empty channels and direct messages, with status labels, progress feedback, and accessibility support.
  * Added support for streaming updates from OpenCode connections.

* **Bug Fixes**
  * Reduced flicker when agents transition between streamed responses.
  * Preserved timeline scrolling and new-message behavior while presence indicators are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->