### PR TITLE
v0.1.1-rc.1

### DIFF
--- a/.chalk/skills/release/SKILL.md
+++ b/.chalk/skills/release/SKILL.md
@@ -5,7 +5,7 @@ description: >
   CHANGELOG [Unreleased], promote nightly to master, tag, verify the npm dist-tag
   and GitHub Release, dogfood a release candidate on the prod hub, and sync master
   back. Use when the user says "release", "cut a release", "ship a version",
-  "publish stable", "cut an rc", "tag v0.2.0", or "promote the rc".
+  "publish stable", "cut an rc", "tag v0.1.1", or "promote the rc".
 ---
 
 # /release -- Cut a relay-ide release
@@ -92,19 +92,23 @@ Use `/changelog` for entry wording and category rules.
 
 ## Step 2: Choose the version
 
-Pre-1.0 semantics — the current line is `0.y.z`:
+Pre-1.0 semantics — the current line is `0.y.z`, on the cargo-style convention:
+**the minor is the breaking-change axis.** Everything additive — features and
+fixes alike — rides the patch bump; only a break moves the minor.
 
-| `[Unreleased]` contains           | Bump  | Example                                                                |
-| --------------------------------- | ----- | ---------------------------------------------------------------------- |
-| Any `Added` or `Changed` entry    | minor | 0.1.0 -> 0.2.0                                                         |
-| Only `Fixed` / `Security` entries | patch | 0.1.0 -> 0.1.1                                                         |
-| Breaking change                   | minor | pre-1.0 absorbs breaks in minor; call it out at the top of the section |
+| `[Unreleased]` contains                                            | Bump  | Example        |
+| ------------------------------------------------------------------ | ----- | -------------- |
+| Only additive entries (`Added` / `Changed` / `Fixed` / `Security`) | patch | 0.1.1 -> 0.1.2 |
+| Any breaking change                                                | minor | 0.1.x -> 0.2.0 |
+
+A breaking release must call the break out at the top of its changelog section —
+pre-1.0 the version number alone does not warn anyone.
 
 Never bump to `1.0.0` from this skill. Leaving 0.x is a product decision and
 needs an explicit operator call.
 
 Release candidates carry the target stable version plus `-rc.N`: the first
-candidate for `0.2.0` is `0.2.0-rc.1`, the next is `0.2.0-rc.2`. `-rc.N` is the
+candidate for `0.1.1` is `0.1.1-rc.1`, the next is `0.1.1-rc.2`. `-rc.N` is the
 only prerelease shape with a publish lane; any other suffix fails CI's classify
 step.
 
@@ -127,7 +131,7 @@ Then edit `CHANGELOG.md`:
 - Update the link refs at the bottom: point `[Unreleased]` at
   `compare/vX.Y.Z...nightly` and add `[X.Y.Z]` -> `releases/tag/vX.Y.Z`.
 - For a release candidate, the section stays `## [X.Y.Z]` with the target stable
-  version. CI falls back from `0.2.0-rc.1` to the `0.2.0` section, so both the
+  version. CI falls back from `0.1.1-rc.1` to the `0.1.1` section, so both the
   rc and the eventual stable release reuse one section. Do not write an
   `-rc.N` heading.
 - Group the drained section when it is large. Under roughly 25 entries, keep the
@@ -281,13 +285,13 @@ Skipping this makes the next release PR replay old commits and the next
 2. **Squash-merging the release PR.** CI does not catch this one; `master` and
    `nightly` diverge and you pay for it at the Step 8 back-merge and again on
    the next release PR. Use `--merge`.
-3. **Tag/version mismatch.** `git tag v0.2.0` on a tree whose `package.json`
-   says `0.1.0` fails the classify step. Read the version back before tagging.
+3. **Tag/version mismatch.** `git tag v0.1.2` on a tree whose `package.json`
+   says `0.1.1` fails the classify step. Read the version back before tagging.
 4. **Invented prerelease shapes.** Only `X.Y.Z` and `X.Y.Z-rc.N` have lanes.
    `-beta.1`, `-next.1`, bare `-rc`, `-rc.x`, `-rc.0`, and `-rc.1.2` all fail the
    shape gate before npm is touched.
 5. **An `-rc.N` changelog heading.** CI looks for `## [X.Y.Z]` first and falls
