### PR TITLE
fix(channels): v2 healing migration heals in-situ at hub boot (#1209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ workflow.
   and later read marks reach your other devices again instead of being swallowed
   (#1318).
 - A chat you create with an explicit repo or terminal target now runs in the workspace you just selected, instead of in the project of whatever terminal was still open (#1303)
+- Historical duplicated Claude replies are healed on hub start even when the
+  database already passed the schema version that first shipped the repair, the
+  operator's unread mark now follows the messages the repair renumbers instead
+  of skipping the tail of the channel, and every pass logs its result instead of
+  staying silent when it removes nothing (#1209)
 
 ### Changed
 

--- a/docs/references/devbox-hub-deploy.md
+++ b/docs/references/devbox-hub-deploy.md
@@ -185,20 +185,42 @@ the fresh-config-dir workaround: start from a clean config dir carrying only
 `config.json`, `channel-chat.db`, and `workspace-topics.db`, with zero
 serialized sessions.
 
-### Duplicate-row healing (channel-chat v1 → v2)
+### Duplicate-row healing (channel-chat Claude echo aliases)
 
-The v1 → v2 `channel-chat` migration (#1207) heals historical Claude echo duplicates on the first boot at schema v2 (it logs `channel schema v2 healed N historical Claude echo duplicate row(s)`). If it heals 0 rows in-situ but duplicates are still visible (hot-WAL state, #1209), force the heal to re-run against the flushed database:
+The `channel-chat` store repairs historical Claude echo duplicates (#1207) once
+per database, on the first boot that finds no marker row for it in
+`channel_heal_state`. It is not a numbered schema step: #1209 was a database that
+reached the version which first shipped the repair without the repair having
+run, and a numbered step never revisits a version it has passed. The pass logs
+its result on the boot that runs it, including a pass that removes nothing:
+
+```
+channel Claude echo alias heal: 0 candidate pair(s) matched, 0 duplicate row(s) removed
+```
+
+Upgrading is enough — no operator action is needed. Check the log line, or the
+ledger row it wrote:
 
 ```bash
 DAILY_HUB=~/.config/relay-ide/daily-hub
+sqlite3 "$DAILY_HUB/channel-chat.db" "SELECT * FROM channel_heal_state;"
+```
+
+If duplicates are still visible after a boot that logged a pass, re-arm it by
+deleting the marker and restarting:
+
+```bash
 systemctl --user stop relay-daily-hub.service
-sqlite3 "$DAILY_HUB/channel-chat.db" "SELECT version FROM schema_version;"   # confirm it reads 2
-sqlite3 "$DAILY_HUB/channel-chat.db" "UPDATE schema_version SET version = 1;" # reset to 1
-systemctl --user start relay-daily-hub.service   # reopen re-runs the v1 -> v2 heal
+sqlite3 "$DAILY_HUB/channel-chat.db" \
+  "DELETE FROM channel_heal_state WHERE heal_id = 'claude-echo-alias-v1';"
+systemctl --user start relay-daily-hub.service   # reopen re-runs the repair
 systemctl --user status relay-daily-hub.service --no-pager
 ```
 
-`schema_version` is a single-row table in `channel-chat.db`; the heal pass runs whenever the recorded version is below 2, so resetting it to 1 and reopening re-runs the dedupe and lands back at v2.
+Do NOT rewind `schema_version` to force a repair. The v2 lane rebuilds
+`channel_messages` from a column (`source_session_id`) that v5 renamed, so
+replaying it against a modern database throws on open and the hub fails to
+start. The marker row exists precisely so recovery never needs that.
 
 ### npm publish lag (#1215)
 

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -1330,6 +1330,56 @@ interface LegacyClaudeEchoAliasCandidate {
   duplicate_completed_at: string;
 }
 
+interface LegacyClaudeEchoHealResult {
+  /** Rows the SQL predicate matched, BEFORE the bounded-signature guards. */
+  candidates: number;
+  /** Duplicate rows actually removed. */
+  healed: number;
+}
+
+/**
+ * Candidate pairs for the pre-v2 Claude stream/echo alias, held as ONE SQL
+ * string so the cheap `EXISTS` probe on the boot path and the full pass that
+ * follows it can never drift apart. It reads the head schema
+ * (`source_runtime_id`, post-v5 rename) because the heal now runs after every
+ * numbered migration rather than inside one.
+ */
+const LEGACY_CLAUDE_ECHO_CANDIDATE_SQL = `SELECT keeper.id AS keeper_id,
+        duplicate.id AS duplicate_id,
+        keeper.channel_id AS channel_id,
+        keeper.source_item_id AS keeper_item_id,
+        duplicate.source_item_id AS duplicate_item_id,
+        keeper.created_at AS keeper_created_at,
+        duplicate.created_at AS duplicate_created_at,
+        keeper.completed_at AS keeper_completed_at,
+        duplicate.completed_at AS duplicate_completed_at
+   FROM channel_messages keeper
+   JOIN channel_messages duplicate
+     ON duplicate.channel_id = keeper.channel_id
+    AND duplicate.seq = keeper.seq + 1
+    AND duplicate.source_runtime_id = keeper.source_runtime_id
+    AND duplicate.source_turn_id = keeper.source_turn_id
+    AND duplicate.sender_kind = keeper.sender_kind
+    AND duplicate.sender_id = keeper.sender_id
+    AND duplicate.sender_display IS keeper.sender_display
+    AND duplicate.kind = keeper.kind
+    AND duplicate.status = keeper.status
+    AND duplicate.thread_id IS keeper.thread_id
+    AND duplicate.parent_message_id IS keeper.parent_message_id
+    AND duplicate.body_text = keeper.body_text
+    AND duplicate.body_format = keeper.body_format
+    AND duplicate.meta_json IS keeper.meta_json
+  WHERE keeper.sender_kind = 'agent'
+    AND keeper.sender_id = 'agent:claude'
+    AND keeper.kind = 'message'
+    AND keeper.status = 'complete'
+    AND keeper.completed_at IS NOT NULL
+    AND duplicate.completed_at IS NOT NULL
+    AND keeper.source_runtime_id IS NOT NULL
+    AND keeper.source_turn_id IS NOT NULL
+    AND keeper.source_item_id GLOB '*-1'
+    AND duplicate.source_item_id GLOB '*-0'`;
+
 function legacyClaudeItemBase(
   itemId: string,
   suffix: '-1' | '-0'
@@ -1347,49 +1397,26 @@ function legacyClaudeItemBase(
  *
  * Deleted aliases are migration-only exceptions to the append-only runtime
  * contract. References are repointed to the earliest durable id, affected
- * channels are resequenced in-place, and persisted agent-delivery cursors are
- * translated before resequencing. Browser-local read cursors cannot be
- * translated here; full-snapshot head clamping remains their recovery lane.
+ * channels are resequenced in-place, and every persisted seq cursor is
+ * translated before resequencing: agent delivery cursors AND the operator's
+ * durable last-read marks. A mark left untranslated would slide DOWN with the
+ * rows and silently swallow the unread tail — `listReadState`'s head clamp only
+ * catches a mark stranded ABOVE the head, never one that moved with the log.
+ *
+ * Callers must run this AFTER `CHANNEL_READ_STATE_SCHEMA_SQL` (i.e. from
+ * `runMigrations`, never from inside a numbered `schema_version` lane) so that
+ * table exists to be translated.
+ *
+ * Returns the candidate count alongside the healed count so the caller can log
+ * a ZERO pass. #1209 burned a day of forensics precisely because a pass that
+ * healed nothing printed nothing, leaving "the migration ran" and "the
+ * migration healed" indistinguishable from the log.
  */
-function healLegacyClaudeEchoAliases(db: Database.Database): number {
+function healLegacyClaudeEchoAliases(
+  db: Database.Database
+): LegacyClaudeEchoHealResult {
   const candidates = db
-    .prepare(
-      `SELECT keeper.id AS keeper_id,
-              duplicate.id AS duplicate_id,
-              keeper.channel_id AS channel_id,
-              keeper.source_item_id AS keeper_item_id,
-              duplicate.source_item_id AS duplicate_item_id,
-              keeper.created_at AS keeper_created_at,
-              duplicate.created_at AS duplicate_created_at,
-              keeper.completed_at AS keeper_completed_at,
-              duplicate.completed_at AS duplicate_completed_at
-         FROM channel_messages keeper
-         JOIN channel_messages duplicate
-           ON duplicate.channel_id = keeper.channel_id
-          AND duplicate.seq = keeper.seq + 1
-          AND duplicate.source_session_id = keeper.source_session_id
-          AND duplicate.source_turn_id = keeper.source_turn_id
-          AND duplicate.sender_kind = keeper.sender_kind
-          AND duplicate.sender_id = keeper.sender_id
-          AND duplicate.sender_display IS keeper.sender_display
-          AND duplicate.kind = keeper.kind
-          AND duplicate.status = keeper.status
-          AND duplicate.thread_id IS keeper.thread_id
-          AND duplicate.parent_message_id IS keeper.parent_message_id
-          AND duplicate.body_text = keeper.body_text
-          AND duplicate.body_format = keeper.body_format
-          AND duplicate.meta_json IS keeper.meta_json
-        WHERE keeper.sender_kind = 'agent'
-          AND keeper.sender_id = 'agent:claude'
-          AND keeper.kind = 'message'
-          AND keeper.status = 'complete'
-          AND keeper.completed_at IS NOT NULL
-          AND duplicate.completed_at IS NOT NULL
-          AND keeper.source_session_id IS NOT NULL
-          AND keeper.source_turn_id IS NOT NULL
-          AND keeper.source_item_id GLOB '*-1'
-          AND duplicate.source_item_id GLOB '*-0'`
-    )
+    .prepare(LEGACY_CLAUDE_ECHO_CANDIDATE_SQL)
     .all() as LegacyClaudeEchoAliasCandidate[];
 
   const affectedChannels = new Set<string>();
@@ -1437,8 +1464,13 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
     affectedChannels.add(candidate.channel_id);
   }
 
+  // Selected/updated BY ROWID rather than by (channel_id, agent_framework):
+  // v3 re-keyed the table to (channel_id, profile_actor_id), and two profiles of
+  // one provider can share a framework in one channel. Keying by rowid
+  // translates each binding's own cursor instead of stamping the last computed
+  // cursor onto its siblings.
   const selectBindings = db.prepare(
-    `SELECT channel_id, agent_framework, provider_session_json
+    `SELECT rowid AS binding_rowid, provider_session_json
        FROM channel_agent_bindings WHERE channel_id = ?`
   );
   const translateSeq = db.prepare(
@@ -1447,7 +1479,20 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
   );
   const updateBinding = db.prepare(
     `UPDATE channel_agent_bindings SET provider_session_json = ?
-      WHERE channel_id = ? AND agent_framework = ?`
+      WHERE rowid = ?`
+  );
+  // Same `COUNT(*) WHERE seq <= cursor` translation the delivery cursors get,
+  // applied to the operator's durable last-read mark (#1308 slice 3 item 1).
+  // `updated_at` is deliberately NOT touched: the mark still points at the same
+  // durable message, so nothing about WHEN the operator read it changed.
+  const translateReadMark = db.prepare(
+    `UPDATE ${CHANNEL_READ_STATE_TABLE}
+        SET last_read_seq = (
+              SELECT COUNT(*) FROM channel_messages
+               WHERE channel_messages.channel_id = ?
+                 AND channel_messages.seq <=
+                     ${CHANNEL_READ_STATE_TABLE}.last_read_seq)
+      WHERE ${CHANNEL_READ_STATE_TABLE}.channel_id = ?`
   );
   const selectOrderedIds = db.prepare(
     'SELECT id FROM channel_messages WHERE channel_id = ? ORDER BY seq ASC'
@@ -1458,8 +1503,7 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
 
   for (const channelId of affectedChannels) {
     const bindings = selectBindings.all(channelId) as Array<{
-      channel_id: string;
-      agent_framework: string;
+      binding_rowid: number;
       provider_session_json: string;
     }>;
     for (const binding of bindings) {
@@ -1477,14 +1521,15 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
             ...providerSession,
             lastDeliveredSeq: translated.count,
           }),
-          channelId,
-          binding.agent_framework
+          binding.binding_rowid
         );
       } catch {
         // Invalid legacy provider state is preserved byte-for-byte; migration
         // must not turn an unrelated malformed binding into DB unavailability.
       }
     }
+
+    translateReadMark.run(channelId, channelId);
 
     const ordered = selectOrderedIds.all(channelId) as Array<{ id: string }>;
     // The negative lane avoids transient UNIQUE(channel_id, seq) collisions
@@ -1497,7 +1542,7 @@ function healLegacyClaudeEchoAliases(db: Database.Database): number {
     }
   }
 
-  return duplicateIds.size;
+  return { candidates: candidates.length, healed: duplicateIds.size };
 }
 
 /**
@@ -1537,6 +1582,39 @@ CREATE TABLE IF NOT EXISTS ${CHANNEL_READ_STATE_TABLE} (
   updated_at    TEXT NOT NULL
 );
 `;
+
+const CHANNEL_HEAL_STATE_TABLE = 'channel_heal_state';
+
+/**
+ * Ledger of one-shot historical repairs that have already run on this db
+ * (#1209).
+ *
+ * Auxiliary table, created on EVERY open, for the same reason
+ * `channel_read_state` and `channel_search_state` are: a numbered
+ * `schema_version` step fires exactly once, so a repair welded to one can never
+ * run on a db that reached that version WITHOUT it — restored from a stamped
+ * copy, rolled forward out of order, or hand-stamped. That is precisely what
+ * #1209 hit: the version said the repair had happened and the duplicate rows
+ * were still there, with no way back short of editing `schema_version`.
+ *
+ * A marker row is cheaper than a version bump in both directions. It does not
+ * make the db unopenable by an older hub (a numbered bump does — `current >
+ * SCHEMA_VERSION` throws), and re-arming a pass is
+ * `DELETE FROM channel_heal_state WHERE heal_id = '...'` rather than rewinding
+ * a schema version past migrations that must not replay. The row is also the
+ * diagnostic: it records what the pass saw and what it removed.
+ */
+const CHANNEL_HEAL_STATE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS ${CHANNEL_HEAL_STATE_TABLE} (
+  heal_id      TEXT PRIMARY KEY,
+  completed_at TEXT NOT NULL,
+  candidates   INTEGER NOT NULL,
+  healed       INTEGER NOT NULL
+);
+`;
+
+/** Marker id for the pre-v2 Claude stream/echo alias repair (#1207, #1209). */
+const CLAUDE_ECHO_HEAL_ID = 'claude-echo-alias-v1';
 
 /**
  * Durable completeness marker for the index, and the resume cursor for a
@@ -1840,9 +1918,91 @@ function ensureChannelSearchIndex(db: Database.Database): void {
   );
 }
 
+/**
+ * Run the pre-v2 Claude echo alias repair once per database (#1207, #1209).
+ *
+ * Gated on a marker ROW, not on a `schema_version` step. The v2 lane welded the
+ * heal to the CHECK-widening rebuild, so it could only ever fire on the single
+ * boot that carried a db across the 1 -> 2 boundary; a db that arrived at v2 or
+ * later without that exact lane executing its heal could never heal again, and
+ * printed nothing to say so. Version numbers describe SHAPE, and the shape was
+ * already correct — what was missing was a repair, which is state.
+ *
+ * The WAL hypothesis in #1209 is refuted (see the migration tests): the old v2
+ * lane read the duplicate rows itself when it copied them into
+ * `channel_messages_v2`, then healed the renamed table in the SAME transaction
+ * on the SAME connection, so any row that survived the rebuild was by
+ * definition visible to the heal. A hot, uncheckpointed WAL copy heals
+ * normally. (The issue's second suspect — a concurrent writer holding the db —
+ * is untested here, but it cannot produce the reported outcome either: rows the
+ * rebuild did not see would not be in the table afterwards, and the reported
+ * db still had them.)
+ *
+ * This is a bounded historical repair, not an every-boot sweep. On a db that
+ * has already run it the whole cost is one primary-key lookup; on one that has
+ * not, an `EXISTS` probe short-circuits on the first matching pair (or scans
+ * once, ever, and writes the marker).
+ *
+ * When there IS work, the FTS index is torn down first and rebuilt afterwards
+ * by `ensureChannelSearchIndex`. Healing renumbers `seq` for every row of an
+ * affected channel, so leaving the sync triggers live would fire one FTS delete
+ * plus one re-insert per row inside this transaction — the exact unbounded
+ * tokenization stall the batched backfill exists to avoid — and would hard-fail
+ * the boot on a db whose FTS table was dropped while its triggers survived.
+ */
+function ensureLegacyClaudeEchoHeal(db: Database.Database): void {
+  db.exec(CHANNEL_HEAL_STATE_SCHEMA_SQL);
+  const done = db
+    .prepare(`SELECT 1 FROM ${CHANNEL_HEAL_STATE_TABLE} WHERE heal_id = ?`)
+    .get(CLAUDE_ECHO_HEAL_ID);
+  if (done) return;
+  const hasCandidates = db.prepare(
+    `SELECT EXISTS (${LEGACY_CLAUDE_ECHO_CANDIDATE_SQL}) AS present`
+  );
+  const recordPass = db.prepare(
+    `INSERT INTO ${CHANNEL_HEAL_STATE_TABLE}
+       (heal_id, completed_at, candidates, healed)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(heal_id) DO UPDATE SET
+       completed_at = excluded.completed_at,
+       candidates   = excluded.candidates,
+       healed       = excluded.healed`
+  );
+  const result = db.transaction((): LegacyClaudeEchoHealResult => {
+    const pending = (hasCandidates.get() as { present: number }).present === 1;
+    let pass: LegacyClaudeEchoHealResult = { candidates: 0, healed: 0 };
+    if (pending) {
+      for (const trigger of CHANNEL_SEARCH_TRIGGERS) {
+        db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
+      }
+      db.exec(`DROP TABLE IF EXISTS ${CHANNEL_SEARCH_TABLE}`);
+      pass = healLegacyClaudeEchoAliases(db);
+    }
+    recordPass.run(
+      CLAUDE_ECHO_HEAL_ID,
+      new Date().toISOString(),
+      pass.candidates,
+      pass.healed
+    );
+    return pass;
+  })();
+  // Logged on every path, including a ZERO pass: this runs at most once per db,
+  // so it is one line per db — not boot noise — and it is the difference between
+  // "the repair ran" and "the repair healed", which #1209 could not tell apart.
+  logger.info(
+    'channel Claude echo alias heal: %d candidate pair(s) matched, %d duplicate row(s) removed',
+    result.candidates,
+    result.healed
+  );
+}
+
 function runMigrations(db: Database.Database): void {
   runSchemaMigrations(db);
   db.exec(CHANNEL_READ_STATE_SCHEMA_SQL);
+  // Order matters both ways: the heal translates `channel_read_state` (created
+  // above) and may drop the search index, which `ensureChannelSearchIndex`
+  // (below) then rebuilds in bounded batches.
+  ensureLegacyClaudeEchoHeal(db);
   ensureChannelSearchIndex(db);
 }
 
@@ -1868,7 +2028,7 @@ function runSchemaMigrations(db: Database.Database): void {
     return;
   }
   if (current < 2) {
-    const healed = db.transaction(() => {
+    db.transaction(() => {
       // SQLite cannot widen a CHECK constraint in place. Rebuild only the
       // message table, preserving every durable row and its sequence/source
       // identity, then recreate its indexes against the replacement table.
@@ -1914,8 +2074,10 @@ function runSchemaMigrations(db: Database.Database): void {
         ALTER TABLE channel_messages_v2 RENAME TO channel_messages;
       `);
 
-      const healedCount = healLegacyClaudeEchoAliases(db);
-
+      // The Claude echo alias heal used to live HERE, inside the rebuild. It
+      // now runs from `runMigrations` behind its own marker row: welding it to
+      // this one-shot lane is what made #1209 unrecoverable, and the rebuild
+      // itself has nothing to do with the duplicates.
       db.exec(`
         CREATE INDEX idx_chm_channel_seq
           ON channel_messages(channel_id, seq);
@@ -1931,14 +2093,7 @@ function runSchemaMigrations(db: Database.Database): void {
           WHERE client_message_id IS NOT NULL;
       `);
       db.prepare('UPDATE schema_version SET version = 2').run();
-      return healedCount;
     })();
-    if (healed > 0) {
-      logger.info(
-        'channel schema v2 healed %d historical Claude echo duplicate row(s)',
-        healed
-      );
-    }
   }
   if (current < 3) {
     db.transaction(() => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -1,9 +1,10 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { format } from 'node:util';
 
 import Database from 'better-sqlite3';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildChannelMessageSearchSql,
@@ -373,6 +374,378 @@ describe('channel-message-store schema migration', () => {
           '{"claudeSessionId":"session-live","lastDeliveredSeq":2}',
       },
     ]);
+
+    // The repair is recorded as a marker ROW, not as a schema version. That is
+    // what keeps an older hub able to open this db (a version bump would make
+    // `current > SCHEMA_VERSION` throw) and makes re-arming a DELETE instead of
+    // a schema-version rewind. Two pairs matched the SQL predicate; only the
+    // one carrying the bounded echo signature was removed.
+    expect(
+      inspect
+        .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
+        .all()
+    ).toEqual([{ heal_id: 'claude-echo-alias-v1', candidates: 2, healed: 1 }]);
+  });
+
+  // #1209: the dogfood hub migrated a live db to the v2 schema and healed ZERO
+  // rows, while the identical predicate healed correctly when the same db was
+  // re-run offline. The reported suspect was WAL state; it is refuted by the
+  // `hot, uncheckpointed WAL` case below. The real defect is structural — the
+  // heal was welded to the one-shot v2 rebuild, so a db that arrived at v2 or
+  // later without that exact lane running its heal could never heal again, and
+  // said nothing about it. The repair is now gated on a marker ROW, so it runs
+  // whenever it has not run, whatever the schema version says.
+  it('heals a head-schema db that never ran the repair, and translates its cursors', () => {
+    const file = dbPath();
+    // Build a REAL head-schema db (search table + triggers included), clear the
+    // heal marker, and plant the un-healed rows: exactly the shape #1209 found
+    // in dogfood — modern schema, version stamped past the v2 heal, duplicates
+    // still present.
+    store(file).close();
+    const seeded = new Database(file);
+    seeded.exec(`
+      DELETE FROM channel_heal_state;
+      INSERT INTO channel_messages VALUES (
+        'chm:stranded-keeper', 'topic:stranded-heal', 1, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'unhealed echo body', 'markdown', '{"providerId":"claude"}',
+        'runtime-stranded', 'turn-stranded', 'msg-turn-stranded-provider-1', NULL,
+        '2026-07-19T09:00:00.100Z', '2026-07-19T09:00:00.100Z',
+        '2026-07-19T09:00:00.100Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:stranded-duplicate', 'topic:stranded-heal', 2, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'unhealed echo body', 'markdown', '{"providerId":"claude"}',
+        'runtime-stranded', 'turn-stranded', 'msg-turn-stranded-provider-0', NULL,
+        '2026-07-19T09:00:00.180Z', '2026-07-19T09:00:00.180Z',
+        '2026-07-19T09:00:00.102Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:stranded-reply', 'topic:stranded-heal', 3, 'message', 'complete',
+        'human', 'human:operator', 'operator', 'chm:stranded-duplicate',
+        'chm:stranded-duplicate', 'reply to the echo', 'markdown', NULL,
+        NULL, NULL, NULL, NULL,
+        '2026-07-19T09:00:01.000Z', '2026-07-19T09:00:01.000Z',
+        '2026-07-19T09:00:01.000Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:stranded-tail', 'topic:stranded-heal', 4, 'message', 'complete',
+        'human', 'human:operator', 'operator', NULL, NULL, 'tail', 'markdown',
+        NULL, NULL, NULL, NULL, NULL,
+        '2026-07-19T09:00:02.000Z', '2026-07-19T09:00:02.000Z',
+        '2026-07-19T09:00:02.000Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:stranded-legit-0', 'topic:stranded-no-heal', 1, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'legitimate repeated body', 'markdown', '{"providerId":"claude"}',
+        'runtime-legit', 'turn-legit', 'msg-turn-legit-provider-0', NULL,
+        '2026-07-19T09:10:00.000Z', '2026-07-19T09:10:00.000Z',
+        '2026-07-19T09:10:00.000Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:stranded-legit-1', 'topic:stranded-no-heal', 2, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'legitimate repeated body', 'markdown', '{"providerId":"claude"}',
+        'runtime-legit', 'turn-legit', 'msg-turn-legit-provider-1', NULL,
+        '2026-07-19T09:10:00.001Z', '2026-07-19T09:10:00.001Z',
+        '2026-07-19T09:10:00.001Z'
+      );
+      INSERT INTO channel_agent_bindings VALUES (
+        'topic:stranded-heal', 'agent-profile:claude:default', 'claude',
+        'runtime-stranded',
+        '{"claudeSessionId":"runtime-stranded","lastDeliveredSeq":4}',
+        '2026-07-19T08:00:00.000Z', '2026-07-19T08:00:00.000Z'
+      );
+      INSERT INTO channel_agent_bindings VALUES (
+        'topic:stranded-heal', 'agent-profile:claude:reviewer', 'claude',
+        'runtime-b',
+        '{"claudeSessionId":"runtime-b","lastDeliveredSeq":2}',
+        '2026-07-19T08:00:00.000Z', '2026-07-19T08:00:00.000Z'
+      );
+      INSERT INTO channel_read_state VALUES (
+        'topic:stranded-heal', 3, '2026-07-19T09:00:05.000Z'
+      );
+    `);
+    seeded.close();
+
+    const healed = store(file);
+    // The echo alias is collapsed onto the earliest durable id, its references
+    // are repointed, and the channel is left gap-free.
+    expect(
+      healed
+        .history('topic:stranded-heal', { limit: 20 })
+        .map((m) => [m.id, m.seq])
+    ).toEqual([
+      ['chm:stranded-keeper', 1],
+      ['chm:stranded-reply', 2],
+      ['chm:stranded-tail', 3],
+    ]);
+    expect(healed.getMessage('chm:stranded-duplicate')).toBeNull();
+    expect(healed.getMessage('chm:stranded-reply')).toMatchObject({
+      threadId: 'chm:stranded-keeper',
+      parentMessageId: 'chm:stranded-keeper',
+    });
+    expect(healed.getMessage('chm:stranded-keeper')?.replyCount).toBe(1);
+    // A same-turn pair that does NOT carry the bounded echo signature is a
+    // legitimate multi-item turn and must survive untouched.
+    expect(
+      healed.history('topic:stranded-no-heal', { limit: 20 }).map((m) => m.id)
+    ).toEqual(['chm:stranded-legit-0', 'chm:stranded-legit-1']);
+    // The removed row leaves the search index with it: the heal tears the index
+    // down and `ensureChannelSearchIndex` rebuilds it from the healed rows.
+    expect(
+      healed.searchMessages({ query: 'unhealed' }).map((hit) => hit.messageId)
+    ).toEqual(['chm:stranded-keeper']);
+    // Each binding's own delivery cursor is translated: 4 -> 3 and 2 -> 1. Two
+    // profiles of one provider share a channel and a framework, so a cursor
+    // keyed by framework would overwrite its sibling.
+    expect(
+      healed.getBinding('topic:stranded-heal', 'agent-profile:claude:default')
+        ?.providerSession['lastDeliveredSeq']
+    ).toBe(3);
+    expect(
+      healed.getBinding('topic:stranded-heal', 'agent-profile:claude:reviewer')
+        ?.providerSession['lastDeliveredSeq']
+    ).toBe(1);
+    // The operator's durable read mark is translated with the rows: it pointed
+    // at `chm:stranded-reply` (seq 3 of 4) with `chm:stranded-tail` unread, and
+    // it still does (seq 2 of 3). Left untranslated it would read 3 — the head —
+    // and swallow the unread tail, which the head clamp in `listReadState`
+    // cannot detect because the mark moved DOWN with the log, not above it.
+    expect(healed.listReadState()).toEqual([
+      {
+        channelId: 'topic:stranded-heal',
+        lastReadSeq: 2,
+        updatedAt: '2026-07-19T09:00:05.000Z',
+      },
+    ]);
+
+    const inspect = new Database(file, { readonly: true });
+    cleanup.push(() => inspect.close());
+    // No schema bump: the repair records a marker row, so a db healed by this
+    // hub still opens on one built before the repair existed.
+    expect(
+      (
+        inspect.prepare('SELECT version FROM schema_version').get() as {
+          version: number;
+        }
+      ).version
+    ).toBe(6);
+    expect(
+      inspect
+        .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
+        .all()
+    ).toEqual([{ heal_id: 'claude-echo-alias-v1', candidates: 1, healed: 1 }]);
+
+    // Reopening is a no-op: the pass is idempotent and cannot re-collapse the
+    // rows it already healed.
+    const reopened = store(file);
+    expect(
+      reopened
+        .history('topic:stranded-heal', { limit: 20 })
+        .map((m) => [m.id, m.seq])
+    ).toEqual([
+      ['chm:stranded-keeper', 1],
+      ['chm:stranded-reply', 2],
+      ['chm:stranded-tail', 3],
+    ]);
+    expect(
+      reopened.getBinding('topic:stranded-heal', 'agent-profile:claude:default')
+        ?.providerSession['lastDeliveredSeq']
+    ).toBe(3);
+  });
+
+  // The other half of #1209: the v2 pass logged only when it removed rows, so a
+  // pass that healed nothing was indistinguishable from a pass that never ran.
+  it('logs a zero heal pass so a silent no-op is visible in the hub log', () => {
+    const file = dbPath();
+    const seeded = store(file);
+    seeded.appendComplete({
+      channelId: 'topic:nothing-to-heal',
+      sender: HUMAN,
+      text: 'no duplicates here',
+    });
+    seeded.close();
+    // Re-arming is a DELETE against the marker ledger — the operator recovery
+    // #1209 asked for, instead of rewinding `schema_version` past migrations
+    // that must not replay.
+    const rearm = new Database(file);
+    rearm.exec('DELETE FROM channel_heal_state');
+    rearm.close();
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    cleanup.push(() => infoSpy.mockRestore());
+    store(file);
+    const healLine = infoSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('Claude echo alias heal')
+    );
+    expect(healLine).toBeDefined();
+    expect(format(...(healLine as [string, ...unknown[]]))).toBe(
+      '[channel-message-store] channel Claude echo alias heal: 0 candidate pair(s) matched, 0 duplicate row(s) removed'
+    );
+  });
+
+  // A db that has already run the repair does not scan for it again: the marker
+  // row is the gate, so an unrelated later boot cannot pay for the self-join or
+  // print a second line about it.
+  it('does not re-run or re-log the repair once the marker row exists', () => {
+    const file = dbPath();
+    store(file).close();
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    cleanup.push(() => infoSpy.mockRestore());
+    store(file).close();
+    expect(
+      infoSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('Claude echo alias heal')
+      )
+    ).toHaveLength(0);
+  });
+
+  // The repair renumbers `seq` for every row of an affected channel. With the
+  // FTS sync triggers live that is one index delete + re-insert per row inside
+  // the boot transaction — and on a db whose FTS TABLE was dropped while its
+  // triggers survived (an operator poking at the db, a backup restored
+  // mid-migration) the very first write raises `no such table:
+  // channel_messages_fts` and the hub cannot boot at all. The heal therefore
+  // drops the index itself and lets `ensureChannelSearchIndex` rebuild it.
+  it('heals a db whose FTS table was dropped while its triggers survived', () => {
+    const file = dbPath();
+    store(file).close();
+    const seeded = new Database(file);
+    seeded.exec(`
+      DELETE FROM channel_heal_state;
+      INSERT INTO channel_messages VALUES (
+        'chm:fts-keeper', 'topic:fts-heal', 1, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'orphan trigger echo body', 'markdown', '{"providerId":"claude"}',
+        'runtime-fts', 'turn-fts', 'msg-turn-fts-provider-1', NULL,
+        '2026-07-19T11:00:00.100Z', '2026-07-19T11:00:00.100Z',
+        '2026-07-19T11:00:00.100Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:fts-duplicate', 'topic:fts-heal', 2, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'orphan trigger echo body', 'markdown', '{"providerId":"claude"}',
+        'runtime-fts', 'turn-fts', 'msg-turn-fts-provider-0', NULL,
+        '2026-07-19T11:00:00.180Z', '2026-07-19T11:00:00.180Z',
+        '2026-07-19T11:00:00.102Z'
+      );
+    `);
+    // Drop the index table only. All three sync triggers survive, so any write
+    // to `channel_messages` now references a table that no longer exists.
+    seeded.exec('DROP TABLE channel_messages_fts');
+    expect(
+      seeded
+        .prepare(
+          `SELECT COUNT(*) AS count FROM sqlite_master
+            WHERE type = 'trigger' AND name LIKE 'channel_messages_fts%'`
+        )
+        .get()
+    ).toEqual({ count: 3 });
+    seeded.close();
+
+    const healed = store(file);
+    expect(
+      healed.history('topic:fts-heal', { limit: 20 }).map((m) => [m.id, m.seq])
+    ).toEqual([['chm:fts-keeper', 1]]);
+    // The index is back, rebuilt over the healed rows.
+    expect(
+      healed.searchMessages({ query: 'orphan' }).map((hit) => hit.messageId)
+    ).toEqual(['chm:fts-keeper']);
+  });
+
+  // #1209 refutation evidence for the FIRST of the issue's two suspects: that
+  // the boot-time connection read a pre-checkpoint WAL snapshot in which the
+  // duplicate rows were not yet visible. It cannot work that way — the old v2
+  // lane copied every row through
+  // `INSERT INTO channel_messages_v2 SELECT ... FROM channel_messages` and then
+  // healed the renamed table inside the SAME transaction on the SAME
+  // connection, so a row that survived the rebuild was by definition visible to
+  // the heal. This pins that behaviour against a db carrying a hot,
+  // uncheckpointed WAL written by a still-open connection.
+  //
+  // The issue's second suspect (another connection holding the db) is NOT
+  // exercised here. It cannot produce the reported outcome either — rows a
+  // read snapshot hid from the heal would equally have been hidden from the
+  // rebuild's own SELECT, so they would not be in the table afterwards, and the
+  // dogfood db still had them — but that is an argument, not a fixture. It is
+  // also moot for recovery now: the repair is gated on a marker row, so a pass
+  // that saw nothing is re-armed with a DELETE rather than stranded forever.
+  it('heals a v1 db copied with a hot, uncheckpointed WAL', () => {
+    const sourceFile = dbPath();
+    const source = new Database(sourceFile);
+    source.pragma('journal_mode = WAL');
+    source.pragma('synchronous = NORMAL');
+    source.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version VALUES (1);
+      CREATE TABLE channel_messages (
+        id TEXT PRIMARY KEY, channel_id TEXT NOT NULL, seq INTEGER NOT NULL,
+        kind TEXT NOT NULL DEFAULT 'message' CHECK (kind IN ('message','system')),
+        status TEXT NOT NULL DEFAULT 'complete'
+          CHECK (status IN ('streaming','complete','interrupted','failed')),
+        sender_kind TEXT NOT NULL CHECK (sender_kind IN ('human','agent','system')),
+        sender_id TEXT NOT NULL, sender_display TEXT, thread_id TEXT,
+        parent_message_id TEXT, body_text TEXT NOT NULL DEFAULT '',
+        body_format TEXT NOT NULL DEFAULT 'markdown', meta_json TEXT,
+        source_session_id TEXT, source_turn_id TEXT, source_item_id TEXT,
+        client_message_id TEXT, created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL, completed_at TEXT,
+        UNIQUE (channel_id, seq)
+      );
+      CREATE TABLE channel_members (
+        channel_id TEXT NOT NULL, member_kind TEXT NOT NULL,
+        member_id TEXT NOT NULL, joined_at TEXT NOT NULL,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        PRIMARY KEY (channel_id, member_kind, member_id)
+      );
+      CREATE TABLE channel_agent_bindings (
+        channel_id TEXT NOT NULL, agent_framework TEXT NOT NULL,
+        session_id TEXT, provider_session_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        PRIMARY KEY (channel_id, agent_framework)
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:wal-keeper', 'topic:wal-heal', 1, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'hot wal echo body', 'markdown', '{"providerId":"claude"}',
+        'session-wal', 'turn-wal', 'msg-turn-wal-provider-1', NULL,
+        '2026-07-19T10:00:00.100Z', '2026-07-19T10:00:00.100Z',
+        '2026-07-19T10:00:00.100Z'
+      );
+      INSERT INTO channel_messages VALUES (
+        'chm:wal-duplicate', 'topic:wal-heal', 2, 'message', 'complete',
+        'agent', 'agent:claude', 'claude', NULL, NULL,
+        'hot wal echo body', 'markdown', '{"providerId":"claude"}',
+        'session-wal', 'turn-wal', 'msg-turn-wal-provider-0', NULL,
+        '2026-07-19T10:00:00.180Z', '2026-07-19T10:00:00.180Z',
+        '2026-07-19T10:00:00.102Z'
+      );
+    `);
+    // The source hub is STILL RUNNING: nothing has checkpointed, so the main db
+    // file holds only its header page and every row lives in the -wal.
+    const walSize = fs.statSync(`${sourceFile}-wal`).size;
+    expect(walSize).toBeGreaterThan(0);
+    const copyFile = dbPath();
+    for (const suffix of ['', '-wal', '-shm']) {
+      if (fs.existsSync(`${sourceFile}${suffix}`)) {
+        fs.copyFileSync(`${sourceFile}${suffix}`, `${copyFile}${suffix}`);
+      }
+    }
+    source.close();
+
+    const migrated = store(copyFile);
+    expect(
+      migrated.history('topic:wal-heal', { limit: 20 }).map((m) => m.id)
+    ).toEqual(['chm:wal-keeper']);
+    expect(migrated.getMessage('chm:wal-duplicate')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Defect

Rolling the dogfood hub onto the #1207 channel-chat migration against a live db
holding 7 known Claude echo duplicate pairs stamped the schema forward, healed
**0 rows, and logged nothing**. The same db, copied and re-run offline with
`schema_version` reset, healed 7. Duplicated Claude replies stayed visible in
the channel, with no operator recovery short of hand-editing `schema_version` —
the exact "version-reset dance" #1209 asked to replace.

## Root cause

The heal was welded to the one-shot v1 -> v2 CHECK-widening rebuild. A numbered
migration step never revisits a version it has passed, so a database that
arrived at v2 or later **without that exact lane executing its heal** — restored
from an already-stamped copy, rolled forward out of order, hand-stamped — could
never heal again. And because the log line was gated on `count > 0`, "the
migration ran" and "the migration healed" were indistinguishable from the
journal.

The issue's WAL hypothesis is **refuted**: the v2 lane copies every row itself
through `INSERT INTO channel_messages_v2 SELECT ... FROM channel_messages` and
then heals the renamed table in the SAME transaction on the SAME connection, so
any row that survived the rebuild was by definition visible to the heal. A
hot/uncheckpointed WAL copy heals normally (pinned by a fixture). The issue's
second suspect (a concurrent writer holding the db) is not fixtured, and the
code comments now say exactly that instead of claiming more than was tested — it
cannot produce the reported outcome either, since rows a read snapshot hid from
the heal would equally have been hidden from the rebuild's own SELECT.

## Fix

- The repair runs from `runMigrations` behind a **marker row** in a new
  `channel_heal_state` ledger, not behind a `schema_version` step — the same
  unconditional `IF NOT EXISTS` shape `channel_read_state` and
  `channel_search_state` already use, and for the reason this file already
  documents twice: a numbered step fires once and can never repair state it has
  passed. It fires whenever it has not run, whatever the version says.
- `SCHEMA_VERSION` stays **6**. No one-way door: a db healed by this hub still
  opens on a hub built before the repair existed, and re-arming the pass is
  `DELETE FROM channel_heal_state WHERE heal_id = 'claude-echo-alias-v1'`
  instead of rewinding a schema version past migrations that must not replay
  (the v2 lane reads a column v5 renamed — replaying it throws on open).
- The heal leaves the v2 lane entirely, so there is now ONE heal path over ONE
  schema shape; the dual-column parameterization is gone.
- **Read marks are translated.** The pass renumbers `seq` for every row of an
  affected channel; a durable `channel_read_state.last_read_seq` left alone
  slides DOWN with the rows and silently marks the unread tail as read. The head
  clamp in `listReadState` only catches a mark stranded ABOVE the head, never
  one that moved with the log. The mark now gets the same
  `COUNT(*) WHERE seq <= cursor` translation the agent delivery cursors get;
  `updated_at` is deliberately untouched.
- **The FTS index is torn down for the duration** when there is work to do, and
  rebuilt by the unconditional `ensureChannelSearchIndex` that follows. Leaving
  the sync triggers live meant one FTS delete + re-insert per row inside the
  boot transaction — the unbounded tokenization stall the batched backfill
  exists to avoid — and hard-failed boot with
  `no such table: main.channel_messages_fts` on a db whose FTS table was dropped
  while its triggers survived, a state `ensureChannelSearchIndex` was built to
  self-repair.
- Every pass logs its result, zero included:
  `channel Claude echo alias heal: N candidate pair(s) matched, M duplicate row(s) removed`.
  A db that has already run it pays one primary-key lookup per boot and logs
  nothing.

## Verification

- `npm run check` — 0 errors (warning count identical to the pre-change
  baseline).
- `npx vitest run test/channel-message-store.test.ts` — 68 passed (node 22,
  sqlite-backed).
- Dependent channel suites green together: `channel-message-store`,
  `channel-agent-binder`, `channel-agent-bridge`,
  `channel-agent-bridge-zero-row`, `channel-claude-duplicate-row`,
  `channel-hub`, `channel-mention-e2e`, `channel-routes`, `channel-thread-e2e`,
  `channel-topic-orphan-sweep`, `ws-channels-upgrade`, `codex-native-adapter` —
  391 passed / 0 failed.
- `test/auth.test.ts` drift guard — 25 passed. No new HTTP routes, no new
  gateway verbs.
- **Anti-vacuity, three independent probes** (revert → red → restore):
  1. Restore `server/channel-message-store.ts` from `nightly` → 4 migration
     tests go red, including `heals a head-schema db that never ran the repair`.
  2. Delete only `translateReadMark.run(...)` → `heals a head-schema db that
     never ran the repair, and translates its cursors` fails on the read-mark
     assertion.
  3. Delete only the trigger/table teardown → `heals a db whose FTS table was
     dropped while its triggers survived` fails.

New/changed coverage: head-schema db that never ran the repair (rows, thread
reparenting, gap-free seq, per-profile delivery cursors, read mark, marker
ledger row), marker-row idempotence (no re-run, no second log line), dropped-FTS
-table-with-live-triggers boot, zero-pass logging, and the retained hot-WAL
refutation fixture.

## Review trail

One adversarial review returned `concern` with 3 P2 and 2 P3 findings. All three
P2s are applied as described above (read-mark translation, FTS teardown, marker
row instead of the version bump and its one-way door). P3 #1 (per-row trigger
churn during resequencing) is fully covered by the FTS teardown, as the review
itself noted. P3 #2 (the refutation being narrower than the prose) is applied by
narrowing the claim: the code and the WAL fixture now name which of the issue's
two suspects is fixtured and which is argued. The concurrent-writer variant
remains unfixtured, and is moot for recovery now that the pass is re-armable.

Refs #1209. Pre-v0.1.1-stable hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
