### PR TITLE
feat(channels): add provider command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ workflow.
 #### Added
 
 - Create and name new folders directly in the local Add Project browser (#1338)
+- `@agent/` opens a provider-aware command palette for channel controls,
+  including Codex Fast Mode, model, and reasoning-effort changes (#1344)
 
 #### Changed
 

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -72,6 +72,35 @@ Mapping rules:
 `ProtocolAdapterV2` normalizes rich items into `AgentDetailCardV2`. The channel
 bridge bounds and persists those cards beside channel messages.
 
+## Command catalogs and channel control lane
+
+Adapters may expose `getSlashCommands()` and `executeControlCommand()` from
+`ProtocolAdapterV2`. A catalog entry declares its dispatch: `relay-control`
+commands are safe for Relay to execute; `agent` commands remain provider-native
+prompt/skill input. The channel binder never branches on a provider name: it
+uses an adapter's live catalog after connecting, and may use a redaction-safe
+static catalog only for pre-bind previews.
+
+Channel controls are addressed by the exact profile actor ID, never by
+display name. This keeps same-provider named profiles and their mention
+disambiguators isolated. The dedicated `POST /channels/:id/agent-commands`
+lane requires `context:write`, rejects archived channels, requires explicit
+confirmation for destructive catalog entries, and does not persist a channel
+message or create a mention context packet. Normal posts that look like a
+targeted control (`@agent/command` or `@agent /command`) are rejected so they
+cannot accidentally route as prose.
+
+Only advertise controls the live provider can execute. Where provider metadata
+lists models, service tiers, or reasoning efforts, derive command arguments
+from that metadata and refresh the catalog on a model change. A missing catalog
+may use a documented static fallback; an available catalog must reject values
+it does not support. Codex currently implements Relay-owned controls including
+Fast Mode through this contract. Claude, OpenCode, and Hermes must not be
+presented as supporting a channel control until their own adapters expose and
+execute it.
+
+## Provider extension policy
+
 Use:
 
 - `reasoning` for thinking/analysis summaries;

--- a/frontend/src/components/chat/AgentCommandPalette.css
+++ b/frontend/src/components/chat/AgentCommandPalette.css
@@ -1,0 +1,80 @@
+/* Provider command previews share MentionPalette's compact, TUI-native float. */
+.agent-command-palette {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(100% + 8px);
+  z-index: 11;
+  max-height: 260px;
+  overflow: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.agent-command-palette__row {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-height: 44px;
+  box-sizing: border-box;
+  padding: 6px 10px 6px 18px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.agent-command-palette__row:hover,
+.agent-command-palette__row--active {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.agent-command-palette__row--active::before {
+  content: '>';
+  position: absolute;
+  left: 4px;
+  top: 9px;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.agent-command-palette__main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.agent-command-palette__name {
+  color: var(--text);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.agent-command-palette__hint,
+.agent-command-palette__source,
+.agent-command-palette__detail,
+.agent-command-palette__empty {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.agent-command-palette__source {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.agent-command-palette__detail {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-command-palette__empty {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+}

--- a/frontend/src/components/chat/AgentCommandPalette.tsx
+++ b/frontend/src/components/chat/AgentCommandPalette.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import type { AgentSlashCommandV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+import './AgentCommandPalette.css';
+
+export type AgentCommandPaletteRow =
+  | { kind: 'command'; command: AgentSlashCommandV2 }
+  | {
+      kind: 'argument';
+      value: string;
+      label?: string;
+      description?: string;
+    }
+  | { kind: 'confirm'; value: 'confirm' | 'cancel' };
+
+interface AgentCommandPaletteProps {
+  rows: readonly AgentCommandPaletteRow[];
+  activeIndex: number;
+  visible: boolean;
+  disabled?: boolean;
+  label: string;
+  emptyMessage?: string;
+  onSelect: (index: number) => void;
+}
+
+/**
+ * Provider-aware command-preview palette for the channel composer. It is
+ * intentionally presentation-first like MentionPalette: the composer owns
+ * keyboard/IME semantics and dispatches dedicated controls, never messages.
+ */
+export const AgentCommandPalette: React.FC<AgentCommandPaletteProps> = ({
+  rows,
+  activeIndex,
+  visible,
+  disabled = false,
+  label,
+  emptyMessage,
+  onSelect,
+}) => (
+  <div
+    id="channel-agent-command-palette"
+    className="agent-command-palette"
+    role="listbox"
+    aria-label={label}
+    aria-disabled={disabled || undefined}
+    style={{ display: visible ? undefined : 'none' }}
+  >
+    {rows.length === 0 ? (
+      <div className="agent-command-palette__empty" role="status">
+        {emptyMessage ?? 'no commands available'}
+      </div>
+    ) : (
+      rows.map((row, index) => {
+        const active = index === activeIndex;
+        const id = `channel-agent-command-option-${index}`;
+        const main =
+          row.kind === 'command'
+            ? `/${row.command.name}`
+            : row.kind === 'argument'
+              ? (row.label ?? row.value)
+              : row.value === 'confirm'
+                ? 'confirm'
+                : 'cancel';
+        const detail =
+          row.kind === 'command'
+            ? row.command.description
+            : row.kind === 'argument'
+              ? row.description
+              : row.value === 'confirm'
+                ? 'run this destructive command'
+                : 'return to command choices';
+        const hint =
+          row.kind === 'command' ? row.command.argumentHint : undefined;
+        return (
+          <div
+            id={id}
+            key={
+              row.kind === 'command'
+                ? (row.command.id ?? row.command.name)
+                : `${row.kind}:${row.value}`
+            }
+            className={`agent-command-palette__row${active ? ' agent-command-palette__row--active' : ''}`}
+            role="option"
+            aria-selected={active}
+            aria-disabled={disabled || undefined}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              if (!disabled) onSelect(index);
+            }}
+          >
+            <div className="agent-command-palette__main">
+              <span className="agent-command-palette__name">{main}</span>
+              {hint ? (
+                <span className="agent-command-palette__hint">{hint}</span>
+              ) : null}
+              {row.kind === 'command' && row.command.sourceLabel ? (
+                <span className="agent-command-palette__source">
+                  {row.command.sourceLabel}
+                </span>
+              ) : null}
+            </div>
+            {detail ? (
+              <span className="agent-command-palette__detail">{detail}</span>
+            ) : null}
+          </div>
+        );
+      })
+    )}
+  </div>
+);
+
+export default AgentCommandPalette;

--- a/frontend/src/components/chat/ChannelComposer.css
+++ b/frontend/src/components/chat/ChannelComposer.css
@@ -56,6 +56,18 @@
   opacity: 0.85;
 }
 
+.ch-composer__command-status {
+  min-height: 0;
+  padding: 0 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.ch-composer__command-status:empty {
+  display: none;
+}
+
 .ch-composer__bar {
   display: flex;
   align-items: center;

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -17,12 +17,23 @@ import {
   filterMentionContacts,
   isMentionContactSelectable,
   mentionInsertText,
+  type MentionContact,
 } from '../../../../shared/mention-contacts.js';
+import type { AgentSlashCommandV2 } from '../../../../shared/agent-chat-protocol-v2.js';
 import { createBrowserId } from '../../lib/browserId.js';
-import { fetchChannelRoster, uploadChannelImages } from '../../lib/api.js';
+import {
+  executeChannelAgentCommand,
+  fetchChannelRoster,
+  uploadChannelImages,
+  type RosterEntry,
+} from '../../lib/api.js';
 import { buildMentionContacts } from '../../lib/chat/mention-contacts.js';
 import { detectTrigger } from './slashTrigger.js';
 import { createLineBreakSubmitGuard } from './composerInput.js';
+import {
+  AgentCommandPalette,
+  type AgentCommandPaletteRow,
+} from './AgentCommandPalette.js';
 import { MentionPalette } from './MentionPalette.js';
 
 const ALLOWED_IMAGE_MIMES = new Set([
@@ -59,6 +70,86 @@ function defaultSendLabel(steeringMode: BusyAgentSteeringMode): string {
   if (steeringMode === 'all') return 'steer';
   if (steeringMode === 'some') return 'steer / queue';
   return 'queue';
+}
+
+type CommandPhase = 'arguments' | 'confirm' | null;
+
+interface MentionCommandTrigger {
+  contact: MentionContact;
+  rosterEntry: RosterEntry | undefined;
+  /** Includes the selected profile mention and immediately-adjacent `/`. */
+  commandStart: number;
+  /** End of the command-name token (before a possible argument). */
+  commandEnd: number;
+  commandQuery: string;
+  argument: string;
+}
+
+function isMentionBoundary(text: string, at: number): boolean {
+  return at === 0 || !/[A-Za-z0-9_.]/.test(text.charAt(at - 1));
+}
+
+/**
+ * Resolve only an EXACT addressable mention immediately followed by `/`.
+ * Comparing against `mentionInsertText` preserves custom-profile collision
+ * tokens (`@Reviewer#abc123/`) instead of guessing identity from display text.
+ */
+function detectMentionCommandTrigger(
+  text: string,
+  caret: number,
+  contacts: readonly MentionContact[],
+  roster: readonly RosterEntry[]
+): MentionCommandTrigger | null {
+  const beforeCaret = text.slice(0, caret);
+  let best:
+    | { contact: MentionContact; index: number; needle: string }
+    | undefined;
+  for (const contact of contacts) {
+    const mention = mentionInsertText(contact);
+    // MentionPalette inserts a single trailing space. Accept that exact bridge
+    // as well as the compact hand-typed `@codex/`, but never arbitrary prose.
+    const candidates = [`${mention}/`, `${mention} /`];
+    for (const needle of candidates) {
+      const index = beforeCaret.toLowerCase().lastIndexOf(needle.toLowerCase());
+      if (index < 0 || !isMentionBoundary(beforeCaret, index)) continue;
+      const rest = beforeCaret.slice(index + needle.length);
+      if (/\n/.test(rest)) continue;
+      if (!best || index > best.index) best = { contact, index, needle };
+    }
+  }
+  if (!best) return null;
+  const rest = beforeCaret.slice(best.index + best.needle.length);
+  const nameMatch = /^(\S*)/.exec(rest);
+  const commandQuery = nameMatch?.[1] ?? '';
+  const commandEnd = best.index + best.needle.length + commandQuery.length;
+  return {
+    contact: best.contact,
+    rosterEntry: roster.find((entry) => entry.id === best.contact.id),
+    commandStart: best.index,
+    commandEnd,
+    commandQuery,
+    argument: rest.slice(commandQuery.length).trim(),
+  };
+}
+
+function commandMatches(command: AgentSlashCommandV2, query: string): boolean {
+  const normalized = query.toLowerCase();
+  return (
+    normalized.length === 0 ||
+    command.name.toLowerCase().startsWith(normalized) ||
+    (command.aliases ?? []).some((alias) =>
+      alias.toLowerCase().startsWith(normalized)
+    )
+  );
+}
+
+function needsConfirmation(command: AgentSlashCommandV2): boolean {
+  return (
+    command.destructive === true ||
+    ['clear', 'new', 'reset', 'rollback', 'archive'].includes(
+      command.collisionKey ?? command.name
+    )
+  );
 }
 
 interface PendingImage {
@@ -126,6 +217,11 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   const [caret, setCaret] = useState(0);
   const [activeIndex, setActiveIndex] = useState(0);
   const [paletteDismissed, setPaletteDismissed] = useState(false);
+  const [commandPhase, setCommandPhase] = useState<CommandPhase>(null);
+  const [selectedCommand, setSelectedCommand] =
+    useState<AgentSlashCommandV2 | null>(null);
+  const [commandStatus, setCommandStatus] = useState<string | null>(null);
+  const [commandPending, setCommandPending] = useState(false);
   const [images, setImages] = useState<PendingImage[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
 
@@ -269,8 +365,42 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         : filterMentionContacts(contacts, triggerQuery),
     [triggerQuery, contacts]
   );
+  const commandTrigger = useMemo(
+    () => detectMentionCommandTrigger(draft, caret, contacts, rosterData ?? []),
+    [draft, caret, contacts, rosterData]
+  );
+  const commandEntries = useMemo(
+    () =>
+      (commandTrigger?.rosterEntry?.commands ?? []).filter(
+        (command) =>
+          command.dispatch === 'relay-control' &&
+          commandMatches(command, commandTrigger?.commandQuery ?? '')
+      ),
+    [commandTrigger]
+  );
+  const commandArgumentRows = useMemo<AgentCommandPaletteRow[]>(() => {
+    if (!selectedCommand) return [];
+    return (selectedCommand.args ?? [])
+      .filter((option) =>
+        option.value
+          .toLowerCase()
+          .startsWith((commandTrigger?.argument ?? '').toLowerCase())
+      )
+      .map((option) => ({ kind: 'argument', ...option }));
+  }, [selectedCommand, commandTrigger?.argument]);
+  const commandRows = useMemo<AgentCommandPaletteRow[]>(() => {
+    if (commandPhase === 'confirm') {
+      return [
+        { kind: 'confirm', value: 'confirm' },
+        { kind: 'confirm', value: 'cancel' },
+      ];
+    }
+    if (commandPhase === 'arguments') return commandArgumentRows;
+    return commandEntries.map((command) => ({ kind: 'command', command }));
+  }, [commandArgumentRows, commandEntries, commandPhase]);
   const paletteVisible =
     trigger !== null && !paletteDismissed && entries.length > 0;
+  const commandPaletteVisible = commandTrigger !== null && !paletteDismissed;
 
   const resize = useCallback(() => {
     const el = textareaRef.current;
@@ -291,6 +421,28 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     setActiveIndex(0);
     setPaletteDismissed(false);
   }, [draft]);
+
+  // Command intent only survives edits that keep the same exact addressed
+  // profile and command token. This prevents a stale profile id executing after
+  // a rename, collision-token edit, or moving the caret into ordinary prose.
+  useEffect(() => {
+    if (!commandTrigger) {
+      setCommandPhase(null);
+      setSelectedCommand(null);
+      return;
+    }
+    if (
+      selectedCommand &&
+      commandTrigger.commandQuery &&
+      ![selectedCommand.name, ...(selectedCommand.aliases ?? [])].some(
+        (name) =>
+          name.toLowerCase() === commandTrigger.commandQuery.toLowerCase()
+      )
+    ) {
+      setCommandPhase(null);
+      setSelectedCommand(null);
+    }
+  }, [commandTrigger, selectedCommand]);
 
   const updateCaret = useCallback(() => {
     const el = textareaRef.current;
@@ -377,10 +529,181 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     });
   }, [trigger, entries, activeIndex, draft]);
 
+  const executeCommand = useCallback(
+    (command: AgentSlashCommandV2, args?: string, confirmed = false) => {
+      if (!commandTrigger || commandPending) return;
+      const normalizedArgs = args?.trim();
+      if (command.argumentHint && !normalizedArgs) {
+        setCommandStatus(`/${command.name} requires ${command.argumentHint}`);
+        setCommandPhase('arguments');
+        return;
+      }
+      // The server independently rejects destructive controls without this
+      // acknowledgement. Keep the same invariant in the UI so Enter on a
+      // typed argument cannot skip the visible confirmation row.
+      if (needsConfirmation(command) && !confirmed) {
+        setSelectedCommand(command);
+        setCommandPhase('confirm');
+        setCommandStatus(
+          `confirm /${command.name} for @${commandTrigger.contact.displayName}`
+        );
+        return;
+      }
+      setCommandPending(true);
+      setCommandStatus(
+        `running /${command.name} for @${commandTrigger.contact.displayName}…`
+      );
+      void executeChannelAgentCommand(channelId, {
+        profileId: commandTrigger.contact.id,
+        command: command.name,
+        ...(normalizedArgs ? { args: normalizedArgs } : {}),
+        ...(confirmed ? { confirmed: true } : {}),
+      })
+        .then(() => {
+          setCommandStatus(
+            `/${command.name} applied to @${commandTrigger.contact.displayName}`
+          );
+          setDraft('');
+          setCaret(0);
+          setCommandPhase(null);
+          setSelectedCommand(null);
+          setPaletteDismissed(true);
+        })
+        .catch((error) => {
+          const detail =
+            error instanceof Error ? error.message : 'command failed';
+          setCommandStatus(`/${command.name} failed: ${detail}`);
+        })
+        .finally(() => setCommandPending(false));
+    },
+    [channelId, commandPending, commandTrigger]
+  );
+
+  const selectCommand = useCallback(
+    (command: AgentSlashCommandV2) => {
+      if (!commandTrigger) return;
+      const replacement = `/${command.name}`;
+      const nextDraft =
+        draft.slice(
+          0,
+          commandTrigger.commandStart +
+            mentionInsertText(commandTrigger.contact).length
+        ) +
+        replacement +
+        draft.slice(commandTrigger.commandEnd);
+      const nextCaret =
+        commandTrigger.commandStart +
+        mentionInsertText(commandTrigger.contact).length +
+        replacement.length;
+      setDraft(nextDraft);
+      setCaret(nextCaret);
+      setActiveIndex(0);
+      setSelectedCommand(command);
+      if ((command.args?.length ?? 0) > 0 || command.argumentHint) {
+        setCommandPhase('arguments');
+        setCommandStatus(
+          command.args?.length
+            ? `choose a value for /${command.name}`
+            : `type a value for /${command.name}`
+        );
+      } else {
+        executeCommand(command, commandTrigger.argument);
+      }
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.selectionStart = nextCaret;
+        el.selectionEnd = nextCaret;
+        el.focus();
+      });
+    },
+    [commandTrigger, draft, executeCommand]
+  );
+
+  const activateCommandRow = useCallback(
+    (index: number) => {
+      const row = commandRows[index];
+      if (!row) {
+        // A typed model name has no enumerated row. Enter confirms it only
+        // after the command has already been chosen in the first palette.
+        if (
+          commandPhase === 'arguments' &&
+          selectedCommand &&
+          commandTrigger?.argument
+        ) {
+          executeCommand(selectedCommand, commandTrigger.argument);
+        }
+        return;
+      }
+      if (row.kind === 'command') {
+        selectCommand(row.command);
+        return;
+      }
+      if (row.kind === 'argument') {
+        if (selectedCommand) executeCommand(selectedCommand, row.value);
+        return;
+      }
+      if (row.value === 'cancel') {
+        setCommandPhase(null);
+        setSelectedCommand(null);
+        setCommandStatus('command cancelled');
+        return;
+      }
+      if (selectedCommand) {
+        executeCommand(selectedCommand, commandTrigger?.argument, true);
+      }
+    },
+    [
+      commandPhase,
+      commandRows,
+      commandTrigger?.argument,
+      executeCommand,
+      selectCommand,
+      selectedCommand,
+    ]
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       const nativeEvent = e.nativeEvent as KeyboardEvent;
       if (e.key === 'Enter' && nativeEvent.isComposing) return;
+
+      if (commandPaletteVisible) {
+        if (e.key === 'ArrowDown' && commandRows.length > 0) {
+          e.preventDefault();
+          setActiveIndex((i) => Math.min(i + 1, commandRows.length - 1));
+          return;
+        }
+        if (e.key === 'ArrowUp' && commandRows.length > 0) {
+          e.preventDefault();
+          setActiveIndex((i) => Math.max(i - 1, 0));
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setPaletteDismissed(true);
+          setCommandPhase(null);
+          setSelectedCommand(null);
+          return;
+        }
+        if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
+          e.preventDefault();
+          activateCommandRow(activeIndex);
+          return;
+        }
+      }
+
+      // A command-shaped draft is never a channel message. Escape only hides
+      // the preview; pressing Enter again reopens it instead of accidentally
+      // posting `@agent/command` through mention routing.
+      if (
+        commandTrigger !== null &&
+        ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab')
+      ) {
+        e.preventDefault();
+        setPaletteDismissed(false);
+        return;
+      }
 
       if (paletteVisible) {
         if (e.key === 'ArrowDown') {
@@ -425,7 +748,18 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         else submit();
       }
     },
-    [paletteVisible, entries, activeIndex, applyMention, busy, submit]
+    [
+      commandPaletteVisible,
+      commandRows.length,
+      activateCommandRow,
+      commandTrigger,
+      paletteVisible,
+      entries,
+      activeIndex,
+      applyMention,
+      busy,
+      submit,
+    ]
   );
 
   // Mobile IME parity: some IMEs only report a beforeinput line-break intent for
@@ -435,6 +769,14 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     (inputEvent: InputEvent) => {
       if (!lineBreakGuardRef.current.consumesAsSubmit(inputEvent)) return;
       inputEvent.preventDefault();
+      if (commandPaletteVisible) {
+        activateCommandRow(activeIndex);
+        return;
+      }
+      if (commandTrigger !== null) {
+        setPaletteDismissed(false);
+        return;
+      }
       if (paletteVisible) {
         const entry = entries[activeIndex];
         if (entry && isMentionContactSelectable(entry)) applyMention();
@@ -442,7 +784,16 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       }
       submit();
     },
-    [paletteVisible, entries, activeIndex, applyMention, submit]
+    [
+      commandPaletteVisible,
+      activateCommandRow,
+      commandTrigger,
+      paletteVisible,
+      entries,
+      activeIndex,
+      applyMention,
+      submit,
+    ]
   );
 
   useEffect(() => {
@@ -510,6 +861,23 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         </div>
       ) : null}
       <div className="ch-composer__mention-anchor">
+        <AgentCommandPalette
+          rows={commandRows}
+          activeIndex={activeIndex}
+          visible={commandPaletteVisible}
+          disabled={commandPending}
+          label={`commands for ${commandTrigger?.contact.displayName ?? 'agent'}`}
+          emptyMessage={
+            commandPhase === 'arguments' && selectedCommand
+              ? commandTrigger?.argument
+                ? `press enter to use “${commandTrigger.argument}”`
+                : `type ${selectedCommand.argumentHint ?? 'a value'}`
+              : commandPending
+                ? 'applying command…'
+                : 'no commands available for this agent'
+          }
+          onSelect={activateCommandRow}
+        />
         <MentionPalette
           contacts={entries}
           activeIndex={activeIndex}
@@ -526,6 +894,15 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           rows={1}
           enterKeyHint="send"
           aria-label="message input"
+          aria-controls={
+            commandPaletteVisible ? 'channel-agent-command-palette' : undefined
+          }
+          aria-expanded={commandPaletteVisible}
+          aria-activedescendant={
+            commandPaletteVisible && commandRows.length > 0
+              ? `channel-agent-command-option-${activeIndex}`
+              : undefined
+          }
           data-pending={postPending ? 'true' : 'false'}
           onChange={(event) => {
             setDraft(event.currentTarget.value);
@@ -539,6 +916,9 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           onDrop={handleImageDrop}
           onDragOver={(e) => e.preventDefault()}
         />
+      </div>
+      <div className="ch-composer__command-status" aria-live="polite">
+        {commandStatus}
       </div>
       {images.length > 0 ? (
         <div

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -55,6 +55,7 @@ import type {
   ChannelReadStateUpdateRequest,
   ChannelReadStateUpdateResponse,
 } from '../../../shared/channel-chat-protocol.js';
+import type { AgentSlashCommandV2 } from '../../../shared/agent-chat-protocol-v2.js';
 import type {
   WorkflowRunProjection,
   WorkflowRunState,
@@ -2127,6 +2128,8 @@ export interface RosterEntry {
     /** Whether the live harness accepts the default native steer action. */
     steerSupported?: boolean;
   } | null;
+  /** Provider-aware control previews. An absent list means discovery is unavailable. */
+  commands?: AgentSlashCommandV2[];
 }
 
 export async function fetchChannelRoster(
@@ -2138,6 +2141,30 @@ export async function fetchChannelRoster(
     })
   );
   return Array.isArray(data.roster) ? data.roster : [];
+}
+
+/** Execute a channel agent control without creating or routing a channel message. */
+export async function executeChannelAgentCommand(
+  channelId: string,
+  input: {
+    profileId: string;
+    command: string;
+    args?: string;
+    /** Required by the server for context-changing/destructive controls. */
+    confirmed?: boolean;
+  }
+): Promise<{ config?: Record<string, unknown> }> {
+  const data = await json<{ config?: Record<string, unknown> }>(
+    await fetch(`/channels/${encodeURIComponent(channelId)}/agent-commands`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify(input),
+    })
+  );
+  return data;
 }
 
 /**

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -24,6 +24,7 @@ import type {
   ChannelAgentRuntime,
   CreateChannelAgentRuntimeParams,
 } from './channel-agent-runtime.js';
+import { relayControlCatalogForProvider } from '../shared/agent-command-catalog.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
 import type { AgentProfileStore } from './agent-profile-store.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
@@ -47,6 +48,7 @@ import type {
   AgentApprovalItemV2,
   AgentLiveStateUpdatedPatchV2,
   AgentPatchV2,
+  AgentSlashCommandV2,
 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
 import { isDmChannel } from '../shared/dm-channels.js';
@@ -165,6 +167,8 @@ export interface ChannelAgentRosterEntry {
     /** Whether this live harness accepts the default safe-boundary steer. */
     steerSupported: boolean;
   } | null;
+  /** Provider previews are safe to show before a binding exists. */
+  commands?: AgentSlashCommandV2[];
 }
 
 export type ChannelAgentStatusBroadcaster = (
@@ -241,6 +245,14 @@ export interface ChannelAgentBinder {
     decision: AgentApprovalDecisionV2
   ): Promise<void>;
   rosterForChannel(channelId: string): Promise<ChannelAgentRosterEntry[]>;
+  executeCommand(
+    channelId: string,
+    profileActorId: string,
+    command: string,
+    args?: string,
+    confirmed?: boolean
+  ): Promise<{ config?: Record<string, unknown> }>;
+  isControlMessage(text: string): boolean;
   setStatusBroadcaster(broadcaster: ChannelAgentStatusBroadcaster): void;
   close(): void;
 }
@@ -370,6 +382,23 @@ export interface ChannelRetryResult {
   /** The ORIGINAL trigger that was re-routed — never a new timeline row. */
   triggerMessageId: string;
   profileActorId: string;
+}
+
+/** A command lane rejection is deliberately not a channel-message failure. */
+export class ChannelAgentCommandError extends Error {
+  constructor(
+    message: string,
+    readonly reasonCode:
+      | 'UNKNOWN_PROFILE'
+      | 'UNAVAILABLE'
+      | 'UNKNOWN_COMMAND'
+      | 'UNSUPPORTED_DISPATCH'
+      | 'UNSUPPORTED_PROVIDER'
+      | 'CONFIRMATION_REQUIRED'
+  ) {
+    super(message);
+    this.name = 'ChannelAgentCommandError';
+  }
 }
 
 export class ChannelAgentRoleConflictError extends Error {
@@ -2544,6 +2573,23 @@ export function createChannelAgentBinder(
         const row = store.getBinding(channelId, profile.id);
         const runtimeId = binding?.runtimeId ?? row?.runtimeId ?? null;
         const runtime = runtimeId ? deps.runtimes.get(runtimeId) : undefined;
+        const baseCommands = relayControlCatalogForProvider(
+          profile.providerId
+        ).filter((command) => command.collisionKey !== 'fast');
+        const liveCommands = (
+          binding?.adapter?.getSlashCommands?.() ?? []
+        ).filter((command) => command.dispatch === 'relay-control');
+        const commands = [...baseCommands, ...liveCommands].reduce<
+          AgentSlashCommandV2[]
+        >((merged, command) => {
+          const key = command.collisionKey ?? command.name;
+          if (
+            !merged.some((entry) => (entry.collisionKey ?? entry.name) === key)
+          ) {
+            merged.push(command);
+          }
+          return merged;
+        }, []);
         return {
           id: profile.id,
           displayName: await rosterDisplayName(profile),
@@ -2567,9 +2613,139 @@ export function createChannelAgentBinder(
                   binding !== undefined && supportsSafeBoundarySteer(binding),
               }
             : null,
+          ...(commands.length > 0 ? { commands } : {}),
         };
       })
     );
+  }
+
+  async function executeCommand(
+    channelId: string,
+    profileActorId: string,
+    command: string,
+    args?: string,
+    confirmed?: boolean
+  ): Promise<{ config?: Record<string, unknown> }> {
+    // Actor id is the sole authority boundary. Never resolve a display name here.
+    const targets = await getTargets();
+    const stored = deps.agentProfileStore?.list() ?? [];
+    const profiles = [
+      ...stored,
+      ...targets
+        .filter(
+          (target) =>
+            !stored.some((profile) => profile.providerId === target.id)
+        )
+        .map((target) => defaultProfileForProvider(target.id)),
+    ];
+    const profile = profiles.find(
+      (candidate) => candidate.id === profileActorId
+    );
+    if (!profile) {
+      throw new ChannelAgentCommandError(
+        'unknown agent profile',
+        'UNKNOWN_PROFILE'
+      );
+    }
+    const target = targets.find(
+      (candidate) => candidate.id === profile.providerId
+    );
+    if (!target?.available) {
+      throw new ChannelAgentCommandError('agent is unavailable', 'UNAVAILABLE');
+    }
+    let binding = live.get(bindingKey(channelId, profileActorId));
+    let preview =
+      binding?.adapter?.getSlashCommands?.() ??
+      relayControlCatalogForProvider(profile.providerId).filter(
+        (entry) => entry.collisionKey !== 'fast'
+      );
+    const name = command.trim().toLowerCase();
+    let selected = preview.find(
+      (entry) => entry.name === name || (entry.aliases ?? []).includes(name)
+    );
+    // Static catalog entries make pre-bind previews possible. Other adapters
+    // may expose their own relay controls only after connect; discover those
+    // through the same adapter contract rather than a provider branch.
+    if (!selected && !binding) {
+      binding = await ensureProfileBinding(channelId, profile);
+      preview = binding.adapter?.getSlashCommands?.() ?? [];
+      selected = preview.find(
+        (entry) => entry.name === name || (entry.aliases ?? []).includes(name)
+      );
+    }
+    if (!selected) {
+      throw new ChannelAgentCommandError(
+        'unknown provider command',
+        'UNKNOWN_COMMAND'
+      );
+    }
+    if (selected.dispatch !== 'relay-control') {
+      throw new ChannelAgentCommandError(
+        'agent-dispatch commands are not executable in channels',
+        'UNSUPPORTED_DISPATCH'
+      );
+    }
+    if (selected.destructive && confirmed !== true) {
+      throw new ChannelAgentCommandError(
+        'command confirmation is required',
+        'CONFIRMATION_REQUIRED'
+      );
+    }
+    binding ??= await ensureProfileBinding(channelId, profile);
+    if (!binding.adapter?.executeControlCommand) {
+      throw new ChannelAgentCommandError(
+        'provider command controls are unavailable',
+        'UNSUPPORTED_PROVIDER'
+      );
+    }
+    return binding.adapter.executeControlCommand({
+      command: selected.name,
+      ...(args ? { args } : {}),
+      ...(confirmed !== undefined ? { confirmed } : {}),
+    });
+  }
+
+  function isControlMessage(text: string): boolean {
+    const profiles =
+      deps.agentProfileStore?.list() ??
+      deps.knownProviderIds.map((providerId) =>
+        defaultProfileForProvider(providerId)
+      );
+    let at = 0;
+    while (at < text.length) {
+      at = text.indexOf('@', at);
+      if (at < 0) break;
+      if (at > 0 && /[A-Za-z0-9_.]/.test(text[at - 1]!)) {
+        at += 1;
+        continue;
+      }
+      // Parse each candidate suffix independently: the durable parser dedupes
+      // same-profile mentions for routing, while this admission check must see
+      // every occurrence (for example `@codex hello @codex/compact`).
+      const mention = parseMentions(
+        text.slice(at),
+        deps.knownProviderIds,
+        profiles
+      )[0];
+      if (!mention?.profileId || !mention.providerId) {
+        at += 1;
+        continue;
+      }
+      const suffix = text.slice(at + mention.raw.length);
+      const command = suffix
+        .match(/^\s*\/([^\s]+)(?:\s|$)/)?.[1]
+        ?.toLowerCase();
+      if (
+        command &&
+        relayControlCatalogForProvider(mention.providerId).some(
+          (entry) =>
+            entry.name === command || (entry.aliases ?? []).includes(command)
+        )
+      )
+        return true;
+      at += Math.max(1, mention.raw.length);
+    }
+    return false;
   }
 
   return {
@@ -2581,6 +2757,8 @@ export function createChannelAgentBinder(
     retryMessage,
     respondToApproval,
     rosterForChannel,
+    executeCommand,
+    isControlMessage,
     setStatusBroadcaster(broadcaster) {
       statusBroadcaster = broadcaster;
     },

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -30,6 +30,7 @@ import {
 import {
   ChannelAgentBusyError,
   ChannelAgentNoActiveTurnError,
+  ChannelAgentCommandError,
   ChannelAgentNotFoundError,
   ChannelAgentRoleConflictError,
   ChannelMessageNotRetryableError,
@@ -174,6 +175,11 @@ export interface ChannelChatRouterDeps {
     }
   ) => RequestHandler;
 }
+
+type PersistedChannelGuard = (
+  req: Request,
+  res: Response
+) => WorkspaceTopic | null;
 
 interface GatewayErrorBody {
   error: {
@@ -447,6 +453,91 @@ function mapStoreError(res: Response, error: unknown): void {
   );
 }
 
+/**
+ * Dedicated provider-control lane. It neither persists a channel row nor
+ * passes through mention context-packet construction.
+ */
+function createAgentCommandsHandler(
+  deps: ChannelChatRouterDeps,
+  requirePersistedChannel: PersistedChannelGuard
+): RequestHandler {
+  return (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const binder = binderOr503(res, deps.binder);
+    if (!binder) return;
+    const body = req.body as Record<string, unknown>;
+    const profileId =
+      typeof body['profileId'] === 'string' ? body['profileId'] : '';
+    const command = typeof body['command'] === 'string' ? body['command'] : '';
+    const args = typeof body['args'] === 'string' ? body['args'] : undefined;
+    const confirmed = body['confirmed'] === true;
+    if (!profileId || !command) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'profileId and command are required',
+        false
+      );
+      return;
+    }
+    binder
+      .executeCommand(topic.id, profileId, command, args, confirmed)
+      .then((result) => res.json({ ok: true, ...result }))
+      .catch((error) => {
+        if (error instanceof ChannelAgentCommandError) {
+          sendGatewayError(res, 'INVALID_ARGUMENT', error.message, false, {
+            profileId,
+            command,
+            reasonCode: error.reasonCode,
+          });
+          return;
+        }
+        mapStoreError(res, error);
+      });
+  };
+}
+
+function rejectChannelControlMessage(
+  res: Response,
+  binder: ChannelAgentBinder | null | undefined,
+  text: string
+): boolean {
+  if (!binder?.isControlMessage?.(text)) return false;
+  sendGatewayError(
+    res,
+    'INVALID_ARGUMENT',
+    'agent commands must use the channel agent-commands control endpoint',
+    false,
+    { reasonCode: 'CHANNEL_COMMAND_REQUIRES_CONTROL_LANE' }
+  );
+  return true;
+}
+
+function rejectEmptyChannelPost(
+  res: Response,
+  text: string,
+  parts: readonly unknown[]
+): boolean {
+  if (text.length > 0 || parts.length > 0) return false;
+  sendGatewayError(
+    res,
+    'INVALID_ARGUMENT',
+    'text or at least one image part is required',
+    false,
+    { fields: ['text', 'parts'] }
+  );
+  return true;
+}
+
 function parseSeqQuery(value: unknown): number | undefined {
   const raw = Array.isArray(value) ? value[0] : value;
   if (typeof raw !== 'string' || !raw.trim()) return undefined;
@@ -589,6 +680,8 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     deps.requireWriteActorAuth?.('channels.interrupt') ?? auth;
   const approvalAuth =
     deps.requireWriteActorAuth?.('channels.respond-approval') ?? auth;
+  const agentCommandsAuth =
+    deps.requireWriteActorAuth?.('channels.agent-commands') ?? auth;
   const uploadImages = multer({
     storage: multer.memoryStorage(),
     limits: {
@@ -1099,6 +1192,9 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       );
       return;
     }
+    // Provider-neutral binder catalog owns the recognition rule, including
+    // exact profile identity and both @profile/command and @profile /command.
+    if (rejectChannelControlMessage(res, deps.binder, text)) return;
     let parts: import('../shared/channel-chat-protocol.js').ChannelMessagePart[] =
       [];
     if (body['parts'] !== undefined) {
@@ -1111,16 +1207,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
         return;
       }
     }
-    if (text.length === 0 && parts.length === 0) {
-      sendGatewayError(
-        res,
-        'INVALID_ARGUMENT',
-        'text or at least one image part is required',
-        false,
-        { fields: ['text', 'parts'] }
-      );
-      return;
-    }
+    if (rejectEmptyChannelPost(res, text, parts)) return;
     const format =
       body['format'] === 'text' || body['format'] === 'markdown'
         ? (body['format'] as ChannelBodyFormat)
@@ -1438,6 +1525,12 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       .then((roster) => res.json({ roster }))
       .catch((error) => mapStoreError(res, error));
   });
+
+  router.post(
+    '/channels/:id/agent-commands',
+    agentCommandsAuth,
+    createAgentCommandsHandler(deps, requirePersistedChannel)
+  );
 
   // #1259 slice 4: operator designates (spawns / resumes) the persistent
   // orchestrator for a product channel. Operator lane ONLY — scoped actors are

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -109,6 +109,7 @@ export const CLI_GATEWAY_ACTOR_WRITE_COMMANDS = [
   'workspace-topics.archive',
   'workspace-topics.restore',
   'channels.post',
+  'channels.agent-commands',
   'channels.interrupt',
   'channels.respond-approval',
 ] as const;
@@ -359,6 +360,7 @@ export function cliGatewayActorCommandCapabilities(
     return ['context:read'];
   if (
     command === 'channels.post' ||
+    command === 'channels.agent-commands' ||
     command === 'channels.interrupt' ||
     command === 'channels.respond-approval'
   )

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -31,6 +31,13 @@ export interface AgentSendMessageInputV2 {
   clientMessageId?: string;
 }
 
+/** Explicit Relay control invocation. Never represents a user prompt. */
+export interface AgentControlCommandInputV2 {
+  command: string;
+  args?: string;
+  confirmed?: boolean;
+}
+
 export interface AgentInterruptInputV2 {
   turnId?: string;
 }
@@ -89,6 +96,10 @@ export interface ProtocolAdapterV2 {
    * boundary. Optional because legacy harnesses can only queue a follow-up.
    */
   steerMessage?(input: AgentSendMessageInputV2): Promise<void>;
+  /** Provider-owned Relay control lane; absent means commands are unsupported. */
+  executeControlCommand?(
+    input: AgentControlCommandInputV2
+  ): Promise<{ config?: Record<string, unknown> }>;
   interrupt(input: AgentInterruptInputV2): Promise<void>;
   respondToApproval(input: AgentApprovalResponseInputV2): Promise<void>;
   respondToInput(input: AgentInputResponseInputV2): Promise<void>;
@@ -98,6 +109,8 @@ export interface ProtocolAdapterV2 {
   readonly status: AdapterStatus;
   readonly runtimeOwnership: 'spawned' | 'attached';
   readonly agentType: string;
+  /** Redaction-safe command previews for a currently connected session. */
+  getSlashCommands?(): import('../shared/agent-chat-protocol-v2.js').AgentSlashCommandV2[];
 }
 
 export abstract class BaseProtocolAdapterV2 implements ProtocolAdapterV2 {

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -8,6 +8,7 @@ import type {
   AgentApprovalResponseInputV2,
   AgentInputResponseInputV2,
   AgentInterruptInputV2,
+  AgentControlCommandInputV2,
   AgentSendMessageInputV2,
 } from '../protocol-adapter-v2.js';
 import type {
@@ -29,6 +30,7 @@ import {
 import { createLogger } from '../logger.js';
 import fs from 'node:fs';
 import path from 'node:path';
+import { relayControlCatalogForProvider } from '../../shared/agent-command-catalog.js';
 
 const logger = createLogger('codex-native-adapter');
 
@@ -126,7 +128,10 @@ const CODEX_CAPABILITIES: AgentCapabilitySetV2 = {
 
 // ── Relay-owned bake-ins ───────────────────────────────────────────────────
 
-const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
+const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] =
+  relayControlCatalogForProvider('codex');
+/*
+export const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
   {
     id: 'relay:clear',
     name: 'new',
@@ -136,6 +141,7 @@ const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
     sourceLabel: 'Relay',
     dispatch: 'relay-control',
     collisionKey: 'clear',
+    destructive: true,
   },
   {
     id: 'relay:resume',
@@ -159,6 +165,31 @@ const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
     collisionKey: 'model',
   },
   {
+    id: 'relay:effort',
+    name: 'effort',
+    description: 'Set Codex reasoning effort for subsequent responses',
+    argumentHint: '<low|medium|high|xhigh|max|ultra>',
+    args: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'].map((value) => ({ value })),
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'effort',
+  },
+  {
+    id: 'relay:fast',
+    name: 'fast',
+    description: 'Enable or disable Codex Fast Mode for subsequent responses',
+    argumentHint: '<on|off>',
+    args: [
+      { value: 'on', label: 'on', description: 'Use the fast service tier' },
+      { value: 'off', label: 'off', description: 'Use the default service tier' },
+    ],
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'fast',
+  },
+  {
     id: 'relay:compact',
     name: 'compact',
     description: 'Compact the current Codex thread context',
@@ -176,6 +207,7 @@ const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
     sourceLabel: 'Relay',
     dispatch: 'relay-control',
     collisionKey: 'rollback',
+    destructive: true,
   },
   {
     id: 'relay:archive',
@@ -185,6 +217,7 @@ const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
     sourceLabel: 'Relay',
     dispatch: 'relay-control',
     collisionKey: 'archive',
+    destructive: true,
   },
   {
     id: 'relay:unarchive',
@@ -223,7 +256,7 @@ const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
     dispatch: 'relay-control',
     collisionKey: 'fork',
   },
-];
+];*/
 
 // ── Approval support shapes ────────────────────────────────────────────────
 
@@ -511,6 +544,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   private activeStartedAt: string | null = null;
   private completedActiveTurn = false;
   private readonly queue: QueuedCodexMessage[] = [];
+  /** Runtime controls survive follow-up turns on this adapter, never raw prompts. */
+  private pendingModelOverride: string | null = null;
+  private pendingEffortOverride: string | null = null;
+  private pendingServiceTier: 'fast' | null = null;
 
   // Pending approvals keyed by relay item id (e.g. "approval-{requestId}")
   private readonly pendingApprovals = new Map<
@@ -536,7 +573,6 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     string,
     Record<string, unknown>
   >();
-  private pendingModelOverride: string | null = null;
 
   // Reasoning streaming buffers, keyed by relayItemId. Used to preserve the
   // accumulated text when item/completed arrives with an empty or
@@ -553,6 +589,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   // Slash commands
   private slashCommandsLoaded = false;
+  private commandCatalog: AgentSlashCommandV2[] = [...RELAY_CODEX_COMMANDS];
+  private fastModeAvailable = false;
+  private supportedReasoningEfforts: string[] | null = null;
+  private modelCatalog: Record<string, unknown>[] = [];
+  private skillCommands: AgentSlashCommandV2[] = [];
 
   constructor(clientFactory?: CodexClientFactory) {
     super();
@@ -562,6 +603,12 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   get status(): AdapterStatus {
     return this._status;
+  }
+
+  getSlashCommands(): AgentSlashCommandV2[] {
+    return this.commandCatalog.filter(
+      (command) => command.collisionKey !== 'fast' || this.fastModeAvailable
+    );
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -586,6 +633,9 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           persistExtendedHistory: false,
           ...(config.model || this.pendingModelOverride
             ? { model: this.pendingModelOverride ?? config.model }
+            : {}),
+          ...(this.initialServiceTier(config)
+            ? { serviceTier: this.initialServiceTier(config) }
             : {}),
         });
 
@@ -746,6 +796,26 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.releasePendingNativeSteerTerminal(pending);
   }
 
+  async executeControlCommand(
+    input: AgentControlCommandInputV2
+  ): Promise<{ config?: Record<string, unknown> }> {
+    const command = input.command.trim().toLowerCase();
+    const known = RELAY_CODEX_COMMANDS.find(
+      (entry) =>
+        entry.dispatch === 'relay-control' &&
+        (entry.name === command || (entry.aliases ?? []).includes(command))
+    );
+    if (!known) throw new Error('unsupported Codex control command');
+    if (known.collisionKey === 'fast' && !this.fastModeAvailable) {
+      throw new Error('Codex Fast Mode is unavailable for the selected model');
+    }
+    await this.handleControlAction(
+      known.collisionKey ?? known.name,
+      input.args?.trim() ?? ''
+    );
+    return { config: this.currentControlConfig() };
+  }
+
   async interrupt(_input: AgentInterruptInputV2): Promise<void> {
     if (this.nativeActiveTurnId !== null && this.client !== null) {
       try {
@@ -834,6 +904,12 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         input: buildCodexTurnInput(input.content, input.attachments),
         ...(this.pendingModelOverride
           ? { model: this.pendingModelOverride }
+          : {}),
+        ...(this.initialEffort(this.config)
+          ? { effort: this.initialEffort(this.config) }
+          : {}),
+        ...(this.pendingServiceTier
+          ? { serviceTier: this.pendingServiceTier }
           : {}),
       });
     } catch (err) {
@@ -2640,8 +2716,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     try {
       switch (action) {
         case 'clear': {
-          await this.disconnect();
-          await this.connect(this.config!);
+          // Do not call BaseProtocolAdapterV2.disconnect(): it clears the
+          // channel bridge/onPatch subscribers that must survive a fresh thread.
+          const config = this.config;
+          await this.teardownState();
+          await this.connect(config);
           emitControl('success');
           break;
         }
@@ -2663,8 +2742,56 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         }
 
         case 'model': {
-          this.pendingModelOverride = arg || null;
-          this.emitSessionUpdate({ config: arg ? { model: arg } : {} });
+          if (!arg) throw new Error('model requires an argument');
+          const clearFastTier =
+            this.pendingServiceTier === 'fast' &&
+            this.modelCatalog.length > 0 &&
+            !this.modelSupportsFast(arg);
+          await this.updateThreadSettings({
+            model: arg,
+            ...(clearFastTier ? { serviceTier: null } : {}),
+          });
+          this.pendingModelOverride = arg;
+          if (clearFastTier) this.pendingServiceTier = null;
+          this.recomputeModelCommands();
+          this.emitSessionUpdate({ config: { model: arg } });
+          emitControl('success', arg);
+          break;
+        }
+
+        case 'effort': {
+          if (
+            !['low', 'medium', 'high', 'xhigh', 'max', 'ultra'].includes(arg)
+          ) {
+            throw new Error(
+              'effort requires low, medium, high, xhigh, max, or ultra'
+            );
+          }
+          if (
+            this.supportedReasoningEfforts !== null &&
+            !this.supportedReasoningEfforts.includes(arg)
+          ) {
+            throw new Error(
+              `effort ${arg} is not supported by the selected model`
+            );
+          }
+          await this.updateThreadSettings({ effort: arg });
+          this.pendingEffortOverride = arg;
+          this.emitSessionUpdate({ config: { effort: arg } });
+          emitControl('success', arg);
+          break;
+        }
+
+        case 'fast': {
+          if (arg !== 'on' && arg !== 'off') {
+            throw new Error('fast requires on or off');
+          }
+          const serviceTier = arg === 'on' ? 'fast' : null;
+          await this.updateThreadSettings({ serviceTier });
+          this.pendingServiceTier = serviceTier;
+          this.emitSessionUpdate({
+            config: { providerOptions: { serviceTier } },
+          });
           emitControl('success', arg);
           break;
         }
@@ -2777,7 +2904,113 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       const message = err instanceof Error ? err.message : String(err);
       emitControl('error', message);
       logger.warn(`Codex control action '${action}' failed:`, err);
+      throw err;
     }
+  }
+
+  /** Current public settings only; intentionally excludes app-server config/env. */
+  private currentControlConfig(): Record<string, unknown> {
+    return {
+      ...(this.pendingModelOverride
+        ? { model: this.pendingModelOverride }
+        : {}),
+      ...(this.pendingEffortOverride
+        ? { effort: this.pendingEffortOverride }
+        : {}),
+      providerOptions: { serviceTier: this.pendingServiceTier },
+    };
+  }
+
+  private async updateThreadSettings(
+    settings: Record<string, unknown>
+  ): Promise<void> {
+    if (!this.client || !this.providerSessionId) {
+      throw new Error('Codex thread is not connected');
+    }
+    await this.client.call('thread/settings/update', {
+      threadId: this.providerSessionId,
+      ...settings,
+    });
+  }
+
+  private initialEffort(config: AdapterConfig): string | null {
+    const extra = isRecord(config.extra) ? config.extra : {};
+    return (
+      this.pendingEffortOverride ??
+      (typeof extra.effort === 'string' && extra.effort ? extra.effort : null)
+    );
+  }
+
+  private initialServiceTier(config: AdapterConfig): 'fast' | null {
+    const extra = isRecord(config.extra) ? config.extra : {};
+    return (
+      this.pendingServiceTier ?? (extra.serviceTier === 'fast' ? 'fast' : null)
+    );
+  }
+
+  private recomputeModelCommands(): void {
+    const selected = this.pendingModelOverride ?? this.config?.model;
+    const selectedModel = selected
+      ? this.modelCatalog.find(
+          (model) =>
+            model.id === selected ||
+            model.model === selected ||
+            model.name === selected
+        )
+      : (this.modelCatalog.find((model) => model.isDefault === true) ??
+        this.modelCatalog[0]);
+    this.fastModeAvailable = this.modelSupportsFast(selected);
+    const efforts = selectedModel?.supportedReasoningEfforts;
+    this.supportedReasoningEfforts =
+      this.modelCatalog.length === 0
+        ? null
+        : Array.isArray(efforts)
+          ? efforts.flatMap((effort) =>
+              typeof effort === 'string'
+                ? [effort]
+                : isRecord(effort) && typeof effort.reasoningEffort === 'string'
+                  ? [effort.reasoningEffort]
+                  : []
+            )
+          : [];
+    const controls = RELAY_CODEX_COMMANDS.flatMap((command) => {
+      if (command.collisionKey === 'fast' && !this.fastModeAvailable) return [];
+      if (command.collisionKey === 'effort' && this.supportedReasoningEfforts) {
+        return [
+          {
+            ...command,
+            args: this.supportedReasoningEfforts.map((value) => ({ value })),
+          },
+        ];
+      }
+      return [command];
+    });
+    this.commandCatalog = mergeCodexCommandCatalog(
+      this.skillCommands,
+      controls
+    );
+  }
+
+  private modelSupportsFast(modelId: string | null | undefined): boolean {
+    const model = modelId
+      ? this.modelCatalog.find(
+          (candidate) =>
+            candidate.id === modelId ||
+            candidate.model === modelId ||
+            candidate.name === modelId
+        )
+      : (this.modelCatalog.find((candidate) => candidate.isDefault === true) ??
+        this.modelCatalog[0]);
+    const tiers = model?.serviceTiers;
+    return (
+      (Array.isArray(tiers) &&
+        tiers.some(
+          (tier) =>
+            tier === 'fast' ||
+            (isRecord(tier) && (tier.value === 'fast' || tier.id === 'fast'))
+        )) ||
+      (isRecord(tiers) && tiers.fast !== false && tiers.fast !== undefined)
+    );
   }
 
   // ── Internal: slash commands ──────────────────────────────────────────────
@@ -2786,7 +3019,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     if (this.slashCommandsLoaded || !this.client) return;
 
     try {
-      const [skillsResult, _modelsResult] = await Promise.all([
+      const [skillsResult, modelsResult] = await Promise.all([
         this.client.call<{ skills: unknown[] }>('skills/list', { cwd: [cwd] }),
         this.client.call('model/list').catch(() => null),
       ]);
@@ -2804,9 +3037,19 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         }
       }
 
-      const catalog = mergeCodexCommandCatalog(skills, RELAY_CODEX_COMMANDS);
+      this.skillCommands = skills;
+      const models = Array.isArray(modelsResult)
+        ? modelsResult
+        : isRecord(modelsResult) && Array.isArray(modelsResult.data)
+          ? modelsResult.data
+          : isRecord(modelsResult) && Array.isArray(modelsResult.models)
+            ? modelsResult.models
+            : [];
+      this.modelCatalog = models.filter(isRecord);
+      this.recomputeModelCommands();
+      this.emitLiveState({ fastModeAvailable: this.fastModeAvailable });
       this.slashCommandsLoaded = true;
-      this.emitSessionUpdate({ slashCommands: catalog });
+      this.emitSessionUpdate({ slashCommands: this.commandCatalog });
     } catch (err) {
       logger.warn('Codex skills/list fetch failed:', err);
     }
@@ -2830,6 +3073,16 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           : {}),
         config: {
           ...(this.config.model ? { model: this.config.model } : {}),
+          ...(this.initialEffort(this.config)
+            ? { effort: this.initialEffort(this.config)! }
+            : {}),
+          ...(this.initialServiceTier(this.config)
+            ? {
+                providerOptions: {
+                  serviceTier: this.initialServiceTier(this.config),
+                },
+              }
+            : {}),
         },
       }),
     });

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -90,6 +90,10 @@ export interface AgentSlashCommandV2 {
   collisionKey?: string;
   /** Provider-native trigger prefix the wire expects when dispatch is 'agent'. Adapters set this; UI passes it through unchanged. */
   nativePrefix?: '/' | '$';
+  /** Enumerated safe arguments for a command preview, when the provider exposes them. */
+  args?: Array<{ value: string; label?: string; description?: string }>;
+  /** UI hint only; server-side dispatch remains capability checked. */
+  destructive?: boolean;
 }
 
 export interface AgentSessionV2 {
@@ -1681,6 +1685,22 @@ function isSlashCommand(value: unknown): boolean {
   ) {
     return false;
   }
+  if (
+    value.args !== undefined &&
+    !(
+      Array.isArray(value.args) &&
+      value.args.every(
+        (arg) =>
+          isRecord(arg) &&
+          typeof arg.value === 'string' &&
+          (arg.label === undefined || typeof arg.label === 'string') &&
+          (arg.description === undefined || typeof arg.description === 'string')
+      )
+    )
+  )
+    return false;
+  if (value.destructive !== undefined && typeof value.destructive !== 'boolean')
+    return false;
   return true;
 }
 

--- a/shared/agent-command-catalog.ts
+++ b/shared/agent-command-catalog.ts
@@ -1,0 +1,143 @@
+import type { AgentSlashCommandV2 } from './agent-chat-protocol-v2.js';
+
+/** Static, redaction-safe Relay controls. Provider adapters add live commands. */
+const CODEX_CONTROLS: AgentSlashCommandV2[] = [
+  {
+    id: 'relay:clear',
+    name: 'new',
+    aliases: ['clear', 'reset'],
+    description: 'Start a fresh Codex thread',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'clear',
+    destructive: true,
+  },
+  {
+    id: 'relay:resume',
+    name: 'continue',
+    aliases: ['resume'],
+    description: 'Resume a saved Codex thread by id',
+    argumentHint: '<threadId>',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'resume',
+  },
+  {
+    id: 'relay:model',
+    name: 'model',
+    description: 'Switch model for subsequent Codex responses',
+    argumentHint: '<model>',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'model',
+  },
+  {
+    id: 'relay:effort',
+    name: 'effort',
+    description: 'Set Codex reasoning effort for subsequent responses',
+    argumentHint: '<low|medium|high|xhigh|max|ultra>',
+    args: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'].map((value) => ({
+      value,
+    })),
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'effort',
+  },
+  {
+    id: 'relay:fast',
+    name: 'fast',
+    description: 'Enable or disable Codex Fast Mode for subsequent responses',
+    argumentHint: '<on|off>',
+    args: [
+      { value: 'on', label: 'on', description: 'Use the fast service tier' },
+      {
+        value: 'off',
+        label: 'off',
+        description: 'Use the default service tier',
+      },
+    ],
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'fast',
+  },
+  {
+    id: 'relay:compact',
+    name: 'compact',
+    description: 'Compact the current Codex thread context',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'compact',
+  },
+  {
+    id: 'relay:rollback',
+    name: 'rollback',
+    description: 'Roll back N turns in the current thread',
+    argumentHint: '<n>',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'rollback',
+    destructive: true,
+  },
+  {
+    id: 'relay:archive',
+    name: 'archive',
+    description: 'Archive the current Codex thread',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'archive',
+    destructive: true,
+  },
+  {
+    id: 'relay:unarchive',
+    name: 'unarchive',
+    description: 'Unarchive the current Codex thread',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'unarchive',
+  },
+  {
+    id: 'relay:goal',
+    name: 'goal',
+    description: 'Get, set, or clear the goal for the current thread',
+    argumentHint: 'set <text> | get | clear',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'goal',
+  },
+  {
+    id: 'relay:review',
+    name: 'review',
+    description: 'Enter review mode for the current thread',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'review',
+  },
+  {
+    id: 'relay:fork',
+    name: 'fork',
+    description: 'Fork the current Codex thread',
+    source: 'relay',
+    sourceLabel: 'Relay',
+    dispatch: 'relay-control',
+    collisionKey: 'fork',
+  },
+];
+
+export function relayControlCatalogForProvider(
+  providerId: string
+): AgentSlashCommandV2[] {
+  return providerId === 'codex'
+    ? CODEX_CONTROLS.map((command) => ({ ...command }))
+    : [];
+}

