### PR TITLE
fix(codex): agentState leaves initializing once the first turn runs (#1254)

### DIFF
--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -1,6 +1,9 @@
 import crypto from 'node:crypto';
 
-import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
+import type {
+  AgentPatchV2,
+  AgentSessionLiveStateV2,
+} from '../shared/agent-chat-protocol-v2.js';
 import {
   collaborationPromptAppendix,
   type AgentRole,
@@ -122,6 +125,122 @@ function providerSessionFromPatch(
   return undefined;
 }
 
+type ChannelAgentState = ChannelAgentRuntime['agentState'];
+
+/** A state that owes its answer to a human, not to the model. */
+function parkedOnOperator(state: ChannelAgentState): boolean {
+  return state === 'permission-prompt' || state === 'waiting-for-input';
+}
+
+/**
+ * Map a live state onto a run state.
+ *
+ * `authoritative` marks a COMPLETE live state (the one embedded in
+ * `agent-session-snapshot-v2`), whose `waitingOn` can be trusted. An incremental
+ * `agent-live-state-updated-v2` is a `Partial`, and its `idle` may be a compat
+ * artifact rather than a real one — see `nextAgentState`.
+ */
+function stateFromLive(
+  current: ChannelAgentState,
+  live: Partial<AgentSessionLiveStateV2>,
+  authoritative: boolean
+): ChannelAgentState | undefined {
+  const status = live.status;
+  if (!status) return undefined;
+  switch (status) {
+    case 'working':
+      return 'processing';
+    case 'waiting':
+      switch (live.waitingOn) {
+        case 'approval':
+          return 'permission-prompt';
+        case 'question':
+        case 'plan':
+          return 'waiting-for-input';
+        default:
+          // `tool`/`network` — and a wait that names no counterparty — are the
+          // runtime waiting on itself. The turn is still running and nobody owes
+          // it an answer, so this must NOT park the machine: a system wait that
+          // parked would swallow the real `idle` that ends the turn.
+          return 'processing';
+      }
+    case 'error':
+      return 'error';
+    default:
+      // `idle` and `disconnected` both claim "no turn is running", which is a
+      // lie while a prompt is outstanding.
+      return !authoritative && parkedOnOperator(current) ? undefined : 'idle';
+  }
+}
+
+/**
+ * Derive the next `agentState` from an adapter patch, or `undefined` when the
+ * patch carries no run-state signal at all (#1254).
+ *
+ * `agentState` is internal runtime bookkeeping: the status the channel UI
+ * renders is `ChannelAgentBinder`'s separate `binding.status`. This reducer
+ * exists so the field stops contradicting itself, not to move a rendered
+ * surface.
+ *
+ * Three rules keep the machine honest:
+ *
+ *  - `agent-live-state-updated-v2` carries a PARTIAL live state: every field is
+ *    optional and a patch may narrow to a single key. `rejectQueued` emits a
+ *    bare `{ queueLength: 0 }`, and in `claude-adapter` that fires MID-TURN when
+ *    a runtime-env refresh boundary fails. A statusless patch says nothing about
+ *    the run state, so it must not be read as "idle" — the previous mapping
+ *    collapsed every statusless patch to `idle` while forcing `runtime.idle` to
+ *    `false`, so the two fields disagreed.
+ *  - A bare `idle` cannot clear a prompt the operator still owes an answer to.
+ *    `hermes-adapter` fires `chat:session-status {status:'idle',
+ *    waitingOn:'approval'}` next to a permission prompt, and
+ *    `shared/agent-chat-v1-compat.ts` maps every `idle` to `{status:'idle',
+ *    waitingOn:null}` — so a bare mid-approval idle is indistinguishable from a
+ *    real one. Ignore it while parked, the same rule `ChannelAgentBinder`
+ *    applies (#1181 defect 3). Only waits a HUMAN owes an answer to park the
+ *    machine; a `tool`/`network` wait keeps running. The exits from a parked
+ *    state are a turn terminal (it ends the turn that owned the prompt), the
+ *    next live state that names a status, and a complete snapshot.
+ *  - Turn lifecycle is a run-state signal in its own right. Nothing in the
+ *    protocol requires an adapter to pair a full live state with every turn, so
+ *    a started turn — or the first output item of one — moves a fresh runtime
+ *    off `initializing`, and a completed turn lands it on `idle`.
+ *    `agent-session-snapshot-v2` carries a complete live state for the same
+ *    reason: a resume that delivers only a snapshot still has to leave
+ *    `initializing`.
+ *
+ * `agent-error-v2` is deliberately NOT a run-state signal: adapters also use it
+ * for input-validation complaints that leave the run untouched (codex answers a
+ * malformed `/resume` or `/goal` with one). The run state comes from the turn
+ * terminal or live `status:'error'` that follows a real failure.
+ */
+function nextAgentState(
+  current: ChannelAgentState,
+  patch: AgentPatchV2
+): ChannelAgentState | undefined {
+  switch (patch.type) {
+    case 'agent-live-state-updated-v2':
+      return stateFromLive(current, patch.live, false);
+    case 'agent-session-snapshot-v2':
+      return stateFromLive(current, patch.session.live, true);
+    case 'agent-turn-started-v2':
+      return 'processing';
+    case 'agent-turn-completed-v2':
+      return 'idle';
+    case 'agent-item-started-v2':
+      // An approval item IS the prompt, whatever live state the adapter pairs
+      // with it (codex pairs `waiting`/`approval`; not every adapter does).
+      if (patch.item.type === 'approval') return 'permission-prompt';
+      return current === 'initializing' ? 'processing' : undefined;
+    case 'agent-item-delta-v2':
+      // First output of the first turn. Only promote out of `initializing`:
+      // mid-turn items must never clobber an outstanding prompt.
+      return current === 'initializing' ? 'processing' : undefined;
+    default:
+      return undefined;
+  }
+}
+
 export class ChannelAgentRuntimeManager {
   private readonly runtimes = new Map<string, ChannelAgentRuntime>();
   private readonly endHandlers = new Set<RuntimeEndHandler>();
@@ -226,18 +345,10 @@ export class ChannelAgentRuntimeManager {
         };
       }
       runtime.lastActivity = new Date().toISOString();
-      if (patch.type === 'agent-live-state-updated-v2') {
-        runtime.idle = patch.live.status === 'idle';
-        runtime.agentState =
-          patch.live.status === 'working'
-            ? 'processing'
-            : patch.live.status === 'waiting'
-              ? patch.live.waitingOn === 'approval'
-                ? 'permission-prompt'
-                : 'waiting-for-input'
-              : patch.live.status === 'error'
-                ? 'error'
-                : 'idle';
+      const next = nextAgentState(runtime.agentState, patch);
+      if (next) {
+        runtime.agentState = next;
+        runtime.idle = next === 'idle';
       }
     });
     this.patchUnlisteners.set(id, unlisten);
@@ -274,8 +385,14 @@ export class ChannelAgentRuntimeManager {
       if (savedResumeId && adapter.capabilities.resume) {
         await adapter.resumeSession(savedResumeId);
       }
-      runtime.agentState = 'idle';
-      runtime.idle = true;
+      // Promote out of `initializing` only. Adapters emit patches from inside
+      // `connect()`/`resumeSession()` (codex emits its snapshot and live state
+      // before `connect` resolves), so the listener above can already have
+      // recorded a live turn — stamping `idle` unconditionally here erased it.
+      if (runtime.agentState === 'initializing') {
+        runtime.agentState = 'idle';
+        runtime.idle = true;
+      }
       return runtime;
     } catch (error) {
       this.runtimes.delete(id);

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -9,11 +9,17 @@ import type {
   AdapterConfig,
   ProtocolAdapterV2,
 } from '../server/protocol-adapter-v2.js';
+import type {
+  AgentPatchV2,
+  AgentSessionLiveStateV2,
+} from '../shared/agent-chat-protocol-v2.js';
 import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
 
 const adapterState = vi.hoisted(() => ({
   last: null as TestAdapter | null,
   all: [] as TestAdapter[],
+  /** Runs inside `connect()`, before it resolves. */
+  onConnect: null as ((adapter: TestAdapter) => void) | null,
 }));
 
 class TestAdapter implements ProtocolAdapterV2 {
@@ -30,8 +36,12 @@ class TestAdapter implements ProtocolAdapterV2 {
   disconnectError: Error | null = null;
   private readonly handlers = new Set<AgentPatchHandlerV2>();
 
-  async connect(_config: AdapterConfig): Promise<void> {
+  sessionId = 'channel-runtime';
+
+  async connect(config: AdapterConfig): Promise<void> {
     this.status = 'connected';
+    this.sessionId = config.sessionId;
+    adapterState.onConnect?.(this);
   }
   async disconnect(): Promise<void> {
     this.status = 'disconnected';
@@ -52,15 +62,61 @@ class TestAdapter implements ProtocolAdapterV2 {
     return () => this.handlers.delete(handler);
   }
   broadcastPatch(): void {}
+  emitPatch(patch: AgentPatchV2): void {
+    for (const handler of [...this.handlers]) handler(patch);
+  }
   emitProviderSession(threadId: string): void {
-    for (const handler of this.handlers) {
-      handler({
-        type: 'agent-session-updated-v2',
-        sessionId: 'channel-runtime',
-        timestamp: '2026-07-26T00:00:00.000Z',
-        providerSession: { threadId },
-      });
-    }
+    this.emitPatch({
+      type: 'agent-session-updated-v2',
+      sessionId: 'channel-runtime',
+      timestamp: '2026-07-26T00:00:00.000Z',
+      providerSession: { threadId },
+    });
+  }
+  emitLiveState(live: Partial<AgentSessionLiveStateV2>): void {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: '2026-07-26T00:00:00.000Z',
+      live,
+    });
+  }
+  emitSnapshot(live: Partial<AgentSessionLiveStateV2>): void {
+    const session = emptyAgentSessionV2({
+      id: this.sessionId,
+      provider: 'codex',
+      cwd: '/tmp',
+    });
+    this.emitPatch({
+      type: 'agent-session-snapshot-v2',
+      sessionId: this.sessionId,
+      timestamp: '2026-07-26T00:00:00.000Z',
+      session: { ...session, live: { ...session.live, ...live } },
+    });
+  }
+  emitTurnStarted(turnId: string): void {
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sessionId,
+      timestamp: '2026-07-26T00:00:00.000Z',
+      turn: {
+        id: turnId,
+        status: 'running',
+        inputMessageId: `user-${turnId}`,
+        items: [],
+        startedAt: '2026-07-26T00:00:00.000Z',
+      },
+    });
+  }
+  emitTurnCompleted(turnId: string): void {
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: '2026-07-26T00:00:00.000Z',
+      turnId,
+      status: 'completed',
+      completedAt: '2026-07-26T00:00:00.000Z',
+    });
   }
 }
 