-   back to the base version; an `## [0.2.0-rc.1]` heading orphans the stable
+   back to the base version; an `## [0.1.1-rc.1]` heading orphans the stable
    release's notes.
 6. **Assuming `@nightly` advanced.** Publishes occasionally get skipped for a
    merge. Check `npm view relay-ide@nightly version` against the head you think

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ workflow.
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-08-04
+## [0.1.1] - 2026-08-04
+
+This is the first public release of the channel era, branded v0.1; it ships as
+`0.1.1` because npm's `0.1.0` was consumed by the 2026-04 package rename.
 
 Everything in this section shipped on `@nightly` only, before this release. The
 last tagged release is `v3.19.0` (2026-03-28), and `0.1.0` was published from
@@ -166,6 +169,6 @@ Package renamed from `claude-remote-cli` to `relay-ide` and first published unde
 the new name. Published from `nightly` without a git tag, so there is no release
 tag to link — the npm version is the record.
 
-[Unreleased]: https://github.com/donovan-yohan/relay-ide/compare/v0.2.0...nightly
-[0.2.0]: https://github.com/donovan-yohan/relay-ide/releases/tag/v0.2.0
+[Unreleased]: https://github.com/donovan-yohan/relay-ide/compare/v0.1.1...nightly
+[0.1.1]: https://github.com/donovan-yohan/relay-ide/releases/tag/v0.1.1
 [0.1.0]: https://www.npmjs.com/package/relay-ide/v/0.1.0