--- a/test/agent-chat-protocol-v2.test.ts
+++ b/test/agent-chat-protocol-v2.test.ts
@@ -135,6 +135,31 @@ describe('Agent Chat Protocol v2', () => {
         session: makeSession(),
       })
     ).toBe(true);
+
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        slashCommands: [
+          {
+            name: 'fast',
+            dispatch: 'relay-control',
+            args: [{ value: 'on', label: 'on' }],
+            destructive: false,
+          },
+        ],
+      })
+    ).toBe(true);
+
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        slashCommands: [{ name: 'fast', args: [{ value: 1 }] }],
+      })
+    ).toBe(false);
   });
 
   it('applies the reducer full flow with text deltas and turn completion', () => {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -17,7 +17,11 @@ import {
 } from '../server/protocol-adapter-v2.js';
 import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentRole } from '../shared/agent-roster.js';
-import { builtInAgentProfileId } from '../shared/agent-profile.js';
+import {
+  builtInAgentProfileId,
+  computeMentionDisambiguators,
+} from '../shared/agent-profile.js';
+import { relayControlCatalogForProvider } from '../shared/agent-command-catalog.js';
 import {
   dmChannelCreateInput,
   dmChannelTopicId,
@@ -1193,6 +1197,191 @@ function makeBinder(cfg: {
 // ── tests ────────────────────────────────────────────────────────────────────
 
 describe('channel-agent-binder — lifecycle', () => {
+  it('discovers and executes only confirmed Codex controls without persisting or routing a message', async () => {
+    const calls: Array<{
+      command: string;
+      args?: string;
+      confirmed?: boolean;
+    }> = [];
+    const { binder, store } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, {
+          getSlashCommands: () => [
+            { name: 'model', dispatch: 'relay-control', collisionKey: 'model' },
+            { name: 'deploy', dispatch: 'agent', collisionKey: 'deploy' },
+          ],
+          executeControlCommand: async (input: {
+            command: string;
+            args?: string;
+            confirmed?: boolean;
+          }) => {
+            calls.push(input);
+            return { config: { model: input.args ?? null } };
+          },
+        });
+        return adapter;
+      },
+      targets: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['codex'],
+    });
+    const profileId = builtInAgentProfileId('codex');
+    const roster = await binder.rosterForChannel(CH);
+    expect(roster[0]?.commands?.map((command) => command.name)).toContain(
+      'model'
+    );
+    expect(
+      roster[0]?.commands?.some((command) => command.name === 'deploy')
+    ).toBe(false);
+    await expect(
+      binder.executeCommand(CH, profileId, 'rollback', '1')
+    ).rejects.toMatchObject({
+      reasonCode: 'CONFIRMATION_REQUIRED',
+    });
+    await binder.executeCommand(CH, profileId, 'model', 'gpt-fast', true);
+    expect(calls).toEqual([
+      { command: 'model', args: 'gpt-fast', confirmed: true },
+    ]);
+    expect(rows(store)).toHaveLength(0);
+  });
+
+  it('targets command controls by exact named-profile Actor ID across a display-name collision', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'mock' }]);
+    const backend = profiles.create({
+      id: 'agent-profile:mock:backend-command',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const audit = profiles.create({
+      id: 'agent-profile:mock:audit-command',
+      providerId: 'mock',
+      displayName: 'Reviewer',
+    });
+    const calls: Array<{ profile: string; command: string }> = [];
+    let created = 0;
+    const { binder } = makeBinder({
+      build: (agentType) => {
+        const profile = ++created === 1 ? backend.id : audit.id;
+        const command = profile === backend.id ? 'model' : 'compact';
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, {
+          getSlashCommands: () => [
+            { name: command, dispatch: 'relay-control', collisionKey: command },
+          ],
+          executeControlCommand: async (input: { command: string }) => {
+            calls.push({ profile, command: input.command });
+            return { config: { profile } };
+          },
+        });
+        return adapter;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      agentProfileStore: profiles,
+    });
+
+    const tokens = computeMentionDisambiguators(profiles.list());
+    expect(
+      parseMentions(
+        `@Reviewer#${tokens.get(backend.id)}`,
+        ['mock'],
+        profiles.list()
+      )[0]?.profileId
+    ).toBe(backend.id);
+    expect(
+      parseMentions(
+        `@Reviewer#${tokens.get(audit.id)}`,
+        ['mock'],
+        profiles.list()
+      )[0]?.profileId
+    ).toBe(audit.id);
+
+    await binder.executeCommand(CH, backend.id, 'model', 'gpt-test');
+    await binder.executeCommand(CH, audit.id, 'compact');
+    expect(calls).toEqual([
+      { profile: backend.id, command: 'model' },
+      { profile: audit.id, command: 'compact' },
+    ]);
+    const roster = await binder.rosterForChannel(CH);
+    expect(
+      roster
+        .find((entry) => entry.id === backend.id)
+        ?.commands?.map((c) => c.name)
+    ).toEqual(['model']);
+    expect(
+      roster
+        .find((entry) => entry.id === audit.id)
+        ?.commands?.map((c) => c.name)
+    ).toEqual(['compact']);
+  });
+
+  it('uses the same adapter control contract for current providers and leaves unsupported providers empty', async () => {
+    const providerIds = ['claude', 'codex', 'opencode', 'hermes'];
+    const calls: Array<{ providerId: string; command: string }> = [];
+    const targets: MentionTarget[] = [
+      ...providerIds.map((id) => ({
+        id,
+        displayName: id,
+        kind: 'framework' as const,
+        available: true,
+        reason: null,
+      })),
+      {
+        id: 'unsupported',
+        displayName: 'unsupported',
+        kind: 'framework' as const,
+        available: false,
+        reason: 'adapter unavailable',
+      },
+    ];
+    const { binder } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, {
+          getSlashCommands: () => [
+            {
+              name: 'compact',
+              dispatch: 'relay-control',
+              collisionKey: 'compact',
+            },
+          ],
+          executeControlCommand: async (input: { command: string }) => {
+            calls.push({ providerId: agentType, command: input.command });
+            return {};
+          },
+        });
+        return adapter;
+      },
+      targets,
+      knownProviderIds: [...providerIds, 'unsupported'],
+    });
+
+    for (const providerId of providerIds) {
+      await binder.executeCommand(
+        CH,
+        builtInAgentProfileId(providerId),
+        'compact'
+      );
+    }
+    expect(calls).toEqual(
+      providerIds.map((providerId) => ({ providerId, command: 'compact' }))
+    );
+    expect(relayControlCatalogForProvider('unsupported')).toEqual([]);
+    await expect(
+      binder.executeCommand(CH, builtInAgentProfileId('unsupported'), 'compact')
+    ).rejects.toMatchObject({ reasonCode: 'UNAVAILABLE' });
+  });
+
   it('keeps same-provider profiles isolated: bindings, sessions, replies, roster, and status all use profile actor ids', async () => {
     const profiles = createAgentProfileStore(':memory:');
     cleanup.push(() => profiles.close());

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -3,7 +3,7 @@ import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import express from 'express';
+import express, { type RequestHandler } from 'express';
 import sharp from 'sharp';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -31,6 +31,7 @@ import {
   ChannelAgentBusyError,
   ChannelAgentRoleConflictError,
   ChannelMessageNotRetryableError,
+  createChannelAgentBinder,
   type ChannelAgentBinder,
 } from '../server/channel-agent-binder.js';
 import {
@@ -95,6 +96,12 @@ async function harness(
      * provable without a pathological corpus or a latency assertion.
      */
     searchTimeBudgetMs?: number;
+    binderFactory?: (deps: {
+      store: ChannelMessageStore;
+      hub: ChannelHub;
+      topicStore: WorkspaceTopicStore;
+    }) => ChannelAgentBinder;
+    requireWriteActorAuth?: (command: string) => RequestHandler;
   } = {}
 ): Promise<Harness> {
   const dir = tmpDir();
@@ -121,6 +128,9 @@ async function harness(
   });
   cleanup.push(() => hub.close());
   const topic = topicStore.create({ workspaceId: 'ws', title: 'General' });
+  const binder =
+    options.binderFactory?.({ store, hub, topicStore }) ?? options.binder;
+  if (options.binderFactory) cleanup.push(() => binder?.close?.());
 
   const app = express();
   app.use(express.json());
@@ -148,9 +158,7 @@ async function harness(
       broadcastEvent: (type, data) => {
         broadcasts.push({ type, ...(data ? { data } : {}) });
       },
-      ...(options.binder
-        ? { binder: options.binder as unknown as ChannelAgentBinder }
-        : {}),
+      ...(binder ? { binder: binder as unknown as ChannelAgentBinder } : {}),
       ...(options.withAuth
         ? {
             requireAuth: (req, res, next) => {
@@ -158,6 +166,9 @@ async function harness(
               res.sendStatus(401);
             },
           }
+        : {}),
+      ...(options.requireWriteActorAuth
+        ? { requireWriteActorAuth: options.requireWriteActorAuth as never }
         : {}),
       ...(options.historyMaxBytes !== undefined
         ? { historyMaxBytes: options.historyMaxBytes }
@@ -1351,6 +1362,9 @@ describe('channel routes — gateway capability mapping', () => {
       'channels.threads.history'
     );
     expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toContain('channels.post');
+    expect(CLI_GATEWAY_ACTOR_WRITE_COMMANDS).toContain(
+      'channels.agent-commands'
+    );
   });
 
   it('maps channels verbs to context read/write capability bits', () => {
@@ -1369,6 +1383,142 @@ describe('channel routes — gateway capability mapping', () => {
     expect(cliGatewayActorCommandCapabilities('channels.post')).toEqual([
       'context:write',
     ]);
+    expect(
+      cliGatewayActorCommandCapabilities('channels.agent-commands')
+    ).toEqual(['context:write']);
+  });
+});
+
+describe('channel routes — agent commands', () => {
+  const commandBinder = (
+    calls: unknown[] = []
+  ): Partial<ChannelAgentBinder> => ({
+    isControlMessage: (text: string) => /@codex\s*\/compact/i.test(text),
+    executeCommand: async (...args: unknown[]) => {
+      calls.push(args);
+      return { config: { model: 'gpt-fast' } };
+    },
+  });
+
+  it('uses the command-specific actor auth lane and denies before dispatch', async () => {
+    const commands: string[] = [];
+    const h = await harness({
+      binder: commandBinder(),
+      requireWriteActorAuth: (command) => (req, res, next) => {
+        commands.push(command);
+        if (command === 'channels.agent-commands') {
+          return res.status(403).json({ error: { code: 'FORBIDDEN' } });
+        }
+        next();
+      },
+    });
+    const res = await req<{ error: unknown }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-commands`,
+      body: {
+        profileId: 'agent-profile:codex:default',
+        command: 'model',
+        args: 'gpt-fast',
+      },
+    });
+    expect(res.status).toBe(403);
+    expect(commands).toEqual(['channels.agent-commands']);
+  });
+
+  it('rejects archived commands and dispatches successful controls without rows', async () => {
+    const calls: unknown[] = [];
+    const h = await harness({ binder: commandBinder(calls) });
+    h.topicStore.archive(h.channelId);
+    const archived = await req<{
+      error: { details?: { reasonCode?: string } };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-commands`,
+      body: {
+        profileId: 'agent-profile:codex:default',
+        command: 'model',
+        args: 'gpt-fast',
+      },
+    });
+    expect(archived.status).toBe(409);
+    expect(calls).toHaveLength(0);
+    h.topicStore.restore(h.channelId);
+    const ok = await req<{ ok: boolean }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-commands`,
+      body: {
+        profileId: 'agent-profile:codex:default',
+        command: 'model',
+        args: 'gpt-fast',
+      },
+    });
+    expect(ok.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(h.store.history(h.channelId, { limit: 10 })).toHaveLength(0);
+  });
+
+  const realControlBinder = ({
+    store,
+    hub,
+    topicStore,
+  }: {
+    store: ChannelMessageStore;
+    hub: ChannelHub;
+    topicStore: WorkspaceTopicStore;
+  }) =>
+    createChannelAgentBinder({
+      store,
+      hub,
+      topicStore,
+      sessions: {
+        createWeb: async () => {
+          throw new Error('control messages must not create a binding');
+        },
+        get: () => undefined,
+        onSessionEnd: () => () => {},
+      },
+      runtimes: {
+        create: async () => {
+          throw new Error('control messages must not create a runtime');
+        },
+        get: () => undefined,
+        destroy: async () => {},
+        onRuntimeEnd: () => () => {},
+      },
+      knownProviderIds: ['codex'],
+      mentionTargets: async () => [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          kind: 'framework' as const,
+          available: true,
+          reason: null,
+        },
+      ],
+      port: 0,
+      configDir: '/tmp',
+    });
+
+  it.each([
+    '@codex/compact',
+    '@codex /compact',
+    'please @codex/compact',
+    '@codex hello @codex/compact',
+  ])('rejects normal-post control form %s before persistence', async (text) => {
+    const h = await harness({ binderFactory: realControlBinder });
+    const res = await req<{
+      error: { details?: { reasonCode?: string } };
+    }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages`,
+      body: { text },
+    });
+    expect(res.status).toBe(400);
+    expect(h.store.history(h.channelId, { limit: 10 })).toHaveLength(0);
   });
 });
 
