### PR TITLE
fix(chat): workspace lane selection outranks stale session context when routing a new chat (#1303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ workflow.
   itself from the hub's answer: the unread dot returns with the next message,
   and later read marks reach your other devices again instead of being swallowed
   (#1318).
+- A chat started from a workspace you just selected runs in that workspace's project instead of the project of whatever terminal was still open (#1303)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ workflow.
   itself from the hub's answer: the unread dot returns with the next message,
   and later read marks reach your other devices again instead of being swallowed
   (#1318).
-- A chat started from a workspace you just selected runs in that workspace's project instead of the project of whatever terminal was still open (#1303)
+- A chat you create with an explicit repo or terminal target now runs in the workspace you just selected, instead of in the project of whatever terminal was still open (#1303)
 
 ### Changed
 

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -59,7 +59,7 @@ import {
 import { AgentAvatar } from './chat/AgentAvatar.js';
 import { leaveChatSurface, openTopicTaskRoom } from '../lib/topic-task-room.js';
 import {
-  applyTopicActiveContext,
+  applyCreateRoutingContext,
   openChannelMessageSelection,
   openTopicSelection,
 } from '../lib/topic-selection.js';
@@ -3276,69 +3276,25 @@ export function TopicSidebarView({
       setMobileControlTopicId(null);
     }
   }, [mobileControlTopicId, model.byId, selectedId]);
-  // #1287: `activeWorkspaceId` and `activeRepoPath` are two halves of ONE
-  // routing decision — `useTopicRoomCreate` files the channel by the first and
-  // derives `routingDefaults.repoPath`/`cwd` from the second. Moving only the
-  // lane pointer would file the chat in the newly chosen project while still
-  // pointing it at the ABANDONED project's repo: a split across two projects,
-  // strictly worse than the consistent-but-stale state it replaced. The lane
-  // row already carries the anchor (`ensureProjectWorkspace` stamps
-  // `defaultRepoPath` on every add-project lane), so the create paths stamp it
-  // alongside the id.
-  //
-  // Applied on the CREATE paths only, never on a bare lane click:
-  // `resolveAppViewMode` returns 'dashboard' the moment `activeRepoPath` is set
-  // and nothing above it is, so writing the repo pointer outside a create would
-  // silently turn selecting a lane into a navigation off the chat landing onto
-  // RepoDashboard. Here the composer opens immediately after and outranks it.
-  // A lane with no repo of its own leaves the pointer untouched — that is the
-  // documented inheritance fallback (`activeSession ?? activeRepoPath ??
-  // repos[0]`), and only add-project lanes carry an anchor.
-  //
-  // #1303: moving `activeRepoPath` is necessary but NOT sufficient — the repo
-  // pointer sits BELOW the active session in the create hook's inheritance
-  // chain, so a terminal still open in the abandoned project silently outranked
-  // it and the create landed back there anyway. The lane choice is therefore
-  // recorded as itself (`laneRepoRouting`), which the hook ranks above session
-  // context. Only the path anchor moves; the lane carries no node of its own,
-  // so the session's node inheritance is left exactly as it was.
-  const applyWorkspaceLaneRouting = useCallback(
-    (workspaceId: string | null) => {
-      if (!workspaceId) return;
-      const laneRepoPath = workspaces.find(
-        (workspace) => workspace.id === workspaceId
-      )?.defaultRepoPath;
-      const ui = useUiStore.getState();
-      if (!laneRepoPath) {
-        // An anchorless lane is an explicit choice to inherit: drop any stamp
-        // an earlier lane left, or the create would route at THAT lane's repo.
-        ui.setLaneRepoRouting(null);
-        return;
-      }
-      ui.setActiveRepoPath(laneRepoPath);
-      ui.setLaneRepoRouting({ workspaceId, repoPath: laneRepoPath });
-    },
+  // #1287/#1303: lane-vs-row precedence and the repo anchor a create inherits
+  // live in `applyCreateRoutingContext` — a named seam rather than component
+  // internals, so the decision can be driven by a regression test exactly as the
+  // button drives it, and so the rail header and each lane's start-chat button
+  // keep sharing ONE body. Only the lane→repo lookup is local, because only the
+  // rail holds the workspace rows.
+  const laneRepoPathById = useCallback(
+    (workspaceId: string) =>
+      workspaces.find((workspace) => workspace.id === workspaceId)
+        ?.defaultRepoPath,
     [workspaces]
   );
   const openCreateTaskRoom = useCallback(() => {
-    const selectedTopic = selectedId ? topicsById.get(selectedId) : undefined;
-    // #1287: the still-highlighted row may belong to a lane the operator has
-    // since navigated away from (select a fresh, empty lane while a channel
-    // from the old workspace stays selected). `applyTopicActiveContext` stamps
-    // `activeWorkspaceId` from the topic, so re-applying it here would file the
-    // new chat back in the OLD lane. An explicit lane selection is the more
-    // recent intent and wins; when the row still lives in the active lane the
-    // context (including repo/worktree inheritance) is applied as before.
-    // Read the live pointer rather than the prop: `selectWorkspaceLane` writes
-    // it straight to the store, so the prop can lag the operator's newest
-    // lane choice within the same interaction.
-    const activeLaneId = useUiStore.getState().activeWorkspaceId;
-    const rowIsInActiveLane =
-      activeLaneId === null || selectedTopic?.workspaceId === activeLaneId;
-    if (rowIsInActiveLane) applyTopicActiveContext(selectedTopic);
-    else applyWorkspaceLaneRouting(activeLaneId);
+    applyCreateRoutingContext({
+      selectedTopic: selectedId ? topicsById.get(selectedId) : undefined,
+      laneRepoPathById,
+    });
     onCreateTaskRoom?.();
-  }, [applyWorkspaceLaneRouting, onCreateTaskRoom, selectedId, topicsById]);
+  }, [laneRepoPathById, onCreateTaskRoom, selectedId, topicsById]);
   // #1287: a workspace lane is selectable in its own right, so a workspace
   // that holds no channels yet can still become the active one. Selecting a
   // channel inside a lane already does this through the topic's context; this

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -3294,13 +3294,29 @@ export function TopicSidebarView({
   // A lane with no repo of its own leaves the pointer untouched — that is the
   // documented inheritance fallback (`activeSession ?? activeRepoPath ??
   // repos[0]`), and only add-project lanes carry an anchor.
+  //
+  // #1303: moving `activeRepoPath` is necessary but NOT sufficient — the repo
+  // pointer sits BELOW the active session in the create hook's inheritance
+  // chain, so a terminal still open in the abandoned project silently outranked
+  // it and the create landed back there anyway. The lane choice is therefore
+  // recorded as itself (`laneRepoRouting`), which the hook ranks above session
+  // context. Only the path anchor moves; the lane carries no node of its own,
+  // so the session's node inheritance is left exactly as it was.
   const applyWorkspaceLaneRouting = useCallback(
     (workspaceId: string | null) => {
       if (!workspaceId) return;
       const laneRepoPath = workspaces.find(
         (workspace) => workspace.id === workspaceId
       )?.defaultRepoPath;
-      if (laneRepoPath) useUiStore.getState().setActiveRepoPath(laneRepoPath);
+      const ui = useUiStore.getState();
+      if (!laneRepoPath) {
+        // An anchorless lane is an explicit choice to inherit: drop any stamp
+        // an earlier lane left, or the create would route at THAT lane's repo.
+        ui.setLaneRepoRouting(null);
+        return;
+      }
+      ui.setActiveRepoPath(laneRepoPath);
+      ui.setLaneRepoRouting({ workspaceId, repoPath: laneRepoPath });
     },
     [workspaces]
   );

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -52,6 +52,7 @@ export function useTopicRoomCreate({
   const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const activeWorkspaceId = useUiStore((s) => s.activeWorkspaceId);
+  const laneRepoRouting = useUiStore((s) => s.laneRepoRouting);
   const defaultAgent = useConfigStore((s) => s.defaultAgent);
   const frameworks = useConfigStore((s) => s.frameworks);
   const activeSession = useMemo(
@@ -80,14 +81,44 @@ export function useTopicRoomCreate({
   const effectiveTitle = effectiveDraftTitle(draft);
   const taskRef = taskRefFromDraft(draft.taskRef, effectiveTitle);
   const defaultNodeId = activeSession?.nodeId ?? undefined;
+  // #1303: a workspace lane the operator explicitly selected outranks EVERY
+  // inherited anchor below it. The lane click is the newest statement of where
+  // this chat belongs, and the create files the channel in that lane
+  // (`activeWorkspaceId`) regardless — so letting a terminal still open in the
+  // project the operator just left decide `repoPath`/`cwd` splits one chat
+  // across two projects. Ranked ABOVE `activeSession`, not merely above
+  // `activeRepoPath`, because that is exactly where the stale session won.
+  //
+  // Only while the stamp still describes the ACTIVE lane: once the operator
+  // moves on, the lane it was about is no longer the one being created in, and
+  // the ordinary inheritance chain is the honest answer again.
+  const laneRepoPath =
+    laneRepoRouting && laneRepoRouting.workspaceId === activeWorkspaceId
+      ? laneRepoRouting.repoPath
+      : undefined;
   // Prefer repo/worktree context when it exists, but launch only needs a cwd
   // anchor. Fresh dev/self-host sessions can rely on the backend's local cwd
   // fallback when no repo has been configured yet.
   const defaultRepoPath =
-    activeSession?.repoPath ?? activeRepoPath ?? repos[0]?.path ?? undefined;
-  const defaultWorktreePath = activeSession?.worktreePath ?? undefined;
+    laneRepoPath ??
+    activeSession?.repoPath ??
+    activeRepoPath ??
+    repos[0]?.path ??
+    undefined;
+  // A worktree and a cwd from the abandoned project are the SAME bug wearing a
+  // different field: `buildTopicRoomLaunchBody` copies both, and `cwd` is what
+  // the process actually starts in — so a lane-routed create that kept them
+  // would claim the new repo and run in the old one. The lane anchor replaces
+  // them wholesale; a lane has no worktree of its own to offer.
+  const defaultWorktreePath = laneRepoPath
+    ? undefined
+    : (activeSession?.worktreePath ?? undefined);
   const defaultCwd =
-    activeSession?.cwd ?? defaultWorktreePath ?? defaultRepoPath ?? undefined;
+    laneRepoPath ??
+    activeSession?.cwd ??
+    defaultWorktreePath ??
+    defaultRepoPath ??
+    undefined;
   const selectedProviderId = draft.providerId.trim() || defaultAgent;
   const nodes = useMemo(
     () =>

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -35,6 +35,23 @@ import { useConfigStore } from '../lib/stores/config.js';
 import type { SessionSummary } from '../lib/types.js';
 
 /**
+ * #1303: a COMMITTED create spends the lane stamp along with the draft it
+ * routed. The store spends it on every composer close, which covers the exits
+ * that navigate away (a launch selects the session, the DM path lands on the
+ * channel) — but `create only` deliberately leaves the composer standing, and
+ * an unspent stamp would silently route the next create in that lane too,
+ * including one reached from the command palette with no lane click at all.
+ *
+ * Deliberately NOT called after the create request returns: a `launch_failed`
+ * result keeps the composer open for a retry, and that retry rebuilds its
+ * launch body from the live defaults — dropping the stamp there would launch
+ * the retry in a different repo than the row that was already created.
+ */
+function spendLaneRepoRouting(): void {
+  useUiStore.getState().setLaneRepoRouting(null);
+}
+
+/**
  * #1058: stateful draft + create/launch plumbing for codex-style topic
  * creation. Owns the draft, resolves workspace defaults (provider, node,
  * repo, worktree, cwd) from the active context, and drives the two-step
@@ -96,11 +113,21 @@ export function useTopicRoomCreate({
     laneRepoRouting && laneRepoRouting.workspaceId === activeWorkspaceId
       ? laneRepoRouting.repoPath
       : undefined;
+  // ...and only where it actually DISAGREES with the session. The lane and the
+  // session naming the same repo is the repo's own dogfood shape — a project
+  // lane plus a terminal open in `<repo>/.worktrees/<issue-slug>` — and there
+  // the session is the strictly better anchor: it knows the worktree, the lane
+  // knows only the main checkout. Overriding unconditionally would start the
+  // agent in the wrong tree of the RIGHT repo, which is the same class of bug
+  // pointed the other way.
+  const laneOverridesSession =
+    laneRepoPath !== undefined && activeSession?.repoPath !== laneRepoPath;
+  const laneAnchor = laneOverridesSession ? laneRepoPath : undefined;
   // Prefer repo/worktree context when it exists, but launch only needs a cwd
   // anchor. Fresh dev/self-host sessions can rely on the backend's local cwd
   // fallback when no repo has been configured yet.
   const defaultRepoPath =
-    laneRepoPath ??
+    laneAnchor ??
     activeSession?.repoPath ??
     activeRepoPath ??
     repos[0]?.path ??
@@ -109,12 +136,13 @@ export function useTopicRoomCreate({
   // different field: `buildTopicRoomLaunchBody` copies both, and `cwd` is what
   // the process actually starts in — so a lane-routed create that kept them
   // would claim the new repo and run in the old one. The lane anchor replaces
-  // them wholesale; a lane has no worktree of its own to offer.
-  const defaultWorktreePath = laneRepoPath
+  // them wholesale; a lane has no worktree of its own to offer. A session
+  // inside the lane's own repo keeps both.
+  const defaultWorktreePath = laneOverridesSession
     ? undefined
     : (activeSession?.worktreePath ?? undefined);
   const defaultCwd =
-    laneRepoPath ??
+    laneAnchor ??
     activeSession?.cwd ??
     defaultWorktreePath ??
     defaultRepoPath ??
@@ -302,6 +330,7 @@ export function useTopicRoomCreate({
             queryKey: ['workspace-topics'],
           });
           setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+          spendLaneRepoRouting();
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -354,6 +383,7 @@ export function useTopicRoomCreate({
           await selectLaunchedSession(result.session);
           setCreatedRoom(null);
           setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+          spendLaneRepoRouting();
           return;
         }
         const result = await createWorkspaceTopicRoomAndMaybeLaunch({
@@ -401,6 +431,7 @@ export function useTopicRoomCreate({
         }
         setCreatedRoom(null);
         setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+        spendLaneRepoRouting();
       } catch (error) {
         const failure = error as WorkspaceTopicLaunchFailure;
         setLaunchFailure({

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -585,8 +585,9 @@ export type ActiveModal =
   | null;
 
 /**
- * #1303: the repo anchor of a workspace lane the operator explicitly selected
- * THIS session, carried together with the lane it came from.
+ * #1303: the repo anchor of the routing statement that opened the CURRENT
+ * composer — a lane the operator just selected, or the channel row they just
+ * opened — carried together with the lane it came from.
  *
  * Deliberately not another `activeRepoPath`: that pointer is persisted, is
  * written by repo-dashboard navigation, and cannot say WHO wrote it — so it can
@@ -595,6 +596,13 @@ export type ActiveModal =
  * and it is keyed by `workspaceId` so it self-invalidates the moment the active
  * lane moves somewhere else instead of following the operator into a lane it
  * was never about.
+ *
+ * SINGLE-USE. It is written immediately before the composer opens and spent
+ * when that composer goes away (`setTopicComposerOpen(false)`, below) or when a
+ * create commits. A stamp that outlived its composer would keep outranking
+ * session context on every later create in the same lane — including creates
+ * the operator reached from the command palette without touching a lane at all
+ * — which is a different, louder bug than the one it fixes.
  */
 export interface LaneRepoRouting {
   workspaceId: string;
@@ -1295,7 +1303,20 @@ export const useUiStore = create<UiState>()((set, get) => ({
     }
   },
   setForceOrgCockpit: (v) => set({ forceOrgCockpit: v }),
-  setTopicComposerOpen: (v) => set({ topicComposerOpen: v }),
+  // #1303: closing the composer SPENDS the lane stamp. The stamp means "the
+  // routing statement that opened THIS composer", and every way out of the
+  // composer runs through here — Escape, a channel/URL/notification navigation,
+  // a launch that selects a session. Enforced in the setter rather than asked
+  // of each caller because the bug this guards against is precisely a caller
+  // that forgets: the eight existing exits would each have to remember, and the
+  // ninth would not. Opening never clears — `openTopicTaskRoom` runs AFTER the
+  // stamp is written.
+  setTopicComposerOpen: (v) =>
+    set(
+      v
+        ? { topicComposerOpen: true }
+        : { topicComposerOpen: false, laneRepoRouting: null }
+    ),
   setActiveChannelId: (v) =>
     set({
       activeChannelId: v,

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -584,6 +584,23 @@ export type ActiveModal =
   | { modal: 'handoff-plan' }
   | null;
 
+/**
+ * #1303: the repo anchor of a workspace lane the operator explicitly selected
+ * THIS session, carried together with the lane it came from.
+ *
+ * Deliberately not another `activeRepoPath`: that pointer is persisted, is
+ * written by repo-dashboard navigation, and cannot say WHO wrote it — so it can
+ * never answer "did the operator just choose a lane?". This one is
+ * session-transient (no localStorage slot) because the intent it records is,
+ * and it is keyed by `workspaceId` so it self-invalidates the moment the active
+ * lane moves somewhere else instead of following the operator into a lane it
+ * was never about.
+ */
+export interface LaneRepoRouting {
+  workspaceId: string;
+  repoPath: string;
+}
+
 // ── State interface ────────────────────────────────────────────────────────
 export interface UiState {
   sidebarOpen: boolean;
@@ -592,6 +609,7 @@ export interface UiState {
   searchQuery: string;
   activeRepoPath: string | null;
   activeWorkspaceId: string | null;
+  laneRepoRouting: LaneRepoRouting | null;
   terminalFontSize: number;
   hasHardwareKeyboard: boolean;
   keyboardOpen: boolean;
@@ -748,6 +766,7 @@ export interface UiState {
   saveTerminalFontSize: () => void;
   setActiveRepoPath: (v: string | null) => void;
   setActiveWorkspaceId: (id: string | null) => void;
+  setLaneRepoRouting: (routing: LaneRepoRouting | null) => void;
   setFileDiffViewMode: (v: DiffViewMode) => void;
   setFileWordWrap: (v: boolean) => void;
   toggleRightSidebarCollapsed: () => void;
@@ -811,6 +830,9 @@ export const useUiStore = create<UiState>()((set, get) => ({
   searchQuery: '',
   activeRepoPath: ls(ACTIVE_WORKSPACE_KEY),
   activeWorkspaceId: loadPersistedActiveWorkspaceId(),
+  // #1303: no `ls(...)` here on purpose — see `LaneRepoRouting`. A reload has
+  // no "just selected" lane, so a fresh tab starts with session inheritance.
+  laneRepoRouting: null,
   terminalFontSize: loadTerminalFontSize(),
   hasHardwareKeyboard: false,
   keyboardOpen: false,
@@ -872,6 +894,8 @@ export const useUiStore = create<UiState>()((set, get) => ({
     else lsSave(ACTIVE_WORKSPACE_GROUP_KEY, id);
     set({ activeWorkspaceId: id });
   },
+
+  setLaneRepoRouting: (routing) => set({ laneRepoRouting: routing }),
 
   setFileDiffViewMode: (v) => {
     lsSave(DIFF_VIEW_MODE_KEY, v);

--- a/frontend/src/lib/topic-selection.ts
+++ b/frontend/src/lib/topic-selection.ts
@@ -16,6 +16,10 @@ export function applyTopicActiveContext(
   if (!topic) return;
   const context = resolveTopicActiveContext(topic);
   const ui = useUiStore.getState();
+  // #1303: this topic's context is now the newest routing intent, so a lane
+  // the operator picked earlier is spent — leaving the stamp would let it
+  // outrank the very context being applied here on the next create.
+  ui.setLaneRepoRouting(null);
   ui.setActiveWorkspaceId(context.workspaceId);
   if (context.repoPath) ui.setActiveRepoPath(context.repoPath);
 }

--- a/frontend/src/lib/topic-selection.ts
+++ b/frontend/src/lib/topic-selection.ts
@@ -13,15 +13,124 @@ import { useUiStore } from './stores/ui.js';
 export function applyTopicActiveContext(
   topic: WorkspaceTopic | undefined
 ): void {
-  if (!topic) return;
-  const context = resolveTopicActiveContext(topic);
   const ui = useUiStore.getState();
-  // #1303: this topic's context is now the newest routing intent, so a lane
-  // the operator picked earlier is spent — leaving the stamp would let it
-  // outrank the very context being applied here on the next create.
-  ui.setLaneRepoRouting(null);
+  const context = topic ? resolveTopicActiveContext(topic) : null;
+  // #1303: this navigation is now the newest routing statement, so it REPLACES
+  // the lane stamp rather than merely surviving it — a lane the operator picked
+  // earlier must not outrank the row they just opened, and a row that names a
+  // repo must not be undercut by session context on the next create (the repo
+  // pointer alone sits below `activeSession` in the create hook's chain).
+  //
+  // Written BEFORE the `!topic` bail on purpose: `openChannelMessageSelection`
+  // routinely opens a channel whose topic the caller could not resolve, and
+  // `select(id, fallbackTopic)` can too. The main pane still changes, so a
+  // stamp minted for some other lane is just as stale there — clearing it is
+  // the honest answer, and the ordinary inheritance chain takes over.
+  ui.setLaneRepoRouting(
+    context?.repoPath
+      ? { workspaceId: context.workspaceId, repoPath: context.repoPath }
+      : null
+  );
+  if (!context) return;
   ui.setActiveWorkspaceId(context.workspaceId);
   if (context.repoPath) ui.setActiveRepoPath(context.repoPath);
+}
+
+/**
+ * #1287: a workspace lane carries the repo anchor `ensureProjectWorkspace`
+ * stamps on every add-project workspace, and a create needs BOTH halves of that
+ * routing decision — `useTopicRoomCreate` files the channel by
+ * `activeWorkspaceId` and derives `routingDefaults.repoPath`/`cwd` from the repo
+ * anchor. Moving only the lane pointer files the chat in the newly chosen
+ * project while still pointing it at the ABANDONED project's repo: a split
+ * across two projects, strictly worse than the consistent-but-stale state it
+ * replaced.
+ *
+ * Applied on the CREATE paths only, never on a bare lane click:
+ * `resolveAppViewMode` returns 'dashboard' the moment `activeRepoPath` is set
+ * and nothing above it is, so writing the repo pointer outside a create would
+ * silently turn selecting a lane into a navigation off the chat landing onto
+ * RepoDashboard. On a create the composer opens immediately after and outranks
+ * it.
+ *
+ * #1303: the pointer alone cannot carry the choice — it sits BELOW the active
+ * session in the create hook's inheritance chain, so a terminal still open in
+ * the abandoned project outranked it and the create landed back there anyway.
+ * The lane is therefore recorded as itself, and the hook ranks that above
+ * session context. An anchorless lane (or none) records nothing and leaves the
+ * pointer alone: that is the documented inheritance fallback
+ * (`activeSession ?? activeRepoPath ?? repos[0]`). Only the path anchor moves —
+ * a lane has no node of its own, so session node inheritance is untouched.
+ */
+export function applyLaneRepoRouting(
+  workspaceId: string | null,
+  laneRepoPathById: (workspaceId: string) => string | null | undefined
+): void {
+  const ui = useUiStore.getState();
+  const laneRepoPath = workspaceId ? laneRepoPathById(workspaceId) : undefined;
+  if (!workspaceId || !laneRepoPath) {
+    // Drop any stamp an earlier lane left, or the create would route at THAT
+    // lane's repo while being filed in this one.
+    ui.setLaneRepoRouting(null);
+    return;
+  }
+  ui.setActiveRepoPath(laneRepoPath);
+  ui.setLaneRepoRouting({ workspaceId, repoPath: laneRepoPath });
+}
+
+/**
+ * Resolve where a NEW chat runs, at the moment its composer is opened — the one
+ * body behind every new-chat entry point in the rail (#1287: the header button
+ * and each lane's own start-chat button share it so they cannot drift).
+ *
+ * #1287: the still-highlighted row may belong to a lane the operator has since
+ * navigated away from (select a fresh, empty lane while a channel from the old
+ * workspace stays selected). `applyTopicActiveContext` stamps
+ * `activeWorkspaceId` from the topic, so re-applying it then would file the new
+ * chat back in the OLD lane. An explicit lane selection is the more recent
+ * intent and wins.
+ *
+ * #1303: when the row IS in the active lane, applying its context is necessary
+ * but NOT sufficient, and that is the shape the bug actually ships in. Opening a
+ * channel never clears `activeSessionId` (App's effect fires on CHANGE only), so
+ * a terminal from a different project stays the active session while the
+ * operator works in this lane — and the row they have highlighted is typically a
+ * DM, whose `routingDefaults` carries `providerId` alone
+ * (`dmChannelCreateInput`). It names no repo, leaves no stamp, and the create
+ * falls through to that stale session. So: whenever nothing has answered the
+ * routing question FOR THE LANE THIS CHAT IS BEING FILED IN, the lane's own
+ * anchor answers it. A row that names a repo of its own is more specific than
+ * its lane and keeps its stamp.
+ *
+ * The answer is derived from THIS interaction alone — whether the row applied
+ * above named a repo — never from whatever stamp happens to be lying in the
+ * store. Reading the existing stamp would make the decision depend on an
+ * earlier, possibly abandoned create in the same lane, which is exactly the
+ * state this function exists to overwrite.
+ *
+ * The live store is re-read rather than trusting the caller's props: lane
+ * selection writes straight to the store, so a prop can lag the operator's
+ * newest choice within one interaction, and `applyTopicActiveContext` may have
+ * moved the lane a line earlier.
+ */
+export function applyCreateRoutingContext(input: {
+  selectedTopic: WorkspaceTopic | undefined;
+  laneRepoPathById: (workspaceId: string) => string | null | undefined;
+}): void {
+  const activeLaneId = useUiStore.getState().activeWorkspaceId;
+  const rowIsInActiveLane =
+    activeLaneId === null || input.selectedTopic?.workspaceId === activeLaneId;
+  const rowRepoPath =
+    rowIsInActiveLane && input.selectedTopic
+      ? resolveTopicActiveContext(input.selectedTopic).repoPath
+      : null;
+  if (rowIsInActiveLane) applyTopicActiveContext(input.selectedTopic);
+  if (!rowRepoPath) {
+    applyLaneRepoRouting(
+      useUiStore.getState().activeWorkspaceId,
+      input.laneRepoPathById
+    );
+  }
 }
 
 /**

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -4,7 +4,10 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WorkspaceTopicCreateInput } from '../shared/workspace-topics.js';
+import type {
+  WorkspaceTopic,
+  WorkspaceTopicCreateInput,
+} from '../shared/workspace-topics.js';
 import {
   buildTopicRoomCreateInput,
   buildTopicRoomLaunchBody,
@@ -42,7 +45,14 @@ import { useConfigStore } from '../frontend/src/lib/stores/config.js';
 import { useToastStore } from '../frontend/src/lib/stores/toasts.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
-import type { FrameworkInfo } from '../frontend/src/lib/types.js';
+import type {
+  FrameworkInfo,
+  SessionSummary,
+} from '../frontend/src/lib/types.js';
+import {
+  applyCreateRoutingContext,
+  openTopicSelection,
+} from '../frontend/src/lib/topic-selection.js';
 import TopicComposer from '../frontend/src/components/TopicComposer.js';
 import ChatHome from '../frontend/src/components/ChatHome.js';
 import { openTopicTaskRoom } from '../frontend/src/lib/topic-task-room.js';
@@ -1063,11 +1073,43 @@ describe('TopicComposer', () => {
       idle: false,
     } as const;
 
-    function seedActiveProjectASession() {
+    const LANE_B_REPO = '/repo/project-b';
+    // The rail's own lane→anchor lookup (`workspaces.find(...).defaultRepoPath`),
+    // as `ensureProjectWorkspace` stamps it on every add-project lane.
+    const laneRepoPathById = (workspaceId: string) =>
+      workspaceId === LANE_B ? LANE_B_REPO : undefined;
+
+    /** A DM row exactly as `dmChannelCreateInput` writes one: no repo anywhere. */
+    function dmTopicIn(workspaceId: string): WorkspaceTopic {
+      return {
+        schemaVersion: 1,
+        id: dmChannelTopicId('claude', workspaceId),
+        workspaceId,
+        source: 'persisted',
+        status: 'active',
+        visibility: 'default',
+        display: { title: 'Claude Code' },
+        grouping: {},
+        promptDefaults: {},
+        routingDefaults: { providerId: 'claude' },
+        linkedRefs: {},
+        state: { pinned: false, muted: false },
+        privacy: {
+          classification: 'internal',
+          retention: 'project',
+          redaction: 'summary',
+          rawDefaultsStored: false,
+        },
+        createdAt: '2026-08-04T00:00:00.000Z',
+        updatedAt: '2026-08-04T00:00:00.000Z',
+      };
+    }
+
+    function seedActiveSession(session: SessionSummary) {
       useSessionsStore.setState({
-        sessions: [projectASession],
+        sessions: [session],
         repos: [],
-        activeSessionId: scopedSessionKey(projectASession),
+        activeSessionId: scopedSessionKey(session),
         refreshAll: vi.fn(async () => {}),
       });
       vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
@@ -1077,7 +1119,11 @@ describe('TopicComposer', () => {
       } as never);
     }
 
-    async function createOnlyFromComposer() {
+    function seedActiveProjectASession() {
+      seedActiveSession(projectASession as unknown as SessionSummary);
+    }
+
+    async function createOnlyFromComposer(callIndex = 0) {
       renderComposer();
       const ta = container.querySelector(
         '.topic-composer__ta'
@@ -1087,7 +1133,7 @@ describe('TopicComposer', () => {
       ) as HTMLButtonElement;
       act(() => {
         setNativeValue(ta, 'start work in the project I just selected');
-        toggle.click();
+        if (toggle.getAttribute('aria-expanded') !== 'true') toggle.click();
       });
       const createOnly = Array.from(
         container.querySelectorAll<HTMLButtonElement>(
@@ -1096,34 +1142,98 @@ describe('TopicComposer', () => {
       ).find((button) => button.textContent === 'create only');
       expect(createOnly).toBeDefined();
       await act(async () => createOnly?.click());
-      return vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
-        .calls[0]?.[0] as
-        | { room: { topic: WorkspaceTopicCreateInput } }
-        | undefined;
+      return vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock.calls[
+        callIndex
+      ]?.[0] as { room: { topic: WorkspaceTopicCreateInput } } | undefined;
     }
 
-    it('routes a lane-selected chat at the lane repo despite an active session in another project', async () => {
+    // The canonical reproduction, driven through the REAL rail disposition
+    // rather than a hand-seeded store: the operator opens project B's Claude DM
+    // (`openTopicSelection`, the row's own handler) and presses new chat
+    // (`applyCreateRoutingContext`, the body both new-chat buttons run). The
+    // selected row IS in the active lane, and it names no repo — so nothing but
+    // the lane can answer where this chat runs, and the project-A terminal is
+    // still `activeSessionId` because opening a channel never clears it.
+    it('routes a lane-B chat at the lane repo when the selected row is a DM and a project-A terminal is still active', async () => {
       seedActiveProjectASession();
-      // Exactly the state `applyWorkspaceLaneRouting` leaves behind when the
-      // operator selects project B's lane and starts a chat from it.
-      useUiStore.setState({
-        activeWorkspaceId: LANE_B,
-        activeRepoPath: '/repo/project-b',
-        laneRepoRouting: { workspaceId: LANE_B, repoPath: '/repo/project-b' },
-      });
+      const dm = dmTopicIn(LANE_B);
+      openTopicSelection(dm);
+      expect(useUiStore.getState().activeWorkspaceId).toBe(LANE_B);
+      applyCreateRoutingContext({ selectedTopic: dm, laneRepoPathById });
+      openTopicTaskRoom();
 
       const arg = await createOnlyFromComposer();
 
       expect(arg?.room.topic.workspaceId).toBe(LANE_B);
-      expect(arg?.room.topic.routingDefaults?.repoPath).toBe('/repo/project-b');
+      expect(arg?.room.topic.routingDefaults?.repoPath).toBe(LANE_B_REPO);
       expect(arg?.room.topic.routingDefaults?.repoPath).not.toBe(
         '/repo/project-a'
       );
       // `cwd` is what the process would actually start in and `worktreePath`
       // names a checkout that only exists inside project A — a fix that moved
       // `repoPath` alone would still land the work in the abandoned project.
-      expect(arg?.room.topic.routingDefaults?.cwd).toBe('/repo/project-b');
+      expect(arg?.room.topic.routingDefaults?.cwd).toBe(LANE_B_REPO);
       expect(arg?.room.topic.routingDefaults?.worktreePath).toBeUndefined();
+    });
+
+    // The mirror image, and the repo's own dogfood shape: one project lane plus
+    // a terminal open in `<repo>/.worktrees/<issue-slug>`. The lane and the
+    // session agree about the REPO, so the session is the better anchor — it
+    // knows the worktree, the lane knows only the main checkout. Overriding here
+    // would start the agent in the wrong tree of the right repo.
+    it('keeps the session worktree when the lane names the repo that session is already in', async () => {
+      seedActiveSession({
+        ...projectASession,
+        id: 'sess-project-b',
+        repoPath: LANE_B_REPO,
+        worktreePath: `${LANE_B_REPO}/.worktrees/feature`,
+        cwd: `${LANE_B_REPO}/.worktrees/feature`,
+      } as unknown as SessionSummary);
+      // Start-chat on lane B's header with no row of that lane selected.
+      useUiStore.setState({ activeWorkspaceId: LANE_B });
+      applyCreateRoutingContext({
+        selectedTopic: undefined,
+        laneRepoPathById,
+      });
+      openTopicTaskRoom();
+
+      const arg = await createOnlyFromComposer();
+
+      expect(arg?.room.topic.routingDefaults?.repoPath).toBe(LANE_B_REPO);
+      expect(arg?.room.topic.routingDefaults?.worktreePath).toBe(
+        `${LANE_B_REPO}/.worktrees/feature`
+      );
+      expect(arg?.room.topic.routingDefaults?.cwd).toBe(
+        `${LANE_B_REPO}/.worktrees/feature`
+      );
+    });
+
+    // The stamp means "the lane click that opened THIS composer". Left standing
+    // it would silently route every later create in the lane — including one the
+    // operator reached from the command palette, which calls `openTopicTaskRoom`
+    // directly and touches no lane at all.
+    it('spends the lane anchor on the create it routed, so the next chat inherits the session again', async () => {
+      seedActiveProjectASession();
+      const dm = dmTopicIn(LANE_B);
+      openTopicSelection(dm);
+      applyCreateRoutingContext({ selectedTopic: dm, laneRepoPathById });
+      openTopicTaskRoom();
+
+      const first = await createOnlyFromComposer();
+      expect(first?.room.topic.routingDefaults?.repoPath).toBe(LANE_B_REPO);
+      expect(useUiStore.getState().laneRepoRouting).toBeNull();
+
+      // Command-palette "new chat": no lane click, same lane still active.
+      openTopicTaskRoom();
+      const second = await createOnlyFromComposer(1);
+
+      expect(second?.room.topic.workspaceId).toBe(LANE_B);
+      expect(second?.room.topic.routingDefaults?.repoPath).toBe(
+        '/repo/project-a'
+      );
+      expect(second?.room.topic.routingDefaults?.cwd).toBe(
+        '/repo/project-a/.worktrees/old-task'
+      );
     });
 
     it('keeps session inheritance when no lane was explicitly selected', async () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -4,6 +4,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceTopicCreateInput } from '../shared/workspace-topics.js';
 import {
   buildTopicRoomCreateInput,
   buildTopicRoomLaunchBody,
@@ -310,6 +311,8 @@ describe('TopicComposer', () => {
       // payload, so a case that selects a lane would otherwise file every
       // later case's chat in it.
       activeWorkspaceId: null,
+      // #1303: same hazard for the lane's repo stamp.
+      laneRepoRouting: null,
     });
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -1038,6 +1041,129 @@ describe('TopicComposer', () => {
     // shell it is the composer, not a re-rendered ChannelView, that mounts.
     renderChatHome(vi.fn());
     expect(container.querySelector('.topic-composer__ta')).not.toBeNull();
+  });
+
+  // #1303: #1287 moved `activeRepoPath` with the lane, but the create hook
+  // reads it BELOW the active session — `activeSession?.repoPath ??
+  // activeRepoPath ?? repos[0]` — so a terminal still open in the project the
+  // operator just left outranked the lane they just chose, and the chat was
+  // filed in project B while routed (and started) in project A.
+  describe('workspace-lane routing vs session inheritance (#1303)', () => {
+    const LANE_B = 'ws:project-b';
+    const projectASession = {
+      id: 'sess-project-a',
+      type: 'terminal',
+      mode: 'pty',
+      repoPath: '/repo/project-a',
+      worktreePath: '/repo/project-a/.worktrees/old-task',
+      cwd: '/repo/project-a/.worktrees/old-task',
+      displayName: 'project A terminal',
+      createdAt: '2026-08-04T00:00:00.000Z',
+      lastActivity: '2026-08-04T00:00:00.000Z',
+      idle: false,
+    } as const;
+
+    function seedActiveProjectASession() {
+      useSessionsStore.setState({
+        sessions: [projectASession],
+        repos: [],
+        activeSessionId: scopedSessionKey(projectASession),
+        refreshAll: vi.fn(async () => {}),
+      });
+      vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mockResolvedValue({
+        status: 'created',
+        topic: { id: 'topic:lane-routed' },
+        workContext: { id: 'wc:lane-routed' },
+      } as never);
+    }
+
+    async function createOnlyFromComposer() {
+      renderComposer();
+      const ta = container.querySelector(
+        '.topic-composer__ta'
+      ) as HTMLTextAreaElement;
+      const toggle = container.querySelector(
+        '.topic-composer__advanced-toggle'
+      ) as HTMLButtonElement;
+      act(() => {
+        setNativeValue(ta, 'start work in the project I just selected');
+        toggle.click();
+      });
+      const createOnly = Array.from(
+        container.querySelectorAll<HTMLButtonElement>(
+          '.topic-composer__advanced-actions button'
+        )
+      ).find((button) => button.textContent === 'create only');
+      expect(createOnly).toBeDefined();
+      await act(async () => createOnly?.click());
+      return vi.mocked(createWorkspaceTopicRoomAndMaybeLaunch).mock
+        .calls[0]?.[0] as
+        | { room: { topic: WorkspaceTopicCreateInput } }
+        | undefined;
+    }
+
+    it('routes a lane-selected chat at the lane repo despite an active session in another project', async () => {
+      seedActiveProjectASession();
+      // Exactly the state `applyWorkspaceLaneRouting` leaves behind when the
+      // operator selects project B's lane and starts a chat from it.
+      useUiStore.setState({
+        activeWorkspaceId: LANE_B,
+        activeRepoPath: '/repo/project-b',
+        laneRepoRouting: { workspaceId: LANE_B, repoPath: '/repo/project-b' },
+      });
+
+      const arg = await createOnlyFromComposer();
+
+      expect(arg?.room.topic.workspaceId).toBe(LANE_B);
+      expect(arg?.room.topic.routingDefaults?.repoPath).toBe('/repo/project-b');
+      expect(arg?.room.topic.routingDefaults?.repoPath).not.toBe(
+        '/repo/project-a'
+      );
+      // `cwd` is what the process would actually start in and `worktreePath`
+      // names a checkout that only exists inside project A — a fix that moved
+      // `repoPath` alone would still land the work in the abandoned project.
+      expect(arg?.room.topic.routingDefaults?.cwd).toBe('/repo/project-b');
+      expect(arg?.room.topic.routingDefaults?.worktreePath).toBeUndefined();
+    });
+
+    it('keeps session inheritance when no lane was explicitly selected', async () => {
+      seedActiveProjectASession();
+      // No lane stamp: a reload, or any create the operator reached without
+      // choosing a lane first. The session context is the honest anchor and
+      // must survive the fix intact.
+      useUiStore.setState({
+        activeWorkspaceId: LANE_B,
+        activeRepoPath: '/repo/project-b',
+        laneRepoRouting: null,
+      });
+
+      const arg = await createOnlyFromComposer();
+
+      expect(arg?.room.topic.routingDefaults?.repoPath).toBe('/repo/project-a');
+      expect(arg?.room.topic.routingDefaults?.worktreePath).toBe(
+        '/repo/project-a/.worktrees/old-task'
+      );
+      expect(arg?.room.topic.routingDefaults?.cwd).toBe(
+        '/repo/project-a/.worktrees/old-task'
+      );
+    });
+
+    it('ignores a stamp left behind by a lane that is no longer the active one', async () => {
+      seedActiveProjectASession();
+      // The operator picked project B's lane, then moved on to another lane.
+      // The stamp describes a lane this chat is no longer being filed in, so it
+      // has no claim on the routing and ordinary inheritance resumes.
+      useUiStore.setState({
+        activeWorkspaceId: 'ws:project-c',
+        activeRepoPath: '/repo/project-b',
+        laneRepoRouting: { workspaceId: LANE_B, repoPath: '/repo/project-b' },
+      });
+
+      const arg = await createOnlyFromComposer();
+
+      expect(arg?.room.topic.workspaceId).toBe('ws:project-c');
+      expect(arg?.room.topic.routingDefaults?.repoPath).toBe('/repo/project-a');
+    });
   });
 
   it('keeps the created room when retrying a terminal launch failure', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -43,6 +43,7 @@ import type {
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
 import { openTopicTaskRoom } from '../frontend/src/lib/topic-task-room.js';
+import { openTopicSelection } from '../frontend/src/lib/topic-selection.js';
 import { makeSession } from './helpers/frontend-factories.js';
 
 (
@@ -246,6 +247,9 @@ describe('TopicSidebarView', () => {
       // green suite hides a real regression.
       topicComposerOpen: false,
       activeWorkspaceId: null,
+      // #1303: the lane's repo stamp is written by the same cases and outranks
+      // session inheritance in every create — same leak, same reset.
+      laneRepoRouting: null,
       pendingChannelThread: null,
       // #1287 slice 5: rail/lane folds are persisted operator intent now, so
       // they outlive a remount by design — reset them between cases or one
@@ -277,6 +281,7 @@ describe('TopicSidebarView', () => {
       repoDashboardTabIntent: null,
       activeChannelId: null,
       topicComposerOpen: false,
+      laneRepoRouting: null,
       pendingChannelThread: null,
       ...resetRailFolds(),
     });
@@ -1832,6 +1837,43 @@ describe('TopicSidebarView', () => {
         OLD_LANE_REPO
       );
     }
+  });
+
+  // #1303: the repo POINTER alone could not carry the lane choice — it sits
+  // below the active session in the create hook's inheritance chain, so a
+  // terminal open in the abandoned project outranked it. The lane choice is
+  // recorded as itself, keyed by the lane it came from, and the create hook
+  // ranks it above session context (see `test/topic-composer.test.ts`).
+  it('records the selected lane as the create anchor, not just the repo pointer (#1303)', async () => {
+    useUiStore.setState({
+      activeWorkspaceId: null,
+      activeRepoPath: OLD_LANE_REPO,
+      laneRepoRouting: null,
+    });
+    await renderWithEmptyLane({ onCreateTaskRoom: vi.fn() });
+
+    const start = container.querySelector<HTMLButtonElement>(
+      `${emptyLaneSelector} [data-workspace-start-chat="${emptyLaneId}"]`
+    );
+    await act(async () => start?.click());
+
+    expect(useUiStore.getState().laneRepoRouting).toEqual({
+      workspaceId: emptyLaneId,
+      repoPath: FRESH_LANE_REPO,
+    });
+
+    // Selecting a channel is a newer routing statement than the lane click, so
+    // the stamp is spent — otherwise it would outrank the context of the very
+    // row the operator just opened on the next create.
+    openTopicSelection(
+      makeTopic({
+        id: 'topic:a',
+        workspaceId: 'ws:a',
+        display: { title: 'Alpha channel' },
+        linkedRefs: {},
+      })
+    );
+    expect(useUiStore.getState().laneRepoRouting).toBeNull();
   });
 
   it('selects the workspace when its mobile lane header is tapped (#1287)', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -43,7 +43,11 @@ import type {
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 import { useUiStore } from '../frontend/src/lib/stores/ui.js';
 import { openTopicTaskRoom } from '../frontend/src/lib/topic-task-room.js';
-import { openTopicSelection } from '../frontend/src/lib/topic-selection.js';
+import {
+  applyTopicActiveContext,
+  openChannelMessageSelection,
+  openTopicSelection,
+} from '../frontend/src/lib/topic-selection.js';
 import { makeSession } from './helpers/frontend-factories.js';
 
 (
@@ -1874,6 +1878,122 @@ describe('TopicSidebarView', () => {
       })
     );
     expect(useUiStore.getState().laneRepoRouting).toBeNull();
+
+    // Same rule for a channel the caller could not resolve to a topic — a
+    // message-search hit routinely has none (`openChannelMessageSelection`), and
+    // the main pane changes all the same, so a stamp minted for some other lane
+    // is just as stale.
+    useUiStore.setState({
+      laneRepoRouting: { workspaceId: emptyLaneId, repoPath: FRESH_LANE_REPO },
+    });
+    openChannelMessageSelection({
+      channelId: 'topic:unresolvable',
+      messageId: 'chm:hit-1' as ChannelMessageId,
+    });
+    expect(useUiStore.getState().laneRepoRouting).toBeNull();
+
+    // And at the seam itself, because the two navigations above spend the stamp
+    // for a SECOND reason (they close the composer): applying an unresolvable
+    // topic's context is itself a routing statement, and `select(id)` with no
+    // resolvable topic reaches this with nothing else to clean up behind it.
+    useUiStore.setState({
+      laneRepoRouting: { workspaceId: emptyLaneId, repoPath: FRESH_LANE_REPO },
+    });
+    applyTopicActiveContext(undefined);
+    expect(useUiStore.getState().laneRepoRouting).toBeNull();
+  });
+
+  // #1303: the canonical reproduction, driven through the DOM. The operator is
+  // IN the fresh lane — they clicked its Claude DM, so that row is the selected
+  // one and `rowIsInActiveLane` is TRUE, which is the branch the first fix
+  // attempt did not cover. A DM's `routingDefaults` carries `providerId` alone
+  // (`dmChannelCreateInput`), so the row answers nothing about where the chat
+  // runs, and without the lane fallback the create inherits whatever terminal is
+  // still open. `test/topic-composer.test.ts` carries the create half.
+  it('anchors a new chat to the active lane when the selected row is a repo-less DM (#1303)', async () => {
+    const dmId = dmChannelTopicId('claude', emptyLaneId);
+    useUiStore.setState({
+      activeWorkspaceId: null,
+      activeRepoPath: OLD_LANE_REPO,
+      laneRepoRouting: null,
+    });
+    await renderWithEmptyLane({
+      onCreateTaskRoom: vi.fn(),
+      topics: [
+        makeTopic({
+          id: 'topic:a',
+          workspaceId: 'ws:a',
+          display: { title: 'Alpha channel' },
+          linkedRefs: {},
+        }),
+        makeTopic({
+          id: dmId,
+          workspaceId: emptyLaneId,
+          display: { title: 'Claude' },
+          routingDefaults: { providerId: 'claude' },
+          linkedRefs: {},
+        }),
+      ],
+    });
+
+    const dmRow = container.querySelector<HTMLButtonElement>(
+      `.topic-workspace-group [data-topic-id="${dmId}"] .topic-row__main`
+    );
+    expect(dmRow).not.toBeNull();
+    await act(async () => dmRow?.click());
+    // Opening the DM moved the lane but could name no repo, and it did NOT
+    // clear the active session — that is the whole trap.
+    expect(useUiStore.getState().activeWorkspaceId).toBe(emptyLaneId);
+    expect(useUiStore.getState().laneRepoRouting).toBeNull();
+
+    const newChat = container.querySelector<HTMLButtonElement>(
+      '.topic-shell__create'
+    );
+    expect(newChat).not.toBeNull();
+    await act(async () => newChat?.click());
+
+    expect(useUiStore.getState().laneRepoRouting).toEqual({
+      workspaceId: emptyLaneId,
+      repoPath: FRESH_LANE_REPO,
+    });
+    expect(useUiStore.getState().activeRepoPath).toBe(FRESH_LANE_REPO);
+  });
+
+  // #1303: a row that names a repo of its own is MORE specific than its lane —
+  // the lane fallback must not overwrite it, or every create in an add-project
+  // lane would collapse onto the main checkout.
+  it('keeps a selected row’s own repo over the lane default (#1303)', async () => {
+    useUiStore.setState({
+      activeWorkspaceId: emptyLaneId,
+      activeRepoPath: null,
+      laneRepoRouting: null,
+    });
+    await renderWithEmptyLane({
+      onCreateTaskRoom: vi.fn(),
+      topics: [
+        makeTopic({
+          id: 'topic:in-fresh-lane',
+          workspaceId: emptyLaneId,
+          display: { title: 'Fresh lane channel' },
+          routingDefaults: { repoPath: '/repo/fresh/nested' },
+          linkedRefs: {},
+        }),
+      ],
+    });
+
+    const row = container.querySelector<HTMLButtonElement>(
+      `[data-topic-id="topic:in-fresh-lane"] .topic-row__main`
+    );
+    await act(async () => row?.click());
+    const newChat = container.querySelector<HTMLButtonElement>(
+      '.topic-shell__create'
+    );
+    await act(async () => newChat?.click());
+
+    expect(useUiStore.getState().laneRepoRouting).toEqual({
+      workspaceId: emptyLaneId,
+      repoPath: '/repo/fresh/nested',
+    });
   });
 
   it('selects the workspace when its mobile lane header is tapped (#1287)', async () => {


### PR DESCRIPTION
## Defect

Start a chat from a workspace lane while a terminal from a *different* project is still open, and the chat is filed in the lane you picked but **runs in the other project**: `routingDefaults.repoPath` is the abandoned project, `cwd` is its worktree, and the agent edits the wrong tree.

## Root cause

`useTopicRoomCreate` derived its anchors as `activeSession?.repoPath ?? activeRepoPath ?? repos[0]`. #1287 moved `activeRepoPath` with the lane, but that pointer sits **below** the active session in the chain, so a terminal still open in the project the operator just left silently outranked the lane they just chose. Opening a channel never clears `activeSessionId` — `App.tsx`'s effect fires only when the id *changes* — so the stale session survives any amount of navigating around the rail.

## Fix

The lane the operator is in becomes a first-class, single-use routing statement (`laneRepoRouting`, `{ workspaceId, repoPath }`, session-transient) that the create hook ranks **above** session context:

- **`applyCreateRoutingContext`** (new named seam in `topic-selection.ts`) owns lane-vs-row precedence for every new-chat entry point. When the selected row names no repo of its own — the common case, since a DM's `routingDefaults` carries `providerId` alone — the active lane's anchor answers instead. The decision is derived from *this* interaction only, never from a stamp lying in the store.
- **`applyTopicActiveContext`** re-stamps a row that names a repo (a row stays more specific than its lane) and clears the stamp *above* the no-topic bail, so opening a channel the caller could not resolve to a topic cannot leave a stale anchor live.
- **The anchor overrides the session only where they disagree about the repo.** A terminal inside the lane's own repo keeps its worktree and `cwd` — that is this repo's own dogfood shape (`<repo>/.worktrees/<issue-slug>`), and overriding it would start the agent in the wrong tree of the *right* repo.
- **Single-use**: spent when the composer closes (enforced in the `setTopicComposerOpen` setter, so no exit can forget) and when a create commits. A later create — including a command-palette one reached with no lane click at all — inherits session context again.

## Verification

- `npm run check` — 0 errors (220 pre-existing warnings, none introduced on changed files).
- Targeted vitest, 243 specs green: `topic-composer`, `topic-sidebar-shell`, `chat-surface-navigation`, `command-palette-message-search`, `command-palette-topic-open`, `channel-view-thread-intent`, `notify-delivery-hook`, `app-view-mode`, `channel-url-route`, `session-lifecycle-handlers`. Full suite runs in CI.
- **Anti-vacuity**: each of the five behavioral changes was reverted individually and the matching regression test went red — lane fallback (3 red), same-repo gate (1), commit-time spend (1), clear-above-guard (1), composer-close spend (1) — then restored.
- New coverage drives the real code paths rather than seeding their post-condition: a DOM-level sidebar case (click lane B's Claude DM row → click new chat) and a create-level case that runs `openTopicSelection` + `applyCreateRoutingContext` with a project-A terminal active.

## Review trail

Adversarial review returned `concern` with 4 valid P0–P2 findings and 1 P3; all are applied.

- **P1** — the fix only landed on the branch where the selected row is *outside* the active lane; the canonical repro takes the other branch and reproduced unchanged. Fixed by the lane fallback above, plus a non-seeded regression test.
- **P1** — the worktree/`cwd` override was unconditional, so a session inside the lane's own repo lost its worktree (pre-fix it inherited correctly). Fixed by the disagreement gate, with a same-repo test.
- **P2** — the stamp was written but never consumed; it survived abandoning the composer, a completed create, and every later create in the lane. Fixed by making it single-use, with a two-create test.
- **P2** — the stamp clear sat below the `if (!topic) return` guard, so a channel open with no resolvable topic left it live. Fixed by clearing before the bail.
- **P3 (applied)** — the changelog entry over-claimed. The default composer path is an agent-task DM, and `dmChannelCreateInput` writes `routingDefaults: { providerId }` only, so DM agents spawn at `os.homedir()` both before and after this change. The entry is narrowed to the surfaces this PR actually changes (`create only`, `terminal-task`, `note`). **Follow-up worth filing:** DM channels inheriting the lane's repo anchor — a separate behavior change to a get-or-create deterministic channel, deliberately out of scope here.

Refs the issue number in the title. Pre-v0.1.1-stable hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
