### PR TITLE
ci: allow manual nightly publish recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   publish:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/nightly'
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to npm
 
 on:
+  # Incident recovery: manually publish current nightly after a missed push event.
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary

- add a manual `workflow_dispatch` entry point to the existing npm publish workflow
- preserve the current nightly push, release tag, environment, provenance, test, and `github.ref` gates unchanged

## Why

This gives maintainers an incident-recovery path to publish the current `nightly` ref when a push webhook is missed.

## Impact

No user-visible change. Manual runs on refs other than `nightly` remain unable to reach the nightly publish steps because the existing `github.ref == 'refs/heads/nightly'` conditions are unchanged.

## Validation

- parsed `.github/workflows/publish.yml` with `yq` and asserted both `push` and `workflow_dispatch` triggers
- `npx prettier --check .github/workflows/publish.yml`
- `git diff --check`
