### PR TITLE
docs: public-readiness pass — README rewrite + channel-era realignment (#1222, #1231, #1223)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,12 @@ need Vite HMR or a fresh build before package-mode verification.
 | Release notes     | `CHANGELOG.md`                         |
 | Deployment        | `docs/references/deployment.md`        |
 | Devbox hub        | `docs/references/devbox-hub-deploy.md` |
+| Manual QA pass    | `docs/references/qa-guide.md`          |
 | ADRs              | `docs/adrs/`                           |
 | Learnings         | `docs/LEARNINGS.md`                    |
+
+`docs/README.md` splits current docs from historical/reference material. Add a
+row there for any new doc.
 
 ## Product and architecture rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ workflow.
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrote the README — the npm landing page — for the 0.1.1 product: a real
+  first-run quickstart (hub, PIN, add project, new chat, `@mention`), the
+  execution-workbench boundary stated up front, the shipped message layer
+  (search, edit/delete, retry, deep links, read sync, notifications, steering),
+  the three install channels with a `CHANGELOG.md` pointer, and a corrected CLI
+  list. `relay-ide --help` now documents `node update` and the `sessions`
+  command family, so the README's "run `--help` for the exact set" holds.
+
 ## [0.1.1] - 2026-08-04
 
 This is the first public release of the channel era, branded v0.1; it ships as

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,10 +2,11 @@
 
 ## Product Context
 
-- **What this is:** Hub/node agentic development environment for managing terminal-native agent tabs across local and remote nodes. Repos and worktrees are the golden-path local Project/Bench case, but the user-facing source of truth is the active tab context: `nodeId`, `cwd`, and `kind`.
-- **Who it's for:** Developers who use CLI agents (Claude Code, Codex, OpenCode, Hermes, and remote node shells) — power users who live in terminals
-- **Space/industry:** Developer tools, CLI companions, terminal multiplexers
-- **Project type:** Web app (mobile-friendly) with terminal-native aesthetic
+- **What this is:** A channel-first workspace for AI coding agents, backed by a hub/node execution model. The primary surface is a conversation: channels and DMs where agents post alongside the operator. Agent identity is a durable **profile actor**, never a terminal tab or provider process. Terminal, file, diff, and artifact views are secondary execution surfaces around the conversation.
+- **Primary rows to design for:** channel/DM sidebar rows, timeline message rows and groups, agent detail cards, the composer (including its steering cluster), roster and status chips.
+- **Who it's for:** Developers who use CLI agents (Claude Code, Codex, OpenCode, Hermes) — power users who live in terminals but want the conversation reachable from a phone.
+- **Space/industry:** Developer tools, CLI companions, agent workbenches
+- **Project type:** Web app (mobile-friendly) with terminal-native aesthetic. Dark-only.
 
 ## Aesthetic Direction
 
@@ -131,7 +132,7 @@ Each color has a muted variant for workspace group backgrounds: `color-mix(in sr
 - **Pattern:** Workspace containers use an outlined border derived from the group's assigned color
 - **Border:** `1px solid color-mix(in srgb, [group-color] 30%, transparent)` — subtle enough to group visually without competing with content
 - **Background:** Pure black (`--bg`) interior — no colored backgrounds
-- **Purpose:** Visual grouping of pinned Projects and active Tabs within a workspace, distinguishable at a glance by border color. In the current local implementation many workspace rows still represent repo/worktree groups; document that as the repo Project/Bench case, not as the universal model.
+- **Purpose:** Visual grouping of a workspace's channels, DMs, and active execution rows, distinguishable at a glance by border color. The sidebar reads the channel-workspace model (`workspace_topics` + `ia_workspaces` + channel summaries), never `config.repos`; a repo is optional context on a channel, not the grouping identity.
 
 ## Alignment Architecture
 
@@ -175,7 +176,7 @@ The terminal identity comes from BEHAVIOR, not just styling. Every animation com
 
 ### 1. ASCII Box-Drawing Buttons
 
-Buttons use Unicode box-drawing corner characters (`┌ ┐ └ ┘`) with CSS border edges between them. On hover, corners upgrade to double-line variants (`╔ ╗ ╚ ╝`) and edges shift to double borders. Implementation: Svelte TuiButton component with corner `<span>` elements and CSS `border-top`/`border-bottom` for edges.
+Buttons use Unicode box-drawing corner characters (`┌ ┐ └ ┘`) with CSS border edges between them. On hover, corners upgrade to double-line variants (`╔ ╗ ╚ ╝`) and edges shift to double borders. Implementation: the React `TuiButton` component with corner `<span>` elements and CSS `border-top`/`border-bottom` for edges.
 
 ### 2. Cipher-Decode Loading
 
@@ -210,7 +211,69 @@ When status text changes (session activates, PR merges, build passes), the old t
 
 A barely-visible (opacity 0.02-0.03) repeating scanline pattern overlays the sidebar. The pattern continuously drifts downward at a slow rate (~8s cycle) creating the optical illusion of a CRT display. On hover over workspace items, a single faint horizontal scanline sweeps down the item (~800ms, ease-in-out). This is the most decorative element — intentionally subtle, an easter egg for close inspection.
 
+## Channel Surface Rules
+
+These are the surfaces most UI work touches today. They post-date the v1/v2
+audit snapshot below and are the live rules.
+
+### Timeline rhythm
+
+- **Consecutive messages from one sender group.** The group carries the avatar,
+  name, and timestamp once; subsequent rows are body-only and hang under the
+  same left gutter. Do not repeat identity chrome per row.
+- **One gutter, everywhere.** Message body, detail card, and image part all
+  align to the same left edge. A card must not inset itself relative to the
+  prose above it.
+- **Rows are edge-to-edge.** Hover and selection states paint the full row
+  width; they do not draw an inset rounded box.
+- **Date and unread markers are full-width rules** with a centered label, not
+  floating pills.
+
+### Agent identity
+
+- Sender identity resolves from the **profile actor id**, not the vendor. Two
+  Claude profiles are two visually distinct participants with their own names
+  and initials avatars. Never label a row with only the provider.
+- Initials avatars use the repo identity color palette, hash-derived from the
+  actor id.
+- Status chips (spawning, thinking, streaming, waiting, idle) are outline-only
+  text with a status dot. No filled badges.
+
+### Detail cards
+
+- Reasoning, tool, code, output, and diff cards are **collapsible and collapsed
+  by default** past a bounded height. The header states kind, title, and status.
+- Card chrome is a single hairline border in `--border`, zero radius, on `--bg`.
+  Cards do not stack shadows or tint their background by kind.
+- Diff cards use the addition/deletion tints defined above; nothing else in a
+  card is colored by semantics.
+- A truncated, interrupted, or failed card says so in the header. Never render a
+  partial result as if it completed.
+
+### Composer
+
+- The composer is a single bordered block pinned to the bottom of the channel.
+- While a bound agent is mid-turn the bar reveals exactly two controls — `queue`
+  and `interrupt & send` — as sibling outline buttons. No menu, no inferred
+  variant, no hidden modifier-only affordance.
+- `interrupt & send` reuses the header interrupt control's black-square
+  vocabulary so the two read as the same action.
+- Queue state is communicated by a dim chip on the sent message and a
+  `(n queued)` suffix on the presence row — both muted, neither alarming.
+
+### Notification stack
+
+- Toasts stack bottom-right, one bordered block each, zero radius, `--surface`
+  background (this is a floating element, so `--surface` is correct here).
+- Every toast is dismissible and states its action in a lowercase verb.
+
 ## Implementation Audit Checklist
+
+> **Historical (2026-03-25 v1/v2 aesthetic audit).** This checklist and the
+> Decisions Log below record the pre-channel terminal-aesthetic overhaul. The
+> ticked rows are still binding as style rules; the checklist itself is not a
+> current status board and has no entries for channel-era surfaces. For those,
+> use "Channel Surface Rules" above.
 
 ### Completed (v1 overhaul)
 
@@ -223,20 +286,26 @@ A barely-visible (opacity 0.02-0.03) repeating scanline pattern overlays the sid
 - [x] Convert PR table pills to outline-only
 - [x] Expand color array in `colors.ts` from 8 to 12 colors
 
-### Pending (v2 micro-interactions + alignment)
+### v2 micro-interactions + alignment
 
-- [ ] Implement TuiButton component with box-drawing corners
-- [ ] Implement cipher-decode loading component
-- [ ] Implement marquee-scroll overflow component
-- [ ] Implement block cursor for focused inputs
-- [ ] Add `>` cursor to ContextMenu and dropdown components
-- [ ] Implement ASCII progress bar and spinner components
-- [ ] Apply cipher-decode to status text transitions
-- [ ] Add scanline CRT overlay to sidebar
+All eight micro-interaction components shipped; the two remaining rows are
+codebase-wide application passes, not components.
+
+- [x] Implement TuiButton component with box-drawing corners — `TuiButton.tsx`
+- [x] Implement cipher-decode loading component — `CipherText.tsx`
+- [x] Implement marquee-scroll overflow component — `MarqueeText.tsx`
+- [x] Implement block cursor for focused inputs — `TuiInput.tsx` (`.tui-cursor`, blinks only when idle)
+- [x] Add `>` cursor to ContextMenu and dropdown components — `TuiMenuItem.tsx` (`.fzf-cursor`)
+- [x] Implement ASCII progress bar and spinner components — `TuiProgress.tsx`
+- [x] Apply cipher-decode to status text transitions — `SessionItem.tsx`, `PrTopBar.tsx`, `BootScreen.tsx`
+- [x] Add scanline CRT overlay to sidebar — `Sidebar.css` (`.sidebar-scanline-overlay`)
 - [ ] Apply alignment architecture tokens and rules across all components
 - [ ] Fix SettingsDialog layout — TOC must attach flush to content, no floating panel
 
 ## Decisions Log
+
+Historical. Every row below is from the 2026-03-25 aesthetic consultation and
+predates the channel product model; the decisions remain binding as style rules.
 
 | Date       | Decision                                      | Rationale                                                                                                                                 |
 | ---------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1,36 +1,24 @@
 # relay-ide
 
-Relay is a channel-first workspace for collaborating with AI coding agents from
-any device. A channel is the durable conversation, a DM is a channel with one
-agent profile, and agents participate alongside people. Relay keeps the
-conversation, mentions, threads, agent output, and orchestration in one
-Slack-style interface while local or paired nodes run the actual coding tools
-and terminals.
+Relay runs AI coding agents on your own machines and puts the conversation with
+them in a browser you can open from anywhere. A channel is the durable
+conversation, a DM is a channel with one agent profile, and agents post into the
+timeline alongside you. Claude Code, Codex, OpenCode, Hermes, and custom
+profiles all participate through the same contract.
 
-The hub serves the React application and stable JSON gateway. Nodes provide
-agent CLIs, shells, files, repositories, and `relay-pty` terminal execution.
-Claude Code, Codex, OpenCode, Hermes, and custom profiles can participate in
-channels without turning provider-specific process state into the product
-model.
+The interface is channel-shaped because that shape is already familiar. The
+product is not a chat platform. Relay is an execution workbench: every message
+is anchored to a real node, working directory, and repository, and the terminal,
+file, diff, and artifact surfaces sit next to the conversation instead of behind
+an integration. Agents run as local processes on the machine you point them at,
+so the work — checkouts, builds, git state — stays where it belongs, and you can
+watch, interrupt, or take over from a phone. If you want a place for your team
+to talk, use a team chat product. Relay is where the work runs. See
+[`docs/WORKBENCH_BOUNDARY.md`](docs/WORKBENCH_BOUNDARY.md) for the full
+boundary.
 
-## What is built
-
-- Durable channels and DMs backed by SQLite conversation history.
-- Human, agent, and system messages with Markdown, streaming updates, native
-  image attachments, mentions, and threaded replies.
-- Rich agent output in the live channel timeline: collapsible reasoning, tool,
-  code, output, and diff cards with syntax highlighting.
-- Agent profiles with built-in vendor profiles, custom profile configuration,
-  availability state, and channel rosters.
-- Mention routing that starts or reuses the addressed profile's runtime,
-  supplies bounded channel context, and mirrors the response into the same
-  conversation.
-- A persistent channel orchestrator that can route work to child agents;
-  lineage is visible in the operator cockpit.
-- Mobile-ready channel navigation, unread state, agent status, approvals,
-  interrupt controls, and terminal fallback.
-- A hub/node execution model for local and paired machines, plus a versioned
-  `relay-ide v1 ... --json` gateway for agent-operable actions.
+Relay is beta. It is dogfooded daily against its own repository, but the surface
+still moves between releases and there is no upgrade-compatibility promise yet.
 
 ## Prerequisites
 
@@ -40,6 +28,83 @@ model.
 | Agent CLI such as Claude Code, Codex, OpenCode, Hermes | Relay launches configured frameworks as private channel runtimes from the node `PATH` |
 | [GitHub CLI (`gh`)](https://cli.github.com/)           | Optional PR and CI integration                                                        |
 | [Tailscale](https://tailscale.com/)                    | Recommended private phone/tablet access                                               |
+
+## Quickstart
+
+```bash
+npm install -g relay-ide
+relay-ide
+```
+
+1. **Open the hub.** Go to `http://localhost:3456`. Relay refuses browser
+   traffic until a PIN is set. Foreground startup prompts in an interactive
+   terminal; background startup can complete setup in the browser.
+2. **Add a project.** The sidebar starts empty. Use an add-project row to point
+   Relay at a directory on this machine. That directory becomes the working
+   directory agents get.
+3. **Start a chat.** Press `new chat`. You get an empty channel bound to that
+   project.
+4. **Mention an agent.** Type `@claude` or `@codex` and send. Relay starts (or
+   reuses) that profile's private runtime on the node, hands it a bounded packet
+   of the channel's own history, and mirrors the reply back into the same
+   conversation. Reasoning, tool calls, code, output, and diffs arrive as
+   collapsible cards on durable rows.
+5. **Keep going.** Reply in the channel, or open a thread on a message to branch
+   without losing the main timeline. Sending while an agent is mid-turn queues
+   your message for its next turn; `cmd/ctrl`+`enter` interrupts the live turn
+   and sends now.
+6. **Manage profiles.** Settings → agent profiles configures provider, model,
+   permission mode, system prompt, and working directory per profile. `@claude`
+   resolves to that vendor's _default_ profile, not its only one — a second
+   Claude profile with different settings is a separate participant with its own
+   name.
+
+A DM is the same thing with one participant: no mention needed, every message
+routes to that profile.
+
+When a new version is published you get an update toast in the corner; one click
+updates the install and reloads.
+
+## What is built
+
+### Conversations
+
+- Durable channels and DMs backed by SQLite conversation history.
+- Human, agent, and system messages with Markdown, streaming updates, native
+  image attachments, mentions, and threaded replies.
+- Rich agent output in the live timeline: collapsible reasoning, tool, code,
+  output, and diff cards with syntax highlighting.
+- Mobile-ready channel navigation, agent status, approvals, interrupt controls,
+  and terminal fallback.
+
+### Messages
+
+- Full-text search across channel history, including archived channels, with
+  two-section sidebar results, a command-palette category, and jump-to-message.
+- Hover toolbar on any message: copy a `#msg-` deep link, edit, or delete.
+- Retry on a failed row instead of retyping it.
+- Cross-device read-state sync. The hub persists your last-read marks and
+  broadcasts moves, so a channel you read on your laptop is not unread on your
+  phone.
+- OS notifications, a favicon badge, and a title count while the tab is hidden.
+- Mid-turn steering: queue for the agent's next turn, or interrupt and send now.
+
+### Agents
+
+- Agent profiles with built-in vendor profiles, per-profile configuration, a
+  vendor gallery, availability state, and channel rosters.
+- Mention routing that starts or reuses the addressed profile's runtime,
+  supplies bounded channel context, and mirrors the response into the same
+  conversation.
+- A persistent channel orchestrator that can route work to child agents;
+  lineage is visible in the operator cockpit.
+
+### Platform
+
+- A hub/node execution model for local and paired machines.
+- A versioned `relay-ide v1 ... --json` gateway for agent-operable actions.
+- Terminal, file, diff, artifact, and evidence surfaces around the conversation.
+- One-click self-update from the browser, plus `relay-ide update` on the host.
 
 ## Install and run
 
@@ -54,10 +119,6 @@ Or install the background hub service:
 relay-ide hub install
 ```
 
-Open `http://localhost:3456`. Relay requires a PIN before accepting browser
-traffic. Foreground startup prompts in an interactive terminal when needed;
-background startup can complete setup in the browser.
-
 Reset the PIN from the host:
 
 ```bash
@@ -67,44 +128,27 @@ relay-ide pin reset
 Do not expose Relay directly to the public internet. For another device, prefer
 Tailscale and open `http://<tailscale-ip>:3456` from the same tailnet.
 
-## Start a conversation
+## Releases and updates
 
-1. Open a workspace in Relay.
-2. Choose a channel or start a DM with an agent profile.
-3. Write normally or mention a profile, such as `@codex`, in a channel.
-4. Keep follow-up discussion in the channel or open a message thread.
-5. Use the channel roster and orchestrator controls to inspect or interrupt
-   active agents.
+Relay publishes three npm dist-tags:
 
-Channels own conversation history. Agent runtimes are replaceable execution
-details bound behind profile identities; they are not separate chat
-destinations.
+| Channel           | Install                            | Cut from                      |
+| ----------------- | ---------------------------------- | ----------------------------- |
+| Stable            | `npm install -g relay-ide`         | `vX.Y.Z` tag on `master`      |
+| Release candidate | `npm install -g relay-ide@rc`      | `vX.Y.Z-rc.N` tag on `master` |
+| Nightly           | `npm install -g relay-ide@nightly` | every push to `nightly`       |
 
-## Source development
+A release candidate is a stable-shaped build soaking before it becomes the
+default install; the stable lane refuses prerelease versions, so an rc can never
+land on `@latest`.
 
-```bash
-npm install
-npm run dev
-```
+`relay-ide update` updates this install in place and restarts the background
+service if one is installed. It follows the `updateChannel` config field
+(`stable` or `nightly`); install `@rc` explicitly with npm. The browser update
+toast performs the same update and reloads when the server returns.
 
-`npm run dev` builds the TypeScript backend, starts an isolated backend on
-`127.0.0.1:3457`, and runs the Vite frontend on `127.0.0.1:5173`. Vite proxies
-REST and WebSocket traffic to the backend.
-
-Useful commands:
-
-```bash
-npm run dev:self
-npm run dev:backend
-npm run dev:vite
-npm run check
-npm test
-npm run build
-```
-
-Use `npm run dev:self` when Relay is developing Relay so the child instance gets
-isolated config, ports, and process identity. See
-[`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md).
+Release notes live in [`CHANGELOG.md`](CHANGELOG.md), which is the source of
+truth for every tagged GitHub Release.
 
 ## Hub and nodes
 
@@ -143,15 +187,45 @@ families:
 
 ```text
 relay-ide                    run the hub
-relay-ide hub ...            install, status, logs, nodes, doctor
-relay-ide node ...           pair, connect, install, link, diagnose
+relay-ide hub ...            install, uninstall, status, logs, nodes, doctor, node-logs
+relay-ide node ...           status, logs, doctor, pair, install, connect, link, update
+relay-ide update             update this install from npm
+relay-ide cockpit ...        read-first terminal cockpit; cockpit get <work-context-id>
+relay-ide sessions ...       get, interventions, scoped list, scoped revoke
 relay-ide v1 ... --json      stable agent-facing gateway
+relay-ide manifest           print this node's capability manifest
 relay-ide worktree ...       git worktree helper
 relay-ide browser <path>     open an HTML artifact
 relay-ide diag bundle ...    write a redacted diagnostics bundle
 relay-ide audit verify ...   verify the security audit chain
 relay-ide pin reset          reset browser authentication
 ```
+
+## Source development
+
+```bash
+npm install
+npm run dev
+```
+
+`npm run dev` builds the TypeScript backend, starts an isolated backend on
+`127.0.0.1:3457`, and runs the Vite frontend on `127.0.0.1:5173`. Vite proxies
+REST and WebSocket traffic to the backend.
+
+Useful commands:
+
+```bash
+npm run dev:self
+npm run dev:backend
+npm run dev:vite
+npm run check
+npm test
+npm run build
+```
+
+Use `npm run dev:self` when Relay is developing Relay so the child instance gets
+isolated config, ports, and process identity. See
+[`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md).
 
 ## Architecture
 
@@ -178,6 +252,7 @@ Start with [`docs/README.md`](docs/README.md), then read:
 - [`docs/CHANNEL_CHAT.md`](docs/CHANNEL_CHAT.md) — conversation and agent model
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — backend and protocol map
 - [`docs/FRONTEND.md`](docs/FRONTEND.md) — live React surface map
+- [`docs/WORKBENCH_BOUNDARY.md`](docs/WORKBENCH_BOUNDARY.md) — product boundary
 - [`DESIGN.md`](DESIGN.md) — visual system
 - [`docs/QUALITY.md`](docs/QUALITY.md) — tests and release gates
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ relay-ide
 1. **Open the hub.** Go to `http://localhost:3456`. Relay refuses browser
    traffic until a PIN is set. Foreground startup prompts in an interactive
    terminal; background startup can complete setup in the browser.
-2. **Add a project.** The sidebar starts empty. Use an add-project row to point
-   Relay at a directory on this machine. That directory becomes the working
-   directory agents get.
+2. **Add a project.** The sidebar starts empty. Click `+ add project` at the
+   bottom of the sidebar and point Relay at a directory on this machine. That
+   directory becomes the working directory agents get.
 3. **Start a chat.** Press `new chat`. You get an empty channel bound to that
    project.
 4. **Mention an agent.** Type `@claude` or `@codex` and send. Relay starts (or
@@ -53,11 +53,12 @@ relay-ide
    without losing the main timeline. Sending while an agent is mid-turn queues
    your message for its next turn; `cmd/ctrl`+`enter` interrupts the live turn
    and sends now.
-6. **Manage profiles.** Settings → agent profiles configures provider, model,
-   permission mode, system prompt, and working directory per profile. `@claude`
-   resolves to that vendor's _default_ profile, not its only one — a second
-   Claude profile with different settings is a separate participant with its own
-   name.
+6. **Manage profiles.** Settings → agent profiles configures provider, display
+   name, model, reasoning effort, system prompt, environment variables, and who
+   the profile responds to. The working directory comes from the channel's
+   project, not the profile. `@claude` resolves to that vendor's _default_
+   profile, not its only one — a second Claude profile with different settings
+   is a separate participant with its own name.
 
 A DM is the same thing with one participant: no mention needed, every message
 routes to that profile.
@@ -79,10 +80,13 @@ updates the install and reloads.
 
 ### Messages
 
-- Full-text search across channel history, including archived channels, with
-  two-section sidebar results, a command-palette category, and jump-to-message.
-- Hover toolbar on any message: copy a `#msg-` deep link, edit, or delete.
-- Retry on a failed row instead of retyping it.
+- Full-text search across channel history, with archived channels included when
+  you turn on `show older chats`, two-section sidebar results, a command-palette
+  category, and jump-to-message.
+- Hover toolbar on any message: copy a `#msg-` deep link. On your own messages:
+  edit or delete.
+- Retry an agent reply that failed, was interrupted, or was truncated instead of
+  retyping the prompt.
 - Cross-device read-state sync. The hub persists your last-read marks and
   broadcasts moves, so a channel you read on your laptop is not unread on your
   phone.
@@ -96,8 +100,8 @@ updates the install and reloads.
 - Mention routing that starts or reuses the addressed profile's runtime,
   supplies bounded channel context, and mirrors the response into the same
   conversation.
-- A persistent channel orchestrator that can route work to child agents;
-  lineage is visible in the operator cockpit.
+- A persistent channel orchestrator that can route work to child agents; the
+  spawned-agent lineage tree renders in the sidebar.
 
 ### Platform
 

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -181,6 +181,15 @@ Commands:
     ssh-bootstrap --target <host> --hub <url>
                                        Print a paste-able bash script to install and pair on a remote host via SSH
     link --hub <url>                   Open and hold the persistent /hub/node-link reverse WebSocket (foreground)
+    update [--check]                   Update the relay-ide install on this node (--check reports only)
+  sessions           Read and control terminal sessions (requires RELAY_IDE_BROWSER_TOKEN)
+    get <session-id>                   Print one session descriptor as JSON
+    interventions <session-id> [--limit <n>]
+                                       List recorded human interventions for a session
+    scoped list [--include-revoked] [--active-only]
+                                       List scoped session grants
+    scoped revoke <session-id> [--node-id <nodeId>] [--reason <reason>]
+                                       Revoke a scoped session grant
   worktree           Manage git worktrees (wraps git worktree)
     add [path] [-b branch]            Create a git worktree
     remove <path>                      Forward to git worktree remove

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,13 +78,23 @@ channel operations:
 
 - list/get channels;
 - page channel history;
+- search message history (`GET /channels/search`, FTS5-backed);
+- read/write operator read-state (`GET /channels/read-state`,
+  `PUT /channels/:id/read-state`);
 - upload/read channel image attachments;
 - read a thread;
 - post a message or reply;
+- edit a message (`PATCH /channels/:id/messages/:messageId`);
+- delete a message (`DELETE /channels/:id/messages/:messageId`);
+- retry a failed message (`POST /channels/:id/messages/:messageId/retry`);
 - read the channel roster;
 - designate an orchestrator;
 - interrupt an agent;
 - answer an approval.
+
+Edit, delete, and retry are operator-only and archived channels refuse them.
+Edits and deletes broadcast directly rather than through the post path, so they
+never raise an agent turn.
 
 `server/channel-hub.ts` owns live WebSocket fan-out on
 `/ws/channels/:channelId`. SQLite is the catch-up buffer. The hub coalesces
@@ -165,9 +175,11 @@ through the relay command manifest and action descriptors. Private browser
 routes, node-link envelopes, provider adapters, and raw database tables are not
 stable adapter APIs.
 
-The gateway covers node discovery, session/process actions, files, channels,
-WorkContexts, context packets, artifacts, handoffs, and bounded supervisor
-reads/actions as advertised by the installed command manifest.
+The gateway covers node discovery, session/process actions, files, channel
+posting (`channels.post`), WorkContexts, context packets, artifacts, handoffs,
+and bounded supervisor reads/actions as advertised by the installed command
+manifest. `channels.post` is the only channel verb; channel reads (list,
+history, search) are browser routes, not gateway verbs.
 
 ## Main code map
 

--- a/docs/BOO_PHILOSOPHY.md
+++ b/docs/BOO_PHILOSOPHY.md
@@ -1,6 +1,10 @@
 # Boo-style terminal substrate audit
 
-Status: current source-of-truth audit for the `coder/boo`-inspired direction. Verify against code/current docs before treating behavior as shipped.
+Status: a **gap audit**, not a feature list. It compares Relay against the
+`coder/boo`-inspired direction and is deliberately weighted toward what is
+missing. The "Philosophy" section states durable rules; everything after it is a
+point-in-time assessment. Verify against code and the current docs before
+treating any row as shipped.
 
 ## Philosophy
 
@@ -40,7 +44,7 @@ evidence projections.
 | `wait --text` / `wait --idle`   | **Partial.** `sessions wait --output-text` and `sessions input --wait-for` do bounded raw output substring waiting; `sessions stream --idle-timeout-ms` detaches a stream after quiet. Missing: rendered-screen/cursor/title/mode wait predicates.                                                                              | `docs/CLI_GATEWAY.md`                                           |
 | `peek --json` / rendered screen | **Partial.** `sessions screen` exposes bounded rendered-screen snapshots for live `relay-pty` sessions. Missing: richer screen wait predicates and direct terminal-model APIs.                                                                                                                                                  | `docs/TERMINAL_BACKENDS.md`, `server/terminal-model-backend.ts` |
 | `attach` / optional UI          | **Partial.** Browser attach and CLI descriptor attach exist; `sessions.stream` attaches to the PTY stream. Missing: power-user CLI/TUI cockpit comparable to `boo ui`; current cockpit is web-first.                                                                                                                            | `docs/CLI_GATEWAY.md`, `docs/WORKBENCH_BOUNDARY.md`             |
-| Session manager cockpit         | **Partial.** Active Work, sidebar attention states, command palette, and Workbench blocks exist, but default desktop chrome is still repo/worktree/session heavy and Workbench canvas is not primary.                                                                                                                           | `docs/FRONTEND.md`, `docs/WORKBENCH_BOUNDARY.md`                |
+| Session manager cockpit         | **Partial.** Default desktop chrome is `TopicSidebarShell`'s channel/DM tree (#1287); Active Work, attention states, and the command palette are the execution/cockpit lane beside it. Missing: a terminal-multiplexer-style power-user session manager. The cockpit is web-first.                                              | `docs/FRONTEND.md`, `docs/WORKBENCH_BOUNDARY.md`                |
 
 ## What is actually built
 
@@ -64,7 +68,7 @@ evidence projections.
 - Direct libghostty terminal-model access is internal. Stable access goes through `sessions.screen`; richer `sessions.peek`/rendered-screen wait commands remain future work.
 - `sessions.input --wait-for` watches raw observed output. It is not a proof that a particular rendered screen/viewport/cursor state exists.
 - `RelayPtySession` exists as a class, but production session creation currently uses the `pty-handler` path with direct `node-pty` spawn plus terminal model. Docs should say `relay-pty` is the default direct PTY/libghostty-backed backend, not that the `RelayPtySession` class owns production sessions.
-- Active Work is strong, but not the default/primary desktop cockpit; the default sidebar still exposes a repo/worktree-first organization.
+- Active Work is strong, but it is not the default desktop surface. The default sidebar is the channel/DM tree (#1287); Active Work is the execution view you navigate to, so operator attention state is split across two surfaces rather than unified in one cockpit.
 
 ### Not built / do not document as shipped
 
@@ -72,7 +76,7 @@ evidence projections.
 - Stable function-key/keymap API beyond the closed `supervisor.sendKey` MVP enum.
 - Durable relay-pty live child-process reattach across server restart. Browser disconnect/live Relay process reattach is fine; server restart is cold resume from saved metadata/scrollback until future daemon/supervisor work lands.
 - A terminal-multiplexer-style power-user CLI/TUI session manager. Relay's richer cockpit is currently web/dashboard oriented.
-- Workbench canvas as the primary integrated cockpit surface.
+- A single unified operator cockpit. Conversation (channel tree) and execution (Active Work) remain separate surfaces. The Workbench canvas/blocks that once aimed at this were removed with the legacy sidebar and pre-channel islands (#1174, #1300) and are not a compatibility target.
 - Public agent sessions, web-mode sessions, agent/co-driven terminal modes, and
   terminal-agent hand-back.
 - Executable handoff launch/resume and workflow-owned planner/worker

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -89,9 +89,99 @@ The hub coalesces text deltas and applies socket watermarks. A lagging client
 can reconnect from its last durable sequence instead of requiring an
 unbounded in-memory queue.
 
-Unread position is browser-local. `ChannelView` captures a channel's last-read
-sequence and the activity store mirrors it to local storage; the durable
-channel store does not claim cross-device read receipts.
+### Read state and unread
+
+Unread is derived client-side; the _marker_ it derives from converges through
+the hub. `ChannelView` captures a channel's last-read sequence into
+`frontend/src/lib/stores/channel-activity.ts`, which is the fast path and
+persists to local storage. The same store pushes the mark to
+`PUT /channels/:id/read-state`, seeds from `GET /channels/read-state`, and
+applies `channel-read-state` broadcasts on `/ws/events`.
+
+The hub is a point of convergence, not a source of truth:
+
+- **Monotonic up.** Merges only ever advance a mark. A device that is behind
+  cannot pull another device's channel back to unread.
+- **Clamp-epoch fence.** A recreated DM reuses its deterministic channel id, so
+  stale hub marks are fenced by the same per-channel clamp epoch the
+  channel-list seed uses; a fresh channel does not inherit a dead one's mark.
+- **Forward-only convergence.** Reading on one device settles the badge on the
+  others. Nothing marks a channel unread remotely.
+
+Unread counts themselves are never stored — they are computed from the marker
+against the durable sequence.
+
+## Search
+
+`GET /channels/search` queries an FTS5 virtual table
+(`channel_messages_fts`) that `server/channel-message-store.ts` maintains as an
+external-content mirror of the searchable subset of `channel_messages`, kept in
+sync by insert/update/delete triggers. Operator text is translated into a MATCH
+expression; terms with no letter or digit are dropped.
+
+- **Refused vs. empty are distinguishable.** Blank text, no letter/digit, or a
+  single term under the minimum length returns an explicit `unavailableReason`
+  instead of an empty result set, so the client never prints "no matches" for a
+  query the index never ran.
+- **Visibility is an allowlist pushed into the query.** Archive state and titles
+  live in `workspace_topics`, a separate database from the message log, so the
+  visible-channel set is resolved first and passed into the index query.
+  Filtering after the fact would let archived hits crowd out live ones.
+- **Reach is the corpus, not the rail.** The allowlist is built from
+  `listAllTopicIds()`, not the sidebar read model's capped `list()`. The rail's
+  cap is a rendering budget; using it silently made older channels unreachable.
+- `includeArchived`, `limit`, `channelId`, and `workspaceId` scope the search.
+
+The UI surfaces results in two sidebar sections (channels and messages), as a
+command-palette category, and as jump-to-message navigation into the timeline.
+
+## Message mutation and retry
+
+Edits and deletes are operator-only and durable, and neither can raise an agent
+turn.
+
+- `PATCH /channels/:id/messages/:messageId` rewrites the body in place. Same id,
+  same `seq`, new body, `meta.editedAt` stamped. The seq space stays gap-free.
+- `DELETE /channels/:id/messages/:messageId` stamps `meta.deletedAt`.
+- Both broadcast directly through the hub rather than going through
+  `postToChannel`, so mention-routing handlers never observe them. Editing a
+  message that mentioned an agent does not re-trigger it.
+- Sender attribution is server-derived on both routes: a body carrying `sender`
+  or `source` is rejected outright rather than ignored, and a non-human sender
+  is refused. An agent cannot edit or delete anyone's message, including its
+  own.
+- Archived channels refuse edit, delete, and retry.
+
+`POST /channels/:id/messages/:messageId/retry` re-drives a failed row through
+the binder. It writes a durable `retrying @…` system row and appends a whole new
+agent turn, which is why an archived channel refuses it. A message that is not
+retryable, or a binding that is already mid-turn, returns a typed reason code
+(`CHANNEL_AGENT_BUSY` and friends) rather than silently doing nothing.
+
+### Deep links
+
+`buildChannelMessageLink` in `frontend/src/lib/url-nav.ts` produces
+`/channel/<segment>#msg-<message id>`; `parseMessageAnchor` is its inverse.
+Resolving an anchor that is not in the loaded window walks older history pages,
+bounded by `ANCHOR_WALK_MAX_PAGES` (8) in `ChannelView.tsx`. Unbounded, a link
+to a deleted or foreign message id would walk the channel to `seq` 1 on every
+open; bounded, the worst case is a fixed number of page fetches and one toast.
+
+## Notifications and badges
+
+While the tab is hidden, unread activity raises an OS notification and marks the
+favicon and title. The runtime lives in `frontend/src/lib/notify/`:
+
+- `leader.ts` elects one leader tab, so N open tabs raise one notification
+  rather than N.
+- `os-notification.ts` owns permission state and delivery.
+- `favicon-badge.ts` and `title-badge.ts` own the tab-level count.
+- `signals.ts` and `producers.ts` derive what is worth announcing.
+
+`notify-settings.ts` holds operator preferences (Settings → notifications) and
+`notify-badge.ts` holds the derived count. Notifications read the same
+client-derived unread state described under "Read state and unread" — they do
+not introduce a second source of truth.
 
 ## DMs and profiles
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -124,6 +124,13 @@ a public session id, identifies an agent in a conversation. Public session and
 inbox commands operate on terminal execution records or WorkContexts; they do not
 launch, resume, or address private channel runtimes.
 
+**Gateway channel surface: `channels.post` only.** It is the sole channel verb
+declared in `shared/cli-gateway-contract.ts`. Channel reads — list, get,
+history, threads, roster, search — are authenticated browser routes and are
+**not** gateway verbs today. An adapter that needs to read a channel uses those
+HTTP routes with a scoped actor credential; do not assume `channels.list` or
+`channels.history` exists because the gateway "covers channels".
+
 The former public agent-session and terminal hand-back contracts are
 superseded. Public terminals are always human-driven. `sessions.input` and
 `supervisor.*` control terminal programs; they are not an alternate agent

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -37,7 +37,9 @@ ChatHome
 
 - joins REST metadata/history with the channel socket reducer;
 - resolves DM identity from workspace-topic routing;
-- tracks browser-local last-read state;
+- captures last-read position into the activity store, which converges it
+  through the hub (see State ownership below);
+- resolves `#msg-` deep links, walking bounded older-history pages;
 - renders archived, disconnected, resync, and unavailable states;
 - fetches the profile roster and current agent status;
 - posts top-level and threaded messages;
@@ -70,6 +72,46 @@ four bounded native images. The thread panel reuses it with a root message id.
 `ChannelThreadPanel` loads the root plus replies, preserves channel identity,
 and posts through the same message contract as the main composer.
 
+While a bound agent is mid-turn the composer reveals two explicit controls:
+`queue` (plain `enter`) and `interrupt & send` (`cmd/ctrl`+`enter`). Steering is
+never inferred from message text.
+
+### Message toolbar and deep links
+
+`ChannelMessageRow` exposes a hover toolbar: copy link, edit, delete, and retry
+on failed rows. Links are `/channel/<segment>#msg-<message id>`, built and
+parsed by `frontend/src/lib/url-nav.ts`. Opening an anchor that is outside the
+loaded window walks older pages up to `ANCHOR_WALK_MAX_PAGES` before giving up
+with a toast.
+
+## Notifications, badges, and update toast
+
+`NotificationStack.tsx` renders the `notifications.ts` stack. `UpdateToast.tsx`
+checks the server version on mount, and on a one-click update reloads through
+`lib/server-restart.ts` once the server returns.
+
+The notification runtime is `frontend/src/lib/notify/`:
+
+| Module               | Responsibility                                         |
+| -------------------- | ------------------------------------------------------ |
+| `leader.ts`          | Elects one leader tab so N tabs raise one notification |
+| `os-notification.ts` | Permission state and OS notification delivery          |
+| `favicon-badge.ts`   | Favicon count badge                                    |
+| `title-badge.ts`     | Document title count                                   |
+| `signals.ts`         | Derives what is worth announcing                       |
+| `producers.ts`       | Maps channel activity into notification signals        |
+| `summary-watch.ts`   | Watches channel summaries for background activity      |
+
+Notifications fire only while the tab is hidden and read the same client-derived
+unread state as the sidebar; they do not add a second source of truth.
+
+## Search
+
+`TopicSidebarShell` renders search results in two sections — matching channels
+and matching messages — from `GET /channels/search`. The same query is a command
+palette category. Selecting a message result navigates to its channel and jumps
+to the row.
+
 ## Data flow
 
 `useChannelChatSocket(channelId)`:
@@ -93,13 +135,25 @@ state after channel recreation.
 
 ### Zustand
 
-| Store                     | Responsibility                                       |
-| ------------------------- | ---------------------------------------------------- |
-| `ui.ts`                   | Active channel/thread, dialogs, and local navigation |
-| `channel-activity.ts`     | Browser-local last-read sequence and unread badges   |
-| `channel-agent-status.ts` | Live profile status keyed by channel/profile         |
-| `sessions.ts`             | Terminal/process session summaries                   |
-| `toasts.store.ts`         | Transient notifications                              |
+| Store                     | Responsibility                                                                         |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| `ui.ts`                   | Active channel/thread, dialogs, and local navigation                                   |
+| `channel-activity.ts`     | Last-read marks: local fast path, hub push/seed, monotonic-up merge, clamp-epoch fence |
+| `channel-agent-status.ts` | Live profile status keyed by channel/profile                                           |
+| `channel-queued-sends.ts` | Client-side memory of messages sent into a busy agent; drives the `queued` chip        |
+| `unread.ts`               | Unread derivation from marks against durable sequence                                  |
+| `notifications.ts`        | Notification stack entries (including the update toast)                                |
+| `notify-settings.ts`      | Operator notification preferences                                                      |
+| `notify-badge.ts`         | Derived badge count for favicon and title                                              |
+| `sessions.ts`             | Terminal/process session summaries                                                     |
+| `toasts.ts`               | Transient notifications                                                                |
+
+Last-read marks are not browser-local. `channel-activity.ts` persists locally as
+the fast path, then pushes to `PUT /channels/:id/read-state`, seeds from
+`GET /channels/read-state`, and applies `channel-read-state` broadcasts from
+`/ws/events`. Merges are monotonic up and fenced per channel by a clamp epoch,
+so a stale device cannot pull a channel back to unread and a recreated DM does
+not inherit a dead one's mark. Unread counts stay client-derived.
 
 ### TanStack Query
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -88,7 +88,7 @@ with a toast.
 
 `NotificationStack.tsx` renders the `notifications.ts` stack. `UpdateToast.tsx`
 checks the server version on mount, and on a one-click update reloads through
-`lib/server-restart.ts` once the server returns.
+`frontend/src/lib/server-restart.ts` once the server returns.
 
 The notification runtime is `frontend/src/lib/notify/`:
 
@@ -208,7 +208,7 @@ device proof when unit/e2e coverage cannot establish the behavior.
 
 ## Styling
 
-- Global tokens live in `frontend/src/app.css`.
+- Global tokens live in `frontend/src/App.css`.
 - Component styles live beside their TSX files.
 - Channel styles use `ChannelView.css`, `ChannelComposer.css`, and
   `ChannelImagePart.css`.

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -6,9 +6,12 @@ Testing patterns and quality standards for Relay IDE.
 
 - vitest (^4.1.2) as test runner, configured in `vitest.config.ts`
 - TypeScript test files in `test/`, run directly via vitest (no compilation step)
-- 99 unit/integration test files covering server modules and frontend utilities
+- The unit/integration suite is the bulk of coverage: several hundred `*.test.ts`
+  files across server modules, shared protocol code, and frontend utilities.
+  Deliberately not counted here — a hard number rots within a week.
 - React 19 frontend with TypeScript strict mode
-- E2E tests (Playwright) in `test/e2e/` are excluded from `npm test` and run separately
+- E2E tests (Playwright) in `test/e2e/` are excluded from `npm test`
+  (`exclude: ['test/e2e/**']`) and run through their own CI job
 - Pre-push hook (`.husky/pre-push`) runs only changed tests via `vitest run --changed`
 - Pre-commit hook: husky + lint-staged (eslint + prettier)
 
@@ -22,12 +25,16 @@ npx vitest run test/auth.test.ts            # Run a single test file
 npx vitest run --changed HEAD~1             # Run only tests affected by recent changes
 npx vitest run --testNamePattern 'pattern'  # Run tests matching a name pattern
 npm run build                               # Build server + frontend
-npm run check                               # Type check everything (tsc)
+npm run check                               # tsc (server) + tsc (frontend) + tsc (test) + eslint .
 ```
+
+`npm run check` is four gates, not one:
+`tsc --noEmit && tsc --noEmit -p frontend/tsconfig.json && npm run typecheck:test && npm run lint`.
+A lint failure fails `check` even when types are clean.
 
 ## Type Checking
 
-TypeScript strict mode covers the full codebase via `tsc`. Both `build` and `test` fail on type errors. CI runs both via `npm run build && npm test`, ensuring no code with type errors can be published.
+TypeScript strict mode covers the full codebase via `tsc`, across three projects: the server/root config, `frontend/tsconfig.json`, and `test/tsconfig.json`. Both `build` and `test` fail on type errors, and the `ci` job runs `npm run check` before `npm run build`, so no code with type errors can be merged or published.
 
 `frontend/tsconfig.json` strict flags: `strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noFallthroughCasesInSwitch`, `skipLibCheck`.
 
@@ -65,7 +72,23 @@ The `.husky/pre-push` hook detects git worktree context and adapts:
 - **Worktree:** runs changed tests, excluding `[needs:git-init]` tests via `--testNamePattern`
 - **No test-related changes:** skips vitest entirely (exits 0)
 
-Full suite always runs in CI (`npm test` in `.github/workflows/publish.yml`).
+## Required gates
+
+Pull requests into `nightly` or `master` must pass three workflows. Drafts are
+skipped.
+
+| Gate        | Workflow                          | What it runs                                                                                                             |
+| ----------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `ci`        | `.github/workflows/ci.yml`        | `npm run check` → `npm run build` → eslint on files changed vs. the base ref → `npm test`                                |
+| `e2e`       | `.github/workflows/ci.yml`        | `needs: ci`. Builds with `RELAY_IDE_E2E_FIXTURES=1` and runs `playwright test --grep smoke` on the hosted Chrome channel |
+| `changelog` | `.github/workflows/changelog.yml` | Fails a PR touching `server/`, `frontend/`, or `shared/` without a `CHANGELOG.md` `[Unreleased]` entry                   |
+
+The `e2e` job is conditional: it detects changed files against the base ref and
+no-ops successfully when the diff is docs/markdown-only. Any other change makes
+it required.
+
+`.github/workflows/publish.yml` is the publish lane (tags and `nightly` pushes),
+not the PR gate. It is not what proves a pull request.
 
 ## Test Isolation Patterns
 
@@ -84,7 +107,7 @@ Full suite always runs in CI (`npm test` in `.github/workflows/publish.yml`).
 
 ## E2E Testing
 
-Playwright component tests live in `test/e2e/`. They are excluded from `npm test` via `vitest.config.ts` (`exclude: ['test/e2e/**']`) and run separately.
+Playwright component tests live in `test/e2e/`. They are excluded from `npm test` via `vitest.config.ts` (`exclude: ['test/e2e/**']`) and run in the dedicated `e2e` job described under Required gates — conditional on the diff touching something other than docs/markdown.
 
 For local/devbox smoke runs, prefer a system browser instead of Playwright's
 downloaded browser cache. On Debian-based devboxes install Chromium once, then

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,43 +1,77 @@
 # Relay documentation
 
-These documents describe behavior present in the repository today. Git history
-holds superseded plans and removed product models; the working tree does not use
+Everything under **Current** describes behavior present in the repository today.
+Everything under **Historical and reference** is dated material kept for
+traceability — snapshots, audits, and per-incident write-ups that were true when
+written and are not maintained against the current tree. Git history holds
+superseded plans and removed product models; the working tree does not use
 historical design documents as product documentation.
 
-## Start here
+Every doc listed here is linked from this index. If you add a doc, add a row.
 
-| Area               | Source                                           |
-| ------------------ | ------------------------------------------------ |
-| User onboarding    | [`../README.md`](../README.md)                   |
-| Agent/repo map     | [`../AGENTS.md`](../AGENTS.md)                   |
-| Channel model      | [`CHANNEL_CHAT.md`](CHANNEL_CHAT.md)             |
-| Architecture       | [`ARCHITECTURE.md`](ARCHITECTURE.md)             |
-| Frontend           | [`FRONTEND.md`](FRONTEND.md)                     |
-| Visual system      | [`../DESIGN.md`](../DESIGN.md)                   |
-| Backend patterns   | [`DESIGN.md`](DESIGN.md)                         |
-| Quality            | [`QUALITY.md`](QUALITY.md)                       |
-| Provider adapters  | [`provider-guide.md`](provider-guide.md)         |
-| Security           | [`SECURITY_POLICY.md`](SECURITY_POLICY.md)       |
-| Session durability | [`SESSION_DURABILITY.md`](SESSION_DURABILITY.md) |
-| Terminal backend   | [`TERMINAL_BACKENDS.md`](TERMINAL_BACKENDS.md)   |
-| Self-hosting       | [`SELF_HOSTING.md`](SELF_HOSTING.md)             |
-| CLI gateway        | [`CLI_GATEWAY.md`](CLI_GATEWAY.md)               |
-| Workbench boundary | [`WORKBENCH_BOUNDARY.md`](WORKBENCH_BOUNDARY.md) |
+## Current
 
-## Hub, node, and operations
+### Start here
 
-| Area             | Source                                                                                 |
-| ---------------- | -------------------------------------------------------------------------------------- |
-| Hub/node package | [`RELAY_HUB_NODE_PACKAGING.md`](RELAY_HUB_NODE_PACKAGING.md)                           |
-| Node bootstrap   | [`RELAY_NODE_BOOTSTRAP.md`](RELAY_NODE_BOOTSTRAP.md)                                   |
-| Pairing UX       | [`ADD_NODE_PAIR_DEVICE_UX.md`](ADD_NODE_PAIR_DEVICE_UX.md)                             |
-| WSL2             | [`WSL2_RELAY_NODE_SUPPORT.md`](WSL2_RELAY_NODE_SUPPORT.md)                             |
-| Federated dev    | [`FEDERATED_DEV.md`](FEDERATED_DEV.md)                                                 |
-| Federation       | [`federated-relay.md`](federated-relay.md)                                             |
-| Deployment       | [`references/deployment.md`](references/deployment.md)                                 |
-| Devbox hub       | [`references/devbox-hub-deploy.md`](references/devbox-hub-deploy.md)                   |
-| Dogfood recovery | [`references/dogfood-recovery.md`](references/dogfood-recovery.md)                     |
-| Browser checks   | [`references/agent-browser-verification.md`](references/agent-browser-verification.md) |
+| Area                 | Source                                                                           |
+| -------------------- | -------------------------------------------------------------------------------- |
+| User onboarding      | [`../README.md`](../README.md)                                                   |
+| Release notes        | [`../CHANGELOG.md`](../CHANGELOG.md)                                             |
+| Agent/repo map       | [`../AGENTS.md`](../AGENTS.md)                                                   |
+| Channel model        | [`CHANNEL_CHAT.md`](CHANNEL_CHAT.md)                                             |
+| Architecture         | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                             |
+| Frontend             | [`FRONTEND.md`](FRONTEND.md)                                                     |
+| Visual system        | [`../DESIGN.md`](../DESIGN.md)                                                   |
+| Backend patterns     | [`DESIGN.md`](DESIGN.md)                                                         |
+| Quality              | [`QUALITY.md`](QUALITY.md)                                                       |
+| Provider adapters    | [`provider-guide.md`](provider-guide.md)                                         |
+| Security             | [`SECURITY_POLICY.md`](SECURITY_POLICY.md)                                       |
+| Handshake grants     | [`OPERATOR_HANDSHAKE_GRANTS.md`](OPERATOR_HANDSHAKE_GRANTS.md)                   |
+| Session durability   | [`SESSION_DURABILITY.md`](SESSION_DURABILITY.md)                                 |
+| Terminal backend     | [`TERMINAL_BACKENDS.md`](TERMINAL_BACKENDS.md)                                   |
+| Self-hosting         | [`SELF_HOSTING.md`](SELF_HOSTING.md)                                             |
+| CLI gateway          | [`CLI_GATEWAY.md`](CLI_GATEWAY.md)                                               |
+| CLI schemas          | [`cli-schema/`](cli-schema/)                                                     |
+| Workbench boundary   | [`WORKBENCH_BOUNDARY.md`](WORKBENCH_BOUNDARY.md)                                 |
+| Agent view artifacts | [`AGENT_VIEW_ARTIFACTS.md`](AGENT_VIEW_ARTIFACTS.md)                             |
+| Handoff artifacts    | [`pipeline-handoff-artifact-template.md`](pipeline-handoff-artifact-template.md) |
+
+### Working in this repo
+
+| Area                    | Source                                                                                 |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| Cross-session learnings | [`LEARNINGS.md`](LEARNINGS.md)                                                         |
+| Review guidance         | [`REVIEW_GUIDANCE.md`](REVIEW_GUIDANCE.md)                                             |
+| Review agent setup      | [`references/review-agent-setup.md`](references/review-agent-setup.md)                 |
+| Manual QA pass          | [`references/qa-guide.md`](references/qa-guide.md)                                     |
+| README screenshots      | [`assets/README.md`](assets/README.md) — spec for the shots the README still needs     |
+| Agent browser checks    | [`references/agent-browser-verification.md`](references/agent-browser-verification.md) |
+
+### Hub, node, and operations
+
+| Area             | Source                                                               |
+| ---------------- | -------------------------------------------------------------------- |
+| Hub/node package | [`RELAY_HUB_NODE_PACKAGING.md`](RELAY_HUB_NODE_PACKAGING.md)         |
+| Node bootstrap   | [`RELAY_NODE_BOOTSTRAP.md`](RELAY_NODE_BOOTSTRAP.md)                 |
+| Pairing UX       | [`ADD_NODE_PAIR_DEVICE_UX.md`](ADD_NODE_PAIR_DEVICE_UX.md)           |
+| WSL2             | [`WSL2_RELAY_NODE_SUPPORT.md`](WSL2_RELAY_NODE_SUPPORT.md)           |
+| Federated dev    | [`FEDERATED_DEV.md`](FEDERATED_DEV.md)                               |
+| Federation       | [`federated-relay.md`](federated-relay.md)                           |
+| Deployment       | [`references/deployment.md`](references/deployment.md)               |
+| Devbox hub       | [`references/devbox-hub-deploy.md`](references/devbox-hub-deploy.md) |
+| Dogfood recovery | [`references/dogfood-recovery.md`](references/dogfood-recovery.md)   |
+
+## Historical and reference
+
+Dated material, not maintained against the current tree. Read the date before
+trusting a claim.
+
+| Area                 | Source                                   | Status                                                                                                           |
+| -------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Boo substrate audit  | [`BOO_PHILOSOPHY.md`](BOO_PHILOSOPHY.md) | Gap audit against the `coder/boo` direction. Aspirational by design — verify against code before citing.         |
+| Bug analyses         | [`bug-analyses/`](bug-analyses/)         | Per-incident write-ups, dated in the filename. Historical; see [`bug-analyses/index.md`](bug-analyses/index.md). |
+| Refactor audits      | [`refactor/`](refactor/)                 | One-off audit snapshots, dated in the filename. Historical.                                                      |
+| Design-system assets | [`design-system/`](design-system/)       | Extracted palette/type CSS and the logo asset. Reference; `../DESIGN.md` is authoritative.                       |
 
 ## Product invariants
 

--- a/docs/adrs/ADR-015-core-primitives-domain-agnostic.md
+++ b/docs/adrs/ADR-015-core-primitives-domain-agnostic.md
@@ -36,10 +36,14 @@ that future:
 
 [^workspace]:
     "Workspace" in this ADR refers to the IDE-layer grouping of repos
-    surfaced in the frontend. The workbench vocabulary in
-    `docs/WORKBENCH_BOUNDARY.md` (View → Workspace → Project → Instance → Bench →
-    Tab) is the canonical product taxonomy; consult that doc to avoid conflating
-    the two senses.
+    surfaced in the frontend, as distinct from a paired node's set of repos.
+    **Historical:** when this ADR was written, the canonical product taxonomy
+    was the six-layer vocabulary View → Workspace → Project → Instance → Bench →
+    Tab, then documented in `docs/WORKBENCH_BOUNDARY.md`. That vocabulary came
+    from #444, which is closed; it is now recorded only in
+    `../federated-relay.md` § "Historical vocabulary (#444 six-layer IA,
+    closed)". The decision below is unaffected — read the current model in
+    `docs/WORKBENCH_BOUNDARY.md` and `docs/CHANNEL_CHAT.md`.
 
 Each assumption is fine for the IDE use case but constrains the broader
 platform story and bleeds repo/IDE semantics into modules that should be

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -38,6 +38,8 @@ by construction.
 
 - Dark theme only — Relay is dark-only (#1174).
 - PNG, 2x device pixel ratio, then compress.
-- Keep each file under ~400 KB; these ship in the npm tarball.
+- Keep each file under ~400 KB — they live in git and are fetched from GitHub
+  when npm renders the README; they are not packed into the tarball
+  (`files` is `dist/` + `scripts/`).
 - No annotations, arrows, or drop shadows. The UI is the screenshot.
 - Recapture when the channel surface changes shape, not on every release.

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,43 @@
+# README assets
+
+**Status: empty. The README has no screenshots and needs them before a public
+`@latest` push.** This file specifies what to capture so the shots are
+consistent and safe to publish.
+
+They are deliberately not committed as placeholders — a broken image on the npm
+landing page is worse than no image. Capture them from a real hub, then add the
+image references to `README.md` above "What is built".
+
+## Required shots
+
+| File                   | Surface                                                                                                                                             | Viewport   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `channel-timeline.png` | A channel mid-conversation: sidebar with a few channels, a human message, an agent reply, one expanded diff or output detail card, the presence row | 1440 × 900 |
+| `mobile-cockpit.png`   | The same channel on a narrow viewport with the composer visible                                                                                     | 390 × 844  |
+
+Optional, if they earn their space: the two-section search results, and the
+message hover toolbar showing copy-link/edit/delete.
+
+## Capture rules
+
+Capture from a **real hub with a real conversation**. Do not use
+`test-channel-timeline.html` — its fixture rows read `timeline row 21` and would
+misrepresent the product.
+
+Before capturing, check the frame for anything that should not be public:
+
+- absolute filesystem paths containing a real username
+- hostnames, tailnet addresses, node names, PINs, tokens
+- private repository names, branch names, issue titles
+- anything in a diff card that is not from a public repo
+
+Prefer capturing against a public repository so diff and output cards are safe
+by construction.
+
+## Conventions
+
+- Dark theme only — Relay is dark-only (#1174).
+- PNG, 2x device pixel ratio, then compress.
+- Keep each file under ~400 KB; these ship in the npm tarball.
+- No annotations, arrows, or drop shadows. The UI is the screenshot.
+- Recapture when the channel surface changes shape, not on every release.

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -59,7 +59,8 @@ Planned/deferred:
 
 - #476 node-log proxy / `logs.tail` / downloadable diagnostic bundles are not implemented. Current CLI diagnostics are `relay-ide node status`, `node logs`, and `node doctor`.
 - #427 policy schema/default ACLs, policy evaluator gates, two-token confirmation, audit sink/verifier, manual/online credential rotation, and an opt-in scheduled credential rotation loop are implemented. External audit shipping and a default rotation cadence in shipped config remain deferred.
-- #444 six-layer IA is product direction, not the persisted backend model in this doc.
+  (The six-layer IA vocabulary that used to be listed here as product direction is
+  historical — see "Historical vocabulary" below.)
 
 ## Hub/Node/Client Terminology
 
@@ -75,24 +76,28 @@ Planned/deferred:
 | **Worktree instance** | A node-local git worktree, identified by `(nodeId, worktreePath)`.                                                                                                                                                                                    | `WorktreeInstance`; git-specific Bench compatibility shape.                |
 | **Global session ID** | A node-scoped session identifier produced by `createGlobalSessionId` in `shared/identity.ts`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(localSessionId)}`. No prefix — the node ID and local ID are URL-encoded and joined by a single colon. | Internal routing identity for a `Session`, not a user-facing work context. |
 
-## Six-Layer Vocabulary Mapping (#444)
+## Historical vocabulary (#444 six-layer IA, closed)
 
-Federated Relay keeps its precise low-level hub/node/repo/session terms, but maps them into the product IA so docs do not imply `repo = Workspace` or `worktree = universal cwd`. The source vocabulary is **View -> Workspace -> Project -> Instance -> Bench -> Tab**.
+> **Historical.** The six-layer product vocabulary — View → Workspace → Project
+> → Instance → Bench → Tab — came from #444, which is closed. It was dropped
+> from `AGENTS.md` and `README.md` in the channel realignment and no current doc
+> uses it. It is recorded here only so older commits and issues remain readable;
+> do not treat it as the live product IA. The current model is in
+> `docs/WORKBENCH_BOUNDARY.md` (canonical nouns) and `docs/CHANNEL_CHAT.md`
+> (conversation model).
 
-| Product term  | Federated meaning                                                               | Low-level term that remains valid                                                                                                                  |
-| ------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **View**      | Browser lens over nodes, projects, tabs, workers, or a workspace-scoped subset. | Hub/client filters and future saved views.                                                                                                         |
-| **Workspace** | User grouping/pins across Projects.                                             | Existing workspace/repo-folder APIs are migration compatibility, not the federation identity model.                                                |
-| **Project**   | Canonical “what” being worked on.                                               | `Repo identity` is a repo-kind Project identity derived from git remotes. Node/agent/playbook Projects may not have repo inventory.                |
-| **Instance**  | A Project realized on a node/host.                                              | `Repo instance` `(nodeId, repoPath)` is a git-specific Instance compatibility shape.                                                               |
-| **Bench**     | cwd + env inside an Instance.                                                   | `Worktree instance` `(nodeId, worktreePath)` is a git Bench compatibility shape. Free/non-git remote cwd is also a Bench-like anchor once modeled. |
-| **Tab**       | User-visible terminal/file/diff/channel/preview surface.                        | A hub/node terminal session and PTY stream back a terminal Tab; `globalSessionId` remains internal routing identity.                               |
+The mapping was: **View** = a browser lens over nodes/projects/tabs;
+**Workspace** = user grouping across Projects; **Project** = the canonical
+"what" (repo identity being the repo-kind case); **Instance** = a Project
+realized on a node (`RepoInstance` = `(nodeId, repoPath)`); **Bench** = cwd + env
+inside an Instance (`WorktreeInstance` = `(nodeId, worktreePath)`); **Tab** = a
+user-visible terminal/file/diff/preview surface.
 
-Worker activity may decorate a Bench or terminal Tab, but participant identity
-belongs to the durable profile actor in its channel. Neither is a federated
-tree node. Use node/host labels for where work runs, repo/project labels for
-what is being worked on, channel/profile identity for who is participating,
-and worker badges only for execution activity.
+What survives from it is the labelling discipline, which is still correct: use
+node/host labels for _where_ work runs, repo/project labels for _what_ is being
+worked on, and channel/profile identity for _who_ is participating. Participant
+identity belongs to the durable profile actor in its channel — never to a path,
+a session, or a tree node.
 
 ### Compatibility boundaries
 
@@ -500,7 +505,7 @@ Content-Type: application/json
 }
 ```
 
-The current node-side `sessions.create` parser reads `repoPath`, `worktreePath`, and `cwd`; it does not read `workspacePath`. Send `cwd` explicitly for remote repo/worktree tabs. If `cwd` is omitted, the node defaults to its host home directory until the #473 create-tab/modal split lands. In the six-layer model, `repoPath` and `worktreePath` remain compatibility fields while `cwd` maps toward the Bench anchor.
+The current node-side `sessions.create` parser reads `repoPath`, `worktreePath`, and `cwd`; it does not read `workspacePath`. Send `cwd` explicitly for remote repo/worktree tabs. If `cwd` is omitted, the node defaults to its host home directory. `repoPath` and `worktreePath` remain compatibility fields; `cwd` is the working-directory anchor.
 
 `type: "agent"`, `mode: "web"`, provider/role launch fields, and
 `controlMode: "agent-driven"` are rejected at the routed session boundary.
@@ -629,7 +634,7 @@ GET /hub/repo-inventory
 Cookie: token={browser-session-cookie}
 ```
 
-Response groups repo instances by canonical git identity, showing per-node paths, branch counts, worktree counts, and online status. In #444 terms this is a repo-kind Project inventory plus git-specific Instance/Bench metadata, not the complete future Project inventory.
+Response groups repo instances by canonical git identity, showing per-node paths, branch counts, worktree counts, and online status. This inventory is deliberately git-specific: it is repo/worktree metadata, not a general inventory of everything a node can work on.
 
 ## File Resource Refs (#616 slice 1)
 
@@ -844,7 +849,7 @@ These were considered during design but are **not implemented** and should not b
 - **Anonymous worker pools** — Every node requires explicit pairing and trust.
 - **Cross-host live process transfer** — Sessions are node-local; re-creating on another node is a cold start.
 - **Real-time workspace state sync** — No conflict-free replicated worktree state.
-- **Full #444 IA migration** — This document maps federation terms to the six-layer vocabulary, but it does not implement Workspace/Project/Instance/Bench CRUD, #473 right-rail migration, #428 file RPC, or a Worker tree node.
+- **Federated Workspace/Project CRUD** — This document describes federation identity (repo identity, repo/worktree instances) but does not implement CRUD over a federated project tree, or a Worker tree node. (Note: file RPC #428 _is_ shipped — see the Implemented list above. The closed #444 six-layer vocabulary this bullet used to reference is recorded under "Historical vocabulary".)
 - **Raw Hermes state sync** — Relay should receive bounded Hermes plugin/integration metadata; it must not scrape or sync raw Hermes profile DBs, memory stores, provider auth, env, or unbounded transcripts/logs.
 - **Hermes/GitHub/Kanban/native-agent replacement** — Relay links and controls existing systems through scoped refs and adapters; it does not clone their dashboards or become their storage/runtime owner.
 - **Phone IDE** — Mobile control prioritizes status, approvals, small input, artifacts, attach, and safe pause/kill/retry. Bulk editing, broad file navigation, and high-risk write flows are out of scope for the v1 workbench loop.

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -80,9 +80,11 @@ Planned/deferred:
 
 > **Historical.** The six-layer product vocabulary — View → Workspace → Project
 > → Instance → Bench → Tab — came from #444, which is closed. It was dropped
-> from `AGENTS.md` and `README.md` in the channel realignment and no current doc
-> uses it. It is recorded here only so older commits and issues remain readable;
-> do not treat it as the live product IA. The current model is in
+> from `AGENTS.md` and `README.md` in the channel realignment and no current
+> product doc uses it; `docs/adrs/ADR-015-core-primitives-domain-agnostic.md`
+> still names it as the vocabulary of its time, which is fine for a dated
+> decision record. It is recorded here only so older commits and issues remain
+> readable; do not treat it as the live product IA. The current model is in
 > `docs/WORKBENCH_BOUNDARY.md` (canonical nouns) and `docs/CHANNEL_CHAT.md`
 > (conversation model).
 

--- a/docs/references/qa-guide.md
+++ b/docs/references/qa-guide.md
@@ -48,7 +48,7 @@ runtime.
 
 ### Projects and channels
 
-- [ ] Add-project row is visible in the empty sidebar
+- [ ] `+ add project` is visible in the empty sidebar
 - [ ] Add a project → its lane appears and persists across reload
 - [ ] `new chat` creates a channel in the selected lane, not the previous one
 - [ ] `new chat` still works immediately after adding a project (#1302)
@@ -143,15 +143,32 @@ Mobile terminal input changes need a fixture under
 
 ## Automated QA with gstack browse
 
-For `/design-review` and `/qa`, the browse tool needs a running server.
+For `/design-review` and `/qa`, the browse tool needs a running server. Pick one
+of the two lanes and browse the URL that lane actually serves the UI on —
+mixing them is how a design review silently reviews stale assets.
 
-1. Start the instance: `npm run dev` (or the package-mode command above)
-2. Verify: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3457/` returns `200`
-3. Authenticate:
+**Dev lane (`npm run dev`).** The backend listens on `127.0.0.1:3457`; the UI
+you must browse is Vite on `127.0.0.1:5173`, which proxies the REST routes and
+`/ws` back to 3457. Frontend edits are live over HMR, no build step. Both
+processes bind `127.0.0.1` only — use that literal, not `localhost`.
+
+1. Start: `npm run dev`
+2. Verify: `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5173/` returns `200`
+3. Browse `http://127.0.0.1:5173`
+
+**Package lane (built assets).** Browse 3457 directly, but only after a build —
+the server serves `dist/frontend` and returns early the moment `index.html`
+exists, so it never rebuilds an edited TSX/CSS change for you.
+
+1. Start: `npm run build && node dist/bin/relay-ide.js --port 3457 --config ~/.config/relay-ide/qa/config.json`
+2. Verify: `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3457/` returns `200`
+3. Browse `http://127.0.0.1:3457`
+
+Then authenticate against whichever URL you started with:
 
 ```bash
 B=~/.claude/skills/gstack/browse/dist/browse
-$B goto "http://localhost:3457"
+$B goto "http://127.0.0.1:5173"   # package lane: http://127.0.0.1:3457
 $B fill @e1 "<pin>"     # PIN input (first textbox on the login page)
 $B click @e2            # Unlock button
 ```
@@ -160,6 +177,9 @@ The cookie persists for the session.
 
 ### Common gotchas
 
+- **Reviewing stale assets** — on the package lane, an unbuilt frontend change
+  is invisible: `ensureFrontendBuilt` returns early when
+  `dist/frontend/index.html` already exists. Rebuild, or use the dev lane.
 - **Port 3456 in use** — that is the default install. Use 3457 for QA.
 - **PIN hash mismatch** — generate at runtime; the scrypt salt is per-run.
 - **Multiple dialog instances** — `document.querySelector('.dialog-shell')` may

--- a/docs/references/qa-guide.md
+++ b/docs/references/qa-guide.md
@@ -1,152 +1,171 @@
 # QA Guide
 
-Quick setup for local testing and visual QA of Relay IDE.
+Manual QA pass for the channel product surface. For automated browser checks
+driven by an agent, see
+[`agent-browser-verification.md`](agent-browser-verification.md).
 
-## Local Dev Server
+## Local QA instance
 
-The production instance runs on port 3456. Use a different port for QA:
-
-```bash
-# Build and start on port 3457 (must use CLI entry point for --port flag)
-npm run build && node dist/bin/relay-ide.js --port 3457 --config "$(pwd)/config.json"
-```
-
-**Important:** Use `dist/bin/relay-ide.js` (not `dist/server/index.js`) — only the CLI entry point parses `--port` and `--config` flags.
-
-## Test PIN Setup
-
-To set or reset PIN to `8888` for QA, run this one-liner (generates a fresh scrypt hash):
+Use `npm run dev`. It builds the backend, starts an isolated instance on
+`127.0.0.1:3457`, runs Vite on `127.0.0.1:5173`, and — critically — puts config
+and every runtime SQLite store under `~/.config/relay-ide/dev/<slug>-<hash>/`
+rather than the checkout.
 
 ```bash
-node -e "
-const crypto = require('crypto');
-const { promisify } = require('util');
-const scrypt = promisify(crypto.scrypt);
-async function main() {
-  const salt = crypto.randomBytes(16).toString('hex');
-  const derived = await scrypt('8888', salt, 64);
-  const hash = 'scrypt:' + salt + ':' + derived.toString('hex');
-  const fs = require('fs');
-  const config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
-  config.pinHash = hash;
-  fs.writeFileSync('config.json', JSON.stringify(config, null, 2));
-  console.log('PIN set to 8888');
-}
-main();
-"
+npm run dev
 ```
 
-Or delete `pinHash` entirely from `config.json` and restart — you'll be prompted to set a new PIN.
+**Never point `--config` at a path inside the repo.** Runtime SQLite must stay
+out of tracked working trees (#961). If you need a package-mode instance rather
+than a dev instance, give it an explicit config directory outside the checkout:
 
-**Note:** Don't paste a pre-generated hash — the scrypt salt must match the runtime. Always generate fresh.
-
-## Test URL
-
+```bash
+npm run build
+node dist/bin/relay-ide.js --port 3457 --config ~/.config/relay-ide/qa/config.json
 ```
-http://localhost:3457
-```
 
-PIN: `8888`
+Only `dist/bin/relay-ide.js` parses `--port` and `--config`;
+`dist/server/index.js` does not.
 
-## QA Checklist — Settings & Webhooks Feature
+The default install runs on 3456. Always use a different port for QA so you do
+not collide with it.
 
-### Settings Modal
+### PIN
 
-- [ ] Open Settings (gear icon in sidebar footer)
-- [ ] Verify full-screen modal with slide-up animation
-- [ ] Verify 4 sections visible: GENERAL, INTEGRATIONS, ADVANCED, ABOUT
-- [ ] Verify section headings are UPPERCASE with terminal aesthetic
-- [ ] Scroll through all sections
-- [ ] Click hamburger (☰) — verify TOC drawer slides from left
-- [ ] Click a TOC item — verify smooth scroll to section
-- [ ] Verify accent highlight bar moves in TOC as you scroll
-- [ ] Type in search bar — verify sections dim/collapse for non-matches
-- [ ] Clear search — verify all sections restore
-- [ ] Close modal — verify fade-out animation
-- [ ] Cmd+K → type "webhook" — verify settings result appears in Spotlight
-- [ ] Select a Spotlight settings result — verify Settings opens scrolled to section
+Relay refuses browser traffic until a PIN is set. Delete `pinHash` from the QA
+config and restart to get the setup prompt, or run `relay-ide pin reset` against
+that config. Do not paste a pre-generated hash — the scrypt salt is generated at
+runtime.
 
-### Settings — GENERAL Section
+## Checklist
 
-- [ ] Change Default Coding Agent — verify persists on reopen
-- [ ] Toggle Continue/YOLO/Tmux/Notifications — verify each persists
-- [ ] Verify each setting has name + description + right-aligned action
+### First run
 
-### Settings — INTEGRATIONS Section
+- [ ] Fresh config directory → PIN setup appears before any content
+- [ ] Set a PIN → lands in the app, sidebar is empty
+- [ ] Reload → still authenticated
+- [ ] Wrong PIN is rejected and rate-limited
 
-- [ ] GitHub row shows connection status (connected/not connected)
-- [ ] Click GitHub row — verify accordion expands
-- [ ] If connected: verify username shown + Disconnect button
-- [ ] Webhooks row shows configuration status
-- [ ] Click Webhooks row — verify accordion expands with setup/status
-- [ ] Jira row shows CLI status
-- [ ] Click Jira row — verify install instructions shown
+### Projects and channels
 
-### Settings — Webhook Setup Flow (requires GitHub connected)
+- [ ] Add-project row is visible in the empty sidebar
+- [ ] Add a project → its lane appears and persists across reload
+- [ ] `new chat` creates a channel in the selected lane, not the previous one
+- [ ] `new chat` still works immediately after adding a project (#1302)
+- [ ] Channel rows show title, last activity, and unread state
+- [ ] Collapse/expand state persists across reload
+- [ ] Archive a channel → leaves the active list; restore returns it
 
-- [ ] Click "Setup Webhooks" — verify loading state
-- [ ] Verify smee channel + secret generated
-- [ ] Verify health indicator shows connection status
-- [ ] Verify backfill banner appears if workspaces exist
-- [ ] Click "Test Connection" — verify ping result
-- [ ] Verify auto-provision toggle works
-- [ ] Click "Remove Setup" — verify confirmation dialog
-- [ ] Confirm removal — verify return to unconfigured state
+### Conversation
 
-### Compact Dialogs (verify DialogShell migration)
+- [ ] Post a human message → appears once, no duplicate row
+- [ ] `@claude` / `@codex` → profile spawns, presence row shows status
+- [ ] Reply streams into the timeline and finalizes complete
+- [ ] Reasoning, tool, code, output, and diff cards render and expand
+- [ ] Code cards syntax-highlight; diff cards show addition/deletion tint
+- [ ] Attach an image → renders inline, survives reload
+- [ ] Interrupt an in-flight turn → partial reply finalizes `interrupted`
+- [ ] DM a profile with no mention → routes to that profile
+- [ ] Scroll up to load older history → anchor row does not jump
 
-- [ ] Open Customize Session — verify fade+scale animation, terminal aesthetic
-- [ ] Open Delete Worktree — verify same animation, outlined danger button
-- [ ] Open Add Workspace — verify same animation, file browser works
-- [ ] All dialogs: verify border-radius 0, monospace buttons, backdrop click closes
+### Threads
 
-### Mobile (resize browser to <600px)
+- [ ] Open a thread on a message → panel opens beside the timeline
+- [ ] Reply in thread → agent reply stays in the thread
+- [ ] Thread reply count updates on the root row
+- [ ] Close and reopen the thread → replies persist
 
-- [ ] Settings modal goes full-screen
-- [ ] TOC drawer works as hamburger flyout
-- [ ] Setting rows stack vertically for wide actions
-- [ ] Integration accordions still work
-- [ ] Compact dialogs fill width
+### Search
 
-### Responsive (between 600px–1200px)
+- [ ] Type a query → two sections appear (channels, messages)
+- [ ] Message result shows a snippet with the match
+- [ ] Select a message result → opens that channel and jumps to the row
+- [ ] Query shorter than the minimum says so, rather than "no matches"
+- [ ] Archived channels appear when included
+- [ ] Cmd+K → same query works as a palette category
 
-- [ ] Settings modal fills viewport
-- [ ] Content area centered with max-width 640px
+### Messages
 
-### Large screens (>1200px)
+- [ ] Hover a message → toolbar appears (copy link, edit, delete)
+- [ ] Copy link → pasting the URL opens that channel scrolled to the message
+- [ ] Deep link to an old message → walks history, or toasts if unreachable
+- [ ] Edit a message → body updates in place, no new row, no agent re-trigger
+- [ ] Delete a message → row reflects deletion
+- [ ] Fail a send (stop the server mid-post) → row shows failed, retry works
+- [ ] Archived channel refuses edit/delete/retry
 
-- [ ] Settings modal has 24px inset from edges
+### Read state and notifications
+
+- [ ] Read a channel on one browser → unread clears on a second browser
+- [ ] A channel read on device A never returns to unread from device B
+- [ ] Hide the tab, receive a message → OS notification (once, not per tab)
+- [ ] Favicon badge and title count update while hidden
+- [ ] Focus the tab → badge and title clear
+- [ ] Two tabs open → exactly one notification per event
+- [ ] Notification settings toggle persists across reload
+
+### Steering
+
+- [ ] Send while an agent is mid-turn → `queued` chip on the message
+- [ ] Presence row shows `(n queued)`
+- [ ] Turn completes → queued messages drain into one next turn
+- [ ] `cmd/ctrl`+`enter` mid-turn → live turn finalizes `interrupted`, new message runs
+- [ ] With no live turn, `cmd/ctrl`+`enter` is a plain send
+- [ ] Chip clears when the queue drains
+
+### Settings
+
+- [ ] Sections render: general, notifications, agent profiles, integrations, nodes, advanced, about
+- [ ] Section headings are lowercase (per `DESIGN.md`)
+- [ ] Change default coding agent → persists on reopen
+- [ ] Create an agent profile → appears in the roster and in `@` autocomplete
+- [ ] Two profiles from one vendor are visually distinct participants
+- [ ] `@claude` resolves to the vendor default profile
+- [ ] TOC drawer, search filter, and Cmd+K deep-link into a section still work
+
+### Update toast
+
+- [ ] With an update available → toast appears bottom-right
+- [ ] One click updates and reloads when the server returns
+- [ ] Dismiss → does not reappear that session
+
+### Mobile (narrow viewport or real device)
+
+- [ ] Channel list → channel → back navigation works
+- [ ] Composer stays visible with the virtual keyboard open
+- [ ] Timeline stays anchored when the keyboard opens
+- [ ] Detail cards are readable and expandable at narrow width
+- [ ] Thread panel is usable full-width
+- [ ] Interrupt and steering controls are tappable
+
+Mobile terminal input changes need a fixture under
+`test/fixtures/mobile-input/` and real-device proof.
 
 ## Automated QA with gstack browse
 
-For `/design-review` and `/qa` skills, the browse tool needs a running server.
+For `/design-review` and `/qa`, the browse tool needs a running server.
 
-### Setup steps
-
-1. **Build**: `npm run build`
-2. **Set PIN**: Run the PIN setup script above
-3. **Start server**: `node dist/bin/relay-ide.js --port 3457 --config "$(pwd)/config.json"`
-   - Must use `dist/bin/relay-ide.js` (CLI entry point), NOT `dist/server/index.js`
-   - `dist/server/index.js` does not parse `--port` or `--config` flags
-   - The `&` backgrounding works but the process must stay alive
-4. **Verify**: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3457/` should return `200`
-
-### Browse tool authentication
-
-The browse tool needs to authenticate with PIN:
+1. Start the instance: `npm run dev` (or the package-mode command above)
+2. Verify: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3457/` returns `200`
+3. Authenticate:
 
 ```bash
 B=~/.claude/skills/gstack/browse/dist/browse
 $B goto "http://localhost:3457"
-$B fill @e1 "8888"      # PIN input (first textbox on login page)
-$B click @e2             # Unlock button
+$B fill @e1 "<pin>"     # PIN input (first textbox on the login page)
+$B click @e2            # Unlock button
 ```
 
-After auth, the cookie persists for the session.
+The cookie persists for the session.
 
 ### Common gotchas
 
-- **Port 3456 in use**: The production instance (installed via `npm install -g relay-ide`) runs on 3456. Always use `--port 3457` for QA.
-- **PIN hash mismatch**: Generate the hash at runtime (not pre-computed). The scrypt salt must be generated on the same machine.
-- **Multiple dialog instances**: `document.querySelector('.dialog-shell')` may return the wrong dialog. Use `.dialog-shell--fullscreen` or `.dialog-shell--compact` to target specific variants. There are 4 DialogShell instances in the DOM (Settings + 3 compact dialogs).
-- **Scroll containers**: The fullscreen settings body is `.dialog-shell--fullscreen .dialog-shell__body`. Scroll via `body.scrollTop = N`.
+- **Port 3456 in use** — that is the default install. Use 3457 for QA.
+- **PIN hash mismatch** — generate at runtime; the scrypt salt is per-run.
+- **Multiple dialog instances** — `document.querySelector('.dialog-shell')` may
+  return the wrong one. Target `.dialog-shell--fullscreen` or
+  `.dialog-shell--compact`.
+- **Scroll containers** — the fullscreen settings body is
+  `.dialog-shell--fullscreen .dialog-shell__body`. Scroll via `body.scrollTop = N`.
+- **Channel timeline scrolling** — the timeline is its own scroll container
+  (`role="log"`, `aria-label="channel timeline"`), not the page.


### PR DESCRIPTION
Public-readiness pass over the docs surface before a `@latest` push. The README
is the npm landing page; it described a product two epics behind the code. This
rewrites it for the 0.1.1 channel product and realigns the docs it points into.

## Audit summary

**9 review findings, all applied.** Each was verified against the code before
the fix landed — no finding was taken on description alone.

| Kind | Count | What it was |
| --- | --- | --- |
| Nonexistent UI/config (P1) | 1 | README told a first-run user to configure a permission mode and a working directory in `Settings → agent profiles`. Neither field exists on `AgentProfile` or `AgentProfileDraft`; cwd comes from the channel. |
| Overstated capability (P2) | 2 | Edit/delete advertised on any message when both are operator-own-row only; search advertised as covering archived channels when `showArchived` starts `false`. |
| Wrong QA lane (P2) | 1 | The `/design-review` + `/qa` setup started `npm run dev` and browsed 3457 — the backend, not the HMR UI — so an unbuilt frontend change silently reviewed as missing. |
| Broken citation (P3) | 2 | `frontend/src/app.css` (real file is `App.css`) and `lib/server-restart.ts`; neither resolves on a case-sensitive filesystem. |
| Wrong rationale (P3) | 1 | `docs/assets` justified its size cap with "these ship in the npm tarball". `files` is `dist/` + `scripts/`. |
| Dangling pointer (P3) | 1 | The new historical banner claimed no current doc used the six-layer vocabulary while ADR-015 still named it and pointed at a doc that no longer carries it. |
| Wrong surface named (P3) | 1 | Orchestrator lineage attributed to the "operator cockpit"; the tree renders in the sidebar. |

Evidence for each is in the fix commit message with the file and symbol that
settled it — `channelMessageEditable`, `CHANNEL_EDIT_HUMAN_ONLY`,
`ensureFrontendBuilt`'s early return, `channel-agent-binder.ts`'s cwd
resolution, `package.json` `files`.

## What the README now says

- **Quickstart is a real first run**, in order: start the hub, set the PIN,
  `+ add project`, `new chat`, `@mention` an agent, manage profiles. Every UI
  label is quoted as it actually renders.
- **The boundary is stated up front** — Relay is an execution workbench, not a
  general chat app.
- **The shipped message layer is described accurately**: full-text search
  (archived channels behind `show older chats`), `#msg-` deep links, edit and
  delete on your own rows, retry on an agent reply that failed / was interrupted
  / was truncated, cross-device read sync, notifications, mid-turn steering.
- **Agents are participants**: `@claude` resolves to that vendor's default
  profile, and a second profile from the same vendor is a separate participant.
- **Three install channels** (stable / rc / nightly) with a `CHANGELOG.md`
  pointer, and a CLI list checked against `bin/relay-ide.ts`.

Alongside the README: `DESIGN.md` reframed for the channel product,
`docs/QUALITY.md` corrected to the real test count and CI gates,
`docs/CHANNEL_CHAT.md` and `docs/ARCHITECTURE.md` completed for the channel
surface, `docs/README.md` split into current vs historical with every doc
indexed, dead surfaces and closed-epic planning marked historical, and
`docs/assets/README.md` added to specify the screenshots the landing page still
needs. `relay-ide --help` gained the `node update` and `sessions` entries the
README's "run `--help` for the exact set" depends on.

## Review trail

- Six authoring commits, then one adversarial review over the whole branch.
- All 9 findings applied in a single fix pass (`05cfd02`), no partial
  dispositions and no deferrals.
- Verification on the exact head: `npm run check` — **0 errors** (220
  pre-existing warnings, unchanged); `prettier --check` clean on all six touched
  files; every relative link and cited repo path in the touched files
  re-resolved by script. The two remaining unresolved paths are pre-existing and
  sit inside blocks explicitly marked historical. Cited npm scripts and
  `relay-ide` subcommands (`hub install`, `pin reset`, `update`, `manifest`,
  `cockpit`, `node update`, `sessions get|interventions|scoped`) re-checked
  against `bin/relay-ide.ts`.
- Docs-only apart from the `--help` text; no runtime behavior changes.

Closes #1222. Refs #1231 #1223. Pre-v0.1.1-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