@@ -1439,7 +1589,11 @@ describe('channel routes — orchestrator designation (#1259)', () => {
     );
 
     const res = await req<{
-      error: { code: string; retryable: boolean; details?: Record<string, unknown> };
+      error: {
+        code: string;
+        retryable: boolean;
+        details?: Record<string, unknown>;
+      };
     }>({
       port: h.port,
       method: 'POST',

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -608,6 +608,7 @@ test('classifies explicitly scoped CLI gateway actor write routes into the actor
     'workspace-topics.archive',
     'workspace-topics.restore',
     'channels.post',
+    'channels.agent-commands',
     'channels.interrupt',
     'channels.respond-approval',
   ]);

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -12,10 +12,17 @@ import {
   CHANNEL_COMPOSER_MAX_IMAGE_BYTES,
   ChannelComposer,
 } from '../../frontend/src/components/chat/ChannelComposer.js';
-import { uploadChannelImages } from '../../frontend/src/lib/api.js';
+import {
+  executeChannelAgentCommand,
+  fetchChannelRoster,
+  uploadChannelImages,
+  type RosterEntry,
+} from '../../frontend/src/lib/api.js';
 
 vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../frontend/src/lib/api.js')>()),
+  executeChannelAgentCommand: vi.fn(),
+  fetchChannelRoster: vi.fn(),
   uploadChannelImages: vi.fn(),
 }));
 
