### PR TITLE
fix(chat): clear pinned agent presence when the runtime dies without an idle transition (#1307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ workflow.
   operator's unread mark now follows the messages the repair renumbers instead
   of skipping the tail of the channel, and every pass logs its result instead of
   staying silent when it removes nothing (#1209)
+- Agent presence no longer sticks on "thinking"/"streaming"/"waiting" after an agent's runtime dies without a clean finish: every teardown path now ends in a terminal idle for the header chip and the in-timeline presence row, and a busy status that has gone stale with nothing bound is retired on the client (#1307)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ workflow.
   operator's unread mark now follows the messages the repair renumbers instead
   of skipping the tail of the channel, and every pass logs its result instead of
   staying silent when it removes nothing (#1209)
-- Agent presence no longer sticks on "thinking"/"streaming"/"waiting" after an agent's runtime dies without a clean finish: every teardown path now ends in a terminal idle for the header chip and the in-timeline presence row, and a busy status that has gone stale with nothing bound is retired on the client (#1307)
+- Agent presence no longer sticks on "thinking"/"streaming"/"waiting" after an agent's runtime dies without a clean finish: every teardown path now ends in a terminal idle for the header chip and the in-timeline presence row, posts still queued behind the dead agent are released with a system row instead of staying counted against it, and a busy status that has gone stale with nothing bound is retired on the client (#1307)
 
 ### Changed
 

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -3092,6 +3092,8 @@ export function TopicSidebarView({
           rosterStatus: entry?.binding?.status,
           rosterUpdatedAt: query.dataUpdatedAt,
           streaming: false,
+          // #1307 staleness floor — same rule the channel header applies.
+          rosterHasLiveBinding: entry?.binding != null,
         });
         // A fresh unbound roster row supersedes a stale idle socket entry. A
         // newer active socket transition still wins through the resolver.

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -41,6 +41,7 @@ import {
   channelAgentStatusKey,
   resolveEffectiveAgentStatus,
   resolveEffectiveQueuedCount,
+  shouldPollRosterForPresence,
   useChannelAgentStatusStore,
 } from '../../lib/stores/channel-agent-status.js';
 import {
@@ -68,12 +69,14 @@ const AUTO_BACKFILL_MAX_CURSOR_PAGES = 4;
  */
 const ANCHOR_WALK_MAX_PAGES = 8;
 /**
- * #1307: how often the roster snapshot is re-fetched while the socket believes
- * an agent in this channel is busy. `staleTime` alone never refetches on its
- * own, so a terminal 'idle' that never reached this client (socket down when the
- * runtime died, tab asleep) had nothing to reconcile it — the chip and the
- * presence row stayed busy for as long as the view stayed mounted. Polling only
- * while something is busy keeps the idle channel free.
+ * #1307: how often the roster snapshot is re-fetched while a busy socket status
+ * in this channel is still newer than that snapshot. `staleTime` alone never
+ * refetches on its own, so a terminal 'idle' that never reached this client
+ * (socket down when the runtime died, tab asleep) had nothing to reconcile it —
+ * the chip and the presence row stayed busy for as long as the view stayed
+ * mounted. See `shouldPollRosterForPresence`: one poll is normally enough, since
+ * the snapshot it lands then outranks every socket transition and disarms the
+ * interval until the next live transition arrives.
  */
 const PRESENCE_ROSTER_POLL_MS = 30_000;
 
@@ -504,21 +507,31 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const queuedCountMap = useChannelAgentStatusStore(
     (s) => s.queuedCountByChannelAgent
   );
-  // #1307: the socket's own claim that something here is busy is exactly the
-  // state that can go stale, so it is what arms the roster poll. Once the roster
-  // (or a live transition) resolves everything back to idle the poll stops.
-  const socketBusyInChannel = useMemo(() => {
-    const prefix = `${channelId} `;
-    return Object.entries(statusMap).some(
-      ([key, status]) => key.startsWith(prefix) && status !== 'idle'
-    );
-  }, [statusMap, channelId]);
+  // #1307: a busy socket status the roster has not yet superseded is exactly the
+  // state that can go stale, so it is what arms the roster poll — and because the
+  // predicate is the same tie-break the resolver uses, the poll self-disarms: the
+  // first snapshot that lands is newer than every socket transition here, so the
+  // roster becomes authoritative and this returns false. `refetchInterval` is a
+  // function so TanStack re-evaluates it against the CURRENT `dataUpdatedAt`
+  // after each fetch settles, not just on re-render.
+  const rosterPollInterval = useCallback(
+    (query: { state: { dataUpdatedAt: number } }): number | false =>
+      shouldPollRosterForPresence({
+        statusByChannelAgent: statusMap,
+        updatedAtByChannelAgent: statusUpdatedAtMap,
+        channelId,
+        rosterUpdatedAt: query.state.dataUpdatedAt,
+      })
+        ? PRESENCE_ROSTER_POLL_MS
+        : false,
+    [statusMap, statusUpdatedAtMap, channelId]
+  );
   const rosterChipsQuery = useQuery({
     queryKey: ['channel-roster', channelId],
     queryFn: () => fetchChannelRoster(channelId),
     staleTime: 30_000,
     retry: false,
-    refetchInterval: socketBusyInChannel ? PRESENCE_ROSTER_POLL_MS : false,
+    refetchInterval: rosterPollInterval,
   });
 
   // On channel switch, drop this channel's per-agent socket statuses so the

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -67,6 +67,15 @@ const AUTO_BACKFILL_MAX_CURSOR_PAGES = 4;
  * number of page fetches and one toast.
  */
 const ANCHOR_WALK_MAX_PAGES = 8;
+/**
+ * #1307: how often the roster snapshot is re-fetched while the socket believes
+ * an agent in this channel is busy. `staleTime` alone never refetches on its
+ * own, so a terminal 'idle' that never reached this client (socket down when the
+ * runtime died, tab asleep) had nothing to reconcile it — the chip and the
+ * presence row stayed busy for as long as the view stayed mounted. Polling only
+ * while something is busy keeps the idle channel free.
+ */
+const PRESENCE_ROSTER_POLL_MS = 30_000;
 
 interface ChannelViewProps {
   channelId: string;
@@ -488,12 +497,6 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   // binding) OR currently non-idle in the live status store, with a `streaming`
   // fallback derived from the timeline reducer so the header degrades gracefully
   // if the events socket lags.
-  const rosterChipsQuery = useQuery({
-    queryKey: ['channel-roster', channelId],
-    queryFn: () => fetchChannelRoster(channelId),
-    staleTime: 30_000,
-    retry: false,
-  });
   const statusMap = useChannelAgentStatusStore((s) => s.statusByChannelAgent);
   const statusUpdatedAtMap = useChannelAgentStatusStore(
     (s) => s.updatedAtByChannelAgent
@@ -501,6 +504,22 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const queuedCountMap = useChannelAgentStatusStore(
     (s) => s.queuedCountByChannelAgent
   );
+  // #1307: the socket's own claim that something here is busy is exactly the
+  // state that can go stale, so it is what arms the roster poll. Once the roster
+  // (or a live transition) resolves everything back to idle the poll stops.
+  const socketBusyInChannel = useMemo(() => {
+    const prefix = `${channelId} `;
+    return Object.entries(statusMap).some(
+      ([key, status]) => key.startsWith(prefix) && status !== 'idle'
+    );
+  }, [statusMap, channelId]);
+  const rosterChipsQuery = useQuery({
+    queryKey: ['channel-roster', channelId],
+    queryFn: () => fetchChannelRoster(channelId),
+    staleTime: 30_000,
+    retry: false,
+    refetchInterval: socketBusyInChannel ? PRESENCE_ROSTER_POLL_MS : false,
+  });
 
   // On channel switch, drop this channel's per-agent socket statuses so the
   // freshly-fetched roster is authoritative on open; live transitions repopulate
@@ -581,6 +600,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         rosterStatus: entry?.binding?.status,
         rosterUpdatedAt,
         streaming,
+        // Staleness floor (#1307): only a roster that says "nothing is bound"
+        // may retire a busy socket status, so a long live turn keeps its chip.
+        rosterHasLiveBinding: entry?.binding != null,
       });
       // Same lane the status came from (#1308 slice 4 item 2c), so the presence
       // row can never pair a live status with a stale count or the reverse.

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -154,6 +154,16 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
 );
 
 /**
+ * How long a live transition stays admissible as evidence that an agent is still
+ * busy (#1307). Deliberately far longer than any plausible round-trip: this is a
+ * last-resort floor under a socket status whose terminal 'idle' was never
+ * delivered, not a turn timeout. It only ever applies while the roster ALSO says
+ * the agent has no runtime bound, so a genuinely long turn — which keeps a live
+ * binding in the roster for its whole duration — is never hidden by it.
+ */
+export const STALE_AGENT_STATUS_MS = 10 * 60 * 1000;
+
+/**
  * Reconcile a live socket status with a freshly-fetched roster snapshot. The
  * socket carries transition-only events (no replay on `/ws/events` reconnect),
  * so a missed terminal 'idle' would otherwise pin the header chip at
@@ -161,6 +171,11 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
  *   • socket wins ONLY when its last transition is at least as new as the roster
  *     snapshot (a genuine live update the roster hasn't observed yet);
  *   • otherwise the roster snapshot is authoritative (fixes the stuck-busy case);
+ *   • a socket-won busy status older than `STALE_AGENT_STATUS_MS` degrades to
+ *     idle when the roster reports no live binding for the agent — the server
+ *     already broadcasts a terminal idle on every runtime teardown, so this is
+ *     the belt for the one case that broadcast cannot cover: a client that was
+ *     not listening when it fired and whose roster snapshot is older still;
  *   • reducer-derived streaming still upgrades a resolved idle (graceful degrade
  *     when the events socket lags), never downgrades.
  */
@@ -170,18 +185,31 @@ export function resolveEffectiveAgentStatus(input: {
   rosterStatus: ChannelAgentStatus | undefined;
   rosterUpdatedAt: number;
   streaming: boolean;
+  /**
+   * Whether the roster snapshot still shows a runtime bound for this agent.
+   * Omitted means "unknown" and is treated as bound — no caller loses its
+   * status to the staleness floor by accident.
+   */
+  rosterHasLiveBinding?: boolean;
+  /** Injectable clock for the staleness floor (tests). */
+  now?: number;
 }): ChannelAgentStatus {
   const { socketStatus, socketUpdatedAt, rosterStatus, rosterUpdatedAt } =
     input;
-  let status: ChannelAgentStatus;
-  if (
+  const socketWins =
     socketStatus !== undefined &&
     socketUpdatedAt !== undefined &&
-    socketUpdatedAt >= rosterUpdatedAt
+    socketUpdatedAt >= rosterUpdatedAt;
+  let status: ChannelAgentStatus = socketWins
+    ? socketStatus
+    : (rosterStatus ?? 'idle');
+  if (
+    socketWins &&
+    status !== 'idle' &&
+    input.rosterHasLiveBinding === false &&
+    (input.now ?? nowMs()) - socketUpdatedAt >= STALE_AGENT_STATUS_MS
   ) {
-    status = socketStatus;
-  } else {
-    status = rosterStatus ?? 'idle';
+    status = 'idle';
   }
   if (status === 'idle' && input.streaming) status = 'streaming';
   return status;

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -216,6 +216,40 @@ export function resolveEffectiveAgentStatus(input: {
 }
 
 /**
+ * Whether a channel still needs the roster re-fetched to settle its presence
+ * chips (#1307).
+ *
+ * Armed on "the socket can still win", NOT on "the socket says busy": it is the
+ * exact predicate `resolveEffectiveAgentStatus` uses to prefer a socket status
+ * over the roster snapshot (`socketUpdatedAt >= rosterUpdatedAt`, non-idle). So
+ * it self-disarms — the moment a poll lands, every socket transition in the
+ * channel is older than the roster snapshot, the roster becomes authoritative
+ * for all of them, and this returns false. A fresh live transition re-arms it.
+ *
+ * Arming on the raw status alone would poll forever: nothing writes the
+ * reconciled verdict back into the store, so a status the roster has already
+ * superseded stays 'thinking' in `statusByChannelAgent` for the lifetime of the
+ * mounted view.
+ */
+export function shouldPollRosterForPresence(input: {
+  statusByChannelAgent: Record<string, ChannelAgentStatus>;
+  updatedAtByChannelAgent: Record<string, number>;
+  channelId: string;
+  /** The roster query's `dataUpdatedAt` (0 before the first successful fetch). */
+  rosterUpdatedAt: number;
+}): boolean {
+  const prefix = `${input.channelId} `;
+  for (const [key, status] of Object.entries(input.statusByChannelAgent)) {
+    if (!key.startsWith(prefix)) continue;
+    if (status === 'idle') continue;
+    const socketUpdatedAt = input.updatedAtByChannelAgent[key];
+    if (socketUpdatedAt !== undefined && socketUpdatedAt >= input.rosterUpdatedAt)
+      return true;
+  }
+  return false;
+}
+
+/**
  * Same precedence rule as `resolveEffectiveAgentStatus`, applied to the queue
  * depth (#1308 slice 4). Kept as a sibling rather than folded into the status
  * resolver so every existing caller of that function is untouched; both read the

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -93,6 +93,15 @@ const YOLO_PERMISSION_MODE = 'bypassPermissions';
 const QUEUE_CAP = 8;
 /** Force-drain a genuinely-stuck turn after this long (paused while waitingOn != null). */
 const DEFAULT_WATCHDOG_MS = 5 * 60 * 1000;
+/**
+ * Presence liveness sweep (#1307). The watchdog cannot bound a dead runtime: it
+ * is disarmed for as long as `waitingOn !== null` and is never armed at all once
+ * a turn ends, so a binding whose runtime disappeared through a path that never
+ * reached `onRuntimeEnd` would keep broadcasting its last status forever. The
+ * sweep re-derives liveness from the runtime registry instead of trusting the
+ * teardown event to arrive.
+ */
+const DEFAULT_PRESENCE_SWEEP_MS = 30 * 1000;
 /** Consecutive agent-authored routed turns allowed between human/gateway posts. */
 export const MAX_CONSECUTIVE_AGENT_TURNS = 4;
 /** Dedupe identical unavailable/cross-node system rows per (channel, agent). */
@@ -175,6 +184,8 @@ export interface ChannelAgentBinderDeps {
   configDir: string;
   localNodeId?: string;
   watchdogMs?: number;
+  /** Interval of the dead-runtime presence sweep (#1307); tests shorten it. */
+  presenceSweepMs?: number;
   yolo?: boolean;
   now?: () => number;
 }
@@ -379,6 +390,7 @@ export function createChannelAgentBinder(
   const { store, hub, topicStore } = deps;
   const localNodeId = deps.localNodeId ?? DEFAULT_LOCAL_NODE_ID;
   const watchdogMs = deps.watchdogMs ?? DEFAULT_WATCHDOG_MS;
+  const presenceSweepMs = deps.presenceSweepMs ?? DEFAULT_PRESENCE_SWEEP_MS;
   const yolo = deps.yolo ?? CHANNEL_BINDING_YOLO_DEFAULT;
   const now = deps.now ?? (() => Date.now());
 
@@ -407,6 +419,8 @@ export function createChannelAgentBinder(
   const unsubRuntimeEnd = deps.runtimes.onRuntimeEnd((runtimeId) =>
     handleRuntimeEnd(runtimeId)
   );
+  const presenceSweep = setInterval(sweepDeadBindings, presenceSweepMs);
+  presenceSweep.unref?.();
 
   // ── system-row helpers ──────────────────────────────────────────────────────
 
@@ -1394,6 +1408,24 @@ export function createChannelAgentBinder(
     finishTurn(binding);
   }
 
+  /**
+   * Terminal presence for a runtime that died under an open turn (#1307).
+   * Deliberately NOT `finishTurn`: it must also clear a binding whose turn was
+   * already over but whose status never came back (a spawn that never
+   * completed), and it must not `pump` a queued turn into an adapter that is
+   * known to be gone.
+   */
+  function markDeadRuntimeIdle(binding: LiveBinding): void {
+    binding.activeTurnId = null;
+    binding.activeContent = null;
+    binding.activeAttachments = [];
+    binding.waitingOn = null;
+    binding.sawStream = false;
+    binding.announcedApprovals.clear();
+    disarmWatchdog(binding);
+    setStatus(binding, 'idle');
+  }
+
   function finishTurn(binding: LiveBinding): void {
     if (binding.activeTurnId === null) return;
     binding.activeTurnId = null;
@@ -1452,36 +1484,7 @@ export function createChannelAgentBinder(
         }
         break;
       case 'agent-live-state-updated-v2':
-        if (patch.live.status === 'idle') {
-          // A runtime that reports `idle` has no active turn. Finalize ours even
-          // when a matching `agent-turn-completed-v2` never fired (or arrives
-          // after this idle live-state): hermes can emit `session-status idle`
-          // without a paired turn-completed when its turn id was already
-          // cleared, and the `waitingOn` branch below would otherwise flip the
-          // binding back to 'thinking' and wedge presence forever (#1181 defect
-          // 3).
-          //
-          // BUT while an approval is outstanding (or the binding is otherwise
-          // waiting) the idle is a lie: hermes fires `session-status
-          // {status:'idle', waitingOn:'approval'}` alongside a permission
-          // prompt, and the legacy compat mapping strips the `waitingOn` for the
-          // idle case (agent-chat-v1-compat.ts), so a BARE idle arrives
-          // mid-approval. Ignore it entirely then — finalizing would abandon the
-          // approval and let `pump` dispatch a concurrent turn to the same
-          // runtime, and falling through to `updateWaiting(null)` would clobber
-          // the waiting state and re-arm the watchdog against the parked turn.
-          if (
-            binding.activeTurnId !== null &&
-            binding.announcedApprovals.size === 0 &&
-            binding.waitingOn === null
-          ) {
-            finishTurn(binding);
-          }
-          break;
-        }
-        if (patch.live.waitingOn !== undefined) {
-          updateWaiting(binding, patch.live.waitingOn);
-        }
+        handleLiveState(binding, patch.live);
         break;
       case 'agent-turn-completed-v2': {
         // The bridge listener runs first, so any terminally-opened row has
@@ -1558,6 +1561,57 @@ export function createChannelAgentBinder(
         break;
       default:
         break;
+    }
+  }
+
+  function handleLiveState(
+    binding: LiveBinding,
+    live: import('../shared/agent-chat-protocol-v2.js').AgentLiveStateUpdatedPatchV2['live']
+  ): void {
+    if (live.status === 'disconnected') {
+      // The runtime is GONE, not resting (#1307). A `disconnected` live state is
+      // only emitted for an UNEXPECTED transport/process death — every
+      // deliberate teardown detaches its listeners first — so unlike a bare
+      // `idle` this is terminal even mid-approval: a dead process can never
+      // answer the prompt, and leaving the binding parked at 'waiting' pins the
+      // chip and the in-timeline presence row with nothing left to unpin them
+      // (the watchdog is disarmed for exactly that state).
+      //
+      // Presence only. The queue drain, the durable unbind, and the live-map
+      // delete belong to `releaseBinding`, which runs when the runtime's own
+      // teardown lands; pumping a queued turn into a dead adapter here would
+      // just manufacture a send-failure row.
+      markDeadRuntimeIdle(binding);
+      return;
+    }
+    if (live.status === 'idle') {
+      // A runtime that reports `idle` has no active turn. Finalize ours even
+      // when a matching `agent-turn-completed-v2` never fired (or arrives after
+      // this idle live-state): hermes can emit `session-status idle` without a
+      // paired turn-completed when its turn id was already cleared, and the
+      // `waitingOn` branch below would otherwise flip the binding back to
+      // 'thinking' and wedge presence forever (#1181 defect 3).
+      //
+      // BUT while an approval is outstanding (or the binding is otherwise
+      // waiting) the idle is a lie: hermes fires `session-status
+      // {status:'idle', waitingOn:'approval'}` alongside a permission prompt,
+      // and the legacy compat mapping strips the `waitingOn` for the idle case
+      // (agent-chat-v1-compat.ts), so a BARE idle arrives mid-approval. Ignore
+      // it entirely then — finalizing would abandon the approval and let `pump`
+      // dispatch a concurrent turn to the same runtime, and falling through to
+      // `updateWaiting(null)` would clobber the waiting state and re-arm the
+      // watchdog against the parked turn.
+      if (
+        binding.activeTurnId !== null &&
+        binding.announcedApprovals.size === 0 &&
+        binding.waitingOn === null
+      ) {
+        finishTurn(binding);
+      }
+      return;
+    }
+    if (live.waitingOn !== undefined) {
+      updateWaiting(binding, live.waitingOn);
     }
   }
 
@@ -1942,7 +1996,8 @@ export function createChannelAgentBinder(
       // queued behind someone else's live turn) and a no-op once it is being
       // answered.
       if (
-        binding.activeTurnId === channelTurnId(message.id, binding.profileActorId)
+        binding.activeTurnId ===
+        channelTurnId(message.id, binding.profileActorId)
       ) {
         continue;
       }
@@ -1993,44 +2048,93 @@ export function createChannelAgentBinder(
 
   // ── runtime death ───────────────────────────────────────────────────────────
 
+  /**
+   * The ONE teardown for a binding whose runtime is gone (#1307). Every path
+   * that observes a dead runtime — the `onRuntimeEnd` callback and the liveness
+   * sweep — funnels through here, so a runtime can never end without a terminal
+   * `idle` reaching the socket: the header chip and the in-timeline presence row
+   * both render that broadcast, and the watchdog cannot bound them (it is
+   * disarmed while `waitingOn !== null` and unarmed once a turn is over).
+   */
+  function releaseBinding(key: string, binding: LiveBinding): void {
+    binding.unbind?.(); // bridge finalizes any open stream 'interrupted'
+    binding.patchUnlisten?.();
+    disarmWatchdog(binding);
+    for (const queued of binding.queue) {
+      postSystemRow(
+        binding.channelId,
+        `@${binding.displayName} runtime ended before delivering a queued message.`,
+        { parentMessageId: parentForTrigger(queued.trigger) }
+      );
+    }
+    binding.queue = [];
+    binding.adapter = null;
+    binding.unbind = null;
+    binding.patchUnlisten = null;
+    binding.activeTurnId = null;
+    binding.parentMessageIdByTurn.clear();
+    binding.activeContent = null;
+    binding.activeAttachments = [];
+    binding.waitingOn = null;
+    binding.sawStream = false;
+    binding.announcedApprovals.clear();
+    setStatus(binding, 'idle');
+    // The binding may already have BEEN idle, so the dropped queue needs its
+    // own emit — otherwise the chip keeps a count for a dead runtime.
+    emitAgentStatus(binding);
+    live.delete(key);
+    try {
+      store.upsertBinding({
+        channelId: binding.channelId,
+        profileActorId: binding.profileActorId,
+        agentFramework: binding.framework,
+        runtimeId: null,
+      });
+    } catch (err) {
+      logger.warn('channel binder unbind persist failed:', err);
+    }
+  }
+
   function handleRuntimeEnd(runtimeId: string): void {
     for (const [key, binding] of live) {
       if (binding.runtimeId !== runtimeId) continue;
-      binding.unbind?.(); // bridge finalizes any open stream 'interrupted'
-      binding.patchUnlisten?.();
-      disarmWatchdog(binding);
-      for (const queued of binding.queue) {
-        postSystemRow(
-          binding.channelId,
-          `@${binding.displayName} runtime ended before delivering a queued message.`,
-          { parentMessageId: parentForTrigger(queued.trigger) }
-        );
+      releaseBinding(key, binding);
+    }
+  }
+
+  /**
+   * Dead-runtime sweep (#1307). `onRuntimeEnd` fires from exactly one place — an
+   * explicit `runtimes.destroy` — and its handlers are invoked best-effort, so a
+   * runtime that goes away any other way (a release that threw halfway, a
+   * manager shutdown, a teardown path added later) leaves this binding pinned at
+   * whatever it was doing when it died. Liveness is therefore re-derived from
+   * the runtime registry on a timer rather than trusted to an event.
+   */
+  function sweepDeadBindings(): void {
+    if (closed) return;
+    for (const [key, binding] of live) {
+      if (binding.runtimeId === null) continue;
+      // A (re)bind in flight owns this entry: `doEnsureBinding` keeps the old
+      // runtime id on the provisional binding while it awaits a spawn, and
+      // `attachRuntime` is about to overwrite it. Releasing here would delete a
+      // binding that is being rebuilt.
+      if (inflight.has(key)) continue;
+      if (
+        healthyRuntime(
+          binding.runtimeId,
+          binding.framework,
+          binding.profileActorId
+        )
+      ) {
+        continue;
       }
-      binding.queue = [];
-      binding.adapter = null;
-      binding.unbind = null;
-      binding.patchUnlisten = null;
-      binding.activeTurnId = null;
-      binding.parentMessageIdByTurn.clear();
-      binding.activeContent = null;
-      binding.activeAttachments = [];
-      binding.waitingOn = null;
-      binding.announcedApprovals.clear();
-      setStatus(binding, 'idle');
-      // The binding may already have BEEN idle, so the dropped queue needs its
-      // own emit — otherwise the chip keeps a count for a dead runtime.
-      emitAgentStatus(binding);
-      live.delete(key);
-      try {
-        store.upsertBinding({
-          channelId: binding.channelId,
-          profileActorId: binding.profileActorId,
-          agentFramework: binding.framework,
-          runtimeId: null,
-        });
-      } catch (err) {
-        logger.warn('channel binder unbind persist failed:', err);
-      }
+      logger.warn('channel binder released a binding with no live runtime', {
+        channelId: binding.channelId,
+        profileActorId: binding.profileActorId,
+        runtimeId: binding.runtimeId,
+        status: binding.status,
+      });
+      releaseBinding(key, binding);
     }
   }
 
@@ -2256,12 +2360,27 @@ export function createChannelAgentBinder(
     },
     close() {
       closed = true;
+      clearInterval(presenceSweep);
       unsubRuntimeEnd();
       for (const binding of live.values()) {
         disarmWatchdog(binding);
         binding.unbind?.();
         binding.patchUnlisten?.();
         binding.parentMessageIdByTurn.clear();
+        // Terminal presence on shutdown (#1307). The socket carries transitions
+        // only, so a binding torn down mid-turn would leave every attached
+        // client pinned at thinking/streaming/waiting until something else made
+        // it refetch a roster. Broadcast is best-effort: the transport may
+        // already be closing, and that must not abort the rest of shutdown.
+        binding.queue = [];
+        binding.activeTurnId = null;
+        binding.waitingOn = null;
+        binding.status = 'idle';
+        try {
+          emitAgentStatus(binding);
+        } catch (err) {
+          logger.warn('channel binder shutdown status broadcast failed:', err);
+        }
       }
       live.clear();
       inflight.clear();

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -38,7 +38,12 @@ import {
   type ChannelMessage,
   type ChannelPostSteering,
 } from '../shared/channel-chat-protocol.js';
-import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
+import type {
+  AgentApprovalDecisionV2,
+  AgentApprovalItemV2,
+  AgentLiveStateUpdatedPatchV2,
+  AgentPatchV2,
+} from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
 import { isDmChannel } from '../shared/dm-channels.js';
 import { workspaceTopicAgentRuntimeLinkPatch } from '../shared/workspace-topics.js';
@@ -94,12 +99,15 @@ const QUEUE_CAP = 8;
 /** Force-drain a genuinely-stuck turn after this long (paused while waitingOn != null). */
 const DEFAULT_WATCHDOG_MS = 5 * 60 * 1000;
 /**
- * Presence liveness sweep (#1307). The watchdog cannot bound a dead runtime: it
- * is disarmed for as long as `waitingOn !== null` and is never armed at all once
- * a turn ends, so a binding whose runtime disappeared through a path that never
- * reached `onRuntimeEnd` would keep broadcasting its last status forever. The
- * sweep re-derives liveness from the runtime registry instead of trusting the
- * teardown event to arrive.
+ * Presence liveness sweep (#1307). `onRuntimeEnd` is the binder's ONLY teardown
+ * signal and it fires from exactly one place — an explicit `runtimes.destroy` —
+ * with best-effort, individually try/caught handlers. A runtime that leaves the
+ * registry any other way therefore leaves this binding holding a dead adapter:
+ * `healthyRuntime` keeps saying yes, every rebind reuses the corpse, and the
+ * binding never returns to idle. The watchdog cannot bound that (it is disarmed
+ * for as long as `waitingOn !== null` and is never armed at all once a turn
+ * ends), so liveness is re-derived from the runtime registry on a timer rather
+ * than trusted to an event.
  */
 const DEFAULT_PRESENCE_SWEEP_MS = 30 * 1000;
 /** Consecutive agent-authored routed turns allowed between human/gateway posts. */
@@ -1409,11 +1417,32 @@ export function createChannelAgentBinder(
   }
 
   /**
+   * Drop every trigger waiting on a binding whose runtime is gone (#1307), with
+   * one system row each so the operator sees exactly which posts never ran. The
+   * caller broadcasts afterwards: the queue depth rides the same
+   * `channel-agent-status` event as the status, so it must be empty BEFORE the
+   * terminal idle goes out or the queued-send chips stay lit against an agent
+   * that is idle and unbound.
+   */
+  function dropQueuedTurns(binding: LiveBinding): void {
+    for (const queued of binding.queue) {
+      postSystemRow(
+        binding.channelId,
+        `@${binding.displayName} runtime ended before delivering a queued message.`,
+        { parentMessageId: parentForTrigger(queued.trigger) }
+      );
+    }
+    binding.queue = [];
+  }
+
+  /**
    * Terminal presence for a runtime that died under an open turn (#1307).
    * Deliberately NOT `finishTurn`: it must also clear a binding whose turn was
    * already over but whose status never came back (a spawn that never
    * completed), and it must not `pump` a queued turn into an adapter that is
-   * known to be gone.
+   * known to be gone — those triggers are dropped here instead, so the single
+   * idle broadcast carries `queuedCount: 0` and bumps the drain generation the
+   * queued-send chips key off (#1308 slice 4).
    */
   function markDeadRuntimeIdle(binding: LiveBinding): void {
     binding.activeTurnId = null;
@@ -1423,7 +1452,11 @@ export function createChannelAgentBinder(
     binding.sawStream = false;
     binding.announcedApprovals.clear();
     disarmWatchdog(binding);
+    dropQueuedTurns(binding);
     setStatus(binding, 'idle');
+    // The binding may already have BEEN idle (a spawn that never completed), so
+    // the dropped queue needs its own emit — `setStatus` dedupes on status.
+    emitAgentStatus(binding);
   }
 
   function finishTurn(binding: LiveBinding): void {
@@ -1447,7 +1480,7 @@ export function createChannelAgentBinder(
 
   function handleBindingPatch(
     binding: LiveBinding,
-    patch: import('../shared/agent-chat-protocol-v2.js').AgentPatchV2
+    patch: AgentPatchV2
   ): void {
     switch (patch.type) {
       case 'agent-session-updated-v2':
@@ -1566,21 +1599,28 @@ export function createChannelAgentBinder(
 
   function handleLiveState(
     binding: LiveBinding,
-    live: import('../shared/agent-chat-protocol-v2.js').AgentLiveStateUpdatedPatchV2['live']
+    live: AgentLiveStateUpdatedPatchV2['live']
   ): void {
     if (live.status === 'disconnected') {
-      // The runtime is GONE, not resting (#1307). A `disconnected` live state is
-      // only emitted for an UNEXPECTED transport/process death — every
-      // deliberate teardown detaches its listeners first — so unlike a bare
-      // `idle` this is terminal even mid-approval: a dead process can never
-      // answer the prompt, and leaving the binding parked at 'waiting' pins the
-      // chip and the in-timeline presence row with nothing left to unpin them
-      // (the watchdog is disarmed for exactly that state).
+      // The runtime is GONE, not resting (#1307). This branch is reached only on
+      // an UNEXPECTED transport/process death: codex-native emits it when its
+      // client closes on its own, a deliberate `disconnect()` tears down state
+      // without re-emitting, and the legacy v1 compat maps its `disconnected`
+      // session-status to `idle` (agent-chat-v1-compat.ts). A dead process can
+      // never answer an approval prompt or finish its turn, so this is terminal
+      // even mid-approval — the one thing a bare `idle` must never be.
       //
-      // Presence only. The queue drain, the durable unbind, and the live-map
-      // delete belong to `releaseBinding`, which runs when the runtime's own
-      // teardown lands; pumping a queued turn into a dead adapter here would
-      // just manufacture a send-failure row.
+      // Before this branch existed the patch fell through to the `waitingOn`
+      // handling below (codex carries an explicit `waitingOn: null`), which was
+      // wrong in both directions: mid-approval it flipped 'waiting' → 'thinking'
+      // and RE-ARMED the watchdog, so five minutes later the watchdog
+      // force-drained the turn — abandoning the approval and pumping a queued
+      // turn into the dead adapter for a guaranteed send-failure row — and with
+      // no active turn it did nothing at all.
+      //
+      // Presence and the queue only. The durable unbind and the live-map delete
+      // belong to `releaseBinding`, which runs when the runtime's own teardown
+      // lands (or when the sweep notices it never did).
       markDeadRuntimeIdle(binding);
       return;
     }
@@ -1629,7 +1669,7 @@ export function createChannelAgentBinder(
 
   function handleApprovalStarted(
     binding: LiveBinding,
-    item: import('../shared/agent-chat-protocol-v2.js').AgentApprovalItemV2
+    item: AgentApprovalItemV2
   ): void {
     if (binding.announcedApprovals.has(item.requestId)) return;
     binding.announcedApprovals.add(item.requestId);
@@ -1652,7 +1692,7 @@ export function createChannelAgentBinder(
 
   function handleApprovalResolved(
     binding: LiveBinding,
-    item: import('../shared/agent-chat-protocol-v2.js').AgentApprovalItemV2
+    item: AgentApprovalItemV2
   ): void {
     if (!binding.announcedApprovals.has(item.requestId)) return;
     binding.announcedApprovals.delete(item.requestId);
@@ -2060,14 +2100,9 @@ export function createChannelAgentBinder(
     binding.unbind?.(); // bridge finalizes any open stream 'interrupted'
     binding.patchUnlisten?.();
     disarmWatchdog(binding);
-    for (const queued of binding.queue) {
-      postSystemRow(
-        binding.channelId,
-        `@${binding.displayName} runtime ended before delivering a queued message.`,
-        { parentMessageId: parentForTrigger(queued.trigger) }
-      );
-    }
-    binding.queue = [];
+    // No-op when `markDeadRuntimeIdle` already drained on the `disconnected`
+    // patch, so a death that fires both paths posts one row per trigger.
+    dropQueuedTurns(binding);
     binding.adapter = null;
     binding.unbind = null;
     binding.patchUnlisten = null;

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -345,6 +345,31 @@ export class ChannelAgentRuntimeManager {
         };
       }
       runtime.lastActivity = new Date().toISOString();
+      if (
+        patch.type === 'agent-live-state-updated-v2' &&
+        patch.live.status === 'disconnected'
+      ) {
+        // Unexpected process/transport death (#1307). Adapters emit this only
+        // when the child went away on its own — a deliberate `disconnect()`
+        // detaches first — and none of them respawn on the next send, so the
+        // runtime is dead, not resting. Ending it here is what turns a silent
+        // death into the terminal `onRuntimeEnd` notification the channel binder
+        // needs to release its binding and broadcast idle presence; without it
+        // the runtime stays 'active' in this registry forever.
+        //
+        // This runs BEFORE `nextAgentState` (#1254) deliberately: that reducer
+        // maps `disconnected` onto `idle` — and drops it entirely while the
+        // machine is parked on an operator prompt — which is the right reading
+        // for a live runtime but would leave a dead one wedged.
+        logger.warn('channel runtime reported disconnected; ending it', {
+          runtimeId: id,
+          providerId: runtime.providerId,
+        });
+        runtime.agentState = 'error';
+        runtime.idle = true;
+        void this.destroy(id);
+        return;
+      }
       const next = nextAgentState(runtime.agentState, patch);
       if (next) {
         runtime.agentState = next;

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -410,9 +410,20 @@ export class ChannelAgentRuntimeManager {
       if (savedResumeId && adapter.capabilities.resume) {
         await adapter.resumeSession(savedResumeId);
       }
-      // Promote out of `initializing` only. Adapters emit patches from inside
-      // `connect()`/`resumeSession()` (codex emits its snapshot and live state
-      // before `connect` resolves), so the listener above can already have
+      // The child can die INSIDE those awaits (#1307). Adapters flip to
+      // 'connected' partway through connect/resume, so the disconnect listener
+      // above is live and may already have ended this runtime — dropping it from
+      // the registry and disconnecting its adapter. Returning it anyway would
+      // hand the caller a corpse: the channel binder would attach a bridge to a
+      // dead adapter and persist `runtimeId` durably for a runtime that no
+      // longer exists. Fail instead, so the caller's normal spawn-failure path
+      // runs.
+      if (this.runtimes.get(id) !== runtime) {
+        throw new Error('Channel agent runtime died during connect');
+      }
+      // Promote out of `initializing` only (#1254). Adapters emit patches from
+      // inside `connect()`/`resumeSession()` (codex emits its snapshot and live
+      // state before `connect` resolves), so the listener above can already have
       // recorded a live turn — stamping `idle` unconditionally here erased it.
       if (runtime.agentState === 'initializing') {
         runtime.agentState = 'idle';

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -672,6 +672,89 @@ class DeferredAdapter extends BaseProtocolAdapterV2 {
   }
 }
 
+// ── parked-on-approval adapter (#1307) ───────────────────────────────────────
+// Opens a turn and parks it on an approval, which is the ONE state the watchdog
+// deliberately refuses to force-drain (draining it would abandon the approval).
+// Presence therefore has no timer under it: if the runtime dies here without a
+// terminal transition, the header chip and the in-timeline presence row stay
+// busy forever. `die()` models the unexpected process/transport death an adapter
+// reports as a `disconnected` live state; the runtime can also be made to vanish
+// from the registry with no notification at all (`forgetWithoutEnd`).
+class ParkedOnApprovalAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    streaming: true,
+    interrupt: true,
+  };
+  readonly sendCalls: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'parked';
+
+  constructor(readonly agentType: string) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(_i: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(_i: AgentApprovalResponseInputV2): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.sendCalls.push(input.turnId);
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `user-${input.turnId}`,
+        items: [],
+        startedAt: 't',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: {
+        status: 'waiting',
+        activeTurnId: input.turnId,
+        waitingOn: 'approval',
+        error: null,
+      },
+    });
+  }
+
+  /** Unexpected process death, as codex reports it when its client closes. */
+  die(): void {
+    this._status = 'disconnected';
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: {
+        status: 'disconnected',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        queueLength: 0,
+      },
+    });
+  }
+}
+
 // ── idle-without-turn-completed adapter (#1181 defect 3) ─────────────────────
 // Emits `working` then a trailing `idle` live-state but NO agent-turn-completed-v2
 // (and no assistant item) — the shape a hermes turn produces when it signals
@@ -1035,6 +1118,7 @@ function makeBinder(cfg: {
   knownProviderIds: string[];
   topicStore?: WorkspaceTopicStore | null;
   watchdogMs?: number;
+  presenceSweepMs?: number;
   throwOnCreate?: boolean;
   yolo?: boolean;
   gate?: Promise<void>;
@@ -1065,6 +1149,9 @@ function makeBinder(cfg: {
     port: 0,
     configDir: '/tmp',
     ...(cfg.watchdogMs !== undefined ? { watchdogMs: cfg.watchdogMs } : {}),
+    ...(cfg.presenceSweepMs !== undefined
+      ? { presenceSweepMs: cfg.presenceSweepMs }
+      : {}),
     ...(cfg.yolo !== undefined ? { yolo: cfg.yolo } : {}),
   });
   cleanup.push(() => binder.close());
@@ -4372,5 +4459,116 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
     // thread the operator was actually working in.
     expect(failure.threadId).toBe(root.id);
     expect(failure.parentMessageId).toBe(steer.id);
+  });
+});
+
+// ── presence teardown (#1307) ────────────────────────────────────────────────
+// A runtime that dies without a terminal transition used to pin channel-agent
+// presence at thinking/streaming/waiting: the header chip AND the in-timeline
+// presence row render the same broadcast, and the watchdog cannot bound the
+// worst case (it is disarmed for as long as `waitingOn !== null`). Every
+// teardown path must therefore end in an `idle` broadcast of its own.
+
+const PARKED_TARGETS: MentionTarget[] = [
+  {
+    id: 'parked',
+    displayName: 'Parked',
+    kind: 'framework',
+    available: true,
+    reason: null,
+  },
+];
+
+function makeParkedBinder(cfg: { presenceSweepMs?: number } = {}) {
+  const harness = makeBinder({
+    build: (agentType) => new ParkedOnApprovalAdapter(agentType),
+    targets: PARKED_TARGETS,
+    knownProviderIds: ['parked'],
+    ...(cfg.presenceSweepMs !== undefined
+      ? { presenceSweepMs: cfg.presenceSweepMs }
+      : {}),
+  });
+  const events: Array<Record<string, unknown>> = [];
+  const statuses: string[] = [];
+  harness.binder.setStatusBroadcaster((_type, data) => {
+    if (data['agentId'] === builtInAgentProfileId('parked')) {
+      events.push(data);
+      statuses.push(String(data['status']));
+    }
+  });
+  return { ...harness, events, statuses };
+}
+
+async function parkedOnApproval(
+  harness: ReturnType<typeof makeParkedBinder>
+): Promise<ParkedOnApprovalAdapter> {
+  await waitFor(() => harness.sessions.spawns() === 1);
+  const adapter = harness.sessions.adapterFor(
+    harness.sessions.firstSessionId()
+  ) as ParkedOnApprovalAdapter;
+  await waitFor(() => adapter.sendCalls.length === 1);
+  await waitFor(() => harness.statuses.at(-1) === 'waiting');
+  return adapter;
+}
+
+describe('channel-agent-binder — presence teardown (#1307)', () => {
+  it('broadcasts a terminal idle when the runtime dies under a turn parked on approval', async () => {
+    const harness = makeParkedBinder();
+    const { binder, store, statuses } = harness;
+    post(store, binder, '@parked go', ['parked']);
+    const adapter = await parkedOnApproval(harness);
+
+    // The watchdog is explicitly disarmed in this state, so nothing else can
+    // ever move this binding off 'waiting'.
+    adapter.die();
+    await waitFor(() => statuses.at(-1) === 'idle');
+    expect(statuses).toContain('waiting');
+    expect(statuses.at(-1)).toBe('idle');
+  });
+
+  it('sweeps a binding whose runtime vanished with no end event to idle, drains its queue, and durably unbinds', async () => {
+    const harness = makeParkedBinder({ presenceSweepMs: 10 });
+    const { binder, store, sessions, events, statuses } = harness;
+    post(store, binder, '@parked one', ['parked']);
+    await parkedOnApproval(harness);
+    post(store, binder, '@parked two', ['parked']);
+    await waitFor(() => events.at(-1)?.['queuedCount'] === 1);
+
+    // The runtime disappears WITHOUT `onRuntimeEnd` ever firing — a release that
+    // threw halfway, a manager torn down out from under the binder, any teardown
+    // path that never reaches the one event the binder subscribes to.
+    sessions.forgetWithoutEnd(sessions.firstSessionId());
+
+    await waitFor(() => statuses.at(-1) === 'idle');
+    expect(events.at(-1)?.['queuedCount']).toBe(0);
+    expect(
+      store.getBinding(CH, builtInAgentProfileId('parked'))?.runtimeId
+    ).toBeNull();
+    const ended = systemRows(store).filter((row) =>
+      row.body.text.includes('runtime ended before delivering a queued message')
+    );
+    expect(ended).toHaveLength(1);
+    // Nothing re-routes on its own: a swept binding stays down until the next
+    // mention, so the operator never gets a silent respawn they did not ask for.
+    expect(sessions.spawns()).toBe(1);
+  });
+
+  it('leaves a live runtime alone: the sweep never retires a binding that is genuinely waiting', async () => {
+    const harness = makeParkedBinder({ presenceSweepMs: 5 });
+    const { binder, store, statuses } = harness;
+    post(store, binder, '@parked go', ['parked']);
+    await parkedOnApproval(harness);
+    // Many sweep ticks with the runtime still registered and healthy.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(statuses.at(-1)).toBe('waiting');
+  });
+
+  it('broadcasts a terminal idle for a busy binding on shutdown', async () => {
+    const harness = makeParkedBinder();
+    const { binder, store, statuses } = harness;
+    post(store, binder, '@parked go', ['parked']);
+    await parkedOnApproval(harness);
+    binder.close();
+    expect(statuses.at(-1)).toBe('idle');
   });
 });

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -4526,6 +4526,31 @@ describe('channel-agent-binder — presence teardown (#1307)', () => {
     expect(statuses.at(-1)).toBe('idle');
   });
 
+  it('drops the queue on the same broadcast as the terminal idle, so no chip stays lit against a dead runtime', async () => {
+    // `onRuntimeEnd` never fires here (the death is the adapter's own report),
+    // so this covers the window BEFORE `releaseBinding` — up to a whole sweep
+    // interval when the teardown event never arrives at all. An idle broadcast
+    // carrying `queuedCount > 0` would leave the #1308 queued-send chips lit
+    // with nothing left to drain them.
+    const harness = makeParkedBinder();
+    const { binder, store, events, statuses } = harness;
+    post(store, binder, '@parked one', ['parked']);
+    const adapter = await parkedOnApproval(harness);
+    post(store, binder, '@parked two', ['parked']);
+    await waitFor(() => events.at(-1)?.['queuedCount'] === 1);
+
+    adapter.die();
+    await waitFor(() => statuses.at(-1) === 'idle');
+    expect(events.at(-1)?.['queuedCount']).toBe(0);
+    // One row per dropped trigger, and nothing was pumped into the dead adapter.
+    expect(
+      systemRows(store).filter((row) =>
+        row.body.text.includes('runtime ended before delivering a queued message')
+      )
+    ).toHaveLength(1);
+    expect(adapter.sendCalls).toHaveLength(1);
+  });
+
   it('sweeps a binding whose runtime vanished with no end event to idle, drains its queue, and durably unbinds', async () => {
     const harness = makeParkedBinder({ presenceSweepMs: 10 });
     const { binder, store, sessions, events, statuses } = harness;

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -118,6 +118,23 @@ class TestAdapter implements ProtocolAdapterV2 {
       completedAt: '2026-07-26T00:00:00.000Z',
     });
   }
+  /** Unexpected process/transport death (#1307). */
+  emitDisconnected(): void {
+    for (const handler of [...this.handlers]) {
+      handler({
+        type: 'agent-live-state-updated-v2',
+        sessionId: 'channel-runtime',
+        timestamp: '2026-07-26T00:00:00.000Z',
+        live: {
+          status: 'disconnected',
+          activeTurnId: null,
+          waitingOn: null,
+          activeRequestIds: [],
+          queueLength: 0,
+        },
+      });
+    }
+  }
 }
 
 vi.mock('../server/protocol-adapters/index.js', () => ({
@@ -535,6 +552,32 @@ describe('ChannelAgentRuntimeManager', () => {
     expect(channelAgentRuntimes.get(runtime.id)).toBeUndefined();
     offThrowing();
     offHealthy();
+  });
+
+  it('ends a runtime whose adapter reports an unexpected disconnect (#1307)', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+    });
+    const ended: string[] = [];
+    const off = channelAgentRuntimes.onRuntimeEnd((id) => ended.push(id));
+
+    // No `destroy` call anywhere: the child died on its own. Without this the
+    // runtime stays 'active' in the registry forever and the channel binder —
+    // whose ONLY teardown signal is `onRuntimeEnd` — keeps broadcasting the
+    // status the agent had when it died.
+    adapterState.last!.emitDisconnected();
+    await vi.waitFor(() => expect(ended).toEqual([runtime.id]));
+
+    expect(channelAgentRuntimes.get(runtime.id)).toBeUndefined();
+    expect(runtime.status).toBe('disconnected');
+    off();
   });
 
   it('closes every runtime when one adapter disconnect rejects', async () => {

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -20,6 +20,8 @@ const adapterState = vi.hoisted(() => ({
   all: [] as TestAdapter[],
   /** Runs inside `connect()`, before it resolves. */
   onConnect: null as ((adapter: TestAdapter) => void) | null,
+  /** Make the next adapter report its child dying from inside `connect` (#1307). */
+  dieDuringConnect: false,
 }));
 
 class TestAdapter implements ProtocolAdapterV2 {
@@ -39,9 +41,15 @@ class TestAdapter implements ProtocolAdapterV2 {
   sessionId = 'channel-runtime';
 
   async connect(config: AdapterConfig): Promise<void> {
+    // Real adapters flip to 'connected' partway through their own connect, so
+    // the manager's disconnect listener is already live when the child dies.
     this.status = 'connected';
     this.sessionId = config.sessionId;
     adapterState.onConnect?.(this);
+    if (adapterState.dieDuringConnect) {
+      await Promise.resolve();
+      this.emitDisconnected();
+    }
   }
   async disconnect(): Promise<void> {
     this.status = 'disconnected';
@@ -156,6 +164,7 @@ afterEach(async () => {
   adapterState.last = null;
   adapterState.all.length = 0;
   adapterState.onConnect = null;
+  adapterState.dieDuringConnect = false;
 });
 
 describe('ChannelAgentRuntimeManager agentState (#1254)', () => {
@@ -578,6 +587,30 @@ describe('ChannelAgentRuntimeManager', () => {
     expect(channelAgentRuntimes.get(runtime.id)).toBeUndefined();
     expect(runtime.status).toBe('disconnected');
     off();
+  });
+
+  it('rejects instead of returning a runtime the disconnect listener already ended (#1307)', async () => {
+    // The death lands INSIDE `create`'s own connect await, so the listener
+    // installed above has already destroyed this runtime by the time connect
+    // resolves. Returning it anyway would hand the channel binder a corpse: it
+    // would attach its bridge to the disconnected adapter and persist
+    // `runtimeId` durably for a runtime that is no longer in the registry.
+    const { channelAgentRuntimes } = await runtimeModule();
+    adapterState.dieDuringConnect = true;
+
+    await expect(
+      channelAgentRuntimes.create({
+        id: 'channel-runtime',
+        providerId: 'codex',
+        profileActorId: 'agent-profile:codex:default',
+        cwd: '/tmp',
+        displayName: '#eng · Codex',
+        port: 3456,
+        configDir: '/tmp',
+      })
+    ).rejects.toThrow(/died during connect/);
+
+    expect(channelAgentRuntimes.get('channel-runtime')).toBeUndefined();
   });
 
   it('closes every runtime when one adapter disconnect rejects', async () => {

--- a/test/channel-agent-status-reconcile.test.ts
+++ b/test/channel-agent-status-reconcile.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   channelAgentStatusKey,
   resolveEffectiveAgentStatus,
+  STALE_AGENT_STATUS_MS,
   useChannelAgentStatusStore,
 } from '../frontend/src/lib/stores/channel-agent-status.js';
 
@@ -71,6 +72,57 @@ describe('resolveEffectiveAgentStatus', () => {
         streaming: false,
       })
     ).toBe('idle');
+  });
+
+  // #1307 staleness floor. The server broadcasts a terminal idle on every
+  // runtime teardown, but a client that was not listening when it fired keeps a
+  // busy status the socket will never correct — and while that status stays
+  // newer than the roster snapshot it wins the tie-break forever.
+  it('retires a socket-won busy status older than the floor once the roster shows no live binding', () => {
+    const socketUpdatedAt = 1_000_000;
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'thinking',
+        socketUpdatedAt,
+        rosterStatus: undefined,
+        rosterUpdatedAt: socketUpdatedAt - 1,
+        streaming: false,
+        rosterHasLiveBinding: false,
+        now: socketUpdatedAt + STALE_AGENT_STATUS_MS,
+      })
+    ).toBe('idle');
+  });
+
+  it('keeps a busy status while the roster still shows a live binding, however old the transition', () => {
+    // The long-turn guard: an agent that has been thinking for an hour is still
+    // bound, and its chip must not blink out from under the operator.
+    const socketUpdatedAt = 1_000_000;
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'thinking',
+        socketUpdatedAt,
+        rosterStatus: 'thinking',
+        rosterUpdatedAt: socketUpdatedAt - 1,
+        streaming: false,
+        rosterHasLiveBinding: true,
+        now: socketUpdatedAt + STALE_AGENT_STATUS_MS * 6,
+      })
+    ).toBe('thinking');
+  });
+
+  it('keeps a busy status that is younger than the floor even when nothing is bound', () => {
+    const socketUpdatedAt = 1_000_000;
+    expect(
+      resolveEffectiveAgentStatus({
+        socketStatus: 'streaming',
+        socketUpdatedAt,
+        rosterStatus: undefined,
+        rosterUpdatedAt: socketUpdatedAt - 1,
+        streaming: false,
+        rosterHasLiveBinding: false,
+        now: socketUpdatedAt + STALE_AGENT_STATUS_MS - 1,
+      })
+    ).toBe('streaming');
   });
 
   it('reducer-derived streaming upgrades a resolved idle but never downgrades a live status', () => {

--- a/test/channel-agent-status-reconcile.test.ts
+++ b/test/channel-agent-status-reconcile.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   channelAgentStatusKey,
   resolveEffectiveAgentStatus,
+  shouldPollRosterForPresence,
   STALE_AGENT_STATUS_MS,
   useChannelAgentStatusStore,
 } from '../frontend/src/lib/stores/channel-agent-status.js';
@@ -183,5 +184,75 @@ describe('useChannelAgentStatusStore — timestamped reconciliation state', () =
     // The other channel is untouched.
     expect(state.statusByChannelAgent[c2]).toBe('thinking');
     expect(state.updatedAtByChannelAgent[c2]).toBeGreaterThan(0);
+  });
+});
+
+// #1307 roster poll arming. `staleTime` alone never refetches, so a busy socket
+// status whose terminal 'idle' never arrived had nothing to reconcile it while
+// the view stayed mounted. The poll must arm on that case AND disarm itself once
+// a snapshot has landed — nothing writes the reconciled verdict back into the
+// store, so arming on the raw status alone would poll every open channel view
+// forever.
+describe('shouldPollRosterForPresence', () => {
+  const CH = 'chan-1';
+  const key = channelAgentStatusKey(CH, 'mock');
+
+  it('arms while a busy socket status is still newer than the roster snapshot', () => {
+    expect(
+      shouldPollRosterForPresence({
+        statusByChannelAgent: { [key]: 'thinking' },
+        updatedAtByChannelAgent: { [key]: 5_000 },
+        channelId: CH,
+        rosterUpdatedAt: 4_000,
+      })
+    ).toBe(true);
+  });
+
+  it('disarms once a poll lands: the fresh snapshot outranks the socket transition', () => {
+    // Arm → poll → disarm, driven only by `dataUpdatedAt` advancing past the
+    // socket's last transition. This is the exact tie-break the resolver uses,
+    // so the moment the poll stops the roster is already authoritative for the
+    // chip: the status it renders can no longer come from the stale socket entry.
+    const armed = {
+      statusByChannelAgent: { [key]: 'thinking' as const },
+      updatedAtByChannelAgent: { [key]: 5_000 },
+      channelId: CH,
+      rosterUpdatedAt: 4_000,
+    };
+    expect(shouldPollRosterForPresence(armed)).toBe(true);
+    expect(
+      shouldPollRosterForPresence({ ...armed, rosterUpdatedAt: 5_001 })
+    ).toBe(false);
+    // A fresh live transition re-arms it.
+    expect(
+      shouldPollRosterForPresence({
+        ...armed,
+        updatedAtByChannelAgent: { [key]: 6_000 },
+        rosterUpdatedAt: 5_001,
+      })
+    ).toBe(true);
+  });
+
+  it('stays disarmed for an idle channel and ignores other channels', () => {
+    expect(
+      shouldPollRosterForPresence({
+        statusByChannelAgent: { [key]: 'idle' },
+        updatedAtByChannelAgent: { [key]: 9_000 },
+        channelId: CH,
+        rosterUpdatedAt: 1_000,
+      })
+    ).toBe(false);
+    expect(
+      shouldPollRosterForPresence({
+        statusByChannelAgent: {
+          [channelAgentStatusKey('other', 'mock')]: 'thinking',
+        },
+        updatedAtByChannelAgent: {
+          [channelAgentStatusKey('other', 'mock')]: 9_000,
+        },
+        channelId: CH,
+        rosterUpdatedAt: 1_000,
+      })
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Defect

A channel agent's presence could stick on "thinking" / "streaming" / "waiting"
forever. The header chip and — since #1277 — the in-timeline presence row both
render the same `channel-agent-status` broadcast, and that broadcast carries
transitions only. If a runtime died without emitting a terminal transition,
nothing ever moved the binding off its last status.

The watchdog cannot bound the worst case by design: it is disarmed for as long
as `waitingOn !== null` (force-draining a turn parked on an approval would
abandon the approval) and it is never armed at all once a turn is over. A turn
parked on an approval whose process then died therefore had no timer under it.

## Root cause

`handleRuntimeEnd` already broadcast a terminal idle, but it is reachable only
from an explicit `runtimes.destroy` — and nothing called that when a child
process died on its own. The runtime stayed `status: 'active'` in the registry
forever, so `healthyRuntime` kept saying yes and every subsequent rebind reused
the dead adapter: the binding was wedged on a corpse with no path back to idle.

Separately, codex-native's `disconnected` live state carries an explicit
`waitingOn: null`, so it fell through to `updateWaiting(binding, null)`. Mid-
approval that flipped `waiting` → `thinking` and re-armed the watchdog, which
five minutes later force-drained the turn — abandoning the approval and pumping
a queued turn into the dead adapter for a guaranteed send-failure row.

On the client, `resolveEffectiveAgentStatus` already lets a fresher roster
snapshot win, but `staleTime` alone never refetches, so a client that was not
listening when a terminal idle fired had nothing to reconcile it with.

## Fix

Server — every teardown path ends in a terminal idle:

- `ChannelAgentRuntimeManager` ends a runtime whose adapter reports a
  `disconnected` live state, turning a silent death into the `onRuntimeEnd` the
  binder subscribes to. `create()` re-checks registry ownership after its
  connect/resume awaits so a child that dies inside that window fails the spawn
  instead of handing the binder a runtime that has already been destroyed.
- The binder treats `disconnected` as terminal even mid-approval (a dead process
  can never answer the prompt) and drops the triggers queued behind it, so the
  single idle broadcast carries `queuedCount: 0`.
- `handleRuntimeEnd`'s body is extracted to `releaseBinding`, and a periodic
  liveness sweep re-derives liveness from the runtime registry — a runtime that
  goes away without the event still drains, unbinds durably, and broadcasts idle.
- Shutdown broadcasts a terminal idle for any binding torn down mid-turn.

Client — a belt under the one case the broadcast cannot cover:

- A busy socket status still newer than the roster snapshot arms a 30s roster
  poll. The predicate is the resolver's own tie-break, so it self-disarms: the
  first snapshot that lands outranks every socket transition in the channel and
  the interval stops until a fresh live transition re-arms it.
- A socket-won busy status older than 10 minutes degrades to idle only while the
  roster also reports no live binding, so a genuinely long turn keeps its chip.

## Verification

- `npm run check` — 0 errors (220 pre-existing warnings; the four files touched
  here lint clean, including the `sonarjs/no-duplicate-string` warning this
  branch had introduced into `channel-agent-binder.ts`).
- Targeted vitest on node 22, 390 passing across `channel-agent-binder`,
  `channel-agent-runtime`, `channel-agent-status-reconcile`,
  `channel-agent-bridge`, `channel-view-presence`, `channel-timeline-presence`,
  `channel-view-orchestrator`, `channel-steering`, `cockpit-presence`, and
  `topic-sidebar-shell`.
- Anti-vacuity, three reverts each confirmed red then restored:
  - Remove the binder's `disconnected` branch → the two teardown regression
    tests time out waiting for the terminal idle.
  - Remove the queue drop from `markDeadRuntimeIdle` → terminal broadcast
    carries `queuedCount: 1`.
  - Arm the roster poll on the raw busy status → the disarm assertion fails.
  - Remove `create()`'s ownership re-check → the death-during-connect test gets
    a runtime back instead of a rejection.

## Review trail

One adversarial review returned "concern" with five findings; all five are
addressed in `44dc5089`.

- P2 roster poll never self-disarmed (armed on the raw store status, which
  nothing reconciles back) → re-armed on the resolver's tie-break, extracted as
  `shouldPollRosterForPresence` with arm→poll→disarm coverage.
- P2 `create()` could return a runtime the new listener had already destroyed →
  ownership re-check routes the failure through the normal spawn-failure row.
- P3 idle broadcast with a populated queue left queued-send chips lit against a
  dead agent → shared `dropQueuedTurns`, one row per trigger either way.
- P3 new comments asserted a root cause the code contradicts → both blocks now
  describe the real pre-fix behavior and the real unbounded case.
- P3 new lint warning → inline type imports hoisted.

Refs #1307. Pre-v0.1.1-stable hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
