### PR TITLE
feat(search): wall-clock ceiling on FTS queries with structured timeout (#1316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- Message search no longer freezes the hub on a broad query. A prefix that would
+  expand across too much of the transcript is now declined before the index is
+  read, and any search that outruns its wall-clock budget is abandoned instead of
+  holding the server; both answer "type more characters" rather than a misleading
+  "no matches". Ordinary searches are unchanged. (#1316)
+
 ## [0.1.1] - 2026-08-04
 
 This is the first public release of the channel era, branded v0.1; it ships as

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -1978,6 +1978,16 @@ function messageEmptyStateText(input: {
   if (input.unavailableReason === 'no_searchable_term') {
     return 'no searchable term to look up';
   }
+  // #1316. Both are cost answers, not corpus answers: the first was refused
+  // before the index was read, the second was cut off part way through it. The
+  // copy therefore asks for a narrower query and never says "no matches" —
+  // whatever the operator is looking for may well be in the transcript.
+  if (input.unavailableReason === 'search_query_too_broad') {
+    return 'too many matches to rank — type more characters';
+  }
+  if (input.unavailableReason === 'search_timeout') {
+    return 'search took too long — type more characters';
+  }
   return `no message matches for “${input.searchQuery.trim()}”`;
 }
 

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -14,6 +14,7 @@ import {
   CHANNEL_HISTORY_DEFAULT_LIMIT,
   CHANNEL_HISTORY_MAX_LIMIT,
   ChannelMessageStoreError,
+  ChannelSearchRefusedError,
   channelSearchUnavailableReason,
   type ChannelHistoryFilter,
   type ChannelMessageStore,
@@ -734,6 +735,21 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       const body: ChannelMessageSearchResponse = { query, results, truncated };
       res.json(body);
     } catch (error) {
+      // A cost refusal is an ANSWER, not a failure (#1316): the store either
+      // declined a prefix this corpus cannot afford or abandoned the read at
+      // its wall-clock ceiling. Same 200-with-a-reason shape the static
+      // refusals above use, for the same reason — an error status (or an empty
+      // `results`) would make the client claim the transcript was searched.
+      if (error instanceof ChannelSearchRefusedError) {
+        const refused: ChannelMessageSearchResponse = {
+          query,
+          results: [],
+          truncated: false,
+          unavailableReason: error.reason,
+        };
+        res.json(refused);
+        return;
+      }
       mapStoreError(res, error);
     }
   });

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -16,8 +16,11 @@ import {
   CHANNEL_SEARCH_HIGHLIGHT_OPEN,
   CHANNEL_SEARCH_MAX_RESULTS,
   CHANNEL_SEARCH_MIN_QUERY_CHARS,
+  CHANNEL_SEARCH_PREFIX_DOC_BUDGET,
+  CHANNEL_SEARCH_PREFIX_TERM_BUDGET,
   CHANNEL_SEARCH_QUERY_MAX_CHARS,
   CHANNEL_SEARCH_SNIPPET_ELLIPSIS,
+  CHANNEL_SEARCH_TIME_BUDGET_MS,
   isChannelMessagePart,
   isChannelAgentDetail,
   parseMentions,
@@ -183,6 +186,131 @@ const CHANNEL_SEARCH_TRIGGERS = [
 
 /** Terms accepted from one query; a longer query is a paste, not a search. */
 const CHANNEL_SEARCH_MAX_TERMS = 12;
+
+/**
+ * Per-connection view of the FTS5 TERM index, used only by the pre-flight cost
+ * gate (#1316). `fts5vocab` in `row` mode yields one row per distinct term with
+ * its document and occurrence counts, and its `xBestIndex` accepts range
+ * constraints on `term`, so `term >= p AND term < p⁺` is a b-tree SEEK over the
+ * prefix rather than a scan of the dictionary.
+ *
+ * Declared in `temp.` deliberately. It is a pure read-through onto the index
+ * that already exists, so persisting it would add a schema object (and a
+ * migration, and a rebuild hazard) for something every connection can derive in
+ * microseconds. Being per-connection also means it survives the drop/recreate
+ * that `rebuildChannelSearchIndex` performs — fts5vocab resolves its target at
+ * query time, not at CREATE time.
+ */
+const CHANNEL_SEARCH_VOCAB_TABLE = 'temp.relay_channel_search_vocab';
+
+/**
+ * Name of the per-row user function that enforces the wall-clock ceiling.
+ *
+ * Registered per connection by `registerChannelSearchTick`. Exported so a test
+ * opening its OWN `better-sqlite3` handle against the same file (the query-plan
+ * assertion does) can install a no-op before preparing the production SQL —
+ * SQLite resolves function names at prepare time, so the SQL is unpreparable on
+ * a connection that has not registered it.
+ */
+export const CHANNEL_SEARCH_TICK_FUNCTION = 'relay_channel_search_tick';
+
+/**
+ * Thrown out of `searchMessages` when the store refuses or abandons a read.
+ *
+ * A separate class rather than `ChannelMessageStoreError` because this is not a
+ * caller error: the route answers HTTP 200 with the structured
+ * `unavailableReason`, exactly as it already does for `query_too_short`. The
+ * distinction the client needs is "the index did not (fully) answer", not a
+ * failure — printing "no matches" for either of these would assert something
+ * about the transcript that was never checked.
+ */
+export class ChannelSearchRefusedError extends Error {
+  readonly reason: 'search_query_too_broad' | 'search_timeout';
+
+  constructor(reason: 'search_query_too_broad' | 'search_timeout') {
+    super(`channel search refused: ${reason}`);
+    this.name = 'ChannelSearchRefusedError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Install the wall-clock tick on one connection.
+ *
+ * `deterministic: false` is the LOAD-BEARING option, not documentation: SQLite
+ * hoists constant subexpressions out of the row loop, and only the
+ * non-deterministic flag keeps this one inside it. The row id is passed as an
+ * argument for the same reason belt goes with braces — an expression that reads
+ * a column of the driving table cannot be evaluated anywhere but per row, on
+ * any SQLite version.
+ *
+ * `isExpired` is a callback rather than a deadline value because one connection
+ * serves every search: better-sqlite3 is synchronous, so no second read can
+ * begin while one is inside `.all()`, and the store simply moves the deadline
+ * before each call.
+ */
+export function registerChannelSearchTick(
+  db: Database.Database,
+  isExpired: () => boolean
+): void {
+  db.function(
+    CHANNEL_SEARCH_TICK_FUNCTION,
+    { deterministic: false },
+    (_rowid: unknown) => {
+      if (isExpired()) throw new ChannelSearchRefusedError('search_timeout');
+      return 1;
+    }
+  );
+}
+
+/**
+ * The half-open term range the trailing `*` of `raw` will expand over, or null
+ * when the query has no prefix term to bound.
+ *
+ * Mirrors `buildChannelSearchMatchQuery`: only the FINAL term takes `*`, and
+ * only once it is at least `CHANNEL_SEARCH_MIN_QUERY_CHARS` code points. The
+ * returned bounds are compared against terms as FTS5 STORED them, so the text
+ * is folded the way `unicode61 remove_diacritics 2` folds it — lowercased, with
+ * combining marks stripped — and reduced to its LAST tokenizer token, because
+ * `"foo-bar" *` is the two-token phrase `foo bar` with the prefix on `bar`.
+ *
+ * The folding is an approximation of unicode61's table (Turkish dotless i, ß,
+ * and pre-decomposed exotica diverge). Every divergence lands the probe on a
+ * range that holds FEWER terms than the real query will match, so the gate
+ * fails OPEN — it can under-refuse a hostile query, never over-refuse an honest
+ * one. The wall-clock ceiling is what covers the residue.
+ *
+ * Exported for tests: this is the half of the gate that has to agree with a C
+ * tokenizer, so it deserves direct assertions rather than only end-to-end ones.
+ */
+export function channelSearchPrefixRange(
+  raw: string
+): { low: string; high: string } | null {
+  const terms = collectChannelSearchTerms(raw);
+  const last = terms[terms.length - 1];
+  if (last === undefined) return null;
+  if ([...last].length < CHANNEL_SEARCH_MIN_QUERY_CHARS) return null;
+  const folded = last
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase();
+  const tokens = folded.split(/[^\p{L}\p{N}]+/u).filter((part) => part !== '');
+  const low = tokens[tokens.length - 1];
+  if (low === undefined) return null;
+  const points = [...low];
+  const tail = points[points.length - 1]?.codePointAt(0);
+  if (tail === undefined) return null;
+  // Successor of the last code point, skipping the surrogate block (which is
+  // not a scalar value) so `String.fromCodePoint` cannot produce a lone
+  // surrogate that would bind as invalid UTF-8.
+  let next = tail + 1;
+  if (next >= 0xd800 && next <= 0xdfff) next = 0xe000;
+  if (next > 0x10ffff) return null;
+  return {
+    low,
+    high: points.slice(0, -1).join('') + String.fromCodePoint(next),
+  };
+}
 
 /** `snippet()` window, in tokens (FTS5 allows 1..64). */
 const CHANNEL_SEARCH_SNIPPET_TOKENS = 20;
@@ -393,6 +521,15 @@ export function buildChannelSearchMatchQuery(raw: string): string | null {
  * Ranking is bm25 ascending — SQLite returns a more-negative score for a better
  * match — with newest-first as the tiebreak so two equally relevant rows
  * present the recent one first.
+ *
+ * `relay_channel_search_tick(<fts>.rowid)` is the wall-clock ceiling (#1316).
+ * It sits immediately after the MATCH and reads a column of the DRIVING table
+ * on purpose: SQLite evaluates a WHERE term in the loop of the last table it
+ * references, so this one fires once per FTS-matched row — before the rowid
+ * probe into `channel_messages` and before the channel allowlist discards
+ * anything — which is the earliest per-row hook the query has. It never filters
+ * (it returns 1 or throws), so the query plan is unchanged; the plan test
+ * asserts that.
  */
 export function buildChannelMessageSearchSql(channelIdCount: number): string {
   const channelClause =
@@ -413,6 +550,7 @@ export function buildChannelMessageSearchSql(channelIdCount: number): string {
            FROM ${CHANNEL_SEARCH_TABLE}
            CROSS JOIN channel_messages m ON m.rowid = ${CHANNEL_SEARCH_TABLE}.rowid
           WHERE ${CHANNEL_SEARCH_TABLE} MATCH ?
+            AND ${CHANNEL_SEARCH_TICK_FUNCTION}(${CHANNEL_SEARCH_TABLE}.rowid)
             ${channelClause}
           ORDER BY score ASC, m.seq DESC
           LIMIT ?`;
@@ -848,6 +986,12 @@ export interface ChannelMessageStore {
    * Thread replies ARE included. Returns hits, not `ChannelMessage` rows: a
    * result is a jump target plus an excerpt, and shipping full 256KB bodies for
    * 50 hits would make the response a transcript dump.
+   *
+   * Throws `ChannelSearchRefusedError` when the cost gate refuses the prefix
+   * (`search_query_too_broad`) or the wall-clock ceiling cuts the read off
+   * (`search_timeout`) — see #1316. Both are 200-with-a-reason at the route, not
+   * errors; what they must never become is an empty array, which would claim
+   * the corpus was searched and held nothing.
    */
   searchMessages(input: ChannelMessageSearchQuery): ChannelMessageSearchHit[];
   /** Root-inclusive history for one canonical thread. */
@@ -1862,7 +2006,24 @@ export function initChannelMessageStore(
   return createChannelMessageStore(path.join(configDir, 'channel-chat.db'));
 }
 
-export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
+export interface ChannelMessageStoreOptions {
+  /**
+   * Wall-clock ceiling for one ranked index read, in milliseconds. Defaults to
+   * `CHANNEL_SEARCH_TIME_BUDGET_MS`.
+   *
+   * Overridable because the ceiling is otherwise only provable by a latency
+   * assertion, and a latency assertion is exactly the kind of test a faster CI
+   * box deletes silently — the same reasoning that made the minimum-length
+   * guard assert on the EXPRESSION rather than on milliseconds. A test sets
+   * `0` and gets a deterministic `search_timeout` on the first matched row.
+   */
+  searchTimeBudgetMs?: number;
+}
+
+export function createChannelMessageStore(
+  dbPath: string,
+  options: ChannelMessageStoreOptions = {}
+): ChannelMessageStore {
   const db = new Database(dbPath);
   try {
     db.pragma('journal_mode = WAL');
@@ -1871,6 +2032,77 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
   } catch (error) {
     db.close();
     throw error;
+  }
+
+  // ── search cost guards (#1316) ────────────────────────────────────────────
+  const searchTimeBudgetMs =
+    options.searchTimeBudgetMs ?? CHANNEL_SEARCH_TIME_BUDGET_MS;
+  // Deadline for the read currently inside `.all()`. A single mutable value is
+  // safe precisely because better-sqlite3 is synchronous: nothing else on this
+  // thread can start a second read while one is running, which is the same
+  // property that makes the ceiling necessary in the first place.
+  let searchDeadline = Number.POSITIVE_INFINITY;
+  registerChannelSearchTick(db, () => Date.now() >= searchDeadline);
+  // Created AFTER `runMigrations`, so the FTS table it reads through already
+  // exists on a fresh db. Failure is not fatal: the vocabulary is only used by
+  // the pre-flight gate, and a store that cannot pre-flight still has the
+  // wall-clock ceiling.
+  let searchVocab: Database.Statement | null = null;
+  try {
+    db.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS ${CHANNEL_SEARCH_VOCAB_TABLE}
+         USING fts5vocab(main, ${CHANNEL_SEARCH_TABLE}, row)`
+    );
+    searchVocab = db.prepare(
+      `SELECT doc FROM ${CHANNEL_SEARCH_VOCAB_TABLE}
+        WHERE term >= ? AND term < ?`
+    );
+  } catch (error) {
+    logger.warn(
+      'channel search cost pre-flight unavailable (%s); falling back to the wall-clock ceiling alone',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  /**
+   * Refuse a prefix whose expansion this corpus cannot afford, BEFORE reading.
+   *
+   * Walks the term index over the prefix range and stops at the first budget it
+   * blows. Both budgets are also the walk's own bound, so the check costs at
+   * most `CHANNEL_SEARCH_PREFIX_TERM_BUDGET` b-tree steps no matter how large
+   * the transcript grows (measured ≤6ms at 1025 terms).
+   *
+   * Fails OPEN on any error. `fts5vocab` reads the index by name at query time,
+   * so a mid-rebuild window (`rebuildChannelSearchIndex` drops and recreates
+   * the table) surfaces as `no such fts5 table` — and a store that cannot cost
+   * a query must still answer it, with the ceiling as the remaining guard.
+   */
+  function refuseOverBroadPrefix(raw: string): void {
+    if (!searchVocab) return;
+    const range = channelSearchPrefixRange(raw);
+    if (!range) return;
+    let terms = 0;
+    let docs = 0;
+    try {
+      for (const row of searchVocab.iterate(range.low, range.high) as Iterable<{
+        doc: number;
+      }>) {
+        terms += 1;
+        docs += row.doc;
+        if (
+          terms > CHANNEL_SEARCH_PREFIX_TERM_BUDGET ||
+          docs > CHANNEL_SEARCH_PREFIX_DOC_BUDGET
+        ) {
+          throw new ChannelSearchRefusedError('search_query_too_broad');
+        }
+      }
+    } catch (error) {
+      if (error instanceof ChannelSearchRefusedError) throw error;
+      logger.warn(
+        'channel search cost pre-flight failed (%s); running the query under the wall-clock ceiling',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
   }
 
   // Point reads can be emitted directly on the WS lane (stream finalization and
@@ -2457,20 +2689,45 @@ export function createChannelMessageStore(dbPath: string): ChannelMessageStore {
       const channelIds =
         input.channelIds === undefined ? null : [...input.channelIds];
       if (channelIds !== null && channelIds.length === 0) return [];
+      // Cost gate BEFORE the read (#1316): the cheapest query is the one that
+      // never starts, and the doclist-merge setup this refuses is the one part
+      // of the read the wall-clock ceiling below cannot interrupt.
+      refuseOverBroadPrefix(input.query);
       // `+ 1` is the LOOKAHEAD allowance, not a wider page: a caller paging at
       // the maximum asks for one row past it purely to learn whether more hits
       // existed. Without it, `truncated` could never be true on a full page.
       const limit = cleanLimit(input.limit, CHANNEL_SEARCH_MAX_RESULTS + 1);
-      const rows = db
-        .prepare(buildChannelMessageSearchSql(channelIds?.length ?? 0))
-        .all(
-          CHANNEL_SEARCH_HIGHLIGHT_OPEN,
-          CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
-          CHANNEL_SEARCH_SNIPPET_ELLIPSIS,
-          match,
-          ...(channelIds ?? []),
-          limit
-        ) as ChannelSearchRow[];
+      // The deadline is armed around THIS call only, and disarmed in `finally`
+      // so a leftover value can never abort an unrelated later read. The
+      // ceiling reaches the query through `relay_channel_search_tick`, which
+      // throws `ChannelSearchRefusedError('search_timeout')` from inside
+      // sqlite; better-sqlite3 propagates the original object, so no error
+      // string has to be pattern-matched here.
+      searchDeadline = Date.now() + searchTimeBudgetMs;
+      let rows: ChannelSearchRow[];
+      try {
+        rows = db
+          .prepare(buildChannelMessageSearchSql(channelIds?.length ?? 0))
+          .all(
+            CHANNEL_SEARCH_HIGHLIGHT_OPEN,
+            CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
+            CHANNEL_SEARCH_SNIPPET_ELLIPSIS,
+            match,
+            ...(channelIds ?? []),
+            limit
+          ) as ChannelSearchRow[];
+      } catch (error) {
+        if (error instanceof ChannelSearchRefusedError) {
+          logger.warn(
+            'channel search exceeded its %dms budget for %j; answering search_timeout',
+            searchTimeBudgetMs,
+            match
+          );
+        }
+        throw error;
+      } finally {
+        searchDeadline = Number.POSITIVE_INFINITY;
+      }
       return rows.map(searchRowToHit);
     },
 

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -206,13 +206,14 @@ const CHANNEL_SEARCH_VOCAB_TABLE = 'temp.relay_channel_search_vocab';
 /**
  * Name of the per-row user function that enforces the wall-clock ceiling.
  *
- * Registered per connection by `registerChannelSearchTick`. Exported so a test
- * opening its OWN `better-sqlite3` handle against the same file (the query-plan
- * assertion does) can install a no-op before preparing the production SQL —
- * SQLite resolves function names at prepare time, so the SQL is unpreparable on
- * a connection that has not registered it.
+ * Module-local: the name is an implementation detail shared between
+ * `registerChannelSearchTick` and the SQL builder, and nothing outside this file
+ * should be spelling it. A caller preparing the production SQL on its OWN
+ * `better-sqlite3` handle (the query-plan test does) must still install the
+ * function first, because SQLite resolves function names at prepare time — but
+ * it does that through `registerChannelSearchTick`, which is the exported seam.
  */
-export const CHANNEL_SEARCH_TICK_FUNCTION = 'relay_channel_search_tick';
+const CHANNEL_SEARCH_TICK_FUNCTION = 'relay_channel_search_tick';
 
 /**
  * Thrown out of `searchMessages` when the store refuses or abandons a read.
@@ -274,11 +275,25 @@ export function registerChannelSearchTick(
  * combining marks stripped — and reduced to its LAST tokenizer token, because
  * `"foo-bar" *` is the two-token phrase `foo bar` with the prefix on `bar`.
  *
- * The folding is an approximation of unicode61's table (Turkish dotless i, ß,
- * and pre-decomposed exotica diverge). Every divergence lands the probe on a
- * range that holds FEWER terms than the real query will match, so the gate
- * fails OPEN — it can under-refuse a hostile query, never over-refuse an honest
- * one. The wall-clock ceiling is what covers the residue.
+ * The folding is an APPROXIMATION of unicode61's table, and where it diverges
+ * the probe costs a DIFFERENT term range than the query expands over — not a
+ * conservative subset of it. Measured, on Greek, where two divergences compound:
+ * `remove_diacritics 2` KEEPS the tonos (FTS5 stores `ΣΊΣΥΦΟΣ` as `σίσυφοσ`,
+ * U+03C3 U+03AF …) while NFD mark-stripping removes it, and `toLowerCase` maps a
+ * trailing Σ to FINAL sigma U+03C2 while unicode61 always folds to U+03C3. So
+ * `ΣΊΣ` probes `[σις, σισ)` — and the stored term begins `σί`, which sorts BELOW
+ * that range (U+03AF < U+03B9). The probe counts zero terms for a prefix that
+ * does match. Turkish dotless i and ß are in the same family.
+ *
+ * Do not read that as a safety guarantee. Disjoint ranges carry no ordering, so
+ * a divergence can under-count (measured above) or over-count; what is bounded
+ * is the CONSEQUENCE in each direction. Under-counting leaves the read to the
+ * doc budget and the wall-clock ceiling, which is the pre-#1316 position for
+ * that query and no worse. Over-counting refuses a query the operator then
+ * narrows, which is visible and recoverable. Latin-script text — what the
+ * budgets were calibrated on, and what the transcript is overwhelmingly made of
+ * — folds identically, so this is a correctness note about the edges rather
+ * than about the working path.
  *
  * Exported for tests: this is the half of the gate that has to agree with a C
  * tokenizer, so it deserves direct assertions rather than only end-to-end ones.
@@ -2018,6 +2033,19 @@ export interface ChannelMessageStoreOptions {
    * `0` and gets a deterministic `search_timeout` on the first matched row.
    */
   searchTimeBudgetMs?: number;
+  /**
+   * State of the pre-flight cost gate. `'auto'` (default) builds the `fts5vocab`
+   * view and gates on it; `'unavailable'` reproduces the DEGRADED state the
+   * store falls into when that view cannot be built.
+   *
+   * A state rather than an on/off switch, and present for one reason: failing
+   * open is a documented contract, and an undocumented untested fallback is how
+   * a guard quietly stops being one. The degraded path is not equivalent to the
+   * guarded path — the wall-clock ceiling is a per-row hook, so a zero-row query
+   * is unbounded without the pre-flight — so what it actually does deserves an
+   * assertion instead of a comment.
+   */
+  searchCostPreflight?: 'auto' | 'unavailable';
 }
 
 export function createChannelMessageStore(
@@ -2044,25 +2072,46 @@ export function createChannelMessageStore(
   let searchDeadline = Number.POSITIVE_INFINITY;
   registerChannelSearchTick(db, () => Date.now() >= searchDeadline);
   // Created AFTER `runMigrations`, so the FTS table it reads through already
-  // exists on a fresh db. Failure is not fatal: the vocabulary is only used by
-  // the pre-flight gate, and a store that cannot pre-flight still has the
-  // wall-clock ceiling.
+  // exists on a fresh db. Failure is not fatal, but it is not harmless either:
+  // the pre-flight is the ONLY bound on a prefix that emits no rows (see
+  // `CHANNEL_SEARCH_PREFIX_DOC_BUDGET`), so a store running without it is back
+  // to pre-#1316 behaviour for that shape. Degraded, and logged as such.
   let searchVocab: Database.Statement | null = null;
-  try {
-    db.exec(
-      `CREATE VIRTUAL TABLE IF NOT EXISTS ${CHANNEL_SEARCH_VOCAB_TABLE}
+  if (options.searchCostPreflight !== 'unavailable') {
+    try {
+      db.exec(
+        `CREATE VIRTUAL TABLE IF NOT EXISTS ${CHANNEL_SEARCH_VOCAB_TABLE}
          USING fts5vocab(main, ${CHANNEL_SEARCH_TABLE}, row)`
-    );
-    searchVocab = db.prepare(
-      `SELECT doc FROM ${CHANNEL_SEARCH_VOCAB_TABLE}
+      );
+      searchVocab = db.prepare(
+        `SELECT doc FROM ${CHANNEL_SEARCH_VOCAB_TABLE}
         WHERE term >= ? AND term < ?`
-    );
-  } catch (error) {
-    logger.warn(
-      'channel search cost pre-flight unavailable (%s); falling back to the wall-clock ceiling alone',
-      error instanceof Error ? error.message : String(error)
-    );
+      );
+    } catch (error) {
+      logger.warn(
+        'channel search cost pre-flight unavailable (%s); prefix cost is now bounded only by the wall-clock ceiling, which does not cover zero-row queries',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
   }
+
+  // Refusal telemetry. `CHANNEL_SEARCH_PREFIX_TERM_BUDGET` is an absolute term
+  // count measured against one corpus, while prefix expansion grows with
+  // vocabulary — so the failure mode of a stale budget is ordinary prefixes
+  // silently refusing, on every keystroke of a live search, with no signal that
+  // the GUARD rather than the corpus is the cause. Counting refusals and
+  // surfacing the rate is what makes that transition visible. Throttled to one
+  // line a minute (carrying the count since the last line) so a debounced live
+  // search cannot turn the signal into a flood.
+  let searchRefusals = 0;
+  let searchRefusalsAtLastLog = 0;
+  let searchRefusalLoggedAt = 0;
+  const SEARCH_REFUSAL_LOG_INTERVAL_MS = 60_000;
+  // Latched so a persistent pre-flight fault (a dropped index, a corrupt
+  // vocabulary) reports once rather than once per keystroke. The condition is a
+  // property of the store, not of the query, so repeating it per call adds
+  // volume without adding information.
+  let searchPreflightFaultLogged = false;
 
   /**
    * Refuse a prefix whose expansion this corpus cannot afford, BEFORE reading.
@@ -2075,7 +2124,11 @@ export function createChannelMessageStore(
    * Fails OPEN on any error. `fts5vocab` reads the index by name at query time,
    * so a mid-rebuild window (`rebuildChannelSearchIndex` drops and recreates
    * the table) surfaces as `no such fts5 table` — and a store that cannot cost
-   * a query must still answer it, with the ceiling as the remaining guard.
+   * a query must still answer it. Note what "open" costs here: the wall-clock
+   * ceiling is a per-ROW hook, so it does not cover a query that returns no
+   * rows. Failing open is the right call for a transient rebuild window and a
+   * real regression if it becomes permanent, which is why it is logged rather
+   * than swallowed.
    */
   function refuseOverBroadPrefix(raw: string): void {
     if (!searchVocab) return;
@@ -2093,16 +2146,48 @@ export function createChannelMessageStore(
           terms > CHANNEL_SEARCH_PREFIX_TERM_BUDGET ||
           docs > CHANNEL_SEARCH_PREFIX_DOC_BUDGET
         ) {
+          noteSearchRefusal(terms, docs);
           throw new ChannelSearchRefusedError('search_query_too_broad');
         }
       }
     } catch (error) {
       if (error instanceof ChannelSearchRefusedError) throw error;
-      logger.warn(
-        'channel search cost pre-flight failed (%s); running the query under the wall-clock ceiling',
-        error instanceof Error ? error.message : String(error)
-      );
+      if (!searchPreflightFaultLogged) {
+        searchPreflightFaultLogged = true;
+        logger.warn(
+          'channel search cost pre-flight failed (%s); running queries under the wall-clock ceiling alone until this clears (logged once)',
+          error instanceof Error ? error.message : String(error)
+        );
+      }
     }
+  }
+
+  /**
+   * Record an over-broad refusal, logging the SHAPE of the query and never its
+   * text — operator search input can carry pasted secrets or ticket bodies, and
+   * this path is reachable repeatedly by any capability holder.
+   */
+  function noteSearchRefusal(terms: number, docs: number): void {
+    searchRefusals += 1;
+    const now = Date.now();
+    if (
+      searchRefusalLoggedAt !== 0 &&
+      now - searchRefusalLoggedAt < SEARCH_REFUSAL_LOG_INTERVAL_MS
+    ) {
+      return;
+    }
+    const sinceLast = searchRefusals - searchRefusalsAtLastLog;
+    searchRefusalsAtLastLog = searchRefusals;
+    searchRefusalLoggedAt = now;
+    logger.warn(
+      'channel search refused an over-broad prefix (%d terms / %d docs vs budgets %d/%d); %d refusal(s) since the last line, %d total. A rising rate means the corpus has outgrown CHANNEL_SEARCH_PREFIX_TERM_BUDGET, not that search is broken.',
+      terms,
+      docs,
+      CHANNEL_SEARCH_PREFIX_TERM_BUDGET,
+      CHANNEL_SEARCH_PREFIX_DOC_BUDGET,
+      sinceLast,
+      searchRefusals
+    );
   }
 
   // Point reads can be emitted directly on the WS lane (stream finalization and
@@ -2718,10 +2803,16 @@ export function createChannelMessageStore(
           ) as ChannelSearchRow[];
       } catch (error) {
         if (error instanceof ChannelSearchRefusedError) {
+          // SHAPE, not text. Operator search input is exactly the place a
+          // pasted secret or a credential someone is hunting for in the
+          // transcript shows up, and this line is reachable repeatedly by any
+          // CONTEXT_READ holder. Term count and the prefix length are what
+          // diagnose a timeout; the words are not.
           logger.warn(
-            'channel search exceeded its %dms budget for %j; answering search_timeout',
+            'channel search exceeded its %dms budget (%d term(s), %d-char prefix); answering search_timeout',
             searchTimeBudgetMs,
-            match
+            match.split(' AND ').length,
+            channelSearchPrefixRange(input.query)?.low.length ?? 0
           );
         }
         throw error;

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -447,19 +447,44 @@ export const CHANNEL_SEARCH_MIN_QUERY_CHARS = 3;
  * Term COUNT specifically, because that is the part of the cost that cannot be
  * interrupted. FTS5 opens one doclist iterator per matching term and merges
  * them; that setup happens before the first row is visible, so the wall-clock
- * ceiling below cannot see it. Measured on a 50k-message / 163MB corpus with a
- * 72,795-term vocabulary: `"a" *` 4281 terms, 475ms before the first row, 1086ms
- * total; `"con" *` 973 terms, 23ms to first row, 108ms total; `"the" *` 115
- * terms, 29ms; `"sear" *` 13 terms, 25ms. 1024 terms therefore refuses only the
- * shapes the minimum already refuses at that size (`"a"`, `"b"`) while leaving
- * every real three-character prefix intact, and caps the un-interruptible
- * window near ~110ms.
+ * ceiling below cannot see it.
+ *
+ * CALIBRATION CORPUS — 50k messages / 163MB / 72,795 distinct terms, which is
+ * daily-driver size as of #1316, NOT a ceiling on what Relay will hold. All of
+ * the numbers below are measurements against that corpus and must be RE-MEASURED
+ * as the transcript grows; this constant is an absolute term count while prefix
+ * expansion grows with vocabulary (roughly Heaps' law, so ~sqrt of corpus size).
+ * Measured: `"a" *` 4281 terms, 475ms before the first row, 1086ms total;
+ * `"con" *` 973 terms, 23ms to first row, 108ms total; `"the" *` 115 terms,
+ * 29ms; `"sear" *` 13 terms, 25ms.
+ *
+ * 2048 is set from the `"con" *` measurement, not from the pathological one:
+ * 973 terms is the heaviest LEGITIMATE three-character prefix recorded, so the
+ * budget carries ~2.1x headroom over it and only crosses into refusing `con` at
+ * roughly a 4x corpus. At 1024 the same query sat 5% under the budget — one
+ * corpus doubling from an ordinary prefix silently answering
+ * `search_query_too_broad` on every keystroke of a live search. `"a" *` (4281)
+ * and every shape the minimum already refuses stay refused at 2048.
+ *
+ * What it costs: the permitted corner of the region (this budget's worth of
+ * terms carrying `CHANNEL_SEARCH_PREFIX_DOC_BUDGET` postings) measures ~262ms of
+ * un-interruptible setup — the two gates land in the same band by construction,
+ * so widening this one alone does not move the composed worst case past what the
+ * doc budget already allows.
+ *
+ * Observability, because an absolute budget against a growing corpus fails
+ * SILENTLY: the store counts refusals and logs a throttled line carrying the
+ * count and which budget blew, so a corpus crossing the threshold shows up as a
+ * rising refusal rate rather than as "search stopped working". `channel-message-
+ * store.test.ts` additionally pins this value to the measured band, so lowering
+ * it under the legitimate query or raising it past the doc budget's window fails
+ * a test rather than a production search.
  *
  * The walk itself is bounded by this same number — it stops at the budget
  * rather than counting the whole range — so the pre-flight cost does NOT grow
  * with the corpus: measured ≤6ms at 1025 terms.
  */
-export const CHANNEL_SEARCH_PREFIX_TERM_BUDGET = 1024;
+export const CHANNEL_SEARCH_PREFIX_TERM_BUDGET = 2048;
 
 /**
  * Pre-flight ceiling on the postings behind the trailing `*`, summed over the
@@ -467,11 +492,26 @@ export const CHANNEL_SEARCH_PREFIX_TERM_BUDGET = 1024;
  *
  * Complements the term budget: a prefix can be narrow in terms and enormous in
  * rows (`"abc" *` was 2 terms / 72,240 documents on the calibration corpus).
- * Row cost IS interruptible, so this is a courtesy — an immediate
- * `search_query_too_broad` instead of burning the whole wall-clock budget to
- * answer `search_timeout` — and the threshold is set an order of magnitude
- * above the ordinary band for that reason. At the measured ~4300 documents per
- * millisecond, one million documents is ~230ms of ranking.
+ *
+ * This is LOAD-BEARING, not a courtesy, and the distinction matters to anyone
+ * who touches the number. `CHANNEL_SEARCH_TIME_BUDGET_MS` is enforced by a
+ * per-row hook, so it only bounds rows the query EMITS — a query that emits
+ * zero rows never calls it once. Measured on a 200k-row index with an ALREADY
+ * EXPIRED deadline: `"conf" *` throws on tick 1 as designed, while
+ * `"alpha" AND "conf" *` (both terms ~100k docs, empty intersection) completes
+ * normally in 40ms having called the hook 0 times. `buildChannelSearchMatchQuery`
+ * joins terms with ` AND `, so two typed words are exactly that shape. For any
+ * AND expression that merges a wide prefix doclist and then intersects it away,
+ * THIS budget is the only bound in the system.
+ *
+ * So the threshold is a direct statement about the longest un-interruptible
+ * synchronous window the hub will accept, and widening it widens that window
+ * one-for-one. Measured at exactly this budget (2000 terms / 1,000,000
+ * postings): 262ms for the prefix alone, 40ms for the zero-row AND. Ten million
+ * would be ~2.6s of un-interruptible event-loop block — which is the defect
+ * #1316 was filed for, restored, and invisible to a per-row ceiling. The test
+ * suite pins the relationship (permitted window ≤ the wall-clock ceiling) so
+ * that widening fails a test rather than a production hub.
  *
  * The sum is a LOWER bound (the walk stops at the term budget), so the gate can
  * only fire when the prefix genuinely carries that many postings; it never
@@ -488,17 +528,35 @@ export const CHANNEL_SEARCH_PREFIX_DOC_BUDGET = 1_000_000;
  * non-deterministic call out of the loop, so it runs once per FTS-matched row
  * and throws once the budget is spent; the store answers `search_timeout`.
  *
- * What this does and does not bound: everything after the first row is cut off
- * within one row of the deadline (measured — a 1086ms query aborts at 478ms,
- * which is exactly when its first row appeared). The doclist-merge setup BEFORE
- * that first row is not interruptible, which is what
- * `CHANNEL_SEARCH_PREFIX_TERM_BUDGET` exists to bound. Cost of carrying the
- * hook on ordinary queries is ~0.2µs/row — 103ms → 113ms on the heaviest
- * measured legitimate query, and unmeasurable on the 25ms band.
+ * What this does and does not bound. It covers rows the query EMITS: everything
+ * after the first row is cut off within one row of the deadline (measured — a
+ * 1086ms query aborts at 478ms, which is exactly when its first row appeared).
+ * It covers nothing else, and there are two such gaps, both owned by the
+ * pre-flight budgets rather than by this one:
+ *  * the doclist-merge setup BEFORE the first row is not interruptible
+ *    (`CHANNEL_SEARCH_PREFIX_TERM_BUDGET`);
+ *  * a query that emits ZERO rows never reaches the hook at all, so it cannot be
+ *    interrupted anywhere (`CHANNEL_SEARCH_PREFIX_DOC_BUDGET` — see the measured
+ *    `"alpha" AND "conf" *` case recorded there). Do not read this constant as
+ *    covering row cost in general; it covers returned rows.
+ * Cost of carrying the hook on ordinary queries is ~0.2µs/row — 103ms → 113ms
+ * on the heaviest measured legitimate query, and unmeasurable on the 25ms band.
  *
  * 750ms is ~7x the heaviest legitimate query measured at daily-driver size
  * (`"con" *`, 108ms) and well under the 2805ms worst case #1316 recorded, so it
- * is a backstop rather than a second gate.
+ * is a backstop rather than a second gate. Deliberately not tightened toward
+ * that 108ms band: the legitimate band grows with the corpus (the issue already
+ * measured 158ms for a three-character prefix), so a tight ceiling would convert
+ * corpus growth into timeouts on honest queries.
+ *
+ * RESIDUAL, recorded rather than claimed away: the three layers bound one query,
+ * not the route. Composed worst case is ~262ms of un-interruptible setup plus
+ * this ceiling — roughly 1.0s of synchronous block, versus 2805ms before #1316.
+ * `/channels/search` has no admission control and better-sqlite3 is synchronous
+ * on one shared connection, so concurrent searches serialize and each stall is
+ * also felt by WS catch-up, read-state and presence on that connection.
+ * Single-flight admission or moving the read off-thread is the remaining fix,
+ * tracked in #1330; this constant does not pretend to be it.
  */
 export const CHANNEL_SEARCH_TIME_BUDGET_MS = 750;
 

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -427,25 +427,103 @@ export const CHANNEL_SEARCH_QUERY_MAX_CHARS = 256;
  * 100-200ms band at that size. It BOUNDS the pathological shape; it does not
  * bound the worst case, which still grows with corpus size. Anyone widening the
  * expression (longer prefixes, new operator syntax) is spending that budget and
- * should re-measure — the durable fix is a wall-clock/progress-handler ceiling
- * answering `unavailableReason: 'search_timeout'`, or moving the read off the
- * request thread.
+ * should re-measure. It is the FIRST of three layers now; #1316 added the two
+ * that bound the residual worst case — `CHANNEL_SEARCH_PREFIX_TERM_BUDGET` /
+ * `CHANNEL_SEARCH_PREFIX_DOC_BUDGET` (refuse before reading) and
+ * `CHANNEL_SEARCH_TIME_BUDGET_MS` (stop mid-read).
  */
 export const CHANNEL_SEARCH_MIN_QUERY_CHARS = 3;
 
 /**
- * Why a search request produced no index read.
+ * Pre-flight ceiling on how far the trailing `*` may expand, in DISTINCT TERMS.
+ *
+ * `CHANNEL_SEARCH_MIN_QUERY_CHARS` bounds the pathological SHAPE but not the
+ * worst case: expansion is a property of the corpus, so a three-character
+ * prefix that is cheap on a small transcript is not cheap on a large one. This
+ * is the corpus-aware half — before the ranked read runs, the store walks the
+ * FTS5 term index (`fts5vocab`) over `[prefix, prefix+1)` and refuses with
+ * `search_query_too_broad` if the prefix covers more terms than this.
+ *
+ * Term COUNT specifically, because that is the part of the cost that cannot be
+ * interrupted. FTS5 opens one doclist iterator per matching term and merges
+ * them; that setup happens before the first row is visible, so the wall-clock
+ * ceiling below cannot see it. Measured on a 50k-message / 163MB corpus with a
+ * 72,795-term vocabulary: `"a" *` 4281 terms, 475ms before the first row, 1086ms
+ * total; `"con" *` 973 terms, 23ms to first row, 108ms total; `"the" *` 115
+ * terms, 29ms; `"sear" *` 13 terms, 25ms. 1024 terms therefore refuses only the
+ * shapes the minimum already refuses at that size (`"a"`, `"b"`) while leaving
+ * every real three-character prefix intact, and caps the un-interruptible
+ * window near ~110ms.
+ *
+ * The walk itself is bounded by this same number — it stops at the budget
+ * rather than counting the whole range — so the pre-flight cost does NOT grow
+ * with the corpus: measured ≤6ms at 1025 terms.
+ */
+export const CHANNEL_SEARCH_PREFIX_TERM_BUDGET = 1024;
+
+/**
+ * Pre-flight ceiling on the postings behind the trailing `*`, summed over the
+ * terms the vocabulary walk visited.
+ *
+ * Complements the term budget: a prefix can be narrow in terms and enormous in
+ * rows (`"abc" *` was 2 terms / 72,240 documents on the calibration corpus).
+ * Row cost IS interruptible, so this is a courtesy — an immediate
+ * `search_query_too_broad` instead of burning the whole wall-clock budget to
+ * answer `search_timeout` — and the threshold is set an order of magnitude
+ * above the ordinary band for that reason. At the measured ~4300 documents per
+ * millisecond, one million documents is ~230ms of ranking.
+ *
+ * The sum is a LOWER bound (the walk stops at the term budget), so the gate can
+ * only fire when the prefix genuinely carries that many postings; it never
+ * refuses a query on an over-estimate.
+ */
+export const CHANNEL_SEARCH_PREFIX_DOC_BUDGET = 1_000_000;
+
+/**
+ * Wall-clock ceiling on a single ranked index read, in milliseconds.
+ *
+ * better-sqlite3 is synchronous and exposes no `sqlite3_progress_handler`, so
+ * the ceiling is built from the one per-row hook it does expose: a
+ * non-deterministic user function in the WHERE clause. SQLite may not hoist a
+ * non-deterministic call out of the loop, so it runs once per FTS-matched row
+ * and throws once the budget is spent; the store answers `search_timeout`.
+ *
+ * What this does and does not bound: everything after the first row is cut off
+ * within one row of the deadline (measured — a 1086ms query aborts at 478ms,
+ * which is exactly when its first row appeared). The doclist-merge setup BEFORE
+ * that first row is not interruptible, which is what
+ * `CHANNEL_SEARCH_PREFIX_TERM_BUDGET` exists to bound. Cost of carrying the
+ * hook on ordinary queries is ~0.2µs/row — 103ms → 113ms on the heaviest
+ * measured legitimate query, and unmeasurable on the 25ms band.
+ *
+ * 750ms is ~7x the heaviest legitimate query measured at daily-driver size
+ * (`"con" *`, 108ms) and well under the 2805ms worst case #1316 recorded, so it
+ * is a backstop rather than a second gate.
+ */
+export const CHANNEL_SEARCH_TIME_BUDGET_MS = 750;
+
+/**
+ * Why a search request produced no index read, or no COMPLETE one.
  *  * `empty_query` — nothing but whitespace was submitted.
  *  * `query_too_short` — one term below CHANNEL_SEARCH_MIN_QUERY_CHARS, which
  *    is refused rather than run (see that constant).
  *  * `no_searchable_term` — text arrived but held no letter or digit (`***`),
  *    so there is no term to look up.
- * Absent means the index WAS consulted, so an empty `results` is a real miss.
+ *  * `search_query_too_broad` — the trailing prefix expands past
+ *    CHANNEL_SEARCH_PREFIX_TERM_BUDGET / CHANNEL_SEARCH_PREFIX_DOC_BUDGET on
+ *    THIS corpus, so the read was refused before it started (#1316).
+ *  * `search_timeout` — the read started and was cut off at
+ *    CHANNEL_SEARCH_TIME_BUDGET_MS (#1316).
+ * Absent means the index WAS consulted to completion, so an empty `results` is
+ * a real miss. The last two are corpus- and timing-dependent, so a client must
+ * treat them as "narrow the query", never as "this text is not in the log".
  */
 export type ChannelSearchUnavailableReason =
   | 'empty_query'
   | 'query_too_short'
-  | 'no_searchable_term';
+  | 'no_searchable_term'
+  | 'search_query_too_broad'
+  | 'search_timeout';
 
 export interface ChannelSearchSnippetSegment {
   text: string;

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../server/channel-message-store.js';
 import {
   CHANNEL_SEARCH_MIN_QUERY_CHARS,
+  CHANNEL_SEARCH_PREFIX_DOC_BUDGET,
   CHANNEL_SEARCH_PREFIX_TERM_BUDGET,
   CHANNEL_SEARCH_TIME_BUDGET_MS,
   type ChannelSenderRef,
@@ -40,7 +41,10 @@ function dbPath(): string {
 
 function store(
   pathOverride?: string,
-  options?: { searchTimeBudgetMs?: number }
+  options?: {
+    searchTimeBudgetMs?: number;
+    searchCostPreflight?: 'auto' | 'unavailable';
+  }
 ): ChannelMessageStore {
   const s = createChannelMessageStore(pathOverride ?? dbPath(), options ?? {});
   cleanup.push(() => s.close());
@@ -2019,10 +2023,26 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       low: 'bar',
       high: 'bas',
     });
+    // Pinned because it is the documented LIMIT of the fold, not a success case.
+    // Two divergences compound on this input: `remove_diacritics 2` KEEPS the
+    // Greek tonos (FTS5 stores `ΣΊΣΥΦΟΣ` as `σίσυφοσ`, U+03AF intact) where NFD
+    // mark-stripping removes it, and `String.toLowerCase` maps a trailing Σ to
+    // FINAL sigma U+03C2 where unicode61 always folds to U+03C3. The probe range
+    // is therefore [σις, σισ) while the stored term begins `σί` — U+03AF sorts
+    // below U+03B9, so the term is outside the range entirely and the walk counts
+    // ZERO. Disjoint, not a conservative subset, which is exactly what the
+    // `channelSearchPrefixRange` docblock now says instead of claiming the gate
+    // always fails open. Asserted so a tokenizer or fold change surfaces here
+    // rather than as a silently mis-costed gate.
+    expect(channelSearchPrefixRange('ΣΊΣ')).toEqual({
+      low: 'σις',
+      high: 'σισ',
+    });
   });
 
   it('refuses a prefix this corpus cannot afford, before reading the index', () => {
-    const s = store();
+    const file = dbPath();
+    const s = store(file);
     // Every row contributes one term under the shared `zzq` prefix, so the
     // prefix expansion is exactly the row count — the pathological shape #1316
     // measured, reproduced at a size a test can afford.
@@ -2049,6 +2069,59 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
     // A trailing term below the minimum never gets `*`, so it is never costed —
     // it is refused by the older, cheaper guard instead.
     expect(s.searchMessages({ query: 'zz' })).toEqual([]);
+
+    // DEGRADED CONTRACT. The pre-flight fails OPEN when the `fts5vocab` view
+    // cannot be built, which is right for the mid-rebuild window it was written
+    // for and a real loss of coverage if it becomes permanent — so what the
+    // fallback actually does is asserted here rather than left an untested
+    // branch. Same file, same corpus, second connection (the view is `temp.`,
+    // so it is genuinely per-connection): the store still ANSWERS, and the
+    // prefix the gate would have refused now runs under the wall-clock ceiling
+    // alone. That ceiling is a per-ROW hook, so this is strictly weaker than the
+    // guarded path, not equivalent to it.
+    const degraded = store(file, { searchCostPreflight: 'unavailable' });
+    expect(() => degraded.searchMessages({ query: 'zzq' })).not.toThrow();
+    expect(degraded.searchMessages({ query: 'broadcast' })).toHaveLength(50);
+  });
+
+  it('pins the search cost budgets to the band they were measured against', () => {
+    // Mirrors of the measurements recorded in the CHANNEL_SEARCH_PREFIX_*
+    // docblocks (shared/channel-chat-protocol.ts). Re-measuring the corpus means
+    // updating BOTH — this test is what makes moving a budget out of the
+    // measured band fail here instead of on a production hub, which the store
+    // tests above cannot do because they seed relative to the constant and stay
+    // green at any value.
+    const heaviestLegitimatePrefixTerms = 973; // `"con" *`, 108ms
+    const pathologicalPrefixTerms = 4281; // `"a" *`, 1086ms — must stay refused
+    const docsRankedPerMs = 4300;
+    const measuredLegitimateWorstMs = 158; // #1316, three-char prefix at 50k
+
+    // Headroom over the heaviest LEGITIMATE prefix, because prefix expansion
+    // grows with vocabulary while this budget is an absolute count: too tight
+    // and ordinary words start answering `search_query_too_broad` on every
+    // keystroke as the transcript grows, with nothing saying the guard is why.
+    expect(CHANNEL_SEARCH_PREFIX_TERM_BUDGET).toBeGreaterThanOrEqual(
+      heaviestLegitimatePrefixTerms * 2
+    );
+    expect(CHANNEL_SEARCH_PREFIX_TERM_BUDGET).toBeLessThan(
+      pathologicalPrefixTerms
+    );
+
+    // The doc budget is the ONLY bound on a query that emits no rows — an AND
+    // whose intersection is empty never reaches the per-row ceiling at all — so
+    // what it permits IS an un-interruptible synchronous window. Keeping that
+    // window inside the interruptible ceiling is the invariant; ten times this
+    // budget is ~2.3s of frozen event loop, which is the defect #1316 was filed
+    // for.
+    expect(
+      CHANNEL_SEARCH_PREFIX_DOC_BUDGET / docsRankedPerMs
+    ).toBeLessThanOrEqual(CHANNEL_SEARCH_TIME_BUDGET_MS);
+
+    // And the ceiling has to stay clear of the legitimate band it backstops, or
+    // it stops being a backstop and becomes a second gate on honest queries.
+    expect(CHANNEL_SEARCH_TIME_BUDGET_MS).toBeGreaterThan(
+      measuredLegitimateWorstMs * 2
+    );
   });
 
   it('abandons a read that outruns its wall-clock budget', () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -10,13 +10,18 @@ import {
   buildChannelSearchMatchQuery,
   buildChannelThreadHistorySql,
   buildChannelThreadSummarySql,
+  channelSearchPrefixRange,
   channelSearchUnavailableReason,
   createChannelMessageStore,
+  registerChannelSearchTick,
   ChannelMessageStoreError,
+  ChannelSearchRefusedError,
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import {
   CHANNEL_SEARCH_MIN_QUERY_CHARS,
+  CHANNEL_SEARCH_PREFIX_TERM_BUDGET,
+  CHANNEL_SEARCH_TIME_BUDGET_MS,
   type ChannelSenderRef,
 } from '../shared/channel-chat-protocol.js';
 import { builtInAgentProfileId } from '../shared/agent-profile.js';
@@ -33,8 +38,11 @@ function dbPath(): string {
   return path.join(dir, 'channel-chat.db');
 }
 
-function store(pathOverride?: string): ChannelMessageStore {
-  const s = createChannelMessageStore(pathOverride ?? dbPath());
+function store(
+  pathOverride?: string,
+  options?: { searchTimeBudgetMs?: number }
+): ChannelMessageStore {
+  const s = createChannelMessageStore(pathOverride ?? dbPath(), options ?? {});
   cleanup.push(() => s.close());
   return s;
 }
@@ -1983,6 +1991,90 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
     expect(s.searchMessages({ query: 'note' })).toHaveLength(1);
   });
 
+  it('bounds the prefix range the way the FTS5 tokenizer stored the terms', () => {
+    // Only the FINAL term takes `*`, and only at the minimum length — the range
+    // must agree with `buildChannelSearchMatchQuery` or the gate would cost a
+    // prefix the query never runs.
+    expect(channelSearchPrefixRange('')).toBeNull();
+    expect(channelSearchPrefixRange('ab')).toBeNull();
+    expect(channelSearchPrefixRange('deploy a')).toBeNull();
+    expect(channelSearchPrefixRange('deploy')).toEqual({
+      low: 'deploy',
+      high: 'deploz',
+    });
+    expect(channelSearchPrefixRange('a deploy')).toEqual({
+      low: 'deploy',
+      high: 'deploz',
+    });
+    // Folded the way `unicode61 remove_diacritics 2` folds: case and combining
+    // marks are gone before the range is computed, so an operator typing
+    // `Déploy` probes the same terms the query will actually match.
+    expect(channelSearchPrefixRange('Déploy')).toEqual({
+      low: 'deploy',
+      high: 'deploz',
+    });
+    // `"foo-bar" *` is the two-token phrase `foo bar` with the prefix on the
+    // LAST token, so that is the token the range has to cover.
+    expect(channelSearchPrefixRange('foo-bar')).toEqual({
+      low: 'bar',
+      high: 'bas',
+    });
+  });
+
+  it('refuses a prefix this corpus cannot afford, before reading the index', () => {
+    const s = store();
+    // Every row contributes one term under the shared `zzq` prefix, so the
+    // prefix expansion is exactly the row count — the pathological shape #1316
+    // measured, reproduced at a size a test can afford.
+    const overBudget = CHANNEL_SEARCH_PREFIX_TERM_BUDGET + 8;
+    for (let i = 0; i < overBudget; i += 1) {
+      seq(s, 'topic:alpha', `broadcast zzq${i.toString(36)} payload`);
+    }
+    expect(() => s.searchMessages({ query: 'zzq' })).toThrow(
+      ChannelSearchRefusedError
+    );
+    try {
+      s.searchMessages({ query: 'zzq' });
+      expect.unreachable('over-broad prefix must be refused');
+    } catch (error) {
+      expect((error as ChannelSearchRefusedError).reason).toBe(
+        'search_query_too_broad'
+      );
+    }
+    // The gate is on the PREFIX expansion, not on the corpus: an exact term in
+    // the same store still answers, and a longer prefix over the same rows
+    // narrows back under the budget instead of staying refused.
+    expect(s.searchMessages({ query: 'broadcast' })).toHaveLength(50);
+    expect(s.searchMessages({ query: 'zzq1' }).length).toBeGreaterThan(0);
+    // A trailing term below the minimum never gets `*`, so it is never costed —
+    // it is refused by the older, cheaper guard instead.
+    expect(s.searchMessages({ query: 'zz' })).toEqual([]);
+  });
+
+  it('abandons a read that outruns its wall-clock budget', () => {
+    // Budget 0 makes the ceiling fire on the FIRST matched row, which is what
+    // keeps this a contract test rather than a latency test: a faster CI box
+    // cannot quietly turn it green, and it needs no pathological corpus.
+    const s = store(undefined, { searchTimeBudgetMs: 0 });
+    seq(s, 'topic:alpha', 'the deployment pipeline is wedged');
+    try {
+      s.searchMessages({ query: 'deployment' });
+      expect.unreachable('an exhausted budget must abandon the read');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChannelSearchRefusedError);
+      expect((error as ChannelSearchRefusedError).reason).toBe(
+        'search_timeout'
+      );
+    }
+    // The ceiling is armed per call and disarmed afterwards, so it can only
+    // ever abort the read it was armed for — a store on the shipped budget
+    // answers the same query normally.
+    const normal = store();
+    seq(normal, 'topic:alpha', 'the deployment pipeline is wedged');
+    expect(normal.searchMessages({ query: 'deployment' })).toHaveLength(1);
+    expect(CHANNEL_SEARCH_TIME_BUDGET_MS).toBeGreaterThan(0);
+  });
+
   it('backfills an existing db idempotently and rebuilds a dropped index', () => {
     const file = dbPath();
     const seeded = createChannelMessageStore(file);
@@ -2258,6 +2350,11 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       text: 'query plan subject',
     });
     const raw = new Database(file);
+    // The production SQL carries the #1316 wall-clock hook, and SQLite resolves
+    // function names at PREPARE time, so a second handle has to install it too.
+    // A no-op is the right stub: the assertion is about the plan, and the whole
+    // point of putting the hook in the WHERE clause is that it never adds to one.
+    registerChannelSearchTick(raw, () => false);
     const plan = raw
       .prepare(`EXPLAIN QUERY PLAN ${buildChannelMessageSearchSql(1)}`)
       .all('', '', '…', '"plan"', 'topic:alpha', 10) as Array<{

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -46,6 +46,7 @@ import {
   CHANNEL_SEARCH_HIGHLIGHT_CLOSE,
   CHANNEL_SEARCH_HIGHLIGHT_OPEN,
   CHANNEL_SEARCH_MAX_RESULTS,
+  CHANNEL_SEARCH_PREFIX_TERM_BUDGET,
   parseChannelSearchSnippet,
   type ChannelEventV1,
 } from '../shared/channel-chat-protocol.js';
@@ -87,6 +88,12 @@ async function harness(
      * tiebreak SQLite is free to resolve either way.
      */
     topicClock?: () => string;
+    /**
+     * Wall-clock ceiling for one search read (#1316). `0` makes the ceiling
+     * fire on the first matched row, so the route's `search_timeout` mapping is
+     * provable without a pathological corpus or a latency assertion.
+     */
+    searchTimeBudgetMs?: number;
   } = {}
 ): Promise<Harness> {
   const dir = tmpDir();
@@ -95,7 +102,12 @@ async function harness(
     now: options.topicClock ?? (() => '2026-07-18T00:00:00.000Z'),
   });
   cleanup.push(() => topicStore.close());
-  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+  const store = createChannelMessageStore(
+    path.join(dir, 'channel-chat.db'),
+    options.searchTimeBudgetMs === undefined
+      ? {}
+      : { searchTimeBudgetMs: options.searchTimeBudgetMs }
+  );
   cleanup.push(() => store.close());
   const attachmentStore = createChannelAttachmentStore({
     dbPath: path.join(dir, 'channel-attachments.db'),
@@ -2225,6 +2237,43 @@ describe('channel routes — message search (#1308 slice 2 item 1)', () => {
     const miss = await search(h, 'q=zzzznotpresent');
     expect(miss.body.results).toEqual([]);
     expect(miss.body.unavailableReason).toBeUndefined();
+  });
+
+  it('answers a cost refusal with 200 and a reason, not an error status (#1316)', async () => {
+    const h = await harness();
+    // Seeded through the store, not the route: this needs one distinct term per
+    // row under a shared prefix to reproduce the expansion #1316 measured, and
+    // 1032 HTTP round trips would buy nothing the store call does not.
+    for (let i = 0; i < CHANNEL_SEARCH_PREFIX_TERM_BUDGET + 8; i += 1) {
+      h.store.appendComplete({
+        channelId: h.channelId,
+        sender: { kind: 'human', id: 'human:operator' },
+        text: `broadcast zzq${i.toString(36)} payload`,
+      });
+    }
+    const broad = await search(h, 'q=zzq');
+    // 200, not 4xx/5xx: the request was well formed and the corpus is fine —
+    // what failed is affordability, which the client answers by narrowing.
+    expect(broad.status).toBe(200);
+    expect(broad.body.results).toEqual([]);
+    expect(broad.body.truncated).toBe(false);
+    expect(broad.body.unavailableReason).toBe('search_query_too_broad');
+    // Same store, same request shape: an ordinary query is untouched by the
+    // gate and still reports NO reason, so an empty result stays meaningful.
+    const ordinary = await search(h, 'q=broadcast');
+    expect(ordinary.status).toBe(200);
+    expect(ordinary.body.results.length).toBeGreaterThan(0);
+    expect(ordinary.body.unavailableReason).toBeUndefined();
+  });
+
+  it('answers search_timeout when a read outruns its wall-clock ceiling (#1316)', async () => {
+    const timed = await harness({ searchTimeBudgetMs: 0 });
+    await post(timed, timed.channelId, 'the deployment pipeline is wedged');
+    const res = await search(timed, 'q=deployment');
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([]);
+    expect(res.body.truncated).toBe(false);
+    expect(res.body.unavailableReason).toBe('search_timeout');
   });
 
   it('reaches channels the rail read model would have cut off', async () => {

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -4389,6 +4389,31 @@ describe('TopicSidebarView', () => {
       );
     });
 
+    it('asks for a narrower query when the index refused or abandoned the read (#1316)', async () => {
+      // Both reasons are COST answers, so neither may claim the transcript was
+      // searched. `search_query_too_broad` is refused before the read starts;
+      // `search_timeout` is cut off part way through it. If either printed "no
+      // matches", the operator would read a corpus claim off a query the index
+      // never finished — the same failure the older reasons already avoid.
+      for (const [reason, copy] of [
+        ['search_query_too_broad', 'too many matches to rank'],
+        ['search_timeout', 'search took too long'],
+      ] as const) {
+        await renderView({
+          topics: [],
+          sessions: [],
+          surfaces: [],
+          searchQuery: 'zzq',
+          searchResults: [],
+          messageResults: [],
+          messageSearchUnavailableReason: reason,
+        });
+        expect(container.textContent).toContain(copy);
+        expect(container.textContent).toContain('type more characters');
+        expect(container.textContent).not.toContain('no message matches for');
+      }
+    });
+
     it('opens the channel and asks it to jump when a message hit is clicked', async () => {
       useUiStore.setState({ sidebarOpen: true, activeChannelId: null });
       await renderView({


### PR DESCRIPTION
## Defect

`/channels/search` runs a synchronous better-sqlite3 FTS read inline on the request thread. `CHANNEL_SEARCH_MIN_QUERY_CHARS = 3` bounds the *pathological shape* (a one-character prefix) but not the *worst case*, because prefix expansion is a property of the corpus, not of the query. Measured on a 50k-message / 179MB transcript: `"w" *` 2805ms, `"w1" *` 1079ms, `"w12" *` 158ms. A hostile-or-unlucky three-character prefix on a larger transcript holds the entire Node event loop — WebSocket channel traffic, PTY streaming and `/healthz` included — for as long as the ranking takes.

## Root cause

Ranking is the unbounded part. FTS5 expands the trailing `*` across every matching term, opens one doclist iterator per term, merges them, and `bm25()` must score every matched row before `LIMIT` can discard it. None of that yields to the event loop, and better-sqlite3 exposes no `sqlite3_progress_handler` to interrupt it.

## Fix

Three layers, each bounding a different part of the cost.

1. **Pre-flight term budget** (`CHANNEL_SEARCH_PREFIX_TERM_BUDGET = 2048`). Before the read, the store walks the FTS5 term index through a per-connection `fts5vocab` view over `[prefix, prefix⁺)` and refuses with `search_query_too_broad` if the prefix expands too far. Term count specifically, because the doclist-merge setup happens *before the first row exists* and no per-row hook can see it. The walk is bounded by the budget itself, so pre-flight cost does not grow with the corpus (≤6ms at 1025 terms).
2. **Pre-flight doc budget** (`CHANNEL_SEARCH_PREFIX_DOC_BUDGET = 1_000_000`). A prefix can be narrow in terms and enormous in postings (`"abc" *` was 2 terms / 72,240 docs on the calibration corpus).
3. **Wall-clock ceiling** (`CHANNEL_SEARCH_TIME_BUDGET_MS = 750`). Built from the one per-row hook better-sqlite3 does expose: a non-deterministic user function in the WHERE clause, positioned to read a column of the driving table so SQLite cannot hoist it out of the row loop. It throws once the budget is spent and the store answers `search_timeout`.

Both refusals are **200-with-a-reason**, not error statuses — the same shape `query_too_short` already uses. The client renders "type more characters" and never "no matches", because neither answer says anything about what is in the transcript. `ChannelSearchUnavailableReason` gains `search_query_too_broad` and `search_timeout`.

## Review trail

An adversarial review returned **concern** on the first implementation (cb087c20): two P2s and five P3s. The second commit (b2ae566b) closes them.

**The load-bearing finding.** The ceiling is a per-**row** hook, so it only bounds rows the query *emits* — a query returning zero rows never calls it. Verified on a 200k-row index with an already-expired deadline:

| expression | ticks | outcome |
|---|---|---|
| `"conf" *` | 1 | throws, as designed |
| `"alpha" AND "conf" *` (both ~100k docs, empty intersection) | **0** | completes normally, 40ms |

`buildChannelSearchMatchQuery` joins terms with ` AND `, so two typed words are exactly that shape. The doc budget — documented as "a courtesy" on the grounds that "row cost IS interruptible" — is in fact the **only** bound that shape has. Docblock rewritten to say so, with the measurement recorded and the cost of widening stated one-for-one.

**Findings applied**

- **P2** doc-budget docblock: "courtesy" framing was false; now records that it is load-bearing for zero-row AND expressions, with the 0-tick measurement and the 262ms un-interruptible window measured at exactly this budget.
- **P2** term budget `1024 → 2048`: 1024 sat 5% under the heaviest *legitimate* prefix the docblock itself records (`"con" *`, 973 terms). Since the budget is an absolute count and vocabulary grows with the corpus, one doubling would have flipped an ordinary three-character prefix to `search_query_too_broad` on every keystroke of a live search, with nothing indicating the guard rather than the corpus was the cause. 2048 keeps ~2.1x headroom and still refuses `"a" *` (4281 terms). Calibration corpus is now named in the docblock with a re-measure instruction, and refusals are counted and logged (throttled, with the count and which budget blew).
- **P3** pre-flight fail-open is now a *tested contract* (`searchCostPreflight: 'unavailable'`) rather than an untested branch; its per-query warn is latched so a persistent fault cannot emit one line per keystroke.
- **P3** the timeout log no longer prints the operator's query text — search input is exactly where a pasted secret shows up, and the path is reachable repeatedly by any `CONTEXT_READ` holder. It logs shape: term count and prefix length.
- **P3** `channelSearchPrefixRange` no longer claims every fold divergence fails open. Measured: `ΣΊΣ` probes `[σις, σισ)` while FTS5 stores `σίσυφοσ` — U+03AF sorts below U+03B9, so the term is outside the range and the walk counts **zero**. Two divergences compound (tonos survives `remove_diacritics 2`; `toLowerCase` emits final sigma U+03C2 where unicode61 folds to U+03C3). The docblock now states disjoint-not-subset, and an assertion pins it.
- **P3** `CHANNEL_SEARCH_TICK_FUNCTION` un-exported; its stated rationale was stale one commit after being written.
- **P3** residual **recorded rather than claimed away**, in the `CHANNEL_SEARCH_TIME_BUDGET_MS` docblock: composed worst case is ~262ms un-interruptible setup + the 750ms ceiling ≈ **1.0s**, versus 2805ms before. `/channels/search` still has no admission control and shares one synchronous connection with WS catch-up, read-state and presence. Tracked in #1330. Deliberately not fixed by tightening the ceiling — the legitimate band grows with the corpus (158ms for an ordinary prefix at 50k), so a tight ceiling converts corpus growth into timeouts on honest queries.

**Backpressure, not prose.** The review noted the store test seeds `BUDGET + 8` rows and therefore stays green at any budget value. A new test pins both budgets to the measured band, so moving one out of it fails here instead of on a hub.

## Verification

`npm run check` — **0 errors** (220 pre-existing warnings).

Targeted vitest, node 22 (sqlite-backed): `channel-message-store` + `channel-routes` + `topic-sidebar-shell` + `auth` — **274 passed, 0 failed**. `auth.test.ts` is included as the route-inventory drift guard; no new HTTP route and no new gateway verb, so both inventories are unchanged.

**Anti-vacuity** — each mechanism reverted individually, confirmed red, restored:

| reverted | result |
|---|---|
| per-row tick removed from the production SQL | `abandons a read that outruns its wall-clock budget` FAILS; route `search_timeout` FAILS |
| `refuseOverBroadPrefix` call removed | `refuses a prefix this corpus cannot afford` FAILS; route `search_query_too_broad` FAILS |
| term budget back to 1024 | budget pin FAILS — `expected 1024 to be greater than or equal to 1946` |
| doc budget widened to 10M (the exact hazard the review named) | budget pin FAILS — `expected 2325.58… to be less than or equal to 750` |

Restored, re-verified: 0 errors, 274 passing.

Refs #1316. Pre-v0.1.1-stable hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
