### PR TITLE
feat(agents): add Pi native RPC provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ workflow.
 #### Added
 
 - Run Prime Agent as a built-in terminal and channel provider through its native RPC mode (#1340)
+- Run Pi as a built-in terminal and channel provider through its native JSONL RPC mode
 - Control Prime Agent models, reasoning, compaction, and fresh sessions from the `@agent/` command palette (#1345)
 - Create and name new folders directly in the local Add Project browser (#1338)
 - Start project-scoped channels and direct messages from per-project sidebar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ workflow.
 #### Added
 
 - Run Prime Agent as a built-in terminal and channel provider through its native RPC mode (#1340)
-- Run Pi as a built-in terminal and channel provider through its native JSONL RPC mode
+- Run Pi as a built-in terminal and channel provider through its native JSONL RPC mode (#1349)
 - Control Prime Agent models, reasoning, compaction, and fresh sessions from the `@agent/` command palette (#1345)
 - Create and name new folders directly in the local Add Project browser (#1338)
 - Start project-scoped channels and direct messages from per-project sidebar

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -35,6 +35,7 @@ refresh. Capabilities must describe only implemented behavior.
 | OpenCode    | `opencode`    | native SDK/events                      |
 | Hermes      | `hermes`      | Responses API/SSE                      |
 | Prime Agent | `prime-agent` | `prime-agent` RPC                      |
+| Pi          | `pi`          | `pi --mode rpc` JSONL                  |
 
 Prime Agent is a first-class channel provider. Its adapter maps accepted prompts and `agent_end` boundaries to Relay turn
 lifecycle, `message_update` text and
@@ -59,6 +60,22 @@ targets the Prime Agent 0.7 RPC contract; a runtime that cannot return a valid
 live model catalog publishes no connected command catalog.
 
 The `prime-agent` executable is also available as a normal terminal launch, but
+that surface stays a generic PTY: Relay does not parse terminal output or infer
+channel capabilities from it.
+
+Pi is a first-class channel provider. Its adapter maps accepted prompts and `agent_settled` boundaries to Relay turn
+lifecycle, `message_update` text and
+thinking deltas to assistant and reasoning items, and
+`tool_execution_start|update|end` to canonical command, file-change, or dynamic
+tool items. It advertises text, reasoning, tools, command execution, file
+changes, queueing, interrupt, resume, compaction, telemetry, and streaming; unsupported
+approval, question, plan, and queue-cancellation operations remain false. Because Pi steering stays within one native run, Relay queues concurrent
+messages locally and sends a fresh RPC prompt after each `agent_settled`, preserving
+one durable Relay turn per message. Channel subprocesses currently launch with
+`--no-extensions` because blocking `extension_ui_request` dialogs are not mapped
+to Relay approvals/questions yet.
+
+The `pi` executable is also available as a normal terminal launch, but
 that surface stays a generic PTY: Relay does not parse terminal output or infer
 channel capabilities from it.
 

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -56,8 +56,11 @@ as persisted chat messages or token-consuming prompts. Model and thinking
 arguments are validated against live Prime metadata; if discovery is unavailable,
 the adapter fails closed instead of guessing. Prime skills, prompt templates,
 and TUI-only commands are not exposed as channel controls. This control surface
-targets the Prime Agent 0.7 RPC contract; a runtime that cannot return a valid
-live model catalog publishes no connected command catalog.
+is installed-tested with Prime Agent 0.7.0. It assumes strict-LF JSONL records,
+a correlated `get_state` readiness response, `agent_end` as the settled run
+boundary, and `sessionActions.queuedCount` as a finite non-negative integer; a
+runtime that cannot return a valid live model catalog publishes no connected
+command catalog.
 
 The `prime-agent` executable is also available as a normal terminal launch, but
 that surface stays a generic PTY: Relay does not parse terminal output or infer
@@ -75,9 +78,40 @@ one durable Relay turn per message. Channel subprocesses currently launch with
 `--no-extensions` because blocking `extension_ui_request` dialogs are not mapped
 to Relay approvals/questions yet.
 
+The Pi channel transport is installed-tested with Pi 0.83.0. It assumes
+strict-LF JSONL records, a correlated `get_state` readiness response,
+`agent_settled` as the settled run boundary, and a finite non-negative
+`pendingMessageCount`. These are protocol compatibility assumptions rather than
+an assertion that every earlier or later provider version behaves identically.
+
 The `pi` executable is also available as a normal terminal launch, but
 that surface stays a generic PTY: Relay does not parse terminal output or infer
 channel capabilities from it.
+
+### Live Pi and Prime RPC smoke
+
+Run the opt-in, model-backed protocol probe with an explicit provider:
+
+```bash
+RELAY_AGENT_RPC_SMOKE_LIVE=1 \
+RELAY_AGENT_RPC_SMOKE_CREDENTIALS=1 \
+RELAY_AGENT_RPC_SMOKE_PI_MODEL=<provider/model> \
+npm run smoke:agent-rpc -- --provider pi
+```
+
+Use `--provider prime-agent` with
+`RELAY_AGENT_RPC_SMOKE_PRIME_MODEL`, or `--provider both` with both model
+variables. `RELAY_AGENT_RPC_SMOKE_MODEL` is the shared model fallback; optional
+command overrides are `RELAY_AGENT_RPC_SMOKE_PI_COMMAND` and
+`RELAY_AGENT_RPC_SMOKE_PRIME_COMMAND`. The harness skips only when an explicit
+live/credential gate, executable, model selection, provider model
+configuration, or credential is missing. Transport, readiness, protocol,
+unsupported-capability, timeout, and temporary-provider failures exit nonzero.
+
+This smoke makes real model calls, but runs each provider in disposable cwd and
+session directories with tools, extensions, skills, templates, themes, context
+files, and Pi telemetry disabled. Cleanup removes those directories, and output
+omits prompts, provider stderr, credentials, and raw session identifiers.
 
 ## Identity boundary
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -43,6 +43,7 @@
   --sender-hermes: var(--color-sky);
   --sender-opencode: var(--color-indigo);
   --sender-prime-agent: var(--color-purple);
+  --sender-pi: var(--color-purple);
   --sender-system: var(--text-muted);
 
   /* Typography */

--- a/frontend/src/components/AgentBadge.tsx
+++ b/frontend/src/components/AgentBadge.tsx
@@ -89,6 +89,27 @@ export function AgentBadge({ agent }: AgentBadgeProps) {
     );
   }
 
+  if (agent === 'pi') {
+    return (
+      <svg
+        className="agent-badge"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-label="Pi"
+      >
+        <text
+          x="1.5"
+          y="16.5"
+          fontFamily="serif"
+          fontSize="18"
+          fill="currentColor"
+        >
+          π
+        </text>
+      </svg>
+    );
+  }
+
   const fallbackLetter = agent ? agent[0]!.toUpperCase() : '?';
   return (
     <span className="agent-badge agent-badge--fallback" aria-label={agent}>

--- a/frontend/src/lib/chat/sender-identity.ts
+++ b/frontend/src/lib/chat/sender-identity.ts
@@ -26,7 +26,8 @@ export type KnownAgentGlyph =
   | 'codex'
   | 'hermes'
   | 'opencode'
-  | 'prime-agent';
+  | 'prime-agent'
+  | 'pi';
 
 export interface SenderIdentity {
   /** Display label — human is always 'you'. */
@@ -44,6 +45,7 @@ const KNOWN_AGENT_COLOR_VAR: Record<string, string> = {
   hermes: '--sender-hermes',
   opencode: '--sender-opencode',
   'prime-agent': '--sender-prime-agent',
+  pi: '--sender-pi',
 };
 
 const KNOWN_AGENT_GLYPHS: readonly KnownAgentGlyph[] = [
@@ -52,6 +54,7 @@ const KNOWN_AGENT_GLYPHS: readonly KnownAgentGlyph[] = [
   'hermes',
   'opencode',
   'prime-agent',
+  'pi',
 ];
 
 function isKnownGlyph(value: string): value is KnownAgentGlyph {

--- a/frontend/src/lib/topic-create.ts
+++ b/frontend/src/lib/topic-create.ts
@@ -58,6 +58,7 @@ export const FALLBACK_PROVIDER_IDS = [
   'opencode',
   'hermes',
   'prime-agent',
+  'pi',
 ];
 
 export type TopicProviderOption = {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "sandbox:dev": "node dist/scripts/sandbox-cli.js",
     "agent-browser": "node dist/scripts/agent-browser-cli.js",
     "test": "vitest run",
+    "smoke:agent-rpc": "npm run build:server && node dist/scripts/agent-rpc-smoke.js",
     "test:smoke:multi-node": "vitest run test/hub-cross-node-pty.test.ts test/multi-node-smoke.test.ts",
     "diagnose:channel-memory": "npm run build:server && node --expose-gc dist/scripts/channel-memory-load.js",
     "test:e2e": "playwright test",

--- a/scripts/agent-rpc-smoke.ts
+++ b/scripts/agent-rpc-smoke.ts
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { accessSync, constants, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { delimiter, isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { PiAgentRpcClient } from '../server/pi-agent-rpc-client.js';
+import { PrimeAgentRpcClient } from '../server/prime-agent-rpc-client.js';
+
+const PI = 'pi';
+const PRIME_AGENT = 'prime-agent';
+
+export type SmokeProvider = typeof PI | typeof PRIME_AGENT;
+
+type RpcMessage = Record<string, unknown>;
+
+type RpcClient = {
+  start(): Promise<RpcMessage>;
+  call(type: string, fields?: Record<string, unknown>): Promise<RpcMessage>;
+  stop(): Promise<void>;
+  on(event: 'event', listener: (message: RpcMessage) => void): unknown;
+  off(event: 'event', listener: (message: RpcMessage) => void): unknown;
+};
+
+export interface ProviderSmokeOptions {
+  provider: SmokeProvider;
+  command: string;
+  model: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+export interface ProviderSmokeResult {
+  provider: SmokeProvider;
+  terminalEvent: 'agent_settled' | 'agent_end';
+  sessionHash: string;
+}
+
+export interface SmokeCliOptions {
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  log?: (line: string) => void;
+}
+
+const DISABLED_LOCAL_FEATURE_ARGS = [
+  '--no-extensions',
+  '--no-skills',
+  '--no-prompt-templates',
+  '--no-themes',
+  '--no-context-files',
+  '--no-tools',
+] as const;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 60_000;
+const LIVE_GATE = 'RELAY_AGENT_RPC_SMOKE_LIVE';
+const CREDENTIAL_GATE = 'RELAY_AGENT_RPC_SMOKE_CREDENTIALS';
+const GET_STATE = 'get_state';
+
+function record(value: unknown): RpcMessage {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as RpcMessage)
+    : {};
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0)
+    throw new Error(`${label} was missing from RPC response`);
+  return value;
+}
+
+function assertCorrelatedResponse(message: RpcMessage, command: string): void {
+  if (message.type !== 'response')
+    throw new Error(`${command} did not return an RPC response`);
+  requiredString(message.id, `${command} response id`);
+  if (message.command !== command)
+    throw new Error(`${command} response command did not match request`);
+  if (message.success !== true) throw new Error(`${command} was unsuccessful`);
+}
+
+function hashIdentifier(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 10);
+}
+
+function sessionIdFrom(message: RpcMessage): string {
+  return requiredString(record(message.data).sessionId, 'sessionId');
+}
+
+function assertConfiguredModel(message: RpcMessage): void {
+  const model = record(record(message.data).model);
+  if (typeof model.id !== 'string' || model.id.length === 0)
+    throw new Error('provider model unavailable or not configured');
+}
+
+function parseTimeout(value: string | undefined): number {
+  if (!value) return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1_000 || parsed > MAX_TIMEOUT_MS)
+    throw new Error(
+      'RELAY_AGENT_RPC_SMOKE_TIMEOUT_MS must be an integer from 1000 to 60000'
+    );
+  return parsed;
+}
+
+function terminalEvent(provider: SmokeProvider): 'agent_settled' | 'agent_end' {
+  return provider === PI ? 'agent_settled' : 'agent_end';
+}
+
+function commandFor(provider: SmokeProvider): string {
+  return provider === PI ? PI : PRIME_AGENT;
+}
+
+function resumeArgs(provider: SmokeProvider, sessionId: string): string[] {
+  return provider === PI
+    ? ['--session-id', sessionId, '--offline']
+    : ['--resume', sessionId, '--offline'];
+}
+
+function createClient(
+  provider: SmokeProvider,
+  command: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number
+): RpcClient {
+  const processEnv = Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    )
+  );
+  delete processEnv.CLAUDECODE;
+  if (provider === PI) processEnv.PI_TELEMETRY = '0';
+  const options = {
+    command,
+    args,
+    cwd,
+    env: processEnv,
+    readinessTimeoutMs: timeoutMs,
+    requestTimeoutMs: timeoutMs,
+    stopTimeoutMs: Math.min(timeoutMs, 2_000),
+  };
+  return provider === PI
+    ? new PiAgentRpcClient(options)
+    : new PrimeAgentRpcClient(options);
+}
+
+function waitForEvent(
+  client: RpcClient,
+  type: string,
+  timeoutMs: number
+): { promise: Promise<RpcMessage>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let settled = false;
+  let rejectPromise: ((reason: Error) => void) | undefined;
+  const listener = (message: RpcMessage) => {
+    if (message.type !== type || settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    client.off('event', listener);
+    resolvePromise?.(message);
+  };
+  let resolvePromise: ((message: RpcMessage) => void) | undefined;
+  const promise = new Promise<RpcMessage>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      client.off('event', listener);
+      reject(new Error(`timed out waiting for ${type}`));
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  // A failure before the caller awaits this event still needs a handled
+  // rejection when finally() cancels the listener during cleanup.
+  void promise.catch(() => undefined);
+  client.on('event', listener);
+  return {
+    promise,
+    cancel: () => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      client.off('event', listener);
+      rejectPromise?.(new Error(`stopped waiting for ${type}`));
+    },
+  };
+}
+
+function baseArgs(model: string, sessionDir: string): string[] {
+  return [
+    '--mode',
+    'rpc',
+    ...DISABLED_LOCAL_FEATURE_ARGS,
+    '--session-dir',
+    sessionDir,
+    '--model',
+    model,
+  ];
+}
+
+/**
+ * Runs a real provider protocol probe. This function intentionally has no live
+ * environment gate so deterministic tests can call it with a fake executable;
+ * the CLI entrypoint applies the gate before invoking it.
+ */
+export async function runProviderSmoke(
+  options: ProviderSmokeOptions
+): Promise<ProviderSmokeResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const env = options.env ?? process.env;
+  const root = mkdtempSync(join(tmpdir(), 'relay-agent-rpc-smoke-'));
+  const cwd = join(root, 'cwd');
+  const sessionDir = join(root, 'sessions');
+  const terminal = terminalEvent(options.provider);
+  let client: RpcClient | undefined;
+  let resumed: RpcClient | undefined;
+  const waits: ReturnType<typeof waitForEvent>[] = [];
+
+  try {
+    // Providers own their contents, but spawn requires cwd to exist. Keeping
+    // both directories under one mkdtemp root makes cleanup atomic.
+    mkdirSync(cwd);
+    mkdirSync(sessionDir);
+    const args = baseArgs(options.model, sessionDir);
+    client = createClient(
+      options.provider,
+      options.command,
+      args,
+      cwd,
+      env,
+      timeoutMs
+    );
+
+    const ready = await client.start();
+    assertCorrelatedResponse(ready, GET_STATE);
+    assertConfiguredModel(ready);
+    const sessionId = sessionIdFrom(ready);
+
+    const normalStart = waitForEvent(client, 'agent_start', timeoutMs);
+    const normalTerminal = waitForEvent(client, terminal, timeoutMs);
+    waits.push(normalStart, normalTerminal);
+    // This prompt is intentionally never logged. Keep the normal completion
+    // tiny and deterministic so the smoke proves the terminal boundary without
+    // spending its timeout budget on response generation.
+    const normalPrompt = await client.call('prompt', {
+      message: 'Reply with exactly: OK',
+    });
+    assertCorrelatedResponse(normalPrompt, 'prompt');
+    await normalStart.promise;
+    await normalTerminal.promise;
+    const normalSettled = await client.call(GET_STATE);
+    assertCorrelatedResponse(normalSettled, GET_STATE);
+    if (record(normalSettled.data).isStreaming !== false)
+      throw new Error(
+        'provider remained streaming after normal terminal event'
+      );
+
+    const abortStart = waitForEvent(client, 'agent_start', timeoutMs);
+    const abortTerminal = waitForEvent(client, terminal, timeoutMs);
+    waits.push(abortStart, abortTerminal);
+    const abortPrompt = await client.call('prompt', {
+      message:
+        'Begin another long response about deterministic testing. Do not use tools.',
+    });
+    assertCorrelatedResponse(abortPrompt, 'prompt');
+    await abortStart.promise;
+    const abort = await client.call('abort');
+    assertCorrelatedResponse(abort, 'abort');
+    await abortTerminal.promise;
+
+    const settled = await client.call(GET_STATE);
+    assertCorrelatedResponse(settled, GET_STATE);
+    if (record(settled.data).isStreaming !== false)
+      throw new Error('provider remained streaming after abort terminal event');
+    await client.stop();
+    client = undefined;
+
+    resumed = createClient(
+      options.provider,
+      options.command,
+      [...args, ...resumeArgs(options.provider, sessionId)],
+      cwd,
+      env,
+      timeoutMs
+    );
+    const resumedState = await resumed.start();
+    assertCorrelatedResponse(resumedState, GET_STATE);
+    if (sessionIdFrom(resumedState) !== sessionId)
+      throw new Error('resume did not restore the original provider session');
+
+    return {
+      provider: options.provider,
+      terminalEvent: terminal,
+      sessionHash: hashIdentifier(sessionId),
+    };
+  } finally {
+    for (const wait of waits) wait.cancel();
+    await resumed?.stop().catch(() => undefined);
+    await client?.stop().catch(() => undefined);
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function commandAvailable(command: string, env: NodeJS.ProcessEnv): boolean {
+  const candidates =
+    isAbsolute(command) || command.includes('/')
+      ? [command]
+      : (env.PATH ?? '').split(delimiter).map((entry) => join(entry, command));
+  return candidates.some((candidate) => {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function readProvider(argv: string[]): SmokeProvider[] {
+  const selected =
+    argv.find((arg) => arg.startsWith('--provider='))?.slice(11) ??
+    argv[argv.indexOf('--provider') + 1];
+  if (!selected || selected === 'both') return [PI, PRIME_AGENT];
+  if (selected === PI) return [PI];
+  if (selected === PRIME_AGENT || selected === 'prime') return [PRIME_AGENT];
+  throw new Error('provider must be pi, prime-agent, or both');
+}
+
+function modelFor(
+  provider: SmokeProvider,
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  return (
+    env[
+      provider === PI
+        ? 'RELAY_AGENT_RPC_SMOKE_PI_MODEL'
+        : 'RELAY_AGENT_RPC_SMOKE_PRIME_MODEL'
+    ] ?? env.RELAY_AGENT_RPC_SMOKE_MODEL
+  );
+}
+
+function commandEnvName(provider: SmokeProvider): string {
+  return provider === PI
+    ? 'RELAY_AGENT_RPC_SMOKE_PI_COMMAND'
+    : 'RELAY_AGENT_RPC_SMOKE_PRIME_COMMAND';
+}
+
+function providerSkipReason(error: unknown): string | undefined {
+  const message = error instanceof Error ? error.message.toLowerCase() : '';
+  if (
+    /(?:no (?:configured )?model|model.*(?:not found|unknown|not configured|missing|not selected)|(?:not found|unknown|not configured|missing|not selected).*model)/.test(
+      message
+    )
+  )
+    return 'provider reported missing or unconfigured model';
+  if (
+    /(?:auth|credential|api key|login|unauthori[sz]ed|forbidden|access token)/.test(
+      message
+    )
+  )
+    return 'provider reported missing or invalid credentials';
+  return undefined;
+}
+
+export async function runSmokeCli(
+  options: SmokeCliOptions = {}
+): Promise<number> {
+  const argv = options.argv ?? process.argv.slice(2);
+  const env = options.env ?? process.env;
+  const log = options.log ?? console.log;
+  let providers: SmokeProvider[];
+  try {
+    providers = readProvider(argv);
+  } catch (error) {
+    log(
+      `ERROR agent RPC smoke: ${error instanceof Error ? error.message : 'invalid arguments'}`
+    );
+    return 1;
+  }
+
+  if (env[LIVE_GATE] !== '1') {
+    for (const provider of providers)
+      log(
+        `SKIP ${provider}: set ${LIVE_GATE}=1 to allow model-backed RPC calls`
+      );
+    return 0;
+  }
+  if (env[CREDENTIAL_GATE] !== '1') {
+    for (const provider of providers)
+      log(
+        `SKIP ${provider}: set ${CREDENTIAL_GATE}=1 after configuring provider credentials`
+      );
+    return 0;
+  }
+
+  let failed = false;
+  for (const provider of providers) {
+    const model = modelFor(provider, env);
+    if (!model) {
+      log(
+        `SKIP ${provider}: configure RELAY_AGENT_RPC_SMOKE_${provider === PI ? 'PI' : 'PRIME'}_MODEL or RELAY_AGENT_RPC_SMOKE_MODEL`
+      );
+      continue;
+    }
+    const command = env[commandEnvName(provider)] ?? commandFor(provider);
+    if (!commandAvailable(command, env)) {
+      log(`SKIP ${provider}: command unavailable (${command})`);
+      continue;
+    }
+    try {
+      const result = await runProviderSmoke({
+        provider,
+        command,
+        model,
+        env,
+        timeoutMs: parseTimeout(env.RELAY_AGENT_RPC_SMOKE_TIMEOUT_MS),
+      });
+      log(
+        `PASS ${provider}: terminal=${result.terminalEvent} session=${result.sessionHash}`
+      );
+    } catch (error) {
+      // Deliberately do not print provider stderr, prompt text, or raw session
+      // identifiers. The concise failure still gives CI a trustworthy signal.
+      const skip = providerSkipReason(error);
+      if (skip) log(`SKIP ${provider}: ${skip}`);
+      else {
+        log(`FAIL ${provider}: RPC smoke contract did not complete`);
+        failed = true;
+      }
+    }
+  }
+  return failed ? 1 : 0;
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
+  runSmokeCli().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/scripts/agent-rpc-smoke.ts
+++ b/scripts/agent-rpc-smoke.ts
@@ -76,7 +76,12 @@ function assertCorrelatedResponse(message: RpcMessage, command: string): void {
   requiredString(message.id, `${command} response id`);
   if (message.command !== command)
     throw new Error(`${command} response command did not match request`);
-  if (message.success !== true) throw new Error(`${command} was unsuccessful`);
+  if (message.success !== true)
+    throw new Error(
+      typeof message.error === 'string' && message.error.length > 0
+        ? message.error
+        : `${command} was unsuccessful`
+    );
 }
 
 function hashIdentifier(value: string): string {
@@ -320,9 +325,10 @@ function commandAvailable(command: string, env: NodeJS.ProcessEnv): boolean {
 }
 
 function readProvider(argv: string[]): SmokeProvider[] {
+  const positionalIndex = argv.indexOf('--provider');
   const selected =
     argv.find((arg) => arg.startsWith('--provider='))?.slice(11) ??
-    argv[argv.indexOf('--provider') + 1];
+    (positionalIndex >= 0 ? argv[positionalIndex + 1] : undefined);
   if (!selected || selected === 'both') return [PI, PRIME_AGENT];
   if (selected === PI) return [PI];
   if (selected === PRIME_AGENT || selected === 'prime') return [PRIME_AGENT];
@@ -357,7 +363,7 @@ function providerSkipReason(error: unknown): string | undefined {
   )
     return 'provider reported missing or unconfigured model';
   if (
-    /(?:auth|credential|api key|login|unauthori[sz]ed|forbidden|access token)/.test(
+    /(?:\bauth(?:entication|orization)?\b|\bcredentials?\b|\bapi[ -]?key\b|\blogin\b|\bunauthori[sz]ed\b|\bforbidden\b|\baccess token\b)/.test(
       message
     )
   )
@@ -396,6 +402,16 @@ export async function runSmokeCli(
     return 0;
   }
 
+  let timeoutMs: number;
+  try {
+    timeoutMs = parseTimeout(env.RELAY_AGENT_RPC_SMOKE_TIMEOUT_MS);
+  } catch (error) {
+    log(
+      `ERROR agent RPC smoke: ${error instanceof Error ? error.message : 'invalid timeout'}`
+    );
+    return 1;
+  }
+
   let failed = false;
   for (const provider of providers) {
     const model = modelFor(provider, env);
@@ -416,7 +432,7 @@ export async function runSmokeCli(
         command,
         model,
         env,
-        timeoutMs: parseTimeout(env.RELAY_AGENT_RPC_SMOKE_TIMEOUT_MS),
+        timeoutMs,
       });
       log(
         `PASS ${provider}: terminal=${result.terminalEvent} session=${result.sessionHash}`
@@ -437,7 +453,14 @@ export async function runSmokeCli(
 
 const entrypoint = process.argv[1];
 if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
-  runSmokeCli().then((code) => {
-    process.exitCode = code;
-  });
+  void runSmokeCli()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error: unknown) => {
+      console.error(
+        `ERROR agent RPC smoke: ${error instanceof Error ? error.message : String(error)}`
+      );
+      process.exitCode = 1;
+    });
 }

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -109,7 +109,9 @@ function providerResumeId(
           ? 'hermesResponseId'
           : providerId === 'prime-agent'
             ? 'primeAgentSessionId'
-            : undefined;
+            : providerId === 'pi'
+              ? 'piSessionId'
+              : undefined;
   if (!key) return undefined;
   const value = state[key];
   return typeof value === 'string' && value.length > 0 ? value : undefined;

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -65,6 +65,7 @@ const DEFAULT_KNOWN_PROVIDER_IDS = [
   'opencode',
   'hermes',
   'prime-agent',
+  'pi',
 ];
 
 /**

--- a/server/pi-agent-rpc-client.ts
+++ b/server/pi-agent-rpc-client.ts
@@ -1,0 +1,301 @@
+import { EventEmitter } from 'node:events';
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+
+export interface PiAgentRpcMessage extends Record<string, unknown> {
+  type: string;
+}
+
+export interface PiAgentRpcClientOptions {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  requestTimeoutMs?: number;
+  readinessTimeoutMs?: number;
+  maxBufferBytes?: number;
+  maxRecordBytes?: number;
+  stopTimeoutMs?: number;
+  spawn?: (
+    command: string,
+    args: string[],
+    options: { cwd?: string; env?: Record<string, string>; stdio: 'pipe' }
+  ) => ChildProcess;
+}
+
+interface PendingCall {
+  resolve: (value: PiAgentRpcMessage) => void;
+  reject: (error: Error) => void;
+  command: string;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Strict-LF JSONL client for `pi --mode rpc`. */
+export class PiAgentRpcClient extends EventEmitter {
+  private child: ChildProcess | null = null;
+  private buffer = Buffer.alloc(0);
+  private stopPromise: Promise<void> | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<string, PendingCall>();
+  private readonly writes: string[] = [];
+  private draining = false;
+
+  constructor(private readonly options: PiAgentRpcClientOptions = {}) {
+    super();
+    // An EventEmitter `error` without a listener terminates Node. Transport
+    // errors are still observable, but are safe during early process startup.
+    this.on('error', () => undefined);
+  }
+
+  async start(): Promise<PiAgentRpcMessage> {
+    if (this.child || this.stopPromise)
+      throw new Error('PiAgentRpcClient already started');
+    const spawnFn = this.options.spawn ?? nodeSpawn;
+    const child = spawnFn(
+      this.options.command ?? 'pi',
+      this.options.args ?? ['--mode', 'rpc'],
+      {
+        ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
+        ...(this.options.env ? { env: this.options.env } : {}),
+        stdio: 'pipe',
+      }
+    );
+    this.child = child;
+    this.buffer = Buffer.alloc(0);
+    child.stdout?.on('data', (chunk: Buffer | string) => this.consume(chunk));
+    child.stderr?.on('data', (chunk: Buffer | string) =>
+      this.emit('stderr', String(chunk))
+    );
+    child.stdin?.on('error', (error: Error) => this.emit('error', error));
+    child.stdout?.on('error', (error: Error) => this.emit('error', error));
+    child.stderr?.on('error', (error: Error) => this.emit('error', error));
+    child.on('error', (error: Error) => {
+      this.rejectPending(error);
+      this.emit('error', error);
+    });
+    child.on('close', (code) => {
+      if (this.child === child) this.child = null;
+      const error = new Error(`pi rpc exited (code=${String(code)})`);
+      this.rejectPending(error);
+      this.emit('close', code);
+    });
+
+    // RPC has no initialize handshake. A correlated get_state response is the
+    // readiness barrier and supplies durable session identity.
+    return this.callWithTimeout(
+      'get_state',
+      {},
+      this.options.readinessTimeoutMs ?? 10_000
+    );
+  }
+
+  call(
+    type: string,
+    fields: Record<string, unknown> = {}
+  ): Promise<PiAgentRpcMessage> {
+    return this.callWithTimeout(
+      type,
+      fields,
+      this.options.requestTimeoutMs ?? 30_000
+    );
+  }
+
+  private callWithTimeout(
+    type: string,
+    fields: Record<string, unknown>,
+    timeoutMs: number
+  ): Promise<PiAgentRpcMessage> {
+    if (!this.child)
+      return Promise.reject(new Error('PiAgentRpcClient is not started'));
+    const id = `relay-${this.nextId++}`;
+    const promise = new Promise<PiAgentRpcMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(`pi RPC ${type} timed out after ${timeoutMs}ms`)
+        );
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, { resolve, reject, command: type, timer });
+    });
+    this.enqueue({ id, type, ...fields });
+    return promise;
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    const child = this.child;
+    if (!child) return;
+
+    this.child = null;
+    this.rejectPending(new Error('PiAgentRpcClient stopped'));
+    this.stopPromise = this.terminate(child).finally(() => {
+      this.stopPromise = null;
+    });
+    return this.stopPromise;
+  }
+
+  private async terminate(child: ChildProcess): Promise<void> {
+    let closed = false;
+    const onClose = () => {
+      closed = true;
+    };
+    child.once('close', onClose);
+    const waitForClose = (timeoutMs: number): Promise<boolean> =>
+      new Promise((resolve) => {
+        if (closed) {
+          resolve(true);
+          return;
+        }
+        const onWaitClose = () => {
+          clearTimeout(timer);
+          resolve(true);
+        };
+        const timer = setTimeout(() => {
+          child.removeListener('close', onWaitClose);
+          resolve(closed);
+        }, timeoutMs);
+        timer.unref?.();
+        child.once('close', onWaitClose);
+      });
+    const timeoutMs = this.options.stopTimeoutMs ?? 2_000;
+
+    try {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // The process may already have exited.
+      }
+      if (await waitForClose(timeoutMs)) return;
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // The process may already have exited.
+      }
+      await waitForClose(timeoutMs);
+    } finally {
+      child.removeListener('close', onClose);
+    }
+  }
+
+  private consume(chunk: Buffer | string): void {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.buffer = Buffer.concat([this.buffer, bytes]);
+    const maxBufferBytes = this.options.maxBufferBytes ?? 16 * 1024 * 1024;
+    let newline: number;
+    // Deliberately split only on ASCII LF. U+2028/U+2029 are JSON content.
+    while ((newline = this.buffer.indexOf(0x0a)) !== -1) {
+      let lineBytes = this.buffer.subarray(0, newline);
+      this.buffer = this.buffer.subarray(newline + 1);
+      if (lineBytes.at(-1) === 0x0d) lineBytes = lineBytes.subarray(0, -1);
+      if (lineBytes.length === 0) continue;
+      const maxRecordBytes = this.options.maxRecordBytes ?? 8 * 1024 * 1024;
+      if (lineBytes.length > maxRecordBytes) {
+        this.emit(
+          'protocolError',
+          new Error(`pi RPC record exceeded ${maxRecordBytes} bytes`)
+        );
+        continue;
+      }
+      const line = lineBytes.toString('utf8');
+      let value: unknown;
+      try {
+        value = JSON.parse(line);
+      } catch (error) {
+        this.emit(
+          'protocolError',
+          new Error(
+            `Invalid pi RPC JSON: ${error instanceof Error ? error.message : String(error)}`
+          )
+        );
+        continue;
+      }
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        this.emit(
+          'protocolError',
+          new Error('Invalid pi RPC record: expected object')
+        );
+        continue;
+      }
+      const message = value as PiAgentRpcMessage;
+      if (message.type === 'response' && typeof message.id === 'string') {
+        const pending = this.pending.get(message.id);
+        if (!pending) {
+          this.emit(
+            'protocolError',
+            new Error(`Uncorrelated pi RPC response id: ${message.id}`)
+          );
+          continue;
+        }
+        this.pending.delete(message.id);
+        clearTimeout(pending.timer);
+        if (message.command !== pending.command) {
+          pending.reject(
+            new Error(
+              `pi RPC response command mismatch: expected ${pending.command}, got ${String(message.command)}`
+            )
+          );
+        } else if (message.success !== true) {
+          pending.reject(
+            new Error(
+              typeof message.error === 'string'
+                ? message.error
+                : `${pending.command} failed`
+            )
+          );
+        } else {
+          pending.resolve(message);
+        }
+      } else {
+        this.emit('event', message);
+      }
+    }
+
+    // Check again after consuming complete records: a chunk can contain valid
+    // lines followed by an oversized unterminated tail.
+    if (this.buffer.length > maxBufferBytes) {
+      this.buffer = Buffer.alloc(0);
+      const error = new Error(
+        `pi RPC input buffer exceeded ${maxBufferBytes} bytes`
+      );
+      this.emit('protocolError', error);
+      // Discarding an unterminated record loses framing. Stop rather than risk
+      // interpreting a later suffix as a fresh trusted record.
+      void this.stop().catch((stopError: unknown) =>
+        this.emit(
+          'error',
+          stopError instanceof Error ? stopError : new Error(String(stopError))
+        )
+      );
+    }
+  }
+
+  private enqueue(message: Record<string, unknown>): void {
+    this.writes.push(`${JSON.stringify(message)}\n`);
+    this.flush();
+  }
+
+  private flush(): void {
+    if (this.draining) return;
+    const stdin = this.child?.stdin;
+    if (!stdin) return;
+    while (this.writes.length) {
+      const line = this.writes.shift()!;
+      if (!stdin.write(line)) {
+        this.draining = true;
+        stdin.once('drain', () => {
+          this.draining = false;
+          this.flush();
+        });
+        return;
+      }
+    }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/server/pi-agent-rpc-client.ts
+++ b/server/pi-agent-rpc-client.ts
@@ -138,9 +138,7 @@ export class PiAgentRpcClient extends EventEmitter {
     const promise = new Promise<PiAgentRpcMessage>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(
-          new Error(`pi RPC ${type} timed out after ${timeoutMs}ms`)
-        );
+        reject(new Error(`pi RPC ${type} timed out after ${timeoutMs}ms`));
       }, timeoutMs);
       timer.unref?.();
       this.pending.set(id, { resolve, reject, command: type, timer });
@@ -312,7 +310,18 @@ export class PiAgentRpcClient extends EventEmitter {
     if (!stdin) return;
     while (this.writes.length) {
       const line = this.writes.shift()!;
-      if (!stdin.write(line)) {
+      let accepted: boolean;
+      try {
+        accepted = stdin.write(line);
+      } catch (error) {
+        const failure =
+          error instanceof Error ? error : new Error(String(error));
+        this.writes.length = 0;
+        this.rejectPending(failure);
+        this.emit('error', failure);
+        return;
+      }
+      if (!accepted) {
         this.draining = true;
         const onDrain = () => {
           this.detachDrainListener = null;

--- a/server/pi-agent-rpc-client.ts
+++ b/server/pi-agent-rpc-client.ts
@@ -38,6 +38,8 @@ export class PiAgentRpcClient extends EventEmitter {
   private readonly pending = new Map<string, PendingCall>();
   private readonly writes: string[] = [];
   private draining = false;
+  private detachChildListeners: (() => void) | null = null;
+  private detachDrainListener: (() => void) | null = null;
 
   constructor(private readonly options: PiAgentRpcClientOptions = {}) {
     super();
@@ -61,31 +63,57 @@ export class PiAgentRpcClient extends EventEmitter {
     );
     this.child = child;
     this.buffer = Buffer.alloc(0);
-    child.stdout?.on('data', (chunk: Buffer | string) => this.consume(chunk));
-    child.stderr?.on('data', (chunk: Buffer | string) =>
-      this.emit('stderr', String(chunk))
-    );
-    child.stdin?.on('error', (error: Error) => this.emit('error', error));
-    child.stdout?.on('error', (error: Error) => this.emit('error', error));
-    child.stderr?.on('error', (error: Error) => this.emit('error', error));
-    child.on('error', (error: Error) => {
+    const onStdoutData = (chunk: Buffer | string) => this.consume(chunk);
+    const onStderrData = (chunk: Buffer | string) =>
+      this.emit('stderr', String(chunk));
+    const onStreamError = (error: Error) => this.emit('error', error);
+    const onChildError = (error: Error) => {
       this.rejectPending(error);
       this.emit('error', error);
-    });
-    child.on('close', (code) => {
-      if (this.child === child) this.child = null;
+    };
+    const onClose = (code: number | null) => {
+      if (this.child === child) {
+        this.child = null;
+        this.resetTransportState(
+          new Error(`pi rpc exited (code=${String(code)})`)
+        );
+        this.removeChildListeners();
+      }
       const error = new Error(`pi rpc exited (code=${String(code)})`);
       this.rejectPending(error);
       this.emit('close', code);
-    });
+    };
+    child.stdout?.on('data', onStdoutData);
+    child.stderr?.on('data', onStderrData);
+    child.stdin?.on('error', onStreamError);
+    child.stdout?.on('error', onStreamError);
+    child.stderr?.on('error', onStreamError);
+    child.on('error', onChildError);
+    child.on('close', onClose);
+    this.detachChildListeners = () => {
+      child.stdout?.removeListener('data', onStdoutData);
+      child.stderr?.removeListener('data', onStderrData);
+      child.stdin?.removeListener('error', onStreamError);
+      child.stdout?.removeListener('error', onStreamError);
+      child.stderr?.removeListener('error', onStreamError);
+      child.removeListener('error', onChildError);
+      child.removeListener('close', onClose);
+    };
 
     // RPC has no initialize handshake. A correlated get_state response is the
     // readiness barrier and supplies durable session identity.
-    return this.callWithTimeout(
-      'get_state',
-      {},
-      this.options.readinessTimeoutMs ?? 10_000
-    );
+    try {
+      return await this.callWithTimeout(
+        'get_state',
+        {},
+        this.options.readinessTimeoutMs ?? 10_000
+      );
+    } catch (error) {
+      // A failed readiness barrier must not leave a live child, drain handler,
+      // or unsent request behind for a later start attempt.
+      await this.stop().catch(() => undefined);
+      throw error;
+    }
   }
 
   call(
@@ -124,10 +152,14 @@ export class PiAgentRpcClient extends EventEmitter {
   async stop(): Promise<void> {
     if (this.stopPromise) return this.stopPromise;
     const child = this.child;
-    if (!child) return;
+    if (!child) {
+      this.resetTransportState(new Error('PiAgentRpcClient stopped'));
+      return;
+    }
 
     this.child = null;
-    this.rejectPending(new Error('PiAgentRpcClient stopped'));
+    this.resetTransportState(new Error('PiAgentRpcClient stopped'));
+    this.removeChildListeners();
     this.stopPromise = this.terminate(child).finally(() => {
       this.stopPromise = null;
     });
@@ -282,10 +314,13 @@ export class PiAgentRpcClient extends EventEmitter {
       const line = this.writes.shift()!;
       if (!stdin.write(line)) {
         this.draining = true;
-        stdin.once('drain', () => {
+        const onDrain = () => {
+          this.detachDrainListener = null;
           this.draining = false;
           this.flush();
-        });
+        };
+        this.detachDrainListener = () => stdin.removeListener('drain', onDrain);
+        stdin.once('drain', onDrain);
         return;
       }
     }
@@ -297,5 +332,20 @@ export class PiAgentRpcClient extends EventEmitter {
       pending.reject(error);
     }
     this.pending.clear();
+  }
+
+  private resetTransportState(error: Error): void {
+    this.rejectPending(error);
+    this.buffer = Buffer.alloc(0);
+    this.writes.length = 0;
+    this.nextId = 1;
+    this.detachDrainListener?.();
+    this.detachDrainListener = null;
+    this.draining = false;
+  }
+
+  private removeChildListeners(): void {
+    this.detachChildListeners?.();
+    this.detachChildListeners = null;
   }
 }

--- a/server/prime-agent-rpc-client.ts
+++ b/server/prime-agent-rpc-client.ts
@@ -38,6 +38,8 @@ export class PrimeAgentRpcClient extends EventEmitter {
   private readonly pending = new Map<string, PendingCall>();
   private readonly writes: string[] = [];
   private draining = false;
+  private detachChildListeners: (() => void) | null = null;
+  private detachDrainListener: (() => void) | null = null;
 
   constructor(private readonly options: PrimeAgentRpcClientOptions = {}) {
     super();
@@ -61,31 +63,57 @@ export class PrimeAgentRpcClient extends EventEmitter {
     );
     this.child = child;
     this.buffer = Buffer.alloc(0);
-    child.stdout?.on('data', (chunk: Buffer | string) => this.consume(chunk));
-    child.stderr?.on('data', (chunk: Buffer | string) =>
-      this.emit('stderr', String(chunk))
-    );
-    child.stdin?.on('error', (error: Error) => this.emit('error', error));
-    child.stdout?.on('error', (error: Error) => this.emit('error', error));
-    child.stderr?.on('error', (error: Error) => this.emit('error', error));
-    child.on('error', (error: Error) => {
+    const onStdoutData = (chunk: Buffer | string) => this.consume(chunk);
+    const onStderrData = (chunk: Buffer | string) =>
+      this.emit('stderr', String(chunk));
+    const onStreamError = (error: Error) => this.emit('error', error);
+    const onChildError = (error: Error) => {
       this.rejectPending(error);
       this.emit('error', error);
-    });
-    child.on('close', (code) => {
-      if (this.child === child) this.child = null;
+    };
+    const onClose = (code: number | null) => {
+      if (this.child === child) {
+        this.child = null;
+        this.resetTransportState(
+          new Error(`prime-agent rpc exited (code=${String(code)})`)
+        );
+        this.removeChildListeners();
+      }
       const error = new Error(`prime-agent rpc exited (code=${String(code)})`);
       this.rejectPending(error);
       this.emit('close', code);
-    });
+    };
+    child.stdout?.on('data', onStdoutData);
+    child.stderr?.on('data', onStderrData);
+    child.stdin?.on('error', onStreamError);
+    child.stdout?.on('error', onStreamError);
+    child.stderr?.on('error', onStreamError);
+    child.on('error', onChildError);
+    child.on('close', onClose);
+    this.detachChildListeners = () => {
+      child.stdout?.removeListener('data', onStdoutData);
+      child.stderr?.removeListener('data', onStderrData);
+      child.stdin?.removeListener('error', onStreamError);
+      child.stdout?.removeListener('error', onStreamError);
+      child.stderr?.removeListener('error', onStreamError);
+      child.removeListener('error', onChildError);
+      child.removeListener('close', onClose);
+    };
 
     // RPC has no initialize handshake. A correlated get_state response is the
     // readiness barrier and supplies durable session identity.
-    return this.callWithTimeout(
-      'get_state',
-      {},
-      this.options.readinessTimeoutMs ?? 10_000
-    );
+    try {
+      return await this.callWithTimeout(
+        'get_state',
+        {},
+        this.options.readinessTimeoutMs ?? 10_000
+      );
+    } catch (error) {
+      // A failed readiness barrier must not leave a live child, drain handler,
+      // or unsent request behind for a later start attempt.
+      await this.stop().catch(() => undefined);
+      throw error;
+    }
   }
 
   call(
@@ -124,10 +152,14 @@ export class PrimeAgentRpcClient extends EventEmitter {
   async stop(): Promise<void> {
     if (this.stopPromise) return this.stopPromise;
     const child = this.child;
-    if (!child) return;
+    if (!child) {
+      this.resetTransportState(new Error('PrimeAgentRpcClient stopped'));
+      return;
+    }
 
     this.child = null;
-    this.rejectPending(new Error('PrimeAgentRpcClient stopped'));
+    this.resetTransportState(new Error('PrimeAgentRpcClient stopped'));
+    this.removeChildListeners();
     this.stopPromise = this.terminate(child).finally(() => {
       this.stopPromise = null;
     });
@@ -282,10 +314,13 @@ export class PrimeAgentRpcClient extends EventEmitter {
       const line = this.writes.shift()!;
       if (!stdin.write(line)) {
         this.draining = true;
-        stdin.once('drain', () => {
+        const onDrain = () => {
+          this.detachDrainListener = null;
           this.draining = false;
           this.flush();
-        });
+        };
+        this.detachDrainListener = () => stdin.removeListener('drain', onDrain);
+        stdin.once('drain', onDrain);
         return;
       }
     }
@@ -297,5 +332,20 @@ export class PrimeAgentRpcClient extends EventEmitter {
       pending.reject(error);
     }
     this.pending.clear();
+  }
+
+  private resetTransportState(error: Error): void {
+    this.rejectPending(error);
+    this.buffer = Buffer.alloc(0);
+    this.writes.length = 0;
+    this.nextId = 1;
+    this.detachDrainListener?.();
+    this.detachDrainListener = null;
+    this.draining = false;
+  }
+
+  private removeChildListeners(): void {
+    this.detachChildListeners?.();
+    this.detachChildListeners = null;
   }
 }

--- a/server/prime-agent-rpc-client.ts
+++ b/server/prime-agent-rpc-client.ts
@@ -312,7 +312,18 @@ export class PrimeAgentRpcClient extends EventEmitter {
     if (!stdin) return;
     while (this.writes.length) {
       const line = this.writes.shift()!;
-      if (!stdin.write(line)) {
+      let accepted: boolean;
+      try {
+        accepted = stdin.write(line);
+      } catch (error) {
+        const failure =
+          error instanceof Error ? error : new Error(String(error));
+        this.writes.length = 0;
+        this.rejectPending(failure);
+        this.emit('error', failure);
+        return;
+      }
+      if (!accepted) {
         this.draining = true;
         const onDrain = () => {
           this.detachDrainListener = null;

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -257,11 +257,13 @@ export function collectLanguageServerDiagnostics(
     .filter((proc) => proc.languageServerKind)
     .map((proc) => {
       const ancestors = ancestorsOf(proc, byPid);
-      const relayOwnedLikely = [proc, ...ancestors].some((candidate) =>
-        /relay-ide|relayctl|claude|codex|opencode|hermes|prime-agent|\bpi\b/i.test(
-          candidate.commandLine
-        )
-      );
+      const relayOwnedLikely = [proc, ...ancestors].some((candidate) => {
+        return (
+          /relay-ide|relayctl|claude|codex|opencode|hermes|prime-agent/i.test(
+            candidate.commandLine
+          ) || /(?:^|\/)pi$/i.test(candidate.command)
+        );
+      });
       return {
         pid: proc.pid,
         ppid: proc.ppid,

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -258,7 +258,7 @@ export function collectLanguageServerDiagnostics(
     .map((proc) => {
       const ancestors = ancestorsOf(proc, byPid);
       const relayOwnedLikely = [proc, ...ancestors].some((candidate) =>
-        /relay-ide|relayctl|claude|codex|opencode|hermes|prime-agent/i.test(
+        /relay-ide|relayctl|claude|codex|opencode|hermes|prime-agent|\bpi\b/i.test(
           candidate.commandLine
         )
       );

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -7,12 +7,14 @@ import { OpenCodeAttachedAdapter } from './opencode-attached-adapter.js';
 import { HermesProtocolAdapter } from './hermes-adapter.js';
 import { CodexNativeProtocolAdapter } from './codex-native-adapter.js';
 import { PrimeAgentProtocolAdapter } from './prime-agent-adapter.js';
+import { PiAgentProtocolAdapter } from './pi-agent-adapter.js';
 
 export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
   mock: () => new MockProtocolAdapterV2(),
   claude: () => new ClaudeProtocolAdapter(),
   codex: () => new CodexNativeProtocolAdapter(),
   'prime-agent': () => new PrimeAgentProtocolAdapter(),
+  pi: () => new PiAgentProtocolAdapter(),
   opencode: () =>
     new LegacyProtocolAdapterV2Bridge(new OpenCodeProtocolAdapter(), {
       text: true,

--- a/server/protocol-adapters/pi-agent-adapter.ts
+++ b/server/protocol-adapters/pi-agent-adapter.ts
@@ -59,6 +59,11 @@ function record(value: unknown): RpcRecord {
 function string(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback;
 }
+function queueCount(value: unknown): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : 0;
+}
 function resultText(value: unknown): string {
   const content = record(value).content;
   if (!Array.isArray(content)) return typeof value === 'string' ? value : '';
@@ -133,6 +138,9 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private turnUsage: AgentUsageV2 | undefined;
   private clientGeneration = 0;
   private readonly queued: AgentSendMessageInputV2[] = [];
+  private toolFallbackSequence = 0;
+  private readonly anonymousToolIds = new Map<string, string[]>();
+  private readonly pendingAnonymousToolIds = new Map<string, string[]>();
   private queueAdvanceInFlight = false;
   private providerExtensionSequence = 0;
   private readonly items = new Map<string, AgentItemV2>();
@@ -167,7 +175,8 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       args.push('--append-system-prompt', config.systemPromptAppendix);
     // Pi resumes a durable session by exact project session id (`--session-id`),
     // the analog of Prime Agent's `--resume <sessionId>`.
-    if (config.resumeSessionId) args.push('--session-id', config.resumeSessionId);
+    if (config.resumeSessionId)
+      args.push('--session-id', config.resumeSessionId);
     const env = { ...cleanEnv(), ...(config.processEnv ?? {}) };
     delete env['CLAUDECODE'];
     const client = this.clientFactory({
@@ -204,9 +213,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         waitingOn: null,
         activeRequestIds: [],
         proposedPlanItemId: null,
-        queueLength: Number(
-          record(response.data).pendingMessageCount ?? 0
-        ),
+        queueLength: queueCount(record(response.data).pendingMessageCount),
         fastModeAvailable: false,
         error: null,
       });
@@ -224,6 +231,8 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.queued.length = 0;
     this.queueAdvanceInFlight = false;
     this.items.clear();
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
   }
 
   private async teardownClient(): Promise<void> {
@@ -339,10 +348,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       const message = record(event.message);
       if (message.stopReason === 'aborted') this.abortRequested = true;
       if (message.stopReason === 'error')
-        this.turnFailure = string(
-          message.errorMessage,
-          'Pi generation failed'
-        );
+        this.turnFailure = string(message.errorMessage, 'Pi generation failed');
       this.finishMessageItems(
         this.abortRequested
           ? 'cancelled'
@@ -431,7 +437,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         this.emitDelta(id, { summary: delta.delta });
     } else if (kind === 'toolcall_end') {
       const toolCall = record(delta.toolCall);
-      const id = string(toolCall.id, `${this.activeTurnId}-tool-${index}`);
+      const id = this.toolIdForPreview(toolCall, index);
       this.ensureTool(
         id,
         string(toolCall.name, 'tool'),
@@ -451,7 +457,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
 
   private startTool(event: RpcRecord): void {
     if (!this.activeTurnId) return;
-    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    const id = this.toolIdForStart(event);
     const name = string(event.toolName, 'tool');
     const args = toolArguments(event.args);
     // Empty-args guard: a command/file tool with missing required fields is
@@ -468,8 +474,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   private isEmptyToolCall(name: string, args: RpcRecord): boolean {
-    if (isCommandTool(name))
-      return string(args.command).trim().length === 0;
+    if (isCommandTool(name)) return string(args.command).trim().length === 0;
     if (isFileTool(name))
       return string(args.path ?? args.file_path).trim().length === 0;
     return false;
@@ -503,15 +508,13 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     // without `streamingBehavior` is rejected in that state (pi RPC docs), so use
     // `steer`: it queues while running and is delivered after the current turn's
     // tool calls finish, before the next LLM call.
-    void client
-      .call('steer', { message: corrective })
-      .catch((error) => {
-        if (this._status === 'connected') {
-          this.emitError(
-            `Failed to send corrective prompt to Pi: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-      });
+    void client.call('steer', { message: corrective }).catch((error) => {
+      if (this._status === 'connected') {
+        this.emitError(
+          `Failed to send corrective prompt to Pi: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    });
   }
 
   private ensureTool(id: string, name: string, args: RpcRecord): void {
@@ -555,7 +558,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
 
   private updateTool(event: RpcRecord, result: unknown, done: boolean): void {
     if (!this.activeTurnId) return;
-    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    const id = this.toolIdForUpdate(event);
     this.ensureTool(
       id,
       string(event.toolName, 'tool'),
@@ -597,6 +600,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     else return;
     this.items.set(id, updated);
     this.emitItemUpdated(updated);
+    if (done) this.forgetAnonymousToolId(event, id);
   }
 
   private finishMessageItems(
@@ -725,11 +729,20 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       const payload: RpcRecord = { message: next.content };
       const images = this.readImages(next.attachments);
       if (images.length) payload.images = images;
-      await this.submitNativeInput(this.requireClient(), next, payload);
+      try {
+        await this.submitNativeInput(this.requireClient(), next, payload);
+      } catch (error) {
+        this.handleTransportClose(
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
     } catch (error) {
-      this.handleTransportClose(
-        error instanceof Error ? error : new Error(String(error))
-      );
+      const failure = error instanceof Error ? error : new Error(String(error));
+      // Attachment files are Relay-local input. A file can be removed or
+      // invalidated after enqueue, which must fail only this attributed turn;
+      // the provider transport remains usable for later queued messages.
+      this.emitError(failure.message);
+      this.completeTurn('failed', failure.message);
     } finally {
       this.queueAdvanceInFlight = false;
       if (!this.activeTurnId) void this.advanceQueuedTurn();
@@ -744,6 +757,9 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.assistantMessageSequence = -1;
     this.turnUsage = undefined;
     this.items.clear();
+    this.toolFallbackSequence = 0;
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
     this.emptyToolCounts.clear();
     const timestamp = nowIso();
     this.emitPatch({
@@ -812,6 +828,8 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.turnFailure = null;
     this.turnUsage = undefined;
     this.emptyToolCounts.clear();
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
     this.emitLive({
       status: this.queued.length ? 'working' : 'idle',
       activeTurnId: null,
@@ -830,6 +848,48 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       turnId: this.activeTurnId,
       item,
     });
+  }
+  private fallbackToolId(index?: number): string {
+    return `${this.activeTurnId}-tool-fallback-${this.assistantMessageSequence}-${index ?? 'none'}-${++this.toolFallbackSequence}`;
+  }
+  private toolIdForStart(event: RpcRecord): string {
+    const providerId = string(event.toolCallId).trim();
+    if (providerId) return providerId;
+    const name = string(event.toolName, 'tool');
+    const pending = this.pendingAnonymousToolIds.get(name);
+    const id = pending?.shift() ?? this.fallbackToolId();
+    if (pending?.length === 0) this.pendingAnonymousToolIds.delete(name);
+    this.anonymousToolIds.set(name, [
+      ...(this.anonymousToolIds.get(name) ?? []),
+      id,
+    ]);
+    return id;
+  }
+  private toolIdForUpdate(event: RpcRecord): string {
+    const providerId = string(event.toolCallId).trim();
+    if (providerId) return providerId;
+    const name = string(event.toolName, 'tool');
+    return this.anonymousToolIds.get(name)?.[0] ?? this.toolIdForStart(event);
+  }
+  private toolIdForPreview(toolCall: RpcRecord, index: number): string {
+    const providerId = string(toolCall.id).trim();
+    if (providerId) return providerId;
+    const name = string(toolCall.name, 'tool');
+    const id = this.fallbackToolId(index);
+    this.pendingAnonymousToolIds.set(name, [
+      ...(this.pendingAnonymousToolIds.get(name) ?? []),
+      id,
+    ]);
+    return id;
+  }
+  private forgetAnonymousToolId(event: RpcRecord, id: string): void {
+    if (string(event.toolCallId).trim()) return;
+    const name = string(event.toolName, 'tool');
+    const ids = this.anonymousToolIds.get(name);
+    if (!ids) return;
+    const remaining = ids.filter((candidate) => candidate !== id);
+    if (remaining.length) this.anonymousToolIds.set(name, remaining);
+    else this.anonymousToolIds.delete(name);
   }
   private emitDelta(
     id: string,
@@ -911,6 +971,8 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.queueAdvanceInFlight = false;
     this.items.clear();
     this.emptyToolCounts.clear();
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
   }
 
   private emitLive(live: Partial<AgentSessionLiveStateV2>): void {
@@ -944,7 +1006,9 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
   private get providerSession(): Record<string, string> {
     return {
-      ...(this.providerSessionId ? { piSessionId: this.providerSessionId } : {}),
+      ...(this.providerSessionId
+        ? { piSessionId: this.providerSessionId }
+        : {}),
       ...(this.providerSessionFile
         ? { piSessionFile: this.providerSessionFile }
         : {}),

--- a/server/protocol-adapters/pi-agent-adapter.ts
+++ b/server/protocol-adapters/pi-agent-adapter.ts
@@ -84,6 +84,21 @@ function toolArguments(value: unknown): RpcRecord {
   }
   return {};
 }
+function stableToolArgs(value: unknown): string {
+  if (Array.isArray(value))
+    return `[${value.map((entry) => stableToolArgs(entry)).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const object = value as RpcRecord;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableToolArgs(object[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+function toolIdentityKey(name: string, args: RpcRecord): string {
+  return `${name}\0${stableToolArgs(args)}`;
+}
 function isCommandTool(name: string): boolean {
   return /^(bash|shell|exec|terminal)$/i.test(name);
 }
@@ -151,6 +166,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   // reset a stuck tool's streak (an empty `bash` loop keeps counting regardless
   // of interleaved `edit` calls).
   private readonly emptyToolCounts = new Map<string, number>();
+  private readonly suppressedEmptyToolIds = new Set<string>();
 
   constructor(
     private readonly clientFactory: ClientFactory = (options) =>
@@ -233,6 +249,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.items.clear();
     this.anonymousToolIds.clear();
     this.pendingAnonymousToolIds.clear();
+    this.suppressedEmptyToolIds.clear();
   }
 
   private async teardownClient(): Promise<void> {
@@ -464,6 +481,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     // rejected by the harness validator (no usable tool result), which makes the
     // model retry the identical empty call until it exhausts output tokens.
     if (this.isEmptyToolCall(name, args)) {
+      this.suppressedEmptyToolIds.add(id);
       this.handleEmptyToolCall(name);
       return;
     }
@@ -499,7 +517,8 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   private injectCorrectivePrompt(name: string): void {
-    const client = this.requireClient();
+    const client = this._status === 'connected' ? this.client : null;
+    if (!client) return;
     const corrective =
       `Your previous ${name} tool call omitted the required arguments (received empty). ` +
       `Re-issue the call with a concrete command/path, or if no tool is needed, ` +
@@ -559,6 +578,13 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private updateTool(event: RpcRecord, result: unknown, done: boolean): void {
     if (!this.activeTurnId) return;
     const id = this.toolIdForUpdate(event);
+    if (this.suppressedEmptyToolIds.has(id)) {
+      if (done) {
+        this.suppressedEmptyToolIds.delete(id);
+        this.forgetAnonymousToolId(event, id);
+      }
+      return;
+    }
     this.ensureTool(
       id,
       string(event.toolName, 'tool'),
@@ -761,6 +787,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.anonymousToolIds.clear();
     this.pendingAnonymousToolIds.clear();
     this.emptyToolCounts.clear();
+    this.suppressedEmptyToolIds.clear();
     const timestamp = nowIso();
     this.emitPatch({
       type: 'agent-turn-started-v2',
@@ -830,6 +857,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.emptyToolCounts.clear();
     this.anonymousToolIds.clear();
     this.pendingAnonymousToolIds.clear();
+    this.suppressedEmptyToolIds.clear();
     this.emitLive({
       status: this.queued.length ? 'working' : 'idle',
       activeTurnId: null,
@@ -856,11 +884,12 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const providerId = string(event.toolCallId).trim();
     if (providerId) return providerId;
     const name = string(event.toolName, 'tool');
-    const pending = this.pendingAnonymousToolIds.get(name);
+    const key = toolIdentityKey(name, toolArguments(event.args));
+    const pending = this.pendingAnonymousToolIds.get(key);
     const id = pending?.shift() ?? this.fallbackToolId();
-    if (pending?.length === 0) this.pendingAnonymousToolIds.delete(name);
-    this.anonymousToolIds.set(name, [
-      ...(this.anonymousToolIds.get(name) ?? []),
+    if (pending?.length === 0) this.pendingAnonymousToolIds.delete(key);
+    this.anonymousToolIds.set(key, [
+      ...(this.anonymousToolIds.get(key) ?? []),
       id,
     ]);
     return id;
@@ -869,27 +898,43 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const providerId = string(event.toolCallId).trim();
     if (providerId) return providerId;
     const name = string(event.toolName, 'tool');
-    return this.anonymousToolIds.get(name)?.[0] ?? this.toolIdForStart(event);
+    const args = toolArguments(event.args);
+    const exact = this.anonymousToolIds.get(toolIdentityKey(name, args))?.[0];
+    if (exact) return exact;
+    // If args are absent, concurrent same-name events are indistinguishable;
+    // FIFO is the only truthful fallback available from the provider stream.
+    if (Object.keys(args).length === 0) {
+      for (const [key, ids] of this.anonymousToolIds) {
+        if (key.startsWith(`${name}\0`) && ids[0]) return ids[0];
+      }
+    }
+    return this.toolIdForStart(event);
   }
   private toolIdForPreview(toolCall: RpcRecord, index: number): string {
     const providerId = string(toolCall.id).trim();
     if (providerId) return providerId;
     const name = string(toolCall.name, 'tool');
+    const key = toolIdentityKey(
+      name,
+      toolArguments(toolCall.arguments ?? toolCall.args)
+    );
     const id = this.fallbackToolId(index);
-    this.pendingAnonymousToolIds.set(name, [
-      ...(this.pendingAnonymousToolIds.get(name) ?? []),
+    this.pendingAnonymousToolIds.set(key, [
+      ...(this.pendingAnonymousToolIds.get(key) ?? []),
       id,
     ]);
     return id;
   }
   private forgetAnonymousToolId(event: RpcRecord, id: string): void {
     if (string(event.toolCallId).trim()) return;
-    const name = string(event.toolName, 'tool');
-    const ids = this.anonymousToolIds.get(name);
-    if (!ids) return;
-    const remaining = ids.filter((candidate) => candidate !== id);
-    if (remaining.length) this.anonymousToolIds.set(name, remaining);
-    else this.anonymousToolIds.delete(name);
+    for (const [key, ids] of this.anonymousToolIds) {
+      const remaining = ids.filter((candidate) => candidate !== id);
+      if (remaining.length !== ids.length) {
+        if (remaining.length) this.anonymousToolIds.set(key, remaining);
+        else this.anonymousToolIds.delete(key);
+        return;
+      }
+    }
   }
   private emitDelta(
     id: string,
@@ -973,6 +1018,7 @@ export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.emptyToolCounts.clear();
     this.anonymousToolIds.clear();
     this.pendingAnonymousToolIds.clear();
+    this.suppressedEmptyToolIds.clear();
   }
 
   private emitLive(live: Partial<AgentSessionLiveStateV2>): void {

--- a/server/protocol-adapters/pi-agent-adapter.ts
+++ b/server/protocol-adapters/pi-agent-adapter.ts
@@ -1,0 +1,1029 @@
+import * as fs from 'node:fs';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentSendMessageInputV2,
+} from '../protocol-adapter-v2.js';
+import type {
+  AgentCapabilitySetV2,
+  AgentItemV2,
+  AgentSessionLiveStateV2,
+  AgentUsageV2,
+} from '../../shared/agent-chat-protocol-v2.js';
+import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+import { cleanEnv } from '../utils.js';
+import {
+  PiAgentRpcClient,
+  type PiAgentRpcClientOptions,
+  type PiAgentRpcMessage,
+} from '../pi-agent-rpc-client.js';
+
+const CAPABILITIES: AgentCapabilitySetV2 = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: false,
+  questions: false,
+  plans: false,
+  slashCommands: false,
+  queue: true,
+  cancelQueued: false,
+  interrupt: true,
+  resume: true,
+  fork: false,
+  rollback: false,
+  compact: true,
+  telemetry: true,
+  rateLimits: false,
+  streaming: true,
+};
+
+type ClientFactory = (options: PiAgentRpcClientOptions) => PiAgentRpcClient;
+type RpcRecord = Record<string, unknown>;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+function record(value: unknown): RpcRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as RpcRecord)
+    : {};
+}
+function string(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+function resultText(value: unknown): string {
+  const content = record(value).content;
+  if (!Array.isArray(content)) return typeof value === 'string' ? value : '';
+  return content
+    .map((part) => string(record(part).text))
+    .filter(Boolean)
+    .join('\n');
+}
+function toolArguments(value: unknown): RpcRecord {
+  if (value && typeof value === 'object' && !Array.isArray(value))
+    return value as RpcRecord;
+  if (typeof value === 'string') {
+    try {
+      return record(JSON.parse(value));
+    } catch {
+      return { raw: value };
+    }
+  }
+  return {};
+}
+function isCommandTool(name: string): boolean {
+  return /^(bash|shell|exec|terminal)$/i.test(name);
+}
+function isFileTool(name: string): boolean {
+  return /^(edit|write|patch|apply_patch|create|delete|move)/i.test(name);
+}
+
+const MAX_IMAGE_COUNT = 4;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGE_TOTAL_BYTES = MAX_IMAGE_COUNT * MAX_IMAGE_BYTES;
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+function matchesImageSignature(bytes: Buffer, mimeType: string): boolean {
+  if (mimeType === 'image/png')
+    return bytes
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  if (mimeType === 'image/jpeg')
+    return bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  if (mimeType === 'image/gif') {
+    const signature = bytes.subarray(0, 6).toString('ascii');
+    return signature === 'GIF87a' || signature === 'GIF89a';
+  }
+  return (
+    mimeType === 'image/webp' &&
+    bytes.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    bytes.subarray(8, 12).toString('ascii') === 'WEBP'
+  );
+}
+
+export class PiAgentProtocolAdapter extends BaseProtocolAdapterV2 {
+  readonly agentType = 'pi';
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities = CAPABILITIES;
+  readonly resumesProviderSessionDuringConnect = true;
+
+  private _status: AdapterStatus = 'disconnected';
+  private config: AdapterConfig | null = null;
+  private client: PiAgentRpcClient | null = null;
+  private providerSessionId: string | null = null;
+  private providerSessionFile: string | null = null;
+  private activeTurnId: string | null = null;
+  private activeStartedMs = 0;
+  private abortRequested = false;
+  private turnFailure: string | null = null;
+  private assistantMessageSequence = -1;
+  private turnUsage: AgentUsageV2 | undefined;
+  private clientGeneration = 0;
+  private readonly queued: AgentSendMessageInputV2[] = [];
+  private queueAdvanceInFlight = false;
+  private providerExtensionSequence = 0;
+  private readonly items = new Map<string, AgentItemV2>();
+  // Empty-args guard state: a command/file tool with missing required fields
+  // is rejected by the harness validator, returns no usable tool result, and the
+  // model burns output tokens retrying the identical empty call. Counts are
+  // tracked PER TOOL NAME so a valid invocation of an unrelated tool cannot
+  // reset a stuck tool's streak (an empty `bash` loop keeps counting regardless
+  // of interleaved `edit` calls).
+  private readonly emptyToolCounts = new Map<string, number>();
+
+  constructor(
+    private readonly clientFactory: ClientFactory = (options) =>
+      new PiAgentRpcClient({ ...options, spawn: nodeSpawn })
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this.config = config;
+    this._status = 'connecting';
+    const args = ['--mode', 'rpc', '--no-extensions'];
+    const provider = string(config.extra?.['provider']);
+    const thinking = string(config.extra?.['effort']);
+    if (provider) args.push('--provider', provider);
+    if (config.model) args.push('--model', config.model);
+    if (thinking) args.push('--thinking', thinking);
+    if (config.systemPromptAppendix)
+      args.push('--append-system-prompt', config.systemPromptAppendix);
+    // Pi resumes a durable session by exact project session id (`--session-id`),
+    // the analog of Prime Agent's `--resume <sessionId>`.
+    if (config.resumeSessionId) args.push('--session-id', config.resumeSessionId);
+    const env = { ...cleanEnv(), ...(config.processEnv ?? {}) };
+    delete env['CLAUDECODE'];
+    const client = this.clientFactory({
+      command: 'pi',
+      args,
+      cwd: config.cwd,
+      env,
+    });
+    this.client = client;
+    const generation = ++this.clientGeneration;
+    const current = (): boolean =>
+      this.client === client && this.clientGeneration === generation;
+    client.on('event', (event: PiAgentRpcMessage) => {
+      if (current()) this.handleEvent(event);
+    });
+    client.on('protocolError', (error: Error) => {
+      if (current()) this.handleTransportClose(error);
+    });
+    client.on('error', (error: Error) => {
+      if (current()) this.handleTransportClose(error);
+    });
+    client.on('close', () => {
+      if (current() && this._status !== 'disconnected')
+        this.handleTransportClose(new Error('pi RPC transport closed'));
+    });
+    try {
+      const response = await client.start();
+      this.applyState(record(response.data));
+      this._status = 'connected';
+      this.emitSnapshot();
+      this.emitLive({
+        status: record(response.data).isStreaming === true ? 'working' : 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        proposedPlanItemId: null,
+        queueLength: Number(
+          record(response.data).pendingMessageCount ?? 0
+        ),
+        fastModeAvailable: false,
+        error: null,
+      });
+    } catch (error) {
+      this._status = 'disconnected';
+      await client.stop().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+    await this.teardownClient();
+    this.activeTurnId = null;
+    this.queued.length = 0;
+    this.queueAdvanceInFlight = false;
+    this.items.clear();
+  }
+
+  private async teardownClient(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    this.clientGeneration += 1;
+    await client?.stop();
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.config) throw new Error('Cannot reconnect before connect');
+    const config = {
+      ...this.config,
+      ...(this.providerSessionId
+        ? { resumeSessionId: this.providerSessionId }
+        : {}),
+    };
+    this.resetForTransportSwitch('Pi transport reconnected');
+    this._status = 'disconnected';
+    await this.teardownClient();
+    await this.connect(config);
+  }
+
+  async resumeSession(sessionId: string): Promise<void> {
+    if (!this.config) throw new Error('Cannot resumeSession before connect');
+    const config = { ...this.config, resumeSessionId: sessionId };
+    this.resetForTransportSwitch('Pi session switched');
+    this._status = 'disconnected';
+    await this.teardownClient();
+    await this.connect(config);
+  }
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    const client = this.requireClient();
+    const payload: RpcRecord = { message: input.content };
+    const images = this.readImages(input.attachments);
+    if (images.length) payload.images = images;
+    if (this.activeTurnId) {
+      // Pi `steer`/`follow_up` stay inside the current native run and therefore
+      // have no separate agent_settled boundary that Relay can attribute to this
+      // turn. Keep Relay turns local and submit a fresh prompt after settle.
+      this.queued.push(input);
+      this.emitLive({
+        status: 'working',
+        activeTurnId: this.activeTurnId,
+        queueLength: this.queued.length,
+      });
+      return;
+    }
+
+    this.startTurn(input);
+    try {
+      await this.submitNativeInput(client, input, payload);
+    } catch (error) {
+      // A timeout is ambiguous: Pi may have accepted the prompt. Stop the
+      // private runtime so late events/tools cannot outlive Relay attribution.
+      this.handleTransportClose(
+        error instanceof Error ? error : new Error(String(error))
+      );
+      throw error;
+    }
+  }
+
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    if (!this.activeTurnId) return;
+    if (input.turnId && input.turnId !== this.activeTurnId) return;
+    this.abortRequested = true;
+    try {
+      await this.requireClient().call('abort');
+    } catch (error) {
+      this.abortRequested = false;
+      throw error;
+    }
+  }
+  async respondToApproval(_input: AgentApprovalResponseInputV2): Promise<void> {
+    throw new Error('Pi RPC approvals are not mapped');
+  }
+  async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
+    throw new Error('Pi RPC questions are not mapped');
+  }
+
+  private handleEvent(event: PiAgentRpcMessage): void {
+    const type = event.type;
+    // Pi emits `agent_end` before `agent_settled`; `agent_end` may still be
+    // followed by an automatic retry, compaction retry, or queued continuation.
+    // `agent_settled` is the session-level settled boundary (emitted in a
+    // `finally`, so it also fires on error/abort), and is the safe Relay turn
+    // boundary.
+    if (type === 'turn_start' || type === 'turn_end') return;
+    if (type === 'agent_end') return;
+    if (type === 'message_start') {
+      if (record(event.message).role === 'assistant')
+        this.assistantMessageSequence += 1;
+      return;
+    }
+    if (type === 'agent_settled') {
+      this.completeTurn(
+        this.abortRequested
+          ? 'interrupted'
+          : this.turnFailure
+            ? 'failed'
+            : 'completed',
+        this.turnFailure ?? undefined
+      );
+      void this.advanceQueuedTurn();
+      return;
+    }
+    if (type === 'message_update') {
+      this.handleMessageUpdate(record(event.assistantMessageEvent));
+      return;
+    }
+    if (type === 'message_end') {
+      const message = record(event.message);
+      if (message.stopReason === 'aborted') this.abortRequested = true;
+      if (message.stopReason === 'error')
+        this.turnFailure = string(
+          message.errorMessage,
+          'Pi generation failed'
+        );
+      this.finishMessageItems(
+        this.abortRequested
+          ? 'cancelled'
+          : this.turnFailure
+            ? 'failed'
+            : 'completed'
+      );
+      this.captureUsage(message);
+      return;
+    }
+    if (type === 'tool_execution_start') {
+      this.startTool(event);
+      return;
+    }
+    if (type === 'tool_execution_update') {
+      this.updateTool(event, event.partialResult, false);
+      return;
+    }
+    if (type === 'tool_execution_end') {
+      this.updateTool(event, event.result, true);
+      return;
+    }
+    if (type === 'queue_update') {
+      // Pi queues steering/follow-up messages only; Relay submits one prompt per
+      // message. Combine the native count with Relay's pending prompts: the
+      // native event must not hide work already queued by Relay.
+      const nativeQueueLength =
+        (Array.isArray(event.steering) ? event.steering.length : 0) +
+        (Array.isArray(event.followUp) ? event.followUp.length : 0);
+      this.emitLive({
+        queueLength: this.queued.length + nativeQueueLength,
+      });
+      return;
+    }
+    if (type === 'compaction_end') {
+      this.emitProviderExtension({
+        kind: 'contextCompaction',
+        reason: string(event.reason, 'threshold'),
+        ...(event.result ? { result: record(event.result) } : {}),
+      });
+      return;
+    }
+    if (type === 'extension_error') {
+      this.emitProviderExtension(
+        {
+          kind: 'extensionError',
+          error: string(event.error, 'Pi extension error'),
+        },
+        'debug'
+      );
+      return;
+    }
+    if (type === 'auto_retry_end' && event.success === false) {
+      this.turnFailure = string(event.finalError, 'Pi retry failed');
+      this.emitError(this.turnFailure);
+    }
+  }
+
+  private handleMessageUpdate(delta: RpcRecord): void {
+    if (!this.activeTurnId) return;
+    const kind = string(delta.type);
+    const index = Number(delta.contentIndex ?? 0);
+    if (kind === 'text_start' || kind === 'text_delta') {
+      const id = `${this.activeTurnId}-assistant-${Math.max(0, this.assistantMessageSequence)}-${index}`;
+      this.ensureItem(id, {
+        type: 'assistantMessage',
+        id,
+        text: '',
+        phase: 'answer',
+        status: 'running',
+        startedAt: nowIso(),
+      });
+      if (kind === 'text_delta' && typeof delta.delta === 'string')
+        this.emitDelta(id, { text: delta.delta });
+    } else if (kind === 'thinking_start' || kind === 'thinking_delta') {
+      const id = `${this.activeTurnId}-reasoning-${Math.max(0, this.assistantMessageSequence)}-${index}`;
+      this.ensureItem(id, {
+        type: 'reasoning',
+        id,
+        summary: '',
+        visibility: 'full',
+        status: 'running',
+        startedAt: nowIso(),
+      });
+      if (kind === 'thinking_delta' && typeof delta.delta === 'string')
+        this.emitDelta(id, { summary: delta.delta });
+    } else if (kind === 'toolcall_end') {
+      const toolCall = record(delta.toolCall);
+      const id = string(toolCall.id, `${this.activeTurnId}-tool-${index}`);
+      this.ensureTool(
+        id,
+        string(toolCall.name, 'tool'),
+        toolArguments(toolCall.arguments ?? toolCall.args)
+      );
+    } else if (kind === 'error') {
+      if (delta.reason === 'aborted') this.abortRequested = true;
+      else {
+        this.turnFailure = string(
+          delta.error,
+          string(delta.reason, 'Pi generation error')
+        );
+        this.emitError(this.turnFailure);
+      }
+    }
+  }
+
+  private startTool(event: RpcRecord): void {
+    if (!this.activeTurnId) return;
+    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    const name = string(event.toolName, 'tool');
+    const args = toolArguments(event.args);
+    // Empty-args guard: a command/file tool with missing required fields is
+    // rejected by the harness validator (no usable tool result), which makes the
+    // model retry the identical empty call until it exhausts output tokens.
+    if (this.isEmptyToolCall(name, args)) {
+      this.handleEmptyToolCall(name);
+      return;
+    }
+    // A non-empty invocation of this tool is legitimate progress — clear only
+    // THIS tool's empty streak (an unrelated tool's valid call must not reset it).
+    this.emptyToolCounts.delete(name);
+    this.ensureTool(id, name, args);
+  }
+
+  private isEmptyToolCall(name: string, args: RpcRecord): boolean {
+    if (isCommandTool(name))
+      return string(args.command).trim().length === 0;
+    if (isFileTool(name))
+      return string(args.path ?? args.file_path).trim().length === 0;
+    return false;
+  }
+
+  private handleEmptyToolCall(name: string): void {
+    if (!this.activeTurnId) return;
+    // Per-tool consecutive count: `bash, edit, edit` only counts the `edit`
+    // repeats, and an interleaved valid call of another tool never resets `bash`.
+    const count = (this.emptyToolCounts.get(name) ?? 0) + 1;
+    this.emptyToolCounts.set(name, count);
+    this.emitError(
+      `Pi ${name} call received empty arguments (missing required field); the model should re-issue it with a concrete command/path or answer directly`
+    );
+    // Once the same empty tool has repeated, inject a corrective prompt into the
+    // harness so it self-corrects instead of burning output tokens on retries.
+    // Trigger exactly at count === 3 so a burst of empty calls (5+) queues only
+    // one corrective steer, not one per extra call.
+    if (count === 3) {
+      this.injectCorrectivePrompt(name);
+    }
+  }
+
+  private injectCorrectivePrompt(name: string): void {
+    const client = this.requireClient();
+    const corrective =
+      `Your previous ${name} tool call omitted the required arguments (received empty). ` +
+      `Re-issue the call with a concrete command/path, or if no tool is needed, ` +
+      `answer directly without calling ${name}.`;
+    // Pi is actively streaming when this fires (tool_execution_start). A `prompt`
+    // without `streamingBehavior` is rejected in that state (pi RPC docs), so use
+    // `steer`: it queues while running and is delivered after the current turn's
+    // tool calls finish, before the next LLM call.
+    void client
+      .call('steer', { message: corrective })
+      .catch((error) => {
+        if (this._status === 'connected') {
+          this.emitError(
+            `Failed to send corrective prompt to Pi: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      });
+  }
+
+  private ensureTool(id: string, name: string, args: RpcRecord): void {
+    if (!this.activeTurnId || this.items.has(id)) return;
+    let item: AgentItemV2;
+    if (isCommandTool(name))
+      item = {
+        type: 'commandExecution',
+        id,
+        command: string(args.command, JSON.stringify(args)),
+        ...(string(args.cwd) ? { cwd: string(args.cwd) } : {}),
+        output: '',
+        status: 'running',
+        startedAt: nowIso(),
+      };
+    else if (
+      isFileTool(name) &&
+      string(args.path ?? args.file_path).length > 0
+    ) {
+      const path = string(args.path ?? args.file_path);
+      item = {
+        type: 'fileChange',
+        id,
+        paths: [{ path, status: /delete/i.test(name) ? 'deleted' : 'edited' }],
+        applyStatus: 'pending',
+        status: 'running',
+        startedAt: nowIso(),
+      };
+    } else
+      item = {
+        type: 'dynamicToolCall',
+        id,
+        namespace: 'pi',
+        tool: name,
+        arguments: args,
+        status: 'running',
+        startedAt: nowIso(),
+      };
+    this.ensureItem(id, item);
+  }
+
+  private updateTool(event: RpcRecord, result: unknown, done: boolean): void {
+    if (!this.activeTurnId) return;
+    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    this.ensureTool(
+      id,
+      string(event.toolName, 'tool'),
+      toolArguments(event.args)
+    );
+    const item = this.items.get(id);
+    if (!item) return;
+    const text = resultText(result);
+    if (!done) {
+      if (item.type === 'commandExecution')
+        this.emitDelta(id, { output: text }, 'replace');
+      else if (item.type === 'dynamicToolCall')
+        this.emitDelta(id, { content: text }, 'replace');
+      return;
+    }
+    let updated: AgentItemV2;
+    if (item.type === 'commandExecution')
+      updated = {
+        ...item,
+        output: text,
+        exitCode: event.isError === true ? 1 : 0,
+        status: event.isError === true ? 'failed' : 'completed',
+        completedAt: nowIso(),
+      };
+    else if (item.type === 'fileChange')
+      updated = {
+        ...item,
+        applyStatus: event.isError === true ? 'failed' : 'applied',
+        status: event.isError === true ? 'failed' : 'completed',
+        completedAt: nowIso(),
+      };
+    else if (item.type === 'dynamicToolCall')
+      updated = {
+        ...item,
+        result,
+        status: event.isError === true ? 'failed' : 'completed',
+        completedAt: nowIso(),
+      };
+    else return;
+    this.items.set(id, updated);
+    this.emitItemUpdated(updated);
+  }
+
+  private finishMessageItems(
+    status: 'completed' | 'failed' | 'cancelled' = 'completed'
+  ): void {
+    for (const [id, item] of this.items) {
+      if (
+        item.status !== 'running' ||
+        (item.type !== 'assistantMessage' && item.type !== 'reasoning')
+      )
+        continue;
+      const updated: AgentItemV2 = {
+        ...item,
+        status,
+        completedAt: nowIso(),
+        ...(status === 'failed' && this.turnFailure
+          ? { error: this.turnFailure }
+          : {}),
+      };
+      this.items.set(id, updated);
+      this.emitItemUpdated(updated);
+    }
+  }
+
+  private terminalizeRunningItems(
+    status: 'completed' | 'failed' | 'cancelled',
+    error?: string
+  ): void {
+    this.finishMessageItems(status);
+    for (const [id, item] of this.items) {
+      if (item.status !== 'running') continue;
+      let updated: AgentItemV2;
+      if (item.type === 'fileChange')
+        updated = {
+          ...item,
+          status,
+          applyStatus: status === 'completed' ? 'applied' : 'failed',
+          completedAt: nowIso(),
+          ...(error ? { error } : {}),
+        };
+      else
+        updated = {
+          ...item,
+          status,
+          completedAt: nowIso(),
+          ...(error ? { error } : {}),
+        };
+      this.items.set(id, updated);
+      this.emitItemUpdated(updated);
+    }
+  }
+
+  private captureUsage(message: RpcRecord): void {
+    if (message.role !== 'assistant') return;
+    const usage = record(message.usage);
+    const cost = record(usage.cost);
+    const number = (value: unknown): number | undefined =>
+      typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+    const inputTokens = number(usage.input);
+    const outputTokens = number(usage.output);
+    const cacheReadTokens = number(usage.cacheRead);
+    const cacheWriteTokens = number(usage.cacheWrite);
+    const costUsd = number(cost.total);
+    const previous = this.turnUsage ?? {};
+    const add = (
+      prior: number | undefined,
+      next: number | undefined
+    ): number | undefined => (next === undefined ? prior : (prior ?? 0) + next);
+    const accumulatedInput = add(previous.inputTokens, inputTokens);
+    const accumulatedOutput = add(previous.outputTokens, outputTokens);
+    const accumulatedCacheRead = add(previous.cacheReadTokens, cacheReadTokens);
+    const accumulatedCacheWrite = add(
+      previous.cacheWriteTokens,
+      cacheWriteTokens
+    );
+    const accumulatedCost = add(previous.costUsd ?? undefined, costUsd);
+    this.turnUsage = {
+      ...(accumulatedInput !== undefined
+        ? { inputTokens: accumulatedInput }
+        : {}),
+      ...(accumulatedOutput !== undefined
+        ? { outputTokens: accumulatedOutput }
+        : {}),
+      ...(accumulatedCacheRead !== undefined
+        ? { cacheReadTokens: accumulatedCacheRead }
+        : {}),
+      ...(accumulatedCacheWrite !== undefined
+        ? { cacheWriteTokens: accumulatedCacheWrite }
+        : {}),
+      ...(accumulatedCost !== undefined ? { costUsd: accumulatedCost } : {}),
+    };
+  }
+
+  private async submitNativeInput(
+    client: PiAgentRpcClient,
+    input: AgentSendMessageInputV2,
+    payload: RpcRecord
+  ): Promise<void> {
+    if (input.content.trim() !== '/compact') {
+      await client.call('prompt', payload);
+      return;
+    }
+    const response = await client.call('compact');
+    this.emitProviderExtension({
+      kind: 'contextCompaction',
+      ...record(response.data),
+    });
+    this.completeTurn('completed');
+    void this.advanceQueuedTurn();
+  }
+
+  private async advanceQueuedTurn(): Promise<void> {
+    if (
+      this.queueAdvanceInFlight ||
+      this.activeTurnId ||
+      this.queued.length === 0 ||
+      this._status !== 'connected'
+    ) {
+      return;
+    }
+    const next = this.queued.shift();
+    if (!next) return;
+    this.queueAdvanceInFlight = true;
+    this.startTurn(next);
+    try {
+      const payload: RpcRecord = { message: next.content };
+      const images = this.readImages(next.attachments);
+      if (images.length) payload.images = images;
+      await this.submitNativeInput(this.requireClient(), next, payload);
+    } catch (error) {
+      this.handleTransportClose(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    } finally {
+      this.queueAdvanceInFlight = false;
+      if (!this.activeTurnId) void this.advanceQueuedTurn();
+    }
+  }
+
+  private startTurn(input: AgentSendMessageInputV2): void {
+    this.activeTurnId = input.turnId;
+    this.activeStartedMs = Date.now();
+    this.abortRequested = false;
+    this.turnFailure = null;
+    this.assistantMessageSequence = -1;
+    this.turnUsage = undefined;
+    this.items.clear();
+    this.emptyToolCounts.clear();
+    const timestamp = nowIso();
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sessionId,
+      timestamp,
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `user-${input.turnId}`,
+        items: [],
+        startedAt: timestamp,
+      },
+    });
+    this.ensureItem(`user-${input.turnId}`, {
+      type: 'userMessage',
+      id: `user-${input.turnId}`,
+      text: input.content,
+      status: 'completed',
+      completedAt: timestamp,
+      ...(input.attachments
+        ? {
+            attachments: input.attachments.map((attachment) => ({
+              type: attachment.type,
+              path: attachment.path,
+              mimeType: attachment.mimeType,
+            })),
+          }
+        : {}),
+    });
+    this.emitLive({
+      status: 'working',
+      activeTurnId: input.turnId,
+      queueLength: this.queued.length,
+    });
+  }
+
+  private completeTurn(
+    status: 'completed' | 'interrupted' | 'failed',
+    error?: string
+  ): void {
+    const turnId = this.activeTurnId;
+    if (!turnId) return;
+    this.terminalizeRunningItems(
+      status === 'completed'
+        ? 'completed'
+        : status === 'interrupted'
+          ? 'cancelled'
+          : 'failed',
+      error
+    );
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId,
+      status,
+      completedAt: nowIso(),
+      durationMs: Date.now() - this.activeStartedMs,
+      ...(this.turnUsage ? { usage: this.turnUsage } : {}),
+      ...(error ? { error } : {}),
+    });
+    this.activeTurnId = null;
+    this.items.clear();
+    this.abortRequested = false;
+    this.turnFailure = null;
+    this.turnUsage = undefined;
+    this.emptyToolCounts.clear();
+    this.emitLive({
+      status: this.queued.length ? 'working' : 'idle',
+      activeTurnId: null,
+      queueLength: this.queued.length,
+      error: error ?? null,
+    });
+  }
+
+  private ensureItem(id: string, item: AgentItemV2): void {
+    if (this.items.has(id) || !this.activeTurnId) return;
+    this.items.set(id, item);
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId: this.activeTurnId,
+      item,
+    });
+  }
+  private emitDelta(
+    id: string,
+    delta: {
+      text?: string;
+      summary?: string;
+      output?: string;
+      content?: string;
+    },
+    mode?: 'replace'
+  ): void {
+    if (!this.activeTurnId) return;
+    const item = this.items.get(id);
+    if (item && mode !== 'replace') {
+      if (item.type === 'assistantMessage' && delta.text)
+        item.text += delta.text;
+      if (item.type === 'reasoning' && delta.summary)
+        item.summary += delta.summary;
+    }
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId: this.activeTurnId,
+      itemId: id,
+      ...(mode ? { mode } : {}),
+      delta,
+    });
+  }
+  private emitItemUpdated(item: AgentItemV2): void {
+    if (this.activeTurnId)
+      this.emitPatch({
+        type: 'agent-item-updated-v2',
+        sessionId: this.sessionId,
+        timestamp: nowIso(),
+        turnId: this.activeTurnId,
+        item,
+      });
+  }
+  private emitError(message: string): void {
+    this.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      message,
+      ...(this.activeTurnId ? { turnId: this.activeTurnId } : {}),
+    });
+  }
+  private emitProviderExtension(
+    payload: Record<string, unknown>,
+    visibility: 'normal' | 'debug' = 'normal'
+  ): void {
+    if (!this.activeTurnId) return;
+    const sequence = ++this.providerExtensionSequence;
+    const timestamp = nowIso();
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp,
+      turnId: this.activeTurnId,
+      item: {
+        type: 'providerExtension',
+        id: `ext-pi-${this.activeTurnId}-${sequence}`,
+        namespace: 'pi',
+        payload,
+        ...(visibility === 'debug'
+          ? { metadata: { eventVisibility: 'debug' } }
+          : {}),
+        status: 'completed',
+        startedAt: timestamp,
+        completedAt: timestamp,
+      },
+    });
+  }
+
+  private resetForTransportSwitch(reason: string): void {
+    if (this.activeTurnId) this.completeTurn('failed', reason);
+    this.queued.length = 0;
+    this.queueAdvanceInFlight = false;
+    this.items.clear();
+    this.emptyToolCounts.clear();
+  }
+
+  private emitLive(live: Partial<AgentSessionLiveStateV2>): void {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      live,
+    });
+  }
+
+  private applyState(data: RpcRecord): void {
+    this.providerSessionId = string(data.sessionId) || this.providerSessionId;
+    this.providerSessionFile =
+      string(data.sessionFile) || this.providerSessionFile;
+  }
+  private emitSnapshot(): void {
+    if (!this.config) return;
+    this.emitPatch({
+      type: 'agent-session-snapshot-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      session: emptyAgentSessionV2({
+        id: this.sessionId,
+        provider: 'pi',
+        cwd: this.config.cwd,
+        capabilities: this.capabilities,
+        providerSession: this.providerSession,
+      }),
+    });
+  }
+  private get providerSession(): Record<string, string> {
+    return {
+      ...(this.providerSessionId ? { piSessionId: this.providerSessionId } : {}),
+      ...(this.providerSessionFile
+        ? { piSessionFile: this.providerSessionFile }
+        : {}),
+    };
+  }
+  private get sessionId(): string {
+    return this.config?.sessionId ?? 'pi';
+  }
+  private requireClient(): PiAgentRpcClient {
+    if (this._status !== 'connected' || !this.client)
+      throw new Error('Pi adapter is not connected');
+    return this.client;
+  }
+  private handleTransportClose(error: Error): void {
+    if (this._status === 'disconnected') return;
+    if (this.activeTurnId) this.completeTurn('failed', error.message);
+    this.queued.length = 0;
+    this.queueAdvanceInFlight = false;
+    this._status = 'disconnected';
+    const client = this.client;
+    this.client = null;
+    this.clientGeneration += 1;
+    void client?.stop().catch(() => undefined);
+    this.emitError(error.message);
+    this.emitLive({
+      status: 'disconnected',
+      activeTurnId: null,
+      queueLength: 0,
+      error: error.message,
+    });
+  }
+  private readImages(
+    attachments: AgentSendMessageInputV2['attachments'] = []
+  ): RpcRecord[] {
+    const imageAttachments = attachments.filter(
+      (attachment) => attachment.type === 'image'
+    );
+    if (imageAttachments.length > MAX_IMAGE_COUNT) {
+      throw new Error(`Pi accepts at most ${MAX_IMAGE_COUNT} images`);
+    }
+    const images: RpcRecord[] = [];
+    let totalBytes = 0;
+    for (const attachment of imageAttachments) {
+      const mimeType = attachment.mimeType ?? '';
+      if (!SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) {
+        throw new Error(
+          `Unsupported Pi image MIME type: ${mimeType || 'missing'}`
+        );
+      }
+      try {
+        const stat = fs.lstatSync(attachment.path);
+        if (!stat.isFile() || stat.isSymbolicLink())
+          throw new Error('attachment must be a regular non-symlink file');
+        if (stat.size > MAX_IMAGE_BYTES)
+          throw new Error(`attachment exceeds ${MAX_IMAGE_BYTES} bytes`);
+        totalBytes += stat.size;
+        if (totalBytes > MAX_IMAGE_TOTAL_BYTES)
+          throw new Error(
+            `attachments exceed ${MAX_IMAGE_TOTAL_BYTES} aggregate bytes`
+          );
+        const bytes = fs.readFileSync(attachment.path);
+        if (
+          bytes.length > MAX_IMAGE_BYTES ||
+          !matchesImageSignature(bytes, mimeType)
+        ) {
+          throw new Error('attachment bytes do not match the declared image');
+        }
+        images.push({
+          type: 'image',
+          data: bytes.toString('base64'),
+          mimeType,
+        });
+      } catch (error) {
+        throw new Error(
+          `Cannot read Pi image attachment ${attachment.path}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error }
+        );
+      }
+    }
+    return images;
+  }
+}

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -89,6 +89,21 @@ function toolArguments(value: unknown): RpcRecord {
   }
   return {};
 }
+function stableToolArgs(value: unknown): string {
+  if (Array.isArray(value))
+    return `[${value.map((entry) => stableToolArgs(entry)).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const object = value as RpcRecord;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableToolArgs(object[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+function toolIdentityKey(name: string, args: RpcRecord): string {
+  return `${name}\0${stableToolArgs(args)}`;
+}
 function isCommandTool(name: string): boolean {
   return /^(bash|shell|exec|terminal)$/i.test(name);
 }
@@ -885,11 +900,12 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const providerId = string(event.toolCallId).trim();
     if (providerId) return providerId;
     const name = string(event.toolName, 'tool');
-    const pending = this.pendingAnonymousToolIds.get(name);
+    const key = toolIdentityKey(name, toolArguments(event.args));
+    const pending = this.pendingAnonymousToolIds.get(key);
     const id = pending?.shift() ?? this.fallbackToolId();
-    if (pending?.length === 0) this.pendingAnonymousToolIds.delete(name);
-    this.anonymousToolIds.set(name, [
-      ...(this.anonymousToolIds.get(name) ?? []),
+    if (pending?.length === 0) this.pendingAnonymousToolIds.delete(key);
+    this.anonymousToolIds.set(key, [
+      ...(this.anonymousToolIds.get(key) ?? []),
       id,
     ]);
     return id;
@@ -898,27 +914,43 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const providerId = string(event.toolCallId).trim();
     if (providerId) return providerId;
     const name = string(event.toolName, 'tool');
-    return this.anonymousToolIds.get(name)?.[0] ?? this.toolIdForStart(event);
+    const args = toolArguments(event.args);
+    const exact = this.anonymousToolIds.get(toolIdentityKey(name, args))?.[0];
+    if (exact) return exact;
+    // If args are absent, concurrent same-name events are indistinguishable;
+    // FIFO is the only truthful fallback available from the provider stream.
+    if (Object.keys(args).length === 0) {
+      for (const [key, ids] of this.anonymousToolIds) {
+        if (key.startsWith(`${name}\0`) && ids[0]) return ids[0];
+      }
+    }
+    return this.toolIdForStart(event);
   }
   private toolIdForPreview(toolCall: RpcRecord, index: number): string {
     const providerId = string(toolCall.id).trim();
     if (providerId) return providerId;
     const name = string(toolCall.name, 'tool');
+    const key = toolIdentityKey(
+      name,
+      toolArguments(toolCall.arguments ?? toolCall.args)
+    );
     const id = this.fallbackToolId(index);
-    this.pendingAnonymousToolIds.set(name, [
-      ...(this.pendingAnonymousToolIds.get(name) ?? []),
+    this.pendingAnonymousToolIds.set(key, [
+      ...(this.pendingAnonymousToolIds.get(key) ?? []),
       id,
     ]);
     return id;
   }
   private forgetAnonymousToolId(event: RpcRecord, id: string): void {
     if (string(event.toolCallId).trim()) return;
-    const name = string(event.toolName, 'tool');
-    const ids = this.anonymousToolIds.get(name);
-    if (!ids) return;
-    const remaining = ids.filter((candidate) => candidate !== id);
-    if (remaining.length) this.anonymousToolIds.set(name, remaining);
-    else this.anonymousToolIds.delete(name);
+    for (const [key, ids] of this.anonymousToolIds) {
+      const remaining = ids.filter((candidate) => candidate !== id);
+      if (remaining.length !== ids.length) {
+        if (remaining.length) this.anonymousToolIds.set(key, remaining);
+        else this.anonymousToolIds.delete(key);
+        return;
+      }
+    }
   }
   private emitDelta(
     id: string,

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -64,6 +64,11 @@ function record(value: unknown): RpcRecord {
 function string(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback;
 }
+function queueCount(value: unknown): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : 0;
+}
 function resultText(value: unknown): string {
   const content = record(value).content;
   if (!Array.isArray(content)) return typeof value === 'string' ? value : '';
@@ -138,6 +143,9 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private turnUsage: AgentUsageV2 | undefined;
   private clientGeneration = 0;
   private readonly queued: AgentSendMessageInputV2[] = [];
+  private toolFallbackSequence = 0;
+  private readonly anonymousToolIds = new Map<string, string[]>();
+  private readonly pendingAnonymousToolIds = new Map<string, string[]>();
   private queueAdvanceInFlight = false;
   private providerExtensionSequence = 0;
   private readonly items = new Map<string, AgentItemV2>();
@@ -219,8 +227,8 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         waitingOn: null,
         activeRequestIds: [],
         proposedPlanItemId: null,
-        queueLength: Number(
-          record(record(response.data).sessionActions).queuedCount ?? 0
+        queueLength: queueCount(
+          record(record(response.data).sessionActions).queuedCount
         ),
         fastModeAvailable: false,
         error: null,
@@ -239,6 +247,8 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.queued.length = 0;
     this.queueAdvanceInFlight = false;
     this.items.clear();
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
   }
 
   private async teardownClient(): Promise<void> {
@@ -460,7 +470,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     if (type === 'session_action_update') {
       const actions = record(event.actions);
       this.emitLive({
-        queueLength: Number(actions.queuedCount ?? this.queued.length),
+        queueLength: this.queued.length + queueCount(actions.queuedCount),
       });
       return;
     }
@@ -510,7 +520,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         this.emitDelta(id, { summary: delta.delta });
     } else if (kind === 'toolcall_end') {
       const toolCall = record(delta.toolCall);
-      const id = string(toolCall.id, `${this.activeTurnId}-tool-${index}`);
+      const id = this.toolIdForPreview(toolCall, index);
       this.ensureTool(
         id,
         string(toolCall.name, 'tool'),
@@ -530,7 +540,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
 
   private startTool(event: RpcRecord): void {
     if (!this.activeTurnId) return;
-    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    const id = this.toolIdForStart(event);
     this.ensureTool(
       id,
       string(event.toolName, 'tool'),
@@ -579,7 +589,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
 
   private updateTool(event: RpcRecord, result: unknown, done: boolean): void {
     if (!this.activeTurnId) return;
-    const id = string(event.toolCallId, `${this.activeTurnId}-tool`);
+    const id = this.toolIdForUpdate(event);
     this.ensureTool(
       id,
       string(event.toolName, 'tool'),
@@ -621,6 +631,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     else return;
     this.items.set(id, updated);
     this.emitItemUpdated(updated);
+    if (done) this.forgetAnonymousToolId(event, id);
   }
 
   private finishMessageItems(
@@ -749,11 +760,20 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       const payload: RpcRecord = { message: next.content };
       const images = this.readImages(next.attachments);
       if (images.length) payload.images = images;
-      await this.submitNativeInput(this.requireClient(), next, payload);
+      try {
+        await this.submitNativeInput(this.requireClient(), next, payload);
+      } catch (error) {
+        this.handleTransportClose(
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
     } catch (error) {
-      this.handleTransportClose(
-        error instanceof Error ? error : new Error(String(error))
-      );
+      const failure = error instanceof Error ? error : new Error(String(error));
+      // Attachment files are Relay-local input. A file can be removed or
+      // invalidated after enqueue, which must fail only this attributed turn;
+      // the provider transport remains usable for later queued messages.
+      this.emitError(failure.message);
+      this.completeTurn('failed', failure.message);
     } finally {
       this.queueAdvanceInFlight = false;
       if (!this.activeTurnId) void this.advanceQueuedTurn();
@@ -768,6 +788,9 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.assistantMessageSequence = -1;
     this.turnUsage = undefined;
     this.items.clear();
+    this.toolFallbackSequence = 0;
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
     const timestamp = nowIso();
     this.emitPatch({
       type: 'agent-turn-started-v2',
@@ -834,6 +857,8 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.abortRequested = false;
     this.turnFailure = null;
     this.turnUsage = undefined;
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
     this.emitLive({
       status: this.queued.length ? 'working' : 'idle',
       activeTurnId: null,
@@ -852,6 +877,48 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       turnId: this.activeTurnId,
       item,
     });
+  }
+  private fallbackToolId(index?: number): string {
+    return `${this.activeTurnId}-tool-fallback-${this.assistantMessageSequence}-${index ?? 'none'}-${++this.toolFallbackSequence}`;
+  }
+  private toolIdForStart(event: RpcRecord): string {
+    const providerId = string(event.toolCallId).trim();
+    if (providerId) return providerId;
+    const name = string(event.toolName, 'tool');
+    const pending = this.pendingAnonymousToolIds.get(name);
+    const id = pending?.shift() ?? this.fallbackToolId();
+    if (pending?.length === 0) this.pendingAnonymousToolIds.delete(name);
+    this.anonymousToolIds.set(name, [
+      ...(this.anonymousToolIds.get(name) ?? []),
+      id,
+    ]);
+    return id;
+  }
+  private toolIdForUpdate(event: RpcRecord): string {
+    const providerId = string(event.toolCallId).trim();
+    if (providerId) return providerId;
+    const name = string(event.toolName, 'tool');
+    return this.anonymousToolIds.get(name)?.[0] ?? this.toolIdForStart(event);
+  }
+  private toolIdForPreview(toolCall: RpcRecord, index: number): string {
+    const providerId = string(toolCall.id).trim();
+    if (providerId) return providerId;
+    const name = string(toolCall.name, 'tool');
+    const id = this.fallbackToolId(index);
+    this.pendingAnonymousToolIds.set(name, [
+      ...(this.pendingAnonymousToolIds.get(name) ?? []),
+      id,
+    ]);
+    return id;
+  }
+  private forgetAnonymousToolId(event: RpcRecord, id: string): void {
+    if (string(event.toolCallId).trim()) return;
+    const name = string(event.toolName, 'tool');
+    const ids = this.anonymousToolIds.get(name);
+    if (!ids) return;
+    const remaining = ids.filter((candidate) => candidate !== id);
+    if (remaining.length) this.anonymousToolIds.set(name, remaining);
+    else this.anonymousToolIds.delete(name);
   }
   private emitDelta(
     id: string,
@@ -932,6 +999,8 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.queued.length = 0;
     this.queueAdvanceInFlight = false;
     this.items.clear();
+    this.anonymousToolIds.clear();
+    this.pendingAnonymousToolIds.clear();
   }
 
   private emitLive(live: Partial<AgentSessionLiveStateV2>): void {

--- a/server/types.ts
+++ b/server/types.ts
@@ -54,7 +54,8 @@ export type BuiltinFrameworkId =
   | 'codex'
   | 'opencode'
   | 'hermes'
-  | 'prime-agent';
+  | 'prime-agent'
+  | 'pi';
 export type EventSourceType = 'hooks' | 'plugin' | 'parser' | 'timer';
 export type ContinuePolicy = 'always' | 'never';
 export type BranchLifecycleState = 'active' | 'stale' | 'merged';
@@ -193,6 +194,25 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
     command: 'prime-agent',
     // The terminal surface remains a generic PTY. Channel conversations use
     // Prime Agent's native RPC adapter rather than terminal-output parsing.
+    continueArgs: ['--continue'],
+    yoloArgs: [],
+    parserType: 'generic',
+    eventSource: 'timer',
+    capabilities: {
+      supportsHooks: false,
+      supportsContinue: true,
+      supportsYolo: false,
+      supportsTelemetry: true,
+      supportsAttachedRuntime: false,
+      supportsChannelAgents: true,
+    },
+  },
+  pi: {
+    id: 'pi',
+    displayName: 'Pi',
+    command: 'pi',
+    // The terminal surface remains a generic PTY. Channel conversations use
+    // Pi's native RPC adapter rather than terminal-output parsing.
     continueArgs: ['--continue'],
     yoloArgs: [],
     parserType: 'generic',

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -6,6 +6,7 @@ export type AgentProviderV2 =
   | 'opencode'
   | 'hermes'
   | 'prime-agent'
+  | 'pi'
   | 'mock'
   | (string & {});
 

--- a/shared/agent-profile.ts
+++ b/shared/agent-profile.ts
@@ -48,7 +48,7 @@ export interface AgentProfile {
    * `builtInAgentProfileId(providerId)`.
    */
   id: string;
-  /** Framework catalog key (`AgentFramework.id`): claude/codex/opencode/hermes/prime-agent/custom. */
+  /** Framework catalog key (`AgentFramework.id`): claude/codex/opencode/hermes/prime-agent/pi/custom. */
   providerId: string;
   /**
    * Free-form, possibly multi-word display name. EMPTY ('') on a built-in

--- a/shared/workspace-topics.ts
+++ b/shared/workspace-topics.ts
@@ -414,6 +414,7 @@ const BUILTIN_PROVIDER_IDS = new Set([
   'opencode',
   'hermes',
   'prime-agent',
+  'pi',
   'terminal',
 ]);
 

--- a/test/agent-rpc-smoke.test.ts
+++ b/test/agent-rpc-smoke.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  runProviderSmoke,
+  runSmokeCli,
+  type SmokeProvider,
+} from '../scripts/agent-rpc-smoke.js';
+
+let tmp: string | undefined;
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = undefined;
+});
+
+function fixture(provider: SmokeProvider): { command: string; log: string } {
+  tmp = mkdtempSync(join(tmpdir(), 'relay-agent-rpc-smoke-test-'));
+  const command = join(tmp, `${provider}.mjs`);
+  const log = join(tmp, 'events.jsonl');
+  writeFileSync(
+    command,
+    `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+const args = process.argv.slice(2);
+const terminal = process.env.FAKE_PROVIDER === 'pi' ? 'agent_settled' : 'agent_end';
+const failure = process.env.FAKE_FAILURE;
+const missingModel = process.env.FAKE_MISSING_MODEL === '1';
+let promptCount = 0;
+appendFileSync(process.env.FAKE_RPC_LOG, JSON.stringify({ args, cwd: process.cwd(), piTelemetry: process.env.PI_TELEMETRY }) + '\\n');
+const emit = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+for await (const line of createInterface({ input: process.stdin })) {
+  const request = JSON.parse(line);
+  if (request.type === 'get_state') {
+    if (failure) {
+      emit({ id: request.id, type: 'response', command: 'get_state', success: false, error: failure });
+      continue;
+    }
+    emit({ id: request.id, type: 'response', command: 'get_state', success: true, data: { sessionId: 'fixture-session', isStreaming: false, ...(missingModel ? {} : { model: { id: 'fixture-model' } }) } });
+  } else if (request.type === 'prompt') {
+    const expectedIntent = promptCount === 0
+      ? request.message === 'Reply with exactly: OK'
+      : request.message.startsWith('Begin another long response');
+    if (!expectedIntent) {
+      emit({ id: request.id, type: 'response', command: 'prompt', success: false, error: 'unexpected prompt intent' });
+      continue;
+    }
+    emit({ id: request.id, type: 'response', command: 'prompt', success: true });
+    emit({ type: 'agent_start' });
+    promptCount += 1;
+    if (promptCount === 1) emit({ type: terminal });
+  } else if (request.type === 'abort') {
+    emit({ id: request.id, type: 'response', command: 'abort', success: true });
+    emit({ type: terminal });
+  }
+}
+`
+  );
+  chmodSync(command, 0o755);
+  return { command, log };
+}
+
+function fixtureEvents(
+  log: string
+): Array<{ args: string[]; cwd: string; piTelemetry?: string }> {
+  return readFileSync(log, 'utf8')
+    .trim()
+    .split('\n')
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          args: string[];
+          cwd: string;
+          piTelemetry?: string;
+        }
+    );
+}
+
+describe('agent RPC smoke harness', () => {
+  it.each([
+    ['pi', 'agent_settled'],
+    ['prime-agent', 'agent_end'],
+  ] as const)(
+    'runs %s through active abort and same-session resume',
+    async (provider, terminal) => {
+      const { command, log } = fixture(provider);
+      const result = await runProviderSmoke({
+        provider,
+        command,
+        model: 'fixture-model',
+        timeoutMs: 1_000,
+        env: {
+          ...process.env,
+          FAKE_PROVIDER: provider,
+          FAKE_RPC_LOG: log,
+          PI_TELEMETRY: '1',
+        },
+      });
+
+      expect(result).toEqual({
+        provider,
+        terminalEvent: terminal,
+        sessionHash: expect.stringMatching(/^[a-f0-9]{10}$/),
+      });
+      const starts = fixtureEvents(log);
+      expect(starts).toHaveLength(2);
+      for (const start of starts)
+        expect(start.args).toEqual(
+          expect.arrayContaining([
+            '--mode',
+            'rpc',
+            '--no-extensions',
+            '--no-skills',
+            '--no-prompt-templates',
+            '--no-themes',
+            '--no-context-files',
+            '--no-tools',
+            '--session-dir',
+            expect.any(String),
+            '--model',
+            'fixture-model',
+          ])
+        );
+      expect(starts[1]!.args).toEqual(
+        expect.arrayContaining(
+          provider === 'pi'
+            ? ['--session-id', 'fixture-session', '--offline']
+            : ['--resume', 'fixture-session', '--offline']
+        )
+      );
+      expect(starts.map((start) => start.piTelemetry)).toEqual(
+        provider === 'pi' ? ['0', '0'] : ['1', '1']
+      );
+      expect(existsSync(starts[0]!.cwd)).toBe(false);
+      const sessionDirIndex = starts[0]!.args.indexOf('--session-dir');
+      expect(existsSync(starts[0]!.args[sessionDirIndex + 1]!)).toBe(false);
+    }
+  );
+
+  it('skips without the explicit live and credential gates', async () => {
+    const output: string[] = [];
+    await expect(
+      runSmokeCli({
+        argv: ['--provider', 'pi'],
+        env: {},
+        log: (line) => output.push(line),
+      })
+    ).resolves.toBe(0);
+    expect(output).toEqual([
+      'SKIP pi: set RELAY_AGENT_RPC_SMOKE_LIVE=1 to allow model-backed RPC calls',
+    ]);
+
+    output.length = 0;
+    await expect(
+      runSmokeCli({
+        argv: ['--provider', 'pi'],
+        env: { RELAY_AGENT_RPC_SMOKE_LIVE: '1' },
+        log: (line) => output.push(line),
+      })
+    ).resolves.toBe(0);
+    expect(output).toEqual([
+      'SKIP pi: set RELAY_AGENT_RPC_SMOKE_CREDENTIALS=1 after configuring provider credentials',
+    ]);
+  });
+
+  it('reports a missing provider binary as a skip, not a pass', async () => {
+    const output: string[] = [];
+    await expect(
+      runSmokeCli({
+        argv: ['--provider=prime-agent'],
+        env: {
+          RELAY_AGENT_RPC_SMOKE_LIVE: '1',
+          RELAY_AGENT_RPC_SMOKE_CREDENTIALS: '1',
+          RELAY_AGENT_RPC_SMOKE_MODEL: 'fixture-model',
+          RELAY_AGENT_RPC_SMOKE_PRIME_COMMAND: join(
+            tmpdir(),
+            'not-a-real-prime-agent'
+          ),
+        },
+        log: (line) => output.push(line),
+      })
+    ).resolves.toBe(0);
+    expect(output).toEqual([
+      expect.stringContaining('SKIP prime-agent: command unavailable'),
+    ]);
+  });
+
+  it.each([
+    ['model unavailable', 'model not found', 'missing or unconfigured model'],
+    [
+      'credentials unavailable',
+      'authentication required',
+      'missing or invalid credentials',
+    ],
+  ])(
+    'turns explicit provider %s responses into a skip',
+    async (_name, failure, expected) => {
+      const { command, log } = fixture('pi');
+      const output: string[] = [];
+      await expect(
+        runSmokeCli({
+          argv: ['--provider=pi'],
+          env: {
+            ...process.env,
+            RELAY_AGENT_RPC_SMOKE_LIVE: '1',
+            RELAY_AGENT_RPC_SMOKE_CREDENTIALS: '1',
+            RELAY_AGENT_RPC_SMOKE_MODEL: 'fixture-model',
+            RELAY_AGENT_RPC_SMOKE_PI_COMMAND: command,
+            FAKE_PROVIDER: 'pi',
+            FAKE_RPC_LOG: log,
+            FAKE_FAILURE: failure,
+          },
+          log: (line) => output.push(line),
+        })
+      ).resolves.toBe(0);
+      expect(output).toEqual([expect.stringContaining(expected)]);
+    }
+  );
+
+  it('turns a successful get_state without a configured model into a skip', async () => {
+    const { command, log } = fixture('pi');
+    const output: string[] = [];
+    await expect(
+      runSmokeCli({
+        argv: ['--provider=pi'],
+        env: {
+          ...process.env,
+          RELAY_AGENT_RPC_SMOKE_LIVE: '1',
+          RELAY_AGENT_RPC_SMOKE_CREDENTIALS: '1',
+          RELAY_AGENT_RPC_SMOKE_MODEL: 'fixture-model',
+          RELAY_AGENT_RPC_SMOKE_PI_COMMAND: command,
+          FAKE_PROVIDER: 'pi',
+          FAKE_RPC_LOG: log,
+          FAKE_MISSING_MODEL: '1',
+        },
+        log: (line) => output.push(line),
+      })
+    ).resolves.toBe(0);
+    expect(output).toEqual([
+      expect.stringContaining(
+        'SKIP pi: provider reported missing or unconfigured model'
+      ),
+    ]);
+  });
+
+  it.each([
+    'provider temporarily unavailable',
+    'unsupported RPC capability',
+    'incompatible RPC protocol',
+  ])(
+    'fails closed for provider protocol/runtime error: %s',
+    async (failure) => {
+      const { command, log } = fixture('pi');
+      const output: string[] = [];
+      await expect(
+        runSmokeCli({
+          argv: ['--provider=pi'],
+          env: {
+            ...process.env,
+            RELAY_AGENT_RPC_SMOKE_LIVE: '1',
+            RELAY_AGENT_RPC_SMOKE_CREDENTIALS: '1',
+            RELAY_AGENT_RPC_SMOKE_MODEL: 'fixture-model',
+            RELAY_AGENT_RPC_SMOKE_PI_COMMAND: command,
+            FAKE_PROVIDER: 'pi',
+            FAKE_RPC_LOG: log,
+            FAKE_FAILURE: failure,
+          },
+          log: (line) => output.push(line),
+        })
+      ).resolves.toBe(1);
+      expect(output).toEqual(['FAIL pi: RPC smoke contract did not complete']);
+    }
+  );
+});

--- a/test/agent-rpc-smoke.test.ts
+++ b/test/agent-rpc-smoke.test.ts
@@ -97,7 +97,7 @@ describe('agent RPC smoke harness', () => {
         provider,
         command,
         model: 'fixture-model',
-        timeoutMs: 1_000,
+        timeoutMs: 10_000,
         env: {
           ...process.env,
           FAKE_PROVIDER: provider,
@@ -172,6 +172,20 @@ describe('agent RPC smoke harness', () => {
     ]);
   });
 
+  it('ignores unrelated argv when provider was not specified', async () => {
+    const output: string[] = [];
+    await expect(
+      runSmokeCli({
+        argv: ['unrelated'],
+        env: {},
+        log: (line) => output.push(line),
+      })
+    ).resolves.toBe(0);
+    expect(output).toHaveLength(2);
+    expect(output[0]).toContain('SKIP pi:');
+    expect(output[1]).toContain('SKIP prime-agent:');
+  });
+
   it('reports a missing provider binary as a skip, not a pass', async () => {
     const output: string[] = [];
     await expect(
@@ -225,6 +239,49 @@ describe('agent RPC smoke harness', () => {
       expect(output).toEqual([expect.stringContaining(expected)]);
     }
   );
+
+  it.each(['authority denied', 'author rejected'])(
+    'does not classify unrelated auth substring as credentials: %s',
+    async (failure) => {
+      const { command, log } = fixture('pi');
+      const output: string[] = [];
+      await expect(
+        runSmokeCli({
+          argv: ['--provider=pi'],
+          env: {
+            ...process.env,
+            RELAY_AGENT_RPC_SMOKE_LIVE: '1',
+            RELAY_AGENT_RPC_SMOKE_CREDENTIALS: '1',
+            RELAY_AGENT_RPC_SMOKE_MODEL: 'fixture-model',
+            RELAY_AGENT_RPC_SMOKE_PI_COMMAND: command,
+            FAKE_PROVIDER: 'pi',
+            FAKE_RPC_LOG: log,
+            FAKE_FAILURE: failure,
+          },
+          log: (line) => output.push(line),
+        })
+      ).resolves.toBe(1);
+      expect(output).toEqual(['FAIL pi: RPC smoke contract did not complete']);
+    }
+  );
+
+  it('reports an invalid timeout once as an operator error', async () => {
+    const output: string[] = [];
+    await expect(
+      runSmokeCli({
+        argv: ['--provider=both'],
+        env: {
+          RELAY_AGENT_RPC_SMOKE_LIVE: '1',
+          RELAY_AGENT_RPC_SMOKE_CREDENTIALS: '1',
+          RELAY_AGENT_RPC_SMOKE_TIMEOUT_MS: 'nope',
+        },
+        log: (line) => output.push(line),
+      })
+    ).resolves.toBe(1);
+    expect(output).toEqual([
+      'ERROR agent RPC smoke: RELAY_AGENT_RPC_SMOKE_TIMEOUT_MS must be an integer from 1000 to 60000',
+    ]);
+  });
 
   it('turns a successful get_state without a configured model into a skip', async () => {
     const { command, log } = fixture('pi');

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -538,6 +538,27 @@ describe('ChannelAgentRuntimeManager', () => {
     expect(adapterState.last?.resumed).toEqual([]);
   });
 
+  it('passes Pi provider identity as an atomic resume id', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    adapterState.resumeDuringConnect = true;
+
+    await channelAgentRuntimes.create({
+      id: 'pi-runtime',
+      providerId: 'pi',
+      profileActorId: 'agent-profile:pi:default',
+      cwd: '/tmp',
+      displayName: '#eng · Pi',
+      port: 3456,
+      configDir: '/tmp',
+      providerSession: { piSessionId: 'pi-session-1' },
+    });
+
+    expect(adapterState.last?.connectConfigs).toEqual([
+      expect.objectContaining({ resumeSessionId: 'pi-session-1' }),
+    ]);
+    expect(adapterState.last?.resumed).toEqual([]);
+  });
+
   it('captures provider identity and rejects duplicate runtime ids', async () => {
     const { channelAgentRuntimes } = await runtimeModule();
     const runtime = await channelAgentRuntimes.create({

--- a/test/framework-types.test.ts
+++ b/test/framework-types.test.ts
@@ -16,6 +16,7 @@ test('BUILTIN_FRAMEWORKS contains all first-class providers', () => {
   expect('opencode' in BUILTIN_FRAMEWORKS).toBeTruthy();
   expect('hermes' in BUILTIN_FRAMEWORKS).toBeTruthy();
   expect('prime-agent' in BUILTIN_FRAMEWORKS).toBeTruthy();
+  expect('pi' in BUILTIN_FRAMEWORKS).toBeTruthy();
 });
 
 test('claude framework has correct values', () => {
@@ -108,6 +109,25 @@ test('prime-agent framework exposes native channels and a generic PTY', () => {
   expect(prime.parserType).toBe('generic');
   expect(prime.eventSource).toBe('timer');
   expect(prime.capabilities).toMatchObject({
+    supportsHooks: false,
+    supportsContinue: true,
+    supportsYolo: false,
+    supportsTelemetry: true,
+    supportsAttachedRuntime: false,
+    supportsChannelAgents: true,
+  });
+});
+
+test('pi framework exposes native channels and a generic PTY', () => {
+  const pi = BUILTIN_FRAMEWORKS['pi'];
+  expect(pi.id).toBe('pi');
+  expect(pi.displayName).toBe('Pi');
+  expect(pi.command).toBe('pi');
+  expect(pi.continueArgs).toEqual(['--continue']);
+  expect(pi.yoloArgs).toEqual([]);
+  expect(pi.parserType).toBe('generic');
+  expect(pi.eventSource).toBe('timer');
+  expect(pi.capabilities).toMatchObject({
     supportsHooks: false,
     supportsContinue: true,
     supportsYolo: false,

--- a/test/frameworks-api.test.ts
+++ b/test/frameworks-api.test.ts
@@ -29,6 +29,9 @@ beforeAll(async () => {
   const fakePrimeAgent = path.join(fakeBinDir, 'prime-agent');
   fs.writeFileSync(fakePrimeAgent, '#!/bin/sh\nexit 0\n');
   fs.chmodSync(fakePrimeAgent, 0o755);
+  const fakePi = path.join(fakeBinDir, 'pi');
+  fs.writeFileSync(fakePi, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(fakePi, 0o755);
 
   const hermesProbeApp = express();
   hermesProbeApp.get('/health', (_req, res) => {
@@ -89,6 +92,7 @@ describe('GET /api/frameworks', () => {
     expect(ids).toContain('opencode');
     expect(ids).toContain('hermes');
     expect(ids).toContain('prime-agent');
+    expect(ids).toContain('pi');
   });
 
   it('each framework entry has id, displayName, command, capabilities, eventSource, and availability', async () => {
@@ -203,6 +207,31 @@ describe('GET /api/frameworks', () => {
     expect(hermes!.channelAvailability?.reason).toContain(
       'Responses API is not enabled'
     );
+  });
+
+  it('returns Pi as an installed first-class channel provider', async () => {
+    const res = await fetch(url('/api/frameworks'));
+    const body = (await res.json()) as {
+      frameworks: Array<{
+        id: string;
+        displayName: string;
+        command: string;
+        eventSource: string;
+        capabilities: Record<string, boolean>;
+        availability?: { installed: boolean; path?: string };
+      }>;
+    };
+    const pi = body.frameworks.find((f) => f.id === 'pi');
+    expect(pi).toMatchObject({
+      displayName: 'Pi',
+      command: 'pi',
+      eventSource: 'timer',
+    });
+    expect(pi!.capabilities.supportsChannelAgents).toBe(true);
+    expect(pi!.availability).toEqual({
+      installed: true,
+      path: path.join(fakeBinDir, 'pi'),
+    });
   });
 
   it('does not include internal fields like parserType or continueArgs', async () => {

--- a/test/lib/chat/sender-identity.test.ts
+++ b/test/lib/chat/sender-identity.test.ts
@@ -37,6 +37,7 @@ describe('resolveSenderIdentity', () => {
     ['hermes', 'var(--sender-hermes)'],
     ['opencode', 'var(--sender-opencode)'],
     ['prime-agent', 'var(--sender-prime-agent)'],
+    ['pi', 'var(--sender-pi)'],
   ] as const)(
     'keeps the curated vendor token + glyph for the %s DEFAULT profile',
     (providerId, colorVar) => {
@@ -125,6 +126,7 @@ describe('resolveSenderIdentity', () => {
     ['hermes', 'var(--sender-hermes)'],
     ['opencode', 'var(--sender-opencode)'],
     ['prime-agent', 'var(--sender-prime-agent)'],
+    ['pi', 'var(--sender-pi)'],
   ] as const)(
     'heals a legacy agent:%s row to the curated vendor token + glyph',
     (providerId, colorVar) => {

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -161,6 +161,40 @@ describe('process-tree session runtime reaping', () => {
     }
   });
 
+  it('recognizes Pi ancestors as Relay-owned language-server runtimes', () => {
+    const procRoot = mkdtempSync(`${tmpdir()}/relay-proc-`);
+    try {
+      writeFileSync(`${procRoot}/uptime`, '1000 0');
+      writeFakeProc(procRoot, {
+        pid: 250,
+        ppid: 1,
+        pgid: 250,
+        command: 'pi',
+        cmdlineArgs: ['pi', '--mode', 'rpc'],
+      });
+      writeFakeProc(procRoot, {
+        pid: 251,
+        ppid: 250,
+        pgid: 250,
+        command: 'node',
+        cmdlineArgs: ['node', '/typescript/lib/tsserver.js'],
+      });
+
+      const diagnostics = collectLanguageServerDiagnostics({
+        procRoot,
+        uptimeSeconds: 1000,
+        clockTickHz: 100,
+      });
+
+      expect(diagnostics.processes[0]?.relayOwnedLikely).toBe(true);
+      expect(diagnostics.processes[0]?.ancestors[0]?.commandLine).toBe(
+        'pi --mode rpc'
+      );
+    } finally {
+      rmSync(procRoot, { recursive: true, force: true });
+    }
+  });
+
   it('redacts likely secrets from language-server diagnostics', () => {
     expect(
       redactCommandLine(

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -195,6 +195,36 @@ describe('process-tree session runtime reaping', () => {
     }
   });
 
+  it('does not treat a Pi argument as a Pi executable', () => {
+    const procRoot = mkdtempSync(`${tmpdir()}/relay-proc-`);
+    try {
+      writeFileSync(`${procRoot}/uptime`, '1000 0');
+      writeFakeProc(procRoot, {
+        pid: 250,
+        ppid: 1,
+        pgid: 250,
+        command: 'node',
+        cmdlineArgs: ['node', 'worker', '--label', 'pi'],
+      });
+      writeFakeProc(procRoot, {
+        pid: 251,
+        ppid: 250,
+        pgid: 250,
+        command: 'node',
+        cmdlineArgs: ['node', '/typescript/lib/tsserver.js'],
+      });
+
+      const diagnostics = collectLanguageServerDiagnostics({
+        procRoot,
+        uptimeSeconds: 1000,
+        clockTickHz: 100,
+      });
+      expect(diagnostics.processes[0]?.relayOwnedLikely).toBe(false);
+    } finally {
+      rmSync(procRoot, { recursive: true, force: true });
+    }
+  });
+
   it('redacts likely secrets from language-server diagnostics', () => {
     expect(
       redactCommandLine(

--- a/test/server/pi-agent-rpc-client.test.ts
+++ b/test/server/pi-agent-rpc-client.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
+import { PiAgentRpcClient } from '../../server/pi-agent-rpc-client.js';
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+describe('PiAgentRpcClient', () => {
+  it('uses get_state as a correlated readiness barrier', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    let outbound = '';
+    child.stdin.on('data', (chunk) => {
+      outbound += String(chunk);
+      const line = outbound.split('\n')[0];
+      if (line) {
+        const request = JSON.parse(line) as { id: string; type: string };
+        child.stdout.write(
+          JSON.stringify({
+            id: request.id,
+            type: 'response',
+            command: request.type,
+            success: true,
+            data: { sessionId: 's1' },
+          }) + '\n'
+        );
+      }
+    });
+    const ready = await client.start();
+    expect(JSON.parse(outbound.trim())).toMatchObject({ type: 'get_state' });
+    expect(ready.data).toEqual({ sessionId: 's1' });
+  });
+
+  it('splits on LF only and preserves Unicode line separators inside JSON', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        `{"id":"${request.id}","type":"response","command":"get_state","success":true}\r\n`
+      );
+    });
+    await client.start();
+    const events: unknown[] = [];
+    client.on('event', (event) => events.push(event));
+    child.stdout.write('{"type":"message_update","text":"a\u2028b\u2029c"}\n');
+    expect(events).toEqual([
+      { type: 'message_update', text: 'a\u2028b\u2029c' },
+    ]);
+  });
+
+  it('decodes UTF-8 characters split across stdout chunks', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    const events: unknown[] = [];
+    client.on('event', (event) => events.push(event));
+    const record = Buffer.from(
+      JSON.stringify({ type: 'message_update', text: 'before 😀 after' }) + '\n'
+    );
+    const emoji = Buffer.from('😀');
+    const splitAt = record.indexOf(emoji) + 2;
+    child.stdout.write(record.subarray(0, splitAt));
+    child.stdout.write(record.subarray(splitAt));
+    expect(events).toEqual([
+      { type: 'message_update', text: 'before 😀 after' },
+    ]);
+  });
+
+  it('rejects failed and mismatched correlated responses', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.on('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string; type: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: request.type,
+          success: request.type === 'get_state',
+          error: 'nope',
+        }) + '\n'
+      );
+    });
+    await client.start();
+    await expect(client.call('prompt', { message: 'x' })).rejects.toThrow(
+      'nope'
+    );
+  });
+
+  it('bounds oversized records and a trailing unterminated tail', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+      maxBufferBytes: 32,
+      maxRecordBytes: 100,
+      stopTimeoutMs: 5,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    const errors: Error[] = [];
+    const events: unknown[] = [];
+    client.on('protocolError', (error) => errors.push(error));
+    client.on('event', (event) => events.push(event));
+    child.stdout.write(
+      JSON.stringify({ type: 'event', text: 'y'.repeat(120) }) + '\n'
+    );
+    child.stdout.write(
+      JSON.stringify({ type: 'event', accepted: true }) + '\n' + 'x'.repeat(33)
+    );
+    expect(events).toEqual([{ type: 'event', accepted: true }]);
+    expect(errors.map((error) => error.message)).toEqual([
+      expect.stringContaining('record exceeded'),
+      expect.stringContaining('input buffer exceeded'),
+    ]);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', 0);
+  });
+
+  it('awaits close and escalates stop to SIGKILL after a bounded delay', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      const client = new PiAgentRpcClient({
+        spawn: () => child as unknown as ChildProcess,
+        stopTimeoutMs: 10,
+      });
+      child.stdin.once('data', (chunk) => {
+        const request = JSON.parse(String(chunk)) as { id: string };
+        child.stdout.write(
+          JSON.stringify({
+            id: request.id,
+            type: 'response',
+            command: 'get_state',
+            success: true,
+          }) + '\n'
+        );
+      });
+      await client.start();
+
+      let stopped = false;
+      const stopping = client.stop().then(() => {
+        stopped = true;
+      });
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(stopped).toBe(false);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(stopped).toBe(false);
+      child.emit('close', 0);
+      await stopping;
+      expect(stopped).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('times out readiness when get_state never responds', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+      readinessTimeoutMs: 5,
+    });
+    await expect(client.start()).rejects.toThrow('get_state timed out');
+  });
+
+  it('times out correlated commands independently', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+      requestTimeoutMs: 5,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    await expect(client.call('prompt', { message: 'wait' })).rejects.toThrow(
+      'prompt timed out'
+    );
+  });
+});

--- a/test/server/pi-agent-rpc-client.test.ts
+++ b/test/server/pi-agent-rpc-client.test.ts
@@ -206,6 +206,86 @@ describe('PiAgentRpcClient', () => {
     await expect(client.start()).rejects.toThrow('get_state timed out');
   });
 
+  it('cleans a failed readiness attempt before a later start', async () => {
+    const failed = fakeChild();
+    const ready = fakeChild();
+    ready.kill.mockImplementation(() => {
+      ready.emit('close', 0);
+      return true;
+    });
+    ready.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string; type: string };
+      ready.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: request.type,
+          success: true,
+        }) + '\n'
+      );
+    });
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(failed as unknown as ChildProcess)
+      .mockReturnValueOnce(ready as unknown as ChildProcess);
+    const client = new PiAgentRpcClient({
+      spawn,
+      readinessTimeoutMs: 1,
+      stopTimeoutMs: 1,
+    });
+
+    await expect(client.start()).rejects.toThrow('get_state timed out');
+    expect(failed.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(failed.listenerCount('close')).toBe(0);
+    expect(failed.stdout.listenerCount('data')).toBe(0);
+    await expect(client.start()).resolves.toMatchObject({
+      command: 'get_state',
+      success: true,
+    });
+  });
+
+  it('rejects backpressured calls and removes queued writes on stop', async () => {
+    const child = fakeChild();
+    child.kill.mockImplementation(() => {
+      child.emit('close', 0);
+      return true;
+    });
+    let writeCount = 0;
+    const write = child.stdin.write.bind(child.stdin);
+    vi.spyOn(child.stdin, 'write').mockImplementation((chunk) => {
+      writeCount += 1;
+      if (writeCount === 1) {
+        write(chunk);
+        return true;
+      }
+      return false;
+    });
+    child.stdin.on('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string; type: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: request.type,
+          success: true,
+        }) + '\n'
+      );
+    });
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    await client.start();
+    const first = client.call('prompt', { message: 'one' });
+    const second = client.call('prompt', { message: 'two' });
+
+    await client.stop();
+    child.stdin.emit('drain');
+    await expect(first).rejects.toThrow('PiAgentRpcClient stopped');
+    await expect(second).rejects.toThrow('PiAgentRpcClient stopped');
+    expect(writeCount).toBe(2);
+    expect(child.stdin.listenerCount('drain')).toBe(0);
+  });
+
   it('times out correlated commands independently', async () => {
     const child = fakeChild();
     const client = new PiAgentRpcClient({

--- a/test/server/pi-agent-rpc-client.test.ts
+++ b/test/server/pi-agent-rpc-client.test.ts
@@ -202,8 +202,35 @@ describe('PiAgentRpcClient', () => {
     const client = new PiAgentRpcClient({
       spawn: () => child as unknown as ChildProcess,
       readinessTimeoutMs: 5,
+      stopTimeoutMs: 1,
     });
     await expect(client.start()).rejects.toThrow('get_state timed out');
+  });
+
+  it('rejects calls when stdin.write throws synchronously', async () => {
+    const child = fakeChild();
+    const client = new PiAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    vi.spyOn(child.stdin, 'write').mockImplementation(() => {
+      throw new Error('stdin exploded');
+    });
+
+    await expect(client.call('prompt', { message: 'x' })).rejects.toThrow(
+      'stdin exploded'
+    );
   });
 
   it('cleans a failed readiness attempt before a later start', async () => {

--- a/test/server/prime-agent-rpc-client.test.ts
+++ b/test/server/prime-agent-rpc-client.test.ts
@@ -202,8 +202,35 @@ describe('PrimeAgentRpcClient', () => {
     const client = new PrimeAgentRpcClient({
       spawn: () => child as unknown as ChildProcess,
       readinessTimeoutMs: 5,
+      stopTimeoutMs: 1,
     });
     await expect(client.start()).rejects.toThrow('get_state timed out');
+  });
+
+  it('rejects calls when stdin.write throws synchronously', async () => {
+    const child = fakeChild();
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    child.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: 'get_state',
+          success: true,
+        }) + '\n'
+      );
+    });
+    await client.start();
+    vi.spyOn(child.stdin, 'write').mockImplementation(() => {
+      throw new Error('stdin exploded');
+    });
+
+    await expect(client.call('prompt', { message: 'x' })).rejects.toThrow(
+      'stdin exploded'
+    );
   });
 
   it('cleans a failed readiness attempt before a later start', async () => {

--- a/test/server/prime-agent-rpc-client.test.ts
+++ b/test/server/prime-agent-rpc-client.test.ts
@@ -206,6 +206,86 @@ describe('PrimeAgentRpcClient', () => {
     await expect(client.start()).rejects.toThrow('get_state timed out');
   });
 
+  it('cleans a failed readiness attempt before a later start', async () => {
+    const failed = fakeChild();
+    const ready = fakeChild();
+    ready.kill.mockImplementation(() => {
+      ready.emit('close', 0);
+      return true;
+    });
+    ready.stdin.once('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string; type: string };
+      ready.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: request.type,
+          success: true,
+        }) + '\n'
+      );
+    });
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(failed as unknown as ChildProcess)
+      .mockReturnValueOnce(ready as unknown as ChildProcess);
+    const client = new PrimeAgentRpcClient({
+      spawn,
+      readinessTimeoutMs: 1,
+      stopTimeoutMs: 1,
+    });
+
+    await expect(client.start()).rejects.toThrow('get_state timed out');
+    expect(failed.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(failed.listenerCount('close')).toBe(0);
+    expect(failed.stdout.listenerCount('data')).toBe(0);
+    await expect(client.start()).resolves.toMatchObject({
+      command: 'get_state',
+      success: true,
+    });
+  });
+
+  it('rejects backpressured calls and removes queued writes on stop', async () => {
+    const child = fakeChild();
+    child.kill.mockImplementation(() => {
+      child.emit('close', 0);
+      return true;
+    });
+    let writeCount = 0;
+    const write = child.stdin.write.bind(child.stdin);
+    vi.spyOn(child.stdin, 'write').mockImplementation((chunk) => {
+      writeCount += 1;
+      if (writeCount === 1) {
+        write(chunk);
+        return true;
+      }
+      return false;
+    });
+    child.stdin.on('data', (chunk) => {
+      const request = JSON.parse(String(chunk)) as { id: string; type: string };
+      child.stdout.write(
+        JSON.stringify({
+          id: request.id,
+          type: 'response',
+          command: request.type,
+          success: true,
+        }) + '\n'
+      );
+    });
+    const client = new PrimeAgentRpcClient({
+      spawn: () => child as unknown as ChildProcess,
+    });
+    await client.start();
+    const first = client.call('prompt', { message: 'one' });
+    const second = client.call('prompt', { message: 'two' });
+
+    await client.stop();
+    child.stdin.emit('drain');
+    await expect(first).rejects.toThrow('PrimeAgentRpcClient stopped');
+    await expect(second).rejects.toThrow('PrimeAgentRpcClient stopped');
+    expect(writeCount).toBe(2);
+    expect(child.stdin.listenerCount('drain')).toBe(0);
+  });
+
   it('times out correlated commands independently', async () => {
     const child = fakeChild();
     const client = new PrimeAgentRpcClient({

--- a/test/server/protocol-adapters/pi-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/pi-agent-adapter.test.ts
@@ -173,6 +173,21 @@ describe('PiAgentProtocolAdapter', () => {
     });
   });
 
+  it('publishes only a finite non-negative Pi pending count at connect', async () => {
+    const { adapter, client, patches } = harness();
+    vi.spyOn(client, 'start').mockResolvedValue({
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: { pendingMessageCount: Number.NaN },
+    });
+    await adapter.connect(config);
+    expect(patches.at(-1)).toMatchObject({
+      type: 'agent-live-state-updated-v2',
+      live: { queueLength: 0 },
+    });
+  });
+
   it('submits queued Relay turns as fresh prompts after real agent_settled boundaries', async () => {
     const { adapter, client, call, patches } = harness();
     await adapter.connect(config);
@@ -293,6 +308,135 @@ describe('PiAgentProtocolAdapter', () => {
       })
     ).rejects.toThrow('Cannot read Pi image attachment');
     expect(call).not.toHaveBeenCalled();
+  });
+
+  it('fails an invalidated queued attachment locally and advances later turns', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'relay-pi-queued-image-'));
+    const path = join(directory, 'image.png');
+    writeFileSync(
+      path,
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    );
+    try {
+      const { adapter, client, call, patches } = harness();
+      await adapter.connect(config);
+      await adapter.sendMessage({ turnId: 't1', content: 'one' });
+      await adapter.sendMessage({
+        turnId: 't2',
+        content: 'image',
+        attachments: [{ type: 'image', path, mimeType: 'image/png' }],
+      });
+      await adapter.sendMessage({ turnId: 't3', content: 'three' });
+      rmSync(path);
+
+      client.emit('event', { type: 'agent_settled' });
+      await vi.waitFor(() =>
+        expect(
+          call.mock.calls
+            .filter(([type]) => type === 'prompt')
+            .map(([, payload]) => (payload as { message: string }).message)
+        ).toEqual(['one', 'three'])
+      );
+      expect(adapter.status).toBe('connected');
+      expect(patches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'agent-error-v2',
+            turnId: 't2',
+            message: expect.stringContaining('Cannot read Pi image attachment'),
+          }),
+          expect.objectContaining({
+            type: 'agent-turn-completed-v2',
+            turnId: 't2',
+            status: 'failed',
+          }),
+        ])
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('assigns unique item ids when Pi omits tool call ids', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'tools' });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolName: 'bash',
+      args: { command: 'one' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolName: 'bash',
+      args: { command: 'two' },
+    });
+    const ids = patches
+      .filter(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { type?: string }).type === 'commandExecution'
+      )
+      .map((patch) => (patch.item as { id: string }).id);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('reuses an anonymous streamed tool id through Pi execution completion', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'tool' });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'toolcall_end',
+        contentIndex: 0,
+        toolCall: { name: 'bash', arguments: { command: 'pwd' } },
+      },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_update',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+      partialResult: { content: [{ type: 'text', text: '/tm' }] },
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+      result: { content: [{ type: 'text', text: '/tmp' }] },
+      isError: false,
+    });
+
+    const started = patches.filter(
+      (patch) =>
+        patch.type === 'agent-item-started-v2' &&
+        (patch.item as { type?: string }).type === 'commandExecution'
+    );
+    expect(started).toHaveLength(1);
+    const id = (started[0]!.item as { id: string }).id;
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          itemId: id,
+          delta: { output: '/tm' },
+        }),
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            id,
+            output: '/tmp',
+            status: 'completed',
+          }),
+        }),
+      ])
+    );
   });
 
   it('bounds image count and rejects MIME-mismatched bytes', async () => {
@@ -665,7 +809,9 @@ describe('PiAgentProtocolAdapter', () => {
     expect(steerCalls[0]?.[1]).toMatchObject({
       message: expect.stringContaining('bash'),
     });
-    expect(call.mock.calls.filter(([type]) => type === 'prompt').length).toBe(1); // the initial sendMessage
+    expect(call.mock.calls.filter(([type]) => type === 'prompt').length).toBe(
+      1
+    ); // the initial sendMessage
   });
 
   it('does not inject after interleaved empty calls from different tools', async () => {

--- a/test/server/protocol-adapters/pi-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/pi-agent-adapter.test.ts
@@ -1,0 +1,785 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { PiAgentRpcClient } from '../../../server/pi-agent-rpc-client.js';
+import { PiAgentProtocolAdapter } from '../../../server/protocol-adapters/pi-agent-adapter.js';
+
+const config = {
+  cwd: '/tmp',
+  port: 1,
+  sessionId: 'relay-session',
+  hookToken: 'x',
+  configDir: '/tmp',
+};
+
+function harness() {
+  const client = new PiAgentRpcClient();
+  vi.spyOn(client, 'start').mockResolvedValue({
+    type: 'response',
+    command: 'get_state',
+    success: true,
+    data: {
+      sessionId: 'pi-1',
+      sessionFile: '/tmp/pi-1.jsonl',
+      isStreaming: false,
+    },
+  });
+  const call = vi
+    .spyOn(client, 'call')
+    .mockResolvedValue({ type: 'response', command: 'prompt', success: true });
+  vi.spyOn(client, 'stop').mockResolvedValue();
+  const adapter = new PiAgentProtocolAdapter(() => client);
+  const patches: Array<Record<string, unknown>> = [];
+  adapter.onPatch((patch) =>
+    patches.push(patch as unknown as Record<string, unknown>)
+  );
+  return { adapter, client, call, patches };
+}
+
+describe('PiAgentProtocolAdapter', () => {
+  it('publishes honest capabilities and provider session identity after get_state', async () => {
+    const { adapter, patches } = harness();
+    await adapter.connect(config);
+    expect(adapter.agentType).toBe('pi');
+    expect(adapter.capabilities).toMatchObject({
+      text: true,
+      queue: true,
+      interrupt: true,
+      resume: true,
+      approvals: false,
+      questions: false,
+      compact: true,
+      telemetry: true,
+    });
+    const snapshot = patches.find(
+      (patch) => patch.type === 'agent-session-snapshot-v2'
+    );
+    expect(snapshot?.session).toMatchObject({
+      provider: 'pi',
+      providerSession: {
+        piSessionId: 'pi-1',
+        piSessionFile: '/tmp/pi-1.jsonl',
+      },
+    });
+  });
+
+  it('maps streaming text, thinking, and command tools to V2 patches', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'hello' });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'answer',
+      },
+    });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'thinking_delta',
+        contentIndex: 1,
+        delta: 'thought',
+      },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolCallId: 'tool-1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: '/tmp' }] },
+      isError: false,
+    });
+    client.emit('event', {
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        usage: {
+          input: 10,
+          output: 4,
+          cacheRead: 2,
+          cacheWrite: 1,
+          cost: { total: 0.25 },
+        },
+      },
+    });
+    client.emit('event', { type: 'agent_settled' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          itemId: 't1-assistant-0-0',
+          delta: { text: 'answer' },
+        }),
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          itemId: 't1-reasoning-0-1',
+          delta: { summary: 'thought' },
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't1',
+          status: 'completed',
+          usage: {
+            inputTokens: 10,
+            outputTokens: 4,
+            cacheReadTokens: 2,
+            cacheWriteTokens: 1,
+            costUsd: 0.25,
+          },
+        }),
+      ])
+    );
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { type?: string }).type === 'commandExecution'
+      )
+    ).toBe(true);
+  });
+
+  it('queues locally while active and uses abort for interrupt', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+    await adapter.interrupt({ turnId: 't1' });
+    expect(call.mock.calls.map(([type]) => type)).toEqual(['prompt', 'abort']);
+  });
+
+  it('combines Relay and native Pi queues in its live queue count', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+
+    client.emit('event', {
+      type: 'queue_update',
+      steering: ['native steer'],
+      followUp: ['native follow-up'],
+    });
+
+    expect(patches.at(-1)).toMatchObject({
+      type: 'agent-live-state-updated-v2',
+      live: { queueLength: 3 },
+    });
+  });
+
+  it('submits queued Relay turns as fresh prompts after real agent_settled boundaries', async () => {
+    const { adapter, client, call, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+    await adapter.sendMessage({ turnId: 't3', content: 'three' });
+
+    client.emit('event', { type: 'turn_end' });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(0);
+
+    client.emit('event', { type: 'agent_settled' });
+    await vi.waitFor(() =>
+      expect(
+        patches
+          .filter((patch) => patch.type === 'agent-turn-started-v2')
+          .map((patch) => (patch.turn as { id: string }).id)
+      ).toEqual(['t1', 't2'])
+    );
+    client.emit('event', { type: 'agent_settled' });
+    await vi.waitFor(() =>
+      expect(
+        patches
+          .filter((patch) => patch.type === 'agent-turn-started-v2')
+          .map((patch) => (patch.turn as { id: string }).id)
+      ).toEqual(['t1', 't2', 't3'])
+    );
+    client.emit('event', { type: 'agent_settled' });
+
+    expect(
+      patches
+        .filter((patch) => patch.type === 'agent-turn-completed-v2')
+        .map((patch) => patch.turnId)
+    ).toEqual(['t1', 't2', 't3']);
+    expect(
+      call.mock.calls
+        .filter(([type]) => type === 'prompt')
+        .map(([, payload]) => (payload as { message: string }).message)
+    ).toEqual(['one', 'two', 'three']);
+  });
+
+  it('fails closed when a queued prompt acknowledgement is ambiguous', async () => {
+    const { adapter, client, call, patches } = harness();
+    call.mockImplementation(async (type, payload) => {
+      if (
+        type === 'prompt' &&
+        (payload as { message?: string }).message === 'two'
+      )
+        throw new Error('prompt timed out');
+      return { type: 'response', command: type, success: true };
+    });
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+    client.emit('event', { type: 'agent_settled' });
+
+    await vi.waitFor(() => expect(adapter.status).toBe('disconnected'));
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't2',
+          status: 'failed',
+        }),
+      ])
+    );
+  });
+
+  it('fails closed on protocol corruption and unexpected close', async () => {
+    const corrupted = harness();
+    await corrupted.adapter.connect(config);
+    corrupted.client.emit('protocolError', new Error('bad record'));
+    expect(corrupted.adapter.status).toBe('disconnected');
+    expect(corrupted.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-live-state-updated-v2',
+          live: expect.objectContaining({ status: 'disconnected' }),
+        }),
+      ])
+    );
+
+    const closed = harness();
+    await closed.adapter.connect(config);
+    await closed.adapter.sendMessage({ turnId: 't1', content: 'one' });
+    closed.client.emit('close', 1);
+    expect(closed.adapter.status).toBe('disconnected');
+    expect(closed.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't1',
+          status: 'failed',
+        }),
+        expect.objectContaining({
+          type: 'agent-live-state-updated-v2',
+          live: expect.objectContaining({ status: 'disconnected' }),
+        }),
+      ])
+    );
+  });
+
+  it('rejects unreadable image attachments explicitly', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    await expect(
+      adapter.sendMessage({
+        turnId: 't1',
+        content: 'image',
+        attachments: [
+          {
+            type: 'image',
+            path: '/definitely/missing.png',
+            mimeType: 'image/png',
+          },
+        ],
+      })
+    ).rejects.toThrow('Cannot read Pi image attachment');
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('bounds image count and rejects MIME-mismatched bytes', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'relay-pi-image-'));
+    const path = join(directory, 'image.png');
+    try {
+      writeFileSync(path, 'not an image');
+      const mismatched = harness();
+      await mismatched.adapter.connect(config);
+      await expect(
+        mismatched.adapter.sendMessage({
+          turnId: 'bad-image',
+          content: 'image',
+          attachments: [{ type: 'image', path, mimeType: 'image/png' }],
+        })
+      ).rejects.toThrow('do not match the declared image');
+
+      const excessive = harness();
+      await excessive.adapter.connect(config);
+      await expect(
+        excessive.adapter.sendMessage({
+          turnId: 'many-images',
+          content: 'images',
+          attachments: Array.from({ length: 5 }, () => ({
+            type: 'image' as const,
+            path,
+            mimeType: 'image/png',
+          })),
+        })
+      ).rejects.toThrow('at most 4 images');
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed on an ambiguous initial prompt acknowledgement', async () => {
+    const { adapter, client, call, patches } = harness();
+    call.mockImplementation(async (type) => {
+      if (type === 'prompt') throw new Error('prompt timed out');
+      return { type: 'response', command: type, success: true };
+    });
+    await adapter.connect(config);
+    await expect(
+      adapter.sendMessage({ turnId: 'timeout', content: 'hello' })
+    ).rejects.toThrow('prompt timed out');
+    expect(adapter.status).toBe('disconnected');
+    expect(client.stop).toHaveBeenCalled();
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-turn-completed-v2' && patch.turnId === 'timeout'
+      )
+    ).toEqual([expect.objectContaining({ status: 'failed' })]);
+  });
+
+  it('maps extension errors to nonfatal debug diagnostics', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'hello' });
+    client.emit('event', { type: 'extension_error', error: 'hook failed' });
+    client.emit('event', { type: 'agent_settled' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-started-v2',
+          item: expect.objectContaining({
+            type: 'providerExtension',
+            payload: { kind: 'extensionError', error: 'hook failed' },
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 't1',
+          status: 'completed',
+        }),
+      ])
+    );
+  });
+
+  it('runs /compact through native RPC and terminalizes the Relay turn', async () => {
+    const { adapter, call, patches } = harness();
+    call.mockImplementation(async (type) => ({
+      type: 'response',
+      command: type,
+      success: true,
+      ...(type === 'compact' ? { data: { tokensBefore: 100 } } : {}),
+    }));
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 'compact', content: '/compact' });
+    expect(call.mock.calls.map(([type]) => type)).toEqual(['compact']);
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'compact',
+          status: 'completed',
+        }),
+      ])
+    );
+  });
+
+  it('disables extensions until extension UI requests are mapped', async () => {
+    const client = new PiAgentRpcClient();
+    vi.spyOn(client, 'start').mockResolvedValue({
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: {},
+    });
+    vi.spyOn(client, 'call').mockResolvedValue({
+      type: 'response',
+      command: 'set_steering_mode',
+      success: true,
+    });
+    vi.spyOn(client, 'stop').mockResolvedValue();
+    let args: string[] | undefined;
+    const adapter = new PiAgentProtocolAdapter((options) => {
+      args = options.args;
+      return client;
+    });
+    await adapter.connect({
+      ...config,
+      model: 'gpt-5.6-sol',
+      extra: { provider: 'openai-codex', effort: 'high' },
+    });
+    expect(args).toEqual([
+      '--mode',
+      'rpc',
+      '--no-extensions',
+      '--provider',
+      'openai-codex',
+      '--model',
+      'gpt-5.6-sol',
+      '--thinking',
+      'high',
+    ]);
+  });
+
+  it('resumes a durable session by exact pi project session id', async () => {
+    const client = new PiAgentRpcClient();
+    vi.spyOn(client, 'start').mockResolvedValue({
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: { sessionId: 'pi-session-1', sessionFile: '/tmp/s.jsonl' },
+    });
+    vi.spyOn(client, 'stop').mockResolvedValue();
+    let args: string[] | undefined;
+    const adapter = new PiAgentProtocolAdapter((options) => {
+      args = options.args;
+      return client;
+    });
+    await adapter.connect({ ...config, resumeSessionId: 'pi-session-1' });
+    expect(args).toEqual([
+      '--mode',
+      'rpc',
+      '--no-extensions',
+      '--session-id',
+      'pi-session-1',
+    ]);
+  });
+
+  it('completes a turn only on agent_settled, not on the earlier agent_end', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    client.emit('event', { type: 'agent_end', messages: [] });
+    expect(
+      patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+    ).toHaveLength(0);
+    client.emit('event', { type: 'agent_settled' });
+    expect(
+      patches
+        .filter((patch) => patch.type === 'agent-turn-completed-v2')
+        .map((patch) => patch.turnId)
+    ).toEqual(['t1']);
+  });
+
+  it('uses unique assistant ids across a tool-loop second assistant message', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'loop' });
+    client.emit('event', {
+      type: 'message_start',
+      message: { role: 'assistant' },
+    });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'first',
+      },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'tool-loop',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolCallId: 'tool-loop',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: '/tmp' }] },
+      isError: false,
+    });
+    client.emit('event', {
+      type: 'message_start',
+      message: { role: 'assistant' },
+    });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'second',
+      },
+    });
+    client.emit('event', { type: 'agent_settled' });
+    const assistantIds = patches
+      .filter(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { type: string }).type === 'assistantMessage'
+      )
+      .map((patch) => (patch.item as { id: string }).id);
+    expect(assistantIds).toEqual(['t1-assistant-0-0', 't1-assistant-1-0']);
+  });
+
+  it('fails generation errors and terminalizes running tools; abort cancels them', async () => {
+    const failed = harness();
+    await failed.adapter.connect(config);
+    await failed.adapter.sendMessage({ turnId: 'failed', content: 'fail' });
+    failed.client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'running-tool',
+      toolName: 'bash',
+      args: { command: 'sleep 1' },
+    });
+    failed.client.emit('event', {
+      type: 'auto_retry_end',
+      success: false,
+      finalError: 'quota exhausted',
+    });
+    failed.client.emit('event', { type: 'agent_settled' });
+    expect(failed.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            id: 'running-tool',
+            status: 'failed',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'failed',
+          status: 'failed',
+          error: 'quota exhausted',
+        }),
+      ])
+    );
+
+    const aborted = harness();
+    await aborted.adapter.connect(config);
+    await aborted.adapter.sendMessage({ turnId: 'aborted', content: 'abort' });
+    aborted.client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'abort-tool',
+      toolName: 'bash',
+      args: { command: 'sleep 1' },
+    });
+    await aborted.adapter.interrupt({ turnId: 'aborted' });
+    aborted.client.emit('event', { type: 'agent_settled' });
+    expect(aborted.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            id: 'abort-tool',
+            status: 'cancelled',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'aborted',
+          status: 'interrupted',
+        }),
+      ])
+    );
+  });
+
+  it('ignores stale old-client close after reconnect and keeps patch listeners', async () => {
+    const clients = [new PiAgentRpcClient(), new PiAgentRpcClient()];
+    for (const client of clients) {
+      vi.spyOn(client, 'start').mockResolvedValue({
+        type: 'response',
+        command: 'get_state',
+        success: true,
+        data: { sessionId: 'pi' },
+      });
+      vi.spyOn(client, 'stop').mockResolvedValue();
+      vi.spyOn(client, 'call').mockResolvedValue({
+        type: 'response',
+        command: 'prompt',
+        success: true,
+      });
+    }
+    let index = 0;
+    const adapter = new PiAgentProtocolAdapter(() => clients[index++]!);
+    const patches: Array<Record<string, unknown>> = [];
+    adapter.onPatch((patch) =>
+      patches.push(patch as unknown as Record<string, unknown>)
+    );
+    await adapter.connect(config);
+    await adapter.reconnect();
+    clients[0]!.emit('close', 1);
+    expect(adapter.status).toBe('connected');
+    await adapter.sendMessage({ turnId: 'after-reconnect', content: 'alive' });
+    clients[1]!.emit('event', { type: 'agent_settled' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'after-reconnect',
+        }),
+      ])
+    );
+  });
+
+  it('guards empty-args command calls and steers after repeated empty calls', async () => {
+    const { adapter, client, call, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't-empty', content: 'do it' });
+
+    // Empty bash call: no command.
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'empty-1',
+      toolName: 'bash',
+      args: {},
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'empty-2',
+      toolName: 'bash',
+      args: {},
+    });
+    // Only the third consecutive empty call injects a corrective steer.
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'empty-3',
+      toolName: 'bash',
+      args: {},
+    });
+
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-error-v2',
+          message: expect.stringContaining('empty arguments'),
+        }),
+      ])
+    );
+    // Corrective is a `steer` (pi rejects `prompt` during streaming), not a bare
+    // `prompt`, so the first two empty calls must not have called anything.
+    const steerCalls = call.mock.calls.filter(([type]) => type === 'steer');
+    expect(steerCalls.length).toBe(1);
+    expect(steerCalls[0]?.[1]).toMatchObject({
+      message: expect.stringContaining('bash'),
+    });
+    expect(call.mock.calls.filter(([type]) => type === 'prompt').length).toBe(1); // the initial sendMessage
+  });
+
+  it('does not inject after interleaved empty calls from different tools', async () => {
+    const { adapter, client, call } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't-mixed', content: 'go' });
+
+    // bash, then edit, then edit: the edit counter is per-tool, so only two
+    // consecutive empty `edit` calls do not yet trigger a steer.
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'b1',
+      toolName: 'bash',
+      args: {},
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'e1',
+      toolName: 'edit',
+      args: {},
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'e2',
+      toolName: 'edit',
+      args: {},
+    });
+
+    expect(call.mock.calls.filter(([type]) => type === 'steer').length).toBe(0);
+
+    // A third consecutive empty `edit` now injects.
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'e3',
+      toolName: 'edit',
+      args: {},
+    });
+    expect(call.mock.calls.filter(([type]) => type === 'steer').length).toBe(1);
+  });
+
+  it('keeps an empty-bash streak despite interleaved valid calls of other tools', async () => {
+    const { adapter, client, call } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't-interleave', content: 'go' });
+
+    // Empty bash, then a VALID edit, then empty bash, then empty bash: the valid
+    // edit clears only the edit tool's streak, so the bash count still reaches 3
+    // and steers despite the interleaved valid call.
+    const emptyBash = (i: string) => ({
+      type: 'tool_execution_start',
+      toolCallId: i,
+      toolName: 'bash',
+      args: {},
+    });
+    client.emit('event', emptyBash('e1'));
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'v1',
+      toolName: 'edit',
+      args: { path: '/tmp/a.ts' },
+    });
+    client.emit('event', emptyBash('e2'));
+    client.emit('event', emptyBash('e3'));
+
+    expect(call.mock.calls.filter(([type]) => type === 'steer').length).toBe(1);
+  });
+
+  it('clears only the matching tool streak on a valid invocation', async () => {
+    const { adapter, client, call } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't-valid', content: 'go' });
+
+    // Two empty bash calls, then a valid bash call: the valid call clears only
+    // bash's streak, so the next empty bash is back to count 1 (no steer yet).
+    const emptyBash = (i: string) => ({
+      type: 'tool_execution_start',
+      toolCallId: i,
+      toolName: 'bash',
+      args: {},
+    });
+    client.emit('event', emptyBash('e1'));
+    client.emit('event', emptyBash('e2'));
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'v1',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', emptyBash('e3'));
+    client.emit('event', emptyBash('e4'));
+
+    expect(call.mock.calls.filter(([type]) => type === 'steer').length).toBe(0);
+
+    // A third consecutive empty bash call after the valid reset triggers.
+    client.emit('event', emptyBash('e5'));
+    expect(call.mock.calls.filter(([type]) => type === 'steer').length).toBe(1);
+  });
+
+  it('queues only one corrective steer per empty-call burst', async () => {
+    const { adapter, client, call } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't-burst', content: 'go' });
+
+    // A burst of five empty bash calls triggers a steer at count 3 only — counts
+    // 4 and 5 must not queue additional steers.
+    for (let i = 1; i <= 5; i += 1) {
+      client.emit('event', {
+        type: 'tool_execution_start',
+        toolCallId: `b${i}`,
+        toolName: 'bash',
+        args: {},
+      });
+    }
+
+    expect(call.mock.calls.filter(([type]) => type === 'steer').length).toBe(1);
+  });
+});

--- a/test/server/protocol-adapters/pi-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/pi-agent-adapter.test.ts
@@ -439,6 +439,52 @@ describe('PiAgentProtocolAdapter', () => {
     );
   });
 
+  it('routes interleaved anonymous Pi tools by name and args', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'tools' });
+    for (const command of ['one', 'two'])
+      client.emit('event', {
+        type: 'tool_execution_start',
+        toolName: 'bash',
+        args: { command },
+      });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      args: { command: 'two' },
+      result: { content: [{ type: 'text', text: 'second' }] },
+      isError: false,
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      args: { command: 'one' },
+      result: { content: [{ type: 'text', text: 'first' }] },
+      isError: false,
+    });
+    const started = patches
+      .filter((patch) => patch.type === 'agent-item-started-v2')
+      .map((patch) => patch.item as { id: string; command?: string })
+      .filter((item) => item.command);
+    const idByCommand = new Map(started.map((item) => [item.command, item.id]));
+    const completed = patches
+      .filter((patch) => patch.type === 'agent-item-updated-v2')
+      .map((patch) => patch.item as { id: string; output?: string });
+    expect(completed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: idByCommand.get('one'),
+          output: 'first',
+        }),
+        expect.objectContaining({
+          id: idByCommand.get('two'),
+          output: 'second',
+        }),
+      ])
+    );
+  });
+
   it('bounds image count and rejects MIME-mismatched bytes', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'relay-pi-image-'));
     const path = join(directory, 'image.png');
@@ -812,6 +858,46 @@ describe('PiAgentProtocolAdapter', () => {
     expect(call.mock.calls.filter(([type]) => type === 'prompt').length).toBe(
       1
     ); // the initial sendMessage
+  });
+
+  it('does not recreate a suppressed empty tool when its end event arrives', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't-empty-end', content: 'go' });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolCallId: 'empty-end',
+      toolName: 'bash',
+      args: {},
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolCallId: 'empty-end',
+      toolName: 'bash',
+      args: {},
+      result: { content: [{ type: 'text', text: 'invalid' }] },
+      isError: true,
+    });
+    expect(
+      patches.filter(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { id?: string }).id === 'empty-end'
+      )
+    ).toHaveLength(0);
+  });
+
+  it('does not throw when corrective steering loses its client', async () => {
+    const { adapter } = harness();
+    await adapter.connect(config);
+    await adapter.disconnect();
+    expect(() =>
+      (
+        adapter as unknown as {
+          injectCorrectivePrompt(name: string): void;
+        }
+      ).injectCorrectivePrompt('bash')
+    ).not.toThrow();
   });
 
   it('does not inject after interleaved empty calls from different tools', async () => {

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -691,6 +691,52 @@ describe('PrimeAgentProtocolAdapter', () => {
     );
   });
 
+  it('routes interleaved anonymous Prime tools by name and args', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'tools' });
+    for (const command of ['one', 'two'])
+      client.emit('event', {
+        type: 'tool_execution_start',
+        toolName: 'bash',
+        args: { command },
+      });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      args: { command: 'two' },
+      result: { content: [{ type: 'text', text: 'second' }] },
+      isError: false,
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      args: { command: 'one' },
+      result: { content: [{ type: 'text', text: 'first' }] },
+      isError: false,
+    });
+    const started = patches
+      .filter((patch) => patch.type === 'agent-item-started-v2')
+      .map((patch) => patch.item as { id: string; command?: string })
+      .filter((item) => item.command);
+    const idByCommand = new Map(started.map((item) => [item.command, item.id]));
+    const completed = patches
+      .filter((patch) => patch.type === 'agent-item-updated-v2')
+      .map((patch) => patch.item as { id: string; output?: string });
+    expect(completed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: idByCommand.get('one'),
+          output: 'first',
+        }),
+        expect.objectContaining({
+          id: idByCommand.get('two'),
+          output: 'second',
+        }),
+      ])
+    );
+  });
+
   it('bounds image count and rejects MIME-mismatched bytes', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'relay-prime-image-'));
     const path = join(directory, 'image.png');

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -402,6 +402,40 @@ describe('PrimeAgentProtocolAdapter', () => {
     ]);
   });
 
+  it('validates Prime native queue counts and preserves local queued work', async () => {
+    const { adapter, client, patches } = harness();
+    vi.spyOn(client, 'start').mockResolvedValue({
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: { sessionActions: { queuedCount: Number.POSITIVE_INFINITY } },
+    });
+    await adapter.connect(config);
+    expect(patches.at(-1)).toMatchObject({
+      type: 'agent-live-state-updated-v2',
+      live: { queueLength: 0 },
+    });
+
+    await adapter.sendMessage({ turnId: 't1', content: 'one' });
+    await adapter.sendMessage({ turnId: 't2', content: 'two' });
+    client.emit('event', {
+      type: 'session_action_update',
+      actions: { queuedCount: 'not-a-number' },
+    });
+    expect(patches.at(-1)).toMatchObject({
+      type: 'agent-live-state-updated-v2',
+      live: { queueLength: 1 },
+    });
+    client.emit('event', {
+      type: 'session_action_update',
+      actions: { queuedCount: 2 },
+    });
+    expect(patches.at(-1)).toMatchObject({
+      type: 'agent-live-state-updated-v2',
+      live: { queueLength: 3 },
+    });
+  });
+
   it('submits queued Relay turns as fresh prompts after real agent_end boundaries', async () => {
     const { adapter, client, call, patches } = harness();
     await adapter.connect(config);
@@ -524,6 +558,137 @@ describe('PrimeAgentProtocolAdapter', () => {
     expect(call.mock.calls.map(([type]) => type)).toEqual([
       'get_available_models',
     ]);
+  });
+
+  it('fails an invalidated queued attachment locally and advances later turns', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'relay-prime-queued-image-'));
+    const path = join(directory, 'image.png');
+    writeFileSync(
+      path,
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    );
+    try {
+      const { adapter, client, call, patches } = harness();
+      await adapter.connect(config);
+      await adapter.sendMessage({ turnId: 't1', content: 'one' });
+      await adapter.sendMessage({
+        turnId: 't2',
+        content: 'image',
+        attachments: [{ type: 'image', path, mimeType: 'image/png' }],
+      });
+      await adapter.sendMessage({ turnId: 't3', content: 'three' });
+      rmSync(path);
+
+      client.emit('event', { type: 'agent_end' });
+      await vi.waitFor(() =>
+        expect(
+          call.mock.calls
+            .filter(([type]) => type === 'prompt')
+            .map(([, payload]) => (payload as { message: string }).message)
+        ).toEqual(['one', 'three'])
+      );
+      expect(adapter.status).toBe('connected');
+      expect(patches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'agent-error-v2',
+            turnId: 't2',
+            message: expect.stringContaining(
+              'Cannot read Prime Agent image attachment'
+            ),
+          }),
+          expect.objectContaining({
+            type: 'agent-turn-completed-v2',
+            turnId: 't2',
+            status: 'failed',
+          }),
+        ])
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('assigns unique item ids when Prime omits tool call ids', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'tools' });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolName: 'bash',
+      args: { command: 'one' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolName: 'bash',
+      args: { command: 'two' },
+    });
+    const ids = patches
+      .filter(
+        (patch) =>
+          patch.type === 'agent-item-started-v2' &&
+          (patch.item as { type?: string }).type === 'commandExecution'
+      )
+      .map((patch) => (patch.item as { id: string }).id);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('reuses an anonymous streamed tool id through Prime execution completion', async () => {
+    const { adapter, client, patches } = harness();
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 't1', content: 'tool' });
+    client.emit('event', {
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'toolcall_end',
+        contentIndex: 0,
+        toolCall: { name: 'bash', arguments: { command: 'pwd' } },
+      },
+    });
+    client.emit('event', {
+      type: 'tool_execution_start',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    });
+    client.emit('event', {
+      type: 'tool_execution_update',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+      partialResult: { content: [{ type: 'text', text: '/tm' }] },
+    });
+    client.emit('event', {
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+      result: { content: [{ type: 'text', text: '/tmp' }] },
+      isError: false,
+    });
+
+    const started = patches.filter(
+      (patch) =>
+        patch.type === 'agent-item-started-v2' &&
+        (patch.item as { type?: string }).type === 'commandExecution'
+    );
+    expect(started).toHaveLength(1);
+    const id = (started[0]!.item as { id: string }).id;
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          itemId: id,
+          delta: { output: '/tm' },
+        }),
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            id,
+            output: '/tmp',
+            status: 'completed',
+          }),
+        }),
+      ])
+    );
   });
 
   it('bounds image count and rejects MIME-mismatched bytes', async () => {


### PR DESCRIPTION
## Summary

- add Pi as a built-in terminal and channel provider through its native JSONL RPC mode
- harden both Pi and Prime Agent RPC client lifecycle, queued-turn isolation, queue counts, and anonymous tool identity
- add an opt-in, privacy-bounded live RPC smoke for normal completion, active abort, and same-session resume
- document the installed-tested Pi 0.83.0 and Prime Agent 0.7.0 protocol assumptions

## Why

This recovers the abandoned Pi RPC worktree and closes the shared production-readiness gaps found while comparing it with the already-merged Prime Agent provider. Pi and Prime Agent remain separate providers with distinct binaries and terminal boundaries: Pi settles at `agent_settled`; Prime Agent settles at `agent_end`.

## Production hardening

- readiness failures now terminate the child and clear listeners, pending calls, buffered writes, and backpressure state
- synchronous stdin write failures now reject pending work and close the transport cleanly in both clients
- stop rejects queued calls and cannot leak a stale drain callback into a later start
- an attachment invalidated while queued fails only its Relay turn; the provider remains connected and later turns continue
- native queue counts are accepted only as finite non-negative safe integers and are composed with Relay-local queued work
- missing native tool IDs receive argument-aware collision-resistant identities that stay stable from streamed preview through interleaved execution completion
- Pi process ownership uses the executable identity instead of arbitrary command-line text, and empty tool events stay suppressed for their full lifecycle
- live smoke disables tools and local resources, forces Pi telemetry off, hashes session IDs, removes temporary state, and distinguishes configuration skips from runtime failures with truthful native error reporting

## Verification

Exact head: `4e382ac33aa26ebe91dd54b2d8dc785d26c8df4f`

Exact tree: `ee84be3fb3d4ec88b61b631c6448a9aa41a96acd`

- `npm run check` on Node 24.16.0 — passed with 0 errors (227 existing warnings)
- exact-head RPC client/adapter/smoke/process suites — 6 files, 99 tests passed
- `npm run build:server` on the exact head — passed
- exact-head GitHub CI — full typecheck, build, changed-file lint, and 475 files / 6,228 tests passed
- exact-head GitHub E2E — passed
- installed Pi 0.83.0 live smoke — prompt stream, active abort, and exact-session resume passed; terminal `agent_settled`
- installed Prime Agent 0.7.0 live smoke — prompt stream, active abort, and exact-session resume passed; terminal `agent_end`
- broad adversarial review plus focused exact-head fix reviews — no remaining P0/P1/P2 findings
- `git diff --check` — passed

## Live smoke

The smoke is opt-in because it makes real model-backed calls. See `docs/provider-guide.md` for the required live/credential gates and provider model variables.
