### PR TITLE
feat(projects): create folders in picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ workflow.
 
 ## [Unreleased]
 
+### Added
+
+- Create and name new folders directly in the local Add Project browser (#1338)
+
 ## [0.1.1] - 2026-08-05
 
 This is the first public release of the channel era, branded v0.1; it ships as

--- a/frontend/src/components/FileBrowser.css
+++ b/frontend/src/components/FileBrowser.css
@@ -9,6 +9,10 @@
   gap: 8px;
 }
 
+.new-root-folder-btn {
+  flex-shrink: 0;
+}
+
 .filter-input {
   flex: 1;
   background: var(--bg);
@@ -75,6 +79,24 @@
 
 .tree-row.selected {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.new-folder-btn {
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.tree-row:hover .new-folder-btn,
+.tree-row.selected .new-folder-btn,
+.tree-row.focused .new-folder-btn,
+.new-folder-btn:focus-visible {
+  opacity: 1;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .new-folder-btn {
+    opacity: 1;
+  }
 }
 
 .expand-btn {
@@ -155,4 +177,49 @@
   color: var(--text-muted);
   border-top: 1px solid var(--border);
   text-align: center;
+}
+
+.folder-create-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid var(--border);
+  padding: 8px;
+}
+
+.folder-create-label,
+.folder-create-error {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-create-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.folder-create-input {
+  min-width: 0;
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  outline: none;
+  padding: 4px 8px;
+}
+
+.folder-create-input:focus {
+  border-color: var(--accent);
+}
+
+.folder-create-error {
+  color: var(--status-error);
 }

--- a/frontend/src/components/FileBrowser.tsx
+++ b/frontend/src/components/FileBrowser.tsx
@@ -8,7 +8,12 @@ import React, {
   useState,
 } from 'react';
 import TuiCheckbox from './TuiCheckbox.js';
-import { browseFsDirectory, type BrowseEntry } from '../lib/api.js';
+import TuiButton from './TuiButton.js';
+import {
+  browseFsDirectory,
+  createWorkspaceFolder,
+  type BrowseEntry,
+} from '../lib/api.js';
 import './FileBrowser.css';
 
 export interface FileBrowserHandle {
@@ -57,6 +62,55 @@ function collectSelected(nodes: BrowseNode[]): string[] {
   return result;
 }
 
+function findNode(nodes: BrowseNode[], targetPath: string): BrowseNode | null {
+  for (const node of nodes) {
+    if (node.path === targetPath) return node;
+    if (node.children) {
+      const found = findNode(node.children, targetPath);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function mergeCreatedEntry(
+  entries: BrowseEntry[],
+  createdEntry?: BrowseEntry
+): BrowseEntry[] {
+  if (!createdEntry || entries.some((entry) => entry.path === createdEntry.path)) {
+    return entries;
+  }
+  return [...entries, createdEntry].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+  );
+}
+
+function mergeBrowseNodes(
+  entries: BrowseEntry[],
+  previousNodes: BrowseNode[],
+  depth: number,
+  selectedPath?: string
+): BrowseNode[] {
+  const previousByPath = new Map(
+    previousNodes.map((node) => [node.path, node])
+  );
+  return entries.map((entry) => {
+    const existing = previousByPath.get(entry.path);
+    if (existing) {
+      existing.name = entry.name;
+      existing.isGitRepo = entry.isGitRepo;
+      existing.hasChildren =
+        entry.hasChildren || Boolean(existing.children?.length);
+      existing.depth = depth;
+      if (entry.path === selectedPath) existing.selected = true;
+      return existing;
+    }
+    const node = entryToNode(entry, depth);
+    node.selected = entry.path === selectedPath;
+    return node;
+  });
+}
+
 function flattenVisible(nodes: BrowseNode[], filter: string): BrowseNode[] {
   const result: BrowseNode[] = [];
   for (const node of nodes) {
@@ -78,6 +132,7 @@ interface TreeRowProps {
   focused: boolean;
   onToggleExpand: () => void;
   onToggleSelect: () => void;
+  onCreateFolder: () => void;
 }
 
 function TreeRow({
@@ -85,6 +140,7 @@ function TreeRow({
   focused,
   onToggleExpand,
   onToggleSelect,
+  onCreateFolder,
 }: TreeRowProps) {
   const cls = [
     'tree-row',
@@ -103,7 +159,11 @@ function TreeRow({
       aria-level={node.depth + 1}
       onClick={(e) => {
         const target = e.target as HTMLElement;
-        if (target.closest('.expand-btn') || target.closest('.tui-checkbox'))
+        if (
+          target.closest('.expand-btn') ||
+          target.closest('.tui-checkbox') ||
+          target.closest('.new-folder-btn')
+        )
           return;
         if (node.hasChildren && !node.expanded) onToggleExpand();
         else onToggleSelect();
@@ -138,6 +198,18 @@ function TreeRow({
           git
         </span>
       )}
+      <TuiButton
+        variant="ghost"
+        size="sm"
+        className="new-folder-btn"
+        aria-label={`new folder in ${node.name}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onCreateFolder();
+        }}
+      >
+        new folder
+      </TuiButton>
     </div>
   );
 }
@@ -148,6 +220,7 @@ interface TreeViewProps {
   rootTruncated: { shown: number; total: number } | null;
   onToggleExpand: (node: BrowseNode) => void;
   onToggleSelect: (node: BrowseNode) => void;
+  onCreateFolder: (node: BrowseNode) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   filterText: string;
   initialLoading: boolean;
@@ -159,6 +232,7 @@ function TreeView({
   rootTruncated,
   onToggleExpand,
   onToggleSelect,
+  onCreateFolder,
   onKeyDown,
   filterText,
   initialLoading,
@@ -188,6 +262,7 @@ function TreeView({
               focused={i === focusIndex}
               onToggleExpand={() => onToggleExpand(node)}
               onToggleSelect={() => onToggleSelect(node)}
+              onCreateFolder={() => onCreateFolder(node)}
             />
           ))}
           {rootTruncated && (
@@ -214,7 +289,13 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
     shown: number;
     total: number;
   } | null>(null);
+  const [rootPath, setRootPath] = useState('');
+  const [folderParentPath, setFolderParentPath] = useState<string | null>(null);
+  const [folderName, setFolderName] = useState('');
+  const [folderError, setFolderError] = useState('');
+  const [creatingFolder, setCreatingFolder] = useState(false);
   const treeRef = useRef<BrowseNode[]>([]);
+  const folderNameInputRef = useRef<HTMLInputElement>(null);
 
   function syncTree(newTree: BrowseNode[]) {
     treeRef.current = newTree;
@@ -222,19 +303,27 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
     onSelectedPathsChange(collectSelected(newTree));
   }
 
-  const loadRoot = useCallback(async () => {
+  const loadRoot = useCallback(async (createdEntry?: BrowseEntry) => {
     setInitialLoading(true);
     setRootTruncated(null);
     try {
       const data = await browseFsDirectory();
-      const newTree = data.entries.map((e) => entryToNode(e, 0));
-      treeRef.current = newTree;
-      setTree(newTree);
-      if (data.truncated)
-        setRootTruncated({ shown: data.entries.length, total: data.total });
+      const entries = mergeCreatedEntry(data.entries, createdEntry);
+      const newTree = mergeBrowseNodes(
+        entries,
+        treeRef.current,
+        0,
+        createdEntry?.path
+      );
+      setRootPath(data.resolved);
+      const total = Math.max(data.total, entries.length);
+      if (total > entries.length)
+        setRootTruncated({ shown: entries.length, total });
+      syncTree(newTree);
     } catch {
       treeRef.current = [];
       setTree([]);
+      setRootPath('');
     } finally {
       setInitialLoading(false);
     }
@@ -244,10 +333,17 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
     void loadRoot();
   }, [loadRoot]);
 
+  useEffect(() => {
+    if (folderParentPath) folderNameInputRef.current?.focus();
+  }, [folderParentPath]);
+
   useImperativeHandle(ref, () => ({
     reset() {
       setFilterText('');
       setFocusIndex(-1);
+      setFolderParentPath(null);
+      setFolderName('');
+      setFolderError('');
       function deselectAll(nodes: BrowseNode[]) {
         for (const n of nodes) {
           n.selected = false;
@@ -284,6 +380,62 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
     }
     node.expanded = true;
     setTree([...treeRef.current]);
+  }
+
+  async function refreshNodeChildren(
+    node: BrowseNode,
+    createdEntry?: BrowseEntry
+  ) {
+    const data = await browseFsDirectory(node.path);
+    const entries = mergeCreatedEntry(data.entries, createdEntry);
+    node.children = mergeBrowseNodes(
+      entries,
+      node.children ?? [],
+      node.depth + 1,
+      createdEntry?.path
+    );
+    node.hasChildren = node.children.length > 0;
+    const total = Math.max(data.total, entries.length);
+    node.truncatedInfo = total > entries.length
+      ? { shown: entries.length, total }
+      : null;
+    node.expanded = true;
+    syncTree(treeRef.current);
+  }
+
+  function beginFolderCreate(parentPath: string) {
+    setFolderParentPath(parentPath);
+    setFolderName('');
+    setFolderError('');
+  }
+
+  function cancelFolderCreate() {
+    if (creatingFolder) return;
+    setFolderParentPath(null);
+    setFolderName('');
+    setFolderError('');
+  }
+
+  async function createFolder() {
+    if (!folderParentPath || creatingFolder) return;
+    setCreatingFolder(true);
+    setFolderError('');
+    try {
+      const entry = await createWorkspaceFolder(folderParentPath, folderName);
+      if (folderParentPath === rootPath) {
+        await loadRoot(entry);
+      } else {
+        const parent = findNode(treeRef.current, folderParentPath);
+        if (!parent) throw new Error('parent folder is no longer visible');
+        await refreshNodeChildren(parent, entry);
+      }
+      setFolderParentPath(null);
+      setFolderName('');
+    } catch (err) {
+      setFolderError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreatingFolder(false);
+    }
   }
 
   function toggleSelect(node: BrowseNode) {
@@ -341,13 +493,70 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
           autoComplete="off"
           spellCheck={false}
         />
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          className="new-root-folder-btn"
+          disabled={!rootPath || initialLoading}
+          onClick={() => beginFolderCreate(rootPath)}
+        >
+          new folder
+        </TuiButton>
       </div>
+      {folderParentPath && (
+        <div className="folder-create-editor">
+          <label htmlFor="new-folder-name" className="folder-create-label">
+            new folder in {folderParentPath}
+          </label>
+          <div className="folder-create-controls">
+            <input
+              ref={folderNameInputRef}
+              id="new-folder-name"
+              className="folder-create-input"
+              aria-label={`new folder name in ${folderParentPath}`}
+              value={folderName}
+              onChange={(e) => setFolderName(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void createFolder();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelFolderCreate();
+                }
+              }}
+              placeholder="folder name"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={creatingFolder}
+            />
+            <TuiButton
+              variant="primary"
+              size="sm"
+              disabled={creatingFolder || !folderName.trim()}
+              onClick={() => void createFolder()}
+            >
+              {creatingFolder ? 'creating...' : 'create'}
+            </TuiButton>
+            <TuiButton
+              variant="ghost"
+              size="sm"
+              disabled={creatingFolder}
+              onClick={cancelFolderCreate}
+            >
+              cancel
+            </TuiButton>
+          </div>
+          {folderError && <p className="folder-create-error">{folderError}</p>}
+        </div>
+      )}
       <TreeView
         visibleNodes={visibleNodes}
         focusIndex={focusIndex}
         rootTruncated={rootTruncated}
         onToggleExpand={(n) => void toggleExpand(n)}
         onToggleSelect={toggleSelect}
+        onCreateFolder={(n) => beginFolderCreate(n.path)}
         onKeyDown={handleTreeKeydown}
         filterText={filterText}
         initialLoading={initialLoading}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -313,6 +313,20 @@ export interface BrowseResponse {
   total: number;
 }
 
+/** Create one direct child directory for the local Add Project browser. */
+export async function createWorkspaceFolder(
+  parentPath: string,
+  name: string
+): Promise<BrowseEntry> {
+  return json<BrowseEntry>(
+    await fetch('/workspaces/folders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parentPath, name }),
+    })
+  );
+}
+
 export async function resolveCommandCenterAssistantIntent(
   query: string
 ): Promise<CommandCenterAssistantResult> {

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -1770,6 +1770,112 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     res.json({ resolved, entries, truncated, total });
   });
 
+  // POST /workspaces/folders — create one local directory for Add Project.
+  // This deliberately stays alongside the local browse API. Remote hosts do
+  // not expose a mkdir file-RPC capability, so they must not silently use this
+  // host's filesystem.
+  router.post('/folders', async (req: Request, res: Response) => {
+    const parentPath = req.body?.parentPath;
+    const rawName = req.body?.name;
+
+    if (typeof parentPath !== 'string' || !parentPath.trim()) {
+      res.status(400).json({ error: 'parentPath must be a directory path' });
+      return;
+    }
+    if (typeof rawName !== 'string') {
+      res.status(400).json({ error: 'folder name must be a string' });
+      return;
+    }
+
+    const name = rawName.trim();
+    if (
+      !name ||
+      name === '.' ||
+      name === '..' ||
+      name.includes('\0') ||
+      path.isAbsolute(name) ||
+      name.includes('/') ||
+      name.includes('\\')
+    ) {
+      res.status(400).json({ error: 'folder name must be one safe path component' });
+      return;
+    }
+
+    let realParent: string;
+    try {
+      realParent = await fs.promises.realpath(
+        path.resolve(expandTilde(parentPath.trim()))
+      );
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EACCES' || code === 'EPERM') {
+        res.status(403).json({ error: 'Permission denied' });
+      } else if (code === 'ENOENT') {
+        res.status(404).json({ error: 'Parent folder does not exist' });
+      } else {
+        res.status(400).json({ error: 'Could not resolve parent folder' });
+      }
+      return;
+    }
+
+    try {
+      const parentStat = await fs.promises.stat(realParent);
+      if (!parentStat.isDirectory()) {
+        res.status(400).json({ error: 'Parent path is not a directory' });
+        return;
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EACCES' || code === 'EPERM') {
+        res.status(403).json({ error: 'Permission denied' });
+      } else if (code === 'ENOENT') {
+        res.status(404).json({ error: 'Parent folder does not exist' });
+      } else {
+        res.status(400).json({ error: 'Could not inspect parent folder' });
+      }
+      return;
+    }
+
+    const folderPath = path.join(realParent, name);
+    const relative = path.relative(realParent, folderPath);
+    if (
+      !relative ||
+      relative === '..' ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative)
+    ) {
+      res.status(400).json({ error: 'folder path must stay inside its parent' });
+      return;
+    }
+
+    try {
+      // Non-recursive by design: a typo cannot create a hierarchy outside the
+      // single direct child the operator named.
+      await fs.promises.mkdir(folderPath);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EEXIST') {
+        res.status(409).json({ error: 'Folder already exists' });
+      } else if (code === 'EACCES' || code === 'EPERM') {
+        res.status(403).json({ error: 'Permission denied' });
+      } else if (code === 'ENOENT') {
+        res.status(404).json({ error: 'Parent folder does not exist' });
+      } else {
+        logger.error('Failed to create workspace folder:', err);
+        res.status(500).json({ error: 'Could not create folder' });
+      }
+      return;
+    }
+
+    res.status(201).json({
+      name,
+      path: folderPath,
+      isGitRepo: false,
+      hasChildren: false,
+      isDirectory: true,
+    });
+  });
+
   // GET /workspaces/autocomplete — path prefix autocomplete
   router.get('/autocomplete', async (req: Request, res: Response) => {
     const prefix = typeof req.query.prefix === 'string' ? req.query.prefix : '';

--- a/test/components/AddWorkspaceDialog.test.ts
+++ b/test/components/AddWorkspaceDialog.test.ts
@@ -31,6 +31,7 @@ import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
 const mocks = vi.hoisted(() => ({
   addWorkspacesBulk: vi.fn(),
   browseFsDirectory: vi.fn(),
+  createWorkspaceFolder: vi.fn(),
   fetchHubNodes: vi.fn(),
   createTerminalSession: vi.fn(),
 }));
@@ -42,6 +43,7 @@ vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
     ...actual,
     addWorkspacesBulk: mocks.addWorkspacesBulk,
     browseFsDirectory: mocks.browseFsDirectory,
+    createWorkspaceFolder: mocks.createWorkspaceFolder,
     fetchHubNodes: mocks.fetchHubNodes,
   };
 });
@@ -188,14 +190,19 @@ function text(selector: string): string {
     .join(' | ');
 }
 
-/** Click the browser row whose `.node-name` matches. Rows with no children
- *  select on click (see `FileBrowser`'s `TreeRow`), which is the real user
- *  gesture that populates `selectedPaths`. */
-async function selectPath(name: string): Promise<void> {
+function treeRow(name: string): HTMLElement {
   const row = Array.from(container.querySelectorAll('.tree-row')).find(
     (el) => el.querySelector('.node-name')?.textContent === name
   );
   if (!row) throw new Error(`no browser row named ${name}`);
+  return row as HTMLElement;
+}
+
+/** Click the browser row whose `.node-name` matches. Rows with no children
+ *  select on click (see `FileBrowser`'s `TreeRow`), which is the real user
+ *  gesture that populates `selectedPaths`. */
+async function selectPath(name: string): Promise<void> {
+  const row = treeRow(name);
   await act(async () => {
     row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
@@ -229,6 +236,24 @@ async function typeRemoteCwd(cwd: string): Promise<void> {
   await flush();
 }
 
+async function typeFolderName(name: string): Promise<HTMLInputElement> {
+  const input = container.querySelector(
+    '#new-folder-name'
+  ) as HTMLInputElement;
+  if (!input) throw new Error('new folder editor not rendered');
+  const setValue = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  if (!setValue) throw new Error('no native value setter');
+  await act(async () => {
+    setValue.call(input, name);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await flush();
+  return input;
+}
+
 function submitButton(): HTMLButtonElement {
   const btn = container.querySelector(
     '.add-workspace-footer-actions .tui-btn--primary'
@@ -247,6 +272,7 @@ async function submit(): Promise<void> {
 beforeEach(() => {
   mocks.addWorkspacesBulk.mockReset();
   mocks.browseFsDirectory.mockReset();
+  mocks.createWorkspaceFolder.mockReset();
   mocks.fetchHubNodes.mockReset();
   mocks.createTerminalSession.mockReset();
   mocks.browseFsDirectory.mockResolvedValue(browseResponse());
@@ -293,6 +319,217 @@ describe('<AddWorkspaceDialog /> render (#1298)', () => {
     expect(submitButton().disabled).toBe(true);
     expect(submitButton().textContent).toContain('add project');
     expect(text('.add-workspace-selected-count').trim()).toBe('');
+  });
+
+  it('creates a root folder inline, refreshes it, and selects it on Enter', async () => {
+    const NEW_PROJECT = '/home/me/code/new-project';
+    mocks.browseFsDirectory
+      .mockResolvedValueOnce(browseResponse())
+      .mockResolvedValueOnce({
+        ...browseResponse(),
+        entries: [
+          ...browseResponse().entries,
+          {
+            name: 'new-project',
+            path: NEW_PROJECT,
+            isGitRepo: false,
+            hasChildren: false,
+          },
+        ],
+        total: 3,
+      });
+    mocks.createWorkspaceFolder.mockResolvedValue({
+      name: 'new-project',
+      path: NEW_PROJECT,
+      isGitRepo: false,
+      hasChildren: false,
+      isDirectory: true,
+    });
+    await mountAndOpen();
+
+    const newFolder = container.querySelector(
+      '.new-root-folder-btn'
+    ) as HTMLButtonElement;
+    expect(newFolder.disabled).toBe(false);
+    await act(async () => {
+      newFolder.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const input = await typeFolderName('  new-project  ');
+    expect(document.activeElement).toBe(input);
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await flush();
+
+    expect(mocks.createWorkspaceFolder).toHaveBeenCalledWith(
+      '/home/me/code',
+      '  new-project  '
+    );
+    expect(mocks.browseFsDirectory).toHaveBeenCalledTimes(2);
+    expect(text('.tree-row.selected .node-name')).toContain('new-project');
+    expect(text('.add-workspace-selected-count')).toContain('1 selected');
+    expect(container.querySelector('#new-folder-name')).toBeNull();
+  });
+
+  it('targets a directory with its accessible action and Escape cancels the inline editor', async () => {
+    await mountAndOpen();
+
+    const action = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.new-folder-btn')
+    ).find((button) => button.getAttribute('aria-label') === 'new folder in notes');
+    expect(action).toBeTruthy();
+    await act(async () => {
+      action?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const input = await typeFolderName('scratch');
+    expect(text('.folder-create-label')).toContain(NOTES);
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    await flush();
+
+    expect(container.querySelector('#new-folder-name')).toBeNull();
+    expect(mocks.createWorkspaceFolder).not.toHaveBeenCalled();
+  });
+
+  it('keeps a create error in the inline editor for correction', async () => {
+    mocks.createWorkspaceFolder.mockRejectedValue(new Error('Folder already exists'));
+    await mountAndOpen();
+    const newFolder = container.querySelector(
+      '.new-root-folder-btn'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      newFolder.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const input = await typeFolderName('new-project');
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await flush();
+
+    expect(text('.folder-create-error')).toContain('Folder already exists');
+    expect((container.querySelector('#new-folder-name') as HTMLInputElement).value).toBe(
+      'new-project'
+    );
+  });
+
+  it('preserves expanded descendants and their selection when a root refresh adds a folder', async () => {
+    const PROJECTS = '/home/me/code/projects';
+    const NESTED = `${PROJECTS}/nested`;
+    const LEAF = `${NESTED}/leaf`;
+    const CREATED = '/home/me/code/new-project';
+    mocks.browseFsDirectory
+      .mockResolvedValueOnce({
+        resolved: '/home/me/code',
+        entries: [
+          { name: 'projects', path: PROJECTS, isGitRepo: false, hasChildren: true },
+        ],
+        truncated: false,
+        total: 1,
+      })
+      .mockResolvedValueOnce({
+        resolved: PROJECTS,
+        entries: [
+          { name: 'nested', path: NESTED, isGitRepo: false, hasChildren: true },
+        ],
+        truncated: false,
+        total: 1,
+      })
+      .mockResolvedValueOnce({
+        resolved: NESTED,
+        entries: [
+          { name: 'leaf', path: LEAF, isGitRepo: false, hasChildren: false },
+        ],
+        truncated: false,
+        total: 1,
+      })
+      .mockResolvedValueOnce({
+        resolved: '/home/me/code',
+        entries: [
+          { name: 'new-project', path: CREATED, isGitRepo: false, hasChildren: false },
+          { name: 'projects', path: PROJECTS, isGitRepo: false, hasChildren: true },
+        ],
+        truncated: false,
+        total: 2,
+      });
+    mocks.createWorkspaceFolder.mockResolvedValue({
+      name: 'new-project',
+      path: CREATED,
+      isGitRepo: false,
+      hasChildren: false,
+      isDirectory: true,
+    });
+    await mountAndOpen();
+    await selectPath('projects');
+    await selectPath('nested');
+    await selectPath('leaf');
+
+    const newFolder = container.querySelector(
+      '.new-root-folder-btn'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      newFolder.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const input = await typeFolderName('new-project');
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await flush();
+
+    expect(treeRow('projects').getAttribute('aria-expanded')).toBe('true');
+    expect(treeRow('nested').getAttribute('aria-expanded')).toBe('true');
+    expect(treeRow('leaf').className).toContain('selected');
+    expect(treeRow('new-project').className).toContain('selected');
+    expect(text('.add-workspace-selected-count')).toContain('2 selected');
+  });
+
+  it('merges a created folder omitted by a truncated browse response and keeps the notice accurate', async () => {
+    const entries = Array.from({ length: 100 }, (_, index) => ({
+      name: `dir-${String(index).padStart(3, '0')}`,
+      path: `/home/me/code/dir-${String(index).padStart(3, '0')}`,
+      isGitRepo: false,
+      hasChildren: false,
+    }));
+    const CREATED = '/home/me/code/z-project';
+    mocks.browseFsDirectory
+      .mockResolvedValueOnce({
+        resolved: '/home/me/code',
+        entries,
+        truncated: true,
+        total: 101,
+      })
+      .mockResolvedValueOnce({
+        resolved: '/home/me/code',
+        entries,
+        truncated: true,
+        total: 102,
+      });
+    mocks.createWorkspaceFolder.mockResolvedValue({
+      name: 'z-project',
+      path: CREATED,
+      isGitRepo: false,
+      hasChildren: false,
+      isDirectory: true,
+    });
+    await mountAndOpen();
+    const newFolder = container.querySelector(
+      '.new-root-folder-btn'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      newFolder.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const input = await typeFolderName('z-project');
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await flush();
+
+    expect(container.querySelectorAll('.tree-row')).toHaveLength(101);
+    expect(treeRow('z-project').className).toContain('selected');
+    expect(text('.truncated-notice')).toContain('Showing 101 of 102');
+    expect(
+      Array.from(container.querySelectorAll('.node-name')).at(-1)?.textContent
+    ).toBe('z-project');
   });
 
   it('enables submit and counts the selection once a folder is picked', async () => {

--- a/test/fs-browse.test.ts
+++ b/test/fs-browse.test.ts
@@ -252,6 +252,70 @@ describe('GET /workspaces/browse', () => {
   });
 });
 
+describe('POST /workspaces/folders', () => {
+  async function createFolder(parentPath: unknown, name: unknown): Promise<Response> {
+    return fetch(`${baseUrl}/workspaces/folders`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parentPath, name }),
+    });
+  }
+
+  test('creates one direct child and returns a browse-shaped entry', async () => {
+    const parentPath = path.join(tmpDir, 'browsable', 'empty-dir');
+    const res = await createFolder(parentPath, 'new-project');
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      name: 'new-project',
+      path: path.join(parentPath, 'new-project'),
+      isGitRepo: false,
+      hasChildren: false,
+      isDirectory: true,
+    });
+    expect(
+      fs.statSync(path.join(parentPath, 'new-project')).isDirectory()
+    ).toBe(true);
+  });
+
+  test('returns 409 when the direct child already exists', async () => {
+    const parentPath = path.join(tmpDir, 'browsable', 'empty-dir');
+    const res = await createFolder(parentPath, 'new-project');
+
+    expect(res.status).toBe(409);
+    expect((await res.json() as { error: string }).error).toContain('exists');
+  });
+
+  test.each([
+    '',
+    '   ',
+    '.',
+    '..',
+    'child/grandchild',
+    'child\\grandchild',
+    '/absolute',
+    '\\absolute',
+    'nul\0name',
+  ])('rejects unsafe folder name %j', async (name) => {
+    const parentPath = path.join(tmpDir, 'browsable', 'empty-dir');
+    const res = await createFolder(parentPath, name);
+
+    expect(res.status).toBe(400);
+    expect(fs.existsSync(path.join(parentPath, 'child'))).toBe(false);
+  });
+
+  test('rejects a missing or file parent clearly and never creates recursively', async () => {
+    const missingParent = path.join(tmpDir, 'browsable', 'does-not-exist');
+    const missing = await createFolder(missingParent, 'nested');
+    expect(missing.status).toBe(404);
+    expect(fs.existsSync(missingParent)).toBe(false);
+
+    const fileParent = path.join(tmpDir, 'browsable', 'file.txt');
+    const file = await createFolder(fileParent, 'nested');
+    expect(file.status).toBe(400);
+  });
+});
+
 describe('POST /workspaces/bulk', () => {
   test('adds multiple workspaces', async () => {
     const dir1 = path.join(tmpDir, 'browsable', 'visible-dir');


### PR DESCRIPTION
## Summary

- add a local `POST /workspaces/folders` contract that creates one validated direct child directory
- add root and per-directory `new folder` actions with inline naming, Enter/Escape handling, and error feedback
- refresh and select the created folder so the existing `add project` flow can submit it immediately
- preserve expanded/selected descendants across refreshes and keep created folders visible beyond the 100-entry browse cap
- expose per-directory actions on touch/coarse pointers

Remote-host project creation remains out of scope because the remote Add Project lane is terminal-only and has no mkdir file-RPC capability.

## Verification

- `npm test -- test/fs-browse.test.ts test/components/AddWorkspaceDialog.test.ts` — 55 passed
- `npm run check` — passed
- `git diff --check` — passed
- adversarial review + focused re-review — no P0/P1 findings remain

## Runtime evidence

Focused happy-dom interaction coverage verifies inline create/cancel/error/refresh/selection behavior. No new browser E2E fixture was added for this dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline folder creation to the workspace file browser.
  * Create folders at the root or within existing folders using a name field, Enter, or a button.
  * Cancel folder creation with Escape or a cancel button.
  * Newly created folders are selected and retained in the current tree view.
  * Added clear validation and error messages for invalid or duplicate folder names.

* **Bug Fixes**
  * Improved tree state preservation while folders load or refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->