### PR TITLE
fix(channels): expose channel creation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ workflow.
 
 ## [Unreleased]
 
+### Channel workspace and sidebar
+
+#### Changed
+
+- The new-chat composer now lets operators create normal channels, and DMs cannot be designated as orchestration channels (#1337)
+
 ## [0.1.1] - 2026-08-05
 
 This is the first public release of the channel era, branded v0.1; it ships as

--- a/frontend/src/components/TopicComposer.css
+++ b/frontend/src/components/TopicComposer.css
@@ -37,6 +37,62 @@
   font-size: var(--font-size-sm);
 }
 
+.topic-composer__destination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.topic-composer__destination button {
+  min-height: 32px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.topic-composer__destination button:hover,
+.topic-composer__destination button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.topic-composer__destination button.is-selected {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.topic-composer__channel-name {
+  display: grid;
+  gap: 3px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.topic-composer__channel-name input {
+  min-width: 0;
+  min-height: 32px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+}
+
+.topic-composer__channel-name input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
 .topic-composer__ta {
   min-width: 0;
   padding: 8px;

--- a/frontend/src/components/TopicComposer.tsx
+++ b/frontend/src/components/TopicComposer.tsx
@@ -85,6 +85,8 @@ function primaryIntentForTemplate(templateKind: WorkspaceTopicTemplateKind) {
   return templateKind === 'note' ? 'create-only' : 'create-and-launch';
 }
 
+type ComposerDestination = 'direct-message' | 'channel';
+
 function composerSubmitDisabled(input: {
   effectiveTitle: string;
   submitting: boolean;
@@ -127,6 +129,7 @@ export default function TopicComposer({
     draft,
     updateDraft,
     submit,
+    createChannel,
     submittingIntent,
     launchFailure,
     effectiveTitle,
@@ -141,6 +144,9 @@ export default function TopicComposer({
     cwdOptions,
   } = useTopicRoomCreate({ onLaunched: onSelectSession });
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [destination, setDestination] =
+    useState<ComposerDestination>('direct-message');
+  const [channelName, setChannelName] = useState('');
   const taRef = useRef<HTMLTextAreaElement>(null);
 
   // #1058: focus on mount (desktop only — see the isMobileDevice guard).
@@ -195,6 +201,9 @@ export default function TopicComposer({
     launchProviderUnavailable:
       primaryIntent === 'create-and-launch' && providerUnavailable,
   });
+  const creatingChannel = destination === 'channel';
+  const channelDisabled = !channelName.trim() || Boolean(submittingIntent);
+  const submitDisabled = creatingChannel ? channelDisabled : disabled;
   // #1103: never render a raw node id — resolve through the roster or fall
   // back to a generic label.
   const routedNodeId = previewCreate.routingDefaults?.nodeId;
@@ -213,9 +222,51 @@ export default function TopicComposer({
           aria-label="new chat"
           onSubmit={(event: FormEvent) => {
             event.preventDefault();
-            if (!disabled) void submit(primaryIntent);
+            if (!submitDisabled) {
+              if (creatingChannel) void createChannel(channelName);
+              else void submit(primaryIntent);
+            }
           }}
         >
+          <div
+            className="topic-composer__destination"
+            role="group"
+            aria-label="chat type"
+          >
+            <button
+              type="button"
+              aria-pressed={destination === 'direct-message'}
+              className={
+                destination === 'direct-message' ? 'is-selected' : undefined
+              }
+              onClick={() => setDestination('direct-message')}
+            >
+              direct message
+            </button>
+            <button
+              type="button"
+              aria-pressed={creatingChannel}
+              className={creatingChannel ? 'is-selected' : undefined}
+              onClick={() => {
+                setDestination('channel');
+                setAdvancedOpen(false);
+              }}
+            >
+              channel
+            </button>
+          </div>
+          {creatingChannel ? (
+            <label className="topic-composer__channel-name">
+              <span>channel name</span>
+              <input
+                value={channelName}
+                onChange={(event) => setChannelName(event.target.value)}
+                placeholder="e.g. release coordination"
+                aria-label="channel name"
+                autoComplete="off"
+              />
+            </label>
+          ) : null}
           <textarea
             ref={taRef}
             className="topic-composer__ta"
@@ -226,17 +277,22 @@ export default function TopicComposer({
                 event.key === 'Enter' &&
                 !event.shiftKey &&
                 !event.nativeEvent.isComposing &&
-                !disabled
+                !submitDisabled
               ) {
                 event.preventDefault();
-                void submit(primaryIntent);
+                if (creatingChannel) void createChannel(channelName);
+                else void submit(primaryIntent);
               } else if (event.key === 'Escape') {
                 // Composer opened over an active session — Escape returns to
                 // it. No-op on the bare landing (flag already false).
                 setTopicComposerOpen(false);
               }
             }}
-            placeholder="what should the agent do?"
+            placeholder={
+              creatingChannel
+                ? 'optional opening message'
+                : 'what should the agent do?'
+            }
             rows={4}
             aria-label="first message"
             // Focus is applied imperatively (see the mount effect above) so
@@ -245,37 +301,50 @@ export default function TopicComposer({
             // would pop the software keyboard on every app open, so it's
             // skipped entirely there (not just scroll-suppressed).
           />
-          <TopicComposerProviderRow
-            providerOptions={providerOptions}
-            selectedProviderId={selectedProviderId}
-            selectedProviderOption={selectedProviderOption}
-            providerUnavailable={providerUnavailable}
-            onProviderChange={(providerId) => updateDraft({ providerId })}
-          />
+          {!creatingChannel ? (
+            <TopicComposerProviderRow
+              providerOptions={providerOptions}
+              selectedProviderId={selectedProviderId}
+              selectedProviderOption={selectedProviderOption}
+              providerUnavailable={providerUnavailable}
+              onProviderChange={(providerId) => updateDraft({ providerId })}
+            />
+          ) : null}
           <div className="topic-composer__bar">
             <span className="topic-composer__context">
-              using {selectedProviderOption?.label ?? preview.providerLabel} in{' '}
-              {preview.cwdLabel}
+              {creatingChannel
+                ? 'agents can collaborate here once you mention or invite them'
+                : `using ${selectedProviderOption?.label ?? preview.providerLabel} in ${preview.cwdLabel}`}
             </span>
-            <TuiButton variant="primary" type="submit" disabled={disabled}>
-              {launchSubmitLabel({
-                submittingIntent,
-                launchDisabled,
-                launchFailure,
-              })}
+            <TuiButton
+              variant="primary"
+              type="submit"
+              disabled={submitDisabled}
+            >
+              {creatingChannel
+                ? submittingIntent === 'create-only'
+                  ? 'creating…'
+                  : 'create channel'
+                : launchSubmitLabel({
+                    submittingIntent,
+                    launchDisabled,
+                    launchFailure,
+                  })}
             </TuiButton>
           </div>
-          <button
-            type="button"
-            className="topic-composer__advanced-toggle"
-            aria-expanded={advancedOpen}
-            aria-controls="topic-composer-advanced"
-            onClick={() => setAdvancedOpen((prev) => !prev)}
-          >
-            <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
-            route/context
-          </button>
-          {advancedOpen ? (
+          {!creatingChannel ? (
+            <button
+              type="button"
+              className="topic-composer__advanced-toggle"
+              aria-expanded={advancedOpen}
+              aria-controls="topic-composer-advanced"
+              onClick={() => setAdvancedOpen((prev) => !prev)}
+            >
+              <span aria-hidden="true">{advancedOpen ? '▾ ' : '▸ '}</span>
+              route/context
+            </button>
+          ) : null}
+          {!creatingChannel && advancedOpen ? (
             <div
               className="topic-composer__advanced"
               id="topic-composer-advanced"

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -893,7 +893,10 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             })}
           </span>
         ) : null}
-        {rosterChipsQuery.isSuccess && !hasOrchestrator ? (
+        {topicQuery.isSuccess &&
+        !isDm &&
+        rosterChipsQuery.isSuccess &&
+        !hasOrchestrator ? (
           <button
             type="button"
             className="ch-designate-orchestrator"

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -481,6 +481,7 @@ export function useTopicRoomCreate({
       setSubmittingIntent('create-only');
       setLaunchFailure(null);
       const prompt = draft.prompt.trim();
+      let navigatedToCreatedChannel = false;
       try {
         const channelRoutingDefaults = {
           ...(previewCreate.routingDefaults?.nodeId
@@ -526,6 +527,7 @@ export function useTopicRoomCreate({
         // and postOpeningPrompt supplies the established archived-channel toast.
         const ui = useUiStore.getState();
         ui.setActiveChannelId(topic.id);
+        navigatedToCreatedChannel = true;
         ui.setTopicComposerOpen(false);
         ui.setForceOrgCockpit(false);
         try {
@@ -566,10 +568,10 @@ export function useTopicRoomCreate({
             : {}),
           ...(error instanceof HttpError ? { status: error.status } : {}),
         });
-        // If navigation already occurred, the Composer is gone and the error
-        // must remain visible to the operator. Creation failures stay in the
-        // Composer's inline failure state as well.
-        if (useUiStore.getState().activeChannelId) {
+        // Only an error after this attempt landed on its new channel needs a
+        // toast: the Composer is gone. An existing channel must not turn an
+        // inline create failure into a misleading duplicate toast.
+        if (navigatedToCreatedChannel) {
           useToastStore
             .getState()
             .showToast(`could not create channel — ${message}`);

--- a/frontend/src/hooks/useTopicRoomCreate.ts
+++ b/frontend/src/hooks/useTopicRoomCreate.ts
@@ -1,12 +1,15 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import type {
-  WorkspaceTopicCreateInput,
-  WorkspaceTopicLaunchIntent,
+import {
+  parseWorkspaceTopicConflictDetails,
+  type WorkspaceTopicCreateInput,
+  type WorkspaceTopicLaunchIntent,
 } from '../../../shared/workspace-topics.js';
 import {
+  createWorkspaceTopic,
   createWorkspaceTopicRoomAndMaybeLaunch,
   fetchHubNodes,
+  fetchWorkspaceTopic,
   launchWorkspaceTopicRoom,
   HttpError,
   type WorkspaceTopicLaunchFailure,
@@ -465,11 +468,134 @@ export function useTopicRoomCreate({
     ]
   );
 
+  /**
+   * Create a normal multi-party channel. Unlike agent work, this deliberately
+   * carries neither a deterministic DM id nor a provider routing default: the
+   * resulting topic is a channel where the operator can invite/mention agents.
+   */
+  const createChannel = useCallback(
+    async (title: string) => {
+      const channelTitle = title.trim();
+      if (!channelTitle || submittingIntent) return;
+
+      setSubmittingIntent('create-only');
+      setLaunchFailure(null);
+      const prompt = draft.prompt.trim();
+      try {
+        const channelRoutingDefaults = {
+          ...(previewCreate.routingDefaults?.nodeId
+            ? { nodeId: previewCreate.routingDefaults.nodeId }
+            : {}),
+          ...(previewCreate.routingDefaults?.repoPath
+            ? { repoPath: previewCreate.routingDefaults.repoPath }
+            : {}),
+          ...(previewCreate.routingDefaults?.worktreePath
+            ? { worktreePath: previewCreate.routingDefaults.worktreePath }
+            : {}),
+          ...(previewCreate.routingDefaults?.cwd
+            ? { cwd: previewCreate.routingDefaults.cwd }
+            : {}),
+        };
+        const input: WorkspaceTopicCreateInput = {
+          id: topicIdReservation.current.reserve(),
+          workspaceId: previewCreate.workspaceId,
+          title: channelTitle,
+          ...(prompt ? { description: prompt.slice(0, 240) } : {}),
+          ...(Object.keys(channelRoutingDefaults).length
+            ? { routingDefaults: channelRoutingDefaults }
+            : {}),
+        };
+        let topic;
+        try {
+          topic = await createWorkspaceTopic(input);
+        } catch (error) {
+          // The opaque id is reserved for this attempt, so a retry after a
+          // timeout/double submit may collide with the exact channel it already
+          // created. Adopt that normal channel just as topic-room creation does.
+          const conflict =
+            error instanceof HttpError && error.status === 409
+              ? parseWorkspaceTopicConflictDetails(error.details)
+              : null;
+          if (!conflict) throw error;
+          topic = await fetchWorkspaceTopic(conflict.blockingTopicId);
+        }
+        topicIdReservation.current.release();
+
+        // Navigate before the optional opening post. This makes an archived
+        // adopted channel recoverable through ChannelView's restore control,
+        // and postOpeningPrompt supplies the established archived-channel toast.
+        const ui = useUiStore.getState();
+        ui.setActiveChannelId(topic.id);
+        ui.setTopicComposerOpen(false);
+        ui.setForceOrgCockpit(false);
+        try {
+          await queryClient.invalidateQueries({
+            queryKey: ['workspace-topics'],
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          useToastStore
+            .getState()
+            .showToast(
+              `channel created, but sidebar refresh failed — ${message}`
+            );
+        }
+        setDraft(TOPIC_ROOM_DRAFT_EMPTY);
+        spendLaneRepoRouting();
+        if (!prompt) return;
+        try {
+          await postOpeningPrompt(topic.id, prompt);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          useToastStore
+            .getState()
+            .showToast(
+              `channel created, but opening message failed — ${message}`
+            );
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setLaunchFailure({
+          stage: 'topic',
+          message,
+          retryable: true,
+          ...(error instanceof HttpError && error.code
+            ? { code: error.code }
+            : {}),
+          ...(error instanceof HttpError ? { status: error.status } : {}),
+        });
+        // If navigation already occurred, the Composer is gone and the error
+        // must remain visible to the operator. Creation failures stay in the
+        // Composer's inline failure state as well.
+        if (useUiStore.getState().activeChannelId) {
+          useToastStore
+            .getState()
+            .showToast(`could not create channel — ${message}`);
+        }
+      } finally {
+        setSubmittingIntent(null);
+      }
+    },
+    [
+      draft.prompt,
+      previewCreate.routingDefaults?.cwd,
+      previewCreate.routingDefaults?.nodeId,
+      previewCreate.routingDefaults?.repoPath,
+      previewCreate.routingDefaults?.worktreePath,
+      previewCreate.workspaceId,
+      queryClient,
+      submittingIntent,
+    ]
+  );
+
   return {
     draft,
     updateDraft,
     reset,
     submit,
+    createChannel,
     submittingIntent,
     launchFailure,
     effectiveTitle,

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -5,6 +5,7 @@ import type { Request, RequestHandler, Response } from 'express';
 import multer from 'multer';
 
 import type { RelayCliGatewayErrorCode } from '../shared/cli-gateway-contract.js';
+import { isDmChannel } from '../shared/dm-channels.js';
 import {
   authenticatedCliGatewayActorCredential,
   type CliGatewayActorReadCommand,
@@ -1445,6 +1446,19 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
   router.post('/channels/:id/orchestrator', auth, (req, res) => {
     const topic = requirePersistedChannel(req, res);
     if (!topic) return;
+    // A DM already addresses exactly one provider. A persistent orchestrator
+    // would add a second, unrelated participant (and historically defaulted to
+    // Claude when no framework was specified), so this is group-channel only.
+    if (isDmChannel(topic)) {
+      sendGatewayError(
+        res,
+        'UNSUPPORTED',
+        'direct messages cannot designate an orchestrator',
+        false,
+        { channelId: topic.id, reasonCode: 'DM_ORCHESTRATOR_UNSUPPORTED' }
+      );
+      return;
+    }
     const binder = binderOr503(res, deps.binder);
     if (!binder) return;
     const requested = req.query['framework'];

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -50,6 +50,7 @@ import {
   parseChannelSearchSnippet,
   type ChannelEventV1,
 } from '../shared/channel-chat-protocol.js';
+import { dmChannelCreateInput } from '../shared/dm-channels.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -1417,6 +1418,42 @@ describe('channel routes — orchestrator designation (#1259)', () => {
     });
     expect(res.status).toBe(200);
     expect(seen).toEqual(['claude']);
+  });
+
+  it('refuses DM designation before invoking the binder', async () => {
+    let called = false;
+    const h = await harness({
+      binder: {
+        ensureOrchestrator: async () => {
+          called = true;
+          return { runtimeId: 'orch-dm', status: 'idle' } as never;
+        },
+      },
+    });
+    const dm = h.topicStore.create(
+      dmChannelCreateInput({
+        providerId: 'codex',
+        providerDisplayName: 'Codex',
+        workspaceId: 'ws:local',
+      })
+    );
+
+    const res = await req<{
+      error: { code: string; retryable: boolean; details?: Record<string, unknown> };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${dm.id}/orchestrator`,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('UNSUPPORTED');
+    expect(res.body.error.retryable).toBe(false);
+    expect(res.body.error.details).toEqual({
+      channelId: dm.id,
+      reasonCode: 'DM_ORCHESTRATOR_UNSUPPORTED',
+    });
+    expect(called).toBe(false);
   });
 
   it('maps a role conflict to SESSION_CONFLICT', async () => {

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -4,6 +4,7 @@ import React, { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { dmChannelTopicId } from '../../shared/dm-channels.js';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
@@ -74,6 +75,7 @@ const { ChannelView } =
   await import('../../frontend/src/components/chat/ChannelView.js');
 
 const CHANNEL_ID = 'topic:operator-lane';
+const CODEX_DM_CHANNEL_ID = dmChannelTopicId('codex', 'ws:local');
 
 function topicFixture() {
   return {
@@ -156,6 +158,28 @@ afterEach(async () => {
 });
 
 describe('ChannelView orchestrator control (#1242)', () => {
+  it('waits for confirmed topic identity before offering designation', async () => {
+    let resolveTopic: ((topic: ReturnType<typeof topicFixture>) => void) | null =
+      null;
+    mocks.fetchWorkspaceTopic.mockReturnValue(
+      new Promise<ReturnType<typeof topicFixture>>((resolve) => {
+        resolveTopic = resolve;
+      })
+    );
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+
+    await render();
+
+    expect(container.querySelector('.ch-designate-orchestrator')).toBeNull();
+
+    resolveTopic?.(topicFixture());
+    await flush();
+
+    expect(
+      container.querySelector('.ch-designate-orchestrator')
+    ).not.toBeNull();
+  });
+
   it('waits for the roster before offering designation', async () => {
     let resolveRoster:
       | ((entries: ReturnType<typeof rosterEntry>[]) => void)
@@ -203,6 +227,30 @@ describe('ChannelView orchestrator control (#1242)', () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: ['channel-roster', CHANNEL_ID],
     });
+  });
+
+  it('never offers designation in a confirmed DM', async () => {
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: CODEX_DM_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'Codex' },
+      routingDefaults: { providerId: 'codex' },
+    });
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChannelView, { channelId: CODEX_DM_CHANNEL_ID })
+        )
+      );
+    });
+    await flush();
+
+    expect(container.querySelector('.ch-designate-orchestrator')).toBeNull();
+    expect(mocks.designateChannelOrchestrator).not.toHaveBeenCalled();
   });
 
   it('uses the braille text-motion state while designation is pending', async () => {

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -759,6 +759,37 @@ describe('TopicComposer', () => {
     expect(useSessionsStore.getState().activeSessionId).toBeNull();
   });
 
+  it('keeps a failed channel create inline when another channel is open', async () => {
+    const { HttpError } = await import('../frontend/src/lib/api.js');
+    vi.mocked(createWorkspaceTopic).mockRejectedValue(
+      new HttpError(503, 'hub unreachable')
+    );
+    useUiStore.setState({ activeChannelId: 'topic:already-open' });
+    useToastStore.setState({ toasts: [] });
+    renderComposer();
+
+    const channelChoice = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[aria-pressed]')
+    ).find((button) => button.textContent === 'channel');
+    act(() => channelChoice?.click());
+    const name = container.querySelector<HTMLInputElement>(
+      'input[aria-label="channel name"]'
+    );
+    act(() => setNativeInputValue(name!, 'release coordination'));
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(useUiStore.getState().activeChannelId).toBe('topic:already-open');
+    expect(container.querySelector('.topic-composer__failure')?.textContent).toContain(
+      'hub unreachable'
+    );
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
   it('keeps a created channel out of creation-failure state when its opening message fails', async () => {
     const { HttpError } = await import('../frontend/src/lib/api.js');
     vi.mocked(createWorkspaceTopic).mockResolvedValue({

--- a/test/topic-composer.test.ts
+++ b/test/topic-composer.test.ts
@@ -72,6 +72,15 @@ function setNativeValue(el: HTMLTextAreaElement, value: string) {
   el.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
+function setNativeInputValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
 function setSelectValue(el: HTMLSelectElement, value: string) {
   const setter = Object.getOwnPropertyDescriptor(
     HTMLSelectElement.prototype,
@@ -678,6 +687,123 @@ describe('TopicComposer', () => {
       expect.objectContaining({ text: 'triage the reconnect flake' })
     );
     expect(useUiStore.getState().activeChannelId).toBe(dmId);
+  });
+
+  it('creates and opens a named channel without looking up a DM', async () => {
+    vi.mocked(createWorkspaceTopic).mockResolvedValue({
+      id: 'topic:release-coordination',
+      workspaceId: 'ws:local',
+      routingDefaults: {},
+      display: { title: 'release coordination' },
+    } as never);
+    vi.mocked(postChannelMessage).mockResolvedValue({} as never);
+    useUiStore.setState({ activeRepoPath: '/repo/relay' });
+    renderComposer();
+
+    const channelChoice = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[aria-pressed]')
+    ).find((button) => button.textContent === 'channel');
+    expect(channelChoice).toBeDefined();
+    act(() => channelChoice?.click());
+
+    const name = container.querySelector<HTMLInputElement>(
+      'input[aria-label="channel name"]'
+    );
+    const create = container.querySelector<HTMLButtonElement>(
+      '.topic-composer__bar button[type="submit"]'
+    );
+    expect(name).not.toBeNull();
+    expect(create.disabled).toBe(true);
+    expect(container.querySelector('.topic-composer__provider-row')).toBeNull();
+
+    const opening = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    act(() => {
+      setNativeInputValue(name!, 'release coordination');
+      setNativeValue(opening, 'coordinate the release train');
+    });
+    expect(create.disabled).toBe(false);
+
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(fetchWorkspaceTopic).not.toHaveBeenCalled();
+    expect(createWorkspaceTopic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'ws:local',
+        title: 'release coordination',
+        description: 'coordinate the release train',
+      })
+    );
+    const createInput = vi.mocked(createWorkspaceTopic).mock.calls[0]?.[0];
+    expect(createInput?.id).not.toBe(dmChannelTopicId('claude', null));
+    expect(createInput?.routingDefaults).toEqual({
+      repoPath: '/repo/relay',
+      cwd: '/repo/relay',
+    });
+    expect(createInput?.routingDefaults).not.toHaveProperty('providerId');
+    expect(createInput?.routingDefaults).not.toHaveProperty('agentId');
+    expect(createWorkspaceTopicRoomAndMaybeLaunch).not.toHaveBeenCalled();
+    expect(postChannelMessage).toHaveBeenCalledWith(
+      'topic:release-coordination',
+      expect.objectContaining({ text: 'coordinate the release train' })
+    );
+    expect(useUiStore.getState().activeChannelId).toBe(
+      'topic:release-coordination'
+    );
+    expect(useSessionsStore.getState().activeSessionId).toBeNull();
+  });
+
+  it('keeps a created channel out of creation-failure state when its opening message fails', async () => {
+    const { HttpError } = await import('../frontend/src/lib/api.js');
+    vi.mocked(createWorkspaceTopic).mockResolvedValue({
+      id: 'topic:release-coordination',
+      workspaceId: 'ws:local',
+      routingDefaults: {},
+      display: { title: 'release coordination' },
+    } as never);
+    vi.mocked(postChannelMessage).mockRejectedValue(
+      new HttpError(503, 'hub unreachable')
+    );
+    useToastStore.setState({ toasts: [] });
+    renderComposer();
+
+    const channelChoice = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[aria-pressed]')
+    ).find((button) => button.textContent === 'channel');
+    act(() => channelChoice?.click());
+    const name = container.querySelector<HTMLInputElement>(
+      'input[aria-label="channel name"]'
+    );
+    const opening = container.querySelector(
+      '.topic-composer__ta'
+    ) as HTMLTextAreaElement;
+    act(() => {
+      setNativeInputValue(name!, 'release coordination');
+      setNativeValue(opening, 'coordinate the release train');
+    });
+    const form = container.querySelector(
+      '.topic-composer__form'
+    ) as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(useUiStore.getState().activeChannelId).toBe(
+      'topic:release-coordination'
+    );
+    expect(container.querySelector('.topic-composer__failure')).toBeNull();
+    const messages = useToastStore
+      .getState()
+      .toasts.map((toast) => toast.message);
+    expect(messages).toEqual([
+      'channel created, but opening message failed — hub unreachable',
+    ]);
   });
 
   it('routes a one-off provider override to its DM channel', async () => {


### PR DESCRIPTION
## What changed

- Adds an explicit `direct message` / `channel` choice to the new-chat composer.
- Creates named multi-agent channels without pinning them to one provider while preserving node/repo/worktree/cwd routing.
- Hides orchestrator designation in direct messages and rejects DM designation at the API boundary.
- Keeps opening-message failures separate from channel-creation failures.

## Why

The only visible new-chat path selected an agent and therefore created a deterministic DM. There was no first-class UX for creating a normal collaborative channel. The channel header also exposed `designate orchestrator` in DMs; that endpoint defaults to Claude, so using it from a Codex DM incorrectly added a Claude Code orchestrator.

## Impact

Operators can now create normal project-bound channels for multi-agent collaboration. Direct messages remain two-party conversations and cannot accidentally gain an unrelated orchestrator.

## Validation

- `npm test -- --run test/topic-composer.test.ts test/components/channel-view-orchestrator.test.ts test/channel-routes.test.ts` — 109 passed
- `npm run check` — passed with 0 errors (existing warning baseline remains)
- `npm run build` — passed
- adversarial review + focused re-review — passed
- isolated browser smoke — created and opened `#release coordination`; channel mode hid the agent picker

The host-wide full-suite invocation was attempted but remained output-silent under unrelated long-running Vitest contention and was interrupted; CI is the authoritative full-suite gate for this PR.