@@ -82,6 +138,304 @@ afterEach(async () => {
   await channelAgentRuntimes.close();
   adapterState.last = null;
   adapterState.all.length = 0;
+  adapterState.onConnect = null;
+});
+
+describe('ChannelAgentRuntimeManager agentState (#1254)', () => {
+  it('leaves initializing as soon as the first turn runs and lands idle when it completes', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    // Codex delivers its first prompt natively (#1240), so the turn lifecycle
+    // can arrive while the runtime is still `initializing` — before any full
+    // live state was ever observed.
+    const observed: string[] = [];
+    adapterState.onConnect = (adapter) => {
+      adapter.emitTurnStarted('turn-1');
+      observed.push(
+        channelAgentRuntimes.get('channel-runtime')?.agentState ?? 'missing'
+      );
+      adapter.emitTurnCompleted('turn-1');
+      observed.push(
+        channelAgentRuntimes.get('channel-runtime')?.agentState ?? 'missing'
+      );
+    };
+
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+
+    expect(observed).toEqual(['processing', 'idle']);
+    expect(runtime.agentState).toBe('idle');
+    expect(runtime.idle).toBe(true);
+  });
+
+  it('promotes initializing on the first output item of a turn', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const observed: string[] = [];
+    adapterState.onConnect = (adapter) => {
+      adapter.emitPatch({
+        type: 'agent-item-started-v2',
+        sessionId: adapter.sessionId,
+        timestamp: '2026-07-26T00:00:00.000Z',
+        turnId: 'turn-1',
+        item: {
+          id: 'assistant-1',
+          type: 'assistantMessage',
+          text: 'CODEX_OK',
+          status: 'streaming',
+        },
+      });
+      observed.push(
+        channelAgentRuntimes.get('channel-runtime')?.agentState ?? 'missing'
+      );
+    };
+
+    await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+
+    expect(observed).toEqual(['processing']);
+  });
+
+  it('keeps a live turn observed during connect instead of stamping idle', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    adapterState.onConnect = (adapter) => {
+      adapter.emitLiveState({ status: 'working', activeTurnId: 'turn-1' });
+    };
+
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+
+    expect(runtime.agentState).toBe('processing');
+    expect(runtime.idle).toBe(false);
+  });
+
+  it('ignores a partial live state that carries no status', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+    const adapter = adapterState.last!;
+
+    adapter.emitLiveState({ status: 'working', activeTurnId: 'turn-1' });
+    expect(runtime.agentState).toBe('processing');
+
+    // `rejectQueued` emits a bare `{ queueLength }`; in claude-adapter that
+    // fires mid-turn when a runtime-env refresh boundary fails.
+    adapter.emitLiveState({ queueLength: 0 });
+    expect(runtime.agentState).toBe('processing');
+    expect(runtime.idle).toBe(false);
+
+    adapter.emitLiveState({ status: 'waiting', waitingOn: 'approval' });
+    expect(runtime.agentState).toBe('permission-prompt');
+
+    // The approval is answered, so the turn resumes and then ends.
+    adapter.emitLiveState({ status: 'working', activeTurnId: 'turn-1' });
+    expect(runtime.agentState).toBe('processing');
+
+    adapter.emitLiveState({ status: 'idle', activeTurnId: null });
+    expect(runtime.agentState).toBe('idle');
+    expect(runtime.idle).toBe(true);
+  });
+
+  it('keeps an outstanding approval when a bare idle live state arrives', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'hermes',
+      profileActorId: 'agent-profile:hermes:default',
+      cwd: '/tmp',
+      displayName: '#eng · Hermes',
+      port: 3456,
+      configDir: '/tmp',
+    });
+    const adapter = adapterState.last!;
+
+    adapter.emitLiveState({ status: 'waiting', waitingOn: 'approval' });
+    expect(runtime.agentState).toBe('permission-prompt');
+
+    // hermes fires `session-status {status:'idle', waitingOn:'approval'}`
+    // alongside the prompt, and the v1 compat mapping strips `waitingOn` from
+    // every idle — so a BARE idle arrives mid-approval (#1181 defect 3).
+    adapter.emitLiveState({
+      status: 'idle',
+      activeTurnId: null,
+      waitingOn: null,
+    });
+    expect(runtime.agentState).toBe('permission-prompt');
+    expect(runtime.idle).toBe(false);
+
+    // A question prompt is parked on the operator the same way.
+    adapter.emitLiveState({ status: 'waiting', waitingOn: 'question' });
+    expect(runtime.agentState).toBe('waiting-for-input');
+    adapter.emitLiveState({ status: 'idle', activeTurnId: null });
+    expect(runtime.agentState).toBe('waiting-for-input');
+    expect(runtime.idle).toBe(false);
+
+    // A turn terminal is authoritative: it ends the turn that owned the prompt,
+    // so it is the guaranteed exit from a parked state.
+    adapter.emitTurnCompleted('turn-1');
+    expect(runtime.agentState).toBe('idle');
+    expect(runtime.idle).toBe(true);
+  });
+
+  it('keeps running through a system wait so the idle that ends the turn lands', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+    const adapter = adapterState.last!;
+
+    // `tool` and `network` waits are the runtime waiting on itself — nobody owes
+    // it an answer, so they must not park the machine against a later idle.
+    for (const waitingOn of ['tool', 'network'] as const) {
+      adapter.emitLiveState({
+        status: 'waiting',
+        activeTurnId: 'turn-1',
+        waitingOn,
+      });
+      expect(runtime.agentState).toBe('processing');
+      expect(runtime.idle).toBe(false);
+
+      adapter.emitLiveState({ status: 'idle', activeTurnId: null });
+      expect(runtime.agentState).toBe('idle');
+      expect(runtime.idle).toBe(true);
+    }
+  });
+
+  it('leaves initializing on a resume that delivers only a session snapshot', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const observed: string[] = [];
+    adapterState.onConnect = (adapter) => {
+      // `agent-session-snapshot-v2` embeds a COMPLETE live state.
+      adapter.emitSnapshot({ status: 'working', activeTurnId: 'turn-1' });
+      observed.push(
+        channelAgentRuntimes.get('channel-runtime')?.agentState ?? 'missing'
+      );
+    };
+
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+
+    expect(observed).toEqual(['processing']);
+    expect(runtime.agentState).toBe('processing');
+
+    // A snapshot's `waitingOn` is trustworthy, so its idle clears a prompt that
+    // an incremental patch could not.
+    const adapter = adapterState.last!;
+    adapter.emitLiveState({ status: 'waiting', waitingOn: 'approval' });
+    expect(runtime.agentState).toBe('permission-prompt');
+    adapter.emitSnapshot({ status: 'idle' });
+    expect(runtime.agentState).toBe('idle');
+    expect(runtime.idle).toBe(true);
+  });
+
+  it('reports an approval item as a permission prompt even before its live state', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const observed: string[] = [];
+    adapterState.onConnect = (adapter) => {
+      adapter.emitPatch({
+        type: 'agent-item-started-v2',
+        sessionId: adapter.sessionId,
+        timestamp: '2026-07-26T00:00:00.000Z',
+        turnId: 'turn-1',
+        item: {
+          id: 'approval-1',
+          type: 'approval',
+          requestId: 'req-1',
+          kind: 'command',
+          description: 'Run command: ls',
+          target: 'ls',
+          status: 'pending',
+        },
+      });
+      observed.push(
+        channelAgentRuntimes.get('channel-runtime')?.agentState ?? 'missing'
+      );
+    };
+
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+
+    expect(observed).toEqual(['permission-prompt']);
+    expect(runtime.agentState).toBe('permission-prompt');
+    expect(runtime.idle).toBe(false);
+  });
+
+  it('leaves the run state alone for an agent-error-v2 complaint', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+    const adapter = adapterState.last!;
+
+    adapter.emitLiveState({ status: 'working', activeTurnId: 'turn-1' });
+    // Codex answers a malformed slash command with `agent-error-v2` and keeps
+    // running, so the patch carries no run-state signal.
+    adapter.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: adapter.sessionId,
+      timestamp: '2026-07-26T00:00:00.000Z',
+      message: 'resume requires a thread id argument: /resume <threadId>',
+    });
+    expect(runtime.agentState).toBe('processing');
+    expect(runtime.idle).toBe(false);
+
+    // A real failure reports itself through the live state.
+    adapter.emitLiveState({ status: 'error', error: 'runtime exited' });
+    expect(runtime.agentState).toBe('error');
+    expect(runtime.idle).toBe(false);
+  });
 });
 
 describe('ChannelAgentRuntimeManager', () => {


### PR DESCRIPTION
No user-visible change: `ChannelAgentRuntime.agentState`/`.idle` have no reader outside `server/channel-agent-runtime.ts` and its tests (repo-wide grep over `server/`, `shared/`, `frontend/`, `test/`). The status the channel UI renders is `ChannelAgentBinder`'s separate `binding.status`, broadcast as `channel-agent-status`. This PR makes the internal state machine self-consistent; it does not move a rendered surface.

## Defect

`ChannelAgentRuntime.agentState` was derived from `agent-live-state-updated-v2` alone, through an ad-hoc ternary chain, and read that patch wrong:

1. **Statusless patches collapsed to `idle`.** `patch.live` is a PARTIAL live state — every field is optional. The chain fell through to `'idle'` for any patch without `status`, while `runtime.idle` was set from `status === 'idle'` and therefore went to `false`. The two fields disagreed: idle-but-not-idle.
2. **A bare `idle` cleared an outstanding approval.** `permission-prompt` was overwritten by an idle that only *looks* idle.
3. **Turn lifecycle was ignored entirely.** An adapter that reports a turn without pairing a full live state stayed pinned at `initializing` for the whole turn. `agent-session-snapshot-v2` was ignored the same way, though it carries a complete live state — a resume that delivers only a snapshot never left `initializing`.
4. **`create()` clobbered.** It stamped `agentState = 'idle'` unconditionally after connect/resume, erasing any turn the patch listener had already recorded.

## Root cause

- The statusless mid-turn emission is real and it is `claude`, not `codex`: `rejectQueued` emits a bare `{ queueLength: 0 }` (`server/protocol-adapters/claude-adapter.ts`), reached mid-turn from `drainQueue`'s runtime-env-refresh failure path and from `forceRuntimeEnvRefreshBoundary`. Codex's `rejectQueued` is only reachable from `teardownState()` (disconnect), so the earlier codex framing of this defect was wrong and has been dropped from the code comment and commit message.
- The bare mid-approval idle is also real: `hermes-adapter` fires `chat:session-status {status:'idle', waitingOn:'approval'}` next to a permission prompt, and `shared/agent-chat-v1-compat.ts` maps every `idle` to `{status:'idle', waitingOn:null}` — so the approval marker is stripped before the runtime ever sees it. This is the exact hazard `ChannelAgentBinder` guards against (#1181 defect 3); the runtime had no such guard.
- Adapters emit patches from inside `connect()`/`resumeSession()` (codex emits its snapshot and live state before `connect` resolves), so the post-connect stamp raced the listener.

## Fix

`server/channel-agent-runtime.ts` — one documented reducer, `nextAgentState(current, patch)`, over a shared `stateFromLive(current, live, authoritative)`:

- statusless live patch → `undefined` (state untouched);
- `working` → `processing`; `error` → `error`;
- `waiting` splits by who owes the answer: `approval` → `permission-prompt`, `question`/`plan` → `waiting-for-input`, and `tool`/`network` (a wait naming no counterparty) → `processing`, because a system wait must not park the machine;
- bare `idle`/`disconnected` → ignored while the runtime is parked on the operator; the exits from a parked state are a turn terminal, the next status-bearing live state, and an authoritative snapshot;
- `agent-turn-started-v2` → `processing`, `agent-turn-completed-v2` → `idle`;
- `agent-session-snapshot-v2` → applied through the same mapping with `authoritative: true`: its live state is complete, so its `waitingOn` is trustworthy and its `idle` needs no guard;
- `agent-item-started-v2` with an `approval` item → `permission-prompt` whatever live state the adapter pairs with it; any other first item of a turn promotes only out of `initializing`;
- `agent-error-v2` is deliberately non-terminal for run state — codex also uses it for slash-command usage complaints (`/resume`, `/goal` with a bad argument) that leave the run untouched, so the run state comes from the turn terminal or a live `status:'error'` that follows a real failure. Documented in the reducer and covered by a characterization test.

`runtime.idle` is now derived from the resulting state, so the two fields cannot disagree. `create()` promotes out of `initializing` only.

## Verification

- `npm run check` — 0 errors (220 pre-existing warnings, none in the touched files).
- `npx vitest run test/channel-agent-runtime.test.ts` — 14/14 pass (9 in the `agentState (#1254)` describe).
- Adjacent suites that construct channel runtimes or feed the reducer: `channel-agent-binder`, `channel-thread-e2e`, `channel-mention-e2e`, `sessions-orchestrator-credential`, `agent-chat-v1-compat` — 6 files / 140 tests pass together, on Node 22 locally.
- Full `ci` job green on the previous head (`519f4a7a`), which carried the same reducer minus the two CodeRabbit fixes.
- **Anti-vacuity**: reverting `server/channel-agent-runtime.ts` to `nightly` with the tests in place turns 8 of the 9 `agentState` tests red (initializing-off-turn-start, first-item promotion, connect-time live turn, statusless patch, bare-idle-mid-approval, system-wait-then-idle, snapshot-only resume, approval item); restoring the fix returns all 14 to green. The 9th (`agent-error-v2` complaint) passes pre-fix by construction — it is a characterization test for a deliberate non-behavior, not a regression test.

## Review trail

**Adversarial review** returned `concern`. Applied: **P1** — reframed as internal state-machine hygiene; the PR does not close #1254 and says so out loud (see Scope). **P2** — the approval-clobber guard, with a test that emits `waiting`/`approval` then a bare `{status:'idle', waitingOn:null}` and asserts the state holds. **P2** — changelog gate taken via the declared exemption plus the `no-user-visible-change` label, since the corrected field has no product reader. **P3 (applied)** — the wrong codex root-cause narrative rewritten in both the comment and the commit body; approval items discriminated in the item-started branch. **P3 (refuted, documented instead)** — mapping `agent-error-v2` to the `error` state would park the runtime in `error` on a malformed slash command, because codex emits that patch for input-validation complaints (`codex-native-adapter.ts` `/resume`, `/rollback`, `/goal` arms); the reducer now documents why the patch is non-terminal. **Evidence-limit note refuted** — the sqlite-backed binder/bridge suites do run locally on Node 22 (140 tests green above), so CI is not the only regression signal.

**CodeRabbit** on head `519f4a7a`. Both findings valid and fixed: the Major one caught a regression the P2 guard introduced — `parkedOnOperator` covered every non-approval wait, so a `tool`/`network` wait would have swallowed the idle that ends the turn; the wait mapping now splits by counterparty and a new test drives both system waits through to `idle`. The Minor one (snapshot patches carry live state) is fixed by the `authoritative` branch above, with a test that a snapshot-only resume leaves `initializing`.

## Scope

#1254 asks for accurate codex status in the roster/cockpit. That surface renders `binding.status`, not `agentState`, and the codex output parser the issue names (`server/pty-handler.ts`, `parserType: 'codex'`) no longer exists — #1283 removed the agent-PTY conversation surface. `agentState` is the surviving `initializing` state machine; this PR makes it honest and leaves the product ask open.

Refs #1254. Pre-v0.1.1-stable hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
