### PR TITLE
fix(channels): recover Codex conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ workflow.
 
 - The new-chat composer now lets operators create normal channels, and DMs cannot be designated as orchestration channels (#1337)
 
+#### Fixed
+
+- Existing Codex channel conversations now recover after a hub/runtime restart,
+  and user message bubbles no longer collapse into character-by-character
+  wrapping
+
 ## [0.1.1] - 2026-08-05
 
 This is the first public release of the channel era, branded v0.1; it ships as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ workflow.
 
 - Existing Codex channel conversations now recover after a hub/runtime restart,
   and user message bubbles no longer collapse into character-by-character
-  wrapping
+  wrapping (#1339)
 
 ## [0.1.1] - 2026-08-05
 

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -539,6 +539,14 @@
   line-height: 1.6;
 }
 
+/* Markdown prose gets this wrapper so a streaming cursor can sit after it.
+   Keep it shrink-safe for agent rows; human rows below deliberately stretch it
+   before sizing the bubble, otherwise a right-aligned flex item resolves from
+   its min-content width and can split ordinary words one character at a time. */
+.ch-msg__body-wrap {
+  min-width: 0;
+}
+
 /* human message bubble — reuses .tl-text--user treatment (right-aligned) */
 .ch-msg--user .ch-msg__body {
   color: var(--text);
@@ -546,9 +554,23 @@
   border: 1px solid var(--border);
   padding: 8px 12px;
   margin: 0 0 0 auto;
+  box-sizing: border-box;
+  min-width: min(100%, 8ch);
   max-width: 75%;
   width: fit-content;
   align-self: flex-end;
+  /* Preserve ordinary word boundaries; only an unbroken URL/hash may split. */
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+/* `align-items: flex-end` makes an auto-sized markdown wrapper shrink-wrap.
+   Give it the lane width first, then let the nested bubble use its intrinsic
+   size against that stable available width. */
+.ch-msg--user .ch-msg__body-wrap {
+  align-self: stretch;
+  width: 100%;
+  min-width: 0;
 }
 
 .ch-msg--user {

--- a/frontend/src/test-channel-timeline.tsx
+++ b/frontend/src/test-channel-timeline.tsx
@@ -123,10 +123,35 @@ function Fixture(): React.ReactElement {
       const seq = (current[current.length - 1]?.seq ?? 0) + 1;
       return [
         ...current,
-        message(seq, 'my new message', {
-          kind: 'human',
-          id: 'human:operator',
-        }),
+        {
+          ...message(seq, 'did we open a PR?', {
+            kind: 'human',
+            id: 'human:operator',
+          }),
+          // This is intentionally markdown: MessageBody introduces the
+          // cursor wrapper on this live path, which used to shrink user bubbles
+          // down to their min-content width.
+          body: { text: 'did we open a PR?', format: 'markdown' },
+        },
+      ];
+    });
+  }, []);
+
+  const appendOwnLongToken = useCallback(() => {
+    setMessages((current) => {
+      const seq = (current[current.length - 1]?.seq ?? 0) + 1;
+      return [
+        {
+          ...message(
+            seq,
+            'https://relay.example.dev/recover/conversation/this-token-must-wrap-without-overflowing-the-mobile-timeline',
+            { kind: 'human', id: 'human:operator' }
+          ),
+          body: {
+            text: 'https://relay.example.dev/recover/conversation/this-token-must-wrap-without-overflowing-the-mobile-timeline',
+            format: 'markdown',
+          },
+        },
       ];
     });
   }, []);
@@ -234,6 +259,9 @@ function Fixture(): React.ReactElement {
         </button>
         <button data-testid="append-own" onClick={appendOwn}>
           append own
+        </button>
+        <button data-testid="append-own-long-token" onClick={appendOwnLongToken}>
+          append own long token
         </button>
         <button data-testid="append-truncated" onClick={appendTruncated}>
           append truncated

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -378,12 +378,20 @@ export class ChannelAgentRuntimeManager {
     });
     this.patchUnlisteners.set(id, unlisten);
 
