### PR TITLE
feat(channels): mid-turn steering — queued-for-next-turn + interrupt-and-send (#1308 slice 4)

### DIFF
--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -225,6 +225,39 @@ binding's FIFO queue, and the queue drains on turn completion.
   pending triggers but never loses messages — every queued post is already
   durable — and the operator re-triggers by sending again.
 
+#### Steering in the UI
+
+The composer is the steering surface. While a bound agent is mid-turn its bar
+reveals two explicit controls — no menu, no inference:
+
+- **queue** (also plain <kbd>enter</kbd>) posts with no steering field, so the
+  message waits for the live turn.
+- **interrupt & send** (also <kbd>cmd/ctrl</kbd>+<kbd>enter</kbd>) posts
+  `steering: "interrupt"`, reusing the header control's black-square vocabulary.
+  With no live turn the modifier is a plain send, never a silent variant.
+
+The thread panel's composer inherits both, because a threaded reply queues on
+exactly the same binding.
+
+Two read-back affordances make the wait visible:
+
+- the in-timeline presence row suffixes the agent's activity with
+  `(n queued)`, resolved from `queuedCount` on the same lane its status came
+  from (socket transition or roster snapshot, whichever is newer);
+- a message the operator sent into a busy agent grows a dim chip reading
+  `queued — <agent> is mid-turn`.
+
+**The chip's signal.** Steering intent is deliberately not persisted, so the
+durable row cannot say a message is waiting; the chip is client-side memory of
+the send. It is created from the send-time agent status and retired by a
+per-agent _drain generation_ derived from `queuedCount`: the generation advances
+on any transition that reports an empty queue, which is exactly what the binder
+emits when it splices the queued run out, immediately before the consuming turn
+starts. A send snapshots the generation before its POST and keeps the chip only
+while that snapshot is still current, so a turn that drains during the round trip
+leaves no chip behind. Both imprecisions fail toward silence: a send that queued
+can miss its chip, and one that was already consumed can never keep one.
+
 ## Limits and failure behavior
 
 - Message bodies and detail payloads are byte-bounded.

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -195,6 +195,36 @@ Channel controls include:
 - inspect roster availability and live status;
 - designate the channel orchestrator.
 
+### Mid-turn steering
+
+Posting to a channel whose bound profile is already mid-turn never opens a
+second concurrent turn and never drops the message. The post joins that
+binding's FIFO queue, and the queue drains on turn completion.
+
+- **Queue (default).** Every human post that arrived while the agent was busy
+  drains into ONE next turn. The newest of them is the trigger; the rest arrive
+  as context rows of the same packet, because the packet is rebuilt from the
+  durable message log. Three impatient messages cost one turn, not three.
+- **Interrupt and send.** The post route takes an explicit `steering:
+  "interrupt"` body field. It cancels the live turn through the same interrupt
+  path the header control uses — the partial reply finalizes `interrupted` — and
+  the new message triggers as soon as that turn releases. Steering is never
+  inferred from message text.
+- **Agent posts never steer.** Sender attribution is server-derived, so an
+  agent (including a CLI-gateway actor) cannot cancel another agent's turn, and
+  agent-authored triggers are never coalesced away. Agent fan-out stays bounded
+  by the consecutive-agent-turn brake.
+- **Queue cap.** The per-binding cap still bounds distinct queued turns. An
+  over-cap post that would have coalesced with the queue tail supersedes it
+  instead of being refused — same trigger, same packet — so fast operator typing
+  is never announced as dropped. Anything the tail cannot represent (another
+  thread, an agent-authored trigger) still produces the explicit drop row.
+- **Observability.** The `channel-agent-status` event and the roster's
+  `binding` object both carry `queuedCount`.
+- **Restart.** The queue is in-memory turn-trigger state. A hub restart loses
+  pending triggers but never loses messages — every queued post is already
+  durable — and the operator re-triggers by sending again.
+
 ## Limits and failure behavior
 
 - Message bodies and detail payloads are byte-bounded.

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -201,15 +201,24 @@ Posting to a channel whose bound profile is already mid-turn never opens a
 second concurrent turn and never drops the message. The post joins that
 binding's FIFO queue, and the queue drains on turn completion.
 
-- **Queue (default).** Every human post that arrived while the agent was busy
-  drains into ONE next turn. The newest of them is the trigger; the rest arrive
-  as context rows of the same packet, because the packet is rebuilt from the
+- **Queue (default).** Human posts that arrived while the agent was busy drain
+  into ONE next turn. The newest of them is the trigger; the rest arrive as
+  context rows of the same packet, because the packet is rebuilt from the
   durable message log. Three impatient messages cost one turn, not three.
-- **Interrupt and send.** The post route takes an explicit `steering:
-  "interrupt"` body field. It cancels the live turn through the same interrupt
-  path the header control uses — the partial reply finalizes `interrupted` — and
-  the new message triggers as soon as that turn releases. Steering is never
-  inferred from message text.
+- **What never coalesces.** Coalescing folds older posts into a newer one's
+  packet, so it only applies where that fold is lossless. A run stops at a post
+  from another thread scope, an agent-authored post, a post whose sequence
+  number is not strictly newer than the run's head (a send retried after a
+  transport failure is re-queued behind newer posts, and must not swallow
+  them), or a post carrying **image attachments** — the per-packet image budget
+  is per packet, not per message, so an image-bearing post keeps
+  one-trigger-one-turn and its own budget. Anything the run stops at simply
+  drains on the following completion.
+- **Interrupt and send.** The post route takes an explicit `steering` body
+  field set to `"interrupt"`. It cancels the live turn through the same
+  interrupt path the header control uses — the partial reply finalizes
+  `interrupted` — and the new message triggers as soon as that turn releases.
+  Steering is never inferred from message text.
 - **Agent posts never steer.** Sender attribution is server-derived, so an
   agent (including a CLI-gateway actor) cannot cancel another agent's turn, and
   agent-authored triggers are never coalesced away. Agent fan-out stays bounded
@@ -217,8 +226,13 @@ binding's FIFO queue, and the queue drains on turn completion.
 - **Queue cap.** The per-binding cap still bounds distinct queued turns. An
   over-cap post that would have coalesced with the queue tail supersedes it
   instead of being refused — same trigger, same packet — so fast operator typing
-  is never announced as dropped. Anything the tail cannot represent (another
-  thread, an agent-authored trigger) still produces the explicit drop row.
+  is never announced as dropped. Anything the tail cannot represent — see "what
+  never coalesces" above — still produces the explicit drop row.
+- **Idempotent replay still steers.** The post route dedupes on
+  `clientMessageId`, and the composer keeps that id after a failed send. A
+  replay that carries `steering` therefore applies the interrupt to the
+  already-persisted row rather than swallowing it; the message is not re-routed,
+  because it is already queued.
 - **Observability.** The `channel-agent-status` event and the roster's
   `binding` object both carry `queuedCount`.
 - **Restart.** The queue is in-memory turn-trigger state. A hub restart loses
@@ -256,7 +270,9 @@ emits when it splices the queued run out, immediately before the consuming turn
 starts. A send snapshots the generation before its POST and keeps the chip only
 while that snapshot is still current, so a turn that drains during the round trip
 leaves no chip behind. Both imprecisions fail toward silence: a send that queued
-can miss its chip, and one that was already consumed can never keep one.
+can miss its chip, and one that was already consumed can never keep one. Marks
+are swept on every insert, so the client's memory of them is bounded by sends
+still waiting rather than by session length.
 
 ## Limits and failure behavior
 

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -208,12 +208,20 @@ binding's FIFO queue, and the queue drains on turn completion.
 - **What never coalesces.** Coalescing folds older posts into a newer one's
   packet, so it only applies where that fold is lossless. A run stops at a post
   from another thread scope, an agent-authored post, a post whose sequence
-  number is not strictly newer than the run's head (a send retried after a
-  transport failure is re-queued behind newer posts, and must not swallow
-  them), or a post carrying **image attachments** — the per-packet image budget
-  is per packet, not per message, so an image-bearing post keeps
-  one-trigger-one-turn and its own budget. Anything the run stops at simply
-  drains on the following completion.
+  number is not strictly newer than the run's head, or a post carrying **image
+  attachments** — the per-packet image budget is per packet, not per message, so
+  an image-bearing post keeps one-trigger-one-turn and its own budget. Anything
+  the run stops at simply drains on the following completion.
+- **Re-queued sends never coalesce, in either direction.** A send retried after
+  a transport failure is re-queued behind whatever arrived meanwhile, and the
+  turn that displaced it has already advanced the binding's delivery cursor past
+  its sequence number. Context rows are selected with `seq > lastDeliveredSeq`,
+  so such a post cannot survive as a context row of anyone else's packet — it
+  would be neither trigger nor context and would vanish. It therefore always
+  triggers its own turn, where the packet footer renders it unconditionally,
+  whether it sits at the head of a would-be run or in the middle of one. At the
+  queue cap it is never superseded and never supersedes; that case takes the
+  explicit drop row instead.
 - **Interrupt and send.** The post route takes an explicit `steering` body
   field set to `"interrupt"`. It cancels the live turn through the same
   interrupt path the header control uses — the partial reply finalizes
@@ -232,7 +240,10 @@ binding's FIFO queue, and the queue drains on turn completion.
   `clientMessageId`, and the composer keeps that id after a failed send. A
   replay that carries `steering` therefore applies the interrupt to the
   already-persisted row rather than swallowing it; the message is not re-routed,
-  because it is already queued.
+  because it is already queued. The replay skips a binding whose live turn was
+  triggered by that same message: if it drained between the two posts, the turn
+  now running IS the operator's answer, and cancelling it would be the opposite
+  of what they asked for.
 - **Observability.** The `channel-agent-status` event and the roster's
   `binding` object both carry `queuedCount`.
 - **Restart.** The queue is in-memory turn-trigger state. A hub restart loses

--- a/frontend/src/components/chat/ChannelComposer.css
+++ b/frontend/src/components/chat/ChannelComposer.css
@@ -165,6 +165,51 @@
   opacity: 0.4;
 }
 
