### PR TITLE
feat(search): full-text message search — FTS5 index, sidebar sections, palette, jump-to-message (#1308 slice 2)

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -40,7 +40,10 @@ import {
   type MessagePaletteResult,
 } from '../lib/command-palette-message-results.js';
 import type { PipelineHandoffArtifactEnvelope } from '../lib/pipeline-handoff-timeline.js';
-import type { ChannelMessageSearchResult } from '../../../shared/channel-chat-protocol.js';
+import {
+  CHANNEL_SEARCH_MIN_QUERY_CHARS,
+  type ChannelMessageSearchResult,
+} from '../../../shared/channel-chat-protocol.js';
 import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
 import { openChannelMessageSelection } from '../lib/topic-selection.js';
 import {
@@ -645,14 +648,20 @@ function useArtifactPaletteResults(
  *
  * `enabled` carries `open` because the palette unmounts nothing when it closes
  * (`usePaletteState` only resets `query` on the way back IN), so without it a
- * closed palette would keep refetching the last query the operator typed.
+ * closed palette would keep refetching the last query the operator typed. It
+ * also carries CHANNEL_SEARCH_MIN_QUERY_CHARS: the palette is a keystroke
+ * surface over the same FTS5 index as the sidebar, and a one-character prefix
+ * query ranks essentially the whole corpus inside a synchronous sqlite call on
+ * the hub's event loop. The server refuses that shape too; this keeps the
+ * palette from asking. Other categories keep answering from the first
+ * character — they are in-memory filters, not index reads.
  */
 function useMessagePaletteResults(
   debouncedQuery: string,
   open: boolean
 ): MessagePaletteResult[] {
   const trimmed = debouncedQuery.trim();
-  const enabled = open && trimmed.length > 0;
+  const enabled = open && trimmed.length >= CHANNEL_SEARCH_MIN_QUERY_CHARS;
   const { data } = useQuery({
     queryKey: ['channel-message-search', 'palette', trimmed],
     queryFn: () =>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -34,12 +34,20 @@ import {
   fetchArtifactPaletteResults,
   type ArtifactPaletteResult,
 } from '../lib/command-palette-artifact-results.js';
+import {
+  buildMessagePaletteResults,
+  MESSAGE_PALETTE_LIMIT,
+  type MessagePaletteResult,
+} from '../lib/command-palette-message-results.js';
 import type { PipelineHandoffArtifactEnvelope } from '../lib/pipeline-handoff-timeline.js';
+import type { ChannelMessageSearchResult } from '../../../shared/channel-chat-protocol.js';
 import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
+import { openChannelMessageSelection } from '../lib/topic-selection.js';
 import {
   executeCommandCenterAssistantCommand,
   fetchWorkspaceTopics,
   resolveCommandCenterAssistantIntent,
+  searchChannelMessages,
 } from '../lib/api.js';
 import {
   commandCenterAssistantCopy,
@@ -167,6 +175,13 @@ type PaletteResult =
       data: PipelineHandoffArtifactEnvelope;
     }
   | {
+      type: 'message';
+      id: string;
+      label: string;
+      sublabel?: string;
+      data: ChannelMessageSearchResult;
+    }
+  | {
       type: 'pr' | 'attention';
       id: string;
       label: string;
@@ -247,6 +262,8 @@ function categoryIcon(type: PaletteResult['type']): string {
       return '▸';
     case 'topic':
       return '◇';
+    case 'message':
+      return '"';
     case 'artifact':
       return '▤';
     case 'pr':
@@ -263,6 +280,13 @@ function categoryIcon(type: PaletteResult['type']): string {
   }
 }
 
+/**
+ * `message` (#1308 slice 2 item 3) deliberately claims no tab of its own, the
+ * same disposition `ticket` has: it shows in `all` and nowhere else. A `topics`
+ * tab that also listed message rows would stop being a filter for topics, and a
+ * ninth tab would cost every operator a longer Tab cycle to buy a filter for a
+ * category that is already capped at five rows.
+ */
 function matchesTab(type: PaletteResult['type'], activeTab: Tab): boolean {
   if (activeTab === 'all') return true;
   if (activeTab === 'sessions') return type === 'session' || type === 'command';
@@ -379,7 +403,9 @@ function buildResults(
   activeTab: Tab,
   actionContext: ActionContext,
   /** Hub-wide artifact search results (#1065) — already fetched+filtered server-side for `q`. */
-  artifactResults: ArtifactPaletteResult[]
+  artifactResults: ArtifactPaletteResult[],
+  /** Hub-wide message search hits (#1308 slice 2) — ranked and capped server-side for `q`. */
+  messageResults: MessagePaletteResult[]
 ): PaletteResult[] {
   const items: PaletteResult[] = [];
   if (!q) {
@@ -436,6 +462,14 @@ function buildResults(
   }
   for (const topic of buildTopicPaletteResults(q, cachedTopics, 5)) {
     items.push(topic);
+  }
+  // Directly after `topics`, the other half of the same question: `topics`
+  // answers "which chat was that?", `messages` answers "where was that said?".
+  // They are never merged into one ranked list — a bm25 body score and a
+  // substring title match share no unit (the sidebar's two sections, #1308
+  // slice 2 item 2, split for the same reason).
+  for (const result of messageResults) {
+    items.push(result);
   }
   for (const result of artifactResults) {
     items.push(result);
@@ -533,6 +567,7 @@ function useGroupedResults(
           { type: 'workspace', label: 'workspaces' },
           { type: 'session', label: 'sessions' },
           { type: 'topic', label: 'topics' },
+          { type: 'message', label: 'messages' },
           { type: 'artifact', label: 'artifacts' },
           { type: 'pr', label: 'pull requests' },
           { type: 'ticket', label: 'tickets' },
@@ -590,6 +625,48 @@ function useArtifactPaletteResults(
   }, [debouncedQuery, cachedTopics, open]);
 
   return results;
+}
+
+/**
+ * Hub-wide message search for the palette (#1308 slice 2 item 3).
+ *
+ * The palette runs its OWN query rather than reading the sidebar's message-search
+ * cache — the #1287/#1289 lesson that `useCachedData` already learned for
+ * topics: `TopicSidebarShell` is the only other producer of that cache entry and
+ * it never mounts while the sidebar is collapsed, so a cache-only palette would
+ * show an empty `messages` category forever for exactly the operators who reach
+ * for a palette instead of a rail.
+ *
+ * The key is namespaced `palette` instead of reusing the sidebar's
+ * `['channel-message-search', q, scope, archive]`. That key does not mention its
+ * own page size, so sharing it would let whichever surface asked first fix the
+ * other's row count — the palette's 5-row answer would become the sidebar's
+ * 20-row section, silently claiming it was not truncated.
+ *
+ * `enabled` carries `open` because the palette unmounts nothing when it closes
+ * (`usePaletteState` only resets `query` on the way back IN), so without it a
+ * closed palette would keep refetching the last query the operator typed.
+ */
+function useMessagePaletteResults(
+  debouncedQuery: string,
+  open: boolean
+): MessagePaletteResult[] {
+  const trimmed = debouncedQuery.trim();
+  const enabled = open && trimmed.length > 0;
+  const { data } = useQuery({
+    queryKey: ['channel-message-search', 'palette', trimmed],
+    queryFn: () =>
+      searchChannelMessages({ q: trimmed, limit: MESSAGE_PALETTE_LIMIT }),
+    enabled,
+    staleTime: 10_000,
+  });
+  return useMemo(
+    // Gate on `enabled`, not just on `data`: a disabled query keeps serving its
+    // last result, which would flash the previous query's hits over an empty
+    // input on the next open.
+    () => (enabled ? buildMessagePaletteResults(data?.results ?? []) : []),
+    [enabled, data]
+  );
 }
 
 // ── usePaletteState hook ───────────────────────────────────────────────────────
@@ -660,6 +737,8 @@ function usePaletteHandlers(
   onSelectTopic: ((topic: WorkspaceTopic) => void) | undefined,
   onSelectPr: (pr: PullRequest) => void,
   cachedActiveWork: WorkContextActiveGroup[],
+  /** Corpus a message hit's channel is resolved against for workspace/repo context. */
+  cachedTopics: WorkspaceTopic[],
   onOpenSettings?: (sectionId: string) => void
 ) {
   const scrollFocusedIntoView = useCallback(() => {
@@ -689,7 +768,23 @@ function usePaletteHandlers(
         onSelectSession(scopedSessionKey(item.data as SessionSummary));
       else if (item.type === 'topic')
         onSelectTopic?.(item.data as WorkspaceTopic);
-      else if (item.type === 'artifact') {
+      else if (item.type === 'message') {
+        // #1308 slice 2 item 3: identical disposition to the sidebar's message
+        // hit — open the channel, then hand `ChannelView` the anchor it already
+        // knows how to resolve (slice 1's bounded history walk, jump highlight,
+        // and reply → thread-panel mapping). Shared gate, not an `onSelect*`
+        // prop, because both entry points must open a hit the same way and a
+        // per-caller prop is exactly how that drifts.
+        const hit = item.data as ChannelMessageSearchResult;
+        openChannelMessageSelection({
+          channelId: hit.channelId,
+          messageId: hit.messageId,
+          // The hit's channel is often absent from the palette's topic corpus
+          // (a message can match in a chat whose title does not); the gate opens
+          // it by id anyway and uses a resolved topic for context only.
+          topic: cachedTopics.find((topic) => topic.id === hit.channelId),
+        });
+      } else if (item.type === 'artifact') {
         // #1065: no direct deep-link into the evidence artifacts tab exists
         // yet (see PR notes) — copy the artifact reference and navigate to
         // the owning workspace as the cheapest existing open path so the
@@ -717,6 +812,7 @@ function usePaletteHandlers(
       onSelectTopic,
       onSelectPr,
       cachedActiveWork,
+      cachedTopics,
       onOpenSettings,
     ]
   );
@@ -1020,6 +1116,7 @@ export function CommandPalette({
     cachedTopics,
     open
   );
+  const messageResults = useMessagePaletteResults(debouncedQuery, open);
 
   const results = useMemo(
     () =>
@@ -1036,7 +1133,8 @@ export function CommandPalette({
         needsAttention,
         activeTab,
         actionContext,
-        artifactResults
+        artifactResults,
+        messageResults
       ),
     [
       debouncedQuery,
@@ -1052,6 +1150,7 @@ export function CommandPalette({
       activeTab,
       actionContext,
       artifactResults,
+      messageResults,
     ]
   );
   const groupedResults = useGroupedResults(results, debouncedQuery);
@@ -1091,6 +1190,7 @@ export function CommandPalette({
     onSelectTopic,
     onSelectPr,
     cachedActiveWork,
+    cachedTopics,
     onOpenSettings
   );
 

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -131,6 +131,109 @@
   grid-column: 1 / -1;
 }
 
+/* #1308 slice 2 item 2: `chats` + `messages` sections under one search field. */
+.topic-search-sections {
+  display: grid;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+}
+
+.topic-search-section__header {
+  padding: 4px 10px 2px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.topic-search-section__empty {
+  padding: 2px 10px 6px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.topic-search-section__empty.error {
+  color: var(--status-warning);
+}
+
+/* The chat section owns the bottom rule for the whole block instead. */
+.topic-search-sections .topic-search-results {
+  border-bottom: 0;
+  padding-top: 0;
+}
+
+.topic-message-results {
+  display: grid;
+  gap: 2px;
+  padding: 0 8px 6px;
+}
+
+.topic-message-result {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  padding: 3px 4px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.58rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.topic-message-result:hover,
+.topic-message-result:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text);
+  outline: none;
+}
+
+.topic-message-result__head {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.topic-message-result__channel {
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topic-message-result__sender,
+.topic-message-result__thread,
+.topic-message-result__archived {
+  white-space: nowrap;
+}
+
+.topic-message-result__time {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+/* Two lines of context, then clip: a hit is a jump affordance, not a reader. */
+.topic-message-result__snippet {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow-wrap: anywhere;
+}
+
+.topic-message-result__hit {
+  background: transparent;
+  color: var(--accent);
+}
+
+.topic-message-result__truncated {
+  padding: 2px 4px;
+  color: var(--text-muted);
+}
+
 .topic-tree,
 .topic-child-list {
   list-style: none;
@@ -1077,6 +1180,19 @@
 
   .topic-archived-toggle {
     padding: 8px 10px;
+  }
+
+  /* #1308 slice 2 item 2: message hits are the panel's only full-row tap
+     target, so they carry the same 44px rhythm as the chat rows below. */
+  .topic-message-result {
+    min-height: 44px;
+    align-content: center;
+    padding: 4px 6px;
+    font-size: var(--font-size-xs);
+  }
+
+  .topic-search-section__empty {
+    font-size: var(--font-size-xs);
   }
 
   .topic-archived-toggle__btn {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
 import {
+  CHANNEL_SEARCH_MIN_QUERY_CHARS,
   parseChannelSearchSnippet,
   parseMentions,
   type ChannelMessageId,
@@ -1968,12 +1969,28 @@ function topicEmptyStateText(input: {
   return `no chat matches for “${input.searchQuery.trim()}”`;
 }
 
+/**
+ * Message-section empty state.
+ *
+ * `unavailableReason` is the server's (or, for a query the client refuses to
+ * send at all, the shell's) statement that the index was NEVER consulted. Each
+ * reason gets its own copy because "no matches" is a factual claim about the
+ * corpus: printing it for a query nothing ever looked up tells the operator
+ * their words are not in the transcript when the truth is that the search never
+ * ran.
+ */
 function messageEmptyStateText(input: {
   unavailableReason?: string | undefined;
   searchQuery: string;
 }): string {
   if (input.unavailableReason === 'empty_query') {
     return 'type to search messages';
+  }
+  if (input.unavailableReason === 'query_too_short') {
+    return `type ${CHANNEL_SEARCH_MIN_QUERY_CHARS} characters to search messages`;
+  }
+  if (input.unavailableReason === 'no_searchable_term') {
+    return 'no searchable term to look up';
   }
   return `no message matches for “${input.searchQuery.trim()}”`;
 }
@@ -3558,6 +3575,15 @@ export function TopicSidebarShell({
   // just the request — the #1288 lesson: two archive states sharing one key
   // serve the first answer to the second question, and the operator sees the
   // toggle do nothing.
+  //
+  // Gated at CHANNEL_SEARCH_MIN_QUERY_CHARS, unlike the chats section above:
+  // chat-title search is a JS scan over a bounded topic list, but a message
+  // query is an FTS5 prefix read whose one-character form ranks essentially the
+  // whole corpus and — synchronous sqlite on the request path — freezes the hub
+  // event loop while it does. The server refuses the same shape; this gate just
+  // means the first keystroke costs no request at all.
+  const messageSearchEnabled =
+    normalizedSearchQuery.length >= CHANNEL_SEARCH_MIN_QUERY_CHARS;
   const messageSearchQuery = useQuery({
     queryKey: [
       'channel-message-search',
@@ -3576,7 +3602,7 @@ export function TopicSidebarShell({
         includeArchived: showArchived,
         ...(scopedWorkspaceId ? { workspaceId: scopedWorkspaceId } : {}),
       }),
-    enabled: normalizedSearchQuery.length > 0,
+    enabled: messageSearchEnabled,
     staleTime: 10_000,
   });
   const surfacesQuery = useQuery<WorkspaceSurface[]>({
@@ -3668,9 +3694,18 @@ export function TopicSidebarShell({
     [searchData]
   );
   const messageSearchData = messageSearchQuery.data;
+  // Read against what is TYPED, not against the settled value: while the
+  // debounce is still running on a third character the section must keep
+  // showing the previous state rather than flashing "type 3 characters" for
+  // one frame on its way to results.
+  const messageSearchTooShort =
+    typedSearchQuery.length < CHANNEL_SEARCH_MIN_QUERY_CHARS;
   const messageResults = useMemo(
-    () => messageSearchData?.results ?? EMPTY_MESSAGE_RESULTS,
-    [messageSearchData]
+    () =>
+      messageSearchTooShort
+        ? EMPTY_MESSAGE_RESULTS
+        : (messageSearchData?.results ?? EMPTY_MESSAGE_RESULTS),
+    [messageSearchTooShort, messageSearchData]
   );
   // Keep the arrays passed to TopicSidebarView referentially stable so its
   // model/topicsById memoization is not invalidated on every render.
@@ -3730,12 +3765,24 @@ export function TopicSidebarShell({
       messageResults={messageResults}
       messageSearchLoading={
         searchActive &&
+        !messageSearchTooShort &&
         (searchDebouncePending ||
           (messageSearchQuery.isFetching && searchSettled))
       }
-      messageSearchError={messageSearchQuery.isError && searchSettled}
-      messageSearchTruncated={messageSearchData?.truncated ?? false}
-      messageSearchUnavailableReason={messageSearchData?.unavailableReason}
+      messageSearchError={
+        !messageSearchTooShort && messageSearchQuery.isError && searchSettled
+      }
+      messageSearchTruncated={
+        messageSearchTooShort ? false : (messageSearchData?.truncated ?? false)
+      }
+      // A refused query never reaches the server, so the reason it would have
+      // sent is synthesized here — otherwise the section falls through to
+      // "no message matches", a claim about a search that never ran.
+      messageSearchUnavailableReason={
+        messageSearchTooShort
+          ? 'query_too_short'
+          : messageSearchData?.unavailableReason
+      }
       onSearchQueryChange={setSearchQuery}
       onSearchRetry={() => {
         void topicSearchQuery.refetch();

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -17,10 +17,7 @@ import {
   MessageSquare,
   TriangleAlert,
 } from 'lucide-react';
-import {
-  builtInAgentProfileId,
-  parseAgentProfileProviderId,
-} from '../../../shared/agent-profile.js';
+import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
 import {
   parseChannelSearchSnippet,
   parseMentions,
@@ -47,6 +44,10 @@ import {
   type ChannelAgentStatus,
 } from '../lib/api.js';
 import type { CockpitRosterAttention } from '../lib/state/cockpit-attention.js';
+import {
+  CURRENT_OPERATOR_SENDER_ID,
+  senderShortLabel,
+} from '../lib/channel-sender-label.js';
 import { deriveColor } from '../lib/colors.js';
 import { resolveSenderIdentity } from '../lib/chat/sender-identity.js';
 import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
@@ -58,6 +59,7 @@ import { AgentAvatar } from './chat/AgentAvatar.js';
 import { leaveChatSurface, openTopicTaskRoom } from '../lib/topic-task-room.js';
 import {
   applyTopicActiveContext,
+  openChannelMessageSelection,
   openTopicSelection,
 } from '../lib/topic-selection.js';
 import type { SessionSummary } from '../lib/types.js';
@@ -149,7 +151,6 @@ const MOBILE_COCKPIT_ROSTER_BATCH_SIZE = 12;
  * refetches.
  */
 const CHANNEL_SUMMARY_REFRESH_THROTTLE_MS = 10_000;
-const CURRENT_OPERATOR_SENDER_ID = 'human:operator';
 const CURRENT_OPERATOR_MENTION_NAME = 'operator';
 
 function useMobileCockpitViewport(): boolean {
@@ -216,54 +217,15 @@ function channelRowPreview(summary: ChannelRailSummary | null): string | null {
 }
 
 /**
- * Short sender label for a row snippet. NEVER derived by splitting `senderId`:
- * an agent's id is its profile Actor id (`agent-profile:<vendor>:default`, or
- * `agent-profile:<vendor>:<uuid>` for a custom profile), so the trailing segment
- * is `default`/a uuid, not a name (#1234, `shared/channel-chat-protocol.ts`).
- * Read the server-resolved `senderDisplayName`, then `providerId`, and only then
- * fall back to the vendor segment of a profile id / the name half of a
- * `human:<actorId>` ref.
+ * Short sender label for a row snippet, over the shared precedence in
+ * `lib/channel-sender-label.ts` (#1308 slice 2 item 3 lifted it there so the
+ * command palette's message hits label senders identically). Kept as a named
+ * wrapper because a rail summary's `lastMessage` is the rail's own shape.
  */
 function channelRowSenderLabel(
   last: NonNullable<ChannelRailSummary['lastMessage']>
 ): string {
   return senderShortLabel(last);
-}
-
-/**
- * The rule itself, over the three fields any sender-bearing row carries. Split
- * out of `channelRowSenderLabel` (#1308 slice 2) so a message-search hit — which
- * is not a `ChannelRailSummary` — labels its sender by the SAME precedence
- * instead of growing a second, drifting copy.
- */
-function senderShortLabel(sender: {
-  senderId: string;
-  senderDisplayName?: string | undefined;
-  providerId?: string | undefined;
-}): string {
-  if (sender.senderId === CURRENT_OPERATOR_SENDER_ID) return 'you';
-  const label =
-    sender.senderDisplayName?.trim() ||
-    sender.providerId?.trim() ||
-    senderLabelFromId(sender.senderId);
-  return label === 'operator' ? 'you' : label;
-}
-
-/** Last-resort label for a sender id with no server-resolved name/vendor. */
-function senderLabelFromId(senderId: string): string {
-  // CLI-gateway actor rows are `agent:<actorId>` where the actor id may itself
-  // be a profile id (`deriveSender`), so unwrap that prefix first.
-  const withoutAgentPrefix = senderId.startsWith('agent:')
-    ? senderId.slice('agent:'.length)
-    : senderId;
-  // `agent-profile:<vendor>:<rest>` — the VENDOR segment names the sender; the
-  // trailing segment is `default` or a uuid.
-  const vendor = parseAgentProfileProviderId(withoutAgentPrefix);
-  if (vendor) return vendor;
-  const separator = withoutAgentPrefix.indexOf(':');
-  return separator === -1
-    ? withoutAgentPrefix
-    : withoutAgentPrefix.slice(separator + 1);
 }
 
 /**
@@ -3222,43 +3184,29 @@ export function TopicSidebarView({
     },
     [onSelectSession, searchResumeTargetFor, select]
   );
-  // #1308 slice 2 item 2: a message hit opens its channel AND asks that channel
-  // to land on the exact message. The anchor is written AFTER the channel open
-  // on purpose — `setActiveChannelId` clears any un-consumed anchor, so the
-  // other order would erase the intent it had just recorded (same contract the
-  // `#msg-` deep link in `useUrlNav` follows, and the same reason
-  // `openThread` records its thread intent second).
+  // #1308 slice 2: a message hit opens its channel AND asks that channel to land
+  // on the exact message. Both writes — and the order they must happen in — live
+  // in `openChannelMessageSelection`, shared with the command palette's
+  // `messages` category (item 3) so the two entry points cannot drift into
+  // opening the same hit differently. The rail-local state (selected row,
+  // mobile control sheet) is all that stays here.
   //
-  // Nothing here resolves, scrolls, or paginates: `ChannelView` already owns the
-  // bounded backwards walk, the not-in-recent-history toast, and the jump
-  // emphasis (#1308 slice 1), and it opens the thread panel by itself when the
-  // landed row turns out to be a reply. Reimplementing any of that here would
-  // give search a second scroll path that could disagree with the deep link.
-  //
-  // A hit's channel is routinely ABSENT from `topicsById`: while searching, the
+  // `topicsById` routinely does NOT hold a hit's channel: while searching, the
   // rail renders the chat-search topics, and a message can match in a channel
-  // whose title does not. `openTopicSelection` is a no-op for anything it
-  // cannot prove persisted, so an unresolved (or non-persisted) id falls back to
-  // the two writes that gate performs rather than silently dropping the click
-  // and leaving an anchor pointed at a channel nobody opened.
+  // whose title does not. The shared gate opens the channel by id regardless and
+  // treats a resolved topic as workspace/repo context only, so an unknown id
+  // still lands the operator on the message instead of dropping the click.
   const openMessageResult = useCallback(
     (hit: ChannelMessageSearchResult) => {
-      const topic = topicsById.get(hit.channelId);
-      if (topic?.source === 'persisted') {
-        // Known topic: route through the shared gate so the hit also lands the
-        // channel's workspace/repo context, exactly like clicking its rail row.
-        select(hit.channelId, topic);
-      } else {
-        setSelectedId(hit.channelId);
-        setMobileControlTopicId(null);
-        const ui = useUiStore.getState();
-        ui.setActiveChannelId(hit.channelId);
-        ui.setTopicComposerOpen(false);
-      }
-      useUiStore.getState().requestChannelMessage(hit.channelId, hit.messageId);
-      useUiStore.getState().closeSidebar();
+      setSelectedId(hit.channelId);
+      setMobileControlTopicId(null);
+      openChannelMessageSelection({
+        channelId: hit.channelId,
+        messageId: hit.messageId,
+        topic: topicsById.get(hit.channelId),
+      });
     },
-    [select, topicsById]
+    [topicsById]
   );
   const selectMobile = useCallback(
     (id: string) => {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -22,8 +22,10 @@ import {
   parseAgentProfileProviderId,
 } from '../../../shared/agent-profile.js';
 import {
+  parseChannelSearchSnippet,
   parseMentions,
   type ChannelMessageId,
+  type ChannelMessageSearchResult,
 } from '../../../shared/channel-chat-protocol.js';
 import type { WorkspaceSurface } from '../../../shared/workspace-surfaces.js';
 import {
@@ -39,6 +41,7 @@ import {
   fetchWorkspaceTopics,
   interruptChannelAgent,
   postChannelMessage,
+  searchChannelMessages,
   searchWorkspaceTopics,
   sendSessionInput,
   type ChannelAgentStatus,
@@ -224,11 +227,25 @@ function channelRowPreview(summary: ChannelRailSummary | null): string | null {
 function channelRowSenderLabel(
   last: NonNullable<ChannelRailSummary['lastMessage']>
 ): string {
-  if (last.senderId === CURRENT_OPERATOR_SENDER_ID) return 'you';
+  return senderShortLabel(last);
+}
+
+/**
+ * The rule itself, over the three fields any sender-bearing row carries. Split
+ * out of `channelRowSenderLabel` (#1308 slice 2) so a message-search hit — which
+ * is not a `ChannelRailSummary` — labels its sender by the SAME precedence
+ * instead of growing a second, drifting copy.
+ */
+function senderShortLabel(sender: {
+  senderId: string;
+  senderDisplayName?: string | undefined;
+  providerId?: string | undefined;
+}): string {
+  if (sender.senderId === CURRENT_OPERATOR_SENDER_ID) return 'you';
   const label =
-    last.senderDisplayName?.trim() ||
-    last.providerId?.trim() ||
-    senderLabelFromId(last.senderId);
+    sender.senderDisplayName?.trim() ||
+    sender.providerId?.trim() ||
+    senderLabelFromId(sender.senderId);
   return label === 'operator' ? 'you' : label;
 }
 
@@ -1989,6 +2006,110 @@ function topicEmptyStateText(input: {
   return `no chat matches for “${input.searchQuery.trim()}”`;
 }
 
+function messageEmptyStateText(input: {
+  unavailableReason?: string | undefined;
+  searchQuery: string;
+}): string {
+  if (input.unavailableReason === 'empty_query') {
+    return 'type to search messages';
+  }
+  return `no message matches for “${input.searchQuery.trim()}”`;
+}
+
+/**
+ * The matched runs of a hit's snippet (#1308 slice 2 item 2).
+ *
+ * The server delimits matches with two Private Use Area sentinels rather than
+ * markup precisely so this stays a TEXT render: every run becomes a text node
+ * and the emphasis is our own element, so an operator or agent message
+ * containing `<mark>` cannot forge a highlight. Emphasis is color
+ * (`var(--accent)`), never a background wash or a weight change — DESIGN.md
+ * keeps one accent and the row is already at caption size, where bolding a
+ * two-character run just makes it blurry.
+ */
+function MessageSnippet({ snippet }: { snippet: string }) {
+  const segments = parseChannelSearchSnippet(snippet);
+  return (
+    <span className="topic-message-result__snippet">
+      {segments.map((segment, index) =>
+        segment.highlight ? (
+          <mark
+            // Index keys: segments are a pure function of one immutable
+            // snippet string, so a given row's runs never reorder.
+            key={index}
+            className="topic-message-result__hit"
+          >
+            {segment.text}
+          </mark>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        )
+      )}
+    </span>
+  );
+}
+
+/**
+ * The `messages` half of sidebar search (#1308 slice 2 item 2).
+ *
+ * A row is ONE button, not a row plus an `open` action: unlike a chat hit —
+ * which may reach a channel, resume a session, or be dead — every message hit
+ * has exactly one destination (that message, in that channel), so a separate
+ * action control would be a second control for the row's only gesture and a
+ * smaller tap target on a phone.
+ */
+function MessageSearchResults({
+  results,
+  truncated,
+  onOpenMessage,
+}: {
+  results: ChannelMessageSearchResult[];
+  truncated: boolean;
+  onOpenMessage: (hit: ChannelMessageSearchResult) => void;
+}) {
+  return (
+    <div
+      className="topic-message-results"
+      aria-label="message search result details"
+    >
+      {results.map((hit) => (
+        <button
+          key={hit.messageId}
+          type="button"
+          className="topic-message-result"
+          data-message-id={hit.messageId}
+          title={`open ${hit.channelTitle} at this message`}
+          onClick={() => onOpenMessage(hit)}
+        >
+          <span className="topic-message-result__head">
+            <span className="topic-message-result__channel">
+              {hit.channelTitle}
+            </span>
+            <span className="topic-message-result__sender">
+              {senderShortLabel(hit)}
+            </span>
+            {hit.threadId ? (
+              <span className="topic-message-result__thread">thread</span>
+            ) : null}
+            {hit.archived ? (
+              <span className="topic-message-result__archived">older</span>
+            ) : null}
+            <span className="topic-message-result__time">
+              {formatRelativeTimeCompact(hit.createdAt)}
+            </span>
+          </span>
+          <MessageSnippet snippet={hit.snippet} />
+        </button>
+      ))}
+      {truncated ? (
+        <div className="topic-message-result__truncated">
+          results truncated; refine search
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function MobileRailRows({
   nodes,
   statusByChannelAgent,
@@ -2255,10 +2376,16 @@ function TopicSearchPanel({
   searchResults,
   searchTruncated,
   searchUnavailableReason,
+  messageResults,
+  messageLoading,
+  messageError,
+  messageTruncated,
+  messageUnavailableReason,
   onSearchQueryChange,
   onSearchRetry,
   onSearchClear,
   onOpenTopic,
+  onOpenMessage,
   searchScope = 'all',
   onToggleSearchScope,
   canScope = false,
@@ -2271,10 +2398,16 @@ function TopicSearchPanel({
   searchResults: WorkspaceTopicSearchResult[];
   searchTruncated: boolean;
   searchUnavailableReason?: string | undefined;
+  messageResults: ChannelMessageSearchResult[];
+  messageLoading: boolean;
+  messageError: boolean;
+  messageTruncated: boolean;
+  messageUnavailableReason?: string | undefined;
   onSearchQueryChange?: ((query: string) => void) | undefined;
   onSearchRetry?: (() => void) | undefined;
   onSearchClear?: (() => void) | undefined;
   onOpenTopic: (result: WorkspaceTopicSearchResult) => void;
+  onOpenMessage: (hit: ChannelMessageSearchResult) => void;
   searchScope?: 'all' | 'workspace';
   onToggleSearchScope?: (() => void) | undefined;
   canScope?: boolean;
@@ -2331,7 +2464,10 @@ function TopicSearchPanel({
           searching chat history…
         </div>
       ) : null}
-      {model.items.length === 0 && !searchLoading && !searchError ? (
+      {!searchActive &&
+      model.items.length === 0 &&
+      !searchLoading &&
+      !searchError ? (
         <div className="topic-shell-state">
           {topicEmptyStateText({
             searchActive,
@@ -2340,13 +2476,61 @@ function TopicSearchPanel({
           })}
         </div>
       ) : null}
+      {/* #1308 slice 2 item 2: search answers two different questions — "which
+          chat was that?" and "where was that said?" — so the results are two
+          labelled sections rather than one ranked list. Merging them would put
+          a bm25 message score in the same order as a topic-title score, two
+          scales that share no unit, and the operator could not tell which kind
+          of answer they were looking at. */}
       {searchActive ? (
-        <TopicSearchResults
-          results={searchResults}
-          truncated={searchTruncated}
-          onOpenTopic={onOpenTopic}
-          resumeTargetFor={resumeTargetFor}
-        />
+        <div className="topic-search-sections" aria-label="search results">
+          <section
+            className="topic-search-section"
+            aria-label="chat search results"
+          >
+            <div className="topic-search-section__header">chats</div>
+            {searchResults.length > 0 || searchTruncated ? (
+              <TopicSearchResults
+                results={searchResults}
+                truncated={searchTruncated}
+                onOpenTopic={onOpenTopic}
+                resumeTargetFor={resumeTargetFor}
+              />
+            ) : searchLoading || searchError ? null : (
+              <div className="topic-search-section__empty">
+                {topicEmptyStateText({
+                  searchActive,
+                  searchUnavailableReason,
+                  searchQuery,
+                })}
+              </div>
+            )}
+          </section>
+          <section
+            className="topic-search-section"
+            aria-label="message search results"
+          >
+            <div className="topic-search-section__header">messages</div>
+            {messageResults.length > 0 ? (
+              <MessageSearchResults
+                results={messageResults}
+                truncated={messageTruncated}
+                onOpenMessage={onOpenMessage}
+              />
+            ) : messageError ? (
+              <div className="topic-search-section__empty error">
+                message search unavailable
+              </div>
+            ) : messageLoading ? null : (
+              <div className="topic-search-section__empty">
+                {messageEmptyStateText({
+                  unavailableReason: messageUnavailableReason,
+                  searchQuery,
+                })}
+              </div>
+            )}
+          </section>
+        </div>
       ) : null}
     </>
   );
@@ -2355,8 +2539,34 @@ function TopicSearchPanel({
 const EMPTY_TOPICS: WorkspaceTopic[] = [];
 const EMPTY_SURFACES: WorkspaceSurface[] = [];
 const EMPTY_SEARCH_RESULTS: WorkspaceTopicSearchResult[] = [];
+const EMPTY_MESSAGE_RESULTS: ChannelMessageSearchResult[] = [];
+
 const EMPTY_WORKSPACES: TopicNavWorkspace[] = [];
 const EMPTY_CHANNEL_SUMMARIES: ChannelRailSummary[] = [];
+
+/**
+ * Settle window for the sidebar search input (#1308 slice 2 item 2). Matches
+ * the command palette's 150ms so the two search affordances feel identical.
+ */
+const SEARCH_DEBOUNCE_MS = 150;
+
+/**
+ * `value`, held back until it has stopped changing for `delayMs`.
+ *
+ * Used for the search field: every keystroke used to mint a fresh TanStack key
+ * and a fresh request, and item 2 adds a SECOND query behind the same field —
+ * doubling that. The debounce lives above both queries rather than inside
+ * either, so one settled value drives both sections.
+ */
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [settled, setSettled] = useState(value);
+  useEffect(() => {
+    if (Object.is(settled, value)) return;
+    const timer = setTimeout(() => setSettled(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [delayMs, settled, value]);
+  return settled;
+}
 
 /** Show/hide older chats toggle; renders nothing without a handler. */
 function ArchivedToggle({
@@ -2657,6 +2867,11 @@ export function TopicSidebarView({
   searchResults = [],
   searchTruncated = false,
   searchUnavailableReason,
+  messageResults = EMPTY_MESSAGE_RESULTS,
+  messageSearchLoading = false,
+  messageSearchError = false,
+  messageSearchTruncated = false,
+  messageSearchUnavailableReason,
   surfacesError = false,
   onSearchQueryChange,
   onSearchRetry,
@@ -2701,6 +2916,12 @@ export function TopicSidebarView({
   searchResults?: WorkspaceTopicSearchResult[];
   searchTruncated?: boolean;
   searchUnavailableReason?: string | undefined;
+  /** #1308 slice 2: full-text message hits for the search panel's second section. */
+  messageResults?: ChannelMessageSearchResult[];
+  messageSearchLoading?: boolean;
+  messageSearchError?: boolean;
+  messageSearchTruncated?: boolean;
+  messageSearchUnavailableReason?: string | undefined;
   surfacesError?: boolean;
   onSearchQueryChange?: ((query: string) => void) | undefined;
   onSearchRetry?: (() => void) | undefined;
@@ -3001,6 +3222,44 @@ export function TopicSidebarView({
     },
     [onSelectSession, searchResumeTargetFor, select]
   );
+  // #1308 slice 2 item 2: a message hit opens its channel AND asks that channel
+  // to land on the exact message. The anchor is written AFTER the channel open
+  // on purpose — `setActiveChannelId` clears any un-consumed anchor, so the
+  // other order would erase the intent it had just recorded (same contract the
+  // `#msg-` deep link in `useUrlNav` follows, and the same reason
+  // `openThread` records its thread intent second).
+  //
+  // Nothing here resolves, scrolls, or paginates: `ChannelView` already owns the
+  // bounded backwards walk, the not-in-recent-history toast, and the jump
+  // emphasis (#1308 slice 1), and it opens the thread panel by itself when the
+  // landed row turns out to be a reply. Reimplementing any of that here would
+  // give search a second scroll path that could disagree with the deep link.
+  //
+  // A hit's channel is routinely ABSENT from `topicsById`: while searching, the
+  // rail renders the chat-search topics, and a message can match in a channel
+  // whose title does not. `openTopicSelection` is a no-op for anything it
+  // cannot prove persisted, so an unresolved (or non-persisted) id falls back to
+  // the two writes that gate performs rather than silently dropping the click
+  // and leaving an anchor pointed at a channel nobody opened.
+  const openMessageResult = useCallback(
+    (hit: ChannelMessageSearchResult) => {
+      const topic = topicsById.get(hit.channelId);
+      if (topic?.source === 'persisted') {
+        // Known topic: route through the shared gate so the hit also lands the
+        // channel's workspace/repo context, exactly like clicking its rail row.
+        select(hit.channelId, topic);
+      } else {
+        setSelectedId(hit.channelId);
+        setMobileControlTopicId(null);
+        const ui = useUiStore.getState();
+        ui.setActiveChannelId(hit.channelId);
+        ui.setTopicComposerOpen(false);
+      }
+      useUiStore.getState().requestChannelMessage(hit.channelId, hit.messageId);
+      useUiStore.getState().closeSidebar();
+    },
+    [select, topicsById]
+  );
   const selectMobile = useCallback(
     (id: string) => {
       select(id);
@@ -3220,10 +3479,16 @@ export function TopicSidebarView({
         searchResults={searchResults}
         searchTruncated={searchTruncated}
         searchUnavailableReason={searchUnavailableReason}
+        messageResults={messageResults}
+        messageLoading={messageSearchLoading}
+        messageError={messageSearchError}
+        messageTruncated={messageSearchTruncated}
+        messageUnavailableReason={messageSearchUnavailableReason}
         onSearchQueryChange={onSearchQueryChange}
         onSearchRetry={onSearchRetry}
         onSearchClear={onSearchClear}
         onOpenTopic={openSearchResult}
+        onOpenMessage={openMessageResult}
         searchScope={searchScope}
         onToggleSearchScope={onToggleSearchScope}
         canScope={activeWorkspaceId != null}
@@ -3295,7 +3560,19 @@ export function TopicSidebarShell({
   const [searchScope, setSearchScope] = useState<'all' | 'workspace'>('all');
   const scopedWorkspaceId =
     searchScope === 'workspace' ? activeWorkspaceId : null;
-  const normalizedSearchQuery = searchQuery.trim();
+  const typedSearchQuery = searchQuery.trim();
+  // ONE debounce for ONE input (#1308 slice 2 item 2). Both sections read this
+  // settled value, so a keystroke costs one topic query and one message query,
+  // and the two sections can never answer different prefixes of what the
+  // operator typed. Sharing it is also why the pending window below is a single
+  // flag: with a debounce per section, "searching…" would clear twice.
+  const normalizedSearchQuery = useDebouncedValue(
+    typedSearchQuery,
+    SEARCH_DEBOUNCE_MS
+  );
+  // Still-typing counts as loading. Without it the panel renders a confident
+  // "no matches" for the PREVIOUS settled query while a newer one is pending.
+  const searchDebouncePending = typedSearchQuery !== normalizedSearchQuery;
   const [showArchived, setShowArchived] = useState(false);
   const topicsQuery = useQuery({
     // Keep the canonical key for the default (active) view so shared cache and
@@ -3322,6 +3599,31 @@ export function TopicSidebarShell({
     queryFn: () =>
       searchWorkspaceTopics({
         q: normalizedSearchQuery,
+        limit: 20,
+        includeArchived: showArchived,
+        ...(scopedWorkspaceId ? { workspaceId: scopedWorkspaceId } : {}),
+      }),
+    enabled: normalizedSearchQuery.length > 0,
+    staleTime: 10_000,
+  });
+  // #1308 slice 2: the `messages` section. `showArchived` rides the KEY, not
+  // just the request — the #1288 lesson: two archive states sharing one key
+  // serve the first answer to the second question, and the operator sees the
+  // toggle do nothing.
+  const messageSearchQuery = useQuery({
+    queryKey: [
+      'channel-message-search',
+      normalizedSearchQuery,
+      scopedWorkspaceId ?? 'all',
+      showArchived ? 'with-archived' : 'active-only',
+    ],
+    queryFn: () =>
+      searchChannelMessages({
+        q: normalizedSearchQuery,
+        // Same page size the chats section asks for: the sidebar is a jump
+        // affordance, and 50 message rows under a 240px rail is a transcript.
+        // The server's `truncated` flag then says "refine" rather than lying
+        // about having found everything.
         limit: 20,
         includeArchived: showArchived,
         ...(scopedWorkspaceId ? { workspaceId: scopedWorkspaceId } : {}),
@@ -3408,11 +3710,19 @@ export function TopicSidebarShell({
       if (timer !== undefined) clearTimeout(timer);
     };
   }, [queryClient]);
-  const searchActive = normalizedSearchQuery.length > 0;
+  // The panel is "searching" from the first keystroke, so the sections mount
+  // against what the operator typed rather than against the settled value.
+  const searchActive = typedSearchQuery.length > 0;
+  const searchSettled = normalizedSearchQuery.length > 0;
   const searchData = topicSearchQuery.data;
   const searchResults = useMemo(
     () => searchData?.results ?? EMPTY_SEARCH_RESULTS,
     [searchData]
+  );
+  const messageSearchData = messageSearchQuery.data;
+  const messageResults = useMemo(
+    () => messageSearchData?.results ?? EMPTY_MESSAGE_RESULTS,
+    [messageSearchData]
   );
   // Keep the arrays passed to TopicSidebarView referentially stable so its
   // model/topicsById memoization is not invalidated on every render.
@@ -3460,13 +3770,29 @@ export function TopicSidebarShell({
           : (topicsQuery.data?.derived ?? false)
       }
       searchQuery={searchQuery}
-      searchLoading={topicSearchQuery.isFetching && searchActive}
-      searchError={topicSearchQuery.isError && searchActive}
+      searchLoading={
+        searchActive &&
+        (searchDebouncePending ||
+          (topicSearchQuery.isFetching && searchSettled))
+      }
+      searchError={topicSearchQuery.isError && searchSettled}
       searchResults={searchResults}
       searchTruncated={searchData?.truncated ?? false}
       searchUnavailableReason={searchData?.unavailableReason}
+      messageResults={messageResults}
+      messageSearchLoading={
+        searchActive &&
+        (searchDebouncePending ||
+          (messageSearchQuery.isFetching && searchSettled))
+      }
+      messageSearchError={messageSearchQuery.isError && searchSettled}
+      messageSearchTruncated={messageSearchData?.truncated ?? false}
+      messageSearchUnavailableReason={messageSearchData?.unavailableReason}
       onSearchQueryChange={setSearchQuery}
-      onSearchRetry={() => void topicSearchQuery.refetch()}
+      onSearchRetry={() => {
+        void topicSearchQuery.refetch();
+        void messageSearchQuery.refetch();
+      }}
       onSearchClear={() => setSearchQuery('')}
       onSelectSession={onSelectSession}
       onCreateTaskRoom={openTopicTaskRoom}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -48,6 +48,8 @@ import type {
   ChannelMessage,
   ChannelMessageId,
   ChannelMessagePart,
+  ChannelMessageSearchResponse,
+  ChannelMessageSearchResult,
 } from '../../../shared/channel-chat-protocol.js';
 import type {
   WorkflowRunProjection,
@@ -1792,6 +1794,53 @@ export async function fetchChannels(): Promise<ChannelSummaryView[]> {
     })
   );
   return Array.isArray(data.channels) ? data.channels : [];
+}
+
+/**
+ * Full-text message search (#1308 slice 2). Rides `channels.history` — the same
+ * durable log, the same capability — so no gateway verb is added.
+ *
+ * `includeArchived` mirrors `searchWorkspaceTopics` so ONE operator control (the
+ * show-older-chats toggle) governs both sidebar sections; the server resolves
+ * archive state from the topic store and scopes the index query by it.
+ *
+ * Every field is re-validated here rather than trusted: this response is fed
+ * straight into a click handler that navigates, so a malformed row must degrade
+ * to "no hits", never to a jump at `undefined`.
+ */
+export async function searchChannelMessages(args: {
+  q: string;
+  includeArchived?: boolean;
+  workspaceId?: string;
+  channelId?: string;
+  limit?: number;
+}): Promise<ChannelMessageSearchResponse> {
+  const params = new URLSearchParams();
+  params.set('q', args.q);
+  if (args.includeArchived) params.set('includeArchived', '1');
+  if (args.workspaceId) params.set('workspaceId', args.workspaceId);
+  if (args.channelId) params.set('channelId', args.channelId);
+  if (args.limit) params.set('limit', String(args.limit));
+  const data = await json<ChannelMessageSearchResponse>(
+    await fetch(`/channels/search?${params.toString()}`, {
+      headers: { 'x-relay-capabilities': 'context:read' },
+    })
+  );
+  const results = Array.isArray(data.results)
+    ? data.results.filter(
+        (hit): hit is ChannelMessageSearchResult =>
+          typeof hit?.messageId === 'string' &&
+          typeof hit.channelId === 'string'
+      )
+    : [];
+  return {
+    query: typeof data.query === 'string' ? data.query : args.q,
+    results,
+    truncated: Boolean(data.truncated),
+    ...(data.unavailableReason
+      ? { unavailableReason: data.unavailableReason }
+      : {}),
+  };
 }
 
 export interface ChannelHistoryPage {

--- a/frontend/src/lib/channel-sender-label.ts
+++ b/frontend/src/lib/channel-sender-label.ts
@@ -1,0 +1,55 @@
+import { parseAgentProfileProviderId } from '../../../shared/agent-profile.js';
+
+/**
+ * Canonical sender id for a browser-authored channel post
+ * (`channel-chat-router` `deriveSender`).
+ */
+export const CURRENT_OPERATOR_SENDER_ID = 'human:operator';
+
+/** The three sender fields every channel row shape carries. */
+export interface ChannelSenderLabelFields {
+  senderId: string;
+  senderDisplayName?: string | undefined;
+  providerId?: string | undefined;
+}
+
+/**
+ * Short sender label for a compact row (rail snippet, search hit, palette
+ * sublabel).
+ *
+ * Lifted out of `TopicSidebarShell` (#1308 slice 2 item 3) because the command
+ * palette now renders message-search hits too, and a second copy of this
+ * precedence would be free to drift into labelling an agent `default`.
+ *
+ * NEVER derived by splitting `senderId`: an agent's id is its profile Actor id
+ * (`agent-profile:<vendor>:default`, or `agent-profile:<vendor>:<uuid>` for a
+ * custom profile), so the trailing segment is `default`/a uuid, not a name
+ * (#1234, `shared/channel-chat-protocol.ts`). Read the server-resolved
+ * `senderDisplayName`, then `providerId`, and only then fall back to the vendor
+ * segment of a profile id / the name half of a `human:<actorId>` ref.
+ */
+export function senderShortLabel(sender: ChannelSenderLabelFields): string {
+  if (sender.senderId === CURRENT_OPERATOR_SENDER_ID) return 'you';
+  const label =
+    sender.senderDisplayName?.trim() ||
+    sender.providerId?.trim() ||
+    senderLabelFromId(sender.senderId);
+  return label === 'operator' ? 'you' : label;
+}
+
+/** Last-resort label for a sender id with no server-resolved name/vendor. */
+export function senderLabelFromId(senderId: string): string {
+  // CLI-gateway actor rows are `agent:<actorId>` where the actor id may itself
+  // be a profile id (`deriveSender`), so unwrap that prefix first.
+  const withoutAgentPrefix = senderId.startsWith('agent:')
+    ? senderId.slice('agent:'.length)
+    : senderId;
+  // `agent-profile:<vendor>:<rest>` — the VENDOR segment names the sender; the
+  // trailing segment is `default` or a uuid.
+  const vendor = parseAgentProfileProviderId(withoutAgentPrefix);
+  if (vendor) return vendor;
+  const separator = withoutAgentPrefix.indexOf(':');
+  return separator === -1
+    ? withoutAgentPrefix
+    : withoutAgentPrefix.slice(separator + 1);
+}

--- a/frontend/src/lib/command-palette-message-results.ts
+++ b/frontend/src/lib/command-palette-message-results.ts
@@ -1,0 +1,84 @@
+import {
+  parseChannelSearchSnippet,
+  type ChannelMessageSearchResult,
+} from '../../../shared/channel-chat-protocol.js';
+import { senderShortLabel } from './channel-sender-label.js';
+
+export interface MessagePaletteResult {
+  type: 'message';
+  id: string;
+  label: string;
+  sublabel: string;
+  data: ChannelMessageSearchResult;
+}
+
+/**
+ * How many message hits the palette shows, and asks the server for.
+ *
+ * Five, the same cap every other palette category uses (`workspaces`,
+ * `sessions`, `topics`, `artifacts`). The palette is a jump affordance stacked
+ * with seven other categories, so a category that spends more rows than its
+ * neighbours pushes them under the fold — the sidebar's `messages` section, with
+ * a panel to itself, is where 20 rows belong.
+ */
+export const MESSAGE_PALETTE_LIMIT = 5;
+
+/**
+ * A server snippet as ONE palette line.
+ *
+ * Two things happen here, both load-bearing:
+ *
+ * - the highlight sentinels are CONSUMED. They are Private Use Area code points
+ *   (`shared/channel-chat-protocol.ts`), so leaving them in would print tofu
+ *   boxes in the middle of every match. The palette row is a single ellipsized
+ *   line of `.item-label`, with no element of its own to hang emphasis on, so
+ *   unlike the sidebar's snippet renderer it drops the runs' emphasis rather
+ *   than rendering it — the query the operator just typed is still on screen in
+ *   the input above.
+ * - whitespace collapses. A message body is multi-line prose or a code block;
+ *   its newlines and runs of indentation would either break the row's single-line
+ *   rhythm or render as a long empty gap before the matched text.
+ */
+export function messagePaletteSnippetText(snippet: string): string {
+  return parseChannelSearchSnippet(snippet)
+    .map((segment) => segment.text)
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function toResult(hit: ChannelMessageSearchResult): MessagePaletteResult {
+  const text = messagePaletteSnippetText(hit.snippet);
+  const where = [hit.channelTitle, senderShortLabel(hit)];
+  // A reply's destination is its thread panel, not the main lane, so the row
+  // says so before the operator commits to the jump.
+  if (hit.threadId) where.push('thread');
+  return {
+    type: 'message',
+    id: `message-${hit.messageId}`,
+    // Indexed rows always carry body text (tombstones are excluded from the
+    // index and system/detail rows never enter it), so the fallback is only
+    // ever reached by a malformed payload — it must still not render an empty,
+    // unclickable-looking row.
+    label: text || '(no preview)',
+    sublabel: where.join(' · '),
+    data: hit,
+  };
+}
+
+/**
+ * Pure mapping from already-fetched search hits to palette result objects,
+ * mirroring `command-palette-topic-results.ts`: the fetch itself lives in the
+ * palette's own query so this stays testable without a network stub.
+ *
+ * The cap is applied here as well as in the request. The server honours
+ * `limit`, but this list is rendered next to seven other capped categories and
+ * a future caller (or a cache entry populated by a wider request) must not be
+ * able to spend the whole palette on messages.
+ */
+export function buildMessagePaletteResults(
+  hits: ChannelMessageSearchResult[],
+  limit = MESSAGE_PALETTE_LIMIT
+): MessagePaletteResult[] {
+  return hits.slice(0, limit).map(toResult);
+}

--- a/frontend/src/lib/topic-selection.ts
+++ b/frontend/src/lib/topic-selection.ts
@@ -1,3 +1,4 @@
+import type { ChannelMessageId } from '../../../shared/channel-chat-protocol.js';
 import {
   resolveTopicActiveContext,
   type WorkspaceTopic,
@@ -47,4 +48,43 @@ export function openTopicSelectionFromPalette(
 ): void {
   openTopicSelection(topic);
   useUiStore.getState().closeSidebar();
+}
+
+/**
+ * Open a channel AND ask it to land on ONE message (#1308 slice 2): the
+ * disposition of every message-search hit, wherever it was clicked — the sidebar
+ * `messages` section (item 2) and the command palette's `messages` category
+ * (item 3). Shared rather than written twice because the ORDER below is a
+ * contract, not a style choice, and a second copy is free to get it backwards.
+ *
+ * Nothing here resolves, scrolls, or paginates. `ChannelView` already owns the
+ * bounded backwards walk, the not-in-recent-history toast, the jump emphasis,
+ * and the reply → thread-panel mapping shipped in slice 1; a second scroll path
+ * here could only disagree with the `#msg-…` deep link.
+ *
+ * The channel is opened by its own id rather than by `topic.id`: a hit's channel
+ * is routinely absent from whatever topic corpus the caller has (chat-title
+ * search returns the chats it matched, and a message can match in a channel
+ * whose title did not), and it is nonetheless a real channel — the message came
+ * out of its log. A topic, when the caller does resolve one, only contributes
+ * the workspace/repo context a rail row would have applied.
+ *
+ * The drawer closes because a jump always changes the main pane, and on mobile
+ * both entry points float over it. On desktop `sidebarOpen` is already false, so
+ * that write is a no-op there.
+ */
+export function openChannelMessageSelection(input: {
+  channelId: string;
+  messageId: ChannelMessageId;
+  topic?: WorkspaceTopic | undefined;
+}): void {
+  applyTopicActiveContext(input.topic);
+  const ui = useUiStore.getState();
+  ui.setActiveChannelId(input.channelId);
+  ui.setTopicComposerOpen(false);
+  // AFTER the open, never before: `setActiveChannelId` clears an un-consumed
+  // anchor, so the other order erases the intent it has just recorded (the same
+  // contract the `#msg-` deep link in `useUrlNav` and `openThread` follow).
+  ui.requestChannelMessage(input.channelId, input.messageId);
+  ui.closeSidebar();
 }

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -36,9 +36,13 @@ import type { WorkspaceTopicStore } from './workspace-topics.js';
 import type { WorkspaceTopic } from '../shared/workspace-topics.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import {
+  CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_QUERY_MAX_CHARS,
   parseMentions,
   type ChannelBodyFormat,
   type ChannelMessage,
+  type ChannelMessageSearchResponse,
+  type ChannelMessageSearchResult,
   type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 
@@ -417,6 +421,23 @@ function parseHistoryLimit(value: unknown): number {
   return Math.max(1, Math.min(CHANNEL_HISTORY_MAX_LIMIT, parsed));
 }
 
+function parseStringQuery(value: unknown): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+/** Same truthiness the `/workspace-topics` search route uses for its flags. */
+function parseBooleanQuery(value: unknown): boolean {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw === 'true' || raw === '1';
+}
+
+function parseSearchLimit(value: unknown): number {
+  const parsed = parseSeqQuery(value);
+  if (parsed === undefined) return CHANNEL_SEARCH_MAX_RESULTS;
+  return Math.max(1, Math.min(CHANNEL_SEARCH_MAX_RESULTS, parsed));
+}
+
 function channelSummaryView(
   store: ChannelMessageStore,
   topic: WorkspaceTopic
@@ -505,6 +526,11 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   const listAuth = deps.requireReadActorAuth?.('channels.list') ?? auth;
   const getAuth = deps.requireReadActorAuth?.('channels.get') ?? auth;
   const historyAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
+  // Search is a filtered read of the same durable message log `channels.history`
+  // already grants, so it rides that verb rather than minting a new gateway
+  // command: a credential that may read a channel's transcript may search it,
+  // and one that may not, cannot.
+  const searchAuth = deps.requireReadActorAuth?.('channels.history') ?? auth;
   const threadHistoryAuth =
     deps.requireReadActorAuth?.('channels.threads.history') ?? auth;
   const postAuth = deps.requireWriteActorAuth?.('channels.post') ?? auth;
@@ -558,6 +584,87 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         )
         .map((topic) => channelSummaryView(store, topic));
       res.json({ channels });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  // MUST stay above `/channels/:id`: Express matches in registration order, and
+  // a literal segment registered after a parameter route is unreachable. (Topic
+  // ids are all `topic:`-prefixed, so `search` can never BE a channel id — the
+  // ordering is about routing, not about a namespace collision.)
+  router.get('/channels/search', searchAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topicStore = topicStoreOr503(res, deps.topicStore);
+    if (!topicStore) return;
+
+    const rawQuery =
+      parseStringQuery(req.query['q']) ?? parseStringQuery(req.query['query']);
+    const query = (rawQuery ?? '')
+      .slice(0, CHANNEL_SEARCH_QUERY_MAX_CHARS)
+      .trim();
+    if (!query) {
+      const empty: ChannelMessageSearchResponse = {
+        query,
+        results: [],
+        truncated: false,
+        unavailableReason: 'empty_query',
+      };
+      res.json(empty);
+      return;
+    }
+    const includeArchived = parseBooleanQuery(req.query['includeArchived']);
+    const limit = parseSearchLimit(req.query['limit']);
+    const scopeChannelId = parseStringQuery(req.query['channelId']);
+    const scopeWorkspaceId = parseStringQuery(req.query['workspaceId']);
+
+    try {
+      // Archive state and titles live in workspace_topics, a SEPARATE database
+      // from the message log, so the visible-channel set is resolved here and
+      // pushed INTO the index query as an allowlist. Filtering after the fact
+      // would let 50 archived hits crowd out live ones and return a short page.
+      // Same bound as `GET /channels` (the store's 200-row list read model), so
+      // search reaches exactly the channels the rail can render.
+      const visible = new Map<string, WorkspaceTopic>();
+      for (const topic of topicStore.list({ includeArchived: true })) {
+        if (topic.source !== 'persisted') continue;
+        if (scopeChannelId && topic.id !== scopeChannelId) continue;
+        if (scopeWorkspaceId && topic.workspaceId !== scopeWorkspaceId)
+          continue;
+        if (!includeArchived && topic.status === 'archived') continue;
+        visible.set(topic.id, topic);
+      }
+      if (visible.size === 0) {
+        const empty: ChannelMessageSearchResponse = {
+          query,
+          results: [],
+          truncated: false,
+        };
+        res.json(empty);
+        return;
+      }
+      // Overfetch by one so `truncated` reports "there were more" without a
+      // second COUNT over the index. The extra row is never returned.
+      const hits = store.searchMessages({
+        query,
+        channelIds: [...visible.keys()],
+        limit: limit + 1,
+      });
+      const truncated = hits.length > limit;
+      const results: ChannelMessageSearchResult[] = hits
+        .slice(0, limit)
+        .map((hit) => {
+          const topic = visible.get(hit.channelId);
+          return {
+            ...hit,
+            channelTitle: topic?.display.title ?? hit.channelId,
+            archived: topic?.status === 'archived',
+          };
+        });
+      const body: ChannelMessageSearchResponse = { query, results, truncated };
+      res.json(body);
     } catch (error) {
       mapStoreError(res, error);
     }

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -14,6 +14,7 @@ import {
   CHANNEL_HISTORY_DEFAULT_LIMIT,
   CHANNEL_HISTORY_MAX_LIMIT,
   ChannelMessageStoreError,
+  channelSearchUnavailableReason,
   type ChannelHistoryFilter,
   type ChannelMessageStore,
 } from './channel-message-store.js';
@@ -605,14 +606,20 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     const query = (rawQuery ?? '')
       .slice(0, CHANNEL_SEARCH_QUERY_MAX_CHARS)
       .trim();
-    if (!query) {
-      const empty: ChannelMessageSearchResponse = {
+    // Asked BEFORE any work: the store owns the predicate for what it will and
+    // will not run (blank text, no letter/digit, one term under the minimum
+    // searchable length), and answering from it keeps "refused" distinguishable
+    // from "consulted and empty". Without the distinction the client prints
+    // "no matches" for a query the index never saw.
+    const unavailableReason = channelSearchUnavailableReason(query);
+    if (unavailableReason) {
+      const unavailable: ChannelMessageSearchResponse = {
         query,
         results: [],
         truncated: false,
-        unavailableReason: 'empty_query',
+        unavailableReason,
       };
-      res.json(empty);
+      res.json(unavailable);
       return;
     }
     const includeArchived = parseBooleanQuery(req.query['includeArchived']);
@@ -625,12 +632,26 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       // from the message log, so the visible-channel set is resolved here and
       // pushed INTO the index query as an allowlist. Filtering after the fact
       // would let 50 archived hits crowd out live ones and return a short page.
-      // Same bound as `GET /channels` (the store's 200-row list read model), so
-      // search reaches exactly the channels the rail can render.
+      //
+      // Enumerated through `listAllTopicIds()`, NOT `list()`. `list()` is the
+      // rail READ MODEL: it caps at WORKSPACE_TOPICS_MAX_LIST_ENTRIES (200) by
+      // `updated_at DESC` across all workspaces while the store retains up to
+      // WORKSPACE_TOPICS_MAX_STORED_ENTRIES (500), so building the allowlist
+      // from it made every message in the 201st-and-older channel silently
+      // unreachable — indexed, matching, and never returned, with no
+      // `truncated` signal to admit it. Worse, the scope filters ran AFTER that
+      // global window, so asking for one workspace narrowed the ANSWER instead
+      // of the search space. Reach must be the corpus; the rail's cap is a
+      // rendering budget. Cost is bounded by the 500-row retention: at most 500
+      // point reads on a debounced, minimum-length query.
+      const candidateIds = scopeChannelId
+        ? [scopeChannelId]
+        : topicStore.listAllTopicIds();
       const visible = new Map<string, WorkspaceTopic>();
-      for (const topic of topicStore.list({ includeArchived: true })) {
+      for (const candidateId of candidateIds) {
+        const topic = topicStore.get(candidateId);
+        if (!topic) continue;
         if (topic.source !== 'persisted') continue;
-        if (scopeChannelId && topic.id !== scopeChannelId) continue;
         if (scopeWorkspaceId && topic.workspaceId !== scopeWorkspaceId)
           continue;
         if (!includeArchived && topic.status === 'archived') continue;

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -12,10 +12,16 @@ import {
   CHANNEL_EDITED_AT_META_KEY,
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
   CHANNEL_MESSAGE_MAX_IMAGE_PARTS,
+  CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+  CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_QUERY_MAX_CHARS,
+  CHANNEL_SEARCH_SNIPPET_ELLIPSIS,
   isChannelMessagePart,
   isChannelAgentDetail,
   parseMentions,
   type ChannelAgentDetail,
+  type ChannelMessageSearchHit,
   type ChannelBodyFormat,
   type ChannelMemberRef,
   type ChannelMention,
@@ -47,7 +53,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 5;
+const SCHEMA_VERSION = 6;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -157,6 +163,199 @@ export function buildChannelThreadSummarySql(): string {
           LIMIT @limit`;
 }
 
+// ── full-text search index (#1308 slice 2 item 1) ───────────────────────────
+
+/** FTS5 virtual table mirroring the searchable subset of `channel_messages`. */
+const CHANNEL_SEARCH_TABLE = 'channel_messages_fts';
+
+/**
+ * Trigger names kept in one list so the boot-time integrity check can assert
+ * the complete set exists — a partially-dropped set is exactly the state that
+ * silently stops indexing while search keeps answering from a stale index.
+ */
+const CHANNEL_SEARCH_TRIGGERS = [
+  'channel_messages_fts_ai',
+  'channel_messages_fts_au',
+  'channel_messages_fts_ad',
+] as const;
+
+/** Terms accepted from one query; a longer query is a paste, not a search. */
+const CHANNEL_SEARCH_MAX_TERMS = 12;
+
+/** `snippet()` window, in tokens (FTS5 allows 1..64). */
+const CHANNEL_SEARCH_SNIPPET_TOKENS = 20;
+
+/**
+ * Rows the index carries, as a SQL predicate over one alias of
+ * `channel_messages`. Shared verbatim by the sync triggers and the backfill so
+ * the index contents cannot drift from what a rebuild would produce.
+ *
+ * Excluded, in order of why:
+ *  * `kind = 'system'` — hub bookkeeping ("agent restarted", sweep notices).
+ *    Searching for prose must not surface the machine's own chatter.
+ *  * `status = 'streaming'` — a half-written body would be indexed at whatever
+ *    prefix the writer had flushed, then re-indexed on every delta. Streaming
+ *    rows enter the index exactly once, through the finalize UPDATE.
+ *  * `meta.agentDetail IS NOT NULL` — agent detail cards are tool payloads
+ *    (`beginStream` with `text: ''`, finalized with the card in meta), not
+ *    conversation. Same predicate `replyCountSql` and the thread aggregate
+ *    already use, so "what counts as a real message" has ONE definition here.
+ *  * empty `body_text` — nothing to match, and it is also the shape a tombstone
+ *    leaves behind.
+ *  * `meta.deletedAt IS NOT NULL` — a tombstone is the operator's statement
+ *    that this row has no body; an index that still answered for its old text
+ *    would be an undelete through the back door.
+ *
+ * Thread replies are deliberately NOT excluded: a reply is a message, and the
+ * deep link the result row produces resolves a reply to its root and opens the
+ * thread panel (#1308 slice 1).
+ */
+function channelSearchIndexablePredicate(alias: string): string {
+  return `${alias}.kind = 'message'
+      AND ${alias}.status <> 'streaming'
+      AND ${alias}.body_text <> ''
+      AND json_extract(${alias}.meta_json, '$.agentDetail') IS NULL
+      AND json_extract(${alias}.meta_json, '$.${CHANNEL_DELETED_AT_META_KEY}') IS NULL`;
+}
+
+/**
+ * DDL for the index and its sync triggers.
+ *
+ * `content='channel_messages'` is the EXTERNAL CONTENT form: FTS5 stores only
+ * the inverted index and reads column values back from the source row by
+ * rowid, so a 256KB body is never duplicated on disk. `id`/`channel_id` ride
+ * along as UNINDEXED columns — they name the hit for `snippet()`-adjacent
+ * reads without polluting the term dictionary with opaque `topic:`/`chm:`
+ * identifiers, and channel scoping is done by joining back to
+ * `channel_messages` (a real index) rather than by matching an id as text.
+ *
+ * Tokenizer: `unicode61 remove_diacritics 2` (NOT `porter`). Channel bodies are
+ * dense with identifiers — file paths, symbol names, branch names, error codes
+ * — and the operator is nearly always searching for a literal string they
+ * remember seeing. Porter stemming would fold `running`/`runs` together, but it
+ * would equally fold `Files`→`file` and mangle identifier fragments, making an
+ * exact-token search for code lossy and its misses unexplainable. `unicode61`
+ * gives predictable exact-token matching; `remove_diacritics 2` still folds
+ * accents so `café` matches `cafe` without touching ASCII identifiers.
+ *
+ * Sync is TRIGGER-based rather than code-level upsert on purpose: this store
+ * has seven distinct write paths into `channel_messages` (append, begin/update/
+ * finalize stream, provisional-terminal resolution, edit, delete) plus two
+ * sweeps that delete rows outright. A trigger cannot be forgotten by a future
+ * eighth path; a call site can. The `'delete'` command form is required by
+ * external-content FTS5 — it must be handed the ORIGINAL column values so the
+ * matching index entries can be found before the row changed.
+ */
+const CHANNEL_SEARCH_SCHEMA_SQL = `
+CREATE VIRTUAL TABLE IF NOT EXISTS ${CHANNEL_SEARCH_TABLE} USING fts5(
+  id UNINDEXED,
+  channel_id UNINDEXED,
+  body_text,
+  content='channel_messages',
+  tokenize='unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER IF NOT EXISTS channel_messages_fts_ai
+AFTER INSERT ON channel_messages BEGIN
+  INSERT INTO ${CHANNEL_SEARCH_TABLE}(rowid, id, channel_id, body_text)
+  SELECT new.rowid, new.id, new.channel_id, new.body_text
+   WHERE ${channelSearchIndexablePredicate('new')};
+END;
+
+CREATE TRIGGER IF NOT EXISTS channel_messages_fts_ad
+AFTER DELETE ON channel_messages BEGIN
+  INSERT INTO ${CHANNEL_SEARCH_TABLE}(${CHANNEL_SEARCH_TABLE}, rowid, id, channel_id, body_text)
+  SELECT 'delete', old.rowid, old.id, old.channel_id, old.body_text
+   WHERE ${channelSearchIndexablePredicate('old')};
+END;
+
+CREATE TRIGGER IF NOT EXISTS channel_messages_fts_au
+AFTER UPDATE ON channel_messages BEGIN
+  INSERT INTO ${CHANNEL_SEARCH_TABLE}(${CHANNEL_SEARCH_TABLE}, rowid, id, channel_id, body_text)
+  SELECT 'delete', old.rowid, old.id, old.channel_id, old.body_text
+   WHERE ${channelSearchIndexablePredicate('old')};
+  INSERT INTO ${CHANNEL_SEARCH_TABLE}(rowid, id, channel_id, body_text)
+  SELECT new.rowid, new.id, new.channel_id, new.body_text
+   WHERE ${channelSearchIndexablePredicate('new')};
+END;
+`;
+
+/**
+ * Translate operator text into an FTS5 MATCH expression.
+ *
+ * Every term is emitted as a QUOTED phrase. That is the escaping strategy, not
+ * a stylistic choice: inside a phrase the only character with meaning is `"`
+ * (doubled to escape), so an operator pasting `NOT`, `a:b`, `foo*` or `(` gets
+ * a literal search instead of a syntax error or an accidental operator. The
+ * final term additionally takes the `*` prefix operator so a search feels live
+ * while the operator is still typing the word.
+ *
+ * Terms with no letter or digit are dropped — they would tokenize to an empty
+ * phrase, which FTS5 rejects outright. A query left with no usable term returns
+ * null, and the caller reports it as unsearchable rather than running it.
+ *
+ * Exported for tests: the escaping contract is the security-relevant half of
+ * this feature and deserves direct assertions, not only end-to-end coverage.
+ */
+export function buildChannelSearchMatchQuery(raw: string): string | null {
+  const terms = raw
+    .slice(0, CHANNEL_SEARCH_QUERY_MAX_CHARS)
+    .split(/\s+/)
+    .map((term) => term.replaceAll('"', ' ').trim())
+    .filter((term) => /[\p{L}\p{N}]/u.test(term))
+    .slice(0, CHANNEL_SEARCH_MAX_TERMS);
+  if (terms.length === 0) return null;
+  return terms
+    .map((term, index) =>
+      index === terms.length - 1 ? `"${term}" *` : `"${term}"`
+    )
+    .join(' AND ');
+}
+
+/**
+ * Production search query, exported for the same reason the thread builders
+ * are: a query-plan test can EXPLAIN the exact SQL instead of a hand-copied
+ * approximation that drifts into a full-table walk.
+ *
+ * `CROSS JOIN` is the join-order hint, not a cartesian product (same idiom, and
+ * the same reason, as `buildChannelThreadSummarySql`): SQLite never reorders
+ * across one. With a plain `JOIN`, the `m.channel_id IN (...)` allowlist is
+ * enough to tempt the planner into driving from `channel_messages`
+ * (`SEARCH m USING INDEX idx_chm_channel_seq (channel_id=?)`), which walks
+ * EVERY message in every visible channel and probes the FTS index per row —
+ * turning a term lookup into a full transcript scan that grows with history.
+ * Pinning the order keeps the shape the query-plan test locks in: the FTS index
+ * drives, and `channel_messages` is probed by rowid (its INTEGER PRIMARY KEY
+ * alias), so the allowlist is a filter over matched rows rather than a scan.
+ *
+ * Ranking is bm25 ascending — SQLite returns a more-negative score for a better
+ * match — with newest-first as the tiebreak so two equally relevant rows
+ * present the recent one first.
+ */
+export function buildChannelMessageSearchSql(channelIdCount: number): string {
+  const channelClause =
+    channelIdCount > 0
+      ? `AND m.channel_id IN (${Array.from({ length: channelIdCount }, () => '?').join(', ')})`
+      : '';
+  return `SELECT m.id            AS id,
+                m.channel_id     AS channel_id,
+                m.thread_id      AS thread_id,
+                m.seq            AS seq,
+                m.sender_kind    AS sender_kind,
+                m.sender_id      AS sender_id,
+                m.sender_display AS sender_display,
+                m.meta_json      AS meta_json,
+                m.created_at     AS created_at,
+                snippet(${CHANNEL_SEARCH_TABLE}, 2, ?, ?, ?, ${CHANNEL_SEARCH_SNIPPET_TOKENS}) AS snippet,
+                bm25(${CHANNEL_SEARCH_TABLE}) AS score
+           FROM ${CHANNEL_SEARCH_TABLE}
+           CROSS JOIN channel_messages m ON m.rowid = ${CHANNEL_SEARCH_TABLE}.rowid
+          WHERE ${CHANNEL_SEARCH_TABLE} MATCH ?
+            ${channelClause}
+          ORDER BY score ASC, m.seq DESC
+          LIMIT ?`;
+}
+
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS channel_messages (
   id                TEXT PRIMARY KEY,
@@ -239,6 +438,21 @@ interface ChannelMessageRow {
   updated_at: string;
   completed_at: string | null;
   reply_count?: number;
+}
+
+/** Projection of the FTS join (#1308 slice 2 item 1). */
+interface ChannelSearchRow {
+  id: string;
+  channel_id: string;
+  thread_id: string | null;
+  seq: number;
+  sender_kind: string;
+  sender_id: string;
+  sender_display: string | null;
+  meta_json: string | null;
+  created_at: string;
+  snippet: string;
+  score: number;
 }
 
 /** Projection of the thread aggregate join (#1287 slice 5 item 18). */
@@ -432,6 +646,19 @@ export interface ChannelHistoryFilter {
   threadId?: string;
 }
 
+export interface ChannelMessageSearchQuery {
+  /** Raw operator text; normalized into an FTS5 expression by the store. */
+  query: string;
+  /**
+   * Channels the caller is allowed to see, resolved from the topic store (a
+   * DIFFERENT database, so archive state cannot be filtered in this SQL). An
+   * EMPTY array means "no visible channel" and returns nothing — it is never
+   * read as "no filter", which would leak an archived channel's bodies.
+   */
+  channelIds?: readonly string[];
+  limit?: number;
+}
+
 export interface ChannelBinding {
   channelId: string;
   /** Durable AgentProfile actor identity; binding/session ownership key. */
@@ -509,6 +736,17 @@ export interface ChannelMessageStore {
     clientMessageId: string
   ): ChannelMessage | null;
   history(channelId: string, filter?: ChannelHistoryFilter): ChannelMessage[];
+  /**
+   * Ranked full-text search over durable message bodies (#1308 slice 2 item 1).
+   *
+   * Reads the FTS5 index, never the message table directly, so the searchable
+   * set is exactly what the sync triggers admitted: prose rows only — no system
+   * bookkeeping, no agent detail cards, no tombstones, no half-written streams.
+   * Thread replies ARE included. Returns hits, not `ChannelMessage` rows: a
+   * result is a jump target plus an excerpt, and shipping full 256KB bodies for
+   * 50 hits would make the response a transcript dump.
+   */
+  searchMessages(input: ChannelMessageSearchQuery): ChannelMessageSearchHit[];
   /** Root-inclusive history for one canonical thread. */
   threadHistory(
     channelId: string,
@@ -743,6 +981,27 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
   return message;
 }
 
+function searchRowToHit(row: ChannelSearchRow): ChannelMessageSearchHit {
+  const meta = parseMeta(row.meta_json);
+  const providerId =
+    typeof meta?.['providerId'] === 'string'
+      ? (meta['providerId'] as string)
+      : undefined;
+  return {
+    messageId: row.id as ChannelMessageId,
+    channelId: row.channel_id,
+    threadId: (row.thread_id as ChannelMessageId | null) ?? null,
+    seq: row.seq,
+    snippet: row.snippet,
+    senderKind: row.sender_kind as ChannelSenderRef['kind'],
+    senderId: row.sender_id,
+    ...(row.sender_display ? { senderDisplayName: row.sender_display } : {}),
+    ...(providerId ? { providerId } : {}),
+    createdAt: row.created_at,
+    score: row.score,
+  };
+}
+
 function buildMeta(input: {
   mentions?: ChannelMention[];
   parts?: ChannelMessagePart[];
@@ -944,7 +1203,79 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
   return duplicateIds.size;
 }
 
+/**
+ * Rebuild the search index from `channel_messages`, in place.
+ *
+ * `'delete-all'` rather than FTS5's own `'rebuild'`: `rebuild` re-derives the
+ * index from EVERY content row, which would drag system rows, detail cards,
+ * tombstones and half-written streams back in. The index is a filtered
+ * projection, so the backfill has to apply the same predicate the triggers do.
+ */
+function rebuildChannelSearchIndex(db: Database.Database): number {
+  db.prepare(
+    `INSERT INTO ${CHANNEL_SEARCH_TABLE}(${CHANNEL_SEARCH_TABLE}) VALUES('delete-all')`
+  ).run();
+  const result = db
+    .prepare(
+      `INSERT INTO ${CHANNEL_SEARCH_TABLE}(rowid, id, channel_id, body_text)
+       SELECT m.rowid, m.id, m.channel_id, m.body_text
+         FROM channel_messages m
+        WHERE ${channelSearchIndexablePredicate('m')}`
+    )
+    .run();
+  return result.changes;
+}
+
+/**
+ * Boot-time integrity check for the search index (#1308 slice 2 item 1).
+ *
+ * Runs on EVERY open, not once behind a `schema_version` step, because the
+ * index is a derived artifact: a numbered migration fires exactly once and can
+ * therefore never repair a table or trigger that was dropped afterwards (by an
+ * operator poking at the db, by a restored backup taken mid-migration, or by a
+ * future rebuild of `channel_messages` — the v2 lane already drops and renames
+ * that table, and a DROP takes its triggers with it). Detect-and-rebuild is
+ * cheap: two `sqlite_master` lookups on a healthy db, and a full reindex only
+ * when something is actually missing.
+ *
+ * Idempotent by construction — a healthy db returns before touching anything,
+ * and the repair path is delete-all + backfill, so running it twice produces
+ * the same index as running it once.
+ */
+function ensureChannelSearchIndex(db: Database.Database): void {
+  const hasTable = db
+    .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(CHANNEL_SEARCH_TABLE);
+  const triggerCount = (
+    db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM sqlite_master
+          WHERE type = 'trigger'
+            AND name IN (${CHANNEL_SEARCH_TRIGGERS.map(() => '?').join(', ')})`
+      )
+      .get(...CHANNEL_SEARCH_TRIGGERS) as { count: number }
+  ).count;
+  if (hasTable && triggerCount === CHANNEL_SEARCH_TRIGGERS.length) return;
+
+  const indexed = db.transaction(() => {
+    // A partially-present trigger set is repaired by replacing all three: the
+    // `IF NOT EXISTS` creates below would otherwise leave a stale survivor
+    // whose body predates whatever change caused the repair.
+    for (const trigger of CHANNEL_SEARCH_TRIGGERS) {
+      db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
+    }
+    db.exec(CHANNEL_SEARCH_SCHEMA_SQL);
+    return rebuildChannelSearchIndex(db);
+  })();
+  logger.info('channel search index rebuilt over %d message row(s)', indexed);
+}
+
 function runMigrations(db: Database.Database): void {
+  runSchemaMigrations(db);
+  ensureChannelSearchIndex(db);
+}
+
+function runSchemaMigrations(db: Database.Database): void {
   db.exec(
     'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
   );
@@ -1087,6 +1418,28 @@ function runMigrations(db: Database.Database): void {
         'ALTER TABLE channel_messages RENAME COLUMN source_session_id TO source_runtime_id'
       );
       db.prepare('UPDATE schema_version SET version = 5').run();
+    })();
+  }
+  if (current < 6) {
+    db.transaction(() => {
+      // Search index (#1308 slice 2 item 1). This step only DROPS whatever an
+      // earlier version left behind and records the version — the table, the
+      // triggers and the backfill are built by `ensureChannelSearchIndex`,
+      // which runs unconditionally on every open so a dropped index is
+      // repaired rather than being stranded behind a one-shot migration.
+      // Dropping here is what makes an upgrade re-derive the index under the
+      // CURRENT tokenizer/predicate instead of inheriting an older shape.
+      //
+      // Ordering note: this is the LAST numbered step, so it always runs after
+      // the v2 lane's `DROP TABLE channel_messages` / rename. The v2 rebuild
+      // therefore can never destroy triggers this step created — at v2 time no
+      // FTS object exists yet — and a fresh db skips both by jumping straight
+      // to SCHEMA_VERSION.
+      for (const trigger of CHANNEL_SEARCH_TRIGGERS) {
+        db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
+      }
+      db.exec(`DROP TABLE IF EXISTS ${CHANNEL_SEARCH_TABLE}`);
+      db.prepare('UPDATE schema_version SET version = 6').run();
     })();
   }
 }
@@ -1682,6 +2035,31 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
         )
         .all(params) as ChannelMessageRow[];
       return rows.reverse().map(rowToMessage);
+    },
+
+    searchMessages(input) {
+      const match = buildChannelSearchMatchQuery(input.query);
+      if (match === null) return [];
+      // Distinct + explicit: an empty allowlist is "nothing visible", so it
+      // short-circuits instead of falling through to an unscoped search.
+      const channelIds =
+        input.channelIds === undefined ? null : [...input.channelIds];
+      if (channelIds !== null && channelIds.length === 0) return [];
+      // `+ 1` is the LOOKAHEAD allowance, not a wider page: a caller paging at
+      // the maximum asks for one row past it purely to learn whether more hits
+      // existed. Without it, `truncated` could never be true on a full page.
+      const limit = cleanLimit(input.limit, CHANNEL_SEARCH_MAX_RESULTS + 1);
+      const rows = db
+        .prepare(buildChannelMessageSearchSql(channelIds?.length ?? 0))
+        .all(
+          CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+          CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+          CHANNEL_SEARCH_SNIPPET_ELLIPSIS,
+          match,
+          ...(channelIds ?? []),
+          limit
+        ) as ChannelSearchRow[];
+      return rows.map(searchRowToHit);
     },
 
     threadHistory(channelId, rootMessageId, filter = {}) {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -15,6 +15,7 @@ import {
   CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
   CHANNEL_SEARCH_HIGHLIGHT_OPEN,
   CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_MIN_QUERY_CHARS,
   CHANNEL_SEARCH_QUERY_MAX_CHARS,
   CHANNEL_SEARCH_SNIPPET_ELLIPSIS,
   isChannelMessagePart,
@@ -22,6 +23,7 @@ import {
   parseMentions,
   type ChannelAgentDetail,
   type ChannelMessageSearchHit,
+  type ChannelSearchUnavailableReason,
   type ChannelBodyFormat,
   type ChannelMemberRef,
   type ChannelMention,
@@ -281,33 +283,81 @@ END;
 `;
 
 /**
- * Translate operator text into an FTS5 MATCH expression.
+ * Split operator text into the terms a MATCH expression may quote.
  *
- * Every term is emitted as a QUOTED phrase. That is the escaping strategy, not
- * a stylistic choice: inside a phrase the only character with meaning is `"`
- * (doubled to escape), so an operator pasting `NOT`, `a:b`, `foo*` or `(` gets
- * a literal search instead of a syntax error or an accidental operator. The
- * final term additionally takes the `*` prefix operator so a search feels live
- * while the operator is still typing the word.
- *
- * Terms with no letter or digit are dropped — they would tokenize to an empty
- * phrase, which FTS5 rejects outright. A query left with no usable term returns
- * null, and the caller reports it as unsearchable rather than running it.
- *
- * Exported for tests: the escaping contract is the security-relevant half of
- * this feature and deserves direct assertions, not only end-to-end coverage.
+ * Terms with no letter or digit are dropped. Not because FTS5 would reject them
+ * — `MATCH '"***" *'` and `MATCH '"" *'` both execute cleanly and return zero
+ * rows — but because such a term can only ever contribute an empty phrase, so
+ * running it is a guaranteed-empty index read the caller can answer without a
+ * query. Length is counted in CODE POINTS: `[...term].length` so an astral
+ * character counts once rather than twice as UTF-16 units.
  */
-export function buildChannelSearchMatchQuery(raw: string): string | null {
-  const terms = raw
+function collectChannelSearchTerms(raw: string): string[] {
+  return raw
     .slice(0, CHANNEL_SEARCH_QUERY_MAX_CHARS)
     .split(/\s+/)
     .map((term) => term.replaceAll('"', ' ').trim())
     .filter((term) => /[\p{L}\p{N}]/u.test(term))
     .slice(0, CHANNEL_SEARCH_MAX_TERMS);
-  if (terms.length === 0) return null;
+}
+
+/**
+ * Why this query will not be dispatched to the index, or null when it will be.
+ *
+ * Exported so the route can answer `unavailableReason` from the SAME predicate
+ * the store applies, instead of inferring "no usable term" from an empty result
+ * array — which is indistinguishable from a genuine miss and made the client
+ * print "no matches" for text the index was never asked about.
+ */
+export function channelSearchUnavailableReason(
+  raw: string
+): ChannelSearchUnavailableReason | null {
+  if (raw.trim().length === 0) return 'empty_query';
+  const terms = collectChannelSearchTerms(raw);
+  if (terms.length === 0) return 'no_searchable_term';
+  if (
+    terms.length === 1 &&
+    [...(terms[0] ?? '')].length < CHANNEL_SEARCH_MIN_QUERY_CHARS
+  ) {
+    return 'query_too_short';
+  }
+  return null;
+}
+
+/**
+ * Translate operator text into an FTS5 MATCH expression.
+ *
+ * Every term is emitted as a QUOTED phrase. That is the escaping strategy, not
+ * a stylistic choice: inside a phrase the only character with meaning is `"`
+ * (doubled to escape), so an operator pasting `NOT`, `a:b`, `foo*` or `(` gets
+ * a literal search instead of a syntax error or an accidental operator.
+ *
+ * The final term takes the `*` prefix operator so a search feels live while the
+ * operator is still typing the word — but ONLY once it is at least
+ * `CHANNEL_SEARCH_MIN_QUERY_CHARS` code points long, and a query that reduces
+ * to one term shorter than that is refused outright (null). A one-character
+ * prefix expands to nearly the whole term dictionary, and `bm25()` +
+ * `ORDER BY score` must rank every match before `LIMIT` drops it; with
+ * synchronous better-sqlite3 on the request path that is a multi-second-to-
+ * multi-ten-second freeze of the entire hub event loop, reachable by one
+ * keystroke. Longer queries keep every term: `a` is a fine filter next to a
+ * real word, since the AND already bounds the match set.
+ *
+ * A query with no usable term returns null too, and the caller reports it via
+ * `channelSearchUnavailableReason` rather than running it.
+ *
+ * Exported for tests: the escaping contract is the security-relevant half of
+ * this feature and deserves direct assertions, not only end-to-end coverage.
+ */
+export function buildChannelSearchMatchQuery(raw: string): string | null {
+  if (channelSearchUnavailableReason(raw) !== null) return null;
+  const terms = collectChannelSearchTerms(raw);
+  const last = terms.length - 1;
   return terms
     .map((term, index) =>
-      index === terms.length - 1 ? `"${term}" *` : `"${term}"`
+      index === last && [...term].length >= CHANNEL_SEARCH_MIN_QUERY_CHARS
+        ? `"${term}" *`
+        : `"${term}"`
     )
     .join(' AND ');
 }
@@ -325,8 +375,20 @@ export function buildChannelSearchMatchQuery(raw: string): string | null {
  * EVERY message in every visible channel and probes the FTS index per row —
  * turning a term lookup into a full transcript scan that grows with history.
  * Pinning the order keeps the shape the query-plan test locks in: the FTS index
- * drives, and `channel_messages` is probed by rowid (its INTEGER PRIMARY KEY
- * alias), so the allowlist is a filter over matched rows rather than a scan.
+ * drives, and `channel_messages` is probed by rowid, so the allowlist is a
+ * filter over matched rows rather than a scan.
+ *
+ * That rowid is the table's IMPLICIT one — `channel_messages.id` is `TEXT
+ * PRIMARY KEY`, so there is no INTEGER PRIMARY KEY alias to make it stable.
+ * The external-content index keys every entry by that implicit rowid, which
+ * makes it the join key AND the identity contract:
+ *   * NEVER `VACUUM` (or `INSERT INTO ... SELECT` rebuild) `channel-chat.db`
+ *     without calling `rebuildChannelSearchIndex` afterwards. VACUUM renumbers
+ *     implicit rowids; the index would keep pointing at the OLD numbers and
+ *     search would answer with other channels' bodies under correct-looking
+ *     snippets — silent, and invisible to every existing assertion.
+ *   * `channel_messages` must never be declared `WITHOUT ROWID`; that removes
+ *     the mapping outright. A migration test asserts both of these.
  *
  * Ranking is bm25 ascending — SQLite returns a more-negative score for a better
  * match — with newest-first as the tiebreak so two equally relevant rows
@@ -1204,26 +1266,80 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
 }
 
 /**
+ * Source rows scanned per backfill commit. Bounded so a rebuild never holds one
+ * write transaction over the whole table: a single unbounded transaction grows
+ * the WAL by the size of the entire index and returns SQLITE_BUSY to any other
+ * process that opens the db meanwhile (dev and prod hubs sharing a config dir
+ * do exactly that), for as long as tokenization takes.
+ */
+const CHANNEL_SEARCH_BACKFILL_BATCH_ROWS = 5_000;
+
+/**
  * Rebuild the search index from `channel_messages`, in place.
  *
  * `'delete-all'` rather than FTS5's own `'rebuild'`: `rebuild` re-derives the
  * index from EVERY content row, which would drag system rows, detail cards,
  * tombstones and half-written streams back in. The index is a filtered
  * projection, so the backfill has to apply the same predicate the triggers do.
+ *
+ * Batched over rowid RANGES, not over `LIMIT/OFFSET` of the filtered set: the
+ * range bound comes from the source table's own rowid order, so each commit
+ * scans a bounded slice regardless of how selective the predicate is, and no
+ * row can be skipped or double-indexed by a shifting offset. Callers may pass
+ * `onBatch` to make a long rebuild visible in the journal instead of silent.
+ *
+ * The upper bound is SNAPSHOT once, before the first commit. Splitting the
+ * rebuild into several transactions means the sync triggers are live between
+ * them, so a row appended mid-rebuild is already indexed by the insert trigger;
+ * without the snapshot a later batch would re-scan it and index it twice.
+ * Snapshot below, triggers above, no overlap.
+ *
+ * MUST also be called after any maintenance that renumbers implicit rowids —
+ * see the rowid contract on `buildChannelMessageSearchSql`.
  */
-function rebuildChannelSearchIndex(db: Database.Database): number {
+function rebuildChannelSearchIndex(
+  db: Database.Database,
+  onBatch?: (progress: { scannedThrough: number; indexed: number }) => void
+): number {
   db.prepare(
     `INSERT INTO ${CHANNEL_SEARCH_TABLE}(${CHANNEL_SEARCH_TABLE}) VALUES('delete-all')`
   ).run();
-  const result = db
-    .prepare(
-      `INSERT INTO ${CHANNEL_SEARCH_TABLE}(rowid, id, channel_id, body_text)
-       SELECT m.rowid, m.id, m.channel_id, m.body_text
-         FROM channel_messages m
-        WHERE ${channelSearchIndexablePredicate('m')}`
-    )
-    .run();
-  return result.changes;
+  const snapshotMaxRowid =
+    (
+      db.prepare('SELECT MAX(rowid) AS hi FROM channel_messages').get() as {
+        hi: number | null;
+      }
+    ).hi ?? 0;
+  const nextBound = db.prepare(
+    `SELECT MAX(rowid) AS hi FROM (
+       SELECT rowid FROM channel_messages
+        WHERE rowid > ? AND rowid <= ? ORDER BY rowid LIMIT ?)`
+  );
+  const insertBatch = db.prepare(
+    `INSERT INTO ${CHANNEL_SEARCH_TABLE}(rowid, id, channel_id, body_text)
+     SELECT m.rowid, m.id, m.channel_id, m.body_text
+       FROM channel_messages m
+      WHERE m.rowid > ? AND m.rowid <= ?
+        AND ${channelSearchIndexablePredicate('m')}`
+  );
+  const commitBatch = db.transaction(
+    (from: number, through: number): number =>
+      insertBatch.run(from, through).changes
+  );
+  let indexed = 0;
+  let cursor = 0;
+  while (cursor < snapshotMaxRowid) {
+    const { hi } = nextBound.get(
+      cursor,
+      snapshotMaxRowid,
+      CHANNEL_SEARCH_BACKFILL_BATCH_ROWS
+    ) as { hi: number | null };
+    if (hi === null) break;
+    indexed += commitBatch(cursor, hi);
+    cursor = hi;
+    onBatch?.({ scannedThrough: cursor, indexed });
+  }
+  return indexed;
 }
 
 /**
@@ -1241,6 +1357,16 @@ function rebuildChannelSearchIndex(db: Database.Database): number {
  * Idempotent by construction — a healthy db returns before touching anything,
  * and the repair path is delete-all + backfill, so running it twice produces
  * the same index as running it once.
+ *
+ * The repair is two phases on purpose. The DDL commits FIRST, so the sync
+ * triggers are live for the whole backfill and a row appended mid-rebuild is
+ * indexed by them (the backfill's snapshot bound keeps the two from
+ * overlapping). The backfill then runs in bounded commits OUTSIDE that
+ * transaction — this is the hub boot path, and the previous single-transaction
+ * form held one writer over the entire tokenization pass (measured ~4s per 50k
+ * messages, so ~16s of silent stall on a 200k-message store) with nothing in
+ * the journal to explain the pause. Row counts and elapsed time are logged
+ * either way.
  */
 function ensureChannelSearchIndex(db: Database.Database): void {
   const hasTable = db
@@ -1257,7 +1383,7 @@ function ensureChannelSearchIndex(db: Database.Database): void {
   ).count;
   if (hasTable && triggerCount === CHANNEL_SEARCH_TRIGGERS.length) return;
 
-  const indexed = db.transaction(() => {
+  db.transaction(() => {
     // A partially-present trigger set is repaired by replacing all three: the
     // `IF NOT EXISTS` creates below would otherwise leave a stale survivor
     // whose body predates whatever change caused the repair.
@@ -1265,9 +1391,37 @@ function ensureChannelSearchIndex(db: Database.Database): void {
       db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
     }
     db.exec(CHANNEL_SEARCH_SCHEMA_SQL);
-    return rebuildChannelSearchIndex(db);
   })();
-  logger.info('channel search index rebuilt over %d message row(s)', indexed);
+
+  const sourceRows = (
+    db.prepare('SELECT COUNT(*) AS count FROM channel_messages').get() as {
+      count: number;
+    }
+  ).count;
+  const startedAt = Date.now();
+  logger.info(
+    'channel search index missing; backfilling over %d message row(s)',
+    sourceRows
+  );
+  const indexed = rebuildChannelSearchIndex(
+    db,
+    // One line per commit only once the store is big enough for the rebuild to
+    // be felt; below one batch the start/finish pair already says everything.
+    sourceRows > CHANNEL_SEARCH_BACKFILL_BATCH_ROWS
+      ? (progress) =>
+          logger.info(
+            'channel search backfill: %d row(s) indexed through rowid %d',
+            progress.indexed,
+            progress.scannedThrough
+          )
+      : undefined
+  );
+  logger.info(
+    'channel search index rebuilt over %d message row(s) (%d indexed) in %dms',
+    sourceRows,
+    indexed,
+    Date.now() - startedAt
+  );
 }
 
 function runMigrations(db: Database.Database): void {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -1275,12 +1275,126 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
 const CHANNEL_SEARCH_BACKFILL_BATCH_ROWS = 5_000;
 
 /**
- * Rebuild the search index from `channel_messages`, in place.
+ * Durable completeness marker for the index, and the resume cursor for a
+ * backfill that did not finish.
+ *
+ * Batching the backfill into bounded commits (so boot never holds one writer
+ * over the whole tokenization pass) made a NEW on-disk state reachable: table +
+ * triggers present, index populated only up to some rowid. Presence of the DDL
+ * therefore no longer implies a complete index, and the difference is invisible
+ * — batches walk rowid ASCENDING, so a truncated backfill is missing the NEWEST
+ * messages, which is exactly what an operator searches for. This row is the
+ * only thing that can tell the two apart, so it is written INSIDE the same
+ * transaction that creates the DDL and empties the index, advanced inside each
+ * batch commit, and flipped to `complete` only after the last one.
+ *
+ * Single row by construction (`CHECK (id = 1)`): there is one index per db, and
+ * a second row would be a second, contradictory answer to "is it complete".
+ */
+const CHANNEL_SEARCH_STATE_TABLE = 'channel_search_state';
+
+const CHANNEL_SEARCH_STATE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS ${CHANNEL_SEARCH_STATE_TABLE} (
+  id                    INTEGER PRIMARY KEY CHECK (id = 1),
+  status                TEXT NOT NULL CHECK (status IN ('building','complete')),
+  indexed_through_rowid INTEGER NOT NULL,
+  snapshot_max_rowid    INTEGER NOT NULL,
+  updated_at            TEXT NOT NULL
+);
+`;
+
+type ChannelSearchIndexState = {
+  status: 'building' | 'complete';
+  /** Highest source rowid whose batch has COMMITTED into the index. */
+  indexedThroughRowid: number;
+  /** Upper bound of the backfill, snapshot when it began. */
+  snapshotMaxRowid: number;
+};
+
+/** Marker row, or null when it is absent or unreadable (treat as incomplete). */
+function readChannelSearchIndexState(
+  db: Database.Database
+): ChannelSearchIndexState | null {
+  const row = db
+    .prepare(
+      `SELECT status, indexed_through_rowid, snapshot_max_rowid
+         FROM ${CHANNEL_SEARCH_STATE_TABLE} WHERE id = 1`
+    )
+    .get() as
+    | {
+        status: string;
+        indexed_through_rowid: number;
+        snapshot_max_rowid: number;
+      }
+    | undefined;
+  if (!row) return null;
+  if (row.status !== 'building' && row.status !== 'complete') return null;
+  return {
+    status: row.status,
+    indexedThroughRowid: row.indexed_through_rowid,
+    snapshotMaxRowid: row.snapshot_max_rowid,
+  };
+}
+
+/**
+ * Create the index DDL, empty the index, and claim a backfill — atomically.
+ *
+ * All four steps share one transaction on purpose. `'delete-all'` outside it
+ * would let a crash between the truncate and the marker leave an EMPTIED index
+ * that the next boot mistakes for a resumable partial one, and would then
+ * double-index everything it did keep. Either the whole claim lands (empty
+ * index, marker says `building` from rowid 0) or none of it does (no table, so
+ * the next boot repairs from scratch).
  *
  * `'delete-all'` rather than FTS5's own `'rebuild'`: `rebuild` re-derives the
  * index from EVERY content row, which would drag system rows, detail cards,
  * tombstones and half-written streams back in. The index is a filtered
  * projection, so the backfill has to apply the same predicate the triggers do.
+ *
+ * The upper bound is SNAPSHOT here, before the first batch commits. Splitting
+ * the backfill into several transactions means the sync triggers are live
+ * between them, so a row appended mid-rebuild is already indexed by the insert
+ * trigger; without the snapshot a later batch would re-scan it and index it
+ * twice. Snapshot below, triggers above, no overlap — and the bound is
+ * PERSISTED so a resume keeps the same split instead of re-deriving a newer
+ * bound that would overlap the trigger-indexed tail.
+ */
+function beginChannelSearchBackfill(
+  db: Database.Database
+): ChannelSearchIndexState {
+  return db.transaction((): ChannelSearchIndexState => {
+    // A partially-present trigger set is repaired by replacing all three: the
+    // `IF NOT EXISTS` creates below would otherwise leave a stale survivor
+    // whose body predates whatever change caused the repair.
+    for (const trigger of CHANNEL_SEARCH_TRIGGERS) {
+      db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
+    }
+    db.exec(CHANNEL_SEARCH_SCHEMA_SQL);
+    db.prepare(
+      `INSERT INTO ${CHANNEL_SEARCH_TABLE}(${CHANNEL_SEARCH_TABLE}) VALUES('delete-all')`
+    ).run();
+    const snapshotMaxRowid =
+      (
+        db.prepare('SELECT MAX(rowid) AS hi FROM channel_messages').get() as {
+          hi: number | null;
+        }
+      ).hi ?? 0;
+    db.prepare(
+      `INSERT INTO ${CHANNEL_SEARCH_STATE_TABLE}
+         (id, status, indexed_through_rowid, snapshot_max_rowid, updated_at)
+       VALUES (1, 'building', 0, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         status = 'building',
+         indexed_through_rowid = 0,
+         snapshot_max_rowid = excluded.snapshot_max_rowid,
+         updated_at = excluded.updated_at`
+    ).run(snapshotMaxRowid, new Date().toISOString());
+    return { status: 'building', indexedThroughRowid: 0, snapshotMaxRowid };
+  })();
+}
+
+/**
+ * Run (or finish) the claimed backfill from `state.indexedThroughRowid`.
  *
  * Batched over rowid RANGES, not over `LIMIT/OFFSET` of the filtered set: the
  * range bound comes from the source table's own rowid order, so each commit
@@ -1288,28 +1402,17 @@ const CHANNEL_SEARCH_BACKFILL_BATCH_ROWS = 5_000;
  * row can be skipped or double-indexed by a shifting offset. Callers may pass
  * `onBatch` to make a long rebuild visible in the journal instead of silent.
  *
- * The upper bound is SNAPSHOT once, before the first commit. Splitting the
- * rebuild into several transactions means the sync triggers are live between
- * them, so a row appended mid-rebuild is already indexed by the insert trigger;
- * without the snapshot a later batch would re-scan it and index it twice.
- * Snapshot below, triggers above, no overlap.
- *
- * MUST also be called after any maintenance that renumbers implicit rowids —
- * see the rowid contract on `buildChannelMessageSearchSql`.
+ * The cursor advances INSIDE the batch transaction. A cursor written after the
+ * commit could be lost to a crash in between, and re-running that range would
+ * insert every one of its rows into the index a second time — external-content
+ * FTS5 has no upsert, so duplicates would surface as duplicate hits that a
+ * later `'delete'` only half removes.
  */
-function rebuildChannelSearchIndex(
+function runChannelSearchBackfill(
   db: Database.Database,
+  state: ChannelSearchIndexState,
   onBatch?: (progress: { scannedThrough: number; indexed: number }) => void
 ): number {
-  db.prepare(
-    `INSERT INTO ${CHANNEL_SEARCH_TABLE}(${CHANNEL_SEARCH_TABLE}) VALUES('delete-all')`
-  ).run();
-  const snapshotMaxRowid =
-    (
-      db.prepare('SELECT MAX(rowid) AS hi FROM channel_messages').get() as {
-        hi: number | null;
-      }
-    ).hi ?? 0;
   const nextBound = db.prepare(
     `SELECT MAX(rowid) AS hi FROM (
        SELECT rowid FROM channel_messages
@@ -1322,16 +1425,23 @@ function rebuildChannelSearchIndex(
       WHERE m.rowid > ? AND m.rowid <= ?
         AND ${channelSearchIndexablePredicate('m')}`
   );
+  const advanceCursor = db.prepare(
+    `UPDATE ${CHANNEL_SEARCH_STATE_TABLE}
+        SET indexed_through_rowid = ?, updated_at = ? WHERE id = 1`
+  );
   const commitBatch = db.transaction(
-    (from: number, through: number): number =>
-      insertBatch.run(from, through).changes
+    (from: number, through: number): number => {
+      const { changes } = insertBatch.run(from, through);
+      advanceCursor.run(through, new Date().toISOString());
+      return changes;
+    }
   );
   let indexed = 0;
-  let cursor = 0;
-  while (cursor < snapshotMaxRowid) {
+  let cursor = state.indexedThroughRowid;
+  while (cursor < state.snapshotMaxRowid) {
     const { hi } = nextBound.get(
       cursor,
-      snapshotMaxRowid,
+      state.snapshotMaxRowid,
       CHANNEL_SEARCH_BACKFILL_BATCH_ROWS
     ) as { hi: number | null };
     if (hi === null) break;
@@ -1339,7 +1449,25 @@ function rebuildChannelSearchIndex(
     cursor = hi;
     onBatch?.({ scannedThrough: cursor, indexed });
   }
+  db.prepare(
+    `UPDATE ${CHANNEL_SEARCH_STATE_TABLE}
+        SET status = 'complete', indexed_through_rowid = ?, updated_at = ?
+      WHERE id = 1`
+  ).run(state.snapshotMaxRowid, new Date().toISOString());
   return indexed;
+}
+
+/**
+ * Rebuild the search index from `channel_messages`, in place, from scratch.
+ *
+ * MUST be called after any maintenance that renumbers implicit rowids — see the
+ * rowid contract on `buildChannelMessageSearchSql`.
+ */
+function rebuildChannelSearchIndex(
+  db: Database.Database,
+  onBatch?: (progress: { scannedThrough: number; indexed: number }) => void
+): number {
+  return runChannelSearchBackfill(db, beginChannelSearchBackfill(db), onBatch);
 }
 
 /**
@@ -1358,17 +1486,31 @@ function rebuildChannelSearchIndex(
  * and the repair path is delete-all + backfill, so running it twice produces
  * the same index as running it once.
  *
- * The repair is two phases on purpose. The DDL commits FIRST, so the sync
- * triggers are live for the whole backfill and a row appended mid-rebuild is
- * indexed by them (the backfill's snapshot bound keeps the two from
- * overlapping). The backfill then runs in bounded commits OUTSIDE that
- * transaction — this is the hub boot path, and the previous single-transaction
- * form held one writer over the entire tokenization pass (measured ~4s per 50k
- * messages, so ~16s of silent stall on a 200k-message store) with nothing in
- * the journal to explain the pause. Row counts and elapsed time are logged
- * either way.
+ * "Healthy" is table + all three triggers + a marker row that says the last
+ * backfill FINISHED. Structure alone is not enough: the backfill commits in
+ * bounded batches (below), so `table + triggers + half an index` is reachable
+ * whenever the process dies mid-backfill — an OOM kill or a systemd restart on
+ * the boot path, which is precisely where this runs. Batches walk rowid
+ * ascending, so what a truncated backfill is missing is the NEWEST messages,
+ * and nothing about the schema would ever say so.
+ *
+ * The repair is two phases on purpose. The DDL, the truncate and the `building`
+ * marker commit FIRST, as one transaction, so the sync triggers are live for
+ * the whole backfill and a row appended mid-rebuild is indexed by them (the
+ * backfill's persisted snapshot bound keeps the two from overlapping). The
+ * backfill then runs in bounded commits OUTSIDE that transaction — the previous
+ * single-transaction form held one writer over the entire tokenization pass
+ * (measured ~4s per 50k messages, so ~16s of silent stall on a 200k-message
+ * store) with nothing in the journal to explain the pause.
+ *
+ * An interrupted backfill RESUMES from its cursor rather than restarting: a
+ * store big enough for the pass to be interrupted is a store big enough for
+ * restart-from-zero to be interrupted again at the same place, so restarting
+ * would make a crash-looping hub never converge. Row counts and elapsed time
+ * are logged on every path.
  */
 function ensureChannelSearchIndex(db: Database.Database): void {
+  db.exec(CHANNEL_SEARCH_STATE_SCHEMA_SQL);
   const hasTable = db
     .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
     .get(CHANNEL_SEARCH_TABLE);
@@ -1381,17 +1523,13 @@ function ensureChannelSearchIndex(db: Database.Database): void {
       )
       .get(...CHANNEL_SEARCH_TRIGGERS) as { count: number }
   ).count;
-  if (hasTable && triggerCount === CHANNEL_SEARCH_TRIGGERS.length) return;
-
-  db.transaction(() => {
-    // A partially-present trigger set is repaired by replacing all three: the
-    // `IF NOT EXISTS` creates below would otherwise leave a stale survivor
-    // whose body predates whatever change caused the repair.
-    for (const trigger of CHANNEL_SEARCH_TRIGGERS) {
-      db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
-    }
-    db.exec(CHANNEL_SEARCH_SCHEMA_SQL);
-  })();
+  const structurallyIntact =
+    Boolean(hasTable) && triggerCount === CHANNEL_SEARCH_TRIGGERS.length;
+  // Only an intact structure can carry a trustworthy marker: if the table or a
+  // trigger is gone, whatever the marker claims describes an index that no
+  // longer exists (or stopped being maintained), so it is not read at all.
+  const marker = structurallyIntact ? readChannelSearchIndexState(db) : null;
+  if (marker?.status === 'complete') return;
 
   const sourceRows = (
     db.prepare('SELECT COUNT(*) AS count FROM channel_messages').get() as {
@@ -1399,23 +1537,37 @@ function ensureChannelSearchIndex(db: Database.Database): void {
     }
   ).count;
   const startedAt = Date.now();
-  logger.info(
-    'channel search index missing; backfilling over %d message row(s)',
-    sourceRows
-  );
-  const indexed = rebuildChannelSearchIndex(
-    db,
-    // One line per commit only once the store is big enough for the rebuild to
-    // be felt; below one batch the start/finish pair already says everything.
+  // Resume only when the structure is intact AND a claim exists: a missing
+  // marker under an intact structure is a pre-marker db (or a hand-edited one),
+  // whose index cannot be trusted to line up with any cursor — rebuild it.
+  const resuming = structurallyIntact && marker !== null;
+  if (resuming) {
+    logger.info(
+      'channel search index backfill was interrupted; resuming from rowid %d through %d over %d message row(s)',
+      marker.indexedThroughRowid,
+      marker.snapshotMaxRowid,
+      sourceRows
+    );
+  } else {
+    logger.info(
+      'channel search index missing; backfilling over %d message row(s)',
+      sourceRows
+    );
+  }
+  // One line per commit only once the store is big enough for the rebuild to be
+  // felt; below one batch the start/finish pair already says everything.
+  const onBatch =
     sourceRows > CHANNEL_SEARCH_BACKFILL_BATCH_ROWS
-      ? (progress) =>
+      ? (progress: { scannedThrough: number; indexed: number }) =>
           logger.info(
             'channel search backfill: %d row(s) indexed through rowid %d',
             progress.indexed,
             progress.scannedThrough
           )
-      : undefined
-  );
+      : undefined;
+  const indexed = resuming
+    ? runChannelSearchBackfill(db, marker, onBatch)
+    : rebuildChannelSearchIndex(db, onBatch);
   logger.info(
     'channel search index rebuilt over %d message row(s) (%d indexed) in %dms',
     sourceRows,

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -374,6 +374,39 @@ export const CHANNEL_SEARCH_MAX_RESULTS = 50;
 /** Query text beyond this is truncated before it reaches the index. */
 export const CHANNEL_SEARCH_QUERY_MAX_CHARS = 256;
 
+/**
+ * Shortest term that may carry the FTS5 prefix operator, and the shortest
+ * single-term query that is dispatched to the index at all.
+ *
+ * This is a LOAD-BEARING guard, not a UX nicety. `buildChannelSearchMatchQuery`
+ * appends `*` to the final term so search feels live while typing, and a
+ * one-character prefix expands to essentially the whole term dictionary: every
+ * matching row must then be scored by `bm25()` and sorted before `LIMIT` can
+ * discard it. better-sqlite3 is synchronous and the route runs the query inline,
+ * so on a daily-driver-sized transcript that single keystroke holds the Node
+ * event loop — WebSocket channel traffic, PTY streaming and `/healthz` included
+ * — for as long as the ranking takes (tens of seconds at 50k messages).
+ *
+ * Both halves are enforced server-side (the store refuses to build the
+ * expression) and mirrored client-side (no request is issued at all), because a
+ * UI-only gate is not a guard: the route is reachable by any capability holder.
+ */
+export const CHANNEL_SEARCH_MIN_QUERY_CHARS = 3;
+
+/**
+ * Why a search request produced no index read.
+ *  * `empty_query` — nothing but whitespace was submitted.
+ *  * `query_too_short` — one term below CHANNEL_SEARCH_MIN_QUERY_CHARS, which
+ *    is refused rather than run (see that constant).
+ *  * `no_searchable_term` — text arrived but held no letter or digit (`***`),
+ *    so there is no term to look up.
+ * Absent means the index WAS consulted, so an empty `results` is a real miss.
+ */
+export type ChannelSearchUnavailableReason =
+  | 'empty_query'
+  | 'query_too_short'
+  | 'no_searchable_term';
+
 export interface ChannelSearchSnippetSegment {
   text: string;
   /** true when this run was a matched term and should be emphasized. */
@@ -446,8 +479,13 @@ export interface ChannelMessageSearchResponse {
   results: ChannelMessageSearchResult[];
   /** true when more hits existed than the cap returned. */
   truncated: boolean;
-  /** Set when the query could not be run at all, e.g. it held no searchable term. */
-  unavailableReason?: 'empty_query';
+  /**
+   * Set when the query was never dispatched to the index. Distinguishing this
+   * from a real miss is the whole point: without it a refused query and a
+   * consulted-but-empty index are the same response, and the client claims
+   * "no matches" for text the server declined to look up.
+   */
+  unavailableReason?: ChannelSearchUnavailableReason;
 }
 
 interface ChannelEventBaseV1 {

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -390,6 +390,17 @@ export const CHANNEL_SEARCH_QUERY_MAX_CHARS = 256;
  * Both halves are enforced server-side (the store refuses to build the
  * expression) and mirrored client-side (no request is issued at all), because a
  * UI-only gate is not a guard: the route is reachable by any capability holder.
+ *
+ * Budget this value was chosen against — measured through the production SQL on
+ * a 50k-message / 179MB corpus with a ~20k-term vocabulary: `"w" *` 2805ms
+ * (now refused), `"w1" *` 1079ms (refused), `"w12" *` 158ms, `"the" *` 140ms.
+ * So 3 code points buys ~18x on the worst shape and lands ordinary queries in a
+ * 100-200ms band at that size. It BOUNDS the pathological shape; it does not
+ * bound the worst case, which still grows with corpus size. Anyone widening the
+ * expression (longer prefixes, new operator syntax) is spending that budget and
+ * should re-measure — the durable fix is a wall-clock/progress-handler ceiling
+ * answering `unavailableReason: 'search_timeout'`, or moving the read off the
+ * request thread.
  */
 export const CHANNEL_SEARCH_MIN_QUERY_CHARS = 3;
 

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -343,6 +343,113 @@ export function isChannelMessageTombstone(message: ChannelMessage): boolean {
   );
 }
 
+// ── message search contract (#1308 slice 2 item 1) ──────────────────────────
+
+/**
+ * Snippet highlight sentinels.
+ *
+ * SQLite's `snippet()` wraps every matched term in a caller-supplied pair of
+ * strings. We deliberately do NOT emit markup (`<mark>`, `<b>`, …): the snippet
+ * is derived from an arbitrary operator/agent message body, so any tag we
+ * injected would have to be sanitized again on the client, and a body that
+ * already contains that tag would be indistinguishable from our own marker.
+ *
+ * Instead the delimiters are two Unicode Private Use Area code points. PUA has
+ * no assigned meaning, is never produced by a keyboard or by a model writing
+ * prose or code, survives JSON transport unchanged, and carries no HTML
+ * semantics — so `parseChannelSearchSnippet` can split on them and the renderer
+ * emits plain text nodes plus its own highlight element. (A body that literally
+ * contained U+E000 would confuse the split; that is accepted, it is not
+ * reachable from any real authoring path.)
+ */
+export const CHANNEL_SEARCH_HIGHLIGHT_OPEN = '\uE000';
+export const CHANNEL_SEARCH_HIGHLIGHT_CLOSE = '\uE001';
+
+/** Ellipsis `snippet()` uses when the match is not at a body boundary. */
+export const CHANNEL_SEARCH_SNIPPET_ELLIPSIS = '…';
+
+/** Hard cap on returned hits — search is a jump affordance, not a transcript. */
+export const CHANNEL_SEARCH_MAX_RESULTS = 50;
+
+/** Query text beyond this is truncated before it reaches the index. */
+export const CHANNEL_SEARCH_QUERY_MAX_CHARS = 256;
+
+export interface ChannelSearchSnippetSegment {
+  text: string;
+  /** true when this run was a matched term and should be emphasized. */
+  highlight: boolean;
+}
+
+/**
+ * Split a server snippet into plain/highlighted runs. Shared so the renderer
+ * and the contract test agree on the delimiter by construction rather than by
+ * two copies of the same string literal.
+ */
+export function parseChannelSearchSnippet(
+  snippet: string
+): ChannelSearchSnippetSegment[] {
+  const segments: ChannelSearchSnippetSegment[] = [];
+  let rest = snippet;
+  while (rest.length > 0) {
+    const open = rest.indexOf(CHANNEL_SEARCH_HIGHLIGHT_OPEN);
+    if (open === -1) break;
+    const close = rest.indexOf(CHANNEL_SEARCH_HIGHLIGHT_CLOSE, open + 1);
+    if (close === -1) break;
+    if (open > 0)
+      segments.push({ text: rest.slice(0, open), highlight: false });
+    const inner = rest.slice(open + 1, close);
+    if (inner.length > 0) segments.push({ text: inner, highlight: true });
+    rest = rest.slice(close + 1);
+  }
+  if (rest.length > 0) segments.push({ text: rest, highlight: false });
+  return segments;
+}
+
+/**
+ * One indexed message match. Deliberately jump-shaped: `channelId` +
+ * `messageId` is exactly what the #1308 slice 1 deep link
+ * (`/channel/<segment>#msg-<messageId>`) consumes, so a result row reuses the
+ * shipped bounded-history walk and jump highlight instead of a second
+ * scroll-to-message path.
+ */
+export interface ChannelMessageSearchHit {
+  messageId: ChannelMessageId;
+  channelId: string;
+  /** Canonical thread root when the hit is a reply, else null. */
+  threadId: ChannelMessageId | null;
+  seq: number;
+  /** Highlighted excerpt; split with `parseChannelSearchSnippet`. */
+  snippet: string;
+  senderKind: ChannelSenderKind;
+  senderId: string;
+  /**
+   * Persisted `sender_display`. Never derive a label by splitting `senderId` —
+   * it is a profile Actor id (`agent-profile:<vendor>:default`), not a name.
+   */
+  senderDisplayName?: string;
+  /** Vendor framework id for agent rows; the authoritative label fallback. */
+  providerId?: string;
+  createdAt: string;
+  /** Raw bm25 relevance (more negative is a better match); results are sorted. */
+  score: number;
+}
+
+/** A hit decorated with the channel identity the router resolves. */
+export interface ChannelMessageSearchResult extends ChannelMessageSearchHit {
+  channelTitle: string;
+  archived: boolean;
+}
+
+export interface ChannelMessageSearchResponse {
+  /** Echo of the accepted query text (already length-capped and trimmed). */
+  query: string;
+  results: ChannelMessageSearchResult[];
+  /** true when more hits existed than the cap returned. */
+  truncated: boolean;
+  /** Set when the query could not be run at all, e.g. it held no searchable term. */
+  unavailableReason?: 'empty_query';
+}
+
 interface ChannelEventBaseV1 {
   channelId: string;
   timestamp: string;

--- a/test/channel-chat-protocol.test.ts
+++ b/test/channel-chat-protocol.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyChannelEventV1,
+  CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+  CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  parseChannelSearchSnippet,
   initialChannelReducerState,
   isChannelEventV1,
   parseMentions,
@@ -659,7 +662,9 @@ describe('channel-message-deleted-v1', () => {
         )
       )
     ).toBe(false);
-    expect(isChannelEventV1(deleted(tombstone({ kind: 'system' })))).toBe(false);
+    expect(isChannelEventV1(deleted(tombstone({ kind: 'system' })))).toBe(
+      false
+    );
   });
 
   it('rejects a tombstone arriving on the edit lane', () => {
@@ -774,5 +779,44 @@ describe('parseMentions', () => {
     expect(parseMentions('@claude @claude @Claude', known)).toEqual([
       { raw: '@claude', providerId: 'claude' },
     ]);
+  });
+});
+
+describe('search snippet segmentation (#1308 slice 2 item 1)', () => {
+  const open = CHANNEL_SEARCH_HIGHLIGHT_OPEN;
+  const close = CHANNEL_SEARCH_HIGHLIGHT_CLOSE;
+
+  it('splits a snippet into plain and highlighted runs', () => {
+    expect(
+      parseChannelSearchSnippet(`…ship the ${open}relay${close} hub today`)
+    ).toEqual([
+      { text: '…ship the ', highlight: false },
+      { text: 'relay', highlight: true },
+      { text: ' hub today', highlight: false },
+    ]);
+  });
+
+  it('carries markup-looking body text through as PLAIN text', () => {
+    // The delimiters are Private Use Area code points precisely so a body that
+    // itself contains markup is never mistaken for our own highlight marker.
+    expect(parseChannelSearchSnippet(`<b>${open}bold${close}</b>`)).toEqual([
+      { text: '<b>', highlight: false },
+      { text: 'bold', highlight: true },
+      { text: '</b>', highlight: false },
+    ]);
+  });
+
+  it('degrades to one plain run when no marker pair is present', () => {
+    expect(parseChannelSearchSnippet('no markers here')).toEqual([
+      { text: 'no markers here', highlight: false },
+    ]);
+    // An unbalanced marker must not silently swallow the tail.
+    expect(parseChannelSearchSnippet(`trailing ${open}open`)).toEqual([
+      { text: `trailing ${open}open`, highlight: false },
+    ]);
+  });
+
+  it('returns nothing for an empty snippet', () => {
+    expect(parseChannelSearchSnippet('')).toEqual([]);
   });
 });

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -6,6 +6,8 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  buildChannelMessageSearchSql,
+  buildChannelSearchMatchQuery,
   buildChannelThreadHistorySql,
   buildChannelThreadSummarySql,
   createChannelMessageStore,
@@ -325,7 +327,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(5);
+    ).toBe(6);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -977,7 +979,9 @@ describe('channel-message-store streaming lifecycle', () => {
     expect(thread[0]?.body.text).toBe('');
     expect(s.getMessage(root.id)?.replyCount).toBe(1);
     expect(
-      s.listChannelThreadSummaries('topic:c').threads.map((t) => t.rootMessageId)
+      s
+        .listChannelThreadSummaries('topic:c')
+        .threads.map((t) => t.rootMessageId)
     ).toEqual([root.id]);
   });
 
@@ -1775,5 +1779,246 @@ describe('channel-message-store boot sweeps', () => {
     expect(s.history('topic:gone')).toHaveLength(0);
     expect(s.history('topic:live')).toHaveLength(1);
     expect(s.listMembers('topic:gone')).toHaveLength(0);
+  });
+});
+
+describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => {
+  function seq(s: ChannelMessageStore, channelId: string, text: string) {
+    return s.appendComplete({ channelId, sender: HUMAN, text });
+  }
+
+  it('indexes a durable row on insert and finds it by term', () => {
+    const s = store();
+    const posted = seq(s, 'topic:alpha', 'the deployment pipeline is wedged');
+    const hits = s.searchMessages({ query: 'wedged' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      messageId: posted.id,
+      channelId: 'topic:alpha',
+      seq: posted.seq,
+      senderKind: 'human',
+      senderId: 'human:operator',
+      threadId: null,
+      createdAt: posted.createdAt,
+    });
+    expect(hits[0]?.snippet).toContain('wedged');
+    expect(hits[0]?.score).toBeLessThan(0);
+  });
+
+  it('re-indexes an edited body and stops matching the replaced text', () => {
+    const s = store();
+    const posted = seq(s, 'topic:alpha', 'original haystack sentence');
+    s.editMessage({
+      channelId: 'topic:alpha',
+      messageId: posted.id,
+      editorId: 'human:operator',
+      text: 'replacement needle sentence',
+    });
+    expect(s.searchMessages({ query: 'haystack' })).toHaveLength(0);
+    expect(
+      s.searchMessages({ query: 'needle' }).map((hit) => hit.messageId)
+    ).toEqual([posted.id]);
+  });
+
+  it('drops a tombstoned row out of the index', () => {
+    const s = store();
+    const posted = seq(s, 'topic:alpha', 'secret budget spreadsheet');
+    expect(s.searchMessages({ query: 'spreadsheet' })).toHaveLength(1);
+    s.deleteMessage({
+      channelId: 'topic:alpha',
+      messageId: posted.id,
+      deleterId: 'human:operator',
+    });
+    expect(s.searchMessages({ query: 'spreadsheet' })).toHaveLength(0);
+  });
+
+  it('indexes a streaming row only once it is finalized', () => {
+    const s = store();
+    const streaming = s.beginStream({
+      channelId: 'topic:alpha',
+      sender: AGENT,
+      source: { runtimeId: 'runtime-1', turnId: 'turn-1', itemId: 'item-1' },
+      text: 'partial migrat',
+    });
+    s.updateStreamText(streaming.id, 'partial migration plan');
+    expect(s.searchMessages({ query: 'migration' })).toHaveLength(0);
+
+    s.finalizeStream(streaming.id, {
+      text: 'complete migration plan',
+      status: 'complete',
+    });
+    const hits = s.searchMessages({ query: 'migration' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      messageId: streaming.id,
+      senderKind: 'agent',
+      providerId: 'claude',
+    });
+  });
+
+  it('excludes agent detail cards and system rows, and includes thread replies', () => {
+    const s = store();
+    const root = seq(s, 'topic:alpha', 'kubernetes rollout question');
+    const reply = s.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'kubernetes rollout answer',
+      parentMessageId: root.id,
+    });
+    s.appendComplete({
+      channelId: 'topic:alpha',
+      kind: 'system',
+      sender: { kind: 'system', id: 'system' },
+      text: 'kubernetes agent restarted',
+    });
+    const detail = s.beginStream({
+      channelId: 'topic:alpha',
+      sender: AGENT,
+      source: { runtimeId: 'runtime-2', turnId: 'turn-2', itemId: 'detail-1' },
+      agentDetail: {
+        itemId: 'detail-1',
+        card: {
+          kind: 'thought',
+          title: 'kubernetes get pods',
+          status: 'running',
+          content: 'kubernetes tool payload',
+        },
+      },
+    });
+    s.finalizeStream(detail.id, { text: '', status: 'complete' });
+
+    const ids = s
+      .searchMessages({ query: 'kubernetes' })
+      .map((hit) => hit.messageId);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids)).toEqual(new Set([root.id, reply.id]));
+    expect(
+      s
+        .searchMessages({ query: 'kubernetes' })
+        .find((h) => h.messageId === reply.id)?.threadId
+    ).toBe(root.id);
+  });
+
+  it('ranks the denser match first and caps results', () => {
+    const s = store();
+    seq(s, 'topic:alpha', 'a long note that mentions relay once in passing');
+    const dense = seq(s, 'topic:alpha', 'relay relay relay');
+    const ranked = s.searchMessages({ query: 'relay' });
+    expect(ranked[0]?.messageId).toBe(dense.id);
+    expect(ranked[0]!.score).toBeLessThan(ranked[1]!.score);
+
+    for (let i = 0; i < 60; i += 1) {
+      seq(s, 'topic:alpha', `bulk relay row ${i}`);
+    }
+    expect(s.searchMessages({ query: 'relay' })).toHaveLength(50);
+    expect(s.searchMessages({ query: 'relay', limit: 3 })).toHaveLength(3);
+  });
+
+  it('scopes results to the caller-supplied channel allowlist', () => {
+    const s = store();
+    const visible = seq(s, 'topic:visible', 'shared incident report');
+    seq(s, 'topic:hidden', 'shared incident report');
+    expect(
+      s
+        .searchMessages({ query: 'incident', channelIds: ['topic:visible'] })
+        .map((hit) => hit.messageId)
+    ).toEqual([visible.id]);
+    // An EMPTY allowlist means "nothing visible", never "no filter".
+    expect(s.searchMessages({ query: 'incident', channelIds: [] })).toEqual([]);
+    expect(s.searchMessages({ query: 'incident' })).toHaveLength(2);
+  });
+
+  it('treats operator text as literal terms, never as FTS5 operators', () => {
+    const s = store();
+    const posted = seq(s, 'topic:alpha', 'the NOT gate inverts a signal');
+    expect(buildChannelSearchMatchQuery('NOT gate')).toBe('"NOT" AND "gate" *');
+    expect(
+      s.searchMessages({ query: 'NOT gate' }).map((hit) => hit.messageId)
+    ).toEqual([posted.id]);
+    // A quote cannot terminate the generated phrase.
+    expect(buildChannelSearchMatchQuery('say "hi"')).toBe('"say" AND "hi" *');
+    // Nothing tokenizable is not a query at all.
+    expect(buildChannelSearchMatchQuery('  ***  ')).toBeNull();
+    expect(s.searchMessages({ query: '***' })).toEqual([]);
+  });
+
+  it('backfills an existing db idempotently and rebuilds a dropped index', () => {
+    const file = dbPath();
+    const seeded = createChannelMessageStore(file);
+    seeded.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'durable backfill subject',
+    });
+    const tombstoned = seeded.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'backfill tombstone subject',
+    });
+    seeded.deleteMessage({
+      channelId: 'topic:alpha',
+      messageId: tombstoned.id,
+      deleterId: 'human:operator',
+    });
+    seeded.close();
+
+    // Rewind to a genuine pre-#1308 (v5) db: no index, no triggers, older
+    // schema_version — the exact shape an upgrading hub opens.
+    const raw = new Database(file);
+    raw.exec('DROP TRIGGER channel_messages_fts_ai');
+    raw.exec('DROP TRIGGER channel_messages_fts_au');
+    raw.exec('DROP TRIGGER channel_messages_fts_ad');
+    raw.exec('DROP TABLE channel_messages_fts');
+    raw.exec('UPDATE schema_version SET version = 5');
+    raw.close();
+
+    const reopened = store(file);
+    expect(
+      reopened.searchMessages({ query: 'backfill' }).map((h) => h.snippet)
+    ).toHaveLength(1);
+    expect(reopened.searchMessages({ query: 'tombstone' })).toHaveLength(0);
+    reopened.close();
+
+    // Reopening a healthy db must not duplicate index entries.
+    const again = store(file);
+    expect(again.searchMessages({ query: 'backfill' })).toHaveLength(1);
+    const counted = new Database(file);
+    const rows = counted
+      .prepare(
+        'SELECT COUNT(*) AS count FROM channel_messages_fts WHERE channel_messages_fts MATCH \'"backfill"\''
+      )
+      .get() as { count: number };
+    const version = counted
+      .prepare('SELECT version FROM schema_version')
+      .get() as { version: number };
+    counted.close();
+    expect(rows.count).toBe(1);
+    expect(version.version).toBe(6);
+  });
+
+  it('drives the search from the FTS index, probing messages by rowid', () => {
+    const file = dbPath();
+    const s = store(file);
+    s.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'query plan subject',
+    });
+    const raw = new Database(file);
+    const plan = raw
+      .prepare(`EXPLAIN QUERY PLAN ${buildChannelMessageSearchSql(1)}`)
+      .all('', '', '…', '"plan"', 'topic:alpha', 10) as Array<{
+      detail: string;
+    }>;
+    raw.close();
+    const details = plan.map((row) => row.detail);
+    // The FTS index must DRIVE (first) and `channel_messages` must be probed by
+    // rowid — not the reverse, which walks every message in every allowed
+    // channel. A plain JOIN regresses to exactly that; see the CROSS JOIN note
+    // on `buildChannelMessageSearchSql`.
+    expect(details[0]).toMatch(
+      /channel_messages_fts VIRTUAL TABLE INDEX .*M\d/
+    );
+    expect(details[1]).toMatch(/SEARCH m USING INTEGER PRIMARY KEY/);
   });
 });

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -1962,9 +1962,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
     expect(buildChannelSearchMatchQuery('𝟙𝟚')).toBeNull();
     // A short term next to a real one keeps its exact-phrase filter.
     expect(buildChannelSearchMatchQuery('deploy a')).toBe('"deploy" AND "a"');
-    expect(buildChannelSearchMatchQuery('a deploy')).toBe(
-      '"a" AND "deploy" *'
-    );
+    expect(buildChannelSearchMatchQuery('a deploy')).toBe('"a" AND "deploy" *');
   });
 
   it('names why a refused query was never dispatched to the index', () => {
@@ -2094,6 +2092,127 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
     // 1 anchor + every non-system bulk row, each exactly once.
     expect(indexed.count).toBe(1 + total - total / 10);
     expect(reopened.searchMessages({ query: 'batchword' })).toHaveLength(50);
+  });
+
+  it('finishes a crash-truncated backfill instead of trusting the DDL', () => {
+    const file = dbPath();
+    const seeded = createChannelMessageStore(file);
+    for (let i = 0; i < 6; i += 1) {
+      seeded.appendComplete({
+        channelId: 'topic:alpha',
+        sender: HUMAN,
+        text: `needle${i} shared subject`,
+      });
+    }
+    seeded.close();
+
+    // Reproduce the exact on-disk state a kill mid-backfill leaves behind:
+    // table + all three triggers committed, the marker still claiming
+    // `building`, and index entries present only up to the cursor. Batches walk
+    // rowid ASCENDING, so what is missing is the NEWEST messages — the ones an
+    // operator is most likely to search for, and the shape that a
+    // presence-only integrity check reports as healthy forever.
+    const raw = new Database(file);
+    const cutoff = (
+      raw
+        .prepare(
+          'SELECT rowid AS id FROM channel_messages ORDER BY rowid LIMIT 1 OFFSET 2'
+        )
+        .get() as { id: number }
+    ).id;
+    raw
+      .prepare(
+        `INSERT INTO channel_messages_fts(channel_messages_fts, rowid, id, channel_id, body_text)
+         SELECT 'delete', m.rowid, m.id, m.channel_id, m.body_text
+           FROM channel_messages m WHERE m.rowid > ?`
+      )
+      .run(cutoff);
+    raw
+      .prepare(
+        `UPDATE channel_search_state
+            SET status = 'building',
+                indexed_through_rowid = ?,
+                snapshot_max_rowid =
+                  (SELECT MAX(rowid) FROM channel_messages)`
+      )
+      .run(cutoff);
+    const truncatedTail = (
+      raw
+        .prepare(
+          `SELECT COUNT(*) AS count FROM channel_messages_fts
+            WHERE channel_messages_fts MATCH '"needle5"'`
+        )
+        .get() as { count: number }
+    ).count;
+    raw.close();
+    // Pre-condition: the tail really is unsearchable in the crashed db.
+    expect(truncatedTail).toBe(0);
+
+    const reopened = store(file);
+    expect(reopened.searchMessages({ query: 'needle5' })).toHaveLength(1);
+    expect(reopened.searchMessages({ query: 'needle0' })).toHaveLength(1);
+    // Exactly once each: a resume that re-ran an already-committed range would
+    // double-index the head, and external-content FTS5 has no upsert to absorb
+    // it. This is also why the cursor advances inside the batch transaction.
+    expect(reopened.searchMessages({ query: 'shared' })).toHaveLength(6);
+    reopened.close();
+
+    const marked = new Database(file);
+    const state = marked
+      .prepare(
+        'SELECT status, indexed_through_rowid FROM channel_search_state WHERE id = 1'
+      )
+      .get() as { status: string; indexed_through_rowid: number };
+    const headEntries = marked
+      .prepare(
+        `SELECT COUNT(*) AS count FROM channel_messages_fts
+          WHERE channel_messages_fts MATCH '"needle0"'`
+      )
+      .get() as { count: number };
+    marked.close();
+    expect(state.status).toBe('complete');
+    expect(state.indexed_through_rowid).toBeGreaterThanOrEqual(cutoff);
+    expect(headEntries.count).toBe(1);
+
+    // A second open must be a no-op: the marker, not the DDL, is what says so.
+    const again = store(file);
+    expect(again.searchMessages({ query: 'shared' })).toHaveLength(6);
+  });
+
+  it('rebuilds when the completeness marker is absent under an intact index', () => {
+    const file = dbPath();
+    const seeded = store(file);
+    seeded.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'markerless subject',
+    });
+    seeded.close();
+
+    // A db written before the marker existed (or one an operator edited) has an
+    // index nothing can vouch for. It is not resumable — there is no cursor to
+    // resume from — so it must be rebuilt from scratch, exactly once.
+    const raw = new Database(file);
+    raw.exec('DELETE FROM channel_search_state');
+    raw.close();
+
+    const reopened = store(file);
+    expect(reopened.searchMessages({ query: 'markerless' })).toHaveLength(1);
+    reopened.close();
+
+    const counted = new Database(file);
+    const entries = counted
+      .prepare(
+        `SELECT COUNT(*) AS count FROM channel_messages_fts
+          WHERE channel_messages_fts MATCH '"markerless"'`
+      )
+      .get() as { count: number };
+    const state = counted
+      .prepare('SELECT status FROM channel_search_state WHERE id = 1')
+      .get() as { status: string };
+    counted.close();
+    expect(entries.count).toBe(1);
+    expect(state.status).toBe('complete');
   });
 
   it('keeps the implicit-rowid contract the external-content index rides on', () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -10,11 +10,15 @@ import {
   buildChannelSearchMatchQuery,
   buildChannelThreadHistorySql,
   buildChannelThreadSummarySql,
+  channelSearchUnavailableReason,
   createChannelMessageStore,
   ChannelMessageStoreError,
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
-import type { ChannelSenderRef } from '../shared/channel-chat-protocol.js';
+import {
+  CHANNEL_SEARCH_MIN_QUERY_CHARS,
+  type ChannelSenderRef,
+} from '../shared/channel-chat-protocol.js';
 import { builtInAgentProfileId } from '../shared/agent-profile.js';
 
 const cleanup: Array<() => void> = [];
@@ -1935,11 +1939,50 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
     expect(
       s.searchMessages({ query: 'NOT gate' }).map((hit) => hit.messageId)
     ).toEqual([posted.id]);
-    // A quote cannot terminate the generated phrase.
-    expect(buildChannelSearchMatchQuery('say "hi"')).toBe('"say" AND "hi" *');
+    // A quote cannot terminate the generated phrase. `hi` is under the minimum
+    // prefix length, so it stays an EXACT phrase — the AND already bounds the
+    // match set, so a short trailing term needs no prefix expansion.
+    expect(buildChannelSearchMatchQuery('say "hi"')).toBe('"say" AND "hi"');
     // Nothing tokenizable is not a query at all.
     expect(buildChannelSearchMatchQuery('  ***  ')).toBeNull();
     expect(s.searchMessages({ query: '***' })).toEqual([]);
+  });
+
+  it('never builds a prefix expression for a short trailing term', () => {
+    // The P0 guard: `*` on a one-character term expands to nearly the whole
+    // term dictionary, and bm25 must rank every match before LIMIT drops it —
+    // synchronously, on the hub's event loop. Asserted on the EXPRESSION, not
+    // on latency, so the guard cannot be lost to a faster machine.
+    expect(CHANNEL_SEARCH_MIN_QUERY_CHARS).toBe(3);
+    expect(buildChannelSearchMatchQuery('a')).toBeNull();
+    expect(buildChannelSearchMatchQuery('ab')).toBeNull();
+    expect(buildChannelSearchMatchQuery('  a  ')).toBeNull();
+    expect(buildChannelSearchMatchQuery('abc')).toBe('"abc" *');
+    // Astral characters count once: length is code points, not UTF-16 units.
+    expect(buildChannelSearchMatchQuery('𝟙𝟚')).toBeNull();
+    // A short term next to a real one keeps its exact-phrase filter.
+    expect(buildChannelSearchMatchQuery('deploy a')).toBe('"deploy" AND "a"');
+    expect(buildChannelSearchMatchQuery('a deploy')).toBe(
+      '"a" AND "deploy" *'
+    );
+  });
+
+  it('names why a refused query was never dispatched to the index', () => {
+    const s = store();
+    seq(s, 'topic:alpha', 'a note that would match almost any prefix');
+    expect(channelSearchUnavailableReason('   ')).toBe('empty_query');
+    expect(channelSearchUnavailableReason('***')).toBe('no_searchable_term');
+    expect(channelSearchUnavailableReason('a')).toBe('query_too_short');
+    expect(channelSearchUnavailableReason('ab')).toBe('query_too_short');
+    expect(channelSearchUnavailableReason('abc')).toBeNull();
+    expect(channelSearchUnavailableReason('a note')).toBeNull();
+    // The store agrees with the predicate: every refused shape returns no hits
+    // WITHOUT reading the index, so the caller must not read an empty array as
+    // "searched and found nothing".
+    for (const query of ['   ', '***', 'a', 'ab']) {
+      expect(s.searchMessages({ query })).toEqual([]);
+    }
+    expect(s.searchMessages({ query: 'note' })).toHaveLength(1);
   });
 
   it('backfills an existing db idempotently and rebuilds a dropped index', () => {
@@ -1994,6 +2037,97 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
     counted.close();
     expect(rows.count).toBe(1);
     expect(version.version).toBe(6);
+  });
+
+  it('backfills across more than one batch without dropping or duplicating rows', () => {
+    const file = dbPath();
+    const seeded = store(file);
+    seeded.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'batchword anchor row',
+    });
+    seeded.close();
+
+    // Raw inserts so the fixture crosses the 5k-row commit boundary quickly.
+    // The point is the rowid-range cursor: a batched backfill that mis-bounds a
+    // range silently skips or double-indexes whole 5k blocks, and a small
+    // fixture would never leave the first batch to notice.
+    const total = 5_200;
+    const raw = new Database(file);
+    const insert = raw.prepare(
+      `INSERT INTO channel_messages
+         (id, channel_id, seq, kind, sender_kind, sender_id, body_text, created_at, updated_at)
+       VALUES (?, 'topic:alpha', ?, ?, 'human', 'human:operator', ?, ?, ?)`
+    );
+    const now = new Date().toISOString();
+    raw.transaction(() => {
+      for (let i = 0; i < total; i += 1) {
+        // Every tenth row is hub bookkeeping: the predicate must be applied per
+        // batch, not only to the first one.
+        const systemRow = i % 10 === 0;
+        insert.run(
+          `chm:bulk-${i}`,
+          i + 2,
+          systemRow ? 'system' : 'message',
+          `batchword bulk row ${i}`,
+          now,
+          now
+        );
+      }
+    })();
+    raw.exec('DROP TRIGGER channel_messages_fts_ai');
+    raw.exec('DROP TRIGGER channel_messages_fts_au');
+    raw.exec('DROP TRIGGER channel_messages_fts_ad');
+    raw.exec('DROP TABLE channel_messages_fts');
+    raw.close();
+
+    const reopened = store(file);
+    const counted = new Database(file);
+    const indexed = counted
+      .prepare(
+        `SELECT COUNT(*) AS count FROM channel_messages_fts
+          WHERE channel_messages_fts MATCH '"batchword"'`
+      )
+      .get() as { count: number };
+    counted.close();
+    // 1 anchor + every non-system bulk row, each exactly once.
+    expect(indexed.count).toBe(1 + total - total / 10);
+    expect(reopened.searchMessages({ query: 'batchword' })).toHaveLength(50);
+  });
+
+  it('keeps the implicit-rowid contract the external-content index rides on', () => {
+    const file = dbPath();
+    const s = store(file);
+    s.appendComplete({
+      channelId: 'topic:alpha',
+      sender: HUMAN,
+      text: 'rowid contract subject',
+    });
+    const raw = new Database(file);
+    const ddl = (
+      raw
+        .prepare(
+          `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'channel_messages'`
+        )
+        .get() as { sql: string }
+    ).sql;
+    raw.close();
+    // `id` is TEXT PRIMARY KEY, so the FTS join key is the table's IMPLICIT
+    // rowid. WITHOUT ROWID would remove that mapping outright and break every
+    // index entry; assert the declaration can never acquire it.
+    expect(ddl).not.toMatch(/WITHOUT\s+ROWID/i);
+    expect(ddl).toMatch(/id\s+TEXT PRIMARY KEY/);
+
+    // Implicit rowids are renumbered by VACUUM, which would silently repoint
+    // every index entry at a different message — search answering with another
+    // channel's body under a correct-looking snippet. No maintenance path in
+    // the store may issue one without rebuilding the index afterwards.
+    const source = fs.readFileSync(
+      new URL('../server/channel-message-store.ts', import.meta.url),
+      'utf8'
+    );
+    expect(source).not.toMatch(/^\s*[^*/\n]*\bVACUUM\b/im);
   });
 
   it('drives the search from the FTS index, probing messages by rowid', () => {

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -42,7 +42,13 @@ import {
   createWorkspaceTopicStore,
   type WorkspaceTopicStore,
 } from '../server/workspace-topics.js';
-import type { ChannelEventV1 } from '../shared/channel-chat-protocol.js';
+import {
+  CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+  CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  CHANNEL_SEARCH_MAX_RESULTS,
+  parseChannelSearchSnippet,
+  type ChannelEventV1,
+} from '../shared/channel-chat-protocol.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -1932,5 +1938,244 @@ describe('channel routes — message delete (#1308 slice 1 item 4)', () => {
       'CHANNEL_MESSAGE_NOT_EDITABLE'
     );
     expect(h.store.getMessage(posted.id)?.body.text).toBe('');
+  });
+});
+
+describe('channel routes — message search (#1308 slice 2 item 1)', () => {
+  interface SearchBody {
+    query: string;
+    results: Array<{
+      messageId: string;
+      channelId: string;
+      channelTitle: string;
+      archived: boolean;
+      seq: number;
+      threadId: string | null;
+      snippet: string;
+      senderKind: string;
+      senderId: string;
+      senderDisplayName?: string;
+      createdAt: string;
+      score: number;
+    }>;
+    truncated: boolean;
+    unavailableReason?: string;
+  }
+
+  async function post(
+    h: Harness,
+    channelId: string,
+    text: string,
+    extra: Record<string, unknown> = {}
+  ): Promise<{ id: string; seq: number }> {
+    const res = await req<{ message: { id: string; seq: number } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(channelId)}/messages`,
+      body: { text, ...extra },
+    });
+    expect(res.status).toBe(201);
+    return res.body.message;
+  }
+
+  function search(
+    h: Harness,
+    query: string
+  ): Promise<{
+    status: number;
+    body: SearchBody;
+  }> {
+    return req<SearchBody>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/search?${query}`,
+    });
+  }
+
+  it('returns ranked jump-shaped hits with channel identity', async () => {
+    const h = await harness();
+    const passing = await post(h, h.channelId, 'we mention relay once here');
+    const dense = await post(h, h.channelId, 'relay relay relay');
+    const reply = await post(h, h.channelId, 'relay follow-up in thread', {
+      parentMessageId: passing.id,
+    });
+
+    const res = await search(h, 'q=relay');
+    expect(res.status).toBe(200);
+    expect(res.body.query).toBe('relay');
+    expect(res.body.truncated).toBe(false);
+    expect(res.body.results.map((hit) => hit.messageId)).toContain(dense.id);
+    expect(res.body.results[0]?.messageId).toBe(dense.id);
+    // Thread replies are searchable; the hit names its root so the #1308 slice 1
+    // deep link can open the thread panel.
+    const replyHit = res.body.results.find((hit) => hit.messageId === reply.id);
+    expect(replyHit).toMatchObject({
+      channelId: h.channelId,
+      channelTitle: 'General',
+      archived: false,
+      threadId: passing.id,
+      senderKind: 'human',
+    });
+    expect(replyHit?.snippet).toContain('relay');
+    expect(replyHit?.seq).toBe(reply.seq);
+    expect(replyHit?.createdAt).toEqual(expect.any(String));
+  });
+
+  it('wraps matched terms in the shared plain-text highlight sentinels', async () => {
+    const h = await harness();
+    await post(h, h.channelId, 'the migration playbook is ready');
+    const res = await search(h, 'q=playbook');
+    const snippet = res.body.results[0]?.snippet ?? '';
+    expect(snippet).toContain(
+      `${CHANNEL_SEARCH_HIGHLIGHT_OPEN}playbook${CHANNEL_SEARCH_HIGHLIGHT_CLOSE}`
+    );
+    // No markup crosses the wire — the client renders its own emphasis.
+    expect(snippet).not.toContain('<');
+    expect(
+      parseChannelSearchSnippet(snippet).filter((segment) => segment.highlight)
+    ).toEqual([{ text: 'playbook', highlight: true }]);
+  });
+
+  it('hides archived channels unless includeArchived is set', async () => {
+    const h = await harness();
+    const archivedTopic = h.topicStore.create({
+      workspaceId: 'ws',
+      title: 'Old Incident',
+    });
+    await post(h, h.channelId, 'quarantine notes live here');
+    const buried = await post(
+      h,
+      archivedTopic.id,
+      'quarantine notes archived here'
+    );
+    h.topicStore.archive(archivedTopic.id);
+
+    const hidden = await search(h, 'q=quarantine');
+    expect(hidden.body.results.map((hit) => hit.channelId)).toEqual([
+      h.channelId,
+    ]);
+
+    const shown = await search(h, 'q=quarantine&includeArchived=true');
+    const archivedHit = shown.body.results.find(
+      (hit) => hit.messageId === buried.id
+    );
+    expect(archivedHit).toMatchObject({
+      channelId: archivedTopic.id,
+      channelTitle: 'Old Incident',
+      archived: true,
+    });
+  });
+
+  it('excludes detail cards, system rows and tombstones; re-indexes an edit', async () => {
+    const h = await harness();
+    const prose = await post(h, h.channelId, 'rollback checklist step one');
+    const doomed = await post(h, h.channelId, 'rollback checklist step two');
+    h.store.appendComplete({
+      channelId: h.channelId,
+      kind: 'system',
+      sender: { kind: 'system', id: 'system' },
+      text: 'rollback checklist system notice',
+    });
+    const detail = h.store.beginStream({
+      channelId: h.channelId,
+      sender: { kind: 'agent', id: 'agent:claude', providerId: 'claude' },
+      source: { runtimeId: 'runtime-1', turnId: 'turn-1', itemId: 'item-1' },
+      agentDetail: {
+        itemId: 'item-1',
+        card: {
+          kind: 'thought',
+          title: 'rollback checklist card',
+          status: 'running',
+          content: 'rollback checklist payload',
+        },
+      },
+    });
+    h.store.finalizeStream(detail.id, { text: '', status: 'complete' });
+
+    expect(
+      (await search(h, 'q=rollback')).body.results.map((hit) => hit.messageId)
+    ).toEqual(expect.arrayContaining([prose.id, doomed.id]));
+    expect((await search(h, 'q=rollback')).body.results).toHaveLength(2);
+
+    const messageUrl = `/channels/${encodeURIComponent(h.channelId)}/messages/${encodeURIComponent(doomed.id)}`;
+    expect(
+      (await req({ port: h.port, method: 'DELETE', url: messageUrl })).status
+    ).toBe(200);
+    expect(
+      (await search(h, 'q=rollback')).body.results.map((hit) => hit.messageId)
+    ).toEqual([prose.id]);
+
+    expect(
+      (
+        await req({
+          port: h.port,
+          method: 'PATCH',
+          url: `/channels/${encodeURIComponent(h.channelId)}/messages/${encodeURIComponent(prose.id)}`,
+          body: { text: 'rollforward checklist step one' },
+        })
+      ).status
+    ).toBe(200);
+    expect((await search(h, 'q=rollback')).body.results).toHaveLength(0);
+    expect(
+      (await search(h, 'q=rollforward')).body.results.map(
+        (hit) => hit.messageId
+      )
+    ).toEqual([prose.id]);
+  });
+
+  it('scopes by channel, caps the page, and reports an empty query', async () => {
+    const h = await harness();
+    const other = h.topicStore.create({ workspaceId: 'ws', title: 'Other' });
+    await post(h, h.channelId, 'shared telemetry note');
+    const elsewhere = await post(h, other.id, 'shared telemetry note');
+
+    expect(
+      (
+        await search(h, `q=telemetry&channelId=${encodeURIComponent(other.id)}`)
+      ).body.results.map((hit) => hit.messageId)
+    ).toEqual([elsewhere.id]);
+
+    const capped = await search(h, 'q=telemetry&limit=1');
+    expect(capped.body.results).toHaveLength(1);
+    expect(capped.body.truncated).toBe(true);
+
+    const empty = await search(h, 'q=%20%20');
+    expect(empty.status).toBe(200);
+    expect(empty.body.results).toEqual([]);
+    expect(empty.body.unavailableReason).toBe('empty_query');
+  });
+
+  it('requires context:read and is reachable only past the auth gate', async () => {
+    const h = await harness({ withAuth: true });
+    const unauthenticated = await fetch(
+      `http://127.0.0.1:${h.port}/channels/search?q=anything`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(unauthenticated.status).toBe(401);
+
+    const forbidden = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'GET',
+      url: '/channels/search?q=anything',
+      capabilities: '',
+      headers: { Authorization: 'Bearer test' },
+    });
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('still reports truncation on a full default page', async () => {
+    const h = await harness();
+    for (let i = 0; i < CHANNEL_SEARCH_MAX_RESULTS + 5; i += 1) {
+      h.store.appendComplete({
+        channelId: h.channelId,
+        sender: { kind: 'human', id: 'human:operator' },
+        text: `saturation row ${i}`,
+      });
+    }
+    const res = await search(h, 'q=saturation');
+    expect(res.body.results).toHaveLength(CHANNEL_SEARCH_MAX_RESULTS);
+    // A page that is exactly full must not silently claim it was the whole set.
+    expect(res.body.truncated).toBe(true);
   });
 });

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -78,12 +78,19 @@ async function harness(
     historyMaxBytes?: number;
     withAuth?: boolean;
     binder?: Partial<ChannelAgentBinder>;
+    /**
+     * Monotonic topic clock. The default is frozen, which is fine until a test
+     * cares about `updated_at DESC` rank — the rail read model's ordering — and
+     * needs "older than the 200 most recent" to be a fact rather than a
+     * tiebreak SQLite is free to resolve either way.
+     */
+    topicClock?: () => string;
   } = {}
 ): Promise<Harness> {
   const dir = tmpDir();
   const topicStore = createWorkspaceTopicStore({
     dbPath: path.join(dir, 'topics.db'),
-    now: () => '2026-07-18T00:00:00.000Z',
+    now: options.topicClock ?? (() => '2026-07-18T00:00:00.000Z'),
   });
   cleanup.push(() => topicStore.close());
   const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
@@ -2143,6 +2150,88 @@ describe('channel routes — message search (#1308 slice 2 item 1)', () => {
     expect(empty.status).toBe(200);
     expect(empty.body.results).toEqual([]);
     expect(empty.body.unavailableReason).toBe('empty_query');
+  });
+
+  it('names a refused query instead of reporting it as a miss', async () => {
+    const h = await harness();
+    await post(h, h.channelId, 'a note the index would happily match');
+
+    // Text arrived, but nothing tokenizable: the index was never read, so the
+    // client must not print "no matches for ***".
+    const unsearchable = await search(h, 'q=***');
+    expect(unsearchable.status).toBe(200);
+    expect(unsearchable.body.results).toEqual([]);
+    expect(unsearchable.body.unavailableReason).toBe('no_searchable_term');
+
+    // Below the minimum searchable length the server refuses too — the UI gate
+    // is a courtesy, this route is reachable by any capability holder.
+    for (const short of ['q=a', 'q=ab']) {
+      const refused = await search(h, short);
+      expect(refused.body.results).toEqual([]);
+      expect(refused.body.unavailableReason).toBe('query_too_short');
+    }
+
+    // A dispatched query that genuinely misses carries NO reason, which is how
+    // the client tells "searched and found nothing" from "never searched".
+    const miss = await search(h, 'q=zzzznotpresent');
+    expect(miss.body.results).toEqual([]);
+    expect(miss.body.unavailableReason).toBeUndefined();
+  });
+
+  it('reaches channels the rail read model would have cut off', async () => {
+    // `topicStore.list()` caps at 200 rows by `updated_at DESC`; the store keeps
+    // up to 500. Building the search allowlist from that read model made every
+    // message in an older channel unreachable — indexed, matching, and never
+    // returned, with no truncation signal.
+    let tick = 0;
+    const h = await harness({
+      topicClock: () => new Date(Date.UTC(2026, 0, 1) + tick++ * 60_000).toISOString(),
+    });
+    const buried = await post(h, h.channelId, 'buried needle in an old chat');
+    for (let i = 0; i < 220; i += 1) {
+      h.topicStore.create({ workspaceId: 'ws', title: `Filler ${i}` });
+    }
+    expect(h.topicStore.list({ includeArchived: true })).toHaveLength(200);
+    expect(
+      h.topicStore
+        .list({ includeArchived: true })
+        .some((topic) => topic.id === h.channelId)
+    ).toBe(false);
+
+    const res = await search(h, 'q=needle');
+    expect(res.status).toBe(200);
+    expect(res.body.results.map((hit) => hit.messageId)).toEqual([buried.id]);
+    expect(res.body.results[0]?.channelTitle).toBe('General');
+  });
+
+  it('lets workspace scoping narrow the answer, never the reach', async () => {
+    let tick = 0;
+    const h = await harness({
+      topicClock: () => new Date(Date.UTC(2026, 0, 1) + tick++ * 60_000).toISOString(),
+    });
+    const scoped = await post(h, h.channelId, 'scoped needle for one workspace');
+    // 220 newer channels in ANOTHER workspace. Scoping applied after a global
+    // 200-row window would leave nothing of `ws` to search at all.
+    for (let i = 0; i < 220; i += 1) {
+      h.topicStore.create({ workspaceId: 'ws-other', title: `Other ${i}` });
+    }
+    const res = await search(h, 'q=needle&workspaceId=ws');
+    expect(res.body.results.map((hit) => hit.messageId)).toEqual([scoped.id]);
+
+    // The scope still excludes: a hit in the other workspace stays out.
+    const elsewhere = h.topicStore.create({
+      workspaceId: 'ws-other',
+      title: 'Loud',
+    });
+    await post(h, elsewhere.id, 'needle somewhere else entirely');
+    expect(
+      (await search(h, 'q=needle&workspaceId=ws')).body.results.map(
+        (hit) => hit.messageId
+      )
+    ).toEqual([scoped.id]);
+    expect(
+      (await search(h, 'q=needle')).body.results.map((hit) => hit.messageId)
+    ).toHaveLength(2);
   });
 
   it('requires context:read and is reachable only past the auth gate', async () => {

--- a/test/command-palette-message-results.test.ts
+++ b/test/command-palette-message-results.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMessagePaletteResults,
+  MESSAGE_PALETTE_LIMIT,
+  messagePaletteSnippetText,
+} from '../frontend/src/lib/command-palette-message-results.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
+import {
+  CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+  CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  type ChannelMessageId,
+  type ChannelMessageSearchResult,
+} from '../shared/channel-chat-protocol.js';
+
+const NOW = '2026-08-03T00:00:00Z';
+
+function makeHit(
+  overrides: Partial<ChannelMessageSearchResult> = {}
+): ChannelMessageSearchResult {
+  return {
+    messageId: 'chm:hit-1' as ChannelMessageId,
+    channelId: 'topic:alpha',
+    threadId: null,
+    seq: 12,
+    snippet: `rebuilt the ${CHANNEL_SEARCH_HIGHLIGHT_OPEN}sqlite${CHANNEL_SEARCH_HIGHLIGHT_CLOSE} index`,
+    senderKind: 'agent',
+    senderId: builtInAgentProfileId('claude'),
+    providerId: 'claude',
+    createdAt: NOW,
+    score: -3.2,
+    channelTitle: 'Build UI shell',
+    archived: false,
+    ...overrides,
+  };
+}
+
+describe('messagePaletteSnippetText', () => {
+  it('consumes the highlight sentinels rather than rendering them', () => {
+    // A palette row is one ellipsized `.item-label` with nowhere to hang
+    // emphasis, so the runs are flattened — but the Private Use Area delimiters
+    // must never survive into the label, where they print as tofu boxes.
+    const text = messagePaletteSnippetText(makeHit().snippet);
+    expect(text).toBe('rebuilt the sqlite index');
+    expect(text).not.toContain(CHANNEL_SEARCH_HIGHLIGHT_OPEN);
+    expect(text).not.toContain(CHANNEL_SEARCH_HIGHLIGHT_CLOSE);
+  });
+
+  it('collapses the newlines and indentation a real message body carries', () => {
+    expect(
+      messagePaletteSnippetText(
+        `  …then\n\n    ${CHANNEL_SEARCH_HIGHLIGHT_OPEN}ran${CHANNEL_SEARCH_HIGHLIGHT_CLOSE}\tnpm  test  `
+      )
+    ).toBe('…then ran npm test');
+  });
+});
+
+describe('buildMessagePaletteResults', () => {
+  it('maps a hit to a jump-shaped palette row labelled by its snippet', () => {
+    const results = buildMessagePaletteResults([makeHit()]);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: 'message',
+      id: 'message-chm:hit-1',
+      label: 'rebuilt the sqlite index',
+      // Channel first (where), then the sender label the rail uses.
+      sublabel: 'Build UI shell · claude',
+    });
+    // The hit itself rides along: selection needs channelId + messageId.
+    expect(results[0]?.data.channelId).toBe('topic:alpha');
+    expect(results[0]?.data.messageId).toBe('chm:hit-1');
+  });
+
+  it('labels the sender by display name / provider, never by splitting a profile id', () => {
+    // `agent-profile:claude:default` — the trailing segment is `default`, so a
+    // naive split would label every built-in agent identically (#1234).
+    expect(
+      buildMessagePaletteResults([makeHit({ providerId: undefined })])[0]
+        ?.sublabel
+    ).toBe('Build UI shell · claude');
+    expect(
+      buildMessagePaletteResults([
+        makeHit({ senderDisplayName: 'Reviewer', providerId: 'codex' }),
+      ])[0]?.sublabel
+    ).toBe('Build UI shell · Reviewer');
+    expect(
+      buildMessagePaletteResults([
+        makeHit({ senderKind: 'human', senderId: 'human:operator' }),
+      ])[0]?.sublabel
+    ).toBe('Build UI shell · you');
+  });
+
+  it('marks a thread reply so the operator knows the jump opens a panel', () => {
+    const [result] = buildMessagePaletteResults([
+      makeHit({ threadId: 'chm:root-1' as ChannelMessageId }),
+    ]);
+    expect(result?.sublabel).toBe('Build UI shell · claude · thread');
+  });
+
+  it('caps at five hits, the same discipline every other palette category uses', () => {
+    const many = Array.from({ length: 9 }, (_, index) =>
+      makeHit({ messageId: `chm:hit-${index}` as ChannelMessageId })
+    );
+    expect(MESSAGE_PALETTE_LIMIT).toBe(5);
+    expect(buildMessagePaletteResults(many)).toHaveLength(5);
+    expect(buildMessagePaletteResults(many).map((r) => r.id)).toEqual([
+      'message-chm:hit-0',
+      'message-chm:hit-1',
+      'message-chm:hit-2',
+      'message-chm:hit-3',
+      'message-chm:hit-4',
+    ]);
+  });
+
+  it('never renders an empty, unclickable-looking row for a bodyless payload', () => {
+    expect(
+      buildMessagePaletteResults([makeHit({ snippet: '   ' })])[0]?.label
+    ).toBe('(no preview)');
+  });
+});

--- a/test/command-palette-message-search.test.ts
+++ b/test/command-palette-message-search.test.ts
@@ -1,0 +1,365 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CommandPalette from '../frontend/src/components/CommandPalette.js';
+import { openTopicSelectionFromPalette } from '../frontend/src/lib/topic-selection.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import { _resetForTesting } from '../frontend/src/lib/actions/registry.js';
+import type { ActionContext } from '../frontend/src/lib/actions/types.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
+import {
+  CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+  CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  type ChannelMessageId,
+  type ChannelMessageSearchResult,
+} from '../shared/channel-chat-protocol.js';
+import type {
+  WorkspaceTopic,
+  WorkspaceTopicListResponse,
+} from '../shared/workspace-topics.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NOW = '2026-08-03T00:00:00Z';
+
+/** The palette holds a keystroke for 150ms before either search query runs. */
+const DEBOUNCE_SETTLE_MS = 250;
+
+const actionContext: ActionContext = {
+  view: 'session',
+  workspacePath: '/repo',
+  cwd: '/repo',
+  isMobile: false,
+};
+
+function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
+  return {
+    schemaVersion: 1,
+    id: 'topic:alpha',
+    workspaceId: 'workspace:alpha',
+    source: 'persisted',
+    status: 'active',
+    visibility: 'default',
+    display: { title: 'Build UI shell' },
+    grouping: {},
+    promptDefaults: {},
+    routingDefaults: { nodeId: 'devbox', repoPath: '/repo/relay' },
+    linkedRefs: {},
+    state: { pinned: false, muted: false },
+    privacy: {
+      classification: 'internal',
+      retention: 'project',
+      redaction: 'summary',
+      rawDefaultsStored: false,
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function listResponse(topics: WorkspaceTopic[]): WorkspaceTopicListResponse {
+  return { topics, truncated: false, derived: false };
+}
+
+function makeHit(
+  overrides: Partial<ChannelMessageSearchResult> = {}
+): ChannelMessageSearchResult {
+  return {
+    messageId: 'chm:hit-1' as ChannelMessageId,
+    channelId: 'topic:alpha',
+    threadId: null,
+    seq: 12,
+    snippet: `rebuilt the ${CHANNEL_SEARCH_HIGHLIGHT_OPEN}sqlite${CHANNEL_SEARCH_HIGHLIGHT_CLOSE} index`,
+    senderKind: 'agent',
+    senderId: builtInAgentProfileId('claude'),
+    providerId: 'claude',
+    createdAt: NOW,
+    score: -3.2,
+    channelTitle: 'Build UI shell',
+    archived: false,
+    ...overrides,
+  };
+}
+
+async function flushQueryEffects() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('<CommandPalette /> message search (#1308 slice 2 item 3)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+  let searchUrls: string[];
+  let searchHits: ChannelMessageSearchResult[];
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetForTesting();
+    useUiStore.setState({
+      activeChannelId: null,
+      topicComposerOpen: true,
+      sidebarOpen: true,
+      pendingChannelMessage: null,
+    });
+    searchUrls = [];
+    searchHits = [makeHit()];
+    fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/channels/search')) {
+        searchUrls.push(url);
+        return Response.json({
+          query: 'sqlite',
+          results: searchHits,
+          truncated: false,
+        });
+      }
+      if (url.startsWith('/workspace-topics')) {
+        return Response.json(listResponse([makeTopic()]));
+      }
+      throw new Error(`unstubbed fetch in unit test: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    useUiStore.setState({
+      activeChannelId: null,
+      topicComposerOpen: false,
+      sidebarOpen: false,
+      pendingChannelMessage: null,
+    });
+    useUiStore.getState().setActiveRepoPath(null);
+    useUiStore.getState().setActiveWorkspaceId(null);
+    _resetForTesting();
+  });
+
+  async function renderPalette(open = true) {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(CommandPalette, {
+            open,
+            workspaces: [],
+            sessions: [],
+            actionContext,
+            onClose: vi.fn(),
+            onSelectWorkspace: vi.fn(),
+            onSelectSession: vi.fn(),
+            onSelectTopic: openTopicSelectionFromPalette,
+            onSelectPr: vi.fn(),
+          })
+        )
+      );
+      await flushQueryEffects();
+    });
+  }
+
+  /** Type into the palette input and let the 150ms debounce + query settle. */
+  async function search(text: string) {
+    const input = container.querySelector(
+      '.palette-search-input'
+    ) as HTMLInputElement;
+    await act(async () => {
+      setInputValue(input, text);
+      await flushQueryEffects();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_SETTLE_MS));
+      await flushQueryEffects();
+    });
+    await act(async () => {
+      await flushQueryEffects();
+    });
+  }
+
+  function group(label: string): HTMLElement | null {
+    const header = [...container.querySelectorAll('.palette-category')].find(
+      (el) => el.textContent?.trim() === label
+    );
+    return (header?.parentElement as HTMLElement | undefined) ?? null;
+  }
+
+  function messageRow(): HTMLElement {
+    const row = group('messages')?.querySelector('.palette-item');
+    if (!row) throw new Error('no message row rendered');
+    return row as HTMLElement;
+  }
+
+  it('renders a messages category from the search endpoint, under topics', async () => {
+    await renderPalette();
+    await search('sqlite');
+
+    expect(searchUrls).toHaveLength(1);
+    // The palette asks for its own five rows rather than reusing the sidebar's
+    // twenty-row page under a key that never mentions a page size.
+    expect(searchUrls[0]).toContain('q=sqlite');
+    expect(searchUrls[0]).toContain('limit=5');
+
+    const categories = [...container.querySelectorAll('.palette-category')].map(
+      (el) => el.textContent?.trim()
+    );
+    expect(categories).toContain('messages');
+    // The other half of the same question sits directly above it.
+    expect(categories.indexOf('messages')).toBe(
+      categories.indexOf('topics') + 1
+    );
+
+    const row = messageRow();
+    // Snippet as the label, with the PUA sentinels consumed; channel + sender
+    // as the dim sublabel.
+    expect(row.querySelector('.item-label')?.textContent).toBe(
+      'rebuilt the sqlite index'
+    );
+    expect(row.textContent).not.toContain(CHANNEL_SEARCH_HIGHLIGHT_OPEN);
+    expect(row.querySelector('.item-sublabel')?.textContent).toBe(
+      'Build UI shell · claude'
+    );
+  });
+
+  it('caps the category at five hits even if the server hands back more', async () => {
+    searchHits = Array.from({ length: 9 }, (_, index) =>
+      makeHit({ messageId: `chm:hit-${index}` as ChannelMessageId })
+    );
+    await renderPalette();
+    await search('sqlite');
+
+    expect(group('messages')?.querySelectorAll('.palette-item')).toHaveLength(
+      5
+    );
+  });
+
+  it('opens the hit channel and writes the S1 jump anchor when selected', async () => {
+    await renderPalette();
+    await search('sqlite');
+
+    await act(async () => messageRow().click());
+
+    expect(useUiStore.getState().activeChannelId).toBe('topic:alpha');
+    // Written AFTER the channel open, which clears an un-consumed anchor.
+    expect(useUiStore.getState().pendingChannelMessage).toEqual({
+      channelId: 'topic:alpha',
+      messageId: 'chm:hit-1',
+    });
+    expect(useUiStore.getState().topicComposerOpen).toBe(false);
+    // The channel's own workspace/repo context lands too, exactly as clicking
+    // its rail row would.
+    expect(useUiStore.getState().activeWorkspaceId).toBe('workspace:alpha');
+    expect(useUiStore.getState().activeRepoPath).toBe('/repo/relay');
+    // The palette floats over the mobile drawer, which must not stay open.
+    expect(useUiStore.getState().sidebarOpen).toBe(false);
+  });
+
+  it('still opens a hit whose channel is absent from the palette topic corpus', async () => {
+    // Routine: chat search returns the chats whose TITLE matched, and a message
+    // can match in a channel whose title did not.
+    searchHits = [
+      makeHit({
+        channelId: 'topic:unlisted',
+        messageId: 'chm:hit-9' as ChannelMessageId,
+        channelTitle: 'Unlisted lane',
+      }),
+    ];
+    await renderPalette();
+    await search('sqlite');
+
+    await act(async () => messageRow().click());
+
+    expect(useUiStore.getState().activeChannelId).toBe('topic:unlisted');
+    expect(useUiStore.getState().pendingChannelMessage).toEqual({
+      channelId: 'topic:unlisted',
+      messageId: 'chm:hit-9',
+    });
+  });
+
+  it('anchors a thread hit on the reply itself so ChannelView opens its panel', async () => {
+    // The palette deliberately does NOT resolve the root: `ChannelView` maps a
+    // reply anchor to `activeThreadRootId` (test/components/channel-message-jump).
+    // Handing it the ROOT would land the jump on the main lane instead.
+    searchHits = [
+      makeHit({
+        messageId: 'chm:reply-9' as ChannelMessageId,
+        threadId: 'chm:root-1' as ChannelMessageId,
+      }),
+    ];
+    await renderPalette();
+    await search('sqlite');
+
+    expect(messageRow().querySelector('.item-sublabel')?.textContent).toContain(
+      'thread'
+    );
+    await act(async () => messageRow().click());
+
+    expect(useUiStore.getState().pendingChannelMessage).toEqual({
+      channelId: 'topic:alpha',
+      messageId: 'chm:reply-9',
+    });
+  });
+
+  it('never searches while the palette is closed', async () => {
+    // `usePaletteState` only clears `query` on the way back IN, so a closed
+    // palette still holds the last query the operator typed — without `open` in
+    // `enabled`, every background refetch would hit the hub for a panel nobody
+    // is looking at.
+    await renderPalette();
+    await search('sqlite');
+    expect(searchUrls).toHaveLength(1);
+
+    await renderPalette(false);
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['channel-message-search'],
+      });
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_SETTLE_MS));
+      await flushQueryEffects();
+    });
+
+    expect(searchUrls).toHaveLength(1);
+    expect(container.querySelector('.palette-item')).toBeNull();
+  });
+
+  it('does not search for an empty query', async () => {
+    await renderPalette();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_SETTLE_MS));
+      await flushQueryEffects();
+    });
+
+    expect(searchUrls).toHaveLength(0);
+    expect(
+      [...container.querySelectorAll('.palette-category')].map((el) =>
+        el.textContent?.trim()
+      )
+    ).not.toContain('messages');
+  });
+});

--- a/test/command-palette-message-search.test.ts
+++ b/test/command-palette-message-search.test.ts
@@ -14,6 +14,7 @@ import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import {
   CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
   CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  CHANNEL_SEARCH_MIN_QUERY_CHARS,
   type ChannelMessageId,
   type ChannelMessageSearchResult,
 } from '../shared/channel-chat-protocol.js';
@@ -361,5 +362,28 @@ describe('<CommandPalette /> message search (#1308 slice 2 item 3)', () => {
         el.textContent?.trim()
       )
     ).not.toContain('messages');
+  });
+
+  it('does not search below the minimum searchable query length', async () => {
+    // A one-character prefix ranks essentially the whole FTS corpus inside a
+    // synchronous sqlite call on the hub event loop. The palette debounces the
+    // keystroke but would otherwise still SEND it, so the gate is the length,
+    // not the pause.
+    expect(CHANNEL_SEARCH_MIN_QUERY_CHARS).toBe(3);
+    await renderPalette();
+    await search('s');
+    expect(searchUrls).toEqual([]);
+    await search('sq');
+    expect(searchUrls).toEqual([]);
+    expect(
+      [...container.querySelectorAll('.palette-category')].map((el) =>
+        el.textContent?.trim()
+      )
+    ).not.toContain('messages');
+
+    // The third character is what buys the index read.
+    await search('sql');
+    expect(searchUrls).toHaveLength(1);
+    expect(searchUrls[0]).toContain('q=sql');
   });
 });

--- a/test/components/channel-message-jump.test.ts
+++ b/test/components/channel-message-jump.test.ts
@@ -281,6 +281,40 @@ describe('ChannelView deep-link message anchor', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 
+  // #1308 slice 2 item 2 reuses this exact path for a search hit, and a thread
+  // hit is the case where the anchor row is NOT a main-lane row. The sidebar
+  // hands over the reply's own id and resolves nothing itself, so this is the
+  // only place the reply → panel + root-emphasis mapping is proved.
+  it('opens the thread panel and emphasizes the root when the anchor is a reply', async () => {
+    const root1 = message(1);
+    const reply = message(2, {
+      id: 'chm:reply-2' as ChannelMessageId,
+      threadId: root1.id,
+      parentMessageId: root1.id,
+    });
+    mocks.messages = [root1, reply, message(3)];
+    await mount();
+
+    expect(useUiStore.getState().activeThreadRootId).toBeNull();
+
+    await act(async () => {
+      useUiStore
+        .getState()
+        .requestChannelMessage(CHANNEL_ID, 'chm:reply-2' as ChannelMessageId);
+    });
+    await act(async () => {});
+
+    expect(useUiStore.getState().activeThreadRootId).toBe(root1.id);
+    // The reply has no main-lane row, so the emphasis lands on its root — a
+    // jump at the reply id would scroll to nothing.
+    expect(
+      container
+        .querySelector('.ch-msg--jump')
+        ?.getAttribute('data-channel-message-id')
+    ).toBe(root1.id);
+    expect(useUiStore.getState().pendingChannelMessage).toBeNull();
+  });
+
   it('gives up immediately when there is no older history left to walk', async () => {
     mocks.messages = [message(1), message(2)];
     mocks.hasMoreOlder = false;

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -17,6 +17,12 @@ import {
   TopicSidebarView,
 } from '../frontend/src/components/TopicSidebarShell.js';
 import { builtInAgentProfileId } from '../shared/agent-profile.js';
+import {
+  CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+  CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  type ChannelMessageId,
+  type ChannelMessageSearchResult,
+} from '../shared/channel-chat-protocol.js';
 import { createWorkspaceId, LOCAL_WORKSPACE_ID } from '../shared/workspace.js';
 import { dmChannelTopicId } from '../frontend/src/lib/dm-channels.js';
 import {
@@ -84,18 +90,34 @@ async function flushQueryEffects() {
  * `flushQueryEffects()` intermittently asserts against the pre-render DOM.
  * Polling the DOM itself makes the wait a condition, mirroring the drain fix in
  * 03aff413 without hard-coding how many ticks the chain happens to take.
+ *
+ * The budget is WALL CLOCK rather than a tick count (#1308 slice 2): the search
+ * field debounces before it queries at all, so a tick-counted poll drains a
+ * few microtasks in well under the settle window and reports a timeout before
+ * the request the case is waiting for was ever sent. Still a condition poll —
+ * it returns the instant the DOM satisfies `check` — with a ceiling that
+ * outlasts a real debounce instead of one that outlasts only a microtask chain.
  */
+const WAIT_FOR_RENDERED_TIMEOUT_MS = 2_000;
+const WAIT_FOR_RENDERED_POLL_MS = 10;
+
 async function waitForRendered(
   check: () => boolean,
   description: string
 ): Promise<void> {
-  for (let attempt = 0; attempt < 25; attempt++) {
+  const deadline = Date.now() + WAIT_FOR_RENDERED_TIMEOUT_MS;
+  for (;;) {
     if (check()) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
     await act(async () => {
       await flushQueryEffects();
+      await new Promise((resolve) =>
+        setTimeout(resolve, WAIT_FOR_RENDERED_POLL_MS)
+      );
     });
   }
-  throw new Error(`timed out waiting for ${description}`);
 }
 
 function makeTopic(overrides: Partial<WorkspaceTopic> = {}): WorkspaceTopic {
@@ -160,6 +182,31 @@ function setInputValue(input: HTMLInputElement, value: string) {
   )?.set;
   if (setter) setter.call(input, value);
   else input.value = value;
+}
+
+/**
+ * One `/channels/search` hit (#1308 slice 2). The snippet carries the REAL
+ * Private Use Area sentinels, imported rather than retyped, so the renderer and
+ * the server contract cannot drift apart behind a hand-written literal.
+ */
+function makeMessageHit(
+  overrides: Partial<ChannelMessageSearchResult> = {}
+): ChannelMessageSearchResult {
+  return {
+    messageId: 'chm:hit-1' as ChannelMessageId,
+    channelId: 'topic:alpha',
+    threadId: null,
+    seq: 12,
+    snippet: `rebuilt the ${CHANNEL_SEARCH_HIGHLIGHT_OPEN}sqlite${CHANNEL_SEARCH_HIGHLIGHT_CLOSE} index`,
+    senderKind: 'agent',
+    senderId: builtInAgentProfileId('claude'),
+    providerId: 'claude',
+    createdAt: NOW,
+    score: -3.2,
+    channelTitle: 'Build UI shell',
+    archived: false,
+    ...overrides,
+  };
 }
 
 function makeSurface(
@@ -3156,6 +3203,30 @@ describe('TopicSidebarView', () => {
       expect(precedes(search, results)).toBe(true);
       expect(precedes(results, cockpit)).toBe(true);
     });
+
+    it('keeps the message section above the fold with the chats section (#1308 slice 2)', async () => {
+      // The mobile "search surface" is not a second component — it is this
+      // panel, ordered above the cockpit. So the new section is only above the
+      // fold on a phone if it renders INSIDE the panel; a message section
+      // appended after the tree would be legal on desktop and unreachable on a
+      // phone without scrolling past every channel row.
+      await renderView({
+        searchQuery: 'sqlite',
+        messageResults: [makeMessageHit()],
+      });
+
+      const search = container.querySelector('.topic-search');
+      const messages = container.querySelector(
+        '.topic-search-section[aria-label="message search results"]'
+      );
+      const cockpit = container.querySelector('.topic-mobile-cockpit');
+      const mobileList = container.querySelector('.topic-mobile-list');
+
+      expect(messages?.querySelector('.topic-message-result')).not.toBeNull();
+      expect(precedes(search, messages)).toBe(true);
+      expect(precedes(messages, cockpit)).toBe(true);
+      expect(precedes(messages, mobileList)).toBe(true);
+    });
   });
 
   it('uses a two-step audited mobile reply preview before sending input', async () => {
@@ -4152,5 +4223,270 @@ describe('TopicSidebarView', () => {
     });
     expect(container.textContent).not.toContain('no chat matches for');
     queryClient.clear();
+  });
+
+  // ── message search section (#1308 slice 2 item 2) ─────────────────────────
+  describe('message search section (#1308 slice 2)', () => {
+    it('renders chats and messages as two labelled sections with emphasized matches', async () => {
+      await renderView({
+        topics: [
+          makeTopic({ id: 'topic:hit', display: { title: 'Hit lane' } }),
+        ],
+        sessions: [],
+        surfaces: [],
+        searchQuery: 'sqlite',
+        searchResults: [
+          {
+            topic: makeTopic({
+              id: 'topic:hit',
+              display: { title: 'Hit lane' },
+            }),
+            score: 90,
+            freshness: 'fresh',
+            matches: [
+              {
+                kind: 'topic',
+                field: 'display.title',
+                label: 'chat title',
+                value: 'Hit lane',
+              },
+            ],
+            action: { kind: 'open-topic', topicId: 'topic:hit' },
+          },
+        ],
+        messageResults: [makeMessageHit()],
+      });
+
+      const sections = Array.from(
+        container.querySelectorAll('.topic-search-section')
+      );
+      expect(sections.map((s) => s.getAttribute('aria-label'))).toEqual([
+        'chat search results',
+        'message search results',
+      ]);
+      expect(
+        sections.map(
+          (s) => s.querySelector('.topic-search-section__header')?.textContent
+        )
+      ).toEqual(['chats', 'messages']);
+
+      // A chat hit still renders in the chats section, unchanged.
+      expect(sections[0]?.textContent).toContain('Hit lane');
+      expect(sections[0]?.querySelector('.topic-search-result')).not.toBeNull();
+
+      const row = sections[1]?.querySelector(
+        '.topic-message-result'
+      ) as HTMLButtonElement;
+      expect(row).not.toBeNull();
+      // Channel title, sender label, snippet, relative stamp.
+      expect(
+        row.querySelector('.topic-message-result__channel')?.textContent
+      ).toBe('Build UI shell');
+      expect(
+        row.querySelector('.topic-message-result__sender')?.textContent
+      ).toBe('claude');
+      expect(
+        row.querySelector('.topic-message-result__time')?.textContent
+      ).toBeTruthy();
+      // The PUA sentinels are consumed, never rendered, and the matched run is
+      // its own element rather than markup smuggled through the body.
+      const snippet = row.querySelector('.topic-message-result__snippet');
+      expect(snippet?.textContent).toBe('rebuilt the sqlite index');
+      expect(snippet?.textContent).not.toContain(CHANNEL_SEARCH_HIGHLIGHT_OPEN);
+      expect(row.querySelector('.topic-message-result__hit')?.textContent).toBe(
+        'sqlite'
+      );
+    });
+
+    it('shows a per-section empty state so a hit in one section is not read as both', async () => {
+      await renderView({
+        topics: [],
+        sessions: [],
+        surfaces: [],
+        searchQuery: 'apollo',
+        searchResults: [],
+        messageResults: [],
+      });
+
+      expect(container.textContent).toContain('no chat matches for “apollo”');
+      expect(container.textContent).toContain(
+        'no message matches for “apollo”'
+      );
+    });
+
+    it('opens the channel and asks it to jump when a message hit is clicked', async () => {
+      useUiStore.setState({ sidebarOpen: true, activeChannelId: null });
+      await renderView({
+        // Deliberately NOT in `topics`: chat-title search returns the chats it
+        // matched, and a message can match in a channel whose title did not.
+        topics: [],
+        sessions: [],
+        surfaces: [],
+        searchQuery: 'sqlite',
+        searchResults: [],
+        messageResults: [makeMessageHit()],
+      });
+
+      const row = container.querySelector(
+        '.topic-message-result'
+      ) as HTMLButtonElement;
+      await act(async () => row.click());
+
+      expect(useUiStore.getState().activeChannelId).toBe('topic:alpha');
+      // The S1 anchor, written AFTER the channel open (which clears it).
+      expect(useUiStore.getState().pendingChannelMessage).toEqual({
+        channelId: 'topic:alpha',
+        messageId: 'chm:hit-1',
+      });
+      expect(useUiStore.getState().sidebarOpen).toBe(false);
+      expect(onSelectSession).not.toHaveBeenCalled();
+    });
+
+    it('anchors a thread hit on the reply itself so the S1 walk opens its panel', async () => {
+      // The sidebar deliberately does NOT resolve the root or open the panel:
+      // `ChannelView` maps a reply anchor to `activeThreadRootId` (proved in
+      // test/components/channel-message-jump.test.ts). Handing it the ROOT id
+      // here would land the jump on the main lane and never open the thread.
+      useUiStore.setState({ sidebarOpen: true, activeChannelId: null });
+      await renderView({
+        topics: [],
+        sessions: [],
+        surfaces: [],
+        searchQuery: 'sqlite',
+        searchResults: [],
+        messageResults: [
+          makeMessageHit({
+            messageId: 'chm:reply-9' as ChannelMessageId,
+            threadId: 'chm:root-1' as ChannelMessageId,
+          }),
+        ],
+      });
+
+      const row = container.querySelector(
+        '.topic-message-result'
+      ) as HTMLButtonElement;
+      expect(
+        row.querySelector('.topic-message-result__thread')?.textContent
+      ).toBe('thread');
+
+      await act(async () => row.click());
+
+      expect(useUiStore.getState().pendingChannelMessage).toEqual({
+        channelId: 'topic:alpha',
+        messageId: 'chm:reply-9',
+      });
+    });
+
+    it('threads the show-older-chats toggle into BOTH search requests', async () => {
+      // #1288 lesson, applied to the second section: the toggle has to reach
+      // the message query's KEY as well as its params, or TanStack serves the
+      // active-only answer to the include-archived question.
+      const topicQueries: Record<string, string>[] = [];
+      const messageQueries: Record<string, string>[] = [];
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith('/workspace-topics/search')) {
+          const params = new URL(url, 'http://relay.test').searchParams;
+          topicQueries.push(Object.fromEntries(params));
+          return Response.json({
+            query: 'archived',
+            results: [],
+            truncated: false,
+            derived: false,
+          });
+        }
+        if (url.startsWith('/channels/search')) {
+          const params = new URL(url, 'http://relay.test').searchParams;
+          messageQueries.push(Object.fromEntries(params));
+          const includeArchived = params.get('includeArchived') === '1';
+          return Response.json({
+            query: 'archived',
+            results: includeArchived
+              ? [
+                  makeMessageHit({
+                    channelTitle: 'Archived lane',
+                    archived: true,
+                    snippet: 'said archived once',
+                  }),
+                ]
+              : [],
+            truncated: false,
+          });
+        }
+        return Response.json({
+          topics: [],
+          surfaces: [],
+          nodes: [],
+          workspaces: [],
+          truncated: false,
+          derived: false,
+        });
+      }) as unknown as typeof fetch;
+      vi.stubGlobal('fetch', fetchMock);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+
+      await act(async () => {
+        root.render(
+          React.createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            React.createElement(TopicSidebarShell, { onSelectSession })
+          )
+        );
+      });
+      await act(async () => {
+        await flushQueryEffects();
+      });
+
+      const searchInput = container.querySelector(
+        '.topic-search__input'
+      ) as HTMLInputElement;
+      await act(async () => {
+        setInputValue(searchInput, 'archived');
+        searchInput.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            data: 'archived',
+            inputType: 'insertText',
+          })
+        );
+      });
+      await waitForRendered(
+        () =>
+          container.textContent?.includes('no message matches for') === true,
+        'the empty message-search section'
+      );
+
+      // One shared debounce: one request per section for the whole word.
+      expect(topicQueries).toEqual([{ q: 'archived', limit: '20' }]);
+      expect(messageQueries).toEqual([{ q: 'archived', limit: '20' }]);
+      expect(container.textContent).not.toContain('Archived lane');
+
+      const archivedToggle = container.querySelector(
+        '.topic-archived-toggle__btn'
+      ) as HTMLButtonElement;
+      await act(async () => {
+        archivedToggle.click();
+      });
+      await waitForRendered(
+        () => container.textContent?.includes('Archived lane') === true,
+        'the archived message-search hit'
+      );
+
+      expect(topicQueries).toContainEqual({
+        q: 'archived',
+        includeArchived: '1',
+        limit: '20',
+      });
+      expect(messageQueries).toContainEqual({
+        q: 'archived',
+        includeArchived: '1',
+        limit: '20',
+      });
+      expect(container.textContent).not.toContain('no message matches for');
+      queryClient.clear();
+    });
   });
 });

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -20,6 +20,7 @@ import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import {
   CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
   CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+  CHANNEL_SEARCH_MIN_QUERY_CHARS,
   type ChannelMessageId,
   type ChannelMessageSearchResult,
 } from '../shared/channel-chat-protocol.js';
@@ -4486,6 +4487,111 @@ describe('TopicSidebarView', () => {
         limit: '20',
       });
       expect(container.textContent).not.toContain('no message matches for');
+      queryClient.clear();
+    });
+
+    it('refuses to search messages below the minimum query length', async () => {
+      // A one-character prefix ranks essentially the whole FTS corpus inside a
+      // synchronous sqlite call on the hub's event loop, so the rail must not
+      // send it at all. Chat-title search is an in-memory scan and keeps
+      // answering from the first keystroke.
+      expect(CHANNEL_SEARCH_MIN_QUERY_CHARS).toBe(3);
+      const topicQueries: string[] = [];
+      const messageQueries: string[] = [];
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith('/workspace-topics/search')) {
+          topicQueries.push(url);
+          return Response.json({
+            query: 'sq',
+            results: [],
+            truncated: false,
+            derived: false,
+          });
+        }
+        if (url.startsWith('/channels/search')) {
+          messageQueries.push(url);
+          return Response.json({
+            query: 'sq',
+            results: [makeMessageHit()],
+            truncated: false,
+          });
+        }
+        return Response.json({
+          topics: [],
+          surfaces: [],
+          nodes: [],
+          workspaces: [],
+          truncated: false,
+          derived: false,
+        });
+      }) as unknown as typeof fetch;
+      vi.stubGlobal('fetch', fetchMock);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+
+      await act(async () => {
+        root.render(
+          React.createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            React.createElement(TopicSidebarShell, { onSelectSession })
+          )
+        );
+      });
+      await act(async () => {
+        await flushQueryEffects();
+      });
+
+      const searchInput = container.querySelector(
+        '.topic-search__input'
+      ) as HTMLInputElement;
+      await act(async () => {
+        setInputValue(searchInput, 'sq');
+        searchInput.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            data: 'sq',
+            inputType: 'insertText',
+          })
+        );
+      });
+      await waitForRendered(
+        () =>
+          container.textContent?.includes(
+            'type 3 characters to search messages'
+          ) === true,
+        'the too-short message-search state'
+      );
+
+      // The chats section is an in-memory scan, so it still answers two
+      // characters; only the index read is withheld.
+      await waitForRendered(
+        () => topicQueries.length === 1,
+        'the chat-title search for the same two characters'
+      );
+      expect(messageQueries).toEqual([]);
+      // The refusal is named, never dressed up as a miss over a corpus nothing
+      // consulted.
+      expect(container.textContent).not.toContain('no message matches for');
+
+      await act(async () => {
+        setInputValue(searchInput, 'sql');
+        searchInput.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            data: 'l',
+            inputType: 'insertText',
+          })
+        );
+      });
+      await waitForRendered(
+        () => container.textContent?.includes('Build UI shell') === true,
+        'the message hit once the query is long enough'
+      );
+      expect(messageQueries).toHaveLength(1);
+      expect(messageQueries[0]).toContain('q=sql');
       queryClient.clear();
     });
   });


### PR DESCRIPTION
Slice 2 of #1308 makes the channel transcript searchable. Until now the only
question Relay could answer was "which chat was that?" (topic titles); it could
not answer "where was that said?". This adds an FTS5 index over the durable
message log, a ranked search endpoint that rides the existing
`channels.history` read grant, and two surfaces over it — a `messages` section
in the sidebar and a `messages` category in the command palette — both landing
the operator on the exact message via slice 1's jump machinery.

## The three items

**Item 1 — FTS5 index + ranked search endpoint** (`55e7a12d`)

`channel_messages_fts` is an EXTERNAL-CONTENT FTS5 table
(`content='channel_messages'`), so a 256KB body is never duplicated on disk —
only the inverted index is stored, and column values are read back from the
source row by rowid. Tokenizer is `unicode61 remove_diacritics 2`, deliberately
NOT `porter`: channel bodies are dense with file paths, symbol names and error
codes, and the operator is almost always searching for a literal string they
remember seeing. `GET /channels/search` resolves the visible-channel allowlist
from `workspace_topics` (a separate db), pushes it INTO the index query, and
returns bm25-ranked hits with `snippet()` highlights, `truncated`, and an
explicit `unavailableReason`.

**Item 2 — sidebar message-search section with jump-to-message** (`35e7dfda`)

One field, two labelled sections (`chats`, `messages`) under one 150ms
debounce, each with its own empty state — a bm25 message score and a
topic-title score share no unit, so a merged ranking would order answers by a
number that means nothing across the two. `showArchived` rides both query KEYS,
not just both requests. Clicking a hit reuses slice 1: open the channel, then
write the `requestChannelMessage` anchor (in that order — `setActiveChannelId`
clears an unconsumed anchor), so `ChannelView` owns the bounded backwards walk,
the not-in-recent-history toast, the jump emphasis, and the reply →
thread-panel mapping. No second scroll path.

**Item 3 — command palette `messages` category** (`c366e829`)

The palette FETCHES rather than reading the sidebar's cache:
`TopicSidebarShell` is that cache's only other producer and never mounts while
the sidebar is collapsed, so a cache-only category would stay permanently empty
for exactly the operators who reach for a palette instead of a rail (the
#1287/#1289 trap). Namespaced query key (`palette`) so the palette's 5-row cap
can never fix the sidebar's 20-row section, and `enabled` is gated on `open` so
a closed palette stops refetching the last thing typed.

## Index coherence — every mutation path

The index is a FILTERED projection of `channel_messages`, kept in sync by three
`AFTER INSERT` / `AFTER UPDATE` / `AFTER DELETE` triggers rather than by
code-level upserts. That is the load-bearing choice: this store has many write
paths into `channel_messages`, and a trigger cannot be forgotten by a future
one — a call site can. Every path below is covered without touching any of
them:

| Path | Effect on the index |
| --- | --- |
| `appendComplete` | INSERT → indexed |
| `beginStream` | INSERT with `status='streaming'` → NOT indexed (a half-written body would be indexed at whatever prefix was flushed) |
| `updateStreamText` | UPDATE while streaming → still excluded, no re-index churn per delta |
| `updateAgentDetail` | UPDATE setting `meta.agentDetail` → excluded (tool payload, not conversation) |
| `resolveProvisionalAgentDetailTerminal` | UPDATE → excluded by the same predicate |
| `finalizeStream` | UPDATE to `complete` → enters the index exactly once |
| `editMessage` | UPDATE `body_text` → old terms deleted, new terms inserted |
| `deleteMessage` | UPDATE setting `meta.deletedAt` → removed (a tombstone that still answered would be an undelete through the back door) |
| `sweepStaleStreaming` | UPDATE `status` → follows the predicate in both directions |
| `sweepOrphans` | `DELETE FROM channel_messages WHERE channel_id = ?` → entries removed |
| duplicate/alias heal + seq renumber migrations | UPDATE/DELETE → covered by the same triggers |

The indexable predicate itself (`channelSearchIndexablePredicate`) is shared
VERBATIM between the triggers and the backfill, so index contents cannot drift
from what a rebuild would produce: `kind='message'`, not streaming, non-empty
body, no `meta.agentDetail`, no `meta.deletedAt`. System rows (hub
bookkeeping), agent detail cards, half-written streams and tombstones are all
out. Thread replies are deliberately IN — a reply is a message, and the deep
link resolves it to its root and opens the thread panel.

The join key is `channel_messages`' IMPLICIT rowid (`id` is `TEXT PRIMARY KEY`,
so there is no INTEGER PRIMARY KEY alias). That is an identity contract, now
asserted by a test rather than only stated in prose: the table may never be
declared `WITHOUT ROWID`, and no store path may `VACUUM` without rebuilding the
index afterwards — VACUUM renumbers implicit rowids, and the index would then
answer with other channels' bodies under correct-looking snippets.

## Migration and backfill safety

Schema goes v5 → v6. The index is a DERIVED artifact, so its integrity check
runs on EVERY open rather than once behind a numbered migration step: a
numbered migration fires exactly once and could never repair a table or trigger
dropped afterwards (operator surgery, a backup restored mid-migration, or the
v2 lane that already drops and renames `channel_messages` — a DROP takes its
triggers with it).

Completeness is now STATED, not inferred from DDL presence (`fc5db7eb`):

- a `channel_search_state` row carries `status` (`building`/`complete`), the
  committed rowid cursor and the snapshot bound;
- the DDL, the index truncate and the `building` marker commit as ONE
  transaction, so a crash can never leave an EMPTIED index that the next boot
  mistakes for a resumable partial one;
- the backfill then runs OUTSIDE that transaction in 5k-row commits, so boot
  never holds one writer over the whole tokenization pass (~4s per 50k rows, so
  ~16s of silent stall at 200k) and never returns SQLITE_BUSY to a second
  process sharing the config dir for that long;
- the cursor advances INSIDE each batch transaction — a cursor written after
  the commit could be lost to a crash in between, and replaying that range
  would double-index it (external-content FTS5 has no upsert, and a later
  `'delete'` would only half remove the duplicates);
- `complete` is written only after the last batch, and the boot check returns
  early ONLY on that marker. Without it, `table + triggers + half an index` was
  reachable and indistinguishable from healthy — permanently. Batches walk
  rowid ASCENDING, so the missing remainder is the NEWEST messages, i.e.
  exactly what an operator searches for;
- an interrupted backfill RESUMES from its cursor against the PERSISTED
  snapshot bound. Restart-from-zero would never converge on a store big enough
  to be interrupted (this repo has a documented OOM-kill/systemd-restart
  incident on the boot path), and re-deriving a fresh bound would overlap the
  tail the live triggers already indexed;
- a missing marker under an intact structure (pre-marker db, hand-edited db) is
  NOT resumable — there is no cursor to trust — so it rebuilds from scratch.

The backfill is batched over rowid RANGES, not `LIMIT/OFFSET` of the filtered
set, so each commit scans a bounded slice regardless of predicate selectivity
and no row can be skipped or double-indexed by a shifting offset. The upper
bound is snapshot once, before the first commit, so a row appended mid-rebuild
is indexed by the live trigger and never re-scanned by a later batch. Row
counts, per-batch progress and elapsed time are logged on every path.

## FTS injection handling

Operator text never reaches the MATCH parser as syntax. Every term is emitted
as a QUOTED phrase — inside an FTS5 phrase the only character with meaning is
`"`, which is stripped before quoting — so `NOT`, `a:b`, `foo*`, `(`, `^` and
friends are searched literally instead of parsed as operators or throwing a
syntax error. Additional bounds, all server-side and mirrored client-side (a
UI-only gate is not a guard; the route is reachable by any capability holder):

- query truncated to `CHANNEL_SEARCH_QUERY_MAX_CHARS` (256) and split into at
  most `CHANNEL_SEARCH_MAX_TERMS` (12) terms — beyond that it is a paste, not a
  search;
- terms with no letter or digit are dropped (they can only contribute an empty
  phrase; verified that FTS5 executes `'"***" *'` and `'"" *'` cleanly rather
  than rejecting them, so this is about not running a guaranteed-empty read);
- the trailing `*` prefix operator requires `CHANNEL_SEARCH_MIN_QUERY_CHARS`
  (3) code points, counted as code points (`[...term].length`) so an astral
  character counts once. A single-term query below that is refused outright and
  reported as `query_too_short`;
- channel scoping is a bound-parameter allowlist joined back to
  `channel_messages`, never string-interpolated ids, and the ids stay UNINDEXED
  in the FTS table so `topic:`/`chm:` identifiers never pollute the term
  dictionary.

Refused queries are reported through `unavailableReason` from the SAME
predicate the store applies, so "we did not run this" stays distinguishable
from "we ran it and found nothing" — the client no longer prints "no matches"
for text the index was never asked about.

## Review trail

Round 1 (adversarial, over the three feature commits) → batched fix pass in
`8692d220`:

- **P0** — a single-character type-ahead query froze the whole hub. `*` was
  appended to the final term unconditionally behind a 150ms debounce, so one
  keystroke issued `MATCH '"a" *'`: a prefix over nearly the entire term
  dictionary that bm25 + `ORDER BY` must rank in full before `LIMIT` drops it,
  inside a synchronous better-sqlite3 call on the request path. Fixed by the
  3-code-point minimum, enforced in the store and mirrored in both clients.
- **P2** — search reach was the rail's 200-row read model, not the corpus. The
  allowlist came from `topicStore.list()` (capped at 200 by `updated_at DESC`
  across all workspaces, against 500 retained) with scope filters applied in JS
  AFTER that global window, so older channels were silently unsearchable and
  workspace scoping shrank the ANSWER instead of the search space. Now
  enumerated through `listAllTopicIds()`.
- **P2** — the v5→v6 index build ran delete-all + backfill in one unbounded
  write transaction on the boot path, silently. Now batched + logged.
- **P3** — refused queries were indistinguishable from real misses
  (`unavailableReason`); two load-bearing comments corrected (implicit-rowid
  contract, FTS5 empty-phrase behaviour) and the rowid contract promoted from
  prose to a test.

Round 2 (re-review of the changed hunks) → `fc5db7eb`:

- **P1 (applied)** — the P2 batching fix made a crash-truncated backfill
  permanent and undetectable, because the boot check still gated on DDL
  presence alone. Fixed as described above; the reviewer's own fixture is now a
  regression test, confirmed as a negative control (restoring the previous
  presence-only gate makes the new test fail on exactly the missing tail).
- **P3 (noted, partially applied)** — the 3-char minimum bounds the
  pathological shape but not the worst case, which still scales with corpus
  size. The measured band is now recorded next to the constant (50k-message /
  179MB corpus: `"w" *` 2805ms — now refused, `"w1" *` 1079ms — refused,
  `"w12" *` 158ms, `"the" *` 140ms) so the next person changing the expression
  knows the budget they are spending. **Follow-up, not in this PR:** a
  `sqlite3_progress_handler`-style abort or wall-clock ceiling answering
  `unavailableReason: 'search_timeout'`, or moving the search read off the
  request thread.

## Verification

- `npm run check` — 0 errors (220 pre-existing `sonarjs/no-duplicate-string`
  warnings, unchanged).
- `npm test` — full suite green at head: **453 files / 5677 tests passed**
  (node v22.22.3). An earlier run under load flaked on `test/sandbox.test.ts`,
  `test/server-startup.test.ts` and `test/hermes-image-input.test.ts` (the
  known load-sensitive set); all three pass on isolate-rerun and the subsequent
  full run was clean.
- New coverage in this pass: a crash-truncated backfill resumes and makes the
  tail searchable with every row indexed exactly once; a markerless-but-intact
  index rebuilds from scratch exactly once; both assert the marker ends
  `complete`.
- Negative control for the P1 fix: temporarily restoring the presence-only gate
  makes the new test fail (`needle5` absent after reopen); restoring the fix
  makes it pass.
- Pre-existing slice-2 coverage retained: FTS escaping/contract unit tests,
  `EXPLAIN QUERY PLAN` assertion that the index DRIVES and `channel_messages` is
  probed by rowid, multi-batch backfill (5,200 rows) with per-batch predicate
  application, v5→v6 upgrade + idempotent reopen, route tests, sidebar and
  palette tests.

Refs #1308 (slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-text message search to the command palette and topic sidebar.
  * Search results show highlighted snippets, sender details, channels, timestamps, and thread context.
  * Selecting a result opens the relevant channel and jumps directly to the message or thread.
  * Added support for workspace, channel, and archived-content filtering.
  * Displays clear empty, error, unavailable, and truncated-result states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->