### PR TITLE
feat(chat): OS notifications, favicon badge, title count (#1308 slice 5)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,7 @@ import { startShikiGc } from './lib/stores/shiki-gc.js';
 import { IA_WORKSPACES_QUERY_KEY } from './lib/hooks/use-ia-workspaces.js';
 import type { ActionContext } from './lib/actions/types.js';
 import { useEventSocket } from './hooks/useEventSocket.js';
+import { useNotifyDelivery } from './hooks/useNotifyDelivery.js';
 import { useVisibilityRefresh } from './hooks/useVisibilityRefresh.js';
 import { useAppShortcuts } from './hooks/useAppShortcuts.js';
 import { useActionRegistry } from './hooks/useActionRegistry.js';
@@ -1282,6 +1283,12 @@ export default function App() {
     }, 500);
     return () => clearTimeout(timer);
   }, [authAuthenticated, activeRepoPath, activeSessionId]);
+
+  // ── Channel notifications (#1308 slice 5) ──────────────────────────────────
+  // Mounted next to the event socket because it is the same kind of lane: an
+  // app-lifetime subscription with no rendered output of its own. Gated on auth
+  // so a signed-out tab neither fetches summaries nor badges its own favicon.
+  useNotifyDelivery(authAuthenticated, queryClient);
 
   // ── Event socket ───────────────────────────────────────────────────────────
   useEventSocket({

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -21,7 +21,6 @@ import { builtInAgentProfileId } from '../../../shared/agent-profile.js';
 import {
   CHANNEL_SEARCH_MIN_QUERY_CHARS,
   parseChannelSearchSnippet,
-  parseMentions,
   type ChannelMessageId,
   type ChannelMessageSearchResult,
 } from '../../../shared/channel-chat-protocol.js';
@@ -47,7 +46,7 @@ import {
 } from '../lib/api.js';
 import type { CockpitRosterAttention } from '../lib/state/cockpit-attention.js';
 import {
-  CURRENT_OPERATOR_SENDER_ID,
+  messageMentionsOperator,
   senderShortLabel,
 } from '../lib/channel-sender-label.js';
 import { deriveColor } from '../lib/colors.js';
@@ -153,7 +152,6 @@ const MOBILE_COCKPIT_ROSTER_BATCH_SIZE = 12;
  * refetches.
  */
 const CHANNEL_SUMMARY_REFRESH_THROTTLE_MS = 10_000;
-const CURRENT_OPERATOR_MENTION_NAME = 'operator';
 
 function useMobileCockpitViewport(): boolean {
   const [matches, setMatches] = useState(
@@ -180,28 +178,15 @@ function useMobileCockpitViewport(): boolean {
  * persist an empty body), which is exactly the row an operator would read as
  * "the last message".
  *
- * `lastMessage.mentions` is authoritative: the server computes it over the FULL
- * body (persisted mentions when the write path resolved them), so a mention past
- * the 200-char preview cut-off still counts. The preview parse below is only the
- * fallback for a payload predating that field.
+ * The predicate itself lives in `channel-sender-label.ts` (#1308 slice 5): the
+ * notification lane raises its MENTION trigger from the same rows, and a second
+ * copy here would be free to drift into badging a mention that never notifies.
  */
 function summaryMentionsCurrentOperator(
   summary: ChannelRailSummary | null
 ): boolean {
   const last = summary?.lastMessage;
-  if (!last) return false;
-  if (last.senderId === CURRENT_OPERATOR_SENDER_ID) return false;
-  // Browser-authored channel posts are canonically `human:operator` with the
-  // display name `Operator` (channel-chat-router deriveSender).
-  const mentions =
-    last.mentions ??
-    // Legacy payload without the field: parse the truncated preview with the
-    // shared parser rather than introducing a cockpit-only tokenizer.
-    parseMentions(last.preview);
-  return mentions.some(
-    (mention) =>
-      mention.raw.slice(1).toLowerCase() === CURRENT_OPERATOR_MENTION_NAME
-  );
+  return last ? messageMentionsOperator(last) : false;
 }
 
 /**

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -267,6 +267,10 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
     const setAdvancedMode = useUiStore((s) => s.setAdvancedMode);
     const [searchQuery, setSearchQuery] = useState('');
     const [tocOpen, setTocOpen] = useState(false);
+    // This dialog is rendered unconditionally into a native `<dialog>` and never
+    // unmounts, so "opened" is not a mount. Sections whose state is read from
+    // outside React (the browser's notification permission) take this instead.
+    const [openNonce, setOpenNonce] = useState(0);
 
     const contentRefCallback = useCallback((el: HTMLDivElement | null) => {
       contentElRef.current = el;
@@ -327,6 +331,7 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
         }));
         setDevtoolsEnabled(localStorage.getItem('devtools-enabled') === 'true');
         setNotifPerm(getPermissionState());
+        setOpenNonce((n) => n + 1);
         void loadAllData();
         shellRef.current?.open();
         if (scrollToId)
@@ -454,7 +459,10 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
               searchQuery={searchQuery}
               handlers={configHandlers}
             />
-            <SettingsNotificationsSection searchQuery={searchQuery} />
+            <SettingsNotificationsSection
+              searchQuery={searchQuery}
+              openNonce={openNonce}
+            />
             <SettingsAgentProfilesSection searchQuery={searchQuery} />
             <IntegrationsSection
               searchQuery={searchQuery}

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -39,6 +39,7 @@ import {
 import { reloadWhenServerReturns } from '../../lib/server-restart.js';
 import { useSessionsStore } from '../../lib/stores/sessions.js';
 import { useConfigStore } from '../../lib/stores/config.js';
+import { useNotifySettingsStore } from '../../lib/stores/notify-settings.js';
 import { isFrameworkAvailable } from './CustomizeSessionDialog.js';
 import {
   requestPermission,
@@ -88,6 +89,9 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
   general: [
     'default coding agent',
     'notifications',
+    'mentions',
+    'direct message',
+    'turn complete',
     'rename',
     'renamer',
     'branch name',
@@ -574,7 +578,51 @@ function GeneralSection({
           disabled={notifDisabled}
         />
       </SettingRow>
+      <ChannelNotifyRows />
     </section>
+  );
+}
+
+/**
+ * Which channel events may notify (#1308 slice 5). Device-local, so unlike the
+ * row above it writes localStorage, not `PUT /config`: notification preference
+ * belongs to THIS browser and its OS permission grant, not to the account.
+ */
+function ChannelNotifyRows() {
+  const settings = useNotifySettingsStore((state) => state.settings);
+  const setNotifySetting = useNotifySettingsStore(
+    (state) => state.setNotifySetting
+  );
+  return (
+    <>
+      <SettingRow
+        name="Channel Mentions"
+        description="Notify when a channel message mentions @operator"
+      >
+        <TuiCheckbox
+          checked={settings.mentions}
+          onChange={(v) => setNotifySetting('mentions', v)}
+        />
+      </SettingRow>
+      <SettingRow
+        name="Direct Message Replies"
+        description="Notify when an agent replies in a direct message channel"
+      >
+        <TuiCheckbox
+          checked={settings.dmReplies}
+          onChange={(v) => setNotifySetting('dmReplies', v)}
+        />
+      </SettingRow>
+      <SettingRow
+        name="Turn Complete"
+        description="Notify when an agent finishes a turn in a channel you are not viewing"
+      >
+        <TuiCheckbox
+          checked={settings.turnComplete}
+          onChange={(v) => setNotifySetting('turnComplete', v)}
+        />
+      </SettingRow>
+    </>
   );
 }
 

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -39,7 +39,9 @@ import {
 import { reloadWhenServerReturns } from '../../lib/server-restart.js';
 import { useSessionsStore } from '../../lib/stores/sessions.js';
 import { useConfigStore } from '../../lib/stores/config.js';
-import { useNotifySettingsStore } from '../../lib/stores/notify-settings.js';
+import SettingsNotificationsSection, {
+  NOTIFICATIONS_SECTION_KEYWORDS,
+} from './SettingsNotificationsSection.js';
 import { isFrameworkAvailable } from './CustomizeSessionDialog.js';
 import {
   requestPermission,
@@ -67,6 +69,7 @@ const DEFAULT_CONFIG: ConfigState = {
 
 const TOC_SECTIONS = [
   { id: 'section-general', label: 'general' },
+  { id: 'section-notifications', label: 'notifications' },
   {
     id: 'section-agent-profiles',
     label: 'agents',
@@ -89,14 +92,12 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
   general: [
     'default coding agent',
     'notifications',
-    'mentions',
-    'direct message',
-    'turn complete',
     'rename',
     'renamer',
     'branch name',
     'session name',
   ],
+  notifications: NOTIFICATIONS_SECTION_KEYWORDS,
   'agent-profiles': ['agents', 'profiles', 'claude', 'codex', 'opencode'],
   integrations: [
     'github',
@@ -453,6 +454,7 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
               searchQuery={searchQuery}
               handlers={configHandlers}
             />
+            <SettingsNotificationsSection searchQuery={searchQuery} />
             <SettingsAgentProfilesSection searchQuery={searchQuery} />
             <IntegrationsSection
               searchQuery={searchQuery}
@@ -578,51 +580,7 @@ function GeneralSection({
           disabled={notifDisabled}
         />
       </SettingRow>
-      <ChannelNotifyRows />
     </section>
-  );
-}
-
-/**
- * Which channel events may notify (#1308 slice 5). Device-local, so unlike the
- * row above it writes localStorage, not `PUT /config`: notification preference
- * belongs to THIS browser and its OS permission grant, not to the account.
- */
-function ChannelNotifyRows() {
-  const settings = useNotifySettingsStore((state) => state.settings);
-  const setNotifySetting = useNotifySettingsStore(
-    (state) => state.setNotifySetting
-  );
-  return (
-    <>
-      <SettingRow
-        name="Channel Mentions"
-        description="Notify when a channel message mentions @operator"
-      >
-        <TuiCheckbox
-          checked={settings.mentions}
-          onChange={(v) => setNotifySetting('mentions', v)}
-        />
-      </SettingRow>
-      <SettingRow
-        name="Direct Message Replies"
-        description="Notify when an agent replies in a direct message channel"
-      >
-        <TuiCheckbox
-          checked={settings.dmReplies}
-          onChange={(v) => setNotifySetting('dmReplies', v)}
-        />
-      </SettingRow>
-      <SettingRow
-        name="Turn Complete"
-        description="Notify when an agent finishes a turn in a channel you are not viewing"
-      >
-        <TuiCheckbox
-          checked={settings.turnComplete}
-          onChange={(v) => setNotifySetting('turnComplete', v)}
-        />
-      </SettingRow>
-    </>
   );
 }
 

--- a/frontend/src/components/dialogs/SettingsNotificationsSection.tsx
+++ b/frontend/src/components/dialogs/SettingsNotificationsSection.tsx
@@ -1,0 +1,136 @@
+// Settings › notifications (#1308 slice 5 item 2).
+//
+// Its OWN section rather than three more rows under general, following the
+// `SettingsAgentProfilesSection` precedent: the lane has a permission state, a
+// grant affordance, and three triggers, which is a topic, not a setting.
+//
+// Device-local by design. Unlike general's `Notifications` row (which writes
+// `PUT /config` to arm the legacy per-session push lane), everything here is
+// localStorage: a notification preference belongs to THIS browser and the OS
+// permission grant it holds, and syncing it would be wrong as well as more
+// expensive.
+import { useEffect, useState } from 'react';
+import SettingRow from './SettingRow.js';
+import TuiButton from '../TuiButton.js';
+import TuiCheckbox from '../TuiCheckbox.js';
+import {
+  notifyPermissionState,
+  type NotifyPermissionState,
+} from '../../lib/notify/os-notification.js';
+import { notifyOsNotifier } from '../../lib/notify/runtime.js';
+import { useNotifySettingsStore } from '../../lib/stores/notify-settings.js';
+
+/** Search terms that keep this section undimmed (mirrors `SECTION_KEYWORDS`). */
+export const NOTIFICATIONS_SECTION_KEYWORDS = [
+  'notifications',
+  'browser notifications',
+  'desktop notifications',
+  'permission',
+  'mentions',
+  'direct message',
+  'dm',
+  'turn complete',
+  'badge',
+  'favicon',
+];
+
+function matchesSearch(query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    'notifications'.includes(q) ||
+    NOTIFICATIONS_SECTION_KEYWORDS.some((term) => term.includes(q))
+  );
+}
+
+const PERMISSION_DESCRIPTION: Record<NotifyPermissionState, string> = {
+  granted: 'this browser may show relay notifications',
+  denied: 'blocked by the browser — re-allow in site settings',
+  default: 'relay will ask the first time a channel event earns a notification',
+  unsupported: 'not supported in this browser',
+};
+
+export function SettingsNotificationsSection({
+  searchQuery,
+}: {
+  searchQuery: string;
+}) {
+  const settings = useNotifySettingsStore((state) => state.settings);
+  const setNotifySetting = useNotifySettingsStore(
+    (state) => state.setNotifySetting
+  );
+  const [permission, setPermission] =
+    useState<NotifyPermissionState>('default');
+
+  useEffect(() => {
+    // READ, never request. `Notification.permission` is a plain property — the
+    // prompt only ever comes from `requestPermission`, which this section fires
+    // exclusively from the button below.
+    setPermission(notifyPermissionState());
+  }, []);
+
+  return (
+    <section
+      id="section-notifications"
+      className={[
+        'settings-dialog-section',
+        !matchesSearch(searchQuery) ? 'dimmed' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <h3 className="settings-dialog-section-heading">notifications</h3>
+      <SettingRow
+        name="Browser Notifications"
+        description={PERMISSION_DESCRIPTION[permission]}
+      >
+        {permission === 'default' ? (
+          <TuiButton
+            variant="primary"
+            size="sm"
+            onClick={() => {
+              // The gesture-backed path. Safari has always required a user
+              // gesture for `requestPermission`, and Firefox has since 72 — so
+              // the lazy first-event ask can be refused outright there, and
+              // this button is the only grant that always works.
+              void notifyOsNotifier().requestPermission().then(setPermission);
+            }}
+          >
+            enable
+          </TuiButton>
+        ) : (
+          <span className="setting-description">{permission}</span>
+        )}
+      </SettingRow>
+      <SettingRow
+        name="Channel Mentions"
+        description="Notify when a channel message mentions @operator"
+      >
+        <TuiCheckbox
+          checked={settings.mentions}
+          onChange={(v) => setNotifySetting('mentions', v)}
+        />
+      </SettingRow>
+      <SettingRow
+        name="Direct Message Replies"
+        description="Notify when an agent replies in a direct message channel"
+      >
+        <TuiCheckbox
+          checked={settings.dmReplies}
+          onChange={(v) => setNotifySetting('dmReplies', v)}
+        />
+      </SettingRow>
+      <SettingRow
+        name="Turn Complete"
+        description="Notify when an agent finishes a turn in a channel you are not viewing"
+      >
+        <TuiCheckbox
+          checked={settings.turnComplete}
+          onChange={(v) => setNotifySetting('turnComplete', v)}
+        />
+      </SettingRow>
+    </section>
+  );
+}
+
+export default SettingsNotificationsSection;

--- a/frontend/src/components/dialogs/SettingsNotificationsSection.tsx
+++ b/frontend/src/components/dialogs/SettingsNotificationsSection.tsx
@@ -52,8 +52,20 @@ const PERMISSION_DESCRIPTION: Record<NotifyPermissionState, string> = {
 
 export function SettingsNotificationsSection({
   searchQuery,
+  openNonce = 0,
 }: {
   searchQuery: string;
+  /**
+   * Bumped every time the settings dialog is opened.
+   *
+   * `SettingsDialog` is rendered UNCONDITIONALLY from `App` into a native
+   * `<dialog>` that `showModal` reveals — it never unmounts, so a mount-only
+   * read would run once at app boot and never again. An operator who was
+   * `denied` at boot and then re-allowed Relay in browser site settings would
+   * be told they are blocked, with no enable button, for the rest of the tab's
+   * life.
+   */
+  openNonce?: number;
 }) {
   const settings = useNotifySettingsStore((state) => state.settings);
   const setNotifySetting = useNotifySettingsStore(
@@ -67,6 +79,33 @@ export function SettingsNotificationsSection({
     // prompt only ever comes from `requestPermission`, which this section fires
     // exclusively from the button below.
     setPermission(notifyPermissionState());
+  }, [openNonce]);
+
+  // Live updates while the dialog is already open: a lazy grant obtained from
+  // the notify lane itself, or a change made in browser site settings, both land
+  // here. Best effort — Safari has no `permissions.query` for notifications, and
+  // the reject is swallowed because `openNonce` already covers the open path.
+  useEffect(() => {
+    const perms =
+      typeof navigator === 'undefined' ? undefined : navigator.permissions;
+    if (!perms || typeof perms.query !== 'function') return;
+    let cancelled = false;
+    let status: PermissionStatus | null = null;
+    const onChange = () => setPermission(notifyPermissionState());
+    void perms
+      .query({ name: 'notifications' as PermissionName })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        status = result;
+        result.addEventListener('change', onChange);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+      status?.removeEventListener('change', onChange);
+    };
   }, []);
 
   return (

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -9,7 +9,13 @@ import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useChannelActivityStore } from '../lib/stores/channel-activity.js';
-import { useChannelAgentStatusStore } from '../lib/stores/channel-agent-status.js';
+import {
+  channelAgentStatusKey,
+  useChannelAgentStatusStore,
+} from '../lib/stores/channel-agent-status.js';
+import { notifyFromAgentStatus } from '../lib/notify/producers.js';
+import { notifyChannelFromTopic } from '../lib/notify/signals.js';
+import type { WorkspaceTopic } from '../../../shared/workspace-topics.js';
 import type { AccountTelemetry, SessionTelemetry } from '../lib/types.js';
 import type { SessionEventScope } from '../../../shared/node-boundary.js';
 import type {
@@ -239,6 +245,28 @@ function hasCachedChannelRow(
     if (topics.topics.some((topic) => topic.id === channelId)) return true;
   }
   return !sawCachedList;
+}
+
+/**
+ * Channel descriptor for the notify lane (#1308 slice 5), resolved from the
+ * topic caches this module already reads for `hasCachedChannelRow`.
+ *
+ * Cache-only, never a fetch: a turn-complete signal for a channel no list has
+ * loaded has no title to name and no DM-ness to derive, and the honest answer is
+ * to raise no signal rather than notify about `topic:01j…`.
+ */
+function cachedNotifyChannel(
+  queryClient: QueryClient,
+  channelId: string
+): ReturnType<typeof notifyChannelFromTopic> | null {
+  for (const queryKey of TOPIC_LIST_QUERY_KEYS) {
+    const topics = queryClient.getQueryData<{ topics?: WorkspaceTopic[] }>(
+      queryKey
+    );
+    const topic = topics?.topics?.find((row) => row.id === channelId);
+    if (topic) return notifyChannelFromTopic(topic);
+  }
+  return null;
 }
 
 const HUB_NODE_REVERSE_LINK_ROUTE = 'reverse-link';
@@ -610,9 +638,27 @@ export function useEventSocket({
           );
       },
       'channel-agent-status': (msg) => {
+        // Read BEFORE the store records the new value: turn-complete is a
+        // busy→idle EDGE, and the previous status is gone the instant
+        // `recordStatus` lands.
+        const previous =
+          useChannelAgentStatusStore.getState().statusByChannelAgent[
+            channelAgentStatusKey(msg.channelId, msg.agentId)
+          ];
         useChannelAgentStatusStore
           .getState()
           .recordStatus(msg.channelId, msg.agentId, msg.status, msg.runtimeId);
+        // #1308 slice 5: the ONE trigger the socket carries end to end. Default
+        // OFF, so this is inert until the operator opts in from Settings.
+        const notifyChannel = cachedNotifyChannel(queryClient, msg.channelId);
+        if (notifyChannel) {
+          notifyFromAgentStatus({
+            channel: notifyChannel,
+            agentId: msg.agentId,
+            previous,
+            next: msg.status,
+          });
+        }
         // The status store alone cannot carry a binding: a newly bound agent's
         // chip is dropped the moment it goes idle (the header keeps a chip for
         // an unbound agent only while it is busy), and a remotely-designated

--- a/frontend/src/hooks/useNotifyDelivery.ts
+++ b/frontend/src/hooks/useNotifyDelivery.ts
@@ -24,6 +24,7 @@ import {
   createFaviconBadge,
   type FaviconBadge,
 } from '../lib/notify/favicon-badge.js';
+import { notifyPermissionState } from '../lib/notify/os-notification.js';
 import { resetNotifyRuntime } from '../lib/notify/runtime.js';
 import {
   channelSummariesHaveObserver,
@@ -77,6 +78,27 @@ const VISIBLE_SUMMARY_REFRESH_MS = 45_000;
 function messageTriggersEnabled(): boolean {
   const settings = currentNotifySettings();
   return settings.mentions || settings.dmReplies;
+}
+
+/**
+ * How long a refresh must wait, decided at FIRE time.
+ *
+ * A HIDDEN tab is only worth the short window when the OS tier can actually
+ * fire, because that tier is the only thing a hidden tab can show. Permission
+ * still does NOT gate whether the refresh happens — `default` must keep the
+ * short cadence or the lazy grant is unreachable (see `messageTriggersEnabled`)
+ * — but `denied`, and a browser with no Notification API at all (an iOS Safari
+ * tab outside an installed PWA), can produce nothing but a favicon dot nobody
+ * is looking at. Those wait the long window rather than holding the hub at a
+ * ten-second `GET /channels` cadence, times every open tab, for the whole
+ * length of an agent turn.
+ */
+function summaryRefreshDelayMs(doc: Document): number {
+  if (!doc.hidden) return VISIBLE_SUMMARY_REFRESH_MS;
+  const permission = notifyPermissionState();
+  return permission === 'denied' || permission === 'unsupported'
+    ? VISIBLE_SUMMARY_REFRESH_MS
+    : HIDDEN_SUMMARY_REFRESH_MS;
 }
 
 export function useNotifyDelivery(
@@ -164,32 +186,48 @@ export function useNotifyDelivery(
   //     Without this the operator gets no mention or DM badge, dot, title count
   //     or notification at all after the boot seed.
   //
-  // Standing down for a mounted rail is decided at FIRE time, not schedule time:
-  // the rail can mount or unmount inside the window, and the question that
-  // matters is who owns the fetch when it is due.
+  // BOTH the stand-down and the WINDOW are decided at FIRE time, not schedule
+  // time: the rail can mount or unmount inside the window, and the tab can be
+  // switched away from inside it. An operator who generates activity with the
+  // tab visible (long window armed) and then switches away is exactly the case
+  // where the OS tier becomes the only tier — waiting out the window the tab
+  // no longer deserves would delay that first notification by up to 45s.
   useEffect(() => {
     if (!enabled) return;
     const doc = typeof document === 'undefined' ? null : document;
     if (!doc) return;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let armedAt = 0;
+    const fire = (): void => {
+      timer = undefined;
+      const required = summaryRefreshDelayMs(doc);
+      const elapsed = Date.now() - armedAt;
+      // Re-armed for the REMAINDER, never restarted from now: the trailing
+      // guarantee below is measured from the activity that armed the window, so
+      // a tab that went visible mid-window waits out the rest of the long one
+      // and no more.
+      if (elapsed < required) {
+        timer = setTimeout(fire, required - elapsed);
+        return;
+      }
+      // Standing down applies to a VISIBLE tab only. The rail keeps its
+      // observer mounted while hidden but deliberately suppresses its own
+      // refetch there, so an observer on a hidden tab means nobody is
+      // fetching at all — which is the gap this lane exists to fill.
+      if (!doc.hidden && channelSummariesHaveObserver(queryClient)) return;
+      void refreshChannelSummaries(queryClient);
+    };
     const unsubscribe = useChannelActivityStore.subscribe((state, previous) => {
       if (state.latestSeqByChannel === previous.latestSeqByChannel) return;
       if (!messageTriggersEnabled()) return;
-      if (timer !== undefined) return;
       // Trailing, and NOT reset by later activity: an agent streaming a long
       // turn must not be able to starve the refresh it is the reason for.
-      const delay = doc.hidden
-        ? HIDDEN_SUMMARY_REFRESH_MS
-        : VISIBLE_SUMMARY_REFRESH_MS;
-      timer = setTimeout(() => {
-        timer = undefined;
-        // Standing down applies to a VISIBLE tab only. The rail keeps its
-        // observer mounted while hidden but deliberately suppresses its own
-        // refetch there, so an observer on a hidden tab means nobody is
-        // fetching at all — which is the gap this lane exists to fill.
-        if (!doc.hidden && channelSummariesHaveObserver(queryClient)) return;
-        void refreshChannelSummaries(queryClient);
-      }, delay);
+      if (timer !== undefined) return;
+      armedAt = Date.now();
+      // Always the SHORT tick first. It is only a wake-up, not a fetch: `fire`
+      // re-arms for the remainder when the window it finds is the longer one,
+      // which is what lets the decision be made late without ever being late.
+      timer = setTimeout(fire, HIDDEN_SUMMARY_REFRESH_MS);
     });
     return () => {
       unsubscribe();

--- a/frontend/src/hooks/useNotifyDelivery.ts
+++ b/frontend/src/hooks/useNotifyDelivery.ts
@@ -4,11 +4,12 @@
 //   1. the MENTION / DM-REPLY producer, fed by the `/channels` summary payload;
 //   2. the favicon dot + title count, both derived from the badge store and the
 //      slice-3 read position — never from a second unread implementation;
-//   3. a narrowly-scoped background refresh so the OS tier is not dead while
-//      the tab is hidden.
+//   3. a narrowly-scoped summary refresh for the two cases the rail cannot
+//      cover — a hidden tab (where the rail suppresses its own refresh) and a
+//      collapsed sidebar (where the rail is not mounted at all).
 //
-// Nothing here requests notification permission. That happens on the first
-// event that would actually notify (`os-notification.ts`) or from the explicit
+// Nothing here requests notification permission. That happens in the runtime,
+// from the first gate-approved event (`notify/runtime.ts`), or from the explicit
 // button in Settings › notifications.
 //
 // It reads the query CACHE and takes the client as an argument rather than
@@ -23,8 +24,9 @@ import {
   createFaviconBadge,
   type FaviconBadge,
 } from '../lib/notify/favicon-badge.js';
-import { notifyPermissionState } from '../lib/notify/os-notification.js';
+import { resetNotifyRuntime } from '../lib/notify/runtime.js';
 import {
+  channelSummariesHaveObserver,
   ensureNotifySummaryCaches,
   refreshChannelSummaries,
   watchChannelSummaries,
@@ -41,25 +43,38 @@ import {
 import { currentNotifySettings } from '../lib/stores/notify-settings.js';
 
 /**
- * Trailing window for the hidden-tab summary refresh.
+ * Trailing window for the summary refresh while the tab is HIDDEN.
  *
- * Long — an order of magnitude above the rail's own foreground throttle. This
- * lane exists to keep OS notifications alive for a tab nobody is looking at, and
- * `GET /channels` is O(channels) server-side, so it buys latency down to ten
- * seconds and no more.
+ * `GET /channels` is O(channels) server-side, so this buys notification latency
+ * down to ten seconds and no more.
  */
 const HIDDEN_SUMMARY_REFRESH_MS = 10_000;
 
 /**
- * True when a summary refresh could actually produce an OS notification.
+ * Trailing window while the tab is VISIBLE.
  *
- * The refresh is gated on this rather than run unconditionally, so the hub pays
- * nothing extra for an operator who never granted permission or switched every
- * message trigger off. Turn-complete is excluded on purpose: it is fed by the
- * socket and needs no fetch.
+ * Deliberately longer. A visible tab usually has the rail mounted, in which case
+ * this lane stands down entirely (see `channelSummariesHaveObserver`); the only
+ * case it covers is a COLLAPSED sidebar, where nothing else fetches the summary
+ * list and the operator would otherwise get no mention or DM badge at all — the
+ * exact hole `ensureNotifySummaryCaches` only plugs once, at boot.
  */
-function osTierReachable(): boolean {
-  if (notifyPermissionState() !== 'granted') return false;
+const VISIBLE_SUMMARY_REFRESH_MS = 45_000;
+
+/**
+ * True when a summary refresh could produce anything the operator would see.
+ *
+ * PERMISSION IS NOT CHECKED HERE, and that is the point: a refresh feeds the
+ * in-app badge tier (favicon dot, title count) as well as the OS tier, and the
+ * badge tier needs no grant. Gating this on `granted` made the OS tier
+ * unreachable on a fresh browser — the only lane that can produce a payload
+ * while hidden refused to run until permission existed, and permission was only
+ * ever requested from an event that lane produced.
+ *
+ * Turn-complete is excluded on purpose: it is fed by the socket and needs no
+ * fetch.
+ */
+function messageTriggersEnabled(): boolean {
   const settings = currentNotifySettings();
   return settings.mentions || settings.dmReplies;
 }
@@ -75,7 +90,15 @@ export function useNotifyDelivery(
     // seen by the subscription rather than missed in the gap.
     const stop = watchChannelSummaries(queryClient);
     void ensureNotifySummaryCaches(queryClient);
-    return stop;
+    return () => {
+      stop();
+      // Stopping the watcher is not enough. The gate's per-channel seq ledger,
+      // its OS rate-limit windows and the badge flags all outlive it, so after
+      // an auth expiry and a re-auth every seq already recorded would be
+      // permanently replay-suppressed — a message the operator never read could
+      // not raise its badge again on this tab.
+      resetNotifyRuntime();
+    };
   }, [enabled, queryClient]);
 
   // ── favicon + title ────────────────────────────────────────────────────────
@@ -129,7 +152,21 @@ export function useNotifyDelivery(
     current.favicon.set(count > 0);
   }, [enabled, attentionCount]);
 
-  // ── hidden-tab summary refresh ─────────────────────────────────────────────
+  // ── self-sufficient summary refresh ────────────────────────────────────────
+  //
+  // Two lanes the rail cannot cover, and it owns the ONLY activity-driven
+  // `['channels']` refetch:
+  //   * HIDDEN tab — the rail deliberately suppresses its refresh there, which
+  //     is exactly when the OS tier is the only tier there is;
+  //   * COLLAPSED sidebar — `TopicSidebarShell` is unmounted, so its
+  //     `invalidateQueries(['channels'])` refetches nothing (invalidation is
+  //     `refetchType: 'active'`) and no observer exists to fetch on its own.
+  //     Without this the operator gets no mention or DM badge, dot, title count
+  //     or notification at all after the boot seed.
+  //
+  // Standing down for a mounted rail is decided at FIRE time, not schedule time:
+  // the rail can mount or unmount inside the window, and the question that
+  // matters is who owns the fetch when it is due.
   useEffect(() => {
     if (!enabled) return;
     const doc = typeof document === 'undefined' ? null : document;
@@ -137,20 +174,22 @@ export function useNotifyDelivery(
     let timer: ReturnType<typeof setTimeout> | undefined;
     const unsubscribe = useChannelActivityStore.subscribe((state, previous) => {
       if (state.latestSeqByChannel === previous.latestSeqByChannel) return;
-      // Visible tabs are already covered: the rail refetches the summary list on
-      // its own (tighter) throttle, and this lane's producer runs off whatever
-      // payload that produces. A HIDDEN tab is the gap — the rail deliberately
-      // suppresses its refresh there, which is exactly when the OS tier is the
-      // only tier there is.
-      if (!doc.hidden) return;
-      if (!osTierReachable()) return;
+      if (!messageTriggersEnabled()) return;
       if (timer !== undefined) return;
       // Trailing, and NOT reset by later activity: an agent streaming a long
       // turn must not be able to starve the refresh it is the reason for.
+      const delay = doc.hidden
+        ? HIDDEN_SUMMARY_REFRESH_MS
+        : VISIBLE_SUMMARY_REFRESH_MS;
       timer = setTimeout(() => {
         timer = undefined;
+        // Standing down applies to a VISIBLE tab only. The rail keeps its
+        // observer mounted while hidden but deliberately suppresses its own
+        // refetch there, so an observer on a hidden tab means nobody is
+        // fetching at all — which is the gap this lane exists to fill.
+        if (!doc.hidden && channelSummariesHaveObserver(queryClient)) return;
         void refreshChannelSummaries(queryClient);
-      }, HIDDEN_SUMMARY_REFRESH_MS);
+      }, delay);
     });
     return () => {
       unsubscribe();

--- a/frontend/src/hooks/useNotifyDelivery.ts
+++ b/frontend/src/hooks/useNotifyDelivery.ts
@@ -1,0 +1,160 @@
+// Mounts the channel-notification delivery surfaces (#1308 slice 5 item 2).
+//
+// One hook, called once from `App`, owning three things:
+//   1. the MENTION / DM-REPLY producer, fed by the `/channels` summary payload;
+//   2. the favicon dot + title count, both derived from the badge store and the
+//      slice-3 read position — never from a second unread implementation;
+//   3. a narrowly-scoped background refresh so the OS tier is not dead while
+//      the tab is hidden.
+//
+// Nothing here requests notification permission. That happens on the first
+// event that would actually notify (`os-notification.ts`) or from the explicit
+// button in Settings › notifications.
+//
+// It reads the query CACHE and takes the client as an argument rather than
+// calling `useQuery`/`useQueryClient`: `App` renders `QueryClientProvider` in
+// its own JSX, so the component body itself is outside the context — the same
+// reason `useEventSocket` is handed the client. Reading the cache is also the
+// cheaper shape: the rail already fetches both payloads, and a second observer
+// would only add fetch policy this lane has no opinion about.
+import { useEffect, useRef, useState } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import {
+  createFaviconBadge,
+  type FaviconBadge,
+} from '../lib/notify/favicon-badge.js';
+import { notifyPermissionState } from '../lib/notify/os-notification.js';
+import {
+  ensureNotifySummaryCaches,
+  refreshChannelSummaries,
+  watchChannelSummaries,
+} from '../lib/notify/summary-watch.js';
+import {
+  createTitleBadge,
+  type TitleBadge,
+} from '../lib/notify/title-badge.js';
+import { useChannelActivityStore } from '../lib/stores/channel-activity.js';
+import {
+  countAttentionChannels,
+  useNotifyBadgeStore,
+} from '../lib/stores/notify-badge.js';
+import { currentNotifySettings } from '../lib/stores/notify-settings.js';
+
+/**
+ * Trailing window for the hidden-tab summary refresh.
+ *
+ * Long — an order of magnitude above the rail's own foreground throttle. This
+ * lane exists to keep OS notifications alive for a tab nobody is looking at, and
+ * `GET /channels` is O(channels) server-side, so it buys latency down to ten
+ * seconds and no more.
+ */
+const HIDDEN_SUMMARY_REFRESH_MS = 10_000;
+
+/**
+ * True when a summary refresh could actually produce an OS notification.
+ *
+ * The refresh is gated on this rather than run unconditionally, so the hub pays
+ * nothing extra for an operator who never granted permission or switched every
+ * message trigger off. Turn-complete is excluded on purpose: it is fed by the
+ * socket and needs no fetch.
+ */
+function osTierReachable(): boolean {
+  if (notifyPermissionState() !== 'granted') return false;
+  const settings = currentNotifySettings();
+  return settings.mentions || settings.dmReplies;
+}
+
+export function useNotifyDelivery(
+  enabled: boolean,
+  queryClient: QueryClient
+): void {
+  // ── mention / DM-reply producer ────────────────────────────────────────────
+  useEffect(() => {
+    if (!enabled) return;
+    // Watch FIRST, then ensure: a payload that lands between the two calls is
+    // seen by the subscription rather than missed in the gap.
+    const stop = watchChannelSummaries(queryClient);
+    void ensureNotifySummaryCaches(queryClient);
+    return stop;
+  }, [enabled, queryClient]);
+
+  // ── favicon + title ────────────────────────────────────────────────────────
+  // Both stores are subscribed IMPERATIVELY rather than through selectors: the
+  // count is derived from two of them at once, so a selector on either would
+  // re-render `App` — the whole tree — every time any channel's read mark moved
+  // or any flag was raised. Recomputing into `useState` renders only when the
+  // NUMBER changes, which is the only thing these surfaces draw.
+  const [attentionCount, setAttentionCount] = useState(0);
+  useEffect(() => {
+    const recompute = (): void => {
+      setAttentionCount(
+        countAttentionChannels(
+          useNotifyBadgeStore.getState().flagByChannel,
+          useChannelActivityStore.getState().lastReadByChannel
+        )
+      );
+    };
+    recompute();
+    const unsubscribeFlags = useNotifyBadgeStore.subscribe(recompute);
+    const unsubscribeReads = useChannelActivityStore.subscribe(recompute);
+    return () => {
+      unsubscribeFlags();
+      unsubscribeReads();
+    };
+  }, []);
+
+  const surfaces = useRef<{ favicon: FaviconBadge; title: TitleBadge } | null>(
+    null
+  );
+  useEffect(() => {
+    // Constructed inside an effect, never at module scope: both capture the
+    // document's ORIGINAL favicon href and title, which must be read after the
+    // page exists and before this lane has written to either.
+    surfaces.current = {
+      favicon: createFaviconBadge(),
+      title: createTitleBadge(),
+    };
+    return () => {
+      surfaces.current?.favicon.reset();
+      surfaces.current?.title.reset();
+      surfaces.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const current = surfaces.current;
+    if (!current) return;
+    const count = enabled ? attentionCount : 0;
+    current.title.set(count);
+    current.favicon.set(count > 0);
+  }, [enabled, attentionCount]);
+
+  // ── hidden-tab summary refresh ─────────────────────────────────────────────
+  useEffect(() => {
+    if (!enabled) return;
+    const doc = typeof document === 'undefined' ? null : document;
+    if (!doc) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = useChannelActivityStore.subscribe((state, previous) => {
+      if (state.latestSeqByChannel === previous.latestSeqByChannel) return;
+      // Visible tabs are already covered: the rail refetches the summary list on
+      // its own (tighter) throttle, and this lane's producer runs off whatever
+      // payload that produces. A HIDDEN tab is the gap — the rail deliberately
+      // suppresses its refresh there, which is exactly when the OS tier is the
+      // only tier there is.
+      if (!doc.hidden) return;
+      if (!osTierReachable()) return;
+      if (timer !== undefined) return;
+      // Trailing, and NOT reset by later activity: an agent streaming a long
+      // turn must not be able to starve the refresh it is the reason for.
+      timer = setTimeout(() => {
+        timer = undefined;
+        void refreshChannelSummaries(queryClient);
+      }, HIDDEN_SUMMARY_REFRESH_MS);
+    });
+    return () => {
+      unsubscribe();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [enabled, queryClient]);
+}

--- a/frontend/src/lib/channel-sender-label.ts
+++ b/frontend/src/lib/channel-sender-label.ts
@@ -1,10 +1,24 @@
 import { parseAgentProfileProviderId } from '../../../shared/agent-profile.js';
+import { parseMentions } from '../../../shared/channel-chat-protocol.js';
 
 /**
  * Canonical sender id for a browser-authored channel post
  * (`channel-chat-router` `deriveSender`).
  */
 export const CURRENT_OPERATOR_SENDER_ID = 'human:operator';
+
+/**
+ * The one mention token that addresses the human operator.
+ *
+ * VERIFIED (#1308 slice 5): `parseMentions` resolves mentions against an
+ * AGENT-PROFILE contact set only — there is no human contact, no
+ * `profileId`/`providerId` a human can carry, and no server-side operator
+ * mention target. `@operator` therefore lands as an UNRESOLVED mention ref
+ * (`{ raw: '@operator' }`), and the raw token is the entire contract. That is
+ * already how the rail's mention lane works; the notification lane reads the
+ * same signal rather than inventing a second definition.
+ */
+export const CURRENT_OPERATOR_MENTION_NAME = 'operator';
 
 /** The three sender fields every channel row shape carries. */
 export interface ChannelSenderLabelFields {
@@ -35,6 +49,39 @@ export function senderShortLabel(sender: ChannelSenderLabelFields): string {
     sender.providerId?.trim() ||
     senderLabelFromId(sender.senderId);
   return label === 'operator' ? 'you' : label;
+}
+
+/** The row fields the operator-mention verdict is computed from. */
+export interface OperatorMentionFields {
+  senderId: string;
+  /** Truncated body text. Only read when `mentions` is absent (legacy payload). */
+  preview: string;
+  mentions?: readonly { raw: string }[] | undefined;
+}
+
+/**
+ * True when a channel row mentions the human operator.
+ *
+ * ONE definition, shared by the rail's mention lane (#1287) and the
+ * notification lane (#1308 slice 5) — a second copy of this predicate would be
+ * free to drift into notifying on a mention the sidebar does not badge.
+ *
+ * `mentions` is authoritative: the server computes it over the FULL body, so a
+ * mention past the 200-char preview cut-off still counts. Parsing the truncated
+ * preview is the fallback for a payload predating that field, and uses the
+ * SHARED tokenizer (code fences, inline code, and `local@domain` spans are
+ * already excluded there) rather than a lane-local regex.
+ *
+ * The operator's own posts never mention the operator: a row this device wrote
+ * is echoed back over the socket, and self-notification is noise.
+ */
+export function messageMentionsOperator(row: OperatorMentionFields): boolean {
+  if (row.senderId === CURRENT_OPERATOR_SENDER_ID) return false;
+  const mentions = row.mentions ?? parseMentions(row.preview);
+  return mentions.some(
+    (mention) =>
+      mention.raw.slice(1).toLowerCase() === CURRENT_OPERATOR_MENTION_NAME
+  );
 }
 
 /** Last-resort label for a sender id with no server-resolved name/vendor. */

--- a/frontend/src/lib/notify/copy.ts
+++ b/frontend/src/lib/notify/copy.ts
@@ -1,0 +1,85 @@
+// Notification copy (#1308 slice 5 item 2). PURE — no DOM, no stores.
+//
+// One source for every string the delivery surfaces render, so the OS body and
+// any later in-app surface cannot drift into describing the same event two ways.
+//
+// DESIGN.md rules that bind here: lowercase prose, mono spirit, NO emoji —
+// including in an OS notification body, which renders on a lock screen next to
+// whatever else the operator has running.
+//
+// Two things deliberately never reach a notification:
+//   * message text. A channel transcript is not lock-screen material, and the
+//     row that triggered the signal is exactly the row most likely to be
+//     sensitive.
+//   * a raw sender/actor id. The label is `senderShortLabel`'s output, the same
+//     one the rail renders (#1234: an actor id is not a name).
+import type { NotifyEvent } from './signals.js';
+
+/**
+ * OS notification title.
+ *
+ * The product name, not the channel: the brief's body copy already carries
+ * `in <channel>`, and an OS notification that says the channel twice reads as a
+ * bug. Lowercase per DESIGN.md — the browser renders the origin next to it
+ * anyway, so this is Relay's own label, not a proper noun.
+ */
+export const NOTIFY_OS_TITLE = 'relay';
+
+/** The event fields the copy is composed from. */
+export type NotifyCopyInput = Pick<
+  NotifyEvent,
+  'reason' | 'senderLabel' | 'channelTitle' | 'count'
+>;
+
+/**
+ * OS notification body: `<agent> replied in <channel>`.
+ *
+ * The channel title is the operator's OWN text and is used VERBATIM — Relay
+ * lowercases its own copy, not the operator's. Everything Relay authors around
+ * it stays lowercase, which is what `notifyRelayCopyFragment` lets a test
+ * assert without the operator's title fighting the invariant.
+ *
+ * A coalesced run (the gate held OS notifications back inside its rate-limit
+ * window) is reported with the mono-spirit separator the rest of the UI uses:
+ * `claude replied in impl 1308 · 3 new`.
+ */
+export function notifyOsBody(event: NotifyCopyInput): string {
+  const base = `${notifyRelayCopyFragment(event)} in ${event.channelTitle}`;
+  return event.count > 1 ? `${base} · ${event.count} new` : base;
+}
+
+/**
+ * The Relay-authored half of the body — everything except the operator's own
+ * channel title. Exported so the lowercase/no-emoji/no-transcript invariant is
+ * testable on the fragment Relay actually controls.
+ */
+export function notifyRelayCopyFragment(
+  event: Pick<NotifyCopyInput, 'reason' | 'senderLabel'>
+): string {
+  if (event.reason === 'mention') return `${event.senderLabel} mentioned you`;
+  if (event.reason === 'dm-reply') return `${event.senderLabel} replied`;
+  return `${event.senderLabel} finished`;
+}
+
+/**
+ * Document title while unread DM/mention channels exist: `(3) Relay`.
+ *
+ * N counts CHANNELS, not messages — the tab title is a "where should I look"
+ * signal, and a number that tracks raw message volume turns a single chatty
+ * agent into a permanent alarm. `Relay` keeps its capital: it is the product
+ * name the tab already showed, and the zero case must restore it byte-for-byte.
+ */
+export function formatNotifyTitle(base: string, count: number): string {
+  return count > 0 ? `(${count}) ${base}` : base;
+}
+
+/**
+ * Strip a count prefix this module may have written earlier.
+ *
+ * The base title is captured from the live document, and a hot reload (or a
+ * second badger constructed over an already-badged document) would otherwise
+ * capture `(2) Relay` as the base and compound it to `(3) (2) Relay`.
+ */
+export function stripNotifyTitlePrefix(title: string): string {
+  return title.replace(/^\(\d+\)\s+/, '');
+}

--- a/frontend/src/lib/notify/copy.ts
+++ b/frontend/src/lib/notify/copy.ts
@@ -62,6 +62,29 @@ export function notifyRelayCopyFragment(
 }
 
 /**
+ * Tag for the collapsed burst notification.
+ *
+ * CONSTANT, unlike the per-channel `notifyChannelKey`: a growing overflow must
+ * replace its own previous line in the notification centre, which is the whole
+ * point of collapsing the burst in the first place.
+ */
+export const NOTIFY_OS_OVERFLOW_KEY = 'relay-channels';
+
+/**
+ * Collapsed body for a burst the global budget held back:
+ * `12 channels have new messages`.
+ *
+ * Names no channel and no sender. A digest exists because listing them one by
+ * one IS the storm it replaces, and the operator's next move is the same either
+ * way: open Relay and look at the rail, which already carries every dot.
+ */
+export function notifyOsOverflowBody(channelCount: number): string {
+  return channelCount === 1
+    ? '1 channel has new messages'
+    : `${channelCount} channels have new messages`;
+}
+
+/**
  * Document title while unread DM/mention channels exist: `(3) Relay`.
  *
  * N counts CHANNELS, not messages — the tab title is a "where should I look"

--- a/frontend/src/lib/notify/favicon-badge.ts
+++ b/frontend/src/lib/notify/favicon-badge.ts
@@ -25,6 +25,17 @@ const DOT_RING_RATIO = 0.05;
 const DOT_COLOR = '#d97757';
 /** Pure black — `--bg`. The ring is a cut-out, not a second colour. */
 const DOT_RING_COLOR = '#000000';
+/**
+ * MIME type of the badged data URL, which `canvasFaviconRenderer` always
+ * encodes as PNG.
+ *
+ * The document ships `<link rel="icon" href="/icon.svg" type="image/svg+xml">`.
+ * Rewriting only `href` would leave a PNG payload advertised as SVG, and `type`
+ * is a support HINT browsers are entitled to act on: an engine that honours it
+ * can refuse to decode the resource, so the tab silently loses its icon (or
+ * keeps the stale one) exactly when the badge is supposed to appear.
+ */
+const BADGED_ICON_TYPE = 'image/png';
 
 /** Renders a badged data URL from a base icon href, or null if it cannot. */
 export type FaviconRenderer = (baseHref: string) => Promise<string | null>;
@@ -122,6 +133,9 @@ export function createFaviconBadge(
   // `getAttribute`, not `.href`: the property resolves to an absolute URL, and
   // writing that back would silently rewrite a relative href the app ships.
   const baseHref = link?.getAttribute('href') ?? null;
+  // Captured alongside the href and restored with it: the two attributes
+  // describe ONE resource and must never be written apart.
+  const baseType = link?.getAttribute('type') ?? null;
   let badgedHref: string | null = null;
   let rendering = false;
   /** What the operator last asked for; the async render checks it on landing. */
@@ -129,9 +143,18 @@ export function createFaviconBadge(
 
   function apply(): void {
     if (!link || baseHref === null) return;
-    const next = active && badgedHref ? badgedHref : baseHref;
-    if (link.getAttribute('href') === next) return;
-    link.setAttribute('href', next);
+    const badged = active ? badgedHref : null;
+    const nextHref = badged ?? baseHref;
+    if (link.getAttribute('href') !== nextHref) {
+      link.setAttribute('href', nextHref);
+    }
+    const nextType = badged === null ? baseType : BADGED_ICON_TYPE;
+    if (nextType === null) {
+      // The document shipped no `type`; badging must not invent a permanent one.
+      link.removeAttribute('type');
+    } else if (link.getAttribute('type') !== nextType) {
+      link.setAttribute('type', nextType);
+    }
   }
 
   return {

--- a/frontend/src/lib/notify/favicon-badge.ts
+++ b/frontend/src/lib/notify/favicon-badge.ts
@@ -1,0 +1,173 @@
+// Favicon dot-overlay for unread DM/mention channels (#1308 slice 5 item 2).
+//
+// The favicon IDENTITY does not change: the base image is whatever the document
+// already points at (`/icon.svg`, the #1284-era mark), drawn into a canvas with
+// a small accent dot composited over its bottom-right corner. Nothing here
+// swaps in a different artwork, and clearing restores the ORIGINAL href — not a
+// re-render of it — so a browser that had already cached the icon keeps it.
+//
+// Everything is best-effort. A canvas that will not give a 2D context
+// (happy-dom, a locked-down webview), an icon that fails to decode, a document
+// with no `<link rel="icon">` — each degrades to "no badge", never to a throw:
+// the title count and the OS notification are separate surfaces and must not be
+// taken down with it.
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('notify-favicon');
+
+/** Canvas edge in CSS pixels. 64 is the largest size browsers ask for. */
+const FAVICON_CANVAS_SIZE = 64;
+/** Dot radius, as a fraction of the canvas edge. */
+const DOT_RADIUS_RATIO = 0.22;
+/** Ring drawn under the dot so it reads against a light OR dark tab strip. */
+const DOT_RING_RATIO = 0.05;
+/** Terracotta — `--accent` in `App.css`, DESIGN.md's one brand colour. */
+const DOT_COLOR = '#d97757';
+/** Pure black — `--bg`. The ring is a cut-out, not a second colour. */
+const DOT_RING_COLOR = '#000000';
+
+/** Renders a badged data URL from a base icon href, or null if it cannot. */
+export type FaviconRenderer = (baseHref: string) => Promise<string | null>;
+
+export interface FaviconBadgeOptions {
+  /** Defaults to the ambient document; null disables the lane entirely. */
+  doc?: Document | null;
+  /** Injectable so tests do not need a real canvas. */
+  render?: FaviconRenderer;
+}
+
+export interface FaviconBadge {
+  /** Show or hide the dot. Idempotent; safe to call on every render. */
+  set: (active: boolean) => void;
+  /** Restore the original href and drop the cached badge. */
+  reset: () => void;
+}
+
+/**
+ * Locate the icon link. NEVER creates one: this lane overlays the app's icon
+ * and has no artwork of its own, so a document that ships no icon leaves it
+ * inert rather than minting an empty `<link rel="icon">` that would suppress
+ * the browser's own `/favicon.ico` probe.
+ *
+ * `rel~="icon"` matches `icon` and `shortcut icon` alike; the FIRST match wins
+ * because that is the one the browser resolves.
+ */
+function findIconLink(doc: Document): HTMLLinkElement | null {
+  return doc.querySelector<HTMLLinkElement>('link[rel~="icon"]');
+}
+
+/**
+ * Default renderer: draw the base icon, then a ringed dot over its bottom-right.
+ *
+ * SVG sources work because `/icon.svg` carries intrinsic `width`/`height` —
+ * without those, `drawImage` sizes an SVG inconsistently across engines. Same
+ * origin throughout, so the canvas is never tainted and `toDataURL` is legal.
+ */
+export const canvasFaviconRenderer: FaviconRenderer = async (baseHref) => {
+  if (typeof document === 'undefined' || typeof Image === 'undefined') {
+    return null;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = FAVICON_CANVAS_SIZE;
+  canvas.height = FAVICON_CANVAS_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  const image = await loadImage(baseHref);
+  if (!image) return null;
+  try {
+    ctx.drawImage(image, 0, 0, FAVICON_CANVAS_SIZE, FAVICON_CANVAS_SIZE);
+    const radius = FAVICON_CANVAS_SIZE * DOT_RADIUS_RATIO;
+    const ring = FAVICON_CANVAS_SIZE * DOT_RING_RATIO;
+    const cx = FAVICON_CANVAS_SIZE - radius - ring;
+    const cy = FAVICON_CANVAS_SIZE - radius - ring;
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius + ring, 0, Math.PI * 2);
+    ctx.fillStyle = DOT_RING_COLOR;
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+    ctx.fillStyle = DOT_COLOR;
+    ctx.fill();
+    return canvas.toDataURL('image/png');
+  } catch (err) {
+    logger.warn('favicon badge render failed', err);
+    return null;
+  }
+};
+
+function loadImage(src: string): Promise<HTMLImageElement | null> {
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => resolve(null);
+    image.src = src;
+  });
+}
+
+/**
+ * Per-instance state in a closure (the `createNotifyGate` precedent): the base
+ * href is captured ONCE, on construction, before anything can have badged it.
+ */
+export function createFaviconBadge(
+  options: FaviconBadgeOptions = {}
+): FaviconBadge {
+  const doc =
+    options.doc === undefined
+      ? typeof document === 'undefined'
+        ? null
+        : document
+      : options.doc;
+  const render = options.render ?? canvasFaviconRenderer;
+  const link = doc ? findIconLink(doc) : null;
+  // `getAttribute`, not `.href`: the property resolves to an absolute URL, and
+  // writing that back would silently rewrite a relative href the app ships.
+  const baseHref = link?.getAttribute('href') ?? null;
+  let badgedHref: string | null = null;
+  let rendering = false;
+  /** What the operator last asked for; the async render checks it on landing. */
+  let active = false;
+
+  function apply(): void {
+    if (!link || baseHref === null) return;
+    const next = active && badgedHref ? badgedHref : baseHref;
+    if (link.getAttribute('href') === next) return;
+    link.setAttribute('href', next);
+  }
+
+  return {
+    set: (next) => {
+      if (active === next) {
+        // Still re-apply: a hot-reload or an unrelated writer may have reset
+        // the href underneath us, and this call is cheap when it has not.
+        apply();
+        return;
+      }
+      active = next;
+      if (!next || badgedHref || rendering || !baseHref) {
+        apply();
+        return;
+      }
+      rendering = true;
+      void render(baseHref)
+        .then((result) => {
+          badgedHref = result;
+        })
+        .catch((err) => {
+          logger.warn('favicon badge render rejected', err);
+        })
+        .finally(() => {
+          rendering = false;
+          // Re-read `active` rather than trusting the value at call time: the
+          // operator may have read the channel while the icon was decoding, and
+          // painting a dot onto an already-clear tab is the one visible bug
+          // this lane can produce.
+          apply();
+        });
+    },
+    reset: () => {
+      active = false;
+      badgedHref = null;
+      apply();
+    },
+  };
+}

--- a/frontend/src/lib/notify/leader.ts
+++ b/frontend/src/lib/notify/leader.ts
@@ -1,0 +1,144 @@
+// Cross-tab election for the OS notification tier (#1308 slice 5 item 2).
+//
+// The gate, the coalesce ledger and the badge store are per-PAGE singletons, so
+// two Relay tabs evaluate the same `/channels` payload independently and each
+// one calls `notifier.deliver`. The per-channel `tag` usually collapses the
+// result to a single notification-centre entry, but tag replacement is scoped
+// per page on several engines and a replace can re-alert — so the operator
+// hears the same agent reply twice, and a burst raises the permission prompt
+// once per tab.
+//
+// ONLY the OS tier is elected. The favicon dot and the title count are
+// legitimately per-tab (each tab draws its own chrome), so every tab keeps
+// running its own gate and its own badge store; this decides which one is
+// allowed to reach the operator's desktop.
+//
+// A TIMESTAMPED LEASE in `localStorage`, not a `BroadcastChannel` heartbeat:
+// the lease is renewed by the very deliveries it guards, so it needs no timer
+// and no background chatter, it expires on its own if the holder is frozen or
+// killed rather than closed cleanly, and `localStorage` is the cross-tab
+// channel this lane already depends on (`notify-settings` persists there).
+// Where storage is unavailable — a private-mode webview, a non-DOM test
+// environment — the lane degrades to "always leader", which is single-tab
+// behaviour and never silences a notification.
+
+/** Storage key holding `{ id, at }` for the current lease. */
+export const NOTIFY_LEADER_STORAGE_KEY = 'relay-notify-leader';
+
+/**
+ * Lease length.
+ *
+ * Comfortably shorter than the 60s per-channel OS window, so a tab that closes
+ * mid-burst does not mute the survivors for a whole minute; comfortably longer
+ * than the 10s burst window, so an active leader cannot lose the lease between
+ * two notifications of the same burst.
+ */
+export const NOTIFY_LEADER_LEASE_MS = 15_000;
+
+/** The `localStorage` subset this lane uses. Injectable for tests. */
+export interface NotifyLeaderStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+export interface NotifyLeader {
+  /**
+   * True when THIS tab owns the OS tier right now. Renews the lease as a side
+   * effect, so a tab that keeps delivering keeps the lease.
+   */
+  claim: (now?: number) => boolean;
+  /** Give the lease up if we hold it (sign-out, tests). */
+  release: () => void;
+}
+
+export interface NotifyLeaderOptions {
+  /** Defaults to a fresh random id — one per page, per notifier lifetime. */
+  id?: string;
+  /** Defaults to ambient `localStorage`; null disables election entirely. */
+  storage?: NotifyLeaderStorage | null;
+  key?: string;
+  leaseMs?: number;
+}
+
+function ambientStorage(): NotifyLeaderStorage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    // Reading `localStorage` THROWS on a cookie-blocked origin in Chrome.
+    return null;
+  }
+}
+
+function randomLeaderId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+interface LeaseRecord {
+  id: string;
+  at: number;
+}
+
+function parseLease(raw: string | null): LeaseRecord | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { id, at } = parsed as { id?: unknown; at?: unknown };
+    if (typeof id !== 'string' || typeof at !== 'number') return null;
+    return { id, at };
+  } catch {
+    return null;
+  }
+}
+
+export function createNotifyLeader(
+  options: NotifyLeaderOptions = {}
+): NotifyLeader {
+  const storage =
+    options.storage === undefined ? ambientStorage() : options.storage;
+  const key = options.key ?? NOTIFY_LEADER_STORAGE_KEY;
+  const leaseMs = options.leaseMs ?? NOTIFY_LEADER_LEASE_MS;
+  const id = options.id ?? randomLeaderId();
+
+  if (!storage) return { claim: () => true, release: () => {} };
+
+  function read(): LeaseRecord | null {
+    try {
+      return parseLease(storage?.getItem(key) ?? null);
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    claim: (nowInput) => {
+      const now = nowInput ?? Date.now();
+      const held = read();
+      if (held !== null && held.id !== id) {
+        const age = now - held.at;
+        // A stamp from the FUTURE beyond one lease is a skewed or corrupted
+        // clock, not a live holder — treating it as live would mute this tab
+        // forever. `age` inside ±lease is the only "someone else has it" case.
+        if (age < leaseMs && age > -leaseMs) return false;
+      }
+      try {
+        storage?.setItem(key, JSON.stringify({ id, at: now }));
+      } catch {
+        // Quota, private mode, a storage partition that went away: fall back to
+        // single-tab behaviour rather than silencing this tab's notifications.
+        return true;
+      }
+      return true;
+    },
+    release: () => {
+      const held = read();
+      if (held !== null && held.id !== id) return;
+      try {
+        storage?.removeItem(key);
+      } catch {
+        // Best effort; the lease expires on its own.
+      }
+    },
+  };
+}

--- a/frontend/src/lib/notify/os-notification.ts
+++ b/frontend/src/lib/notify/os-notification.ts
@@ -98,6 +98,16 @@ export interface OsNotifier {
   /**
    * ONE collapsed notification for a burst the gate's global budget held back.
    * Carries a constant tag, so a growing overflow replaces its own line.
+   *
+   * COALESCED, not immediate. The gate raises `osOverflow` on every event that
+   * GROWS the held-back set, so a single producer pass over a reconnect payload
+   * calls this once per held-back channel — twelve calls for the fifteen-DM
+   * shape the burst budget exists to cap. Constructing a Notification per call
+   * would put the storm straight back: `tag` replacement is per-page on several
+   * engines and a replace can re-alert, so the operator would hear fifteen
+   * alerts instead of the promised three plus one. Calls made inside one
+   * synchronous pass therefore flush as a single notification carrying the
+   * LARGEST count seen — the digest the cap promised.
    */
   deliverOverflow: (channelCount: number) => void;
   /**
@@ -122,8 +132,26 @@ export interface OsNotifier {
    * into two prompts.
    */
   requestPermission: () => Promise<NotifyPermissionState>;
-  /** Forget the in-flight request memo and the prime one-shot (sign-out, tests). */
+  /**
+   * Forget the in-flight request memo, the prime one-shot and any digest still
+   * waiting to flush (sign-out, tests).
+   */
   reset: () => void;
+}
+
+/**
+ * Run the coalesced digest flush at the end of the current synchronous pass.
+ *
+ * A microtask, not a timer: the producer loop that raises overflow is
+ * synchronous, so this is the first moment the whole burst is known, and it
+ * adds no observable latency to the one notification the operator does get.
+ */
+function scheduleOverflowFlush(flush: () => void): void {
+  if (typeof queueMicrotask === 'function') {
+    queueMicrotask(flush);
+    return;
+  }
+  void Promise.resolve().then(flush);
 }
 
 /**
@@ -146,6 +174,10 @@ export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
   let pendingRequest: Promise<NotifyPermissionState> | null = null;
   /** Whether the one gestureless prime has already been spent. */
   let primed = false;
+  /** Largest held-back channel count awaiting the coalesced digest flush. */
+  let pendingOverflow = 0;
+  /** Whether a flush is already queued for the current pass. */
+  let overflowScheduled = false;
 
   function requestPermission(): Promise<NotifyPermissionState> {
     const ctor = resolveCtor();
@@ -247,13 +279,28 @@ export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
     });
   }
 
+  function flushOverflow(): void {
+    overflowScheduled = false;
+    const channelCount = pendingOverflow;
+    pendingOverflow = 0;
+    if (channelCount <= 0) return;
+    void present((ctor) => showOverflow(channelCount, ctor));
+  }
+
   return {
     deliver: (event) => {
       if (!event.os) return Promise.resolve(false);
       return present((ctor) => show(event, ctor));
     },
     deliverOverflow: (channelCount) => {
-      void present((ctor) => showOverflow(channelCount, ctor));
+      if (channelCount <= 0) return;
+      // The LARGEST count wins, not the last: the gate reports the held-back
+      // set's size as it grows, so the final call in a pass already describes
+      // every channel the earlier ones did.
+      pendingOverflow = Math.max(pendingOverflow, channelCount);
+      if (overflowScheduled) return;
+      overflowScheduled = true;
+      scheduleOverflowFlush(flushOverflow);
     },
     primePermission: () => {
       if (primed) return;
@@ -269,6 +316,10 @@ export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
     reset: () => {
       pendingRequest = null;
       primed = false;
+      // The queued flush is left to run and no-op on a zero count: cancelling
+      // it would need a handle the microtask queue does not hand back, and a
+      // reset notifier must not show a digest for a lane that just went away.
+      pendingOverflow = 0;
     },
   };
 }

--- a/frontend/src/lib/notify/os-notification.ts
+++ b/frontend/src/lib/notify/os-notification.ts
@@ -1,0 +1,197 @@
+// OS Notification delivery for channel notify events (#1308 slice 5 item 2).
+//
+// PERMISSION IS REQUESTED LAZILY, NEVER ON LOAD. A permission prompt fired at
+// boot is hostile: the operator has been shown nothing yet, so they have no way
+// to judge the ask, and a reflexive "block" is unrecoverable from inside the
+// page. Nothing here runs at import; the first request happens on the first
+// event that would ACTUALLY have produced a notification (gate-approved, OS
+// tier), and Settings › notifications offers the same grant behind an explicit
+// button for the browsers that require a user gesture (Safari always; Firefox
+// since it tied `requestPermission` to user activation).
+//
+// Deliberately independent of `lib/notifications.ts`, which owns the LEGACY
+// per-session web-push lane (service worker + VAPID + `PUT /config`). Nothing
+// here registers a service worker: this slice adds no push infrastructure.
+import { NOTIFY_OS_TITLE, notifyOsBody } from './copy.js';
+import type { NotifyEvent } from './signals.js';
+
+/** Permission states, plus the browser that has no Notification API at all. */
+export type NotifyPermissionState =
+  | 'unsupported'
+  | 'default'
+  | 'granted'
+  | 'denied';
+
+/**
+ * Structural stand-in for a live `Notification`.
+ *
+ * Written structurally rather than against the DOM lib type so a test can pass
+ * a plain fake class, and so this module type-checks in a build that has no DOM
+ * lib loaded. The only members the lane uses are the two below.
+ */
+export interface NotificationLike {
+  onclick: ((event?: unknown) => void) | null;
+  close: () => void;
+}
+
+/** Structural stand-in for the `Notification` constructor + its statics. */
+export interface NotificationCtorLike {
+  new (
+    title: string,
+    options?: {
+      body?: string;
+      tag?: string;
+      data?: unknown;
+      silent?: boolean;
+    }
+  ): NotificationLike;
+  permission: NotificationPermission;
+  requestPermission: () => Promise<NotificationPermission>;
+}
+
+/** The `Notification` constructor, or null where the API does not exist. */
+export function resolveNotificationCtor(): NotificationCtorLike | null {
+  const ctor = (globalThis as { Notification?: unknown }).Notification;
+  return typeof ctor === 'function' ? (ctor as NotificationCtorLike) : null;
+}
+
+/** Current permission, treating an absent API as its own state. */
+export function notifyPermissionState(
+  ctor: NotificationCtorLike | null = resolveNotificationCtor()
+): NotifyPermissionState {
+  if (!ctor) return 'unsupported';
+  const permission = ctor.permission;
+  return permission === 'granted' || permission === 'denied'
+    ? permission
+    : 'default';
+}
+
+export interface OsNotifierDeps {
+  /**
+   * Resolved once per `deliver`, not captured at construction: a page can be
+   * constructed before the API is patched in (tests), and re-reading costs a
+   * property access.
+   */
+  resolveCtor?: () => NotificationCtorLike | null;
+  /** Bring the tab forward on click. */
+  focusWindow?: () => void;
+  /** Route to the clicked channel. Called AFTER focus, so the surface is visible. */
+  openChannel: (channelId: string) => void;
+}
+
+export interface OsNotifier {
+  /**
+   * Show `event` if the OS tier is reachable. Fire-and-forget: a permission
+   * round trip must never make the caller (a socket handler) async.
+   */
+  deliver: (event: NotifyEvent) => void;
+  /**
+   * Ask for permission now, from an explicit operator action (the Settings
+   * button). Same memoized request as the lazy path, so the two cannot race
+   * into two prompts.
+   */
+  requestPermission: () => Promise<NotifyPermissionState>;
+  /** Forget the in-flight request memo (sign-out, tests). */
+  reset: () => void;
+}
+
+/**
+ * Per-notifier state in a closure rather than module singletons, so one test
+ * case cannot leak a granted permission memo into the next.
+ */
+export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
+  const resolveCtor = deps.resolveCtor ?? resolveNotificationCtor;
+  const focusWindow =
+    deps.focusWindow ??
+    (() => {
+      if (typeof window !== 'undefined') window.focus();
+    });
+  /**
+   * The one in-flight permission request. Chrome resolves a second concurrent
+   * `requestPermission()` with the first prompt's answer, but Safari has
+   * historically rejected it — and an event burst is exactly how two would be
+   * issued at once.
+   */
+  let pendingRequest: Promise<NotifyPermissionState> | null = null;
+
+  function requestPermission(): Promise<NotifyPermissionState> {
+    const ctor = resolveCtor();
+    if (!ctor) return Promise.resolve('unsupported');
+    const current = notifyPermissionState(ctor);
+    // 'denied' is terminal from inside the page — asking again is a no-op the
+    // browser answers instantly, and treating it as askable would put the
+    // Settings button in a state that can never change.
+    if (current !== 'default') return Promise.resolve(current);
+    if (pendingRequest) return pendingRequest;
+    // An async IIFE, not `Promise.resolve().then(...)`: the prompt must be
+    // raised SYNCHRONOUSLY inside the call that decided to raise it. Browsers
+    // that require user activation lose the gesture across a microtask hop, so
+    // deferring would break the one path (the Settings button) that is
+    // guaranteed to work on Safari.
+    pendingRequest = (async () => {
+      try {
+        const result = await ctor.requestPermission();
+        return result === 'granted' || result === 'denied' ? result : 'default';
+      } catch {
+        // A browser that rejects (no user gesture, or a legacy callback-only
+        // implementation) leaves the operator exactly where they were: no
+        // notification, no crash, and the Settings button still offers a
+        // gesture-backed retry.
+        return notifyPermissionState(resolveCtor());
+      } finally {
+        pendingRequest = null;
+      }
+    })();
+    return pendingRequest;
+  }
+
+  function show(event: NotifyEvent, ctor: NotificationCtorLike): void {
+    let notification: NotificationLike;
+    try {
+      notification = new ctor(NOTIFY_OS_TITLE, {
+        body: notifyOsBody(event),
+        // One live notification per channel: a newer event REPLACES the
+        // previous one in the notification centre instead of stacking, which is
+        // the same coalescing promise `event.count` reports inside the body.
+        tag: event.key,
+        data: { channelId: event.channelId },
+      });
+    } catch {
+      // Constructing a Notification throws on Android Chrome (service-worker
+      // notifications only) and in a few embedded webviews. Nothing about the
+      // in-app tier depends on this succeeding.
+      return;
+    }
+    notification.onclick = () => {
+      focusWindow();
+      deps.openChannel(event.channelId);
+      notification.close();
+    };
+  }
+
+  return {
+    deliver: (event) => {
+      if (!event.os) return;
+      const ctor = resolveCtor();
+      if (!ctor) return;
+      const permission = notifyPermissionState(ctor);
+      if (permission === 'denied') return;
+      if (permission === 'granted') {
+        show(event, ctor);
+        return;
+      }
+      // FIRST eligible event: this is the only place the lazy prompt is armed.
+      // The event is shown once the grant lands, not dropped — the operator
+      // said yes to being told about THIS.
+      void requestPermission().then((result) => {
+        if (result !== 'granted') return;
+        const grantedCtor = resolveCtor();
+        if (grantedCtor) show(event, grantedCtor);
+      });
+    },
+    requestPermission,
+    reset: () => {
+      pendingRequest = null;
+    },
+  };
+}

--- a/frontend/src/lib/notify/os-notification.ts
+++ b/frontend/src/lib/notify/os-notification.ts
@@ -12,7 +12,12 @@
 // Deliberately independent of `lib/notifications.ts`, which owns the LEGACY
 // per-session web-push lane (service worker + VAPID + `PUT /config`). Nothing
 // here registers a service worker: this slice adds no push infrastructure.
-import { NOTIFY_OS_TITLE, notifyOsBody } from './copy.js';
+import {
+  NOTIFY_OS_OVERFLOW_KEY,
+  NOTIFY_OS_TITLE,
+  notifyOsBody,
+  notifyOsOverflowBody,
+} from './copy.js';
 import type { NotifyEvent } from './signals.js';
 
 /** Permission states, plus the browser that has no Notification API at all. */
@@ -81,17 +86,43 @@ export interface OsNotifierDeps {
 
 export interface OsNotifier {
   /**
-   * Show `event` if the OS tier is reachable. Fire-and-forget: a permission
-   * round trip must never make the caller (a socket handler) async.
+   * Show `event` if the OS tier is reachable.
+   *
+   * Fire-and-forget for the CALLER — a permission round trip must never make a
+   * socket handler async — but the returned promise reports whether a
+   * `Notification` was actually constructed, so the gate can refund the
+   * rate-limit slot it charged when nothing was shown. Resolves synchronously
+   * (one microtask) on every path except the lazy permission request.
    */
-  deliver: (event: NotifyEvent) => void;
+  deliver: (event: NotifyEvent) => Promise<boolean>;
+  /**
+   * ONE collapsed notification for a burst the gate's global budget held back.
+   * Carries a constant tag, so a growing overflow replaces its own line.
+   */
+  deliverOverflow: (channelCount: number) => void;
+  /**
+   * Arm the permission prompt from a moment the browser can actually raise it,
+   * without showing anything.
+   *
+   * `deliver`'s lazy ask only fires for an OS-tier event, which by construction
+   * only exists while `document.hidden` — precisely when Safari and Firefox
+   * refuse to prompt at all (both tie `requestPermission` to user activation)
+   * and when Chrome defers the prompt until the tab returns. A gate-approved
+   * event on a VISIBLE, focused tab is the same "something worth telling you
+   * about just happened" evidence, delivered where the ask can land.
+   *
+   * At most one request per notifier lifetime, and only from `default` — a
+   * browser that refuses the ungestured ask must not be re-asked on every
+   * subsequent event.
+   */
+  primePermission: () => void;
   /**
    * Ask for permission now, from an explicit operator action (the Settings
    * button). Same memoized request as the lazy path, so the two cannot race
    * into two prompts.
    */
   requestPermission: () => Promise<NotifyPermissionState>;
-  /** Forget the in-flight request memo (sign-out, tests). */
+  /** Forget the in-flight request memo and the prime one-shot (sign-out, tests). */
   reset: () => void;
 }
 
@@ -113,6 +144,8 @@ export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
    * issued at once.
    */
   let pendingRequest: Promise<NotifyPermissionState> | null = null;
+  /** Whether the one gestureless prime has already been spent. */
+  let primed = false;
 
   function requestPermission(): Promise<NotifyPermissionState> {
     const ctor = resolveCtor();
@@ -145,7 +178,7 @@ export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
     return pendingRequest;
   }
 
-  function show(event: NotifyEvent, ctor: NotificationCtorLike): void {
+  function show(event: NotifyEvent, ctor: NotificationCtorLike): boolean {
     let notification: NotificationLike;
     try {
       notification = new ctor(NOTIFY_OS_TITLE, {
@@ -160,38 +193,82 @@ export function createOsNotifier(deps: OsNotifierDeps): OsNotifier {
       // Constructing a Notification throws on Android Chrome (service-worker
       // notifications only) and in a few embedded webviews. Nothing about the
       // in-app tier depends on this succeeding.
-      return;
+      return false;
     }
     notification.onclick = () => {
       focusWindow();
       deps.openChannel(event.channelId);
       notification.close();
     };
+    return true;
+  }
+
+  /** The burst digest. No channel to route to, so a click only brings the tab up. */
+  function showOverflow(
+    channelCount: number,
+    ctor: NotificationCtorLike
+  ): boolean {
+    let notification: NotificationLike;
+    try {
+      notification = new ctor(NOTIFY_OS_TITLE, {
+        body: notifyOsOverflowBody(channelCount),
+        tag: NOTIFY_OS_OVERFLOW_KEY,
+      });
+    } catch {
+      return false;
+    }
+    notification.onclick = () => {
+      focusWindow();
+      notification.close();
+    };
+    return true;
+  }
+
+  /**
+   * The permission dance every delivery path shares. Resolves TRUE only once
+   * `build` has actually constructed a notification, which is what lets the
+   * gate tell a shown event from a swallowed one.
+   */
+  function present(
+    build: (ctor: NotificationCtorLike) => boolean
+  ): Promise<boolean> {
+    const ctor = resolveCtor();
+    if (!ctor) return Promise.resolve(false);
+    const permission = notifyPermissionState(ctor);
+    if (permission === 'denied') return Promise.resolve(false);
+    if (permission === 'granted') return Promise.resolve(build(ctor));
+    // FIRST eligible event and no grant yet: arm the lazy prompt. The event is
+    // shown once the grant lands, not dropped — the operator said yes to being
+    // told about THIS.
+    return requestPermission().then((result) => {
+      if (result !== 'granted') return false;
+      const grantedCtor = resolveCtor();
+      return grantedCtor ? build(grantedCtor) : false;
+    });
   }
 
   return {
     deliver: (event) => {
-      if (!event.os) return;
+      if (!event.os) return Promise.resolve(false);
+      return present((ctor) => show(event, ctor));
+    },
+    deliverOverflow: (channelCount) => {
+      void present((ctor) => showOverflow(channelCount, ctor));
+    },
+    primePermission: () => {
+      if (primed) return;
       const ctor = resolveCtor();
       if (!ctor) return;
-      const permission = notifyPermissionState(ctor);
-      if (permission === 'denied') return;
-      if (permission === 'granted') {
-        show(event, ctor);
-        return;
-      }
-      // FIRST eligible event: this is the only place the lazy prompt is armed.
-      // The event is shown once the grant lands, not dropped — the operator
-      // said yes to being told about THIS.
-      void requestPermission().then((result) => {
-        if (result !== 'granted') return;
-        const grantedCtor = resolveCtor();
-        if (grantedCtor) show(event, grantedCtor);
-      });
+      // `granted`/`denied` are both settled; neither spends the one shot, so a
+      // browser that only gains the API later can still be primed.
+      if (notifyPermissionState(ctor) !== 'default') return;
+      primed = true;
+      void requestPermission();
     },
     requestPermission,
     reset: () => {
       pendingRequest = null;
+      primed = false;
     },
   };
 }

--- a/frontend/src/lib/notify/producers.ts
+++ b/frontend/src/lib/notify/producers.ts
@@ -1,0 +1,117 @@
+// Signal producers: the two streams the client already receives, reduced to
+// item-1 signals and pushed through the shared runtime (#1308 slice 5 item 2).
+//
+// NO NEW HTTP ROUTE AND NO NEW GATEWAY VERB. Both carriers already exist:
+//   * `GET /channels` — the rail's summary list. Its `lastMessage` is the only
+//     stream that carries sender identity and server-computed mention refs, so
+//     it is the ONLY possible source for the mention and DM-reply triggers. The
+//     `channel-activity` broadcast carries `{ channelId, latestSeq }` and
+//     nothing else, so it can say a channel moved but never who moved it.
+//   * `channel-agent-status` on `/ws/events` — a complete transition stream, so
+//     turn-complete needs no fetch at all.
+import type { ChannelAgentStatus } from '../api.js';
+import { senderShortLabel } from '../channel-sender-label.js';
+import type { WorkspaceTopic } from '../../../../shared/workspace-topics.js';
+import { deliverNotifySignal } from './runtime.js';
+import {
+  deriveMessageSignal,
+  deriveTurnCompleteSignal,
+  notifyChannelFromTopic,
+  type NotifyChannel,
+  type NotifyEvent,
+  type NotifyMessageRow,
+} from './signals.js';
+
+/** The subset of a `/channels` row this lane reads. */
+export interface NotifySummaryRow {
+  id: string;
+  lastMessage: NotifyMessageRow | null;
+}
+
+/**
+ * Channel descriptors by id, from the topic list the rail already fetches.
+ *
+ * The topic record is what carries DM-ness (`routingDefaults.providerId` +
+ * `workspaceId`, recomputed through `isDmChannel`) and the operator's title;
+ * the `/channels` summary carries neither. A channel with no cached topic is
+ * skipped rather than guessed at — a DM misidentified as a plain channel would
+ * silently drop the DM-reply trigger, and the reverse would notify on every
+ * agent message in a busy implementation channel.
+ */
+export type NotifyTopicRecord = Pick<
+  WorkspaceTopic,
+  'id' | 'display' | 'workspaceId' | 'routingDefaults'
+>;
+
+export function notifyChannelIndex(
+  topics: readonly NotifyTopicRecord[]
+): Map<string, NotifyChannel> {
+  const index = new Map<string, NotifyChannel>();
+  for (const topic of topics)
+    index.set(topic.id, notifyChannelFromTopic(topic));
+  return index;
+}
+
+export interface NotifySummaryPassInput {
+  rows: readonly NotifySummaryRow[];
+  channels: ReadonlyMap<string, NotifyChannel>;
+  /** False for the first payload after mount — see `DeliverNotifyOptions`. */
+  osTier?: boolean;
+  at?: number;
+}
+
+/**
+ * MENTION + DM-REPLY, from one `/channels` payload.
+ *
+ * Idempotent by construction: the payload is refetched on reconnect, on focus,
+ * and whenever an unknown channel shows activity, and the gate's per-channel
+ * replay guard is what stops the same `lastMessage` notifying twice. This
+ * function therefore does not need — and deliberately does not keep — a
+ * "rows I have already seen" ledger of its own.
+ */
+export function notifyFromChannelSummaries(
+  input: NotifySummaryPassInput
+): NotifyEvent[] {
+  const at = input.at ?? Date.now();
+  const delivered: NotifyEvent[] = [];
+  for (const row of input.rows) {
+    if (!row.lastMessage) continue;
+    const channel = input.channels.get(row.id);
+    if (!channel) continue;
+    const signal = deriveMessageSignal(row.lastMessage, channel, at);
+    if (!signal) continue;
+    const event = deliverNotifySignal(signal, {
+      now: at,
+      ...(input.osTier === undefined ? {} : { osTier: input.osTier }),
+    });
+    if (event) delivered.push(event);
+  }
+  return delivered;
+}
+
+export interface NotifyAgentStatusInput {
+  channel: NotifyChannel;
+  agentId: string;
+  /** Status held BEFORE this transition — read before the store records it. */
+  previous: ChannelAgentStatus | undefined;
+  next: ChannelAgentStatus;
+  at?: number;
+}
+
+/** TURN COMPLETE, from one `channel-agent-status` transition. */
+export function notifyFromAgentStatus(
+  input: NotifyAgentStatusInput
+): NotifyEvent | null {
+  const at = input.at ?? Date.now();
+  const signal = deriveTurnCompleteSignal({
+    channel: input.channel,
+    // The agent id is a profile Actor id, so it goes through the shared label
+    // resolver — never split for a name (#1234).
+    agentLabel: senderShortLabel({ senderId: input.agentId }),
+    previous: input.previous,
+    next: input.next,
+    at,
+  });
+  if (!signal) return null;
+  return deliverNotifySignal(signal, { now: at });
+}

--- a/frontend/src/lib/notify/runtime.ts
+++ b/frontend/src/lib/notify/runtime.ts
@@ -1,0 +1,124 @@
+// The bridge between item 1's signal derivation and item 2's delivery surfaces
+// (#1308 slice 5 item 2).
+//
+// One process-wide gate and one OS notifier, because both hold ledgers that
+// MUST outlive any React tree: the gate's per-channel replay guard and
+// rate-limit window, and the notifier's single in-flight permission request. A
+// per-component instance would re-notify every row on remount and could prompt
+// twice at once.
+//
+// Everything here reads stores non-reactively (`getState()`). Callers are socket
+// handlers and query effects, not renders.
+import { useChannelActivityStore } from '../stores/channel-activity.js';
+import { useNotifyBadgeStore } from '../stores/notify-badge.js';
+import { currentNotifySettings } from '../stores/notify-settings.js';
+import { useUiStore } from '../stores/ui.js';
+import { openChannelFromNotification } from '../topic-selection.js';
+import { createOsNotifier, type OsNotifier } from './os-notification.js';
+import {
+  createNotifyGate,
+  type NotifyEvent,
+  type NotifyGate,
+  type NotifyGateContext,
+  type NotifySignal,
+} from './signals.js';
+
+let gate: NotifyGate = createNotifyGate();
+let notifier: OsNotifier = createOsNotifier({
+  openChannel: openChannelFromNotification,
+});
+
+/** The shared OS notifier — Settings uses it for the explicit permission ask. */
+export function notifyOsNotifier(): OsNotifier {
+  return notifier;
+}
+
+/**
+ * Ambient gate context: settings, the open channel, this tab's visibility, and
+ * the read position the slice-3 stores already converge.
+ *
+ * `document.hasFocus()` is read defensively — a few embedded webviews do not
+ * implement it. An absent probe degrades to FOCUSED, which is the conservative
+ * direction: `document.hidden` is the stronger of the two signals and is
+ * universally available, so a visible tab with the channel open is treated as
+ * being watched rather than notified at.
+ */
+function gateContext(
+  channelId: string,
+  now: number,
+  osTier: boolean
+): NotifyGateContext {
+  const doc = typeof document === 'undefined' ? null : document;
+  const lastReadSeq =
+    useChannelActivityStore.getState().lastReadByChannel[channelId];
+  return {
+    settings: currentNotifySettings(),
+    activeChannelId: useUiStore.getState().activeChannelId,
+    // `osTier: false` is reported to the gate as a VISIBLE tab rather than
+    // handled after the fact, and that is the whole point: the gate charges its
+    // per-channel rate-limit window when it grants the OS tier, so dropping the
+    // notification downstream would burn a 60s slot the operator never got a
+    // notification for and swallow the next real one.
+    documentHidden: osTier && (doc?.hidden ?? false),
+    windowFocused:
+      typeof doc?.hasFocus === 'function' ? doc.hasFocus() : Boolean(doc),
+    ...(lastReadSeq !== undefined ? { lastReadSeq } : {}),
+    now,
+  };
+}
+
+export interface DeliverNotifyOptions {
+  now?: number;
+  /**
+   * Allow the OS tier. False for a BOOT SEED: the first `/channels` payload
+   * describes everything that happened while this client was away, so a tab
+   * restored into the background would otherwise fire one notification per
+   * unread channel at once. Those rows still earn their in-app badge — they are
+   * genuinely unread — they just are not news worth a notification centre entry.
+   */
+  osTier?: boolean;
+}
+
+/**
+ * Run one signal through the gate and, if it survives, deliver it.
+ *
+ * Both tiers fire from here so they cannot disagree about what happened: the
+ * in-app flag ALWAYS (an event only exists once it has passed the setting, the
+ * replay guard, the read position, and the open-and-focused suppression), and
+ * the OS notification only when the gate marked it `os`.
+ *
+ * Returns the delivered event so callers and tests can assert on it.
+ */
+export function deliverNotifySignal(
+  signal: NotifySignal,
+  options: DeliverNotifyOptions = {}
+): NotifyEvent | null {
+  const event = gate.evaluate(
+    signal,
+    gateContext(
+      signal.channel.id,
+      options.now ?? Date.now(),
+      options.osTier ?? true
+    )
+  );
+  if (!event) return null;
+  useNotifyBadgeStore
+    .getState()
+    .flagChannel(event.channelId, { seq: event.seq, reason: event.reason });
+  notifier.deliver(event);
+  return event;
+}
+
+/**
+ * Drop every ledger and rebuild the singletons.
+ *
+ * Used by tests, and on sign-out: a gate that remembers another account's seqs
+ * would silence that account's first real message on this device.
+ */
+export function resetNotifyRuntime(): void {
+  gate.reset();
+  notifier.reset();
+  gate = createNotifyGate();
+  notifier = createOsNotifier({ openChannel: openChannelFromNotification });
+  useNotifyBadgeStore.getState().reset();
+}

--- a/frontend/src/lib/notify/runtime.ts
+++ b/frontend/src/lib/notify/runtime.ts
@@ -149,6 +149,12 @@ export function deliverNotifySignal(
   } else if (event.osOverflow > 0 && leader.claim(now)) {
     // Mutually exclusive with `os` by construction: overflow is only ever set
     // on an event the burst budget refused.
+    //
+    // Called once per HELD-BACK CHANNEL — the gate raises `osOverflow` on every
+    // event that grows the set — so the notifier coalesces these into a single
+    // digest at the end of the pass. Doing it there rather than here is what
+    // makes a burst spread across the summary pass AND the status stream still
+    // collapse to one notification.
     notifier.deliverOverflow(event.osOverflow);
   }
   primePermissionIfWatching(osTier);

--- a/frontend/src/lib/notify/runtime.ts
+++ b/frontend/src/lib/notify/runtime.ts
@@ -14,6 +14,7 @@ import { useNotifyBadgeStore } from '../stores/notify-badge.js';
 import { currentNotifySettings } from '../stores/notify-settings.js';
 import { useUiStore } from '../stores/ui.js';
 import { openChannelFromNotification } from '../topic-selection.js';
+import { createNotifyLeader, type NotifyLeader } from './leader.js';
 import { createOsNotifier, type OsNotifier } from './os-notification.js';
 import {
   createNotifyGate,
@@ -27,6 +28,9 @@ let gate: NotifyGate = createNotifyGate();
 let notifier: OsNotifier = createOsNotifier({
   openChannel: openChannelFromNotification,
 });
+// Constructed eagerly but INERT until claimed: nothing is read or written until
+// an event actually reaches the OS tier, so importing this module costs nothing.
+let leader: NotifyLeader = createNotifyLeader();
 
 /** The shared OS notifier — Settings uses it for the explicit permission ask. */
 export function notifyOsNotifier(): OsNotifier {
@@ -80,12 +84,37 @@ export interface DeliverNotifyOptions {
 }
 
 /**
+ * Arm the lazy permission prompt from a LIVE event on a tab the operator is
+ * looking at.
+ *
+ * The OS-tier ask in `os-notification.ts` can only fire for an `os` event,
+ * which by construction only exists while `document.hidden` — exactly when
+ * Safari and Firefox refuse to raise a prompt (both tie `requestPermission` to
+ * user activation) and Chrome defers it. So a fresh browser could reach the
+ * documented lazy grant only by accident. A gate-approved event on a VISIBLE,
+ * FOCUSED tab is the same evidence that something notification-worthy just
+ * happened, delivered where the ask can actually land.
+ *
+ * The BOOT SEED is excluded (`osTier: false`): a prompt raised at page load,
+ * before the operator has been shown anything, is the hostile ask this lane
+ * refuses to make.
+ */
+function primePermissionIfWatching(osTier: boolean): void {
+  if (!osTier) return;
+  const doc = typeof document === 'undefined' ? null : document;
+  if (!doc || doc.hidden) return;
+  if (typeof doc.hasFocus === 'function' && !doc.hasFocus()) return;
+  notifier.primePermission();
+}
+
+/**
  * Run one signal through the gate and, if it survives, deliver it.
  *
  * Both tiers fire from here so they cannot disagree about what happened: the
  * in-app flag ALWAYS (an event only exists once it has passed the setting, the
  * replay guard, the read position, and the open-and-focused suppression), and
- * the OS notification only when the gate marked it `os`.
+ * the OS notification only when the gate marked it `os` AND this tab holds the
+ * cross-tab lease.
  *
  * Returns the delivered event so callers and tests can assert on it.
  */
@@ -93,32 +122,57 @@ export function deliverNotifySignal(
   signal: NotifySignal,
   options: DeliverNotifyOptions = {}
 ): NotifyEvent | null {
-  const event = gate.evaluate(
+  // Captured, not re-read: `resetNotifyRuntime` can swap the singleton while a
+  // permission request is in flight, and refunding a FRESH gate would poison a
+  // ledger that never charged anything.
+  const activeGate = gate;
+  const now = options.now ?? Date.now();
+  const osTier = options.osTier ?? true;
+  const event = activeGate.evaluate(
     signal,
-    gateContext(
-      signal.channel.id,
-      options.now ?? Date.now(),
-      options.osTier ?? true
-    )
+    gateContext(signal.channel.id, now, osTier)
   );
   if (!event) return null;
   useNotifyBadgeStore
     .getState()
     .flagChannel(event.channelId, { seq: event.seq, reason: event.reason });
-  notifier.deliver(event);
+  if (event.os) {
+    // A tab that loses the lease reports its event as UNDELIVERED, so the gate
+    // hands the window back: a follower that later becomes the leader must not
+    // be sitting on rate-limit slots it never spent.
+    const delivered = leader.claim(now)
+      ? notifier.deliver(event)
+      : Promise.resolve(false);
+    void delivered.then((shown) => {
+      if (!shown) activeGate.refundOs(event);
+    });
+  } else if (event.osOverflow > 0 && leader.claim(now)) {
+    // Mutually exclusive with `os` by construction: overflow is only ever set
+    // on an event the burst budget refused.
+    notifier.deliverOverflow(event.osOverflow);
+  }
+  primePermissionIfWatching(osTier);
   return event;
 }
 
 /**
  * Drop every ledger and rebuild the singletons.
  *
- * Used by tests, and on sign-out: a gate that remembers another account's seqs
- * would silence that account's first real message on this device.
+ * Called from `useNotifyDelivery` when the lane is disabled (sign-out, auth
+ * expiry) and by tests. Stopping the watcher is NOT enough on its own: the
+ * gate's per-channel seq ledger, the OS rate-limit windows and the badge flags
+ * all outlive it, so after a re-auth every seq already recorded would be
+ * permanently replay-suppressed and an unread message could never raise its
+ * badge again on this tab.
  */
 export function resetNotifyRuntime(): void {
   gate.reset();
   notifier.reset();
+  // Released, not just dropped: a lease left behind under a discarded id would
+  // lock this origin's OS tier out for its full duration.
+  leader.release();
   gate = createNotifyGate();
   notifier = createOsNotifier({ openChannel: openChannelFromNotification });
+  leader = createNotifyLeader();
   useNotifyBadgeStore.getState().reset();
 }

--- a/frontend/src/lib/notify/signals.ts
+++ b/frontend/src/lib/notify/signals.ts
@@ -102,6 +102,14 @@ export interface NotifyEvent {
    */
   count: number;
   /**
+   * Channels the GLOBAL burst budget has held back inside the current window,
+   * including this one — or `0` when nothing overflowed. Only ever non-zero
+   * when `os` is false, and only on the event that GREW the held-back set, so
+   * item 2 can render one collapsed digest per new channel instead of one
+   * notification per channel.
+   */
+  osOverflow: number;
+  /**
    * Lowercase-safe short label for the sender/agent, carried through from the
    * signal. Copy is composed by `notify/copy.ts` (item 2) rather than here: the
    * OS tier renders title and body as one unit and needs the channel inside the
@@ -118,6 +126,25 @@ export interface NotifyEvent {
  * back-and-forth still pings.
  */
 export const NOTIFY_OS_RATE_LIMIT_MS = 60_000;
+
+/**
+ * GLOBAL burst budget: at most this many OS notifications across ALL channels
+ * inside `NOTIFY_OS_BURST_WINDOW_MS`.
+ *
+ * The per-channel limit above says nothing about a pass that walks a WHOLE
+ * `/channels` payload. A hidden tab whose socket reconnects refetches the
+ * summary list, and under the #1242 orchestrator epic — one DM channel per
+ * agent profile — fifteen DM rows can each carry a fresh agent reply: fifteen
+ * channels, fifteen untouched 60s windows, fifteen notification-centre entries
+ * at once, none of which replaces another because the tag is per channel. That
+ * is the normal shape of a reconnect, not an edge case.
+ *
+ * Overflow is not dropped: the held-back channels are counted and reported on
+ * `osOverflow`, which item 2 renders as ONE collapsed notification. The in-app
+ * badge tier is untouched — every held-back channel still gets its dot.
+ */
+export const NOTIFY_OS_BURST_LIMIT = 3;
+export const NOTIFY_OS_BURST_WINDOW_MS = 10_000;
 
 /**
  * Busy statuses whose fall to `idle` is a completed TURN.
@@ -290,6 +317,23 @@ export interface NotifyGate {
     signal: NotifySignal,
     ctx: NotifyGateContext
   ) => NotifyEvent | null;
+  /**
+   * Hand back the OS budget an event consumed when the notification was never
+   * actually shown.
+   *
+   * `evaluate` charges the per-channel window and the global burst slot at
+   * DECISION time, because that is the only place the ledgers live — but the
+   * delivery downstream can still drop the event (permission `denied` or
+   * `unsupported`, a `Notification` constructor that throws, a `default`
+   * permission request the operator dismisses, or another tab holding the
+   * cross-tab lease). Without a refund the first, never-displayed event burns
+   * a 60s slot and the next real message in that channel is swallowed as a
+   * coalesce increment that shows nothing.
+   *
+   * The replay guard is deliberately NOT refunded: the row was evaluated and
+   * did earn its in-app badge, so re-raising it would double-badge.
+   */
+  refundOs: (event: Pick<NotifyEvent, 'channelId' | 'count'>) => void;
   /** Forget every per-channel ledger entry (sign-out, tests). */
   reset: () => void;
 }
@@ -306,6 +350,26 @@ export function createNotifyGate(): NotifyGate {
   const lastOsAtByChannel = new Map<string, number>();
   /** OS notifications this channel swallowed since its last fire. */
   const coalescedByChannel = new Map<string, number>();
+  /** Timestamps of the OS grants inside the current burst window, oldest first. */
+  const osFiredAt: number[] = [];
+  /** Channels the burst budget has held back in the current window. */
+  const overflowChannels = new Set<string>();
+
+  /**
+   * Drop burst grants that have aged out. The held-back set is cleared with
+   * them: once the window is empty the burst is over, and the next overflow is
+   * a new one that starts counting at one.
+   */
+  function pruneBurstLedger(now: number): void {
+    while (osFiredAt.length > 0) {
+      const oldest = osFiredAt[0];
+      if (oldest === undefined || now - oldest < NOTIFY_OS_BURST_WINDOW_MS) {
+        break;
+      }
+      osFiredAt.shift();
+    }
+    if (osFiredAt.length === 0) overflowChannels.clear();
+  }
 
   function evaluate(
     signal: NotifySignal,
@@ -349,23 +413,40 @@ export function createNotifyGate(): NotifyGate {
     //    already has the in-app badge in view.
     let os = ctx.documentHidden;
     let count = 1;
+    let osOverflow = 0;
     if (os) {
       const lastOsAt = lastOsAtByChannel.get(channelId);
-      if (
-        lastOsAt !== undefined &&
-        ctx.now - lastOsAt < NOTIFY_OS_RATE_LIMIT_MS
-      ) {
-        // Inside the window: swallow the OS tier and remember the miss so the
-        // next fire can say how many piled up.
+      const withinChannelWindow =
+        lastOsAt !== undefined && ctx.now - lastOsAt < NOTIFY_OS_RATE_LIMIT_MS;
+      pruneBurstLedger(ctx.now);
+      // Checked BEFORE anything is charged: a refusal must leave both ledgers
+      // exactly as it found them.
+      const burstExhausted = osFiredAt.length >= NOTIFY_OS_BURST_LIMIT;
+      if (withinChannelWindow || burstExhausted) {
+        // Held back: swallow the OS tier and remember the miss so the next fire
+        // can say how many piled up.
         coalescedByChannel.set(
           channelId,
           (coalescedByChannel.get(channelId) ?? 0) + 1
         );
         os = false;
+        // A channel the per-channel limiter would have swallowed anyway is not
+        // burst overflow — it already has a live notification of its own, and
+        // counting it would inflate the digest with channels the operator can
+        // see.
+        if (burstExhausted && !withinChannelWindow) {
+          const before = overflowChannels.size;
+          overflowChannels.add(channelId);
+          // Only the event that GREW the set reports overflow: a channel that
+          // overflows twice in one window must not re-alert the digest.
+          if (overflowChannels.size > before)
+            osOverflow = overflowChannels.size;
+        }
       } else {
         count = (coalescedByChannel.get(channelId) ?? 0) + 1;
         coalescedByChannel.delete(channelId);
         lastOsAtByChannel.set(channelId, ctx.now);
+        osFiredAt.push(ctx.now);
       }
     }
 
@@ -377,18 +458,34 @@ export function createNotifyGate(): NotifyGate {
       badge: true,
       os,
       count,
+      osOverflow,
       senderLabel: signal.senderLabel,
       seq: signal.seq,
       at: signal.at,
     };
   }
 
+  function refundOs(event: Pick<NotifyEvent, 'channelId' | 'count'>): void {
+    lastOsAtByChannel.delete(event.channelId);
+    // The undelivered event stood for `count` signals — itself plus whatever it
+    // was flushing — and none of them was seen, so all of them go back on the
+    // coalesce pile rather than evaporating.
+    coalescedByChannel.set(event.channelId, event.count);
+    // Give the burst slot back too. The most recent grant is popped rather than
+    // matched by timestamp: refunds are same-window and the ledger is a COUNT,
+    // so which entry leaves it only shifts the window edge by microseconds.
+    osFiredAt.pop();
+  }
+
   return {
     evaluate,
+    refundOs,
     reset: () => {
       lastSeqByChannel.clear();
       lastOsAtByChannel.clear();
       coalescedByChannel.clear();
+      osFiredAt.length = 0;
+      overflowChannels.clear();
     },
   };
 }

--- a/frontend/src/lib/notify/signals.ts
+++ b/frontend/src/lib/notify/signals.ts
@@ -101,10 +101,13 @@ export interface NotifyEvent {
    * held OS notifications back and this one flushes the coalesced run.
    */
   count: number;
-  /** Notification title. */
-  title: string;
-  /** Notification body — lowercase, no emoji, and never message text. */
-  body: string;
+  /**
+   * Lowercase-safe short label for the sender/agent, carried through from the
+   * signal. Copy is composed by `notify/copy.ts` (item 2) rather than here: the
+   * OS tier renders title and body as one unit and needs the channel inside the
+   * sentence, so a body baked at gate time would have to be re-cut downstream.
+   */
+  senderLabel: string;
   seq: number;
   at: number;
 }
@@ -185,7 +188,9 @@ export interface NotifyMessageRow {
 }
 
 /** Flatten a live channel message onto the shared row shape. */
-export function notifyRowFromMessage(message: ChannelMessage): NotifyMessageRow {
+export function notifyRowFromMessage(
+  message: ChannelMessage
+): NotifyMessageRow {
   return {
     seq: message.seq,
     senderId: message.sender.id,
@@ -281,7 +286,10 @@ export interface NotifyGateContext {
 
 export interface NotifyGate {
   /** Decide one signal. Returns null when nothing should be shown. */
-  evaluate: (signal: NotifySignal, ctx: NotifyGateContext) => NotifyEvent | null;
+  evaluate: (
+    signal: NotifySignal,
+    ctx: NotifyGateContext
+  ) => NotifyEvent | null;
   /** Forget every per-channel ledger entry (sign-out, tests). */
   reset: () => void;
 }
@@ -369,8 +377,7 @@ export function createNotifyGate(): NotifyGate {
       badge: true,
       os,
       count,
-      title: signal.channel.title,
-      body: notifyBody(signal, count),
+      senderLabel: signal.senderLabel,
       seq: signal.seq,
       at: signal.at,
     };
@@ -389,20 +396,4 @@ export function createNotifyGate(): NotifyGate {
 /** Notification tag: one live notification per channel. */
 export function notifyChannelKey(channelId: string): string {
   return `relay-channel:${channelId}`;
-}
-
-/**
- * Notification body. Lowercase, no emoji, no message text — an OS notification
- * renders on a lock screen, and a channel transcript is not lock-screen
- * material. The coalesce count is appended with the mono-spirit separator the
- * rest of the UI uses.
- */
-function notifyBody(signal: NotifySignal, count: number): string {
-  const base =
-    signal.reason === 'mention'
-      ? `${signal.senderLabel} mentioned you`
-      : signal.reason === 'dm-reply'
-        ? `${signal.senderLabel} replied`
-        : `${signal.senderLabel} finished`;
-  return count > 1 ? `${base} · ${count} new` : base;
 }

--- a/frontend/src/lib/notify/signals.ts
+++ b/frontend/src/lib/notify/signals.ts
@@ -110,6 +110,17 @@ export interface NotifyEvent {
    */
   osOverflow: number;
   /**
+   * The `now` at which the gate CHARGED this channel's rate-limit window and a
+   * global burst slot. Present only when the OS tier was granted (`os: true`).
+   *
+   * It exists so a refund can be matched rather than assumed. `deliver` is
+   * asynchronous on the lazy-permission path, and an operator can sit on a
+   * permission prompt for minutes — long enough for a later event in the same
+   * channel to fire and write a fresh window. A refund that cleared whatever it
+   * found would hand back a charge it never made.
+   */
+  osChargedAt?: number | undefined;
+  /**
    * Lowercase-safe short label for the sender/agent, carried through from the
    * signal. Copy is composed by `notify/copy.ts` (item 2) rather than here: the
    * OS tier renders title and body as one unit and needs the channel inside the
@@ -311,6 +322,18 @@ export interface NotifyGateContext {
   now: number;
 }
 
+/**
+ * What a refund needs from the event it is handing back.
+ *
+ * `osChargedAt` is what makes the refund IDENTIFIABLE rather than positional —
+ * see the field's note on `NotifyEvent`. An event that carries no stamp charged
+ * nothing, so there is nothing to hand back.
+ */
+export type NotifyOsRefund = Pick<
+  NotifyEvent,
+  'channelId' | 'count' | 'osChargedAt'
+>;
+
 export interface NotifyGate {
   /** Decide one signal. Returns null when nothing should be shown. */
   evaluate: (
@@ -333,7 +356,7 @@ export interface NotifyGate {
    * The replay guard is deliberately NOT refunded: the row was evaluated and
    * did earn its in-app badge, so re-raising it would double-badge.
    */
-  refundOs: (event: Pick<NotifyEvent, 'channelId' | 'count'>) => void;
+  refundOs: (event: NotifyOsRefund) => void;
   /** Forget every per-channel ledger entry (sign-out, tests). */
   reset: () => void;
 }
@@ -414,6 +437,7 @@ export function createNotifyGate(): NotifyGate {
     let os = ctx.documentHidden;
     let count = 1;
     let osOverflow = 0;
+    let osChargedAt: number | undefined;
     if (os) {
       const lastOsAt = lastOsAtByChannel.get(channelId);
       const withinChannelWindow =
@@ -447,6 +471,8 @@ export function createNotifyGate(): NotifyGate {
         coalescedByChannel.delete(channelId);
         lastOsAtByChannel.set(channelId, ctx.now);
         osFiredAt.push(ctx.now);
+        // Stamped so a refund can prove it is handing back THIS charge.
+        osChargedAt = ctx.now;
       }
     }
 
@@ -459,22 +485,44 @@ export function createNotifyGate(): NotifyGate {
       os,
       count,
       osOverflow,
+      ...(osChargedAt === undefined ? {} : { osChargedAt }),
       senderLabel: signal.senderLabel,
       seq: signal.seq,
       at: signal.at,
     };
   }
 
-  function refundOs(event: Pick<NotifyEvent, 'channelId' | 'count'>): void {
-    lastOsAtByChannel.delete(event.channelId);
+  function refundOs(event: NotifyOsRefund): void {
+    const chargedAt = event.osChargedAt;
+    // No stamp means the OS tier was never granted, so neither ledger was
+    // touched. Refunding anyway would credit a coalesce pile for signals that
+    // were never held back.
+    if (chargedAt === undefined) return;
     // The undelivered event stood for `count` signals — itself plus whatever it
     // was flushing — and none of them was seen, so all of them go back on the
     // coalesce pile rather than evaporating.
-    coalescedByChannel.set(event.channelId, event.count);
-    // Give the burst slot back too. The most recent grant is popped rather than
-    // matched by timestamp: refunds are same-window and the ledger is a COUNT,
-    // so which entry leaves it only shifts the window edge by microseconds.
-    osFiredAt.pop();
+    //
+    // ADDED, not assigned: `deliver` is asynchronous on the lazy-permission
+    // path, which is the long one — the operator can leave the prompt up while
+    // more messages land in the same channel and coalesce behind it. Assigning
+    // would destroy exactly those, and the next fire would undercount the run
+    // the operator never saw.
+    coalescedByChannel.set(
+      event.channelId,
+      (coalescedByChannel.get(event.channelId) ?? 0) + event.count
+    );
+    // Matched, not assumed. A refund can land long after its event was
+    // evaluated, by which time a LATER event in this channel may have fired for
+    // real and written a fresh window; clearing that one would let the channel
+    // notify twice inside its 60s limit.
+    if (lastOsAtByChannel.get(event.channelId) === chargedAt) {
+      lastOsAtByChannel.delete(event.channelId);
+    }
+    // Same reasoning for the global burst slot: the entry this event pushed is
+    // spliced out by its own timestamp rather than popping whichever grant
+    // happens to be newest, which on a late refund is somebody else's.
+    const slot = osFiredAt.indexOf(chargedAt);
+    if (slot !== -1) osFiredAt.splice(slot, 1);
   }
 
   return {

--- a/frontend/src/lib/notify/signals.ts
+++ b/frontend/src/lib/notify/signals.ts
@@ -1,0 +1,408 @@
+// Notify-signal derivation for channel notifications (#1308 slice 5 item 1).
+//
+// PURE. This module decides WHETHER something is worth telling the operator
+// about and WHICH tier it earns; it never touches the Notification API, the
+// favicon, the title, or any store. Item 2 owns delivery and consumes the
+// `NotifyEvent` this returns.
+//
+// Deliberately `lib/notify/`, not `lib/notifications/`: `lib/notifications.ts`
+// already exists and owns the LEGACY per-session web-push lane (service worker
+// + VAPID + `PUT /config`). A sibling directory of the same name would resolve
+// fine but read as one module in two places. The two lanes are unrelated —
+// nothing here registers a service worker, and this slice adds no push infra.
+//
+// Everything reads streams the client already has:
+//   * message rows — the channel chat socket for the open channel, and the
+//     `/channels` list summary's `lastMessage` (which carries server-computed
+//     `mentions` over the FULL body) for every other channel;
+//   * `channel-agent-status` — the per-channel agent status transitions;
+//   * `channel-activity` + the read-sync stores (#1308 slice 3) — the read
+//     position, which is READ here and never recomputed.
+// No new HTTP route, no new gateway verb.
+import type { ChannelAgentStatus } from '../api.js';
+import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+import type { WorkspaceTopic } from '../../../../shared/workspace-topics.js';
+import type { TopicNavItem } from '../state/topic-nav.js';
+import { isDmChannel } from '../dm-channels.js';
+import {
+  CURRENT_OPERATOR_SENDER_ID,
+  messageMentionsOperator,
+  senderShortLabel,
+} from '../channel-sender-label.js';
+import type {
+  NotifySettingKey,
+  NotifySettings,
+} from '../stores/notify-settings.js';
+
+/**
+ * Why the operator is being told.
+ *
+ * MENTION exists because `@operator` is a real, already-shipped signal: mention
+ * refs resolve against an agent-profile contact set only, so a human mention
+ * lands as an unresolved `{ raw: '@operator' }` ref — see
+ * `messageMentionsOperator` in `channel-sender-label.ts` for the verification
+ * note. It is NOT N/A.
+ */
+export type NotifyReason = 'mention' | 'dm-reply' | 'turn-complete';
+
+/** The channel a signal is raised against. */
+export interface NotifyChannel {
+  id: string;
+  /**
+   * Operator-authored channel title, used VERBATIM in notification copy. Relay
+   * copy is lowercase (DESIGN.md) but the operator's own title is their text,
+   * not a label this lane gets to restyle.
+   */
+  title: string;
+  /** Derived, never a server marker — see `shared/dm-channels.ts`. */
+  isDm: boolean;
+}
+
+/** One notify-worthy thing that happened, before any gating. */
+export interface NotifySignal {
+  reason: NotifyReason;
+  channel: NotifyChannel;
+  /**
+   * Message seq the signal was raised for, or 0 for a status-only signal
+   * (turn-complete carries no row). Drives both the replay guard and the
+   * read-position gate, so a signal with a real row MUST carry its seq.
+   */
+  seq: number;
+  /** Lowercase-safe short label for the sender/agent (`senderShortLabel`). */
+  senderLabel: string;
+  at: number;
+}
+
+/** Delivery decision for one signal. Consumed by item 2. */
+export interface NotifyEvent {
+  /**
+   * Per-CHANNEL coalesce key. Item 2 passes it as the `Notification` tag so a
+   * newer notification for the same channel replaces the previous one in the
+   * OS notification centre rather than stacking.
+   */
+  key: string;
+  reason: NotifyReason;
+  channelId: string;
+  channelTitle: string;
+  /**
+   * In-app tier (badge / title count). Always true on a returned event: an
+   * event only exists once the trigger passed its setting, its replay guard,
+   * the read position, and the open-and-focused suppression — a survivor of all
+   * four is worth an in-app mark regardless of tab visibility.
+   */
+  badge: true;
+  /**
+   * OS Notification tier. True only when the tab is HIDDEN and this channel's
+   * rate-limit window is open. A visible tab gets the in-app tier only.
+   */
+  os: boolean;
+  /**
+   * Signals this event stands for. `1` normally; `> 1` when the rate limiter
+   * held OS notifications back and this one flushes the coalesced run.
+   */
+  count: number;
+  /** Notification title. */
+  title: string;
+  /** Notification body — lowercase, no emoji, and never message text. */
+  body: string;
+  seq: number;
+  at: number;
+}
+
+/**
+ * One OS notification per channel per minute. Long enough that a streaming
+ * agent cannot machine-gun the notification centre, short enough that a real
+ * back-and-forth still pings.
+ */
+export const NOTIFY_OS_RATE_LIMIT_MS = 60_000;
+
+/**
+ * Busy statuses whose fall to `idle` is a completed TURN.
+ *
+ * `spawning` is excluded on purpose: `spawning → idle` without ever thinking is
+ * a runtime that failed to come up, which is not a turn the operator was
+ * waiting on the result of.
+ */
+const TURN_BUSY_STATUSES: readonly ChannelAgentStatus[] = [
+  'thinking',
+  'streaming',
+  'waiting',
+];
+
+const SETTING_BY_REASON: Readonly<Record<NotifyReason, NotifySettingKey>> = {
+  mention: 'mentions',
+  'dm-reply': 'dmReplies',
+  'turn-complete': 'turnComplete',
+};
+
+/** True when the operator has this trigger switched on. */
+export function notifyReasonEnabled(
+  settings: NotifySettings,
+  reason: NotifyReason
+): boolean {
+  return settings[SETTING_BY_REASON[reason]];
+}
+
+/** Derive the channel descriptor a signal needs from a persisted topic record. */
+export function notifyChannelFromTopic(
+  topic: Pick<
+    WorkspaceTopic,
+    'id' | 'display' | 'workspaceId' | 'routingDefaults'
+  >
+): NotifyChannel {
+  return {
+    id: topic.id,
+    title: topic.display.title,
+    isDm: isDmChannel(topic) !== null,
+  };
+}
+
+/**
+ * Same descriptor from the rail's derived nav model, which has already resolved
+ * DM-ness and the display title. Preferred by any caller that holds a nav item:
+ * re-deriving `isDmChannel` off a second shape is how the two lanes drift.
+ */
+export function notifyChannelFromNavItem(
+  item: Pick<TopicNavItem, 'id' | 'title' | 'isDirectMessage'>
+): NotifyChannel {
+  return { id: item.id, title: item.title, isDm: item.isDirectMessage };
+}
+
+/**
+ * The row shape both message streams reduce to. Structurally satisfied as-is by
+ * the channel-list summary's `lastMessage`; `notifyRowFromMessage` maps a live
+ * `ChannelMessage` onto it.
+ */
+export interface NotifyMessageRow {
+  seq: number;
+  senderId: string;
+  senderKind: 'human' | 'agent' | 'system';
+  senderDisplayName?: string | undefined;
+  providerId?: string | undefined;
+  mentions?: readonly { raw: string }[] | undefined;
+  /** Truncated body text. Only read when `mentions` is absent. */
+  preview: string;
+}
+
+/** Flatten a live channel message onto the shared row shape. */
+export function notifyRowFromMessage(message: ChannelMessage): NotifyMessageRow {
+  return {
+    seq: message.seq,
+    senderId: message.sender.id,
+    senderKind: message.sender.kind,
+    ...(message.sender.displayName !== undefined
+      ? { senderDisplayName: message.sender.displayName }
+      : {}),
+    ...(message.sender.providerId !== undefined
+      ? { providerId: message.sender.providerId }
+      : {}),
+    ...(message.mentions !== undefined ? { mentions: message.mentions } : {}),
+    preview: message.body.text,
+  };
+}
+
+/**
+ * MENTION and DM-REPLY, from one incoming row. At most ONE signal per row, with
+ * mention winning: an agent that both replies in a DM and writes `@operator` is
+ * one event, and the stronger reason is the one addressed at the operator.
+ *
+ * Returns null for the operator's own rows (this device's post is echoed back
+ * over the socket) and for system rows (join/leave/approval scaffolding is
+ * timeline furniture, not a message someone sent).
+ */
+export function deriveMessageSignal(
+  row: NotifyMessageRow,
+  channel: NotifyChannel,
+  at: number
+): NotifySignal | null {
+  if (row.senderId === CURRENT_OPERATOR_SENDER_ID) return null;
+  if (row.senderKind === 'system') return null;
+  const senderLabel = senderShortLabel({
+    senderId: row.senderId,
+    senderDisplayName: row.senderDisplayName,
+    providerId: row.providerId,
+  });
+  const base = { channel, seq: row.seq, senderLabel, at };
+  if (messageMentionsOperator(row)) return { reason: 'mention', ...base };
+  if (channel.isDm && row.senderKind === 'agent') {
+    return { reason: 'dm-reply', ...base };
+  }
+  return null;
+}
+
+/**
+ * TURN COMPLETE, from a `channel-agent-status` transition.
+ *
+ * SIMPLIFICATION (sanctioned by the slice brief): this does not correlate the
+ * turn back to a trigger message the operator sent. The binder's turn id is
+ * `chturn-<triggerMessageId>-<profileActorId>` and the status broadcast does not
+ * carry it, so the correlation would need a per-turn client-side ledger that the
+ * open/hidden gate plus the turn-complete setting (default OFF) buy for free.
+ * What IS enforced: a real busy→idle edge, and — through the gate — a channel
+ * the operator is not currently looking at.
+ */
+export function deriveTurnCompleteSignal(input: {
+  channel: NotifyChannel;
+  agentLabel: string;
+  previous: ChannelAgentStatus | undefined;
+  next: ChannelAgentStatus;
+  at: number;
+}): NotifySignal | null {
+  if (input.next !== 'idle') return null;
+  if (input.previous === undefined) return null;
+  if (!TURN_BUSY_STATUSES.includes(input.previous)) return null;
+  return {
+    reason: 'turn-complete',
+    channel: input.channel,
+    seq: 0,
+    senderLabel: input.agentLabel,
+    at: input.at,
+  };
+}
+
+/** Everything outside the signal that decides its fate. */
+export interface NotifyGateContext {
+  settings: NotifySettings;
+  /** `useUiStore.activeChannelId` — the channel open in the timeline. */
+  activeChannelId: string | null;
+  /** `document.hidden`. */
+  documentHidden: boolean;
+  /** `document.hasFocus()`. */
+  windowFocused: boolean;
+  /**
+   * The operator's last-read seq for this signal's channel, read from the
+   * read-sync stores (#1308 slice 3). Unread arithmetic is NOT reimplemented
+   * here — this only refuses a signal for a row the operator has already read,
+   * which is how a mark set on another device silences this one.
+   */
+  lastReadSeq?: number | undefined;
+  now: number;
+}
+
+export interface NotifyGate {
+  /** Decide one signal. Returns null when nothing should be shown. */
+  evaluate: (signal: NotifySignal, ctx: NotifyGateContext) => NotifyEvent | null;
+  /** Forget every per-channel ledger entry (sign-out, tests). */
+  reset: () => void;
+}
+
+/**
+ * Per-channel gate state. Kept in a closure rather than a module singleton so
+ * one test case cannot leak into the next and so a signed-out client can drop
+ * it wholesale.
+ */
+export function createNotifyGate(): NotifyGate {
+  /** Highest seq already evaluated per channel — the replay guard. */
+  const lastSeqByChannel = new Map<string, number>();
+  /** When this channel last fired an OS notification. */
+  const lastOsAtByChannel = new Map<string, number>();
+  /** OS notifications this channel swallowed since its last fire. */
+  const coalescedByChannel = new Map<string, number>();
+
+  function evaluate(
+    signal: NotifySignal,
+    ctx: NotifyGateContext
+  ): NotifyEvent | null {
+    const channelId = signal.channel.id;
+
+    // 1. Operator setting. An off trigger is off in BOTH tiers — the in-app
+    //    badge lane is "regardless of tab visibility", not "regardless of what
+    //    the operator asked for". Unread dots are a separate, always-on surface.
+    if (!notifyReasonEnabled(ctx.settings, signal.reason)) return null;
+
+    // 2. Replay guard. The list payload that carries `lastMessage` is refetched
+    //    on reconnect, on focus, and whenever an unknown channel shows activity
+    //    — without this every refetch would re-notify the same row.
+    if (signal.seq > 0) {
+      const seen = lastSeqByChannel.get(channelId);
+      if (seen !== undefined && seen >= signal.seq) return null;
+      lastSeqByChannel.set(channelId, signal.seq);
+    }
+
+    // 3. Already read — including read on ANOTHER device, which is exactly what
+    //    slice 3 made knowable.
+    if (
+      signal.seq > 0 &&
+      ctx.lastReadSeq !== undefined &&
+      signal.seq <= ctx.lastReadSeq
+    ) {
+      return null;
+    }
+
+    // 4. The operator is looking straight at it. Open AND visible AND focused —
+    //    an open channel in a background tab is not being watched.
+    const watching =
+      channelId === ctx.activeChannelId &&
+      !ctx.documentHidden &&
+      ctx.windowFocused;
+    if (watching) return null;
+
+    // 5. Tiering. OS notifications are for a hidden tab only; a visible tab
+    //    already has the in-app badge in view.
+    let os = ctx.documentHidden;
+    let count = 1;
+    if (os) {
+      const lastOsAt = lastOsAtByChannel.get(channelId);
+      if (
+        lastOsAt !== undefined &&
+        ctx.now - lastOsAt < NOTIFY_OS_RATE_LIMIT_MS
+      ) {
+        // Inside the window: swallow the OS tier and remember the miss so the
+        // next fire can say how many piled up.
+        coalescedByChannel.set(
+          channelId,
+          (coalescedByChannel.get(channelId) ?? 0) + 1
+        );
+        os = false;
+      } else {
+        count = (coalescedByChannel.get(channelId) ?? 0) + 1;
+        coalescedByChannel.delete(channelId);
+        lastOsAtByChannel.set(channelId, ctx.now);
+      }
+    }
+
+    return {
+      key: notifyChannelKey(channelId),
+      reason: signal.reason,
+      channelId,
+      channelTitle: signal.channel.title,
+      badge: true,
+      os,
+      count,
+      title: signal.channel.title,
+      body: notifyBody(signal, count),
+      seq: signal.seq,
+      at: signal.at,
+    };
+  }
+
+  return {
+    evaluate,
+    reset: () => {
+      lastSeqByChannel.clear();
+      lastOsAtByChannel.clear();
+      coalescedByChannel.clear();
+    },
+  };
+}
+
+/** Notification tag: one live notification per channel. */
+export function notifyChannelKey(channelId: string): string {
+  return `relay-channel:${channelId}`;
+}
+
+/**
+ * Notification body. Lowercase, no emoji, no message text — an OS notification
+ * renders on a lock screen, and a channel transcript is not lock-screen
+ * material. The coalesce count is appended with the mono-spirit separator the
+ * rest of the UI uses.
+ */
+function notifyBody(signal: NotifySignal, count: number): string {
+  const base =
+    signal.reason === 'mention'
+      ? `${signal.senderLabel} mentioned you`
+      : signal.reason === 'dm-reply'
+        ? `${signal.senderLabel} replied`
+        : `${signal.senderLabel} finished`;
+  return count > 1 ? `${base} · ${count} new` : base;
+}

--- a/frontend/src/lib/notify/summary-watch.ts
+++ b/frontend/src/lib/notify/summary-watch.ts
@@ -8,6 +8,7 @@
 // so this adds an observer's worth of nothing.
 import type { QueryClient } from '@tanstack/react-query';
 import { fetchChannels, fetchWorkspaceTopics } from '../api.js';
+import { useNotifyBadgeStore } from '../stores/notify-badge.js';
 import { notifyChannelIndex, notifyFromChannelSummaries } from './producers.js';
 import type { NotifySummaryRow, NotifyTopicRecord } from './producers.js';
 
@@ -47,6 +48,25 @@ export async function ensureNotifySummaryCaches(
 }
 
 /**
+ * True when something is already OBSERVING `['channels']` — in practice the
+ * rail, which refetches the summary list on its own throttle.
+ *
+ * The notify lane's refresh exists to cover the rail being unmounted (collapsed
+ * sidebar) or deliberately suppressed (hidden tab). When the rail IS mounted and
+ * visible it is the cheaper producer and already runs, so this lane must stand
+ * down rather than double the hub's `GET /channels` load — which is O(channels)
+ * server-side.
+ */
+export function channelSummariesHaveObserver(
+  queryClient: QueryClient
+): boolean {
+  const query = queryClient
+    .getQueryCache()
+    .find({ queryKey: [NOTIFY_CHANNELS_QUERY_KEY], exact: true });
+  return (query?.getObserversCount() ?? 0) > 0;
+}
+
+/**
  * Force a fresh `/channels` payload into the cache.
  *
  * `fetchQuery`, not `invalidateQueries`: invalidation only refetches queries
@@ -82,6 +102,28 @@ export async function refreshChannelSummaries(
  * replay guard is what makes the pass idempotent, which is also why this lane
  * keeps no "rows I have already seen" ledger of its own.
  */
+/**
+ * Drop badge flags for channels the active topic list no longer contains.
+ *
+ * `['workspace-topics']` (the exact key, which is always the ACTIVE view — the
+ * archived one rides a distinct key) is the closest thing this lane has to a
+ * channel-deleted signal: a flagged channel that has left it was deleted or
+ * archived, and neither should keep pulling the operator's eye to a tab.
+ *
+ * Skipped on a TRUNCATED payload, which is a page of the corpus rather than the
+ * whole of it — pruning against it would clear flags for channels that exist.
+ */
+function pruneBadgesForMissingChannels(
+  channels: ReadonlyMap<string, unknown>,
+  truncated: boolean
+): void {
+  if (truncated) return;
+  const badges = useNotifyBadgeStore.getState();
+  for (const channelId of Object.keys(badges.flagByChannel)) {
+    if (!channels.has(channelId)) badges.clearChannel(channelId);
+  }
+}
+
 export function watchChannelSummaries(queryClient: QueryClient): () => void {
   let seeded = false;
 
@@ -89,20 +131,19 @@ export function watchChannelSummaries(queryClient: QueryClient): () => void {
     const rows = queryClient.getQueryData<NotifySummaryRow[]>([
       NOTIFY_CHANNELS_QUERY_KEY,
     ]);
-    const topics = queryClient.getQueryData<{ topics?: NotifyTopicRecord[] }>([
-      NOTIFY_TOPICS_QUERY_KEY,
-    ]);
+    const topics = queryClient.getQueryData<{
+      topics?: NotifyTopicRecord[];
+      truncated?: boolean;
+    }>([NOTIFY_TOPICS_QUERY_KEY]);
     // BOTH are required, and either can land second on a cold boot — which is
     // why the subscription below watches both keys rather than just the
     // channel list.
     if (!rows || !topics?.topics?.length) return;
+    const channels = notifyChannelIndex(topics.topics);
+    pruneBadgesForMissingChannels(channels, topics.truncated === true);
     const osTier = seeded;
     seeded = true;
-    notifyFromChannelSummaries({
-      rows,
-      channels: notifyChannelIndex(topics.topics),
-      osTier,
-    });
+    notifyFromChannelSummaries({ rows, channels, osTier });
   }
 
   runPass();

--- a/frontend/src/lib/notify/summary-watch.ts
+++ b/frontend/src/lib/notify/summary-watch.ts
@@ -1,0 +1,120 @@
+// Feeds the mention / DM-reply producer from the query cache (#1308 slice 5
+// item 2).
+//
+// A plain subscription, not a `useQuery`: `App` renders `QueryClientProvider`
+// inside its own JSX, so the component body that mounts this lane is outside
+// the context (the same reason `useEventSocket` is handed the client). Reading
+// the cache is also the cheaper shape — the rail already fetches both payloads,
+// so this adds an observer's worth of nothing.
+import type { QueryClient } from '@tanstack/react-query';
+import { fetchChannels, fetchWorkspaceTopics } from '../api.js';
+import { notifyChannelIndex, notifyFromChannelSummaries } from './producers.js';
+import type { NotifySummaryRow, NotifyTopicRecord } from './producers.js';
+
+/** `GET /channels` — the only stream carrying sender identity + mention refs. */
+export const NOTIFY_CHANNELS_QUERY_KEY = 'channels';
+/** `GET /workspace-topics` — carries DM-ness and the operator's channel title. */
+export const NOTIFY_TOPICS_QUERY_KEY = 'workspace-topics';
+
+/** Same staleness the rail declares for each key, so this never double-fetches. */
+const CHANNELS_STALE_MS = 5 * 60_000;
+const TOPICS_STALE_MS = 30_000;
+
+/**
+ * Make sure both payloads exist, fetching only what is missing or stale.
+ *
+ * The rail is the normal producer of both caches, but it UNMOUNTS with a
+ * collapsed sidebar — and an operator who collapsed it would otherwise get no
+ * channel notifications at all, silently. `ensureQueryData` respects the same
+ * staleTime the rail declares, so on the common path (rail mounted, data fresh)
+ * this costs zero requests.
+ */
+export async function ensureNotifySummaryCaches(
+  queryClient: QueryClient
+): Promise<void> {
+  await Promise.allSettled([
+    queryClient.ensureQueryData({
+      queryKey: [NOTIFY_CHANNELS_QUERY_KEY],
+      queryFn: fetchChannels,
+      staleTime: CHANNELS_STALE_MS,
+    }),
+    queryClient.ensureQueryData({
+      queryKey: [NOTIFY_TOPICS_QUERY_KEY],
+      queryFn: () => fetchWorkspaceTopics(),
+      staleTime: TOPICS_STALE_MS,
+    }),
+  ]);
+}
+
+/**
+ * Force a fresh `/channels` payload into the cache.
+ *
+ * `fetchQuery`, not `invalidateQueries`: invalidation only refetches queries
+ * that have an ACTIVE observer, so with the rail unmounted it would mark the
+ * cache stale and nothing would ever fetch it. Fetching writes the same cache
+ * entry, so `watchChannelSummaries` sees it and a later rail mount reads it too.
+ */
+export async function refreshChannelSummaries(
+  queryClient: QueryClient
+): Promise<void> {
+  try {
+    await queryClient.fetchQuery({
+      queryKey: [NOTIFY_CHANNELS_QUERY_KEY],
+      queryFn: fetchChannels,
+      staleTime: 0,
+    });
+  } catch {
+    // Best effort. A missed refresh costs one delayed notification; the next
+    // activity burst arms another window.
+  }
+}
+
+/**
+ * Run the producer over whatever is cached now, then on every later update of
+ * either payload. Returns the unsubscribe.
+ *
+ * The FIRST pass badges without notifying: it describes everything that happened
+ * while this client was away, so a tab restored into the background would
+ * otherwise fire one notification per unread channel at once. Those rows are
+ * genuinely unread and earn their in-app badge; none of them is news.
+ *
+ * Re-running on an update that changed nothing is free — the gate's per-channel
+ * replay guard is what makes the pass idempotent, which is also why this lane
+ * keeps no "rows I have already seen" ledger of its own.
+ */
+export function watchChannelSummaries(queryClient: QueryClient): () => void {
+  let seeded = false;
+
+  function runPass(): void {
+    const rows = queryClient.getQueryData<NotifySummaryRow[]>([
+      NOTIFY_CHANNELS_QUERY_KEY,
+    ]);
+    const topics = queryClient.getQueryData<{ topics?: NotifyTopicRecord[] }>([
+      NOTIFY_TOPICS_QUERY_KEY,
+    ]);
+    // BOTH are required, and either can land second on a cold boot — which is
+    // why the subscription below watches both keys rather than just the
+    // channel list.
+    if (!rows || !topics?.topics?.length) return;
+    const osTier = seeded;
+    seeded = true;
+    notifyFromChannelSummaries({
+      rows,
+      channels: notifyChannelIndex(topics.topics),
+      osTier,
+    });
+  }
+
+  runPass();
+  return queryClient.getQueryCache().subscribe((event) => {
+    const key = event.query.queryKey;
+    if (!Array.isArray(key)) return;
+    if (
+      key[0] !== NOTIFY_CHANNELS_QUERY_KEY &&
+      key[0] !== NOTIFY_TOPICS_QUERY_KEY
+    ) {
+      return;
+    }
+    runPass();
+  });
+}

--- a/frontend/src/lib/notify/summary-watch.ts
+++ b/frontend/src/lib/notify/summary-watch.ts
@@ -135,12 +135,20 @@ export function watchChannelSummaries(queryClient: QueryClient): () => void {
       topics?: NotifyTopicRecord[];
       truncated?: boolean;
     }>([NOTIFY_TOPICS_QUERY_KEY]);
-    // BOTH are required, and either can land second on a cold boot — which is
-    // why the subscription below watches both keys rather than just the
-    // channel list.
-    if (!rows || !topics?.topics?.length) return;
-    const channels = notifyChannelIndex(topics.topics);
-    pruneBadgesForMissingChannels(channels, topics.truncated === true);
+    // The PRUNE runs before the notify guard, and is keyed on the topic payload
+    // EXISTING rather than being non-empty. Deleting or archiving the last
+    // remaining channel empties that list — which is at once the only case
+    // where every cached badge is provably stale and a case the notify pass has
+    // nothing to do, so a prune behind its guard would leave the favicon dot
+    // and title count pinned for the life of the tab.
+    const channels = topics?.topics ? notifyChannelIndex(topics.topics) : null;
+    if (channels) {
+      pruneBadgesForMissingChannels(channels, topics?.truncated === true);
+    }
+    // BOTH payloads are required for the notify pass, and either can land
+    // second on a cold boot — which is why the subscription below watches both
+    // keys rather than just the channel list.
+    if (!rows || !channels || channels.size === 0) return;
     const osTier = seeded;
     seeded = true;
     notifyFromChannelSummaries({ rows, channels, osTier });

--- a/frontend/src/lib/notify/title-badge.ts
+++ b/frontend/src/lib/notify/title-badge.ts
@@ -1,0 +1,43 @@
+// Document-title unread count (#1308 slice 5 item 2).
+//
+// `(3) Relay` while unread DM/mention CHANNELS exist, and the exact original
+// title back at zero. The base is captured once from the live document rather
+// than hard-coded, so the tab keeps whatever `index.html` shipped.
+import { formatNotifyTitle, stripNotifyTitlePrefix } from './copy.js';
+
+export interface TitleBadgeOptions {
+  /** Defaults to the ambient document; null disables the lane entirely. */
+  doc?: Document | null;
+}
+
+export interface TitleBadge {
+  /** Apply a count. Idempotent; 0 restores the captured base title. */
+  set: (count: number) => void;
+  /** Restore the base title. */
+  reset: () => void;
+}
+
+export function createTitleBadge(options: TitleBadgeOptions = {}): TitleBadge {
+  const doc =
+    options.doc === undefined
+      ? typeof document === 'undefined'
+        ? null
+        : document
+      : options.doc;
+  // Stripped on capture: a hot reload constructs a second badger over a
+  // document this lane may already have prefixed, and `(2) Relay` captured as
+  // the base compounds to `(3) (2) Relay` forever after.
+  const base = doc ? stripNotifyTitlePrefix(doc.title) : '';
+
+  function apply(count: number): void {
+    if (!doc) return;
+    const next = formatNotifyTitle(base, Math.max(0, Math.trunc(count)));
+    if (doc.title === next) return;
+    doc.title = next;
+  }
+
+  return {
+    set: (count) => apply(count),
+    reset: () => apply(0),
+  };
+}

--- a/frontend/src/lib/stores/notify-badge.ts
+++ b/frontend/src/lib/stores/notify-badge.ts
@@ -1,0 +1,95 @@
+// Attention-badge state for the favicon dot and the title count (#1308 slice 5
+// item 2).
+//
+// UNREAD IS NOT REIMPLEMENTED HERE. The store holds only the channels an item-1
+// signal actually raised, each stamped with the seq that raised it; whether one
+// still counts is answered by the SAME read position the rail's unread dot uses
+// (`channel-activity`'s `lastReadByChannel`, hub-synced since slice 3). That is
+// what makes the badge converge cross-device for free: a channel read on the
+// phone raises the mark, the mark broadcasts, and the desktop's dot and count
+// drop without this lane knowing a read happened.
+//
+// In-memory ON PURPOSE — no localStorage. A flag is a claim about what has
+// happened since this tab connected; persisting it would light a reloaded tab
+// up from a set nothing can be trusted to expire, and the boot channel-list
+// payload re-raises every signal that is genuinely still unread anyway.
+import { create } from 'zustand';
+import type { NotifyReason } from '../notify/signals.js';
+
+/** One flagged channel. */
+export interface NotifyBadgeFlag {
+  /** Seq of the row that raised it; 0 for a status-only signal. */
+  seq: number;
+  reason: NotifyReason;
+}
+
+/**
+ * Reasons that earn a favicon dot / title count.
+ *
+ * DM replies and mentions only: both are addressed AT the operator. A turn
+ * completing is a workflow event on a channel the operator may have fanned out
+ * and stopped watching — it can still raise an OS notification when they opt
+ * in, but it must not pin a permanent dot on the tab.
+ */
+const BADGE_REASONS: readonly NotifyReason[] = ['mention', 'dm-reply'];
+
+export function reasonEarnsBadge(reason: NotifyReason): boolean {
+  return BADGE_REASONS.includes(reason);
+}
+
+interface NotifyBadgeState {
+  flagByChannel: Record<string, NotifyBadgeFlag>;
+  /** Record a gate-approved signal. Higher seq wins; equal/lower is ignored. */
+  flagChannel: (channelId: string, flag: NotifyBadgeFlag) => void;
+  /** Drop a channel's flag outright (channel deleted, sign-out). */
+  clearChannel: (channelId: string) => void;
+  reset: () => void;
+}
+
+export const useNotifyBadgeStore = create<NotifyBadgeState>((set) => ({
+  flagByChannel: {},
+  flagChannel: (channelId, flag) =>
+    set((state) => {
+      if (!reasonEarnsBadge(flag.reason)) return state;
+      const current = state.flagByChannel[channelId];
+      if (current !== undefined && current.seq >= flag.seq) return state;
+      return {
+        flagByChannel: { ...state.flagByChannel, [channelId]: flag },
+      };
+    }),
+  clearChannel: (channelId) =>
+    set((state) => {
+      if (state.flagByChannel[channelId] === undefined) return state;
+      const next = { ...state.flagByChannel };
+      delete next[channelId];
+      return { flagByChannel: next };
+    }),
+  reset: () => set({ flagByChannel: {} }),
+}));
+
+/**
+ * How many channels currently deserve the operator's attention.
+ *
+ * CHANNELS, not messages (`docs`/DESIGN: the tab title is a "where do I look"
+ * signal). A flag survives until the read mark reaches the seq that raised it,
+ * so:
+ *   * reading here clears it — `markChannelRead` writes `lastReadByChannel`;
+ *   * reading on ANOTHER device clears it — the `channel-read-state` broadcast
+ *     merges into the same map;
+ *   * a NEWER message re-raises it, because the new flag carries a higher seq.
+ *
+ * A seq-0 flag (status-only signal) can never be cleared by a read mark, which
+ * is the second reason `reasonEarnsBadge` refuses turn-complete.
+ */
+export function countAttentionChannels(
+  flagByChannel: Readonly<Record<string, NotifyBadgeFlag>>,
+  lastReadByChannel: Readonly<Record<string, number>>
+): number {
+  let count = 0;
+  for (const [channelId, flag] of Object.entries(flagByChannel)) {
+    if (!reasonEarnsBadge(flag.reason)) continue;
+    if ((lastReadByChannel[channelId] ?? 0) >= flag.seq) continue;
+    count += 1;
+  }
+  return count;
+}

--- a/frontend/src/lib/stores/notify-settings.ts
+++ b/frontend/src/lib/stores/notify-settings.ts
@@ -1,0 +1,120 @@
+// Operator-owned notification triggers (#1308 slice 5). Client-local and
+// localStorage-backed, following the `advancedMode` pattern in `ui.ts`: a
+// notification preference is a property of THIS device (its tab, its OS
+// permission grant, its notification centre), not of the operator's account, so
+// syncing it through the hub would be wrong as well as more expensive.
+//
+// This is deliberately NOT the legacy `defaultNotifications` config
+// (`lib/notifications.ts` → `PUT /config`), which arms per-SESSION web-push for
+// the PTY lane. That lane keeps its own server-side switch untouched.
+import { create } from 'zustand';
+
+/** localStorage slot for the persisted trigger set. */
+export const NOTIFY_SETTINGS_KEY = 'relay-notify-settings';
+
+/**
+ * Which channel events are allowed to raise a notification.
+ *
+ * Defaults: mentions and DM replies ON (both are addressed AT the operator and
+ * are rare enough that a missed one is the expensive outcome), turn-complete
+ * OFF (an orchestrator fanning work out walks a dozen agents through
+ * thinking→idle per minute; opting in is the only defensible default).
+ */
+export interface NotifySettings {
+  /** An incoming message that mentions `@operator`. */
+  mentions: boolean;
+  /** An agent message arriving in a DM channel. */
+  dmReplies: boolean;
+  /** An agent turn settling back to idle. */
+  turnComplete: boolean;
+}
+
+export type NotifySettingKey = keyof NotifySettings;
+
+export const DEFAULT_NOTIFY_SETTINGS: NotifySettings = Object.freeze({
+  mentions: true,
+  dmReplies: true,
+  turnComplete: false,
+});
+
+/**
+ * Parse a persisted payload, per-key. Unknown keys are dropped and a key with a
+ * non-boolean (or missing) value falls back to its default, so a partial write
+ * from an older build — or a hand-edited slot — degrades one toggle at a time
+ * instead of resetting the whole set.
+ */
+export function parseNotifySettings(raw: string | null): NotifySettings {
+  if (!raw) return { ...DEFAULT_NOTIFY_SETTINGS };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...DEFAULT_NOTIFY_SETTINGS };
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { ...DEFAULT_NOTIFY_SETTINGS };
+  }
+  const record = parsed as Record<string, unknown>;
+  const next = { ...DEFAULT_NOTIFY_SETTINGS };
+  for (const key of Object.keys(DEFAULT_NOTIFY_SETTINGS) as NotifySettingKey[]) {
+    const value = record[key];
+    if (typeof value === 'boolean') next[key] = value;
+  }
+  return next;
+}
+
+export function serializeNotifySettings(settings: NotifySettings): string {
+  return JSON.stringify({
+    mentions: settings.mentions,
+    dmReplies: settings.dmReplies,
+    turnComplete: settings.turnComplete,
+  });
+}
+
+function loadNotifySettings(): NotifySettings {
+  try {
+    return parseNotifySettings(localStorage.getItem(NOTIFY_SETTINGS_KEY));
+  } catch {
+    return { ...DEFAULT_NOTIFY_SETTINGS };
+  }
+}
+
+function persistNotifySettings(settings: NotifySettings): void {
+  try {
+    localStorage.setItem(NOTIFY_SETTINGS_KEY, serializeNotifySettings(settings));
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+interface NotifySettingsState {
+  settings: NotifySettings;
+  setNotifySetting: (key: NotifySettingKey, enabled: boolean) => void;
+  toggleNotifySetting: (key: NotifySettingKey) => void;
+  /** Restore every trigger to its default. */
+  resetNotifySettings: () => void;
+}
+
+export const useNotifySettingsStore = create<NotifySettingsState>((set, get) => ({
+  settings: loadNotifySettings(),
+  setNotifySetting: (key, enabled) => {
+    const current = get().settings;
+    if (current[key] === enabled) return;
+    const next = { ...current, [key]: enabled };
+    persistNotifySettings(next);
+    set({ settings: next });
+  },
+  toggleNotifySetting: (key) => {
+    get().setNotifySetting(key, !get().settings[key]);
+  },
+  resetNotifySettings: () => {
+    const next = { ...DEFAULT_NOTIFY_SETTINGS };
+    persistNotifySettings(next);
+    set({ settings: next });
+  },
+}));
+
+/** Non-reactive read for the socket handlers that evaluate signals. */
+export function currentNotifySettings(): NotifySettings {
+  return useNotifySettingsStore.getState().settings;
+}

--- a/frontend/src/lib/topic-selection.ts
+++ b/frontend/src/lib/topic-selection.ts
@@ -51,6 +51,30 @@ export function openTopicSelectionFromPalette(
 }
 
 /**
+ * Disposition of a clicked OS notification (#1308 slice 5 item 2).
+ *
+ * The channel is opened by ID ALONE — deliberately not routed through a topic
+ * lookup. A notification can be clicked minutes later, from a tab whose topic
+ * corpus has since been refetched, filtered, or never loaded at all (the click
+ * may be the event that wakes a discarded tab), and a lookup miss must not turn
+ * into "clicked the notification, nothing happened". `ChannelView` already owns
+ * the unknown/deleted case, exactly as it does for a `/channel/<id>` deep link.
+ *
+ * No message anchor: the notification body deliberately carries no message
+ * text, and the event that raised it may have been coalesced with others, so
+ * the honest destination is the channel at its live bottom.
+ *
+ * The drawer closes for the same reason the other openers close it — the main
+ * pane just changed, and on mobile the drawer floats over it.
+ */
+export function openChannelFromNotification(channelId: string): void {
+  const ui = useUiStore.getState();
+  ui.setActiveChannelId(channelId);
+  ui.setTopicComposerOpen(false);
+  ui.closeSidebar();
+}
+
+/**
  * Open a channel AND ask it to land on ONE message (#1308 slice 2): the
  * disposition of every message-search hit, wherever it was clicked — the sidebar
  * `messages` section (item 2) and the command palette's `messages` category

--- a/test/lib/notify-badge-surfaces.test.ts
+++ b/test/lib/notify-badge-surfaces.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+// #1308 slice 5 item 2 — the two in-app delivery surfaces: the favicon dot and
+// the title count, driven through their update AND clear cycles.
+//
+// The canvas compositor is injected. happy-dom has no 2D context, and the real
+// renderer's contract ("produce a data URL or null") is exactly the seam a test
+// should stand at: what matters is that the link href moves to the badged icon
+// and comes BACK to the original byte-for-byte.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFaviconBadge } from '../../frontend/src/lib/notify/favicon-badge.js';
+import { createTitleBadge } from '../../frontend/src/lib/notify/title-badge.js';
+
+const BASE_ICON = '/icon.svg';
+const BADGED = 'data:image/png;base64,BADGED';
+
+function resetDocument(): void {
+  document.head.innerHTML = `<link rel="icon" href="${BASE_ICON}" type="image/svg+xml" />`;
+  document.title = 'Relay';
+}
+
+function iconHref(): string | null {
+  return (
+    document
+      .querySelector<HTMLLinkElement>('link[rel~="icon"]')
+      ?.getAttribute('href') ?? null
+  );
+}
+
+beforeEach(() => {
+  resetDocument();
+});
+
+describe('favicon badge', () => {
+  it('overlays the EXISTING icon and restores it byte-for-byte', async () => {
+    const render = vi.fn(async () => BADGED);
+    const badge = createFaviconBadge({ render });
+
+    badge.set(true);
+    await vi.waitFor(() => expect(iconHref()).toBe(BADGED));
+    // Identity preserved: the base was read from the document, not hard-coded.
+    expect(render).toHaveBeenCalledWith(BASE_ICON);
+
+    badge.set(false);
+    expect(iconHref()).toBe(BASE_ICON);
+  });
+
+  it('renders the composite once across many update cycles', async () => {
+    const render = vi.fn(async () => BADGED);
+    const badge = createFaviconBadge({ render });
+    badge.set(true);
+    await vi.waitFor(() => expect(iconHref()).toBe(BADGED));
+    badge.set(false);
+    badge.set(true);
+    badge.set(false);
+    badge.set(true);
+    await vi.waitFor(() => expect(iconHref()).toBe(BADGED));
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not paint a dot onto a tab that was read while the icon decoded', async () => {
+    let resolveRender: (value: string) => void = () => {};
+    const render = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRender = resolve;
+        })
+    );
+    const badge = createFaviconBadge({ render });
+    badge.set(true);
+    // The operator reads the channel before the composite lands.
+    badge.set(false);
+    resolveRender(BADGED);
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+    expect(iconHref()).toBe(BASE_ICON);
+  });
+
+  it('degrades to the base icon when the composite cannot be produced', async () => {
+    const badge = createFaviconBadge({ render: async () => null });
+    badge.set(true);
+    await Promise.resolve();
+    expect(iconHref()).toBe(BASE_ICON);
+  });
+
+  it('survives a renderer that rejects', async () => {
+    const badge = createFaviconBadge({
+      render: async () => {
+        throw new Error('canvas unavailable');
+      },
+    });
+    expect(() => badge.set(true)).not.toThrow();
+    await vi.waitFor(() => expect(iconHref()).toBe(BASE_ICON));
+  });
+
+  it('is inert with no document', () => {
+    const badge = createFaviconBadge({ doc: null, render: async () => BADGED });
+    expect(() => {
+      badge.set(true);
+      badge.set(false);
+      badge.reset();
+    }).not.toThrow();
+  });
+
+  it('mints no icon link for a document that ships none', async () => {
+    document.head.innerHTML = '';
+    const render = vi.fn(async () => BADGED);
+    const badge = createFaviconBadge({ render });
+    badge.set(true);
+    await Promise.resolve();
+    // An empty `<link rel="icon">` would suppress the browser's own
+    // `/favicon.ico` probe, so the lane stays inert instead.
+    expect(document.querySelector('link[rel~="icon"]')).toBeNull();
+    expect(render).not.toHaveBeenCalled();
+  });
+});
+
+describe('title count', () => {
+  it('prefixes the count and restores the clean title at zero', () => {
+    const badge = createTitleBadge();
+    badge.set(3);
+    expect(document.title).toBe('(3) Relay');
+    badge.set(1);
+    expect(document.title).toBe('(1) Relay');
+    badge.set(0);
+    expect(document.title).toBe('Relay');
+  });
+
+  it('restores the clean title on reset (unmount)', () => {
+    const badge = createTitleBadge();
+    badge.set(5);
+    badge.reset();
+    expect(document.title).toBe('Relay');
+  });
+
+  it('cannot compound its own prefix across a remount', () => {
+    createTitleBadge().set(2);
+    expect(document.title).toBe('(2) Relay');
+    // A second badger constructed over the already-badged document (hot reload,
+    // StrictMode double-mount) must capture `Relay`, not `(2) Relay`.
+    const second = createTitleBadge();
+    second.set(3);
+    expect(document.title).toBe('(3) Relay');
+    second.set(0);
+    expect(document.title).toBe('Relay');
+  });
+
+  it('is inert with no document', () => {
+    const badge = createTitleBadge({ doc: null });
+    expect(() => {
+      badge.set(4);
+      badge.reset();
+    }).not.toThrow();
+  });
+});

--- a/test/lib/notify-badge-surfaces.test.ts
+++ b/test/lib/notify-badge-surfaces.test.ts
@@ -18,12 +18,16 @@ function resetDocument(): void {
   document.title = 'Relay';
 }
 
+function iconLink(): HTMLLinkElement | null {
+  return document.querySelector<HTMLLinkElement>('link[rel~="icon"]');
+}
+
 function iconHref(): string | null {
-  return (
-    document
-      .querySelector<HTMLLinkElement>('link[rel~="icon"]')
-      ?.getAttribute('href') ?? null
-  );
+  return iconLink()?.getAttribute('href') ?? null;
+}
+
+function iconType(): string | null {
+  return iconLink()?.getAttribute('type') ?? null;
 }
 
 beforeEach(() => {
@@ -42,6 +46,32 @@ describe('favicon badge', () => {
 
     badge.set(false);
     expect(iconHref()).toBe(BASE_ICON);
+  });
+
+  it('rewrites the MIME type with the href and restores it', async () => {
+    // The document ships `type="image/svg+xml"` and the composite is a PNG data
+    // URL. `type` is a support hint browsers are entitled to act on, so leaving
+    // it stale can cost the tab its icon exactly when the dot should appear.
+    const badge = createFaviconBadge({ render: async () => BADGED });
+    expect(iconType()).toBe('image/svg+xml');
+
+    badge.set(true);
+    await vi.waitFor(() => expect(iconHref()).toBe(BADGED));
+    expect(iconType()).toBe('image/png');
+
+    badge.set(false);
+    expect(iconHref()).toBe(BASE_ICON);
+    expect(iconType()).toBe('image/svg+xml');
+  });
+
+  it('invents no MIME type for a link that shipped none', async () => {
+    document.head.innerHTML = `<link rel="icon" href="${BASE_ICON}" />`;
+    const badge = createFaviconBadge({ render: async () => BADGED });
+    badge.set(true);
+    await vi.waitFor(() => expect(iconHref()).toBe(BADGED));
+    expect(iconType()).toBe('image/png');
+    badge.set(false);
+    expect(iconType()).toBeNull();
   });
 
   it('renders the composite once across many update cycles', async () => {

--- a/test/lib/notify-copy.test.ts
+++ b/test/lib/notify-copy.test.ts
@@ -1,0 +1,87 @@
+// #1308 slice 5 item 2 — notification copy. Pure: no DOM, no stores.
+import { describe, it, expect } from 'vitest';
+import {
+  formatNotifyTitle,
+  notifyOsBody,
+  notifyRelayCopyFragment,
+  stripNotifyTitlePrefix,
+  NOTIFY_OS_TITLE,
+  type NotifyCopyInput,
+} from '../../frontend/src/lib/notify/copy.js';
+
+function copy(overrides: Partial<NotifyCopyInput> = {}): NotifyCopyInput {
+  return {
+    reason: 'mention',
+    senderLabel: 'claude',
+    channelTitle: 'impl 1308',
+    count: 1,
+    ...overrides,
+  };
+}
+
+describe('OS notification body', () => {
+  it('names the agent, the verb, and the channel', () => {
+    expect(notifyOsBody(copy())).toBe('claude mentioned you in impl 1308');
+    expect(notifyOsBody(copy({ reason: 'dm-reply' }))).toBe(
+      'claude replied in impl 1308'
+    );
+    expect(
+      notifyOsBody(copy({ reason: 'turn-complete', senderLabel: 'codex' }))
+    ).toBe('codex finished in impl 1308');
+  });
+
+  it('reports a coalesced run with the mono-spirit separator', () => {
+    expect(notifyOsBody(copy({ reason: 'dm-reply', count: 3 }))).toBe(
+      'claude replied in impl 1308 · 3 new'
+    );
+  });
+
+  it('uses the operator channel title verbatim, without restyling it', () => {
+    expect(notifyOsBody(copy({ channelTitle: 'Impl 1308' }))).toBe(
+      'claude mentioned you in Impl 1308'
+    );
+  });
+
+  it('never carries message text', () => {
+    // The copy input has no field a body could be smuggled through — the only
+    // free-text field is the operator's own channel title.
+    expect(notifyOsBody(copy())).not.toContain('pushed the branch');
+  });
+});
+
+describe('relay-authored copy fragment', () => {
+  const fragments = [
+    notifyRelayCopyFragment({ reason: 'mention', senderLabel: 'claude' }),
+    notifyRelayCopyFragment({ reason: 'dm-reply', senderLabel: 'claude' }),
+    notifyRelayCopyFragment({ reason: 'turn-complete', senderLabel: 'codex' }),
+  ];
+
+  it('is lowercase with no emoji (DESIGN.md)', () => {
+    for (const fragment of fragments) {
+      expect(fragment).toBe(fragment.toLowerCase());
+      expect(fragment).not.toMatch(/\p{Extended_Pictographic}/u);
+    }
+  });
+
+  it('titles the notification with relay, not the channel', () => {
+    // The channel is already inside the body; repeating it as the title reads
+    // as a bug on every platform that renders both lines.
+    expect(NOTIFY_OS_TITLE).toBe('relay');
+    expect(NOTIFY_OS_TITLE).toBe(NOTIFY_OS_TITLE.toLowerCase());
+  });
+});
+
+describe('document title', () => {
+  it('prefixes a channel count and restores the clean title at zero', () => {
+    expect(formatNotifyTitle('Relay', 3)).toBe('(3) Relay');
+    expect(formatNotifyTitle('Relay', 1)).toBe('(1) Relay');
+    expect(formatNotifyTitle('Relay', 0)).toBe('Relay');
+  });
+
+  it('strips a prefix it wrote earlier so counts cannot compound', () => {
+    expect(stripNotifyTitlePrefix('(3) Relay')).toBe('Relay');
+    expect(stripNotifyTitlePrefix('Relay')).toBe('Relay');
+    // A parenthesised title that is not a count is left alone.
+    expect(stripNotifyTitlePrefix('(beta) Relay')).toBe('(beta) Relay');
+  });
+});

--- a/test/lib/notify-delivery-hook.test.ts
+++ b/test/lib/notify-delivery-hook.test.ts
@@ -35,6 +35,23 @@ vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => ({
 const HIDDEN_REFRESH_MS = 10_000;
 const VISIBLE_REFRESH_MS = 45_000;
 
+/**
+ * happy-dom ships no Notification API, and the hook now reads the permission
+ * state to decide the hidden CADENCE (not whether to refresh at all). Stubbed
+ * explicitly so every case states the browser it is describing rather than
+ * inheriting the environment's absence.
+ */
+class FakeNotification {
+  static permission: NotificationPermission = 'default';
+  static requestPermission = vi.fn(async () => FakeNotification.permission);
+  close(): void {}
+}
+
+function setPermission(permission: NotificationPermission): void {
+  FakeNotification.permission = permission;
+  (globalThis as { Notification?: unknown }).Notification = FakeNotification;
+}
+
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 let client: QueryClient;
@@ -95,6 +112,7 @@ beforeEach(() => {
   document.title = 'Relay';
   setHidden(false);
   document.hasFocus = () => true;
+  setPermission('default');
   localStorage.clear();
   resetNotifyRuntime();
   useNotifySettingsStore.getState().resetNotifySettings();
@@ -130,12 +148,69 @@ describe('summary refresh gate', () => {
     // hidden, the lazy prompt only fires from an OS-tier event, and this refresh
     // is the only lane that can produce a payload while hidden. Gating it on a
     // grant made the whole tier unreachable on a fresh browser.
+    setPermission('default');
+    setHidden(true);
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('stretches the HIDDEN cadence when the OS tier can never fire', async () => {
+    // `denied` is terminal from inside the page, so this tab can produce
+    // nothing but a favicon dot nobody is looking at. It must not hold the hub
+    // at a ten-second `GET /channels` cadence — which is O(channels)
+    // server-side — for the whole length of an agent turn, times every tab.
+    setPermission('denied');
+    setHidden(true);
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+    // It still converges — the badge tier needs no grant.
+    await advance(VISIBLE_REFRESH_MS - HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('stretches it for a browser with no Notification API at all', async () => {
+    // An iOS Safari tab outside an installed PWA.
     delete (globalThis as { Notification?: unknown }).Notification;
     setHidden(true);
     await mount();
     apiMock.fetchChannels.mockClear();
     await channelActivity(4);
     await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+    await advance(VISIBLE_REFRESH_MS - HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks the WINDOW at fire time, not schedule time', async () => {
+    // Activity while the tab is visible arms the long window; the operator then
+    // switches away, where the OS tier is the only tier there is. Waiting out
+    // the window the tab no longer deserves would delay that notification by up
+    // to 45 seconds.
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    setHidden(true);
+    await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits out the REMAINDER when a hidden tab comes back', async () => {
+    // The reverse transition must not fetch early: the window is measured from
+    // the activity that armed it, not restarted by the visibility change.
+    setHidden(true);
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    setHidden(false);
+    await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+    await advance(VISIBLE_REFRESH_MS - HIDDEN_REFRESH_MS);
     expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
   });
 

--- a/test/lib/notify-delivery-hook.test.ts
+++ b/test/lib/notify-delivery-hook.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment happy-dom
+// #1308 slice 5 item 2 — `useNotifyDelivery`, the hook `App` mounts once.
+//
+// What is under test is the REFRESH GATE, because that is the lane's only
+// backstop: `TopicSidebarShell` owns the sole activity-driven
+// `invalidateQueries(['channels'])` and unmounts with a collapsed sidebar, and
+// invalidation without an active observer refetches nothing. If this gate is
+// wrong the operator gets no mention badge, no dot, no title count and no
+// notification — silently.
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { createRoot, type Root } from 'react-dom/client';
+import { useNotifyDelivery } from '../../frontend/src/hooks/useNotifyDelivery.js';
+import { resetNotifyRuntime } from '../../frontend/src/lib/notify/runtime.js';
+import { useChannelActivityStore } from '../../frontend/src/lib/stores/channel-activity.js';
+import { useNotifyBadgeStore } from '../../frontend/src/lib/stores/notify-badge.js';
+import { useNotifySettingsStore } from '../../frontend/src/lib/stores/notify-settings.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const apiMock = vi.hoisted(() => ({
+  fetchChannels: vi.fn(),
+  fetchWorkspaceTopics: vi.fn(),
+}));
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  fetchChannels: apiMock.fetchChannels,
+  fetchWorkspaceTopics: apiMock.fetchWorkspaceTopics,
+}));
+
+/** Windows declared by the hook; kept in step with it deliberately. */
+const HIDDEN_REFRESH_MS = 10_000;
+const VISIBLE_REFRESH_MS = 45_000;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let client: QueryClient;
+
+function Harness({ enabled }: { enabled: boolean }) {
+  useNotifyDelivery(enabled, client);
+  return null;
+}
+
+async function mount(enabled = true): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(React.createElement(Harness, { enabled }));
+  });
+}
+
+async function rerender(enabled: boolean): Promise<void> {
+  await act(async () => {
+    root!.render(React.createElement(Harness, { enabled }));
+  });
+}
+
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', {
+    value: hidden,
+    configurable: true,
+  });
+}
+
+/** Move a channel's latest seq — the socket signal the refresh rides. */
+async function channelActivity(seq: number): Promise<void> {
+  await act(async () => {
+    useChannelActivityStore.setState({
+      latestSeqByChannel: { 'topic:impl-1308': seq },
+    });
+  });
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+  // Let the fetch settle.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  apiMock.fetchChannels.mockReset();
+  apiMock.fetchChannels.mockResolvedValue([]);
+  apiMock.fetchWorkspaceTopics.mockReset();
+  apiMock.fetchWorkspaceTopics.mockResolvedValue({ topics: [] });
+  document.head.innerHTML = '<link rel="icon" href="/icon.svg" />';
+  document.title = 'Relay';
+  setHidden(false);
+  document.hasFocus = () => true;
+  localStorage.clear();
+  resetNotifyRuntime();
+  useNotifySettingsStore.getState().resetNotifySettings();
+  useChannelActivityStore.setState({
+    latestSeqByChannel: {},
+    lastReadByChannel: {},
+  });
+  client = new QueryClient();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  client.clear();
+  vi.useRealTimers();
+});
+
+describe('summary refresh gate', () => {
+  it('refreshes a VISIBLE tab whose rail is unmounted (collapsed sidebar)', async () => {
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(VISIBLE_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes a HIDDEN tab with permission still at `default`', async () => {
+    // The circular dependency this closes: an OS-tier event only exists while
+    // hidden, the lazy prompt only fires from an OS-tier event, and this refresh
+    // is the only lane that can produce a payload while hidden. Gating it on a
+    // grant made the whole tier unreachable on a fresh browser.
+    delete (globalThis as { Notification?: unknown }).Notification;
+    setHidden(true);
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refreshes a HIDDEN tab whose rail is mounted', async () => {
+    // The rail keeps its `['channels']` observer while hidden but suppresses its
+    // own refetch there (`pendingWhileHidden`), so an observer count of 1 on a
+    // hidden tab means NOBODY is fetching — the exact gap this lane fills.
+    setHidden(true);
+    await mount();
+    const observer = new QueryObserver(client, {
+      queryKey: ['channels'],
+      queryFn: apiMock.fetchChannels,
+      staleTime: 5 * 60_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(HIDDEN_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it('stands down while a VISIBLE tab rail is observing the same key', async () => {
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    const observer = new QueryObserver(client, {
+      queryKey: ['channels'],
+      queryFn: apiMock.fetchChannels,
+      staleTime: 5 * 60_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(VISIBLE_REFRESH_MS);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('decides ownership at FIRE time, not schedule time', async () => {
+    // The rail can unmount inside the window; what matters is who owns the
+    // fetch when it comes due.
+    const observer = new QueryObserver(client, {
+      queryKey: ['channels'],
+      queryFn: apiMock.fetchChannels,
+      staleTime: 5 * 60_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    unsubscribe();
+    await advance(VISIBLE_REFRESH_MS);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('costs nothing when both message triggers are off', async () => {
+    useNotifySettingsStore.getState().setNotifySetting('mentions', false);
+    useNotifySettingsStore.getState().setNotifySetting('dmReplies', false);
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(VISIBLE_REFRESH_MS);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+  });
+
+  it('is trailing, so a streaming turn cannot starve the refresh', async () => {
+    await mount();
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(1);
+    await advance(VISIBLE_REFRESH_MS - 1_000);
+    await channelActivity(2);
+    await channelActivity(3);
+    await advance(1_000);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('lane teardown', () => {
+  it('drops every ledger when the lane is disabled (sign-out, auth expiry)', async () => {
+    await mount();
+    useNotifyBadgeStore
+      .getState()
+      .flagChannel('topic:impl-1308', { seq: 9, reason: 'mention' });
+    expect(
+      Object.keys(useNotifyBadgeStore.getState().flagByChannel)
+    ).toHaveLength(1);
+
+    await rerender(false);
+    // Stopping the watcher alone would leave the badge flags, the gate's seq
+    // ledger and the OS windows behind — so after a re-auth an unread message
+    // could never raise its badge again on this tab.
+    expect(useNotifyBadgeStore.getState().flagByChannel).toEqual({});
+  });
+
+  it('stops refreshing once disabled', async () => {
+    await mount();
+    await rerender(false);
+    apiMock.fetchChannels.mockClear();
+    await channelActivity(4);
+    await advance(VISIBLE_REFRESH_MS);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+  });
+
+  it('restores the document title it found', async () => {
+    await mount();
+    await act(async () => {
+      useNotifyBadgeStore
+        .getState()
+        .flagChannel('topic:impl-1308', { seq: 9, reason: 'mention' });
+    });
+    expect(document.title).toBe('(1) Relay');
+    await rerender(false);
+    expect(document.title).toBe('Relay');
+  });
+});

--- a/test/lib/notify-leader.test.ts
+++ b/test/lib/notify-leader.test.ts
@@ -1,0 +1,124 @@
+// #1308 slice 5 item 2 — cross-tab election for the OS notification tier.
+//
+// Storage is injected, so "two tabs" is two leaders over one map and the lease
+// clock is an argument rather than a timer. No DOM needed: the module's only
+// ambient dependency is `localStorage`, and the null-storage path is asserted
+// explicitly.
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createNotifyLeader,
+  NOTIFY_LEADER_LEASE_MS,
+  NOTIFY_LEADER_STORAGE_KEY,
+  type NotifyLeaderStorage,
+} from '../../frontend/src/lib/notify/leader.js';
+
+const NOW = 1_800_000_000_000;
+
+function memoryStorage(): NotifyLeaderStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+  };
+}
+
+let storage: ReturnType<typeof memoryStorage>;
+
+beforeEach(() => {
+  storage = memoryStorage();
+});
+
+describe('lease', () => {
+  it('gives the tier to exactly one of two tabs', () => {
+    const a = createNotifyLeader({ id: 'a', storage });
+    const b = createNotifyLeader({ id: 'b', storage });
+    expect(a.claim(NOW)).toBe(true);
+    expect(b.claim(NOW + 1)).toBe(false);
+    // And it stays put while the holder keeps delivering.
+    expect(a.claim(NOW + 2)).toBe(true);
+    expect(b.claim(NOW + 3)).toBe(false);
+  });
+
+  it('is renewed by the deliveries it guards, so no timer is needed', () => {
+    const a = createNotifyLeader({ id: 'a', storage });
+    const b = createNotifyLeader({ id: 'b', storage });
+    a.claim(NOW);
+    a.claim(NOW + NOTIFY_LEADER_LEASE_MS - 1);
+    // `b` measures the lease from the RENEWAL, not the original claim.
+    expect(b.claim(NOW + NOTIFY_LEADER_LEASE_MS + 1)).toBe(false);
+  });
+
+  it('expires so a killed tab cannot mute the survivors', () => {
+    const a = createNotifyLeader({ id: 'a', storage });
+    const b = createNotifyLeader({ id: 'b', storage });
+    a.claim(NOW);
+    expect(b.claim(NOW + NOTIFY_LEADER_LEASE_MS)).toBe(true);
+    // Taking over means holding it: `a` is now the follower.
+    expect(a.claim(NOW + NOTIFY_LEADER_LEASE_MS + 1)).toBe(false);
+  });
+
+  it('hands over on release rather than waiting out the lease', () => {
+    const a = createNotifyLeader({ id: 'a', storage });
+    const b = createNotifyLeader({ id: 'b', storage });
+    a.claim(NOW);
+    a.release();
+    expect(storage.map.get(NOTIFY_LEADER_STORAGE_KEY)).toBeUndefined();
+    expect(b.claim(NOW + 1)).toBe(true);
+  });
+
+  it('never releases a lease it does not hold', () => {
+    const a = createNotifyLeader({ id: 'a', storage });
+    const b = createNotifyLeader({ id: 'b', storage });
+    a.claim(NOW);
+    b.release();
+    expect(a.claim(NOW + 1)).toBe(true);
+    expect(b.claim(NOW + 2)).toBe(false);
+  });
+});
+
+describe('degradation', () => {
+  it('is always leader with no storage — single-tab behaviour, never silence', () => {
+    const solo = createNotifyLeader({ id: 'a', storage: null });
+    expect(solo.claim(NOW)).toBe(true);
+    expect(solo.claim(NOW + 1)).toBe(true);
+    expect(() => solo.release()).not.toThrow();
+  });
+
+  it('claims through a storage that refuses to write', () => {
+    // Private mode, quota, a partition that went away: muting notifications
+    // would be a worse answer than the duplicate this election exists to avoid.
+    const readOnly: NotifyLeaderStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('QuotaExceededError');
+      },
+      removeItem: () => {},
+    };
+    expect(createNotifyLeader({ id: 'a', storage: readOnly }).claim(NOW)).toBe(
+      true
+    );
+  });
+
+  it('ignores a corrupt or foreign record', () => {
+    storage.setItem(NOTIFY_LEADER_STORAGE_KEY, 'not json');
+    expect(createNotifyLeader({ id: 'a', storage }).claim(NOW)).toBe(true);
+    storage.setItem(NOTIFY_LEADER_STORAGE_KEY, JSON.stringify({ id: 7 }));
+    expect(createNotifyLeader({ id: 'b', storage }).claim(NOW)).toBe(true);
+  });
+
+  it('treats a wildly future stamp as a skewed clock, not a live holder', () => {
+    // Otherwise one machine an hour ahead locks the tier out of this tab for
+    // the rest of its life.
+    storage.setItem(
+      NOTIFY_LEADER_STORAGE_KEY,
+      JSON.stringify({ id: 'other', at: NOW + 3_600_000 })
+    );
+    expect(createNotifyLeader({ id: 'a', storage }).claim(NOW)).toBe(true);
+  });
+});

--- a/test/lib/notify-os-notification.test.ts
+++ b/test/lib/notify-os-notification.test.ts
@@ -71,6 +71,7 @@ function osEvent(overrides: Partial<NotifyEvent> = {}): NotifyEvent {
     badge: true,
     os: true,
     count: 1,
+    osOverflow: 0,
     senderLabel: 'claude',
     seq: 12,
     at: 1_800_000_000_000,
@@ -102,7 +103,7 @@ describe('permission', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent({ os: false }));
+    void notifier.deliver(osEvent({ os: false }));
     expect(requestPermission).not.toHaveBeenCalled();
     expect(shown).toHaveLength(0);
   });
@@ -113,7 +114,7 @@ describe('permission', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent());
+    void notifier.deliver(osEvent());
     expect(requestPermission).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(shown).toHaveLength(1));
   });
@@ -124,9 +125,9 @@ describe('permission', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent({ seq: 1 }));
-    notifier.deliver(osEvent({ seq: 2 }));
-    notifier.deliver(osEvent({ seq: 3 }));
+    void notifier.deliver(osEvent({ seq: 1 }));
+    void notifier.deliver(osEvent({ seq: 2 }));
+    void notifier.deliver(osEvent({ seq: 3 }));
     expect(requestPermission).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(shown).toHaveLength(3));
   });
@@ -137,7 +138,7 @@ describe('permission', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent());
+    void notifier.deliver(osEvent());
     await expect(notifier.requestPermission()).resolves.toBe('denied');
     expect(shown).toHaveLength(0);
   });
@@ -148,7 +149,7 @@ describe('permission', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent());
+    void notifier.deliver(osEvent());
     expect(requestPermission).not.toHaveBeenCalled();
     expect(shown).toHaveLength(0);
   });
@@ -181,7 +182,7 @@ describe('notification payload', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent());
+    void notifier.deliver(osEvent());
     expect(shown).toHaveLength(1);
     expect(shown[0]?.title).toBe('relay');
     expect(shown[0]?.options).toEqual({
@@ -199,7 +200,7 @@ describe('notification payload', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent({ reason: 'mention', count: 4 }));
+    void notifier.deliver(osEvent({ reason: 'mention', count: 4 }));
     expect(shown[0]?.options?.body).toBe(
       'claude mentioned you in impl 1308 · 4 new'
     );
@@ -211,7 +212,7 @@ describe('notification payload', () => {
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
-    notifier.deliver(osEvent());
+    void notifier.deliver(osEvent());
     expect(JSON.stringify(shown[0])).not.toContain('pushed the branch');
   });
 
@@ -232,6 +233,172 @@ describe('notification payload', () => {
   });
 });
 
+describe('delivery reporting', () => {
+  // The gate charges a 60s per-channel slot at DECISION time, so it needs to
+  // know when nothing was actually shown or the next real message is swallowed.
+  it('reports true only once a notification was constructed', async () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    await expect(notifier.deliver(osEvent())).resolves.toBe(true);
+  });
+
+  it('reports false when the tier was never eligible', async () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    await expect(notifier.deliver(osEvent({ os: false }))).resolves.toBe(false);
+  });
+
+  it('reports false when permission is denied or the API is absent', async () => {
+    const { ctor } = makeCtor('denied');
+    const denied = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    await expect(denied.deliver(osEvent())).resolves.toBe(false);
+    const unsupported = createOsNotifier({
+      resolveCtor: () => null,
+      openChannel: vi.fn(),
+    });
+    await expect(unsupported.deliver(osEvent())).resolves.toBe(false);
+  });
+
+  it('reports false when the operator dismisses the prompt', async () => {
+    const { ctor } = makeCtor('default', 'denied');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    await expect(notifier.deliver(osEvent())).resolves.toBe(false);
+    expect(shown).toHaveLength(0);
+  });
+
+  it('reports false when the constructor throws', async () => {
+    class ThrowingNotification {
+      static permission: NotificationPermission = 'granted';
+      static requestPermission = vi.fn();
+      constructor() {
+        throw new TypeError('illegal constructor');
+      }
+    }
+    const notifier = createOsNotifier({
+      resolveCtor: () =>
+        ThrowingNotification as unknown as NotificationCtorLike,
+      openChannel: vi.fn(),
+    });
+    await expect(notifier.deliver(osEvent())).resolves.toBe(false);
+  });
+});
+
+describe('burst digest', () => {
+  it('collapses the held-back run into one notification', () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliverOverflow(12);
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.title).toBe('relay');
+    expect(shown[0]?.options).toEqual({
+      body: '12 channels have new messages',
+      // Constant tag: a growing overflow replaces its own line rather than
+      // stacking one entry per held-back channel.
+      tag: 'relay-channels',
+    });
+  });
+
+  it('names no channel and routes nowhere but the tab', () => {
+    const { ctor } = makeCtor('granted');
+    const openChannel = vi.fn();
+    const focusWindow = vi.fn();
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      focusWindow,
+      openChannel,
+    });
+    notifier.deliverOverflow(1);
+    expect(shown[0]?.options?.body).toBe('1 channel has new messages');
+    shown[0]?.onclick?.();
+    expect(focusWindow).toHaveBeenCalledTimes(1);
+    expect(openChannel).not.toHaveBeenCalled();
+    expect(shown[0]?.closed).toBe(true);
+  });
+
+  it('no-ops when denied', () => {
+    const { ctor } = makeCtor('denied');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliverOverflow(5);
+    expect(shown).toHaveLength(0);
+  });
+});
+
+describe('permission prime', () => {
+  it('asks once and shows nothing', () => {
+    const { ctor, requestPermission } = makeCtor('default', 'granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.primePermission();
+    notifier.primePermission();
+    notifier.primePermission();
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(shown).toHaveLength(0);
+  });
+
+  it('does not re-ask after a browser that refuses the ungestured call', async () => {
+    // Safari always, Firefox since 72: the reject must not turn every later
+    // event into another attempt.
+    const { ctor, requestPermission } = makeCtor(
+      'default',
+      new Error('user gesture required')
+    );
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.primePermission();
+    await vi.waitFor(() => expect(requestPermission).toHaveBeenCalledTimes(1));
+    notifier.primePermission();
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('never asks from a settled state', () => {
+    for (const state of ['granted', 'denied'] as const) {
+      const { ctor, requestPermission } = makeCtor(state);
+      const notifier = createOsNotifier({
+        resolveCtor: () => ctor,
+        openChannel: vi.fn(),
+      });
+      notifier.primePermission();
+      expect(requestPermission).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not spend its one shot while the API is absent', () => {
+    const { ctor, requestPermission } = makeCtor('default', 'granted');
+    let live: NotificationCtorLike | null = null;
+    const notifier = createOsNotifier({
+      resolveCtor: () => live,
+      openChannel: vi.fn(),
+    });
+    notifier.primePermission();
+    expect(requestPermission).not.toHaveBeenCalled();
+    live = ctor;
+    notifier.primePermission();
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('click routing', () => {
   it('focuses the tab, opens the channel, then closes the notification', () => {
     const { ctor } = makeCtor('granted');
@@ -242,7 +409,7 @@ describe('click routing', () => {
       focusWindow,
       openChannel,
     });
-    notifier.deliver(osEvent());
+    void notifier.deliver(osEvent());
     const live = shown.at(-1);
     expect(live?.onclick).toBeTypeOf('function');
     live?.onclick?.();

--- a/test/lib/notify-os-notification.test.ts
+++ b/test/lib/notify-os-notification.test.ts
@@ -1,0 +1,257 @@
+// #1308 slice 5 item 2 — OS Notification delivery.
+//
+// The Notification API is stubbed with a plain class, so every case is
+// deterministic and nothing here depends on a real browser permission.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createOsNotifier,
+  notifyPermissionState,
+  type NotificationCtorLike,
+} from '../../frontend/src/lib/notify/os-notification.js';
+import type { NotifyEvent } from '../../frontend/src/lib/notify/signals.js';
+
+interface FakeInstance {
+  index: number;
+  title: string;
+  options: { body?: string; tag?: string; data?: unknown } | undefined;
+  onclick: ((event?: unknown) => void) | null;
+  closed: boolean;
+}
+
+/** Every notification the lane constructed, in order. */
+const shown: FakeInstance[] = [];
+
+function makeCtor(
+  permission: NotificationPermission,
+  requestResult: NotificationPermission | Error = 'granted'
+): { ctor: NotificationCtorLike; requestPermission: ReturnType<typeof vi.fn> } {
+  const requestPermission = vi.fn(async () => {
+    if (requestResult instanceof Error) throw requestResult;
+    FakeNotification.permission = requestResult;
+    return requestResult;
+  });
+  class FakeNotification {
+    static permission: NotificationPermission = permission;
+    static requestPermission = requestPermission;
+    readonly self: FakeInstance;
+    onclick: ((event?: unknown) => void) | null = null;
+    constructor(title: string, options?: FakeInstance['options']) {
+      this.self = {
+        index: shown.length,
+        title,
+        options,
+        onclick: null,
+        closed: false,
+      };
+      // Mirror assignments onto the record so a test can fire the click.
+      Object.defineProperty(this, 'onclick', {
+        get: () => this.self.onclick,
+        set: (handler) => {
+          this.self.onclick = handler;
+        },
+      });
+      shown.push(this.self);
+    }
+    close(): void {
+      this.self.closed = true;
+    }
+  }
+  return {
+    ctor: FakeNotification as unknown as NotificationCtorLike,
+    requestPermission,
+  };
+}
+
+function osEvent(overrides: Partial<NotifyEvent> = {}): NotifyEvent {
+  return {
+    key: 'relay-channel:topic:impl-1308',
+    reason: 'dm-reply',
+    channelId: 'topic:impl-1308',
+    channelTitle: 'impl 1308',
+    badge: true,
+    os: true,
+    count: 1,
+    senderLabel: 'claude',
+    seq: 12,
+    at: 1_800_000_000_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  shown.length = 0;
+});
+
+describe('permission', () => {
+  it('reports unsupported when the API is absent', () => {
+    expect(notifyPermissionState(null)).toBe('unsupported');
+  });
+
+  it('is NEVER requested by constructing the notifier', () => {
+    // The whole "no prompt on load" contract: building the lane — which is what
+    // App does on mount — must not touch `requestPermission`.
+    const { ctor, requestPermission } = makeCtor('default');
+    createOsNotifier({ resolveCtor: () => ctor, openChannel: vi.fn() });
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('is NEVER requested for an event that is not on the OS tier', () => {
+    // A gate-approved badge-only event (visible tab) is not an eligible event.
+    const { ctor, requestPermission } = makeCtor('default');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent({ os: false }));
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(shown).toHaveLength(0);
+  });
+
+  it('is requested lazily on the FIRST eligible event, then shows it', async () => {
+    const { ctor, requestPermission } = makeCtor('default', 'granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent());
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(shown).toHaveLength(1));
+  });
+
+  it('prompts once across a burst of eligible events', async () => {
+    const { ctor, requestPermission } = makeCtor('default', 'granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent({ seq: 1 }));
+    notifier.deliver(osEvent({ seq: 2 }));
+    notifier.deliver(osEvent({ seq: 3 }));
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(shown).toHaveLength(3));
+  });
+
+  it('shows nothing when the operator refuses the prompt', async () => {
+    const { ctor } = makeCtor('default', 'denied');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent());
+    await expect(notifier.requestPermission()).resolves.toBe('denied');
+    expect(shown).toHaveLength(0);
+  });
+
+  it('no-ops when denied, and never asks again', () => {
+    const { ctor, requestPermission } = makeCtor('denied');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent());
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(shown).toHaveLength(0);
+  });
+
+  it('no-ops when the API is unsupported', () => {
+    const notifier = createOsNotifier({
+      resolveCtor: () => null,
+      openChannel: vi.fn(),
+    });
+    expect(() => notifier.deliver(osEvent())).not.toThrow();
+    expect(shown).toHaveLength(0);
+  });
+
+  it('degrades to the current state when the request is refused', async () => {
+    // Safari/Firefox reject `requestPermission` without a user gesture.
+    const { ctor } = makeCtor('default', new Error('user gesture required'));
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    await expect(notifier.requestPermission()).resolves.toBe('default');
+    expect(shown).toHaveLength(0);
+  });
+});
+
+describe('notification payload', () => {
+  it('is constructed with the relay title, composed body, and per-channel tag', () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent());
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.title).toBe('relay');
+    expect(shown[0]?.options).toEqual({
+      body: 'claude replied in impl 1308',
+      // Per-channel tag: a newer notification replaces the previous one instead
+      // of stacking, which is the promise `count` reports inside the body.
+      tag: 'relay-channel:topic:impl-1308',
+      data: { channelId: 'topic:impl-1308' },
+    });
+  });
+
+  it('renders a coalesced mention run', () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent({ reason: 'mention', count: 4 }));
+    expect(shown[0]?.options?.body).toBe(
+      'claude mentioned you in impl 1308 · 4 new'
+    );
+  });
+
+  it('never carries transcript text', () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliver(osEvent());
+    expect(JSON.stringify(shown[0])).not.toContain('pushed the branch');
+  });
+
+  it('survives a constructor that throws (android chrome, webviews)', () => {
+    class ThrowingNotification {
+      static permission: NotificationPermission = 'granted';
+      static requestPermission = vi.fn();
+      constructor() {
+        throw new TypeError('illegal constructor');
+      }
+    }
+    const notifier = createOsNotifier({
+      resolveCtor: () =>
+        ThrowingNotification as unknown as NotificationCtorLike,
+      openChannel: vi.fn(),
+    });
+    expect(() => notifier.deliver(osEvent())).not.toThrow();
+  });
+});
+
+describe('click routing', () => {
+  it('focuses the tab, opens the channel, then closes the notification', () => {
+    const { ctor } = makeCtor('granted');
+    const focusWindow = vi.fn();
+    const openChannel = vi.fn();
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      focusWindow,
+      openChannel,
+    });
+    notifier.deliver(osEvent());
+    const live = shown.at(-1);
+    expect(live?.onclick).toBeTypeOf('function');
+    live?.onclick?.();
+    expect(focusWindow).toHaveBeenCalledTimes(1);
+    expect(openChannel).toHaveBeenCalledWith('topic:impl-1308');
+    // Focus BEFORE routing: the surface must be visible when it changes.
+    expect(focusWindow.mock.invocationCallOrder[0]).toBeLessThan(
+      openChannel.mock.invocationCallOrder[0] as number
+    );
+    expect(live?.closed).toBe(true);
+  });
+});

--- a/test/lib/notify-os-notification.test.ts
+++ b/test/lib/notify-os-notification.test.ts
@@ -296,13 +296,17 @@ describe('delivery reporting', () => {
 });
 
 describe('burst digest', () => {
-  it('collapses the held-back run into one notification', () => {
+  /** The digest is coalesced onto a microtask, so a pass must be let finish. */
+  const flush = (): Promise<void> => Promise.resolve();
+
+  it('collapses the held-back run into one notification', async () => {
     const { ctor } = makeCtor('granted');
     const notifier = createOsNotifier({
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
     notifier.deliverOverflow(12);
+    await flush();
     expect(shown).toHaveLength(1);
     expect(shown[0]?.title).toBe('relay');
     expect(shown[0]?.options).toEqual({
@@ -313,7 +317,41 @@ describe('burst digest', () => {
     });
   });
 
-  it('names no channel and routes nowhere but the tab', () => {
+  it('constructs ONE notification for a whole pass, not one per channel', async () => {
+    // The gate raises `osOverflow` on every event that grows the held-back set,
+    // so a reconnect pass calls this once per held-back channel. Constructing a
+    // Notification per call puts the storm back: `tag` replacement is per-page
+    // on several engines, and a replace can re-alert.
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    for (let count = 1; count <= 12; count += 1) notifier.deliverOverflow(count);
+    await flush();
+    expect(shown).toHaveLength(1);
+    // The LARGEST count, because the last call already describes every channel
+    // the earlier ones did.
+    expect(shown[0]?.options?.body).toBe('12 channels have new messages');
+  });
+
+  it('opens a fresh digest for the next pass', async () => {
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliverOverflow(4);
+    await flush();
+    notifier.deliverOverflow(2);
+    await flush();
+    expect(shown.map((entry) => entry.options?.body)).toEqual([
+      '4 channels have new messages',
+      '2 channels have new messages',
+    ]);
+  });
+
+  it('names no channel and routes nowhere but the tab', async () => {
     const { ctor } = makeCtor('granted');
     const openChannel = vi.fn();
     const focusWindow = vi.fn();
@@ -323,6 +361,7 @@ describe('burst digest', () => {
       openChannel,
     });
     notifier.deliverOverflow(1);
+    await flush();
     expect(shown[0]?.options?.body).toBe('1 channel has new messages');
     shown[0]?.onclick?.();
     expect(focusWindow).toHaveBeenCalledTimes(1);
@@ -330,13 +369,27 @@ describe('burst digest', () => {
     expect(shown[0]?.closed).toBe(true);
   });
 
-  it('no-ops when denied', () => {
+  it('no-ops when denied', async () => {
     const { ctor } = makeCtor('denied');
     const notifier = createOsNotifier({
       resolveCtor: () => ctor,
       openChannel: vi.fn(),
     });
     notifier.deliverOverflow(5);
+    await flush();
+    expect(shown).toHaveLength(0);
+  });
+
+  it('drops a digest the lane no longer wants shown', async () => {
+    // Sign-out lands between the pass and its flush.
+    const { ctor } = makeCtor('granted');
+    const notifier = createOsNotifier({
+      resolveCtor: () => ctor,
+      openChannel: vi.fn(),
+    });
+    notifier.deliverOverflow(6);
+    notifier.reset();
+    await flush();
     expect(shown).toHaveLength(0);
   });
 });

--- a/test/lib/notify-producers.test.ts
+++ b/test/lib/notify-producers.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment happy-dom
+// #1308 slice 5 item 2 — the whole delivery path, end to end in one process:
+// a `/channels` summary row (or a `channel-agent-status` edge) → item 1's
+// derivation + gate → the OS Notification API and the badge store.
+//
+// The Notification API is stubbed on `globalThis`; everything else is the real
+// module graph, including the real ui/activity stores, so the read gate and the
+// click routing are exercised as shipped rather than mocked around.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  notifyChannelIndex,
+  notifyFromAgentStatus,
+  notifyFromChannelSummaries,
+  type NotifySummaryRow,
+  type NotifyTopicRecord,
+} from '../../frontend/src/lib/notify/producers.js';
+import { resetNotifyRuntime } from '../../frontend/src/lib/notify/runtime.js';
+import { useChannelActivityStore } from '../../frontend/src/lib/stores/channel-activity.js';
+import {
+  countAttentionChannels,
+  useNotifyBadgeStore,
+} from '../../frontend/src/lib/stores/notify-badge.js';
+import { useNotifySettingsStore } from '../../frontend/src/lib/stores/notify-settings.js';
+import { useUiStore } from '../../frontend/src/lib/stores/ui.js';
+import { dmChannelTopicId } from '../../shared/dm-channels.js';
+
+const CLAUDE_PROFILE = 'agent-profile:claude:default';
+const IMPL_ID = 'topic:impl-1308';
+const DM_ID = dmChannelTopicId('claude', null);
+const NOW = 1_800_000_000_000;
+
+interface Shown {
+  title: string;
+  options: { body?: string; tag?: string; data?: unknown } | undefined;
+  onclick: ((event?: unknown) => void) | null;
+}
+const shown: Shown[] = [];
+
+class FakeNotification {
+  static permission: NotificationPermission = 'granted';
+  static requestPermission = vi.fn(async () => FakeNotification.permission);
+  readonly record: Shown;
+  constructor(title: string, options?: Shown['options']) {
+    this.record = { title, options, onclick: null };
+    Object.defineProperty(this, 'onclick', {
+      get: () => this.record.onclick,
+      set: (handler) => {
+        this.record.onclick = handler;
+      },
+    });
+    shown.push(this.record);
+  }
+  close(): void {}
+}
+
+function topic(
+  id: string,
+  title: string,
+  routing?: { providerId: string }
+): NotifyTopicRecord {
+  return {
+    id,
+    display: { title },
+    workspaceId: null,
+    ...(routing ? { routingDefaults: routing } : {}),
+  } as unknown as NotifyTopicRecord;
+}
+
+const channels = notifyChannelIndex([
+  topic(IMPL_ID, 'impl 1308'),
+  topic(DM_ID, 'claude', { providerId: 'claude' }),
+]);
+
+function summaryRow(
+  id: string,
+  overrides: Partial<NonNullable<NotifySummaryRow['lastMessage']>> = {}
+): NotifySummaryRow {
+  return {
+    id,
+    lastMessage: {
+      seq: 12,
+      senderId: CLAUDE_PROFILE,
+      senderKind: 'agent',
+      senderDisplayName: 'claude',
+      providerId: 'claude',
+      preview: 'pushed the branch',
+      ...overrides,
+    },
+  };
+}
+
+function attentionCount(): number {
+  return countAttentionChannels(
+    useNotifyBadgeStore.getState().flagByChannel,
+    useChannelActivityStore.getState().lastReadByChannel
+  );
+}
+
+/** Put the tab where OS notifications are allowed: hidden and unfocused. */
+function backgroundTab(): void {
+  Object.defineProperty(document, 'hidden', {
+    value: true,
+    configurable: true,
+  });
+  document.hasFocus = () => false;
+}
+
+function foregroundTab(): void {
+  Object.defineProperty(document, 'hidden', {
+    value: false,
+    configurable: true,
+  });
+  document.hasFocus = () => true;
+}
+
+beforeEach(() => {
+  shown.length = 0;
+  FakeNotification.permission = 'granted';
+  FakeNotification.requestPermission.mockClear();
+  (globalThis as { Notification?: unknown }).Notification = FakeNotification;
+  resetNotifyRuntime();
+  useNotifySettingsStore.getState().resetNotifySettings();
+  useChannelActivityStore.setState({ lastReadByChannel: {} });
+  useUiStore.getState().setActiveChannelId(null);
+  backgroundTab();
+});
+
+afterEach(() => {
+  delete (globalThis as { Notification?: unknown }).Notification;
+});
+
+describe('mention and DM-reply from a /channels payload', () => {
+  it('constructs the notification with the right payload and flags the badge', () => {
+    const delivered = notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]).toMatchObject({
+      reason: 'dm-reply',
+      channelId: DM_ID,
+      os: true,
+      badge: true,
+    });
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.title).toBe('relay');
+    expect(shown[0]?.options).toEqual({
+      body: 'claude replied in claude',
+      tag: `relay-channel:${DM_ID}`,
+      data: { channelId: DM_ID },
+    });
+    expect(attentionCount()).toBe(1);
+  });
+
+  it('raises a mention in a non-DM channel from server-computed refs', () => {
+    notifyFromChannelSummaries({
+      rows: [summaryRow(IMPL_ID, { mentions: [{ raw: '@operator' }] })],
+      channels,
+      at: NOW,
+    });
+    expect(shown[0]?.options?.body).toBe('claude mentioned you in impl 1308');
+    expect(attentionCount()).toBe(1);
+  });
+
+  it('stays silent for an ordinary agent message in a plain channel', () => {
+    notifyFromChannelSummaries({
+      rows: [summaryRow(IMPL_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    expect(attentionCount()).toBe(0);
+  });
+
+  it('never notifies twice for the same row across refetches', () => {
+    const rows = [summaryRow(DM_ID)];
+    notifyFromChannelSummaries({ rows, channels, at: NOW });
+    notifyFromChannelSummaries({ rows, channels, at: NOW + 1 });
+    notifyFromChannelSummaries({ rows, channels, at: NOW + 2 });
+    expect(shown).toHaveLength(1);
+  });
+
+  it('respects a read mark set on another device', () => {
+    useChannelActivityStore.setState({ lastReadByChannel: { [DM_ID]: 12 } });
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    expect(attentionCount()).toBe(0);
+  });
+
+  it('drops the badge when the read mark catches up afterwards', () => {
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(attentionCount()).toBe(1);
+    // The `channel-read-state` broadcast lands (another device read the DM).
+    useChannelActivityStore.setState({ lastReadByChannel: { [DM_ID]: 12 } });
+    expect(attentionCount()).toBe(0);
+  });
+
+  it('stays silent for the channel the operator is looking at', () => {
+    foregroundTab();
+    useUiStore.getState().setActiveChannelId(DM_ID);
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    expect(attentionCount()).toBe(0);
+  });
+
+  it('badges but does not notify while the tab is visible', () => {
+    foregroundTab();
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    expect(attentionCount()).toBe(1);
+  });
+
+  it('badges the boot payload without firing a notification storm', () => {
+    // A tab restored into the background: every unread DM in the seed payload
+    // is genuinely unread, and none of it is news.
+    notifyFromChannelSummaries({
+      rows: [
+        summaryRow(DM_ID),
+        summaryRow(IMPL_ID, {
+          mentions: [{ raw: '@operator' }],
+        }),
+      ],
+      channels,
+      osTier: false,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    expect(attentionCount()).toBe(2);
+    // And the rate-limit window was not burned: a real event straight after
+    // still notifies.
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID, { seq: 13 })],
+      channels,
+      at: NOW + 1,
+    });
+    expect(shown).toHaveLength(1);
+  });
+
+  it('skips a channel with no cached topic rather than guessing at it', () => {
+    notifyFromChannelSummaries({
+      rows: [summaryRow('topic:unknown')],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+  });
+
+  it('ignores the operator own posts echoed back', () => {
+    notifyFromChannelSummaries({
+      rows: [
+        summaryRow(DM_ID, {
+          senderId: 'human:operator',
+          senderKind: 'human',
+          senderDisplayName: 'Operator',
+        }),
+      ],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+  });
+
+  it('honours the operator switching DM replies off', () => {
+    useNotifySettingsStore.getState().setNotifySetting('dmReplies', false);
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    expect(attentionCount()).toBe(0);
+  });
+});
+
+describe('turn complete from channel-agent-status', () => {
+  const channel = channels.get(IMPL_ID);
+
+  it('is off by default', () => {
+    notifyFromAgentStatus({
+      channel: channel!,
+      agentId: CLAUDE_PROFILE,
+      previous: 'thinking',
+      next: 'idle',
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+  });
+
+  it('fires on a busy→idle edge once the operator opts in', () => {
+    useNotifySettingsStore.getState().setNotifySetting('turnComplete', true);
+    notifyFromAgentStatus({
+      channel: channel!,
+      agentId: CLAUDE_PROFILE,
+      previous: 'streaming',
+      next: 'idle',
+      at: NOW,
+    });
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.options?.body).toBe('claude finished in impl 1308');
+    // A finished turn is not an unread DM/mention, so the tab stays clean.
+    expect(attentionCount()).toBe(0);
+  });
+
+  it('ignores a runtime that never came up (spawning→idle)', () => {
+    useNotifySettingsStore.getState().setNotifySetting('turnComplete', true);
+    notifyFromAgentStatus({
+      channel: channel!,
+      agentId: CLAUDE_PROFILE,
+      previous: 'spawning',
+      next: 'idle',
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+  });
+});
+
+describe('click routing', () => {
+  it('opens the notified channel', () => {
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(useUiStore.getState().activeChannelId).toBeNull();
+    shown[0]?.onclick?.();
+    expect(useUiStore.getState().activeChannelId).toBe(DM_ID);
+  });
+});
+
+describe('permission', () => {
+  it('is never requested just by running the producers', () => {
+    FakeNotification.permission = 'granted';
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('is requested only once an eligible event actually reaches the OS tier', () => {
+    FakeNotification.permission = 'default';
+    // Visible tab: badge tier only, so nothing is eligible yet.
+    foregroundTab();
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+
+    backgroundTab();
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID, { seq: 13 })],
+      channels,
+      at: NOW + 1,
+    });
+    expect(FakeNotification.requestPermission).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/lib/notify-producers.test.ts
+++ b/test/lib/notify-producers.test.ts
@@ -470,7 +470,7 @@ describe('global burst budget', () => {
     )
   );
 
-  it('collapses a reconnect storm into three notifications plus one digest', () => {
+  it('collapses a reconnect storm into three notifications plus one digest', async () => {
     const rows = [...burstChannels.keys()].map((id) => summaryRow(id));
     const delivered = notifyFromChannelSummaries({
       rows,
@@ -480,8 +480,13 @@ describe('global burst budget', () => {
     // Every row still earns its in-app mark.
     expect(delivered).toHaveLength(8);
     expect(attentionCount()).toBe(8);
-    // Three per-channel notifications, then ONE digest line that keeps
-    // replacing itself (constant tag) as the held-back set grows.
+    // The digest is coalesced onto a microtask, so the pass must be let finish.
+    await Promise.resolve();
+    // Three per-channel notifications and ONE digest line — FOUR Notification
+    // constructions for eight rows. Anything per-held-back-channel would be
+    // eight, which is the storm the cap exists to prevent: `tag` replacement is
+    // per-page on several engines and a replace can re-alert.
+    expect(shown).toHaveLength(4);
     const perChannel = shown.filter((entry) =>
       entry.options?.tag?.startsWith('relay-channel:')
     );
@@ -490,11 +495,8 @@ describe('global burst budget', () => {
     );
     expect(perChannel).toHaveLength(3);
     expect(perChannel[0]?.options?.body).toBe('claude replied in agent 0');
+    // One line, carrying the whole held-back set.
     expect(digests.map((entry) => entry.options?.body)).toEqual([
-      '1 channel has new messages',
-      '2 channels have new messages',
-      '3 channels have new messages',
-      '4 channels have new messages',
       '5 channels have new messages',
     ]);
   });

--- a/test/lib/notify-producers.test.ts
+++ b/test/lib/notify-producers.test.ts
@@ -14,6 +14,10 @@ import {
   type NotifySummaryRow,
   type NotifyTopicRecord,
 } from '../../frontend/src/lib/notify/producers.js';
+import {
+  NOTIFY_LEADER_LEASE_MS,
+  NOTIFY_LEADER_STORAGE_KEY,
+} from '../../frontend/src/lib/notify/leader.js';
 import { resetNotifyRuntime } from '../../frontend/src/lib/notify/runtime.js';
 import { useChannelActivityStore } from '../../frontend/src/lib/stores/channel-activity.js';
 import {
@@ -118,6 +122,10 @@ beforeEach(() => {
   FakeNotification.permission = 'granted';
   FakeNotification.requestPermission.mockClear();
   (globalThis as { Notification?: unknown }).Notification = FakeNotification;
+  // Includes the cross-tab lease: a record left behind under ANOTHER tab's id
+  // survives `resetNotifyRuntime` by design (releasing someone else's lease is
+  // exactly what a leader election must not do).
+  localStorage.clear();
   resetNotifyRuntime();
   useNotifySettingsStore.getState().resetNotifySettings();
   useChannelActivityStore.setState({ lastReadByChannel: {} });
@@ -331,6 +339,48 @@ describe('turn complete from channel-agent-status', () => {
   });
 });
 
+describe('cross-tab lease', () => {
+  function otherTabHoldsLease(at: number): void {
+    localStorage.setItem(
+      NOTIFY_LEADER_STORAGE_KEY,
+      JSON.stringify({ id: 'other-tab', at })
+    );
+  }
+
+  it('constructs no notification while another tab holds the lease', () => {
+    otherTabHoldsLease(NOW);
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    // The in-app tier is legitimately per-tab: this tab still draws its own dot.
+    expect(attentionCount()).toBe(1);
+  });
+
+  it('refunds the window it never spent, so a takeover still fires', async () => {
+    otherTabHoldsLease(NOW);
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      at: NOW,
+    });
+    expect(shown).toHaveLength(0);
+    // The refund rides a microtask (delivery is reported asynchronously).
+    await Promise.resolve();
+    await Promise.resolve();
+    // Lease lapsed, this tab takes over. Without the refund the suppressed event
+    // would still be holding a 60s slot and this message would show nothing.
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID, { seq: 13 })],
+      channels,
+      at: NOW + NOTIFY_LEADER_LEASE_MS,
+    });
+    expect(shown).toHaveLength(1);
+  });
+});
+
 describe('click routing', () => {
   it('opens the notified channel', () => {
     notifyFromChannelSummaries({
@@ -355,23 +405,97 @@ describe('permission', () => {
     expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
   });
 
-  it('is requested only once an eligible event actually reaches the OS tier', () => {
+  it('is requested only once a LIVE event survives the gate', () => {
     FakeNotification.permission = 'default';
-    // Visible tab: badge tier only, so nothing is eligible yet.
+    // The boot seed describes what happened while the client was away. A prompt
+    // there lands before the operator has been shown anything, which is the one
+    // ask this lane refuses to make.
     foregroundTab();
     notifyFromChannelSummaries({
       rows: [summaryRow(DM_ID)],
       channels,
+      osTier: false,
       at: NOW,
     });
     expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
 
-    backgroundTab();
+    // A live event on a VISIBLE, FOCUSED tab: the only moment Safari and
+    // Firefox will raise the prompt at all, so this is where it is armed.
     notifyFromChannelSummaries({
       rows: [summaryRow(DM_ID, { seq: 13 })],
       channels,
       at: NOW + 1,
     });
     expect(FakeNotification.requestPermission).toHaveBeenCalledTimes(1);
+    // And no notification was shown for it — a visible tab is badge tier only.
+    expect(shown).toHaveLength(0);
+  });
+
+  it('is not requested from a hidden tab that cannot show a prompt', () => {
+    // Chrome defers the prompt to the tab's return; Safari and Firefox reject it
+    // outright. The OS-tier ask in `os-notification.ts` still covers this path —
+    // what must NOT happen is the prime spending its one shot here.
+    FakeNotification.permission = 'default';
+    backgroundTab();
+    notifyFromChannelSummaries({
+      rows: [summaryRow(DM_ID)],
+      channels,
+      osTier: false,
+      at: NOW,
+    });
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('asks at most once across a burst', () => {
+    FakeNotification.permission = 'default';
+    foregroundTab();
+    for (let seq = 20; seq < 25; seq += 1) {
+      notifyFromChannelSummaries({
+        rows: [summaryRow(DM_ID, { seq })],
+        channels,
+        at: NOW + seq,
+      });
+    }
+    expect(FakeNotification.requestPermission).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('global burst budget', () => {
+  /** One DM channel per agent profile — the #1242 reconnect shape. */
+  const burstChannels = notifyChannelIndex(
+    Array.from({ length: 8 }, (_, index) =>
+      topic(dmChannelTopicId(`agent-${index}`, null), `agent ${index}`, {
+        providerId: `agent-${index}`,
+      })
+    )
+  );
+
+  it('collapses a reconnect storm into three notifications plus one digest', () => {
+    const rows = [...burstChannels.keys()].map((id) => summaryRow(id));
+    const delivered = notifyFromChannelSummaries({
+      rows,
+      channels: burstChannels,
+      at: NOW,
+    });
+    // Every row still earns its in-app mark.
+    expect(delivered).toHaveLength(8);
+    expect(attentionCount()).toBe(8);
+    // Three per-channel notifications, then ONE digest line that keeps
+    // replacing itself (constant tag) as the held-back set grows.
+    const perChannel = shown.filter((entry) =>
+      entry.options?.tag?.startsWith('relay-channel:')
+    );
+    const digests = shown.filter(
+      (entry) => entry.options?.tag === 'relay-channels'
+    );
+    expect(perChannel).toHaveLength(3);
+    expect(perChannel[0]?.options?.body).toBe('claude replied in agent 0');
+    expect(digests.map((entry) => entry.options?.body)).toEqual([
+      '1 channel has new messages',
+      '2 channels have new messages',
+      '3 channels have new messages',
+      '4 channels have new messages',
+      '5 channels have new messages',
+    ]);
   });
 });

--- a/test/lib/notify-signals.test.ts
+++ b/test/lib/notify-signals.test.ts
@@ -516,15 +516,86 @@ describe('gate — refund for an event that was never shown', () => {
     ).toMatchObject({ os: true });
   });
 
-  it('carries the undelivered run into the next fire', () => {
+  it('ADDS the undelivered run to the signals that piled up meanwhile', () => {
+    // `deliver` is asynchronous on the lazy-permission path — the long one. The
+    // operator leaves the prompt up while two more messages land in the same
+    // channel and coalesce behind it. Assigning the refund would destroy those
+    // two, and the next fire would undercount the run nobody saw.
     const gate = createNotifyGate();
     const first = gate.evaluate(messageSignal({ seq: 1 }), gateContext());
+    expect(first).toMatchObject({ os: true, count: 1 });
     gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 1 }));
-    // Two signals stood behind that notification and neither was seen.
-    gate.refundOs({ channelId: first!.channelId, count: 2 });
+    gate.evaluate(messageSignal({ seq: 3 }), gateContext({ now: NOW + 2 }));
+    // The prompt is finally dismissed; nothing was ever shown.
+    gate.refundOs(first!);
     expect(
-      gate.evaluate(messageSignal({ seq: 3 }), gateContext({ now: NOW + 2 }))
-    ).toMatchObject({ os: true, count: 3 });
+      gate.evaluate(messageSignal({ seq: 4 }), gateContext({ now: NOW + 3 }))
+    ).toMatchObject({ os: true, count: 4 });
+  });
+
+  it('refunds only the charge it actually made', () => {
+    // A dismissal can land minutes after its event was evaluated. By then a
+    // LATER message in the same channel may have fired for real and written a
+    // fresh window — clearing that one would let the channel notify twice
+    // inside its 60s limit.
+    const gate = createNotifyGate();
+    const stale = gate.evaluate(messageSignal({ seq: 1 }), gateContext());
+    expect(
+      gate.evaluate(
+        messageSignal({ seq: 2 }),
+        gateContext({ now: NOW + NOTIFY_OS_RATE_LIMIT_MS + 1 })
+      )
+    ).toMatchObject({ os: true });
+    gate.refundOs(stale!);
+    expect(
+      gate.evaluate(
+        messageSignal({ seq: 3 }),
+        gateContext({ now: NOW + NOTIFY_OS_RATE_LIMIT_MS + 2 })
+      )
+    ).toMatchObject({ os: false });
+  });
+
+  it('gives back its OWN burst slot, not the newest one', () => {
+    // Popping the newest grant leaves the REFUNDED event's timestamp in the
+    // ledger and drops a live one's. The count is right for the moment, but the
+    // window edges are now somebody else's: the stale entry ages out early and
+    // frees a slot that a still-live grant should have been holding, so the
+    // budget lets a fourth notification through inside one 10s window.
+    const gate = createNotifyGate();
+    const grant = (id: string, now: number) =>
+      gate.evaluate(
+        messageSignal({ seq: 1, channel: { ...channel, id } }),
+        gateContext({ now })
+      );
+    const stale = grant('topic:burst-a', NOW);
+    expect(stale).toMatchObject({ os: true });
+    // Two more grants land near the END of the window, so they outlive the
+    // first by nine seconds.
+    expect(grant('topic:burst-b', NOW + 9_000)).toMatchObject({ os: true });
+    expect(grant('topic:burst-c', NOW + 9_000)).toMatchObject({ os: true });
+    // The first was never shown; refunding it reopens exactly one slot.
+    gate.refundOs(stale!);
+    expect(grant('topic:burst-d', NOW + 9_500)).toMatchObject({ os: true });
+    // Three live grants (b, c, d) still sit inside the window here, so the
+    // budget is spent. Only a's expired ghost could open a fourth.
+    expect(
+      grant('topic:burst-e', NOW + NOTIFY_OS_BURST_WINDOW_MS + 1)
+    ).toMatchObject({ os: false });
+  });
+
+  it('is a no-op for an event that never charged anything', () => {
+    // A visible-tab event holds no window and no burst slot, so crediting a
+    // coalesce pile for it would inflate the next fire's count.
+    const gate = createNotifyGate();
+    const visible = gate.evaluate(
+      messageSignal({ seq: 1 }),
+      gateContext({ documentHidden: false })
+    );
+    expect(visible).toMatchObject({ os: false });
+    gate.refundOs(visible!);
+    expect(
+      gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 1 }))
+    ).toMatchObject({ os: true, count: 1 });
   });
 
   it('hands the burst slot back too', () => {

--- a/test/lib/notify-signals.test.ts
+++ b/test/lib/notify-signals.test.ts
@@ -11,6 +11,8 @@ import {
   notifyChannelFromNavItem,
   notifyChannelFromTopic,
   notifyRowFromMessage,
+  NOTIFY_OS_BURST_LIMIT,
+  NOTIFY_OS_BURST_WINDOW_MS,
   NOTIFY_OS_RATE_LIMIT_MS,
   type NotifyChannel,
   type NotifyGateContext,
@@ -411,6 +413,147 @@ describe('gate — per-channel rate limit and coalescing', () => {
     expect(
       gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 5 }))
     ).toMatchObject({ os: true, count: 1 });
+  });
+});
+
+describe('gate — global burst budget', () => {
+  /** One fresh channel per index, so the PER-CHANNEL limiter never fires. */
+  function burstSignal(index: number, seq = 1): NotifySignal {
+    return messageSignal({
+      seq,
+      channel: {
+        ...channel,
+        id: `topic:burst-${index}`,
+        title: `burst ${index}`,
+      },
+    });
+  }
+
+  it('caps simultaneous OS notifications across ALL channels', () => {
+    // The reconnect shape: one `/channels` payload, fifteen DM rows, fifteen
+    // untouched 60s windows. Without a global budget that is fifteen
+    // notification-centre entries at once, none replacing another.
+    const gate = createNotifyGate();
+    const events = Array.from({ length: 8 }, (_, index) =>
+      gate.evaluate(burstSignal(index), gateContext({ now: NOW + index }))
+    );
+    expect(events.filter((event) => event?.os).length).toBe(
+      NOTIFY_OS_BURST_LIMIT
+    );
+    // The in-app tier is untouched: every held-back channel still earns a badge.
+    expect(events.every((event) => event?.badge === true)).toBe(true);
+  });
+
+  it('reports the held-back run as a growing collapsed count', () => {
+    const gate = createNotifyGate();
+    for (let index = 0; index < NOTIFY_OS_BURST_LIMIT; index += 1) {
+      expect(
+        gate.evaluate(burstSignal(index), gateContext({ now: NOW }))
+      ).toMatchObject({ os: true, osOverflow: 0 });
+    }
+    const first = gate.evaluate(burstSignal(90), gateContext({ now: NOW + 1 }));
+    const second = gate.evaluate(
+      burstSignal(91),
+      gateContext({ now: NOW + 2 })
+    );
+    expect(first).toMatchObject({ os: false, osOverflow: 1 });
+    expect(second).toMatchObject({ os: false, osOverflow: 2 });
+  });
+
+  it('does not re-alert the digest for a channel already held back', () => {
+    const gate = createNotifyGate();
+    for (let index = 0; index < NOTIFY_OS_BURST_LIMIT; index += 1) {
+      gate.evaluate(burstSignal(index), gateContext({ now: NOW }));
+    }
+    expect(
+      gate.evaluate(burstSignal(90, 1), gateContext({ now: NOW + 1 }))
+    ).toMatchObject({ osOverflow: 1 });
+    expect(
+      gate.evaluate(burstSignal(90, 2), gateContext({ now: NOW + 2 }))
+    ).toMatchObject({ os: false, osOverflow: 0 });
+  });
+
+  it('does not count a per-channel repeat as burst overflow', () => {
+    // That channel already has a live notification the operator can see; adding
+    // it to the digest would describe the same thing twice.
+    const gate = createNotifyGate();
+    for (let index = 0; index < NOTIFY_OS_BURST_LIMIT; index += 1) {
+      gate.evaluate(burstSignal(index), gateContext({ now: NOW }));
+    }
+    expect(
+      gate.evaluate(burstSignal(0, 2), gateContext({ now: NOW + 1 }))
+    ).toMatchObject({ os: false, osOverflow: 0 });
+  });
+
+  it('opens a fresh budget once the window lapses', () => {
+    const gate = createNotifyGate();
+    for (let index = 0; index < NOTIFY_OS_BURST_LIMIT; index += 1) {
+      gate.evaluate(burstSignal(index), gateContext({ now: NOW }));
+    }
+    expect(
+      gate.evaluate(burstSignal(90), gateContext({ now: NOW + 1 }))
+    ).toMatchObject({ os: false });
+    expect(
+      gate.evaluate(
+        burstSignal(91),
+        gateContext({ now: NOW + NOTIFY_OS_BURST_WINDOW_MS })
+      )
+    ).toMatchObject({ os: true });
+  });
+});
+
+describe('gate — refund for an event that was never shown', () => {
+  it('lets the next message in that channel fire again', () => {
+    // Permission was `default`, the operator dismissed the prompt, and nothing
+    // was displayed. Without a refund the burnt 60s slot swallows the next real
+    // message as a silent coalesce increment.
+    const gate = createNotifyGate();
+    const first = gate.evaluate(messageSignal({ seq: 1 }), gateContext());
+    expect(first).toMatchObject({ os: true, count: 1 });
+    gate.refundOs(first!);
+    expect(
+      gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 10 }))
+    ).toMatchObject({ os: true });
+  });
+
+  it('carries the undelivered run into the next fire', () => {
+    const gate = createNotifyGate();
+    const first = gate.evaluate(messageSignal({ seq: 1 }), gateContext());
+    gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 1 }));
+    // Two signals stood behind that notification and neither was seen.
+    gate.refundOs({ channelId: first!.channelId, count: 2 });
+    expect(
+      gate.evaluate(messageSignal({ seq: 3 }), gateContext({ now: NOW + 2 }))
+    ).toMatchObject({ os: true, count: 3 });
+  });
+
+  it('hands the burst slot back too', () => {
+    const gate = createNotifyGate();
+    const events = Array.from({ length: NOTIFY_OS_BURST_LIMIT }, (_, index) =>
+      gate.evaluate(
+        messageSignal({
+          seq: 1,
+          channel: { ...channel, id: `topic:burst-${index}` },
+        }),
+        gateContext({ now: NOW })
+      )
+    );
+    gate.refundOs(events.at(-1)!);
+    expect(
+      gate.evaluate(
+        messageSignal({ seq: 1, channel: { ...channel, id: 'topic:burst-x' } }),
+        gateContext({ now: NOW + 1 })
+      )
+    ).toMatchObject({ os: true });
+  });
+
+  it('does NOT refund the replay guard — the row still earned its badge', () => {
+    const gate = createNotifyGate();
+    const first = gate.evaluate(messageSignal({ seq: 5 }), gateContext());
+    gate.refundOs(first!);
+    expect(
+      gate.evaluate(messageSignal({ seq: 5 }), gateContext({ now: NOW + 10 }))
+    ).toBeNull();
   });
 });
 

--- a/test/lib/notify-signals.test.ts
+++ b/test/lib/notify-signals.test.ts
@@ -226,9 +226,10 @@ describe('deriveTurnCompleteSignal', () => {
 });
 
 describe('channel + row adapters', () => {
-  function topic(id: string, providerId: string): Parameters<
-    typeof notifyChannelFromTopic
-  >[0] {
+  function topic(
+    id: string,
+    providerId: string
+  ): Parameters<typeof notifyChannelFromTopic>[0] {
     return {
       id: id as WorkspaceTopic['id'],
       display: { title: 'claude' },
@@ -360,7 +361,9 @@ describe('gate — per-channel rate limit and coalescing', () => {
       gateContext({ now: NOW + NOTIFY_OS_RATE_LIMIT_MS })
     );
     expect(fourth).toMatchObject({ os: true, count: 3 });
-    expect(fourth?.body).toBe('claude mentioned you · 3 new');
+    // The label rides through to delivery, which is where copy is composed
+    // (`notify/copy.ts` renders this run as `… · 3 new`).
+    expect(fourth?.senderLabel).toBe('claude');
   });
 
   it('resets the coalesce count after it is flushed', () => {
@@ -426,12 +429,20 @@ describe('gate — operator settings', () => {
     const gate = createNotifyGate();
     expect(
       gate.evaluate(
-        messageSignal({ reason: 'turn-complete', seq: 0, senderLabel: 'codex' }),
+        messageSignal({
+          reason: 'turn-complete',
+          seq: 0,
+          senderLabel: 'codex',
+        }),
         gateContext({
           settings: { ...DEFAULT_NOTIFY_SETTINGS, turnComplete: true },
         })
       )
-    ).toMatchObject({ os: true, body: 'codex finished' });
+    ).toMatchObject({
+      os: true,
+      reason: 'turn-complete',
+      senderLabel: 'codex',
+    });
   });
 
   it('gates mentions off', () => {
@@ -462,7 +473,9 @@ describe('gate — operator settings', () => {
 describe('gate — replay guard and read position', () => {
   it('refuses a seq it has already evaluated', () => {
     const gate = createNotifyGate();
-    expect(gate.evaluate(messageSignal({ seq: 7 }), gateContext())).not.toBeNull();
+    expect(
+      gate.evaluate(messageSignal({ seq: 7 }), gateContext())
+    ).not.toBeNull();
     expect(gate.evaluate(messageSignal({ seq: 7 }), gateContext())).toBeNull();
     expect(gate.evaluate(messageSignal({ seq: 6 }), gateContext())).toBeNull();
   });
@@ -494,49 +507,47 @@ describe('gate — replay guard and read position', () => {
     const gate = createNotifyGate();
     gate.evaluate(messageSignal({ seq: 7 }), gateContext());
     gate.reset();
-    expect(gate.evaluate(messageSignal({ seq: 7 }), gateContext())).toMatchObject(
-      { os: true, count: 1 }
-    );
+    expect(
+      gate.evaluate(messageSignal({ seq: 7 }), gateContext())
+    ).toMatchObject({ os: true, count: 1 });
   });
 });
 
-describe('notification copy', () => {
-  it('is lowercase prose with no emoji and no transcript text', () => {
-    const gate = createNotifyGate();
-    const bodies = [
-      gate.evaluate(messageSignal({ seq: 1 }), gateContext())?.body,
-      createNotifyGate().evaluate(
-        messageSignal({ reason: 'dm-reply', channel: dmChannel, seq: 1 }),
-        gateContext()
-      )?.body,
-      createNotifyGate().evaluate(
-        messageSignal({ reason: 'turn-complete', seq: 0 }),
-        gateContext({
-          settings: { ...DEFAULT_NOTIFY_SETTINGS, turnComplete: true },
-        })
-      )?.body,
-    ];
-    expect(bodies).toEqual([
-      'claude mentioned you',
-      'claude replied',
-      'claude finished',
-    ]);
-    for (const body of bodies) {
-      expect(body).toBeDefined();
-      expect(body).toBe(body?.toLowerCase());
-      expect(body).not.toMatch(/\p{Extended_Pictographic}/u);
-      // Message text never reaches an OS notification / lock screen.
-      expect(body).not.toContain('pushed the branch');
-    }
-  });
-
-  it('titles with the operator own channel title, verbatim', () => {
+// Copy itself is delivery (item 2) and is covered by `notify-copy.test.ts`.
+// What the gate still owes the delivery lane is the RAW MATERIAL: the channel
+// title verbatim, the sender label, and the coalesce count.
+describe('event payload handed to delivery', () => {
+  it('carries the operator channel title verbatim', () => {
     const gate = createNotifyGate();
     const event = gate.evaluate(
       messageSignal({ channel: { ...channel, title: 'Impl 1308' } }),
       gateContext()
     );
-    expect(event?.title).toBe('Impl 1308');
     expect(event?.channelTitle).toBe('Impl 1308');
+  });
+
+  it('carries the sender label for every reason', () => {
+    expect(
+      createNotifyGate().evaluate(
+        messageSignal({ reason: 'dm-reply', channel: dmChannel, seq: 1 }),
+        gateContext()
+      )
+    ).toMatchObject({ reason: 'dm-reply', senderLabel: 'claude', count: 1 });
+    expect(
+      createNotifyGate().evaluate(
+        messageSignal({ reason: 'turn-complete', seq: 0 }),
+        gateContext({
+          settings: { ...DEFAULT_NOTIFY_SETTINGS, turnComplete: true },
+        })
+      )
+    ).toMatchObject({ reason: 'turn-complete', senderLabel: 'claude' });
+  });
+
+  it('never carries message text', () => {
+    const event = createNotifyGate().evaluate(
+      messageSignal({ seq: 1 }),
+      gateContext()
+    );
+    expect(JSON.stringify(event)).not.toContain('pushed the branch');
   });
 });

--- a/test/lib/notify-signals.test.ts
+++ b/test/lib/notify-signals.test.ts
@@ -1,0 +1,542 @@
+// #1308 slice 5 item 1 — notify-signal derivation + gating.
+//
+// Everything here is pure: no Notification API, no DOM, no stores. The gate's
+// clock and visibility are injected through `NotifyGateContext`, so the
+// rate-limit cases are deterministic rather than timer-driven.
+import { describe, it, expect } from 'vitest';
+import {
+  createNotifyGate,
+  deriveMessageSignal,
+  deriveTurnCompleteSignal,
+  notifyChannelFromNavItem,
+  notifyChannelFromTopic,
+  notifyRowFromMessage,
+  NOTIFY_OS_RATE_LIMIT_MS,
+  type NotifyChannel,
+  type NotifyGateContext,
+  type NotifyMessageRow,
+  type NotifySignal,
+} from '../../frontend/src/lib/notify/signals.js';
+import { DEFAULT_NOTIFY_SETTINGS } from '../../frontend/src/lib/stores/notify-settings.js';
+import { dmChannelTopicId } from '../../shared/dm-channels.js';
+import type { ChannelMessage } from '../../shared/channel-chat-protocol.js';
+import type { WorkspaceTopic } from '../../shared/workspace-topics.js';
+
+const OPERATOR_ID = 'human:operator';
+const CLAUDE_PROFILE = 'agent-profile:claude:default';
+const NOW = 1_800_000_000_000;
+
+const channel: NotifyChannel = {
+  id: 'topic:impl-1308',
+  title: 'impl 1308',
+  isDm: false,
+};
+const dmChannel: NotifyChannel = {
+  id: dmChannelTopicId('claude', null),
+  title: 'claude',
+  isDm: true,
+};
+
+function agentRow(overrides: Partial<NotifyMessageRow> = {}): NotifyMessageRow {
+  return {
+    seq: 10,
+    senderId: CLAUDE_PROFILE,
+    senderKind: 'agent',
+    senderDisplayName: 'claude',
+    providerId: 'claude',
+    preview: 'pushed the branch',
+    ...overrides,
+  };
+}
+
+function gateContext(
+  overrides: Partial<NotifyGateContext> = {}
+): NotifyGateContext {
+  return {
+    settings: { ...DEFAULT_NOTIFY_SETTINGS },
+    activeChannelId: null,
+    documentHidden: true,
+    windowFocused: false,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function messageSignal(overrides: Partial<NotifySignal> = {}): NotifySignal {
+  return {
+    reason: 'mention',
+    channel,
+    seq: 10,
+    senderLabel: 'claude',
+    at: NOW,
+    ...overrides,
+  };
+}
+
+describe('deriveMessageSignal — MENTION', () => {
+  it('raises a mention from server-resolved mention refs', () => {
+    const signal = deriveMessageSignal(
+      agentRow({ mentions: [{ raw: '@operator' }] }),
+      channel,
+      NOW
+    );
+    expect(signal).toMatchObject({
+      reason: 'mention',
+      seq: 10,
+      senderLabel: 'claude',
+    });
+    expect(signal?.channel.id).toBe(channel.id);
+  });
+
+  it('matches the mention token case-insensitively', () => {
+    const signal = deriveMessageSignal(
+      agentRow({ mentions: [{ raw: '@Operator' }] }),
+      channel,
+      NOW
+    );
+    expect(signal?.reason).toBe('mention');
+  });
+
+  it('falls back to parsing the preview when the payload carries no refs', () => {
+    const signal = deriveMessageSignal(
+      agentRow({ preview: 'blocked on the migration @operator' }),
+      channel,
+      NOW
+    );
+    expect(signal?.reason).toBe('mention');
+  });
+
+  it('does not fire for an @operator inside a code span', () => {
+    // Proves the SHARED tokenizer is doing the work — a lane-local regex would
+    // notify on a transcript that merely quotes the token.
+    const signal = deriveMessageSignal(
+      agentRow({ preview: 'the docs say `@operator` is the mention target' }),
+      channel,
+      NOW
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('never notifies on the operator own echoed post', () => {
+    const signal = deriveMessageSignal(
+      agentRow({
+        senderId: OPERATOR_ID,
+        senderKind: 'human',
+        mentions: [{ raw: '@operator' }],
+      }),
+      channel,
+      NOW
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('ignores system rows', () => {
+    const signal = deriveMessageSignal(
+      agentRow({
+        senderId: 'system',
+        senderKind: 'system',
+        mentions: [{ raw: '@operator' }],
+      }),
+      channel,
+      NOW
+    );
+    expect(signal).toBeNull();
+  });
+});
+
+describe('deriveMessageSignal — DM REPLY', () => {
+  it('raises a dm-reply for an agent message in a DM channel', () => {
+    const signal = deriveMessageSignal(agentRow(), dmChannel, NOW);
+    expect(signal).toMatchObject({ reason: 'dm-reply', senderLabel: 'claude' });
+  });
+
+  it('does not raise a dm-reply in a regular channel', () => {
+    expect(deriveMessageSignal(agentRow(), channel, NOW)).toBeNull();
+  });
+
+  it('does not raise a dm-reply for a human row', () => {
+    const signal = deriveMessageSignal(
+      agentRow({ senderId: 'human:pair', senderKind: 'human' }),
+      dmChannel,
+      NOW
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('prefers MENTION over DM REPLY so one row is one event', () => {
+    const signal = deriveMessageSignal(
+      agentRow({ mentions: [{ raw: '@operator' }] }),
+      dmChannel,
+      NOW
+    );
+    expect(signal?.reason).toBe('mention');
+  });
+});
+
+describe('deriveTurnCompleteSignal', () => {
+  it.each(['thinking', 'streaming', 'waiting'] as const)(
+    'raises turn-complete on %s -> idle',
+    (previous) => {
+      const signal = deriveTurnCompleteSignal({
+        channel,
+        agentLabel: 'claude',
+        previous,
+        next: 'idle',
+        at: NOW,
+      });
+      expect(signal).toMatchObject({ reason: 'turn-complete', seq: 0 });
+    }
+  );
+
+  it('does not treat a failed spawn as a completed turn', () => {
+    expect(
+      deriveTurnCompleteSignal({
+        channel,
+        agentLabel: 'claude',
+        previous: 'spawning',
+        next: 'idle',
+        at: NOW,
+      })
+    ).toBeNull();
+  });
+
+  it('needs a known previous status (a first-seen idle is not an edge)', () => {
+    expect(
+      deriveTurnCompleteSignal({
+        channel,
+        agentLabel: 'claude',
+        previous: undefined,
+        next: 'idle',
+        at: NOW,
+      })
+    ).toBeNull();
+  });
+
+  it('ignores transitions that do not land on idle', () => {
+    expect(
+      deriveTurnCompleteSignal({
+        channel,
+        agentLabel: 'claude',
+        previous: 'thinking',
+        next: 'streaming',
+        at: NOW,
+      })
+    ).toBeNull();
+  });
+});
+
+describe('channel + row adapters', () => {
+  function topic(id: string, providerId: string): Parameters<
+    typeof notifyChannelFromTopic
+  >[0] {
+    return {
+      id: id as WorkspaceTopic['id'],
+      display: { title: 'claude' },
+      workspaceId: null as unknown as WorkspaceTopic['workspaceId'],
+      routingDefaults: { providerId },
+    };
+  }
+
+  it('derives DM-ness from the deterministic id, not a marker', () => {
+    expect(
+      notifyChannelFromTopic(topic(dmChannelTopicId('claude', null), 'claude'))
+    ).toEqual({ id: dmChannel.id, title: 'claude', isDm: true });
+    expect(notifyChannelFromTopic(topic('topic:impl-1308', 'claude'))).toEqual({
+      id: 'topic:impl-1308',
+      title: 'claude',
+      isDm: false,
+    });
+  });
+
+  it('reuses the rail nav model DM verdict', () => {
+    expect(
+      notifyChannelFromNavItem({
+        id: dmChannel.id as WorkspaceTopic['id'],
+        title: 'claude',
+        isDirectMessage: true,
+      })
+    ).toEqual({ id: dmChannel.id, title: 'claude', isDm: true });
+  });
+
+  it('flattens a live channel message onto the shared row shape', () => {
+    const message = {
+      seq: 42,
+      sender: {
+        kind: 'agent',
+        id: CLAUDE_PROFILE,
+        displayName: 'claude',
+        providerId: 'claude',
+      },
+      body: { text: 'done @operator', format: 'markdown' },
+      mentions: [{ raw: '@operator' }],
+    } as unknown as ChannelMessage;
+    expect(notifyRowFromMessage(message)).toEqual({
+      seq: 42,
+      senderId: CLAUDE_PROFILE,
+      senderKind: 'agent',
+      senderDisplayName: 'claude',
+      providerId: 'claude',
+      mentions: [{ raw: '@operator' }],
+      preview: 'done @operator',
+    });
+  });
+});
+
+describe('gate — visibility tiers', () => {
+  it('fires the OS tier only when the tab is hidden', () => {
+    const gate = createNotifyGate();
+    const hidden = gate.evaluate(messageSignal(), gateContext());
+    expect(hidden).toMatchObject({ os: true, badge: true, count: 1 });
+
+    const visible = createNotifyGate().evaluate(
+      messageSignal(),
+      gateContext({ documentHidden: false, windowFocused: true })
+    );
+    expect(visible).toMatchObject({ os: false, badge: true });
+  });
+
+  it('suppresses entirely for the channel that is open AND focused', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal(),
+        gateContext({
+          activeChannelId: channel.id,
+          documentHidden: false,
+          windowFocused: true,
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('still notifies for the open channel when the tab is hidden', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal(),
+        gateContext({ activeChannelId: channel.id, documentHidden: true })
+      )
+    ).toMatchObject({ os: true });
+  });
+
+  it('still badges the open channel when the window is blurred', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal(),
+        gateContext({
+          activeChannelId: channel.id,
+          documentHidden: false,
+          windowFocused: false,
+        })
+      )
+    ).toMatchObject({ os: false, badge: true });
+  });
+});
+
+describe('gate — per-channel rate limit and coalescing', () => {
+  it('fires once per channel per window and reports the coalesced run', () => {
+    const gate = createNotifyGate();
+    const first = gate.evaluate(
+      messageSignal({ seq: 1 }),
+      gateContext({ now: NOW })
+    );
+    expect(first).toMatchObject({ os: true, count: 1 });
+
+    const second = gate.evaluate(
+      messageSignal({ seq: 2 }),
+      gateContext({ now: NOW + 1_000 })
+    );
+    const third = gate.evaluate(
+      messageSignal({ seq: 3 }),
+      gateContext({ now: NOW + 2_000 })
+    );
+    // Held back from the OS tier, but the operator still gets an in-app mark.
+    expect(second).toMatchObject({ os: false, badge: true, count: 1 });
+    expect(third).toMatchObject({ os: false, badge: true, count: 1 });
+
+    const fourth = gate.evaluate(
+      messageSignal({ seq: 4 }),
+      gateContext({ now: NOW + NOTIFY_OS_RATE_LIMIT_MS })
+    );
+    expect(fourth).toMatchObject({ os: true, count: 3 });
+    expect(fourth?.body).toBe('claude mentioned you · 3 new');
+  });
+
+  it('resets the coalesce count after it is flushed', () => {
+    const gate = createNotifyGate();
+    gate.evaluate(messageSignal({ seq: 1 }), gateContext({ now: NOW }));
+    gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 1 }));
+    gate.evaluate(
+      messageSignal({ seq: 3 }),
+      gateContext({ now: NOW + NOTIFY_OS_RATE_LIMIT_MS })
+    );
+    const next = gate.evaluate(
+      messageSignal({ seq: 4 }),
+      gateContext({ now: NOW + 2 * NOTIFY_OS_RATE_LIMIT_MS })
+    );
+    expect(next).toMatchObject({ os: true, count: 1 });
+  });
+
+  it('rate-limits per channel, not globally', () => {
+    const gate = createNotifyGate();
+    const other: NotifyChannel = { ...channel, id: 'topic:other' };
+    expect(
+      gate.evaluate(messageSignal({ seq: 1 }), gateContext())
+    ).toMatchObject({ os: true });
+    expect(
+      gate.evaluate(
+        messageSignal({ seq: 1, channel: other }),
+        gateContext({ now: NOW + 10 })
+      )
+    ).toMatchObject({ os: true, count: 1 });
+  });
+
+  it('keys the coalesce tag per channel', () => {
+    const gate = createNotifyGate();
+    expect(gate.evaluate(messageSignal(), gateContext())?.key).toBe(
+      `relay-channel:${channel.id}`
+    );
+  });
+
+  it('a visible-tab signal does not consume the OS window', () => {
+    const gate = createNotifyGate();
+    gate.evaluate(
+      messageSignal({ seq: 1 }),
+      gateContext({ documentHidden: false, windowFocused: true })
+    );
+    expect(
+      gate.evaluate(messageSignal({ seq: 2 }), gateContext({ now: NOW + 5 }))
+    ).toMatchObject({ os: true, count: 1 });
+  });
+});
+
+describe('gate — operator settings', () => {
+  it('is off for turn-complete by default', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal({ reason: 'turn-complete', seq: 0 }),
+        gateContext()
+      )
+    ).toBeNull();
+  });
+
+  it('fires turn-complete once the operator opts in', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal({ reason: 'turn-complete', seq: 0, senderLabel: 'codex' }),
+        gateContext({
+          settings: { ...DEFAULT_NOTIFY_SETTINGS, turnComplete: true },
+        })
+      )
+    ).toMatchObject({ os: true, body: 'codex finished' });
+  });
+
+  it('gates mentions off', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal(),
+        gateContext({
+          settings: { ...DEFAULT_NOTIFY_SETTINGS, mentions: false },
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('gates dm replies off', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(
+        messageSignal({ reason: 'dm-reply', channel: dmChannel }),
+        gateContext({
+          settings: { ...DEFAULT_NOTIFY_SETTINGS, dmReplies: false },
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('gate — replay guard and read position', () => {
+  it('refuses a seq it has already evaluated', () => {
+    const gate = createNotifyGate();
+    expect(gate.evaluate(messageSignal({ seq: 7 }), gateContext())).not.toBeNull();
+    expect(gate.evaluate(messageSignal({ seq: 7 }), gateContext())).toBeNull();
+    expect(gate.evaluate(messageSignal({ seq: 6 }), gateContext())).toBeNull();
+  });
+
+  it('refuses a row the operator already read (possibly on another device)', () => {
+    const gate = createNotifyGate();
+    expect(
+      gate.evaluate(messageSignal({ seq: 7 }), gateContext({ lastReadSeq: 7 }))
+    ).toBeNull();
+    expect(
+      gate.evaluate(messageSignal({ seq: 8 }), gateContext({ lastReadSeq: 7 }))
+    ).not.toBeNull();
+  });
+
+  it('does not apply the seq guard to status-only signals', () => {
+    const gate = createNotifyGate();
+    const settings = { ...DEFAULT_NOTIFY_SETTINGS, turnComplete: true };
+    const turn = messageSignal({ reason: 'turn-complete', seq: 0 });
+    expect(gate.evaluate(turn, gateContext({ settings }))).not.toBeNull();
+    expect(
+      gate.evaluate(
+        turn,
+        gateContext({ settings, now: NOW + NOTIFY_OS_RATE_LIMIT_MS })
+      )
+    ).not.toBeNull();
+  });
+
+  it('forgets every ledger on reset', () => {
+    const gate = createNotifyGate();
+    gate.evaluate(messageSignal({ seq: 7 }), gateContext());
+    gate.reset();
+    expect(gate.evaluate(messageSignal({ seq: 7 }), gateContext())).toMatchObject(
+      { os: true, count: 1 }
+    );
+  });
+});
+
+describe('notification copy', () => {
+  it('is lowercase prose with no emoji and no transcript text', () => {
+    const gate = createNotifyGate();
+    const bodies = [
+      gate.evaluate(messageSignal({ seq: 1 }), gateContext())?.body,
+      createNotifyGate().evaluate(
+        messageSignal({ reason: 'dm-reply', channel: dmChannel, seq: 1 }),
+        gateContext()
+      )?.body,
+      createNotifyGate().evaluate(
+        messageSignal({ reason: 'turn-complete', seq: 0 }),
+        gateContext({
+          settings: { ...DEFAULT_NOTIFY_SETTINGS, turnComplete: true },
+        })
+      )?.body,
+    ];
+    expect(bodies).toEqual([
+      'claude mentioned you',
+      'claude replied',
+      'claude finished',
+    ]);
+    for (const body of bodies) {
+      expect(body).toBeDefined();
+      expect(body).toBe(body?.toLowerCase());
+      expect(body).not.toMatch(/\p{Extended_Pictographic}/u);
+      // Message text never reaches an OS notification / lock screen.
+      expect(body).not.toContain('pushed the branch');
+    }
+  });
+
+  it('titles with the operator own channel title, verbatim', () => {
+    const gate = createNotifyGate();
+    const event = gate.evaluate(
+      messageSignal({ channel: { ...channel, title: 'Impl 1308' } }),
+      gateContext()
+    );
+    expect(event?.title).toBe('Impl 1308');
+    expect(event?.channelTitle).toBe('Impl 1308');
+  });
+});

--- a/test/lib/notify-summary-watch.test.ts
+++ b/test/lib/notify-summary-watch.test.ts
@@ -3,8 +3,9 @@
 // producer. Uses a REAL `QueryClient`, so the key match, the cold-boot ordering,
 // and the unsubscribe are exercised as shipped.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
 import {
+  channelSummariesHaveObserver,
   ensureNotifySummaryCaches,
   refreshChannelSummaries,
 } from '../../frontend/src/lib/notify/summary-watch.js';
@@ -88,6 +89,7 @@ beforeEach(() => {
     configurable: true,
   });
   document.hasFocus = () => false;
+  localStorage.clear();
   resetNotifyRuntime();
   useNotifySettingsStore.getState().resetNotifySettings();
   useChannelActivityStore.setState({ lastReadByChannel: {} });
@@ -199,5 +201,79 @@ describe('cache bootstrap and refresh', () => {
     apiMock.fetchChannels.mockRejectedValue(new Error('hub unreachable'));
     await expect(refreshChannelSummaries(client)).resolves.toBeUndefined();
     expect(shown).toHaveLength(0);
+  });
+});
+
+describe('rail ownership probe', () => {
+  // The notify lane's refresh must stand down when the rail is mounted (it
+  // fetches on a tighter throttle already) and take over when it is not —
+  // otherwise a collapsed sidebar leaves NOTHING refetching `['channels']`,
+  // because `invalidateQueries` defaults to `refetchType: 'active'`.
+  it('is false with the rail unmounted, true while it observes', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    expect(channelSummariesHaveObserver(client)).toBe(false);
+
+    const observer = new QueryObserver(client, {
+      queryKey: ['channels'],
+      queryFn: apiMock.fetchChannels,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    expect(channelSummariesHaveObserver(client)).toBe(true);
+
+    unsubscribe();
+    expect(channelSummariesHaveObserver(client)).toBe(false);
+  });
+
+  it('does not count an observer on a DIFFERENT key', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    const observer = new QueryObserver(client, {
+      queryKey: ['workspace-topics'],
+      queryFn: () => apiMock.fetchWorkspaceTopics(),
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    expect(channelSummariesHaveObserver(client)).toBe(false);
+    unsubscribe();
+  });
+});
+
+describe('badge pruning', () => {
+  it('drops the dot for a channel that left the active topic list', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    expect(attentionCount()).toBe(1);
+
+    // The DM was deleted or archived: `['workspace-topics']` is always the
+    // ACTIVE view (the archived one rides a distinct key), so its absence is
+    // the closest thing this lane has to a channel-deleted signal.
+    client.setQueryData(['workspace-topics'], {
+      topics: [
+        {
+          id: 'topic:impl-1308',
+          display: { title: 'impl 1308' },
+          workspaceId: null,
+        },
+      ],
+    });
+    expect(attentionCount()).toBe(0);
+  });
+
+  it('keeps every flag when the topic payload is TRUNCATED', () => {
+    // A page of the corpus is not evidence of deletion.
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    expect(attentionCount()).toBe(1);
+    client.setQueryData(['workspace-topics'], {
+      topics: [
+        {
+          id: 'topic:impl-1308',
+          display: { title: 'impl 1308' },
+          workspaceId: null,
+        },
+      ],
+      truncated: true,
+    });
+    expect(attentionCount()).toBe(1);
   });
 });

--- a/test/lib/notify-summary-watch.test.ts
+++ b/test/lib/notify-summary-watch.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+// #1308 slice 5 item 2 — the query-cache lane that feeds the mention/DM-reply
+// producer. Uses a REAL `QueryClient`, so the key match, the cold-boot ordering,
+// and the unsubscribe are exercised as shipped.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  ensureNotifySummaryCaches,
+  refreshChannelSummaries,
+} from '../../frontend/src/lib/notify/summary-watch.js';
+import { resetNotifyRuntime } from '../../frontend/src/lib/notify/runtime.js';
+import { watchChannelSummaries } from '../../frontend/src/lib/notify/summary-watch.js';
+import { useChannelActivityStore } from '../../frontend/src/lib/stores/channel-activity.js';
+import {
+  countAttentionChannels,
+  useNotifyBadgeStore,
+} from '../../frontend/src/lib/stores/notify-badge.js';
+import { useNotifySettingsStore } from '../../frontend/src/lib/stores/notify-settings.js';
+import { useUiStore } from '../../frontend/src/lib/stores/ui.js';
+import { dmChannelTopicId } from '../../shared/dm-channels.js';
+
+const DM_ID = dmChannelTopicId('claude', null);
+const CLAUDE_PROFILE = 'agent-profile:claude:default';
+
+// Only the two fetchers this lane calls are stubbed; everything else in the API
+// client (the read-state push the activity store makes, for one) stays real.
+const apiMock = vi.hoisted(() => ({
+  fetchChannels: vi.fn(),
+  fetchWorkspaceTopics: vi.fn(),
+}));
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  fetchChannels: apiMock.fetchChannels,
+  fetchWorkspaceTopics: apiMock.fetchWorkspaceTopics,
+}));
+
+const shown: { options?: { body?: string } }[] = [];
+
+class FakeNotification {
+  static permission: NotificationPermission = 'granted';
+  static requestPermission = vi.fn(async () => FakeNotification.permission);
+  onclick: ((event?: unknown) => void) | null = null;
+  constructor(_title: string, options?: { body?: string }) {
+    shown.push({ options });
+  }
+  close(): void {}
+}
+
+const TOPICS = {
+  topics: [
+    {
+      id: DM_ID,
+      display: { title: 'claude' },
+      workspaceId: null,
+      routingDefaults: { providerId: 'claude' },
+    },
+  ],
+};
+
+function dmRows(seq: number) {
+  return [
+    {
+      id: DM_ID,
+      lastMessage: {
+        seq,
+        senderId: CLAUDE_PROFILE,
+        senderKind: 'agent' as const,
+        senderDisplayName: 'claude',
+        providerId: 'claude',
+        preview: 'pushed the branch',
+      },
+    },
+  ];
+}
+
+let client: QueryClient;
+let stop: (() => void) | undefined;
+
+beforeEach(() => {
+  shown.length = 0;
+  apiMock.fetchChannels.mockReset();
+  apiMock.fetchChannels.mockResolvedValue(dmRows(13));
+  apiMock.fetchWorkspaceTopics.mockReset();
+  apiMock.fetchWorkspaceTopics.mockResolvedValue(TOPICS);
+  (globalThis as { Notification?: unknown }).Notification = FakeNotification;
+  Object.defineProperty(document, 'hidden', {
+    value: true,
+    configurable: true,
+  });
+  document.hasFocus = () => false;
+  resetNotifyRuntime();
+  useNotifySettingsStore.getState().resetNotifySettings();
+  useChannelActivityStore.setState({ lastReadByChannel: {} });
+  useUiStore.getState().setActiveChannelId(null);
+  client = new QueryClient();
+});
+
+afterEach(() => {
+  stop?.();
+  stop = undefined;
+  client.clear();
+  delete (globalThis as { Notification?: unknown }).Notification;
+});
+
+function attentionCount(): number {
+  return countAttentionChannels(
+    useNotifyBadgeStore.getState().flagByChannel,
+    useChannelActivityStore.getState().lastReadByChannel
+  );
+}
+
+describe('channel summary watch', () => {
+  it('seeds badges from what is already cached, without notifying', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    expect(attentionCount()).toBe(1);
+    expect(shown).toHaveLength(0);
+  });
+
+  it('notifies on the payload AFTER the seed', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    client.setQueryData(['channels'], dmRows(13));
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.options?.body).toBe('claude replied in claude');
+  });
+
+  it('tolerates either payload landing second on a cold boot', () => {
+    stop = watchChannelSummaries(client);
+    // Channels first: no topics yet, so nothing can be derived and the seed has
+    // not been spent.
+    client.setQueryData(['channels'], dmRows(12));
+    expect(attentionCount()).toBe(0);
+    client.setQueryData(['workspace-topics'], TOPICS);
+    // The topics update re-runs the pass, which is the seed.
+    expect(attentionCount()).toBe(1);
+    expect(shown).toHaveLength(0);
+  });
+
+  it('ignores updates to unrelated caches', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    client.setQueryData(['hub-nodes'], [{ nodeId: 'node-1' }]);
+    client.setQueryData(['active-work'], []);
+    expect(shown).toHaveLength(0);
+  });
+
+  it('stops feeding the producer once unsubscribed', () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    stop();
+    stop = undefined;
+    client.setQueryData(['channels'], dmRows(13));
+    expect(shown).toHaveLength(0);
+  });
+});
+
+describe('cache bootstrap and refresh', () => {
+  it('fetches both payloads when nothing has (collapsed sidebar boot)', async () => {
+    stop = watchChannelSummaries(client);
+    await ensureNotifySummaryCaches(client);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+    expect(apiMock.fetchWorkspaceTopics).toHaveBeenCalledTimes(1);
+    // The bootstrap is the SEED: badged, not notified.
+    expect(attentionCount()).toBe(1);
+    expect(shown).toHaveLength(0);
+  });
+
+  it('fetches nothing when the rail already filled both caches', async () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    await ensureNotifySummaryCaches(client);
+    expect(apiMock.fetchChannels).not.toHaveBeenCalled();
+    expect(apiMock.fetchWorkspaceTopics).not.toHaveBeenCalled();
+  });
+
+  it('refreshes with no mounted observer, which is what wakes a hidden tab', async () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    expect(shown).toHaveLength(0);
+    // Nothing observes `['channels']` here — the rail is unmounted — so an
+    // invalidation would be inert. A direct fetch writes the cache and the
+    // watch sees it.
+    await refreshChannelSummaries(client);
+    expect(apiMock.fetchChannels).toHaveBeenCalledTimes(1);
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.options?.body).toBe('claude replied in claude');
+  });
+
+  it('survives a refresh that fails', async () => {
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    apiMock.fetchChannels.mockRejectedValue(new Error('hub unreachable'));
+    await expect(refreshChannelSummaries(client)).resolves.toBeUndefined();
+    expect(shown).toHaveLength(0);
+  });
+});

--- a/test/lib/notify-summary-watch.test.ts
+++ b/test/lib/notify-summary-watch.test.ts
@@ -258,6 +258,19 @@ describe('badge pruning', () => {
     expect(attentionCount()).toBe(0);
   });
 
+  it('drops the dot when the LAST channel leaves the list', () => {
+    // The one case where every cached badge is provably stale — and the one
+    // case the notify pass has nothing to do, so a prune behind the notify
+    // guard never reached it and the dot and title count stayed pinned for the
+    // life of the tab.
+    client.setQueryData(['channels'], dmRows(12));
+    client.setQueryData(['workspace-topics'], TOPICS);
+    stop = watchChannelSummaries(client);
+    expect(attentionCount()).toBe(1);
+    client.setQueryData(['workspace-topics'], { topics: [] });
+    expect(attentionCount()).toBe(0);
+  });
+
   it('keeps every flag when the topic payload is TRUNCATED', () => {
     // A page of the corpus is not evidence of deletion.
     client.setQueryData(['channels'], dmRows(12));

--- a/test/stores/notify-badge-store.test.ts
+++ b/test/stores/notify-badge-store.test.ts
@@ -1,0 +1,107 @@
+// #1308 slice 5 item 2 — attention-badge state behind the favicon dot and the
+// title count. Pure store logic; no DOM.
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  countAttentionChannels,
+  reasonEarnsBadge,
+  useNotifyBadgeStore,
+} from '../../frontend/src/lib/stores/notify-badge.js';
+
+const CHANNEL = 'topic:impl-1308';
+const DM = 'topic:dm~claude~workspace-local';
+
+beforeEach(() => {
+  useNotifyBadgeStore.getState().reset();
+});
+
+describe('which reasons earn a badge', () => {
+  it('counts mentions and DM replies, never turn-complete', () => {
+    expect(reasonEarnsBadge('mention')).toBe(true);
+    expect(reasonEarnsBadge('dm-reply')).toBe(true);
+    // A finished turn is a workflow event on a channel the operator may have
+    // fanned out and stopped watching — it can notify, but it must not pin a
+    // permanent dot on the tab (its seq is 0, so no read mark could clear it).
+    expect(reasonEarnsBadge('turn-complete')).toBe(false);
+  });
+
+  it('refuses to store a turn-complete flag at all', () => {
+    useNotifyBadgeStore
+      .getState()
+      .flagChannel(CHANNEL, { seq: 0, reason: 'turn-complete' });
+    expect(useNotifyBadgeStore.getState().flagByChannel).toEqual({});
+  });
+});
+
+describe('flagging', () => {
+  it('keeps the highest seq per channel', () => {
+    const store = useNotifyBadgeStore.getState();
+    store.flagChannel(CHANNEL, { seq: 10, reason: 'mention' });
+    store.flagChannel(CHANNEL, { seq: 4, reason: 'mention' });
+    expect(useNotifyBadgeStore.getState().flagByChannel[CHANNEL]).toEqual({
+      seq: 10,
+      reason: 'mention',
+    });
+    store.flagChannel(CHANNEL, { seq: 12, reason: 'dm-reply' });
+    expect(useNotifyBadgeStore.getState().flagByChannel[CHANNEL]).toEqual({
+      seq: 12,
+      reason: 'dm-reply',
+    });
+  });
+
+  it('leaves the map identity alone when nothing changed', () => {
+    const store = useNotifyBadgeStore.getState();
+    store.flagChannel(CHANNEL, { seq: 10, reason: 'mention' });
+    const before = useNotifyBadgeStore.getState().flagByChannel;
+    store.flagChannel(CHANNEL, { seq: 10, reason: 'mention' });
+    // Identity stability is load-bearing: the delivery hook memoizes the count
+    // on this object, so a new identity per redundant event would recompute (and
+    // re-apply the favicon) on every message in a busy channel.
+    expect(useNotifyBadgeStore.getState().flagByChannel).toBe(before);
+  });
+
+  it('clears one channel without disturbing the others', () => {
+    const store = useNotifyBadgeStore.getState();
+    store.flagChannel(CHANNEL, { seq: 10, reason: 'mention' });
+    store.flagChannel(DM, { seq: 3, reason: 'dm-reply' });
+    store.clearChannel(CHANNEL);
+    expect(Object.keys(useNotifyBadgeStore.getState().flagByChannel)).toEqual([
+      DM,
+    ]);
+  });
+});
+
+describe('count derived against the read position', () => {
+  it('counts CHANNELS, not messages', () => {
+    const flags = {
+      [CHANNEL]: { seq: 40, reason: 'mention' as const },
+      [DM]: { seq: 12, reason: 'dm-reply' as const },
+    };
+    // Two channels holding many unread messages each are still "2".
+    expect(countAttentionChannels(flags, {})).toBe(2);
+  });
+
+  it('clears a channel once the read mark reaches its seq', () => {
+    const flags = { [CHANNEL]: { seq: 40, reason: 'mention' as const } };
+    expect(countAttentionChannels(flags, { [CHANNEL]: 39 })).toBe(1);
+    expect(countAttentionChannels(flags, { [CHANNEL]: 40 })).toBe(0);
+    // Read PAST it (another device read further) also clears.
+    expect(countAttentionChannels(flags, { [CHANNEL]: 99 })).toBe(0);
+  });
+
+  it('re-raises when a newer message arrives after a read', () => {
+    const store = useNotifyBadgeStore.getState();
+    store.flagChannel(CHANNEL, { seq: 40, reason: 'mention' });
+    const read = { [CHANNEL]: 40 };
+    expect(
+      countAttentionChannels(useNotifyBadgeStore.getState().flagByChannel, read)
+    ).toBe(0);
+    store.flagChannel(CHANNEL, { seq: 41, reason: 'mention' });
+    expect(
+      countAttentionChannels(useNotifyBadgeStore.getState().flagByChannel, read)
+    ).toBe(1);
+  });
+
+  it('is zero with no flags at all', () => {
+    expect(countAttentionChannels({}, { [CHANNEL]: 12 })).toBe(0);
+  });
+});

--- a/test/stores/notify-settings-store.test.ts
+++ b/test/stores/notify-settings-store.test.ts
@@ -1,0 +1,119 @@
+// #1308 slice 5 item 1 — the operator's notification trigger set.
+import { describe, it, beforeEach, expect } from 'vitest';
+
+// Mock localStorage before importing the store (it loads at module init).
+const storage: Record<string, string> = {};
+if (typeof globalThis.localStorage === 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (key: string) => storage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete storage[key];
+      },
+      clear: () => {
+        for (const key of Object.keys(storage)) delete storage[key];
+      },
+      get length() {
+        return Object.keys(storage).length;
+      },
+      key: (index: number) => Object.keys(storage)[index] ?? null,
+    },
+    writable: true,
+  });
+}
+
+const {
+  DEFAULT_NOTIFY_SETTINGS,
+  NOTIFY_SETTINGS_KEY,
+  parseNotifySettings,
+  serializeNotifySettings,
+  useNotifySettingsStore,
+  currentNotifySettings,
+} = await import('../../frontend/src/lib/stores/notify-settings.js');
+
+beforeEach(() => {
+  for (const key of Object.keys(storage)) delete storage[key];
+  useNotifySettingsStore.getState().resetNotifySettings();
+});
+
+describe('notify settings defaults', () => {
+  it('ships mentions + dm replies on and turn-complete off', () => {
+    expect(DEFAULT_NOTIFY_SETTINGS).toEqual({
+      mentions: true,
+      dmReplies: true,
+      turnComplete: false,
+    });
+  });
+
+  it('starts from the defaults with an empty slot', () => {
+    expect(currentNotifySettings()).toEqual(DEFAULT_NOTIFY_SETTINGS);
+  });
+});
+
+describe('parseNotifySettings', () => {
+  it('round-trips a serialized set', () => {
+    const settings = { mentions: false, dmReplies: true, turnComplete: true };
+    expect(parseNotifySettings(serializeNotifySettings(settings))).toEqual(
+      settings
+    );
+  });
+
+  it.each([null, '', 'not json', '[]', '"nope"', '42'])(
+    'degrades %s to the defaults',
+    (raw) => {
+      expect(parseNotifySettings(raw)).toEqual(DEFAULT_NOTIFY_SETTINGS);
+    }
+  );
+
+  it('fills only the keys a partial payload is missing', () => {
+    expect(parseNotifySettings('{"turnComplete":true}')).toEqual({
+      mentions: true,
+      dmReplies: true,
+      turnComplete: true,
+    });
+  });
+
+  it('refuses non-boolean values per key instead of resetting the set', () => {
+    expect(
+      parseNotifySettings('{"mentions":"yes","turnComplete":true,"junk":1}')
+    ).toEqual({ mentions: true, dmReplies: true, turnComplete: true });
+  });
+});
+
+describe('notify settings store', () => {
+  it('persists a toggle to localStorage', () => {
+    useNotifySettingsStore.getState().setNotifySetting('turnComplete', true);
+    expect(currentNotifySettings().turnComplete).toBe(true);
+    expect(parseNotifySettings(storage[NOTIFY_SETTINGS_KEY] ?? null)).toEqual({
+      mentions: true,
+      dmReplies: true,
+      turnComplete: true,
+    });
+  });
+
+  it('does not churn state for a no-op write', () => {
+    const before = currentNotifySettings();
+    useNotifySettingsStore.getState().setNotifySetting('mentions', true);
+    expect(currentNotifySettings()).toBe(before);
+  });
+
+  it('toggles each trigger independently', () => {
+    const { toggleNotifySetting } = useNotifySettingsStore.getState();
+    toggleNotifySetting('mentions');
+    toggleNotifySetting('turnComplete');
+    expect(currentNotifySettings()).toEqual({
+      mentions: false,
+      dmReplies: true,
+      turnComplete: true,
+    });
+  });
+
+  it('restores the defaults on reset', () => {
+    useNotifySettingsStore.getState().setNotifySetting('dmReplies', false);
+    useNotifySettingsStore.getState().resetNotifySettings();
+    expect(currentNotifySettings()).toEqual(DEFAULT_NOTIFY_SETTINGS);
+  });
+});


### PR DESCRIPTION
Channel notifications: an OS notification when an agent wants the operator, and
an in-app badge tier (favicon dot + tab title count) that needs no permission at
all. No new HTTP route and no new gateway verb — both triggers ride streams the
client already receives.

## Item 1 — signal derivation and gating (`8fa514cc`)

`frontend/src/lib/notify/signals.ts`, pure: no Notification API, no DOM, no
stores. Decides WHETHER something is worth telling the operator about and WHICH
tier it earns.

- Three reasons: `mention`, `dm-reply`, `turn-complete`. Mentions come from the
  server-computed `mentions` refs on `/channels`'s `lastMessage` (resolved over
  the FULL body, not the preview); DM replies from a derived `isDmChannel`;
  turn-complete from a real busy→idle edge on `channel-agent-status`.
- Five gates in order: operator setting → per-channel replay guard → read
  position (including a mark set on ANOTHER device, which is what #1308 slice 3
  made knowable) → open-and-focused suppression → tiering.
- OS tier is hidden-tab only, rate-limited to one notification per channel per
  60s, with a GLOBAL burst budget of 3 per 10s across all channels. Held-back
  channels are counted, not dropped, and reported as one collapsed digest.
- The clock and visibility are injected through `NotifyGateContext`, so every
  rate-limit case is deterministic rather than timer-driven.

## Item 2 — delivery surfaces (`a61bc11e`)

`notify/runtime.ts` (one process-wide gate + notifier), `os-notification.ts`,
`favicon-badge.ts`, `title-badge.ts`, `producers.ts`, `summary-watch.ts`,
`leader.ts`, `copy.ts`, plus `useNotifyDelivery` (mounted once from `App`) and
Settings › notifications.

- Both tiers fire from one place so they cannot disagree: the in-app flag
  always, the OS notification only when the gate marked it `os` AND this tab
  holds the cross-tab lease.
- The favicon dot and title count are derived from the badge store and the
  slice-3 read position — never from a second unread implementation. The title
  counts CHANNELS, not messages, so one chatty agent is not a permanent alarm.
- A narrowly-scoped `/channels` refresh covers the two lanes the rail cannot: a
  hidden tab (where the rail suppresses its own refetch) and a collapsed sidebar
  (where the rail is unmounted, so `invalidateQueries` refetches nothing).
- The BOOT SEED badges without notifying. The first payload describes everything
  that happened while the client was away; those rows are genuinely unread and
  earn their dot, but none of them is news worth a notification.

## Storm control

Three independent caps, because each one has a hole the others do not cover:

- **Per channel** — one OS notification per channel per 60s. A streaming agent
  cannot machine-gun the notification centre; held-back signals are counted and
  the next fire reports the run (`claude replied in impl 1308 · 3 new`).
- **Globally** — 3 per 10s across ALL channels. The per-channel limit says
  nothing about a pass that walks a whole `/channels` payload, and under the
  #1242 orchestrator epic (one DM channel per agent profile) a reconnect with
  fifteen fresh DM rows is fifteen untouched windows. That is the normal shape
  of a reconnect, not an edge case.
- **Per pass** — the overflow digest is coalesced into ONE `Notification`
  construction per producer pass. An eight-row burst produces four
  constructions: three per-channel plus one `5 channels have new messages`.
  The in-app badge tier is untouched throughout; every held-back channel still
  gets its dot.

## Multi-tab

Only the OS tier is elected. Two Relay tabs evaluate the same payload
independently, and `tag` replacement is scoped per page on several engines where
a replace can re-alert — so without an election the operator hears the same
reply twice and a burst raises the permission prompt once per tab.

The election is a timestamped lease in `localStorage` (`relay-notify-leader`,
15s), renewed by the very deliveries it guards: no timer, no background chatter,
and it expires on its own if the holder is frozen or killed rather than closed
cleanly. Where storage is unavailable (private-mode webview, non-DOM test env)
the lane degrades to "always leader" — single-tab behaviour, which never
silences a notification. A tab that loses the lease reports its event as
UNDELIVERED so the gate hands the rate-limit window back; a follower that later
becomes leader must not be sitting on slots it never spent.

The favicon dot and title count stay per-tab, because each tab draws its own
chrome.

## Privacy

- **No message text ever reaches a notification.** A channel transcript is not
  lock-screen material, and the row that triggered the signal is exactly the row
  most likely to be sensitive. Bodies are `<agent> replied in <channel>`, where
  the channel title is the operator's own text.
- **No raw actor ids.** The sender label is `senderShortLabel`'s output, the
  same one the rail renders (#1234: an actor id is not a name).
- **The digest names nothing** — no channel, no sender. Listing them one by one
  IS the storm it replaces.
- **Settings are device-local.** Unlike general's `Notifications` row (which
  writes `PUT /config` for the legacy per-session push lane), everything in
  Settings › notifications is `localStorage`: a notification preference belongs
  to THIS browser and the OS grant it holds. Nothing here registers a service
  worker; this slice adds no push infrastructure.
- No emoji anywhere in notification copy (DESIGN.md), including a body that
  renders on a lock screen next to whatever else the operator has running.

## Permission UX

**Never asked on load.** A prompt at boot is hostile: the operator has been
shown nothing yet, so they cannot judge the ask, and a reflexive "block" is
unrecoverable from inside the page.

The ask is armed from the first gate-approved event on a VISIBLE, FOCUSED tab.
That specific moment matters: `deliver`'s own lazy ask can only fire for an
OS-tier event, which by construction only exists while `document.hidden` —
precisely when Safari and Firefox refuse to prompt at all (both tie
`requestPermission` to user activation) and Chrome defers it. So the prompt is
raised from the same "something worth telling you about just happened" evidence,
delivered where it can actually land. At most one ungestured attempt per
notifier lifetime; a browser that refuses is not re-asked on every later event.

The boot seed is excluded. Settings › notifications carries the same grant
behind an explicit button for browsers that require a gesture, and shows the
live permission state. `denied` is treated as terminal from inside the page
rather than as askable, so the button never sits in a state that can never
change. Triggers default to mentions ON, DM replies ON, turn-complete OFF.

Everything except the OS tier works with no grant at all: dot, title count and
rail badges need no permission, so a `denied` browser still converges.

## Review trail

- `f1bef461` — first adversarial review. Closed a P1 permission/refresh deadlock
  (the hidden-tab refresh was gated on `granted`, but the only lane that can
  produce a payload while hidden refused to run until permission existed, and
  permission was only ever requested from an event that lane produced — the OS
  tier was unreachable on a fresh browser), plus the burst budget, the
  undelivered-event refund, the cross-tab lease, and badge pruning.
- `2d949319` — re-review (verdict: concern). Six defects the fix pass itself
  introduced, all applied here as branch-introduced regressions regardless of
  their P rating:
  1. **P2** — the burst digest constructed one `Notification` per held-back
     channel, so the capped path still made 15 constructions for the 15-DM
     scenario. Now coalesced to one per pass, carrying the largest count.
  2. **P3** — `refundOs` assigned the coalesce pile instead of adding to it,
     destroying signals that piled up while a permission prompt was open.
  3. **P3** — `refundOs` cleared the rate-limit window and popped the newest
     burst slot without checking they were the ones it charged. Events now carry
     `osChargedAt` and both ledgers are matched on it.
  4. **P3** — the 10s hidden cadence ran unconditionally, including on `denied`
     browsers and ones with no Notification API. The refresh stays
     permission-blind; the CADENCE does not.
  5. **P3** — the refresh window was chosen at schedule time while the stand-down
     was chosen at fire time. Both are now fire-time, re-arming for the
     remainder so the anti-starvation guarantee is unchanged.
  6. **P3** — badge pruning sat behind the notify guard, so deleting the LAST
     channel left its dot and title count pinned for the life of the tab.

Each of the six carries a test that fails without its fix — verified by
reverting each change and re-running (9 targeted failures across the four
files, then 1 more for the burst-slot case after that test was strengthened).

No P0/P1 findings remain open. No P2/P3 deferred as follow-ups.

## Verification

Exact head `2d949319046279091b56620eb15ea1c1858154b8`, Node v22.22.3.

- `npm run check` — **0 errors** (220 pre-existing `sonarjs` warnings repo-wide;
  none in any file this branch touches).
- `npm test` — **464 files / 5893 tests passed, 0 failed**, 80.98s.
  Two earlier runs each hit a single unrelated flake under load (load average
  17.8 on 8 cores): `FileFeedbackPanel.test.ts` on one run, `sessions.test.ts`
  timeout on the next — different file each time, neither touched by this
  branch. Per the S3 precedent a full-suite rerun beats isolation; the run above
  is a clean full suite taken after the load settled.
- New coverage: 51 cases in `notify-signals`, plus `notify-os-notification`,
  `notify-producers`, `notify-summary-watch`, `notify-delivery-hook`,
  `notify-badge-surfaces`, `notify-copy`, `notify-leader`, and the two store
  suites.

Refs #1308 (slice 5 — notifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser notifications for channel mentions, direct-message replies, and completed turns.
  * Added notification preferences in Settings, including browser permission controls.
  * Added unread attention indicators to the page title and favicon.
  * Notifications can open the relevant channel when selected.
  * Coordinated notification delivery across multiple open tabs.

* **Bug Fixes**
  * Improved mention detection using server-provided mention data, with legacy fallback support.
  * Prevented duplicate, stale, or excessive notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->