--- a/docs/references/deployment.md
+++ b/docs/references/deployment.md
@@ -21,7 +21,7 @@ Every stable and rc tag needs a matching section in [`CHANGELOG.md`](../../CHANG
 | `vX.Y.Z-rc.N` tag on `master` | `X.Y.Z-rc.N`  | `rc`         | yes, prerelease |
 | push to `nightly`             | stamped       | `nightly`    | no              |
 
-The tag must equal `v` + the `package.json` version or CI aborts before publishing. The classify step then gates the version *shape*: only `X.Y.Z` and `X.Y.Z-rc.N` (N starting at 1) have lanes, so malformed stable versions and near-miss candidates — `0.2.0-rc.x`, `0.2.0-rc.1.2`, `0.2.0-beta-rc.1`, bare `0.2.0-rc` — are rejected there rather than reaching npm. The stable publish step re-checks the tag and the version independently and refuses to run if either contains a hyphen, so an rc can never take `@latest`.
+The tag must equal `v` + the `package.json` version or CI aborts before publishing. The classify step then gates the version _shape_: only `X.Y.Z` and `X.Y.Z-rc.N` (N starting at 1) have lanes, so malformed stable versions and near-miss candidates — `0.1.1-rc.x`, `0.1.1-rc.1.2`, `0.1.1-beta-rc.1`, bare `0.1.1-rc` — are rejected there rather than reaching npm. The stable publish step re-checks the tag and the version independently and refuses to run if either contains a hyphen, so an rc can never take `@latest`.
 
 ## Install Channels
 
@@ -77,17 +77,17 @@ Same promotion path as a stable release, but the version carries an `-rc.N` prer
 ```bash
 # 1. Bump to the rc version on nightly and stage the CHANGELOG section
 git checkout nightly
-npm version 0.2.0-rc.1 --no-git-tag-version
-# CHANGELOG.md keeps a ## [0.2.0] section; the rc release body reuses it
+npm version 0.1.1-rc.1 --no-git-tag-version
+# CHANGELOG.md keeps a ## [0.1.1] section; the rc release body reuses it
 git add package.json package-lock.json CHANGELOG.md
-git commit -m "0.2.0-rc.1" && git push origin nightly
+git commit -m "0.1.1-rc.1" && git push origin nightly
 
 # 2. Promote to master and tag
-gh pr create --base master --head nightly --title "v0.2.0-rc.1"
+gh pr create --base master --head nightly --title "v0.1.1-rc.1"
 gh pr merge --merge
 git checkout master && git pull
-git tag v0.2.0-rc.1
-git push origin v0.2.0-rc.1      # CI publishes to npm @rc
+git tag v0.1.1-rc.1
+git push origin v0.1.1-rc.1      # CI publishes to npm @rc
 ```
 
 #### Prerelease-never-latest guard
@@ -136,19 +136,19 @@ blocked — all commits must arrive via PR.
 ```bash
 # 1. Bump version on nightly (no tag yet) and close the CHANGELOG section
 git checkout nightly
-npm version <patch|minor|major> --no-git-tag-version
-# move [Unreleased] entries into a new ## [0.2.0] - YYYY-MM-DD section in CHANGELOG.md
+npm version <patch|minor> --no-git-tag-version
+# move [Unreleased] entries into a new ## [0.1.2] - YYYY-MM-DD section in CHANGELOG.md
 git add package.json package-lock.json CHANGELOG.md
-git commit -m "0.2.0" && git push origin nightly
+git commit -m "0.1.2" && git push origin nightly
 
 # 2. Create and merge a release PR
-gh pr create --base master --head nightly --title "v0.2.0"
+gh pr create --base master --head nightly --title "v0.1.2"
 gh pr merge --merge
 
 # 3. Tag on master and push (tags bypass branch protection)
 git checkout master && git pull
-git tag v0.2.0
-git push origin v0.2.0           # CI publishes to npm @latest
+git tag v0.1.2
+git push origin v0.1.2           # CI publishes to npm @latest
 
 # 4. Sync master back to nightly
 git checkout nightly && git merge master && git push origin nightly
@@ -156,7 +156,7 @@ git checkout nightly && git merge master && git push origin nightly
 
 Use `--merge`, not `--squash`. This is not something CI catches: the tag is created after `git checkout master && git pull`, so a squash commit is on `master` too and the tag-on-master check passes either way. The cost lands at step 4 — a squash rewrites the SHAs, `master` and `nightly` diverge, the back-merge conflicts instead of fast-forwarding, and the next release PR replays the already-released commits.
 
-Pre-1.0 bump semantics: any `Added` or `Changed` entry means a minor bump, a release with only `Fixed`/`Security` entries is a patch, and breaking changes are absorbed by the minor bump. Leaving `0.x` is a product decision, not a mechanical one.
+Pre-1.0 bump semantics follow the cargo-style convention, where the minor is the breaking-change axis: an additive release — `Added`, `Changed`, `Fixed`, or `Security` entries that break nothing — is a **patch** bump (`0.1.1` -> `0.1.2`), and only a breaking change moves the **minor** (`0.1.x` -> `0.2.0`), called out at the top of that changelog section. `major` is not used below 1.0; leaving `0.x` is a product decision, not a mechanical one.
 
 ### 4. Hotfix (skip nightly)
 
@@ -175,14 +175,14 @@ git checkout master && git pull
 git checkout -b hotfix/bump-version
 npm version patch --no-git-tag-version
 git add package.json package-lock.json
-git commit -m "0.2.1" && git push origin hotfix/bump-version
-gh pr create --base master --title "v0.2.1"
+git commit -m "0.1.2" && git push origin hotfix/bump-version
+gh pr create --base master --title "v0.1.2"
 gh pr merge --merge
 
 # 3. Tag and push
 git checkout master && git pull
-git tag v0.2.1
-git push origin v0.2.1           # CI publishes to npm @latest
+git tag v0.1.2
+git push origin v0.1.2           # CI publishes to npm @latest
 
 # 4. Sync the fix back to nightly
 git checkout nightly && git pull
@@ -263,7 +263,7 @@ TypeScript source, test files, docs, and local config are excluded from the publ
 npm pack --dry-run                            # preview what will be included
 npm info relay-ide                            # check stable version
 npm dist-tag ls relay-ide                     # check all dist-tags (latest, rc, nightly)
-gh release view v0.2.0                        # confirm the release body matches CHANGELOG.md
+gh release view v0.1.1                        # confirm the release body matches CHANGELOG.md
 ```
 
 Install smoke in a throwaway prefix, so verifying a release cannot disturb a running hub:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relay-ide",
-  "version": "0.2.0-rc.1",
+  "version": "0.1.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relay-ide",
-      "version": "0.2.0-rc.1",
+      "version": "0.1.1-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-ide",
-  "version": "0.2.0-rc.1",
+  "version": "0.1.1-rc.1",
   "description": "Channel-first workspace for collaborating with AI coding agents from any device",
   "type": "module",
   "main": "dist/server/index.js",


### PR DESCRIPTION
Release candidate v0.1.1-rc.1 — first public release of the channel era, branded v0.1 (0.1.0 was consumed by the 2026-04 package rename). Supersedes the unwound v0.2.0-rc.1; adopts the 0.y.z pre-1.0 convention. See CHANGELOG.md [0.1.1].

No user-visible change beyond the version/branding re-cut — all content already shipped to @nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)