### PR TITLE
feat(agents): add Prime Agent via native RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ workflow.
 
 #### Added
 
+- Run Prime Agent as a built-in terminal and channel provider through its native RPC mode (#1340)
 - Create and name new folders directly in the local Add Project browser (#1338)
 
 #### Changed

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -26,6 +26,32 @@ Required lifecycle:
 Optional methods cover approval, questions, resume, and runtime environment
 refresh. Capabilities must describe only implemented behavior.
 
+## Built-in native transports
+
+| Provider    | Provider id   | Native channel transport               |
+| ----------- | ------------- | -------------------------------------- |
+| Claude Code | `claude`      | persistent subprocess over stream JSON |
+| Codex       | `codex`       | `codex app-server` JSON-RPC            |
+| OpenCode    | `opencode`    | native SDK/events                      |
+| Hermes      | `hermes`      | Responses API/SSE                      |
+| Prime Agent | `prime-agent` | `prime-agent` RPC                      |
+
+Prime Agent is a first-class channel provider. Its adapter maps accepted prompts and `agent_end` boundaries to Relay turn
+lifecycle, `message_update` text and
+thinking deltas to assistant and reasoning items, and
+`tool_execution_start|update|end` to canonical command, file-change, or dynamic
+tool items. It advertises text, reasoning, tools, command execution, file
+changes, queueing, interrupt, resume, telemetry, and streaming; unsupported
+approval, question, plan, and queue-cancellation operations remain false. Relay
+pins Prime's steering scheduler to one-at-a-time so each queued native action has
+one durable Relay turn. Channel subprocesses currently launch with
+`--no-extensions` because blocking `extension_ui_request` dialogs are not mapped
+to Relay approvals/questions yet.
+
+The `prime-agent` executable is also available as a normal terminal launch, but
+that surface stays a generic PTY: Relay does not parse terminal output or infer
+channel capabilities from it.
+
 ## Identity boundary
 
 Keep these identities distinct:

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -41,10 +41,10 @@ lifecycle, `message_update` text and
 thinking deltas to assistant and reasoning items, and
 `tool_execution_start|update|end` to canonical command, file-change, or dynamic
 tool items. It advertises text, reasoning, tools, command execution, file
-changes, queueing, interrupt, resume, telemetry, and streaming; unsupported
-approval, question, plan, and queue-cancellation operations remain false. Relay
-pins Prime's steering scheduler to one-at-a-time so each queued native action has
-one durable Relay turn. Channel subprocesses currently launch with
+changes, queueing, interrupt, resume, compaction, telemetry, and streaming; unsupported
+approval, question, plan, and queue-cancellation operations remain false. Because Prime steering stays within one native run, Relay queues concurrent
+messages locally and sends a fresh RPC prompt after each `agent_end`, preserving
+one durable Relay turn per message. Channel subprocesses currently launch with
 `--no-extensions` because blocking `extension_ui_request` dialogs are not mapped
 to Relay approvals/questions yet.
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -42,6 +42,7 @@
   --sender-codex: var(--color-teal); /* distinct green from --status-success */
   --sender-hermes: var(--color-sky);
   --sender-opencode: var(--color-indigo);
+  --sender-prime-agent: var(--color-purple);
   --sender-system: var(--text-muted);
 
   /* Typography */

--- a/frontend/src/components/AgentBadge.tsx
+++ b/frontend/src/components/AgentBadge.tsx
@@ -73,6 +73,22 @@ export function AgentBadge({ agent }: AgentBadgeProps) {
     );
   }
 
+  if (agent === 'prime-agent') {
+    return (
+      <svg
+        className="agent-badge"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-label="Prime Agent"
+      >
+        <path
+          fill="currentColor"
+          d="M5 4h8a6 6 0 0 1 0 12H8v4H5V4Zm3 3v6h5a3 3 0 0 0 0-6H8Z"
+        />
+      </svg>
+    );
+  }
+
   const fallbackLetter = agent ? agent[0]!.toUpperCase() : '?';
   return (
     <span className="agent-badge agent-badge--fallback" aria-label={agent}>

--- a/frontend/src/lib/chat/sender-identity.ts
+++ b/frontend/src/lib/chat/sender-identity.ts
@@ -21,7 +21,12 @@ import {
 } from '../../../../shared/agent-profile.js';
 import { deriveColor } from '../colors.js';
 
-export type KnownAgentGlyph = 'claude' | 'codex' | 'hermes' | 'opencode';
+export type KnownAgentGlyph =
+  | 'claude'
+  | 'codex'
+  | 'hermes'
+  | 'opencode'
+  | 'prime-agent';
 
 export interface SenderIdentity {
   /** Display label — human is always 'you'. */
@@ -38,6 +43,7 @@ const KNOWN_AGENT_COLOR_VAR: Record<string, string> = {
   codex: '--sender-codex',
   hermes: '--sender-hermes',
   opencode: '--sender-opencode',
+  'prime-agent': '--sender-prime-agent',
 };
 
 const KNOWN_AGENT_GLYPHS: readonly KnownAgentGlyph[] = [
@@ -45,6 +51,7 @@ const KNOWN_AGENT_GLYPHS: readonly KnownAgentGlyph[] = [
   'codex',
   'hermes',
   'opencode',
+  'prime-agent',
 ];
 
 function isKnownGlyph(value: string): value is KnownAgentGlyph {

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -52,7 +52,13 @@ export const TOPIC_ROOM_TEMPLATE_OPTIONS: Array<{
   { value: 'note', label: 'note / room only' },
 ];
 
-export const FALLBACK_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
+export const FALLBACK_PROVIDER_IDS = [
+  'claude',
+  'codex',
+  'opencode',
+  'hermes',
+  'prime-agent',
+];
 
 export type TopicProviderOption = {
   id: string;

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -107,7 +107,9 @@ function providerResumeId(
         ? 'threadId'
         : providerId === 'hermes'
           ? 'hermesResponseId'
-          : undefined;
+          : providerId === 'prime-agent'
+            ? 'primeAgentSessionId'
+            : undefined;
   if (!key) return undefined;
   const value = state[key];
   return typeof value === 'string' && value.length > 0 ? value : undefined;

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -58,7 +58,13 @@ import {
 const CONTEXT_READ = 'context:read';
 const CONTEXT_WRITE = 'context:write';
 
-const DEFAULT_KNOWN_PROVIDER_IDS = ['claude', 'codex', 'opencode', 'hermes'];
+const DEFAULT_KNOWN_PROVIDER_IDS = [
+  'claude',
+  'codex',
+  'opencode',
+  'hermes',
+  'prime-agent',
+];
 
 /**
  * Byte budget for one REST history response. Rows are row-bounded (max 200) but

--- a/server/prime-agent-rpc-client.ts
+++ b/server/prime-agent-rpc-client.ts
@@ -14,6 +14,7 @@ export interface PrimeAgentRpcClientOptions {
   readinessTimeoutMs?: number;
   maxBufferBytes?: number;
   maxRecordBytes?: number;
+  stopTimeoutMs?: number;
   spawn?: (
     command: string,
     args: string[],
@@ -31,7 +32,8 @@ interface PendingCall {
 /** Strict-LF JSONL client for `prime-agent --mode rpc`. */
 export class PrimeAgentRpcClient extends EventEmitter {
   private child: ChildProcess | null = null;
-  private buffer = '';
+  private buffer = Buffer.alloc(0);
+  private stopPromise: Promise<void> | null = null;
   private nextId = 1;
   private readonly pending = new Map<string, PendingCall>();
   private readonly writes: string[] = [];
@@ -45,7 +47,8 @@ export class PrimeAgentRpcClient extends EventEmitter {
   }
 
   async start(): Promise<PrimeAgentRpcMessage> {
-    if (this.child) throw new Error('PrimeAgentRpcClient already started');
+    if (this.child || this.stopPromise)
+      throw new Error('PrimeAgentRpcClient already started');
     const spawnFn = this.options.spawn ?? nodeSpawn;
     const child = spawnFn(
       this.options.command ?? 'prime-agent',
@@ -57,9 +60,8 @@ export class PrimeAgentRpcClient extends EventEmitter {
       }
     );
     this.child = child;
-    child.stdout?.on('data', (chunk: Buffer | string) =>
-      this.consume(String(chunk))
-    );
+    this.buffer = Buffer.alloc(0);
+    child.stdout?.on('data', (chunk: Buffer | string) => this.consume(chunk));
     child.stderr?.on('data', (chunk: Buffer | string) =>
       this.emit('stderr', String(chunk))
     );
@@ -71,7 +73,7 @@ export class PrimeAgentRpcClient extends EventEmitter {
       this.emit('error', error);
     });
     child.on('close', (code) => {
-      this.child = null;
+      if (this.child === child) this.child = null;
       const error = new Error(`prime-agent rpc exited (code=${String(code)})`);
       this.rejectPending(error);
       this.emit('close', code);
@@ -120,44 +122,81 @@ export class PrimeAgentRpcClient extends EventEmitter {
   }
 
   async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
     const child = this.child;
     if (!child) return;
+
     this.child = null;
     this.rejectPending(new Error('PrimeAgentRpcClient stopped'));
-    child.kill('SIGTERM');
+    this.stopPromise = this.terminate(child).finally(() => {
+      this.stopPromise = null;
+    });
+    return this.stopPromise;
   }
 
-  private consume(chunk: string): void {
-    this.buffer += chunk;
-    const maxBufferBytes = this.options.maxBufferBytes ?? 16 * 1024 * 1024;
-    if (
-      Buffer.byteLength(this.buffer) > maxBufferBytes &&
-      !this.buffer.includes('\n')
-    ) {
-      this.buffer = '';
-      this.emit(
-        'protocolError',
-        new Error(
-          `prime-agent RPC input buffer exceeded ${maxBufferBytes} bytes`
-        )
-      );
-      return;
+  private async terminate(child: ChildProcess): Promise<void> {
+    let closed = false;
+    const onClose = () => {
+      closed = true;
+    };
+    child.once('close', onClose);
+    const waitForClose = (timeoutMs: number): Promise<boolean> =>
+      new Promise((resolve) => {
+        if (closed) {
+          resolve(true);
+          return;
+        }
+        const onWaitClose = () => {
+          clearTimeout(timer);
+          resolve(true);
+        };
+        const timer = setTimeout(() => {
+          child.removeListener('close', onWaitClose);
+          resolve(closed);
+        }, timeoutMs);
+        timer.unref?.();
+        child.once('close', onWaitClose);
+      });
+    const timeoutMs = this.options.stopTimeoutMs ?? 2_000;
+
+    try {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // The process may already have exited.
+      }
+      if (await waitForClose(timeoutMs)) return;
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // The process may already have exited.
+      }
+      await waitForClose(timeoutMs);
+    } finally {
+      child.removeListener('close', onClose);
     }
+  }
+
+  private consume(chunk: Buffer | string): void {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.buffer = Buffer.concat([this.buffer, bytes]);
+    const maxBufferBytes = this.options.maxBufferBytes ?? 16 * 1024 * 1024;
     let newline: number;
     // Deliberately split only on ASCII LF. U+2028/U+2029 are JSON content.
-    while ((newline = this.buffer.indexOf('\n')) !== -1) {
-      let line = this.buffer.slice(0, newline);
-      this.buffer = this.buffer.slice(newline + 1);
-      if (line.endsWith('\r')) line = line.slice(0, -1);
-      if (line.length === 0) continue;
+    while ((newline = this.buffer.indexOf(0x0a)) !== -1) {
+      let lineBytes = this.buffer.subarray(0, newline);
+      this.buffer = this.buffer.subarray(newline + 1);
+      if (lineBytes.at(-1) === 0x0d) lineBytes = lineBytes.subarray(0, -1);
+      if (lineBytes.length === 0) continue;
       const maxRecordBytes = this.options.maxRecordBytes ?? 8 * 1024 * 1024;
-      if (Buffer.byteLength(line) > maxRecordBytes) {
+      if (lineBytes.length > maxRecordBytes) {
         this.emit(
           'protocolError',
           new Error(`prime-agent RPC record exceeded ${maxRecordBytes} bytes`)
         );
         continue;
       }
+      const line = lineBytes.toString('utf8');
       let value: unknown;
       try {
         value = JSON.parse(line);
@@ -209,6 +248,24 @@ export class PrimeAgentRpcClient extends EventEmitter {
       } else {
         this.emit('event', message);
       }
+    }
+
+    // Check again after consuming complete records: a chunk can contain valid
+    // lines followed by an oversized unterminated tail.
+    if (this.buffer.length > maxBufferBytes) {
+      this.buffer = Buffer.alloc(0);
+      const error = new Error(
+        `prime-agent RPC input buffer exceeded ${maxBufferBytes} bytes`
+      );
+      this.emit('protocolError', error);
+      // Discarding an unterminated record loses framing. Stop rather than risk
+      // interpreting a later suffix as a fresh trusted record.
+      void this.stop().catch((stopError: unknown) =>
+        this.emit(
+          'error',
+          stopError instanceof Error ? stopError : new Error(String(stopError))
+        )
+      );
     }
   }
 

--- a/server/prime-agent-rpc-client.ts
+++ b/server/prime-agent-rpc-client.ts
@@ -1,0 +1,244 @@
+import { EventEmitter } from 'node:events';
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+
+export interface PrimeAgentRpcMessage extends Record<string, unknown> {
+  type: string;
+}
+
+export interface PrimeAgentRpcClientOptions {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  requestTimeoutMs?: number;
+  readinessTimeoutMs?: number;
+  maxBufferBytes?: number;
+  maxRecordBytes?: number;
+  spawn?: (
+    command: string,
+    args: string[],
+    options: { cwd?: string; env?: Record<string, string>; stdio: 'pipe' }
+  ) => ChildProcess;
+}
+
+interface PendingCall {
+  resolve: (value: PrimeAgentRpcMessage) => void;
+  reject: (error: Error) => void;
+  command: string;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Strict-LF JSONL client for `prime-agent --mode rpc`. */
+export class PrimeAgentRpcClient extends EventEmitter {
+  private child: ChildProcess | null = null;
+  private buffer = '';
+  private nextId = 1;
+  private readonly pending = new Map<string, PendingCall>();
+  private readonly writes: string[] = [];
+  private draining = false;
+
+  constructor(private readonly options: PrimeAgentRpcClientOptions = {}) {
+    super();
+    // An EventEmitter `error` without a listener terminates Node. Transport
+    // errors are still observable, but are safe during early process startup.
+    this.on('error', () => undefined);
+  }
+
+  async start(): Promise<PrimeAgentRpcMessage> {
+    if (this.child) throw new Error('PrimeAgentRpcClient already started');
+    const spawnFn = this.options.spawn ?? nodeSpawn;
+    const child = spawnFn(
+      this.options.command ?? 'prime-agent',
+      this.options.args ?? ['--mode', 'rpc'],
+      {
+        ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
+        ...(this.options.env ? { env: this.options.env } : {}),
+        stdio: 'pipe',
+      }
+    );
+    this.child = child;
+    child.stdout?.on('data', (chunk: Buffer | string) =>
+      this.consume(String(chunk))
+    );
+    child.stderr?.on('data', (chunk: Buffer | string) =>
+      this.emit('stderr', String(chunk))
+    );
+    child.stdin?.on('error', (error: Error) => this.emit('error', error));
+    child.stdout?.on('error', (error: Error) => this.emit('error', error));
+    child.stderr?.on('error', (error: Error) => this.emit('error', error));
+    child.on('error', (error: Error) => {
+      this.rejectPending(error);
+      this.emit('error', error);
+    });
+    child.on('close', (code) => {
+      this.child = null;
+      const error = new Error(`prime-agent rpc exited (code=${String(code)})`);
+      this.rejectPending(error);
+      this.emit('close', code);
+    });
+
+    // RPC has no initialize handshake. A correlated get_state response is the
+    // readiness barrier and supplies durable session identity.
+    return this.callWithTimeout(
+      'get_state',
+      {},
+      this.options.readinessTimeoutMs ?? 10_000
+    );
+  }
+
+  call(
+    type: string,
+    fields: Record<string, unknown> = {}
+  ): Promise<PrimeAgentRpcMessage> {
+    return this.callWithTimeout(
+      type,
+      fields,
+      this.options.requestTimeoutMs ?? 30_000
+    );
+  }
+
+  private callWithTimeout(
+    type: string,
+    fields: Record<string, unknown>,
+    timeoutMs: number
+  ): Promise<PrimeAgentRpcMessage> {
+    if (!this.child)
+      return Promise.reject(new Error('PrimeAgentRpcClient is not started'));
+    const id = `relay-${this.nextId++}`;
+    const promise = new Promise<PrimeAgentRpcMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(`prime-agent RPC ${type} timed out after ${timeoutMs}ms`)
+        );
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, { resolve, reject, command: type, timer });
+    });
+    this.enqueue({ id, type, ...fields });
+    return promise;
+  }
+
+  async stop(): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+    this.child = null;
+    this.rejectPending(new Error('PrimeAgentRpcClient stopped'));
+    child.kill('SIGTERM');
+  }
+
+  private consume(chunk: string): void {
+    this.buffer += chunk;
+    const maxBufferBytes = this.options.maxBufferBytes ?? 16 * 1024 * 1024;
+    if (
+      Buffer.byteLength(this.buffer) > maxBufferBytes &&
+      !this.buffer.includes('\n')
+    ) {
+      this.buffer = '';
+      this.emit(
+        'protocolError',
+        new Error(
+          `prime-agent RPC input buffer exceeded ${maxBufferBytes} bytes`
+        )
+      );
+      return;
+    }
+    let newline: number;
+    // Deliberately split only on ASCII LF. U+2028/U+2029 are JSON content.
+    while ((newline = this.buffer.indexOf('\n')) !== -1) {
+      let line = this.buffer.slice(0, newline);
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line.endsWith('\r')) line = line.slice(0, -1);
+      if (line.length === 0) continue;
+      const maxRecordBytes = this.options.maxRecordBytes ?? 8 * 1024 * 1024;
+      if (Buffer.byteLength(line) > maxRecordBytes) {
+        this.emit(
+          'protocolError',
+          new Error(`prime-agent RPC record exceeded ${maxRecordBytes} bytes`)
+        );
+        continue;
+      }
+      let value: unknown;
+      try {
+        value = JSON.parse(line);
+      } catch (error) {
+        this.emit(
+          'protocolError',
+          new Error(
+            `Invalid prime-agent RPC JSON: ${error instanceof Error ? error.message : String(error)}`
+          )
+        );
+        continue;
+      }
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        this.emit(
+          'protocolError',
+          new Error('Invalid prime-agent RPC record: expected object')
+        );
+        continue;
+      }
+      const message = value as PrimeAgentRpcMessage;
+      if (message.type === 'response' && typeof message.id === 'string') {
+        const pending = this.pending.get(message.id);
+        if (!pending) {
+          this.emit(
+            'protocolError',
+            new Error(`Uncorrelated prime-agent RPC response id: ${message.id}`)
+          );
+          continue;
+        }
+        this.pending.delete(message.id);
+        clearTimeout(pending.timer);
+        if (message.command !== pending.command) {
+          pending.reject(
+            new Error(
+              `prime-agent RPC response command mismatch: expected ${pending.command}, got ${String(message.command)}`
+            )
+          );
+        } else if (message.success !== true) {
+          pending.reject(
+            new Error(
+              typeof message.error === 'string'
+                ? message.error
+                : `${pending.command} failed`
+            )
+          );
+        } else {
+          pending.resolve(message);
+        }
+      } else {
+        this.emit('event', message);
+      }
+    }
+  }
+
+  private enqueue(message: Record<string, unknown>): void {
+    this.writes.push(`${JSON.stringify(message)}\n`);
+    this.flush();
+  }
+
+  private flush(): void {
+    if (this.draining) return;
+    const stdin = this.child?.stdin;
+    if (!stdin) return;
+    while (this.writes.length) {
+      const line = this.writes.shift()!;
+      if (!stdin.write(line)) {
+        this.draining = true;
+        stdin.once('drain', () => {
+          this.draining = false;
+          this.flush();
+        });
+        return;
+      }
+    }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -89,7 +89,9 @@ const LANGUAGE_SERVER_MATCHERS: Array<{
 
 const DEFAULT_CLOCK_TICK_HZ = 100;
 
-export function readProcessTable(options: ProcessTableOptions = {}): ProcessInfo[] {
+export function readProcessTable(
+  options: ProcessTableOptions = {}
+): ProcessInfo[] {
   if (process.platform !== 'linux' && options.procRoot === undefined) return [];
 
   const procRoot = options.procRoot ?? '/proc';
@@ -137,7 +139,10 @@ export function readProcessTable(options: ProcessTableOptions = {}): ProcessInfo
   return processes.sort((a, b) => a.pid - b.pid);
 }
 
-export function descendantsOf(rootPid: number, table: ProcessInfo[]): ProcessInfo[] {
+export function descendantsOf(
+  rootPid: number,
+  table: ProcessInfo[]
+): ProcessInfo[] {
   const children = new Map<number, ProcessInfo[]>();
   for (const proc of table) {
     const bucket = children.get(proc.ppid) ?? [];
@@ -205,7 +210,8 @@ export function scheduleRelayProcessTreeReap(
   const summary = summarizeProcessReap(options.rootPids, table);
   const knownPids = new Set([...summary.rootPids, ...summary.descendantPids]);
   const processGroupIds = new Set(summary.processGroupIds);
-  const killProcess = options.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+  const killProcess =
+    options.killProcess ?? ((pid, signal) => process.kill(pid, signal));
   const logger = options.logger;
 
   if (knownPids.size === 0 && processGroupIds.size === 0) return summary;
@@ -252,7 +258,9 @@ export function collectLanguageServerDiagnostics(
     .map((proc) => {
       const ancestors = ancestorsOf(proc, byPid);
       const relayOwnedLikely = [proc, ...ancestors].some((candidate) =>
-        /relay-ide|relayctl|claude|codex|opencode|hermes/i.test(candidate.commandLine)
+        /relay-ide|relayctl|claude|codex|opencode|hermes|prime-agent/i.test(
+          candidate.commandLine
+        )
       );
       return {
         pid: proc.pid,
@@ -284,14 +292,19 @@ export function collectLanguageServerDiagnostics(
   };
 }
 
-function parseProcStat(stat: string):
+function parseProcStat(
+  stat: string
+):
   | { command: string; ppid: number; pgid: number; startTicks: number }
   | undefined {
   const open = stat.indexOf('(');
   const close = stat.lastIndexOf(')');
   if (open < 0 || close <= open) return undefined;
   const command = stat.slice(open + 1, close);
-  const rest = stat.slice(close + 2).trim().split(/\s+/);
+  const rest = stat
+    .slice(close + 2)
+    .trim()
+    .split(/\s+/);
   const ppid = Number(rest[1]);
   const pgid = Number(rest[2]);
   const startTicks = Number(rest[19]);
@@ -363,7 +376,9 @@ export function redactCommandLine(commandLine: string): string {
   );
 }
 
-function collectCommandLineRedactions(tokens: CommandToken[]): RedactionRange[] {
+function collectCommandLineRedactions(
+  tokens: CommandToken[]
+): RedactionRange[] {
   const redactions: RedactionRange[] = [];
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index]!;
@@ -391,7 +406,9 @@ function secretOptionRedaction(
   if (!token.text.includes('=')) return nextToken;
 
   const valueStart = token.start + token.text.indexOf('=') + 1;
-  return valueStart < token.end ? { start: valueStart, end: token.end } : undefined;
+  return valueStart < token.end
+    ? { start: valueStart, end: token.end }
+    : undefined;
 }
 
 function envAssignmentRedaction(
@@ -415,7 +432,9 @@ function envAssignmentRedaction(
   } else {
     valueEnd = consumeFollowingQuotedFragments(tokens, index) ?? valueEnd;
   }
-  return valueStart < valueEnd ? { start: valueStart, end: valueEnd } : undefined;
+  return valueStart < valueEnd
+    ? { start: valueStart, end: valueEnd }
+    : undefined;
 }
 
 function credentialSchemeRedaction(
@@ -425,12 +444,15 @@ function credentialSchemeRedaction(
   return /^(?:bearer|basic)$/i.test(token.text) ? nextToken : undefined;
 }
 
-function tokenizeCommandLine(commandLine: string): Array<{ start: number; end: number; text: string }> {
+function tokenizeCommandLine(
+  commandLine: string
+): Array<{ start: number; end: number; text: string }> {
   const tokens: Array<{ start: number; end: number; text: string }> = [];
   let index = 0;
 
   while (index < commandLine.length) {
-    while (index < commandLine.length && /\s/.test(commandLine[index]!)) index += 1;
+    while (index < commandLine.length && /\s/.test(commandLine[index]!))
+      index += 1;
     if (index >= commandLine.length) break;
 
     const start = index;
@@ -460,7 +482,8 @@ function consumeUntilQuote(
 ): number {
   for (let index = startIndex; index < tokens.length; index += 1) {
     const token = tokens[index]!;
-    if (token.text.endsWith(quote) && !token.text.endsWith(`\\${quote}`)) return token.end;
+    if (token.text.endsWith(quote) && !token.text.endsWith(`\\${quote}`))
+      return token.end;
   }
   return tokens[startIndex]!.end;
 }
@@ -471,8 +494,12 @@ function consumeFollowingQuotedFragments(
 ): number | undefined {
   for (let index = startIndex + 1; index < tokens.length; index += 1) {
     const token = tokens[index]!;
-    if (/^--?\w/.test(token.text) || /^[A-Z0-9_]+=/.test(token.text)) return undefined;
-    const quoteOffset = Math.max(token.text.indexOf('"'), token.text.indexOf("'"));
+    if (/^--?\w/.test(token.text) || /^[A-Z0-9_]+=/.test(token.text))
+      return undefined;
+    const quoteOffset = Math.max(
+      token.text.indexOf('"'),
+      token.text.indexOf("'")
+    );
     if (quoteOffset >= 0) return token.start + quoteOffset + 1;
     if (token.text.endsWith('"') || token.text.endsWith("'")) return token.end;
   }
@@ -515,14 +542,19 @@ function safeUptimeSeconds(procRoot: string): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function classifyLanguageServer(commandLine: string): LanguageServerKind | undefined {
+function classifyLanguageServer(
+  commandLine: string
+): LanguageServerKind | undefined {
   for (const matcher of LANGUAGE_SERVER_MATCHERS) {
     if (matcher.pattern.test(commandLine)) return matcher.kind;
   }
   return undefined;
 }
 
-function ancestorsOf(proc: ProcessInfo, byPid: Map<number, ProcessInfo>): ProcessInfo[] {
+function ancestorsOf(
+  proc: ProcessInfo,
+  byPid: Map<number, ProcessInfo>
+): ProcessInfo[] {
   const ancestors: ProcessInfo[] = [];
   const seen = new Set<number>([proc.pid]);
   let current = proc;
@@ -539,8 +571,7 @@ function ancestorsOf(proc: ProcessInfo, byPid: Map<number, ProcessInfo>): Proces
 function uniqueSafePids(pids: number[]): number[] {
   return Array.from(new Set(pids))
     .filter(
-      (pid) =>
-        Number.isSafeInteger(pid) && pid > 1 && pid !== process.pid
+      (pid) => Number.isSafeInteger(pid) && pid > 1 && pid !== process.pid
     )
     .sort((a, b) => a - b);
 }

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -6,11 +6,13 @@ import { OpenCodeProtocolAdapter } from './opencode-adapter.js';
 import { OpenCodeAttachedAdapter } from './opencode-attached-adapter.js';
 import { HermesProtocolAdapter } from './hermes-adapter.js';
 import { CodexNativeProtocolAdapter } from './codex-native-adapter.js';
+import { PrimeAgentProtocolAdapter } from './prime-agent-adapter.js';
 
 export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
   mock: () => new MockProtocolAdapterV2(),
   claude: () => new ClaudeProtocolAdapter(),
   codex: () => new CodexNativeProtocolAdapter(),
+  'prime-agent': () => new PrimeAgentProtocolAdapter(),
   opencode: () =>
     new LegacyProtocolAdapterV2Bridge(new OpenCodeProtocolAdapter(), {
       text: true,

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -39,7 +39,7 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   resume: true,
   fork: false,
   rollback: false,
-  compact: false,
+  compact: true,
   telemetry: true,
   rateLimits: false,
   streaming: true,
@@ -88,6 +88,34 @@ function isFileTool(name: string): boolean {
   return /^(edit|write|patch|apply_patch|create|delete|move)/i.test(name);
 }
 
+const MAX_IMAGE_COUNT = 4;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGE_TOTAL_BYTES = MAX_IMAGE_COUNT * MAX_IMAGE_BYTES;
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+function matchesImageSignature(bytes: Buffer, mimeType: string): boolean {
+  if (mimeType === 'image/png')
+    return bytes
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  if (mimeType === 'image/jpeg')
+    return bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  if (mimeType === 'image/gif') {
+    const signature = bytes.subarray(0, 6).toString('ascii');
+    return signature === 'GIF87a' || signature === 'GIF89a';
+  }
+  return (
+    mimeType === 'image/webp' &&
+    bytes.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    bytes.subarray(8, 12).toString('ascii') === 'WEBP'
+  );
+}
+
 export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   readonly agentType = 'prime-agent';
   readonly runtimeOwnership = 'spawned' as const;
@@ -107,8 +135,8 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private turnUsage: AgentUsageV2 | undefined;
   private clientGeneration = 0;
   private readonly queued: AgentSendMessageInputV2[] = [];
-  private readonly acceptedQueued = new Set<AgentSendMessageInputV2>();
-  private queuedAdvancePending = false;
+  private queueAdvanceInFlight = false;
+  private providerExtensionSequence = 0;
   private readonly items = new Map<string, AgentItemV2>();
 
   constructor(
@@ -163,10 +191,6 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     try {
       const response = await client.start();
       this.applyState(record(response.data));
-      // Pin one native scheduler action to one Relay turn. Prime persists this
-      // preference, but setting it on every fresh subprocess keeps attribution
-      // deterministic across upgrades and user configuration changes.
-      await client.call('set_steering_mode', { mode: 'one-at-a-time' });
       this._status = 'connected';
       this.emitSnapshot();
       this.emitLive({
@@ -193,8 +217,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     await this.teardownClient();
     this.activeTurnId = null;
     this.queued.length = 0;
-    this.acceptedQueued.clear();
-    this.queuedAdvancePending = false;
+    this.queueAdvanceInFlight = false;
     this.items.clear();
   }
 
@@ -213,6 +236,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         ? { resumeSessionId: this.providerSessionId }
         : {}),
     };
+    this.resetForTransportSwitch('Prime Agent transport reconnected');
     this._status = 'disconnected';
     await this.teardownClient();
     await this.connect(config);
@@ -221,6 +245,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   async resumeSession(sessionId: string): Promise<void> {
     if (!this.config) throw new Error('Cannot resumeSession before connect');
     const config = { ...this.config, resumeSessionId: sessionId };
+    this.resetForTransportSwitch('Prime Agent session switched');
     this._status = 'disconnected';
     await this.teardownClient();
     await this.connect(config);
@@ -232,42 +257,26 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const images = this.readImages(input.attachments);
     if (images.length) payload.images = images;
     if (this.activeTurnId) {
-      // Enqueue before awaiting the acknowledgement: native events and command
-      // responses share stdout, so a very fast turn may end before the response
-      // promise resumes this continuation. Promotion waits for acceptance.
+      // Prime `steer` stays inside the current native agent run and therefore
+      // has no separate agent_end boundary that Relay can attribute to this
+      // turn. Keep Relay turns local and submit a fresh prompt after agent_end.
       this.queued.push(input);
       this.emitLive({
         status: 'working',
         activeTurnId: this.activeTurnId,
         queueLength: this.queued.length,
       });
-      try {
-        await client.call('steer', payload);
-        this.acceptedQueued.add(input);
-        this.promoteAcceptedQueuedTurn();
-      } catch (error) {
-        const index = this.queued.indexOf(input);
-        if (index !== -1) this.queued.splice(index, 1);
-        this.acceptedQueued.delete(input);
-        // A failed or timed-out acknowledgement is ambiguous once native
-        // lifecycle events may have advanced. Fail closed rather than create a
-        // Relay turn for work Prime may not have accepted.
-        this.handleTransportClose(
-          error instanceof Error ? error : new Error(String(error))
-        );
-        this.emitLive({ queueLength: this.queued.length });
-        throw error;
-      }
       return;
     }
 
     this.startTurn(input);
     try {
-      await client.call('prompt', payload);
+      await this.submitNativeInput(client, input, payload);
     } catch (error) {
-      this.completeTurn(
-        'failed',
-        error instanceof Error ? error.message : String(error)
+      // A timeout is ambiguous: Prime may have accepted the prompt. Stop the
+      // private runtime so late events/tools cannot outlive Relay attribution.
+      this.handleTransportClose(
+        error instanceof Error ? error : new Error(String(error))
       );
       throw error;
     }
@@ -308,8 +317,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
             : 'completed',
         this.turnFailure ?? undefined
       );
-      this.queuedAdvancePending = this.queued.length > 0;
-      this.promoteAcceptedQueuedTurn();
+      void this.advanceQueuedTurn();
       return;
     }
     if (type === 'message_update') {
@@ -354,8 +362,13 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       return;
     }
     if (type === 'extension_error') {
-      this.turnFailure = string(event.error, 'Prime Agent extension error');
-      this.emitError(this.turnFailure);
+      this.emitProviderExtension(
+        {
+          kind: 'extensionError',
+          error: string(event.error, 'Prime Agent extension error'),
+        },
+        'debug'
+      );
       return;
     }
     if (type === 'auto_retry_end' && event.success === false) {
@@ -435,8 +448,11 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         status: 'running',
         startedAt: nowIso(),
       };
-    else if (isFileTool(name)) {
-      const path = string(args.path ?? args.file_path, 'unknown');
+    else if (
+      isFileTool(name) &&
+      string(args.path ?? args.file_path).length > 0
+    ) {
+      const path = string(args.path ?? args.file_path);
       item = {
         type: 'fileChange',
         id,
@@ -595,20 +611,50 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     };
   }
 
-  private promoteAcceptedQueuedTurn(): void {
+  private async submitNativeInput(
+    client: PrimeAgentRpcClient,
+    input: AgentSendMessageInputV2,
+    payload: RpcRecord
+  ): Promise<void> {
+    if (input.content.trim() !== '/compact') {
+      await client.call('prompt', payload);
+      return;
+    }
+    const response = await client.call('compact');
+    this.emitProviderExtension({
+      kind: 'contextCompaction',
+      ...record(response.data),
+    });
+    this.completeTurn('completed');
+    void this.advanceQueuedTurn();
+  }
+
+  private async advanceQueuedTurn(): Promise<void> {
     if (
-      !this.queuedAdvancePending ||
+      this.queueAdvanceInFlight ||
       this.activeTurnId ||
-      this.queued.length === 0
+      this.queued.length === 0 ||
+      this._status !== 'connected'
     ) {
       return;
     }
-    const next = this.queued[0];
-    if (!next || !this.acceptedQueued.has(next)) return;
-    this.queued.shift();
-    this.acceptedQueued.delete(next);
-    this.queuedAdvancePending = false;
+    const next = this.queued.shift();
+    if (!next) return;
+    this.queueAdvanceInFlight = true;
     this.startTurn(next);
+    try {
+      const payload: RpcRecord = { message: next.content };
+      const images = this.readImages(next.attachments);
+      if (images.length) payload.images = images;
+      await this.submitNativeInput(this.requireClient(), next, payload);
+    } catch (error) {
+      this.handleTransportClose(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    } finally {
+      this.queueAdvanceInFlight = false;
+      if (!this.activeTurnId) void this.advanceQueuedTurn();
+    }
   }
 
   private startTurn(input: AgentSendMessageInputV2): void {
@@ -751,6 +797,40 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       ...(this.activeTurnId ? { turnId: this.activeTurnId } : {}),
     });
   }
+  private emitProviderExtension(
+    payload: Record<string, unknown>,
+    visibility: 'normal' | 'debug' = 'normal'
+  ): void {
+    if (!this.activeTurnId) return;
+    const sequence = ++this.providerExtensionSequence;
+    const timestamp = nowIso();
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp,
+      turnId: this.activeTurnId,
+      item: {
+        type: 'providerExtension',
+        id: `ext-prime-agent-${this.activeTurnId}-${sequence}`,
+        namespace: 'prime-agent',
+        payload,
+        ...(visibility === 'debug'
+          ? { metadata: { eventVisibility: 'debug' } }
+          : {}),
+        status: 'completed',
+        startedAt: timestamp,
+        completedAt: timestamp,
+      },
+    });
+  }
+
+  private resetForTransportSwitch(reason: string): void {
+    if (this.activeTurnId) this.completeTurn('failed', reason);
+    this.queued.length = 0;
+    this.queueAdvanceInFlight = false;
+    this.items.clear();
+  }
+
   private emitLive(live: Partial<AgentSessionLiveStateV2>): void {
     this.emitPatch({
       type: 'agent-live-state-updated-v2',
@@ -802,9 +882,12 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     if (this._status === 'disconnected') return;
     if (this.activeTurnId) this.completeTurn('failed', error.message);
     this.queued.length = 0;
-    this.acceptedQueued.clear();
-    this.queuedAdvancePending = false;
+    this.queueAdvanceInFlight = false;
     this._status = 'disconnected';
+    const client = this.client;
+    this.client = null;
+    this.clientGeneration += 1;
+    void client?.stop().catch(() => undefined);
     this.emitError(error.message);
     this.emitLive({
       status: 'disconnected',
@@ -816,14 +899,43 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private readImages(
     attachments: AgentSendMessageInputV2['attachments'] = []
   ): RpcRecord[] {
+    const imageAttachments = attachments.filter(
+      (attachment) => attachment.type === 'image'
+    );
+    if (imageAttachments.length > MAX_IMAGE_COUNT) {
+      throw new Error(`Prime Agent accepts at most ${MAX_IMAGE_COUNT} images`);
+    }
     const images: RpcRecord[] = [];
-    for (const attachment of attachments) {
-      if (attachment.type !== 'image') continue;
+    let totalBytes = 0;
+    for (const attachment of imageAttachments) {
+      const mimeType = attachment.mimeType ?? '';
+      if (!SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) {
+        throw new Error(
+          `Unsupported Prime Agent image MIME type: ${mimeType || 'missing'}`
+        );
+      }
       try {
+        const stat = fs.lstatSync(attachment.path);
+        if (!stat.isFile() || stat.isSymbolicLink())
+          throw new Error('attachment must be a regular non-symlink file');
+        if (stat.size > MAX_IMAGE_BYTES)
+          throw new Error(`attachment exceeds ${MAX_IMAGE_BYTES} bytes`);
+        totalBytes += stat.size;
+        if (totalBytes > MAX_IMAGE_TOTAL_BYTES)
+          throw new Error(
+            `attachments exceed ${MAX_IMAGE_TOTAL_BYTES} aggregate bytes`
+          );
+        const bytes = fs.readFileSync(attachment.path);
+        if (
+          bytes.length > MAX_IMAGE_BYTES ||
+          !matchesImageSignature(bytes, mimeType)
+        ) {
+          throw new Error('attachment bytes do not match the declared image');
+        }
         images.push({
           type: 'image',
-          data: fs.readFileSync(attachment.path).toString('base64'),
-          mimeType: attachment.mimeType,
+          data: bytes.toString('base64'),
+          mimeType,
         });
       } catch (error) {
         throw new Error(

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -1,0 +1,837 @@
+import * as fs from 'node:fs';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentSendMessageInputV2,
+} from '../protocol-adapter-v2.js';
+import type {
+  AgentCapabilitySetV2,
+  AgentItemV2,
+  AgentSessionLiveStateV2,
+  AgentUsageV2,
+} from '../../shared/agent-chat-protocol-v2.js';
+import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+import { cleanEnv } from '../utils.js';
+import {
+  PrimeAgentRpcClient,
+  type PrimeAgentRpcClientOptions,
+  type PrimeAgentRpcMessage,
+} from '../prime-agent-rpc-client.js';
+
+const CAPABILITIES: AgentCapabilitySetV2 = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: false,
+  questions: false,
+  plans: false,
+  slashCommands: false,
+  queue: true,
+  cancelQueued: false,
+  interrupt: true,
+  resume: true,
+  fork: false,
+  rollback: false,
+  compact: false,
+  telemetry: true,
+  rateLimits: false,
+  streaming: true,
+};
+
+type ClientFactory = (
+  options: PrimeAgentRpcClientOptions
+) => PrimeAgentRpcClient;
+type RpcRecord = Record<string, unknown>;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+function record(value: unknown): RpcRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as RpcRecord)
+    : {};
+}
+function string(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+function resultText(value: unknown): string {
+  const content = record(value).content;
+  if (!Array.isArray(content)) return typeof value === 'string' ? value : '';
+  return content
+    .map((part) => string(record(part).text))
+    .filter(Boolean)
+    .join('\n');
+}
+function toolArguments(value: unknown): RpcRecord {
+  if (value && typeof value === 'object' && !Array.isArray(value))
+    return value as RpcRecord;
+  if (typeof value === 'string') {
+    try {
+      return record(JSON.parse(value));
+    } catch {
+      return { raw: value };
+    }
+  }
+  return {};
+}
+function isCommandTool(name: string): boolean {
+  return /^(bash|shell|exec|terminal)$/i.test(name);
+}
+function isFileTool(name: string): boolean {
+  return /^(edit|write|patch|apply_patch|create|delete|move)/i.test(name);
+}
+
+export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
+  readonly agentType = 'prime-agent';
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities = CAPABILITIES;
+  readonly resumesProviderSessionDuringConnect = true;
+
+  private _status: AdapterStatus = 'disconnected';
+  private config: AdapterConfig | null = null;
+  private client: PrimeAgentRpcClient | null = null;
+  private providerSessionId: string | null = null;
+  private providerSessionFile: string | null = null;
+  private activeTurnId: string | null = null;
+  private activeStartedMs = 0;
+  private abortRequested = false;
+  private turnFailure: string | null = null;
+  private assistantMessageSequence = -1;
+  private turnUsage: AgentUsageV2 | undefined;
+  private clientGeneration = 0;
+  private readonly queued: AgentSendMessageInputV2[] = [];
+  private readonly acceptedQueued = new Set<AgentSendMessageInputV2>();
+  private queuedAdvancePending = false;
+  private readonly items = new Map<string, AgentItemV2>();
+
+  constructor(
+    private readonly clientFactory: ClientFactory = (options) =>
+      new PrimeAgentRpcClient({ ...options, spawn: nodeSpawn })
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this.config = config;
+    this._status = 'connecting';
+    const args = ['--mode', 'rpc', '--no-extensions'];
+    const provider = string(config.extra?.['provider']);
+    const thinking = string(config.extra?.['effort']);
+    if (provider) args.push('--provider', provider);
+    if (config.model) args.push('--model', config.model);
+    if (thinking) args.push('--thinking', thinking);
+    if (config.systemPromptAppendix)
+      args.push('--append-system-prompt', config.systemPromptAppendix);
+    if (config.resumeSessionId) args.push('--resume', config.resumeSessionId);
+    const env = { ...cleanEnv(), ...(config.processEnv ?? {}) };
+    delete env['CLAUDECODE'];
+    const client = this.clientFactory({
+      command: 'prime-agent',
+      args,
+      cwd: config.cwd,
+      env,
+    });
+    this.client = client;
+    const generation = ++this.clientGeneration;
+    const current = (): boolean =>
+      this.client === client && this.clientGeneration === generation;
+    client.on('event', (event: PrimeAgentRpcMessage) => {
+      if (current()) this.handleEvent(event);
+    });
+    client.on('protocolError', (error: Error) => {
+      if (current()) this.handleTransportClose(error);
+    });
+    client.on('error', (error: Error) => {
+      if (current()) this.handleTransportClose(error);
+    });
+    client.on('close', () => {
+      if (current() && this._status !== 'disconnected')
+        this.handleTransportClose(
+          new Error('prime-agent RPC transport closed')
+        );
+    });
+    try {
+      const response = await client.start();
+      this.applyState(record(response.data));
+      // Pin one native scheduler action to one Relay turn. Prime persists this
+      // preference, but setting it on every fresh subprocess keeps attribution
+      // deterministic across upgrades and user configuration changes.
+      await client.call('set_steering_mode', { mode: 'one-at-a-time' });
+      this._status = 'connected';
+      this.emitSnapshot();
+      this.emitLive({
+        status: record(response.data).isStreaming === true ? 'working' : 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        proposedPlanItemId: null,
+        queueLength: Number(
+          record(record(response.data).sessionActions).queuedCount ?? 0
+        ),
+        fastModeAvailable: false,
+        error: null,
+      });
+    } catch (error) {
+      this._status = 'disconnected';
+      await client.stop().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+    await this.teardownClient();
+    this.activeTurnId = null;
+    this.queued.length = 0;
+    this.acceptedQueued.clear();
+    this.queuedAdvancePending = false;
+    this.items.clear();
+  }
+
+  private async teardownClient(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    this.clientGeneration += 1;
+    await client?.stop();
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.config) throw new Error('Cannot reconnect before connect');
+    const config = {
+      ...this.config,
+      ...(this.providerSessionId
+        ? { resumeSessionId: this.providerSessionId }
+        : {}),
+    };
+    this._status = 'disconnected';
+    await this.teardownClient();
+    await this.connect(config);
+  }
+
+  async resumeSession(sessionId: string): Promise<void> {
+    if (!this.config) throw new Error('Cannot resumeSession before connect');
+    const config = { ...this.config, resumeSessionId: sessionId };
+    this._status = 'disconnected';
+    await this.teardownClient();
+    await this.connect(config);
+  }
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    const client = this.requireClient();
+    const payload: RpcRecord = { message: input.content };
+    const images = this.readImages(input.attachments);
+    if (images.length) payload.images = images;
+    if (this.activeTurnId) {
+      // Enqueue before awaiting the acknowledgement: native events and command
+      // responses share stdout, so a very fast turn may end before the response
+      // promise resumes this continuation. Promotion waits for acceptance.
+      this.queued.push(input);
+      this.emitLive({
+        status: 'working',
+        activeTurnId: this.activeTurnId,
+        queueLength: this.queued.length,
+      });
+      try {
+        await client.call('steer', payload);
+        this.acceptedQueued.add(input);
+        this.promoteAcceptedQueuedTurn();
+      } catch (error) {
+        const index = this.queued.indexOf(input);
+        if (index !== -1) this.queued.splice(index, 1);
+        this.acceptedQueued.delete(input);
+        // A failed or timed-out acknowledgement is ambiguous once native
+        // lifecycle events may have advanced. Fail closed rather than create a
+        // Relay turn for work Prime may not have accepted.
+        this.handleTransportClose(
+          error instanceof Error ? error : new Error(String(error))
+        );
+        this.emitLive({ queueLength: this.queued.length });
+        throw error;
+      }
+      return;
+    }
+
+    this.startTurn(input);
+    try {
+      await client.call('prompt', payload);
+    } catch (error) {
+      this.completeTurn(
+        'failed',
+        error instanceof Error ? error.message : String(error)
+      );
+      throw error;
+    }
+  }
+
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    if (!this.activeTurnId) return;
+    if (input.turnId && input.turnId !== this.activeTurnId) return;
+    this.abortRequested = true;
+    try {
+      await this.requireClient().call('abort');
+    } catch (error) {
+      this.abortRequested = false;
+      throw error;
+    }
+  }
+  async respondToApproval(_input: AgentApprovalResponseInputV2): Promise<void> {
+    throw new Error('Prime Agent RPC approvals are not mapped');
+  }
+  async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
+    throw new Error('Prime Agent RPC questions are not mapped');
+  }
+
+  private handleEvent(event: PrimeAgentRpcMessage): void {
+    const type = event.type;
+    if (type === 'turn_start' || type === 'turn_end') return;
+    if (type === 'message_start') {
+      if (record(event.message).role === 'assistant')
+        this.assistantMessageSequence += 1;
+      return;
+    }
+    if (type === 'agent_end') {
+      this.completeTurn(
+        this.abortRequested
+          ? 'interrupted'
+          : this.turnFailure
+            ? 'failed'
+            : 'completed',
+        this.turnFailure ?? undefined
+      );
+      this.queuedAdvancePending = this.queued.length > 0;
+      this.promoteAcceptedQueuedTurn();
+      return;
+    }
+    if (type === 'message_update') {
+      this.handleMessageUpdate(record(event.assistantMessageEvent));
+      return;
+    }
+    if (type === 'message_end') {
+      const message = record(event.message);
+      if (message.stopReason === 'aborted') this.abortRequested = true;
+      if (message.stopReason === 'error')
+        this.turnFailure = string(
+          message.errorMessage,
+          'Prime Agent generation failed'
+        );
+      this.finishMessageItems(
+        this.abortRequested
+          ? 'cancelled'
+          : this.turnFailure
+            ? 'failed'
+            : 'completed'
+      );
+      this.captureUsage(message);
+      return;
+    }
+    if (type === 'tool_execution_start') {
+      this.startTool(event);
+      return;
+    }
+    if (type === 'tool_execution_update') {
+      this.updateTool(event, event.partialResult, false);
+      return;
+    }
+    if (type === 'tool_execution_end') {
+      this.updateTool(event, event.result, true);
+      return;
+    }
+    if (type === 'session_action_update') {
+      const actions = record(event.actions);
+      this.emitLive({
+        queueLength: Number(actions.queuedCount ?? this.queued.length),
+      });
+      return;
+    }
+    if (type === 'extension_error') {
+      this.turnFailure = string(event.error, 'Prime Agent extension error');
+      this.emitError(this.turnFailure);
+      return;
+    }
+    if (type === 'auto_retry_end' && event.success === false) {
+      this.turnFailure = string(event.finalError, 'Prime Agent retry failed');
+      this.emitError(this.turnFailure);
+    }
+  }
+
+  private handleMessageUpdate(delta: RpcRecord): void {
+    if (!this.activeTurnId) return;
+    const kind = string(delta.type);
+    const index = Number(delta.contentIndex ?? 0);
+    if (kind === 'text_start' || kind === 'text_delta') {
+      const id = `${this.activeTurnId}-assistant-${Math.max(0, this.assistantMessageSequence)}-${index}`;
+      this.ensureItem(id, {
+        type: 'assistantMessage',
+        id,
+        text: '',
+        phase: 'answer',
+        status: 'running',
+        startedAt: nowIso(),
+      });
+      if (kind === 'text_delta' && typeof delta.delta === 'string')
+        this.emitDelta(id, { text: delta.delta });
+    } else if (kind === 'thinking_start' || kind === 'thinking_delta') {
+      const id = `${this.activeTurnId}-reasoning-${Math.max(0, this.assistantMessageSequence)}-${index}`;
+      this.ensureItem(id, {
+        type: 'reasoning',
+        id,
+        summary: '',
+        visibility: 'full',
+        status: 'running',
+        startedAt: nowIso(),
+      });
+      if (kind === 'thinking_delta' && typeof delta.delta === 'string')
+        this.emitDelta(id, { summary: delta.delta });
+    } else if (kind === 'toolcall_end') {
+      const toolCall = record(delta.toolCall);
+      const id = string(toolCall.id, `${this.activeTurnId}-tool-${index}`);
+      this.ensureTool(
+        id,
+        string(toolCall.name, 'tool'),
+        toolArguments(toolCall.arguments ?? toolCall.args)
+      );
+    } else if (kind === 'error') {
+      if (delta.reason === 'aborted') this.abortRequested = true;
+      else {
+        this.turnFailure = string(
+          delta.error,
+          string(delta.reason, 'Prime Agent generation error')
+        );
+        this.emitError(this.turnFailure);
+      }
+    }
+  }
+
+  private startTool(event: RpcRecord): void {
+    if (!this.activeTurnId) return;
+    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    this.ensureTool(
+      id,
+      string(event.toolName, 'tool'),
+      toolArguments(event.args)
+    );
+  }
+
+  private ensureTool(id: string, name: string, args: RpcRecord): void {
+    if (!this.activeTurnId || this.items.has(id)) return;
+    let item: AgentItemV2;
+    if (isCommandTool(name))
+      item = {
+        type: 'commandExecution',
+        id,
+        command: string(args.command, JSON.stringify(args)),
+        ...(string(args.cwd) ? { cwd: string(args.cwd) } : {}),
+        output: '',
+        status: 'running',
+        startedAt: nowIso(),
+      };
+    else if (isFileTool(name)) {
+      const path = string(args.path ?? args.file_path, 'unknown');
+      item = {
+        type: 'fileChange',
+        id,
+        paths: [{ path, status: /delete/i.test(name) ? 'deleted' : 'edited' }],
+        applyStatus: 'pending',
+        status: 'running',
+        startedAt: nowIso(),
+      };
+    } else
+      item = {
+        type: 'dynamicToolCall',
+        id,
+        namespace: 'prime-agent',
+        tool: name,
+        arguments: args,
+        status: 'running',
+        startedAt: nowIso(),
+      };
+    this.ensureItem(id, item);
+  }
+
+  private updateTool(event: RpcRecord, result: unknown, done: boolean): void {
+    if (!this.activeTurnId) return;
+    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    this.ensureTool(
+      id,
+      string(event.toolName, 'tool'),
+      toolArguments(event.args)
+    );
+    const item = this.items.get(id);
+    if (!item) return;
+    const text = resultText(result);
+    if (!done) {
+      if (item.type === 'commandExecution')
+        this.emitDelta(id, { output: text }, 'replace');
+      else if (item.type === 'dynamicToolCall')
+        this.emitDelta(id, { content: text }, 'replace');
+      return;
+    }
+    let updated: AgentItemV2;
+    if (item.type === 'commandExecution')
+      updated = {
+        ...item,
+        output: text,
+        exitCode: event.isError === true ? 1 : 0,
+        status: event.isError === true ? 'failed' : 'completed',
+        completedAt: nowIso(),
+      };
+    else if (item.type === 'fileChange')
+      updated = {
+        ...item,
+        applyStatus: event.isError === true ? 'failed' : 'applied',
+        status: event.isError === true ? 'failed' : 'completed',
+        completedAt: nowIso(),
+      };
+    else if (item.type === 'dynamicToolCall')
+      updated = {
+        ...item,
+        result,
+        status: event.isError === true ? 'failed' : 'completed',
+        completedAt: nowIso(),
+      };
+    else return;
+    this.items.set(id, updated);
+    this.emitItemUpdated(updated);
+  }
+
+  private finishMessageItems(
+    status: 'completed' | 'failed' | 'cancelled' = 'completed'
+  ): void {
+    for (const [id, item] of this.items) {
+      if (
+        item.status !== 'running' ||
+        (item.type !== 'assistantMessage' && item.type !== 'reasoning')
+      )
+        continue;
+      const updated: AgentItemV2 = {
+        ...item,
+        status,
+        completedAt: nowIso(),
+        ...(status === 'failed' && this.turnFailure
+          ? { error: this.turnFailure }
+          : {}),
+      };
+      this.items.set(id, updated);
+      this.emitItemUpdated(updated);
+    }
+  }
+
+  private terminalizeRunningItems(
+    status: 'completed' | 'failed' | 'cancelled',
+    error?: string
+  ): void {
+    this.finishMessageItems(status);
+    for (const [id, item] of this.items) {
+      if (item.status !== 'running') continue;
+      let updated: AgentItemV2;
+      if (item.type === 'fileChange')
+        updated = {
+          ...item,
+          status,
+          applyStatus: status === 'completed' ? 'applied' : 'failed',
+          completedAt: nowIso(),
+          ...(error ? { error } : {}),
+        };
+      else
+        updated = {
+          ...item,
+          status,
+          completedAt: nowIso(),
+          ...(error ? { error } : {}),
+        };
+      this.items.set(id, updated);
+      this.emitItemUpdated(updated);
+    }
+  }
+
+  private captureUsage(message: RpcRecord): void {
+    if (message.role !== 'assistant') return;
+    const usage = record(message.usage);
+    const cost = record(usage.cost);
+    const number = (value: unknown): number | undefined =>
+      typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+    const inputTokens = number(usage.input);
+    const outputTokens = number(usage.output);
+    const cacheReadTokens = number(usage.cacheRead);
+    const cacheWriteTokens = number(usage.cacheWrite);
+    const costUsd = number(cost.total);
+    const previous = this.turnUsage ?? {};
+    const add = (
+      prior: number | undefined,
+      next: number | undefined
+    ): number | undefined => (next === undefined ? prior : (prior ?? 0) + next);
+    const accumulatedInput = add(previous.inputTokens, inputTokens);
+    const accumulatedOutput = add(previous.outputTokens, outputTokens);
+    const accumulatedCacheRead = add(previous.cacheReadTokens, cacheReadTokens);
+    const accumulatedCacheWrite = add(
+      previous.cacheWriteTokens,
+      cacheWriteTokens
+    );
+    const accumulatedCost = add(previous.costUsd ?? undefined, costUsd);
+    this.turnUsage = {
+      ...(accumulatedInput !== undefined
+        ? { inputTokens: accumulatedInput }
+        : {}),
+      ...(accumulatedOutput !== undefined
+        ? { outputTokens: accumulatedOutput }
+        : {}),
+      ...(accumulatedCacheRead !== undefined
+        ? { cacheReadTokens: accumulatedCacheRead }
+        : {}),
+      ...(accumulatedCacheWrite !== undefined
+        ? { cacheWriteTokens: accumulatedCacheWrite }
+        : {}),
+      ...(accumulatedCost !== undefined ? { costUsd: accumulatedCost } : {}),
+    };
+  }
+
+  private promoteAcceptedQueuedTurn(): void {
+    if (
+      !this.queuedAdvancePending ||
+      this.activeTurnId ||
+      this.queued.length === 0
+    ) {
+      return;
+    }
+    const next = this.queued[0];
+    if (!next || !this.acceptedQueued.has(next)) return;
+    this.queued.shift();
+    this.acceptedQueued.delete(next);
+    this.queuedAdvancePending = false;
+    this.startTurn(next);
+  }
+
+  private startTurn(input: AgentSendMessageInputV2): void {
+    this.activeTurnId = input.turnId;
+    this.activeStartedMs = Date.now();
+    this.abortRequested = false;
+    this.turnFailure = null;
+    this.assistantMessageSequence = -1;
+    this.turnUsage = undefined;
+    this.items.clear();
+    const timestamp = nowIso();
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sessionId,
+      timestamp,
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `user-${input.turnId}`,
+        items: [],
+        startedAt: timestamp,
+      },
+    });
+    this.ensureItem(`user-${input.turnId}`, {
+      type: 'userMessage',
+      id: `user-${input.turnId}`,
+      text: input.content,
+      status: 'completed',
+      completedAt: timestamp,
+      ...(input.attachments
+        ? {
+            attachments: input.attachments.map((attachment) => ({
+              type: attachment.type,
+              path: attachment.path,
+              mimeType: attachment.mimeType,
+            })),
+          }
+        : {}),
+    });
+    this.emitLive({
+      status: 'working',
+      activeTurnId: input.turnId,
+      queueLength: this.queued.length,
+    });
+  }
+
+  private completeTurn(
+    status: 'completed' | 'interrupted' | 'failed',
+    error?: string
+  ): void {
+    const turnId = this.activeTurnId;
+    if (!turnId) return;
+    this.terminalizeRunningItems(
+      status === 'completed'
+        ? 'completed'
+        : status === 'interrupted'
+          ? 'cancelled'
+          : 'failed',
+      error
+    );
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId,
+      status,
+      completedAt: nowIso(),
+      durationMs: Date.now() - this.activeStartedMs,
+      ...(this.turnUsage ? { usage: this.turnUsage } : {}),
+      ...(error ? { error } : {}),
+    });
+    this.activeTurnId = null;
+    this.items.clear();
+    this.abortRequested = false;
+    this.turnFailure = null;
+    this.turnUsage = undefined;
+    this.emitLive({
+      status: this.queued.length ? 'working' : 'idle',
+      activeTurnId: null,
+      queueLength: this.queued.length,
+      error: error ?? null,
+    });
+  }
+
+  private ensureItem(id: string, item: AgentItemV2): void {
+    if (this.items.has(id) || !this.activeTurnId) return;
+    this.items.set(id, item);
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId: this.activeTurnId,
+      item,
+    });
+  }
+  private emitDelta(
+    id: string,
+    delta: {
+      text?: string;
+      summary?: string;
+      output?: string;
+      content?: string;
+    },
+    mode?: 'replace'
+  ): void {
+    if (!this.activeTurnId) return;
+    const item = this.items.get(id);
+    if (item && mode !== 'replace') {
+      if (item.type === 'assistantMessage' && delta.text)
+        item.text += delta.text;
+      if (item.type === 'reasoning' && delta.summary)
+        item.summary += delta.summary;
+    }
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId: this.activeTurnId,
+      itemId: id,
+      ...(mode ? { mode } : {}),
+      delta,
+    });
+  }
+  private emitItemUpdated(item: AgentItemV2): void {
+    if (this.activeTurnId)
+      this.emitPatch({
+        type: 'agent-item-updated-v2',
+        sessionId: this.sessionId,
+        timestamp: nowIso(),
+        turnId: this.activeTurnId,
+        item,
+      });
+  }
+  private emitError(message: string): void {
+    this.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      message,
+      ...(this.activeTurnId ? { turnId: this.activeTurnId } : {}),
+    });
+  }
+  private emitLive(live: Partial<AgentSessionLiveStateV2>): void {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      live,
+    });
+  }
+
+  private applyState(data: RpcRecord): void {
+    this.providerSessionId = string(data.sessionId) || this.providerSessionId;
+    this.providerSessionFile =
+      string(data.sessionFile) || this.providerSessionFile;
+  }
+  private emitSnapshot(): void {
+    if (!this.config) return;
+    this.emitPatch({
+      type: 'agent-session-snapshot-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      session: emptyAgentSessionV2({
+        id: this.sessionId,
+        provider: 'prime-agent',
+        cwd: this.config.cwd,
+        capabilities: this.capabilities,
+        providerSession: this.providerSession,
+      }),
+    });
+  }
+  private get providerSession(): Record<string, string> {
+    return {
+      ...(this.providerSessionId
+        ? { primeAgentSessionId: this.providerSessionId }
+        : {}),
+      ...(this.providerSessionFile
+        ? { primeAgentSessionFile: this.providerSessionFile }
+        : {}),
+    };
+  }
+  private get sessionId(): string {
+    return this.config?.sessionId ?? 'prime-agent';
+  }
+  private requireClient(): PrimeAgentRpcClient {
+    if (this._status !== 'connected' || !this.client)
+      throw new Error('Prime Agent adapter is not connected');
+    return this.client;
+  }
+  private handleTransportClose(error: Error): void {
+    if (this._status === 'disconnected') return;
+    if (this.activeTurnId) this.completeTurn('failed', error.message);
+    this.queued.length = 0;
+    this.acceptedQueued.clear();
+    this.queuedAdvancePending = false;
+    this._status = 'disconnected';
+    this.emitError(error.message);
+    this.emitLive({
+      status: 'disconnected',
+      activeTurnId: null,
+      queueLength: 0,
+      error: error.message,
+    });
+  }
+  private readImages(
+    attachments: AgentSendMessageInputV2['attachments'] = []
+  ): RpcRecord[] {
+    const images: RpcRecord[] = [];
+    for (const attachment of attachments) {
+      if (attachment.type !== 'image') continue;
+      try {
+        images.push({
+          type: 'image',
+          data: fs.readFileSync(attachment.path).toString('base64'),
+          mimeType: attachment.mimeType,
+        });
+      } catch (error) {
+        throw new Error(
+          `Cannot read Prime Agent image attachment ${attachment.path}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error }
+        );
+      }
+    }
+    return images;
+  }
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -49,7 +49,12 @@ export type BackendDisplayState =
  */
 export type SessionType = 'terminal';
 export type AgentType = string;
-export type BuiltinFrameworkId = 'claude' | 'codex' | 'opencode' | 'hermes';
+export type BuiltinFrameworkId =
+  | 'claude'
+  | 'codex'
+  | 'opencode'
+  | 'hermes'
+  | 'prime-agent';
 export type EventSourceType = 'hooks' | 'plugin' | 'parser' | 'timer';
 export type ContinuePolicy = 'always' | 'never';
 export type BranchLifecycleState = 'active' | 'stale' | 'merged';
@@ -179,6 +184,25 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
+      supportsChannelAgents: true,
+    },
+  },
+  'prime-agent': {
+    id: 'prime-agent',
+    displayName: 'Prime Agent',
+    command: 'prime-agent',
+    // The terminal surface remains a generic PTY. Channel conversations use
+    // Prime Agent's native RPC adapter rather than terminal-output parsing.
+    continueArgs: ['--continue'],
+    yoloArgs: [],
+    parserType: 'generic',
+    eventSource: 'timer',
+    capabilities: {
+      supportsHooks: false,
+      supportsContinue: true,
+      supportsYolo: false,
+      supportsTelemetry: true,
+      supportsAttachedRuntime: false,
       supportsChannelAgents: true,
     },
   },

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -5,6 +5,7 @@ export type AgentProviderV2 =
   | 'codex'
   | 'opencode'
   | 'hermes'
+  | 'prime-agent'
   | 'mock'
   | (string & {});
 

--- a/shared/agent-profile.ts
+++ b/shared/agent-profile.ts
@@ -48,7 +48,7 @@ export interface AgentProfile {
    * `builtInAgentProfileId(providerId)`.
    */
   id: string;
-  /** Framework catalog key (`AgentFramework.id`): claude/codex/opencode/hermes/custom. */
+  /** Framework catalog key (`AgentFramework.id`): claude/codex/opencode/hermes/prime-agent/custom. */
   providerId: string;
   /**
    * Free-form, possibly multi-word display name. EMPTY ('') on a built-in

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -413,6 +413,7 @@ const BUILTIN_PROVIDER_IDS = new Set([
   'codex',
   'opencode',
   'hermes',
+  'prime-agent',
   'terminal',
 ]);
 

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -517,6 +517,27 @@ describe('ChannelAgentRuntimeManager', () => {
     expect(adapterState.last?.resumed).toEqual([]);
   });
 
+  it('passes Prime Agent provider identity as an atomic resume id', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    adapterState.resumeDuringConnect = true;
+
+    await channelAgentRuntimes.create({
+      id: 'prime-runtime',
+      providerId: 'prime-agent',
+      profileActorId: 'agent-profile:prime-agent:default',
+      cwd: '/tmp',
+      displayName: '#eng · Prime Agent',
+      port: 3456,
+      configDir: '/tmp',
+      providerSession: { primeAgentSessionId: 'prime-session-1' },
+    });
+
+    expect(adapterState.last?.connectConfigs).toEqual([
+      expect.objectContaining({ resumeSessionId: 'prime-session-1' }),
+    ]);
+    expect(adapterState.last?.resumed).toEqual([]);
+  });
+
   it('captures provider identity and rejects duplicate runtime ids', async () => {
     const { channelAgentRuntimes } = await runtimeModule();
     const runtime = await channelAgentRuntimes.create({

--- a/test/framework-types.test.ts
+++ b/test/framework-types.test.ts
@@ -10,11 +10,12 @@ import type { AgentFramework, EventSourceType } from '../server/types.js';
 
 // ── BUILTIN_FRAMEWORKS structure ──
 
-test('BUILTIN_FRAMEWORKS contains claude, codex, opencode, and hermes', () => {
+test('BUILTIN_FRAMEWORKS contains all first-class providers', () => {
   expect('claude' in BUILTIN_FRAMEWORKS).toBeTruthy();
   expect('codex' in BUILTIN_FRAMEWORKS).toBeTruthy();
   expect('opencode' in BUILTIN_FRAMEWORKS).toBeTruthy();
   expect('hermes' in BUILTIN_FRAMEWORKS).toBeTruthy();
+  expect('prime-agent' in BUILTIN_FRAMEWORKS).toBeTruthy();
 });
 
 test('claude framework has correct values', () => {
@@ -95,6 +96,25 @@ test('hermes framework has correct values', () => {
   expect(hermes.capabilities.supportsTelemetry).toBe(true);
   expect(hermes.capabilities.supportsAttachedRuntime).toBe(true);
   expect(hermes.capabilities.supportsChannelAgents).toBe(true);
+});
+
+test('prime-agent framework exposes native channels and a generic PTY', () => {
+  const prime = BUILTIN_FRAMEWORKS['prime-agent'];
+  expect(prime.id).toBe('prime-agent');
+  expect(prime.displayName).toBe('Prime Agent');
+  expect(prime.command).toBe('prime-agent');
+  expect(prime.continueArgs).toEqual(['--continue']);
+  expect(prime.yoloArgs).toEqual([]);
+  expect(prime.parserType).toBe('generic');
+  expect(prime.eventSource).toBe('timer');
+  expect(prime.capabilities).toMatchObject({
+    supportsHooks: false,
+    supportsContinue: true,
+    supportsYolo: false,
+    supportsTelemetry: true,
+    supportsAttachedRuntime: false,
+    supportsChannelAgents: true,
+  });
 });
 
 test('opencode yoloEnv contains OPENCODE_CONFIG_CONTENT with permission JSON', () => {

--- a/test/frameworks-api.test.ts
+++ b/test/frameworks-api.test.ts
@@ -26,6 +26,9 @@ beforeAll(async () => {
   const fakeHermes = path.join(fakeBinDir, 'hermes');
   fs.writeFileSync(fakeHermes, '#!/bin/sh\nexit 0\n');
   fs.chmodSync(fakeHermes, 0o755);
+  const fakePrimeAgent = path.join(fakeBinDir, 'prime-agent');
+  fs.writeFileSync(fakePrimeAgent, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(fakePrimeAgent, 0o755);
 
   const hermesProbeApp = express();
   hermesProbeApp.get('/health', (_req, res) => {
@@ -85,6 +88,7 @@ describe('GET /api/frameworks', () => {
     expect(ids).toContain('codex');
     expect(ids).toContain('opencode');
     expect(ids).toContain('hermes');
+    expect(ids).toContain('prime-agent');
   });
 
   it('each framework entry has id, displayName, command, capabilities, eventSource, and availability', async () => {
@@ -138,6 +142,31 @@ describe('GET /api/frameworks', () => {
     expect(claude!.eventSource).toBe('hooks');
     expect(claude!.capabilities.supportsHooks).toBe(true);
     expect(claude!.capabilities.supportsTelemetry).toBe(true);
+  });
+
+  it('returns Prime Agent as an installed first-class channel provider', async () => {
+    const res = await fetch(url('/api/frameworks'));
+    const body = (await res.json()) as {
+      frameworks: Array<{
+        id: string;
+        displayName: string;
+        command: string;
+        eventSource: string;
+        capabilities: Record<string, boolean>;
+        availability?: { installed: boolean; path?: string };
+      }>;
+    };
+    const prime = body.frameworks.find((f) => f.id === 'prime-agent');
+    expect(prime).toMatchObject({
+      displayName: 'Prime Agent',
+      command: 'prime-agent',
+      eventSource: 'timer',
+    });
+    expect(prime!.capabilities.supportsChannelAgents).toBe(true);
+    expect(prime!.availability).toEqual({
+      installed: true,
+      path: path.join(fakeBinDir, 'prime-agent'),
+    });
   });
 
   it('opencode framework entry has eventSource=plugin', async () => {

--- a/test/lib/chat/sender-identity.test.ts
+++ b/test/lib/chat/sender-identity.test.ts
@@ -36,6 +36,7 @@ describe('resolveSenderIdentity', () => {
     ['codex', 'var(--sender-codex)'],
     ['hermes', 'var(--sender-hermes)'],
     ['opencode', 'var(--sender-opencode)'],
+    ['prime-agent', 'var(--sender-prime-agent)'],
   ] as const)(
     'keeps the curated vendor token + glyph for the %s DEFAULT profile',
     (providerId, colorVar) => {
@@ -123,6 +124,7 @@ describe('resolveSenderIdentity', () => {
     ['codex', 'var(--sender-codex)'],
     ['hermes', 'var(--sender-hermes)'],
     ['opencode', 'var(--sender-opencode)'],
+    ['prime-agent', 'var(--sender-prime-agent)'],
   ] as const)(
     'heals a legacy agent:%s row to the curated vendor token + glyph',
     (providerId, colorVar) => {

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -12,7 +12,9 @@ import {
   type ProcessInfo,
 } from '../server/process-tree.js';
 
-function proc(overrides: Partial<ProcessInfo> & Pick<ProcessInfo, 'pid' | 'ppid' | 'pgid'>): ProcessInfo {
+function proc(
+  overrides: Partial<ProcessInfo> & Pick<ProcessInfo, 'pid' | 'ppid' | 'pgid'>
+): ProcessInfo {
   return {
     command: 'node',
     commandLine: 'node',
@@ -39,10 +41,16 @@ function writeFakeProc(
     `${options.pid} (${options.command}) S ${options.ppid} ${options.pgid} 1 0 0 0 0 0 0 0 0 0 0 0 20 0 1 0 100`
   );
   writeFileSync(`${procDir}/cmdline`, `${options.cmdlineArgs.join('\0')}\0`);
-  writeFileSync(`${procDir}/status`, `Name:\t${options.command}\nVmRSS:\t${options.rssKb ?? 0} kB\n`);
+  writeFileSync(
+    `${procDir}/status`,
+    `Name:\t${options.command}\nVmRSS:\t${options.rssKb ?? 0} kB\n`
+  );
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 4_000): Promise<void> {
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 4_000
+): Promise<void> {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
     if (predicate()) return;
@@ -54,7 +62,12 @@ async function waitFor(predicate: () => boolean, timeoutMs = 4_000): Promise<voi
 describe('process-tree session runtime reaping', () => {
   it('summarizes descendant language servers before session kill', () => {
     const table: ProcessInfo[] = [
-      proc({ pid: 100, ppid: 1, pgid: 100, commandLine: 'node relay-ide workspace host' }),
+      proc({
+        pid: 100,
+        ppid: 1,
+        pgid: 100,
+        commandLine: 'node relay-ide workspace host',
+      }),
       proc({
         pid: 101,
         ppid: 100,
@@ -84,8 +97,18 @@ describe('process-tree session runtime reaping', () => {
   it('signals process group and descendants for explicit session teardown', () => {
     const calls: Array<{ pid: number; signal: NodeJS.Signals }> = [];
     const table: ProcessInfo[] = [
-      proc({ pid: 200, ppid: 1, pgid: 200, commandLine: 'node relay-ide workspace host' }),
-      proc({ pid: 201, ppid: 200, pgid: 200, commandLine: 'typescript-language-server --stdio' }),
+      proc({
+        pid: 200,
+        ppid: 1,
+        pgid: 200,
+        commandLine: 'node relay-ide workspace host',
+      }),
+      proc({
+        pid: 201,
+        ppid: 200,
+        pgid: 200,
+        commandLine: 'typescript-language-server --stdio',
+      }),
     ];
 
     scheduleRelayProcessTreeReap({
@@ -102,6 +125,40 @@ describe('process-tree session runtime reaping', () => {
       { pid: 201, signal: 'SIGTERM' },
       { pid: 200, signal: 'SIGTERM' },
     ]);
+  });
+
+  it('recognizes Prime Agent ancestors as Relay-owned language-server runtimes', () => {
+    const procRoot = mkdtempSync(`${tmpdir()}/relay-proc-`);
+    try {
+      writeFileSync(`${procRoot}/uptime`, '1000 0');
+      writeFakeProc(procRoot, {
+        pid: 250,
+        ppid: 1,
+        pgid: 250,
+        command: 'prime-agent',
+        cmdlineArgs: ['prime-agent'],
+      });
+      writeFakeProc(procRoot, {
+        pid: 251,
+        ppid: 250,
+        pgid: 250,
+        command: 'node',
+        cmdlineArgs: ['node', '/typescript/lib/tsserver.js'],
+      });
+
+      const diagnostics = collectLanguageServerDiagnostics({
+        procRoot,
+        uptimeSeconds: 1000,
+        clockTickHz: 100,
+      });
+
+      expect(diagnostics.processes[0]?.relayOwnedLikely).toBe(true);
+      expect(diagnostics.processes[0]?.ancestors[0]?.commandLine).toBe(
+        'prime-agent'
+      );
+    } finally {
+      rmSync(procRoot, { recursive: true, force: true });
+    }
   });
 
   it('redacts likely secrets from language-server diagnostics', () => {
@@ -122,10 +179,14 @@ describe('process-tree session runtime reaping', () => {
       redactCommandLine('node relay-ide --token="my secret value" --safe flag')
     ).toBe('node relay-ide --token=[REDACTED] --safe flag');
     expect(
-      redactCommandLine("node relay-ide GITHUB_TOKEN='ghp secret value' --safe flag")
+      redactCommandLine(
+        "node relay-ide GITHUB_TOKEN='ghp secret value' --safe flag"
+      )
     ).toBe('node relay-ide GITHUB_TOKEN=[REDACTED] --safe flag');
     expect(
-      redactCommandLine("node relay-ide GITHUB_TOKEN=*** secret value' --safe flag")
+      redactCommandLine(
+        "node relay-ide GITHUB_TOKEN=*** secret value' --safe flag"
+      )
     ).toBe('node relay-ide GITHUB_TOKEN=[REDACTED] --safe flag');
     expect(redactCommandLine('Authorization Bearer "abc 123" next')).toBe(
       'Authorization Bearer [REDACTED] next'
@@ -246,18 +307,28 @@ describe('process-tree session runtime reaping', () => {
 
     try {
       await waitFor(() => childPid !== undefined);
-      const baseline = readProcessTable().filter((p) => p.languageServerKind).length;
+      const baseline = readProcessTable().filter(
+        (p) => p.languageServerKind
+      ).length;
       await waitFor(() =>
-        readProcessTable().some((p) => p.pid === childPid && p.languageServerKind === 'tsserver')
+        readProcessTable().some(
+          (p) => p.pid === childPid && p.languageServerKind === 'tsserver'
+        )
       );
 
-      scheduleRelayProcessTreeReap({ rootPids: [parentPid], killDelayMs: 50, logger: {} });
+      scheduleRelayProcessTreeReap({
+        rootPids: [parentPid],
+        killDelayMs: 50,
+        logger: {},
+      });
 
       await waitFor(() => {
         const table = readProcessTable();
         return !table.some((p) => p.pid === parentPid || p.pid === childPid);
       });
-      const after = readProcessTable().filter((p) => p.languageServerKind).length;
+      const after = readProcessTable().filter(
+        (p) => p.languageServerKind
+      ).length;
       expect(after).toBeLessThanOrEqual(baseline);
     } finally {
       try {

--- a/test/server/prime-agent-rpc-client.test.ts
+++ b/test/server/prime-agent-rpc-client.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
+import { PrimeAgentRpcClient } from '../../server/prime-agent-rpc-client.js';
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+describe('PrimeAgentRpcClient', () => {
+  it('uses get_state as a correlated readiness barrier', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    let outbound = '';
+    child.stdin.on('data', (chunk) => {
+      outbound += String(chunk);
+      const line = outbound.split('\n')[0];
+      if (line) {
+        const request = JSON.parse(line) as { id: string; type: string };
+        child.stdout.write(
+          JSON.stringify({
+            id: request.id,
+            type: 'response',
+            command: request.type,
+            success: true,
+            data: { sessionId: 's1' },
+          }) + '\n'
+        );
+      }
+    });
+    const ready = await client.start();
+    expect(JSON.parse(outbound.trim())).toMatchObject({ type: 'get_state' });
+    expect(ready.data).toEqual({ sessionId: 's1' });
+  });
+
+  it('splits on LF only and preserves Unicode line separators inside JSON', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        `{"id":"${request.id}","type":"response","command":"get_state","success":true}\r\n`
+      );
+    });
+    await client.start();
+    const events: unknown[] = [];
+    client.on('event', (event) => events.push(event));
+    child.stdout.write('{"type":"message_update","text":"a\u2028b\u2029c"}\n');
+    expect(events).toEqual([
+      { type: 'message_update', text: 'a\u2028b\u2029c' },
+    ]);
+  });
+
+  it('rejects failed and mismatched correlated responses', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.on('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string; type: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: request.type,
+          success: request.type === 'get_state',
+          error: 'nope',
+        }) + '\n'
+      );
+    });
+    await client.start();
+    await expect(client.call('prompt', { message: 'x' })).rejects.toThrow(
+      'nope'
+    );
+  });
+
+  it('bounds unterminated input and oversized records without killing the transport', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+      maxBufferBytes: 32,
+      maxRecordBytes: 100,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    const errors: Error[] = [];
+    client.on('protocolError', (error) => errors.push(error));
+    child.stdout.write('x'.repeat(33));
+    child.stdout.write(
+      JSON.stringify({ type: 'event', text: 'y'.repeat(120) }) + '\n'
+    );
+    expect(errors.map((error) => error.message)).toEqual([
+      expect.stringContaining('input buffer exceeded'),
+      expect.stringContaining('record exceeded'),
+    ]);
+  });
+
+  it('times out readiness when get_state never responds', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+      readinessTimeoutMs: 5,
+    });
+    await expect(client.start()).rejects.toThrow('get_state timed out');
+  });
+
+  it('times out correlated commands independently', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+      requestTimeoutMs: 5,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    await expect(client.call('prompt', { message: 'wait' })).rejects.toThrow(
+      'prompt timed out'
+    );
+  });
+});

--- a/test/server/prime-agent-rpc-client.test.ts
+++ b/test/server/prime-agent-rpc-client.test.ts
@@ -66,6 +66,37 @@ describe('PrimeAgentRpcClient', () => {
     ]);
   });
 
+  it('decodes UTF-8 characters split across stdout chunks', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    const events: unknown[] = [];
+    client.on('event', (event) => events.push(event));
+    const record = Buffer.from(
+      JSON.stringify({ type: 'message_update', text: 'before 😀 after' }) + '\n'
+    );
+    const emoji = Buffer.from('😀');
+    const splitAt = record.indexOf(emoji) + 2;
+    child.stdout.write(record.subarray(0, splitAt));
+    child.stdout.write(record.subarray(splitAt));
+    expect(events).toEqual([
+      { type: 'message_update', text: 'before 😀 after' },
+    ]);
+  });
+
   it('rejects failed and mismatched correlated responses', async () => {
     const child = fakeChild();
     const client = new PrimeAgentRpcClient({
@@ -89,12 +120,13 @@ describe('PrimeAgentRpcClient', () => {
     );
   });
 
-  it('bounds unterminated input and oversized records without killing the transport', async () => {
+  it('bounds oversized records and a trailing unterminated tail', async () => {
     const child = fakeChild();
     const client = new PrimeAgentRpcClient({
       spawn: () => child as unknown as ChildProcess,
       maxBufferBytes: 32,
       maxRecordBytes: 100,
+      stopTimeoutMs: 5,
     });
     child.stdin.once('data', (chunk) => {
       const request = JSON.parse(String(chunk)) as { id: string };
@@ -109,15 +141,60 @@ describe('PrimeAgentRpcClient', () => {
     });
     await client.start();
     const errors: Error[] = [];
+    const events: unknown[] = [];
     client.on('protocolError', (error) => errors.push(error));
-    child.stdout.write('x'.repeat(33));
+    client.on('event', (event) => events.push(event));
     child.stdout.write(
       JSON.stringify({ type: 'event', text: 'y'.repeat(120) }) + '\n'
     );
+    child.stdout.write(
+      JSON.stringify({ type: 'event', accepted: true }) + '\n' + 'x'.repeat(33)
+    );
+    expect(events).toEqual([{ type: 'event', accepted: true }]);
     expect(errors.map((error) => error.message)).toEqual([
-      expect.stringContaining('input buffer exceeded'),
       expect.stringContaining('record exceeded'),
+      expect.stringContaining('input buffer exceeded'),
     ]);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', 0);
+  });
+
+  it('awaits close and escalates stop to SIGKILL after a bounded delay', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      const client = new PrimeAgentRpcClient({
+        spawn: () => child as unknown as ChildProcess,
+        stopTimeoutMs: 10,
+      });
+      child.stdin.once('data', (chunk) => {
+        const request = JSON.parse(String(chunk)) as { id: string };
+        child.stdout.write(
+          JSON.stringify({
+            id: request.id,
+            type: 'response',
+            command: 'get_state',
+            success: true,
+          }) + '\n'
+        );
+      });
+      await client.start();
+
+      let stopped = false;
+      const stopping = client.stop().then(() => {
+        stopped = true;
+      });
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(stopped).toBe(false);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(stopped).toBe(false);
+      child.emit('close', 0);
+      await stopping;
+      expect(stopped).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('times out readiness when get_state never responds', async () => {

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -1,0 +1,463 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PrimeAgentRpcClient } from '../../../server/prime-agent-rpc-client.js';
+import { PrimeAgentProtocolAdapter } from '../../../server/protocol-adapters/prime-agent-adapter.js';
+
+const config = {
+  cwd: '/tmp',
+  port: 1,
+  sessionId: 'relay-session',
+  hookToken: 'x',
+  configDir: '/tmp',
+};
+
+function harness() {
+  const client = new PrimeAgentRpcClient();
+  vi.spyOn(client, 'start').mockResolvedValue({
+    type: 'response',
+    command: 'get_state',
+    success: true,
+    data: {
+      sessionId: 'prime-1',
+      sessionFile: '/tmp/prime-1.jsonl',
+      isStreaming: false,
+    },
+  });
+  const call = vi
+    .spyOn(client, 'call')
+    .mockResolvedValue({ type: 'response', command: 'prompt', success: true });
+  vi.spyOn(client, 'stop').mockResolvedValue();
+  const adapter = new PrimeAgentProtocolAdapter(() => client);
+  const patches: Array<Record<string, unknown>> = [];
+  adapter.onPatch((patch) =>
+    patches.push(patch as unknown as Record<string, unknown>)
+  );
+  return { adapter, client, call, patches };
+}
+
+describe('PrimeAgentProtocolAdapter', () => {
+  it('publishes honest capabilities and provider session identity after get_state', async () => {
+    const { adapter, patches } = harness();
+    await adapter.connect(config);
+    expect(adapter.agentType).toBe('prime-agent');
+    expect(adapter.capabilities).toMatchObject({
+      text: true,
+      queue: true,
+      interrupt: true,
+      resume: true,
+      approvals: false,
+      questions: false,
+      compact: false,
+      telemetry: true,
+    });
+    const snapshot = patches.find(
+      (patch) => patch.type === 'agent-session-snapshot-v2'
+    );
+    expect(snapshot?.session).toMatchObject({
+      provider: 'prime-agent',
+      providerSession: {
+        primeAgentSessionId: 'prime-1',
+        primeAgentSessionFile: '/tmp/prime-1.jsonl',
+      },
+    });
+  });
+
+  it('maps streaming text, thinking, and command tools to V2 patches', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'hello' });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'answer',
+      },
+    });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'thinking_delta',
+        contentIndex: 1,
+        delta: 'thought',
+      },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: '/tmp' }] },
+      isError: false,
+    });
+    client.emit('event', {
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        usage: {
+          input: 10,
+          output: 4,
+          cacheRead: 2,
+          cacheWrite: 1,
+          cost: { total: 0.25 },
+        },
+      },
+    });
+    client.emit('event', { type: 'agent_end' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          itemId: 't1-assistant-0-0',
+          delta: { text: 'answer' },
+        }),
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          itemId: 't1-reasoning-0-1',
+          delta: { summary: 'thought' },
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't1',
+          status: 'completed',
+          usage: {
+            inputTokens: 10,
+            outputTokens: 4,
+            cacheReadTokens: 2,
+            cacheWriteTokens: 1,
+            costUsd: 0.25,
+          },
+        }),
+      ])
+    );
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { type?: string }).type === 'commandExecution'
+      )
+    ).toBe(true);
+  });
+
+  it('uses steer while active and abort for interrupt', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+    await adapter.interrupt({ turnId: 't1' });
+    expect(call.mock.calls.map(([type]) => type)).toEqual([
+      'set_steering_mode',
+      'prompt',
+      'steer',
+      'abort',
+    ]);
+  });
+
+  it('advances multiple accepted steer turns at agent_end boundaries', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+    await adapter.sendMessage({ turnId: 't3', content: 'three' });
+    client.emit('event', { type: 'agent_end' });
+    client.emit('event', { type: 'agent_start' });
+    client.emit('event', { type: 'turn_start' });
+    client.emit('event', { type: 'agent_end' });
+    client.emit('event', { type: 'agent_start' });
+    client.emit('event', { type: 'agent_end' });
+    expect(
+      patches
+        .filter((patch) => patch.type === 'agent-turn-started-v2')
+        .map((patch) => (patch.turn as { id: string }).id)
+    ).toEqual(['t1', 't2', 't3']);
+    expect(
+      patches
+        .filter((patch) => patch.type === 'agent-turn-completed-v2')
+        .map((patch) => patch.turnId)
+    ).toEqual(['t1', 't2', 't3']);
+  });
+
+  it('does not promote a steer turn before its acknowledgement', async () => {
+    const { adapter, client, call, patches } = harness();
+    let rejectSteer: ((error: Error) => void) | undefined;
+    call.mockImplementation(async (type) => {
+      if (type === 'steer') {
+        return new Promise((_, reject) => {
+          rejectSteer = reject;
+        });
+      }
+      return { type: 'response', command: type, success: true };
+    });
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    const queued = adapter.sendMessage({ turnId: 't2', content: 'two' });
+    const rejected = expect(queued).rejects.toThrow('steer rejected');
+
+    client.emit('event', { type: 'agent_end' });
+    expect(
+      patches
+        .filter((patch) => patch.type === 'agent-turn-started-v2')
+        .map((patch) => (patch.turn as { id: string }).id)
+    ).toEqual(['t1']);
+
+    rejectSteer?.(new Error('steer rejected'));
+    await rejected;
+    expect(adapter.status).toBe('disconnected');
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-turn-started-v2' &&
+          (patch.turn as { id: string }).id === 't2'
+      )
+    ).toBe(false);
+  });
+
+  it('fails closed on protocol corruption and unexpected close', async () => {
+    const corrupted = harness();
+    await corrupted.adapter.connect(config);
+    corrupted.client.emit('protocolError', new Error('bad record'));
+    expect(corrupted.adapter.status).toBe('disconnected');
+    expect(corrupted.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-live-state-updated-v2',
+          live: expect.objectContaining({ status: 'disconnected' }),
+        }),
+      ])
+    );
+
+    const closed = harness();
+    await closed.adapter.connect(config);
+    await closed.adapter.sendMessage({ turnId: 't1', content: 'one' });
+    closed.client.emit('close', 1);
+    expect(closed.adapter.status).toBe('disconnected');
+    expect(closed.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't1',
+          status: 'failed',
+        }),
+        expect.objectContaining({
+          type: 'agent-live-state-updated-v2',
+          live: expect.objectContaining({ status: 'disconnected' }),
+        }),
+      ])
+    );
+  });
+
+  it('rejects unreadable image attachments explicitly', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    await expect(
+      adapter.sendMessage({
+        turnId: 't1',
+        content: 'image',
+        attachments: [
+          {
+            type: 'image',
+            path: '/definitely/missing.png',
+            mimeType: 'image/png',
+          },
+        ],
+      })
+    ).rejects.toThrow('Cannot read Prime Agent image attachment');
+    expect(call.mock.calls.map(([type]) => type)).toEqual([
+      'set_steering_mode',
+    ]);
+  });
+
+  it('disables extensions until extension UI requests are mapped', async () => {
+    const client = new PrimeAgentRpcClient();
+    vi.spyOn(client, 'start').mockResolvedValue({
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: {},
+    });
+    vi.spyOn(client, 'call').mockResolvedValue({
+      type: 'response',
+      command: 'set_steering_mode',
+      success: true,
+    });
+    vi.spyOn(client, 'stop').mockResolvedValue();
+    let args: string[] | undefined;
+    const adapter = new PrimeAgentProtocolAdapter((options) => {
+      args = options.args;
+      return client;
+    });
+    await adapter.connect({
+      ...config,
+      model: 'gpt-5.6-sol',
+      extra: { provider: 'openai-codex', effort: 'high' },
+    });
+    expect(args).toEqual([
+      '--mode',
+      'rpc',
+      '--no-extensions',
+      '--provider',
+      'openai-codex',
+      '--model',
+      'gpt-5.6-sol',
+      '--thinking',
+      'high',
+    ]);
+  });
+
+  it('uses unique assistant ids across a tool-loop second assistant message', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'loop' });
+    client.emit('event', {
+      type: 'message_start',
+      message: { role: 'assistant' },
+    });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'first',
+      },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'tool-loop',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolCallId: 'tool-loop',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: '/tmp' }] },
+      isError: false,
+    });
+    client.emit('event', {
+      type: 'message_start',
+      message: { role: 'assistant' },
+    });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'second',
+      },
+    });
+    client.emit('event', { type: 'agent_end' });
+    const assistantIds = patches
+      .filter(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { type: string }).type === 'assistantMessage'
+      )
+      .map((patch) => (patch.item as { id: string }).id);
+    expect(assistantIds).toEqual(['t1-assistant-0-0', 't1-assistant-1-0']);
+  });
+
+  it('fails generation errors and terminalizes running tools; abort cancels them', async () => {
+    const failed = harness();
+    await failed.adapter.connect(config);
+    await failed.adapter.sendMessage({ turnId: 'failed', content: 'fail' });
+    failed.client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'running-tool',
+      toolName: 'bash',
+      args: { command: 'sleep 1' },
+    });
+    failed.client.emit('event', {
+      type: 'auto_retry_end',
+      success: false,
+      finalError: 'quota exhausted',
+    });
+    failed.client.emit('event', { type: 'agent_end' });
+    expect(failed.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            id: 'running-tool',
+            status: 'failed',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'failed',
+          status: 'failed',
+          error: 'quota exhausted',
+        }),
+      ])
+    );
+
+    const aborted = harness();
+    await aborted.adapter.connect(config);
+    await aborted.adapter.sendMessage({ turnId: 'aborted', content: 'abort' });
+    aborted.client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'abort-tool',
+      toolName: 'bash',
+      args: { command: 'sleep 1' },
+    });
+    await aborted.adapter.interrupt({ turnId: 'aborted' });
+    aborted.client.emit('event', { type: 'agent_end' });
+    expect(aborted.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            id: 'abort-tool',
+            status: 'cancelled',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'aborted',
+          status: 'interrupted',
+        }),
+      ])
+    );
+  });
+
+  it('ignores stale old-client close after reconnect and keeps patch listeners', async () => {
+    const clients = [new PrimeAgentRpcClient(), new PrimeAgentRpcClient()];
+    for (const client of clients) {
+      vi.spyOn(client, 'start').mockResolvedValue({
+        type: 'response',
+        command: 'get_state',
+        success: true,
+        data: { sessionId: 'prime' },
+      });
+      vi.spyOn(client, 'stop').mockResolvedValue();
+      vi.spyOn(client, 'call').mockResolvedValue({
+        type: 'response',
+        command: 'prompt',
+        success: true,
+      });
+    }
+    let index = 0;
+    const adapter = new PrimeAgentProtocolAdapter(() => clients[index++]!);
+    const patches: Array<Record<string, unknown>> = [];
+    adapter.onPatch((patch) =>
+      patches.push(patch as unknown as Record<string, unknown>)
+    );
+    await adapter.connect(config);
+    await adapter.reconnect();
+    clients[0]!.emit('close', 1);
+    expect(adapter.status).toBe('connected');
+    await adapter.sendMessage({ turnId: 'after-reconnect', content: 'alive' });
+    clients[1]!.emit('event', { type: 'agent_end' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'after-reconnect',
+        }),
+      ])
+    );
+  });
+});

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { PrimeAgentRpcClient } from '../../../server/prime-agent-rpc-client.js';
 import { PrimeAgentProtocolAdapter } from '../../../server/protocol-adapters/prime-agent-adapter.js';
@@ -46,7 +49,7 @@ describe('PrimeAgentProtocolAdapter', () => {
       resume: true,
       approvals: false,
       questions: false,
-      compact: false,
+      compact: true,
       telemetry: true,
     });
     const snapshot = patches.find(
@@ -143,77 +146,82 @@ describe('PrimeAgentProtocolAdapter', () => {
     ).toBe(true);
   });
 
-  it('uses steer while active and abort for interrupt', async () => {
+  it('queues locally while active and uses abort for interrupt', async () => {
     const { adapter, call } = harness();
     await adapter.connect(config);
     await adapter.sendMessage({ turnId: 't1', content: 'one' });
     await adapter.sendMessage({ turnId: 't2', content: 'two' });
     await adapter.interrupt({ turnId: 't1' });
-    expect(call.mock.calls.map(([type]) => type)).toEqual([
-      'set_steering_mode',
-      'prompt',
-      'steer',
-      'abort',
-    ]);
+    expect(call.mock.calls.map(([type]) => type)).toEqual(['prompt', 'abort']);
   });
 
-  it('advances multiple accepted steer turns at agent_end boundaries', async () => {
-    const { adapter, client, patches } = harness();
+  it('submits queued Relay turns as fresh prompts after real agent_end boundaries', async () => {
+    const { adapter, client, call, patches } = harness();
     await adapter.connect(config);
     await adapter.sendMessage({ turnId: 't1', content: 'one' });
     await adapter.sendMessage({ turnId: 't2', content: 'two' });
     await adapter.sendMessage({ turnId: 't3', content: 'three' });
-    client.emit('event', { type: 'agent_end' });
-    client.emit('event', { type: 'agent_start' });
-    client.emit('event', { type: 'turn_start' });
-    client.emit('event', { type: 'agent_end' });
-    client.emit('event', { type: 'agent_start' });
-    client.emit('event', { type: 'agent_end' });
+
+    client.emit('event', { type: 'turn_end' });
     expect(
-      patches
-        .filter((patch) => patch.type === 'agent-turn-started-v2')
-        .map((patch) => (patch.turn as { id: string }).id)
-    ).toEqual(['t1', 't2', 't3']);
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(0);
+
+    client.emit('event', { type: 'agent_end' });
+    await vi.waitFor(() =>
+      expect(
+        patches
+          .filter((patch) => patch.type === 'agent-turn-started-v2')
+          .map((patch) => (patch.turn as { id: string }).id)
+      ).toEqual(['t1', 't2'])
+    );
+    client.emit('event', { type: 'agent_end' });
+    await vi.waitFor(() =>
+      expect(
+        patches
+          .filter((patch) => patch.type === 'agent-turn-started-v2')
+          .map((patch) => (patch.turn as { id: string }).id)
+      ).toEqual(['t1', 't2', 't3'])
+    );
+    client.emit('event', { type: 'agent_end' });
+
     expect(
       patches
         .filter((patch) => patch.type === 'agent-turn-completed-v2')
         .map((patch) => patch.turnId)
     ).toEqual(['t1', 't2', 't3']);
+    expect(
+      call.mock.calls
+        .filter(([type]) => type === 'prompt')
+        .map(([, payload]) => (payload as { message: string }).message)
+    ).toEqual(['one', 'two', 'three']);
   });
 
-  it('does not promote a steer turn before its acknowledgement', async () => {
+  it('fails closed when a queued prompt acknowledgement is ambiguous', async () => {
     const { adapter, client, call, patches } = harness();
-    let rejectSteer: ((error: Error) => void) | undefined;
-    call.mockImplementation(async (type) => {
-      if (type === 'steer') {
-        return new Promise((_, reject) => {
-          rejectSteer = reject;
-        });
-      }
+    call.mockImplementation(async (type, payload) => {
+      if (
+        type === 'prompt' &&
+        (payload as { message?: string }).message === 'two'
+      )
+        throw new Error('prompt timed out');
       return { type: 'response', command: type, success: true };
     });
     await adapter.connect(config);
     await adapter.sendMessage({ turnId: 't1', content: 'one' });
-    const queued = adapter.sendMessage({ turnId: 't2', content: 'two' });
-    const rejected = expect(queued).rejects.toThrow('steer rejected');
-
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
     client.emit('event', { type: 'agent_end' });
-    expect(
-      patches
-        .filter((patch) => patch.type === 'agent-turn-started-v2')
-        .map((patch) => (patch.turn as { id: string }).id)
-    ).toEqual(['t1']);
 
-    rejectSteer?.(new Error('steer rejected'));
-    await rejected;
-    expect(adapter.status).toBe('disconnected');
-    expect(
-      patches.some(
-        (patch) =>
-          patch.type === 'agent-turn-started-v2' &&
-          (patch.turn as { id: string }).id === 't2'
-      )
-    ).toBe(false);
+    await vi.waitFor(() => expect(adapter.status).toBe('disconnected'));
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't2',
+          status: 'failed',
+        }),
+      ])
+    );
   });
 
   it('fails closed on protocol corruption and unexpected close', async () => {
@@ -266,9 +274,106 @@ describe('PrimeAgentProtocolAdapter', () => {
         ],
       })
     ).rejects.toThrow('Cannot read Prime Agent image attachment');
-    expect(call.mock.calls.map(([type]) => type)).toEqual([
-      'set_steering_mode',
-    ]);
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('bounds image count and rejects MIME-mismatched bytes', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'relay-prime-image-'));
+    const path = join(directory, 'image.png');
+    try {
+      writeFileSync(path, 'not an image');
+      const mismatched = harness();
+      await mismatched.adapter.connect(config);
+      await expect(
+        mismatched.adapter.sendMessage({
+          turnId: 'bad-image',
+          content: 'image',
+          attachments: [{ type: 'image', path, mimeType: 'image/png' }],
+        })
+      ).rejects.toThrow('do not match the declared image');
+
+      const excessive = harness();
+      await excessive.adapter.connect(config);
+      await expect(
+        excessive.adapter.sendMessage({
+          turnId: 'many-images',
+          content: 'images',
+          attachments: Array.from({ length: 5 }, () => ({
+            type: 'image' as const,
+            path,
+            mimeType: 'image/png',
+          })),
+        })
+      ).rejects.toThrow('at most 4 images');
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed on an ambiguous initial prompt acknowledgement', async () => {
+    const { adapter, client, call, patches } = harness();
+    call.mockImplementation(async (type) => {
+      if (type === 'prompt') throw new Error('prompt timed out');
+      return { type: 'response', command: type, success: true };
+    });
+    await adapter.connect(config);
+    await expect(
+      adapter.sendMessage({ turnId: 'timeout', content: 'hello' })
+    ).rejects.toThrow('prompt timed out');
+    expect(adapter.status).toBe('disconnected');
+    expect(client.stop).toHaveBeenCalled();
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-turn-completed-v2' && patch.turnId === 'timeout'
+      )
+    ).toEqual([expect.objectContaining({ status: 'failed' })]);
+  });
+
+  it('maps extension errors to nonfatal debug diagnostics', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'hello' });
+    client.emit('event', { type: 'extension_error', error: 'hook failed' });
+    client.emit('event', { type: 'agent_end' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-started-v2',
+          item: expect.objectContaining({
+            type: 'providerExtension',
+            payload: { kind: 'extensionError', error: 'hook failed' },
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't1',
+          status: 'completed',
+        }),
+      ])
+    );
+  });
+
+  it('runs /compact through native RPC and terminalizes the Relay turn', async () => {
+    const { adapter, call, patches } = harness();
+    call.mockImplementation(async (type) => ({
+      type: 'response',
+      command: type,
+      success: true,
+      ...(type === 'compact' ? { data: { tokensBefore: 100 } } : {}),
+    }));
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 'compact', content: '/compact' });
+    expect(call.mock.calls.map(([type]) => type)).toEqual(['compact']);
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'compact',
+          status: 'completed',
+        }),
+      ])
+    );
   });
 
   it('disables extensions until extension UI requests are mapped', async () => {


### PR DESCRIPTION
## Summary

- add Prime Agent as a built-in Relay framework for terminal and channel sessions
- run channel participants through the native strict-LF `prime-agent --mode rpc` transport
- map text, reasoning, tools, commands, file changes, usage, images, compaction, interruption, queueing, and persisted resume state into `AgentPatchV2`
- add Prime branding/identity plumbing, process-tree recognition, provider documentation, and fixture-driven RPC/adapter coverage
- harden ambiguous acknowledgements, UTF-8/framing bounds, attachment validation, and subprocess teardown/reconnect behavior

Closes #1340

## Verification

- `npm run check`
- `npm run build`
- 91 targeted framework/runtime/RPC/adapter/identity tests pass
- 23 focused Prime RPC client + adapter tests pass after final lifecycle hardening
- installed `prime-agent` 0.7.0 smoke: RPC `get_state` readiness succeeds and shutdown completes
- full suite: 6097 passed; 14 unrelated environment-sensitive failures (forced-color stderr assertions, live Hermes timeout, and existing Linux process-tree reap timeout)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prime Agent as a built-in terminal and channel provider.
  * Added native RPC connectivity with streaming responses, tool execution, session resumption, queuing, interruption, and reconnect support.
  * Added Prime Agent framework metadata, provider discovery, workspace support, and sender branding.

* **Documentation**
  * Documented Prime Agent setup, capabilities, lifecycle, supported operations, and usage modes.

* **Tests**
  * Added comprehensive coverage for RPC communication, session handling, protocol behavior, framework metadata, and user interface integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->