+    const savedResumeId = providerResumeId(
+      params.providerId,
+      params.providerSession
+    );
+
     const config: AdapterConfig = {
       cwd: params.cwd,
       port: params.port,
       sessionId: id,
       hookToken,
       configDir: params.configDir,
+      ...(savedResumeId && adapter.resumesProviderSessionDuringConnect
+        ? { resumeSessionId: savedResumeId }
+        : {}),
       systemPromptAppendix: [
         collaborationPromptAppendix({
           provider: params.providerId,
@@ -401,13 +409,13 @@ export class ChannelAgentRuntimeManager {
       ...(params.extra ? { extra: params.extra } : {}),
     };
 
-    const savedResumeId = providerResumeId(
-      params.providerId,
-      params.providerSession
-    );
     try {
       await adapter.connect(config);
-      if (savedResumeId && adapter.capabilities.resume) {
+      if (
+        savedResumeId &&
+        adapter.capabilities.resume &&
+        !adapter.resumesProviderSessionDuringConnect
+      ) {
         await adapter.resumeSession(savedResumeId);
       }
       // The child can die INSIDE those awaits (#1307). Adapters flip to

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -49,6 +49,11 @@ export type AgentPatchHandlerV2 = (patch: AgentPatchV2) => void;
 
 export interface ProtocolAdapterV2 {
   connect(config: AdapterConfig): Promise<void>;
+  /**
+   * When true, `connect()` consumes `AdapterConfig.resumeSessionId` atomically.
+   * The runtime manager must not follow it with a second `resumeSession()`.
+   */
+  readonly resumesProviderSessionDuringConnect?: boolean;
   disconnect(): Promise<void>;
   /**
    * Replace the runtime-only environment used by an owned subprocess.

--- a/server/protocol-adapter.ts
+++ b/server/protocol-adapter.ts
@@ -21,6 +21,12 @@ export interface AdapterConfig {
   hookToken: string;
   /** relay-ide config directory path */
   configDir: string;
+  /**
+   * Provider-native conversation to restore while establishing this transport.
+   * Adapters that opt into atomic resume use this instead of creating a fresh
+   * provider conversation and immediately replacing it.
+   */
+  resumeSessionId?: string;
   /** Agent permission mode (e.g. 'default' | 'acceptEdits' | 'bypassPermissions') */
   permissionMode?: string;
   /** Model override (e.g. 'claude-opus-4-6') */

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -476,6 +476,12 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   readonly agentType = 'codex';
   readonly runtimeOwnership = 'spawned' as const;
   readonly capabilities = CODEX_CAPABILITIES;
+  /**
+   * A saved Codex thread can be resumed by the initial app-server connection.
+   * This avoids creating a disposable `thread/start` conversation, then
+   * tearing its transport down to resume the durable one.
+   */
+  readonly resumesProviderSessionDuringConnect = true;
 
   private _status: AdapterStatus = 'disconnected';
   private config: AdapterConfig | null = null;
@@ -555,19 +561,25 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
     await client.start();
 
-    const threadResult = await client.call<{ thread: { id: string } }>(
-      'thread/start',
-      {
-        cwd: config.cwd,
-        experimentalRawEvents: false,
-        persistExtendedHistory: false,
-        ...(config.model || this.pendingModelOverride
-          ? { model: this.pendingModelOverride ?? config.model }
-          : {}),
-      }
-    );
+    const threadResult = config.resumeSessionId
+      ? await client.call<{ thread: { id: string } }>('thread/resume', {
+          threadId: config.resumeSessionId,
+          excludeTurns: false,
+        })
+      : await client.call<{ thread: { id: string } }>('thread/start', {
+          cwd: config.cwd,
+          experimentalRawEvents: false,
+          persistExtendedHistory: false,
+          ...(config.model || this.pendingModelOverride
+            ? { model: this.pendingModelOverride ?? config.model }
+            : {}),
+        });
 
-    this.providerSessionId = threadResult.thread.id;
+    // `thread/resume` normally echoes the durable id. Retain the requested id
+    // defensively if an app-server version omits it, rather than replacing the
+    // binding's only recovery handle with an empty session identity.
+    this.providerSessionId =
+      threadResult.thread.id || config.resumeSessionId || null;
     this._status = 'connected';
     this.slashCommandsLoaded = false;
 
@@ -590,53 +602,14 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     if (!this.config) throw new Error('Cannot resumeSession before connect');
     const config = this.config;
 
-    // Tear down existing state
+    // This is a deliberate handoff, not an app-server failure. Mark the first
+    // client detached before stopping it so its expected close event cannot be
+    // reported as an unexpected runtime death to ChannelAgentRuntimeManager.
+    // `connect()` then performs `thread/resume` directly, preserving the
+    // durable provider conversation without a throwaway `thread/start`.
+    this._status = 'disconnected';
     await this.teardownState();
-
-    const client = this.createClient(config);
-    this.client = client;
-    this.wireClientEvents(client);
-
-    await client.start();
-
-    const threadResult = await client.call<{
-      thread: { id: string; turns?: unknown[] };
-    }>('thread/resume', { threadId, excludeTurns: false });
-
-    this.providerSessionId = threadResult.thread.id ?? threadId;
-    this._status = 'connected';
-    this.slashCommandsLoaded = false;
-
-    // Emit snapshot reflecting the resumed thread.
-    // We materialize any turns from the response as completed items.
-    this.emitPatch({
-      type: 'agent-session-snapshot-v2',
-      sessionId: config.sessionId,
-      timestamp: nowIso(),
-      session: emptyAgentSessionV2({
-        id: config.sessionId,
-        provider: 'codex',
-        cwd: config.cwd,
-        capabilities: { ...this.capabilities, resume: true },
-        providerSession: { threadId: this.providerSessionId },
-        config: {
-          ...(config.model ? { model: config.model } : {}),
-        },
-      }),
-    });
-
-    this.emitLiveState({
-      status: 'idle',
-      activeTurnId: null,
-      waitingOn: null,
-      activeRequestIds: [],
-      proposedPlanItemId: null,
-      queueLength: 0,
-      fastModeAvailable: false,
-      error: null,
-    });
-
-    void this.refreshSlashCommands(config.cwd);
+    await this.connect({ ...config, resumeSessionId: threadId });
   }
 
   protected async onDisconnect(): Promise<void> {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1002,6 +1002,7 @@ interface SessionsHarness {
     profileId?: string
   ) => Promise<void>;
   lastCreateParams: () => CreateChannelAgentRuntimeParams | undefined;
+  createParams: () => CreateChannelAgentRuntimeParams[];
 }
 
 function makeSessions(
@@ -1013,10 +1014,12 @@ function makeSessions(
   const endCbs: Array<(id: string) => void> = [];
   let spawns = 0;
   let lastParams: CreateChannelAgentRuntimeParams | undefined;
+  const createParams: CreateChannelAgentRuntimeParams[] = [];
   const sessions: BinderRuntimes = {
     async create(params) {
       spawns++;
       lastParams = params;
+      createParams.push(params);
       if (opts.throwOnCreate) throw new Error('boom: spawn failed');
       // Optional gate: park the spawn so a test can drive a close()/reorder race
       // between runtime creation being invoked and its continuation resuming.
@@ -1099,6 +1102,7 @@ function makeSessions(
       });
     },
     lastCreateParams: () => lastParams,
+    createParams: () => createParams,
   };
 }
 
@@ -2014,6 +2018,42 @@ describe('channel-agent-binder — lifecycle', () => {
       first.id,
       second.id,
     ]);
+  });
+
+  it('keeps a saved provider conversation intact across failed recovery attempts', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2(),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      throwOnCreate: true,
+    });
+    const profileActorId = builtInAgentProfileId('mock');
+    store.upsertBinding({
+      channelId: CH,
+      profileActorId,
+      agentFramework: 'mock',
+      runtimeId: 'stale-runtime',
+      providerSession: { threadId: 'durable-provider-thread' },
+    });
+
+    await expect(binder.ensureBinding(CH, 'mock')).rejects.toThrow(
+      'spawn failed'
+    );
+    await expect(binder.ensureBinding(CH, 'mock')).rejects.toThrow(
+      'spawn failed'
+    );
+
+    expect(sessions.createParams()).toEqual([
+      expect.objectContaining({
+        providerSession: { threadId: 'durable-provider-thread' },
+      }),
+      expect.objectContaining({
+        providerSession: { threadId: 'durable-provider-thread' },
+      }),
+    ]);
+    expect(store.getBinding(CH, profileActorId)?.providerSession).toEqual({
+      threadId: 'durable-provider-thread',
+    });
   });
 });
 

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -22,6 +22,8 @@ const adapterState = vi.hoisted(() => ({
   onConnect: null as ((adapter: TestAdapter) => void) | null,
   /** Make the next adapter report its child dying from inside `connect` (#1307). */
   dieDuringConnect: false,
+  /** Adapter can atomically restore the provider session from connect config. */
+  resumeDuringConnect: false,
 }));
 
 class TestAdapter implements ProtocolAdapterV2 {
@@ -35,8 +37,13 @@ class TestAdapter implements ProtocolAdapterV2 {
   }).capabilities;
   status = 'disconnected' as const | 'connected';
   resumed: string[] = [];