@@ -34,6 +41,52 @@ function setNativeValue(el: HTMLTextAreaElement, value: string): void {
 
 let container: HTMLDivElement;
 let root: Root;
+
+const codexRoster: RosterEntry[] = [
+  {
+    id: 'agent-profile:codex:default',
+    displayName: 'Codex',
+    providerId: 'codex',
+    isDefault: true,
+    isBuiltIn: true,
+    kind: 'framework',
+    available: true,
+    reason: null,
+    binding: null,
+    commands: [
+      {
+        id: 'relay:fast',
+        name: 'fast',
+        description: 'Enable or disable Codex Fast Mode',
+        argumentHint: '<on|off>',
+        args: [
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' },
+        ],
+        source: 'relay',
+        sourceLabel: 'Relay',
+        dispatch: 'relay-control',
+        collisionKey: 'fast',
+      },
+      {
+        id: 'relay:clear',
+        name: 'clear',
+        description: 'Start a fresh session',
+        source: 'relay',
+        sourceLabel: 'Relay',
+        dispatch: 'relay-control',
+        collisionKey: 'clear',
+      },
+      {
+        id: 'native:compact',
+        name: 'compact',
+        description: 'Provider-native command that must not use Relay controls',
+        source: 'sdk',
+        dispatch: 'agent',
+      },
+    ],
+  },
+];
 
 interface RenderOpts {
   onSend?: (
@@ -127,6 +180,48 @@ async function pasteFiles(files: File[]): Promise<Event> {
   return event;
 }
 
+async function settleRoster(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function pressKey(
+  key: string,
+  options: { shiftKey?: boolean } = {}
+): Promise<void> {
+  const ta = container.querySelector('.ch-composer__ta') as HTMLTextAreaElement;
+  await act(async () => {
+    ta.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key,
+        ...options,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function pressMobileSend(): Promise<Event> {
+  const ta = container.querySelector('.ch-composer__ta') as HTMLTextAreaElement;
+  const event = new Event('beforeinput', { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    inputType: { value: 'insertLineBreak' },
+    isComposing: { value: false },
+  });
+  await act(async () => {
+    ta.dispatchEvent(event);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return event;
+}
+
 const imagePart: ChannelImagePart = {
   type: 'image',
   id: 'cha:test-image',
@@ -146,6 +241,9 @@ describe('ChannelComposer (#1178)', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     vi.mocked(uploadChannelImages).mockReset();
+    vi.mocked(fetchChannelRoster).mockResolvedValue(codexRoster);
+    vi.mocked(executeChannelAgentCommand).mockReset();
+    vi.mocked(executeChannelAgentCommand).mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -390,5 +488,223 @@ describe('ChannelComposer (#1178)', () => {
     ) as HTMLButtonElement;
     await act(async () => restore.click());
     expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns an exact @profile/fast pick into a dedicated fast control, never a channel post', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+
+    await act(async () => setNativeValue(ta, '@codex/fast'));
+    await settleRoster();
+    expect(
+      container.querySelector(
+        '[role="listbox"][aria-label="commands for Codex"]'
+      )
+    ).not.toBeNull();
+    expect(ta.getAttribute('aria-controls')).toBe(
+      'channel-agent-command-palette'
+    );
+    expect(ta.getAttribute('aria-activedescendant')).toBe(
+      'channel-agent-command-option-0'
+    );
+
+    // First Enter chooses the command, second chooses the default `on` option.
+    await pressKey('Enter');
+    await pressKey('Enter');
+
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:default',
+      command: 'fast',
+      args: 'on',
+    });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('accepts the single space inserted by mention selection before / commands', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+
+    await act(async () => setNativeValue(ta, '@'));
+    await settleRoster();
+    await pressKey('Enter');
+    expect(ta.value).toBe('@codex ');
+
+    await act(async () => setNativeValue(ta, '@codex /'));
+    await settleRoster();
+    expect(
+      container.querySelector(
+        '[role="listbox"][aria-label="commands for Codex"]'
+      )
+    ).not.toBeNull();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('uses the mobile beforeinput send intent to pick the command and its fast value', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/fast'));
+    await settleRoster();
+
+    expect((await pressMobileSend()).defaultPrevented).toBe(true);
+    expect((await pressMobileSend()).defaultPrevented).toBe(true);
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:default',
+      command: 'fast',
+      args: 'on',
+    });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('escapes the command palette without losing the exact draft or posting it', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/fast'));
+    await settleRoster();
+
+    await pressKey('Escape');
+    expect(ta.value).toBe('@codex/fast');
+    expect(
+      (
+        container.querySelector(
+          '[role="listbox"][aria-label="commands for Codex"]'
+        ) as HTMLElement
+      ).style.display
+    ).toBe('none');
+    // The next Enter reopens the command preview; it can never route this
+    // command-shaped draft as a normal channel message.
+    await pressKey('Enter');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('requires an explicit confirmation row before a destructive command is sent', async () => {
+    await renderComposer();
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/clear'));
+    await settleRoster();
+
+    await pressKey('Enter');
+    expect(executeChannelAgentCommand).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('confirm');
+    await pressKey('Enter');
+
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:default',
+      command: 'clear',
+      confirmed: true,
+    });
+  });
+
+  it('uses the most recent exact profile command, not an earlier mention', async () => {
+    vi.mocked(fetchChannelRoster).mockResolvedValue([
+      ...codexRoster,
+      {
+        id: 'agent-profile:claude:default',
+        displayName: 'Claude',
+        providerId: 'claude',
+        isDefault: true,
+        isBuiltIn: true,
+        kind: 'framework',
+        available: true,
+        reason: null,
+        binding: null,
+        commands: [
+          {
+            id: 'relay:claude-clear',
+            name: 'clear',
+            dispatch: 'relay-control',
+            destructive: true,
+          },
+        ],
+      },
+    ]);
+    await renderComposer();
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/fast … @claude/clear'));
+    await settleRoster();
+
+    expect(
+      container.querySelector('[role="listbox"]')?.getAttribute('aria-label')
+    ).toBe('commands for Claude');
+    await pressKey('Enter');
+    await pressKey('Enter');
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:claude:default',
+      command: 'clear',
+      confirmed: true,
+    });
+  });
+
+  it('keeps collision-token profile identity when selecting a command', async () => {
+    vi.mocked(fetchChannelRoster).mockResolvedValue([
+      ...codexRoster,
+      {
+        id: 'agent-profile:claude:aaaaaa',
+        displayName: 'Reviewer',
+        providerId: 'claude',
+        isDefault: false,
+        isBuiltIn: false,
+        kind: 'framework',
+        available: true,
+        reason: null,
+        binding: null,
+        commands: [
+          { id: 'relay:a-fast', name: 'fast', dispatch: 'relay-control' },
+        ],
+      },
+      {
+        id: 'agent-profile:codex:bbbbbb',
+        displayName: 'Reviewer',
+        providerId: 'codex',
+        isDefault: false,
+        isBuiltIn: false,
+        kind: 'framework',
+        available: true,
+        reason: null,
+        binding: null,
+        commands: [
+          { id: 'relay:b-fast', name: 'fast', dispatch: 'relay-control' },
+        ],
+      },
+    ]);
+    await renderComposer();
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@Reviewer#aaaaaa/fast'));
+    await settleRoster();
+
+    await pressKey('Enter');
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:claude:aaaaaa',
+      command: 'fast',
+    });
+  });
+
+  it('never shows provider-native commands in the Relay control palette', async () => {
+    await renderComposer();
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/'));
+    await settleRoster();
+
+    expect(container.textContent).toContain('/fast');
+    expect(container.textContent).not.toContain('/compact');
   });
 });

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -2873,6 +2873,173 @@ describe('CodexNativeProtocolAdapter — prefix rewrite', () => {
 // ── Relay-control dispatch ────────────────────────────────────────────────────
 
 describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
+  it('uses flat thread/settings/update controls and carries profile effort into turn/start', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect({ ...config, extra: { effort: 'high' } });
+    const client = factory.lastClient!;
+
+    await adapter.sendMessage({ turnId: 'turn-effort-default', content: 'go' });
+    expect(
+      client.calls.find((call) => call.method === 'turn/start')?.params
+    ).toMatchObject({ effort: 'high' });
+
+    await adapter.executeControlCommand?.({ command: 'effort', args: 'ultra' });
+    expect(
+      client.calls.find((call) => call.method === 'thread/settings/update')
+        ?.params
+    ).toMatchObject({
+      threadId: 'thread-1',
+      effort: 'ultra',
+    });
+    await adapter.disconnect();
+  });
+
+  it('clears into a fresh thread without dropping existing patch subscribers', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    await adapter.connect(config);
+    await adapter.executeControlCommand?.({ command: 'clear' });
+    await adapter.sendMessage({
+      turnId: 'after-clear',
+      content: 'still bridged',
+    });
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-turn-started-v2' &&
+          patch.turn.id === 'after-clear'
+      )
+    ).toBe(true);
+    await adapter.disconnect();
+  });
+
+  it('rejects Fast Mode until model/list has advertised the fast service tier', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient?.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-fast',
+          isDefault: true,
+          serviceTiers: [
+            { id: 'fast', name: 'Fast', description: 'Fast tier' },
+          ],
+          supportedReasoningEfforts: [
+            { reasoningEffort: 'low', description: 'Low effort' },
+            { reasoningEffort: 'ultra', description: 'Ultra effort' },
+          ],
+        },
+      ],
+    });
+    await adapter.connect({ ...config, model: 'gpt-fast' });
+    await waitFor(() =>
+      adapter.getSlashCommands().some((command) => command.name === 'fast')
+    );
+    expect(
+      adapter.getSlashCommands().find((command) => command.name === 'effort')
+        ?.args
+    ).toEqual([{ value: 'low' }, { value: 'ultra' }]);
+    await adapter.executeControlCommand?.({ command: 'fast', args: 'on' });
+    expect(
+      factory.lastClient!.calls.find(
+        (call) => call.method === 'thread/settings/update'
+      )?.params
+    ).toMatchObject({
+      threadId: 'thread-1',
+      serviceTier: 'fast',
+    });
+    await adapter.disconnect();
+  });
+
+  it('clears Fast Mode atomically when switching to a model without the fast tier', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient?.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-fast',
+          serviceTiers: [{ id: 'fast' }],
+          supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+        },
+        {
+          id: 'gpt-standard',
+          serviceTiers: [{ id: 'default' }],
+          supportedReasoningEfforts: [{ reasoningEffort: 'medium' }],
+        },
+      ],
+    });
+    await adapter.connect({ ...config, model: 'gpt-fast' });
+    await waitFor(() =>
+      adapter.getSlashCommands().some((command) => command.name === 'fast')
+    );
+
+    await adapter.executeControlCommand?.({ command: 'fast', args: 'on' });
+    await adapter.executeControlCommand?.({
+      command: 'model',
+      args: 'gpt-standard',
+    });
+    const updates = factory.lastClient!.calls.filter(
+      (call) => call.method === 'thread/settings/update'
+    );
+    expect(updates.at(-1)?.params).toMatchObject({
+      threadId: 'thread-1',
+      model: 'gpt-standard',
+      serviceTier: null,
+    });
+
+    await adapter.sendMessage({ turnId: 'standard-turn', content: 'go' });
+    const turn = factory.lastClient!.calls.find(
+      (call) => call.method === 'turn/start'
+    );
+    expect(turn?.params).not.toHaveProperty('serviceTier');
+    await adapter.disconnect();
+  });
+
+  it('rejects live-unsupported reasoning effort while retaining static fallback without a catalog', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient?.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient?.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-fast',
+          serviceTiers: [{ id: 'fast' }],
+          supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+        },
+      ],
+    });
+    await adapter.connect({ ...config, model: 'gpt-fast' });
+    await waitFor(() =>
+      adapter.getSlashCommands().some((command) => command.name === 'fast')
+    );
+
+    await expect(
+      adapter.executeControlCommand?.({ command: 'effort', args: 'ultra' })
+    ).rejects.toThrow('not supported by the selected model');
+    expect(
+      factory.lastClient!.calls.some(
+        (call) => call.method === 'thread/settings/update'
+      )
+    ).toBe(false);
+    await adapter.disconnect();
+  });
+
   it('/compact calls thread/compact/start and emits controlAction extension', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ const SERIAL_SUBPROCESS_FILES = [
   'test/git-divergence.test.ts',
   'test/git-watcher.test.ts',
   'test/workspace-divergence-api.test.ts',
+  'test/work-context-messages.test.ts',
   'test/worktree-cleanup.test.ts',
   'test/sessions.test.ts',
   // These files execute or rebuild the shared dist/bin/relay-ide.js output.


### PR DESCRIPTION
## What

- add a provider-neutral command catalog and dedicated control-command execution lane
- add an accessible `@agent/` command palette that preserves exact named-agent profile identity
- add Codex model, reasoning effort, Fast service tier, and clear/compact controls using live model metadata
- define truthful adapter contracts for Claude Code, Codex, OpenCode, Hermes, and future harnesses

## Why

Harness controls should not become ordinary chat messages or token-consuming turns. This gives Relay a typed, capability-aware command surface whose UI suggestions and server execution both come from the selected named agent's adapter.

## Safety and compatibility

- commands use a dedicated authenticated endpoint and are never persisted as channel messages
- destructive commands require explicit confirmation
- routing uses exact profile IDs, including duplicate-display-name cases
- unsupported harness controls remain explicitly unsupported instead of being guessed
- Codex Fast is exposed only when live `model/list` metadata advertises the `fast` service tier for the selected model

## Verification

- adversarial review plus focused re-review: no unresolved P0/P1 findings
- focused exact-head suite: 290/290 passed
- actor-auth contract: 21/21 passed
- production build: passed
- type/lint check: passed (0 errors; existing warnings only)
- `git diff --check`: clean
- moved the existing Git-backed message-template test into the serial subprocess lane after reproducing its push-time timeout; serial run 9/9 and real-Git stress run 44/44 passed

Exact head: `c0a0ff44`
