### PR TITLE
fix(channel): surface designate-orchestrator errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ workflow.
 
 #### Fixed
 
+- Designate-orchestrator failures now show actionable inline conflict or retry
+  feedback instead of failing silently (#1352)
 - Existing Codex channel conversations now recover after a hub/runtime restart,
   and user message bubbles no longer collapse into character-by-character
   wrapping (#1339)

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -178,6 +178,15 @@
   font-size: inherit;
 }
 
+.ch-designate-orchestrator__error {
+  min-width: 0;
+  color: var(--status-error);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
+  text-transform: lowercase;
+}
+
 .ch-agent-chip__stop {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -62,6 +62,23 @@ const READ_WRITE_VISIBLE_GRACE_MS = 10_000;
 const AUTO_BACKFILL_MAX_ATTEMPTS = 3;
 const AUTO_BACKFILL_RETRY_BASE_MS = 200;
 const AUTO_BACKFILL_MAX_CURSOR_PAGES = 4;
+const DESIGNATE_ORCHESTRATOR_ROLE_CONFLICT =
+  'channel already has a non-orchestrator agent bound';
+const DESIGNATE_ORCHESTRATOR_GENERIC_ERROR =
+  'could not designate orchestrator — try again';
+
+function designateOrchestratorErrorCopy(error: unknown): string {
+  if (
+    error instanceof HttpError &&
+    (error.code === 'SESSION_CONFLICT' ||
+      error.details?.['reasonCode'] === 'CHANNEL_ROLE_CONFLICT')
+  ) {
+    return DESIGNATE_ORCHESTRATOR_ROLE_CONFLICT;
+  }
+
+  return DESIGNATE_ORCHESTRATOR_GENERIC_ERROR;
+}
+
 /**
  * #1308 item 1: how many older-history pages a `#msg-…` deep link may pull
  * before it gives up. Unbounded, a link to a deleted/foreign message id would
@@ -212,6 +229,11 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   }, [channelId, restoreChannel]);
 
   const [designatePending, setDesignatePending] = useState(false);
+  const [designateError, setDesignateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDesignateError(null);
+  }, [channelId]);
 
   /**
    * The busy agents this view would be steering RIGHT NOW, mirrored at render
@@ -844,15 +866,17 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   );
 
   const handleDesignateOrchestrator = useCallback(async () => {
+    setDesignateError(null);
     setDesignatePending(true);
     try {
       await designateChannelOrchestrator(channelId);
       await queryClient.invalidateQueries({
         queryKey: ['channel-roster', channelId],
       });
-    } catch {
-      // Keep the affordance available for a retry; API errors stay local to this
-      // operator control just as interrupt races do.
+    } catch (error) {
+      // Keep the affordance available for a retry, but make the server's stable
+      // role-conflict signal legible beside the operator control.
+      setDesignateError(designateOrchestratorErrorCopy(error));
     } finally {
       setDesignatePending(false);
     }
@@ -989,6 +1013,11 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
               'designate orchestrator'
             )}
           </button>
+        ) : null}
+        {designateError ? (
+          <span className="ch-designate-orchestrator__error" role="alert">
+            {designateError}
+          </span>
         ) : null}
         <span className="ch-header__spacer" />
         {disconnected ? (

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -73,6 +73,7 @@ vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
 
 const { ChannelView } =
   await import('../../frontend/src/components/chat/ChannelView.js');
+const { HttpError } = await import('../../frontend/src/lib/api.js');
 
 const CHANNEL_ID = 'topic:operator-lane';
 const CODEX_DM_CHANNEL_ID = dmChannelTopicId('codex', 'ws:local');
@@ -159,8 +160,9 @@ afterEach(async () => {
 
 describe('ChannelView orchestrator control (#1242)', () => {
   it('waits for confirmed topic identity before offering designation', async () => {
-    let resolveTopic: ((topic: ReturnType<typeof topicFixture>) => void) | null =
-      null;
+    let resolveTopic:
+      | ((topic: ReturnType<typeof topicFixture>) => void)
+      | null = null;
     mocks.fetchWorkspaceTopic.mockReturnValue(
       new Promise<ReturnType<typeof topicFixture>>((resolve) => {
         resolveTopic = resolve;
@@ -273,6 +275,83 @@ describe('ChannelView orchestrator control (#1242)', () => {
     expect(designate?.disabled).toBe(true);
     expect(designate?.textContent).toContain('designating');
     expect(designate?.querySelector('[role="status"]')).not.toBeNull();
+
+    resolveDesignation?.();
+    await flush();
+  });
+
+  it('shows the bound non-orchestrator conflict beside the control', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+    mocks.designateChannelOrchestrator.mockRejectedValue(
+      new HttpError(
+        409,
+        'channel already bound to a non-orchestrator runtime',
+        'SESSION_CONFLICT',
+        false,
+        { reasonCode: 'CHANNEL_ROLE_CONFLICT' }
+      )
+    );
+
+    await render();
+
+    const designate = container.querySelector<HTMLButtonElement>(
+      '.ch-designate-orchestrator'
+    );
+    await act(async () => designate?.click());
+
+    expect(
+      container.querySelector('.ch-designate-orchestrator__error')?.textContent
+    ).toBe('channel already has a non-orchestrator agent bound');
+    expect(designate?.disabled).toBe(false);
+  });
+
+  it('shows the conflict copy for a SESSION_CONFLICT without details', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+    mocks.designateChannelOrchestrator.mockRejectedValue(
+      new HttpError(409, 'session conflict', 'SESSION_CONFLICT')
+    );
+
+    await render();
+
+    const designate = container.querySelector<HTMLButtonElement>(
+      '.ch-designate-orchestrator'
+    );
+    await act(async () => designate?.click());
+
+    expect(
+      container.querySelector('.ch-designate-orchestrator__error')?.textContent
+    ).toBe('channel already has a non-orchestrator agent bound');
+  });
+
+  it('shows a useful generic error and clears it for a retry', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('implementer')]);
+    mocks.designateChannelOrchestrator.mockRejectedValueOnce(
+      new HttpError(503, 'hub unreachable')
+    );
+
+    await render();
+
+    const designate = container.querySelector<HTMLButtonElement>(
+      '.ch-designate-orchestrator'
+    );
+    await act(async () => designate?.click());
+
+    expect(
+      container.querySelector('.ch-designate-orchestrator__error')?.textContent
+    ).toBe('could not designate orchestrator — try again');
+
+    let resolveDesignation: (() => void) | null = null;
+    mocks.designateChannelOrchestrator.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveDesignation = resolve;
+      })
+    );
+    act(() => designate?.click());
+    await flush();
+
+    expect(
+      container.querySelector('.ch-designate-orchestrator__error')
+    ).toBeNull();
 
     resolveDesignation?.();
     await flush();


### PR DESCRIPTION
## Summary

- surface designate-orchestrator failures inline beside the control instead of swallowing them
- show specific copy for the canonical `SESSION_CONFLICT` / `CHANNEL_ROLE_CONFLICT` contract and a generic retry message for other failures
- clear stale errors on retry and channel changes, while keeping the control retryable
- add focused regression coverage and the required `[Unreleased]` changelog entry

## Root cause

`ChannelView.handleDesignateOrchestrator` used a bare `catch {}`. The server's conflict response therefore disappeared and the button only stopped spinning, leaving the operator with no explanation.

## Scope

Frontend error surfacing only. This does not change role-conflict semantics in `server/channel-agent-binder.ts`.

## Validation

Exact head: `df6459c49db6fc881666f6454f538cedc20cc106`

- `npm test -- test/components/channel-view-orchestrator.test.ts` — 9/9 passed
- `npm run check` — passed, 0 errors (227 baseline warnings)
- pre-push changed-test gate — 9 files / 105 tests passed
- `git diff --check origin/nightly...HEAD` — passed

Refs #1352