+/* mid-turn steering cluster (#1308 slice 4). Outline-only, zero radius, mono,
+   lowercase — DESIGN.md buttons. Ghost for the queueing default, danger tint for
+   the member that cancels a live turn, so the destructive one is legible at rest
+   without a confirm step. */
+.ch-composer__steer {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ch-composer__steer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  cursor: pointer;
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
+.ch-composer__steer-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.ch-composer__steer-btn--interrupt {
+  border-color: color-mix(in srgb, var(--status-error) 50%, transparent);
+  color: var(--status-error);
+}
+
+.ch-composer__steer-btn--interrupt:hover {
+  border-color: var(--status-error);
+  color: var(--status-error);
+  background: color-mix(in srgb, var(--status-error) 10%, transparent);
+}
+
 .ch-composer__hint kbd {
   border: 1px solid var(--border);
   padding: 0 4px;
@@ -213,6 +258,12 @@
   .ch-composer__bar {
     gap: 4px;
     padding: 3px 4px;
+  }
+
+  /* Touch has no cmd+enter, so the two explicit steering controls carry the
+     whole feature there and the keyboard hint is dropped rather than wrapped. */
+  .ch-composer__steer ~ .ch-composer__hint {
+    display: none;
   }
 
   .ch-composer__attachments {

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -11,6 +11,7 @@ import type {
   ChannelImagePart,
   ChannelMemberRef,
   ChannelMessagePart,
+  ChannelPostSteering,
 } from '../../../../shared/channel-chat-protocol.js';
 import {
   filterMentionContacts,
@@ -33,6 +34,14 @@ const ALLOWED_IMAGE_MIMES = new Set([
 export const CHANNEL_COMPOSER_MAX_IMAGES = 4;
 export const CHANNEL_COMPOSER_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
+/** Tooltip for the queueing default — names who the message is waiting on. */
+function queuedSendHint(busyAgentLabels: readonly string[]): string {
+  const first = busyAgentLabels[0];
+  return busyAgentLabels.length === 1 && first
+    ? `queue behind ${first}'s turn`
+    : 'queue behind the current turn';
+}
+
 interface PendingImage {
   localId: string;
   file: File;
@@ -53,8 +62,16 @@ interface ChannelComposerProps {
   onSend: (
     text: string,
     clientMessageId: string,
-    parts: ChannelMessagePart[]
+    parts: ChannelMessagePart[],
+    steering?: ChannelPostSteering
   ) => Promise<void>;
+  /**
+   * Labels of the bound agents that are mid-turn right now (#1308 slice 4).
+   * Non-empty reveals the steering cluster: the default send QUEUES behind the
+   * live turn, and an explicit second control interrupts it first. Omitted on
+   * surfaces with no status signal, which simply keeps the plain composer.
+   */
+  busyAgentLabels?: readonly string[];
   postPending: boolean;
   /** 503 CHANNEL_STORE_UNAVAILABLE — persistent inline banner, input stays live. */
   storeDown: boolean;
@@ -70,6 +87,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   placeholder,
   members,
   onSend,
+  busyAgentLabels,
   postPending,
   storeDown,
   archived,
@@ -259,51 +277,58 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     if (el) setCaret(el.selectionStart ?? 0);
   }, []);
 
-  const submit = useCallback(() => {
-    const content = draft.trim();
-    if (sendingRef.current) return;
-    if (images.some((image) => image.status === 'uploading')) {
-      setAttachmentError('wait for image uploads to finish');
-      return;
-    }
-    if (images.some((image) => image.status === 'failed')) {
-      setAttachmentError('retry or remove failed images before sending');
-      return;
-    }
-    const parts = images.flatMap((image) => (image.part ? [image.part] : []));
-    if (!content && parts.length === 0) return;
-    const submittedImageIds = new Set(images.map((image) => image.localId));
-    const submittedImages = images;
-    if (!clientIdRef.current) clientIdRef.current = createBrowserId('chm');
-    const clientMessageId = clientIdRef.current;
-    sendingRef.current = true;
-    void onSend(content, clientMessageId, parts)
-      .then(() => {
-        // Success: the row arrives via the socket, not this promise. Reset the
-        // draft and idempotency key so the next message is a fresh attempt.
-        clientIdRef.current = null;
-        setDraft('');
-        setCaret(0);
-        for (const image of submittedImages) revokePreview(image);
-        updateImages((current) =>
-          current.filter((image) => !submittedImageIds.has(image.localId))
-        );
-        if (
-          imagesRef.current.every((image) =>
-            submittedImageIds.has(image.localId)
-          )
-        ) {
-          setAttachmentError(null);
-        }
-      })
-      .catch(() => {
-        // Keep the draft AND the same clientMessageId so a retry (press enter
-        // again) dedupes server-side instead of double-posting.
-      })
-      .finally(() => {
-        sendingRef.current = false;
-      });
-  }, [draft, images, onSend, revokePreview, updateImages]);
+  // #1308 slice 4 item 2b. `busy` is what turns the bar into a steering cluster;
+  // it is derived from the caller's live status signal, never from the draft.
+  const busy = (busyAgentLabels?.length ?? 0) > 0;
+
+  const submit = useCallback(
+    (steering?: ChannelPostSteering) => {
+      const content = draft.trim();
+      if (sendingRef.current) return;
+      if (images.some((image) => image.status === 'uploading')) {
+        setAttachmentError('wait for image uploads to finish');
+        return;
+      }
+      if (images.some((image) => image.status === 'failed')) {
+        setAttachmentError('retry or remove failed images before sending');
+        return;
+      }
+      const parts = images.flatMap((image) => (image.part ? [image.part] : []));
+      if (!content && parts.length === 0) return;
+      const submittedImageIds = new Set(images.map((image) => image.localId));
+      const submittedImages = images;
+      if (!clientIdRef.current) clientIdRef.current = createBrowserId('chm');
+      const clientMessageId = clientIdRef.current;
+      sendingRef.current = true;
+      void onSend(content, clientMessageId, parts, steering)
+        .then(() => {
+          // Success: the row arrives via the socket, not this promise. Reset the
+          // draft and idempotency key so the next message is a fresh attempt.
+          clientIdRef.current = null;
+          setDraft('');
+          setCaret(0);
+          for (const image of submittedImages) revokePreview(image);
+          updateImages((current) =>
+            current.filter((image) => !submittedImageIds.has(image.localId))
+          );
+          if (
+            imagesRef.current.every((image) =>
+              submittedImageIds.has(image.localId)
+            )
+          ) {
+            setAttachmentError(null);
+          }
+        })
+        .catch(() => {
+          // Keep the draft AND the same clientMessageId so a retry (press enter
+          // again) dedupes server-side instead of double-posting.
+        })
+        .finally(() => {
+          sendingRef.current = false;
+        });
+    },
+    [draft, images, onSend, revokePreview, updateImages]
+  );
 
   // Splice the selected SELECTABLE contact into the draft as plain mention text
   // (no rich pill), replacing the active trigger span. The inserted text
@@ -370,10 +395,17 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       lineBreakGuardRef.current.reset();
       if (e.key === 'Enter') {
         e.preventDefault();
-        submit();
+        // #1308 slice 4 item 2b. Enter keeps its one meaning (send); the
+        // modifier only changes what happens to the agent's LIVE turn, and only
+        // while there is one — cmd/ctrl+enter on an idle channel is a plain
+        // send, never a silently-different action. No conflict: the composer's
+        // own bindings are enter / shift+enter / palette arrows / tab / escape,
+        // and no global handler claims cmd+enter.
+        if ((e.metaKey || e.ctrlKey) && busy) submit('interrupt');
+        else submit();
       }
     },
-    [paletteVisible, entries, activeIndex, applyMention, submit]
+    [paletteVisible, entries, activeIndex, applyMention, busy, submit]
   );
 
   // Mobile IME parity: some IMEs only report a beforeinput line-break intent for
@@ -563,8 +595,48 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         >
           +img
         </button>
+        {busy ? (
+          // Mid-turn steering cluster (#1308 slice 4 item 2b). Two EXPLICIT
+          // actions, no menu and no inference: the default send queues behind
+          // the live turn (the operator's row grows a "queued" chip), and the
+          // second one cancels that turn first. It reuses the header chip's
+          // interrupt glyph — the black square is already the one interrupt
+          // vocabulary in the product — with danger-tinted chrome so the
+          // destructive member of the pair reads differently at rest.
+          <span
+            className="ch-composer__steer"
+            role="group"
+            aria-label="mid-turn steering"
+          >
+            <button
+              type="button"
+              className="ch-composer__steer-btn"
+              onClick={() => submit()}
+              title={queuedSendHint(busyAgentLabels ?? [])}
+            >
+              queue
+            </button>
+            <button
+              type="button"
+              className="ch-composer__steer-btn ch-composer__steer-btn--interrupt"
+              onClick={() => submit('interrupt')}
+              aria-label="interrupt and send"
+              title="interrupt and send"
+            >
+              <span aria-hidden="true">■</span> interrupt &amp; send
+            </button>
+          </span>
+        ) : null}
         <span className="ch-composer__hint">
-          <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline <kbd>@</kbd>mention
+          {busy ? (
+            <>
+              <kbd>↵</kbd>queue <kbd>⌘↵</kbd>interrupt <kbd>⇧↵</kbd>newline
+            </>
+          ) : (
+            <>
+              <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline <kbd>@</kbd>mention
+            </>
+          )}
         </span>
       </div>
     </div>

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -17,6 +17,7 @@ import { createLineBreakSubmitGuard } from './composerInput.js';
 import { respondChannelApproval } from '../../lib/api.js';
 import { buildChannelMessageLink } from '../../lib/url-nav.js';
 import { showToast } from '../../lib/stores/toasts.js';
+import { useQueuedSendNotice } from '../../lib/stores/channel-queued-sends.js';
 
 /** Touch hold before the action toolbar pins open, matching `Terminal.tsx`. */
 const LONG_PRESS_MS = 500;
@@ -647,12 +648,30 @@ const MessageRowTrailer: React.FC<{
   replyCount: number;
   lastReplyHint?: string;
   onOpenThread?: (rootId: ChannelMessageId) => void;
-}> = ({ message, retry, replyCount, lastReplyHint, onOpenThread }) => {
+  /** #1308 slice 4 item 2a: "queued — <agent> is mid-turn", or null. */
+  queuedNotice?: string | null;
+}> = ({
+  message,
+  retry,
+  replyCount,
+  lastReplyHint,
+  onOpenThread,
+  queuedNotice = null,
+}) => {
   const truncationLabel = truncationLabelForMessage(message);
   const showThreadChip =
     message.threadId === null && replyCount > 0 && onOpenThread !== undefined;
   return (
     <>
+      {queuedNotice ? (
+        // The one thing the durable row cannot say: this message reached a busy
+        // agent and is waiting for its next turn. Steering intent is never
+        // persisted, so this is client-side memory of the send — see
+        // `channel-queued-sends`.
+        <span className="ch-msg__tag ch-msg__tag--queued" role="status">
+          {queuedNotice}
+        </span>
+      ) : null}
       {message.status === 'interrupted' ? (
         <span className="ch-msg__tag ch-msg__tag--interrupted">
           interrupted
@@ -765,6 +784,10 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   const streaming = message.status === 'streaming';
   const rowRef = useRef<HTMLDivElement>(null);
   const { actionsVisible, ...affordance } = useRowActionAffordance(rowRef);
+  // Read from the store rather than drilled down the timeline: the same row
+  // component renders in the main lane and the thread panel, and only one of
+  // those two paths would otherwise have been wired (#1308 slice 4 item 2d).
+  const queuedNotice = useQueuedSendNotice(message.id);
   const [retryPending, setRetryPending] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editPending, setEditPending] = useState(false);
@@ -939,6 +962,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
         message={message}
         retry={retry}
         replyCount={replyCount}
+        queuedNotice={queuedNotice}
         {...(lastReplyHint ? { lastReplyHint } : {})}
         {...(onOpenThread ? { onOpenThread } : {})}
       />

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -3,6 +3,7 @@ import type {
   ChannelMessage,
   ChannelMessageId,
   ChannelMessagePart,
+  ChannelPostSteering,
 } from '../../../../shared/channel-chat-protocol.js';
 import { useChannelThread } from '../../hooks/useChannelThread.js';
 import {
@@ -40,8 +41,16 @@ interface ChannelThreadPanelProps {
   onSend: (
     text: string,
     clientMessageId: string,
-    parts: ChannelMessagePart[]
+    parts: ChannelMessagePart[],
+    steering?: ChannelPostSteering
   ) => Promise<void>;
+  /**
+   * Busy agent labels for the thread composer's steering cluster (#1308 slice
+   * 4 item 2d). The thread lane has its OWN send path (`threadId` is attached
+   * there, not in the composer), so it has to be handed the signal explicitly —
+   * a reply into a busy agent queues exactly like a top-level message.
+   */
+  busyAgentLabels?: readonly string[];
   postPending: boolean;
   storeDown: boolean;
   archived: boolean;
@@ -58,6 +67,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
   liveMessages,
   onClose,
   onSend,
+  busyAgentLabels,
   postPending,
   storeDown,
   archived,
@@ -237,6 +247,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
         channelTitle={channelTitle}
         placeholder={isDm ? DM_THREAD_PLACEHOLDER : THREAD_PLACEHOLDER}
         onSend={onSend}
+        {...(busyAgentLabels ? { busyAgentLabels } : {})}
         postPending={postPending}
         storeDown={storeDown}
         archived={archived}

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -738,6 +738,13 @@
   color: var(--text-muted);
 }
 
+/* queued-send chip (#1308 slice 4). Dim by design: it reports a wait, not a
+   fault, and it retires itself the moment the next turn starts consuming. */
+.ch-msg__tag--queued {
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
 /* Inline retry on a failed row (#1308 item 2). Outline-only, square, mono —
    same control vocabulary as the thread chip, tinted to the failure it recovers
    from. No motion: the pending state is a text swap (`retry` → `retrying…`),

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -9,6 +9,7 @@ import type {
   ChannelMessage,
   ChannelMessageId,
   ChannelMessagePart,
+  ChannelPostSteering,
 } from '../../../../shared/channel-chat-protocol.js';
 import { builtInAgentProfileId } from '../../../../shared/agent-profile.js';
 import type { AgentRole } from '../../../../shared/agent-roster.js';
@@ -39,8 +40,14 @@ import {
 import {
   channelAgentStatusKey,
   resolveEffectiveAgentStatus,
+  resolveEffectiveQueuedCount,
   useChannelAgentStatusStore,
 } from '../../lib/stores/channel-agent-status.js';
+import {
+  queuedSendCopy,
+  snapshotQueueDrainSeqs,
+  useChannelQueuedSendsStore,
+} from '../../lib/stores/channel-queued-sends.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { showToast } from '../../lib/stores/toasts.js';
 import { AgentBadge } from '../AgentBadge.js';
@@ -193,31 +200,95 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
 
   const [designatePending, setDesignatePending] = useState(false);
 
+  /**
+   * The busy agents this view would be steering RIGHT NOW, mirrored at render
+   * time (same discipline as `lastSeqRef` above) so the send callbacks can read
+   * the current set without being rebuilt on every status transition. Assigned
+   * further down, once `agentChips` exists.
+   */
+  const steerTargetsRef = useRef<{ agentIds: string[]; labels: string[] }>({
+    agentIds: [],
+    labels: [],
+  });
+
+  /**
+   * One send path for both composers (#1308 slice 4 item 2). It carries the
+   * operator's explicit steering choice to the post route AND owns the queued
+   * chip's bookkeeping, because this is the only place that knows both what the
+   * agent was doing when the message left and which durable row it became.
+   */
+  const postSteered = useCallback(
+    async (
+      text: string,
+      clientMessageId: string,
+      parts: ChannelMessagePart[],
+      steering: ChannelPostSteering | undefined,
+      threadId: ChannelMessageId | null
+    ) => {
+      const targets = steerTargetsRef.current;
+      const statusStore = useChannelAgentStatusStore.getState();
+      // Snapshot BEFORE the round trip: a turn that drains while the POST is in
+      // flight must not leave a chip behind on a message it already consumed.
+      const drainSeqs = snapshotQueueDrainSeqs(
+        channelId,
+        targets.agentIds,
+        statusStore.queueDrainSeqByChannelAgent
+      );
+      const message = await post(text, {
+        clientMessageId,
+        parts,
+        ...(threadId !== null ? { threadId } : {}),
+        ...(steering ? { steering } : {}),
+      });
+      // Nothing was busy → nothing to wait behind. An explicit interrupt is not
+      // a wait either: the operator asked for the live turn to be cancelled, so
+      // announcing the message as "queued" would describe the opposite of what
+      // they chose.
+      if (targets.agentIds.length === 0 || steering === 'interrupt') return;
+      const current =
+        useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent;
+      for (const [key, seq] of Object.entries(drainSeqs)) {
+        if ((current[key] ?? 0) !== seq) return;
+      }
+      useChannelQueuedSendsStore.getState().markQueuedSend(message.id, {
+        channelId,
+        agentIds: targets.agentIds,
+        label: queuedSendCopy(targets.labels),
+        drainSeqs,
+      });
+    },
+    [channelId, post]
+  );
+
   const handleSend = useCallback(
     async (
       text: string,
       clientMessageId: string,
-      parts: ChannelMessagePart[]
+      parts: ChannelMessagePart[],
+      steering?: ChannelPostSteering
     ) => {
-      await post(text, { clientMessageId, parts });
+      await postSteered(text, clientMessageId, parts, steering, null);
     },
-    [post]
+    [postSteered]
   );
 
   const handleThreadSend = useCallback(
     async (
       text: string,
       clientMessageId: string,
-      parts: ChannelMessagePart[]
+      parts: ChannelMessagePart[],
+      steering?: ChannelPostSteering
     ) => {
       if (activeThreadRootId === null) return;
-      await post(text, {
+      await postSteered(
+        text,
         clientMessageId,
-        threadId: activeThreadRootId,
         parts,
-      });
+        steering,
+        activeThreadRootId
+      );
     },
-    [activeThreadRootId, post]
+    [activeThreadRootId, postSteered]
   );
 
   const hasTopLevelMessages = reducer.messages.some(
@@ -427,6 +498,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const statusUpdatedAtMap = useChannelAgentStatusStore(
     (s) => s.updatedAtByChannelAgent
   );
+  const queuedCountMap = useChannelAgentStatusStore(
+    (s) => s.queuedCountByChannelAgent
+  );
 
   // On channel switch, drop this channel's per-agent socket statuses so the
   // freshly-fetched roster is authoritative on open; live transitions repopulate
@@ -434,8 +508,17 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   // never ran and a stale busy chip could survive a channel round-trip (#1167).
   useEffect(() => {
     const { clearChannel } = useChannelAgentStatusStore.getState();
+    const clearQueuedSends = useChannelQueuedSendsStore.getState().clearChannel;
     clearChannel(channelId);
-    return () => clearChannel(channelId);
+    // Queued-send marks are anchored to drain generations that this very reset
+    // discards, so they must go with them — otherwise a mark snapshotted at
+    // generation N would match the fresh zero of a re-entered channel and light
+    // a chip for a send that has long since been answered (#1308 slice 4).
+    clearQueuedSends(channelId);
+    return () => {
+      clearChannel(channelId);
+      clearQueuedSends(channelId);
+    };
   }, [channelId]);
 
   const streamingProfileProviders = useMemo(() => {
@@ -485,6 +568,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       agentId: string;
       status: ChannelAgentStatus;
       role?: AgentRole;
+      queuedCount: number;
       identity: ReturnType<typeof resolveSenderIdentity>;
     }> = [];
     for (const agentId of candidateIds) {
@@ -497,6 +581,14 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         rosterStatus: entry?.binding?.status,
         rosterUpdatedAt,
         streaming,
+      });
+      // Same lane the status came from (#1308 slice 4 item 2c), so the presence
+      // row can never pair a live status with a stale count or the reverse.
+      const queuedCount = resolveEffectiveQueuedCount({
+        socketQueuedCount: queuedCountMap[key],
+        socketUpdatedAt: statusUpdatedAtMap[key],
+        rosterQueuedCount: entry?.binding?.queuedCount,
+        rosterUpdatedAt,
       });
       // Show a chip for a bound agent (even when idle) or one that is currently
       // active/streaming — but drop an unbound agent whose only signal is a stale
@@ -513,6 +605,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       chips.push({
         agentId,
         status,
+        queuedCount,
         ...(entry?.role ? { role: entry.role } : {}),
         identity,
       });
@@ -523,6 +616,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     rosterUpdatedAt,
     statusMap,
     statusUpdatedAtMap,
+    queuedCountMap,
     streamingProfileProviders,
     channelId,
   ]);
@@ -551,6 +645,21 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     }
     return ids;
   }, [agentChips]);
+
+  // #1308 slice 4 item 2b. The composer's steering cluster keys on the SAME chip
+  // signal, so what the composer offers and what the header says the agent is
+  // doing can never disagree.
+  const busyAgentLabels = useMemo(
+    () =>
+      agentChips
+        .filter((chip) => chip.status !== 'idle')
+        .map((chip) => chip.identity.label),
+    [agentChips]
+  );
+  steerTargetsRef.current = {
+    agentIds: [...busyAgentIds],
+    labels: busyAgentLabels,
+  };
 
   // Wired only while the channel is live, exactly like edit/delete below: a
   // retry re-runs a turn against an archived (read-only) channel, so the route
@@ -848,6 +957,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             {...(dmPlaceholder ? { placeholder: dmPlaceholder } : {})}
             {...(channel?.members ? { members: channel.members } : {})}
             onSend={handleSend}
+            busyAgentLabels={busyAgentLabels}
             postPending={postPending}
             storeDown={storeDown}
             archived={archived}
@@ -866,6 +976,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             liveMessages={reducer.messages}
             onClose={() => setActiveThreadRootId(null)}
             onSend={handleThreadSend}
+            busyAgentLabels={busyAgentLabels}
             postPending={postPending}
             storeDown={storeDown}
             archived={archived}

--- a/frontend/src/hooks/useChannelChatSocket.ts
+++ b/frontend/src/hooks/useChannelChatSocket.ts
@@ -7,6 +7,7 @@ import {
   mergeHistoryPage,
   type ChannelMessage,
   type ChannelMessagePart,
+  type ChannelPostSteering,
   type ChannelReducerState,
 } from '../../../shared/channel-chat-protocol.js';
 import {
@@ -70,6 +71,8 @@ export interface UseChannelChatSocketState {
       clientMessageId?: string;
       threadId?: string;
       parts?: ChannelMessagePart[];
+      /** #1308 slice 4: `'interrupt'` cancels the agent's live turn first. */
+      steering?: ChannelPostSteering;
     }
   ) => Promise<ChannelMessage>;
   postPending: boolean;
@@ -411,6 +414,7 @@ export function useChannelChatSocket(
         clientMessageId?: string;
         threadId?: string;
         parts?: ChannelMessagePart[];
+        steering?: ChannelPostSteering;
       }
     ): Promise<ChannelMessage> => {
       const cid = channelIdRef.current;
@@ -427,6 +431,7 @@ export function useChannelChatSocket(
           clientMessageId,
           ...(opts?.parts !== undefined ? { parts: opts.parts } : {}),
           ...(opts?.threadId !== undefined ? { threadId: opts.threadId } : {}),
+          ...(opts?.steering !== undefined ? { steering: opts.steering } : {}),
         });
       } catch (err) {
         if (err instanceof HttpError) setPostError(err);

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -645,9 +645,15 @@ export function useEventSocket({
           useChannelAgentStatusStore.getState().statusByChannelAgent[
             channelAgentStatusKey(msg.channelId, msg.agentId)
           ];
-        useChannelAgentStatusStore
-          .getState()
-          .recordStatus(msg.channelId, msg.agentId, msg.status, msg.runtimeId);
+        useChannelAgentStatusStore.getState().recordStatus(
+          msg.channelId,
+          msg.agentId,
+          msg.status,
+          msg.runtimeId,
+          // A hub that predates #1308 slice 4 omits the field; absent means
+          // "nothing queued", which is also what an unqueued binding reports.
+          msg.queuedCount ?? 0
+        );
         // #1308 slice 5: the ONE trigger the socket carries end to end. Default
         // OFF, so this is inert until the operator opts in from Settings.
         const notifyChannel = cachedNotifyChannel(queryClient, msg.channelId);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1814,7 +1814,9 @@ export async function fetchChannels(): Promise<ChannelSummaryView[]> {
  * Single-operator device sync (#1231): the payload carries no reader identity
  * because there is only ever one reader. This is not a read receipt.
  */
-export async function fetchChannelReadState(): Promise<ChannelReadStateEntry[]> {
+export async function fetchChannelReadState(): Promise<
+  ChannelReadStateEntry[]
+> {
   const data = await json<ChannelReadStateResponse>(
     await fetch('/channels/read-state', {
       headers: { 'x-relay-capabilities': 'context:read' },
@@ -2007,6 +2009,11 @@ export async function postChannelMessage(
     threadId?: string;
     parentMessageId?: string;
     clientMessageId: string;
+    /**
+     * Explicit mid-turn steering (#1308 slice 4). Omitted queues the post behind
+     * the agent's live turn; `'interrupt'` cancels that turn and sends now.
+     */
+    steering?: 'interrupt';
   }
 ): Promise<ChannelMessage> {
   const data = await json<{ message: ChannelMessage }>(
@@ -2093,7 +2100,15 @@ export interface RosterEntry {
   /** Present for a bound runtime when its collaboration role is known. */
   role?: AgentRole;
   /** Present when a live runtime is bound to this agent in the channel. */
-  binding: { runtimeId: string; status: ChannelAgentStatus } | null;
+  binding: {
+    runtimeId: string;
+    status: ChannelAgentStatus;
+    /**
+     * Posts waiting to trigger this agent's NEXT turn (#1308 slice 4).
+     * Optional so an older hub's roster still parses; absent means zero.
+     */
+    queuedCount?: number;
+  } | null;
 }
 
 export async function fetchChannelRoster(

--- a/frontend/src/lib/chat/channel-agent-presence.ts
+++ b/frontend/src/lib/chat/channel-agent-presence.ts
@@ -39,6 +39,8 @@ export interface ChannelAgentPresence {
   /** `var(--sender-*)` token or hash-derived hex from `resolveSenderIdentity`. */
   colorVar: string;
   glyph: KnownAgentGlyph | null;
+  /** Posts waiting to trigger this agent's NEXT turn (#1308 slice 4). */
+  queuedCount: number;
 }
 
 /** Minimal shape of the header chips this projection consumes. */
@@ -46,6 +48,8 @@ export interface ChannelPresenceChip {
   agentId: string;
   status: ChannelAgentStatus;
   identity: { label: string; colorVar: string; glyph: KnownAgentGlyph | null };
+  /** Absent on surfaces that predate the queue signal — treated as zero. */
+  queuedCount?: number;
 }
 
 /** Membership probe — satisfied by both `Set` and `Map` of agent ids. */
@@ -71,6 +75,7 @@ export function selectChannelAgentPresence(
       label: chip.identity.label,
       colorVar: chip.identity.colorVar,
       glyph: chip.identity.glyph,
+      queuedCount: chip.queuedCount ?? 0,
     });
   }
   return rows;
@@ -142,10 +147,25 @@ export function sameStreamingHold(
 
 /** Lowercase presence copy per DESIGN.md — dim secondary text, no emoji. */
 export function channelPresenceCopy(presence: ChannelAgentPresence): string {
-  if (presence.status === 'streaming') return `${presence.label} is responding…`;
+  return `${presenceActivityCopy(presence)}${queuedSuffix(presence.queuedCount)}`;
+}
+
+function presenceActivityCopy(presence: ChannelAgentPresence): string {
+  if (presence.status === 'streaming')
+    return `${presence.label} is responding…`;
   if (presence.status === 'waiting')
     return `${presence.label} is waiting for input`;
   // spawning and thinking read the same to an operator: the agent has the turn
   // and nothing has come back yet.
   return `${presence.label} is thinking…`;
+}
+
+/**
+ * "(n queued)" tail (#1308 slice 4 item 2c). The presence row is the one place
+ * that already says what the agent is doing, so the depth of what is waiting
+ * behind it belongs here rather than in a control of its own. Suffix only —
+ * an empty queue leaves the sentence exactly as it was.
+ */
+function queuedSuffix(queuedCount: number): string {
+  return queuedCount > 0 ? ` (${queuedCount} queued)` : '';
 }

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -20,6 +20,26 @@ interface ChannelAgentStatusState {
   /** Backing runtime id per `${channelId} ${agentId}` (null when unbound). */
   runtimeByChannelAgent: Record<string, string | null>;
   /**
+   * Posts waiting to trigger this binding's NEXT turn (#1308 slice 4), per
+   * `${channelId} ${agentId}`. Absent means the socket has said nothing yet —
+   * NOT zero, so the roster snapshot can still win the reconciliation.
+   */
+  queuedCountByChannelAgent: Record<string, number>;
+  /**
+   * Monotonic "this agent's trigger queue was observed empty" generation, per
+   * `${channelId} ${agentId}` (#1308 slice 4).
+   *
+   * The queued-send chip needs an edge, not a level: `queuedCount` is a shared
+   * aggregate (any operator, any device), so "is anything queued right now"
+   * cannot say whether THIS message is still waiting. A generation counter can:
+   * a send snapshots it, and the chip survives only while the snapshot is still
+   * current. Every recorded transition that reports an empty queue bumps it,
+   * which covers both the real drain (`finishTurn` → `pump` emits `queuedCount
+   * 0` before the next turn starts) and the case where the post never enqueued
+   * at all (the agent's next transition still reports zero).
+   */
+  queueDrainSeqByChannelAgent: Record<string, number>;
+  /**
    * Wall-clock time (ms) of the last live transition per `${channelId}
    * ${agentId}`. Compared against the roster query's `dataUpdatedAt` so a fresh
    * roster snapshot can win over a stale socket status the client never saw go
@@ -31,7 +51,8 @@ interface ChannelAgentStatusState {
     channelId: string,
     agentId: string,
     status: ChannelAgentStatus,
-    runtimeId: string | null
+    runtimeId: string | null,
+    queuedCount?: number
   ) => void;
   /** Drop every agent status/runtime entry for a channel. */
   clearChannel: (channelId: string) => void;
@@ -45,13 +66,16 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
   (set) => ({
     statusByChannelAgent: {},
     runtimeByChannelAgent: {},
+    queuedCountByChannelAgent: {},
+    queueDrainSeqByChannelAgent: {},
     updatedAtByChannelAgent: {},
-    recordStatus: (channelId, agentId, status, runtimeId) =>
+    recordStatus: (channelId, agentId, status, runtimeId, queuedCount = 0) =>
       set((state) => {
         const key = channelAgentStatusKey(channelId, agentId);
         if (
           state.statusByChannelAgent[key] === status &&
-          state.runtimeByChannelAgent[key] === runtimeId
+          state.runtimeByChannelAgent[key] === runtimeId &&
+          state.queuedCountByChannelAgent[key] === queuedCount
         ) {
           return state;
         }
@@ -64,6 +88,20 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
             ...state.runtimeByChannelAgent,
             [key]: runtimeId,
           },
+          queuedCountByChannelAgent: {
+            ...state.queuedCountByChannelAgent,
+            [key]: queuedCount,
+          },
+          // Bumped on the transition itself, not on a later read: an empty queue
+          // reported by ANY transition retires every send that was waiting for
+          // this agent when it was recorded.
+          queueDrainSeqByChannelAgent:
+            queuedCount === 0
+              ? {
+                  ...state.queueDrainSeqByChannelAgent,
+                  [key]: (state.queueDrainSeqByChannelAgent[key] ?? 0) + 1,
+                }
+              : state.queueDrainSeqByChannelAgent,
           updatedAtByChannelAgent: {
             ...state.updatedAtByChannelAgent,
             [key]: nowMs(),
@@ -75,6 +113,8 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
         const prefix = `${channelId} `;
         const status: Record<string, ChannelAgentStatus> = {};
         const runtime: Record<string, string | null> = {};
+        const queued: Record<string, number> = {};
+        const drainSeq: Record<string, number> = {};
         const updatedAt: Record<string, number> = {};
         let changed = false;
         for (const [key, value] of Object.entries(state.statusByChannelAgent)) {
@@ -87,6 +127,16 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
           if (!key.startsWith(prefix)) runtime[key] = value;
         }
         for (const [key, value] of Object.entries(
+          state.queuedCountByChannelAgent
+        )) {
+          if (!key.startsWith(prefix)) queued[key] = value;
+        }
+        for (const [key, value] of Object.entries(
+          state.queueDrainSeqByChannelAgent
+        )) {
+          if (!key.startsWith(prefix)) drainSeq[key] = value;
+        }
+        for (const [key, value] of Object.entries(
           state.updatedAtByChannelAgent
         )) {
           if (!key.startsWith(prefix)) updatedAt[key] = value;
@@ -95,6 +145,8 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
         return {
           statusByChannelAgent: status,
           runtimeByChannelAgent: runtime,
+          queuedCountByChannelAgent: queued,
+          queueDrainSeqByChannelAgent: drainSeq,
           updatedAtByChannelAgent: updatedAt,
         };
       }),
@@ -133,4 +185,31 @@ export function resolveEffectiveAgentStatus(input: {
   }
   if (status === 'idle' && input.streaming) status = 'streaming';
   return status;
+}
+
+/**
+ * Same precedence rule as `resolveEffectiveAgentStatus`, applied to the queue
+ * depth (#1308 slice 4). Kept as a sibling rather than folded into the status
+ * resolver so every existing caller of that function is untouched; both read the
+ * same `(socketUpdatedAt >= rosterUpdatedAt)` tie-break, so the presence row can
+ * never pair one lane's status with the other lane's count.
+ *
+ * There is no `streaming` upgrade here: a reducer-derived stream says an agent
+ * is talking, and says nothing at all about what is waiting behind it.
+ */
+export function resolveEffectiveQueuedCount(input: {
+  socketQueuedCount: number | undefined;
+  socketUpdatedAt: number | undefined;
+  rosterQueuedCount: number | undefined;
+  rosterUpdatedAt: number;
+}): number {
+  const { socketQueuedCount, socketUpdatedAt, rosterQueuedCount } = input;
+  if (
+    socketQueuedCount !== undefined &&
+    socketUpdatedAt !== undefined &&
+    socketUpdatedAt >= input.rosterUpdatedAt
+  ) {
+    return socketQueuedCount;
+  }
+  return rosterQueuedCount ?? 0;
 }

--- a/frontend/src/lib/stores/channel-queued-sends.ts
+++ b/frontend/src/lib/stores/channel-queued-sends.ts
@@ -56,7 +56,11 @@ export interface ChannelQueuedSendMark {
 
 interface ChannelQueuedSendsState {
   marksByMessageId: Record<string, ChannelQueuedSendMark>;
-  /** Record a durable message id as "sent into a busy agent". */
+  /**
+   * Record a durable message id as "sent into a busy agent", sweeping any
+   * already-retired mark on the way in so the map cannot grow unbounded in a
+   * long-lived channel.
+   */
   markQueuedSend: (messageId: string, mark: ChannelQueuedSendMark) => void;
   /** Drop every mark for a channel (channel switch / unmount). */
   clearChannel: (channelId: string) => void;
@@ -66,9 +70,26 @@ export const useChannelQueuedSendsStore = create<ChannelQueuedSendsState>(
   (set) => ({
     marksByMessageId: {},
     markQueuedSend: (messageId, mark) =>
-      set((state) => ({
-        marksByMessageId: { ...state.marksByMessageId, [messageId]: mark },
-      })),
+      set((state) => {
+        // Sweep on write (#1308 slice 4 review). A mark is only ever READ by the
+        // row it names, so a retired one is invisible — but nothing else drops
+        // it until the channel unmounts, and a daily-driver channel stays
+        // mounted for days. Every insert therefore evicts marks whose drain
+        // generation has already moved, which bounds the map at "sends still
+        // waiting" instead of "sends this session".
+        const drainSeqs =
+          useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent;
+        const next: Record<string, ChannelQueuedSendMark> = {};
+        for (const [id, existing] of Object.entries(state.marksByMessageId)) {
+          if (id === messageId) continue; // replaced below
+          if (queuedSendStillWaiting(existing, drainSeqs)) next[id] = existing;
+        }
+        // The new mark is kept as given: its caller has already checked that no
+        // snapshotted generation moved during the POST round-trip, and that
+        // check is the one allowed to decide whether this send gets a chip.
+        next[messageId] = mark;
+        return { marksByMessageId: next };
+      }),
     clearChannel: (channelId) =>
       set((state) => {
         const next: Record<string, ChannelQueuedSendMark> = {};

--- a/frontend/src/lib/stores/channel-queued-sends.ts
+++ b/frontend/src/lib/stores/channel-queued-sends.ts
@@ -1,0 +1,151 @@
+// Queued-send marks (#1308 slice 4 item 2a). When the operator posts while the
+// bound agent is mid-turn, the server queues that post behind the live turn
+// instead of opening a second one. Nothing about the durable row says so — the
+// steering intent is deliberately NOT persisted (`channel-chat-router`), so a
+// replay of history can never re-announce it — which leaves the operator staring
+// at a message that looks sent but produced no reply.
+//
+// This store is the client's own memory of "I sent that one into a busy agent".
+//
+// ── the chosen signal ────────────────────────────────────────────────────────
+// A mark is created from the SEND-TIME agent status (the same `agentChips`
+// signal the header and presence rows already use) and retired by the queue
+// DRAIN GENERATION published with `channel-agent-status` (`queuedCount`, item
+// 1c). Concretely:
+//
+//   1. before issuing the POST, snapshot `queueDrainSeqByChannelAgent` for every
+//      agent that is busy right now;
+//   2. when the POST resolves, register the mark against the returned message id
+//      — but only if no snapshotted generation has moved in the meantime;
+//   3. the chip renders for exactly as long as every snapshotted generation is
+//      still current.
+//
+// The generation moves on any transition that reports an EMPTY queue, which is
+// what `finishTurn` → `pump` emits (`queuedCount 0`) the instant the queued run
+// is spliced out and immediately before the next turn starts. So the chip clears
+// precisely when the next turn begins consuming the message.
+//
+// Two deliberate imprecisions, both failing toward silence rather than a lie:
+//   • step 2's guard drops the mark when a drain raced the POST round-trip. A
+//     send that really did queue can therefore miss its chip; a send that was
+//     already consumed can never keep one.
+//   • the mark targets the agents that were BUSY at send time, not the agents
+//     the server's mention routing actually triggered — the client does not
+//     re-derive routing. In a group channel a message that addresses nobody can
+//     briefly show the chip; it retires at that agent's very next transition,
+//     because an idle-turn transition also reports `queuedCount 0`.
+import { create } from 'zustand';
+import {
+  channelAgentStatusKey,
+  useChannelAgentStatusStore,
+} from './channel-agent-status.js';
+
+export interface ChannelQueuedSendMark {
+  /** Channel the send belongs to — scopes `clearChannel`. */
+  channelId: string;
+  /** Profile Actor ids this send is waiting behind. */
+  agentIds: readonly string[];
+  /**
+   * Row copy, resolved at send time so the chip never needs the roster again
+   * (a mark outlives the identity lookup that produced it).
+   */
+  label: string;
+  /** `queueDrainSeqByChannelAgent` value per agent key when the send was issued. */
+  drainSeqs: Readonly<Record<string, number>>;
+}
+
+interface ChannelQueuedSendsState {
+  marksByMessageId: Record<string, ChannelQueuedSendMark>;
+  /** Record a durable message id as "sent into a busy agent". */
+  markQueuedSend: (messageId: string, mark: ChannelQueuedSendMark) => void;
+  /** Drop every mark for a channel (channel switch / unmount). */
+  clearChannel: (channelId: string) => void;
+}
+
+export const useChannelQueuedSendsStore = create<ChannelQueuedSendsState>(
+  (set) => ({
+    marksByMessageId: {},
+    markQueuedSend: (messageId, mark) =>
+      set((state) => ({
+        marksByMessageId: { ...state.marksByMessageId, [messageId]: mark },
+      })),
+    clearChannel: (channelId) =>
+      set((state) => {
+        const next: Record<string, ChannelQueuedSendMark> = {};
+        let changed = false;
+        for (const [messageId, mark] of Object.entries(
+          state.marksByMessageId
+        )) {
+          if (mark.channelId === channelId) changed = true;
+          else next[messageId] = mark;
+        }
+        return changed ? { marksByMessageId: next } : state;
+      }),
+  })
+);
+
+/** Snapshot the drain generation of every agent a send is about to wait behind. */
+export function snapshotQueueDrainSeqs(
+  channelId: string,
+  agentIds: readonly string[],
+  drainSeqByChannelAgent: Readonly<Record<string, number>>
+): Record<string, number> {
+  const snapshot: Record<string, number> = {};
+  for (const agentId of agentIds) {
+    const key = channelAgentStatusKey(channelId, agentId);
+    snapshot[key] = drainSeqByChannelAgent[key] ?? 0;
+  }
+  return snapshot;
+}
+
+/**
+ * True while every snapshotted generation is still current — i.e. no agent this
+ * send is waiting behind has reported an empty queue since it was issued.
+ *
+ * `every`, not `some`: once ANY addressed agent has drained, the message is no
+ * longer merely waiting, and a chip that outlives the turn it named is worse
+ * than one that clears a beat early.
+ */
+export function queuedSendStillWaiting(
+  mark: ChannelQueuedSendMark,
+  drainSeqByChannelAgent: Readonly<Record<string, number>>
+): boolean {
+  if (mark.agentIds.length === 0) return false;
+  for (const [key, seq] of Object.entries(mark.drainSeqs)) {
+    if ((drainSeqByChannelAgent[key] ?? 0) !== seq) return false;
+  }
+  return true;
+}
+
+/**
+ * Chip copy for one row, or `null` when that row is not (or no longer) waiting.
+ *
+ * Read by `ChannelMessageRow` directly rather than drilled from `ChannelView`,
+ * so the main lane, the thread panel and any future row surface all pick the
+ * chip up from one place. Both selectors collapse to primitives — a label and a
+ * boolean — so the ~every-transition churn of the drain map re-renders only the
+ * rows whose answer actually changed, not every row in the timeline.
+ */
+export function useQueuedSendNotice(messageId: string): string | null {
+  const label = useChannelQueuedSendsStore(
+    (state) => state.marksByMessageId[messageId]?.label ?? null
+  );
+  const waiting = useChannelAgentStatusStore((state) => {
+    const mark =
+      useChannelQueuedSendsStore.getState().marksByMessageId[messageId];
+    return (
+      mark !== undefined &&
+      queuedSendStillWaiting(mark, state.queueDrainSeqByChannelAgent)
+    );
+  });
+  return waiting ? label : null;
+}
+
+/** Lowercase chip copy per DESIGN.md — no emoji, no title case. */
+export function queuedSendCopy(busyLabels: readonly string[]): string {
+  const first = busyLabels[0];
+  if (busyLabels.length === 1 && first) {
+    return `queued — ${first} is mid-turn`;
+  }
+  return 'queued — agents are mid-turn';
+}

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -139,6 +139,12 @@ export type EventMessage =
       agentId: string;
       status: 'spawning' | 'thinking' | 'streaming' | 'waiting' | 'idle';
       runtimeId: string | null;
+      /**
+       * Posts waiting to trigger this agent's NEXT turn (#1308 slice 4).
+       * Optional so a hub that predates the field is still readable; treat an
+       * absent value as zero.
+       */
+      queuedCount?: number;
     }
   | ({
       type: 'session-durability-changed';

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -14,7 +14,7 @@ import {
   type ChannelBinding,
   type ChannelMessageStore,
 } from './channel-message-store.js';
-import type { ChannelHub } from './channel-hub.js';
+import type { ChannelHub, ChannelMessagePostedOptions } from './channel-hub.js';
 import type { Attachment, ProtocolAdapterV2 } from './protocol-adapter-v2.js';
 import type {
   ChannelAgentRuntime,
@@ -36,6 +36,7 @@ import {
   CHANNEL_RETRY_OF_META_KEY,
   type ChannelMention,
   type ChannelMessage,
+  type ChannelPostSteering,
 } from '../shared/channel-chat-protocol.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
@@ -51,6 +52,27 @@ import { workspaceTopicAgentRuntimeLinkPatch } from '../shared/workspace-topics.
 // bridge remains the sole text mirror; the binder registers its OWN onPatch
 // listener (multi-handler) watching only turn lifecycle / live-state / approval
 // items so it can drive the queue, status, watchdog, and approval rows.
+//
+// ── mid-turn steering (#1308 slice 4) ────────────────────────────────────────
+// A post addressed to a binding that is already mid-turn does NOT open a second
+// concurrent turn and is never dropped: `enqueueTurn` appends to the binding's
+// FIFO queue and `pump` refuses to dispatch while `activeTurnId !== null`. On
+// `finishTurn` the queue drains into ONE next turn — every human post that
+// arrived while the agent was busy is coalesced (§`pump`), and all of them ride
+// that turn's context packet for free, because `buildPacket` reads them back out
+// of the durable store (`seq > lastDeliveredSeq`, `seq < trigger.seq`).
+//
+// `steering: 'interrupt'` is the operator's explicit "interrupt and send": the
+// live turn is cancelled through the SAME `adapter.interrupt` path the header
+// chip already uses (the bridge finalizes its partial row `interrupted`), and
+// the queued message dispatches the moment that turn releases.
+//
+// Restart durability (accepted limit, #1308 slice 4): the queue is in-memory
+// TURN-TRIGGER state only. A hub restart loses pending triggers; it never loses
+// messages — every queued post is already durable in `channel_messages`, and the
+// operator re-triggers by sending again. Persisting trigger intent across a
+// restart would also have to survive a runtime that no longer exists, so it is
+// deliberately out of scope for this slice.
 
 const logger = createLogger('channel-agent-binder');
 
@@ -111,7 +133,16 @@ export interface ChannelAgentRosterEntry {
   available: boolean;
   reason: string | null;
   role?: AgentRole;
-  binding: { runtimeId: string; status: ChannelAgentStatus } | null;
+  binding: {
+    runtimeId: string;
+    status: ChannelAgentStatus;
+    /**
+     * Posts waiting to trigger this binding's NEXT turn (#1308 slice 4). Zero
+     * whenever nothing is queued or the runtime is only durably recorded (no
+     * live binding), so the chip renders from one number on both lanes.
+     */
+    queuedCount: number;
+  } | null;
 }
 
 export type ChannelAgentStatusBroadcaster = (
@@ -151,7 +182,8 @@ export interface ChannelAgentBinderDeps {
 export interface ChannelAgentBinder {
   handleMessagePosted(
     message: ChannelMessage,
-    mentions: ChannelMention[]
+    mentions: ChannelMention[],
+    options?: ChannelMessagePostedOptions
   ): void;
   ensureBinding(channelId: string, framework: string): Promise<LiveBinding>;
   /** Designate or resume the one orchestrator bound to a product channel. */
@@ -167,7 +199,10 @@ export interface ChannelAgentBinder {
    * re-posted — the timeline gains one system row superseding the retried row
    * plus whatever the new turn produces.
    */
-  retryMessage(channelId: string, messageId: string): Promise<ChannelRetryResult>;
+  retryMessage(
+    channelId: string,
+    messageId: string
+  ): Promise<ChannelRetryResult>;
   respondToApproval(
     channelId: string,
     agentId: string,
@@ -209,6 +244,9 @@ export interface LiveBinding {
   sawStream: boolean;
   waitingOn: string | null;
   queue: QueuedTurn[];
+  /** Last `(status, queuedCount)` pair broadcast; suppresses duplicate events. */
+  emittedStatus: ChannelAgentStatus;
+  emittedQueuedCount: number;
   watchdog: NodeJS.Timeout | null;
   retriedTurns: Set<string>;
   announcedApprovals: Set<string>;
@@ -509,15 +547,37 @@ export function createChannelAgentBinder(
 
   // ── status ──────────────────────────────────────────────────────────────────
 
-  function setStatus(binding: LiveBinding, status: ChannelAgentStatus): void {
-    if (binding.status === status) return;
-    binding.status = status;
+  /**
+   * Broadcast the binding's observable presence: its status AND how many posts
+   * are waiting to trigger its next turn (#1308 slice 4). Deduped on the PAIR,
+   * not on status alone — a second message arriving while an agent is already
+   * `streaming` moves no status but must still light the queued chip, and the
+   * drain that empties the queue must clear it even though the binding was
+   * already `thinking`.
+   */
+  function emitAgentStatus(binding: LiveBinding): void {
+    const queuedCount = binding.queue.length;
+    if (
+      binding.emittedStatus === binding.status &&
+      binding.emittedQueuedCount === queuedCount
+    ) {
+      return;
+    }
+    binding.emittedStatus = binding.status;
+    binding.emittedQueuedCount = queuedCount;
     statusBroadcaster?.('channel-agent-status', {
       channelId: binding.channelId,
       agentId: binding.profileActorId,
-      status,
+      status: binding.status,
       runtimeId: binding.runtimeId ?? null,
+      queuedCount,
     });
+  }
+
+  function setStatus(binding: LiveBinding, status: ChannelAgentStatus): void {
+    if (binding.status === status) return;
+    binding.status = status;
+    emitAgentStatus(binding);
   }
 
   // ── watchdog ────────────────────────────────────────────────────────────────
@@ -572,6 +632,8 @@ export function createChannelAgentBinder(
       sawStream: false,
       waitingOn: null,
       queue: [],
+      emittedStatus: 'idle',
+      emittedQueuedCount: 0,
       watchdog: null,
       retriedTurns: new Set(),
       announcedApprovals: new Set(),
@@ -916,8 +978,41 @@ export function createChannelAgentBinder(
 
   // ── turn queue + delivery ───────────────────────────────────────────────────
 
-  function enqueueTurn(binding: LiveBinding, trigger: ChannelMessage): void {
+  /**
+   * True when two queued triggers would drain as ONE turn. Single source of
+   * truth for both the drain (`pump`) and the overflow rule below.
+   */
+  function coalescesIntoOneTurn(
+    earlier: ChannelMessage,
+    later: ChannelMessage
+  ): boolean {
+    return (
+      earlier.sender.kind === 'human' &&
+      later.sender.kind === 'human' &&
+      earlier.threadId === later.threadId
+    );
+  }
+
+  function enqueueTurn(
+    binding: LiveBinding,
+    trigger: ChannelMessage,
+    steering?: ChannelPostSteering
+  ): void {
     if (binding.queue.length >= QUEUE_CAP) {
+      const tailIndex = binding.queue.length - 1;
+      const tail = binding.queue[tailIndex];
+      if (tail && coalescesIntoOneTurn(tail.trigger, trigger)) {
+        // A human run drains as one turn triggered by its NEWEST member, so
+        // superseding the tail is identical to appending: same trigger, same
+        // packet (the superseded row is still read back as a context row),
+        // one fewer slot. An operator typing fast is therefore never told
+        // their message was dropped for a turn that was never going to exist.
+        binding.queue[tailIndex] = { trigger };
+        emitAgentStatus(binding);
+        if (steering === 'interrupt') steerInterrupt(binding);
+        pump(binding);
+        return;
+      }
       postSystemRow(
         binding.channelId,
         `@${binding.displayName} has ${QUEUE_CAP} turns queued — message dropped`,
@@ -926,15 +1021,75 @@ export function createChannelAgentBinder(
       return;
     }
     binding.queue.push({ trigger });
+    emitAgentStatus(binding);
+    // Interrupt BEFORE pumping: while a turn is live `pump` is a no-op, and the
+    // cancellation's terminal patch is what releases the binding into
+    // `finishTurn` → `pump` → this message. When nothing is live the interrupt
+    // is a no-op and the pump below dispatches immediately, so "interrupt and
+    // send" degrades cleanly to plain "send".
+    if (steering === 'interrupt') steerInterrupt(binding);
     pump(binding);
   }
 
+  /**
+   * Cancel the binding's live turn on the operator's explicit instruction,
+   * reusing the header chip's own path (`interrupt`) so there is exactly ONE
+   * interrupt semantic in the product: the partial assistant row finalizes
+   * `interrupted` via the bridge, and the adapter's terminal patch drives
+   * `finishTurn`.
+   *
+   * Fire-and-forget with a visible failure: if the adapter refuses, the queued
+   * message stays queued and rides the turn's natural completion (or the
+   * watchdog), which is strictly better than dropping it.
+   */
+  function steerInterrupt(binding: LiveBinding): void {
+    const adapter = binding.adapter;
+    const turnId = binding.activeTurnId;
+    if (!adapter || turnId === null) return;
+    void adapter.interrupt({ turnId }).catch((err) => {
+      if (closed) return;
+      logger.warn('channel binder steering interrupt failed:', err);
+      postSystemRow(
+        binding.channelId,
+        `@${binding.displayName} could not be interrupted: ${errText(err)}`
+      );
+    });
+  }
+
+  /**
+   * Dispatch at most ONE turn from the queue.
+   *
+   * Coalescing (#1308 slice 4): a contiguous run of HUMAN posts in the same
+   * thread scope drains as a single turn triggered by the NEWEST of them. The
+   * older ones are not lost — `buildPacket` reads every row between the delivery
+   * cursor and the trigger straight out of the store, so they arrive as context
+   * rows of that one packet. Three impatient messages therefore cost one turn,
+   * not three.
+   *
+   * Two deliberate limits on the run:
+   *   • thread scope — a threaded packet only carries its own thread, so a
+   *     trigger from another thread (or the channel top level) could not stand
+   *     in for it. Those stay queued and drain on the following completion.
+   *   • human senders only — the packet builder drops an agent's OWN prior rows
+   *     (they already live in the reused provider conversation), so coalescing an
+   *     agent-authored trigger away could silently erase it. Agent posts keep
+   *     one-trigger-one-turn and stay bounded by the consecutive-agent brake.
+   */
   function pump(binding: LiveBinding): void {
     if (binding.activeTurnId !== null) return;
     if (!binding.adapter) return;
-    const next = binding.queue.shift();
-    if (!next) return;
-    sendTurn(binding, next.trigger);
+    const head = binding.queue[0];
+    if (!head) return;
+    let take = 1;
+    while (
+      take < binding.queue.length &&
+      coalescesIntoOneTurn(head.trigger, binding.queue[take]!.trigger)
+    ) {
+      take += 1;
+    }
+    const batch = binding.queue.splice(0, take);
+    emitAgentStatus(binding);
+    sendTurn(binding, batch[batch.length - 1]!.trigger);
   }
 
   function buildPacket(
@@ -1395,7 +1550,8 @@ export function createChannelAgentBinder(
    */
   function routeOne(
     trigger: ChannelMessage,
-    profile: AgentProfile
+    profile: AgentProfile,
+    steering?: ChannelPostSteering
   ): Promise<void> {
     return (async () => {
       try {
@@ -1462,7 +1618,7 @@ export function createChannelAgentBinder(
           throw err;
         }
         if (closed) return; // never enqueue/spawn a turn after close()
-        enqueueTurn(binding, trigger);
+        enqueueTurn(binding, trigger, steering);
       } catch (err) {
         if (closed || err instanceof BinderClosedError) return;
         logger.warn('channel binder route failed:', err);
@@ -1606,7 +1762,8 @@ export function createChannelAgentBinder(
 
   function handleMessagePosted(
     message: ChannelMessage,
-    mentions: ChannelMention[]
+    mentions: ChannelMention[],
+    options?: ChannelMessagePostedOptions
   ): void {
     if (closed) return;
     if (message.kind !== 'message') return; // system rows never route (§1)
@@ -1625,16 +1782,23 @@ export function createChannelAgentBinder(
     const routingMentions = currentProfileMentions(message, mentions);
     const profiles = eligibleProfiles(message, routingMentions);
     if (message.sender.kind === 'agent') {
+      // Steering is deliberately dropped here, not honored-then-braked: the
+      // sender kind is server-derived, so this is the ONE place that can promise
+      // an agent post — including a CLI-gateway actor post — can never cancel
+      // another agent's live turn. Agent traffic keeps its existing brake.
       routeWithBrake(message, profiles);
       return;
     }
+    // Mechanics are explicit (epic #1308 rule): the steering intent comes from
+    // the operator's choice on the post route, never inferred from the text.
+    const steering = options?.steering;
     consecutiveAgentTurns.delete(message.channelId);
     if (profiles.length === 0) {
-      routeImplicitDm(message);
+      routeImplicitDm(message, steering);
       return;
     }
     for (const profile of profiles) {
-      void routeOne(message, profile);
+      void routeOne(message, profile, steering);
     }
   }
 
@@ -1649,7 +1813,10 @@ export function createChannelAgentBinder(
    * never re-trigger itself (`eligibleProfiles`' self-filter does not cover a
    * message with no mentions at all).
    */
-  function routeImplicitDm(message: ChannelMessage): void {
+  function routeImplicitDm(
+    message: ChannelMessage,
+    steering?: ChannelPostSteering
+  ): void {
     const providerId = dmProviderIdFor(message.channelId);
     if (providerId === null) {
       // Legitimate in a multi-party channel: humans chat without addressing an
@@ -1663,7 +1830,7 @@ export function createChannelAgentBinder(
     logger.debug(
       `dm implicit route, channel=${message.channelId} provider=${providerId} profile=${profile.id}`
     );
-    void routeOne(message, profile);
+    void routeOne(message, profile, steering);
   }
 
   function handleAssistantFinalized(message: ChannelMessage): void {
@@ -1702,6 +1869,9 @@ export function createChannelAgentBinder(
       binding.waitingOn = null;
       binding.announcedApprovals.clear();
       setStatus(binding, 'idle');
+      // The binding may already have BEEN idle, so the dropped queue needs its
+      // own emit — otherwise the chip keeps a count for a dead runtime.
+      emitAgentStatus(binding);
       live.delete(key);
       try {
         store.upsertBinding({
@@ -1913,7 +2083,11 @@ export function createChannelAgentBinder(
           reason: target?.reason ?? 'framework unavailable',
           ...(runtime?.role !== undefined ? { role: runtime.role } : {}),
           binding: runtimeId
-            ? { runtimeId, status: binding?.status ?? 'idle' }
+            ? {
+                runtimeId,
+                status: binding?.status ?? 'idle',
+                queuedCount: binding?.queue.length ?? 0,
+              }
             : null,
         };
       })

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -194,6 +194,13 @@ export interface ChannelAgentBinder {
   ): Promise<LiveBinding>;
   interrupt(channelId: string, agentId: string): Promise<void>;
   /**
+   * Apply steering to an ALREADY-persisted row (#1308 slice 4). Used by the post
+   * route when `clientMessageId` idempotency returns an existing row: the
+   * message is already queued, but the operator's interrupt intent would
+   * otherwise be dropped on the floor. Never re-routes the message.
+   */
+  steerExisting(message: ChannelMessage, steering: ChannelPostSteering): void;
+  /**
    * Re-route the ORIGINAL trigger of a failed/interrupted/truncated agent row to
    * the same profile (#1308 slice 1 item 2). The human message is never
    * re-posted — the timeline gains one system row superseding the retried row
@@ -981,6 +988,24 @@ export function createChannelAgentBinder(
   /**
    * True when two queued triggers would drain as ONE turn. Single source of
    * truth for both the drain (`pump`) and the overflow rule below.
+   *
+   * Three conditions, each load-bearing:
+   *   • both HUMAN — see `pump`'s doc comment.
+   *   • same thread scope — see `pump`'s doc comment.
+   *   • STRICTLY INCREASING seq. Coalescing folds the older members into the
+   *     newer one's packet as context rows, which only works while the newer
+   *     one really is newer: `buildPacket` selects rows with `seq <
+   *     trigger.seq`. The queue is NOT guaranteed seq-ordered —
+   *     `handleSendFailure` re-enqueues an older, already-failed trigger behind
+   *     whatever arrived while the transport was failing — so without this
+   *     guard a re-enqueued M1 could swallow a newer M3 that is neither the
+   *     trigger nor a context row of the resulting packet. The message would
+   *     have been spliced out of the queue and produce nothing at all.
+   *   • no image parts on EITHER row. A packet's image budget
+   *     (`PACKET_IMAGE_MAX_COUNT`) is per-packet, not per-message, so folding N
+   *     image-bearing posts into one turn silently spends one budget on all of
+   *     them. Attachments are operator content we promised not to drop, so an
+   *     image-bearing post keeps one-trigger-one-turn and its own budget.
    */
   function coalescesIntoOneTurn(
     earlier: ChannelMessage,
@@ -989,7 +1014,10 @@ export function createChannelAgentBinder(
     return (
       earlier.sender.kind === 'human' &&
       later.sender.kind === 'human' &&
-      earlier.threadId === later.threadId
+      earlier.threadId === later.threadId &&
+      later.seq > earlier.seq &&
+      (earlier.parts?.length ?? 0) === 0 &&
+      (later.parts?.length ?? 0) === 0
     );
   }
 
@@ -1009,7 +1037,7 @@ export function createChannelAgentBinder(
         // their message was dropped for a turn that was never going to exist.
         binding.queue[tailIndex] = { trigger };
         emitAgentStatus(binding);
-        if (steering === 'interrupt') steerInterrupt(binding);
+        if (steering === 'interrupt') steerInterrupt(binding, trigger);
         pump(binding);
         return;
       }
@@ -1027,7 +1055,7 @@ export function createChannelAgentBinder(
     // `finishTurn` → `pump` → this message. When nothing is live the interrupt
     // is a no-op and the pump below dispatches immediately, so "interrupt and
     // send" degrades cleanly to plain "send".
-    if (steering === 'interrupt') steerInterrupt(binding);
+    if (steering === 'interrupt') steerInterrupt(binding, trigger);
     pump(binding);
   }
 
@@ -1040,9 +1068,12 @@ export function createChannelAgentBinder(
    *
    * Fire-and-forget with a visible failure: if the adapter refuses, the queued
    * message stays queued and rides the turn's natural completion (or the
-   * watchdog), which is strictly better than dropping it.
+   * watchdog), which is strictly better than dropping it. The failure row is
+   * parented to the STEERING trigger, exactly like every other binder failure
+   * row — an interrupt issued from a thread panel must explain itself inside
+   * that thread, not at channel top level where the operator is not looking.
    */
-  function steerInterrupt(binding: LiveBinding): void {
+  function steerInterrupt(binding: LiveBinding, trigger: ChannelMessage): void {
     const adapter = binding.adapter;
     const turnId = binding.activeTurnId;
     if (!adapter || turnId === null) return;
@@ -1051,7 +1082,8 @@ export function createChannelAgentBinder(
       logger.warn('channel binder steering interrupt failed:', err);
       postSystemRow(
         binding.channelId,
-        `@${binding.displayName} could not be interrupted: ${errText(err)}`
+        `@${binding.displayName} could not be interrupted: ${errText(err)}`,
+        { parentMessageId: parentForTrigger(trigger) }
       );
     });
   }
@@ -1074,6 +1106,10 @@ export function createChannelAgentBinder(
    *     (they already live in the reused provider conversation), so coalescing an
    *     agent-authored trigger away could silently erase it. Agent posts keep
    *     one-trigger-one-turn and stay bounded by the consecutive-agent brake.
+   *   • image-bearing posts only ever trigger their own turn, so the per-packet
+   *     image budget is never split across several operator messages.
+   * All three live in `coalescesIntoOneTurn`, together with the seq-monotonicity
+   * guard that keeps a re-enqueued failed trigger from swallowing newer posts.
    */
   function pump(binding: LiveBinding): void {
     if (binding.activeTurnId !== null) return;
@@ -1089,7 +1125,17 @@ export function createChannelAgentBinder(
     }
     const batch = binding.queue.splice(0, take);
     emitAgentStatus(binding);
-    sendTurn(binding, batch[batch.length - 1]!.trigger);
+    // Newest member triggers, and "newest" means max seq — NOT last position.
+    // `coalescesIntoOneTurn` is only evaluated head-vs-candidate, so a queue
+    // whose order diverged from seq order (re-enqueue after a send failure)
+    // can still admit a candidate that is newer than the head but older than
+    // an earlier admitted member. Every non-trigger member has a lower seq, so
+    // all of them are read back as context rows of this one packet.
+    let trigger = batch[0]!.trigger;
+    for (const entry of batch) {
+      if (entry.trigger.seq > trigger.seq) trigger = entry.trigger;
+    }
+    sendTurn(binding, trigger);
   }
 
   function buildPacket(
@@ -1803,6 +1849,48 @@ export function createChannelAgentBinder(
   }
 
   /**
+   * Apply an operator's explicit steering intent to a row that ALREADY exists
+   * (#1308 slice 4 review).
+   *
+   * The post route is idempotent on `clientMessageId`, and the composer
+   * deliberately RETAINS that id after a failed send. So an operator whose
+   * "queue" POST looked like it failed but actually landed, and who then presses
+   * "interrupt & send" on the same draft, replays a `clientMessageId` the store
+   * already knows. Returning the stored row alone would silently swallow the
+   * interrupt — the UI would report an interrupt-and-send that did neither.
+   *
+   * This applies the steering HALF only. The message itself is already queued
+   * from the first post, so re-routing it here would double-deliver; what the
+   * operator is still missing is the cancellation. Interrupting is idempotent (a
+   * no-op when the binding has no live turn), which is what makes replaying it
+   * safe on a duplicate.
+   */
+  function steerExisting(
+    message: ChannelMessage,
+    steering: ChannelPostSteering
+  ): void {
+    if (closed) return;
+    if (steering !== 'interrupt') return;
+    if (message.kind !== 'message') return; // system rows never steer (§1)
+    // Server-derived sender kind, the same gate `handleMessagePosted` applies:
+    // an agent post can never cancel another agent's live turn.
+    if (message.sender.kind !== 'human') return;
+    const mentions = currentProfileMentions(message, message.mentions ?? []);
+    let profiles = eligibleProfiles(message, mentions);
+    if (profiles.length === 0) {
+      // Same implicit-DM resolution as `routeImplicitDm`: addressing a DM IS
+      // the mention, so a steered DM post carries no literal `@name` to resolve.
+      const providerId = dmProviderIdFor(message.channelId);
+      if (providerId === null) return;
+      profiles = [defaultProfileForProvider(providerId)];
+    }
+    for (const profile of profiles) {
+      const binding = live.get(bindingKey(message.channelId, profile.id));
+      if (binding) steerInterrupt(binding, message);
+    }
+  }
+
+  /**
    * DM implicit routing. A DM is "a channel with one agent" (ADR-020,
    * `docs/CHANNEL_CHAT.md`), so addressing it IS the mention — a human message
    * in a DM must reach that agent with no literal `@name` typed.
@@ -2099,6 +2187,7 @@ export function createChannelAgentBinder(
     ensureBinding,
     ensureOrchestrator,
     interrupt,
+    steerExisting,
     retryMessage,
     respondToApproval,
     rosterForChannel,

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -225,6 +225,15 @@ export interface ChannelAgentBinder {
 
 interface QueuedTurn {
   trigger: ChannelMessage;
+  /**
+   * Set only by `handleSendFailure`'s re-enqueue after a rebind. Such a trigger
+   * is BELOW the binding's delivery cursor (a newer turn already succeeded and
+   * advanced it past this seq), so it can never survive coalescing as a context
+   * row — `buildMentionContextPacketEnvelope` filters context rows with
+   * `seq > lastDeliveredSeq`. It must therefore always trigger its OWN turn,
+   * where the packet footer renders it unconditionally. See `pump`.
+   */
+  reEnqueued?: true;
 }
 
 export interface LiveBinding {
@@ -1001,6 +1010,10 @@ export function createChannelAgentBinder(
    *     guard a re-enqueued M1 could swallow a newer M3 that is neither the
    *     trigger nor a context row of the resulting packet. The message would
    *     have been spliced out of the queue and produce nothing at all.
+   *     Seq order alone is NOT sufficient for that case: a re-enqueued trigger
+   *     is also below the delivery cursor, so folding it into a NEWER member's
+   *     packet loses it too. `pump` keeps such entries out of runs entirely
+   *     (`QueuedTurn.reEnqueued`); this predicate handles the ordering half.
    *   • no image parts on EITHER row. A packet's image budget
    *     (`PACKET_IMAGE_MAX_COUNT`) is per-packet, not per-message, so folding N
    *     image-bearing posts into one turn silently spends one budget on all of
@@ -1024,18 +1037,32 @@ export function createChannelAgentBinder(
   function enqueueTurn(
     binding: LiveBinding,
     trigger: ChannelMessage,
-    steering?: ChannelPostSteering
+    steering?: ChannelPostSteering,
+    reEnqueued = false
   ): void {
+    const entry: QueuedTurn = reEnqueued
+      ? { trigger, reEnqueued: true }
+      : { trigger };
     if (binding.queue.length >= QUEUE_CAP) {
       const tailIndex = binding.queue.length - 1;
       const tail = binding.queue[tailIndex];
-      if (tail && coalescesIntoOneTurn(tail.trigger, trigger)) {
+      // Neither side may be a re-enqueued trigger: superseding one silently
+      // deletes a message that is below the delivery cursor and therefore
+      // unrecoverable as a context row, and superseding WITH one would delete
+      // the fresh tail in favour of the stale entry. Both fall through to the
+      // explicit drop row below, which at least tells the operator.
+      if (
+        tail &&
+        !tail.reEnqueued &&
+        !reEnqueued &&
+        coalescesIntoOneTurn(tail.trigger, trigger)
+      ) {
         // A human run drains as one turn triggered by its NEWEST member, so
         // superseding the tail is identical to appending: same trigger, same
         // packet (the superseded row is still read back as a context row),
         // one fewer slot. An operator typing fast is therefore never told
         // their message was dropped for a turn that was never going to exist.
-        binding.queue[tailIndex] = { trigger };
+        binding.queue[tailIndex] = entry;
         emitAgentStatus(binding);
         if (steering === 'interrupt') steerInterrupt(binding, trigger);
         pump(binding);
@@ -1048,7 +1075,7 @@ export function createChannelAgentBinder(
       );
       return;
     }
-    binding.queue.push({ trigger });
+    binding.queue.push(entry);
     emitAgentStatus(binding);
     // Interrupt BEFORE pumping: while a turn is live `pump` is a no-op, and the
     // cancellation's terminal patch is what releases the binding into
@@ -1110,6 +1137,9 @@ export function createChannelAgentBinder(
    *     image budget is never split across several operator messages.
    * All three live in `coalescesIntoOneTurn`, together with the seq-monotonicity
    * guard that keeps a re-enqueued failed trigger from swallowing newer posts.
+   * A fourth limit lives here rather than in the predicate because it is a
+   * property of the ENTRY, not of the pair: a re-enqueued trigger never joins a
+   * run in either direction (see below).
    */
   function pump(binding: LiveBinding): void {
     if (binding.activeTurnId !== null) return;
@@ -1117,11 +1147,21 @@ export function createChannelAgentBinder(
     const head = binding.queue[0];
     if (!head) return;
     let take = 1;
-    while (
-      take < binding.queue.length &&
-      coalescesIntoOneTurn(head.trigger, binding.queue[take]!.trigger)
-    ) {
-      take += 1;
+    // A re-enqueued trigger neither STARTS a run nor JOINS one. It sits below
+    // the binding's delivery cursor (the turn that displaced it already
+    // advanced the cursor past its seq), and `buildPacket` selects context rows
+    // with `seq > lastDeliveredSeq` — so folded into someone else's packet it
+    // would be neither trigger nor context row and would vanish entirely, the
+    // exact loss coalescing exists to avoid. Alone it is the trigger, and the
+    // footer renders the trigger unconditionally.
+    if (!head.reEnqueued) {
+      while (
+        take < binding.queue.length &&
+        !binding.queue[take]!.reEnqueued &&
+        coalescesIntoOneTurn(head.trigger, binding.queue[take]!.trigger)
+      ) {
+        take += 1;
+      }
     }
     const batch = binding.queue.splice(0, take);
     emitAgentStatus(binding);
@@ -1334,7 +1374,11 @@ export function createChannelAgentBinder(
           // delivers when the binding is free, and sendTurn re-establishes the
           // status/sawStream/watchdog for the retried turn instead of the
           // fallback overwriting an in-flight turn's lifecycle tracking.
-          enqueueTurn(rebound, trigger);
+          // Marked re-enqueued: the newer turn that took this binding has
+          // already advanced the delivery cursor past this trigger's seq, so it
+          // must get its own turn rather than be coalesced into a later packet
+          // that would filter it out (see `QueuedTurn.reEnqueued` and `pump`).
+          enqueueTurn(rebound, trigger, undefined, true);
           return;
         }
       } catch {
@@ -1863,7 +1907,10 @@ export function createChannelAgentBinder(
    * from the first post, so re-routing it here would double-deliver; what the
    * operator is still missing is the cancellation. Interrupting is idempotent (a
    * no-op when the binding has no live turn), which is what makes replaying it
-   * safe on a duplicate.
+   * safe on a duplicate — with one exception the loop below handles: if the
+   * queued message already DRAINED between the two posts, the live turn is the
+   * one this message triggered, and cancelling it would kill the operator's own
+   * reply.
    */
   function steerExisting(
     message: ChannelMessage,
@@ -1886,7 +1933,20 @@ export function createChannelAgentBinder(
     }
     for (const profile of profiles) {
       const binding = live.get(bindingKey(message.channelId, profile.id));
-      if (binding) steerInterrupt(binding, message);
+      if (!binding) continue;
+      // Never cancel the turn THIS message triggered. Between the two POSTs the
+      // queued message may have drained, so the binding is now running the very
+      // reply the operator is waiting for; replaying the steering there would
+      // interrupt their own answer — the opposite of the intent. Skipping keeps
+      // the replay useful in the case it exists for (the message is still
+      // queued behind someone else's live turn) and a no-op once it is being
+      // answered.
+      if (
+        binding.activeTurnId === channelTurnId(message.id, binding.profileActorId)
+      ) {
+        continue;
+      }
+      steerInterrupt(binding, message);
     }
   }
 

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -37,11 +37,14 @@ import type { WorkspaceTopicStore } from './workspace-topics.js';
 import type { WorkspaceTopic } from '../shared/workspace-topics.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import {
+  CHANNEL_POST_STEERING_VALUES,
   CHANNEL_READ_STATE_EVENT,
   CHANNEL_SEARCH_MAX_RESULTS,
   CHANNEL_SEARCH_QUERY_MAX_CHARS,
+  isChannelPostSteering,
   parseMentions,
   type ChannelBodyFormat,
+  type ChannelPostSteering,
   type ChannelMessage,
   type ChannelMessageSearchResponse,
   type ChannelMessageSearchResult,
@@ -523,6 +526,13 @@ function postToChannel(
     clientMessageId?: string;
     mentions: ReturnType<typeof parseMentions>;
     parts?: import('../shared/channel-chat-protocol.js').ChannelMessagePart[];
+    /**
+     * Explicit mid-turn steering intent (#1308 slice 4). Never persisted on the
+     * row — it governs how the binder TRIGGERS a turn for this post, not what
+     * the durable transcript says. Replaying history therefore cannot re-issue
+     * an interrupt.
+     */
+    steering?: ChannelPostSteering;
   }
 ): ChannelMessage {
   const message = store.appendComplete({
@@ -547,7 +557,11 @@ function postToChannel(
     kind: input.sender.kind === 'agent' ? 'agent' : 'human',
     id: input.sender.id,
   });
-  hub.broadcastCreated(message, input.mentions);
+  hub.broadcastCreated(
+    message,
+    input.mentions,
+    input.steering ? { steering: input.steering } : undefined
+  );
   return message;
 }
 
@@ -1143,6 +1157,29 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         ? body['clientMessageId']
         : undefined;
 
+    // #1308 slice 4: mid-turn steering rides the EXISTING post route as one
+    // additive body field rather than a second route — the operator is sending a
+    // message either way, and the only thing that differs is whether the agent's
+    // live turn is allowed to finish first. Omitted (the default) queues; the
+    // binder is the sole interpreter and ignores it for non-human senders.
+    const suppliedSteering = body['steering'];
+    if (
+      suppliedSteering !== undefined &&
+      !isChannelPostSteering(suppliedSteering)
+    ) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        `steering must be one of: ${CHANNEL_POST_STEERING_VALUES.join(', ')}`,
+        false,
+        { field: 'steering', reasonCode: 'CHANNEL_STEERING_INVALID' }
+      );
+      return;
+    }
+    const steering = isChannelPostSteering(suppliedSteering)
+      ? suppliedSteering
+      : undefined;
+
     const credential = authenticatedCliGatewayActorCredential(req);
     const sourceRuntimeId = authenticatedSourceRuntimeId(
       credential,
@@ -1185,6 +1222,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         ...(clientMessageId ? { clientMessageId } : {}),
         mentions,
         ...(parts.length ? { parts } : {}),
+        ...(steering ? { steering } : {}),
       });
       res.status(201).json({ message });
     } catch (error) {

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -1191,6 +1191,16 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     const sender = deriveSender(req, sourceRuntime);
 
     // clientMessageId idempotency: return the existing row without re-broadcast.
+    //
+    // Steering is the ONE thing a replay must still act on (#1308 slice 4
+    // review). The composer keeps its `clientMessageId` after a failed send, so
+    // an operator whose "queue" POST landed server-side but looked like it
+    // failed, and who then presses "interrupt & send", replays a known id. The
+    // row is already persisted and already queued — re-broadcasting it would
+    // double-deliver the message — but the interrupt has NOT happened yet, and
+    // swallowing it silently would report an interrupt-and-send that did
+    // neither. `steerExisting` applies the cancellation half only, and is a
+    // no-op when the addressed binding has no live turn.
     if (clientMessageId) {
       const existing = store.findByClientMessage(
         id,
@@ -1198,6 +1208,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         clientMessageId
       );
       if (existing) {
+        if (steering) deps.binder?.steerExisting(existing, steering);
         res.status(200).json({ message: existing });
         return;
       }

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -6,6 +6,7 @@ import {
   type ChannelMemberRef,
   type ChannelMention,
   type ChannelMessage,
+  type ChannelPostSteering,
   type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 
@@ -92,9 +93,19 @@ interface Accumulator {
   updateTimer: NodeJS.Timeout | null;
 }
 
+/**
+ * Per-post routing options carried alongside the durable row (#1308 slice 4).
+ * Additive and optional: the hub stays a dumb fan-out and never interprets
+ * `steering` — it only forwards the operator's explicit choice to the binder.
+ */
+export interface ChannelMessagePostedOptions {
+  steering?: ChannelPostSteering;
+}
+
 export type ChannelMessagePostedHandler = (
   message: ChannelMessage,
-  mentions: ChannelMention[]
+  mentions: ChannelMention[],
+  options?: ChannelMessagePostedOptions
 ) => void;
 
 export type ChannelBadgeBroadcaster = (
@@ -121,7 +132,11 @@ export interface ChannelHub {
     ws: ChannelSocket,
     input: { channelId: string; sinceSeq: number | null }
   ): void;
-  broadcastCreated(message: ChannelMessage, mentions?: ChannelMention[]): void;
+  broadcastCreated(
+    message: ChannelMessage,
+    mentions?: ChannelMention[],
+    options?: ChannelMessagePostedOptions
+  ): void;
   beginStreamBroadcast(message: ChannelMessage): void;
   pushDelta(messageId: string, text: string): void;
   /** Debounced authoritative full-row refresh for streaming card state. */
@@ -539,7 +554,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       ws.on('error', () => removeSubscriber(channelId, sub));
     },
 
-    broadcastCreated(message, mentions) {
+    broadcastCreated(message, mentions, options) {
       broadcast(message.channelId, {
         type: 'channel-message-created-v1',
         channelId: message.channelId,
@@ -550,7 +565,7 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
       const resolved = mentions ?? message.mentions ?? [];
       for (const handler of [...postedHandlers]) {
         try {
-          handler(message, resolved);
+          handler(message, resolved, options);
         } catch (err) {
           logger.warn('onMessagePosted handler error:', err);
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1578,8 +1578,8 @@ async function main(): Promise<void> {
       })
     : null;
   if (channelAgentBinder) {
-    channelHub.onMessagePosted((message, mentions) =>
-      channelAgentBinder.handleMessagePosted(message, mentions)
+    channelHub.onMessagePosted((message, mentions, options) =>
+      channelAgentBinder.handleMessagePosted(message, mentions, options)
     );
   }
 

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -62,6 +62,35 @@ export type ChannelTruncationReason =
   | 'restart';
 export type ChannelBodyFormat = 'markdown' | 'text';
 
+/**
+ * Mid-turn steering intent carried on a channel post (#1308 slice 4).
+ *
+ * EXPLICIT MECHANICS ONLY — the operator picks this, it is never inferred from
+ * the message text. Absent (the default) means "queue it": a post addressed to
+ * an agent that is already mid-turn joins that binding's FIFO queue and rides
+ * the NEXT turn. `'interrupt'` means "interrupt and send": the agent's live turn
+ * is cancelled through the existing interrupt path (its partial row finalizes
+ * `interrupted`) and the new message triggers as soon as that turn releases.
+ *
+ * Honored only for HUMAN senders — attribution is server-derived, so an agent
+ * post can never cancel another agent's turn (see the binder's steering gate).
+ */
+export type ChannelPostSteering = 'interrupt';
+
+/** All accepted `steering` body values, for route validation + error copy. */
+export const CHANNEL_POST_STEERING_VALUES: readonly ChannelPostSteering[] = [
+  'interrupt',
+];
+
+export function isChannelPostSteering(
+  value: unknown
+): value is ChannelPostSteering {
+  return (
+    typeof value === 'string' &&
+    (CHANNEL_POST_STEERING_VALUES as readonly string[]).includes(value)
+  );
+}
+
 export interface ChannelSenderRef {
   kind: ChannelSenderKind;
   /**

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -4044,6 +4044,39 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
     expect(adapter.sendCalls).toHaveLength(1);
   });
 
+  // The idempotent-replay lane applies the steering half to an already-stored
+  // row. If the row DRAINED between the two posts, the live turn is the reply
+  // the operator is waiting for — replaying the interrupt there would cancel
+  // their own answer, the exact opposite of "interrupt and send".
+  it('an idempotent steering replay never cancels the turn that message triggered', async () => {
+    const { binder, store, sessions } = makeSteerBinder();
+    postSteering(store, binder, '@steer long task', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    const steerProfile = builtInAgentProfileId('steer');
+
+    // First "interrupt & send": cancels the opener, queues behind it. The
+    // cancellation's terminal patch then releases the binding, so m2 drains and
+    // becomes the LIVE turn — exactly the state the second POST arrives into.
+    const m2 = postSteering(
+      store,
+      binder,
+      '@steer do this',
+      ['steer'],
+      'interrupt'
+    );
+    await waitFor(() => adapter.interruptCalls.length === 1);
+    await waitFor(() => adapter.sendCalls.length === 2);
+    expect(adapter.sendCalls[1]).toBe(channelTurnId(m2.id, steerProfile));
+
+    // The operator's first POST looked like it failed, so they press the button
+    // again with the same clientMessageId — the route replays the steering half.
+    binder.steerExisting(m2, 'interrupt');
+    await new Promise((r) => setTimeout(r, 40));
+    expect(adapter.interruptCalls).toHaveLength(1);
+    expect(adapter.sendCalls).toHaveLength(2);
+  });
+
   it('an agent-authored post never steers: no interrupt, one turn per trigger', async () => {
     const { binder, store, sessions } = makeSteerBinder();
     postSteering(store, binder, '@steer human opener', ['steer'], undefined);
@@ -4210,6 +4243,71 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
     await waitFor(() => live.sendCalls.length === 3);
     expect(live.sendCalls[2]).toBe(channelTurnId(m1.id, steerProfile));
     expect(live.concurrentPeak).toBe(1);
+  });
+
+  // Same setup as above with ONE reordering: m1's parked send fails BEFORE the
+  // third post, so the re-enqueued trigger is the run's HEAD rather than a
+  // coalescing candidate. The seq-monotonicity guard does not fire here
+  // (m3.seq > m1.seq), so without the `reEnqueued` rule `pump` would splice both
+  // out and trigger on m3 — and m1 could not come back as a context row either,
+  // because m2's successful send already advanced `lastDeliveredSeq` past it.
+  it('gives a re-enqueued failed trigger its own turn when it heads the queue', async () => {
+    const built: SteerableAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => {
+        const adapter =
+          built.length === 0
+            ? new ParkedSendAdapter(agentType)
+            : new SteerableAdapter(agentType);
+        built.push(adapter);
+        return adapter;
+      },
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    binder.setStatusBroadcaster((_type, data) => events.push(data));
+    const steerProfile = builtInAgentProfileId('steer');
+
+    const m1 = postSteering(store, binder, '@steer one', ['steer'], undefined);
+    await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
+    const parked = built[0] as ParkedSendAdapter;
+
+    sessions.fireEnd(sessions.firstSessionId());
+
+    // m2 rebinds, delivers (advancing the delivery cursor past m1), and stalls.
+    postSteering(store, binder, '@steer two', ['steer'], undefined);
+    await waitFor(() => built.length === 2 && built[1]!.sendCalls.length === 1);
+    const live = built[1]!;
+
+    // m1's parked send fails FIRST, so it re-enqueues at the head of the queue.
+    parked.failParkedSend();
+    await waitFor(() => events[events.length - 1]?.['queuedCount'] === 1);
+
+    // ...and only then does a newer post land behind it.
+    const m3 = postSteering(
+      store,
+      binder,
+      '@steer three',
+      ['steer'],
+      undefined
+    );
+    await waitFor(() => events[events.length - 1]?.['queuedCount'] === 2);
+
+    // m1 must reach the adapter as its OWN trigger — the footer renders a
+    // trigger unconditionally, which is the only place it can still be carried.
+    live.completeLatest('two reply');
+    await waitFor(() => live.sendCalls.length === 2);
+    expect(live.sendCalls[1]).toBe(channelTurnId(m1.id, steerProfile));
+    expect(live.sendInputs[1]!.content).toContain('@steer one');
+
+    // ...and the newer post is not lost to the re-enqueue either.
+    live.completeLatest('one reply');
+    await waitFor(() => live.sendCalls.length === 3);
+    expect(live.sendCalls[2]).toBe(channelTurnId(m3.id, steerProfile));
+    expect(live.sendInputs[2]!.content).toContain('@steer three');
+    expect(live.concurrentPeak).toBe(1);
+    expect(systemRows(store)).toHaveLength(0);
   });
 
   // The packet image budget is per PACKET, not per message, so folding N

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -3844,6 +3844,34 @@ const STEER_TARGETS: MentionTarget[] = [
   },
 ];
 
+/**
+ * First `sendMessage` parks forever until the test fails it — the shape a dead
+ * transport has when the send hangs and only later rejects. Everything else is
+ * `SteerableAdapter`.
+ */
+class ParkedSendAdapter extends SteerableAdapter {
+  private rejectSend: ((err: unknown) => void) | null = null;
+  override sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    this.sendInputs.push(input);
+    return new Promise<void>((_resolve, reject) => {
+      this.rejectSend = reject;
+    });
+  }
+  failParkedSend(): void {
+    const reject = this.rejectSend;
+    this.rejectSend = null;
+    reject?.(new Error('boom: transport gone'));
+  }
+}
+
+/** Refuses every cancellation so the steering failure row is observable. */
+class RefusingInterruptAdapter extends SteerableAdapter {
+  override async interrupt(): Promise<void> {
+    throw new Error('boom: interrupt refused');
+  }
+}
+
 /** Post with an explicit steering choice, exactly as the post route forwards it. */
 function postSteering(
   store: ChannelMessageStore,
@@ -3851,7 +3879,8 @@ function postSteering(
   text: string,
   knownIds: string[],
   steering: 'interrupt' | undefined,
-  sender: ChannelSenderRef = OPERATOR
+  sender: ChannelSenderRef = OPERATOR,
+  parentMessageId?: string
 ): ChannelMessage {
   const mentions = parseMentions(text, knownIds);
   const message = store.appendComplete({
@@ -3859,12 +3888,40 @@ function postSteering(
     sender,
     text,
     ...(mentions.length ? { mentions } : {}),
+    ...(parentMessageId ? { parentMessageId } : {}),
   });
   binder.handleMessagePosted(
     message,
     message.mentions ?? [],
     steering ? { steering } : undefined
   );
+  return message;
+}
+
+/** Image-bearing post. The payload never resolves — only the turn shape matters. */
+function postSteerImage(
+  store: ChannelMessageStore,
+  binder: ChannelAgentBinder,
+  text: string,
+  partId: string
+): ChannelMessage {
+  const mentions = parseMentions(text, ['steer']);
+  const part: ChannelImagePart = {
+    type: 'image',
+    id: partId,
+    mime: 'image/png',
+    w: 1,
+    h: 1,
+    bytes: 7,
+  };
+  const message = store.appendComplete({
+    channelId: CH,
+    sender: OPERATOR,
+    text,
+    ...(mentions.length ? { mentions } : {}),
+    parts: [part],
+  });
+  binder.handleMessagePosted(message, message.mentions ?? []);
   return message;
 }
 
@@ -4090,5 +4147,132 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
         (row) => row.providerId === 'steer'
       )?.binding?.queuedCount
     ).toBe(0);
+  });
+
+  // The queue is NOT seq-ordered: `handleSendFailure` re-enqueues an older,
+  // already-failed trigger BEHIND whatever arrived while the transport was
+  // failing. Coalescing folds older members into the newest one's packet, so a
+  // run that admitted a stale head would splice a newer post out of the queue
+  // while producing neither a turn for it nor a context row carrying it.
+  it('a re-enqueued failed trigger never swallows a newer queued post', async () => {
+    const built: SteerableAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => {
+        const adapter =
+          built.length === 0
+            ? new ParkedSendAdapter(agentType)
+            : new SteerableAdapter(agentType);
+        built.push(adapter);
+        return adapter;
+      },
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    binder.setStatusBroadcaster((_type, data) => events.push(data));
+    const steerProfile = builtInAgentProfileId('steer');
+
+    const m1 = postSteering(store, binder, '@steer one', ['steer'], undefined);
+    await waitFor(() => built.length === 1 && built[0]!.sendCalls.length === 1);
+    const parked = built[0] as ParkedSendAdapter;
+
+    // The runtime dies while m1's send is still in flight, so the retry lands on
+    // a DIFFERENT binding and takes the re-enqueue branch rather than redeliver.
+    sessions.fireEnd(sessions.firstSessionId());
+
+    // A newer post rebinds and opens its own turn, which stalls...
+    postSteering(store, binder, '@steer two', ['steer'], undefined);
+    await waitFor(() => built.length === 2 && built[1]!.sendCalls.length === 1);
+    const live = built[1]!;
+
+    // ...and a newer-still post queues behind that live turn.
+    const m3 = postSteering(
+      store,
+      binder,
+      '@steer three',
+      ['steer'],
+      undefined
+    );
+    await waitFor(() => events[events.length - 1]?.['queuedCount'] === 1);
+
+    // Only now does m1's parked send fail: it re-enqueues BEHIND m3.
+    parked.failParkedSend();
+    await waitFor(() => events[events.length - 1]?.['queuedCount'] === 2);
+
+    // The drain must trigger on the NEWEST queued post, not the queue tail.
+    live.completeLatest('two reply');
+    await waitFor(() => live.sendCalls.length === 2);
+    expect(live.sendCalls[1]).toBe(channelTurnId(m3.id, steerProfile));
+    expect(live.sendInputs[1]!.content).toContain('@steer three');
+
+    // ...and the re-enqueued older trigger is not lost either — it drains next.
+    live.completeLatest('three reply');
+    await waitFor(() => live.sendCalls.length === 3);
+    expect(live.sendCalls[2]).toBe(channelTurnId(m1.id, steerProfile));
+    expect(live.concurrentPeak).toBe(1);
+  });
+
+  // The packet image budget is per PACKET, not per message, so folding N
+  // image-bearing posts into one turn would silently spend one budget on all of
+  // them. Attachments are operator content the slice promised not to drop.
+  it('never coalesces image-bearing posts, so each keeps its own image budget', async () => {
+    const { binder, store, sessions, events } = makeSteerBinder();
+    postSteering(store, binder, '@steer opener', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    const steerProfile = builtInAgentProfileId('steer');
+
+    const shotA = postSteerImage(store, binder, '@steer shot a', 'cha:shot-a');
+    const shotB = postSteerImage(store, binder, '@steer shot b', 'cha:shot-b');
+    await waitFor(() => events[events.length - 1]?.['queuedCount'] === 2);
+
+    adapter.completeLatest('opener reply');
+    await waitFor(() => adapter.sendCalls.length === 2);
+    expect(adapter.sendCalls[1]).toBe(channelTurnId(shotA.id, steerProfile));
+    adapter.completeLatest('shot a reply');
+    await waitFor(() => adapter.sendCalls.length === 3);
+    expect(adapter.sendCalls[2]).toBe(channelTurnId(shotB.id, steerProfile));
+    expect(adapter.concurrentPeak).toBe(1);
+  });
+
+  it('parents a refused steering interrupt to the thread it was issued from', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => new RefusingInterruptAdapter(agentType),
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'thread root',
+    });
+    post(store, binder, '@steer long task', ['steer'], OPERATOR, root.id);
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as RefusingInterruptAdapter;
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    const steer = postSteering(
+      store,
+      binder,
+      '@steer stop that',
+      ['steer'],
+      'interrupt',
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() =>
+      systemRows(store).some((row) =>
+        row.body.text.includes('could not be interrupted')
+      )
+    );
+    const failure = systemRows(store).find((row) =>
+      row.body.text.includes('could not be interrupted')
+    )!;
+    // Without this the explanation lands at channel top level, away from the
+    // thread the operator was actually working in.
+    expect(failure.threadId).toBe(root.id);
+    expect(failure.parentMessageId).toBe(steer.id);
   });
 });

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -461,6 +461,128 @@ class ApprovalAdapter extends BaseProtocolAdapterV2 {
   }
 }
 
+// ── steerable adapter (#1308 slice 4 mid-turn steering) ──────────────────────
+// Every send opens a turn that streams one partial chunk and then STALLS, so a
+// turn is reliably live when the next post lands. `interrupt` emits the same
+// terminal patch a real cancellation produces; `complete` finishes naturally.
+// Tracks the set of turns the adapter believes are open so a double dispatch is
+// OBSERVED (concurrentPeak > 1) rather than inferred from send counts.
+class SteerableAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    queue: false,
+    interrupt: true,
+    approvals: false,
+    streaming: true,
+  };
+  readonly sendCalls: string[] = [];
+  readonly sendInputs: AgentSendMessageInputV2[] = [];
+  readonly interruptCalls: string[] = [];
+  /** Peak simultaneously-open turns; the binder must never let this exceed 1. */
+  concurrentPeak = 0;
+  private readonly open = new Set<string>();
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'steerable';
+
+  constructor(readonly agentType: string) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    this.sendInputs.push(input);
+    this.open.add(input.turnId);
+    this.concurrentPeak = Math.max(this.concurrentPeak, this.open.size);
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `u-${input.turnId}`,
+        items: [],
+        startedAt: 't',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      item: {
+        type: 'assistantMessage',
+        id: `a-${input.turnId}`,
+        text: '',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      itemId: `a-${input.turnId}`,
+      delta: { text: 'partial…' },
+    });
+    // No terminal patch: the turn stays live until interrupt() or complete().
+  }
+
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    const turnId = input.turnId ?? [...this.open][0];
+    if (turnId === undefined) return;
+    this.interruptCalls.push(turnId);
+    this.closeTurn(turnId, 'interrupted');
+  }
+
+  /** Finish the newest live turn the way a normal completion would. */
+  completeLatest(text = 'done'): void {
+    const turnId = this.sendCalls[this.sendCalls.length - 1];
+    if (turnId === undefined) return;
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      item: {
+        type: 'assistantMessage',
+        id: `a-${turnId}`,
+        text,
+        status: 'completed',
+      },
+    });
+    this.closeTurn(turnId, 'completed');
+  }
+
+  private closeTurn(
+    turnId: string,
+    status: 'completed' | 'interrupted' | 'failed'
+  ): void {
+    if (!this.open.delete(turnId)) return;
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status,
+    });
+  }
+}
+
 // ── deferred-send adapter (send acceptance resolved/rejected on command) ──────
 // sendMessage returns a promise the test resolves (accept) or rejects (transport
 // failure) explicitly, so the send-failure/rebind interleaving is deterministic.
@@ -1634,7 +1756,12 @@ describe('channel-agent-binder — lifecycle', () => {
     expect(sessions.spawns()).toBe(1);
   });
 
-  it('queue overflow past the cap drops the message with a system row', async () => {
+  // #1308 slice 4 changed what the cap means for the operator's own lane: a
+  // contiguous human run drains as ONE turn, so an overflowing post supersedes
+  // the queue tail (identical trigger + packet) instead of being announced as
+  // dropped for a turn that was never going to exist. The drop row is still the
+  // honest answer whenever superseding would NOT be equivalent.
+  it('supersedes rather than drops when an over-cap post coalesces with the tail', async () => {
     const { binder, store } = makeBinder({
       build: () => new ScriptedAdapter('stall', { mode: 'stall' }),
       targets: [
@@ -1653,22 +1780,64 @@ describe('channel-agent-binder — lifecycle', () => {
       sender: OPERATOR,
       text: 'root',
     });
-    const triggers: ChannelMessage[] = [];
-    for (let i = 0; i < 10; i++) {
-      triggers.push(
-        post(store, binder, `@stall ${i}`, ['stall'], OPERATOR, root.id)
-      );
+    for (let i = 0; i < 12; i++) {
+      post(store, binder, `@stall ${i}`, ['stall'], OPERATOR, root.id);
     }
+    await new Promise((r) => setTimeout(r, 120));
+    expect(
+      systemRows(store).filter((m) => m.body.text.includes('message dropped'))
+    ).toHaveLength(0);
+  });
+
+  it('queue overflow past the cap drops a non-coalescing message with a system row', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new ScriptedAdapter('stall', { mode: 'stall' }),
+      targets: [
+        {
+          id: 'stall',
+          displayName: 'Stall',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['stall'],
+    });
+    const rootA = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root a',
+    });
+    const rootB = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root b',
+    });
+    // One live turn plus a full cap of thread-A posts.
+    for (let i = 0; i < 9; i++) {
+      post(store, binder, `@stall a${i}`, ['stall'], OPERATOR, rootA.id);
+    }
+    await new Promise((r) => setTimeout(r, 120));
+    // A thread-B post cannot be represented by the thread-A tail, so the cap
+    // refuses it explicitly rather than silently losing it.
+    const overflow = post(
+      store,
+      binder,
+      '@stall b0',
+      ['stall'],
+      OPERATOR,
+      rootB.id
+    );
     await waitFor(() =>
-      systemRows(store).some((m) => m.body.text.includes('turns queued'))
+      systemRows(store).some((m) => m.body.text.includes('message dropped'))
     );
     const dropped = systemRows(store).filter((m) =>
       m.body.text.includes('message dropped')
     );
     expect(dropped).toHaveLength(1);
     expect(dropped[0]!.body.text).toContain('has 8 turns queued');
-    expect(dropped[0]!.threadId).toBe(root.id);
-    expect(dropped[0]!.parentMessageId).toBe(triggers.at(-1)!.id);
+    expect(dropped[0]!.threadId).toBe(rootB.id);
+    expect(dropped[0]!.parentMessageId).toBe(overflow.id);
   });
 
   it('runtime death unbinds, clears the binding, and respawns on next mention', async () => {
@@ -3299,14 +3468,10 @@ describe('channel-agent-binder — DM implicit routing', () => {
     expect(sessions.spawns()).toBe(1);
 
     // Same gate for the other agent lane: a gateway agent post in the DM.
-    postTo(
-      store,
-      binder,
-      DM_CH,
-      '@codex following up',
-      HERMES_AGENT_SENDER,
-      ['hermes', 'codex']
-    );
+    postTo(store, binder, DM_CH, '@codex following up', HERMES_AGENT_SENDER, [
+      'hermes',
+      'codex',
+    ]);
     await settle();
     expect(systemRowsIn(store, DM_CH)).toHaveLength(0);
     expect(sessions.spawns()).toBe(1);
@@ -3420,7 +3585,9 @@ describe('channel-agent-binder — retry', () => {
     });
     // Exactly one delivery, carrying the SAME deterministic turn identity the
     // lost turn had — a retry re-runs a turn, it does not open a new one.
-    expect(adapter.sendCalls).toEqual([channelTurnId(trigger.id, MOCK_PROFILE)]);
+    expect(adapter.sendCalls).toEqual([
+      channelTurnId(trigger.id, MOCK_PROFILE),
+    ]);
     // The load-bearing invariant: the operator's message is re-routed, never
     // re-posted, so the timeline still holds exactly one copy of it.
     expect(humanRows(store).map((m) => m.id)).toEqual([trigger.id]);
@@ -3476,9 +3643,7 @@ describe('channel-agent-binder — retry', () => {
       ChannelAgentBusyError
     );
     // Nothing was delivered and nothing was superseded by the refused retry.
-    expect(adapter.sendCalls).toEqual([
-      channelTurnId(live.id, MOCK_PROFILE),
-    ]);
+    expect(adapter.sendCalls).toEqual([channelTurnId(live.id, MOCK_PROFILE)]);
     expect(
       systemRows(store).filter(
         (row) => row.meta?.[CHANNEL_RETRY_OF_META_KEY] !== undefined
@@ -3611,7 +3776,9 @@ describe('channel-agent-binder — retry', () => {
 
     await binder.retryMessage(CH, interrupted.id);
     await waitFor(() => adapter.sendCalls.length > 0);
-    expect(adapter.sendCalls).toEqual([channelTurnId(trigger.id, MOCK_PROFILE)]);
+    expect(adapter.sendCalls).toEqual([
+      channelTurnId(trigger.id, MOCK_PROFILE),
+    ]);
   });
 });
 
@@ -3662,5 +3829,266 @@ describe('channel-agent-binder — retry availability', () => {
       )
     ).toHaveLength(0);
     expect(adapter.sendCalls).toHaveLength(0);
+  });
+});
+
+// ── #1308 slice 4: mid-turn steering ─────────────────────────────────────────
+
+const STEER_TARGETS: MentionTarget[] = [
+  {
+    id: 'steer',
+    displayName: 'Steer',
+    kind: 'framework',
+    available: true,
+    reason: null,
+  },
+];
+
+/** Post with an explicit steering choice, exactly as the post route forwards it. */
+function postSteering(
+  store: ChannelMessageStore,
+  binder: ChannelAgentBinder,
+  text: string,
+  knownIds: string[],
+  steering: 'interrupt' | undefined,
+  sender: ChannelSenderRef = OPERATOR
+): ChannelMessage {
+  const mentions = parseMentions(text, knownIds);
+  const message = store.appendComplete({
+    channelId: CH,
+    sender,
+    text,
+    ...(mentions.length ? { mentions } : {}),
+  });
+  binder.handleMessagePosted(
+    message,
+    message.mentions ?? [],
+    steering ? { steering } : undefined
+  );
+  return message;
+}
+
+function makeSteerBinder() {
+  const harness = makeBinder({
+    build: (agentType) => new SteerableAdapter(agentType),
+    targets: STEER_TARGETS,
+    knownProviderIds: ['steer'],
+  });
+  const events: Array<Record<string, unknown>> = [];
+  harness.binder.setStatusBroadcaster((_type, data) => events.push(data));
+  return { ...harness, events };
+}
+
+async function steerAdapter(
+  sessions: ReturnType<typeof makeBinder>['sessions']
+): Promise<SteerableAdapter> {
+  await waitFor(() => sessions.spawns() === 1);
+  return sessions.adapterFor(sessions.firstSessionId()) as SteerableAdapter;
+}
+
+describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
+  it('queues posts that land mid-turn and drains them all into ONE next turn', async () => {
+    const { binder, store, sessions, events } = makeSteerBinder();
+    postSteering(store, binder, '@steer one', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    // Three more posts land while the first turn is still live.
+    postSteering(store, binder, '@steer two', ['steer'], undefined);
+    postSteering(store, binder, '@steer three', ['steer'], undefined);
+    postSteering(store, binder, '@steer four', ['steer'], undefined);
+    await waitFor(() => events.some((event) => event['queuedCount'] === 3));
+    // No concurrent dispatch while the first turn is open — all three queued.
+    expect(adapter.sendCalls).toHaveLength(1);
+
+    adapter.completeLatest('first reply');
+    // Exactly ONE further turn for the three queued posts (coalesced).
+    await waitFor(() => adapter.sendCalls.length === 2);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(adapter.sendCalls).toHaveLength(2);
+    expect(adapter.concurrentPeak).toBe(1);
+
+    // ...and all three ride that one context packet.
+    const packet = adapter.sendInputs[1]!.content;
+    expect(packet).toContain('@steer two');
+    expect(packet).toContain('@steer three');
+    expect(packet).toContain('@steer four');
+    // The newest queued post is the trigger in the packet footer.
+    expect(packet.trimEnd().endsWith('@steer four')).toBe(true);
+  });
+
+  it('never drops a queued trigger and never double-dispatches across finishTurn', async () => {
+    const { binder, store, sessions } = makeSteerBinder();
+    postSteering(store, binder, '@steer first', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    // Interleave a post with the completion of the live turn: the post enqueues
+    // while the previous turn is still active, then finishTurn pumps it. Only
+    // ONE dispatch may result, and it must not be lost.
+    postSteering(store, binder, '@steer second', ['steer'], undefined);
+    adapter.completeLatest('first reply');
+    await waitFor(() => adapter.sendCalls.length === 2);
+    postSteering(store, binder, '@steer third', ['steer'], undefined);
+    adapter.completeLatest('second reply');
+    await waitFor(() => adapter.sendCalls.length === 3);
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(adapter.sendCalls).toHaveLength(3);
+    expect(adapter.concurrentPeak).toBe(1);
+    expect(new Set(adapter.sendCalls).size).toBe(3); // no re-sent turn identity
+    expect(adapter.sendInputs[1]!.content).toContain('@steer second');
+    expect(adapter.sendInputs[2]!.content).toContain('@steer third');
+  });
+
+  it('steering:"interrupt" cancels the live turn and dispatches the new message', async () => {
+    const { binder, store, sessions } = makeSteerBinder();
+    postSteering(store, binder, '@steer long task', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    await waitFor(() =>
+      rows(store).some(
+        (m) => m.sender.providerId === 'steer' && m.status === 'streaming'
+      )
+    );
+    const firstTurn = adapter.sendCalls[0]!;
+
+    postSteering(
+      store,
+      binder,
+      '@steer stop, do this instead',
+      ['steer'],
+      'interrupt'
+    );
+
+    await waitFor(() => adapter.interruptCalls.length === 1);
+    expect(adapter.interruptCalls[0]).toBe(firstTurn);
+    // Existing interrupt semantics: the partial row finalizes `interrupted`.
+    await waitFor(() =>
+      rows(store).some(
+        (m) => m.sender.providerId === 'steer' && m.status === 'interrupted'
+      )
+    );
+    // ...and the steering message triggers its own turn immediately after.
+    await waitFor(() => adapter.sendCalls.length === 2);
+    expect(adapter.concurrentPeak).toBe(1);
+    expect(adapter.sendInputs[1]!.content).toContain(
+      '@steer stop, do this instead'
+    );
+  });
+
+  it('steering:"interrupt" on an idle agent degrades to a plain send', async () => {
+    const { binder, store, sessions } = makeSteerBinder();
+    postSteering(store, binder, '@steer go now', ['steer'], 'interrupt');
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(adapter.interruptCalls).toHaveLength(0);
+    expect(adapter.sendCalls).toHaveLength(1);
+  });
+
+  it('an agent-authored post never steers: no interrupt, one turn per trigger', async () => {
+    const { binder, store, sessions } = makeSteerBinder();
+    postSteering(store, binder, '@steer human opener', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    // A CLI-gateway agent post carrying the same flag must not cancel the turn.
+    postSteering(
+      store,
+      binder,
+      '@steer agent one',
+      ['steer'],
+      'interrupt',
+      AGENT_SENDER
+    );
+    postSteering(
+      store,
+      binder,
+      '@steer agent two',
+      ['steer'],
+      'interrupt',
+      AGENT_SENDER
+    );
+    await new Promise((r) => setTimeout(r, 40));
+    expect(adapter.interruptCalls).toHaveLength(0);
+    expect(adapter.sendCalls).toHaveLength(1);
+
+    // Agent triggers are never coalesced away — each keeps its own turn.
+    adapter.completeLatest('reply one');
+    await waitFor(() => adapter.sendCalls.length === 2);
+    adapter.completeLatest('reply two');
+    await waitFor(() => adapter.sendCalls.length === 3);
+    expect(adapter.concurrentPeak).toBe(1);
+    expect(adapter.sendInputs[1]!.content).toContain('@steer agent one');
+    expect(adapter.sendInputs[2]!.content).toContain('@steer agent two');
+  });
+
+  it('supersedes the queue tail instead of dropping fast operator typing at the cap', async () => {
+    const { binder, store, sessions } = makeSteerBinder();
+    postSteering(store, binder, '@steer opener', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    // Far past QUEUE_CAP: they all collapse into the one next turn, so no slot
+    // pressure and no "message dropped" row is honest here.
+    const total = 20;
+    let last: ChannelMessage | null = null;
+    for (let i = 0; i < total; i += 1) {
+      last = postSteering(
+        store,
+        binder,
+        `@steer burst ${i}`,
+        ['steer'],
+        undefined
+      );
+    }
+    await waitFor(
+      () =>
+        store.getMessage(last!.id) !== null && adapter.sendCalls.length === 1
+    );
+    await new Promise((r) => setTimeout(r, 60));
+    expect(
+      systemRows(store).filter((row) =>
+        row.body.text.includes('message dropped')
+      )
+    ).toHaveLength(0);
+
+    adapter.completeLatest('opener reply');
+    await waitFor(() => adapter.sendCalls.length === 2);
+    const packet = adapter.sendInputs[1]!.content;
+    expect(packet.trimEnd().endsWith(`@steer burst ${total - 1}`)).toBe(true);
+    expect(packet).toContain('@steer burst 0');
+    expect(adapter.concurrentPeak).toBe(1);
+  });
+
+  it('publishes queuedCount on the status event and the roster payload', async () => {
+    const { binder, store, sessions, events } = makeSteerBinder();
+    postSteering(store, binder, '@steer one', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    // Every status event carries the field, additively.
+    expect(events.length).toBeGreaterThan(0);
+    expect(
+      events.every((event) => typeof event['queuedCount'] === 'number')
+    ).toBe(true);
+
+    postSteering(store, binder, '@steer two', ['steer'], undefined);
+    postSteering(store, binder, '@steer three', ['steer'], undefined);
+    await waitFor(() => events.some((event) => event['queuedCount'] === 2));
+    const roster = await binder.rosterForChannel(CH);
+    const entry = roster.find((row) => row.providerId === 'steer');
+    expect(entry?.binding?.queuedCount).toBe(2);
+    expect(entry?.binding?.status).toBe('streaming');
+
+    adapter.completeLatest('reply');
+    await waitFor(() => adapter.sendCalls.length === 2);
+    // The drain is reported, not left stale on the last busy count.
+    expect(events[events.length - 1]?.['queuedCount']).toBe(0);
+    expect(
+      (await binder.rosterForChannel(CH)).find(
+        (row) => row.providerId === 'steer'
+      )?.binding?.queuedCount
+    ).toBe(0);
   });
 });

--- a/test/channel-agent-status-reconcile.test.ts
+++ b/test/channel-agent-status-reconcile.test.ts
@@ -100,6 +100,8 @@ describe('useChannelAgentStatusStore — timestamped reconciliation state', () =
     useChannelAgentStatusStore.setState({
       statusByChannelAgent: {},
       runtimeByChannelAgent: {},
+      queuedCountByChannelAgent: {},
+      queueDrainSeqByChannelAgent: {},
       updatedAtByChannelAgent: {},
     });
   });

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -43,6 +43,7 @@ import {
   BaseProtocolAdapterV2,
   type AdapterConfig,
   type AdapterStatus,
+  type AgentInterruptInputV2,
   type AgentSendMessageInputV2,
   type ProtocolAdapterV2,
 } from '../server/protocol-adapter-v2.js';
@@ -141,6 +142,75 @@ class RecordingAdapter extends BaseProtocolAdapterV2 {
       timestamp: 't',
       turnId: input.turnId,
       status: 'completed',
+    });
+  }
+}
+
+/**
+ * Streams a partial reply and then stalls, so a turn is genuinely live when the
+ * next HTTP post lands (#1308 slice 4). `interrupt` emits the terminal patch a
+ * real cancellation produces, which is what releases the binder's queue.
+ */
+class StallingAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    streaming: true,
+    interrupt: true,
+  };
+  readonly contents: string[] = [];
+  readonly interruptCalls: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'stalling';
+  private live: string | null = null;
+  constructor(readonly agentType: string) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.contents.push(input.content);
+    this.live = input.turnId;
+    const itemId = `a-${input.turnId}`;
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      item: { type: 'assistantMessage', id: itemId, text: '' },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      itemId,
+      delta: { text: 'thinking…' },
+    });
+  }
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    const turnId = input.turnId ?? this.live;
+    if (turnId === null || turnId === undefined) return;
+    this.interruptCalls.push(turnId);
+    this.live = null;
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId,
+      status: 'interrupted',
     });
   }
 }
@@ -280,7 +350,9 @@ async function harness(
     configDir: dir,
   });
   cleanup.push(() => binder.close());
-  hub.onMessagePosted((m, mentions) => binder.handleMessagePosted(m, mentions));
+  hub.onMessagePosted((m, mentions, options) =>
+    binder.handleMessagePosted(m, mentions, options)
+  );
 
   const app = express();
   app.use(express.json());
@@ -838,5 +910,70 @@ describe('mention routing — deleted context (#1308 slice 1 item 4)', () => {
     expect(h.store.getMessage(posted.body.message.id)?.body.text).toBe(
       'operator wrote this'
     );
+  });
+});
+
+// ── #1308 slice 4: mid-turn steering through the post route ──────────────────
+
+describe('mid-turn steering — end-to-end via the post route', () => {
+  it('rejects an unknown steering value without writing a row', async () => {
+    const h = await harness();
+    const before = h.store.history(h.channelId, { limit: 50 }).length;
+    const res = await req<{ error: { details?: Record<string, unknown> } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock hello', steering: 'yolo' },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error.details?.['reasonCode']).toBe(
+      'CHANNEL_STEERING_INVALID'
+    );
+    expect(h.store.history(h.channelId, { limit: 50 })).toHaveLength(before);
+  });
+
+  it('queues a plain post behind a live turn and interrupts on steering:"interrupt"', async () => {
+    const h = await harness((agentType) => new StallingAdapter(agentType));
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock go' },
+    });
+    await waitFor(() => h.adapters().length === 1);
+    const adapter = h.adapters()[0] as StallingAdapter;
+    await waitFor(() => adapter.contents.length === 1);
+
+    // A plain post lands mid-turn: queued, never a second concurrent dispatch.
+    await req({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock also this' },
+    });
+    await new Promise((r) => setTimeout(r, 60));
+    expect(adapter.contents).toHaveLength(1);
+    expect(adapter.interruptCalls).toHaveLength(0);
+
+    // The explicit steering flag cancels the live turn and sends now.
+    const steered = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: '@mock stop and do this', steering: 'interrupt' },
+    });
+    expect(steered.status).toBe(201);
+    await waitFor(() => adapter.interruptCalls.length === 1);
+    await waitFor(() => adapter.contents.length === 2);
+    // Both queued posts ride the one next packet (queue coalescing).
+    expect(adapter.contents[1]).toContain('@mock also this');
+    expect(adapter.contents[1]).toContain('@mock stop and do this');
+    // Existing interrupt semantics: the partial row finalizes `interrupted`.
+    expect(
+      h.store
+        .history(h.channelId, { limit: 50 })
+        .some((m) => m.sender.kind === 'agent' && m.status === 'interrupted')
+    ).toBe(true);
   });
 });

--- a/test/channel-queued-sends.test.ts
+++ b/test/channel-queued-sends.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  channelAgentStatusKey,
+  resolveEffectiveQueuedCount,
+  useChannelAgentStatusStore,
+} from '../frontend/src/lib/stores/channel-agent-status.js';
+import {
+  queuedSendCopy,
+  queuedSendStillWaiting,
+  snapshotQueueDrainSeqs,
+  useChannelQueuedSendsStore,
+} from '../frontend/src/lib/stores/channel-queued-sends.js';
+import {
+  channelPresenceCopy,
+  selectChannelAgentPresence,
+} from '../frontend/src/lib/chat/channel-agent-presence.js';
+
+// #1308 slice 4 item 2. The queued-send chip's whole correctness rests on ONE
+// signal: the per-agent "queue observed empty" generation published with
+// `channel-agent-status`. These tests pin that generation's edges, because the
+// component can only ever be as right as this is.
+
+const CHANNEL = 'topic:ops';
+const CLAUDE = 'agent-profile:claude:default';
+const KEY = channelAgentStatusKey(CHANNEL, CLAUDE);
+
+function resetStores(): void {
+  useChannelAgentStatusStore.setState({
+    statusByChannelAgent: {},
+    runtimeByChannelAgent: {},
+    queuedCountByChannelAgent: {},
+    queueDrainSeqByChannelAgent: {},
+    updatedAtByChannelAgent: {},
+  });
+  useChannelQueuedSendsStore.setState({ marksByMessageId: {} });
+}
+
+describe('queue drain generation (#1308 slice 4)', () => {
+  beforeEach(resetStores);
+
+  it('does not advance while posts are still queued', () => {
+    const record = useChannelAgentStatusStore.getState().recordStatus;
+    record(CHANNEL, CLAUDE, 'streaming', 'rt:1', 1);
+    record(CHANNEL, CLAUDE, 'idle', 'rt:1', 1);
+    const state = useChannelAgentStatusStore.getState();
+    expect(state.queuedCountByChannelAgent[KEY]).toBe(1);
+    expect(state.queueDrainSeqByChannelAgent[KEY] ?? 0).toBe(0);
+  });
+
+  it('advances on the drain the binder emits before the next turn starts', () => {
+    const record = useChannelAgentStatusStore.getState().recordStatus;
+    const seq = (): number =>
+      useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent[KEY] ??
+      0;
+    // The exact server sequence: enqueue, turn ends, queue spliced out, next
+    // turn opens (server/channel-agent-binder finishTurn → pump → sendTurn).
+    record(CHANNEL, CLAUDE, 'streaming', 'rt:1', 1);
+    record(CHANNEL, CLAUDE, 'idle', 'rt:1', 1);
+    expect(seq()).toBe(0);
+    // The splice: this is the transition that retires the chip, and it lands
+    // BEFORE the consuming turn is announced.
+    record(CHANNEL, CLAUDE, 'idle', 'rt:1', 0);
+    expect(seq()).toBe(1);
+    // The consuming turn also reports an empty queue; a further bump is inert
+    // (the mark it would have retired is already gone).
+    record(CHANNEL, CLAUDE, 'thinking', 'rt:1', 0);
+    expect(seq()).toBe(2);
+  });
+
+  it('advances on any empty-queue transition, so a post that never queued still clears', () => {
+    // A group-channel message that addresses nobody enqueues nothing at all —
+    // there is no `queuedCount 1 → 0` edge to wait for, only the busy agent's
+    // own next transition.
+    const record = useChannelAgentStatusStore.getState().recordStatus;
+    record(CHANNEL, CLAUDE, 'streaming', 'rt:1', 0);
+    record(CHANNEL, CLAUDE, 'idle', 'rt:1', 0);
+    expect(
+      useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent[KEY]
+    ).toBe(2);
+  });
+
+  it('clearChannel drops the queue maps for that channel only', () => {
+    const record = useChannelAgentStatusStore.getState().recordStatus;
+    record(CHANNEL, CLAUDE, 'streaming', 'rt:1', 2);
+    record('topic:other', CLAUDE, 'streaming', 'rt:2', 3);
+    useChannelAgentStatusStore.getState().clearChannel(CHANNEL);
+    const state = useChannelAgentStatusStore.getState();
+    expect(state.queuedCountByChannelAgent[KEY]).toBeUndefined();
+    expect(state.queueDrainSeqByChannelAgent[KEY]).toBeUndefined();
+    expect(
+      state.queuedCountByChannelAgent[
+        channelAgentStatusKey('topic:other', CLAUDE)
+      ]
+    ).toBe(3);
+  });
+});
+
+describe('queued-send marks (#1308 slice 4)', () => {
+  beforeEach(resetStores);
+
+  function mark(drainSeqs: Record<string, number>) {
+    return {
+      channelId: CHANNEL,
+      agentIds: [CLAUDE],
+      label: queuedSendCopy(['claude']),
+      drainSeqs,
+    };
+  }
+
+  it('stays visible while the snapshotted generation is current', () => {
+    useChannelAgentStatusStore
+      .getState()
+      .recordStatus(CHANNEL, CLAUDE, 'streaming', 'rt:1', 1);
+    const snapshot = snapshotQueueDrainSeqs(
+      CHANNEL,
+      [CLAUDE],
+      useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
+    );
+    expect(
+      queuedSendStillWaiting(
+        mark(snapshot),
+        useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
+      )
+    ).toBe(true);
+  });
+
+  it('retires the moment that generation advances', () => {
+    const snapshot = snapshotQueueDrainSeqs(CHANNEL, [CLAUDE], {});
+    useChannelAgentStatusStore
+      .getState()
+      .recordStatus(CHANNEL, CLAUDE, 'thinking', 'rt:1', 0);
+    expect(
+      queuedSendStillWaiting(
+        mark(snapshot),
+        useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
+      )
+    ).toBe(false);
+  });
+
+  it('retires when ANY addressed agent drains, not only when all do', () => {
+    const hermes = 'agent-profile:hermes:default';
+    const record = useChannelAgentStatusStore.getState().recordStatus;
+    record(CHANNEL, CLAUDE, 'streaming', 'rt:1', 1);
+    record(CHANNEL, hermes, 'streaming', 'rt:2', 1);
+    const drainSeqs =
+      useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent;
+    const snapshot = snapshotQueueDrainSeqs(
+      CHANNEL,
+      [CLAUDE, hermes],
+      drainSeqs
+    );
+    const multi = {
+      channelId: CHANNEL,
+      agentIds: [CLAUDE, hermes],
+      label: queuedSendCopy(['claude', 'hermes']),
+      drainSeqs: snapshot,
+    };
+    record(CHANNEL, hermes, 'idle', 'rt:2', 0);
+    expect(
+      queuedSendStillWaiting(
+        multi,
+        useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
+      )
+    ).toBe(false);
+  });
+
+  it('never waits on an empty target set', () => {
+    expect(
+      queuedSendStillWaiting(
+        { channelId: CHANNEL, agentIds: [], label: 'x', drainSeqs: {} },
+        {}
+      )
+    ).toBe(false);
+  });
+
+  it('clearChannel drops that channel’s marks only', () => {
+    const store = useChannelQueuedSendsStore.getState();
+    store.markQueuedSend('chm:1', mark({}));
+    store.markQueuedSend('chm:2', { ...mark({}), channelId: 'topic:other' });
+    useChannelQueuedSendsStore.getState().clearChannel(CHANNEL);
+    const marks = useChannelQueuedSendsStore.getState().marksByMessageId;
+    expect(marks['chm:1']).toBeUndefined();
+    expect(marks['chm:2']).toBeDefined();
+  });
+
+  it('names one busy agent and stays generic for several — lowercase, no emoji', () => {
+    expect(queuedSendCopy(['claude'])).toBe('queued — claude is mid-turn');
+    expect(queuedSendCopy(['claude', 'hermes'])).toBe(
+      'queued — agents are mid-turn'
+    );
+  });
+});
+
+describe('resolveEffectiveQueuedCount (#1308 slice 4)', () => {
+  it('socket wins when its transition is at least as new as the roster snapshot', () => {
+    expect(
+      resolveEffectiveQueuedCount({
+        socketQueuedCount: 2,
+        socketUpdatedAt: 200,
+        rosterQueuedCount: 0,
+        rosterUpdatedAt: 200,
+      })
+    ).toBe(2);
+  });
+
+  it('roster wins over a socket count the snapshot has superseded', () => {
+    expect(
+      resolveEffectiveQueuedCount({
+        socketQueuedCount: 3,
+        socketUpdatedAt: 100,
+        rosterQueuedCount: 0,
+        rosterUpdatedAt: 200,
+      })
+    ).toBe(0);
+  });
+
+  it('reads zero from a hub that publishes no count at all', () => {
+    expect(
+      resolveEffectiveQueuedCount({
+        socketQueuedCount: undefined,
+        socketUpdatedAt: undefined,
+        rosterQueuedCount: undefined,
+        rosterUpdatedAt: 200,
+      })
+    ).toBe(0);
+  });
+});
+
+describe('presence copy queued suffix (#1308 slice 4 item 2c)', () => {
+  const chip = (queuedCount: number) => ({
+    agentId: CLAUDE,
+    status: 'streaming' as const,
+    identity: {
+      label: 'claude',
+      colorVar: 'var(--sender-claude)',
+      glyph: null,
+    },
+    queuedCount,
+  });
+
+  it('appends the depth only when something is waiting', () => {
+    const [withQueue] = selectChannelAgentPresence(
+      [chip(1)],
+      new Set<string>()
+    );
+    const [without] = selectChannelAgentPresence([chip(0)], new Set<string>());
+    expect(withQueue && channelPresenceCopy(withQueue)).toBe(
+      'claude is responding… (1 queued)'
+    );
+    expect(without && channelPresenceCopy(without)).toBe(
+      'claude is responding…'
+    );
+  });
+
+  it('counts past one', () => {
+    const [presence] = selectChannelAgentPresence([chip(3)], new Set<string>());
+    expect(presence && channelPresenceCopy(presence)).toBe(
+      'claude is responding… (3 queued)'
+    );
+  });
+});

--- a/test/channel-queued-sends.test.ts
+++ b/test/channel-queued-sends.test.ts
@@ -184,6 +184,41 @@ describe('queued-send marks (#1308 slice 4)', () => {
     expect(marks['chm:2']).toBeDefined();
   });
 
+  // A daily-driver channel stays mounted for days, and `clearChannel` only
+  // fires on switch/unmount, so an append-only map would grow one entry per
+  // queued send for the whole session.
+  it('sweeps retired marks on every insert so the map stays bounded', () => {
+    const record = useChannelAgentStatusStore.getState().recordStatus;
+    record(CHANNEL, CLAUDE, 'streaming', 'rt:1', 1);
+    const snapshot = snapshotQueueDrainSeqs(
+      CHANNEL,
+      [CLAUDE],
+      useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
+    );
+    useChannelQueuedSendsStore
+      .getState()
+      .markQueuedSend('chm:1', mark(snapshot));
+    // Still waiting: an insert must not evict a live mark.
+    useChannelQueuedSendsStore
+      .getState()
+      .markQueuedSend('chm:2', mark(snapshot));
+    expect(
+      Object.keys(useChannelQueuedSendsStore.getState().marksByMessageId).sort()
+    ).toEqual(['chm:1', 'chm:2']);
+
+    // The queue drains, retiring both — the next insert is what collects them.
+    record(CHANNEL, CLAUDE, 'idle', 'rt:1', 0);
+    const fresh = snapshotQueueDrainSeqs(
+      CHANNEL,
+      [CLAUDE],
+      useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
+    );
+    useChannelQueuedSendsStore.getState().markQueuedSend('chm:3', mark(fresh));
+    expect(
+      Object.keys(useChannelQueuedSendsStore.getState().marksByMessageId)
+    ).toEqual(['chm:3']);
+  });
+
   it('names one busy agent and stays generic for several — lowercase, no emoji', () => {
     expect(queuedSendCopy(['claude'])).toBe('queued — claude is mid-turn');
     expect(queuedSendCopy(['claude', 'hermes'])).toBe(

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -626,6 +626,47 @@ describe('channel routes — read / write contract', () => {
     expect(h.store.history(h.channelId)).toHaveLength(1);
   });
 
+  // #1308 slice 4 review: the composer keeps its `clientMessageId` after a
+  // failed send, so "queue → looked like it failed → interrupt & send" replays a
+  // known id. The row must not be duplicated, but the interrupt must still land
+  // — otherwise the UI reports an interrupt-and-send that did neither.
+  it('applies steering on an idempotent replay without re-posting the row', async () => {
+    const steered: Array<{ id: string; steering: string }> = [];
+    const h = await harness({
+      binder: {
+        steerExisting: (message, steering) => {
+          steered.push({ id: message.id, steering });
+        },
+      },
+    });
+    const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;
+    const first = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: { text: 'wait, stop', clientMessageId: 'c-steer' },
+    });
+    expect(first.status).toBe(201);
+    expect(steered).toHaveLength(0); // plain queue post never steers
+
+    const replay = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url,
+      body: {
+        text: 'wait, stop',
+        clientMessageId: 'c-steer',
+        steering: 'interrupt',
+      },
+    });
+    expect(replay.status).toBe(200);
+    expect(replay.body.message.id).toBe(first.body.message.id);
+    expect(h.store.history(h.channelId)).toHaveLength(1);
+    expect(steered).toEqual([
+      { id: first.body.message.id, steering: 'interrupt' },
+    ]);
+  });
+
   it('paginates history with limit and afterSeq', async () => {
     const h = await harness();
     const url = `/channels/${encodeURIComponent(h.channelId)}/messages`;

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -217,7 +217,14 @@ describe('ChannelComposer (#1178)', () => {
     ).toBe('ready');
 
     await enterAgain();
-    expect(onSend).toHaveBeenCalledWith('', expect.any(String), [imagePart]);
+    // The 4th argument is the #1308 slice 4 steering choice — `undefined` on a
+    // plain send, which is what an idle composer always produces.
+    expect(onSend).toHaveBeenCalledWith(
+      '',
+      expect.any(String),
+      [imagePart],
+      undefined
+    );
     expect(container.querySelector('.ch-composer__attachment')).toBeNull();
   });
 
@@ -265,9 +272,12 @@ describe('ChannelComposer (#1178)', () => {
     await act(async () => Promise.resolve());
 
     await typeAndEnter('first post');
-    expect(onSend).toHaveBeenCalledWith('first post', expect.any(String), [
-      imagePart,
-    ]);
+    expect(onSend).toHaveBeenCalledWith(
+      'first post',
+      expect.any(String),
+      [imagePart],
+      undefined
+    );
 
     await pasteFiles([imageFile('second.png')]);
     await act(async () => Promise.resolve());

--- a/test/components/channel-steering.test.ts
+++ b/test/components/channel-steering.test.ts
@@ -1,0 +1,481 @@
+// @vitest-environment happy-dom
+//
+// #1308 slice 4 item 2 — mid-turn steering affordances. The REAL composer,
+// timeline and message rows render here: the feature is a three-way agreement
+// between the live status signal, the post route's `steering` field and the
+// queued chip's own retirement rule, and isolated fixtures of any one of them
+// would prove none of it.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type {
+  ChannelMessage,
+  ChannelMessageId,
+} from '../../shared/channel-chat-protocol.js';
+import type { ChannelAgentStatus } from '../../frontend/src/lib/api.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CHANNEL_ID = 'topic:ops';
+const CLAUDE_ID = 'agent-profile:claude:default';
+const RUNTIME_ID = 'runtime:claude-1';
+
+interface PostOpts {
+  clientMessageId?: string;
+  threadId?: string;
+  steering?: 'interrupt';
+}
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceTopic: vi.fn(),
+  fetchChannelRoster: vi.fn(),
+  post: vi.fn(),
+  messages: [] as unknown[],
+  threadRoot: null as unknown,
+}));
+
+vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../frontend/src/lib/api.js')>();
+  return {
+    ...actual,
+    fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
+    fetchChannelRoster: mocks.fetchChannelRoster,
+  };
+});
+
+vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
+  useChannelChatSocket: () => ({
+    channel: {
+      id: CHANNEL_ID,
+      title: 'ops',
+      visibility: 'default',
+      archived: false,
+      latestSeq: mocks.messages.length,
+      messageCount: mocks.messages.length,
+      lastMessage: null,
+      members: [],
+    },
+    reducer: {
+      channelId: CHANNEL_ID,
+      messages: mocks.messages,
+      lastSeq: mocks.messages.length,
+      needsCatchup: false,
+      inFlight: [],
+      truncated: false,
+    },
+    connected: true,
+    disconnected: false,
+    notFound: false,
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    fullSnapshotRevision: 0,
+    post: mocks.post,
+    postPending: false,
+    postError: null,
+    resync: vi.fn(),
+  }),
+}));
+
+// The thread panel's own history fetch is not what is under test; the panel is
+// here because its composer is a SECOND send path (`threadId` is attached by
+// `ChannelView`, not by the composer) and has to inherit the steering cluster.
+vi.mock('../../frontend/src/hooks/useChannelThread.js', () => ({
+  useChannelThread: () => ({
+    root: mocks.threadRoot,
+    replies: [],
+    hasMoreOlder: false,
+    loadingOlder: false,
+    loadOlder: vi.fn(),
+    loading: false,
+    error: null,
+    rootFloorRevision: 0,
+  }),
+}));
+
+const { ChannelView } =
+  await import('../../frontend/src/components/chat/ChannelView.js');
+const { useUiStore } = await import('../../frontend/src/lib/stores/ui.js');
+const { useChannelAgentStatusStore } =
+  await import('../../frontend/src/lib/stores/channel-agent-status.js');
+const { useChannelQueuedSendsStore } =
+  await import('../../frontend/src/lib/stores/channel-queued-sends.js');
+
+function topicFixture() {
+  return {
+    id: CHANNEL_ID,
+    workspaceId: 'workspace:local',
+    display: { title: 'ops' },
+    routingDefaults: {},
+  };
+}
+
+function rosterEntry(status: ChannelAgentStatus, queuedCount = 0) {
+  return {
+    id: CLAUDE_ID,
+    displayName: 'claude',
+    providerId: 'claude',
+    isDefault: true,
+    isBuiltIn: true,
+    kind: 'framework' as const,
+    available: true,
+    reason: null,
+    binding: { runtimeId: RUNTIME_ID, status, queuedCount },
+  };
+}
+
+function humanMessage(
+  seq: number,
+  text: string,
+  threadId: ChannelMessageId | null
+): ChannelMessage {
+  return {
+    schemaVersion: 1,
+    id: `chm:${seq}` as ChannelMessageId,
+    channelId: CHANNEL_ID,
+    seq,
+    kind: 'message',
+    status: 'complete',
+    sender: { kind: 'human', id: 'operator', displayName: 'you' },
+    body: { text, format: 'markdown' },
+    threadId,
+    parentMessageId: threadId,
+    createdAt: '2026-08-03T10:00:00.000Z',
+    updatedAt: '2026-08-03T10:00:00.000Z',
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let queryClient: QueryClient;
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+async function render(): Promise<void> {
+  await act(async () => {
+    root.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(ChannelView, { channelId: CHANNEL_ID })
+      )
+    );
+  });
+  await flush();
+}
+
+function composers(): HTMLTextAreaElement[] {
+  return [
+    ...container.querySelectorAll<HTMLTextAreaElement>('.ch-composer__ta'),
+  ];
+}
+
+function setNativeValue(el: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function typeAndPressEnter(
+  el: HTMLTextAreaElement,
+  text: string,
+  init: KeyboardEventInit = {}
+): Promise<void> {
+  await act(async () => {
+    setNativeValue(el, text);
+  });
+  await act(async () => {
+    el.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      })
+    );
+  });
+  await flush();
+}
+
+function queuedChips(): string[] {
+  return [...container.querySelectorAll('.ch-msg__tag--queued')].map(
+    (chip) => chip.textContent ?? ''
+  );
+}
+
+function presenceLabels(): string[] {
+  return [...container.querySelectorAll('.ch-presence__label')].map(
+    (label) => label.textContent ?? ''
+  );
+}
+
+beforeEach(() => {
+  mocks.fetchWorkspaceTopic.mockReset();
+  mocks.fetchChannelRoster.mockReset();
+  mocks.post.mockReset();
+  mocks.messages = [];
+  mocks.threadRoot = null;
+  mocks.fetchWorkspaceTopic.mockResolvedValue(topicFixture());
+  mocks.post.mockImplementation(async (text: string, opts?: PostOpts) => {
+    const message = humanMessage(
+      mocks.messages.length + 1,
+      text,
+      (opts?.threadId as ChannelMessageId | undefined) ?? null
+    );
+    mocks.messages = [...mocks.messages, message];
+    return message;
+  });
+  vi.stubGlobal('matchMedia', () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  useUiStore.setState({
+    activeChannelId: null,
+    activeThreadRootId: null,
+    pendingChannelThread: null,
+  });
+  useChannelQueuedSendsStore.setState({ marksByMessageId: {} });
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  queryClient.clear();
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  useUiStore.setState({
+    activeChannelId: null,
+    activeThreadRootId: null,
+    pendingChannelThread: null,
+  });
+});
+
+describe('composer steering cluster (#1308 slice 4 item 2b)', () => {
+  it('stays out of the way while every bound agent is idle', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('idle')]);
+    await render();
+
+    expect(container.querySelector('.ch-composer__steer')).toBeNull();
+    expect(
+      container.querySelector('.ch-composer__hint')?.textContent
+    ).toContain('send');
+  });
+
+  it('reveals queue + interrupt&send the moment the bound agent is mid-turn', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    const cluster = container.querySelector('.ch-composer__steer');
+    expect(cluster).not.toBeNull();
+    expect(cluster?.getAttribute('aria-label')).toBe('mid-turn steering');
+    expect(
+      container.querySelector('.ch-composer__steer-btn')?.textContent
+    ).toBe('queue');
+    const interrupt = container.querySelector(
+      '.ch-composer__steer-btn--interrupt'
+    );
+    // Same interrupt vocabulary as the header chip: the black square.
+    expect(interrupt?.textContent).toContain('■');
+    expect(interrupt?.getAttribute('aria-label')).toBe('interrupt and send');
+  });
+
+  it('posts with no steering by default — the message queues behind the turn', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    const [composer] = composers();
+    await typeAndPressEnter(composer!, 'also check the tests');
+
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+    const [text, opts] = mocks.post.mock.calls[0] as [string, PostOpts];
+    expect(text).toBe('also check the tests');
+    expect(opts.steering).toBeUndefined();
+  });
+
+  it('posts steering:interrupt from the explicit control', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    const [composer] = composers();
+    await act(async () => setNativeValue(composer!, 'stop, do this instead'));
+    const interrupt = container.querySelector<HTMLButtonElement>(
+      '.ch-composer__steer-btn--interrupt'
+    );
+    await act(async () => interrupt?.click());
+    await flush();
+
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+    const [text, opts] = mocks.post.mock.calls[0] as [string, PostOpts];
+    expect(text).toBe('stop, do this instead');
+    expect(opts.steering).toBe('interrupt');
+  });
+
+  it('maps enter to queue-send and cmd/ctrl+enter to interrupt-send', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    await typeAndPressEnter(composers()[0]!, 'first');
+    await typeAndPressEnter(composers()[0]!, 'second', { metaKey: true });
+    await typeAndPressEnter(composers()[0]!, 'third', { ctrlKey: true });
+
+    const steerings = mocks.post.mock.calls.map(
+      (call) => (call[1] as PostOpts).steering
+    );
+    expect(steerings).toEqual([undefined, 'interrupt', 'interrupt']);
+  });
+
+  it('keeps cmd+enter a plain send when nothing is mid-turn', async () => {
+    // The modifier changes what happens to a LIVE turn. With no live turn there
+    // is nothing to cancel, so it must not smuggle a steering flag to a route
+    // that would then interrupt the next agent to pick the message up.
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('idle')]);
+    await render();
+
+    await typeAndPressEnter(composers()[0]!, 'nothing running', {
+      metaKey: true,
+    });
+
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+    expect((mocks.post.mock.calls[0]![1] as PostOpts).steering).toBeUndefined();
+  });
+});
+
+describe('queued chip (#1308 slice 4 item 2a)', () => {
+  it('marks a busy-send row and clears it when the next turn consumes the queue', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    await typeAndPressEnter(composers()[0]!, 'and update the docs');
+    await render();
+
+    expect(queuedChips()).toEqual(['queued — claude is mid-turn']);
+
+    // The binder's drain: the queue is spliced out and reported empty a beat
+    // before the consuming turn is announced.
+    await act(async () => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(CHANNEL_ID, CLAUDE_ID, 'idle', RUNTIME_ID, 0);
+    });
+    await flush();
+
+    expect(queuedChips()).toEqual([]);
+  });
+
+  it('does not mark a send made while every agent is idle', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('idle')]);
+    await render();
+
+    await typeAndPressEnter(composers()[0]!, 'plain send');
+    await render();
+
+    expect(container.querySelectorAll('.ch-msg').length).toBe(1);
+    expect(queuedChips()).toEqual([]);
+  });
+
+  it('does not mark an interrupt-send — the operator refused to wait', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    await typeAndPressEnter(composers()[0]!, 'stop that', { metaKey: true });
+    await render();
+
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+    expect(queuedChips()).toEqual([]);
+  });
+
+  it('drops the mark when a drain lands while the post is still in flight', async () => {
+    // Failing toward silence: the message was already consumed by the time the
+    // row existed, so a chip naming a wait would be a lie.
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    await render();
+
+    mocks.post.mockImplementationOnce(async (text: string) => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(CHANNEL_ID, CLAUDE_ID, 'idle', RUNTIME_ID, 0);
+      const message = humanMessage(mocks.messages.length + 1, text, null);
+      mocks.messages = [...mocks.messages, message];
+      return message;
+    });
+    await typeAndPressEnter(composers()[0]!, 'raced the drain');
+    await render();
+
+    expect(queuedChips()).toEqual([]);
+  });
+});
+
+describe('presence queue depth (#1308 slice 4 item 2c)', () => {
+  it('suffixes the presence row with the queue depth', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('thinking', 2)]);
+    await render();
+
+    expect(presenceLabels()).toEqual(['claude is thinking… (2 queued)']);
+  });
+
+  it('drops the suffix again once the queue empties', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('thinking', 1)]);
+    await render();
+    expect(presenceLabels()).toEqual(['claude is thinking… (1 queued)']);
+
+    await act(async () => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(CHANNEL_ID, CLAUDE_ID, 'thinking', RUNTIME_ID, 0);
+    });
+    await flush();
+
+    expect(presenceLabels()).toEqual(['claude is thinking…']);
+  });
+});
+
+describe('thread composer inherits steering (#1308 slice 4 item 2d)', () => {
+  it('offers the cluster in the thread lane and threads the flag through its own send path', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
+    const rootMessage = humanMessage(1, 'root question', null);
+    mocks.messages = [rootMessage];
+    mocks.threadRoot = rootMessage;
+    await render();
+
+    await act(async () => {
+      useUiStore.getState().requestChannelThread(CHANNEL_ID, rootMessage.id);
+    });
+    await flush();
+
+    const threadComposer = container.querySelector<HTMLTextAreaElement>(
+      '.ch-thread .ch-composer__ta'
+    );
+    expect(threadComposer).not.toBeNull();
+    expect(
+      container.querySelector('.ch-thread .ch-composer__steer')
+    ).not.toBeNull();
+
+    await typeAndPressEnter(threadComposer!, 'reply now', { metaKey: true });
+
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+    const opts = mocks.post.mock.calls[0]![1] as PostOpts;
+    expect(opts.threadId).toBe(rootMessage.id);
+    expect(opts.steering).toBe('interrupt');
+  });
+});


### PR DESCRIPTION
## Behavior found before this slice

A post to a channel whose bound profile was already mid-turn already queued
rather than double-dispatching — that part was never broken. What was missing
was everything around it:

- The queue drained **one turn per trigger**. Three impatient operator messages
  cost three full agent turns, each rebuilding a packet the previous one had
  already covered.
- There was **no operator control**. "Stop, do this instead" was reachable only
  by hitting the header's interrupt square and then typing into the composer —
  two separate actions with a race between them.
- There was **no observability**. A message sent into a busy agent looked
  identical on screen to one that had already been answered. Nothing in the
  timeline, the presence row, or the status event said "this is waiting".

## What ships

### 1. Queue → one next turn (`queued for next turn`)

`8e079b37` (server) · `19e8d613` (UI)

A contiguous run of **human** posts in **one thread scope** now drains as a
single turn triggered by the newest of them. The older members are not
summarized or dropped — `buildPacket` re-reads them straight out of the durable
message log, so they arrive as context rows of that same packet. Three impatient
messages cost one turn.

`queuedCount` is published on `channel-agent-status` and on the roster `binding`
object, deduped on the `(status, queuedCount)` pair so a queue change with no
status change still reaches the client. In the UI a queued message grows a dim
`queued — <agent> is mid-turn` chip and the presence row gains an `(n queued)`
suffix.

### 2. Interrupt and send (`■ interrupt & send`)

`8e079b37` (server) · `19e8d613` (UI)

The existing post route takes an explicit `steering: "interrupt"` body field —
no new route, no new gateway verb. It reuses the header control's
`adapter.interrupt` path, so there is exactly one interrupt semantic in the
product: the partial reply finalizes `interrupted`, and the new message
dispatches as soon as that turn releases. The composer reveals two explicit
controls while a bound agent is mid-turn; enter queues, cmd/ctrl+enter
interrupts. Steering is **never inferred from message text**.

## Races and brake interactions

- **No concurrent turns.** `pump` refuses to dispatch while
  `activeTurnId !== null`, and coalescing splices its run out before dispatch.
  Every steering test asserts `concurrentPeak === 1`.
- **Interrupt happens before the pump.** While a turn is live `pump` is a no-op,
  and the cancellation's terminal patch is what releases the binding into
  `finishTurn → pump → this message`. When nothing is live the interrupt is a
  no-op and the pump dispatches immediately, so "interrupt and send" degrades
  cleanly to a plain send rather than becoming a silently different action.
- **A refused interrupt loses nothing.** The queued message stays queued and
  rides the turn's natural completion or the watchdog. The failure row is
  parented to the steering trigger, so a thread-panel interrupt explains itself
  inside that thread.
- **Agent posts never steer, and never coalesce.** Sender attribution is
  server-derived, so an agent — including a CLI-gateway actor — cannot cancel
  another agent's turn. Agent-authored triggers keep one-turn-per-trigger
  because the packet builder drops an agent's own prior rows, and coalescing one
  away would erase it. The **consecutive-agent-turn brake** is untouched and
  still bounds agent fan-out.
- **Image-bearing posts never coalesce.** The packet image budget is per packet,
  not per message, so folding N image posts into one turn would spend one budget
  on all of them. Each keeps its own turn and its own budget.
- **Out-of-order queue entries never swallow anything.** The queue is not
  seq-ordered: `handleSendFailure` re-enqueues an older, already-failed trigger
  behind whatever arrived while the transport was down. Coalescing therefore
  requires strictly increasing `seq`, `pump` triggers on the max-seq member
  rather than the last element, and a **re-enqueued entry never joins a run in
  either direction** — it sits below the delivery cursor, so it could not
  survive as a context row of anyone else's packet, and always gets its own turn
  where the footer renders it unconditionally.
- **The delivery cursor advances only on send acceptance.** A failed send
  re-offers its rows on the next mention (at-least-once), and the cursor is
  never lowered.
- **Idempotent replay is safe in both directions.** The post route dedupes on
  `clientMessageId` and the composer retains that id after a failed send, so a
  replay carrying `steering` applies the cancellation half without re-posting or
  re-routing the row. It skips a binding whose live turn *that same message*
  triggered — if it drained between the two posts, the running turn is the
  operator's own answer.
- **Queue cap.** An over-cap post that would have coalesced with the tail
  supersedes it (identical trigger, identical packet) instead of being announced
  as dropped for a turn that was never going to exist. Anything the tail cannot
  represent — including a re-enqueued entry on either side — still produces the
  explicit drop row.

## Restart durability

Queued trigger state is **in-memory only**. A hub restart loses pending
triggers; it never loses messages, because every queued post is already durable
in the channel log before it is ever enqueued. The operator re-triggers by
sending again. The client-side queued chip is likewise deliberately
non-persisted — it is memory of a send, keyed by the per-agent drain generation
derived from `queuedCount`, and both of its imprecisions fail toward silence: a
queued send can miss its chip, a consumed one can never keep it.

## Review trail

| Pass | Outcome |
| --- | --- |
| Adversarial review of `8e079b37` + `19e8d613` | **block** — 1×P1 (lossy coalescing), plus image-budget, steering-swallowed-by-idempotency, failure-row parenting, unbounded client store |
| Batch fix pass `6a447a34` | all findings addressed in one commit |
| Re-review of `6a447a34` | **block** — P1 fix incomplete (stale trigger as run *head*, not just candidate); new P2 regression in the idempotency fix |
| Batch fix pass `6c4a4347` | both applied — the P2 was rated P2 but is a regression this branch introduced, so it was fixed rather than deferred |

Both re-review findings were regressions introduced by this branch, and both
regression tests were **verified to fail against the pre-fix binder** before the
fix was restored:

- P1 probe: `pump` dispatched M3's turn instead of M1's — the re-enqueued
  trigger produced no turn, no context row and no system row.
- P2 probe: `interruptCalls` grew to 2 — the replay cancelled the operator's own
  reply.

No P2/P3 findings remain open from either pass.

## Verification

Run at exact head `6c4a4347`:

- `npm run check` — **0 errors** (220 pre-existing `sonarjs` warnings, unchanged)
- `npm test` — **466 files / 5938 tests passed, 0 failed**
- `npx vitest run test/channel-agent-binder.test.ts` — 89 passed
- Pre-fix probes recorded above (both new tests fail without the server change)

One full-suite run showed a transient failure in
`test/hermes-image-input.test.ts > live Hermes gateway image input`, a test that
hits a **real external Hermes gateway** with a 60s request timeout inside a 30s
test timeout. It passes in isolation both with and without this branch's changes
and touches none of the code here; the re-run above is clean.

Refs #1308 (slice 4 — final slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages sent while an agent is busy are now queued in order, with visible queue status.
  * Send immediately by interrupting the active agent turn using the new control or keyboard shortcut.
  * Queue indicators show pending message counts and update as queues drain.
  * Thread composers support the same queue and interrupt actions.
* **Documentation**
  * Added guidance covering queue behavior, retries, interruptions, limits, and interface controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->