### PR TITLE
Steer active agent turns at safe boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ workflow.
 #### Changed
 
 - The new-chat composer now lets operators create normal channels, and DMs cannot be designated as orchestration channels (#1337)
+- Mid-turn channel sends now steer Codex and Claude at their native safe tool
+  boundary by default, while harnesses without that primitive retain a clearly
+  labelled FIFO queue fallback
 
 #### Fixed
 
@@ -75,6 +78,8 @@ chat-first pass) also shipped only on `@nightly` and is not itemized here.
 
 #### Fixed
 
+- Completed thinking detail cards are expandable again instead of rendering a
+  non-interactive disclosure arrow.
 - Hermes reply finalization, duplicate rows, presence, zero-row logging (#1183)
 - Truthful terminal rows and a duplicate-free channel record (#1207)
 - Channel tree data source unified across desktop and mobile (#1208)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ chat-first pass) also shipped only on `@nightly` and is not itemized here.
 
 #### Fixed
 
-- Completed thinking detail cards are expandable again instead of rendering a
-  non-interactive disclosure arrow.
+- Terminal thinking summaries without detail no longer show a non-interactive
+  disclosure arrow; thinking cards with detail remain expandable.
 - Hermes reply finalization, duplicate rows, presence, zero-row logging (#1183)
 - Truthful terminal rows and a duplicate-free channel record (#1207)
 - Channel tree data source unified across desktop and mobile (#1208)

--- a/frontend/src/components/chat/AgentDetailCard.css
+++ b/frontend/src/components/chat/AgentDetailCard.css
@@ -7,7 +7,8 @@
   font-size: var(--font-size-sm);
 }
 
-.ch-agent-card__toggle {
+.ch-agent-card__toggle,
+.ch-agent-card__summary {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
@@ -20,15 +21,14 @@
   color: var(--text);
   font: inherit;
   text-align: left;
+}
+
+.ch-agent-card__toggle {
   cursor: pointer;
 }
 
 .ch-agent-card__toggle:hover:not(:disabled) {
   background: var(--surface-hover);
-}
-
-.ch-agent-card__toggle:disabled {
-  cursor: default;
 }
 
 .ch-agent-card__chevron,

--- a/frontend/src/components/chat/AgentDetailCard.tsx
+++ b/frontend/src/components/chat/AgentDetailCard.tsx
@@ -204,44 +204,62 @@ export const AgentDetailCard: React.FC<AgentDetailCardProps> = ({
   onUserToggle,
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const hasContent = Boolean(card.content);
+  // A terminal `thinking` event may intentionally carry only its summary.
+  // Do not render a disabled disclosure in that case: a chevron promises a
+  // detail panel, while whitespace would only expand into an empty panel.
+  const hasContent = Boolean(card.content?.trim());
   const size = contentSize(card);
   const title = card.path ?? card.title;
+  const bodyId = `agent-detail-body-${itemId}`;
 
   return (
     <div
       className="ch-agent-card"
       data-agent-card-kind={card.kind}
+      data-agent-card-expandable={hasContent ? 'true' : 'false'}
       role="article"
       aria-label={`${card.kind.replace('_', ' ')} ${title}`}
     >
-      <button
-        type="button"
-        className="ch-agent-card__toggle"
-        aria-expanded={expanded}
-        disabled={!hasContent}
-        onClick={() => {
-          onUserToggle?.(itemId);
-          setExpanded((value) => !value);
-        }}
-      >
-        <ChevronRight
-          className={`ch-agent-card__chevron${expanded ? ' ch-agent-card__chevron--open' : ''}`}
-          size={14}
-          strokeWidth={1.5}
-          aria-hidden="true"
-        />
-        <span className="ch-agent-card__icon">
-          <CardIcon kind={card.kind} />
-        </span>
-        <span className="ch-agent-card__title">{title}</span>
-        {size ? <span className="ch-agent-card__size">{size}</span> : null}
-        <span className={`ch-agent-card__status ${statusClass(card.status)}`}>
-          {card.status}
-        </span>
-      </button>
+      {hasContent ? (
+        <button
+          type="button"
+          className="ch-agent-card__toggle"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          onClick={() => {
+            onUserToggle?.(itemId);
+            setExpanded((value) => !value);
+          }}
+        >
+          <ChevronRight
+            className={`ch-agent-card__chevron${expanded ? ' ch-agent-card__chevron--open' : ''}`}
+            size={14}
+            strokeWidth={1.5}
+            aria-hidden="true"
+          />
+          <span className="ch-agent-card__icon">
+            <CardIcon kind={card.kind} />
+          </span>
+          <span className="ch-agent-card__title">{title}</span>
+          {size ? <span className="ch-agent-card__size">{size}</span> : null}
+          <span className={`ch-agent-card__status ${statusClass(card.status)}`}>
+            {card.status}
+          </span>
+        </button>
+      ) : (
+        <div className="ch-agent-card__summary">
+          <span className="ch-agent-card__icon">
+            <CardIcon kind={card.kind} />
+          </span>
+          <span className="ch-agent-card__title">{title}</span>
+          {size ? <span className="ch-agent-card__size">{size}</span> : null}
+          <span className={`ch-agent-card__status ${statusClass(card.status)}`}>
+            {card.status}
+          </span>
+        </div>
+      )}
       {expanded && hasContent ? (
-        <div className="ch-agent-card__body">
+        <div id={bodyId} className="ch-agent-card__body">
           <CardContent card={card} itemId={itemId} />
         </div>
       ) : null}

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -34,12 +34,31 @@ const ALLOWED_IMAGE_MIMES = new Set([
 export const CHANNEL_COMPOSER_MAX_IMAGES = 4;
 export const CHANNEL_COMPOSER_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
-/** Tooltip for the queueing default — names who the message is waiting on. */
-function queuedSendHint(busyAgentLabels: readonly string[]): string {
+type BusyAgentSteeringMode = 'all' | 'some' | 'none';
+
+/** Tooltip for the default delivery path — names who receives the message. */
+function defaultSendHint(
+  busyAgentLabels: readonly string[],
+  steeringMode: BusyAgentSteeringMode
+): string {
   const first = busyAgentLabels[0];
+  if (steeringMode === 'all') {
+    return busyAgentLabels.length === 1 && first
+      ? `steer ${first} after its next safe tool boundary`
+      : 'steer agents after their next safe tool boundary';
+  }
+  if (steeringMode === 'some') {
+    return 'steer supported agents at a safe boundary; queue the rest';
+  }
   return busyAgentLabels.length === 1 && first
     ? `queue behind ${first}'s turn`
     : 'queue behind the current turn';
+}
+
+function defaultSendLabel(steeringMode: BusyAgentSteeringMode): string {
+  if (steeringMode === 'all') return 'steer';
+  if (steeringMode === 'some') return 'steer / queue';
+  return 'queue';
 }
 
 interface PendingImage {
@@ -66,12 +85,12 @@ interface ChannelComposerProps {
     steering?: ChannelPostSteering
   ) => Promise<void>;
   /**
-   * Labels of the bound agents that are mid-turn right now (#1308 slice 4).
-   * Non-empty reveals the steering cluster: the default send QUEUES behind the
-   * live turn, and an explicit second control interrupts it first. Omitted on
-   * surfaces with no status signal, which simply keeps the plain composer.
+   * Labels of the bound agents that are mid-turn right now. Non-empty reveals
+   * the steering cluster; ordinary Enter follows native safe-boundary steering
+   * when available and otherwise retains the queue fallback.
    */
   busyAgentLabels?: readonly string[];
+  busyAgentSteeringMode?: BusyAgentSteeringMode;
   postPending: boolean;
   /** 503 CHANNEL_STORE_UNAVAILABLE — persistent inline banner, input stays live. */
   storeDown: boolean;
@@ -88,6 +107,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   members,
   onSend,
   busyAgentLabels,
+  busyAgentSteeringMode = 'none',
   postPending,
   storeDown,
   archived,
@@ -596,10 +616,9 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           +img
         </button>
         {busy ? (
-          // Mid-turn steering cluster (#1308 slice 4 item 2b). Two EXPLICIT
-          // actions, no menu and no inference: the default send queues behind
-          // the live turn (the operator's row grows a "queued" chip), and the
-          // second one cancels that turn first. It reuses the header chip's
+          // Mid-turn steering cluster. The default follows the harness's own
+          // safe-boundary primitive when supported; legacy harnesses keep the
+          // FIFO queue. The second action cancels the live turn first. It reuses the header chip's
           // interrupt glyph — the black square is already the one interrupt
           // vocabulary in the product — with danger-tinted chrome so the
           // destructive member of the pair reads differently at rest.
@@ -612,9 +631,12 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
               type="button"
               className="ch-composer__steer-btn"
               onClick={() => submit()}
-              title={queuedSendHint(busyAgentLabels ?? [])}
+              title={defaultSendHint(
+                busyAgentLabels ?? [],
+                busyAgentSteeringMode
+              )}
             >
-              queue
+              {defaultSendLabel(busyAgentSteeringMode)}
             </button>
             <button
               type="button"
@@ -630,7 +652,13 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         <span className="ch-composer__hint">
           {busy ? (
             <>
-              <kbd>↵</kbd>queue <kbd>⌘↵</kbd>interrupt <kbd>⇧↵</kbd>newline
+              <kbd>↵</kbd>
+              {busyAgentSteeringMode === 'all'
+                ? 'steer after tool'
+                : busyAgentSteeringMode === 'some'
+                  ? 'steer / queue'
+                  : 'queue'}{' '}
+              <kbd>⌘↵</kbd>interrupt <kbd>⇧↵</kbd>newline
             </>
           ) : (
             <>

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -51,6 +51,8 @@ interface ChannelThreadPanelProps {
    * a reply into a busy agent queues exactly like a top-level message.
    */
   busyAgentLabels?: readonly string[];
+  /** Whether busy harnesses use native steer or the legacy queue fallback. */
+  busyAgentSteeringMode?: 'all' | 'some' | 'none';
   postPending: boolean;
   storeDown: boolean;
   archived: boolean;
@@ -68,6 +70,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
   onClose,
   onSend,
   busyAgentLabels,
+  busyAgentSteeringMode,
   postPending,
   storeDown,
   archived,
@@ -248,6 +251,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
         placeholder={isDm ? DM_THREAD_PLACEHOLDER : THREAD_PLACEHOLDER}
         onSend={onSend}
         {...(busyAgentLabels ? { busyAgentLabels } : {})}
+        {...(busyAgentSteeringMode ? { busyAgentSteeringMode } : {})}
         postPending={postPending}
         storeDown={storeDown}
         archived={archived}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -218,9 +218,18 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
    * the current set without being rebuilt on every status transition. Assigned
    * further down, once `agentChips` exists.
    */
-  const steerTargetsRef = useRef<{ agentIds: string[]; labels: string[] }>({
+  const steerTargetsRef = useRef<{
+    agentIds: string[];
+    labels: string[];
+    queueAgentIds: string[];
+    queueLabels: string[];
+    mode: 'all' | 'some' | 'none';
+  }>({
     agentIds: [],
     labels: [],
+    queueAgentIds: [],
+    queueLabels: [],
+    mode: 'none',
   });
 
   /**
@@ -243,7 +252,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       // flight must not leave a chip behind on a message it already consumed.
       const drainSeqs = snapshotQueueDrainSeqs(
         channelId,
-        targets.agentIds,
+        targets.queueAgentIds,
         statusStore.queueDrainSeqByChannelAgent
       );
       const message = await post(text, {
@@ -256,7 +265,15 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       // a wait either: the operator asked for the live turn to be cancelled, so
       // announcing the message as "queued" would describe the opposite of what
       // they chose.
-      if (targets.agentIds.length === 0 || steering === 'interrupt') return;
+      if (
+        targets.agentIds.length === 0 ||
+        steering === 'interrupt' ||
+        // The native lane is not a future queued turn. Avoid a row chip that
+        // says otherwise; its presence/status copy says "steering pending".
+        targets.queueAgentIds.length === 0
+      ) {
+        return;
+      }
       const current =
         useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent;
       for (const [key, seq] of Object.entries(drainSeqs)) {
@@ -264,8 +281,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       }
       useChannelQueuedSendsStore.getState().markQueuedSend(message.id, {
         channelId,
-        agentIds: targets.agentIds,
-        label: queuedSendCopy(targets.labels),
+        agentIds: targets.queueAgentIds,
+        label: queuedSendCopy(targets.queueLabels),
         drainSeqs,
       });
     },
@@ -507,6 +524,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const queuedCountMap = useChannelAgentStatusStore(
     (s) => s.queuedCountByChannelAgent
   );
+  const steeringCountMap = useChannelAgentStatusStore(
+    (s) => s.steeringCountByChannelAgent
+  );
+  const steerSupportedMap = useChannelAgentStatusStore(
+    (s) => s.steerSupportedByChannelAgent
+  );
   // #1307: a busy socket status the roster has not yet superseded is exactly the
   // state that can go stale, so it is what arms the roster poll — and because the
   // predicate is the same tie-break the resolver uses, the poll self-disarms: the
@@ -601,6 +624,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       status: ChannelAgentStatus;
       role?: AgentRole;
       queuedCount: number;
+      steeringCount: number;
+      steerSupported: boolean;
       identity: ReturnType<typeof resolveSenderIdentity>;
     }> = [];
     for (const agentId of candidateIds) {
@@ -625,6 +650,24 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         rosterQueuedCount: entry?.binding?.queuedCount,
         rosterUpdatedAt,
       });
+      const steeringCount = resolveEffectiveQueuedCount({
+        socketQueuedCount: steeringCountMap[key],
+        socketUpdatedAt: statusUpdatedAtMap[key],
+        rosterQueuedCount: entry?.binding?.steeringCount,
+        rosterUpdatedAt,
+      });
+      const socketSteerSupported = Object.hasOwn(steerSupportedMap, key)
+        ? steerSupportedMap[key]
+          ? 1
+          : 0
+        : undefined;
+      const steerSupported =
+        resolveEffectiveQueuedCount({
+          socketQueuedCount: socketSteerSupported,
+          socketUpdatedAt: statusUpdatedAtMap[key],
+          rosterQueuedCount: entry?.binding?.steerSupported ? 1 : 0,
+          rosterUpdatedAt,
+        }) > 0;
       // Show a chip for a bound agent (even when idle) or one that is currently
       // active/streaming — but drop an unbound agent whose only signal is a stale
       // socket status the roster has since superseded to idle.
@@ -641,6 +684,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         agentId,
         status,
         queuedCount,
+        steeringCount,
+        steerSupported,
         ...(entry?.role ? { role: entry.role } : {}),
         identity,
       });
@@ -652,6 +697,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     statusMap,
     statusUpdatedAtMap,
     queuedCountMap,
+    steeringCountMap,
+    steerSupportedMap,
     streamingProfileProviders,
     channelId,
   ]);
@@ -691,9 +738,26 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         .map((chip) => chip.identity.label),
     [agentChips]
   );
+  const busyAgentSteeringMode = useMemo((): 'all' | 'some' | 'none' => {
+    const busy = agentChips.filter((chip) => chip.status !== 'idle');
+    if (busy.length === 0 || busy.every((chip) => !chip.steerSupported)) {
+      return 'none';
+    }
+    return busy.every((chip) => chip.steerSupported) ? 'all' : 'some';
+  }, [agentChips]);
+  const busyQueueFallback = useMemo(
+    () =>
+      agentChips.filter(
+        (chip) => chip.status !== 'idle' && !chip.steerSupported
+      ),
+    [agentChips]
+  );
   steerTargetsRef.current = {
     agentIds: [...busyAgentIds],
     labels: busyAgentLabels,
+    queueAgentIds: busyQueueFallback.map((chip) => chip.agentId),
+    queueLabels: busyQueueFallback.map((chip) => chip.identity.label),
+    mode: busyAgentSteeringMode,
   };
 
   // Wired only while the channel is live, exactly like edit/delete below: a
@@ -996,6 +1060,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             {...(channel?.members ? { members: channel.members } : {})}
             onSend={handleSend}
             busyAgentLabels={busyAgentLabels}
+            busyAgentSteeringMode={busyAgentSteeringMode}
             postPending={postPending}
             storeDown={storeDown}
             archived={archived}
@@ -1015,6 +1080,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             onClose={() => setActiveThreadRootId(null)}
             onSend={handleThreadSend}
             busyAgentLabels={busyAgentLabels}
+            busyAgentSteeringMode={busyAgentSteeringMode}
             postPending={postPending}
             storeDown={storeDown}
             archived={archived}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -752,13 +753,22 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       ),
     [agentChips]
   );
-  steerTargetsRef.current = {
-    agentIds: [...busyAgentIds],
-    labels: busyAgentLabels,
-    queueAgentIds: busyQueueFallback.map((chip) => chip.agentId),
-    queueLabels: busyQueueFallback.map((chip) => chip.identity.label),
-    mode: busyAgentSteeringMode,
-  };
+  const steerTargets = useMemo(
+    () => ({
+      agentIds: [...busyAgentIds],
+      labels: busyAgentLabels,
+      queueAgentIds: busyQueueFallback.map((chip) => chip.agentId),
+      queueLabels: busyQueueFallback.map((chip) => chip.identity.label),
+      mode: busyAgentSteeringMode,
+    }),
+    [busyAgentIds, busyAgentLabels, busyQueueFallback, busyAgentSteeringMode]
+  );
+  // Send handlers must only observe a committed UI state. Updating the ref
+  // during render lets an abandoned concurrent render steer a different set of
+  // agents than the operator could actually see.
+  useLayoutEffect(() => {
+    steerTargetsRef.current = steerTargets;
+  }, [steerTargets]);
 
   // Wired only while the channel is live, exactly like edit/delete below: a
   // retry re-runs a turn against an archived (read-only) channel, so the route

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -652,7 +652,9 @@ export function useEventSocket({
           msg.runtimeId,
           // A hub that predates #1308 slice 4 omits the field; absent means
           // "nothing queued", which is also what an unqueued binding reports.
-          msg.queuedCount ?? 0
+          msg.queuedCount ?? 0,
+          msg.steeringCount ?? 0,
+          msg.steerSupported ?? false
         );
         // #1308 slice 5: the ONE trigger the socket carries end to end. Default
         // OFF, so this is inert until the operator opts in from Settings.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2010,8 +2010,8 @@ export async function postChannelMessage(
     parentMessageId?: string;
     clientMessageId: string;
     /**
-     * Explicit mid-turn steering (#1308 slice 4). Omitted queues the post behind
-     * the agent's live turn; `'interrupt'` cancels that turn and sends now.
+     * Explicit mid-turn steering. Omitted prefers a harness's native safe-boundary
+     * steer and otherwise queues behind the live turn; `'interrupt'` cancels it.
      */
     steering?: 'interrupt';
   }
@@ -2108,6 +2108,10 @@ export interface RosterEntry {
      * Optional so an older hub's roster still parses; absent means zero.
      */
     queuedCount?: number;
+    /** Safe-boundary steer requests currently attached to the active turn. */
+    steeringCount?: number;
+    /** Whether the live harness accepts the default native steer action. */
+    steerSupported?: boolean;
   } | null;
 }
 

--- a/frontend/src/lib/chat/channel-agent-presence.ts
+++ b/frontend/src/lib/chat/channel-agent-presence.ts
@@ -41,6 +41,8 @@ export interface ChannelAgentPresence {
   glyph: KnownAgentGlyph | null;
   /** Posts waiting to trigger this agent's NEXT turn (#1308 slice 4). */
   queuedCount: number;
+  /** Posts accepted by this agent's native safe-boundary steering lane. */
+  steeringCount: number;
 }
 
 /** Minimal shape of the header chips this projection consumes. */
@@ -50,6 +52,7 @@ export interface ChannelPresenceChip {
   identity: { label: string; colorVar: string; glyph: KnownAgentGlyph | null };
   /** Absent on surfaces that predate the queue signal — treated as zero. */
   queuedCount?: number;
+  steeringCount?: number;
 }
 
 /** Membership probe — satisfied by both `Set` and `Map` of agent ids. */
@@ -76,6 +79,7 @@ export function selectChannelAgentPresence(
       colorVar: chip.identity.colorVar,
       glyph: chip.identity.glyph,
       queuedCount: chip.queuedCount ?? 0,
+      steeringCount: chip.steeringCount ?? 0,
     });
   }
   return rows;
@@ -147,7 +151,7 @@ export function sameStreamingHold(
 
 /** Lowercase presence copy per DESIGN.md — dim secondary text, no emoji. */
 export function channelPresenceCopy(presence: ChannelAgentPresence): string {
-  return `${presenceActivityCopy(presence)}${queuedSuffix(presence.queuedCount)}`;
+  return `${presenceActivityCopy(presence)}${steeringSuffix(presence.steeringCount)}${queuedSuffix(presence.queuedCount)}`;
 }
 
 function presenceActivityCopy(presence: ChannelAgentPresence): string {
@@ -168,4 +172,8 @@ function presenceActivityCopy(presence: ChannelAgentPresence): string {
  */
 function queuedSuffix(queuedCount: number): string {
   return queuedCount > 0 ? ` (${queuedCount} queued)` : '';
+}
+
+function steeringSuffix(steeringCount: number): string {
+  return steeringCount > 0 ? ` (${steeringCount} steering pending)` : '';
 }

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -25,6 +25,10 @@ interface ChannelAgentStatusState {
    * NOT zero, so the roster snapshot can still win the reconciliation.
    */
   queuedCountByChannelAgent: Record<string, number>;
+  /** Native safe-boundary requests still attached to the active turn. */
+  steeringCountByChannelAgent: Record<string, number>;
+  /** Whether a live harness accepts the ordinary native steer action. */
+  steerSupportedByChannelAgent: Record<string, boolean>;
   /**
    * Monotonic "this agent's trigger queue was observed empty" generation, per
    * `${channelId} ${agentId}` (#1308 slice 4).
@@ -52,7 +56,9 @@ interface ChannelAgentStatusState {
     agentId: string,
     status: ChannelAgentStatus,
     runtimeId: string | null,
-    queuedCount?: number
+    queuedCount?: number,
+    steeringCount?: number,
+    steerSupported?: boolean
   ) => void;
   /** Drop every agent status/runtime entry for a channel. */
   clearChannel: (channelId: string) => void;
@@ -67,15 +73,27 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
     statusByChannelAgent: {},
     runtimeByChannelAgent: {},
     queuedCountByChannelAgent: {},
+    steeringCountByChannelAgent: {},
+    steerSupportedByChannelAgent: {},
     queueDrainSeqByChannelAgent: {},
     updatedAtByChannelAgent: {},
-    recordStatus: (channelId, agentId, status, runtimeId, queuedCount = 0) =>
+    recordStatus: (
+      channelId,
+      agentId,
+      status,
+      runtimeId,
+      queuedCount = 0,
+      steeringCount = 0,
+      steerSupported = false
+    ) =>
       set((state) => {
         const key = channelAgentStatusKey(channelId, agentId);
         if (
           state.statusByChannelAgent[key] === status &&
           state.runtimeByChannelAgent[key] === runtimeId &&
-          state.queuedCountByChannelAgent[key] === queuedCount
+          state.queuedCountByChannelAgent[key] === queuedCount &&
+          state.steeringCountByChannelAgent[key] === steeringCount &&
+          state.steerSupportedByChannelAgent[key] === steerSupported
         ) {
           return state;
         }
@@ -91,6 +109,14 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
           queuedCountByChannelAgent: {
             ...state.queuedCountByChannelAgent,
             [key]: queuedCount,
+          },
+          steeringCountByChannelAgent: {
+            ...state.steeringCountByChannelAgent,
+            [key]: steeringCount,
+          },
+          steerSupportedByChannelAgent: {
+            ...state.steerSupportedByChannelAgent,
+            [key]: steerSupported,
           },
           // Bumped on the transition itself, not on a later read: an empty queue
           // reported by ANY transition retires every send that was waiting for
@@ -114,6 +140,8 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
         const status: Record<string, ChannelAgentStatus> = {};
         const runtime: Record<string, string | null> = {};
         const queued: Record<string, number> = {};
+        const steering: Record<string, number> = {};
+        const steerSupported: Record<string, boolean> = {};
         const drainSeq: Record<string, number> = {};
         const updatedAt: Record<string, number> = {};
         let changed = false;
@@ -132,6 +160,16 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
           if (!key.startsWith(prefix)) queued[key] = value;
         }
         for (const [key, value] of Object.entries(
+          state.steeringCountByChannelAgent
+        )) {
+          if (!key.startsWith(prefix)) steering[key] = value;
+        }
+        for (const [key, value] of Object.entries(
+          state.steerSupportedByChannelAgent
+        )) {
+          if (!key.startsWith(prefix)) steerSupported[key] = value;
+        }
+        for (const [key, value] of Object.entries(
           state.queueDrainSeqByChannelAgent
         )) {
           if (!key.startsWith(prefix)) drainSeq[key] = value;
@@ -146,6 +184,8 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
           statusByChannelAgent: status,
           runtimeByChannelAgent: runtime,
           queuedCountByChannelAgent: queued,
+          steeringCountByChannelAgent: steering,
+          steerSupportedByChannelAgent: steerSupported,
           queueDrainSeqByChannelAgent: drainSeq,
           updatedAtByChannelAgent: updatedAt,
         };
@@ -243,7 +283,10 @@ export function shouldPollRosterForPresence(input: {
     if (!key.startsWith(prefix)) continue;
     if (status === 'idle') continue;
     const socketUpdatedAt = input.updatedAtByChannelAgent[key];
-    if (socketUpdatedAt !== undefined && socketUpdatedAt >= input.rosterUpdatedAt)
+    if (
+      socketUpdatedAt !== undefined &&
+      socketUpdatedAt >= input.rosterUpdatedAt
+    )
       return true;
   }
   return false;

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -145,6 +145,10 @@ export type EventMessage =
        * absent value as zero.
        */
       queuedCount?: number;
+      /** Posts held by a native safe-boundary steer on the current turn. */
+      steeringCount?: number;
+      /** This harness uses native safe-boundary steering for ordinary sends. */
+      steerSupported?: boolean;
     }
   | ({
       type: 'session-durability-changed';

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -294,6 +294,7 @@ export interface LiveBinding {
   emittedStatus: ChannelAgentStatus;
   emittedQueuedCount: number;
   emittedSteeringCount: number;
+  emittedSteerSupported: boolean;
   watchdog: NodeJS.Timeout | null;
   retriedTurns: Set<string>;
   announcedApprovals: Set<string>;
@@ -595,6 +596,13 @@ export function createChannelAgentBinder(
     return profile.displayName || (await senderLabelFor(profile.providerId));
   }
 
+  function supportsSafeBoundarySteer(binding: LiveBinding): boolean {
+    return (
+      binding.adapter?.capabilities.steer === true &&
+      binding.adapter.steerMessage !== undefined
+    );
+  }
+
   // ── status ──────────────────────────────────────────────────────────────────
 
   /**
@@ -609,16 +617,19 @@ export function createChannelAgentBinder(
       binding.steeringAcceptedCount +
       binding.steeringQueue.length +
       (binding.steeringInFlight ? 1 : 0);
+    const steerSupported = supportsSafeBoundarySteer(binding);
     if (
       binding.emittedStatus === binding.status &&
       binding.emittedQueuedCount === queuedCount &&
-      binding.emittedSteeringCount === steeringCount
+      binding.emittedSteeringCount === steeringCount &&
+      binding.emittedSteerSupported === steerSupported
     ) {
       return;
     }
     binding.emittedStatus = binding.status;
     binding.emittedQueuedCount = queuedCount;
     binding.emittedSteeringCount = steeringCount;
+    binding.emittedSteerSupported = steerSupported;
     statusBroadcaster?.('channel-agent-status', {
       channelId: binding.channelId,
       agentId: binding.profileActorId,
@@ -626,9 +637,7 @@ export function createChannelAgentBinder(
       runtimeId: binding.runtimeId ?? null,
       queuedCount,
       steeringCount,
-      steerSupported:
-        binding.adapter?.capabilities.steer === true &&
-        binding.adapter.steerMessage !== undefined,
+      steerSupported,
     });
   }
 
@@ -696,6 +705,7 @@ export function createChannelAgentBinder(
       emittedStatus: 'idle',
       emittedQueuedCount: 0,
       emittedSteeringCount: 0,
+      emittedSteerSupported: false,
       watchdog: null,
       retriedTurns: new Set(),
       announcedApprovals: new Set(),
@@ -1163,6 +1173,13 @@ export function createChannelAgentBinder(
     );
   }
 
+  function isCurrentBinding(binding: LiveBinding): boolean {
+    return (
+      live.get(bindingKey(binding.channelId, binding.profileActorId)) ===
+      binding
+    );
+  }
+
   /**
    * Put a post into the provider-native safe-boundary lane. The call is
    * serialized because Codex's `turn/steer` advances its expected native turn
@@ -1218,6 +1235,7 @@ export function createChannelAgentBinder(
         clientMessageId: `${trigger.id}:${binding.profileActorId}`,
       })
       .then(() => {
+        if (!isCurrentBinding(binding)) return;
         // A terminal patch can win the provider-RPC race. Do not resurrect a
         // cleared steering indicator after finishTurn; replay would be unsafe
         // because a late transport result may already have been accepted.
@@ -1227,7 +1245,7 @@ export function createChannelAgentBinder(
         advanceCursor(binding, trigger);
       })
       .catch((err) => {
-        if (closed) return;
+        if (closed || !isCurrentBinding(binding)) return;
         if (err instanceof AgentSteerRejectedError) {
           // Definite provider rejection is safe to deliver once through the
           // normal next-turn FIFO; ambiguous transport failures stay visible
@@ -1247,6 +1265,7 @@ export function createChannelAgentBinder(
         );
       })
       .finally(() => {
+        if (!isCurrentBinding(binding)) return;
         binding.steeringInFlight = false;
         emitAgentStatus(binding);
         // A terminal patch may have arrived while the provider RPC was in
@@ -1589,6 +1608,7 @@ export function createChannelAgentBinder(
       );
     }
     binding.steeringQueue = [];
+    binding.steeringInFlight = false;
     binding.steeringAcceptedCount = 0;
   }
 
@@ -2544,8 +2564,7 @@ export function createChannelAgentBinder(
                   (binding?.steeringQueue.length ?? 0) +
                   (binding?.steeringInFlight ? 1 : 0),
                 steerSupported:
-                  binding?.adapter?.capabilities.steer === true &&
-                  binding.adapter.steerMessage !== undefined,
+                  binding !== undefined && supportsSafeBoundarySteer(binding),
               }
             : null,
         };
@@ -2580,6 +2599,9 @@ export function createChannelAgentBinder(
         // it refetch a roster. Broadcast is best-effort: the transport may
         // already be closing, and that must not abort the rest of shutdown.
         binding.queue = [];
+        binding.steeringQueue = [];
+        binding.steeringInFlight = false;
+        binding.steeringAcceptedCount = 0;
         binding.activeTurnId = null;
         binding.waitingOn = null;
         binding.status = 'idle';

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -15,7 +15,11 @@ import {
   type ChannelMessageStore,
 } from './channel-message-store.js';
 import type { ChannelHub, ChannelMessagePostedOptions } from './channel-hub.js';
-import type { Attachment, ProtocolAdapterV2 } from './protocol-adapter-v2.js';
+import {
+  AgentSteerRejectedError,
+  type Attachment,
+  type ProtocolAdapterV2,
+} from './protocol-adapter-v2.js';
 import type {
   ChannelAgentRuntime,
   CreateChannelAgentRuntimeParams,
@@ -59,13 +63,10 @@ import { workspaceTopicAgentRuntimeLinkPatch } from '../shared/workspace-topics.
 // items so it can drive the queue, status, watchdog, and approval rows.
 //
 // ── mid-turn steering (#1308 slice 4) ────────────────────────────────────────
-// A post addressed to a binding that is already mid-turn does NOT open a second
-// concurrent turn and is never dropped: `enqueueTurn` appends to the binding's
-// FIFO queue and `pump` refuses to dispatch while `activeTurnId !== null`. On
-// `finishTurn` the queue drains into ONE next turn — every human post that
-// arrived while the agent was busy is coalesced (§`pump`), and all of them ride
-// that turn's context packet for free, because `buildPacket` reads them back out
-// of the durable store (`seq > lastDeliveredSeq`, `seq < trigger.seq`).
+// A post addressed to a binding that is already mid-turn never opens a second
+// concurrent turn and is never dropped. Providers exposing `capabilities.steer`
+// receive the post through their own safe-boundary primitive; every other
+// provider uses the existing FIFO queue, which `pump` drains after completion.
 //
 // `steering: 'interrupt'` is the operator's explicit "interrupt and send": the
 // live turn is cancelled through the SAME `adapter.interrupt` path the header
@@ -159,6 +160,10 @@ export interface ChannelAgentRosterEntry {
      * live binding), so the chip renders from one number on both lanes.
      */
     queuedCount: number;
+    /** Posts accepted by a native safe-boundary steering primitive. */
+    steeringCount: number;
+    /** Whether this live harness accepts the default safe-boundary steer. */
+    steerSupported: boolean;
   } | null;
 }
 
@@ -279,9 +284,16 @@ export interface LiveBinding {
   sawStream: boolean;
   waitingOn: string | null;
   queue: QueuedTurn[];
+  /** FIFO of native safe-boundary requests not yet handed to the adapter. */
+  steeringQueue: QueuedTurn[];
+  /** One provider call at a time preserves original operator order. */
+  steeringInFlight: boolean;
+  /** Requests accepted into the active provider turn, cleared when it ends. */
+  steeringAcceptedCount: number;
   /** Last `(status, queuedCount)` pair broadcast; suppresses duplicate events. */
   emittedStatus: ChannelAgentStatus;
   emittedQueuedCount: number;
+  emittedSteeringCount: number;
   watchdog: NodeJS.Timeout | null;
   retriedTurns: Set<string>;
   announcedApprovals: Set<string>;
@@ -586,29 +598,37 @@ export function createChannelAgentBinder(
   // ── status ──────────────────────────────────────────────────────────────────
 
   /**
-   * Broadcast the binding's observable presence: its status AND how many posts
-   * are waiting to trigger its next turn (#1308 slice 4). Deduped on the PAIR,
-   * not on status alone — a second message arriving while an agent is already
-   * `streaming` moves no status but must still light the queued chip, and the
-   * drain that empties the queue must clear it even though the binding was
-   * already `thinking`.
+   * Broadcast the binding's observable presence plus both delivery lanes.
+   * `queuedCount` waits for a future turn; `steeringCount` has been accepted
+   * into a native provider's safe-boundary lane. They must remain separate so
+   * the client never calls a steering request "queued".
    */
   function emitAgentStatus(binding: LiveBinding): void {
     const queuedCount = binding.queue.length;
+    const steeringCount =
+      binding.steeringAcceptedCount +
+      binding.steeringQueue.length +
+      (binding.steeringInFlight ? 1 : 0);
     if (
       binding.emittedStatus === binding.status &&
-      binding.emittedQueuedCount === queuedCount
+      binding.emittedQueuedCount === queuedCount &&
+      binding.emittedSteeringCount === steeringCount
     ) {
       return;
     }
     binding.emittedStatus = binding.status;
     binding.emittedQueuedCount = queuedCount;
+    binding.emittedSteeringCount = steeringCount;
     statusBroadcaster?.('channel-agent-status', {
       channelId: binding.channelId,
       agentId: binding.profileActorId,
       status: binding.status,
       runtimeId: binding.runtimeId ?? null,
       queuedCount,
+      steeringCount,
+      steerSupported:
+        binding.adapter?.capabilities.steer === true &&
+        binding.adapter.steerMessage !== undefined,
     });
   }
 
@@ -670,8 +690,12 @@ export function createChannelAgentBinder(
       sawStream: false,
       waitingOn: null,
       queue: [],
+      steeringQueue: [],
+      steeringInFlight: false,
+      steeringAcceptedCount: 0,
       emittedStatus: 'idle',
       emittedQueuedCount: 0,
+      emittedSteeringCount: 0,
       watchdog: null,
       retriedTurns: new Set(),
       announcedApprovals: new Set(),
@@ -1062,10 +1086,32 @@ export function createChannelAgentBinder(
     steering?: ChannelPostSteering,
     reEnqueued = false
   ): void {
+    // Native harnesses get the user's next instruction at their own tool-safe
+    // boundary. Keep this ahead of the queue branch: while a turn is live the
+    // regular pump cannot dispatch, whereas a provider steer is explicitly
+    // designed to alter that live turn without interrupting its current tool.
+    if (
+      !reEnqueued &&
+      steering !== 'interrupt' &&
+      binding.activeTurnId !== null &&
+      binding.adapter?.capabilities.steer === true &&
+      binding.adapter.steerMessage !== undefined
+    ) {
+      if (occupiedTurnSlots(binding) >= QUEUE_CAP) {
+        postSystemRow(
+          binding.channelId,
+          `@${binding.displayName} has ${QUEUE_CAP} messages pending — message dropped`,
+          { parentMessageId: parentForTrigger(trigger) }
+        );
+        return;
+      }
+      enqueueSteering(binding, trigger);
+      return;
+    }
     const entry: QueuedTurn = reEnqueued
       ? { trigger, reEnqueued: true }
       : { trigger };
-    if (binding.queue.length >= QUEUE_CAP) {
+    if (occupiedTurnSlots(binding) >= QUEUE_CAP) {
       const tailIndex = binding.queue.length - 1;
       const tail = binding.queue[tailIndex];
       // Neither side may be a re-enqueued trigger: superseding one silently
@@ -1092,7 +1138,7 @@ export function createChannelAgentBinder(
       }
       postSystemRow(
         binding.channelId,
-        `@${binding.displayName} has ${QUEUE_CAP} turns queued — message dropped`,
+        `@${binding.displayName} has ${QUEUE_CAP} messages pending — message dropped`,
         { parentMessageId: parentForTrigger(trigger) }
       );
       return;
@@ -1106,6 +1152,108 @@ export function createChannelAgentBinder(
     // send" degrades cleanly to plain "send".
     if (steering === 'interrupt') steerInterrupt(binding, trigger);
     pump(binding);
+  }
+
+  function occupiedTurnSlots(binding: LiveBinding): number {
+    return (
+      binding.queue.length +
+      binding.steeringQueue.length +
+      binding.steeringAcceptedCount +
+      (binding.steeringInFlight ? 1 : 0)
+    );
+  }
+
+  /**
+   * Put a post into the provider-native safe-boundary lane. The call is
+   * serialized because Codex's `turn/steer` advances its expected native turn
+   * id, while Claude's persistent stream-json input is ordered on stdin. No
+   * retry occurs after a provider error: a transport failure can be ambiguous,
+   * and retrying would violate at-most-once delivery.
+   */
+  function enqueueSteering(
+    binding: LiveBinding,
+    trigger: ChannelMessage
+  ): void {
+    binding.steeringQueue.push({ trigger });
+    emitAgentStatus(binding);
+    drainSteering(binding);
+  }
+
+  function drainSteering(binding: LiveBinding): void {
+    if (closed || binding.steeringInFlight || binding.activeTurnId === null) {
+      return;
+    }
+    const adapter = binding.adapter;
+    const steerMessage = adapter?.steerMessage;
+    if (adapter?.capabilities.steer !== true || !steerMessage) return;
+    const entry = binding.steeringQueue.shift();
+    if (!entry) return;
+    const { trigger } = entry;
+    const activeTurnId = binding.activeTurnId;
+    let packet: ResolvedMentionContextPacket;
+    try {
+      packet = buildPacket(binding, trigger);
+    } catch (err) {
+      logger.warn('channel binder steering packet build failed:', err);
+      postSystemRow(
+        binding.channelId,
+        `@${binding.displayName} could not build the steering context: ${errText(err)}`,
+        { parentMessageId: parentForTrigger(trigger) }
+      );
+      emitAgentStatus(binding);
+      drainSteering(binding);
+      return;
+    }
+    binding.steeringInFlight = true;
+    emitAgentStatus(binding);
+    steerMessage
+      .call(adapter, {
+        // The adapter preserves the live provider/Relay turn identity; this id
+        // is retained only for provider implementations that annotate input.
+        turnId: activeTurnId,
+        content: packet.content,
+        ...(packet.attachments.length > 0
+          ? { attachments: packet.attachments }
+          : {}),
+        clientMessageId: `${trigger.id}:${binding.profileActorId}`,
+      })
+      .then(() => {
+        // A terminal patch can win the provider-RPC race. Do not resurrect a
+        // cleared steering indicator after finishTurn; replay would be unsafe
+        // because a late transport result may already have been accepted.
+        if (binding.activeTurnId === activeTurnId) {
+          binding.steeringAcceptedCount += 1;
+        }
+        advanceCursor(binding, trigger);
+      })
+      .catch((err) => {
+        if (closed) return;
+        if (err instanceof AgentSteerRejectedError) {
+          // Definite provider rejection is safe to deliver once through the
+          // normal next-turn FIFO; ambiguous transport failures stay visible
+          // errors and are never replayed.
+          // This request is no longer in flight, so do not make it consume the
+          // final aggregate slot while we move it to the ordinary queue. The
+          // finally below is deliberately idempotent.
+          binding.steeringInFlight = false;
+          enqueueTurn(binding, trigger, undefined, true);
+          return;
+        }
+        logger.warn('channel binder native steering failed:', err);
+        postSystemRow(
+          binding.channelId,
+          `@${binding.displayName} could not accept the steering message: ${errText(err)}`,
+          { parentMessageId: parentForTrigger(trigger) }
+        );
+      })
+      .finally(() => {
+        binding.steeringInFlight = false;
+        emitAgentStatus(binding);
+        // A terminal patch may have arrived while the provider RPC was in
+        // flight. In that case finishTurn moves later entries to the ordinary
+        // FIFO; never issue a stale steer against a completed turn.
+        drainSteering(binding);
+      });
   }
 
   /**
@@ -1433,6 +1581,15 @@ export function createChannelAgentBinder(
       );
     }
     binding.queue = [];
+    for (const steering of binding.steeringQueue) {
+      postSystemRow(
+        binding.channelId,
+        `@${binding.displayName} runtime ended before accepting a steering message.`,
+        { parentMessageId: parentForTrigger(steering.trigger) }
+      );
+    }
+    binding.steeringQueue = [];
+    binding.steeringAcceptedCount = 0;
   }
 
   /**
@@ -1468,6 +1625,17 @@ export function createChannelAgentBinder(
     binding.sawStream = false;
     disarmWatchdog(binding);
     setStatus(binding, 'idle');
+    // If the provider completed before later safe-boundary requests were
+    // accepted, preserve FIFO by falling back to ordinary next-turn delivery.
+    // The in-flight request is intentionally not replayed: its transport result
+    // may be ambiguous, so re-sending it would break at-most-once semantics.
+    if (binding.steeringQueue.length > 0) {
+      binding.queue.push(...binding.steeringQueue);
+      binding.steeringQueue = [];
+      emitAgentStatus(binding);
+    }
+    binding.steeringAcceptedCount = 0;
+    emitAgentStatus(binding);
     pump(binding);
   }
 
@@ -1478,10 +1646,7 @@ export function createChannelAgentBinder(
     if (binding.waitingOn === null) setStatus(binding, 'streaming');
   }
 
-  function handleBindingPatch(
-    binding: LiveBinding,
-    patch: AgentPatchV2
-  ): void {
+  function handleBindingPatch(binding: LiveBinding, patch: AgentPatchV2): void {
     switch (patch.type) {
       case 'agent-session-updated-v2':
         if (patch.providerSession) {
@@ -2374,6 +2539,13 @@ export function createChannelAgentBinder(
                 runtimeId,
                 status: binding?.status ?? 'idle',
                 queuedCount: binding?.queue.length ?? 0,
+                steeringCount:
+                  (binding?.steeringAcceptedCount ?? 0) +
+                  (binding?.steeringQueue.length ?? 0) +
+                  (binding?.steeringInFlight ? 1 : 0),
+                steerSupported:
+                  binding?.adapter?.capabilities.steer === true &&
+                  binding.adapter.steerMessage !== undefined,
               }
             : null,
         };

--- a/server/claude-stream-client.ts
+++ b/server/claude-stream-client.ts
@@ -45,6 +45,12 @@ export interface ClaudeStreamCloseEvent {
   signal: NodeJS.Signals | null;
 }
 
+interface PendingClaudeWrite {
+  line: string;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
 const DEFAULT_MAX_LINE_CHARS = 32 * 1024 * 1024;
 const DEFAULT_STDERR_RING = 50;
 const DEFAULT_AFTER_STDIN_MS = 3000;
@@ -84,7 +90,8 @@ export class ClaudeStreamClient extends EventEmitter {
   private skipping = false;
 
   private readonly stderrRing: string[] = [];
-  private writeQueue: string[] = [];
+  private writeQueue: PendingClaudeWrite[] = [];
+  private readonly writesInFlight = new Set<PendingClaudeWrite>();
   private draining = false;
   private stopPromise: Promise<void> | null = null;
 
@@ -160,6 +167,9 @@ export class ClaudeStreamClient extends EventEmitter {
     child.on('close', (code, signal) => {
       if (this.closed) return;
       this.closed = true;
+      this.rejectPendingWrites(
+        new Error('Claude subprocess closed before stdin write was accepted')
+      );
       this.emit('close', {
         code: code ?? null,
         signal: (signal as NodeJS.Signals | null) ?? null,
@@ -167,18 +177,37 @@ export class ClaudeStreamClient extends EventEmitter {
     });
   }
 
-  /** Serialize one JSON frame + `\n` onto the drain-honoring stdin queue. */
+  /** Queue a best-effort frame; transport errors are handled on the client. */
   write(msg: unknown): void {
-    if (this.closed || !this.child) return;
+    void this.writeAccepted(msg).catch(() => {
+      // `onStdinError`/`close` already emits the durable adapter failure. This
+      // convenience method is intentionally fire-and-forget for controls.
+    });
+  }
+
+  /**
+   * Resolve only after Node has accepted the frame into stdin's write buffer.
+   * Claude stream-json exposes no per-frame application acknowledgement, so
+   * this is the strongest non-terminal receipt available: callback success
+   * plus drain/backpressure/error handling. It does NOT wait for turn output.
+   */
+  writeAccepted(msg: unknown): Promise<void> {
+    if (this.closed || !this.child) {
+      return Promise.reject(new Error('Claude stdin is unavailable'));
+    }
     let line: string;
     try {
       line = JSON.stringify(msg) + '\n';
     } catch (err) {
       logger.warn('failed to serialize claude stdin frame: %s', String(err));
-      return;
+      return Promise.reject(
+        err instanceof Error ? err : new Error(String(err))
+      );
     }
-    this.writeQueue.push(line);
-    this.flush();
+    return new Promise<void>((resolve, reject) => {
+      this.writeQueue.push({ line, resolve, reject });
+      this.flush();
+    });
   }
 
   /** Flush the outbound queue respecting stdin backpressure (drain gating). */
@@ -188,17 +217,28 @@ export class ClaudeStreamClient extends EventEmitter {
     if (!stdin) return;
 
     while (this.writeQueue.length > 0) {
-      const line = this.writeQueue.shift()!;
+      const pending = this.writeQueue.shift()!;
+      this.writesInFlight.add(pending);
       let ok: boolean;
       try {
         // The write callback catches asynchronous stream errors (e.g. a late
         // EPIPE) that would otherwise land on the stdin 'error' listener; the
         // try/catch catches a synchronous throw on an already-destroyed stream.
-        ok = stdin.write(line, (err) => {
-          if (err) this.onStdinError(err as NodeJS.ErrnoException);
+        ok = stdin.write(pending.line, (err) => {
+          this.writesInFlight.delete(pending);
+          if (err) {
+            const error = err as NodeJS.ErrnoException;
+            pending.reject(error);
+            this.onStdinError(error);
+            return;
+          }
+          pending.resolve();
         });
       } catch (err) {
-        this.onStdinError(err as NodeJS.ErrnoException);
+        this.writesInFlight.delete(pending);
+        const error = err instanceof Error ? err : new Error(String(err));
+        pending.reject(error);
+        this.onStdinError(error as NodeJS.ErrnoException);
         return;
       }
       if (this.closed) return;
@@ -227,13 +267,20 @@ export class ClaudeStreamClient extends EventEmitter {
       err?.code ?? 'unknown',
       err?.message ?? String(err)
     );
-    this.writeQueue = [];
+    this.rejectPendingWrites(err);
     this.draining = false;
     this.closed = true;
     this.emit('close', {
       code: null,
       signal: null,
     } satisfies ClaudeStreamCloseEvent);
+  }
+
+  private rejectPendingWrites(error: Error): void {
+    for (const pending of this.writeQueue) pending.reject(error);
+    this.writeQueue = [];
+    for (const pending of this.writesInFlight) pending.reject(error);
+    this.writesInFlight.clear();
   }
 
   private onStdout(chunk: Buffer): void {

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -35,6 +35,14 @@ export interface AgentInterruptInputV2 {
   turnId?: string;
 }
 
+/** A provider explicitly declined a steer before accepting its input. */
+export class AgentSteerRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentSteerRejectedError';
+  }
+}
+
 export interface AgentApprovalResponseInputV2 {
   requestId: string;
   decision: AgentApprovalDecisionV2;
@@ -76,6 +84,11 @@ export interface ProtocolAdapterV2 {
    */
   resumeSession(sessionId: string): Promise<void>;
   sendMessage(input: AgentSendMessageInputV2): Promise<void>;
+  /**
+   * Add an operator message to the active provider turn at its native safe
+   * boundary. Optional because legacy harnesses can only queue a follow-up.
+   */
+  steerMessage?(input: AgentSendMessageInputV2): Promise<void>;
   interrupt(input: AgentInterruptInputV2): Promise<void>;
   respondToApproval(input: AgentApprovalResponseInputV2): Promise<void>;
   respondToInput(input: AgentInputResponseInputV2): Promise<void>;

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -45,6 +45,7 @@ const CLAUDE_CAPABILITIES: AgentCapabilitySetV2 = {
   // init line advertises) is emitted, so the slash-command menu stays off.
   slashCommands: false,
   queue: true,
+  steer: true,
   interrupt: true,
   cancelQueued: false,
   resume: true,
@@ -966,6 +967,33 @@ export class ClaudeProtocolAdapter
     }
 
     this.startTurn(input);
+  }
+
+  /**
+   * Claude's persistent `--input-format stream-json` transport accepts user
+   * frames while output is active (its documented realtime streaming-input
+   * mode). The CLI itself holds the frame until its next safe tool boundary;
+   * Relay must not synthesize an interrupt or timer around that primitive.
+   *
+   * This deliberately does not create a second Relay turn: it changes the
+   * active provider turn's direction and its eventual terminal patch still
+   * completes the original channel binding turn.
+   */
+  async steerMessage(input: AgentSendMessageInputV2): Promise<void> {
+    const client = this.client;
+    if (
+      this._status !== 'connected' ||
+      this.activeTurnId === null ||
+      client === null ||
+      !client.running
+    ) {
+      throw new Error('Cannot steer Claude without an active turn');
+    }
+    this.lastActivityAt = Date.now();
+    client.write({
+      type: 'user',
+      message: { role: 'user', content: this.buildUserContent(input) },
+    });
   }
 
   async interrupt(input: AgentInterruptInputV2): Promise<void> {

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -990,7 +990,7 @@ export class ClaudeProtocolAdapter
       throw new Error('Cannot steer Claude without an active turn');
     }
     this.lastActivityAt = Date.now();
-    client.write({
+    await client.writeAccepted({
       type: 'user',
       message: { role: 'user', content: this.buildUserContent(input) },
     });

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -1,4 +1,7 @@
-import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import {
+  AgentSteerRejectedError,
+  BaseProtocolAdapterV2,
+} from '../protocol-adapter-v2.js';
 import type {
   AdapterConfig,
   AdapterStatus,
@@ -109,6 +112,7 @@ const CODEX_CAPABILITIES: AgentCapabilitySetV2 = {
   plans: true,
   slashCommands: true,
   queue: true,
+  steer: true,
   cancelQueued: true,
   interrupt: true,
   resume: true,
@@ -470,6 +474,13 @@ interface DeferredTurnCompletion {
   timer: NodeJS.Timeout;
 }
 
+/** A live steer RPC that may still replace its expected native turn. */
+interface PendingNativeSteer {
+  relayTurnId: string | null;
+  expectedNativeTurnId: string;
+  terminalNotification: Record<string, unknown> | null;
+}
+
 // ── Main adapter class ─────────────────────────────────────────────────────
 
 export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
@@ -494,6 +505,9 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   // Turn management
   private activeTurnId: string | null = null;
   private nativeActiveTurnId: string | null = null;
+  /** Native turns superseded by a successful `turn/steer` replacement. */
+  private readonly supersededNativeTurnIds = new Set<string>();
+  private pendingNativeSteer: PendingNativeSteer | null = null;
   private activeStartedAt: string | null = null;
   private completedActiveTurn = false;
   private readonly queue: QueuedCodexMessage[] = [];
@@ -659,6 +673,74 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     await this.startTurn(rewrittenInput);
   }
 
+  /**
+   * Codex app-server owns the safe-boundary behavior: `turn/steer` accepts the
+   * new input against the currently active native turn and applies it only when
+   * the provider can safely leave the in-flight operation. Keep the Relay turn
+   * identity intact — this is steering the existing reply, not opening a
+   * concurrent channel turn.
+   */
+  async steerMessage(input: AgentSendMessageInputV2): Promise<void> {
+    if (
+      this._status !== 'connected' ||
+      !this.client ||
+      !this.providerSessionId
+    ) {
+      throw new Error('Cannot steer a Codex message before connect');
+    }
+    const expectedTurnId = this.nativeActiveTurnId;
+    const relayTurnId = this.activeTurnId;
+    if (expectedTurnId === null) {
+      throw new Error('Cannot steer Codex without an active native turn');
+    }
+    const pending: PendingNativeSteer = {
+      relayTurnId,
+      expectedNativeTurnId: expectedTurnId,
+      terminalNotification: null,
+    };
+    this.pendingNativeSteer = pending;
+    const rewritten = this.rewriteContent(input.content);
+    let result: { turnId?: unknown };
+    try {
+      result = await this.client.call<{ turnId?: unknown }>('turn/steer', {
+        threadId: this.providerSessionId,
+        expectedTurnId,
+        input: buildCodexTurnInput(rewritten, input.attachments),
+      });
+    } catch (err) {
+      this.releasePendingNativeSteerTerminal(pending);
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('activeTurnNotSteerable')) {
+        throw new AgentSteerRejectedError(message);
+      }
+      throw err;
+    }
+    // Newer app servers return the successor turn id in the response before
+    // their turn/started notification. Recording it closes the race for a
+    // second FIFO steering request; the notification remains authoritative.
+    const successorId = isRecord(result) ? stringField(result['turnId']) : '';
+    if (
+      successorId &&
+      this.pendingNativeSteer === pending &&
+      this.activeTurnId === relayTurnId
+    ) {
+      this.pendingNativeSteer = null;
+      // Some app-server versions continue the same native turn. Only a new
+      // id proves that the old terminal is a replacement artifact; marking an
+      // unchanged id superseded would suppress its real final completion.
+      if (successorId !== expectedTurnId) {
+        this.supersededNativeTurnIds.add(expectedTurnId);
+      }
+      this.nativeActiveTurnId = successorId;
+      return;
+    }
+    // No replacement id (or an independently-terminal relay turn) leaves the
+    // held completion authoritative. Release it before the caller observes the
+    // resolved steer, so the binder can never advance its delivery cursor past
+    // a message whose original turn was already terminal.
+    this.releasePendingNativeSteerTerminal(pending);
+  }
+
   async interrupt(_input: AgentInterruptInputV2): Promise<void> {
     if (this.nativeActiveTurnId !== null && this.client !== null) {
       try {
@@ -809,6 +891,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
     this.activeTurnId = null;
     this.nativeActiveTurnId = null;
+    this.supersededNativeTurnIds.clear();
+    this.pendingNativeSteer = null;
     this.activeStartedAt = null;
 
     this.emitLiveState({
@@ -1209,6 +1293,27 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     const nativeDurationMs =
       typeof turn['durationMs'] === 'number' ? turn['durationMs'] : undefined;
 
+    const pendingSteer = this.pendingNativeSteer;
+    if (
+      pendingSteer !== null &&
+      nativeTurnId === pendingSteer.expectedNativeTurnId
+    ) {
+      // Do not terminalize Relay while the provider can still confirm that
+      // this native turn was replaced. `steerMessage` either consumes this on
+      // a successful replacement or replays it before rejecting.
+      pendingSteer.terminalNotification = p;
+      return;
+    }
+
+    // `turn/steer` can replace the provider turn at a safe boundary. In that
+    // handoff the old turn's terminal notification can arrive after the steer
+    // reply announces its successor. Only suppress an id we explicitly marked
+    // as superseded: normal app-server fixtures and older versions are allowed
+    // to use a terminal id that differs from the most recent `turn/started`.
+    if (nativeTurnId && this.supersededNativeTurnIds.delete(nativeTurnId)) {
+      return;
+    }
+
     // Map native status → V2 status
     let status: 'completed' | 'interrupted' | 'failed';
     if (nativeStatus === 'interrupted') {
@@ -1272,6 +1377,14 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     }
     this.completeActiveTurn(status, usage, error, nativeDurationMs);
     this.drainQueue();
+  }
+
+  private releasePendingNativeSteerTerminal(pending: PendingNativeSteer): void {
+    if (this.pendingNativeSteer !== pending) return;
+    this.pendingNativeSteer = null;
+    if (pending.terminalNotification) {
+      this.handleTurnCompleted(pending.terminalNotification);
+    }
   }
 
   private handleTurnDiffUpdated(p: Record<string, unknown>): void {

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -693,6 +693,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     if (expectedTurnId === null) {
       throw new Error('Cannot steer Codex without an active native turn');
     }
+    if (this.pendingNativeSteer !== null) {
+      throw new Error(
+        'Cannot steer Codex while a previous steer is unresolved'
+      );
+    }
     const pending: PendingNativeSteer = {
       relayTurnId,
       expectedNativeTurnId: expectedTurnId,

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -19,6 +19,11 @@ export interface AgentCapabilitySetV2 {
   plans?: boolean;
   slashCommands?: boolean;
   queue?: boolean;
+  /**
+   * Accept an operator message into the active turn at the provider's own safe
+   * boundary. Unlike `interrupt`, this must not abort an in-flight tool call.
+   */
+  steer?: boolean;
   interrupt?: boolean;
   cancelQueued?: boolean;
   resume?: boolean;

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -486,7 +486,8 @@ class SteerableAdapter extends BaseProtocolAdapterV2 {
     readonly agentType: string,
     private readonly supportsSafeBoundarySteer = false,
     private readonly rejectsSafeBoundarySteer = false,
-    private readonly failsSafeBoundarySteer = false
+    private readonly failsSafeBoundarySteer = false,
+    private readonly hangsSafeBoundarySteer = false
   ) {
     super();
     this.capabilities = {
@@ -562,6 +563,9 @@ class SteerableAdapter extends BaseProtocolAdapterV2 {
     }
     if (this.failsSafeBoundarySteer) {
       throw new Error('steer transport reset');
+    }
+    if (this.hangsSafeBoundarySteer) {
+      return new Promise<void>(() => {});
     }
     this.steerInputs.push(input);
   }
@@ -4206,6 +4210,42 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
     await waitFor(() => events.at(-1)?.['steeringCount'] === 0);
   });
 
+  it('clears pending native steer status when its runtime dies', async () => {
+    const harness = makeBinder({
+      build: (agentType) =>
+        new SteerableAdapter(agentType, true, false, false, true),
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+    });
+    const events: Array<Record<string, unknown>> = [];
+    harness.binder.setStatusBroadcaster((_type, data) => events.push(data));
+    postSteering(
+      harness.store,
+      harness.binder,
+      '@steer long task',
+      ['steer'],
+      undefined
+    );
+    const adapter = await steerAdapter(harness.sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    postSteering(
+      harness.store,
+      harness.binder,
+      '@steer redirect',
+      ['steer'],
+      undefined
+    );
+    await waitFor(() => adapter.steerAttempts.length === 1);
+    await waitFor(() => events.at(-1)?.['steeringCount'] === 1);
+
+    harness.sessions.fireEnd(harness.sessions.firstSessionId());
+    await waitFor(() => events.at(-1)?.['status'] === 'idle');
+    expect(events.at(-1)).toMatchObject({
+      queuedCount: 0,
+      steeringCount: 0,
+    });
+  });
+
   it('queues posts that land mid-turn and drains them all into ONE next turn', async () => {
     const { binder, store, sessions, events } = makeSteerBinder();
     postSteering(store, binder, '@steer one', ['steer'], undefined);
@@ -4260,8 +4300,8 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
     expect(adapter.sendInputs[2]!.content).toContain('@steer third');
   });
 
-  it('steering:"interrupt" cancels the live turn and dispatches the new message', async () => {
-    const { binder, store, sessions } = makeSteerBinder();
+  it('steering:"interrupt" overrides native steer and cancels the live turn', async () => {
+    const { binder, store, sessions } = makeSteerBinder(true);
     postSteering(store, binder, '@steer long task', ['steer'], undefined);
     const adapter = await steerAdapter(sessions);
     await waitFor(() => adapter.sendCalls.length === 1);
@@ -4282,6 +4322,7 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
 
     await waitFor(() => adapter.interruptCalls.length === 1);
     expect(adapter.interruptCalls[0]).toBe(firstTurn);
+    expect(adapter.steerAttempts).toHaveLength(0);
     // Existing interrupt semantics: the partial row finalizes `interrupted`.
     await waitFor(() =>
       rows(store).some(

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
 import {
+  AgentSteerRejectedError,
   BaseProtocolAdapterV2,
   type AdapterConfig,
   type AdapterStatus,
@@ -469,15 +470,11 @@ class ApprovalAdapter extends BaseProtocolAdapterV2 {
 // OBSERVED (concurrentPeak > 1) rather than inferred from send counts.
 class SteerableAdapter extends BaseProtocolAdapterV2 {
   readonly runtimeOwnership = 'spawned' as const;
-  readonly capabilities: AgentCapabilitySetV2 = {
-    text: true,
-    queue: false,
-    interrupt: true,
-    approvals: false,
-    streaming: true,
-  };
+  readonly capabilities: AgentCapabilitySetV2;
   readonly sendCalls: string[] = [];
   readonly sendInputs: AgentSendMessageInputV2[] = [];
+  readonly steerAttempts: AgentSendMessageInputV2[] = [];
+  readonly steerInputs: AgentSendMessageInputV2[] = [];
   readonly interruptCalls: string[] = [];
   /** Peak simultaneously-open turns; the binder must never let this exceed 1. */
   concurrentPeak = 0;
@@ -485,8 +482,21 @@ class SteerableAdapter extends BaseProtocolAdapterV2 {
   private _status: AdapterStatus = 'disconnected';
   private sid = 'steerable';
 
-  constructor(readonly agentType: string) {
+  constructor(
+    readonly agentType: string,
+    private readonly supportsSafeBoundarySteer = false,
+    private readonly rejectsSafeBoundarySteer = false,
+    private readonly failsSafeBoundarySteer = false
+  ) {
     super();
+    this.capabilities = {
+      text: true,
+      queue: false,
+      steer: supportsSafeBoundarySteer,
+      interrupt: true,
+      approvals: false,
+      streaming: true,
+    };
   }
   get status(): AdapterStatus {
     return this._status;
@@ -540,6 +550,20 @@ class SteerableAdapter extends BaseProtocolAdapterV2 {
       delta: { text: 'partial…' },
     });
     // No terminal patch: the turn stays live until interrupt() or complete().
+  }
+
+  async steerMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.steerAttempts.push(input);
+    if (!this.supportsSafeBoundarySteer) {
+      throw new Error('safe-boundary steering unavailable');
+    }
+    if (this.rejectsSafeBoundarySteer) {
+      throw new AgentSteerRejectedError('activeTurnNotSteerable');
+    }
+    if (this.failsSafeBoundarySteer) {
+      throw new Error('steer transport reset');
+    }
+    this.steerInputs.push(input);
   }
 
   async interrupt(input: AgentInterruptInputV2): Promise<void> {
@@ -1926,7 +1950,7 @@ describe('channel-agent-binder — lifecycle', () => {
       m.body.text.includes('message dropped')
     );
     expect(dropped).toHaveLength(1);
-    expect(dropped[0]!.body.text).toContain('has 8 turns queued');
+    expect(dropped[0]!.body.text).toContain('has 8 messages pending');
     expect(dropped[0]!.threadId).toBe(rootB.id);
     expect(dropped[0]!.parentMessageId).toBe(overflow.id);
   });
@@ -4052,9 +4076,10 @@ function postSteerImage(
   return message;
 }
 
-function makeSteerBinder() {
+function makeSteerBinder(supportsSafeBoundarySteer = false) {
   const harness = makeBinder({
-    build: (agentType) => new SteerableAdapter(agentType),
+    build: (agentType) =>
+      new SteerableAdapter(agentType, supportsSafeBoundarySteer),
     targets: STEER_TARGETS,
     knownProviderIds: ['steer'],
   });
@@ -4071,6 +4096,116 @@ async function steerAdapter(
 }
 
 describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
+  it('bounds accepted native steers at the aggregate queue cap', async () => {
+    const { binder, store, sessions } = makeSteerBinder(true);
+    postSteering(store, binder, '@steer opener', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    for (let i = 0; i < 8; i++) {
+      postSteering(store, binder, `@steer ${i}`, ['steer'], undefined);
+    }
+    await waitFor(() => adapter.steerInputs.length === 8);
+    postSteering(store, binder, '@steer overflow', ['steer'], undefined);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(adapter.steerInputs).toHaveLength(8);
+    expect(
+      rows(store).some((row) => row.body.text.includes('8 messages pending'))
+    ).toBe(true);
+  });
+
+  it('falls back to one ordinary FIFO turn after a definite native steer rejection', async () => {
+    const harness = makeBinder({
+      build: (agentType) => new SteerableAdapter(agentType, true, true),
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+    });
+    postSteering(
+      harness.store,
+      harness.binder,
+      '@steer opener',
+      ['steer'],
+      undefined
+    );
+    const adapter = await steerAdapter(harness.sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    postSteering(
+      harness.store,
+      harness.binder,
+      '@steer fallback',
+      ['steer'],
+      undefined
+    );
+    await waitFor(() => adapter.steerAttempts.length === 1);
+    adapter.completeLatest();
+    await waitFor(() => adapter.sendCalls.length === 2);
+    expect(adapter.sendInputs[1]!.content).toContain('@steer fallback');
+  });
+
+  it('does not replay a steer after an ambiguous transport failure', async () => {
+    const harness = makeBinder({
+      build: (agentType) => new SteerableAdapter(agentType, true, false, true),
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+    });
+    postSteering(
+      harness.store,
+      harness.binder,
+      '@steer opener',
+      ['steer'],
+      undefined
+    );
+    const adapter = await steerAdapter(harness.sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    postSteering(
+      harness.store,
+      harness.binder,
+      '@steer uncertain',
+      ['steer'],
+      undefined
+    );
+    await waitFor(() => adapter.steerAttempts.length === 1);
+    await waitFor(() =>
+      systemRows(harness.store).some((row) =>
+        row.body.text.includes('could not accept the steering message')
+      )
+    );
+
+    adapter.completeLatest();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(adapter.sendCalls).toHaveLength(1);
+    expect(adapter.steerInputs).toHaveLength(0);
+  });
+
+  it('uses a native safe-boundary steer by default and preserves FIFO without a concurrent turn', async () => {
+    const { binder, store, sessions, events } = makeSteerBinder(true);
+    postSteering(store, binder, '@steer long task', ['steer'], undefined);
+    const adapter = await steerAdapter(sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+
+    // No explicit field: a harness that advertises a native steer primitive
+    // receives the operator's next instruction at that provider boundary.
+    postSteering(
+      store,
+      binder,
+      '@steer instead inspect the conflict',
+      ['steer'],
+      undefined
+    );
+    await waitFor(() => adapter.steerInputs.length === 1);
+    expect(adapter.sendCalls).toHaveLength(1);
+    expect(adapter.concurrentPeak).toBe(1);
+    expect(adapter.steerInputs[0]!.content).toContain(
+      '@steer instead inspect the conflict'
+    );
+    // Status is deliberately not the old queued lane: the UI can say
+    // "steering pending" rather than falsely claiming a future turn.
+    expect(events.some((event) => event['steeringCount'] === 1)).toBe(true);
+    expect(events.at(-1)?.['queuedCount']).toBe(0);
+
+    adapter.completeLatest('redirected reply');
+    await waitFor(() => events.at(-1)?.['steeringCount'] === 0);
+  });
+
   it('queues posts that land mid-turn and drains them all into ONE next turn', async () => {
     const { binder, store, sessions, events } = makeSteerBinder();
     postSteering(store, binder, '@steer one', ['steer'], undefined);
@@ -4585,7 +4720,9 @@ describe('channel-agent-binder — presence teardown (#1307)', () => {
     // One row per dropped trigger, and nothing was pumped into the dead adapter.
     expect(
       systemRows(store).filter((row) =>
-        row.body.text.includes('runtime ended before delivering a queued message')
+        row.body.text.includes(
+          'runtime ended before delivering a queued message'
+        )
       )
     ).toHaveLength(1);
     expect(adapter.sendCalls).toHaveLength(1);

--- a/test/channel-agent-status-reconcile.test.ts
+++ b/test/channel-agent-status-reconcile.test.ts
@@ -154,6 +154,8 @@ describe('useChannelAgentStatusStore — timestamped reconciliation state', () =
       statusByChannelAgent: {},
       runtimeByChannelAgent: {},
       queuedCountByChannelAgent: {},
+      steeringCountByChannelAgent: {},
+      steerSupportedByChannelAgent: {},
       queueDrainSeqByChannelAgent: {},
       updatedAtByChannelAgent: {},
     });

--- a/test/claude-stream-client.test.ts
+++ b/test/claude-stream-client.test.ts
@@ -180,6 +180,19 @@ describe('ClaudeStreamClient', () => {
     expect(lines.map((l) => JSON.parse(l).n)).toEqual([1, 2, 3]);
   });
 
+  it('resolves writeAccepted only after stdin accepts the frame', async () => {
+    const child = makeMockChild();
+    const client = makeClient(child);
+    client.start();
+
+    await expect(
+      client.writeAccepted({ steer: 'next tool boundary' })
+    ).resolves.toBeUndefined();
+    expect(child.readStdin().map((line) => JSON.parse(line))).toEqual([
+      { steer: 'next tool boundary' },
+    ]);
+  });
+
   it('captures stderr into a bounded ring buffer', async () => {
     const child = makeMockChild();
     const client = makeClient(child, { stderrRingSize: 2 });

--- a/test/components/channel-message-row.test.ts
+++ b/test/components/channel-message-row.test.ts
@@ -125,6 +125,33 @@ describe('ChannelMessageRow truncation fidelity', () => {
     ).toContain('reasoning content survives channel persistence');
   });
 
+  it('does not advertise a disclosure for a terminal reasoning summary without detail', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: agentMessage({
+            agentDetail: {
+              itemId: 'reason-summary-only',
+              card: {
+                kind: 'thought',
+                title: 'thinking',
+                status: 'completed',
+                content: '   ',
+              },
+            },
+          }),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+
+    const card = container.querySelector('.ch-agent-card');
+    expect(card?.getAttribute('data-agent-card-expandable')).toBe('false');
+    expect(card?.querySelector('.ch-agent-card__toggle')).toBeNull();
+    expect(card?.querySelector('.ch-agent-card__chevron')).toBeNull();
+    expect(card?.textContent).toContain('thinking');
+  });
+
   it('rerenders authoritative streaming card rows without overriding persisted status', async () => {
     const row = (status: 'pending' | 'running', content: string) =>
       agentMessage({

--- a/test/components/channel-steering.test.ts
+++ b/test/components/channel-steering.test.ts
@@ -23,6 +23,8 @@ import type { ChannelAgentStatus } from '../../frontend/src/lib/api.js';
 const CHANNEL_ID = 'topic:ops';
 const CLAUDE_ID = 'agent-profile:claude:default';
 const RUNTIME_ID = 'runtime:claude-1';
+const HERMES_ID = 'agent-profile:hermes:default';
+const HERMES_RUNTIME_ID = 'runtime:hermes-1';
 
 interface PostOpts {
   clientMessageId?: string;
@@ -115,7 +117,12 @@ function topicFixture() {
   };
 }
 
-function rosterEntry(status: ChannelAgentStatus, queuedCount = 0) {
+function rosterEntry(
+  status: ChannelAgentStatus,
+  queuedCount = 0,
+  steerSupported = false,
+  steeringCount = 0
+) {
   return {
     id: CLAUDE_ID,
     displayName: 'claude',
@@ -125,7 +132,13 @@ function rosterEntry(status: ChannelAgentStatus, queuedCount = 0) {
     kind: 'framework' as const,
     available: true,
     reason: null,
-    binding: { runtimeId: RUNTIME_ID, status, queuedCount },
+    binding: {
+      runtimeId: RUNTIME_ID,
+      status,
+      queuedCount,
+      steerSupported,
+      steeringCount,
+    },
   };
 }
 
@@ -250,6 +263,15 @@ beforeEach(() => {
     pendingChannelThread: null,
   });
   useChannelQueuedSendsStore.setState({ marksByMessageId: {} });
+  useChannelAgentStatusStore.setState({
+    statusByChannelAgent: {},
+    runtimeByChannelAgent: {},
+    queuedCountByChannelAgent: {},
+    steeringCountByChannelAgent: {},
+    steerSupportedByChannelAgent: {},
+    queueDrainSeqByChannelAgent: {},
+    updatedAtByChannelAgent: {},
+  });
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 0 } },
   });
@@ -282,7 +304,7 @@ describe('composer steering cluster (#1308 slice 4 item 2b)', () => {
     ).toContain('send');
   });
 
-  it('reveals queue + interrupt&send the moment the bound agent is mid-turn', async () => {
+  it('reveals the queue fallback + interrupt&send for a non-steerable harness', async () => {
     mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
     await render();
 
@@ -300,7 +322,7 @@ describe('composer steering cluster (#1308 slice 4 item 2b)', () => {
     expect(interrupt?.getAttribute('aria-label')).toBe('interrupt and send');
   });
 
-  it('posts with no steering by default — the message queues behind the turn', async () => {
+  it('posts with no steering by default — the backend selects queue or native steer', async () => {
     mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
     await render();
 
@@ -331,7 +353,7 @@ describe('composer steering cluster (#1308 slice 4 item 2b)', () => {
     expect(opts.steering).toBe('interrupt');
   });
 
-  it('maps enter to queue-send and cmd/ctrl+enter to interrupt-send', async () => {
+  it('maps enter to the default delivery lane and cmd/ctrl+enter to interrupt-send', async () => {
     mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
     await render();
 
@@ -343,6 +365,58 @@ describe('composer steering cluster (#1308 slice 4 item 2b)', () => {
       (call) => (call[1] as PostOpts).steering
     );
     expect(steerings).toEqual([undefined, 'interrupt', 'interrupt']);
+  });
+
+  it('labels ordinary Enter as safe-boundary steering for a steer-capable harness', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry('streaming', 0, true),
+    ]);
+    await render();
+
+    const defaultAction = container.querySelector<HTMLButtonElement>(
+      '.ch-composer__steer-btn'
+    );
+    expect(defaultAction?.textContent).toBe('steer');
+    expect(defaultAction?.title).toContain('safe tool boundary');
+    expect(
+      container.querySelector('.ch-composer__hint')?.textContent
+    ).toContain('steer after tool');
+
+    await typeAndPressEnter(composers()[0]!, 'inspect the conflicts next');
+    expect((mocks.post.mock.calls[0]![1] as PostOpts).steering).toBeUndefined();
+  });
+
+  it('reconciles a newer socket steerSupported:false over an older roster true', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry('streaming', 0, true),
+    ]);
+    await render();
+    expect(
+      container.querySelector<HTMLButtonElement>('.ch-composer__steer-btn')
+        ?.textContent
+    ).toBe('steer');
+
+    // A capability downgrade is a real socket value, not an absent field. It
+    // must therefore beat the roster snapshot just like a status transition.
+    await act(async () => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(
+          CHANNEL_ID,
+          CLAUDE_ID,
+          'streaming',
+          RUNTIME_ID,
+          0,
+          0,
+          false
+        );
+    });
+    await flush();
+
+    expect(
+      container.querySelector<HTMLButtonElement>('.ch-composer__steer-btn')
+        ?.textContent
+    ).toBe('queue');
   });
 
   it('keeps cmd+enter a plain send when nothing is mid-turn', async () => {
@@ -405,6 +479,48 @@ describe('queued chip (#1308 slice 4 item 2a)', () => {
     expect(queuedChips()).toEqual([]);
   });
 
+  it('does not paint a native steer as queued', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry('streaming', 0, true),
+    ]);
+    await render();
+
+    await typeAndPressEnter(composers()[0]!, 'change direction');
+    await render();
+
+    expect(queuedChips()).toEqual([]);
+  });
+
+  it('keeps the queued-row chip scoped to non-steerable agents in mixed mode', async () => {
+    const hermes = {
+      ...rosterEntry('streaming'),
+      id: HERMES_ID,
+      displayName: 'hermes',
+      providerId: 'hermes',
+      binding: {
+        runtimeId: HERMES_RUNTIME_ID,
+        status: 'streaming' as const,
+        queuedCount: 0,
+        steeringCount: 0,
+        steerSupported: false,
+      },
+    };
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry('streaming', 0, true),
+      hermes,
+    ]);
+    await render();
+
+    expect(
+      container.querySelector<HTMLButtonElement>('.ch-composer__steer-btn')
+        ?.textContent
+    ).toBe('steer / queue');
+    await typeAndPressEnter(composers()[0]!, 'coordinate the two agents');
+    await render();
+
+    expect(queuedChips()).toEqual(['queued — hermes is mid-turn']);
+  });
+
   it('drops the mark when a drain lands while the post is still in flight', async () => {
     // Failing toward silence: the message was already consumed by the time the
     // row existed, so a chip naming a wait would be a lie.
@@ -427,6 +543,17 @@ describe('queued chip (#1308 slice 4 item 2a)', () => {
 });
 
 describe('presence queue depth (#1308 slice 4 item 2c)', () => {
+  it('names native safe-boundary work as steering pending, never queued', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      rosterEntry('thinking', 0, true, 1),
+    ]);
+    await render();
+
+    expect(presenceLabels()).toEqual([
+      'claude is thinking… (1 steering pending)',
+    ]);
+  });
+
   it('suffixes the presence row with the queue depth', async () => {
     mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('thinking', 2)]);
     await render();

--- a/test/components/channel-timeline-presence.test.ts
+++ b/test/components/channel-timeline-presence.test.ts
@@ -66,6 +66,8 @@ function presence(
     label,
     colorVar: 'var(--sender-hermes)',
     glyph: 'hermes',
+    queuedCount: 0,
+    steeringCount: 0,
   };
 }
 
@@ -204,9 +206,7 @@ describe('advanceStreamingHold (#1277 intra-turn gap)', () => {
   it('reports the earliest pending deadline and ignores live rows', () => {
     expect(nextStreamingHoldExpiry(new Map())).toBeNull();
     expect(
-      nextStreamingHoldExpiry(
-        new Map([[CLAUDE_ID, Number.POSITIVE_INFINITY]])
-      )
+      nextStreamingHoldExpiry(new Map([[CLAUDE_ID, Number.POSITIVE_INFINITY]]))
     ).toBeNull();
     expect(
       nextStreamingHoldExpiry(
@@ -381,9 +381,7 @@ describe('ChannelTimeline presence row (#1277)', () => {
     const row = host.querySelector('.ch-presence__row');
     expect(row).not.toBeNull();
     expect(row?.hasAttribute('data-channel-message-seq')).toBe(false);
-    expect(
-      host.querySelectorAll('[data-channel-message-seq]')
-    ).toHaveLength(1);
+    expect(host.querySelectorAll('[data-channel-message-seq]')).toHaveLength(1);
   });
 
   it('uses the shared braille spinner as its only motion', async () => {
@@ -463,9 +461,7 @@ describe('ChannelTimeline presence row (#1277)', () => {
     const row = host.querySelector('.ch-presence__row');
     expect(row?.textContent).toContain('hermes is thinking…');
     // TuiProgress freezes on frame 0 rather than disappearing.
-    expect(host.querySelector('.ch-presence__spinner')?.textContent).toBe(
-      '⠋'
-    );
+    expect(host.querySelector('.ch-presence__spinner')?.textContent).toBe('⠋');
   });
 
   it('does not inflate the new-message pill when the row appears or clears', async () => {
@@ -514,11 +510,7 @@ describe('useStreamingPresenceHold (#1277)', () => {
   let hookHost: HTMLDivElement;
   let hookRoot: Root;
 
-  function Probe({
-    live,
-  }: {
-    live: ReadonlySet<string>;
-  }): React.ReactElement {
+  function Probe({ live }: { live: ReadonlySet<string> }): React.ReactElement {
     const membership = useStreamingPresenceHold(live, 200);
     return React.createElement('span', {
       'data-suppressed': membership.has(CLAUDE_ID) ? 'yes' : 'no',
@@ -532,9 +524,9 @@ describe('useStreamingPresenceHold (#1277)', () => {
   }
 
   function suppressed(): string | null {
-    return hookHost
-      .querySelector('span')
-      ?.getAttribute('data-suppressed') ?? null;
+    return (
+      hookHost.querySelector('span')?.getAttribute('data-suppressed') ?? null
+    );
   }
 
   beforeEach(() => {

--- a/test/e2e/channel-timeline-scroll.spec.ts
+++ b/test/e2e/channel-timeline-scroll.spec.ts
@@ -60,7 +60,15 @@ test.describe('smoke channel timeline scroll UX (#1193)', () => {
 
     await expect(thought).toHaveAttribute('data-agent-card-kind', 'thought');
     await expect(thought.locator('.ch-agent-card__body')).toHaveCount(0);
-    await thought.locator('.ch-agent-card__toggle').click();
+    const thoughtToggle = thought.locator('.ch-agent-card__toggle');
+    await expect(thoughtToggle).toHaveAttribute('aria-expanded', 'false');
+    await thoughtToggle.click();
+    await expect(thoughtToggle).toHaveAttribute('aria-expanded', 'true');
+    await thoughtToggle.press('Space');
+    await expect(thoughtToggle).toHaveAttribute('aria-expanded', 'false');
+    await thoughtToggle.focus();
+    await thoughtToggle.press('Enter');
+    await expect(thoughtToggle).toHaveAttribute('aria-expanded', 'true');
     await expect(thought.locator('.ch-agent-card__body')).toContainText(
       'reasoning content persisted on the durable channel row'
     );
@@ -277,8 +285,9 @@ test.describe('smoke channel timeline scroll UX (#1193)', () => {
       return {
         lines: range.getClientRects().length,
         bubbleWidth: bubble.getBoundingClientRect().width,
-        rowWidth: bubble.closest<HTMLElement>('.ch-msg')!.getBoundingClientRect()
-          .width,
+        rowWidth: bubble
+          .closest<HTMLElement>('.ch-msg')!
+          .getBoundingClientRect().width,
       };
     });
     // The phrase is short enough for one desktop line and the bubble now gets

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -212,6 +212,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       tools: true,
       approvals: true,
       resume: true,
+      steer: true,
       interrupt: true,
       streaming: true,
       questions: false,
@@ -465,8 +466,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     expect(
       patches.filter(
         (patch) =>
-          patch.type === 'agent-turn-completed-v2' &&
-          patch.turnId === 'turn-A'
+          patch.type === 'agent-turn-completed-v2' && patch.turnId === 'turn-A'
       )
     ).toHaveLength(1);
 
@@ -476,6 +476,43 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       session_id: 'claude-session-refresh-race',
     });
     replacement.child.serverWrite(successResult());
+    await adapter.disconnect();
+  });
+
+  it('writes a realtime stream-json user frame to steer the active turn without queueing or interrupting', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    const patches = collectPatches(adapter);
+    await adapter.connect(baseConfig());
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'run the check' });
+    const child = harness.latest().child;
+    await child.waitForFrames(1);
+
+    await adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'after this tool, inspect the merge conflict instead',
+    });
+    await child.waitForFrames(2);
+
+    expect(child.frames()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'user',
+          message: expect.objectContaining({
+            role: 'user',
+            content: 'after this tool, inspect the merge conflict instead',
+          }),
+        }),
+      ])
+    );
+    expect(
+      child.frames().some((frame) => frame.type === 'control_request')
+    ).toBe(false);
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-started-v2')
+    ).toHaveLength(1);
+
+    child.serverWrite(successResult());
     await adapter.disconnect();
   });
 

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -516,6 +516,18 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     await adapter.disconnect();
   });
 
+  it('rejects a steer before any Claude turn is active', async () => {
+    const harness = makeHarness();
+    const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
+    await adapter.connect(baseConfig());
+
+    await expect(
+      adapter.steerMessage({ turnId: 'turn-none', content: 'redirect' })
+    ).rejects.toThrow('Cannot steer Claude without an active turn');
+    expect(harness.spawns).toHaveLength(0);
+    await adapter.disconnect();
+  });
+
   it('happy path: init → deltas → assistant echo → result reduces to one user + one assistant message with summed iteration usage', async () => {
     const harness = makeHarness();
     const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -11,6 +11,7 @@ import {
   CODEX_TERMINAL_ITEM_GRACE_MS,
   CodexNativeProtocolAdapter,
 } from '../../../server/protocol-adapters/codex-native-adapter.js';
+import { AgentSteerRejectedError } from '../../../server/protocol-adapter-v2.js';
 import type { CodexClientFactory } from '../../../server/protocol-adapters/codex-native-adapter.js';
 import type { AdapterConfig } from '../../../server/protocol-adapter-v2.js';
 import type {
@@ -62,7 +63,9 @@ class StubCodexClient extends EventEmitter {
     this.calls.push({ method, params: params ?? null });
     // Check for a pre-configured response
     if (this.serverResponses.has(method)) {
-      return this.serverResponses.get(method) as T;
+      const response = this.serverResponses.get(method);
+      if (response instanceof Error) throw response;
+      return response as T;
     }
     return {} as T;
   }
@@ -208,6 +211,7 @@ describe('CodexNativeProtocolAdapter — capability set', () => {
       plans: true,
       slashCommands: true,
       queue: true,
+      steer: true,
       cancelQueued: true,
       interrupt: true,
       resume: true,
@@ -387,6 +391,174 @@ describe('CodexNativeProtocolAdapter — sendMessage', () => {
       input: [{ type: 'text', text: 'hello codex' }],
     });
 
+    await adapter.disconnect();
+  });
+
+  it('uses turn/steer against the active native turn without opening a second Relay turn', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient!;
+
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'keep going' });
+    client.feedNotification('turn/started', { turn: { id: 'native-1' } });
+    client.serverResponses.set('turn/steer', { turnId: 'native-2' });
+
+    await adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'instead, inspect the conflict',
+    });
+
+    expect(
+      client.calls.filter((call) => call.method === 'turn/start')
+    ).toHaveLength(1);
+    expect(
+      client.calls.find((call) => call.method === 'turn/steer')?.params
+    ).toMatchObject({
+      threadId: 'thread-1',
+      expectedTurnId: 'native-1',
+      input: [{ type: 'text', text: 'instead, inspect the conflict' }],
+    });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-started-v2')
+    ).toHaveLength(1);
+
+    await adapter.disconnect();
+  });
+
+  it('classifies activeTurnNotSteerable as a definite safe FIFO fallback', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'keep going' });
+    factory.lastClient.feedNotification('turn/started', {
+      turn: { id: 'native-1' },
+    });
+    factory.lastClient.serverResponses.set(
+      'turn/steer',
+      new Error('activeTurnNotSteerable')
+    );
+
+    await expect(
+      adapter.steerMessage({ turnId: 'turn-1', content: 'redirect' })
+    ).rejects.toBeInstanceOf(AgentSteerRejectedError);
+    await adapter.disconnect();
+  });
+
+  it('holds an old terminal until a delayed steer reply confirms its successor', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient;
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'first' });
+    client.feedNotification('turn/started', { turn: { id: 'native-old' } });
+    let release!: (value: { turnId: string }) => void;
+    client.serverResponses.set(
+      'turn/steer',
+      new Promise<{ turnId: string }>((resolve) => {
+        release = resolve;
+      })
+    );
+    const staleSteer = adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'stale redirect',
+    });
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-old', status: 'completed' },
+    });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(0);
+
+    release({ turnId: 'native-new' });
+    await staleSteer;
+    client.serverResponses.set('turn/steer', { turnId: 'native-after' });
+
+    await adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'current redirect',
+    });
+
+    const steerCalls = client.calls.filter(
+      (call) => call.method === 'turn/steer'
+    );
+    expect(steerCalls[1]?.params).toMatchObject({
+      expectedTurnId: 'native-new',
+    });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(0);
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-after', status: 'completed' },
+    });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(1);
+    await adapter.disconnect();
+  });
+
+  it('ignores a superseded native completion after a successful steer replacement', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient;
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'first' });
+    client.feedNotification('turn/started', { turn: { id: 'native-old' } });
+    client.serverResponses.set('turn/steer', { turnId: 'native-new' });
+
+    await adapter.steerMessage({ turnId: 'turn-1', content: 'redirect' });
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-old', status: 'completed' },
+    });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(0);
+
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-new', status: 'completed' },
+    });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(1);
+    await adapter.disconnect();
+  });
+
+  it('keeps a same-id steer as one continuing native turn and accepts its final completion', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient;
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'first' });
+    client.feedNotification('turn/started', { turn: { id: 'native-1' } });
+    client.serverResponses.set('turn/steer', { turnId: 'native-1' });
+
+    await adapter.steerMessage({ turnId: 'turn-1', content: 'continue' });
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-1', status: 'completed' },
+    });
+
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(1);
     await adapter.disconnect();
   });
 

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -508,6 +508,64 @@ describe('CodexNativeProtocolAdapter — sendMessage', () => {
     await adapter.disconnect();
   });
 
+  it('releases a held terminal when Codex accepts steer without a successor id', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient;
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'first' });
+    client.feedNotification('turn/started', { turn: { id: 'native-1' } });
+    client.serverResponses.set('turn/steer', {});
+
+    const steer = adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'redirect',
+    });
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-1', status: 'completed' },
+    });
+    await steer;
+
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(1);
+    await adapter.disconnect();
+  });
+
+  it('rejects a concurrent Codex steer while the previous provider receipt is unresolved', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    const client = factory.lastClient;
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'first' });
+    client.feedNotification('turn/started', { turn: { id: 'native-1' } });
+    let release!: (value: { turnId: string }) => void;
+    client.serverResponses.set(
+      'turn/steer',
+      new Promise<{ turnId: string }>((resolve) => {
+        release = resolve;
+      })
+    );
+
+    const first = adapter.steerMessage({
+      turnId: 'turn-1',
+      content: 'first steer',
+    });
+    await expect(
+      adapter.steerMessage({ turnId: 'turn-1', content: 'second steer' })
+    ).rejects.toThrow('previous steer is unresolved');
+    release({ turnId: 'native-2' });
+    await first;
+    await adapter.disconnect();
+  });
+
   it('ignores a superseded native completion after a successful steer replacement', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);


### PR DESCRIPTION
## What changed

- make ordinary mid-turn sends use Codex `turn/steer` and Claude realtime stream input at the provider's next safe tool boundary
- retain bounded FIFO queue fallback for harnesses without native steering, and keep interrupt-and-send explicit
- distinguish `steering pending` from `queued` through server status, roster reconciliation, composer copy, and message-row chips
- preserve ordering and at-most-once behavior across provider rejection, delayed steering responses, terminal event races, and same-ID Codex continuation
- make completed thinking cards expandable by pointer and keyboard when detail exists, and remove the misleading disabled chevron when a terminal thought has no detail

## Why

Mid-turn human guidance was waiting until an agent fully stopped even when the underlying harness supported safe same-turn steering. Separately, summary-only completed thought rows advertised an expansion affordance that could never open.

## Validation

- adversarial review with no P0/P1 findings remaining
- Node 24 full suite: 470 files, 6,081 tests passed
- pre-push changed suite: 129 files, 1,507 tests passed
- `npm run check` passed (existing warnings only)
- `npm run build` passed
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native mid-turn message steering for supported Codex and Claude sessions without interrupting active work.
  - Added automatic FIFO queuing for unsupported or rejected steering requests.
  - Added composer controls, keyboard hints, and status indicators for steering and queued messages.
  - Improved agent detail cards with accessible, keyboard-friendly expansion behavior.

- **Bug Fixes**
  - Completed reasoning cards containing no meaningful content are no longer expandable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->