### PR TITLE
feat(agents): add Prime Agent command controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ workflow.
 #### Added
 
 - Run Prime Agent as a built-in terminal and channel provider through its native RPC mode (#1340)
+- Control Prime Agent models, reasoning, compaction, and fresh sessions from the `@agent/` command palette (#1345)
 - Create and name new folders directly in the local Add Project browser (#1338)
 - `@agent/` opens a provider-aware command palette for channel controls,
   including Codex Fast Mode, model, and reasoning-effort changes (#1344)

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -48,6 +48,16 @@ one durable Relay turn per message. Channel subprocesses currently launch with
 `--no-extensions` because blocking `extension_ui_request` dialogs are not mapped
 to Relay approvals/questions yet.
 
+The channel command palette discovers Prime models from the connected RPC
+runtime and exposes native `model`, `thinking`/`effort`, `compact`, and confirmed
+`new`/`clear` controls. These execute on Relay's authenticated control lane, not
+as persisted chat messages or token-consuming prompts. Model and thinking
+arguments are validated against live Prime metadata; if discovery is unavailable,
+the adapter fails closed instead of guessing. Prime skills, prompt templates,
+and TUI-only commands are not exposed as channel controls. This control surface
+targets the Prime Agent 0.7 RPC contract; a runtime that cannot return a valid
+live model catalog publishes no connected command catalog.
+
 The `prime-agent` executable is also available as a normal terminal launch, but
 that surface stays a generic PTY: Relay does not parse terminal output or infer
 channel capabilities from it.

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -2576,20 +2576,10 @@ export function createChannelAgentBinder(
         const baseCommands = relayControlCatalogForProvider(
           profile.providerId
         ).filter((command) => command.collisionKey !== 'fast');
-        const liveCommands = (
-          binding?.adapter?.getSlashCommands?.() ?? []
+        const liveCatalog = binding?.adapter?.getSlashCommands;
+        const commands = (
+          liveCatalog ? liveCatalog.call(binding.adapter) : baseCommands
         ).filter((command) => command.dispatch === 'relay-control');
-        const commands = [...baseCommands, ...liveCommands].reduce<
-          AgentSlashCommandV2[]
-        >((merged, command) => {
-          const key = command.collisionKey ?? command.name;
-          if (
-            !merged.some((entry) => (entry.collisionKey ?? entry.name) === key)
-          ) {
-            merged.push(command);
-          }
-          return merged;
-        }, []);
         return {
           id: profile.id,
           displayName: await rosterDisplayName(profile),

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -8,14 +8,17 @@ import type {
   AgentInputResponseInputV2,
   AgentInterruptInputV2,
   AgentSendMessageInputV2,
+  AgentControlCommandInputV2,
 } from '../protocol-adapter-v2.js';
 import type {
   AgentCapabilitySetV2,
   AgentItemV2,
   AgentSessionLiveStateV2,
+  AgentSlashCommandV2,
   AgentUsageV2,
 } from '../../shared/agent-chat-protocol-v2.js';
 import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+import { relayControlCatalogForProvider } from '../../shared/agent-command-catalog.js';
 import { cleanEnv } from '../utils.js';
 import {
   PrimeAgentRpcClient,
@@ -32,7 +35,7 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   approvals: false,
   questions: false,
   plans: false,
-  slashCommands: false,
+  slashCommands: true,
   queue: true,
   cancelQueued: false,
   interrupt: true,
@@ -138,6 +141,11 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private queueAdvanceInFlight = false;
   private providerExtensionSequence = 0;
   private readonly items = new Map<string, AgentItemV2>();
+  private commandCatalog = relayControlCatalogForProvider('prime-agent');
+  private modelCatalog: RpcRecord[] = [];
+  private currentModel: RpcRecord | null = null;
+  private thinkingLevel: string | null = null;
+  private controlInFlight = false;
 
   constructor(
     private readonly clientFactory: ClientFactory = (options) =>
@@ -147,6 +155,16 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
   get status(): AdapterStatus {
     return this._status;
+  }
+
+  getSlashCommands(): AgentSlashCommandV2[] {
+    return this.commandCatalog.map((command) => ({
+      ...command,
+      ...(command.aliases ? { aliases: [...command.aliases] } : {}),
+      ...(command.args
+        ? { args: command.args.map((arg) => ({ ...arg })) }
+        : {}),
+    }));
   }
 
   async connect(config: AdapterConfig): Promise<void> {
@@ -192,7 +210,9 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       const response = await client.start();
       this.applyState(record(response.data));
       this._status = 'connected';
+      await this.refreshControlCommands();
       this.emitSnapshot();
+      this.emitSessionUpdate();
       this.emitLive({
         status: record(response.data).isStreaming === true ? 'working' : 'idle',
         activeTurnId: null,
@@ -252,6 +272,9 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    if (this.controlInFlight) {
+      throw new Error('Prime Agent control command is in progress');
+    }
     const client = this.requireClient();
     const payload: RpcRecord = { message: input.content };
     const images = this.readImages(input.attachments);
@@ -279,6 +302,86 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         error instanceof Error ? error : new Error(String(error))
       );
       throw error;
+    }
+  }
+
+  async executeControlCommand(
+    input: AgentControlCommandInputV2
+  ): Promise<{ config?: Record<string, unknown> }> {
+    const client = this.requireClient();
+    if (this.activeTurnId || this.queued.length > 0) {
+      throw new Error(
+        'Prime Agent controls are unavailable while a turn is active'
+      );
+    }
+    if (this.controlInFlight) {
+      throw new Error('another Prime Agent control command is in progress');
+    }
+    this.controlInFlight = true;
+    try {
+      const command = input.command.trim().toLowerCase();
+      const known = this.commandCatalog.find(
+        (entry) =>
+          entry.dispatch === 'relay-control' &&
+          (entry.name === command || (entry.aliases ?? []).includes(command))
+      );
+      if (!known) throw new Error('unsupported Prime Agent control command');
+      if (known.destructive && input.confirmed !== true) {
+        throw new Error('Prime Agent control command requires confirmation');
+      }
+      const action = known.collisionKey ?? known.name;
+      const args = input.args?.trim() ?? '';
+
+      switch (action) {
+        case 'clear': {
+          const response = await client.call('new_session');
+          if (record(response.data).cancelled === true) {
+            throw new Error('Prime Agent cancelled the new session request');
+          }
+          this.providerSessionId = null;
+          this.providerSessionFile = null;
+          this.items.clear();
+          break;
+        }
+        case 'model': {
+          const selected = this.modelCatalog.find(
+            (model) => this.modelValue(model) === args
+          );
+          if (!selected) {
+            throw new Error(
+              'model must be selected from the live Prime Agent catalog'
+            );
+          }
+          await client.call('set_model', {
+            provider: string(selected.provider),
+            modelId: string(selected.id),
+          });
+          break;
+        }
+        case 'thinking': {
+          const allowed = this.availableThinkingLevels(this.currentModel);
+          if (!allowed.includes(args)) {
+            throw new Error(
+              `thinking must be one of: ${allowed.join(', ') || 'none available'}`
+            );
+          }
+          await client.call('set_thinking_level', { level: args });
+          break;
+        }
+        case 'compact':
+          await client.call('compact');
+          break;
+        default:
+          throw new Error('unsupported Prime Agent control command');
+      }
+
+      const state = await client.call('get_state');
+      this.applyState(record(state.data));
+      this.recomputeControlCommands();
+      this.emitSessionUpdate();
+      return { config: this.currentControlConfig() };
+    } finally {
+      this.controlInFlight = false;
     }
   }
 
@@ -840,10 +943,113 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     });
   }
 
+  private async refreshControlCommands(): Promise<void> {
+    const client = this.requireClient();
+    try {
+      const response = await client.call('get_available_models');
+      const models = record(response.data).models;
+      this.modelCatalog = Array.isArray(models)
+        ? models.map(record).filter((model) => this.modelValue(model) !== '')
+        : [];
+      if (this.modelCatalog.length === 0) {
+        this.commandCatalog = [];
+        return;
+      }
+    } catch {
+      // Older or malformed Prime Agent runtimes must not receive guessed
+      // controls: an advertised command is an executable capability promise.
+      this.modelCatalog = [];
+      this.commandCatalog = [];
+      return;
+    }
+    this.recomputeControlCommands();
+  }
+
+  private modelValue(model: RpcRecord): string {
+    const provider = string(model.provider);
+    const id = string(model.id);
+    return provider && id
+      ? `${encodeURIComponent(provider)}/${encodeURIComponent(id)}`
+      : '';
+  }
+
+  private availableThinkingLevels(model: RpcRecord | null): string[] {
+    if (!model) return [];
+    if (model.reasoning !== true) return ['off'];
+    const levelMap = record(model.thinkingLevelMap);
+    const levels = ['off', 'minimal', 'low', 'medium', 'high'].filter(
+      (level) => levelMap[level] !== null
+    );
+    for (const level of ['xhigh', 'max']) {
+      if (level in levelMap && levelMap[level] !== null) levels.push(level);
+    }
+    return levels;
+  }
+
+  private recomputeControlCommands(): void {
+    const controls = relayControlCatalogForProvider('prime-agent');
+    const thinkingLevels = this.availableThinkingLevels(this.currentModel);
+    this.commandCatalog = controls.flatMap((command) => {
+      if (command.collisionKey === 'model') {
+        if (this.modelCatalog.length === 0) return [];
+        return [
+          {
+            ...command,
+            args: this.modelCatalog.flatMap((model) => {
+              const value = this.modelValue(model);
+              if (!value) return [];
+              return [
+                {
+                  value,
+                  label: string(model.name) || string(model.id),
+                  description: string(model.provider),
+                },
+              ];
+            }),
+          },
+        ];
+      }
+      if (command.collisionKey === 'thinking') {
+        if (thinkingLevels.length === 0) return [];
+        return [
+          {
+            ...command,
+            args: thinkingLevels.map((value) => ({ value })),
+          },
+        ];
+      }
+      return [command];
+    });
+  }
+
+  private currentControlConfig(): Record<string, unknown> {
+    const model = this.currentModel ? this.modelValue(this.currentModel) : '';
+    return {
+      ...(model ? { model } : {}),
+      ...(this.thinkingLevel ? { effort: this.thinkingLevel } : {}),
+      ...(this.currentModel
+        ? { providerOptions: { provider: string(this.currentModel.provider) } }
+        : {}),
+    };
+  }
+
+  private emitSessionUpdate(): void {
+    this.emitPatch({
+      type: 'agent-session-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      providerSession: this.providerSession,
+      config: this.currentControlConfig(),
+      slashCommands: this.getSlashCommands(),
+    });
+  }
+
   private applyState(data: RpcRecord): void {
-    this.providerSessionId = string(data.sessionId) || this.providerSessionId;
-    this.providerSessionFile =
-      string(data.sessionFile) || this.providerSessionFile;
+    this.providerSessionId = string(data.sessionId) || null;
+    this.providerSessionFile = string(data.sessionFile) || null;
+    const model = record(data.model);
+    this.currentModel = string(model.id) ? model : null;
+    this.thinkingLevel = string(data.thinkingLevel) || null;
   }
   private emitSnapshot(): void {
     if (!this.config) return;
@@ -857,6 +1063,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         cwd: this.config.cwd,
         capabilities: this.capabilities,
         providerSession: this.providerSession,
+        config: this.currentControlConfig(),
       }),
     });
   }

--- a/shared/agent-command-catalog.ts
+++ b/shared/agent-command-catalog.ts
@@ -134,10 +134,65 @@ const CODEX_CONTROLS: AgentSlashCommandV2[] = [
   },
 ];
 
+const PRIME_AGENT_CONTROLS: AgentSlashCommandV2[] = [
+  {
+    id: 'relay:prime-agent:new',
+    name: 'new',
+    aliases: ['clear', 'reset'],
+    description: 'Start a fresh Prime Agent session',
+    source: 'builtin',
+    sourceLabel: 'Prime Agent',
+    dispatch: 'relay-control',
+    collisionKey: 'clear',
+    destructive: true,
+  },
+  {
+    id: 'relay:prime-agent:model',
+    name: 'model',
+    description: 'Switch the model for subsequent Prime Agent responses',
+    argumentHint: '<provider/model>',
+    source: 'builtin',
+    sourceLabel: 'Prime Agent',
+    dispatch: 'relay-control',
+    collisionKey: 'model',
+  },
+  {
+    id: 'relay:prime-agent:thinking',
+    name: 'thinking',
+    aliases: ['effort'],
+    description: 'Set Prime Agent reasoning depth',
+    argumentHint: '<off|minimal|low|medium|high|xhigh|max>',
+    args: ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].map(
+      (value) => ({ value })
+    ),
+    source: 'builtin',
+    sourceLabel: 'Prime Agent',
+    dispatch: 'relay-control',
+    collisionKey: 'thinking',
+  },
+  {
+    id: 'relay:prime-agent:compact',
+    name: 'compact',
+    description: 'Compact the current Prime Agent session context',
+    source: 'builtin',
+    sourceLabel: 'Prime Agent',
+    dispatch: 'relay-control',
+    collisionKey: 'compact',
+  },
+];
+
 export function relayControlCatalogForProvider(
   providerId: string
 ): AgentSlashCommandV2[] {
-  return providerId === 'codex'
-    ? CODEX_CONTROLS.map((command) => ({ ...command }))
-    : [];
+  const controls =
+    providerId === 'codex'
+      ? CODEX_CONTROLS
+      : providerId === 'prime-agent'
+        ? PRIME_AGENT_CONTROLS
+        : [];
+  return controls.map((command) => ({
+    ...command,
+    ...(command.aliases ? { aliases: [...command.aliases] } : {}),
+    ...(command.args ? { args: command.args.map((arg) => ({ ...arg })) } : {}),
+  }));
 }

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1208,7 +1208,12 @@ describe('channel-agent-binder — lifecycle', () => {
         const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
         Object.assign(adapter, {
           getSlashCommands: () => [
-            { name: 'model', dispatch: 'relay-control', collisionKey: 'model' },
+            {
+              name: 'model',
+              dispatch: 'relay-control',
+              collisionKey: 'model',
+              args: [{ value: 'gpt-fast', label: 'GPT Fast' }],
+            },
             { name: 'deploy', dispatch: 'agent', collisionKey: 'deploy' },
           ],
           executeControlCommand: async (input: {
@@ -1250,7 +1255,42 @@ describe('channel-agent-binder — lifecycle', () => {
     expect(calls).toEqual([
       { command: 'model', args: 'gpt-fast', confirmed: true },
     ]);
+    const liveRoster = await binder.rosterForChannel(CH);
+    expect(
+      liveRoster[0]?.commands?.find((command) => command.name === 'model')?.args
+    ).toEqual([{ value: 'gpt-fast', label: 'GPT Fast' }]);
     expect(rows(store)).toHaveLength(0);
+  });
+
+  it('treats a connected adapter command catalog as authoritative, including empty', async () => {
+    const { binder } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, { getSlashCommands: () => [] });
+        return adapter;
+      },
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+    });
+
+    const preview = await binder.rosterForChannel(CH);
+    expect(preview[0]?.commands?.map((command) => command.name)).toEqual([
+      'new',
+      'model',
+      'thinking',
+      'compact',
+    ]);
+    await binder.ensureBinding(CH, 'prime-agent');
+    const connected = await binder.rosterForChannel(CH);
+    expect(connected[0]?.commands).toBeUndefined();
   });
 
   it('targets command controls by exact named-profile Actor ID across a display-name collision', async () => {

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -23,11 +23,75 @@ function harness() {
       sessionId: 'prime-1',
       sessionFile: '/tmp/prime-1.jsonl',
       isStreaming: false,
+      thinkingLevel: 'medium',
+      model: {
+        id: 'gpt-prime',
+        name: 'GPT Prime',
+        provider: 'prime-inference',
+        reasoning: true,
+        thinkingLevelMap: { xhigh: 'xhigh' },
+      },
     },
   });
-  const call = vi
-    .spyOn(client, 'call')
-    .mockResolvedValue({ type: 'response', command: 'prompt', success: true });
+  let activeSession = {
+    id: 'prime-1',
+    file: '/tmp/prime-1.jsonl',
+  };
+  const call = vi.spyOn(client, 'call').mockImplementation(async (type) => {
+    if (type === 'new_session') {
+      activeSession = { id: 'prime-2', file: '/tmp/prime-2.jsonl' };
+      return {
+        type: 'response',
+        command: type,
+        success: true,
+        data: { cancelled: false },
+      };
+    }
+    if (type === 'get_available_models') {
+      return {
+        type: 'response',
+        command: type,
+        success: true,
+        data: {
+          models: [
+            {
+              id: 'gpt-prime',
+              name: 'GPT Prime',
+              provider: 'prime-inference',
+              reasoning: true,
+              thinkingLevelMap: { xhigh: 'xhigh' },
+            },
+            {
+              id: 'claude-prime',
+              name: 'Claude Prime',
+              provider: 'prime-inference',
+              reasoning: true,
+            },
+          ],
+        },
+      };
+    }
+    if (type === 'get_state') {
+      return {
+        type: 'response',
+        command: type,
+        success: true,
+        data: {
+          sessionId: activeSession.id,
+          sessionFile: activeSession.file,
+          thinkingLevel: 'medium',
+          model: {
+            id: 'gpt-prime',
+            name: 'GPT Prime',
+            provider: 'prime-inference',
+            reasoning: true,
+            thinkingLevelMap: { xhigh: 'xhigh' },
+          },
+        },
+      };
+    }
+    return { type: 'response', command: type, success: true };
+  });
   vi.spyOn(client, 'stop').mockResolvedValue();
   const adapter = new PrimeAgentProtocolAdapter(() => client);
   const patches: Array<Record<string, unknown>> = [];
@@ -62,6 +126,172 @@ describe('PrimeAgentProtocolAdapter', () => {
         primeAgentSessionFile: '/tmp/prime-1.jsonl',
       },
     });
+  });
+
+  it('discovers live Prime controls and executes them on the RPC control lane', async () => {
+    const { adapter, call, patches } = harness();
+    await adapter.connect(config);
+
+    expect(adapter.getSlashCommands()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'new', destructive: true }),
+        expect.objectContaining({
+          name: 'model',
+          args: expect.arrayContaining([
+            expect.objectContaining({
+              value: 'prime-inference/gpt-prime',
+              label: 'GPT Prime',
+            }),
+          ]),
+        }),
+        expect.objectContaining({
+          name: 'thinking',
+          args: expect.arrayContaining([{ value: 'xhigh' }]),
+        }),
+        expect.objectContaining({ name: 'compact' }),
+      ])
+    );
+
+    await adapter.executeControlCommand({
+      command: 'model',
+      args: 'prime-inference/claude-prime',
+    });
+    await adapter.executeControlCommand({
+      command: 'thinking',
+      args: 'high',
+    });
+    await adapter.executeControlCommand({ command: 'compact' });
+    await expect(
+      adapter.executeControlCommand({ command: 'new' })
+    ).rejects.toThrow('requires confirmation');
+    await adapter.executeControlCommand({ command: 'new', confirmed: true });
+
+    expect(call.mock.calls).toEqual(
+      expect.arrayContaining([
+        ['set_model', { provider: 'prime-inference', modelId: 'claude-prime' }],
+        ['set_thinking_level', { level: 'high' }],
+        ['compact'],
+        ['new_session'],
+      ])
+    );
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-session-updated-v2',
+          slashCommands: expect.any(Array),
+        }),
+        expect.objectContaining({
+          type: 'agent-session-updated-v2',
+          providerSession: {
+            primeAgentSessionId: 'prime-2',
+            primeAgentSessionFile: '/tmp/prime-2.jsonl',
+          },
+        }),
+      ])
+    );
+  });
+
+  it('clears stale optional state after a fresh Prime session', async () => {
+    const { adapter, call, patches } = harness();
+    await adapter.connect(config);
+    call.mockImplementation(async (type) => {
+      if (type === 'new_session') {
+        return {
+          type: 'response',
+          command: type,
+          success: true,
+          data: { cancelled: false },
+        };
+      }
+      if (type === 'get_state') {
+        return {
+          type: 'response',
+          command: type,
+          success: true,
+          data: { sessionId: 'prime-empty' },
+        };
+      }
+      return { type: 'response', command: type, success: true };
+    });
+
+    const result = await adapter.executeControlCommand({
+      command: 'new',
+      confirmed: true,
+    });
+    expect(result.config).toEqual({});
+    expect(patches.at(-1)).toMatchObject({
+      type: 'agent-session-updated-v2',
+      providerSession: { primeAgentSessionId: 'prime-empty' },
+      config: {},
+    });
+    expect(
+      (patches.at(-1)?.providerSession as Record<string, unknown>)?.[
+        'primeAgentSessionFile'
+      ]
+    ).toBeUndefined();
+  });
+
+  it('serializes controls against prompts and other controls', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    let releaseModel!: () => void;
+    const modelGate = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
+    call.mockImplementation(async (type) => {
+      if (type === 'set_model') await modelGate;
+      if (type === 'get_state') {
+        return {
+          type: 'response',
+          command: type,
+          success: true,
+          data: {
+            sessionId: 'prime-1',
+            sessionFile: '/tmp/prime-1.jsonl',
+            thinkingLevel: 'medium',
+            model: {
+              id: 'gpt-prime',
+              provider: 'prime-inference',
+              reasoning: true,
+            },
+          },
+        };
+      }
+      return { type: 'response', command: type, success: true };
+    });
+
+    const changingModel = adapter.executeControlCommand({
+      command: 'model',
+      args: 'prime-inference/gpt-prime',
+    });
+    await vi.waitFor(() =>
+      expect(call).toHaveBeenCalledWith('set_model', {
+        provider: 'prime-inference',
+        modelId: 'gpt-prime',
+      })
+    );
+    await expect(
+      adapter.sendMessage({ turnId: 'racing-turn', content: 'hello' })
+    ).rejects.toThrow('control command is in progress');
+    await expect(
+      adapter.executeControlCommand({ command: 'compact' })
+    ).rejects.toThrow('another Prime Agent control command is in progress');
+
+    releaseModel();
+    await changingModel;
+  });
+
+  it('fails closed when live model discovery is unavailable', async () => {
+    const { adapter, call } = harness();
+    call.mockRejectedValueOnce(new Error('unknown command'));
+    await adapter.connect(config);
+    expect(adapter.getSlashCommands()).toEqual([]);
+    await expect(
+      adapter.executeControlCommand({
+        command: 'model',
+        args: 'guessed/model',
+      })
+    ).rejects.toThrow('unsupported Prime Agent control command');
   });
 
   it('maps streaming text, thinking, and command tools to V2 patches', async () => {
@@ -152,7 +382,11 @@ describe('PrimeAgentProtocolAdapter', () => {
     await adapter.sendMessage({ turnId: 't1', content: 'one' });
     await adapter.sendMessage({ turnId: 't2', content: 'two' });
     await adapter.interrupt({ turnId: 't1' });
-    expect(call.mock.calls.map(([type]) => type)).toEqual(['prompt', 'abort']);
+    expect(call.mock.calls.map(([type]) => type)).toEqual([
+      'get_available_models',
+      'prompt',
+      'abort',
+    ]);
   });
 
   it('submits queued Relay turns as fresh prompts after real agent_end boundaries', async () => {
@@ -274,7 +508,9 @@ describe('PrimeAgentProtocolAdapter', () => {
         ],
       })
     ).rejects.toThrow('Cannot read Prime Agent image attachment');
-    expect(call).not.toHaveBeenCalled();
+    expect(call.mock.calls.map(([type]) => type)).toEqual([
+      'get_available_models',
+    ]);
   });
 
   it('bounds image count and rejects MIME-mismatched bytes', async () => {
@@ -364,7 +600,10 @@ describe('PrimeAgentProtocolAdapter', () => {
     }));
     await adapter.connect(config);
     await adapter.sendMessage({ turnId: 'compact', content: '/compact' });
-    expect(call.mock.calls.map(([type]) => type)).toEqual(['compact']);
+    expect(call.mock.calls.map(([type]) => type)).toEqual([
+      'get_available_models',
+      'compact',
+    ]);
     expect(patches).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -152,6 +152,19 @@ describe('PrimeAgentProtocolAdapter', () => {
       ])
     );
 