+  connectConfigs: AdapterConfig[] = [];
   disconnectError: Error | null = null;
   private readonly handlers = new Set<AgentPatchHandlerV2>();
+
+  get resumesProviderSessionDuringConnect(): boolean {
+    return adapterState.resumeDuringConnect;
+  }
 
   sessionId = 'channel-runtime';
 
@@ -44,6 +51,7 @@ class TestAdapter implements ProtocolAdapterV2 {
     // Real adapters flip to 'connected' partway through their own connect, so
     // the manager's disconnect listener is already live when the child dies.
     this.status = 'connected';
+    this.connectConfigs.push(config);
     this.sessionId = config.sessionId;
     adapterState.onConnect?.(this);
     if (adapterState.dieDuringConnect) {
@@ -165,6 +173,7 @@ afterEach(async () => {
   adapterState.all.length = 0;
   adapterState.onConnect = null;
   adapterState.dieDuringConnect = false;
+  adapterState.resumeDuringConnect = false;
 });
 
 describe('ChannelAgentRuntimeManager agentState (#1254)', () => {
@@ -485,6 +494,27 @@ describe('ChannelAgentRuntimeManager', () => {
     expect(sessions.list().some((session) => session.id === runtime.id)).toBe(
       false
     );
+  });
+
+  it('lets an adapter atomically resume a saved provider session during connect', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    adapterState.resumeDuringConnect = true;
+
+    await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+      providerSession: { threadId: 'provider-thread-1' },
+    });
+
+    expect(adapterState.last?.connectConfigs).toEqual([
+      expect.objectContaining({ resumeSessionId: 'provider-thread-1' }),
+    ]);
+    expect(adapterState.last?.resumed).toEqual([]);
   });
 
   it('captures provider identity and rejects duplicate runtime ids', async () => {

--- a/test/e2e/channel-timeline-scroll.spec.ts
+++ b/test/e2e/channel-timeline-scroll.spec.ts
@@ -259,6 +259,65 @@ test.describe('smoke channel timeline scroll UX (#1193)', () => {
     await expect(page.locator('.ch-new-messages')).toHaveCount(0);
   });
 
+  test('keeps user markdown bubbles readable without mobile overflow', async ({
+    page,
+  }) => {
+    const timeline = await openFixture(page);
+    await page.getByTestId('append-own').click();
+
+    const shortBubble = timeline.locator(
+      '[data-channel-message-seq="71"].ch-msg--user .ch-msg__body'
+    );
+    await expect(shortBubble).toHaveText('did we open a PR?');
+    const shortMetrics = await shortBubble.evaluate((bubble) => {
+      const text = bubble.querySelector('p')?.firstChild;
+      if (!text) throw new Error('missing markdown text node');
+      const range = document.createRange();
+      range.selectNodeContents(text);
+      return {
+        lines: range.getClientRects().length,
+        bubbleWidth: bubble.getBoundingClientRect().width,
+        rowWidth: bubble.closest<HTMLElement>('.ch-msg')!.getBoundingClientRect()
+          .width,
+      };
+    });
+    // The phrase is short enough for one desktop line and the bubble now gets
+    // its available width from the actual ChannelTimeline row, not min-content.
+    expect(shortMetrics.lines).toBe(1);
+    expect(shortMetrics.bubbleWidth).toBeGreaterThan(100);
+    expect(shortMetrics.bubbleWidth).toBeLessThan(shortMetrics.rowWidth);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByTestId('append-own-long-token').click();
+    const longBubble = timeline.locator(
+      '[data-channel-message-seq="72"].ch-msg--user .ch-msg__body'
+    );
+    await expect(longBubble).toBeVisible();
+    const mobileMetrics = await longBubble.evaluate((bubble) => {
+      const row = bubble.closest<HTMLElement>('.ch-msg');
+      if (!row) throw new Error('missing message row');
+      const bubbleRect = bubble.getBoundingClientRect();
+      const rowRect = row.getBoundingClientRect();
+      return {
+        scrollWidth: bubble.scrollWidth,
+        clientWidth: bubble.clientWidth,
+        bubbleLeft: bubbleRect.left,
+        bubbleRight: bubbleRect.right,
+        rowLeft: rowRect.left,
+        rowRight: rowRect.right,
+      };
+    });
+    expect(mobileMetrics.scrollWidth).toBeLessThanOrEqual(
+      mobileMetrics.clientWidth
+    );
+    expect(mobileMetrics.bubbleLeft).toBeGreaterThanOrEqual(
+      mobileMetrics.rowLeft
+    );
+    expect(mobileMetrics.bubbleRight).toBeLessThanOrEqual(
+      mobileMetrics.rowRight
+    );
+  });
+
   test('full snapshots preserve a surviving row and fall back to the unread divider across a gap', async ({
     page,
   }) => {

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -281,6 +281,39 @@ describe('CodexNativeProtocolAdapter — connect', () => {
 
     await adapter.disconnect();
   });
+
+  it('resumes a saved thread directly instead of creating a throwaway thread', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+
+    factory.lastClient?.serverResponses.set('thread/resume', {
+      thread: { id: 'thread-existing' },
+    });
+    factory.lastClient?.serverResponses.set('skills/list', { skills: [] });
+    factory.lastClient?.serverResponses.set('model/list', []);
+
+    await adapter.connect({ ...config, resumeSessionId: 'thread-existing' });
+
+    expect(factory.lastClient?.calls.map((call) => call.method)).toContain(
+      'thread/resume'
+    );
+    expect(factory.lastClient?.calls.map((call) => call.method)).not.toContain(
+      'thread/start'
+    );
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-session-snapshot-v2',
+          session: expect.objectContaining({
+            providerSession: { threadId: 'thread-existing' },
+          }),
+        }),
+      ])
+    );
+
+    await adapter.disconnect();
+  });
 });
 
 // ── Resume ────────────────────────────────────────────────────────────────────
