### PR TITLE
fix(chat): grow composer with long drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ workflow.
 
 - Designate-orchestrator failures now show actionable inline conflict or retry
   feedback instead of failing silently (#1352)
+- Long channel drafts now grow to a conversation-pane-relative cap instead of
+  inner-scrolling after six lines, while preserving most of short mobile
+  timelines (#1355)
 - Existing Codex channel conversations now recover after a hub/runtime restart,
   and user message bubbles no longer collapse into character-by-character
   wrapping (#1339)

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -136,20 +136,20 @@ The fixture web-server runs against a **run-scoped temp config dir**, never the 
 
 There is no fallback, on any side:
 
-| Where                                               | What fails                                                                              |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `playwright.config.ts` (web-server launch)          | an inherited `RELAY_IDE_CONFIG` that is not itself a run-scoped `relay-ide-e2e-*` dir     |
-| `test/e2e/global-setup.ts`                          | a server already listening on the e2e port whose `/healthz` reports a different config    |
-| `server/index.ts` (boot, `RELAY_IDE_E2E_FIXTURES=1`) | a missing, relative, or shared-root config — the server exits 1 before reading anything   |
-| `test/e2e-fixture-config-isolation.test.ts`         | `npm test` (required CI job), including the built server's boot refusal                   |
+| Where                                                | What fails                                                                              |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `playwright.config.ts` (web-server launch)           | an inherited `RELAY_IDE_CONFIG` that is not itself a run-scoped `relay-ide-e2e-*` dir   |
+| `test/e2e/global-setup.ts`                           | a server already listening on the e2e port whose `/healthz` reports a different config  |
+| `server/index.ts` (boot, `RELAY_IDE_E2E_FIXTURES=1`) | a missing, relative, or shared-root config — the server exits 1 before reading anything |
+| `test/e2e-fixture-config-isolation.test.ts`          | `npm test` (required CI job), including the built server's boot refusal                 |
 
 Three properties are worth stating exactly, because the looser versions read the same and are not the same thing:
 
-- **An inherited `RELAY_IDE_CONFIG` is validated, never trusted.** It must be outside every shared root *and* run-scoped — a `relay-ide-e2e-*` directory under `$TMPDIR`. "Not under `~/.config/relay-ide`" was the old rule and it was too weak: `RELAY_IDE_CONFIG=/srv/relay/hub/config.json` exported in a shell passed it and got exactly the silent override #1214 was about, one directory over.
+- **An inherited `RELAY_IDE_CONFIG` is validated, never trusted.** It must be outside every shared root _and_ run-scoped — a `relay-ide-e2e-*` directory under `$TMPDIR`. "Not under `~/.config/relay-ide`" was the old rule and it was too weak: `RELAY_IDE_CONFIG=/srv/relay/hub/config.json` exported in a shell passed it and got exactly the silent override #1214 was about, one directory over.
 - **The temp dir is minted lazily and removed by `globalTeardown`.** `--list`, `--ui`, and `--debug` never start a server and no longer create one; abandoned runs leave a dir behind, and the next mint sweeps `relay-ide-e2e-*` dirs older than a day.
 - **The default port `3466` is not the safeguard.** It avoids the installed hub's `3456`, but `reuseExistingServer` still adopts whatever is listening. `global-setup.ts` probes `/healthz` and refuses any server that does not report this run's config path — the fixture server publishes `fixtureConfigPath` there in fixture mode only. CI does not set `RELAY_IDE_PORT`; the harness owns the port.
 
-Both the harness and the server call `findFixtureConfigIsolationViolation` in `server/runtime-state-paths.ts`, which treats the XDG root *and* the hardcoded `~/.config/relay-ide` root as off-limits (`server/service.ts` ignores XDG, so checking one root leaves the other reachable).
+Both the harness and the server call `findFixtureConfigIsolationViolation` in `server/runtime-state-paths.ts`, which treats the XDG root _and_ the hardcoded `~/.config/relay-ide` root as off-limits (`server/service.ts` ignores XDG, so checking one root leaves the other reachable).
 
 This is #1214: before it, the fixture server inherited the default config resolution. Once a deploy put a PIN in the shared config, every smoke test failed on an unlock screen, and runs that "passed" had only recycled a PIN-less server started before the deploy. Never work around it by pointing `RELAY_IDE_CONFIG` at a hub's config; a per-run temp dir is the only supported value.
 
@@ -161,10 +161,12 @@ Adding an e2e spec therefore means adding **three** things: the spec, `frontend/
 
 Rewrites were deliberately not attempted. Re-pointing a stale component spec at a surface it was not written for produces a test that asserts the wrong thing, and a wrong test is worse than no test — the flows below are recorded as gaps instead.
 
-**Kept (11)** — target resolves *and the suite goes green*:
+**Kept (11)** — target resolves _and the suite goes green_:
+
+This is the original #1299 audit baseline, not a permanent cap. One new live-browser regression spec (`channel-composer-growth.spec.ts`) has since been added, so the current suite has 12 specs.
 
 | Spec                                        | Target                                |
-| --------------------------------------------- | ---------------------------------------- |
+| ------------------------------------------- | ------------------------------------- |
 | `basic.spec.ts`                             | `/` (the app itself)                  |
 | `channel-thread.spec.ts`                    | `test-channel-thread.html`            |
 | `channel-timeline-scroll.spec.ts`           | `test-channel-timeline.html`          |

--- a/frontend/src/components/chat/ChannelComposer.css
+++ b/frontend/src/components/chat/ChannelComposer.css
@@ -10,6 +10,14 @@
   flex-shrink: 0;
 }
 
+.ch-composer__chrome {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
 .ch-composer__banner {
   padding: 6px 12px;
   border-bottom: 1px solid var(--status-error);
@@ -27,7 +35,7 @@
 }
 
 .ch-composer__ta {
-  flex: 1;
+  flex: none;
   width: 100%;
   box-sizing: border-box;
   background: var(--bg);

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -406,14 +406,58 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    const lineHeight = parseInt(getComputedStyle(el).lineHeight, 10) || 20;
-    const maxHeight = lineHeight * 6 + 32;
-    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+
+    const pane = el.closest<HTMLElement>('.ch-main, .ch-thread');
+    const composer = el.closest<HTMLElement>('.ch-composer');
+    const measuredPaneHeight = pane?.clientHeight;
+    const visibleViewportHeight = window.visualViewport?.height;
+    const paneHeight =
+      measuredPaneHeight && visibleViewportHeight
+        ? Math.min(measuredPaneHeight, visibleViewportHeight)
+        : measuredPaneHeight || visibleViewportHeight || window.innerHeight;
+    const composerMaxHeight = Math.floor(paneHeight * 0.45);
+    if (composer) composer.style.maxHeight = `${composerMaxHeight}px`;
+    const naturalHeight = el.getBoundingClientRect().height;
+    const composerChrome = Math.max(
+      0,
+      (composer?.getBoundingClientRect().height ?? naturalHeight) -
+        naturalHeight
+    );
+    // Cap the whole composer, not just its textarea, at 45% of the conversation
+    // pane. Excess attachment/control chrome scrolls within that boundary so the
+    // timeline remains the larger region even on short mobile panes.
+    const maxHeight = Math.max(
+      naturalHeight,
+      composerMaxHeight - composerChrome
+    );
+    const height = Math.max(
+      naturalHeight,
+      Math.min(el.scrollHeight, maxHeight)
+    );
+    el.style.height = `${height}px`;
   }, []);
 
   useEffect(() => {
     resize();
-  }, [draft, resize]);
+  });
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const pane = el.closest<HTMLElement>('.ch-main, .ch-thread');
+    const observer =
+      pane && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(resize)
+        : null;
+    if (pane) observer?.observe(pane);
+    window.addEventListener('resize', resize);
+    window.visualViewport?.addEventListener('resize', resize);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', resize);
+      window.visualViewport?.removeEventListener('resize', resize);
+    };
+  }, [resize]);
 
   // Reset palette selection + reopen it whenever the draft changes (typing after
   // an Escape dismissal re-surfaces the palette).
@@ -917,135 +961,139 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           onDragOver={(e) => e.preventDefault()}
         />
       </div>
-      <div className="ch-composer__command-status" aria-live="polite">
-        {commandStatus}
-      </div>
-      {images.length > 0 ? (
-        <div
-          className="ch-composer__attachments"
-          aria-label="image attachments"
-        >
-          {images.map((image) => (
-            <span
-              key={image.localId}
-              className={`ch-composer__attachment ch-composer__attachment--${image.status}`}
-              title={image.error ?? image.name}
-            >
-              {image.previewUrl ? (
-                <img
-                  className="ch-composer__attachment-thumb"
-                  src={image.previewUrl}
-                  alt=""
-                />
-              ) : null}
-              <span className="ch-composer__attachment-name">{image.name}</span>
-              <span className="ch-composer__attachment-status" role="status">
-                {image.status === 'uploading'
-                  ? 'uploading…'
-                  : image.status === 'failed'
-                    ? 'failed'
-                    : 'ready'}
-              </span>
-              {image.status === 'failed' ? (
+      <div className="ch-composer__chrome">
+        <div className="ch-composer__command-status" aria-live="polite">
+          {commandStatus}
+        </div>
+        {images.length > 0 ? (
+          <div
+            className="ch-composer__attachments"
+            aria-label="image attachments"
+          >
+            {images.map((image) => (
+              <span
+                key={image.localId}
+                className={`ch-composer__attachment ch-composer__attachment--${image.status}`}
+                title={image.error ?? image.name}
+              >
+                {image.previewUrl ? (
+                  <img
+                    className="ch-composer__attachment-thumb"
+                    src={image.previewUrl}
+                    alt=""
+                  />
+                ) : null}
+                <span className="ch-composer__attachment-name">
+                  {image.name}
+                </span>
+                <span className="ch-composer__attachment-status" role="status">
+                  {image.status === 'uploading'
+                    ? 'uploading…'
+                    : image.status === 'failed'
+                      ? 'failed'
+                      : 'ready'}
+                </span>
+                {image.status === 'failed' ? (
+                  <button
+                    type="button"
+                    className="ch-composer__attachment-retry"
+                    onClick={() => void uploadImage(image)}
+                  >
+                    retry
+                  </button>
+                ) : null}
                 <button
                   type="button"
-                  className="ch-composer__attachment-retry"
-                  onClick={() => void uploadImage(image)}
+                  className="ch-composer__attachment-remove"
+                  aria-label={`remove ${image.name}`}
+                  onClick={() => removeImage(image.localId)}
                 >
-                  retry
+                  ×
                 </button>
-              ) : null}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {attachmentError ? (
+          <div className="ch-composer__attachment-error" role="alert">
+            {attachmentError}
+          </div>
+        ) : null}
+        <div className="ch-composer__bar">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            multiple
+            hidden
+            onChange={(event) => {
+              if (event.currentTarget.files)
+                addImageFiles(event.currentTarget.files);
+              event.currentTarget.value = '';
+            }}
+          />
+          <button
+            type="button"
+            className="ch-composer__attach"
+            aria-label="attach image"
+            title="attach image"
+            disabled={images.length >= CHANNEL_COMPOSER_MAX_IMAGES}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            +img
+          </button>
+          {busy ? (
+            // Mid-turn steering cluster. The default follows the harness's own
+            // safe-boundary primitive when supported; legacy harnesses keep the
+            // FIFO queue. The second action cancels the live turn first. It reuses the header chip's
+            // interrupt glyph — the black square is already the one interrupt
+            // vocabulary in the product — with danger-tinted chrome so the
+            // destructive member of the pair reads differently at rest.
+            <span
+              className="ch-composer__steer"
+              role="group"
+              aria-label="mid-turn steering"
+            >
               <button
                 type="button"
-                className="ch-composer__attachment-remove"
-                aria-label={`remove ${image.name}`}
-                onClick={() => removeImage(image.localId)}
+                className="ch-composer__steer-btn"
+                onClick={() => submit()}
+                title={defaultSendHint(
+                  busyAgentLabels ?? [],
+                  busyAgentSteeringMode
+                )}
               >
-                ×
+                {defaultSendLabel(busyAgentSteeringMode)}
+              </button>
+              <button
+                type="button"
+                className="ch-composer__steer-btn ch-composer__steer-btn--interrupt"
+                onClick={() => submit('interrupt')}
+                aria-label="interrupt and send"
+                title="interrupt and send"
+              >
+                <span aria-hidden="true">■</span> interrupt &amp; send
               </button>
             </span>
-          ))}
-        </div>
-      ) : null}
-      {attachmentError ? (
-        <div className="ch-composer__attachment-error" role="alert">
-          {attachmentError}
-        </div>
-      ) : null}
-      <div className="ch-composer__bar">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/png,image/jpeg,image/webp,image/gif"
-          multiple
-          hidden
-          onChange={(event) => {
-            if (event.currentTarget.files)
-              addImageFiles(event.currentTarget.files);
-            event.currentTarget.value = '';
-          }}
-        />
-        <button
-          type="button"
-          className="ch-composer__attach"
-          aria-label="attach image"
-          title="attach image"
-          disabled={images.length >= CHANNEL_COMPOSER_MAX_IMAGES}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          +img
-        </button>
-        {busy ? (
-          // Mid-turn steering cluster. The default follows the harness's own
-          // safe-boundary primitive when supported; legacy harnesses keep the
-          // FIFO queue. The second action cancels the live turn first. It reuses the header chip's
-          // interrupt glyph — the black square is already the one interrupt
-          // vocabulary in the product — with danger-tinted chrome so the
-          // destructive member of the pair reads differently at rest.
-          <span
-            className="ch-composer__steer"
-            role="group"
-            aria-label="mid-turn steering"
-          >
-            <button
-              type="button"
-              className="ch-composer__steer-btn"
-              onClick={() => submit()}
-              title={defaultSendHint(
-                busyAgentLabels ?? [],
-                busyAgentSteeringMode
-              )}
-            >
-              {defaultSendLabel(busyAgentSteeringMode)}
-            </button>
-            <button
-              type="button"
-              className="ch-composer__steer-btn ch-composer__steer-btn--interrupt"
-              onClick={() => submit('interrupt')}
-              aria-label="interrupt and send"
-              title="interrupt and send"
-            >
-              <span aria-hidden="true">■</span> interrupt &amp; send
-            </button>
+          ) : null}
+          <span className="ch-composer__hint">
+            {busy ? (
+              <>
+                <kbd>↵</kbd>
+                {busyAgentSteeringMode === 'all'
+                  ? 'steer after tool'
+                  : busyAgentSteeringMode === 'some'
+                    ? 'steer / queue'
+                    : 'queue'}{' '}
+                <kbd>⌘↵</kbd>interrupt <kbd>⇧↵</kbd>newline
+              </>
+            ) : (
+              <>
+                <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline <kbd>@</kbd>mention
+              </>
+            )}
           </span>
-        ) : null}
-        <span className="ch-composer__hint">
-          {busy ? (
-            <>
-              <kbd>↵</kbd>
-              {busyAgentSteeringMode === 'all'
-                ? 'steer after tool'
-                : busyAgentSteeringMode === 'some'
-                  ? 'steer / queue'
-                  : 'queue'}{' '}
-              <kbd>⌘↵</kbd>interrupt <kbd>⇧↵</kbd>newline
-            </>
-          ) : (
-            <>
-              <kbd>↵</kbd>send <kbd>⇧↵</kbd>newline <kbd>@</kbd>mention
-            </>
-          )}
-        </span>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/test-channel-composer.css
+++ b/frontend/src/test-channel-composer.css
@@ -1,0 +1,24 @@
+html,
+body,
+#app {
+  height: 100%;
+  margin: 0;
+}
+
+.ch-composer-fixture {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  min-height: 0;
+  background: var(--bg);
+}
+
+.ch-composer-fixture__timeline {
+  flex: 1;
+  min-height: 0;
+  padding: 8px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}

--- a/frontend/src/test-channel-composer.tsx
+++ b/frontend/src/test-channel-composer.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import './App.css';
+import './test-channel-composer.css';
+import { ChannelComposer } from './components/chat/ChannelComposer.js';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function Fixture(): React.ReactElement {
+  return (
+    <div className="ch-main ch-composer-fixture">
+      <div className="ch-composer-fixture__timeline" data-testid="timeline">
+        timeline
+      </div>
+      <ChannelComposer
+        channelId="topic:composer-fixture"
+        channelTitle="composer-fixture"
+        members={[
+          {
+            kind: 'human',
+            id: 'human:operator',
+            joinedAt: '2026-08-07T00:00:00.000Z',
+          },
+        ]}
+        onSend={() => Promise.resolve()}
+        postPending={false}
+        storeDown={false}
+        archived={false}
+        onRestore={() => {}}
+        restorePending={false}
+      />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(
+  <QueryClientProvider client={queryClient}>
+    <Fixture />
+  </QueryClientProvider>
+);

--- a/frontend/test-channel-composer.html
+++ b/frontend/test-channel-composer.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Channel composer growth test page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-channel-composer.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,6 +64,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-channel-timeline.html'
   );
+  buildInputs['test-channel-composer'] = resolve(
+    import.meta.dirname,
+    'test-channel-composer.html'
+  );
   buildInputs['test-channel-thread'] = resolve(
     import.meta.dirname,
     'test-channel-thread.html'

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -252,6 +252,36 @@ describe('ChannelComposer (#1178)', () => {
     vi.clearAllMocks();
   });
 
+  it('grows long drafts to a pane-relative cap and preserves most of a short timeline', async () => {
+    Object.defineProperty(container, 'clientHeight', {
+      configurable: true,
+      value: 800,
+    });
+    container.className = 'ch-main';
+    await renderComposer();
+
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    Object.defineProperty(ta, 'scrollHeight', {
+      configurable: true,
+      value: 700,
+    });
+    await act(async () => setNativeValue(ta, 'a long draft'));
+
+    // 45% of the conversation pane: much more than the old six-line cap.
+    expect(ta.style.height).toBe('360px');
+
+    Object.defineProperty(container, 'clientHeight', {
+      configurable: true,
+      value: 320,
+    });
+    await act(async () => window.dispatchEvent(new Event('resize')));
+
+    // A short/mobile pane still leaves the timeline as the larger region.
+    expect(ta.style.height).toBe('144px');
+  });
+
   it('reuses the same clientMessageId on retry after a failed send, then rotates on success', async () => {
     const ids: string[] = [];
     let failNext = true;

--- a/test/e2e-sweep-ledger.test.ts
+++ b/test/e2e-sweep-ledger.test.ts
@@ -10,6 +10,7 @@ import {
   frontendModulesReachedBy,
   KEPT_SPEC_COUNT,
   NEVER_EXISTING_TARGET_SPECS,
+  POST_SWEEP_SPEC_COUNT,
   REPO_ROOT,
   SWEPT_SPECS,
   type SweptSpec,
@@ -47,13 +48,19 @@ describe('#1299 sweep ledger', () => {
   });
 
   it('kept exactly the specs the ledger claims were kept', () => {
-    expect(listSpecFiles()).toHaveLength(KEPT_SPEC_COUNT);
+    expect(listSpecFiles()).toHaveLength(
+      KEPT_SPEC_COUNT + POST_SWEEP_SPEC_COUNT
+    );
   });
 
   it('never re-lists a component that still has a live e2e spec', () => {
     const live = new Set(
       listSpecFiles().map(
-        (spec) => spec.split('/').pop()?.replace(/\.spec\.tsx?$/, '') ?? ''
+        (spec) =>
+          spec
+            .split('/')
+            .pop()
+            ?.replace(/\.spec\.tsx?$/, '') ?? ''
       )
     );
     const overlap = SWEPT_SPECS.map((entry) => entry.component).filter((name) =>

--- a/test/e2e-sweep-ledger.ts
+++ b/test/e2e-sweep-ledger.ts
@@ -245,7 +245,8 @@ export const SWEPT_SPECS: readonly SweptSpec[] = [
   {
     component: 'GitHubIntegration',
     group: 'uncovered-gap',
-    module: 'frontend/src/components/dialogs/integrations/GitHubIntegration.tsx',
+    module:
+      'frontend/src/components/dialogs/integrations/GitHubIntegration.tsx',
   },
   {
     component: 'ImageToast',
@@ -380,6 +381,8 @@ export const SWEPT_SPECS: readonly SweptSpec[] = [
 
 /** Specs kept by the sweep. Asserted against `test/e2e/` by the ledger test. */
 export const KEPT_SPEC_COUNT = 11;
+/** E2E specs added after the #1299 audit baseline. */
+export const POST_SWEEP_SPEC_COUNT = 1;
 
 /**
  * Specs the #1299 target audit found navigating to a page that never existed.

--- a/test/e2e/channel-composer-growth.spec.ts
+++ b/test/e2e/channel-composer-growth.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test';
+
+interface ComposerMetrics {
+  clientHeight: number;
+  scrollHeight: number;
+  renderedHeight: number;
+  composerHeight: number;
+  chromeClientHeight: number;
+  chromeScrollHeight: number;
+  paneHeight: number;
+  timelineHeight: number;
+  oldSixLineCap: number;
+  flexGrow: string;
+}
+
+async function composerMetrics(
+  textarea: import('@playwright/test').Locator
+): Promise<ComposerMetrics> {
+  return textarea.evaluate((element) => {
+    const composer = element.closest<HTMLElement>('.ch-composer');
+    const pane = element.closest<HTMLElement>('.ch-main');
+    const chrome = composer?.querySelector<HTMLElement>('.ch-composer__chrome');
+    const timeline = pane?.querySelector<HTMLElement>(
+      '[data-testid="timeline"]'
+    );
+    if (!composer || !chrome || !pane || !timeline)
+      throw new Error('missing fixture layout');
+    const computed = getComputedStyle(element);
+    const lineHeight = Number.parseFloat(computed.lineHeight);
+    return {
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      renderedHeight: element.getBoundingClientRect().height,
+      composerHeight: composer.getBoundingClientRect().height,
+      chromeClientHeight: chrome.clientHeight,
+      chromeScrollHeight: chrome.scrollHeight,
+      paneHeight: pane.getBoundingClientRect().height,
+      timelineHeight: timeline.getBoundingClientRect().height,
+      oldSixLineCap: lineHeight * 6 + 32,
+      flexGrow: computed.flexGrow,
+    };
+  });
+}
+
+test('composer grows beyond six lines and preserves a short mobile timeline (#1355)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/test-channel-composer.html');
+  const textarea = page.getByRole('textbox', { name: 'message input' });
+  await expect(textarea).toBeVisible();
+  const oneLineHeight = (await composerMetrics(textarea)).renderedHeight;
+
+  await textarea.fill(
+    Array.from({ length: 12 }, (_, index) => `line ${index}`).join('\n')
+  );
+  await expect
+    .poll(async () => (await composerMetrics(textarea)).renderedHeight)
+    .toBeGreaterThan(200);
+  const desktop = await composerMetrics(textarea);
+  expect(desktop.flexGrow).toBe('0');
+  expect(desktop.renderedHeight).toBeGreaterThan(desktop.oldSixLineCap);
+  expect(desktop.scrollHeight - desktop.clientHeight).toBeLessThanOrEqual(1);
+
+  await textarea.fill('short');
+  await expect
+    .poll(async () => (await composerMetrics(textarea)).renderedHeight)
+    .toBeCloseTo(oneLineHeight, 0);
+  const shrunk = await composerMetrics(textarea);
+  expect(shrunk.renderedHeight).toBeGreaterThanOrEqual(oneLineHeight);
+  expect(shrunk.scrollHeight - shrunk.clientHeight).toBeLessThanOrEqual(1);
+
+  await textarea.fill('@');
+  const palette = page.getByRole('listbox', { name: 'agents' });
+  await expect(palette).toBeVisible();
+  const paletteBounds = await palette.evaluate((element) => {
+    const composer = element.closest<HTMLElement>('.ch-composer');
+    if (!composer) throw new Error('missing composer');
+    const paletteRect = element.getBoundingClientRect();
+    const hitTarget = document.elementFromPoint(
+      paletteRect.left + paletteRect.width / 2,
+      paletteRect.top + paletteRect.height / 2
+    );
+    return {
+      height: paletteRect.height,
+      bottom: paletteRect.bottom,
+      composerTop: composer.getBoundingClientRect().top,
+      hitTargetIsPalette: hitTarget !== null && element.contains(hitTarget),
+    };
+  });
+  expect(paletteBounds.height).toBeGreaterThan(0);
+  expect(paletteBounds.bottom).toBeLessThan(paletteBounds.composerTop);
+  expect(paletteBounds.hitTargetIsPalette).toBe(true);
+
+  await page.setViewportSize({ width: 390, height: 360 });
+  await textarea.fill(
+    Array.from({ length: 40 }, (_, index) => `line ${index}`).join('\n')
+  );
+  await expect
+    .poll(async () => (await composerMetrics(textarea)).paneHeight)
+    .toBe(360);
+  await textarea.evaluate((element) => {
+    const chrome = element
+      .closest<HTMLElement>('.ch-composer')
+      ?.querySelector<HTMLElement>('.ch-composer__chrome');
+    if (!chrome) throw new Error('missing composer chrome');
+    const largeChrome = document.createElement('div');
+    largeChrome.dataset.testid = 'large-composer-chrome';
+    largeChrome.style.cssText = 'height: 240px; flex: 0 0 240px;';
+    chrome.append(largeChrome);
+    window.dispatchEvent(new Event('resize'));
+  });
+  const mobile = await composerMetrics(textarea);
+  expect(mobile.scrollHeight).toBeGreaterThan(mobile.clientHeight);
+  expect(mobile.composerHeight).toBeLessThanOrEqual(
+    mobile.paneHeight * 0.45 + 2
+  );
+  expect(mobile.chromeScrollHeight).toBeGreaterThan(mobile.chromeClientHeight);
+  expect(mobile.timelineHeight).toBeGreaterThan(mobile.composerHeight);
+});


### PR DESCRIPTION
## What
- replace the fixed six-line textarea ceiling with a 45%-of-pane composer cap
- let long drafts grow while keeping the timeline larger on short/mobile panes
- constrain oversized attachment/control chrome inside an inner scroll region
- preserve floating mention/command palettes outside the clipped chrome region
- add unit arithmetic and real Chromium geometry/hit-testing coverage

## Why
Long channel drafts became internally scrollable after roughly six lines even when the conversation pane had room. A fixed line count also behaved poorly across desktop, mobile, attachments, and browser flex layout.

## Checklist
- [x] Whole composer remains capped near 45% of the visible conversation pane
- [x] Textarea grows beyond six lines and shrinks back to its natural one-line border box
- [x] Timeline remains the larger region on a 390×360 pane
- [x] Oversized attachment/control chrome scrolls without clipping floating palettes
- [x] Real Chromium regression proves the mention palette is visibly hit-testable
- [x] `DESIGN.md` spacing/type/color rules preserved
- [x] Adversarial and CodeRabbit findings reproduced and resolved

## Verification
- `npm test -- --run test/components/channel-composer.test.ts` — 18/18
- `npx playwright test test/e2e/channel-composer-growth.spec.ts --project=chromium` — 1/1
- changed-test pre-push suite — 136/136 across 11 files
- sweep-ledger regression — 13/13
- `npm run check` — 0 errors (227 baseline warnings)
- negative browser proof: restoring root overflow makes the palette hit-test fail
- exact head: `6fd7025b74d95aa17d73f2da1489682ca89e95f6`

Closes #1355