+    await expect(
+      adapter.executeControlCommand({
+        command: 'model',
+        args: 'other/model',
+      })
+    ).rejects.toThrow('live Prime Agent catalog');
+    await expect(
+      adapter.executeControlCommand({
+        command: 'thinking',
+        args: 'turbo',
+      })
+    ).rejects.toThrow('thinking must be one of');
+
     await adapter.executeControlCommand({
       command: 'model',
       args: 'prime-inference/claude-prime',


### PR DESCRIPTION
## Summary

- expose Prime Agent `model`, `thinking`/`effort`, `compact`, and confirmed `new`/`clear` controls in the provider command palette from #1344
- discover models and supported reasoning levels from the connected Prime RPC runtime and validate opaque options against that live catalog
- execute controls on the authenticated non-message lane, refresh authoritative Prime session/config state, and preserve exact profile routing
- make connected adapter catalogs authoritative over static pre-connect previews and serialize Prime prompts against in-flight controls

Closes #1345

## Verification

- `npm run check`
- `npm run build`
- 213 focused Prime adapter, channel binder, route, and composer tests pass
- adversarial review and focused re-review: no unresolved P0/P1 findings
- live Prime Agent 0.7.0 browser proof: `@prime-agent/` rendered the four native controls and live model/thinking options; `/model` and `/thinking` both completed with applied status without adding channel messages
- screenshot: `/tmp/relay-prime-command-palette.png` (local verification artifact)

Exact head: `c15411f1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prime Agent command-palette controls for model selection, reasoning depth, context compaction, and starting or clearing sessions.
  * Commands now reflect available models and settings from the active connection.
  * Added confirmation safeguards for session-reset actions and validation for command arguments.
* **Bug Fixes**
  * Unsupported or unavailable Prime Agent controls are now hidden instead of appearing unusable.
  * Prevented messages from being sent while a control action is in progress.
* **Documentation**
  * Documented Prime Agent command-palette controls and availability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->