@@ -320,6 +353,13 @@ describe('CodexNativeProtocolAdapter — resumeSession', () => {
         providerSession: { threadId: 'thread-resume-1' },
       }),
     });
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-live-state-updated-v2' &&
+          patch.live.status === 'disconnected'
+      )
+    ).toHaveLength(0);
 
     await adapter.disconnect();
   });


### PR DESCRIPTION
## Summary

- resume stored Codex channel conversations atomically during initial runtime connection
- preserve true unexpected-disconnect teardown while ignoring the planned resume handoff
- prevent right-aligned human markdown bubbles from collapsing to min-content width
- add runtime, binder, adapter, and live ChannelTimeline regression coverage

## Root cause

After a hub restart, Relay first created a new Codex thread and then stopped that app-server client to resume the stored thread. The expected close was emitted while the adapter still appeared connected, so the runtime manager classified the handoff as an unexpected death and aborted recovery. Separately, the human markdown wrapper shrink-wrapped under `align-items: flex-end`; the nested 75% bubble then resolved against a min-content parent and split ordinary words character by character.

## Validation

- 185 focused runtime, binder, and Codex adapter tests
- 13 ChannelTimeline Playwright tests, including desktop short-text and mobile long-token metrics
- `npm run check` (0 errors; 221 existing warnings)
- fixture production build
- broad adversarial review: no P0-P3 findings

## Pattern decision

The recovery transition is atomic and keyed by the durable provider thread ID. Blind retry/backoff was rejected because creating provider conversations is not safely repeatable and would risk duplicate threads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing Codex conversations now recover correctly after hub or runtime restarts.
  * Conversation recovery remains reliable after temporary connection or startup failures.
  * Fixed human message bubbles so Markdown and long URLs wrap correctly without overflowing on desktop or mobile.
  * Improved message layout stability while content is streaming.
* **Tests**
  * Added coverage for conversation recovery, session restoration, responsive message sizing, and long unbroken text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->