### PR TITLE
feat(chat): message toolbar, deep links, retry, edit/delete, system coalescing (#1308 slice 1)

### DIFF
--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -21,10 +21,9 @@ import { createBrowserId } from '../../lib/browserId.js';
 import { fetchChannelRoster, uploadChannelImages } from '../../lib/api.js';
 import { buildMentionContacts } from '../../lib/chat/mention-contacts.js';
 import { detectTrigger } from './slashTrigger.js';
+import { createLineBreakSubmitGuard } from './composerInput.js';
 import { MentionPalette } from './MentionPalette.js';
 
-const LINE_BREAK_INPUT_TYPES = new Set(['insertLineBreak', 'insertParagraph']);
-const LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS = 500;
 const ALLOWED_IMAGE_MIMES = new Set([
   'image/png',
   'image/jpeg',
@@ -78,7 +77,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   restorePending,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const skipNextLineBreakUntilRef = useRef(0);
+  const lineBreakGuardRef = useRef(createLineBreakSubmitGuard());
   // Idempotency (§6.3): one clientMessageId per draft attempt, reused on retry
   // until a send succeeds, so a flaky connection never double-posts.
   const clientIdRef = useRef<string | null>(null);
@@ -365,11 +364,10 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       }
 
       if (e.key === 'Enter' && e.shiftKey) {
-        skipNextLineBreakUntilRef.current =
-          performance.now() + LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS;
+        lineBreakGuardRef.current.deferNextLineBreak();
         return;
       }
-      skipNextLineBreakUntilRef.current = 0;
+      lineBreakGuardRef.current.reset();
       if (e.key === 'Enter') {
         e.preventDefault();
         submit();
@@ -383,16 +381,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   // open, a mention pick) before it mutates the controlled draft.
   const handleBeforeInput = useCallback(
     (inputEvent: InputEvent) => {
-      if (!LINE_BREAK_INPUT_TYPES.has(inputEvent.inputType)) return;
-      if (inputEvent.isComposing) return;
-      if (
-        skipNextLineBreakUntilRef.current > 0 &&
-        performance.now() <= skipNextLineBreakUntilRef.current
-      ) {
-        skipNextLineBreakUntilRef.current = 0;
-        return;
-      }
-      skipNextLineBreakUntilRef.current = 0;
+      if (!lineBreakGuardRef.current.consumesAsSubmit(inputEvent)) return;
       inputEvent.preventDefault();
       if (paletteVisible) {
         const entry = entries[activeIndex];

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -37,6 +37,8 @@ interface ChannelMessageGroupProps {
   onRetryMessage?: (message: ChannelMessage) => Promise<unknown>;
   /** #1308 item 3: rewrite the body of one of the operator's own rows. */
   onEditMessage?: (message: ChannelMessage, text: string) => Promise<unknown>;
+  /** #1308 item 4: tombstone one of the operator's own rows. */
+  onDeleteMessage?: (message: ChannelMessage) => Promise<unknown>;
   /** Profile actor ids currently non-idle in this channel (retry storm brake). */
   busyAgentIds?: ReadonlySet<string>;
   /** Rows a later `meta.retryOfMessageId` system row already superseded. */
@@ -53,6 +55,7 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   highlightedMessageId = null,
   onRetryMessage,
   onEditMessage,
+  onDeleteMessage,
   busyAgentIds,
   retriedMessageIds,
 }) => {
@@ -98,6 +101,7 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
               retried={retriedMessageIds?.has(message.id) ?? false}
               {...(onRetryMessage ? { onRetry: onRetryMessage } : {})}
               {...(onEditMessage ? { onEdit: onEditMessage } : {})}
+              {...(onDeleteMessage ? { onDelete: onDeleteMessage } : {})}
               replyCount={displayedReplyCount(
                 message,
                 derived,

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -35,6 +35,8 @@ interface ChannelMessageGroupProps {
   highlightedMessageId?: ChannelMessageId | null;
   /** #1308 item 2: re-route a failed row's original trigger. */
   onRetryMessage?: (message: ChannelMessage) => Promise<unknown>;
+  /** #1308 item 3: rewrite the body of one of the operator's own rows. */
+  onEditMessage?: (message: ChannelMessage, text: string) => Promise<unknown>;
   /** Profile actor ids currently non-idle in this channel (retry storm brake). */
   busyAgentIds?: ReadonlySet<string>;
   /** Rows a later `meta.retryOfMessageId` system row already superseded. */
@@ -50,6 +52,7 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   onOpenThread,
   highlightedMessageId = null,
   onRetryMessage,
+  onEditMessage,
   busyAgentIds,
   retriedMessageIds,
 }) => {
@@ -94,6 +97,7 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
               retryBusy={busyAgentIds?.has(message.sender.id) ?? false}
               retried={retriedMessageIds?.has(message.id) ?? false}
               {...(onRetryMessage ? { onRetry: onRetryMessage } : {})}
+              {...(onEditMessage ? { onEdit: onEditMessage } : {})}
               replyCount={displayedReplyCount(
                 message,
                 derived,

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -31,6 +31,8 @@ interface ChannelMessageGroupProps {
   replyCounts?: Map<ChannelMessageId, DerivedReplyCount>;
   replyGrowth?: Map<ChannelMessageId, number>;
   onOpenThread?: (rootId: ChannelMessageId) => void;
+  /** #1308 item 1: message a deep link just landed on, if it is in this group. */
+  highlightedMessageId?: ChannelMessageId | null;
 }
 
 export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
@@ -40,6 +42,7 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   replyCounts,
   replyGrowth,
   onOpenThread,
+  highlightedMessageId = null,
 }) => {
   const identity = resolveSenderIdentity(sender);
   const first = messages[0];
@@ -78,6 +81,7 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
               key={message.id}
               message={message}
               channelId={channelId}
+              highlighted={highlightedMessageId === message.id}
               replyCount={displayedReplyCount(
                 message,
                 derived,

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -33,6 +33,12 @@ interface ChannelMessageGroupProps {
   onOpenThread?: (rootId: ChannelMessageId) => void;
   /** #1308 item 1: message a deep link just landed on, if it is in this group. */
   highlightedMessageId?: ChannelMessageId | null;
+  /** #1308 item 2: re-route a failed row's original trigger. */
+  onRetryMessage?: (message: ChannelMessage) => Promise<unknown>;
+  /** Profile actor ids currently non-idle in this channel (retry storm brake). */
+  busyAgentIds?: ReadonlySet<string>;
+  /** Rows a later `meta.retryOfMessageId` system row already superseded. */
+  retriedMessageIds?: ReadonlySet<ChannelMessageId>;
 }
 
 export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
@@ -43,6 +49,9 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   replyGrowth,
   onOpenThread,
   highlightedMessageId = null,
+  onRetryMessage,
+  busyAgentIds,
+  retriedMessageIds,
 }) => {
   const identity = resolveSenderIdentity(sender);
   const first = messages[0];
@@ -82,6 +91,9 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
               message={message}
               channelId={channelId}
               highlighted={highlightedMessageId === message.id}
+              retryBusy={busyAgentIds?.has(message.sender.id) ?? false}
+              retried={retriedMessageIds?.has(message.id) ?? false}
+              {...(onRetryMessage ? { onRetry: onRetryMessage } : {})}
               replyCount={displayedReplyCount(
                 message,
                 derived,

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  channelMessageDeletable,
   channelMessageEditable,
   channelMessageEditedAt,
   channelRetryTarget,
+  isChannelMessageDeleted,
   type ChannelMessage,
   type ChannelMessageId,
 } from '../../../../shared/channel-chat-protocol.js';
@@ -64,6 +66,19 @@ const EDIT_ICON = (
   <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
     <path
       d="M2.5 10.5l7-7 3 3-7 7H2.5v-3zM2.5 14.5h11"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+/** Bin outline — DESIGN.md flat line art, no fill, square caps. */
+const DELETE_ICON = (
+  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M2.5 4.5h11M6 4.5V2.5h4v2M4 4.5l.75 9h6.5l.75-9M6.5 7v4M9.5 7v4"
       stroke="currentColor"
       fill="none"
       strokeWidth="1.5"
@@ -460,14 +475,73 @@ const MessageEditForm: React.FC<{
   );
 };
 
+/**
+ * Two-step delete confirm, inline in the toolbar (#1308 item 4).
+ *
+ * No `window.confirm`: a native modal is a browser chrome dialog in a product
+ * whose whole visual argument is a TUI, it steals focus from the row it is
+ * about, and it cannot be tested or styled. The confirm replaces the toolbar's
+ * contents in place instead, so the question appears exactly where the operator
+ * clicked and the row underneath stays readable — which is the thing being
+ * confirmed.
+ */
+const DeleteConfirmStrip: React.FC<{
+  isHuman: boolean;
+  pending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}> = ({ isHuman, pending, onConfirm, onCancel }) => {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  // Focus the destructive button, not the row: it makes escape/tab meaningful
+  // and it keeps `useRowActionAffordance`'s focus branch true, so the toolbar
+  // cannot unmount from under an open question when the pointer wanders off.
+  useEffect(() => confirmRef.current?.focus(), []);
+  return (
+    <div
+      className={`ch-msg__actions ch-msg__confirm${
+        isHuman ? ' ch-msg__actions--user' : ''
+      }`}
+      role="group"
+      aria-label="delete message confirmation"
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape') return;
+        event.preventDefault();
+        onCancel();
+      }}
+    >
+      <span className="ch-msg__confirm-label">delete?</span>
+      <button
+        ref={confirmRef}
+        type="button"
+        className="ch-msg__confirm-btn ch-msg__confirm-btn--danger"
+        aria-label="confirm delete message"
+        disabled={pending}
+        onClick={onConfirm}
+      >
+        {pending ? 'deleting…' : 'yes'}
+      </button>
+      <button
+        type="button"
+        className="ch-msg__confirm-btn"
+        aria-label="cancel delete message"
+        disabled={pending}
+        onClick={onCancel}
+      >
+        no
+      </button>
+    </div>
+  );
+};
+
 /** Compact hover/focus/long-press toolbar (#1308 item 1, retry added in item 2). */
 const MessageActionToolbar: React.FC<{
   isHuman: boolean;
   onCopyLink: () => void;
-  onCopyText: () => void;
+  onCopyText: (() => void) | null;
   onEdit: (() => void) | null;
+  onDelete: (() => void) | null;
   retry: RetryAffordance | null;
-}> = ({ isHuman, onCopyLink, onCopyText, onEdit, retry }) => (
+}> = ({ isHuman, onCopyLink, onCopyText, onEdit, onDelete, retry }) => (
   <div
     className={`ch-msg__actions${isHuman ? ' ch-msg__actions--user' : ''}`}
     role="group"
@@ -493,15 +567,17 @@ const MessageActionToolbar: React.FC<{
     >
       {LINK_ICON}
     </button>
-    <button
-      type="button"
-      className="ch-msg__action"
-      title="copy text"
-      aria-label="copy message text"
-      onClick={onCopyText}
-    >
-      {COPY_ICON}
-    </button>
+    {onCopyText ? (
+      <button
+        type="button"
+        className="ch-msg__action"
+        title="copy text"
+        aria-label="copy message text"
+        onClick={onCopyText}
+      >
+        {COPY_ICON}
+      </button>
+    ) : null}
     {retry ? (
       <button
         type="button"
@@ -512,6 +588,17 @@ const MessageActionToolbar: React.FC<{
         onClick={retry.onRetry}
       >
         {RETRY_ICON}
+      </button>
+    ) : null}
+    {onDelete ? (
+      <button
+        type="button"
+        className="ch-msg__action ch-msg__action--danger"
+        title="delete"
+        aria-label="delete message"
+        onClick={onDelete}
+      >
+        {DELETE_ICON}
       </button>
     ) : null}
   </div>
@@ -543,6 +630,87 @@ const InlineRetryAffordance: React.FC<{ retry: RetryAffordance }> = ({
     </button>
   );
 
+/**
+ * Everything rendered BELOW a prose row's body: terminal status tags, the
+ * always-visible failed-row retry, the truncation label and the thread entry
+ * point. Split out of `ChannelMessageRow` when the delete affordance landed
+ * (#1308 item 4) — the row function had accumulated one branch per trailing
+ * ornament on top of its own body/editor/toolbar decisions.
+ *
+ * None of it is suppressed on a tombstone: a deleted row keeps its thread chip
+ * (it is still the anchor its replies point at), and a human row carries no
+ * status tags to begin with.
+ */
+const MessageRowTrailer: React.FC<{
+  message: ChannelMessage;
+  retry: RetryAffordance | null;
+  replyCount: number;
+  lastReplyHint?: string;
+  onOpenThread?: (rootId: ChannelMessageId) => void;
+}> = ({ message, retry, replyCount, lastReplyHint, onOpenThread }) => {
+  const truncationLabel = truncationLabelForMessage(message);
+  const showThreadChip =
+    message.threadId === null && replyCount > 0 && onOpenThread !== undefined;
+  return (
+    <>
+      {message.status === 'interrupted' ? (
+        <span className="ch-msg__tag ch-msg__tag--interrupted">
+          interrupted
+        </span>
+      ) : null}
+      {message.status === 'failed' ? (
+        <span className="ch-msg__tag ch-msg__tag--failed">failed</span>
+      ) : null}
+      {retry && message.status === 'failed' ? (
+        <InlineRetryAffordance retry={retry} />
+      ) : null}
+      {truncationLabel ? (
+        <span className="ch-msg__tag ch-msg__tag--truncated">
+          {truncationLabel}
+        </span>
+      ) : null}
+      {showThreadChip && onOpenThread ? (
+        <button
+          type="button"
+          className="ch-msg__thread-chip"
+          onClick={() => onOpenThread(message.id)}
+          aria-label={`${replyCount} repl${replyCount === 1 ? 'y' : 'ies'} — open thread`}
+        >
+          <span className="ch-msg__thread-chip__count">
+            {replyCount} repl{replyCount === 1 ? 'y' : 'ies'}
+          </span>
+          {lastReplyHint ? (
+            <span className="ch-msg__thread-chip__hint">{lastReplyHint}</span>
+          ) : null}
+        </button>
+      ) : null}
+    </>
+  );
+};
+
+const STATUS_ROW_MODIFIERS: Partial<Record<ChannelMessage['status'], string>> = {
+  streaming: 'ch-msg--streaming',
+  truncated: 'ch-msg--truncated',
+  interrupted: 'ch-msg--interrupted',
+  failed: 'ch-msg--failed',
+};
+
+/** Row modifier classes for a prose row — one table lookup plus two flags. */
+function proseRowClassName(
+  message: ChannelMessage,
+  flags: { deleted: boolean; highlighted: boolean }
+): string {
+  return [
+    'ch-msg',
+    message.sender.kind === 'human' ? 'ch-msg--user' : null,
+    STATUS_ROW_MODIFIERS[message.status] ?? null,
+    flags.deleted ? 'ch-msg--deleted' : null,
+    flags.highlighted ? 'ch-msg--jump' : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
 interface ChannelMessageRowProps {
   message: ChannelMessage;
   channelId: string;
@@ -565,6 +733,12 @@ interface ChannelMessageRowProps {
    */
   onEdit?: (message: ChannelMessage, text: string) => Promise<unknown>;
   /**
+   * #1308 item 4. Tombstones this row. Omitted where the surface has no delete
+   * lane, which also removes the affordance; the row never invents one.
+   * Rejecting the promise leaves the confirm open so the operator can retry.
+   */
+  onDelete?: (message: ChannelMessage) => Promise<unknown>;
+  /**
    * The bound profile is non-idle in this channel. Retry stays visible but
    * disabled so a busy agent cannot be stacked with a second turn (storm brake;
    * the server refuses independently).
@@ -584,6 +758,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   highlighted = false,
   onRetry,
   onEdit,
+  onDelete,
   retryBusy = false,
   retried = false,
 }) => {
@@ -593,11 +768,27 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   const [retryPending, setRetryPending] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editPending, setEditPending] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deletePending, setDeletePending] = useState(false);
 
   // Human-authored prose rows only, and only where the surface wired a lane.
   // The predicate is the SHARED one the route enforces, so the button cannot
-  // appear on a row the server would refuse.
+  // appear on a row the server would refuse. Both predicates already exclude a
+  // tombstone, so a deleted row grows neither control.
   const editable = onEdit !== undefined && channelMessageEditable(message);
+  const deletable = onDelete !== undefined && channelMessageDeletable(message);
+  const deleted = isChannelMessageDeleted(message);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!onDelete || deletePending) return;
+    setDeletePending(true);
+    void onDelete(message)
+      .then(() => setConfirmingDelete(false))
+      // Failure keeps the confirm open rather than silently reverting to the
+      // toolbar — the operator asked for this and is owed the outcome.
+      .catch(() => {})
+      .finally(() => setDeletePending(false));
+  }, [deletePending, message, onDelete]);
 
   const handleSaveEdit = useCallback(
     (text: string) => {
@@ -664,18 +855,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
 
   const isHuman = message.sender.kind === 'human';
   const editedAt = channelMessageEditedAt(message);
-  const truncationLabel = truncationLabelForMessage(message);
-  const rowClasses = [
-    'ch-msg',
-    isHuman ? 'ch-msg--user' : null,
-    message.status === 'streaming' ? 'ch-msg--streaming' : null,
-    message.status === 'truncated' ? 'ch-msg--truncated' : null,
-    message.status === 'interrupted' ? 'ch-msg--interrupted' : null,
-    message.status === 'failed' ? 'ch-msg--failed' : null,
-    highlighted ? 'ch-msg--jump' : null,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const rowClasses = proseRowClassName(message, { deleted, highlighted });
 
   const streamStyle =
     streaming && !isHuman
@@ -693,12 +873,24 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       data-channel-message-id={message.id}
       {...affordance}
     >
-      {actionsVisible && !editing ? (
+      {confirmingDelete && deletable ? (
+        // The confirm occupies the toolbar's own slot, so the question sits
+        // where the button the operator just pressed was.
+        <DeleteConfirmStrip
+          isHuman={isHuman}
+          pending={deletePending}
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setConfirmingDelete(false)}
+        />
+      ) : actionsVisible && !editing ? (
         <MessageActionToolbar
           isHuman={isHuman}
           onCopyLink={handleCopyLink}
-          onCopyText={handleCopyText}
+          // A tombstone keeps its deep link — it is still an addressable row and
+          // still a thread anchor — but there is nothing left to copy as text.
+          onCopyText={deleted ? null : handleCopyText}
           onEdit={editable ? () => setEditing(true) : null}
+          onDelete={deletable ? () => setConfirmingDelete(true) : null}
           retry={retry}
         />
       ) : null}
@@ -708,7 +900,11 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
           itemId={message.agentDetail.itemId}
         />
       ) : null}
-      {editing ? (
+      {deleted ? (
+        // Placeholder, not a removal: the row keeps its slot so grouping, the
+        // scroll anchor and any thread chip below stay exactly where they were.
+        <span className="ch-msg__deleted">message deleted</span>
+      ) : editing ? (
         <MessageEditForm
           initialText={message.body.text}
           pending={editPending}
@@ -722,7 +918,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
           streaming={streaming}
         />
       )}
-      {editedAt && !editing ? (
+      {editedAt && !editing && !deleted ? (
         <span className="ch-msg__edited" title={`edited ${editedAt}`}>
           (edited)
         </span>
@@ -739,37 +935,13 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
           ))}
         </div>
       ) : null}
-      {message.status === 'interrupted' ? (
-        <span className="ch-msg__tag ch-msg__tag--interrupted">
-          interrupted
-        </span>
-      ) : null}
-      {message.status === 'failed' ? (
-        <span className="ch-msg__tag ch-msg__tag--failed">failed</span>
-      ) : null}
-      {retry && message.status === 'failed' ? (
-        <InlineRetryAffordance retry={retry} />
-      ) : null}
-      {truncationLabel ? (
-        <span className="ch-msg__tag ch-msg__tag--truncated">
-          {truncationLabel}
-        </span>
-      ) : null}
-      {message.threadId === null && replyCount > 0 && onOpenThread ? (
-        <button
-          type="button"
-          className="ch-msg__thread-chip"
-          onClick={() => onOpenThread(message.id)}
-          aria-label={`${replyCount} repl${replyCount === 1 ? 'y' : 'ies'} — open thread`}
-        >
-          <span className="ch-msg__thread-chip__count">
-            {replyCount} repl{replyCount === 1 ? 'y' : 'ies'}
-          </span>
-          {lastReplyHint ? (
-            <span className="ch-msg__thread-chip__hint">{lastReplyHint}</span>
-          ) : null}
-        </button>
-      ) : null}
+      <MessageRowTrailer
+        message={message}
+        retry={retry}
+        replyCount={replyCount}
+        {...(lastReplyHint ? { lastReplyHint } : {})}
+        {...(onOpenThread ? { onOpenThread } : {})}
+      />
     </div>
   );
 };

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   ChannelMessage,
   ChannelMessageId,
@@ -9,6 +9,57 @@ import { AgentDetailCard } from './AgentDetailCard.js';
 import { ChannelImagePart } from './ChannelImagePart.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { respondChannelApproval } from '../../lib/api.js';
+import { buildChannelMessageLink } from '../../lib/url-nav.js';
+import { showToast } from '../../lib/stores/toasts.js';
+
+/** Touch hold before the action toolbar pins open, matching `Terminal.tsx`. */
+const LONG_PRESS_MS = 500;
+/** Finger travel that cancels a pending long press. */
+const LONG_PRESS_SLOP_PX = 10;
+
+/**
+ * DESIGN.md icon law: flat SVG line art, 1.5px stroke, square caps, no fill.
+ * Sized 12px to sit inside the compact action button without changing row
+ * metrics (the toolbar is absolutely positioned, so it never reflows the lane).
+ */
+const LINK_ICON = (
+  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M6.5 9.5l3-3M7 4.5L8.75 2.75a2.5 2.5 0 013.5 3.5L10.5 8M5.5 8L3.75 9.75a2.5 2.5 0 003.5 3.5L9 11.5"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+const COPY_ICON = (
+  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+    <rect
+      x="5.5"
+      y="5.5"
+      width="8"
+      height="8"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M10.5 2.5h-8v8"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+async function writeClipboard(text: string): Promise<void> {
+  const clipboard = globalThis.navigator?.clipboard;
+  if (!clipboard) throw new Error('clipboard unavailable');
+  await clipboard.writeText(text);
+}
 
 /** DESIGN.md motion effect 4: solid while text is actively arriving, blinks
  * after 530ms of no change. Returns true when the cursor should blink. */
@@ -48,6 +99,100 @@ function truncationLabelForMessage(message: ChannelMessage): string | null {
   return message.status === 'truncated' ? 'truncated' : null;
 }
 
+interface RowActionAffordance {
+  actionsVisible: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onFocus: () => void;
+  onBlur: (event: React.FocusEvent<HTMLDivElement>) => void;
+  onTouchStart: (event: React.TouchEvent<HTMLDivElement>) => void;
+  onTouchMove: (event: React.TouchEvent<HTMLDivElement>) => void;
+  onTouchEnd: () => void;
+}
+
+/**
+ * Reveal rule for the per-message action toolbar (#1308 item 1).
+ *
+ * Three affordances, one state: pointer hover (desktop), focus anywhere in the
+ * row (keyboard — the toolbar buttons themselves are focusable, so tabbing into
+ * a row keeps it open), and a long press (touch, where neither of the first two
+ * exists). The long press pins the toolbar until the next pointer-down outside
+ * the row, which is the only dismissal a touch device can offer.
+ */
+function useRowActionAffordance(
+  rowRef: React.RefObject<HTMLDivElement | null>
+): RowActionAffordance {
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const pressRef = useRef<{
+    timer: ReturnType<typeof setTimeout> | null;
+    x: number;
+    y: number;
+  }>({ timer: null, x: 0, y: 0 });
+
+  const cancelPress = useCallback((): void => {
+    const press = pressRef.current;
+    if (press.timer !== null) clearTimeout(press.timer);
+    press.timer = null;
+  }, []);
+
+  useEffect(() => cancelPress, [cancelPress]);
+
+  useEffect(() => {
+    if (!pinned) return;
+    const dismiss = (event: Event): void => {
+      const row = rowRef.current;
+      if (row && event.target instanceof Node && row.contains(event.target)) {
+        return;
+      }
+      setPinned(false);
+    };
+    // Capture phase: a tap on another row must close this one even though that
+    // row stops nothing — the listener has to win before any React handler.
+    document.addEventListener('pointerdown', dismiss, true);
+    return () => document.removeEventListener('pointerdown', dismiss, true);
+  }, [pinned, rowRef]);
+
+  return {
+    actionsVisible: hovered || focused || pinned,
+    onMouseEnter: () => setHovered(true),
+    onMouseLeave: () => setHovered(false),
+    onFocus: () => setFocused(true),
+    onBlur: (event) => {
+      // Moving focus between the toolbar's own buttons must not close it.
+      const next = event.relatedTarget;
+      if (next instanceof Node && event.currentTarget.contains(next)) return;
+      setFocused(false);
+    },
+    onTouchStart: (event) => {
+      const touch = event.touches[0];
+      if (!touch) return;
+      cancelPress();
+      const press = pressRef.current;
+      press.x = touch.clientX;
+      press.y = touch.clientY;
+      press.timer = setTimeout(() => {
+        press.timer = null;
+        setPinned(true);
+      }, LONG_PRESS_MS);
+    },
+    onTouchMove: (event) => {
+      const press = pressRef.current;
+      if (press.timer === null) return;
+      const touch = event.touches[0];
+      if (!touch) return;
+      if (
+        Math.abs(touch.clientX - press.x) > LONG_PRESS_SLOP_PX ||
+        Math.abs(touch.clientY - press.y) > LONG_PRESS_SLOP_PX
+      ) {
+        cancelPress();
+      }
+    },
+    onTouchEnd: cancelPress,
+  };
+}
+
 interface ChannelMessageRowProps {
   message: ChannelMessage;
   channelId: string;
@@ -55,6 +200,8 @@ interface ChannelMessageRowProps {
   replyCount?: number;
   lastReplyHint?: string;
   onOpenThread?: (rootId: ChannelMessageId) => void;
+  /** #1308 item 1: brief jump emphasis after a deep link lands on this row. */
+  highlighted?: boolean;
 }
 
 export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
@@ -64,9 +211,32 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   replyCount = 0,
   lastReplyHint,
   onOpenThread,
+  highlighted = false,
 }) => {
   const streaming = message.status === 'streaming';
   const blinking = useIdleBlink(message.body.text, streaming);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const { actionsVisible, ...affordance } = useRowActionAffordance(rowRef);
+
+  const handleCopyLink = useCallback(() => {
+    const origin =
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : 'http://localhost';
+    void writeClipboard(
+      buildChannelMessageLink(channelId, message.id, origin)
+    ).then(
+      () => showToast('message link copied', 'info', 2000),
+      () => showToast('could not copy the message link')
+    );
+  }, [channelId, message.id]);
+
+  const handleCopyText = useCallback(() => {
+    void writeClipboard(message.body.text).then(
+      () => showToast('message text copied', 'info', 2000),
+      () => showToast('could not copy the message text')
+    );
+  }, [message.body.text]);
 
   if (variant === 'system' || message.kind === 'system') {
     // System rows carry actionable payloads in `meta` (#1167). An approval
@@ -76,9 +246,10 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
     const hasApproval = typeof approvalRequestId === 'string';
     return (
       <div
-        className="ch-system-msg"
+        className={`ch-system-msg${highlighted ? ' ch-msg--jump' : ''}`}
         role="note"
         data-channel-message-seq={message.seq}
+        data-channel-message-id={message.id}
       >
         <span className="ch-system-msg__label">{message.body.text}</span>
         {hasApproval ? (
@@ -126,6 +297,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
     message.status === 'truncated' ? 'ch-msg--truncated' : null,
     message.status === 'interrupted' ? 'ch-msg--interrupted' : null,
     message.status === 'failed' ? 'ch-msg--failed' : null,
+    highlighted ? 'ch-msg--jump' : null,
   ]
     .filter(Boolean)
     .join(' ');
@@ -156,10 +328,39 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
 
   return (
     <div
+      ref={rowRef}
       className={rowClasses}
       style={streamStyle}
       data-channel-message-seq={message.seq}
+      data-channel-message-id={message.id}
+      {...affordance}
     >
+      {actionsVisible ? (
+        <div
+          className={`ch-msg__actions${isHuman ? ' ch-msg__actions--user' : ''}`}
+          role="group"
+          aria-label="message actions"
+        >
+          <button
+            type="button"
+            className="ch-msg__action"
+            title="copy link"
+            aria-label="copy link to message"
+            onClick={handleCopyLink}
+          >
+            {LINK_ICON}
+          </button>
+          <button
+            type="button"
+            className="ch-msg__action"
+            title="copy text"
+            aria-label="copy message text"
+            onClick={handleCopyText}
+          >
+            {COPY_ICON}
+          </button>
+        </div>
+      ) : null}
       {message.agentDetail ? (
         <AgentDetailCard
           card={message.agentDetail.card}

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  channelMessageEditable,
+  channelMessageEditedAt,
   channelRetryTarget,
   type ChannelMessage,
   type ChannelMessageId,
@@ -9,6 +11,7 @@ import { AssistantMarkdown } from './AssistantMarkdown.js';
 import { AgentDetailCard } from './AgentDetailCard.js';
 import { ChannelImagePart } from './ChannelImagePart.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { createLineBreakSubmitGuard } from './composerInput.js';
 import { respondChannelApproval } from '../../lib/api.js';
 import { buildChannelMessageLink } from '../../lib/url-nav.js';
 import { showToast } from '../../lib/stores/toasts.js';
@@ -48,6 +51,19 @@ const COPY_ICON = (
     />
     <path
       d="M10.5 2.5h-8v8"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+/** Pencil over a rule — DESIGN.md flat line art, no fill, square caps. */
+const EDIT_ICON = (
+  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M2.5 10.5l7-7 3 3-7 7H2.5v-3zM2.5 14.5h11"
       stroke="currentColor"
       fill="none"
       strokeWidth="1.5"
@@ -284,18 +300,190 @@ function retryTitle(retry: RetryAffordance): string {
   return retry.busy ? 'agent is busy' : 'retry';
 }
 
+/**
+ * Body region of a prose row: markdown or plain text, plus the streaming block
+ * cursor. Split out of `ChannelMessageRow` when the in-place editor landed
+ * (#1308 item 3) — the row now chooses between "render the body" and "render
+ * the editor", and keeping both shapes inline made one function own every
+ * branch of both.
+ */
+const MessageBody: React.FC<{
+  message: ChannelMessage;
+  isHuman: boolean;
+  streaming: boolean;
+}> = ({ message, isHuman, streaming }) => {
+  const blinking = useIdleBlink(message.body.text, streaming);
+  const hasText = message.body.text.length > 0;
+  const detailStatus = detailStatusForMessage(message.status);
+  const body = hasText ? (
+    message.body.format === 'markdown' ? (
+      <div className="ch-msg__body">
+        <AssistantMarkdown
+          text={message.body.text}
+          keyPrefix={message.id}
+          codeBlockPresentation={isHuman ? 'plain' : 'card'}
+          codeBlockStatus={detailStatus}
+        />
+      </div>
+    ) : (
+      <pre className="ch-msg__text ch-msg__body">{message.body.text}</pre>
+    )
+  ) : null;
+
+  if (
+    message.body.format !== 'markdown' ||
+    !(hasText || (streaming && !message.agentDetail))
+  ) {
+    return body;
+  }
+  return (
+    <div className="ch-msg__body-wrap">
+      {body}
+      {streaming ? (
+        <span
+          className={`ch-msg__cursor${blinking ? ' ch-msg__cursor--blinking' : ''}`}
+          aria-hidden="true"
+        >
+          █
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+/**
+ * In-place editor for one of the operator's own rows (#1308 item 3).
+ *
+ * Replaces the body where it sits rather than opening a modal or hijacking the
+ * composer: the surrounding rows keep their position, so the edit reads as a
+ * correction to THIS message. Submission rules come from the shared composer
+ * primitive (`createLineBreakSubmitGuard`), so the on-screen send key works the
+ * same here as it does in the composer — the mobile IME path is the whole
+ * reason that primitive exists.
+ */
+const MessageEditForm: React.FC<{
+  initialText: string;
+  pending: boolean;
+  onSave: (text: string) => void;
+  onCancel: () => void;
+}> = ({ initialText, pending, onSave, onCancel }) => {
+  const [draft, setDraft] = useState(initialText);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const guardRef = useRef(createLineBreakSubmitGuard());
+
+  const submit = useCallback(() => {
+    const next = draft.trim();
+    // An empty edit is a delete, which this slice does not own; an unchanged one
+    // is a no-op the server should never be asked to persist.
+    if (next.length === 0) return;
+    if (next === initialText.trim()) {
+      onCancel();
+      return;
+    }
+    onSave(next);
+  }, [draft, initialText, onCancel, onSave]);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.focus();
+    // Caret at the end, not a full selection: the operator is amending an
+    // existing sentence far more often than replacing the whole message.
+    el.selectionStart = el.value.length;
+    el.selectionEnd = el.value.length;
+  }, []);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const handler = (event: InputEvent): void => {
+      if (!guardRef.current.consumesAsSubmit(event)) return;
+      event.preventDefault();
+      submit();
+    };
+    el.addEventListener('beforeinput', handler);
+    return () => el.removeEventListener('beforeinput', handler);
+  }, [submit]);
+
+  return (
+    <div className="ch-msg__edit">
+      <textarea
+        ref={textareaRef}
+        className="ch-msg__edit-ta"
+        aria-label="edit message text"
+        rows={Math.min(8, draft.split('\n').length)}
+        value={draft}
+        disabled={pending}
+        enterKeyHint="done"
+        onChange={(event) => setDraft(event.currentTarget.value)}
+        onKeyDown={(event) => {
+          const native = event.nativeEvent as KeyboardEvent;
+          if (event.key === 'Enter' && native.isComposing) return;
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            onCancel();
+            return;
+          }
+          if (event.key === 'Enter' && event.shiftKey) {
+            guardRef.current.deferNextLineBreak();
+            return;
+          }
+          guardRef.current.reset();
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            submit();
+          }
+        }}
+      />
+      <div className="ch-msg__edit-bar">
+        <button
+          type="button"
+          className="ch-msg__edit-btn"
+          onClick={submit}
+          disabled={pending}
+        >
+          {pending ? 'saving…' : 'save'}
+        </button>
+        <button
+          type="button"
+          className="ch-msg__edit-btn"
+          onClick={onCancel}
+          disabled={pending}
+        >
+          cancel
+        </button>
+        <span className="ch-msg__edit-hint">
+          <kbd>↵</kbd>save <kbd>esc</kbd>cancel <kbd>⇧↵</kbd>newline
+        </span>
+      </div>
+    </div>
+  );
+};
+
 /** Compact hover/focus/long-press toolbar (#1308 item 1, retry added in item 2). */
 const MessageActionToolbar: React.FC<{
   isHuman: boolean;
   onCopyLink: () => void;
   onCopyText: () => void;
+  onEdit: (() => void) | null;
   retry: RetryAffordance | null;
-}> = ({ isHuman, onCopyLink, onCopyText, retry }) => (
+}> = ({ isHuman, onCopyLink, onCopyText, onEdit, retry }) => (
   <div
     className={`ch-msg__actions${isHuman ? ' ch-msg__actions--user' : ''}`}
     role="group"
     aria-label="message actions"
   >
+    {onEdit ? (
+      <button
+        type="button"
+        className="ch-msg__action"
+        title="edit"
+        aria-label="edit message"
+        onClick={onEdit}
+      >
+        {EDIT_ICON}
+      </button>
+    ) : null}
     <button
       type="button"
       className="ch-msg__action"
@@ -371,6 +559,12 @@ interface ChannelMessageRowProps {
    */
   onRetry?: (message: ChannelMessage) => Promise<unknown>;
   /**
+   * #1308 item 3. Rewrites this row's body. Omitted where the surface has no
+   * edit lane, which also removes the affordance; the row never invents one.
+   * Rejecting the promise keeps the editor open with the operator's draft.
+   */
+  onEdit?: (message: ChannelMessage, text: string) => Promise<unknown>;
+  /**
    * The bound profile is non-idle in this channel. Retry stays visible but
    * disabled so a busy agent cannot be stacked with a second turn (storm brake;
    * the server refuses independently).
@@ -389,14 +583,35 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   onOpenThread,
   highlighted = false,
   onRetry,
+  onEdit,
   retryBusy = false,
   retried = false,
 }) => {
   const streaming = message.status === 'streaming';
-  const blinking = useIdleBlink(message.body.text, streaming);
   const rowRef = useRef<HTMLDivElement>(null);
   const { actionsVisible, ...affordance } = useRowActionAffordance(rowRef);
   const [retryPending, setRetryPending] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editPending, setEditPending] = useState(false);
+
+  // Human-authored prose rows only, and only where the surface wired a lane.
+  // The predicate is the SHARED one the route enforces, so the button cannot
+  // appear on a row the server would refuse.
+  const editable = onEdit !== undefined && channelMessageEditable(message);
+
+  const handleSaveEdit = useCallback(
+    (text: string) => {
+      if (!onEdit || editPending) return;
+      setEditPending(true);
+      void onEdit(message, text)
+        .then(() => setEditing(false))
+        // Failure keeps the editor (and the draft) open: the operator's words
+        // are the one thing this component must never silently discard.
+        .catch(() => {})
+        .finally(() => setEditPending(false));
+    },
+    [editPending, message, onEdit]
+  );
 
   const handleRetry = useCallback(() => {
     if (!onRetry || retryPending) return;
@@ -409,7 +624,12 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   // route agree by construction instead of by convention.
   const retry: RetryAffordance | null =
     onRetry !== undefined && channelRetryTarget(message) !== null
-      ? { onRetry: handleRetry, pending: retryPending, busy: retryBusy, retried }
+      ? {
+          onRetry: handleRetry,
+          pending: retryPending,
+          busy: retryBusy,
+          retried,
+        }
       : null;
 
   const handleCopyLink = useCallback(() => {
@@ -443,6 +663,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   }
 
   const isHuman = message.sender.kind === 'human';
+  const editedAt = channelMessageEditedAt(message);
   const truncationLabel = truncationLabelForMessage(message);
   const rowClasses = [
     'ch-msg',
@@ -463,23 +684,6 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
         } as React.CSSProperties)
       : undefined;
 
-  const hasText = message.body.text.length > 0;
-  const detailStatus = detailStatusForMessage(message.status);
-  const body = hasText ? (
-    message.body.format === 'markdown' ? (
-      <div className="ch-msg__body">
-        <AssistantMarkdown
-          text={message.body.text}
-          keyPrefix={message.id}
-          codeBlockPresentation={isHuman ? 'plain' : 'card'}
-          codeBlockStatus={detailStatus}
-        />
-      </div>
-    ) : (
-      <pre className="ch-msg__text ch-msg__body">{message.body.text}</pre>
-    )
-  ) : null;
-
   return (
     <div
       ref={rowRef}
@@ -489,11 +693,12 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       data-channel-message-id={message.id}
       {...affordance}
     >
-      {actionsVisible ? (
+      {actionsVisible && !editing ? (
         <MessageActionToolbar
           isHuman={isHuman}
           onCopyLink={handleCopyLink}
           onCopyText={handleCopyText}
+          onEdit={editable ? () => setEditing(true) : null}
           retry={retry}
         />
       ) : null}
@@ -503,22 +708,25 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
           itemId={message.agentDetail.itemId}
         />
       ) : null}
-      {message.body.format === 'markdown' &&
-      (hasText || (streaming && !message.agentDetail)) ? (
-        <div className="ch-msg__body-wrap">
-          {body}
-          {streaming ? (
-            <span
-              className={`ch-msg__cursor${blinking ? ' ch-msg__cursor--blinking' : ''}`}
-              aria-hidden="true"
-            >
-              █
-            </span>
-          ) : null}
-        </div>
+      {editing ? (
+        <MessageEditForm
+          initialText={message.body.text}
+          pending={editPending}
+          onSave={handleSaveEdit}
+          onCancel={() => setEditing(false)}
+        />
       ) : (
-        body
+        <MessageBody
+          message={message}
+          isHuman={isHuman}
+          streaming={streaming}
+        />
       )}
+      {editedAt && !editing ? (
+        <span className="ch-msg__edited" title={`edited ${editedAt}`}>
+          (edited)
+        </span>
+      ) : null}
       {message.parts && message.parts.length > 0 ? (
         <div className="ch-msg__parts" aria-label="image attachments">
           {message.parts.map((part, index) => (

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import type {
-  ChannelMessage,
-  ChannelMessageId,
+import {
+  channelRetryTarget,
+  type ChannelMessage,
+  type ChannelMessageId,
 } from '../../../../shared/channel-chat-protocol.js';
 import type { AgentDetailCardStatusV2 } from '../../../../shared/agent-chat-protocol-v2.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
@@ -47,6 +48,19 @@ const COPY_ICON = (
     />
     <path
       d="M10.5 2.5h-8v8"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+/** Open circular arrow — DESIGN.md flat line art, no fill, square caps. */
+const RETRY_ICON = (
+  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M13 8a5 5 0 11-1.6-3.7M13 2v3h-3"
       stroke="currentColor"
       fill="none"
       strokeWidth="1.5"
@@ -193,6 +207,154 @@ function useRowActionAffordance(
   };
 }
 
+/**
+ * System rows carry actionable payloads in `meta` (#1167). An approval request
+ * renders approve/deny controls that call the per-agent approvals endpoint;
+ * errors are swallowed (the row heals when the agent re-emits). Split out of
+ * `ChannelMessageRow` so the message row's own branching stays legible.
+ */
+const ChannelSystemMessageRow: React.FC<{
+  message: ChannelMessage;
+  channelId: string;
+  highlighted: boolean;
+}> = ({ message, channelId, highlighted }) => {
+  const approvalRequestId = message.meta?.approvalRequestId;
+  const hasApproval = typeof approvalRequestId === 'string';
+  return (
+    <div
+      className={`ch-system-msg${highlighted ? ' ch-msg--jump' : ''}`}
+      role="note"
+      data-channel-message-seq={message.seq}
+      data-channel-message-id={message.id}
+    >
+      <span className="ch-system-msg__label">{message.body.text}</span>
+      {hasApproval ? (
+        <span className="ch-system-msg__actions">
+          <button
+            type="button"
+            className="ch-system-msg__btn ch-system-msg__btn--approve"
+            onClick={() =>
+              void respondChannelApproval(
+                channelId,
+                String(message.meta?.agentId),
+                String(message.meta?.approvalRequestId),
+                { kind: 'accept', scope: 'once' }
+              ).catch(() => {})
+            }
+          >
+            approve
+          </button>
+          <button
+            type="button"
+            className="ch-system-msg__btn ch-system-msg__btn--deny"
+            onClick={() =>
+              void respondChannelApproval(
+                channelId,
+                String(message.meta?.agentId),
+                String(message.meta?.approvalRequestId),
+                { kind: 'decline' }
+              ).catch(() => {})
+            }
+          >
+            deny
+          </button>
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+/**
+ * Everything the retry affordances need, or `null` when the row cannot be
+ * retried. Resolved once by `ChannelMessageRow` so the toolbar button and the
+ * inline button can never disagree about disabled/superseded state.
+ */
+interface RetryAffordance {
+  onRetry: () => void;
+  /** Request in flight from this row. */
+  pending: boolean;
+  /** Bound profile is non-idle in this channel. */
+  busy: boolean;
+  /** A later system row already superseded this one. */
+  retried: boolean;
+}
+
+function retryTitle(retry: RetryAffordance): string {
+  if (retry.retried) return 'already retried';
+  return retry.busy ? 'agent is busy' : 'retry';
+}
+
+/** Compact hover/focus/long-press toolbar (#1308 item 1, retry added in item 2). */
+const MessageActionToolbar: React.FC<{
+  isHuman: boolean;
+  onCopyLink: () => void;
+  onCopyText: () => void;
+  retry: RetryAffordance | null;
+}> = ({ isHuman, onCopyLink, onCopyText, retry }) => (
+  <div
+    className={`ch-msg__actions${isHuman ? ' ch-msg__actions--user' : ''}`}
+    role="group"
+    aria-label="message actions"
+  >
+    <button
+      type="button"
+      className="ch-msg__action"
+      title="copy link"
+      aria-label="copy link to message"
+      onClick={onCopyLink}
+    >
+      {LINK_ICON}
+    </button>
+    <button
+      type="button"
+      className="ch-msg__action"
+      title="copy text"
+      aria-label="copy message text"
+      onClick={onCopyText}
+    >
+      {COPY_ICON}
+    </button>
+    {retry ? (
+      <button
+        type="button"
+        className="ch-msg__action"
+        title={retryTitle(retry)}
+        aria-label="retry this reply"
+        disabled={retry.busy || retry.pending || retry.retried}
+        onClick={retry.onRetry}
+      >
+        {RETRY_ICON}
+      </button>
+    ) : null}
+  </div>
+);
+
+/**
+ * Always-visible recovery on a `failed` row (#1308 item 2). A failed turn is the
+ * one terminal state nothing about the operator's own action explains, so it
+ * must be reachable without hovering — touch has no hover at all.
+ * Interrupted/truncated keep retry in the toolbar, where it adds no permanent
+ * chrome to rows the operator already accounted for.
+ */
+const InlineRetryAffordance: React.FC<{ retry: RetryAffordance }> = ({
+  retry,
+}) =>
+  retry.retried ? (
+    <span className="ch-msg__tag ch-msg__tag--retried">retried</span>
+  ) : (
+    <button
+      type="button"
+      className="ch-msg__retry"
+      disabled={retry.busy || retry.pending}
+      onClick={retry.onRetry}
+      aria-label="retry this reply"
+      title={retryTitle(retry)}
+    >
+      {RETRY_ICON}
+      <span>{retry.pending ? 'retrying…' : 'retry'}</span>
+    </button>
+  );
+
 interface ChannelMessageRowProps {
   message: ChannelMessage;
   channelId: string;
@@ -202,6 +364,20 @@ interface ChannelMessageRowProps {
   onOpenThread?: (rootId: ChannelMessageId) => void;
   /** #1308 item 1: brief jump emphasis after a deep link lands on this row. */
   highlighted?: boolean;
+  /**
+   * #1308 item 2. Re-routes the row's ORIGINAL trigger message. Omitted where
+   * the surface has no retry lane (isolated fixtures), which also removes the
+   * affordance — the row never invents a retry path of its own.
+   */
+  onRetry?: (message: ChannelMessage) => Promise<unknown>;
+  /**
+   * The bound profile is non-idle in this channel. Retry stays visible but
+   * disabled so a busy agent cannot be stacked with a second turn (storm brake;
+   * the server refuses independently).
+   */
+  retryBusy?: boolean;
+  /** A later system row already superseded this one via `meta.retryOfMessageId`. */
+  retried?: boolean;
 }
 
 export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
@@ -212,11 +388,29 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   lastReplyHint,
   onOpenThread,
   highlighted = false,
+  onRetry,
+  retryBusy = false,
+  retried = false,
 }) => {
   const streaming = message.status === 'streaming';
   const blinking = useIdleBlink(message.body.text, streaming);
   const rowRef = useRef<HTMLDivElement>(null);
   const { actionsVisible, ...affordance } = useRowActionAffordance(rowRef);
+  const [retryPending, setRetryPending] = useState(false);
+
+  const handleRetry = useCallback(() => {
+    if (!onRetry || retryPending) return;
+    setRetryPending(true);
+    void onRetry(message).finally(() => setRetryPending(false));
+  }, [message, onRetry, retryPending]);
+
+  // Retry is offered only where the shared contract can name a trigger to
+  // re-route (`source.turnId` minted by the binder), so the button and the
+  // route agree by construction instead of by convention.
+  const retry: RetryAffordance | null =
+    onRetry !== undefined && channelRetryTarget(message) !== null
+      ? { onRetry: handleRetry, pending: retryPending, busy: retryBusy, retried }
+      : null;
 
   const handleCopyLink = useCallback(() => {
     const origin =
@@ -239,52 +433,12 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   }, [message.body.text]);
 
   if (variant === 'system' || message.kind === 'system') {
-    // System rows carry actionable payloads in `meta` (#1167). An approval
-    // request renders approve/deny controls that call the per-agent approvals
-    // endpoint; errors are swallowed (the row heals when the agent re-emits).
-    const approvalRequestId = message.meta?.approvalRequestId;
-    const hasApproval = typeof approvalRequestId === 'string';
     return (
-      <div
-        className={`ch-system-msg${highlighted ? ' ch-msg--jump' : ''}`}
-        role="note"
-        data-channel-message-seq={message.seq}
-        data-channel-message-id={message.id}
-      >
-        <span className="ch-system-msg__label">{message.body.text}</span>
-        {hasApproval ? (
-          <span className="ch-system-msg__actions">
-            <button
-              type="button"
-              className="ch-system-msg__btn ch-system-msg__btn--approve"
-              onClick={() =>
-                void respondChannelApproval(
-                  channelId,
-                  String(message.meta?.agentId),
-                  String(message.meta?.approvalRequestId),
-                  { kind: 'accept', scope: 'once' }
-                ).catch(() => {})
-              }
-            >
-              approve
-            </button>
-            <button
-              type="button"
-              className="ch-system-msg__btn ch-system-msg__btn--deny"
-              onClick={() =>
-                void respondChannelApproval(
-                  channelId,
-                  String(message.meta?.agentId),
-                  String(message.meta?.approvalRequestId),
-                  { kind: 'decline' }
-                ).catch(() => {})
-              }
-            >
-              deny
-            </button>
-          </span>
-        ) : null}
-      </div>
+      <ChannelSystemMessageRow
+        message={message}
+        channelId={channelId}
+        highlighted={highlighted}
+      />
     );
   }
 
@@ -336,30 +490,12 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       {...affordance}
     >
       {actionsVisible ? (
-        <div
-          className={`ch-msg__actions${isHuman ? ' ch-msg__actions--user' : ''}`}
-          role="group"
-          aria-label="message actions"
-        >
-          <button
-            type="button"
-            className="ch-msg__action"
-            title="copy link"
-            aria-label="copy link to message"
-            onClick={handleCopyLink}
-          >
-            {LINK_ICON}
-          </button>
-          <button
-            type="button"
-            className="ch-msg__action"
-            title="copy text"
-            aria-label="copy message text"
-            onClick={handleCopyText}
-          >
-            {COPY_ICON}
-          </button>
-        </div>
+        <MessageActionToolbar
+          isHuman={isHuman}
+          onCopyLink={handleCopyLink}
+          onCopyText={handleCopyText}
+          retry={retry}
+        />
       ) : null}
       {message.agentDetail ? (
         <AgentDetailCard
@@ -402,6 +538,9 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       ) : null}
       {message.status === 'failed' ? (
         <span className="ch-msg__tag ch-msg__tag--failed">failed</span>
+      ) : null}
+      {retry && message.status === 'failed' ? (
+        <InlineRetryAffordance retry={retry} />
       ) : null}
       {truncationLabel ? (
         <span className="ch-msg__tag ch-msg__tag--truncated">

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -196,14 +196,17 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
                 );
               }
               if (node.kind === 'system') {
-                return (
+                // Threads are short and already scoped to one turn, so the run
+                // node is rendered flat here — the #1308 item 5 fold is a
+                // main-lane noise control, not a thread-panel one.
+                return node.messages.map((message) => (
                   <ChannelMessageRow
-                    key={node.message.id}
-                    message={node.message}
+                    key={message.id}
+                    message={message}
                     channelId={channelId}
                     variant="system"
                   />
-                );
+                ));
               }
               if (node.kind === 'unread-line') return null;
               const firstId = node.messages[0]?.id ?? `thread-group-${index}`;

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -22,6 +22,23 @@ import { useLiveReplyGrowth } from './useLiveReplyGrowth.js';
 
 const RESYNC_BUTTON_DELAY_MS = 5_000;
 
+/**
+ * How long the jump emphasis stays on the row a deep link landed on. The fade
+ * itself is a 400ms ease-out (DESIGN.md motion budget); the extra beat only
+ * keeps the class mounted so the animation is never cut mid-flight.
+ */
+const JUMP_HIGHLIGHT_MS = 600;
+
+/** A deep link asking the timeline to scroll to one message. */
+export interface TimelineJumpTarget {
+  messageId: ChannelMessageId;
+  /**
+   * Monotonic per-request token. Two consecutive links to the SAME message must
+   * re-run the scroll, and `messageId` alone cannot express that.
+   */
+  token: number;
+}
+
 interface ChannelTimelineProps {
   /** Full reducer lane, including thread replies for live reply-count derivation. */
   messages: ChannelMessage[];
@@ -43,6 +60,12 @@ interface ChannelTimelineProps {
    * given and owns no presence policy.
    */
   agentPresence?: readonly ChannelAgentPresence[];
+  /**
+   * #1308 item 1. `ChannelView` owns the bounded history walk that guarantees
+   * the target row is loaded; by the time a target arrives here it is only a
+   * DOM scroll plus the brief jump emphasis.
+   */
+  jumpTarget?: TimelineJumpTarget | null;
 }
 
 export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
@@ -60,8 +83,11 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   onContinueHistory,
   onOpenThread,
   agentPresence = [],
+  jumpTarget = null,
 }) => {
   const [showResyncButton, setShowResyncButton] = useState(false);
+  const [highlightedMessageId, setHighlightedMessageId] =
+    useState<ChannelMessageId | null>(null);
 
   // Replies stay in the reducer for gap/catch-up correctness. Every piece of
   // main-lane geometry consumes this render-only projection so hidden reply seqs
@@ -93,6 +119,33 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
 
   const earliestSeq = topLevelMessages[0]?.seq;
   const reachedBeginning = !hasMoreOlder && earliestSeq === 1;
+
+  // Deep-link jump. Keyed on the request token, never on `messageId`, so a
+  // second link to the same row replays the scroll and the emphasis.
+  const jumpToken = jumpTarget?.token ?? null;
+  const jumpMessageId = jumpTarget?.messageId ?? null;
+  useEffect(() => {
+    if (jumpToken === null || jumpMessageId === null) return;
+    const container = containerRef.current;
+    // Attribute equality rather than a `[data-…="…"]` selector: message ids are
+    // opaque, and a selector would need escaping the row markup does not owe us.
+    const row = container
+      ? Array.from(
+          container.querySelectorAll<HTMLElement>('[data-channel-message-id]')
+        ).find((node) => node.dataset.channelMessageId === jumpMessageId)
+      : undefined;
+    if (row) {
+      // Instant, not smooth: the emphasis is a 400ms fade, so a multi-second
+      // smooth scroll would finish after the cue it is supposed to explain.
+      row.scrollIntoView({ block: 'center' });
+    }
+    setHighlightedMessageId(jumpMessageId);
+    const timer = setTimeout(
+      () => setHighlightedMessageId(null),
+      JUMP_HIGHLIGHT_MS
+    );
+    return () => clearTimeout(timer);
+  }, [containerRef, jumpToken, jumpMessageId]);
 
   useEffect(() => {
     if (!needsCatchup) {
@@ -193,6 +246,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                   message={node.message}
                   channelId={channelId}
                   variant="system"
+                  highlighted={highlightedMessageId === node.message.id}
                 />
               );
             }
@@ -205,6 +259,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 channelId={channelId}
                 replyCounts={replyCounts}
                 replyGrowth={replyGrowth}
+                highlightedMessageId={highlightedMessageId}
                 {...(onOpenThread ? { onOpenThread } : {})}
               />
             );

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   retriedMessageIdFromSystemRow,
   type ChannelMessage,
@@ -9,6 +9,7 @@ import {
   deriveReplyCounts,
   formatDayLabel,
   selectTopLevel,
+  SYSTEM_RUN_COLLAPSE_MIN,
 } from '../../lib/chat/channel-timeline-layout.js';
 import {
   channelPresenceCopy,
@@ -29,6 +30,36 @@ const RESYNC_BUTTON_DELAY_MS = 5_000;
  * keeps the class mounted so the animation is never cut mid-flight.
  */
 const JUMP_HIGHLIGHT_MS = 600;
+
+/**
+ * Chevrons for the collapsed/expanded system-run summary. DESIGN.md icon law:
+ * flat line art, 1.5px stroke, square caps, no fill. Two static paths rather
+ * than one rotated path — DESIGN.md allows text motion only, so the glyph
+ * swaps instead of animating.
+ */
+const CHEVRON_DOWN_ICON = (
+  <svg width="10" height="10" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M3.5 6l4.5 4.5L12.5 6"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+const CHEVRON_UP_ICON = (
+  <svg width="10" height="10" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M3.5 10.5L8 6l4.5 4.5"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+    />
+  </svg>
+);
 
 /** A deep link asking the timeline to scroll to one message. */
 export interface TimelineJumpTarget {
@@ -110,6 +141,20 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   const [showResyncButton, setShowResyncButton] = useState(false);
   const [highlightedMessageId, setHighlightedMessageId] =
     useState<ChannelMessageId | null>(null);
+  // #1308 item 5. Runs the operator opened, keyed by the run's first message id.
+  // Message ids are globally unique and opaque (#1296), so a key from another
+  // channel can never match here and the set needs no per-channel reset.
+  const [expandedSystemRuns, setExpandedSystemRuns] = useState<
+    ReadonlySet<ChannelMessageId>
+  >(() => new Set());
+
+  const toggleSystemRun = useCallback((runKey: ChannelMessageId): void => {
+    setExpandedSystemRuns((current) => {
+      const next = new Set(current);
+      if (!next.delete(runKey)) next.add(runKey);
+      return next;
+    });
+  }, []);
 
   // Replies stay in the reducer for gap/catch-up correctness. Every piece of
   // main-lane geometry consumes this render-only projection so hidden reply seqs
@@ -158,6 +203,21 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   // second link to the same row replays the scroll and the emphasis.
   const jumpToken = jumpTarget?.token ?? null;
   const jumpMessageId = jumpTarget?.messageId ?? null;
+
+  // A deep link to a system row inside a collapsed run must not land on nothing.
+  // Resolved during RENDER, not in the jump effect, so the row is already in the
+  // DOM by the time that effect runs and calls `scrollIntoView` (#1308 item 5).
+  const jumpRunKey = useMemo<ChannelMessageId | null>(() => {
+    if (jumpMessageId === null) return null;
+    for (const node of nodes) {
+      if (node.kind !== 'system') continue;
+      if (node.messages.some((message) => message.id === jumpMessageId)) {
+        return node.messages[0]?.id ?? null;
+      }
+    }
+    return null;
+  }, [nodes, jumpMessageId]);
+
   useEffect(() => {
     if (jumpToken === null || jumpMessageId === null) return;
     const container = containerRef.current;
@@ -274,14 +334,54 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
               );
             }
             if (node.kind === 'system') {
+              const runKey = node.messages[0]?.id ?? null;
+              const collapsible =
+                runKey !== null &&
+                node.messages.length >= SYSTEM_RUN_COLLAPSE_MIN;
+              const expanded =
+                !collapsible ||
+                expandedSystemRuns.has(runKey) ||
+                jumpRunKey === runKey;
+              const lastSeq = node.messages[node.messages.length - 1]?.seq;
               return (
-                <ChannelMessageRow
-                  key={node.message.id}
-                  message={node.message}
-                  channelId={channelId}
-                  variant="system"
-                  highlighted={highlightedMessageId === node.message.id}
-                />
+                // A Fragment, not a wrapper element: `.ch-tl-content` is a flex
+                // column whose 14px gap defines system-row rhythm, and a wrapper
+                // would swallow it for the rows inside the run.
+                <React.Fragment key={`system-${runKey ?? index}`}>
+                  {collapsible ? (
+                    <button
+                      type="button"
+                      className="ch-system-run"
+                      aria-expanded={expanded}
+                      data-channel-system-run={runKey}
+                      // Only while collapsed: the folded rows are out of the DOM,
+                      // so the run stands in for their last seq and the reader
+                      // anchor in `useFollowingScroll` keeps a row to hold onto.
+                      // When expanded the real rows carry it, and a duplicate
+                      // would shadow them in the anchor's `querySelector`.
+                      {...(!expanded && lastSeq !== undefined
+                        ? { 'data-channel-message-seq': lastSeq }
+                        : {})}
+                      onClick={() => runKey && toggleSystemRun(runKey)}
+                    >
+                      <span className="ch-system-run__label">
+                        {node.messages.length} system events
+                      </span>
+                      {expanded ? CHEVRON_UP_ICON : CHEVRON_DOWN_ICON}
+                    </button>
+                  ) : null}
+                  {expanded
+                    ? node.messages.map((message) => (
+                        <ChannelMessageRow
+                          key={message.id}
+                          message={message}
+                          channelId={channelId}
+                          variant="system"
+                          highlighted={highlightedMessageId === message.id}
+                        />
+                      ))
+                    : null}
+                </React.Fragment>
               );
             }
             const firstId = node.messages[0]?.id ?? `group-${index}`;

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -77,6 +77,11 @@ interface ChannelTimelineProps {
    * the mutation; the timeline only routes the callback to the rows.
    */
   onEditMessage?: (message: ChannelMessage, text: string) => Promise<unknown>;
+  /**
+   * #1308 item 4. Tombstones one of the operator's own rows. `ChannelView` owns
+   * the mutation; the timeline only routes the callback to the rows.
+   */
+  onDeleteMessage?: (message: ChannelMessage) => Promise<unknown>;
   /** Profile actor ids currently non-idle here — the retry storm brake. */
   busyAgentIds?: ReadonlySet<string>;
 }
@@ -99,6 +104,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   jumpTarget = null,
   onRetryMessage,
   onEditMessage,
+  onDeleteMessage,
   busyAgentIds,
 }) => {
   const [showResyncButton, setShowResyncButton] = useState(false);
@@ -292,6 +298,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 {...(busyAgentIds ? { busyAgentIds } : {})}
                 {...(onRetryMessage ? { onRetryMessage } : {})}
                 {...(onEditMessage ? { onEditMessage } : {})}
+                {...(onDeleteMessage ? { onDeleteMessage } : {})}
                 {...(onOpenThread ? { onOpenThread } : {})}
               />
             );

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import type {
-  ChannelMessage,
-  ChannelMessageId,
+import {
+  retriedMessageIdFromSystemRow,
+  type ChannelMessage,
+  type ChannelMessageId,
 } from '../../../../shared/channel-chat-protocol.js';
 import {
   buildTimelineNodes,
@@ -66,6 +67,13 @@ interface ChannelTimelineProps {
    * DOM scroll plus the brief jump emphasis.
    */
   jumpTarget?: TimelineJumpTarget | null;
+  /**
+   * #1308 item 2. Re-routes a failed row's original trigger; `ChannelView` owns
+   * the call so the timeline keeps no retry policy of its own.
+   */
+  onRetryMessage?: (message: ChannelMessage) => Promise<unknown>;
+  /** Profile actor ids currently non-idle here — the retry storm brake. */
+  busyAgentIds?: ReadonlySet<string>;
 }
 
 export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
@@ -84,6 +92,8 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   onOpenThread,
   agentPresence = [],
   jumpTarget = null,
+  onRetryMessage,
+  busyAgentIds,
 }) => {
   const [showResyncButton, setShowResyncButton] = useState(false);
   const [highlightedMessageId, setHighlightedMessageId] =
@@ -94,6 +104,18 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   // cannot trigger a pill, move an anchor, or create an inline timeline row.
   const topLevelMessages = useMemo(() => selectTopLevel(messages), [messages]);
   const replyCounts = useMemo(() => deriveReplyCounts(messages), [messages]);
+
+  // #1308 item 2: rows a retry already superseded. Derived from the durable
+  // system row the binder writes (`meta.retryOfMessageId`), not from client
+  // state, so a reload or a second device sees the same supersede marks.
+  const retriedMessageIds = useMemo(() => {
+    const ids = new Set<ChannelMessageId>();
+    for (const message of messages) {
+      const retried = retriedMessageIdFromSystemRow(message);
+      if (retried) ids.add(retried);
+    }
+    return ids;
+  }, [messages]);
   const replyGrowth = useLiveReplyGrowth(messages, {
     scopeKey: channelId,
     fullSnapshotRevision,
@@ -260,6 +282,9 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 replyCounts={replyCounts}
                 replyGrowth={replyGrowth}
                 highlightedMessageId={highlightedMessageId}
+                retriedMessageIds={retriedMessageIds}
+                {...(busyAgentIds ? { busyAgentIds } : {})}
+                {...(onRetryMessage ? { onRetryMessage } : {})}
                 {...(onOpenThread ? { onOpenThread } : {})}
               />
             );

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   retriedMessageIdFromSystemRow,
   type ChannelMessage,
@@ -99,6 +105,12 @@ interface ChannelTimelineProps {
    */
   jumpTarget?: TimelineJumpTarget | null;
   /**
+   * Called once the jump has been scrolled to and its emphasis has faded, so
+   * the owner can drop the request. A jump that is never consumed keeps forcing
+   * its system run open — the operator could not fold it again (#1308 review).
+   */
+  onJumpConsumed?: () => void;
+  /**
    * #1308 item 2. Re-routes a failed row's original trigger; `ChannelView` owns
    * the call so the timeline keeps no retry policy of its own.
    */
@@ -133,6 +145,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   onOpenThread,
   agentPresence = [],
   jumpTarget = null,
+  onJumpConsumed,
   onRetryMessage,
   onEditMessage,
   onDeleteMessage,
@@ -203,6 +216,8 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   // second link to the same row replays the scroll and the emphasis.
   const jumpToken = jumpTarget?.token ?? null;
   const jumpMessageId = jumpTarget?.messageId ?? null;
+  const jumpConsumedRef = useRef(onJumpConsumed);
+  jumpConsumedRef.current = onJumpConsumed;
 
   // A deep link to a system row inside a collapsed run must not land on nothing.
   // Resolved during RENDER, not in the jump effect, so the row is already in the
@@ -233,13 +248,28 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
       // smooth scroll would finish after the cue it is supposed to explain.
       row.scrollIntoView({ block: 'center' });
     }
+    // Hand the render-time force-open over to the operator-owned set before the
+    // request is consumed: the run stays open (the link landed inside it) but is
+    // now held by the same state the summary button toggles, so it can be
+    // folded again instead of being pinned for the life of the view.
+    if (jumpRunKey !== null) {
+      setExpandedSystemRuns((current) =>
+        current.has(jumpRunKey) ? current : new Set(current).add(jumpRunKey)
+      );
+    }
     setHighlightedMessageId(jumpMessageId);
-    const timer = setTimeout(
-      () => setHighlightedMessageId(null),
-      JUMP_HIGHLIGHT_MS
-    );
+    const timer = setTimeout(() => {
+      // Order matters: clear the emphasis FIRST. Consuming the request changes
+      // this effect's deps, and the cleanup that follows must not be what is
+      // responsible for un-highlighting the row.
+      setHighlightedMessageId(null);
+      // Read through a ref, and keep the callback OUT of the deps: an inline
+      // arrow from a re-rendering parent would otherwise restart the scroll and
+      // the timer on every commit.
+      jumpConsumedRef.current?.();
+    }, JUMP_HIGHLIGHT_MS);
     return () => clearTimeout(timer);
-  }, [containerRef, jumpToken, jumpMessageId]);
+  }, [containerRef, jumpToken, jumpMessageId, jumpRunKey]);
 
   useEffect(() => {
     if (!needsCatchup) {

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -72,6 +72,11 @@ interface ChannelTimelineProps {
    * the call so the timeline keeps no retry policy of its own.
    */
   onRetryMessage?: (message: ChannelMessage) => Promise<unknown>;
+  /**
+   * #1308 item 3. Rewrites one of the operator's own rows. `ChannelView` owns
+   * the mutation; the timeline only routes the callback to the rows.
+   */
+  onEditMessage?: (message: ChannelMessage, text: string) => Promise<unknown>;
   /** Profile actor ids currently non-idle here — the retry storm brake. */
   busyAgentIds?: ReadonlySet<string>;
 }
@@ -93,6 +98,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   agentPresence = [],
   jumpTarget = null,
   onRetryMessage,
+  onEditMessage,
   busyAgentIds,
 }) => {
   const [showResyncButton, setShowResyncButton] = useState(false);
@@ -285,6 +291,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 retriedMessageIds={retriedMessageIds}
                 {...(busyAgentIds ? { busyAgentIds } : {})}
                 {...(onRetryMessage ? { onRetryMessage } : {})}
+                {...(onEditMessage ? { onEditMessage } : {})}
                 {...(onOpenThread ? { onOpenThread } : {})}
               />
             );

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -405,6 +405,31 @@
   text-align: center;
 }
 
+/* Coalesced system-run summary (#1308 item 5). Reads as a system row —
+   same muted mono type, same centering — with a chevron to say it opens.
+   Zero radius, outline-only, no fill (DESIGN.md). */
+.ch-system-run {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  align-self: center;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-system-run:hover,
+.ch-system-run:focus-visible {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
 /* approval controls on an actionable system row (#1167) */
 .ch-system-msg__actions {
   display: inline-flex;

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -474,6 +474,7 @@
 
 /* single message row */
 .ch-msg {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -552,6 +553,76 @@
   51%,
   100% {
     opacity: 0;
+  }
+}
+
+/* per-message action toolbar (#1308 item 1). Absolutely positioned so it can
+   never reflow the lane — a row that changed height on hover would fight the
+   follow/anchor scroll model. Mounted only while the row is hovered, focused,
+   or long-press pinned, so the resting DOM is unchanged. */
+.ch-msg__actions {
+  position: absolute;
+  top: -10px;
+  right: 0;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+}
+
+/* A human bubble is right-aligned, so its toolbar sits on the free left edge. */
+.ch-msg__actions--user {
+  right: auto;
+  left: 0;
+}
+
+.ch-msg__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.ch-msg__action + .ch-msg__action {
+  border-left: 1px solid var(--border);
+}
+
+.ch-msg__action:hover,
+.ch-msg__action:focus-visible {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+/* jump emphasis after a deep link lands (#1308 item 1). DESIGN.md text-motion
+   only: a flat background fade, no shimmer, no particles, and inside the 400ms
+   motion budget. */
+.ch-msg--jump {
+  animation: ch-jump-flash 400ms ease-out 1;
+}
+
+@keyframes ch-jump-flash {
+  0% {
+    background: color-mix(in srgb, var(--accent) 24%, transparent);
+  }
+  100% {
+    background: transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ch-msg--jump {
+    animation: none;
+    background: color-mix(in srgb, var(--accent) 24%, transparent);
   }
 }
 

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -613,6 +613,58 @@
   background: transparent;
 }
 
+/* Destructive action (#1308 item 4). Tinted only on hover/focus: at rest it is
+   one icon among peers, and colouring it permanently would make every message
+   carry a standing warning. */
+.ch-msg__action--danger:hover,
+.ch-msg__action--danger:focus-visible {
+  color: var(--status-error);
+}
+
+/* Inline delete confirm (#1308 item 4). Occupies the toolbar's own absolutely
+   positioned slot, so asking the question never reflows the lane and the
+   message being confirmed stays legible underneath — which a browser
+   `confirm()` cannot do. Mono, lowercase, zero radius, no motion. */
+.ch-msg__confirm {
+  gap: 6px;
+  padding: 0 6px;
+}
+
+.ch-msg__confirm-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  text-transform: lowercase;
+}
+
+.ch-msg__confirm-btn {
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-msg__confirm-btn--danger {
+  color: var(--status-error);
+}
+
+.ch-msg__confirm-btn:hover:not(:disabled),
+.ch-msg__confirm-btn:focus-visible:not(:disabled) {
+  border-color: currentColor;
+  background: var(--surface-hover);
+}
+
+.ch-msg__confirm-btn:disabled {
+  color: var(--text-muted);
+  opacity: 0.6;
+  cursor: default;
+}
+
 /* jump emphasis after a deep link lands (#1308 item 1). DESIGN.md text-motion
    only: a flat background fade, no shimmer, no particles, and inside the 400ms
    motion budget. */
@@ -707,6 +759,25 @@
 }
 
 .ch-msg--user .ch-msg__edited {
+  align-self: flex-end;
+}
+
+/* Tombstone placeholder (#1308 item 4). The row keeps its slot — grouping, the
+   scroll anchor and any thread chip below depend on it — and says plainly that
+   something was here. Dim and italic so it reads as absence rather than as a
+   message someone wrote. */
+.ch-msg__deleted {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+/* The placeholder replaces the body, so it inherits the body's alignment — the
+   bubble chrome (`.ch-msg--user .ch-msg__body`) is simply never rendered, since
+   there is no message left to frame. */
+.ch-msg--user .ch-msg__deleted {
   align-self: flex-end;
 }
 

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -603,6 +603,16 @@
   background: var(--surface-hover);
 }
 
+.ch-msg__action:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.ch-msg__action:disabled:hover {
+  color: var(--text-muted);
+  background: transparent;
+}
+
 /* jump emphasis after a deep link lands (#1308 item 1). DESIGN.md text-motion
    only: a flat background fade, no shimmer, no particles, and inside the 400ms
    motion budget. */
@@ -645,6 +655,43 @@
 
 .ch-msg__tag--truncated {
   color: var(--status-warning);
+}
+
+.ch-msg__tag--retried {
+  color: var(--text-muted);
+}
+
+/* Inline retry on a failed row (#1308 item 2). Outline-only, square, mono —
+   same control vocabulary as the thread chip, tinted to the failure it recovers
+   from. No motion: the pending state is a text swap (`retry` → `retrying…`),
+   which is the only motion DESIGN.md allows here. */
+.ch-msg__retry {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  align-self: flex-start;
+  margin-top: var(--space-xs, 4px);
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--status-error);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-msg__retry:hover:not(:disabled),
+.ch-msg__retry:focus-visible:not(:disabled) {
+  border-color: var(--status-error);
+  background: var(--surface-hover);
+}
+
+.ch-msg__retry:disabled {
+  color: var(--text-muted);
+  opacity: 0.6;
+  cursor: default;
 }
 
 /* Thread entry point: outline-only informational navigation, matching the

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -694,6 +694,91 @@
   cursor: default;
 }
 
+/* (edited) suffix (#1308 item 3). Dim, mono, and smaller than the body: it is a
+   provenance note, not a status the eye should stop on. No color token — a
+   tinted marker would read as a warning about a message that is simply correct
+   now. Follows the human bubble to the right edge. */
+.ch-msg__edited {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  opacity: 0.7;
+  margin-top: 2px;
+}
+
+.ch-msg--user .ch-msg__edited {
+  align-self: flex-end;
+}
+
+/* In-place message editor (#1308 item 3). Reuses the composer textarea's
+   metrics — mono, zero radius, underline-only border — so editing a message
+   looks like writing one. Full row width even on a right-aligned human bubble:
+   the 75% bubble cap is a reading-comfort rule, and shrinking the edit surface
+   below the text it holds would be a worse trade. */
+.ch-msg__edit {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 4px;
+}
+
+.ch-msg__edit-ta {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg);
+  color: var(--text);
+  border: none;
+  border-bottom: 1px solid var(--accent);
+  border-radius: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  padding: 8px 12px;
+  resize: none;
+  outline: none;
+}
+
+.ch-msg__edit-ta:disabled {
+  opacity: 0.85;
+}
+
+.ch-msg__edit-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.ch-msg__edit-btn {
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-msg__edit-btn:hover:not(:disabled),
+.ch-msg__edit-btn:focus-visible:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--surface-hover);
+}
+
+.ch-msg__edit-btn:disabled {
+  color: var(--text-muted);
+  opacity: 0.6;
+  cursor: default;
+}
+
+.ch-msg__edit-hint {
+  margin-left: auto;
+}
+
 /* Thread entry point: outline-only informational navigation, matching the
    compact agent-chip vocabulary and DESIGN.md's square control law. */
 .ch-msg__thread-chip {

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -19,6 +19,7 @@ import {
   fetchWorkspaceTopic,
   fetchChannelRoster,
   designateChannelOrchestrator,
+  deleteChannelMessage,
   editChannelMessage,
   interruptChannelAgent,
   retryChannelMessage,
@@ -577,6 +578,26 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     [channelId]
   );
 
+  // #1308 item 4. Same wiring rule as the edit lane: live channels only, no
+  // optimistic apply (the tombstone arrives through
+  // `channel-message-deleted-v1`), rethrown so the row's confirm stays open on a
+  // failed write instead of pretending the row is gone.
+  const handleDeleteMessage = useCallback(
+    async (message: ChannelMessage) => {
+      try {
+        await deleteChannelMessage(channelId, message.id);
+      } catch (error) {
+        showToast(
+          error instanceof HttpError && error.status === 409
+            ? 'could not delete — this message is no longer deletable'
+            : 'could not delete this message'
+        );
+        throw error;
+      }
+    },
+    [channelId]
+  );
+
   const handleInterruptAgent = useCallback(
     (agentId: string) => {
       // 404 (no live binding) / 409 (NO_ACTIVE_TURN) both mean "already idle" —
@@ -785,7 +806,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               agentPresence={agentPresence}
               jumpTarget={jumpTarget}
               onRetryMessage={handleRetryMessage}
-              {...(archived ? {} : { onEditMessage: handleEditMessage })}
+              {...(archived
+                ? {}
+                : {
+                    onEditMessage: handleEditMessage,
+                    onDeleteMessage: handleDeleteMessage,
+                  })}
               busyAgentIds={busyAgentIds}
             />
           ) : (

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -373,6 +373,14 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       return;
     }
     if (anchorLoadingRef.current || loadingOlder) return;
+    // Cold boot is the primary case for this feature: a pasted
+    // `/channel/<id>#msg-…` link writes the intent BEFORE this component
+    // mounts, so the adopt effect above fires on the first commit — while
+    // `reducer.messages` is still `[]` and `hasMoreOlder` is still its `false`
+    // default (it is only ever set from the WS snapshot's `truncated` flag).
+    // "No older history" is not an answer until the channel has actually
+    // answered: hold the walk until the first full snapshot lands.
+    if (fullSnapshotRevision === 0) return;
     if (!hasMoreOlder || anchorWalk.pages >= ANCHOR_WALK_MAX_PAGES) {
       setAnchorWalk(null);
       showToast('that message is not in this chat’s recent history', 'info');
@@ -391,12 +399,19 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   }, [
     anchorWalk,
     anchorWalkTick,
+    fullSnapshotRevision,
     hasMoreOlder,
     loadOlder,
     loadingOlder,
     reducer.messages,
     setActiveThreadRootId,
   ]);
+
+  // The jump is one-shot: `jumpTarget` is what forces a collapsed system run
+  // open and paints the emphasis, so leaving it set for the lifetime of the
+  // channel view would pin that run open (the summary's toggle would have no
+  // visible effect). The timeline calls this once the jump has been consumed.
+  const handleJumpConsumed = useCallback(() => setJumpTarget(null), []);
 
   // Agent presence chips (#1167). One chip per agent that is bound (roster
   // binding) OR currently non-idle in the live status store, with a `streaming`
@@ -537,6 +552,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     return ids;
   }, [agentChips]);
 
+  // Wired only while the channel is live, exactly like edit/delete below: a
+  // retry re-runs a turn against an archived (read-only) channel, so the route
+  // refuses it with CHANNEL_ARCHIVED and offering the button would be dead.
   const handleRetryMessage = useCallback(
     async (message: ChannelMessage) => {
       try {
@@ -805,10 +823,14 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               onOpenThread={setActiveThreadRootId}
               agentPresence={agentPresence}
               jumpTarget={jumpTarget}
-              onRetryMessage={handleRetryMessage}
+              onJumpConsumed={handleJumpConsumed}
               {...(archived
                 ? {}
                 : {
+                    // Retry belongs with edit/delete, not outside the fence: it
+                    // writes a durable system row and appends a whole new agent
+                    // turn, which the route now refuses with CHANNEL_ARCHIVED.
+                    onRetryMessage: handleRetryMessage,
                     onEditMessage: handleEditMessage,
                     onDeleteMessage: handleDeleteMessage,
                   })}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -19,6 +19,7 @@ import {
   fetchWorkspaceTopic,
   fetchChannelRoster,
   designateChannelOrchestrator,
+  editChannelMessage,
   interruptChannelAgent,
   retryChannelMessage,
   HttpError,
@@ -553,6 +554,29 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     [channelId]
   );
 
+  // #1308 item 3. Wired only while the channel is live — an archived channel is
+  // read-only (its composer is already a restore bar), so offering an edit the
+  // route would refuse with CHANNEL_ARCHIVED is a dead affordance. The edited row
+  // arrives back through the socket
+  // (`channel-message-edited-v1`), so nothing is applied optimistically here —
+  // same discipline as posting. Rethrown so the row keeps the operator's draft
+  // on screen instead of closing over a failed write.
+  const handleEditMessage = useCallback(
+    async (message: ChannelMessage, text: string) => {
+      try {
+        await editChannelMessage(channelId, message.id, text);
+      } catch (error) {
+        showToast(
+          error instanceof HttpError && error.status === 409
+            ? 'could not edit — this message is no longer editable'
+            : 'could not edit this message'
+        );
+        throw error;
+      }
+    },
+    [channelId]
+  );
+
   const handleInterruptAgent = useCallback(
     (agentId: string) => {
       // 404 (no live binding) / 409 (NO_ACTIVE_TURN) both mean "already idle" —
@@ -761,6 +785,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               agentPresence={agentPresence}
               jumpTarget={jumpTarget}
               onRetryMessage={handleRetryMessage}
+              {...(archived ? {} : { onEditMessage: handleEditMessage })}
               busyAgentIds={busyAgentIds}
             />
           ) : (

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -5,7 +5,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { ChannelMessagePart } from '../../../../shared/channel-chat-protocol.js';
+import type {
+  ChannelMessageId,
+  ChannelMessagePart,
+} from '../../../../shared/channel-chat-protocol.js';
 import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
 import type { AgentRole } from '../../../../shared/agent-roster.js';
 import './ChannelView.css';
@@ -35,9 +38,10 @@ import {
   useChannelAgentStatusStore,
 } from '../../lib/stores/channel-agent-status.js';
 import { useUiStore } from '../../lib/stores/ui.js';
+import { showToast } from '../../lib/stores/toasts.js';
 import { AgentBadge } from '../AgentBadge.js';
 import { TuiProgress } from '../TuiProgress.js';
-import { ChannelTimeline } from './ChannelTimeline.js';
+import { ChannelTimeline, type TimelineJumpTarget } from './ChannelTimeline.js';
 import { ChannelComposer } from './ChannelComposer.js';
 import { ChannelThreadPanel } from './ChannelThreadPanel.js';
 
@@ -45,6 +49,13 @@ const READ_WRITE_VISIBLE_GRACE_MS = 10_000;
 const AUTO_BACKFILL_MAX_ATTEMPTS = 3;
 const AUTO_BACKFILL_RETRY_BASE_MS = 200;
 const AUTO_BACKFILL_MAX_CURSOR_PAGES = 4;
+/**
+ * #1308 item 1: how many older-history pages a `#msg-…` deep link may pull
+ * before it gives up. Unbounded, a link to a deleted/foreign message id would
+ * walk the channel to seq 1 on every open; bounded, the worst case is a fixed
+ * number of page fetches and one toast.
+ */
+const ANCHOR_WALK_MAX_PAGES = 8;
 
 interface ChannelViewProps {
   channelId: string;
@@ -306,6 +317,82 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     },
     []
   );
+
+  // ── Deep-link message anchor (#1308 item 1) ────────────────────────────────
+  // A `/channel/<id>#msg-<messageId>` link lands here as a store intent. The
+  // target may be far outside the loaded window, so resolving it is a bounded
+  // walk backwards through history rather than a single lookup; the timeline
+  // only ever receives a target it can already render.
+  const pendingChannelMessage = useUiStore((s) => s.pendingChannelMessage);
+  const [anchorWalk, setAnchorWalk] = useState<{
+    messageId: ChannelMessageId;
+    pages: number;
+  } | null>(null);
+  const [jumpTarget, setJumpTarget] = useState<TimelineJumpTarget | null>(null);
+  const jumpTokenRef = useRef(0);
+  const anchorLoadingRef = useRef(false);
+
+  // Drop an in-flight walk when the channel changes: its message id belongs to
+  // the channel that is leaving, and the new one's history would never match.
+  // Declared BEFORE the adopt effect so a channel switch that also carries an
+  // anchor resets first and adopts second — the other order would erase the
+  // anchor it had just accepted (effects run in declaration order).
+  useEffect(() => {
+    anchorLoadingRef.current = false;
+    setAnchorWalk(null);
+    setJumpTarget(null);
+  }, [channelId]);
+
+  useEffect(() => {
+    if (pendingChannelMessage?.channelId !== channelId) return;
+    setAnchorWalk({ messageId: pendingChannelMessage.messageId, pages: 0 });
+    useUiStore.getState().consumeChannelMessageIntent(channelId);
+  }, [channelId, pendingChannelMessage]);
+
+  const [anchorWalkTick, setAnchorWalkTick] = useState(0);
+  useEffect(() => {
+    if (anchorWalk === null) return;
+    const target = reducer.messages.find(
+      (message) => message.id === anchorWalk.messageId
+    );
+    if (target) {
+      setAnchorWalk(null);
+      jumpTokenRef.current += 1;
+      // A reply's row lives in the thread panel, not the main lane. Open the
+      // thread and put the emphasis on its root, which IS a main-lane row —
+      // otherwise the link resolves to a scroll that finds nothing.
+      if (target.threadId !== null) setActiveThreadRootId(target.threadId);
+      setJumpTarget({
+        messageId: target.threadId ?? target.id,
+        token: jumpTokenRef.current,
+      });
+      return;
+    }
+    if (anchorLoadingRef.current || loadingOlder) return;
+    if (!hasMoreOlder || anchorWalk.pages >= ANCHOR_WALK_MAX_PAGES) {
+      setAnchorWalk(null);
+      showToast('that message is not in this chat’s recent history', 'info');
+      return;
+    }
+    anchorLoadingRef.current = true;
+    setAnchorWalk((walk) =>
+      walk === null ? null : { ...walk, pages: walk.pages + 1 }
+    );
+    void loadOlder()
+      .catch(() => {})
+      .finally(() => {
+        anchorLoadingRef.current = false;
+        setAnchorWalkTick((tick) => tick + 1);
+      });
+  }, [
+    anchorWalk,
+    anchorWalkTick,
+    hasMoreOlder,
+    loadOlder,
+    loadingOlder,
+    reducer.messages,
+    setActiveThreadRootId,
+  ]);
 
   // Agent presence chips (#1167). One chip per agent that is bound (roster
   // binding) OR currently non-idle in the live status store, with a `streaming`
@@ -640,6 +727,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               onContinueHistory={continueReplyOnlyBackfill}
               onOpenThread={setActiveThreadRootId}
               agentPresence={agentPresence}
+              jumpTarget={jumpTarget}
             />
           ) : (
             <div className="ch-empty">

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import type {
+  ChannelMessage,
   ChannelMessageId,
   ChannelMessagePart,
 } from '../../../../shared/channel-chat-protocol.js';
@@ -19,6 +20,7 @@ import {
   fetchChannelRoster,
   designateChannelOrchestrator,
   interruptChannelAgent,
+  retryChannelMessage,
   HttpError,
   type ChannelAgentStatus,
 } from '../../lib/api.js';
@@ -521,6 +523,36 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     [agentChips, presenceSuppression]
   );
 
+  // #1308 item 2 storm brake, client half. Same `agentChips` signal the presence
+  // rows use, so the disabled state cannot disagree with what the header says
+  // the agent is doing. The server refuses independently — this only keeps the
+  // operator from firing a request that is already known to be rejected.
+  const busyAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const chip of agentChips) {
+      if (chip.status !== 'idle') ids.add(chip.agentId);
+    }
+    return ids;
+  }, [agentChips]);
+
+  const handleRetryMessage = useCallback(
+    async (message: ChannelMessage) => {
+      try {
+        await retryChannelMessage(channelId, message.id);
+      } catch (error) {
+        // 409 is the storm brake (agent busy) or an unretryable row; both are
+        // operator-legible states rather than faults, so they get the message
+        // the server sent instead of a generic failure.
+        showToast(
+          error instanceof HttpError && error.status === 409
+            ? 'could not retry — the agent is busy'
+            : 'could not retry this message'
+        );
+      }
+    },
+    [channelId]
+  );
+
   const handleInterruptAgent = useCallback(
     (agentId: string) => {
       // 404 (no live binding) / 409 (NO_ACTIVE_TURN) both mean "already idle" —
@@ -728,6 +760,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               onOpenThread={setActiveThreadRootId}
               agentPresence={agentPresence}
               jumpTarget={jumpTarget}
+              onRetryMessage={handleRetryMessage}
+              busyAgentIds={busyAgentIds}
             />
           ) : (
             <div className="ch-empty">

--- a/frontend/src/components/chat/composerInput.ts
+++ b/frontend/src/components/chat/composerInput.ts
@@ -1,0 +1,55 @@
+// Shared chat-input submit primitives (#1308 slice 1 item 3).
+//
+// Extracted verbatim from `ChannelComposer` so the in-place message editor
+// submits by exactly the same rules the composer does — including the mobile
+// path, which is the part that is easy to get wrong: some IMEs report only a
+// `beforeinput` line-break intent for the send key and no reliable `keydown`,
+// so a hand-rolled `onKeyDown` editor would simply not send on those keyboards.
+
+export const LINE_BREAK_INPUT_TYPES = new Set([
+  'insertLineBreak',
+  'insertParagraph',
+]);
+
+/**
+ * Window after a shift+enter keydown during which the matching `beforeinput`
+ * line break is treated as a newline rather than a send.
+ */
+export const LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS = 500;
+
+export interface LineBreakSubmitGuard {
+  /** A shift+enter keydown just fired — let its `beforeinput` insert a newline. */
+  deferNextLineBreak(): void;
+  /** Any other keydown: the next line-break intent is a send again. */
+  reset(): void;
+  /**
+   * True when this `beforeinput` is the on-screen send key and the caller
+   * should submit. Consumes the deferral window, so a deferred line break falls
+   * through as an ordinary newline exactly once.
+   */
+  consumesAsSubmit(event: InputEvent): boolean;
+}
+
+export function createLineBreakSubmitGuard(
+  now: () => number = () => performance.now()
+): LineBreakSubmitGuard {
+  let skipUntil = 0;
+  return {
+    deferNextLineBreak() {
+      skipUntil = now() + LINE_BREAK_BEFOREINPUT_SKIP_WINDOW_MS;
+    },
+    reset() {
+      skipUntil = 0;
+    },
+    consumesAsSubmit(event) {
+      if (!LINE_BREAK_INPUT_TYPES.has(event.inputType)) return false;
+      if (event.isComposing) return false;
+      if (skipUntil > 0 && now() <= skipUntil) {
+        skipUntil = 0;
+        return false;
+      }
+      skipUntil = 0;
+      return true;
+    },
+  };
+}

--- a/frontend/src/hooks/useUrlNav.ts
+++ b/frontend/src/hooks/useUrlNav.ts
@@ -6,6 +6,7 @@ import {
   parseRoute,
   buildPath,
   parseModal,
+  parseMessageAnchor,
   buildQuery,
   type RouteState,
 } from '../lib/url-nav.js';
@@ -26,12 +27,12 @@ import { leaveChatSurface } from '../lib/topic-task-room.js';
  * the shared `leaveChatSurface()` rather than clearing the channel by hand;
  * clearing only half is what made the composer survive a route restore.
  */
-function applyRoute(route: RouteState): void {
+function applyRoute(route: RouteState, hash = ''): void {
   const ui = useUiStore.getState();
   const sessions = useSessionsStore.getState();
 
   switch (route.view) {
-    case 'channel':
+    case 'channel': {
       ui.setActiveChannelId(route.channelId);
       ui.setTopicComposerOpen(false);
       ui.setAnalyticsView(null);
@@ -39,7 +40,15 @@ function applyRoute(route: RouteState): void {
       // still set, closing the channel would drop the operator onto a terminal
       // they never navigated to on this history entry.
       sessions.setActiveSessionId(null);
+      // #1308 item 1: `/channel/<id>#msg-<id>` is a channel open PLUS a scroll
+      // intent. Written after the open on purpose — `setActiveChannelId` clears
+      // any un-consumed anchor so a cancelled navigation cannot fire one later.
+      const anchoredMessageId = parseMessageAnchor(hash);
+      if (anchoredMessageId !== null) {
+        ui.requestChannelMessage(route.channelId, anchoredMessageId);
+      }
       break;
+    }
 
     case 'repo':
       leaveChatSurface();
@@ -156,7 +165,7 @@ export function useUrlNav() {
       // and lets the push effect below move the URL off the dead link. A
       // segment that is not a legal topic id never gets that far — `parseRoute`
       // already resolved it to `home`.
-      applyRoute(route);
+      applyRoute(route, window.location.hash);
       useUiStore.getState().setActiveModal(modal);
       correctUrlToStore();
     }
@@ -195,7 +204,10 @@ export function useUrlNav() {
   useEffect(() => {
     const handler = () => {
       const currentRepos = useSessionsStore.getState().repos;
-      applyRoute(parseRoute(window.location.pathname, currentRepos));
+      applyRoute(
+        parseRoute(window.location.pathname, currentRepos),
+        window.location.hash
+      );
       // Restore modal state from query params
       useUiStore.getState().setActiveModal(parseModal(window.location.search));
       correctUrlToStore();
@@ -203,6 +215,24 @@ export function useUrlNav() {
 
     window.addEventListener('popstate', handler);
     return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  // ── Re-arm a message anchor typed/pasted onto the SAME channel ────────────
+  // A fragment-only change never fires `popstate`, so the handler above cannot
+  // see it. Only the anchor is re-applied: the path is unchanged by definition,
+  // so re-running `applyRoute` would be a no-op that also cleared the anchor.
+  useEffect(() => {
+    const handler = () => {
+      const currentRepos = useSessionsStore.getState().repos;
+      const route = parseRoute(window.location.pathname, currentRepos);
+      if (route.view !== 'channel') return;
+      const messageId = parseMessageAnchor(window.location.hash);
+      if (messageId === null) return;
+      useUiStore.getState().requestChannelMessage(route.channelId, messageId);
+    };
+
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
   }, []);
 
   return { restoreFromUrl };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1999,6 +1999,37 @@ export async function interruptChannelAgent(
   );
 }
 
+/**
+ * Rewrite the body of one of the operator's own channel messages (#1308 slice 1
+ * item 3). The updated row arrives on every device through the socket
+ * (`channel-message-edited-v1`), so callers use the response only to know the
+ * write landed — there is no optimistic local apply, exactly as with posting.
+ * `HttpError` propagates: 403 (not the operator's lane), 409 (not an editable
+ * row / archived channel) and 404 are all operator-legible states.
+ */
+export async function editChannelMessage(
+  channelId: string,
+  messageId: string,
+  text: string
+): Promise<ChannelMessage> {
+  const body = await json<{ message: ChannelMessage }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(
+        messageId
+      )}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ text }),
+      }
+    )
+  );
+  return body.message;
+}
+
 /** What a retry actually re-ran (#1308 slice 1 item 2). */
 export interface ChannelMessageRetryResult {
   messageId: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1999,6 +1999,41 @@ export async function interruptChannelAgent(
   );
 }
 
+/** What a retry actually re-ran (#1308 slice 1 item 2). */
+export interface ChannelMessageRetryResult {
+  messageId: string;
+  /** The ORIGINAL trigger that was re-routed; never a newly posted row. */
+  triggerMessageId: string;
+  profileActorId: string;
+}
+
+/**
+ * Re-route the original trigger of a failed/interrupted/truncated agent row to
+ * the same profile. `HttpError` propagates so callers can distinguish 409
+ * (`CHANNEL_AGENT_BUSY` — the storm brake) from a genuine failure.
+ */
+export async function retryChannelMessage(
+  channelId: string,
+  messageId: string
+): Promise<ChannelMessageRetryResult> {
+  const body = await json<{ ok: true; retry: ChannelMessageRetryResult }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(
+        messageId
+      )}/retry`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({}),
+      }
+    )
+  );
+  return body.retry;
+}
+
 /** Persistent orchestrator binding created by the operator lane. */
 export interface ChannelOrchestratorDesignation {
   ok: true;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2030,6 +2030,33 @@ export async function editChannelMessage(
   return body.message;
 }
 
+/**
+ * Delete one of the operator's own channel messages (#1308 slice 1 item 4).
+ * Returns the TOMBSTONE — the row keeps its id and seq and loses its body — so
+ * a caller can see the state it now holds; the same row also arrives on every
+ * device through the socket (`channel-message-deleted-v1`), so nothing is
+ * applied optimistically here. `HttpError` propagates: 403 (not the operator's
+ * lane), 409 (not a deletable row / archived channel) and 404 are all
+ * operator-legible states.
+ */
+export async function deleteChannelMessage(
+  channelId: string,
+  messageId: string
+): Promise<ChannelMessage> {
+  const body = await json<{ message: ChannelMessage }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(
+        messageId
+      )}`,
+      {
+        method: 'DELETE',
+        headers: { 'x-relay-capabilities': 'context:write' },
+      }
+    )
+  );
+  return body.message;
+}
+
 /** What a retry actually re-ran (#1308 slice 1 item 2). */
 export interface ChannelMessageRetryResult {
   messageId: string;

--- a/frontend/src/lib/chat/channel-timeline-layout.ts
+++ b/frontend/src/lib/chat/channel-timeline-layout.ts
@@ -8,6 +8,12 @@
 // (which also emits a day-divider), the first-unread boundary is crossed (which
 // also emits the unread line), or the gap since the previous message in the
 // running group exceeds GROUP_WINDOW_MS.
+//
+// System rows never join a sender group, but consecutive ones coalesce into a
+// single `system` RUN node (#1308 item 5) so a burst of binder notices reads as
+// one line instead of a wall. A run breaks on exactly the same structural
+// boundaries as a group — an interleaved prose message, a day divider, the
+// unread line — plus any system row that carries its own controls.
 import type {
   ChannelMessage,
   ChannelMessageId,
@@ -75,8 +81,30 @@ function timestampOrder(value: string): number {
 export type TimelineNode =
   | { kind: 'day-divider'; date: string /* YYYY-MM-DD local */ }
   | { kind: 'group'; sender: ChannelSenderRef; messages: ChannelMessage[] }
-  | { kind: 'system'; message: ChannelMessage }
+  /**
+   * A RUN of consecutive system rows (#1308 item 5). Always at least one; the
+   * renderer decides whether a run is long enough to collapse. System rows never
+   * join a sender group, so this node is disjoint from `group`.
+   */
+  | { kind: 'system'; messages: ChannelMessage[] }
   | { kind: 'unread-line' };
+
+/**
+ * Run length at which the timeline folds system rows behind one `n system
+ * events` summary. Two one-line notices read faster than a summary the operator
+ * has to click open, so the fold starts at three (DESIGN.md minimalism).
+ */
+export const SYSTEM_RUN_COLLAPSE_MIN = 3;
+
+/**
+ * Whether a system row may be folded into a run. An approval request row (#1167)
+ * carries its own approve/deny controls — folding it behind a summary would hide
+ * an action the operator is being ASKED to take, so it always stands alone and
+ * breaks the run around it.
+ */
+export function systemRowCoalescable(message: ChannelMessage): boolean {
+  return typeof message.meta?.approvalRequestId !== 'string';
+}
 
 function localDayKeyFromDate(date: Date): string {
   const year = date.getFullYear();
@@ -147,10 +175,11 @@ export function buildTimelineNodes(
 ): TimelineNode[] {
   const nodes: TimelineNode[] = [];
   let group: RunningGroup | null = null;
+  let systemRun: ChannelMessage[] | null = null;
   let prevDay: string | null = null;
   let unreadInserted = lastReadSeq === null;
 
-  const flush = (): void => {
+  const flushGroup = (): void => {
     if (group) {
       nodes.push({
         kind: 'group',
@@ -159,6 +188,21 @@ export function buildTimelineNodes(
       });
       group = null;
     }
+  };
+
+  const flushSystemRun = (): void => {
+    if (systemRun) {
+      nodes.push({ kind: 'system', messages: systemRun });
+      systemRun = null;
+    }
+  };
+
+  // A message is either system or prose, so at most one accumulator is ever
+  // open; `flush` closes whichever it is. Every structural break (day divider,
+  // unread line) goes through it, which is what keeps a run from spanning one.
+  const flush = (): void => {
+    flushGroup();
+    flushSystemRun();
   };
 
   for (const message of messages) {
@@ -179,10 +223,20 @@ export function buildTimelineNodes(
     }
 
     if (message.kind === 'system') {
-      flush();
-      nodes.push({ kind: 'system', message });
+      flushGroup();
+      if (!systemRowCoalescable(message)) {
+        flushSystemRun();
+        nodes.push({ kind: 'system', messages: [message] });
+        continue;
+      }
+      if (!systemRun) systemRun = [];
+      systemRun.push(message);
       continue;
     }
+
+    // Any prose row ends the run — an interleaved human/agent message is exactly
+    // the boundary that makes the surrounding system noise separable.
+    flushSystemRun();
 
     if (group) {
       // Key on the RENDER id so a legacy `agent:<vendor>` row coalesces with a

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -706,6 +706,19 @@ export interface UiState {
     channelId: string;
     rootMessageId: ChannelMessageId;
   } | null;
+  /**
+   * #1308 slice 1: a `#msg-…` deep link (or, later, a search result) asking a
+   * channel to open scrolled to ONE message. Same shape and lifecycle as
+   * `pendingChannelThread` and for the same reason — the target row does not
+   * exist yet when the channel open is written, and it may still be outside the
+   * loaded history window when `ChannelView` mounts. `ChannelView` consumes the
+   * intent once and owns the bounded backfill walk that resolves it.
+   * Session-transient; never persisted.
+   */
+  pendingChannelMessage: {
+    channelId: string;
+    messageId: ChannelMessageId;
+  } | null;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
   /**
@@ -775,6 +788,13 @@ export interface UiState {
   ) => void;
   /** Drop the pending intent once the target channel has consumed it. */
   consumeChannelThreadIntent: (channelId: string) => void;
+  /** #1308 item 1: ask `channelId` to open scrolled to `messageId`. */
+  requestChannelMessage: (
+    channelId: string,
+    messageId: ChannelMessageId
+  ) => void;
+  /** Drop the pending anchor once the target channel has consumed it. */
+  consumeChannelMessageIntent: (channelId: string) => void;
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
@@ -819,6 +839,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   activeChannelId: null,
   activeThreadRootId: null,
   pendingChannelThread: null,
+  pendingChannelMessage: null,
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadStringSet(COLLAPSED_WORKSPACES_KEY),
@@ -1260,6 +1281,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
       // as a surprise thread panel later. `requestChannelThread` is always
       // called AFTER the channel open, so the rail's own path is unaffected.
       pendingChannelThread: null,
+      // Same contract for the #1308 message anchor: a deep link writes the
+      // channel open first and the anchor second, so clearing here only ever
+      // discards an anchor whose channel never mounted.
+      pendingChannelMessage: null,
       // #1287: an open channel outranks `forceOrgCockpit` in resolveAppViewMode,
       // so a channel activation must also drop the one-off cockpit escape hatch
       // (as sessions.setActiveSessionId does) — otherwise a latched flag fires
@@ -1272,6 +1297,12 @@ export const useUiStore = create<UiState>()((set, get) => ({
   consumeChannelThreadIntent: (channelId) => {
     if (get().pendingChannelThread?.channelId !== channelId) return;
     set({ pendingChannelThread: null });
+  },
+  requestChannelMessage: (channelId, messageId) =>
+    set({ pendingChannelMessage: { channelId, messageId } }),
+  consumeChannelMessageIntent: (channelId) => {
+    if (get().pendingChannelMessage?.channelId !== channelId) return;
+    set({ pendingChannelMessage: null });
   },
   setActiveModal: (v) => set({ activeModal: v }),
 

--- a/frontend/src/lib/url-nav.ts
+++ b/frontend/src/lib/url-nav.ts
@@ -1,4 +1,5 @@
 import { isWorkspaceTopicId } from '../../../shared/workspace-topics.js';
+import type { ChannelMessageId } from '../../../shared/channel-chat-protocol.js';
 import type { Repo } from './types.js';
 import type { AnalyticsView } from './stores/ui.js';
 
@@ -95,6 +96,63 @@ export function decodeChannelSegment(segment: string): string | null {
     ? local
     : `${CHANNEL_ID_PREFIX}${local}`;
   return isWorkspaceTopicId(channelId) ? channelId : null;
+}
+
+// ── Message anchor (URL fragment) ────────────────────────────────────────────
+
+/**
+ * A shareable link to ONE message extends the #1297 channel route with a URL
+ * fragment: `/channel/<segment>#msg-<message id suffix>`.
+ *
+ * The anchor deliberately lives in the fragment rather than in `RouteState`.
+ * `parseRoute`/`buildPath` describe which SURFACE is open; a message anchor is a
+ * one-shot scroll intent on the surface the path already names, so it needs no
+ * route variant and no branch of its own in `applyRoute`. The fragment is also
+ * the only part of the URL `buildPath`/`buildQuery` never emit — a same-path
+ * push (open a modal, correct a dead session) therefore cannot clobber it, and
+ * a different-path push drops it exactly when the anchored channel is left.
+ */
+const MESSAGE_ANCHOR_PREFIX = 'msg-';
+const MESSAGE_ID_PREFIX = 'chm:';
+
+/** `#msg-…` fragment for a message id. Inverse of {@link parseMessageAnchor}. */
+export function encodeMessageAnchor(messageId: ChannelMessageId): string {
+  const local = messageId.startsWith(MESSAGE_ID_PREFIX)
+    ? messageId.slice(MESSAGE_ID_PREFIX.length)
+    : messageId;
+  return `#${MESSAGE_ANCHOR_PREFIX}${encodeURIComponent(local)}`;
+}
+
+/**
+ * Message id carried by a URL fragment, or `null` when the fragment is not a
+ * message anchor (no fragment, some other anchor, malformed `%` escape).
+ */
+export function parseMessageAnchor(hash: string): ChannelMessageId | null {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  if (!raw.startsWith(MESSAGE_ANCHOR_PREFIX)) return null;
+  let local: string;
+  try {
+    local = decodeURIComponent(raw.slice(MESSAGE_ANCHOR_PREFIX.length));
+  } catch {
+    return null;
+  }
+  if (local.length === 0) return null;
+  const id = local.startsWith(MESSAGE_ID_PREFIX)
+    ? local
+    : `${MESSAGE_ID_PREFIX}${local}`;
+  return id as ChannelMessageId;
+}
+
+/** Absolute, pasteable link to one message inside one channel. */
+export function buildChannelMessageLink(
+  channelId: string,
+  messageId: ChannelMessageId,
+  origin: string
+): string {
+  const base = origin.endsWith('/') ? origin.slice(0, -1) : origin;
+  return `${base}/channel/${encodeChannelSegment(channelId)}${encodeMessageAnchor(
+    messageId
+  )}`;
 }
 
 // ── Route state ──────────────────────────────────────────────────────────────

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -129,6 +129,7 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
       '/inbox/*',
       '/events/*',
       '/handoffs/*',
+      '/channels/*',
       '/nodes',
       '/hub/audit/*',
       '/hub/nodes/:nodeId/logs',
@@ -137,7 +138,7 @@ export const AUTH_ROUTE_LANE_INVENTORY: AuthRouteLaneInventoryEntry[] = [
     acceptedLanes: ['scoped-actor-credential', 'browser-session'],
     middleware: 'requireCliGatewayAuth',
     notes:
-      'CLI gateway calls prefer a scoped actor credential and retain browser-session compatibility for local/dev callers; this does not make browser cookies node credentials.',
+      'CLI gateway calls prefer a scoped actor credential and retain browser-session compatibility for local/dev callers; this does not make browser cookies node credentials. Channel routes sit here too: they mount with requireCliGatewayAuth and gate writes on a context:write capability check rather than on the lane alone.',
   },
   {
     surface: 'scoped session APIs',

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -31,6 +31,7 @@ import {
 import {
   channelRetryTarget,
   channelTurnId,
+  isChannelMessageDeleted,
   parseMentions,
   CHANNEL_RETRY_OF_META_KEY,
   type ChannelMention,
@@ -1755,6 +1756,16 @@ export function createChannelAgentBinder(
       throw new ChannelMessageNotRetryableError(
         'the message that triggered this turn is no longer in this channel',
         'RETRY_TRIGGER_MISSING'
+      );
+    }
+    // The trigger survives a deletion as a tombstone (#1308 item 4), so the id
+    // still resolves — but re-running the turn would hand a provider the very
+    // text the operator erased. Refused rather than sent empty: an empty packet
+    // footer would spend real tokens asking an agent to reply to nothing.
+    if (isChannelMessageDeleted(trigger)) {
+      throw new ChannelMessageNotRetryableError(
+        'the message that triggered this turn was deleted',
+        'RETRY_TRIGGER_DELETED'
       );
     }
     const profile =

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -29,7 +29,10 @@ import {
   type AgentProfile,
 } from '../shared/agent-profile.js';
 import {
+  channelRetryTarget,
+  channelTurnId,
   parseMentions,
+  CHANNEL_RETRY_OF_META_KEY,
   type ChannelMention,
   type ChannelMessage,
 } from '../shared/channel-chat-protocol.js';
@@ -157,6 +160,13 @@ export interface ChannelAgentBinder {
     profileActorId?: string
   ): Promise<LiveBinding>;
   interrupt(channelId: string, agentId: string): Promise<void>;
+  /**
+   * Re-route the ORIGINAL trigger of a failed/interrupted/truncated agent row to
+   * the same profile (#1308 slice 1 item 2). The human message is never
+   * re-posted — the timeline gains one system row superseding the retried row
+   * plus whatever the new turn produces.
+   */
+  retryMessage(channelId: string, messageId: string): Promise<ChannelRetryResult>;
   respondToApproval(
     channelId: string,
     agentId: string,
@@ -227,6 +237,52 @@ export class ChannelAgentNoActiveTurnError extends Error {
     super(message);
     this.name = 'ChannelAgentNoActiveTurnError';
   }
+}
+
+/**
+ * The row cannot be re-routed: it is not a retryable agent row, its turn id was
+ * not binder-minted (a provider-labelled item), or the original trigger has
+ * since left the channel. `notFound` separates "no such row here" (404) from
+ * "this row is not retryable" (409).
+ */
+export class ChannelMessageNotRetryableError extends Error {
+  constructor(
+    message: string,
+    readonly reasonCode: string,
+    readonly notFound = false
+  ) {
+    super(message);
+    this.name = 'ChannelMessageNotRetryableError';
+  }
+}
+
+/**
+ * Retry-storm brake (#1308 item 2). A retry while the same profile is mid-turn
+ * in this channel would otherwise stack a second turn behind the live one, and
+ * a held-down button would fill the queue to `QUEUE_CAP` before the operator
+ * saw a single reply. Rejected outright — the client also disables the control
+ * from the same signal, this is the fail-closed backstop.
+ */
+export class ChannelAgentBusyError extends Error {
+  constructor(
+    readonly channelId: string,
+    readonly profileActorId: string,
+    readonly status: ChannelAgentStatus
+  ) {
+    super(
+      `agent ${profileActorId} is ${status} in channel ${channelId}; retry is only offered while idle`
+    );
+    this.name = 'ChannelAgentBusyError';
+  }
+}
+
+/** Outcome of a successful `retryMessage` dispatch. */
+export interface ChannelRetryResult {
+  /** The retried (failed/interrupted/truncated) agent row. */
+  messageId: string;
+  /** The ORIGINAL trigger that was re-routed — never a new timeline row. */
+  triggerMessageId: string;
+  profileActorId: string;
 }
 
 export class ChannelAgentRoleConflictError extends Error {
@@ -921,7 +977,7 @@ export function createChannelAgentBinder(
   function sendTurn(binding: LiveBinding, trigger: ChannelMessage): void {
     const adapter = binding.adapter;
     if (!adapter) return;
-    const turnId = `chturn-${trigger.id}-${binding.profileActorId}`;
+    const turnId = channelTurnId(trigger.id, binding.profileActorId);
     // Build the packet BEFORE mutating any binding state: buildPacket does
     // synchronous SQLite work (getBinding/history) that can throw. If it did so
     // AFTER activeTurnId was set (and before the watchdog armed), the binding
@@ -1655,6 +1711,99 @@ export function createChannelAgentBinder(
     await binding.adapter.interrupt({ turnId: binding.activeTurnId });
   }
 
+  /**
+   * #1308 slice 1 item 2. Retry is a re-route, never a re-post: the failed row's
+   * `source.turnId` names the (trigger, profile) pair the turn was raised for,
+   * so the original human message is fetched back out of the store and handed to
+   * the SAME `routeOne` lane a fresh mention would take. Nothing new is written
+   * to the human's lane, so the timeline cannot grow a duplicate of it.
+   *
+   * The retried row is superseded by a system row carrying
+   * `meta.retryOfMessageId`, following `handleSendFailure`'s system-row pattern
+   * rather than mutating a terminal row — the durable record of what failed
+   * stays intact and the supersede marker survives a reload for free.
+   *
+   * The re-run reuses the same deterministic turn identity (§ Amendment 3), so
+   * a provider that derives item ids from the turn rather than per message could
+   * in principle collide with the retried row's source triple and have its reply
+   * deduped. No built-in adapter does that — all four take item ids from the
+   * provider stream — and minting a fresh identity would fork the turn-parent,
+   * watchdog, and `retriedTurns` bookkeeping that keys off it.
+   */
+  async function retryMessage(
+    channelId: string,
+    messageId: string
+  ): Promise<ChannelRetryResult> {
+    if (closed) throw new BinderClosedError();
+    const failed = store.getMessage(messageId);
+    if (!failed || failed.channelId !== channelId) {
+      throw new ChannelMessageNotRetryableError(
+        'message not found in this channel',
+        'CHANNEL_MESSAGE_NOT_FOUND',
+        true
+      );
+    }
+    const target = channelRetryTarget(failed);
+    if (!target) {
+      throw new ChannelMessageNotRetryableError(
+        'only a failed, interrupted, or truncated agent row raised by a routed turn can be retried',
+        'MESSAGE_NOT_RETRYABLE'
+      );
+    }
+    const trigger = store.getMessage(target.triggerMessageId);
+    if (!trigger || trigger.channelId !== channelId) {
+      throw new ChannelMessageNotRetryableError(
+        'the message that triggered this turn is no longer in this channel',
+        'RETRY_TRIGGER_MISSING'
+      );
+    }
+    const profile =
+      deps.agentProfileStore?.get(target.profileActorId) ??
+      (failed.sender.providerId
+        ? defaultProfileForProvider(failed.sender.providerId)
+        : null);
+    if (!profile) {
+      throw new ChannelMessageNotRetryableError(
+        `agent profile ${target.profileActorId} no longer exists`,
+        'AGENT_PROFILE_MISSING'
+      );
+    }
+    // Storm brake: one in-flight or queued turn for this profile is enough to
+    // refuse. `activeTurnId`/`queue` are checked alongside `status` because a
+    // turn is enqueued before the first status transition is broadcast.
+    const binding = live.get(bindingKey(channelId, profile.id));
+    if (
+      binding &&
+      (binding.status !== 'idle' ||
+        binding.activeTurnId !== null ||
+        binding.queue.length > 0)
+    ) {
+      throw new ChannelAgentBusyError(channelId, profile.id, binding.status);
+    }
+    // Availability is checked HERE as well as inside `routeOne` so an
+    // unroutable retry fails as a rejected request instead of as a supersede
+    // mark over a turn that never ran — the mark disables the row's own retry
+    // affordance, so writing it for a no-op would strand the operator.
+    const mentionTarget = await resolveTarget(profile.providerId);
+    if (!mentionTarget?.available) {
+      throw new ChannelMessageNotRetryableError(
+        `@${profile.displayName || profile.providerId} is not available in channels — ${mentionTarget?.reason ?? 'framework unavailable'}`,
+        'AGENT_UNAVAILABLE'
+      );
+    }
+    const label = await rosterDisplayName(profile);
+    postSystemRow(channelId, `retrying @${label} — previous reply ${failed.status}`, {
+      meta: { [CHANNEL_RETRY_OF_META_KEY]: failed.id, agentId: profile.id },
+      parentMessageId: parentForTrigger(trigger),
+    });
+    routeOne(trigger, profile);
+    return {
+      messageId: failed.id,
+      triggerMessageId: trigger.id,
+      profileActorId: profile.id,
+    };
+  }
+
   async function respondToApproval(
     channelId: string,
     agentId: string,
@@ -1719,6 +1868,7 @@ export function createChannelAgentBinder(
     ensureBinding,
     ensureOrchestrator,
     interrupt,
+    retryMessage,
     respondToApproval,
     rosterForChannel,
     setStatusBroadcaster(broadcaster) {

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -339,6 +339,13 @@ export function createChannelAgentBinder(
     }
   >();
   const unavailableRowAt = new Map<string, number>();
+  // Retry storm brake, synchronous half (#1308 review). The `live` binding's
+  // busy state is only observable AFTER `routeOne` has awaited its way to
+  // `enqueueTurn`, so a check against it alone is a TOCTOU: two retries issued
+  // in the same window both see an idle (or absent) binding and both enqueue.
+  // This marker is taken synchronously with the busy check and held until the
+  // route settles, so the second caller is refused rather than admitted.
+  const retryInFlight = new Set<string>();
   let statusBroadcaster: ChannelAgentStatusBroadcaster | null = null;
   let targetsCache: { at: number; value: MentionTarget[] } | null = null;
   let closed = false;
@@ -1380,8 +1387,17 @@ export function createChannelAgentBinder(
     return isDmChannel(topic);
   }
 
-  function routeOne(trigger: ChannelMessage, profile: AgentProfile): void {
-    void (async () => {
+  /**
+   * Fire-and-forget routing of one (trigger, profile) pair. The returned promise
+   * settles once the turn is enqueued (or routing gave up) — callers that only
+   * want the side effect ignore it with `void`; the retry lane hangs its storm
+   * brake off it so the marker is held until the turn is real (#1308 review).
+   */
+  function routeOne(
+    trigger: ChannelMessage,
+    profile: AgentProfile
+  ): Promise<void> {
+    return (async () => {
       try {
         const framework = profile.providerId;
         const target = await resolveTarget(framework);
@@ -1554,7 +1570,7 @@ export function createChannelAgentBinder(
       // the brake, and its turns must not consume the worker-turn allowance.
       // Human posts still reset the ordinary brake state below.
       for (const profile of profiles) {
-        routeOne(message, profile);
+        void routeOne(message, profile);
       }
       return;
     }
@@ -1584,7 +1600,7 @@ export function createChannelAgentBinder(
       state.count += 1;
     }
     for (const profile of profiles) {
-      routeOne(message, profile);
+      void routeOne(message, profile);
     }
   }
 
@@ -1618,7 +1634,7 @@ export function createChannelAgentBinder(
       return;
     }
     for (const profile of profiles) {
-      routeOne(message, profile);
+      void routeOne(message, profile);
     }
   }
 
@@ -1647,7 +1663,7 @@ export function createChannelAgentBinder(
     logger.debug(
       `dm implicit route, channel=${message.channelId} provider=${providerId} profile=${profile.id}`
     );
-    routeOne(message, profile);
+    void routeOne(message, profile);
   }
 
   function handleAssistantFinalized(message: ChannelMessage): void {
@@ -1725,11 +1741,14 @@ export function createChannelAgentBinder(
    * stays intact and the supersede marker survives a reload for free.
    *
    * The re-run reuses the same deterministic turn identity (§ Amendment 3), so
-   * a provider that derives item ids from the turn rather than per message could
-   * in principle collide with the retried row's source triple and have its reply
-   * deduped. No built-in adapter does that — all four take item ids from the
-   * provider stream — and minting a fresh identity would fork the turn-parent,
-   * watchdog, and `retriedTurns` bookkeeping that keys off it.
+   * an adapter that derives item ids from the turn rather than per SEND would
+   * collide with the retried row's source triple — `channel_messages` is unique
+   * on (source_runtime_id, source_turn_id, source_item_id) and inserts are
+   * `DO NOTHING` — and the retried reply would be silently dropped. Minting a
+   * fresh identity would fork the turn-parent, watchdog and `retriedTurns`
+   * bookkeeping that keys off it, so the invariant is pushed onto the adapters
+   * instead: item ids are unique per send, asserted by the mock adapter's own
+   * contract test (`test/mock-v2-adapter.test.ts`).
    */
   async function retryMessage(
     channelId: string,
@@ -1782,7 +1801,15 @@ export function createChannelAgentBinder(
     // Storm brake: one in-flight or queued turn for this profile is enough to
     // refuse. `activeTurnId`/`queue` are checked alongside `status` because a
     // turn is enqueued before the first status transition is broadcast.
-    const binding = live.get(bindingKey(channelId, profile.id));
+    //
+    // Taken TOGETHER with the `retryInFlight` marker, and both synchronously:
+    // everything below this point awaits, and a live binding's busy state only
+    // becomes observable once `routeOne` has awaited its way to `enqueueTurn`.
+    // Without the marker two retries in that window — two devices, or two failed
+    // rows for the same profile — would both read an idle (or, on a cold
+    // binding, absent) binding and both enqueue.
+    const key = bindingKey(channelId, profile.id);
+    const binding = live.get(key);
     if (
       binding &&
       (binding.status !== 'idle' ||
@@ -1791,28 +1818,47 @@ export function createChannelAgentBinder(
     ) {
       throw new ChannelAgentBusyError(channelId, profile.id, binding.status);
     }
-    // Availability is checked HERE as well as inside `routeOne` so an
-    // unroutable retry fails as a rejected request instead of as a supersede
-    // mark over a turn that never ran — the mark disables the row's own retry
-    // affordance, so writing it for a no-op would strand the operator.
-    const mentionTarget = await resolveTarget(profile.providerId);
-    if (!mentionTarget?.available) {
-      throw new ChannelMessageNotRetryableError(
-        `@${profile.displayName || profile.providerId} is not available in channels — ${mentionTarget?.reason ?? 'framework unavailable'}`,
-        'AGENT_UNAVAILABLE'
-      );
+    if (retryInFlight.has(key)) {
+      // Reported as `spawning`, never as the binding's own (still idle, still
+      // absent) status: a turn IS being raised for this profile right now, and
+      // saying "idle" would contradict the refusal in the same sentence.
+      throw new ChannelAgentBusyError(channelId, profile.id, 'spawning');
     }
-    const label = await rosterDisplayName(profile);
-    postSystemRow(channelId, `retrying @${label} — previous reply ${failed.status}`, {
-      meta: { [CHANNEL_RETRY_OF_META_KEY]: failed.id, agentId: profile.id },
-      parentMessageId: parentForTrigger(trigger),
-    });
-    routeOne(trigger, profile);
-    return {
-      messageId: failed.id,
-      triggerMessageId: trigger.id,
-      profileActorId: profile.id,
-    };
+    retryInFlight.add(key);
+    let routed = false;
+    try {
+      // Availability is checked HERE as well as inside `routeOne` so an
+      // unroutable retry fails as a rejected request instead of as a supersede
+      // mark over a turn that never ran — the mark disables the row's own retry
+      // affordance, so writing it for a no-op would strand the operator.
+      const mentionTarget = await resolveTarget(profile.providerId);
+      if (!mentionTarget?.available) {
+        throw new ChannelMessageNotRetryableError(
+          `@${profile.displayName || profile.providerId} is not available in channels — ${mentionTarget?.reason ?? 'framework unavailable'}`,
+          'AGENT_UNAVAILABLE'
+        );
+      }
+      const label = await rosterDisplayName(profile);
+      postSystemRow(
+        channelId,
+        `retrying @${label} — previous reply ${failed.status}`,
+        {
+          meta: { [CHANNEL_RETRY_OF_META_KEY]: failed.id, agentId: profile.id },
+          parentMessageId: parentForTrigger(trigger),
+        }
+      );
+      routed = true;
+      // Held until the route settles — by then the turn is enqueued, so the
+      // binding's own busy state takes over as the brake.
+      void routeOne(trigger, profile).finally(() => retryInFlight.delete(key));
+      return {
+        messageId: failed.id,
+        triggerMessageId: trigger.id,
+        profileActorId: profile.id,
+      };
+    } finally {
+      if (!routed) retryInFlight.delete(key);
+    }
   }
 
   async function respondToApproval(
@@ -1896,6 +1942,7 @@ export function createChannelAgentBinder(
       }
       live.clear();
       inflight.clear();
+      retryInFlight.clear();
       consecutiveAgentTurns.clear();
       unavailableRowAt.clear();
       targetsCache = null;

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -25,9 +25,11 @@ import {
   type ChannelAttachmentStore,
 } from './channel-attachments.js';
 import {
+  ChannelAgentBusyError,
   ChannelAgentNoActiveTurnError,
   ChannelAgentNotFoundError,
   ChannelAgentRoleConflictError,
+  ChannelMessageNotRetryableError,
   type ChannelAgentBinder,
 } from './channel-agent-binder.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
@@ -1040,6 +1042,55 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         });
     }
   );
+
+  // #1308 slice 1 item 2: retry one failed/interrupted/truncated agent row by
+  // re-routing the ORIGINAL trigger message to the same profile.
+  //
+  // Auth shape: the shared `auth` lane (browser session or gateway credential)
+  // plus an explicit `context:write` capability check — NOT a new named actor
+  // command, because this slice adds no CLI gateway verb. The capability gate is
+  // load-bearing rather than decorative: `requireCliGatewayAuth` admits an actor
+  // token on its READ lane, and re-running a turn spends real agent tokens, so a
+  // read-scoped credential must not reach it.
+  router.post('/channels/:id/messages/:messageId/retry', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (!storeOr503(res, deps.store)) return;
+    const binder = binderOr503(res, deps.binder);
+    if (!binder) return;
+    const messageId = req.params['messageId'] ?? '';
+    binder
+      .retryMessage(topic.id, messageId)
+      .then((retry) => res.json({ ok: true, retry }))
+      .catch((error) => {
+        if (error instanceof ChannelMessageNotRetryableError) {
+          sendGatewayError(
+            res,
+            error.notFound ? 'NOT_FOUND' : 'SESSION_CONFLICT',
+            error.message,
+            false,
+            {
+              channelId: topic.id,
+              messageId,
+              reasonCode: error.reasonCode,
+            }
+          );
+          return;
+        }
+        if (error instanceof ChannelAgentBusyError) {
+          sendGatewayError(res, 'SESSION_CONFLICT', error.message, true, {
+            channelId: topic.id,
+            messageId,
+            agentId: error.profileActorId,
+            status: error.status,
+            reasonCode: 'CHANNEL_AGENT_BUSY',
+          });
+          return;
+        }
+        mapStoreError(res, error);
+      });
+  });
 
   // #1167 §7: respond to an in-channel approval request.
   router.post(

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -1059,6 +1059,62 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     }
   });
 
+  // #1308 slice 1 item 4: the operator deletes one of their OWN durable rows.
+  //
+  // DELETE the resource, TOMBSTONE the record. The HTTP verb describes what the
+  // operator asked for; the store never removes the row, because `seq` is the
+  // substrate contract — a hole in the log would break every catch-up cursor,
+  // deep link and thread parent that already names it. The response body is the
+  // tombstone rather than 204, so the caller sees the row it now holds.
+  //
+  // Auth shape is the edit lane's, unchanged: the shared `auth` lane, an
+  // explicit `context:write` check (no new gateway verb, and the existing
+  // `/channels/*` auth-lane inventory entry covers the path), and a human-lane
+  // gate that is the load-bearing one — `requireCliGatewayAuth` admits scoped
+  // ACTOR credentials, and an agent must never be able to erase the operator's
+  // words.
+  router.delete('/channels/:id/messages/:messageId', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const sender = deriveSender(req, undefined);
+    if (sender.kind !== 'human') {
+      sendGatewayError(
+        res,
+        'FORBIDDEN',
+        'only the operator can delete channel messages',
+        false,
+        {
+          channelId: topic.id,
+          reasonCode: 'CHANNEL_DELETE_HUMAN_ONLY',
+        }
+      );
+      return;
+    }
+    try {
+      const message = store.deleteMessage({
+        channelId: topic.id,
+        messageId: req.params['messageId'] ?? '',
+        deleterId: sender.id,
+      });
+      // Broadcast only, exactly as with an edit: no `postToChannel`, so the
+      // mention-routing handlers never run and a deletion can never raise a turn.
+      deps.hub.broadcastDeleted(message);
+      res.json({ message });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
   // #1167 §2: per-request agent roster (framework availability + live binding
   // status). Derived per request — no persistent handle registry.
   router.get('/channels/:id/roster', rosterAuth, (req, res) => {

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -949,6 +949,116 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     }
   });
 
+  // #1308 slice 1 item 3: the operator edits one of their OWN durable rows.
+  //
+  // PATCH, not POST: this replaces a field of an existing resource, and the row
+  // keeps its id/seq/createdAt — the store mutates in place so no seq cursor,
+  // thread link or catch-up window moves.
+  //
+  // Auth shape mirrors the retry lane (#1308 item 2): the shared `auth` lane
+  // plus an explicit `context:write` check, because this slice adds no CLI
+  // gateway verb. The additional human-lane gate below is the load-bearing one —
+  // `requireCliGatewayAuth` admits scoped ACTOR credentials, and an agent must
+  // never be able to rewrite the operator's words.
+  router.patch('/channels/:id/messages/:messageId', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const body = bodyRecord(req);
+    // Same [MF] rule as the post lane: attribution is server-derived, so a body
+    // that tries to name a sender is rejected outright rather than ignored.
+    if ('sender' in body || 'source' in body) {
+      const field = 'sender' in body ? 'sender' : 'source';
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        `${field} is server-derived and must not be supplied in the request body`,
+        false,
+        {
+          field,
+          reasonCode:
+            field === 'sender'
+              ? 'CHANNEL_SENDER_NOT_ALLOWED'
+              : 'CHANNEL_SOURCE_NOT_ALLOWED',
+        }
+      );
+      return;
+    }
+    const sender = deriveSender(req, undefined);
+    if (sender.kind !== 'human') {
+      sendGatewayError(
+        res,
+        'FORBIDDEN',
+        'only the operator can edit channel messages',
+        false,
+        {
+          channelId: topic.id,
+          reasonCode: 'CHANNEL_EDIT_HUMAN_ONLY',
+        }
+      );
+      return;
+    }
+    const text = body['text'];
+    if (typeof text !== 'string') {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'text must be a string',
+        false,
+        {
+          field: 'text',
+        }
+      );
+      return;
+    }
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      // Not a delete lane: clearing a message is its own action with its own
+      // audit shape, so an empty edit is rejected rather than silently emptying
+      // a durable row.
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'edited text must not be empty',
+        false,
+        { field: 'text', reasonCode: 'CHANNEL_MESSAGE_BODY_EMPTY' }
+      );
+      return;
+    }
+    const providerIds = [
+      ...knownProviderIds,
+      ...(topic.routingDefaults.providerId
+        ? [topic.routingDefaults.providerId]
+        : []),
+    ];
+    try {
+      const message = store.editMessage({
+        channelId: topic.id,
+        messageId: req.params['messageId'] ?? '',
+        editorId: sender.id,
+        text: trimmed,
+        mentions: parseMentions(trimmed, providerIds),
+      });
+      // Broadcast only — NEVER `postToChannel`/`broadcastCreated`. Editing must
+      // not re-run the turn the original text triggered (#1308 S1 non-goal);
+      // future packets pick the new body up because the binder reads rows from
+      // the store when it builds one.
+      deps.hub.broadcastEdited(message);
+      res.json({ message });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
   // #1167 §2: per-request agent roster (framework availability + live binding
   // status). Derived per request — no persistent handle registry.
   router.get('/channels/:id/roster', rosterAuth, (req, res) => {

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -1212,16 +1212,43 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   // #1308 slice 1 item 2: retry one failed/interrupted/truncated agent row by
   // re-routing the ORIGINAL trigger message to the same profile.
   //
-  // Auth shape: the shared `auth` lane (browser session or gateway credential)
-  // plus an explicit `context:write` capability check — NOT a new named actor
-  // command, because this slice adds no CLI gateway verb. The capability gate is
-  // load-bearing rather than decorative: `requireCliGatewayAuth` admits an actor
-  // token on its READ lane, and re-running a turn spends real agent tokens, so a
-  // read-scoped credential must not reach it.
+  // Auth shape is the edit/delete lane's, and for the same reason. The shared
+  // `auth` lane plus an explicit `context:write` check comes first (this slice
+  // adds no CLI gateway verb), but `denyMissingCapability` is NOT a credential
+  // scope check — it seeds `provided` from the client-supplied
+  // `x-relay-capabilities` header — so the human-lane gate below is the
+  // load-bearing one. `requireCliGatewayAuth` admits scoped ACTOR credentials,
+  // re-running a turn spends real provider tokens and spawns runtimes, and
+  // `retryMessage` calls `routeOne` directly (outside `routeWithBrake`'s
+  // mention-chain cap), so an agent must never be able to reach it.
   router.post('/channels/:id/messages/:messageId/retry', auth, (req, res) => {
     if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
     const topic = requirePersistedChannel(req, res);
     if (!topic) return;
+    // An archived channel is read-only, exactly as it is for post/edit/delete:
+    // a retry writes a durable `retrying @…` system row and appends a whole new
+    // agent turn, which is the loudest possible violation of that invariant.
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const sender = deriveSender(req, undefined);
+    if (sender.kind !== 'human') {
+      sendGatewayError(
+        res,
+        'FORBIDDEN',
+        'only the operator can retry channel messages',
+        false,
+        {
+          channelId: topic.id,
+          reasonCode: 'CHANNEL_RETRY_HUMAN_ONLY',
+        }
+      );
+      return;
+    }
     if (!storeOr503(res, deps.store)) return;
     const binder = binderOr503(res, deps.binder);
     if (!binder) return;

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 
-import type {
-  ChannelImagePart,
-  ChannelMessage,
+import {
+  isChannelMessageDeleted,
+  type ChannelImagePart,
+  type ChannelMessage,
 } from '../shared/channel-chat-protocol.js';
 import type { ChannelAttachmentStore } from './channel-attachments.js';
 import type { Attachment } from './protocol-adapter-v2.js';
@@ -43,6 +44,15 @@ export const PACKET_FRAMEWORK_IMAGE_SUPPORT: Readonly<Record<string, boolean>> =
 
 const OMITTED_MARKER = '[…earlier messages omitted]';
 const ROW_TRUNCATED_SUFFIX = '…[truncated]';
+/**
+ * Stand-in for a tombstoned thread root (#1308 slice 1 item 4). Deleted rows are
+ * dropped from the context window entirely — see `eligible` below — with one
+ * exception: a thread root is structural, and a thread packet without its root
+ * is not buildable. The root is therefore retained as this marker, so the agent
+ * is told the anchor exists and is gone rather than being handed a blank line
+ * that reads like an empty message.
+ */
+const DELETED_ROW_MARKER = '[message deleted]';
 const THREAD_SCOPE_MARKER =
   '[Thread scope — only this thread is shown; its root message is always included]';
 
@@ -117,10 +127,16 @@ function triggerAttribution(message: ChannelMessage): string {
 
 /** Render one row as `label: text`, agent-tagged, with multi-line bodies indented. */
 function renderRow(message: ChannelMessage): string {
+  // A tombstone reaching this point is a retained thread root; its body is
+  // already empty in the store, so the marker is what stands in for it. Every
+  // other deleted row was filtered out before assembly.
+  const source = isChannelMessageDeleted(message)
+    ? DELETED_ROW_MARKER
+    : message.body.text;
   const truncated =
-    message.body.text.length > PACKET_ROW_MAX_CHARS
-      ? message.body.text.slice(0, PACKET_ROW_MAX_CHARS) + ROW_TRUNCATED_SUFFIX
-      : message.body.text;
+    source.length > PACKET_ROW_MAX_CHARS
+      ? source.slice(0, PACKET_ROW_MAX_CHARS) + ROW_TRUNCATED_SUFFIX
+      : source;
   const lines = truncated.split('\n');
   const first = lines[0] ?? '';
   const rest = lines.slice(1);
@@ -174,8 +190,13 @@ export function buildMentionContextPacketEnvelope(
     if (threadRootId !== null) {
       const isRoot = row.id === threadRootId;
       if (!isRoot && row.threadId !== threadRootId) return false;
+      // A deleted row carries nothing an agent can act on, so it is dropped —
+      // except a thread root, which is structural and is retained as
+      // `DELETED_ROW_MARKER` instead (#1308 slice 1 item 4).
+      if (isChannelMessageDeleted(row)) return isRoot;
       return isRoot || !isOwnAgentRow(row);
     }
+    if (isChannelMessageDeleted(row)) return false;
     return row.seq > input.lastDeliveredSeq && !isOwnAgentRow(row);
   });
 

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -127,6 +127,8 @@ export interface ChannelHub {
   /** Debounced authoritative full-row refresh for streaming card state. */
   updateStreamBroadcast(message: ChannelMessage): void;
   completeStreamBroadcast(message: ChannelMessage): void;
+  /** Fan out an operator edit of an already-durable row (#1308 slice 1 item 3). */
+  broadcastEdited(message: ChannelMessage): void;
   onMessagePosted(handler: ChannelMessagePostedHandler): () => void;
   setBadgeBroadcaster(broadcaster: ChannelBadgeBroadcaster): void;
   channelExists(channelId: string): boolean;
@@ -282,8 +284,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     maxBytes = snapshotMaxBytes,
     keepFirstOverBudget = true
   ): { rows: ChannelMessage[]; truncated: boolean; bytes: number } {
-    if (candidate.length === 0)
-      return { rows: [], truncated: false, bytes: 0 };
+    if (candidate.length === 0) return { rows: [], truncated: false, bytes: 0 };
     const order = keepEnd === 'tail' ? [...candidate].reverse() : candidate;
     const kept: ChannelMessage[] = [];
     let bytes = 0;
@@ -379,7 +380,8 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       // Partial resync merely omits stale replacements and must not pull the
       // cursor back from an otherwise complete fresh catch-up.
       if (freshAssembled.truncated && freshAssembled.rows.length > 0) {
-        snapshotLatestSeq = freshAssembled.rows[freshAssembled.rows.length - 1]!.seq;
+        snapshotLatestSeq =
+          freshAssembled.rows[freshAssembled.rows.length - 1]!.seq;
       }
     }
 
@@ -613,6 +615,21 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         message,
       });
       emitBadge(message.channelId);
+    },
+
+    broadcastEdited(message) {
+      broadcast(message.channelId, {
+        type: 'channel-message-edited-v1',
+        channelId: message.channelId,
+        timestamp: nowIso(),
+        message,
+      });
+      // Deliberately no `emitBadge` and no `onMessagePosted` fan-out. The badge
+      // carries `latestSeq`, which an edit does not move, so it would be inert
+      // noise; and the posted handlers are the mention-routing lane — running
+      // them here would re-trigger a past turn, which this feature explicitly
+      // must not do. The sidebar preview of an edited newest row therefore
+      // heals on the next channel-list fetch rather than instantly.
     },
 
     onMessagePosted(handler) {

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -129,6 +129,8 @@ export interface ChannelHub {
   completeStreamBroadcast(message: ChannelMessage): void;
   /** Fan out an operator edit of an already-durable row (#1308 slice 1 item 3). */
   broadcastEdited(message: ChannelMessage): void;
+  /** Fan out an operator deletion (tombstone) of a row (#1308 slice 1 item 4). */
+  broadcastDeleted(message: ChannelMessage): void;
   onMessagePosted(handler: ChannelMessagePostedHandler): () => void;
   setBadgeBroadcaster(broadcaster: ChannelBadgeBroadcaster): void;
   channelExists(channelId: string): boolean;
@@ -630,6 +632,27 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       // them here would re-trigger a past turn, which this feature explicitly
       // must not do. The sidebar preview of an edited newest row therefore
       // heals on the next channel-list fetch rather than instantly.
+    },
+
+    broadcastDeleted(message) {
+      // An in-flight accumulator would keep appending deltas onto a row the
+      // operator just erased. A human row never streams today, so this is a
+      // structural guard rather than a live case — but it is the same guard
+      // `completeStreamBroadcast` makes, and the cost of omitting it is a
+      // resurrected body.
+      const acc = accumulators.get(message.id);
+      if (acc?.coalesceTimer) clearTimeout(acc.coalesceTimer);
+      if (acc?.updateTimer) clearTimeout(acc.updateTimer);
+      accumulators.delete(message.id);
+      broadcast(message.channelId, {
+        type: 'channel-message-deleted-v1',
+        channelId: message.channelId,
+        timestamp: nowIso(),
+        message,
+      });
+      // No badge and no `onMessagePosted` fan-out, for the same reasons as
+      // `broadcastEdited`: no seq moved, and the posted handlers are the
+      // mention-routing lane — a deletion must never raise a turn.
     },
 
     onMessagePosted(handler) {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -8,6 +8,7 @@ import { createLogger } from './logger.js';
 import {
   CHANNEL_CHAT_PROTOCOL_VERSION,
   CHANNEL_AGENT_DETAIL_MAX_BYTES,
+  CHANNEL_EDITED_AT_META_KEY,
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
   CHANNEL_MESSAGE_MAX_IMAGE_PARTS,
   isChannelMessagePart,
@@ -38,9 +39,10 @@ import {
 //    survives future features.
 //  * Catch-up is ALWAYS DB-backed (the durable seq log is the replay buffer);
 //    there is no in-memory event ring.
-//  * Edits/deletes are out of scope for slice 2 and must NEVER be implemented as
-//    row deletion — that would break gap-free seq. Future mutation lands as new
-//    events over retained rows.
+//  * Edits/deletes must NEVER be implemented as row deletion — that would break
+//    gap-free seq. `editMessage` (#1308 slice 1 item 3) is the sanctioned shape:
+//    the SAME row keeps its id/seq/createdAt and only its body/meta change, so
+//    every seq cursor, catch-up window, and thread parent stays valid.
 
 const SCHEMA_VERSION = 5;
 const logger = createLogger('channel-message-store');
@@ -319,6 +321,22 @@ export interface FinalizeStreamInput {
   agentDetailTerminalAuthority?: 'provisional' | 'explicit';
 }
 
+export interface EditMessageInput {
+  /** Channel scope — an id from another channel is a 404, never a cross-edit. */
+  channelId: string;
+  messageId: string;
+  /**
+   * Server-derived editor identity (never body-supplied). Must equal the row's
+   * own `sender_id`: single-operator today, but ownership is enforced
+   * structurally so a future second identity cannot silently inherit edit rights.
+   */
+  editorId: string;
+  /** Replacement body. Empty text is rejected — deleting is a separate action. */
+  text: string;
+  /** Re-parsed from the new text by the caller; replaces the stored refs. */
+  mentions?: ChannelMention[];
+}
+
 export interface ResolveProvisionalAgentDetailTerminalResult {
   message: ChannelMessage | null;
   transitioned: boolean;
@@ -446,6 +464,15 @@ export interface ChannelMessageStore {
     }
   ): ResolveProvisionalAgentDetailTerminalResult;
   finalizeStream(id: string, input: FinalizeStreamInput): ChannelMessage | null;
+  /**
+   * Operator edit of their OWN human row (#1308 slice 1 item 3). In-place by
+   * design: id, seq, createdAt, thread links and client dedupe key all survive,
+   * so nothing that indexes the timeline by seq has to move. Throws
+   * `ChannelMessageStoreError` 404 (absent / other channel) or 409 (not an
+   * editable row, or not this editor's row) rather than returning null, so the
+   * route can map both without inventing its own vocabulary.
+   */
+  editMessage(input: EditMessageInput): ChannelMessage;
   getMessage(id: string): ChannelMessage | null;
   findByClientMessage(
     channelId: string,
@@ -460,12 +487,16 @@ export interface ChannelMessageStore {
     filter?: ChannelHistoryFilter
   ): ChannelMessage[];
   /**
-   * Rows a reconnecting client may still hold as stale `streaming` copies:
-   * agent-origin rows (source triple set) at or below the reconnect cursor, in
-   * their CURRENT state, nearest the cursor first. Only agent streams mutate in
-   * place (streaming → complete/truncated/interrupted/failed without a new seq), so this is
-   * the exact set catch-up must re-send to heal a stream that finalized while the
-   * client was disconnected. Bounded by `limit`.
+   * Rows a reconnecting client may still hold as a stale copy: rows at or below
+   * the reconnect cursor that mutate IN PLACE (no new seq), in their CURRENT
+   * state, nearest the cursor first. Two such classes exist —
+   *  - agent-origin rows (source triple set), whose stream finalizes
+   *    streaming → complete/truncated/interrupted/failed, and
+   *  - edited rows (#1308 slice 1 item 3), whose body changed under a seq the
+   *    client already consumed.
+   * `history({ afterSeq })` never re-sends either, so both must ride catch-up or
+   * a disconnected device keeps rendering pre-edit text / a stuck stream.
+   * Bounded by `limit`.
    */
   listResyncRows(
     channelId: string,
@@ -1411,6 +1442,84 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       return getMessageById(id);
     },
 
+    editMessage(input) {
+      const row = selectById.get(input.messageId) as
+        | ChannelMessageRow
+        | undefined;
+      // Channel mismatch is reported as absence, not as a conflict: the caller
+      // proved access to ONE channel, so it must not learn that an id it does
+      // not own exists somewhere else.
+      if (!row || row.channel_id !== input.channelId) {
+        throw new ChannelMessageStoreError(
+          404,
+          'channel_message_not_found',
+          'message not found in this channel',
+          { channelId: input.channelId, messageId: input.messageId }
+        );
+      }
+      if (
+        row.kind !== 'message' ||
+        row.sender_kind !== 'human' ||
+        row.status !== 'complete' ||
+        row.sender_id !== input.editorId
+      ) {
+        throw new ChannelMessageStoreError(
+          409,
+          'channel_message_not_editable',
+          'only the operator’s own completed messages can be edited',
+          {
+            channelId: input.channelId,
+            messageId: input.messageId,
+            kind: row.kind,
+            senderKind: row.sender_kind,
+            status: row.status,
+          }
+        );
+      }
+      if (input.text.length === 0) {
+        throw new ChannelMessageStoreError(
+          400,
+          'channel_message_body_empty',
+          'edited message text must not be empty'
+        );
+      }
+      assertMessagePayloadSize(
+        input.text,
+        parseMeta(row.meta_json)?.agentDetail
+      );
+      const now = nowIso();
+      const meta = parseMeta(row.meta_json) ?? {};
+      // Mentions are a projection of the body, so a stale set would outlive the
+      // text that justified it (a removed @claude would keep lighting the
+      // sidebar's mention lane). Re-parsed refs are stored; routing is NOT
+      // re-run — the edit path never reaches the binder.
+      if (input.mentions !== undefined) {
+        if (input.mentions.length > 0) meta.mentions = input.mentions;
+        else delete meta.mentions;
+      }
+      meta[CHANNEL_EDITED_AT_META_KEY] = now;
+      db.prepare(
+        `UPDATE channel_messages
+         SET body_text = @text, meta_json = @metaJson, updated_at = @now
+         WHERE id = @id`
+      ).run({
+        id: input.messageId,
+        text: input.text,
+        metaJson: JSON.stringify(meta),
+        now,
+      });
+      const updated = getMessageById(input.messageId);
+      if (!updated) {
+        throw new ChannelMessageStoreError(
+          404,
+          'channel_message_not_found',
+          'message not found in this channel',
+          { channelId: input.channelId, messageId: input.messageId }
+        );
+      }
+      return updated;
+    },
+
     getMessage(id) {
       return getMessageById(id);
     },
@@ -1525,7 +1634,8 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
                   ${replyCountSql('m')} AS reply_count
              FROM channel_messages m
             WHERE m.channel_id = @channelId AND m.seq <= @uptoSeq
-              AND m.source_runtime_id IS NOT NULL
+              AND (m.source_runtime_id IS NOT NULL
+                   OR json_extract(m.meta_json, '$.${CHANNEL_EDITED_AT_META_KEY}') IS NOT NULL)
             ORDER BY m.seq DESC LIMIT @limit`
         )
         .all({ channelId, uptoSeq, limit: bounded }) as ChannelMessageRow[];

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -8,6 +8,7 @@ import { createLogger } from './logger.js';
 import {
   CHANNEL_CHAT_PROTOCOL_VERSION,
   CHANNEL_AGENT_DETAIL_MAX_BYTES,
+  CHANNEL_DELETED_AT_META_KEY,
   CHANNEL_EDITED_AT_META_KEY,
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
   CHANNEL_MESSAGE_MAX_IMAGE_PARTS,
@@ -40,9 +41,11 @@ import {
 //  * Catch-up is ALWAYS DB-backed (the durable seq log is the replay buffer);
 //    there is no in-memory event ring.
 //  * Edits/deletes must NEVER be implemented as row deletion — that would break
-//    gap-free seq. `editMessage` (#1308 slice 1 item 3) is the sanctioned shape:
-//    the SAME row keeps its id/seq/createdAt and only its body/meta change, so
-//    every seq cursor, catch-up window, and thread parent stays valid.
+//    gap-free seq. `editMessage` (#1308 slice 1 item 3) and `deleteMessage`
+//    (item 4, a tombstone) are the sanctioned shapes: the SAME row keeps its
+//    id/seq/createdAt and only its body/meta change, so every seq cursor,
+//    catch-up window, and thread parent stays valid. Nothing in this file may
+//    ever issue `DELETE FROM channel_messages` for an operator action.
 
 const SCHEMA_VERSION = 5;
 const logger = createLogger('channel-message-store');
@@ -337,6 +340,17 @@ export interface EditMessageInput {
   mentions?: ChannelMention[];
 }
 
+export interface DeleteMessageInput {
+  /** Channel scope — an id from another channel is a 404, never a cross-delete. */
+  channelId: string;
+  messageId: string;
+  /**
+   * Server-derived deleter identity (never body-supplied). Must equal the row's
+   * own `sender_id`, exactly as with `editMessage`.
+   */
+  deleterId: string;
+}
+
 export interface ResolveProvisionalAgentDetailTerminalResult {
   message: ChannelMessage | null;
   transitioned: boolean;
@@ -473,6 +487,21 @@ export interface ChannelMessageStore {
    * route can map both without inventing its own vocabulary.
    */
   editMessage(input: EditMessageInput): ChannelMessage;
+  /**
+   * Operator deletion of their OWN human row (#1308 slice 1 item 4) as a
+   * TOMBSTONE: the row survives with its id, seq, createdAt, thread links and
+   * client dedupe key intact and loses only its body, its attachment refs and
+   * its mentions. Row removal is forbidden here — it would renumber nothing but
+   * would punch a hole in the gap-free seq log every cursor depends on, and it
+   * would orphan the replies of a deleted thread parent.
+   *
+   * Idempotent: deleting an already-deleted row returns the existing tombstone
+   * with its original `deletedAt` rather than throwing, so a second device (or a
+   * double tap) does not surface a spurious error for a state already reached.
+   * Throws 404 (absent / other channel) or 409 (not the operator's own settled
+   * prose row).
+   */
+  deleteMessage(input: DeleteMessageInput): ChannelMessage;
   getMessage(id: string): ChannelMessage | null;
   findByClientMessage(
     channelId: string,
@@ -492,11 +521,11 @@ export interface ChannelMessageStore {
    * state, nearest the cursor first. Two such classes exist —
    *  - agent-origin rows (source triple set), whose stream finalizes
    *    streaming → complete/truncated/interrupted/failed, and
-   *  - edited rows (#1308 slice 1 item 3), whose body changed under a seq the
-   *    client already consumed.
-   * `history({ afterSeq })` never re-sends either, so both must ride catch-up or
-   * a disconnected device keeps rendering pre-edit text / a stuck stream.
-   * Bounded by `limit`.
+   *  - edited and deleted rows (#1308 slice 1 items 3/4), whose body changed
+   *    under a seq the client already consumed.
+   * `history({ afterSeq })` never re-sends any of them, so all must ride
+   * catch-up or a disconnected device keeps rendering pre-edit text, a deleted
+   * body, or a stuck stream. Bounded by `limit`.
    */
   listResyncRows(
     channelId: string,
@@ -629,6 +658,16 @@ function parseMeta(raw: string | null): ChannelMessageMeta | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Whether a raw row is a tombstone (#1308 slice 1 item 4). Read straight off the
+ * persisted meta so every guard in this file agrees with the SQL predicate the
+ * resync/preview queries use.
+ */
+function isTombstoneRow(row: ChannelMessageRow): boolean {
+  const value = parseMeta(row.meta_json)?.[CHANNEL_DELETED_AT_META_KEY];
+  return typeof value === 'string' && value.length > 0;
 }
 
 function rowToMessage(row: ChannelMessageRow): ChannelMessage {
@@ -1461,7 +1500,11 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         row.kind !== 'message' ||
         row.sender_kind !== 'human' ||
         row.status !== 'complete' ||
-        row.sender_id !== input.editorId
+        row.sender_id !== input.editorId ||
+        // A tombstone is not an editable row: an edit writes a body, and
+        // deletion is the operator's statement that this row has none (#1308
+        // item 4). Without this, "edit" would be an undelete.
+        isTombstoneRow(row)
       ) {
         throw new ChannelMessageStoreError(
           409,
@@ -1473,6 +1516,7 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
             kind: row.kind,
             senderKind: row.sender_kind,
             status: row.status,
+            ...(isTombstoneRow(row) ? { deleted: true } : {}),
           }
         );
       }
@@ -1508,6 +1552,76 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         metaJson: JSON.stringify(meta),
         now,
       });
+      const updated = getMessageById(input.messageId);
+      if (!updated) {
+        throw new ChannelMessageStoreError(
+          404,
+          'channel_message_not_found',
+          'message not found in this channel',
+          { channelId: input.channelId, messageId: input.messageId }
+        );
+      }
+      return updated;
+    },
+
+    deleteMessage(input) {
+      const row = selectById.get(input.messageId) as
+        | ChannelMessageRow
+        | undefined;
+      // Channel mismatch reads as absence, same as `editMessage`: a caller that
+      // proved access to ONE channel must not learn that an id it does not own
+      // exists somewhere else.
+      if (!row || row.channel_id !== input.channelId) {
+        throw new ChannelMessageStoreError(
+          404,
+          'channel_message_not_found',
+          'message not found in this channel',
+          { channelId: input.channelId, messageId: input.messageId }
+        );
+      }
+      // Idempotent by design — checked BEFORE the ownership gate would matter,
+      // and returning the ORIGINAL stamp rather than restamping: two devices
+      // racing the same delete must converge on one tombstone, not on whichever
+      // arrived last.
+      if (isTombstoneRow(row)) return rowToMessage(row);
+      if (
+        row.kind !== 'message' ||
+        row.sender_kind !== 'human' ||
+        row.status !== 'complete' ||
+        row.sender_id !== input.deleterId
+      ) {
+        throw new ChannelMessageStoreError(
+          409,
+          'channel_message_not_deletable',
+          'only the operator’s own completed messages can be deleted',
+          {
+            channelId: input.channelId,
+            messageId: input.messageId,
+            kind: row.kind,
+            senderKind: row.sender_kind,
+            status: row.status,
+          }
+        );
+      }
+      const now = nowIso();
+      const meta = parseMeta(row.meta_json) ?? {};
+      // Everything the body implied goes with the body. `mentions` would keep
+      // lighting the sidebar's mention lane for text nobody can read; `parts`
+      // would keep rendering the attached images the operator just erased; the
+      // `editedAt` provenance note is meaningless once there is nothing left to
+      // have been edited. What survives is routing/bookkeeping meta that names
+      // the row rather than its content.
+      delete meta.mentions;
+      delete meta.parts;
+      delete meta[CHANNEL_EDITED_AT_META_KEY];
+      meta[CHANNEL_DELETED_AT_META_KEY] = now;
+      // UPDATE, never DELETE. `seq` is the substrate contract: the row keeps its
+      // number so catch-up windows, deep links and thread parents stay valid.
+      db.prepare(
+        `UPDATE channel_messages
+         SET body_text = '', meta_json = @metaJson, updated_at = @now
+         WHERE id = @id`
+      ).run({ id: input.messageId, metaJson: JSON.stringify(meta), now });
       const updated = getMessageById(input.messageId);
       if (!updated) {
         throw new ChannelMessageStoreError(
@@ -1635,7 +1749,8 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
              FROM channel_messages m
             WHERE m.channel_id = @channelId AND m.seq <= @uptoSeq
               AND (m.source_runtime_id IS NOT NULL
-                   OR json_extract(m.meta_json, '$.${CHANNEL_EDITED_AT_META_KEY}') IS NOT NULL)
+                   OR json_extract(m.meta_json, '$.${CHANNEL_EDITED_AT_META_KEY}') IS NOT NULL
+                   OR json_extract(m.meta_json, '$.${CHANNEL_DELETED_AT_META_KEY}') IS NOT NULL)
             ORDER BY m.seq DESC LIMIT @limit`
         )
         .all({ channelId, uptoSeq, limit: bounded }) as ChannelMessageRow[];
@@ -1665,6 +1780,9 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         .all() as Array<ChannelMessageRow & { cnt?: number }>;
       // Newest prose row per channel — the summary preview reads from this so a
       // turn ending on a detail card (body_text='') does not blank the sidebar.
+      // A tombstone (#1308 item 4) is body-less for the same reason and is
+      // skipped by the same rule: deleting the last message must not leave the
+      // sidebar showing an empty channel.
       const previewRows = new Map<string, ChannelMessageRow>();
       for (const row of db
         .prepare(
@@ -1672,6 +1790,7 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
              SELECT channel_id, MAX(seq) AS max_seq
              FROM channel_messages
              WHERE json_extract(meta_json, '$.agentDetail') IS NULL
+               AND json_extract(meta_json, '$.${CHANNEL_DELETED_AT_META_KEY}') IS NULL
              GROUP BY channel_id
            ) agg
            JOIN channel_messages prose
@@ -1717,12 +1836,14 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       if (!last) {
         return { channelId, latestSeq: 0, messageCount: 0, lastMessage: null };
       }
-      // Preview from the newest prose row; detail cards persist body_text=''.
+      // Preview from the newest prose row; detail cards and tombstones both
+      // persist body_text='' and are skipped for the same reason.
       const previewRow =
         (db
           .prepare(
             `SELECT * FROM channel_messages WHERE channel_id = ?
                AND json_extract(meta_json, '$.agentDetail') IS NULL
+               AND json_extract(meta_json, '$.${CHANNEL_DELETED_AT_META_KEY}') IS NULL
              ORDER BY seq DESC LIMIT 1`
           )
           .get(channelId) as ChannelMessageRow | undefined) ?? last;

--- a/server/protocol-adapters/mock-v2-adapter.ts
+++ b/server/protocol-adapters/mock-v2-adapter.ts
@@ -97,6 +97,17 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   >();
   private readonly delays: MockProtocolAdapterV2Delays;
   private connectGeneration = 0;
+  /**
+   * Sends seen per turn id (#1308 review). Item ids must be unique per SEND,
+   * not per turn: `channel_messages` is unique on
+   * (source_runtime_id, source_turn_id, source_item_id) and inserts are
+   * `ON CONFLICT DO NOTHING`, so a channel retry — which deliberately re-sends
+   * the SAME deterministic turn id — would have its whole reply silently
+   * deduped if item ids were derived from the turn alone. The first send keeps
+   * the historical `<kind>-<turnId>` shape every fixture reads; each re-send
+   * appends its attempt ordinal.
+   */
+  private readonly sendAttempts = new Map<string, number>();
 
   constructor(delays: Partial<MockProtocolAdapterV2Delays> = {}) {
     super();
@@ -289,15 +300,23 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     }
   }
 
+  /** Item-id scope for this send — see `sendAttempts`. */
+  private nextItemScope(turnId: string): string {
+    const attempt = (this.sendAttempts.get(turnId) ?? 0) + 1;
+    this.sendAttempts.set(turnId, attempt);
+    return attempt > 1 ? `${turnId}-a${attempt}` : turnId;
+  }
+
   private async runTurn(
     input: AgentSendMessageInputV2,
     signal: AbortSignal
   ): Promise<void> {
     const startedAt = nowIso();
+    const scope = this.nextItemScope(input.turnId);
     const turn: AgentTurnV2 = {
       id: input.turnId,
       status: 'running',
-      inputMessageId: `user-${input.turnId}`,
+      inputMessageId: `user-${scope}`,
       items: [],
       startedAt,
     };
@@ -311,7 +330,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     });
     this.emitItemStarted(input.turnId, {
       type: 'userMessage',
-      id: `user-${input.turnId}`,
+      id: `user-${scope}`,
       text: input.content,
       completedAt: startedAt,
       status: 'completed',
@@ -326,9 +345,9 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
     try {
       if (this.isApprovalScenario(input.content)) {
-        await this.runApprovalScenario(input.turnId, signal);
+        await this.runApprovalScenario(input.turnId, scope, signal);
       } else {
-        await this.runHappyPath(input.turnId, signal);
+        await this.runHappyPath(input.turnId, scope, signal);
       }
     } catch (err) {
       if (isAbortError(err)) {
@@ -366,12 +385,13 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
   private async runHappyPath(
     turnId: string,
+    scope: string,
     signal: AbortSignal
   ): Promise<void> {
     const text = 'Mock v2 response complete.';
     const assistant: AgentItemV2 = {
       type: 'assistantMessage',
-      id: `assistant-${turnId}`,
+      id: `assistant-${scope}`,
       text: '',
       phase: 'answer',
       status: 'running',
@@ -380,7 +400,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
     this.emitItemStarted(turnId, {
       type: 'reasoning',
-      id: `reasoning-${turnId}`,
+      id: `reasoning-${scope}`,
       summary: 'Mock reasoning summary.',
       visibility: 'summary',
       status: 'completed',
@@ -395,7 +415,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
       sessionId: this.sessionId,
       timestamp: nowIso(),
       turnId,
-      itemId: `assistant-${turnId}`,
+      itemId: `assistant-${scope}`,
       delta: { text },
     });
     await sleep(this.delays.stepMs, signal);
@@ -414,7 +434,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
     this.emitItemStarted(turnId, {
       type: 'commandExecution',
-      id: `command-${turnId}`,
+      id: `command-${scope}`,
       command: 'npm test -- test/components/chat-v2-rendering.test.ts',
       output: 'Mock command output.',
       exitCode: 0,
@@ -426,7 +446,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
     this.emitItemStarted(turnId, {
       type: 'fileChange',
-      id: `file-${turnId}`,
+      id: `file-${scope}`,
       paths: [
         {
           path: 'frontend/src/components/chat/ChannelMessageRow.tsx',
@@ -442,7 +462,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
     this.emitItemStarted(turnId, {
       type: 'dynamicToolCall',
-      id: `dynamic-${turnId}`,
+      id: `dynamic-${scope}`,
       namespace: 'mock',
       tool: 'grep',
       arguments: { pattern: 'chat' },
@@ -454,7 +474,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
     this.emitItemStarted(turnId, {
       type: 'providerExtension',
-      id: `extension-${turnId}`,
+      id: `extension-${scope}`,
       namespace: 'mock',
       payload: { kind: 'mockExtension', message: 'Mock provider extension.' },
       status: 'completed',
@@ -465,10 +485,11 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
   private async runApprovalScenario(
     turnId: string,
+    scope: string,
     signal: AbortSignal
   ): Promise<void> {
-    const approvalId = `approval-${turnId}`;
-    const toolId = `tool-${turnId}`;
+    const approvalId = `approval-${scope}`;
+    const toolId = `tool-${scope}`;
 
     this.emitItemStarted(turnId, {
       type: 'approval',
@@ -520,7 +541,7 @@ export class MockProtocolAdapterV2 extends BaseProtocolAdapterV2 {
       queueLength: this.queue.length,
     });
 
-    await this.runHappyPath(turnId, signal);
+    await this.runHappyPath(turnId, scope, signal);
   }
 
   private waitForApproval(

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -151,6 +151,105 @@ export interface ChannelInFlightRef {
   deltaIndex: number;
 }
 
+// ── retry contract (#1308 slice 1 item 2) ───────────────────────────────────
+
+/**
+ * Prefix of the binder-issued turn identity. A routed turn is named after the
+ * (trigger message, profile) pair it was raised for — that is what makes the
+ * turn deterministic across a redeliver — so the trigger id is recoverable from
+ * any durable row the turn produced. Retry is built on exactly that: it never
+ * re-posts the human message, it re-routes the original one.
+ */
+export const CHANNEL_TURN_ID_PREFIX = 'chturn-';
+
+/** Deterministic turn identity for one routed (trigger, profile) pair. */
+export function channelTurnId(
+  triggerMessageId: ChannelMessageId,
+  profileActorId: string
+): string {
+  return `${CHANNEL_TURN_ID_PREFIX}${triggerMessageId}-${profileActorId}`;
+}
+
+/**
+ * Inverse of `channelTurnId`. Parsed by anchoring on the known prefix AND the
+ * known profile suffix rather than by splitting on `-`: both message ids and
+ * profile actor ids embed UUIDs, so no separator is unambiguous. Returns null
+ * for any turn id the binder did not mint (providers are free to label their
+ * own items — Hermes emits `turn-0` — and those rows simply cannot be retried).
+ */
+export function triggerMessageIdFromTurnId(
+  turnId: string,
+  profileActorId: string
+): ChannelMessageId | null {
+  const suffix = `-${profileActorId}`;
+  if (!turnId.startsWith(CHANNEL_TURN_ID_PREFIX)) return null;
+  if (!turnId.endsWith(suffix) || turnId.length <= suffix.length) return null;
+  const id = turnId.slice(
+    CHANNEL_TURN_ID_PREFIX.length,
+    turnId.length - suffix.length
+  );
+  return id.startsWith('chm:') && id.length > 'chm:'.length
+    ? (id as ChannelMessageId)
+    : null;
+}
+
+/**
+ * Terminal statuses whose turn did NOT deliver a complete reply, so re-running
+ * it is a coherent operator request.
+ *
+ * All three are included deliberately. `failed` is a send/agent error;
+ * `interrupted` is produced both by the operator's ■ AND by a runtime dying
+ * mid-stream (`handleRuntimeEnd` → bridge finalize), which is a lost turn the
+ * operator never chose; `truncated` covers a missing terminal item or a hub
+ * restart as well as the 256KB cap. Retry stays a click — never automatic — so
+ * the operator, not the system, decides whether re-running is worth the tokens.
+ */
+export const CHANNEL_RETRYABLE_STATUSES: readonly ChannelMessageStatus[] = [
+  'failed',
+  'interrupted',
+  'truncated',
+];
+
+/** `meta` key on the system row that supersedes a retried agent row. */
+export const CHANNEL_RETRY_OF_META_KEY = 'retryOfMessageId';
+
+export interface ChannelRetryTarget {
+  /** The ORIGINAL human/agent message the failed turn was raised for. */
+  triggerMessageId: ChannelMessageId;
+  /** Profile actor id that owned the failed turn; the retry re-uses it. */
+  profileActorId: string;
+}
+
+/**
+ * Whether a row can be retried, and against what. Shared so the client's
+ * affordance and the server's route agree by construction: an unresolvable row
+ * never grows a retry button AND is rejected by the route.
+ */
+export function channelRetryTarget(
+  message: ChannelMessage
+): ChannelRetryTarget | null {
+  if (message.kind !== 'message') return null;
+  if (message.sender.kind !== 'agent') return null;
+  if (!CHANNEL_RETRYABLE_STATUSES.includes(message.status)) return null;
+  const turnId = message.source?.turnId;
+  if (!turnId) return null;
+  const profileActorId = message.sender.id;
+  const triggerMessageId = triggerMessageIdFromTurnId(turnId, profileActorId);
+  if (!triggerMessageId || triggerMessageId === message.id) return null;
+  return { triggerMessageId, profileActorId };
+}
+
+/** Agent row a system row supersedes, when it is a retry marker. */
+export function retriedMessageIdFromSystemRow(
+  message: ChannelMessage
+): ChannelMessageId | null {
+  if (message.kind !== 'system') return null;
+  const value = message.meta?.[CHANNEL_RETRY_OF_META_KEY];
+  return typeof value === 'string' && value.startsWith('chm:')
+    ? (value as ChannelMessageId)
+    : null;
+}
+
 interface ChannelEventBaseV1 {
   channelId: string;
   timestamp: string;

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -250,6 +250,39 @@ export function retriedMessageIdFromSystemRow(
     : null;
 }
 
+// ── edit contract (#1308 slice 1 item 3) ────────────────────────────────────
+
+/**
+ * `meta` key stamped when the operator edits their own row. Presence of the key
+ * IS the edited marker — there is no separate boolean, so a row can never claim
+ * to be edited without carrying when it happened.
+ */
+export const CHANNEL_EDITED_AT_META_KEY = 'editedAt';
+
+/** ISO stamp of the last edit, or null for a row that was never edited. */
+export function channelMessageEditedAt(message: ChannelMessage): string | null {
+  const value = message.meta?.[CHANNEL_EDITED_AT_META_KEY];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * Whether the operator may edit this row. Human-authored prose rows only in this
+ * slice: an agent row is a durable record of what a provider actually said, and
+ * a system row is the hub's own bookkeeping — editing either would make the
+ * transcript lie. `complete` excludes an in-flight stream (a human row is never
+ * streaming today, so this is a structural guard, not a live case).
+ *
+ * Shared so the client's affordance and the server's route agree by
+ * construction: a row that grows no edit button is also rejected by the route.
+ */
+export function channelMessageEditable(message: ChannelMessage): boolean {
+  return (
+    message.kind === 'message' &&
+    message.sender.kind === 'human' &&
+    message.status === 'complete'
+  );
+}
+
 interface ChannelEventBaseV1 {
   channelId: string;
   timestamp: string;
@@ -294,6 +327,22 @@ export interface ChannelMessageCompletedEventV1 extends ChannelEventBaseV1 {
   message: ChannelMessage;
 }
 
+/**
+ * Operator edit of an already-durable row (#1308 slice 1 item 3).
+ *
+ * A separate variant rather than a reuse of `channel-message-updated-v1`: that
+ * event is contractually a STREAMING row refresh (its validator rejects any
+ * other status and its reducer ignores a non-streaming target), which is exactly
+ * the shape an edit is not. Widening it would have made every streaming-row
+ * guard in the reducer conditional; this stays additive and leaves the streaming
+ * lane untouched.
+ */
+export interface ChannelMessageEditedEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-message-edited-v1';
+  /** Authoritative full row; same id/seq, new body, `meta.editedAt` stamped. */
+  message: ChannelMessage;
+}
+
 export interface ChannelResyncRequiredEventV1 extends ChannelEventBaseV1 {
   type: 'channel-resync-required-v1';
   latestSeq: number;
@@ -305,6 +354,7 @@ export type ChannelEventV1 =
   | ChannelMessageDeltaEventV1
   | ChannelMessageUpdatedEventV1
   | ChannelMessageCompletedEventV1
+  | ChannelMessageEditedEventV1
   | ChannelResyncRequiredEventV1;
 
 // ── runtime validators ──────────────────────────────────────────────────────
@@ -527,6 +577,13 @@ export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
       );
     case 'channel-message-completed-v1':
       return isChannelMessage(value.message);
+    case 'channel-message-edited-v1':
+      // Same predicate the route enforces: only an editable row can arrive as
+      // an edit, so a malformed or agent-authored payload is dropped at the
+      // wire rather than replacing a durable row in the reducer.
+      return (
+        isChannelMessage(value.message) && channelMessageEditable(value.message)
+      );
     case 'channel-resync-required-v1':
       return typeof value.latestSeq === 'number';
     default:
@@ -717,6 +774,31 @@ export function applyChannelEventV1(
         byId: { ...state.byId, [message.id]: message },
         inFlightDelta,
         quarantined,
+      };
+    }
+
+    case 'channel-message-edited-v1': {
+      const message = event.message;
+      const existing = state.byId[message.id];
+      // Deliberately NOT a catch-up trigger, unlike every other unknown-id case.
+      // An edit adds no seq and closes no gap: an id the client does not hold is
+      // simply a row outside its loaded window (the operator edited something
+      // older on another device). Re-syncing would show the out-of-sync banner
+      // for a timeline that is perfectly in sync, and the edited body arrives
+      // anyway the moment that page is scrolled back into view.
+      if (!existing) return state;
+      // Guards, not corrections: an edit must never resurrect, re-number, or
+      // overwrite a live stream. Any of these means the row on the wire is not
+      // the row this client holds, so the safe move is to keep what is durable.
+      if (existing.status === 'streaming') return state;
+      if (message.seq !== existing.seq) return { ...state, needsCatchup: true };
+      const messages = state.messages.map((row) =>
+        row.id === message.id ? message : row
+      );
+      return {
+        ...state,
+        messages,
+        byId: { ...state.byId, [message.id]: message },
       };
     }
 

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -270,7 +270,9 @@ export function channelMessageEditedAt(message: ChannelMessage): string | null {
  * slice: an agent row is a durable record of what a provider actually said, and
  * a system row is the hub's own bookkeeping — editing either would make the
  * transcript lie. `complete` excludes an in-flight stream (a human row is never
- * streaming today, so this is a structural guard, not a live case).
+ * streaming today, so this is a structural guard, not a live case). A tombstone
+ * is excluded too — an edit of a deleted row would resurrect a body the operator
+ * erased (#1308 item 4).
  *
  * Shared so the client's affordance and the server's route agree by
  * construction: a row that grows no edit button is also rejected by the route.
@@ -279,7 +281,65 @@ export function channelMessageEditable(message: ChannelMessage): boolean {
   return (
     message.kind === 'message' &&
     message.sender.kind === 'human' &&
-    message.status === 'complete'
+    message.status === 'complete' &&
+    !isChannelMessageDeleted(message)
+  );
+}
+
+// ── delete contract (#1308 slice 1 item 4) ──────────────────────────────────
+
+/**
+ * `meta` key stamped when the operator deletes their own row. A deletion is a
+ * TOMBSTONE, never a row removal: `channel_messages.seq` is the substrate's
+ * gap-free log, and every catch-up cursor, deep link and thread parent is a
+ * promise that a seq once issued keeps naming the same row forever.
+ *
+ * The mark lives in `meta` rather than in `status` on purpose. `status` carries
+ * a SQL CHECK constraint, so a `deleted` status would need the constraint
+ * widened plus a table-rebuild migration (`SCHEMA_VERSION` bump, the v2 rebuild
+ * lane) — schema churn buying nothing, since a tombstone is orthogonal to the
+ * streaming lifecycle `status` describes: a deleted row is still `complete`, it
+ * simply no longer has a body. Presence of the key IS the marker, so a row can
+ * never claim to be deleted without carrying when it happened.
+ */
+export const CHANNEL_DELETED_AT_META_KEY = 'deletedAt';
+
+/** ISO stamp of the deletion, or null for a row that is not a tombstone. */
+export function channelMessageDeletedAt(
+  message: ChannelMessage
+): string | null {
+  const value = message.meta?.[CHANNEL_DELETED_AT_META_KEY];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** Whether this row is a tombstone — body wiped, id/seq/links retained. */
+export function isChannelMessageDeleted(message: ChannelMessage): boolean {
+  return channelMessageDeletedAt(message) !== null;
+}
+
+/**
+ * Whether the operator may delete this row. Identical to the edit predicate
+ * today — both are "the operator's own settled prose row" — and kept as its own
+ * name because the two affordances answer different questions and are free to
+ * diverge (a future retention rule could forbid deleting a row an agent already
+ * consumed without touching who may fix a typo).
+ */
+export function channelMessageDeletable(message: ChannelMessage): boolean {
+  return channelMessageEditable(message);
+}
+
+/**
+ * Shape check for a row arriving as a tombstone. Deliberately NOT
+ * `channelMessageDeletable` — that predicate answers "may this be deleted",
+ * which is false for an already-deleted row, so the wire needs its own
+ * post-condition: an operator prose row, marked deleted, with no body left.
+ */
+export function isChannelMessageTombstone(message: ChannelMessage): boolean {
+  return (
+    message.kind === 'message' &&
+    message.sender.kind === 'human' &&
+    isChannelMessageDeleted(message) &&
+    message.body.text.length === 0
   );
 }
 
@@ -343,6 +403,23 @@ export interface ChannelMessageEditedEventV1 extends ChannelEventBaseV1 {
   message: ChannelMessage;
 }
 
+/**
+ * Operator deletion of an already-durable row (#1308 slice 1 item 4).
+ *
+ * Its own variant for the same reason the edit event is: the payload is a row
+ * that must REPLACE a held one in place, and neither the streaming-only
+ * `channel-message-updated-v1` nor the terminal-transition
+ * `channel-message-completed-v1` can carry that without loosening a guard the
+ * streaming lane depends on. Kept separate from the edit event too, so a client
+ * can tell "the operator fixed a typo" from "the operator erased this" without
+ * inspecting `meta` — the two render as different rows.
+ */
+export interface ChannelMessageDeletedEventV1 extends ChannelEventBaseV1 {
+  type: 'channel-message-deleted-v1';
+  /** Authoritative tombstone; same id/seq/thread links, empty body. */
+  message: ChannelMessage;
+}
+
 export interface ChannelResyncRequiredEventV1 extends ChannelEventBaseV1 {
   type: 'channel-resync-required-v1';
   latestSeq: number;
@@ -355,6 +432,7 @@ export type ChannelEventV1 =
   | ChannelMessageUpdatedEventV1
   | ChannelMessageCompletedEventV1
   | ChannelMessageEditedEventV1
+  | ChannelMessageDeletedEventV1
   | ChannelResyncRequiredEventV1;
 
 // ── runtime validators ──────────────────────────────────────────────────────
@@ -584,6 +662,15 @@ export function isChannelEventV1(value: unknown): value is ChannelEventV1 {
       return (
         isChannelMessage(value.message) && channelMessageEditable(value.message)
       );
+    case 'channel-message-deleted-v1':
+      // Post-condition of the route, not its precondition: the payload must be
+      // an operator prose row that is marked deleted AND carries no body left.
+      // A "deletion" still holding text would be a leak of the thing the
+      // operator asked to erase, so it is dropped at the wire.
+      return (
+        isChannelMessage(value.message) &&
+        isChannelMessageTombstone(value.message)
+      );
     case 'channel-resync-required-v1':
       return typeof value.latestSeq === 'number';
     default:
@@ -792,6 +879,31 @@ export function applyChannelEventV1(
       // the row this client holds, so the safe move is to keep what is durable.
       if (existing.status === 'streaming') return state;
       if (message.seq !== existing.seq) return { ...state, needsCatchup: true };
+      const messages = state.messages.map((row) =>
+        row.id === message.id ? message : row
+      );
+      return {
+        ...state,
+        messages,
+        byId: { ...state.byId, [message.id]: message },
+      };
+    }
+
+    case 'channel-message-deleted-v1': {
+      const message = event.message;
+      const existing = state.byId[message.id];
+      // Same three guards as the edit lane, for the same reasons: an unknown id
+      // is a row outside the loaded window (no seq moved, so nothing is missing
+      // — demanding a resync would raise the out-of-sync banner on a healthy
+      // timeline); a live stream is never a tombstone target; and a seq surprise
+      // means the row on the wire is not the row held here.
+      if (!existing) return state;
+      if (existing.status === 'streaming') return state;
+      if (message.seq !== existing.seq) return { ...state, needsCatchup: true };
+      // Replaced in place, never spliced out. The array keeps its length and
+      // order, so grouping, the unread divider's index and every scroll anchor
+      // survive a deletion untouched — and a deleted thread parent stays where
+      // its replies point.
       const messages = state.messages.map((row) =>
         row.id === message.id ? message : row
       );

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -301,6 +301,7 @@ const expectedInventoryCoverage = [
       '/inbox/*',
       '/events/*',
       '/handoffs/*',
+      '/channels/*',
       '/nodes',
       '/hub/audit/*',
       '/hub/nodes/:nodeId/logs',

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -3516,6 +3516,41 @@ describe('channel-agent-binder — retry', () => {
     expect(adapter.sendCalls).toHaveLength(0);
   });
 
+  it('refuses to re-run a turn whose trigger the operator deleted (#1308 item 4)', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+    const failed = failedAgentRow(store, trigger);
+    // A tombstone keeps its id, so the trigger still RESOLVES — re-running the
+    // turn would hand the provider exactly the text the operator erased.
+    store.deleteMessage({
+      channelId: CH,
+      messageId: trigger.id,
+      deleterId: OPERATOR.id,
+    });
+
+    await expect(binder.retryMessage(CH, failed.id)).rejects.toMatchObject({
+      reasonCode: 'RETRY_TRIGGER_DELETED',
+      notFound: false,
+    });
+    expect(adapter.sendCalls).toHaveLength(0);
+    // Refused before the supersede mark: a mark for a turn that never ran would
+    // disable the row's own retry affordance forever.
+    expect(
+      systemRows(store).filter(
+        (row) => row.meta?.[CHANNEL_RETRY_OF_META_KEY] !== undefined
+      )
+    ).toHaveLength(0);
+  });
+
   it('retries interrupted and truncated rows too — every lost turn, not just failed', async () => {
     const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
     const { binder, store } = makeBinder({

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -33,6 +33,7 @@ import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
 import type { ChannelAttachmentStore } from '../server/channel-attachments.js';
 import {
   CHANNEL_BINDING_YOLO_DEFAULT,
+  ChannelAgentBusyError,
   createChannelAgentBinder,
   MAX_CONSECUTIVE_AGENT_TURNS,
   type BinderRuntimes,
@@ -48,7 +49,9 @@ import {
   type WorkspaceTopicStore,
 } from '../server/workspace-topics.js';
 import {
+  channelTurnId,
   parseMentions,
+  CHANNEL_RETRY_OF_META_KEY,
   type ChannelImagePart,
   type ChannelMessage,
   type ChannelSenderRef,
@@ -3356,5 +3359,229 @@ describe('channel-agent-binder — DM implicit routing', () => {
     // Humans chat without addressing an agent — a system row here is spam.
     expect(systemRowsIn(store, CH)).toHaveLength(0);
     expect(repliesIn(store, CH)).toHaveLength(0);
+  });
+});
+
+// ── retry (#1308 slice 1 item 2) ─────────────────────────────────────────────
+
+describe('channel-agent-binder — retry', () => {
+  const MOCK_PROFILE = builtInAgentProfileId('mock');
+
+  /**
+   * Exactly what the bridge writes for a lost turn: a streaming row stamped with
+   * the binder-minted `source.turnId`, finalized to a terminal non-complete
+   * status. Built through the store (not by driving a provider into failing) so
+   * the retry contract is exercised deterministically and without timers.
+   */
+  function failedAgentRow(
+    store: ChannelMessageStore,
+    trigger: ChannelMessage,
+    status: 'failed' | 'interrupted' | 'truncated' = 'failed',
+    turnId = channelTurnId(trigger.id, MOCK_PROFILE)
+  ): ChannelMessage {
+    const stream = store.beginStream({
+      channelId: CH,
+      sender: {
+        kind: 'agent',
+        id: MOCK_PROFILE,
+        providerId: 'mock',
+        displayName: 'Mock',
+      },
+      source: { runtimeId: 'runtime:mock', turnId, itemId: 'assistant-0' },
+    });
+    return store.finalizeStream(stream.id, { text: 'half a re', status })!;
+  }
+
+  function humanRows(store: ChannelMessageStore): ChannelMessage[] {
+    return rows(store).filter((m) => m.sender.kind === 'human');
+  }
+
+  it('re-routes the original trigger exactly once and never duplicates the human message', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+    const failed = failedAgentRow(store, trigger);
+
+    const result = await binder.retryMessage(CH, failed.id);
+    await waitFor(() => adapter.sendCalls.length > 0);
+
+    expect(result).toEqual({
+      messageId: failed.id,
+      triggerMessageId: trigger.id,
+      profileActorId: MOCK_PROFILE,
+    });
+    // Exactly one delivery, carrying the SAME deterministic turn identity the
+    // lost turn had — a retry re-runs a turn, it does not open a new one.
+    expect(adapter.sendCalls).toEqual([channelTurnId(trigger.id, MOCK_PROFILE)]);
+    // The load-bearing invariant: the operator's message is re-routed, never
+    // re-posted, so the timeline still holds exactly one copy of it.
+    expect(humanRows(store).map((m) => m.id)).toEqual([trigger.id]);
+    expect(adapter.sendInputs[0]?.content).toContain('ship the anchor');
+  });
+
+  it('supersedes the retried row with a system row carrying its id', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+    const failed = failedAgentRow(store, trigger);
+
+    await binder.retryMessage(CH, failed.id);
+    await waitFor(() => adapter.sendCalls.length > 0);
+
+    const marker = systemRows(store).find(
+      (row) => row.meta?.[CHANNEL_RETRY_OF_META_KEY] === failed.id
+    );
+    expect(marker).toBeDefined();
+    expect(marker?.body.text).toContain('retrying');
+    // The failed row itself is untouched: it stays the durable record of what
+    // went wrong, and the supersede mark lives on a separate durable row.
+    expect(store.getMessage(failed.id)?.status).toBe('failed');
+  });
+
+  it('refuses to retry while the same profile is mid-turn (storm brake)', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    // Drive a real turn that never completes so the binding is genuinely busy.
+    const live = post(store, binder, '@mock keep going', ['mock']);
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock the earlier one',
+    });
+    const failed = failedAgentRow(store, trigger);
+
+    await expect(binder.retryMessage(CH, failed.id)).rejects.toBeInstanceOf(
+      ChannelAgentBusyError
+    );
+    // Nothing was delivered and nothing was superseded by the refused retry.
+    expect(adapter.sendCalls).toEqual([
+      channelTurnId(live.id, MOCK_PROFILE),
+    ]);
+    expect(
+      systemRows(store).filter(
+        (row) => row.meta?.[CHANNEL_RETRY_OF_META_KEY] !== undefined
+      )
+    ).toHaveLength(0);
+  });
+
+  it('rejects rows no routed turn can be recovered from', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+
+    await expect(binder.retryMessage(CH, 'chm:nope')).rejects.toMatchObject({
+      reasonCode: 'CHANNEL_MESSAGE_NOT_FOUND',
+      notFound: true,
+    });
+    // A human row is not an agent turn.
+    await expect(binder.retryMessage(CH, trigger.id)).rejects.toMatchObject({
+      reasonCode: 'MESSAGE_NOT_RETRYABLE',
+      notFound: false,
+    });
+    // A provider-labelled turn id (Hermes emits `turn-0`) names no trigger.
+    const orphan = failedAgentRow(store, trigger, 'failed', 'turn-0');
+    await expect(binder.retryMessage(CH, orphan.id)).rejects.toMatchObject({
+      reasonCode: 'MESSAGE_NOT_RETRYABLE',
+    });
+    expect(adapter.sendCalls).toHaveLength(0);
+  });
+
+  it('retries interrupted and truncated rows too — every lost turn, not just failed', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+    const interrupted = failedAgentRow(store, trigger, 'interrupted');
+
+    await binder.retryMessage(CH, interrupted.id);
+    await waitFor(() => adapter.sendCalls.length > 0);
+    expect(adapter.sendCalls).toEqual([channelTurnId(trigger.id, MOCK_PROFILE)]);
+  });
+});
+
+describe('channel-agent-binder — retry availability', () => {
+  it('refuses (and does not supersede) when the framework is unavailable', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: [
+        {
+          id: 'mock',
+          displayName: 'Mock',
+          kind: 'framework',
+          available: false,
+          reason: 'cli not installed',
+        },
+      ],
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+    const profileId = builtInAgentProfileId('mock');
+    const stream = store.beginStream({
+      channelId: CH,
+      sender: { kind: 'agent', id: profileId, providerId: 'mock' },
+      source: {
+        runtimeId: 'runtime:mock',
+        turnId: channelTurnId(trigger.id, profileId),
+        itemId: 'assistant-0',
+      },
+    });
+    const failed = store.finalizeStream(stream.id, {
+      text: '',
+      status: 'failed',
+    })!;
+
+    await expect(binder.retryMessage(CH, failed.id)).rejects.toMatchObject({
+      reasonCode: 'AGENT_UNAVAILABLE',
+    });
+    // No supersede mark: the row keeps its retry affordance for when the
+    // framework comes back, instead of being stranded by a turn that never ran.
+    expect(
+      systemRows(store).filter(
+        (row) => row.meta?.[CHANNEL_RETRY_OF_META_KEY] !== undefined
+      )
+    ).toHaveLength(0);
+    expect(adapter.sendCalls).toHaveLength(0);
   });
 });

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -3486,6 +3486,50 @@ describe('channel-agent-binder — retry', () => {
     ).toHaveLength(0);
   });
 
+  it('admits exactly one of two concurrent retries (brake is not a TOCTOU)', async () => {
+    const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock ship the anchor',
+    });
+    // Two different lost rows for the SAME profile — two devices pressing retry
+    // in the same tick. Nothing is bound yet (cold binding after a hub restart),
+    // so the `live` map cannot answer "busy" for either caller.
+    const first = failedAgentRow(store, trigger);
+    const trigger2 = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '@mock and the other one',
+    });
+    const second = failedAgentRow(store, trigger2);
+
+    const results = await Promise.allSettled([
+      binder.retryMessage(CH, first.id),
+      binder.retryMessage(CH, second.id),
+    ]);
+
+    expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
+    const refused = results.find((r) => r.status === 'rejected');
+    expect(refused?.status === 'rejected' && refused.reason).toBeInstanceOf(
+      ChannelAgentBusyError
+    );
+    await waitFor(() => adapter.sendCalls.length > 0);
+    expect(adapter.sendCalls).toHaveLength(1);
+    // The refused retry never wrote a supersede mark either — the row it names
+    // keeps its own retry affordance.
+    expect(
+      systemRows(store).filter(
+        (row) => row.meta?.[CHANNEL_RETRY_OF_META_KEY] !== undefined
+      )
+    ).toHaveLength(1);
+  });
+
   it('rejects rows no routed turn can be recovered from', async () => {
     const adapter = new ScriptedAdapter('mock', { mode: 'stall' });
     const { binder, store } = makeBinder({

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -70,6 +70,15 @@ function updated(m: ChannelMessage): ChannelEventV1 {
   };
 }
 
+function edited(m: ChannelMessage): ChannelEventV1 {
+  return {
+    type: 'channel-message-edited-v1',
+    channelId: CHANNEL,
+    timestamp: 't',
+    message: m,
+  };
+}
+
 function reduce(
   state: ChannelReducerState,
   events: ChannelEventV1[]
@@ -494,6 +503,116 @@ describe('applyChannelEventV1 reducer', () => {
     const b = reduce(initialChannelReducerState(CHANNEL), events);
     expect(a).toEqual(b);
     expect(a.byId['chm:1']?.body.text).toBe('foobar');
+  });
+});
+
+// #1308 slice 1 item 3 — operator message edits. The wire variant is separate
+// from `channel-message-updated-v1` (a streaming-only refresh), so both the
+// validator and the reducer need their own coverage.
+describe('channel-message-edited-v1', () => {
+  const EDITED_META = { editedAt: '2026-08-03T01:00:00.000Z' };
+
+  it('accepts an edited human row and rejects rows no one may edit', () => {
+    expect(isChannelEventV1(edited(message({ meta: EDITED_META })))).toBe(true);
+    // Agent rows are a durable record of what a provider said.
+    expect(
+      isChannelEventV1(
+        edited(
+          message({
+            sender: { kind: 'agent', id: 'agent-profile:mock:default' },
+          })
+        )
+      )
+    ).toBe(false);
+    // System rows are the hub's own bookkeeping.
+    expect(isChannelEventV1(edited(message({ kind: 'system' })))).toBe(false);
+    // A live stream is not an editable row.
+    expect(isChannelEventV1(edited(message({ status: 'streaming' })))).toBe(
+      false
+    );
+  });
+
+  it('replaces the body in place, preserving id and seq', () => {
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+      created(message({ id: 'chm:2' as ChannelMessageId, seq: 2 })),
+      edited(
+        message({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          body: { text: 'corrected', format: 'markdown' },
+          meta: EDITED_META,
+        })
+      ),
+    ]);
+    expect(state.messages.map((m) => m.id)).toEqual(['chm:1', 'chm:2']);
+    expect(state.byId['chm:1']?.body.text).toBe('corrected');
+    expect(state.byId['chm:1']?.seq).toBe(1);
+    expect(state.byId['chm:1']?.meta).toEqual(EDITED_META);
+    expect(state.lastSeq).toBe(2);
+    expect(state.needsCatchup).toBe(false);
+  });
+
+  it('ignores an edit for a row outside the loaded window WITHOUT a catch-up', () => {
+    // An edit adds no seq and closes no gap, so an unknown id means "not loaded
+    // here", not "the timeline is broken". Demanding a resync would show the
+    // out-of-sync banner for a perfectly healthy client.
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+      created(message({ id: 'chm:2' as ChannelMessageId, seq: 2 })),
+    ]);
+    expect(state.needsCatchup).toBe(false);
+    const after = applyChannelEventV1(
+      state,
+      edited(
+        message({
+          id: 'chm:older' as ChannelMessageId,
+          seq: 0,
+          body: { text: 'corrected', format: 'markdown' },
+        })
+      )
+    );
+    expect(after.needsCatchup).toBe(false);
+    expect(after.messages.map((m) => m.id)).toEqual(['chm:1', 'chm:2']);
+  });
+
+  it('never overwrites a live stream and catches up on a seq surprise', () => {
+    const streamingRow = message({
+      id: 'chm:1' as ChannelMessageId,
+      seq: 1,
+      status: 'streaming',
+      body: { text: 'partial', format: 'markdown' },
+    });
+    const streaming = reduce(initialChannelReducerState(CHANNEL), [
+      created(streamingRow),
+    ]);
+    const clobbered = applyChannelEventV1(
+      streaming,
+      edited(
+        message({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          body: { text: 'rewritten', format: 'markdown' },
+        })
+      )
+    );
+    expect(clobbered.byId['chm:1']?.body.text).toBe('partial');
+
+    const settled = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+    ]);
+    const renumbered = applyChannelEventV1(
+      settled,
+      edited(
+        message({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 9,
+          body: { text: 'rewritten', format: 'markdown' },
+        })
+      )
+    );
+    expect(renumbered.needsCatchup).toBe(true);
+    expect(renumbered.byId['chm:1']?.body.text).toBe('hi');
   });
 });
 

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -79,6 +79,24 @@ function edited(m: ChannelMessage): ChannelEventV1 {
   };
 }
 
+function deleted(m: ChannelMessage): ChannelEventV1 {
+  return {
+    type: 'channel-message-deleted-v1',
+    channelId: CHANNEL,
+    timestamp: 't',
+    message: m,
+  };
+}
+
+/** A row in the shape the delete route produces: body wiped, `deletedAt` set. */
+function tombstone(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return message({
+    body: { text: '', format: 'markdown' },
+    meta: { deletedAt: '2026-08-03T02:00:00.000Z' },
+    ...overrides,
+  });
+}
+
 function reduce(
   state: ChannelReducerState,
   events: ChannelEventV1[]
@@ -610,6 +628,119 @@ describe('channel-message-edited-v1', () => {
           body: { text: 'rewritten', format: 'markdown' },
         })
       )
+    );
+    expect(renumbered.needsCatchup).toBe(true);
+    expect(renumbered.byId['chm:1']?.body.text).toBe('hi');
+  });
+});
+
+// #1308 slice 1 item 4 — operator message deletion. A tombstone replaces the
+// row IN PLACE; nothing may ever splice a row out of the seq log.
+describe('channel-message-deleted-v1', () => {
+  it('accepts a wiped operator row and rejects anything still carrying a body', () => {
+    expect(isChannelEventV1(deleted(tombstone()))).toBe(true);
+    // A "deletion" still holding text would leak the very thing the operator
+    // asked to erase, so it is dropped at the wire.
+    expect(
+      isChannelEventV1(
+        deleted(tombstone({ body: { text: 'still here', format: 'markdown' } }))
+      )
+    ).toBe(false);
+    // Unmarked rows are not tombstones.
+    expect(
+      isChannelEventV1(deleted(message({ body: { text: '', format: 'text' } })))
+    ).toBe(false);
+    // Agent rows are a durable record of what a provider said; system rows are
+    // the hub's own bookkeeping.
+    expect(
+      isChannelEventV1(
+        deleted(
+          tombstone({ sender: { kind: 'agent', id: 'agent-profile:mock:x' } })
+        )
+      )
+    ).toBe(false);
+    expect(isChannelEventV1(deleted(tombstone({ kind: 'system' })))).toBe(false);
+  });
+
+  it('rejects a tombstone arriving on the edit lane', () => {
+    // `channelMessageEditable` excludes a deleted row, so a delete cannot be
+    // laundered through the edit event to bypass the tombstone shape check.
+    expect(isChannelEventV1(edited(tombstone()))).toBe(false);
+  });
+
+  it('replaces the row in place, keeping the array length, order and seq', () => {
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+      created(message({ id: 'chm:2' as ChannelMessageId, seq: 2 })),
+      created(message({ id: 'chm:3' as ChannelMessageId, seq: 3 })),
+      deleted(tombstone({ id: 'chm:2' as ChannelMessageId, seq: 2 })),
+    ]);
+    // Grouping, the unread divider and every scroll anchor read positions out of
+    // this array — a splice would move all of them.
+    expect(state.messages.map((m) => m.id)).toEqual([
+      'chm:1',
+      'chm:2',
+      'chm:3',
+    ]);
+    expect(state.messages.map((m) => m.seq)).toEqual([1, 2, 3]);
+    expect(state.byId['chm:2']?.body.text).toBe('');
+    expect(state.byId['chm:2']?.meta?.['deletedAt']).toBe(
+      '2026-08-03T02:00:00.000Z'
+    );
+    expect(state.lastSeq).toBe(3);
+    expect(state.needsCatchup).toBe(false);
+  });
+
+  it('keeps a deleted thread parent as the anchor its replies point at', () => {
+    const root = message({ id: 'chm:root' as ChannelMessageId, seq: 1 });
+    const reply = message({
+      id: 'chm:reply' as ChannelMessageId,
+      seq: 2,
+      threadId: 'chm:root' as ChannelMessageId,
+      parentMessageId: 'chm:root' as ChannelMessageId,
+    });
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(root),
+      created(reply),
+      deleted(tombstone({ id: 'chm:root' as ChannelMessageId, seq: 1 })),
+    ]);
+    expect(state.byId['chm:root']).toBeDefined();
+    expect(state.byId['chm:reply']?.threadId).toBe('chm:root');
+  });
+
+  it('ignores a row outside the loaded window WITHOUT a catch-up, and guards streams and seq surprises', () => {
+    const state = reduce(initialChannelReducerState(CHANNEL), [
+      created(message({ id: 'chm:1' as ChannelMessageId, seq: 1 })),
+    ]);
+    // A deletion adds no seq and closes no gap: an unknown id means "not loaded
+    // here", so demanding a resync would raise the banner on a healthy client.
+    const unknown = applyChannelEventV1(
+      state,
+      deleted(tombstone({ id: 'chm:older' as ChannelMessageId, seq: 0 }))
+    );
+    expect(unknown.needsCatchup).toBe(false);
+    expect(unknown.messages.map((m) => m.id)).toEqual(['chm:1']);
+
+    const streaming = reduce(initialChannelReducerState(CHANNEL), [
+      created(
+        message({
+          id: 'chm:1' as ChannelMessageId,
+          seq: 1,
+          status: 'streaming',
+          body: { text: 'partial', format: 'markdown' },
+        })
+      ),
+    ]);
+    expect(
+      applyChannelEventV1(
+        streaming,
+        deleted(tombstone({ id: 'chm:1' as ChannelMessageId, seq: 1 }))
+      ).byId['chm:1']?.body.text
+    ).toBe('partial');
+
+    const renumbered = applyChannelEventV1(
+      state,
+      deleted(tombstone({ id: 'chm:1' as ChannelMessageId, seq: 9 }))
     );
     expect(renumbered.needsCatchup).toBe(true);
     expect(renumbered.byId['chm:1']?.body.text).toBe('hi');

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -75,6 +75,15 @@ function inThread(
   };
 }
 
+/** A row in the shape `deleteMessage` leaves behind: body wiped, stamp set. */
+function deletedRow(message: ChannelMessage): ChannelMessage {
+  return {
+    ...message,
+    body: { ...message.body, text: '' },
+    meta: { ...message.meta, deletedAt: '2026-08-03T02:00:00.000Z' },
+  };
+}
+
 function imagePart(id: string): ChannelImagePart {
   return {
     type: 'image',
@@ -727,5 +736,77 @@ describe('buildMentionContextPacket', () => {
       lastDeliveredSeq: 0,
     });
     expect(packet).toContain('operator: first line\n    second line');
+  });
+
+  // #1308 slice 1 item 4. A deleted row survives as a tombstone in the store, so
+  // it reaches the builder like any other row — and must never be rendered as an
+  // empty message the agent tries to interpret.
+  it('drops deleted rows from the context window entirely', () => {
+    const rows = [
+      msg(1, OPERATOR, 'keep this'),
+      deletedRow(msg(2, OPERATOR, '')),
+      msg(3, OPERATOR, 'keep this too'),
+    ];
+    const trigger = msg(4, OPERATOR, '@claude go');
+    const envelope = buildMentionContextPacketEnvelope({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(envelope.retainedMessageIds).toEqual([
+      'chm:row-1',
+      'chm:row-3',
+      trigger.id,
+    ]);
+    expect(envelope.content).toContain('operator: keep this');
+    expect(envelope.content).not.toContain('[message deleted]');
+    // No blank `operator:` line where the deleted row used to be.
+    expect(envelope.content).not.toMatch(/operator: *\n/);
+  });
+
+  it('never carries a deleted row’s attachments', () => {
+    const rows = [
+      {
+        ...deletedRow(msg(1, OPERATOR, '')),
+        parts: [imagePart('cha:erased')],
+      },
+    ];
+    const trigger = msg(2, OPERATOR, '@claude go');
+    const envelope = buildMentionContextPacketEnvelope({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(envelope.images).toEqual([]);
+    expect(envelope.retainedMessageIds).toEqual([trigger.id]);
+  });
+
+  it('keeps a deleted thread root as a marked anchor instead of dropping it', () => {
+    // The root is structural — a thread packet without it is not buildable — so
+    // it is the one deleted row that stays, standing in as a marker rather than
+    // as a blank line.
+    const root = deletedRow(msg(1, OPERATOR, ''));
+    const rows = [
+      root,
+      inThread(msg(2, OPERATOR, 'reply one'), root.id, root.id),
+    ];
+    const trigger = inThread(
+      msg(3, OPERATOR, '@claude go'),
+      root.id,
+      'chm:row-2'
+    );
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger,
+      lastDeliveredSeq: 0,
+    });
+    expect(packet).toContain('operator: [message deleted]');
+    expect(packet).toContain('operator: reply one');
   });
 });

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -324,7 +324,7 @@ async function harness(
 
 async function req<T>(input: {
   port: number;
-  method: 'GET' | 'POST' | 'PATCH';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   url: string;
   body?: unknown;
   headers?: Record<string, string>;
@@ -767,6 +767,73 @@ describe('mention routing — edited context (#1308 slice 1 item 3)', () => {
     expect(res.status).toBe(403);
     expect(res.body.error.details?.['reasonCode']).toBe(
       'CHANNEL_EDIT_HUMAN_ONLY'
+    );
+    expect(h.store.getMessage(posted.body.message.id)?.body.text).toBe(
+      'operator wrote this'
+    );
+  });
+});
+
+describe('mention routing — deleted context (#1308 slice 1 item 4)', () => {
+  it('never delivers a deleted body to a later turn', async () => {
+    // The packet-exclusion promise reduces to one question: can a deleted row's
+    // text still reach an adapter? The binder builds packets from store rows at
+    // send time, so this is a property of the real path, not of the pure builder.
+    const h = await harness(
+      (agentType) => new RecordingAdapter(agentType, 'ack')
+    );
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const posted = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'the production password is hunter2' },
+    });
+    expect(posted.status).toBe(201);
+
+    const removed = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${url}/${encodeURIComponent(posted.body.message.id)}`,
+    });
+    expect(removed.status).toBe(200);
+
+    // Deleting must not trigger a turn of its own.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(h.adapters()).toHaveLength(0);
+
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock what did I just say?' },
+    });
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    const adapter = h.adapters()[0] as RecordingAdapter;
+    expect(adapter.contents).toHaveLength(1);
+    expect(adapter.contents[0]).not.toContain('hunter2');
+    // Dropped entirely, not rendered as an empty message the agent must parse.
+    expect(adapter.contents[0]).not.toMatch(/operator: *\n/);
+  });
+
+  it('rejects a delete from a scoped actor credential without touching the row', async () => {
+    const h = await harness();
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const posted = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'operator wrote this' },
+    });
+    const res = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${url}/${encodeURIComponent(posted.body.message.id)}`,
+      headers: { 'x-test-actor-id': 'orchestrator' },
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_DELETE_HUMAN_ONLY'
     );
     expect(h.store.getMessage(posted.body.message.id)?.body.text).toBe(
       'operator wrote this'

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -324,7 +324,7 @@ async function harness(
 
 async function req<T>(input: {
   port: number;
-  method: 'GET' | 'POST';
+  method: 'GET' | 'POST' | 'PATCH';
   url: string;
   body?: unknown;
   headers?: Record<string, string>;
@@ -700,5 +700,76 @@ describe('mention routing — gateway command/capability mapping', () => {
     expect(
       cliGatewayActorCommandCapabilities('channels.respond-approval')
     ).toEqual(['context:write']);
+  });
+});
+
+describe('mention routing — edited context (#1308 slice 1 item 3)', () => {
+  it('delivers the EDITED body to the next turn and never re-runs the old one', async () => {
+    // The whole "agents see the edit" promise reduces to one question: does the
+    // packet the adapter receives carry the new text? The binder builds packets
+    // from store rows at send time, so this is a property of the real path
+    // rather than of the pure builder — assert it end-to-end.
+    const h = await harness(
+      (agentType) => new RecordingAdapter(agentType, 'ack')
+    );
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const posted = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'the deploy is at 3pm' },
+    });
+    expect(posted.status).toBe(201);
+
+    const edited = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${url}/${encodeURIComponent(posted.body.message.id)}`,
+      body: { text: 'the deploy is at 5pm' },
+    });
+    expect(edited.status).toBe(200);
+
+    // Editing must not re-trigger a past turn: no adapter has been spawned and
+    // no agent row exists, even though the edited row is the only one there.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(h.adapters()).toHaveLength(0);
+    expect(agentReply(h.store, h.channelId)).toHaveLength(0);
+
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock when is the deploy?' },
+    });
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    const adapter = h.adapters()[0] as RecordingAdapter;
+    expect(adapter.contents).toHaveLength(1);
+    expect(adapter.contents[0]).toContain('the deploy is at 5pm');
+    expect(adapter.contents[0]).not.toContain('the deploy is at 3pm');
+  });
+
+  it('rejects an edit from a scoped actor credential without touching the row', async () => {
+    const h = await harness();
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const posted = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'operator wrote this' },
+    });
+    const res = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${url}/${encodeURIComponent(posted.body.message.id)}`,
+      body: { text: 'an agent wrote this' },
+      headers: { 'x-test-actor-id': 'orchestrator' },
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_EDIT_HUMAN_ONLY'
+    );
+    expect(h.store.getMessage(posted.body.message.id)?.body.text).toBe(
+      'operator wrote this'
+    );
   });
 });

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -822,6 +822,207 @@ describe('channel-message-store streaming lifecycle', () => {
     );
   });
 
+  // #1308 slice 1 item 4 — deleting one of the operator's own rows. Deletion is
+  // a TOMBSTONE: the row is the substrate's seq log, and a hole in it would
+  // break every catch-up cursor, deep link and thread parent that already names
+  // the seq.
+  it('deleteMessage tombstones the row, keeping id, seq and the seq log intact', () => {
+    const s = store();
+    const first = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'first',
+    });
+    const target = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'ship @claude the anchor',
+      mentions: [{ raw: '@claude', providerId: 'claude' }],
+    });
+    const after = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'after',
+    });
+
+    const tombstone = s.deleteMessage({
+      channelId: 'topic:c',
+      messageId: target.id,
+      deleterId: HUMAN.id,
+    });
+    expect(tombstone.id).toBe(target.id);
+    expect(tombstone.seq).toBe(target.seq);
+    expect(tombstone.createdAt).toBe(target.createdAt);
+    expect(tombstone.body.text).toBe('');
+    expect(typeof tombstone.meta?.['deletedAt']).toBe('string');
+    // Mentions go with the body: a removed message must not keep lighting the
+    // sidebar's mention lane.
+    expect(tombstone.mentions).toBeUndefined();
+
+    // The log is unchanged in length AND in numbering. Renumbering `seq` would
+    // be the one unrecoverable mistake here.
+    const history = s.history('topic:c', { limit: 50 });
+    expect(history.map((m) => m.seq)).toEqual([1, 2, 3]);
+    expect(history.map((m) => m.id)).toEqual([first.id, target.id, after.id]);
+    expect(history[1]?.body.text).toBe('');
+    expect(s.latestSeq('topic:c')).toBe(3);
+    expect(s.getMessage(target.id)?.body.text).toBe('');
+  });
+
+  it('deleteMessage is idempotent and refuses rows the operator does not own', () => {
+    const s = store();
+    const human = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'operator says hi',
+    });
+    const first = s.deleteMessage({
+      channelId: 'topic:c',
+      messageId: human.id,
+      deleterId: HUMAN.id,
+    });
+    // A second delete (another device, a double tap) converges on the SAME
+    // tombstone rather than restamping or throwing.
+    const again = s.deleteMessage({
+      channelId: 'topic:c',
+      messageId: human.id,
+      deleterId: HUMAN.id,
+    });
+    expect(again.meta?.['deletedAt']).toBe(first.meta?.['deletedAt']);
+
+    // A tombstone is not an editable row — an edit would be an undelete.
+    expect(() =>
+      s.editMessage({
+        channelId: 'topic:c',
+        messageId: human.id,
+        editorId: HUMAN.id,
+        text: 'back from the dead',
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_editable' })
+    );
+    expect(s.getMessage(human.id)?.body.text).toBe('');
+
+    // Agent rows are a durable record of what a provider actually said.
+    const agent = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { runtimeId: 'r', turnId: 't', itemId: 'i' },
+    });
+    s.finalizeStream(agent.id, { text: 'agent said this', status: 'complete' });
+    expect(() =>
+      s.deleteMessage({
+        channelId: 'topic:c',
+        messageId: agent.id,
+        deleterId: HUMAN.id,
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_deletable' })
+    );
+    expect(s.getMessage(agent.id)?.body.text).toBe('agent said this');
+
+    // Another identity cannot delete the operator's row...
+    const other = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'still here',
+    });
+    expect(() =>
+      s.deleteMessage({
+        channelId: 'topic:c',
+        messageId: other.id,
+        deleterId: 'agent:claude',
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_deletable' })
+    );
+    // ...and a row in another channel reads as absent, never as a conflict.
+    expect(() =>
+      s.deleteMessage({
+        channelId: 'topic:other',
+        messageId: other.id,
+        deleterId: HUMAN.id,
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_found' })
+    );
+    expect(s.getMessage(other.id)?.body.text).toBe('still here');
+  });
+
+  it('keeps a deleted thread parent as the anchor its replies still point at', () => {
+    const s = store();
+    const root = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'root question',
+    });
+    const reply = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'a reply',
+      parentMessageId: root.id,
+    });
+    expect(reply.threadId).toBe(root.id);
+
+    s.deleteMessage({
+      channelId: 'topic:c',
+      messageId: root.id,
+      deleterId: HUMAN.id,
+    });
+
+    // The root still resolves, still roots the thread, and still counts replies:
+    // removing the row would have orphaned every reply pointing at it.
+    const thread = s.threadHistory('topic:c', root.id, { limit: 50 });
+    expect(thread.map((m) => m.id)).toEqual([root.id, reply.id]);
+    expect(thread[0]?.body.text).toBe('');
+    expect(s.getMessage(root.id)?.replyCount).toBe(1);
+    expect(
+      s.listChannelThreadSummaries('topic:c').threads.map((t) => t.rootMessageId)
+    ).toEqual([root.id]);
+  });
+
+  it('carries tombstones on catch-up and keeps them out of the sidebar preview', () => {
+    const s = store();
+    const kept = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'the visible one',
+    });
+    const doomed = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'about to go',
+    });
+    expect(s.getChannelSummary('topic:c').lastMessage?.preview).toBe(
+      'about to go'
+    );
+
+    s.deleteMessage({
+      channelId: 'topic:c',
+      messageId: doomed.id,
+      deleterId: HUMAN.id,
+    });
+
+    // A deletion mutates a row under a seq the client already consumed, so
+    // `history({ afterSeq })` never re-sends it — without catch-up a device that
+    // was offline keeps rendering the deleted body.
+    const resync = s.listResyncRows('topic:c', 2, 500);
+    expect(resync.map((m) => m.id)).toEqual([doomed.id]);
+    expect(resync[0]?.body.text).toBe('');
+
+    // A body-less newest row must not blank the sidebar, the same rule detail
+    // cards already follow.
+    expect(s.getChannelSummary('topic:c').lastMessage?.preview).toBe(
+      'the visible one'
+    );
+    expect(s.getChannelSummary('topic:c').lastMessage?.id).toBe(kept.id);
+    expect(s.getChannelSummary('topic:c').latestSeq).toBe(2);
+    expect(
+      s.listChannelSummaries().find((c) => c.channelId === 'topic:c')
+        ?.lastMessage?.preview
+    ).toBe('the visible one');
+  });
+
   it('keeps replyCount on point reads, finalization rows, and resync replacements', () => {
     const s = store();
     const root = s.beginStream({

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -714,6 +714,114 @@ describe('channel-message-store streaming lifecycle', () => {
     expect(s.listResyncRows('topic:c', 1, 500)).toHaveLength(0);
   });
 
+  it('listResyncRows also carries edited human rows so a reconnect heals them', () => {
+    // #1308 slice 1 item 3: an edit mutates a row in place under a seq the
+    // client already consumed, so `history({ afterSeq })` never re-sends it.
+    // Without this the device that was offline during the edit renders the old
+    // text until a full reload.
+    const s = store();
+    const human = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'deploy at 3pm',
+    });
+    s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'unedited' });
+    expect(s.listResyncRows('topic:c', 2, 500)).toHaveLength(0);
+
+    s.editMessage({
+      channelId: 'topic:c',
+      messageId: human.id,
+      editorId: HUMAN.id,
+      text: 'deploy at 5pm',
+    });
+    const resync = s.listResyncRows('topic:c', 2, 500);
+    expect(resync.map((m) => m.id)).toEqual([human.id]);
+    expect(resync[0]?.body.text).toBe('deploy at 5pm');
+  });
+
+  it('editMessage rewrites the body in place and refuses rows it does not own', () => {
+    const s = store();
+    const human = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'ship @claude the anchor',
+      mentions: [{ raw: '@claude', providerId: 'claude' }],
+    });
+    s.appendComplete({ channelId: 'topic:c', sender: HUMAN, text: 'after' });
+
+    const edited = s.editMessage({
+      channelId: 'topic:c',
+      messageId: human.id,
+      editorId: HUMAN.id,
+      text: 'ship the anchor tomorrow',
+      mentions: [],
+    });
+    // Identity survives: the whole point of an in-place edit is that nothing
+    // indexing the timeline by id/seq has to move.
+    expect(edited.id).toBe(human.id);
+    expect(edited.seq).toBe(human.seq);
+    expect(edited.createdAt).toBe(human.createdAt);
+    expect(edited.body.text).toBe('ship the anchor tomorrow');
+    expect(typeof edited.meta?.['editedAt']).toBe('string');
+    // Mentions are a projection of the body, so a removed @claude must not keep
+    // lighting the mention lane.
+    expect(edited.mentions).toBeUndefined();
+    expect(s.getMessage(human.id)?.body.text).toBe('ship the anchor tomorrow');
+    expect(s.latestSeq('topic:c')).toBe(2);
+
+    // Agent rows are a durable record of what a provider actually said.
+    const agent = s.beginStream({
+      channelId: 'topic:c',
+      sender: AGENT,
+      source: { runtimeId: 'r', turnId: 't', itemId: 'i' },
+    });
+    s.finalizeStream(agent.id, { text: 'agent said this', status: 'complete' });
+    expect(() =>
+      s.editMessage({
+        channelId: 'topic:c',
+        messageId: agent.id,
+        editorId: HUMAN.id,
+        text: 'agent said something else',
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_editable' })
+    );
+    expect(s.getMessage(agent.id)?.body.text).toBe('agent said this');
+
+    // Another identity cannot edit the operator's row...
+    expect(() =>
+      s.editMessage({
+        channelId: 'topic:c',
+        messageId: human.id,
+        editorId: 'agent:claude',
+        text: 'rewritten by an agent',
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_editable' })
+    );
+    // ...and a row in another channel reads as absent, never as a conflict.
+    expect(() =>
+      s.editMessage({
+        channelId: 'topic:other',
+        messageId: human.id,
+        editorId: HUMAN.id,
+        text: 'cross-channel',
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_not_found' })
+    );
+    expect(() =>
+      s.editMessage({
+        channelId: 'topic:c',
+        messageId: human.id,
+        editorId: HUMAN.id,
+        text: '',
+      })
+    ).toThrowError(
+      expect.objectContaining({ code: 'channel_message_body_empty' })
+    );
+  });
+
   it('keeps replyCount on point reads, finalization rows, and resync replacements', () => {
     const s = store();
     const root = s.beginStream({

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -148,7 +148,7 @@ async function harness(
 
 async function req<T>(input: {
   port: number;
-  method: 'GET' | 'POST';
+  method: 'GET' | 'POST' | 'PATCH';
   url: string;
   body?: unknown;
   capabilities?: string;
@@ -1424,7 +1424,9 @@ describe('channel routes — message retry (#1308 slice 1 item 2)', () => {
         },
       },
     });
-    const res = await req<{ error: { retryable: boolean; details?: Record<string, unknown> } }>({
+    const res = await req<{
+      error: { retryable: boolean; details?: Record<string, unknown> };
+    }>({
       port: h.port,
       method: 'POST',
       url: `/channels/${h.channelId}/messages/chm%3Afailed/retry`,
@@ -1452,11 +1454,13 @@ describe('channel routes — message retry (#1308 slice 1 item 2)', () => {
         },
       },
     });
-    const missing = await req<{ error: { details?: Record<string, unknown> } }>({
-      port: h.port,
-      method: 'POST',
-      url: `/channels/${h.channelId}/messages/chm%3Amissing/retry`,
-    });
+    const missing = await req<{ error: { details?: Record<string, unknown> } }>(
+      {
+        port: h.port,
+        method: 'POST',
+        url: `/channels/${h.channelId}/messages/chm%3Amissing/retry`,
+      }
+    );
     expect(missing.status).toBe(404);
     expect(missing.body.error.details?.['reasonCode']).toBe(
       'CHANNEL_MESSAGE_NOT_FOUND'
@@ -1475,7 +1479,9 @@ describe('channel routes — message retry (#1308 slice 1 item 2)', () => {
   });
 
   it('404s an unknown channel and 503s with no binder configured', async () => {
-    const h = await harness({ binder: { retryMessage: async () => ({}) as never } });
+    const h = await harness({
+      binder: { retryMessage: async () => ({}) as never },
+    });
     const unknown = await req<{ error: unknown }>({
       port: h.port,
       method: 'POST',
@@ -1513,5 +1519,177 @@ describe('channel routes — retry capability gate', () => {
     expect(res.status).toBe(403);
     expect(res.body.error.code).toBe('FORBIDDEN');
     expect(called).toBe(false);
+  });
+});
+
+describe('channel routes — message edit (#1308 slice 1 item 3)', () => {
+  const messagesUrl = (channelId: string): string =>
+    `/channels/${encodeURIComponent(channelId)}/messages`;
+
+  async function postHuman(
+    h: Harness,
+    text: string
+  ): Promise<{ id: string; seq: number }> {
+    const res = await req<{ message: { id: string; seq: number } }>({
+      port: h.port,
+      method: 'POST',
+      url: messagesUrl(h.channelId),
+      body: { text },
+    });
+    expect(res.status).toBe(201);
+    return res.body.message;
+  }
+
+  it('rewrites the body in place, stamps editedAt, and broadcasts the edit', async () => {
+    const h = await harness();
+    const posted = await postHuman(h, 'deploy at 3pm @claude');
+    const sock = fakeSocket();
+    h.hub.handleConnection(sock, { channelId: h.channelId, sinceSeq: null });
+
+    const res = await req<{
+      message: {
+        id: string;
+        seq: number;
+        body: { text: string };
+        meta?: Record<string, unknown>;
+        mentions?: unknown[];
+      };
+    }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`,
+      body: { text: 'deploy at 5pm' },
+    });
+    expect(res.status).toBe(200);
+    // Identity is preserved — a deep link, a thread parent and every seq cursor
+    // that already named this row stay valid.
+    expect(res.body.message.id).toBe(posted.id);
+    expect(res.body.message.seq).toBe(posted.seq);
+    expect(res.body.message.body.text).toBe('deploy at 5pm');
+    expect(typeof res.body.message.meta?.['editedAt']).toBe('string');
+    // Mentions are re-derived from the new text (routing is NOT re-run).
+    expect(res.body.message.mentions).toBeUndefined();
+
+    // Durable, not just echoed back.
+    expect(h.store.getMessage(posted.id)?.body.text).toBe('deploy at 5pm');
+    // No new row: an edit must never grow the timeline.
+    expect(h.store.history(h.channelId, { limit: 50 })).toHaveLength(1);
+
+    const edit = sock.sent.find(
+      (event) => event.type === 'channel-message-edited-v1'
+    );
+    expect(edit?.type).toBe('channel-message-edited-v1');
+    if (edit?.type === 'channel-message-edited-v1') {
+      expect(edit.message.id).toBe(posted.id);
+      expect(edit.message.body.text).toBe('deploy at 5pm');
+    }
+    // Editing is not posting: no created event may ride this lane.
+    expect(
+      sock.sent.some((event) => event.type === 'channel-message-created-v1')
+    ).toBe(false);
+  });
+
+  it('refuses agent rows, the agent lane, empty text, archived channels, and unknown ids', async () => {
+    const h = await harness();
+    const posted = await postHuman(h, 'operator says hi');
+    const agentPost = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messagesUrl(h.channelId),
+      body: { text: 'agent says hi' },
+      headers: { 'x-test-actor-id': 'claude' },
+    });
+    expect(agentPost.status).toBe(201);
+
+    // An agent row is a durable record of what a provider said.
+    const agentRow = await req<{
+      error: { details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(agentPost.body.message.id)}`,
+      body: { text: 'rewritten' },
+    });
+    expect(agentRow.status).toBe(409);
+    expect(agentRow.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_MESSAGE_NOT_EDITABLE'
+    );
+
+    // An actor credential must never be able to rewrite the operator's words —
+    // this lane admits scoped actors, so the human gate is load-bearing.
+    const agentLane = await req<{
+      error: { code: string; details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`,
+      body: { text: 'rewritten by an agent' },
+      headers: { 'x-test-actor-id': 'claude' },
+    });
+    expect(agentLane.status).toBe(403);
+    expect(agentLane.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_EDIT_HUMAN_ONLY'
+    );
+    expect(h.store.getMessage(posted.id)?.body.text).toBe('operator says hi');
+
+    // Clearing a message is a different action with a different audit shape.
+    const empty = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`,
+      body: { text: '   ' },
+    });
+    expect(empty.status).toBe(400);
+    expect(empty.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_MESSAGE_BODY_EMPTY'
+    );
+
+    const missing = await req<{ error: unknown }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/chm%3Anope`,
+      body: { text: 'rewritten' },
+    });
+    expect(missing.status).toBe(404);
+
+    h.topicStore.archive(h.channelId);
+    const archived = await req<{
+      error: { details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`,
+      body: { text: 'rewritten' },
+    });
+    expect(archived.status).toBe(409);
+    expect(archived.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_ARCHIVED'
+    );
+  });
+
+  it('rejects a caller without context:write and a body-supplied sender', async () => {
+    const h = await harness();
+    const posted = await postHuman(h, 'operator says hi');
+    const readOnly = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`,
+      body: { text: 'rewritten' },
+      capabilities: 'context:read',
+    });
+    expect(readOnly.status).toBe(403);
+    expect(readOnly.body.error.code).toBe('FORBIDDEN');
+    expect(h.store.getMessage(posted.id)?.body.text).toBe('operator says hi');
+
+    const forged = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'PATCH',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`,
+      body: { text: 'rewritten', sender: { kind: 'human', id: 'human:other' } },
+    });
+    expect(forged.status).toBe(400);
+    expect(forged.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_SENDER_NOT_ALLOWED'
+    );
   });
 });

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -28,7 +28,9 @@ import {
   createChannelChatRouter,
 } from '../server/channel-chat-router.js';
 import {
+  ChannelAgentBusyError,
   ChannelAgentRoleConflictError,
+  ChannelMessageNotRetryableError,
   type ChannelAgentBinder,
 } from '../server/channel-agent-binder.js';
 import {
@@ -1373,5 +1375,143 @@ describe('channel routes — orchestrator designation (#1259)', () => {
       url: `/channels/${h.channelId}/orchestrator`,
     });
     expect(res.status).toBe(503);
+  });
+});
+
+describe('channel routes — message retry (#1308 slice 1 item 2)', () => {
+  it('re-routes through the binder and echoes what was re-run', async () => {
+    const calls: Array<{ channelId: string; messageId: string }> = [];
+    const h = await harness({
+      binder: {
+        retryMessage: async (channelId: string, messageId: string) => {
+          calls.push({ channelId, messageId });
+          return {
+            messageId,
+            triggerMessageId: 'chm:trigger',
+            profileActorId: 'agent-profile:claude:default',
+          };
+        },
+      },
+    });
+    const res = await req<{
+      ok: boolean;
+      retry: { triggerMessageId: string; profileActorId: string };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Afailed/retry`,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.retry).toEqual({
+      messageId: 'chm:failed',
+      triggerMessageId: 'chm:trigger',
+      profileActorId: 'agent-profile:claude:default',
+    });
+    expect(calls).toEqual([
+      { channelId: h.channelId, messageId: 'chm:failed' },
+    ]);
+  });
+
+  it('maps the busy storm brake to 409 CHANNEL_AGENT_BUSY', async () => {
+    const h = await harness({
+      binder: {
+        retryMessage: async () => {
+          throw new ChannelAgentBusyError(
+            'topic:x',
+            'agent-profile:claude:default',
+            'streaming'
+          );
+        },
+      },
+    });
+    const res = await req<{ error: { retryable: boolean; details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Afailed/retry`,
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error.details?.['reasonCode']).toBe('CHANNEL_AGENT_BUSY');
+    // Retryable: the operator can press again once the agent goes idle.
+    expect(res.body.error.retryable).toBe(true);
+  });
+
+  it('separates a missing row (404) from an unretryable one (409)', async () => {
+    const h = await harness({
+      binder: {
+        retryMessage: async (_channelId: string, messageId: string) => {
+          throw messageId === 'chm:missing'
+            ? new ChannelMessageNotRetryableError(
+                'message not found in this channel',
+                'CHANNEL_MESSAGE_NOT_FOUND',
+                true
+              )
+            : new ChannelMessageNotRetryableError(
+                'not retryable',
+                'MESSAGE_NOT_RETRYABLE'
+              );
+        },
+      },
+    });
+    const missing = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Amissing/retry`,
+    });
+    expect(missing.status).toBe(404);
+    expect(missing.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_MESSAGE_NOT_FOUND'
+    );
+    const unretryable = await req<{
+      error: { details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Acomplete/retry`,
+    });
+    expect(unretryable.status).toBe(409);
+    expect(unretryable.body.error.details?.['reasonCode']).toBe(
+      'MESSAGE_NOT_RETRYABLE'
+    );
+  });
+
+  it('404s an unknown channel and 503s with no binder configured', async () => {
+    const h = await harness({ binder: { retryMessage: async () => ({}) as never } });
+    const unknown = await req<{ error: unknown }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/topic%3Anope/messages/chm%3Afailed/retry`,
+    });
+    expect(unknown.status).toBe(404);
+
+    const noBinder = await harness();
+    const res = await req<{ error: unknown }>({
+      port: noBinder.port,
+      method: 'POST',
+      url: `/channels/${noBinder.channelId}/messages/chm%3Afailed/retry`,
+    });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('channel routes — retry capability gate', () => {
+  it('rejects a caller without context:write before touching the binder', async () => {
+    let called = false;
+    const h = await harness({
+      binder: {
+        retryMessage: async () => {
+          called = true;
+          return {} as never;
+        },
+      },
+    });
+    const res = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Afailed/retry`,
+      capabilities: 'context:read',
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+    expect(called).toBe(false);
   });
 });

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -1499,6 +1499,62 @@ describe('channel routes — message retry (#1308 slice 1 item 2)', () => {
   });
 });
 
+describe('channel routes — retry write fence', () => {
+  it('refuses a retry on an archived channel before touching the binder', async () => {
+    let called = false;
+    const h = await harness({
+      binder: {
+        retryMessage: async () => {
+          called = true;
+          return {} as never;
+        },
+      },
+    });
+    h.topicStore.archive(h.channelId);
+
+    const res = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Afailed/retry`,
+    });
+    // An archived channel is read-only for EVERY write lane: a retry would spawn
+    // a runtime, write a durable `retrying @…` system row and append a whole new
+    // agent turn.
+    expect(res.status).toBe(409);
+    expect(res.body.error.details?.['reasonCode']).toBe('CHANNEL_ARCHIVED');
+    expect(called).toBe(false);
+  });
+
+  it('refuses the agent lane — only the operator may re-run a turn', async () => {
+    let called = false;
+    const h = await harness({
+      binder: {
+        retryMessage: async () => {
+          called = true;
+          return {} as never;
+        },
+      },
+    });
+    // A scoped actor credential carries `context:write`, so the capability gate
+    // admits it; re-running a turn spends real provider tokens and routes
+    // outside the mention-chain brake, so the human gate is the load-bearing one.
+    const res = await req<{
+      error: { code: string; details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages/chm%3Afailed/retry`,
+      headers: { 'x-test-actor-id': 'claude' },
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+    expect(res.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_RETRY_HUMAN_ONLY'
+    );
+    expect(called).toBe(false);
+  });
+});
+
 describe('channel routes — retry capability gate', () => {
   it('rejects a caller without context:write before touching the binder', async () => {
     let called = false;

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -148,7 +148,7 @@ async function harness(
 
 async function req<T>(input: {
   port: number;
-  method: 'GET' | 'POST' | 'PATCH';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   url: string;
   body?: unknown;
   capabilities?: string;
@@ -1691,5 +1691,190 @@ describe('channel routes — message edit (#1308 slice 1 item 3)', () => {
     expect(forged.body.error.details?.['reasonCode']).toBe(
       'CHANNEL_SENDER_NOT_ALLOWED'
     );
+  });
+});
+
+describe('channel routes — message delete (#1308 slice 1 item 4)', () => {
+  const messagesUrl = (channelId: string): string =>
+    `/channels/${encodeURIComponent(channelId)}/messages`;
+
+  async function postHuman(
+    h: Harness,
+    text: string,
+    body: Record<string, unknown> = {}
+  ): Promise<{ id: string; seq: number }> {
+    const res = await req<{ message: { id: string; seq: number } }>({
+      port: h.port,
+      method: 'POST',
+      url: messagesUrl(h.channelId),
+      body: { text, ...body },
+    });
+    expect(res.status).toBe(201);
+    return res.body.message;
+  }
+
+  it('tombstones the row, keeps its seq, and broadcasts the deletion', async () => {
+    const h = await harness();
+    const first = await postHuman(h, 'first');
+    const target = await postHuman(h, 'ship @claude the anchor');
+    const after = await postHuman(h, 'after');
+    const sock = fakeSocket();
+    h.hub.handleConnection(sock, { channelId: h.channelId, sinceSeq: null });
+
+    const res = await req<{
+      message: {
+        id: string;
+        seq: number;
+        body: { text: string };
+        meta?: Record<string, unknown>;
+        mentions?: unknown[];
+      };
+    }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(target.id)}`,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.message.id).toBe(target.id);
+    expect(res.body.message.seq).toBe(target.seq);
+    expect(res.body.message.body.text).toBe('');
+    expect(typeof res.body.message.meta?.['deletedAt']).toBe('string');
+    expect(res.body.message.mentions).toBeUndefined();
+
+    // The seq log is the substrate contract: the row count and the numbering
+    // are both unchanged, so no cursor, deep link or thread parent moved.
+    const history = h.store.history(h.channelId, { limit: 50 });
+    expect(history.map((m) => m.id)).toEqual([first.id, target.id, after.id]);
+    expect(history.map((m) => m.seq)).toEqual([1, 2, 3]);
+    expect(h.store.getMessage(target.id)?.body.text).toBe('');
+
+    const event = sock.sent.find(
+      (e) => e.type === 'channel-message-deleted-v1'
+    );
+    expect(event?.type).toBe('channel-message-deleted-v1');
+    if (event?.type === 'channel-message-deleted-v1') {
+      expect(event.message.id).toBe(target.id);
+      expect(event.message.body.text).toBe('');
+    }
+    // Deleting is not posting: no created event may ride this lane.
+    expect(sock.sent.some((e) => e.type === 'channel-message-created-v1')).toBe(
+      false
+    );
+  });
+
+  it('is idempotent and refuses agent rows, the agent lane, archived channels, and unknown ids', async () => {
+    const h = await harness();
+    const posted = await postHuman(h, 'operator says hi');
+    const url = `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`;
+
+    const first = await req<{ message: { meta?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'DELETE',
+      url,
+    });
+    expect(first.status).toBe(200);
+    // A double tap (or a second device) converges on the same tombstone rather
+    // than surfacing an error for a state already reached.
+    const again = await req<{ message: { meta?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'DELETE',
+      url,
+    });
+    expect(again.status).toBe(200);
+    expect(again.body.message.meta?.['deletedAt']).toBe(
+      first.body.message.meta?.['deletedAt']
+    );
+
+    const agentPost = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: messagesUrl(h.channelId),
+      body: { text: 'agent says hi' },
+      headers: { 'x-test-actor-id': 'claude' },
+    });
+    expect(agentPost.status).toBe(201);
+    const agentRow = await req<{
+      error: { details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(agentPost.body.message.id)}`,
+    });
+    expect(agentRow.status).toBe(409);
+    expect(agentRow.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_MESSAGE_NOT_DELETABLE'
+    );
+
+    // An actor credential must never erase the operator's words — this lane
+    // admits scoped actors, so the human gate is load-bearing.
+    const live = await postHuman(h, 'still here');
+    const agentLane = await req<{
+      error: { code: string; details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(live.id)}`,
+      headers: { 'x-test-actor-id': 'claude' },
+    });
+    expect(agentLane.status).toBe(403);
+    expect(agentLane.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_DELETE_HUMAN_ONLY'
+    );
+    expect(h.store.getMessage(live.id)?.body.text).toBe('still here');
+
+    const missing = await req<{ error: unknown }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${messagesUrl(h.channelId)}/chm%3Anope`,
+    });
+    expect(missing.status).toBe(404);
+
+    h.topicStore.archive(h.channelId);
+    const archived = await req<{
+      error: { details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'DELETE',
+      url: `${messagesUrl(h.channelId)}/${encodeURIComponent(live.id)}`,
+    });
+    expect(archived.status).toBe(409);
+    expect(archived.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_ARCHIVED'
+    );
+    expect(h.store.getMessage(live.id)?.body.text).toBe('still here');
+  });
+
+  it('rejects a caller without context:write, and refuses to edit a tombstone', async () => {
+    const h = await harness();
+    const posted = await postHuman(h, 'operator says hi');
+    const url = `${messagesUrl(h.channelId)}/${encodeURIComponent(posted.id)}`;
+
+    const readOnly = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'DELETE',
+      url,
+      capabilities: 'context:read',
+    });
+    expect(readOnly.status).toBe(403);
+    expect(readOnly.body.error.code).toBe('FORBIDDEN');
+    expect(h.store.getMessage(posted.id)?.body.text).toBe('operator says hi');
+
+    expect((await req({ port: h.port, method: 'DELETE', url })).status).toBe(
+      200
+    );
+    // An edit of a tombstone would be an undelete.
+    const undelete = await req<{
+      error: { details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'PATCH',
+      url,
+      body: { text: 'back from the dead' },
+    });
+    expect(undelete.status).toBe(409);
+    expect(undelete.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_MESSAGE_NOT_EDITABLE'
+    );
+    expect(h.store.getMessage(posted.id)?.body.text).toBe('');
   });
 });

--- a/test/channel-url-route.test.ts
+++ b/test/channel-url-route.test.ts
@@ -16,12 +16,16 @@ import {
 } from '../shared/workspace-topics.js';
 import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
 import {
+  buildChannelMessageLink,
   buildPath,
   decodeChannelSegment,
   encodeChannelSegment,
+  encodeMessageAnchor,
   hashPath,
+  parseMessageAnchor,
   parseRoute,
 } from '../frontend/src/lib/url-nav.js';
+import type { ChannelMessageId } from '../shared/channel-chat-protocol.js';
 import type { Repo } from '../frontend/src/lib/types.js';
 import { useUrlNav } from '../frontend/src/hooks/useUrlNav.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
@@ -115,6 +119,64 @@ describe('channel route encoding', () => {
   });
 });
 
+// #1308 slice 1 item 1: a message deep link is the channel path PLUS a URL
+// fragment. It deliberately adds no `RouteState` variant — `parseRoute` still
+// sees only the pathname, so every existing route assertion is untouched.
+describe('message anchor fragment', () => {
+  const messageId =
+    'chm:9f0c1d2e-3a4b-4c5d-8e9f-0a1b2c3d4e5f' as ChannelMessageId;
+
+  it('round-trips a message id', () => {
+    const anchor = encodeMessageAnchor(messageId);
+    expect(anchor).toBe(`#msg-${messageId.slice('chm:'.length)}`);
+    expect(parseMessageAnchor(anchor)).toBe(messageId);
+    // Browsers hand back `location.hash` with the `#`; a stripped form must
+    // parse identically so callers never have to normalise.
+    expect(parseMessageAnchor(anchor.slice(1))).toBe(messageId);
+  });
+
+  it('ignores fragments that are not message anchors', () => {
+    expect(parseMessageAnchor('')).toBeNull();
+    expect(parseMessageAnchor('#')).toBeNull();
+    expect(parseMessageAnchor('#msg-')).toBeNull();
+    expect(parseMessageAnchor('#settings')).toBeNull();
+    expect(parseMessageAnchor('#msg-%E0%A4%A')).toBeNull();
+  });
+
+  it('builds a link the router can parse back to channel + message', () => {
+    const channelId = mintWorkspaceTopicId();
+    const link = buildChannelMessageLink(
+      channelId,
+      messageId,
+      'https://relay.example'
+    );
+    const url = new URL(link);
+
+    expect(parseRoute(url.pathname, [])).toEqual({
+      view: 'channel',
+      channelId,
+    });
+    expect(parseMessageAnchor(url.hash)).toBe(messageId);
+    // A trailing slash on the origin must not double up in the path.
+    expect(
+      buildChannelMessageLink(channelId, messageId, 'https://relay.example/')
+    ).toBe(link);
+  });
+
+  it('carries a DM channel id and its `~` separators through the link', () => {
+    const dmId = dmChannelTopicId('claude', null);
+    const url = new URL(
+      buildChannelMessageLink(dmId, messageId, 'https://relay.example')
+    );
+
+    expect(parseRoute(url.pathname, [])).toEqual({
+      view: 'channel',
+      channelId: dmId,
+    });
+    expect(parseMessageAnchor(url.hash)).toBe(messageId);
+  });
+});
+
 describe('buildPath channel priority', () => {
   const repos = [makeRepo()];
   const channelId = mintWorkspaceTopicId();
@@ -202,6 +264,7 @@ describe('useUrlNav channel navigation', () => {
       analyticsView: null,
       activeModal: null,
       topicComposerOpen: false,
+      pendingChannelMessage: null,
     });
     useSessionsStore.setState({
       activeSessionId: null,
@@ -243,6 +306,68 @@ describe('useUrlNav channel navigation', () => {
     expect(useUiStore.getState().activeChannelId).toBe(channelId);
     expect(useSessionsStore.getState().activeSessionId).toBeNull();
     expect(window.location.pathname).toBe(channelPath);
+  });
+
+  it('arms a message anchor from a deep-linked fragment', async () => {
+    await mount(`${channelPath}#msg-row-42`);
+
+    await act(async () => {
+      nav.restoreFromUrl();
+    });
+
+    expect(useUiStore.getState().activeChannelId).toBe(channelId);
+    expect(useUiStore.getState().pendingChannelMessage).toEqual({
+      channelId,
+      messageId: 'chm:row-42',
+    });
+    // Neither the correction pass nor the push effect may eat the fragment —
+    // both build URLs from `pathname + search` alone.
+    expect(window.location.hash).toBe('#msg-row-42');
+  });
+
+  it('leaves no anchor for a fragment that is not a message anchor', async () => {
+    await mount(`${channelPath}#section-2`);
+
+    await act(async () => {
+      nav.restoreFromUrl();
+    });
+
+    expect(useUiStore.getState().activeChannelId).toBe(channelId);
+    expect(useUiStore.getState().pendingChannelMessage).toBeNull();
+  });
+
+  it('re-arms the anchor when only the fragment changes', async () => {
+    await mount(channelPath);
+    await act(async () => {
+      nav.restoreFromUrl();
+    });
+    expect(useUiStore.getState().pendingChannelMessage).toBeNull();
+
+    // Pasting a `#msg-…` link for the channel already on screen fires
+    // `hashchange` and never `popstate`, so the route handler cannot see it.
+    window.history.replaceState(null, '', `${channelPath}#msg-row-7`);
+    await act(async () => {
+      window.dispatchEvent(new Event('hashchange'));
+    });
+
+    expect(useUiStore.getState().pendingChannelMessage).toEqual({
+      channelId,
+      messageId: 'chm:row-7',
+    });
+  });
+
+  it('drops an un-consumed anchor when a different channel opens', async () => {
+    await mount(`${channelPath}#msg-row-42`);
+    await act(async () => {
+      nav.restoreFromUrl();
+    });
+    expect(useUiStore.getState().pendingChannelMessage).not.toBeNull();
+
+    await act(async () => {
+      useUiStore.getState().setActiveChannelId(otherChannelId);
+    });
+
+    expect(useUiStore.getState().pendingChannelMessage).toBeNull();
   });
 
   it('sends an unknown channel segment home and rewrites the URL', async () => {

--- a/test/components/channel-message-actions.test.ts
+++ b/test/components/channel-message-actions.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 item 1 — the per-message hover action toolbar. The toolbar is
+// mounted only while the row is hovered/focused/long-press pinned, so "renders
+// on hover" is a DOM assertion here rather than a CSS one: an always-mounted,
+// opacity-hidden toolbar would still be two extra buttons per row in a lane
+// that routinely holds hundreds.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ChannelMessageRow } from '../../frontend/src/components/chat/ChannelMessageRow.js';
+import { encodeChannelSegment } from '../../frontend/src/lib/url-nav.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+const MESSAGE_ID =
+  'chm:9f0c1d2e-3a4b-4c5d-8e9f-0a1b2c3d4e5f' as ChannelMessageId;
+
+function humanMessage(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: MESSAGE_ID,
+    channelId: CHANNEL_ID,
+    seq: 7,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: 'ship the anchor', format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-03T00:00:00.000Z',
+    updatedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ChannelMessageRow action toolbar', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let writeText: ReturnType<typeof vi.fn>;
+
+  async function renderRow(
+    message: ChannelMessage = humanMessage()
+  ): Promise<HTMLElement> {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message,
+          channelId: CHANNEL_ID,
+        })
+      );
+    });
+    const row = container.querySelector<HTMLElement>('.ch-msg');
+    expect(row).not.toBeNull();
+    return row!;
+  }
+
+  async function hover(row: HTMLElement): Promise<void> {
+    // React polyfills onMouseEnter from the delegated `mouseover` listener, so
+    // this is the event a real pointer entry produces.
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+  }
+
+  beforeEach(() => {
+    writeText = vi.fn(async () => {});
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('mounts the toolbar on hover and unmounts it on leave', async () => {
+    const row = await renderRow();
+    expect(row.querySelector('.ch-msg__actions')).toBeNull();
+
+    await hover(row);
+
+    const actions = row.querySelector('.ch-msg__actions');
+    expect(actions).not.toBeNull();
+    expect(actions?.getAttribute('aria-label')).toBe('message actions');
+    expect(
+      Array.from(actions!.querySelectorAll('button')).map((button) =>
+        button.getAttribute('aria-label')
+      )
+    ).toEqual(['copy link to message', 'copy message text']);
+
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+    });
+    expect(row.querySelector('.ch-msg__actions')).toBeNull();
+  });
+
+  it('copies a deep link that names the channel and the message', async () => {
+    const row = await renderRow();
+    await hover(row);
+
+    const copyLink = row.querySelector<HTMLButtonElement>(
+      '[aria-label="copy link to message"]'
+    );
+    await act(async () => copyLink?.click());
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const link = String(writeText.mock.calls[0]?.[0]);
+    expect(link).toBe(
+      `${window.location.origin}/channel/${encodeChannelSegment(CHANNEL_ID)}#msg-${MESSAGE_ID.slice('chm:'.length)}`
+    );
+    // The link must survive a paste into the router that produced it.
+    expect(new URL(link).pathname).toBe(
+      `/channel/${encodeChannelSegment(CHANNEL_ID)}`
+    );
+  });
+
+  it('copies the message body verbatim', async () => {
+    const row = await renderRow(
+      humanMessage({ body: { text: 'line one\nline two', format: 'text' } })
+    );
+    await hover(row);
+
+    const copyText = row.querySelector<HTMLButtonElement>(
+      '[aria-label="copy message text"]'
+    );
+    await act(async () => copyText?.click());
+
+    expect(writeText).toHaveBeenCalledWith('line one\nline two');
+  });
+
+  it('pins the toolbar open on a touch long press and dismisses it outside', async () => {
+    vi.useFakeTimers();
+    try {
+      const row = await renderRow();
+
+      // happy-dom has no Touch constructor; React reads `touches[0]`, so the
+      // synthetic event needs one entry with coordinates.
+      await act(async () => {
+        const event = new MouseEvent('touchstart', { bubbles: true });
+        Object.defineProperty(event, 'touches', {
+          value: [{ clientX: 10, clientY: 10 }],
+        });
+        row.dispatchEvent(event);
+      });
+      expect(row.querySelector('.ch-msg__actions')).toBeNull();
+
+      await act(async () => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(row.querySelector('.ch-msg__actions')).not.toBeNull();
+
+      await act(async () => {
+        document.body.dispatchEvent(new MouseEvent('pointerdown'));
+      });
+      expect(row.querySelector('.ch-msg__actions')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/test/components/channel-message-delete.test.ts
+++ b/test/components/channel-message-delete.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 item 4 — deleting one of the operator's own messages.
+// The affordance and the server route share one predicate
+// (`channelMessageDeletable`), so these tests pin the halves that predicate
+// cannot: that destruction takes two deliberate steps WITHOUT a browser
+// `confirm()`, and that a tombstone still renders as a row.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ChannelMessageRow } from '../../frontend/src/components/chat/ChannelMessageRow.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+const MESSAGE_ID =
+  'chm:1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d' as ChannelMessageId;
+
+function humanMessage(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: MESSAGE_ID,
+    channelId: CHANNEL_ID,
+    seq: 12,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: 'deploy at 3pm', format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-03T00:00:00.000Z',
+    updatedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function tombstone(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return humanMessage({
+    body: { text: '', format: 'text' },
+    meta: { deletedAt: '2026-08-03T02:00:00.000Z' },
+    ...overrides,
+  });
+}
+
+describe('ChannelMessageRow inline delete', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onDelete: ReturnType<typeof vi.fn>;
+
+  async function renderRow(
+    message: ChannelMessage = humanMessage(),
+    props: Record<string, unknown> = {}
+  ): Promise<HTMLElement> {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message,
+          channelId: CHANNEL_ID,
+          onDelete,
+          ...props,
+        })
+      );
+    });
+    const row = container.querySelector<HTMLElement>('.ch-msg');
+    expect(row).not.toBeNull();
+    return row!;
+  }
+
+  async function hover(row: HTMLElement): Promise<void> {
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+  }
+
+  async function openConfirm(row: HTMLElement): Promise<void> {
+    await hover(row);
+    const button = row.querySelector<HTMLButtonElement>(
+      '[aria-label="delete message"]'
+    );
+    expect(button).not.toBeNull();
+    await act(async () => button?.click());
+  }
+
+  beforeEach(() => {
+    onDelete = vi.fn(async () => {});
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('offers delete on the operator’s own live row only', async () => {
+    const own = await renderRow();
+    await hover(own);
+    expect(own.querySelector('[aria-label="delete message"]')).not.toBeNull();
+
+    // An agent row is a durable record of what a provider said.
+    const agent = await renderRow(
+      humanMessage({
+        sender: {
+          kind: 'agent',
+          id: 'agent-profile:claude:default',
+          providerId: 'claude',
+        },
+      })
+    );
+    await hover(agent);
+    expect(agent.querySelector('.ch-msg__actions')).not.toBeNull();
+    expect(agent.querySelector('[aria-label="delete message"]')).toBeNull();
+
+    // An already-deleted row cannot be deleted again.
+    const gone = await renderRow(tombstone());
+    await hover(gone);
+    expect(gone.querySelector('[aria-label="delete message"]')).toBeNull();
+
+    // No delete lane wired → no affordance, even on a human row.
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: humanMessage(),
+          channelId: CHANNEL_ID,
+        })
+      );
+    });
+    const unwired = container.querySelector<HTMLElement>('.ch-msg')!;
+    await hover(unwired);
+    expect(unwired.querySelector('[aria-label="delete message"]')).toBeNull();
+  });
+
+  it('asks inline before deleting and never calls the browser confirm', async () => {
+    // A native modal would steal focus from the row it is about, cannot be
+    // styled to the TUI, and hides the message being confirmed.
+    const nativeConfirm = vi.fn(() => true);
+    vi.stubGlobal('confirm', nativeConfirm);
+    (window as unknown as { confirm: () => boolean }).confirm = nativeConfirm;
+
+    const row = await renderRow();
+    await openConfirm(row);
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(nativeConfirm).not.toHaveBeenCalled();
+    const strip = row.querySelector(
+      '[aria-label="delete message confirmation"]'
+    );
+    expect(strip).not.toBeNull();
+    // The question sits on the row, in the toolbar's own slot.
+    expect(row.textContent).toContain('delete?');
+
+    await act(async () =>
+      row
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="confirm delete message"]'
+        )
+        ?.click()
+    );
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete.mock.calls[0]?.[0]?.id).toBe(MESSAGE_ID);
+    vi.unstubAllGlobals();
+  });
+
+  it('backs out on cancel and on escape without deleting', async () => {
+    const row = await renderRow();
+    await openConfirm(row);
+    await act(async () =>
+      row
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="cancel delete message"]'
+        )
+        ?.click()
+    );
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(
+      row.querySelector('[aria-label="delete message confirmation"]')
+    ).toBeNull();
+
+    await openConfirm(row);
+    await act(async () => {
+      row
+        .querySelector('[aria-label="delete message confirmation"]')
+        ?.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+    });
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(
+      row.querySelector('[aria-label="delete message confirmation"]')
+    ).toBeNull();
+  });
+
+  it('keeps the confirm open when the write fails', async () => {
+    onDelete.mockRejectedValueOnce(new Error('409'));
+    const row = await renderRow();
+    await openConfirm(row);
+    await act(async () =>
+      row
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="confirm delete message"]'
+        )
+        ?.click()
+    );
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    // The operator asked for this and is owed the outcome, not a silent revert.
+    expect(
+      row.querySelector('[aria-label="delete message confirmation"]')
+    ).not.toBeNull();
+  });
+
+  it('renders a tombstone as a dim placeholder that keeps its thread anchor', async () => {
+    const onOpenThread = vi.fn();
+    // The edit lane IS wired here, so the missing edit button below is the
+    // shared predicate refusing a tombstone, not an unwired surface.
+    const row = await renderRow(tombstone(), {
+      replyCount: 2,
+      onOpenThread,
+      onEdit: vi.fn(async () => {}),
+    });
+    expect(row.querySelector('.ch-msg__deleted')?.textContent).toBe(
+      'message deleted'
+    );
+    expect(row.className).toContain('ch-msg--deleted');
+    // The row keeps its identity, so a deep link and a thread parent that named
+    // it stay valid.
+    expect(row.getAttribute('data-channel-message-id')).toBe(MESSAGE_ID);
+    expect(row.getAttribute('data-channel-message-seq')).toBe('12');
+    // Deleting the parent must not strand its replies.
+    const chip = row.querySelector<HTMLButtonElement>('.ch-msg__thread-chip');
+    expect(chip?.textContent).toContain('2 replies');
+    await act(async () => chip?.click());
+    expect(onOpenThread).toHaveBeenCalledWith(MESSAGE_ID);
+
+    // Still addressable (copy-link survives), but there is nothing left to copy
+    // as text and nothing left to edit.
+    await hover(row);
+    expect(
+      row.querySelector('[aria-label="copy link to message"]')
+    ).not.toBeNull();
+    expect(row.querySelector('[aria-label="copy message text"]')).toBeNull();
+    expect(row.querySelector('[aria-label="edit message"]')).toBeNull();
+  });
+});

--- a/test/components/channel-message-edit.test.ts
+++ b/test/components/channel-message-edit.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 item 3 — editing one of the operator's own messages in place.
+// The affordance and the server route share one predicate
+// (`channelMessageEditable`), so these tests pin the two halves that the shared
+// predicate cannot: that the row offers the action ONLY where the predicate
+// allows it, and that the editor hands back exactly what the operator typed.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ChannelMessageRow } from '../../frontend/src/components/chat/ChannelMessageRow.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+const MESSAGE_ID =
+  'chm:1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d' as ChannelMessageId;
+
+function humanMessage(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: MESSAGE_ID,
+    channelId: CHANNEL_ID,
+    seq: 12,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: 'deploy at 3pm', format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-03T00:00:00.000Z',
+    updatedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ChannelMessageRow inline edit', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onEdit: ReturnType<typeof vi.fn>;
+
+  async function renderRow(
+    message: ChannelMessage = humanMessage(),
+    props: Record<string, unknown> = {}
+  ): Promise<HTMLElement> {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message,
+          channelId: CHANNEL_ID,
+          onEdit,
+          ...props,
+        })
+      );
+    });
+    const row = container.querySelector<HTMLElement>('.ch-msg');
+    expect(row).not.toBeNull();
+    return row!;
+  }
+
+  async function hover(row: HTMLElement): Promise<void> {
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+  }
+
+  async function openEditor(row: HTMLElement): Promise<HTMLTextAreaElement> {
+    await hover(row);
+    const edit = row.querySelector<HTMLButtonElement>(
+      '[aria-label="edit message"]'
+    );
+    expect(edit).not.toBeNull();
+    await act(async () => edit?.click());
+    const textarea = row.querySelector<HTMLTextAreaElement>(
+      '[aria-label="edit message text"]'
+    );
+    expect(textarea?.tagName).toBe('TEXTAREA');
+    return textarea!;
+  }
+
+  async function type(
+    textarea: HTMLTextAreaElement,
+    value: string
+  ): Promise<void> {
+    // React tracks the last value it wrote; set through the prototype so the
+    // controlled component sees a real change.
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value'
+    )?.set;
+    await act(async () => {
+      setter?.call(textarea, value);
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  beforeEach(() => {
+    onEdit = vi.fn(async () => {});
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('offers edit on the operator’s own row only', async () => {
+    const own = await renderRow();
+    await hover(own);
+    expect(own.querySelector('[aria-label="edit message"]')).not.toBeNull();
+
+    // Agent rows are a durable record of what a provider said; system rows are
+    // the hub's own bookkeeping. Neither may be rewritten.
+    const agent = await renderRow(
+      humanMessage({
+        sender: {
+          kind: 'agent',
+          id: 'agent-profile:claude:default',
+          providerId: 'claude',
+        },
+      })
+    );
+    await hover(agent);
+    expect(agent.querySelector('.ch-msg__actions')).not.toBeNull();
+    expect(agent.querySelector('[aria-label="edit message"]')).toBeNull();
+
+    // No edit lane wired → no affordance, even on a human row.
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: humanMessage(),
+          channelId: CHANNEL_ID,
+        })
+      );
+    });
+    const unwired = container.querySelector<HTMLElement>('.ch-msg')!;
+    await hover(unwired);
+    expect(unwired.querySelector('[aria-label="edit message"]')).toBeNull();
+  });
+
+  it('saves the edited text on enter and closes the editor', async () => {
+    const row = await renderRow();
+    const textarea = await openEditor(row);
+    // The editor opens seeded with the durable body, not empty.
+    expect(textarea.value).toBe('deploy at 3pm');
+
+    await type(textarea, 'deploy at 5pm');
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onEdit.mock.calls[0]?.[1]).toBe('deploy at 5pm');
+    expect(row.querySelector('textarea')).toBeNull();
+  });
+
+  it('keeps a newline on shift+enter and never sends an unchanged or empty body', async () => {
+    const row = await renderRow();
+    const textarea = await openEditor(row);
+
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+          bubbles: true,
+        })
+      );
+    });
+    expect(onEdit).not.toHaveBeenCalled();
+
+    // Unchanged text closes the editor without a write…
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(row.querySelector('textarea')).toBeNull();
+
+    // …and an emptied body is not a delete lane, so it is refused outright.
+    const reopened = await openEditor(row);
+    await type(reopened, '   ');
+    await act(async () => {
+      reopened.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(row.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('escape abandons the edit and a failed save keeps the draft on screen', async () => {
+    const row = await renderRow();
+    const textarea = await openEditor(row);
+    await type(textarea, 'thrown away');
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(row.querySelector('textarea')).toBeNull();
+
+    onEdit.mockRejectedValueOnce(new Error('409'));
+    const retry = await openEditor(row);
+    await type(retry, 'deploy at 5pm');
+    await act(async () => {
+      retry.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    // The operator's words are the one thing this row must never discard.
+    const stillOpen = row.querySelector<HTMLTextAreaElement>('textarea');
+    expect(stillOpen).not.toBeNull();
+    expect(stillOpen?.value).toBe('deploy at 5pm');
+  });
+
+  it('renders a dim (edited) suffix once the row carries an editedAt stamp', async () => {
+    const plain = await renderRow();
+    expect(plain.querySelector('.ch-msg__edited')).toBeNull();
+
+    const row = await renderRow(
+      humanMessage({
+        body: { text: 'deploy at 5pm', format: 'text' },
+        meta: { editedAt: '2026-08-03T01:00:00.000Z' },
+      })
+    );
+    const marker = row.querySelector('.ch-msg__edited');
+    expect(marker?.textContent).toBe('(edited)');
+    // The stamp itself is available on demand, never as permanent chrome.
+    expect(marker?.getAttribute('title')).toContain('2026-08-03T01:00:00.000Z');
+
+    // The marker is suppressed while the editor is open — the row is mid-change,
+    // not settled.
+    await openEditor(row);
+    expect(row.querySelector('.ch-msg__edited')).toBeNull();
+  });
+});

--- a/test/components/channel-message-jump.test.ts
+++ b/test/components/channel-message-jump.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 item 1 — deep-link jump. The real `ChannelTimeline` /
+// `ChannelMessageRow` render here on purpose: the anchor resolves against the
+// DOM the live lane actually produces, and the bounded backfill walk is only
+// meaningful against `ChannelView`'s own `hasMoreOlder`/`loadOlder` wiring.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+/** Mirrors `ANCHOR_WALK_MAX_PAGES` in `ChannelView`. */
+const ANCHOR_WALK_MAX_PAGES = 8;
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  messages: [] as unknown[],
+  hasMoreOlder: false,
+  loadOlder: vi.fn(async () => {}),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+  };
+});
+
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: CHANNEL_ID,
+      title: 'operator lane',
+      visibility: 'default',
+      archived: false,
+      latestSeq: mocks.messages.length,
+      messageCount: mocks.messages.length,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: CHANNEL_ID,
+      messages: mocks.messages,
+      lastSeq: mocks.messages.length,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: mocks.hasMoreOlder,
+    loadingOlder: false,
+    loadOlder: mocks.loadOlder,
+    fullSnapshotRevision: 0,
+    post: vi.fn(),
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
+  ChannelComposer: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
+  ChannelThreadPanel: () => null,
+}));
+
+const { ChannelView } =
+  await import('../../frontend/src/components/chat/ChannelView.js');
+const { useUiStore } = await import('../../frontend/src/lib/stores/ui.js');
+const { useToastStore } =
+  await import('../../frontend/src/lib/stores/toasts.js');
+
+function message(seq: number, overrides: Partial<ChannelMessage> = {}) {
+  return {
+    schemaVersion: 1,
+    id: `chm:row-${seq}` as ChannelMessageId,
+    channelId: CHANNEL_ID,
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: `row ${seq}`, format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-03T00:00:00.000Z',
+    updatedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  } satisfies ChannelMessage;
+}
+
+describe('ChannelView deep-link message anchor', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+  let scrollIntoView: ReturnType<typeof vi.fn>;
+  let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+
+  async function mount(): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChannelView, { channelId: CHANNEL_ID })
+        )
+      );
+    });
+    // Drain the anchor walk's promise/state ping-pong.
+    await act(async () => {});
+  }
+
+  beforeEach(() => {
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: CHANNEL_ID,
+      workspaceId: 'workspace:local',
+      display: { title: 'operator lane' },
+      routingDefaults: {},
+    });
+    mocks.fetchChannelRoster.mockResolvedValue([]);
+    mocks.messages = [];
+    mocks.hasMoreOlder = false;
+    mocks.loadOlder = vi.fn(async () => {});
+    useUiStore.setState({
+      activeChannelId: CHANNEL_ID,
+      activeThreadRootId: null,
+      pendingChannelThread: null,
+      pendingChannelMessage: null,
+    });
+    useToastStore.setState({ toasts: [] });
+    originalScrollIntoView = Element.prototype.scrollIntoView;
+    scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    vi.useRealTimers();
+  });
+
+  it('scrolls to the anchored row and applies a brief jump emphasis', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.messages = [message(1), message(2), message(3)];
+    await mount();
+
+    expect(container.querySelector('.ch-msg--jump')).toBeNull();
+
+    await act(async () => {
+      useUiStore
+        .getState()
+        .requestChannelMessage(CHANNEL_ID, 'chm:row-2' as ChannelMessageId);
+    });
+    await act(async () => {});
+
+    const highlighted = container.querySelector('.ch-msg--jump');
+    expect(highlighted).not.toBeNull();
+    expect(highlighted?.getAttribute('data-channel-message-id')).toBe(
+      'chm:row-2'
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView.mock.instances[0]).toBe(highlighted);
+    // The intent is one-shot — a leftover would re-fire on the next render.
+    expect(useUiStore.getState().pendingChannelMessage).toBeNull();
+
+    // Emphasis is transient: the row returns to normal without another render
+    // being forced by the operator.
+    await act(async () => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(container.querySelector('.ch-msg--jump')).toBeNull();
+  });
+
+  it('does not jump when the anchor names another channel', async () => {
+    mocks.messages = [message(1)];
+    await mount();
+
+    await act(async () => {
+      useUiStore
+        .getState()
+        .requestChannelMessage(
+          'topic:other-lane',
+          'chm:row-1' as ChannelMessageId
+        );
+    });
+    await act(async () => {});
+
+    expect(container.querySelector('.ch-msg--jump')).toBeNull();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingChannelMessage).not.toBeNull();
+  });
+
+  it('walks older history for an out-of-window anchor and stops at the cap', async () => {
+    mocks.messages = [message(90), message(91)];
+    // Every page comes back without the target: the pathological case a cap
+    // exists for (deleted row, id from another channel, hand-edited link).
+    mocks.hasMoreOlder = true;
+    await mount();
+
+    await act(async () => {
+      useUiStore
+        .getState()
+        .requestChannelMessage(CHANNEL_ID, 'chm:row-1' as ChannelMessageId);
+    });
+    await act(async () => {});
+
+    expect(mocks.loadOlder).toHaveBeenCalledTimes(ANCHOR_WALK_MAX_PAGES);
+    expect(container.querySelector('.ch-msg--jump')).toBeNull();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(
+      useToastStore.getState().toasts.map((toast) => toast.message)
+    ).toContain('that message is not in this chat’s recent history');
+  });
+
+  it('gives up immediately when there is no older history left to walk', async () => {
+    mocks.messages = [message(1), message(2)];
+    mocks.hasMoreOlder = false;
+    await mount();
+
+    await act(async () => {
+      useUiStore
+        .getState()
+        .requestChannelMessage(CHANNEL_ID, 'chm:missing' as ChannelMessageId);
+    });
+    await act(async () => {});
+
+    expect(mocks.loadOlder).not.toHaveBeenCalled();
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+  });
+});

--- a/test/components/channel-message-jump.test.ts
+++ b/test/components/channel-message-jump.test.ts
@@ -28,6 +28,9 @@ const mocks = vi.hoisted(() => ({
   messages: [] as unknown[],
   hasMoreOlder: false,
   loadOlder: vi.fn(async () => {}),
+  // `useChannelChatSocket` only increments this when a FULL snapshot lands, so
+  // `0` is the cold-boot state: connected socket, nothing answered yet.
+  fullSnapshotRevision: 1,
 }));
 
 vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
@@ -66,7 +69,7 @@ vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
     hasMoreOlder: mocks.hasMoreOlder,
     loadingOlder: false,
     loadOlder: mocks.loadOlder,
-    fullSnapshotRevision: 0,
+    fullSnapshotRevision: mocks.fullSnapshotRevision,
     post: vi.fn(),
     postPending: false,
     postError: null,
@@ -136,6 +139,7 @@ describe('ChannelView deep-link message anchor', () => {
     mocks.fetchChannelRoster.mockResolvedValue([]);
     mocks.messages = [];
     mocks.hasMoreOlder = false;
+    mocks.fullSnapshotRevision = 1;
     mocks.loadOlder = vi.fn(async () => {});
     useUiStore.setState({
       activeChannelId: CHANNEL_ID,
@@ -234,6 +238,47 @@ describe('ChannelView deep-link message anchor', () => {
     expect(
       useToastStore.getState().toasts.map((toast) => toast.message)
     ).toContain('that message is not in this chat’s recent history');
+  });
+
+  it('waits for the channel snapshot when the link is opened cold', async () => {
+    // The primary case for this feature: a pasted `/channel/<id>#msg-…` link in
+    // a fresh tab writes the intent BEFORE `ChannelView` mounts, so the adopt
+    // effect fires on the first commit — messages still empty, `hasMoreOlder`
+    // still its `false` default. Giving up there would toast "not in recent
+    // history" about a row that arrives one tick later.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.messages = [];
+    mocks.hasMoreOlder = false;
+    mocks.fullSnapshotRevision = 0;
+    useUiStore
+      .getState()
+      .requestChannelMessage(CHANNEL_ID, 'chm:row-2' as ChannelMessageId);
+
+    await mount();
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Snapshot lands.
+    mocks.messages = [message(1), message(2), message(3)];
+    mocks.fullSnapshotRevision = 1;
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChannelView, { channelId: CHANNEL_ID })
+        )
+      );
+    });
+    await act(async () => {});
+
+    const highlighted = container.querySelector('.ch-msg--jump');
+    expect(highlighted?.getAttribute('data-channel-message-id')).toBe(
+      'chm:row-2'
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 
   it('gives up immediately when there is no older history left to walk', async () => {

--- a/test/components/channel-message-retry.test.ts
+++ b/test/components/channel-message-retry.test.ts
@@ -1,0 +1,298 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 item 2 — the retry affordances on a lost agent turn. The row
+// derives "can this be retried" from the SAME shared contract the server route
+// uses (`channelRetryTarget`), so these assertions are about the affordance
+// obeying that contract, not about a component-local heuristic.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ChannelMessageRow } from '../../frontend/src/components/chat/ChannelMessageRow.js';
+import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import {
+  channelTurnId,
+  CHANNEL_RETRY_OF_META_KEY,
+  type ChannelMessage,
+  type ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+const PROFILE_ID = 'agent-profile:claude:default';
+const TRIGGER_ID = 'chm:11111111-2222-4333-8444-555555555555' as ChannelMessageId;
+const FAILED_ID = 'chm:66666666-7777-4888-8999-aaaaaaaaaaaa' as ChannelMessageId;
+
+function triggerRow(): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: TRIGGER_ID,
+    channelId: CHANNEL_ID,
+    seq: 4,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: '@claude ship the anchor', format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-03T00:00:00.000Z',
+    updatedAt: '2026-08-03T00:00:00.000Z',
+  };
+}
+
+function agentRow(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: FAILED_ID,
+    channelId: CHANNEL_ID,
+    seq: 5,
+    kind: 'message',
+    status: 'failed',
+    sender: { kind: 'agent', id: PROFILE_ID, providerId: 'claude' },
+    body: { text: 'half a re', format: 'markdown' },
+    threadId: null,
+    parentMessageId: null,
+    source: {
+      runtimeId: 'runtime:claude',
+      turnId: channelTurnId(TRIGGER_ID, PROFILE_ID),
+      itemId: 'assistant-0',
+    },
+    createdAt: '2026-08-03T00:00:01.000Z',
+    updatedAt: '2026-08-03T00:00:02.000Z',
+    ...overrides,
+  };
+}
+
+describe('ChannelMessageRow retry affordance', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  async function renderRow(
+    props: Partial<React.ComponentProps<typeof ChannelMessageRow>> = {}
+  ): Promise<HTMLElement> {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: agentRow(),
+          channelId: CHANNEL_ID,
+          ...props,
+        })
+      );
+    });
+    const row = container.querySelector<HTMLElement>('.ch-msg');
+    expect(row).not.toBeNull();
+    return row!;
+  }
+
+  async function hover(row: HTMLElement): Promise<void> {
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('fires the retry lane exactly once per click, with the failed row', async () => {
+    const onRetry = vi.fn(async () => {});
+    const row = await renderRow({ onRetry });
+
+    const inline = row.querySelector<HTMLButtonElement>('.ch-msg__retry');
+    expect(inline).not.toBeNull();
+    await act(async () => inline?.click());
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]?.[0]).toMatchObject({ id: FAILED_ID });
+  });
+
+  it('disables retry while the bound agent is busy in this channel', async () => {
+    const onRetry = vi.fn(async () => {});
+    const row = await renderRow({ onRetry, retryBusy: true });
+
+    const inline = row.querySelector<HTMLButtonElement>('.ch-msg__retry');
+    expect(inline?.disabled).toBe(true);
+    expect(inline?.getAttribute('title')).toBe('agent is busy');
+    await act(async () => inline?.click());
+    expect(onRetry).not.toHaveBeenCalled();
+
+    await hover(row);
+    const toolbarRetry = row.querySelector<HTMLButtonElement>(
+      '.ch-msg__actions [aria-label="retry this reply"]'
+    );
+    expect(toolbarRetry?.disabled).toBe(true);
+  });
+
+  it('holds a single in-flight retry: a second click cannot stack a turn', async () => {
+    let release: (() => void) | undefined;
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    const row = await renderRow({ onRetry });
+    const inline = row.querySelector<HTMLButtonElement>('.ch-msg__retry');
+
+    await act(async () => inline?.click());
+    const pending = row.querySelector<HTMLButtonElement>('.ch-msg__retry');
+    expect(pending?.disabled).toBe(true);
+    expect(pending?.textContent).toContain('retrying');
+
+    await act(async () => pending?.click());
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      release?.();
+    });
+    expect(
+      row.querySelector<HTMLButtonElement>('.ch-msg__retry')?.disabled
+    ).toBe(false);
+  });
+
+  it('replaces the button with a `retried` mark once a retry superseded the row', async () => {
+    const onRetry = vi.fn(async () => {});
+    const row = await renderRow({ onRetry, retried: true });
+
+    expect(row.querySelector('.ch-msg__retry')).toBeNull();
+    expect(row.querySelector('.ch-msg__tag--retried')?.textContent).toBe(
+      'retried'
+    );
+  });
+
+  it('offers interrupted/truncated retry in the toolbar but not inline', async () => {
+    const onRetry = vi.fn(async () => {});
+    for (const status of ['interrupted', 'truncated'] as const) {
+      const row = await renderRow({
+        message: agentRow({ status }),
+        onRetry,
+      });
+      expect(row.querySelector('.ch-msg__retry')).toBeNull();
+      await hover(row);
+      expect(
+        row.querySelector('.ch-msg__actions [aria-label="retry this reply"]')
+      ).not.toBeNull();
+    }
+  });
+
+  it('offers nothing when no routed turn can be recovered', async () => {
+    const onRetry = vi.fn(async () => {});
+    // A completed reply, and a failed row whose turn id the binder never minted
+    // (a provider-labelled item) — neither names a trigger to re-route.
+    for (const message of [
+      agentRow({ status: 'complete' }),
+      agentRow({
+        source: {
+          runtimeId: 'runtime:hermes',
+          turnId: 'turn-0',
+          itemId: 'assistant-0',
+        },
+      }),
+    ]) {
+      const row = await renderRow({ message, onRetry });
+      expect(row.querySelector('.ch-msg__retry')).toBeNull();
+      await hover(row);
+      expect(
+        row.querySelector('.ch-msg__actions [aria-label="retry this reply"]')
+      ).toBeNull();
+    }
+  });
+});
+
+describe('ChannelTimeline retry wiring', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderTimeline(
+    messages: ChannelMessage[],
+    props: Partial<React.ComponentProps<typeof ChannelTimeline>> = {}
+  ): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelTimeline, {
+          messages,
+          lastReadSeq: null,
+          channelId: CHANNEL_ID,
+          channelTitle: 'operator lane',
+          hasMoreOlder: false,
+          loadingOlder: false,
+          loadOlder: async () => {},
+          fullSnapshotRevision: 0,
+          needsCatchup: false,
+          onResync: () => {},
+          ...props,
+        })
+      );
+    });
+  }
+
+  it('retries without ever re-posting the human message', async () => {
+    const onRetryMessage = vi.fn(async () => {});
+    const messages = [triggerRow(), agentRow()];
+    await renderTimeline(messages, { onRetryMessage });
+
+    const rendered = () =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>('[data-channel-message-id]')
+      ).map((node) => node.dataset['channelMessageId']);
+    expect(rendered()).toEqual([TRIGGER_ID, FAILED_ID]);
+
+    const inline = container.querySelector<HTMLButtonElement>('.ch-msg__retry');
+    await act(async () => inline?.click());
+    expect(onRetryMessage).toHaveBeenCalledTimes(1);
+
+    // The server answers with a supersede system row plus a fresh agent row —
+    // and NOT with a second copy of the operator's message.
+    const superseded: ChannelMessage = {
+      ...triggerRow(),
+      id: 'chm:sys-1' as ChannelMessageId,
+      seq: 6,
+      kind: 'system',
+      sender: { kind: 'system', id: 'system' },
+      body: { text: 'retrying @claude — previous reply failed', format: 'text' },
+      meta: { [CHANNEL_RETRY_OF_META_KEY]: FAILED_ID },
+    };
+    await renderTimeline([...messages, superseded], { onRetryMessage });
+
+    expect(
+      rendered().filter((id) => id === TRIGGER_ID)
+    ).toHaveLength(1);
+    expect(container.querySelector('.ch-msg__retry')).toBeNull();
+    expect(container.querySelector('.ch-msg__tag--retried')).not.toBeNull();
+  });
+
+  it('propagates the busy set so a mid-turn agent cannot be re-fired', async () => {
+    const onRetryMessage = vi.fn(async () => {});
+    await renderTimeline([triggerRow(), agentRow()], {
+      onRetryMessage,
+      busyAgentIds: new Set([PROFILE_ID]),
+    });
+
+    const inline = container.querySelector<HTMLButtonElement>('.ch-msg__retry');
+    expect(inline?.disabled).toBe(true);
+    await act(async () => inline?.click());
+    expect(onRetryMessage).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/channel-system-coalescing.test.ts
+++ b/test/components/channel-system-coalescing.test.ts
@@ -1,0 +1,359 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 item 5 — consecutive system rows coalesce into one run.
+// Two layers, because they own different halves of the behaviour: the pure
+// builder decides where a run STARTS and STOPS (the boundary cases), and the
+// real `ChannelTimeline` decides whether a run is folded and how it opens.
+// The renderer is mounted rather than stubbed so the fold is proven against the
+// same DOM the live lane produces — including the day-divider, unread-line and
+// #1306 presence rows a run has to interleave with.
+
+import React, { act } from 'react';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import {
+  buildTimelineNodes,
+  SYSTEM_RUN_COLLAPSE_MIN,
+  type TimelineNode,
+} from '../../frontend/src/lib/chat/channel-timeline-layout.js';
+import type { ChannelAgentPresence } from '../../frontend/src/lib/chat/channel-agent-presence.js';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Day-boundary assertions are local-calendar sensitive — pin TZ so the
+// `23:58Z → 00:01Z` pair really straddles midnight on every machine (#1178).
+const originalTz = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = 'UTC';
+});
+afterAll(() => {
+  if (originalTz === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTz;
+});
+
+const CHANNEL_ID = 'topic:operator-lane';
+
+function base(seq: number, overrides: Partial<ChannelMessage>): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:row-${seq}` as ChannelMessageId,
+    channelId: CHANNEL_ID,
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'human:operator' },
+    body: { text: `row ${seq}`, format: 'text' },
+    threadId: null,
+    parentMessageId: null,
+    createdAt: '2026-08-03T10:00:00.000Z',
+    updatedAt: '2026-08-03T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function sys(seq: number, overrides: Partial<ChannelMessage> = {}) {
+  return base(seq, {
+    kind: 'system',
+    sender: { kind: 'system', id: 'system' },
+    body: { text: `system note ${seq}`, format: 'text' },
+    ...overrides,
+  });
+}
+
+function human(seq: number, overrides: Partial<ChannelMessage> = {}) {
+  return base(seq, overrides);
+}
+
+function runSeqs(nodes: TimelineNode[]): number[][] {
+  return nodes
+    .filter((node): node is Extract<TimelineNode, { kind: 'system' }> =>
+      Boolean(node.kind === 'system')
+    )
+    .map((node) => node.messages.map((message) => message.seq));
+}
+
+function kinds(nodes: TimelineNode[]): string[] {
+  return nodes.map((node) => node.kind);
+}
+
+describe('buildTimelineNodes — system-event coalescing (#1308 item 5)', () => {
+  it('folds consecutive system rows into ONE run node', () => {
+    const nodes = buildTimelineNodes([sys(1), sys(2), sys(3)], null);
+    expect(kinds(nodes)).toEqual(['day-divider', 'system']);
+    expect(runSeqs(nodes)).toEqual([[1, 2, 3]]);
+  });
+
+  it('breaks the run at an interleaved human message', () => {
+    const nodes = buildTimelineNodes(
+      [sys(1), sys(2), human(3), sys(4), sys(5)],
+      null
+    );
+    expect(kinds(nodes)).toEqual(['day-divider', 'system', 'group', 'system']);
+    expect(runSeqs(nodes)).toEqual([
+      [1, 2],
+      [4, 5],
+    ]);
+  });
+
+  it('breaks the run at a day divider', () => {
+    const nodes = buildTimelineNodes(
+      [
+        sys(1, { createdAt: '2026-08-03T23:57:00.000Z' }),
+        sys(2, { createdAt: '2026-08-03T23:58:00.000Z' }),
+        sys(3, { createdAt: '2026-08-04T00:01:00.000Z' }),
+        sys(4, { createdAt: '2026-08-04T00:02:00.000Z' }),
+      ],
+      null
+    );
+    // The divider must sit BETWEEN the two runs, never swallowed inside one.
+    expect(kinds(nodes)).toEqual([
+      'day-divider',
+      'system',
+      'day-divider',
+      'system',
+    ]);
+    expect(runSeqs(nodes)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('breaks the run at the unread line', () => {
+    const nodes = buildTimelineNodes([sys(1), sys(2), sys(3), sys(4)], 2);
+    expect(kinds(nodes)).toEqual([
+      'day-divider',
+      'system',
+      'unread-line',
+      'system',
+    ]);
+    expect(runSeqs(nodes)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('leaves an approval row standing alone and breaks the run around it', () => {
+    // The approval row owns approve/deny buttons — folding it behind a summary
+    // would hide an action the operator is being asked to take.
+    const nodes = buildTimelineNodes(
+      [
+        sys(1),
+        sys(2),
+        sys(3, { meta: { approvalRequestId: 'req-1', agentId: 'a' } }),
+        sys(4),
+        sys(5),
+      ],
+      null
+    );
+    expect(runSeqs(nodes)).toEqual([[1, 2], [3], [4, 5]]);
+  });
+
+  it('emits a single-message run for a lone system row', () => {
+    const nodes = buildTimelineNodes([human(1), sys(2), human(3)], null);
+    expect(kinds(nodes)).toEqual(['day-divider', 'group', 'system', 'group']);
+    expect(runSeqs(nodes)).toEqual([[2]]);
+  });
+});
+
+describe('ChannelTimeline — system-run fold', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const baseProps = {
+    lastReadSeq: null,
+    channelId: CHANNEL_ID,
+    channelTitle: 'operator lane',
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: async () => {},
+    fullSnapshotRevision: 0,
+    needsCatchup: false,
+    onResync: () => {},
+  };
+
+  async function render(
+    props: Record<string, unknown> & { messages: ChannelMessage[] }
+  ): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelTimeline, { ...baseProps, ...props })
+      );
+    });
+  }
+
+  function summary(): HTMLButtonElement | null {
+    return container.querySelector<HTMLButtonElement>('.ch-system-run');
+  }
+
+  function systemRowTexts(): string[] {
+    return Array.from(container.querySelectorAll('.ch-system-msg__label')).map(
+      (node) => node.textContent ?? ''
+    );
+  }
+
+  let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+
+  beforeEach(() => {
+    originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = () => {};
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it(`folds a run of ${SYSTEM_RUN_COLLAPSE_MIN} into one summary the operator can open and close`, async () => {
+    await render({ messages: [sys(1), sys(2), sys(3)] });
+
+    const button = summary();
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain('3 system events');
+    expect(button?.getAttribute('aria-expanded')).toBe('false');
+    // Folded rows are OUT of the DOM — that is the whole point of the fold.
+    expect(systemRowTexts()).toEqual([]);
+    // While folded the summary stands in for the run's last seq so the reader
+    // anchor in `useFollowingScroll` still has a row to hold onto.
+    expect(button?.getAttribute('data-channel-message-seq')).toBe('3');
+
+    await act(async () => {
+      button?.click();
+    });
+    expect(systemRowTexts()).toEqual([
+      'system note 1',
+      'system note 2',
+      'system note 3',
+    ]);
+    expect(summary()?.getAttribute('aria-expanded')).toBe('true');
+    // Expanded, the real rows carry the seq — a duplicate on the summary would
+    // shadow them in the anchor's `querySelector`.
+    expect(summary()?.hasAttribute('data-channel-message-seq')).toBe(false);
+
+    await act(async () => {
+      summary()?.click();
+    });
+    expect(systemRowTexts()).toEqual([]);
+    expect(summary()?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('leaves a short run expanded with no summary to click', async () => {
+    await render({ messages: [sys(1), sys(2)] });
+    expect(summary()).toBeNull();
+    expect(systemRowTexts()).toEqual(['system note 1', 'system note 2']);
+  });
+
+  it('folds each run independently around an interleaved message', async () => {
+    await render({
+      messages: [sys(1), sys(2), sys(3), human(4), sys(5), sys(6), sys(7)],
+    });
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.ch-system-run')
+    );
+    expect(buttons).toHaveLength(2);
+
+    await act(async () => {
+      buttons[0]?.click();
+    });
+    // Opening one run must not open the other.
+    expect(systemRowTexts()).toEqual([
+      'system note 1',
+      'system note 2',
+      'system note 3',
+    ]);
+  });
+
+  it('keeps day dividers, the unread line and the presence row interleaved with folds', async () => {
+    const presence: ChannelAgentPresence[] = [
+      {
+        agentId: 'agent-profile:hermes:default',
+        status: 'thinking',
+        label: 'hermes',
+        colorVar: 'var(--sender-hermes)',
+        glyph: 'hermes',
+      },
+    ];
+    await render({
+      messages: [
+        sys(1, { createdAt: '2026-08-03T23:56:00.000Z' }),
+        sys(2, { createdAt: '2026-08-03T23:57:00.000Z' }),
+        sys(3, { createdAt: '2026-08-03T23:58:00.000Z' }),
+        sys(4, { createdAt: '2026-08-04T00:01:00.000Z' }),
+        sys(5, { createdAt: '2026-08-04T00:02:00.000Z' }),
+        sys(6, { createdAt: '2026-08-04T00:03:00.000Z' }),
+      ],
+      lastReadSeq: 4,
+      agentPresence: presence,
+    });
+
+    // Two days → two dividers; the unread line splits the second day's run, so
+    // that day yields a 1-row run (no fold) plus a 2-row run (no fold).
+    expect(container.querySelectorAll('.ch-day-divider')).toHaveLength(2);
+    expect(
+      container.querySelectorAll('[data-channel-unread-divider]')
+    ).toHaveLength(1);
+    expect(container.querySelectorAll('.ch-system-run')).toHaveLength(1);
+    expect(systemRowTexts()).toEqual([
+      'system note 4',
+      'system note 5',
+      'system note 6',
+    ]);
+    expect(container.querySelectorAll('.ch-presence__row')).toHaveLength(1);
+
+    // Order is what proves interleaving: divider, folded run, divider, unread
+    // line, then the day-2 rows.
+    const order = Array.from(
+      container.querySelectorAll(
+        '.ch-day-divider, .ch-system-run, [data-channel-unread-divider], .ch-system-msg, .ch-presence'
+      )
+    ).map((node) => node.className.split(' ')[0]);
+    expect(order).toEqual([
+      'ch-day-divider',
+      'ch-system-run',
+      'ch-day-divider',
+      'ch-system-msg',
+      'ch-unread-line',
+      'ch-system-msg',
+      'ch-system-msg',
+      'ch-presence',
+    ]);
+  });
+
+  it('opens the run holding a deep-link target so the jump never lands on nothing', async () => {
+    await render({ messages: [sys(1), sys(2), sys(3)] });
+    expect(systemRowTexts()).toEqual([]);
+
+    await render({
+      messages: [sys(1), sys(2), sys(3)],
+      jumpTarget: { messageId: 'chm:row-2' as ChannelMessageId, token: 1 },
+    });
+    expect(systemRowTexts()).toEqual([
+      'system note 1',
+      'system note 2',
+      'system note 3',
+    ]);
+    expect(
+      container
+        .querySelector('.ch-msg--jump')
+        ?.getAttribute('data-channel-message-id')
+    ).toBe('chm:row-2');
+  });
+});

--- a/test/components/channel-system-coalescing.test.ts
+++ b/test/components/channel-system-coalescing.test.ts
@@ -17,6 +17,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
@@ -355,5 +356,44 @@ describe('ChannelTimeline — system-run fold', () => {
         .querySelector('.ch-msg--jump')
         ?.getAttribute('data-channel-message-id')
     ).toBe('chm:row-2');
+  });
+
+  it('lets the operator fold a run again after a deep link opened it', async () => {
+    // The jump is one-shot. If the request were never consumed it would keep
+    // forcing the run open for the life of the view and the summary's toggle
+    // would do nothing visible (#1308 review).
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const onJumpConsumed = vi.fn();
+      await render({
+        messages: [sys(1), sys(2), sys(3)],
+        jumpTarget: { messageId: 'chm:row-2' as ChannelMessageId, token: 1 },
+        onJumpConsumed,
+      });
+      expect(summary()?.getAttribute('aria-expanded')).toBe('true');
+
+      await act(async () => {
+        vi.advanceTimersByTime(700);
+      });
+      expect(onJumpConsumed).toHaveBeenCalledTimes(1);
+
+      // What the owner does on consume: drop the request.
+      await render({
+        messages: [sys(1), sys(2), sys(3)],
+        jumpTarget: null,
+        onJumpConsumed,
+      });
+      // Still open — the run was handed to the operator-owned set, not dropped
+      // out from under them the moment the emphasis faded.
+      expect(systemRowTexts()).toHaveLength(3);
+
+      await act(async () => {
+        summary()?.click();
+      });
+      expect(systemRowTexts()).toEqual([]);
+      expect(summary()?.getAttribute('aria-expanded')).toBe('false');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/components/channel-timeline-grouping.test.ts
+++ b/test/components/channel-timeline-grouping.test.ts
@@ -84,7 +84,8 @@ describe('buildTimelineNodes — mixed fixture', () => {
     const nodes = buildTimelineNodes(fixture, null);
     const system = nodes.find((n) => n.kind === 'system');
     expect(system).toBeTruthy();
-    if (system?.kind === 'system') expect(system.message.seq).toBe(7);
+    if (system?.kind === 'system')
+      expect(system.messages.map((m) => m.seq)).toEqual([7]);
   });
 
   it('inserts the unread line before the first message past lastReadSeq', () => {

--- a/test/components/channel-view-archived-actions.test.ts
+++ b/test/components/channel-view-archived-actions.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 1 — an archived channel is READ-ONLY, and the row action lanes
+// must agree with the routes. Edit and delete were already fenced; retry was
+// not, even though it spawns/reuses an agent runtime, writes a durable
+// `retrying @…` system row and appends a whole new agent turn. These assertions
+// read the props `ChannelView` hands the timeline, because that single spread is
+// where the fence lives.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ChannelMessage } from '../../shared/channel-chat-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:operator-lane';
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  archived: false,
+  timelineProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+  };
+});
+
+const message: ChannelMessage = {
+  schemaVersion: 1,
+  id: 'chm:row-1' as ChannelMessage['id'],
+  channelId: CHANNEL_ID,
+  seq: 1,
+  kind: 'message',
+  status: 'complete',
+  sender: { kind: 'human', id: 'human:operator' },
+  body: { text: 'hello', format: 'text' },
+  threadId: null,
+  parentMessageId: null,
+  createdAt: '2026-08-03T00:00:00.000Z',
+  updatedAt: '2026-08-03T00:00:00.000Z',
+};
+
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: CHANNEL_ID,
+      title: 'operator lane',
+      visibility: 'default',
+      archived: mocks.archived,
+      latestSeq: 1,
+      messageCount: 1,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: CHANNEL_ID,
+      messages: [message],
+      lastSeq: 1,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    fullSnapshotRevision: 1,
+    post: vi.fn(),
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+// Capture what the timeline is handed — the fence is a props spread, so the
+// props ARE the behaviour under test.
+vi.mock('../../frontend/src/components/chat/ChannelTimeline.js', () => ({
+  ChannelTimeline: (props: Record<string, unknown>) => {
+    mocks.timelineProps.push(props);
+    return null;
+  },
+}));
+vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
+  ChannelComposer: () => null,
+}));
+vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
+  ChannelThreadPanel: () => null,
+}));
+
+const { ChannelView } = await import(
+  '../../frontend/src/components/chat/ChannelView.js'
+);
+
+describe('ChannelView row actions — archived fence (#1308)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  async function mount(): Promise<Record<string, unknown>> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChannelView, { channelId: CHANNEL_ID })
+        )
+      );
+    });
+    await act(async () => {});
+    const last = mocks.timelineProps[mocks.timelineProps.length - 1];
+    expect(last).toBeDefined();
+    return last!;
+  }
+
+  beforeEach(() => {
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'operator lane' },
+      routingDefaults: {},
+    });
+    mocks.fetchChannelRoster.mockResolvedValue([]);
+    mocks.timelineProps = [];
+    mocks.archived = false;
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+  });
+
+  it('wires retry, edit and delete on a live channel', async () => {
+    const props = await mount();
+    expect(typeof props['onRetryMessage']).toBe('function');
+    expect(typeof props['onEditMessage']).toBe('function');
+    expect(typeof props['onDeleteMessage']).toBe('function');
+  });
+
+  it('withholds retry along with edit and delete once the channel is archived', async () => {
+    mocks.archived = true;
+    const props = await mount();
+    // Retry is a WRITE: the route answers CHANNEL_ARCHIVED, so rendering the
+    // affordance would be a button whose only outcome is an error toast.
+    expect(props['onRetryMessage']).toBeUndefined();
+    expect(props['onEditMessage']).toBeUndefined();
+    expect(props['onDeleteMessage']).toBeUndefined();
+  });
+});

--- a/test/mock-v2-adapter.test.ts
+++ b/test/mock-v2-adapter.test.ts
@@ -166,6 +166,43 @@ describe('MockProtocolAdapterV2', () => {
     });
   });
 
+  // Adapter contract (#1308 review). A channel retry deliberately RE-SENDS the
+  // same deterministic turn id, and `channel_messages` is unique on
+  // (source_runtime_id, source_turn_id, source_item_id) with `ON CONFLICT DO
+  // NOTHING` — so an adapter whose item ids come from the turn alone would have
+  // the whole retried reply silently deduped. Item ids must be unique per SEND.
+  it('mints distinct item ids when the SAME turn id is sent again (retry lane)', async () => {
+    const adapter = new MockProtocolAdapterV2(zeroDelays);
+    const patches = collectPatches(adapter);
+    await adapter.connect(config);
+
+    const itemIdsSince = (from: number): string[] =>
+      patches
+        .slice(from)
+        .flatMap((patch) =>
+          patch.type === 'agent-item-started-v2'
+            ? [patch.item.id]
+            : patch.type === 'agent-item-updated-v2'
+              ? [patch.item.id]
+              : patch.type === 'agent-item-delta-v2'
+                ? [patch.itemId]
+                : []
+        );
+
+    await adapter.sendMessage({ turnId: 'turn-retry', content: 'hello' });
+    const first = itemIdsSince(0);
+    const mark = patches.length;
+    await adapter.sendMessage({ turnId: 'turn-retry', content: 'hello' });
+    const second = itemIdsSince(mark);
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(second.length).toBe(first.length);
+    // No id survives from the first send into the second.
+    expect(second.filter((id) => first.includes(id))).toEqual([]);
+    // The first send keeps the historical shape every other fixture reads.
+    expect(first).toContain('assistant-turn-retry');
+  });
+
   it('emits a happy-path patch stream that reduces to user and assistant items', async () => {
     const adapter = new MockProtocolAdapterV2(zeroDelays);
     const patches = collectPatches(adapter);


### PR DESCRIPTION
Slice 1 of the daily-driver trust epic: the five message-row affordances that make a channel feel like a chat client you can correct yourself in, rather than an append-only log.

## What landed

- **Per-message hover toolbar + message deep links** (`d734baa4`) — a row-scoped action toolbar plus stable `/channel/<segment>#msg-<id>` fragments that select the channel, walk older pages until the row is found, then scroll and emphasize it.
- **Retry a lost agent turn from the message row** (`ca4d2eb6`) — `POST /channels/:id/messages/:messageId/retry` re-runs the turn a mention should have produced, writing a durable `retrying @…` system row before the new turn appends.
- **Edit your own messages in place** (`2631c08b`) — `PATCH /channels/:id/messages/:messageId` rewrites the body of your own human row in place; the row keeps its identity and only body/meta move.
- **Delete your own messages as a tombstone** (`e3fa00a3`) — `DELETE /channels/:id/messages/:messageId` empties the row rather than removing it, and is idempotent so a second device does not surface a spurious error for a state already reached.
- **Coalesce consecutive system rows in the timeline** (`6cb14f4b`) — runs of adjacent system rows fold behind one summary above `SYSTEM_RUN_COLLAPSE_MIN`, keeping retry/mode chatter from burying the conversation.

Review fix pass: `90d93b6d`.

## Seq / packet safety

The store's gap-free `seq` log is the replay buffer for catch-up, unread arithmetic and thread parents, so **neither edit nor delete is ever a row deletion**. Both are in-place mutations: the row keeps its `id`, `seq`, `createdAt`, thread links and client dedupe key, and only body/meta change. Every seq cursor, catch-up window and thread parent therefore stays valid across both, and the invariant is written down at the top of `server/channel-message-store.ts` so a future feature cannot quietly regress it — nothing in that file may issue `DELETE FROM channel_messages` for an operator action.

Context packets follow the same rule from the other side: deleted rows are dropped from the assembled window entirely, with one exception — a tombstoned **thread root** is structural (a thread packet without its root is not buildable), so it is retained as a `[message deleted]` marker rather than handed to the agent as a blank line that reads like an empty message.

Retry deliberately re-sends the same deterministic turn id, which collided with `channel_messages`' `ON CONFLICT DO NOTHING` uniqueness on `(source_runtime_id, source_turn_id, source_item_id)` — the retried reply was silently deduped. Fixed by minting adapter item ids **per send** rather than per turn; the first send keeps the historical `<kind>-<turnId>` shape every fixture reads, and re-sends carry the attempt ordinal.

## New-route inventory

Three new routes, all under `/channels/:id/messages/:messageId`: `PATCH` (edit), `DELETE` (delete), `POST …/retry`. All three mount on the existing channel auth lane and gate writes on a `context:write` capability check.

This also closed a pre-existing gap: `/channels/*` was **not** in `AUTH_ROUTE_LANE_INVENTORY` at all. It is now listed in both `server/auth.ts` and the expected-coverage list in `test/auth.test.ts` (the drift guard is a test, not `check`), with the lane note recording that channel routes gate on the capability check rather than on the lane alone.

## Review trail

One adversarial review over the five feature commits, batched into a single fix pass (`90d93b6d`) covering:

- deep-link anchor walk held until the channel's first full snapshot lands, so a pasted `#msg-…` link no longer toasts "not in this chat's recent history" about a row arriving one tick later;
- retry given the archived + human-lane gates edit/delete already carried (`denyMissingCapability` seeds from a client-supplied header, so it was never a scope check — a scoped actor could re-run turns outside `routeWithBrake`'s mention-chain cap);
- retry storm brake de-raced from a TOCTOU (two awaits between reading busy state and enqueueing) to a synchronous per-`(channel, profile)` marker held until `routeOne` settles;
- adapter item ids minted per send (above);
- jump consumed once its emphasis fades, handing the force-opened system run to the operator-owned expanded set — a run opened by a deep link could previously never be folded again.

Re-review verdict: **approve**, with three P3 observations carried as follow-ups (below). No P0/P1 outstanding, and no P2 regression introduced by this branch.

## Follow-ups (P3, not blocking)

- `mock-v2-adapter.ts` — `sendAttempts` is an uncapped per-turn map on a long-lived adapter. Entries are tiny, but it is new unbounded retention; bound it by dropping settled turn ids or a small FIFO. Note it must **not** be cleared in `onDisconnect`: `reconnect()` reuses the same `sessionId`, so a reset there would re-mint attempt 1 and reintroduce the exact collision this fix removed.
- Adapter item-id uniqueness is stated as a contract in `channel-agent-binder.ts` but enforced only by one adapter's test. Worth a shared contract test over the registry asserting a re-sent `turnId` yields a disjoint item-id set. (The turn-derived `user-${turnId}` ids in the Claude/Codex adapters are benign today only because the bridge has no `userMessage` handling and never persists them — incidental, so worth documenting as out of scope.)
- `ChannelTimeline.tsx` — the render still ORs `jumpRunKey === runKey` into `expanded` during the 600ms highlight window, so a click on the summary in that window is swallowed and the run collapses ~600ms later instead of immediately. The original "can never be folded" defect is fixed; this is a smaller residual. Also, `jumpRunKey` is computed for non-collapsible runs, so a deep link into a 1–2 row run seeds that key and the run renders pre-expanded if it later grows.

## Verification

- `npm run check` — 0 errors (220 pre-existing style warnings, unchanged).
- `npm test` — full suite on node 22: **451 files / 5624 tests passed**, 0 failures, exit 0. The known-flaky-under-load files (`sandbox.test.ts`, `FileFeedbackPanel`) both passed in the full run; no isolation rerun needed.

Refs #1308 (slice 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message actions for copying links or text, editing, deleting, and retrying eligible agent responses.
  * Added inline editing and deletion confirmation, with clear edited and deleted-message states.
  * Added deep links that open and highlight specific channel messages.
  * Collapsed consecutive system updates into expandable summaries.
  * Added retry status, busy-state feedback, and improved message navigation.
* **Bug Fixes**
  * Improved line-break handling for Shift+Enter and input-method composition.
  * Preserved thread anchors and message identity when messages are edited or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->