### PR TITLE
fix(agents): preflight profile launch commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ workflow.
 
 #### Fixed
 
+- Agent profiles whose launch command is missing now appear unavailable in channel rosters and mention palettes, and spawn races report an actionable configuration error instead of raw `ENOENT` (#1357)
 - Codex reasoning cards now show expandable provider-generated summaries when available, and no longer show inactive expand chevrons when no summary exists
 
 ## [0.1.1] - 2026-08-05

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -1,6 +1,7 @@
 import os from 'node:os';
 
 import { createLogger } from './logger.js';
+import { resolveExecutablePath } from './frameworks.js';
 import { bindSessionToChannel } from './channel-agent-bridge.js';
 import {
   buildMentionContextPacketEnvelope,
@@ -141,6 +142,8 @@ export interface MentionTarget {
   kind: 'framework';
   available: boolean;
   reason: string | null;
+  /** Actual adapter executable; absent for gateway-only channel providers. */
+  command?: string;
 }
 
 export interface ChannelAgentRosterEntry {
@@ -205,6 +208,8 @@ export interface ChannelAgentBinderDeps {
   presenceSweepMs?: number;
   yolo?: boolean;
   now?: () => number;
+  /** Base environment inherited by channel adapter subprocesses. */
+  processEnv?: NodeJS.ProcessEnv;
 }
 
 export interface ChannelAgentBinder {
@@ -464,6 +469,11 @@ export function createChannelAgentBinder(
   const retryInFlight = new Set<string>();
   let statusBroadcaster: ChannelAgentStatusBroadcaster | null = null;
   let targetsCache: { at: number; value: MentionTarget[] } | null = null;
+  let targetsGeneration = 0;
+  let targetsInFlight: {
+    generation: number;
+    promise: Promise<MentionTarget[]>;
+  } | null = null;
   let closed = false;
 
   const unsubRuntimeEnd = deps.runtimes.onRuntimeEnd((runtimeId) =>
@@ -552,13 +562,42 @@ export function createChannelAgentBinder(
 
   // ── availability targets ────────────────────────────────────────────────────
 
+  function invalidateTargets(): void {
+    targetsGeneration += 1;
+    targetsCache = null;
+    targetsInFlight = null;
+  }
+
   async function getTargets(): Promise<MentionTarget[]> {
+    if (closed) return [];
     if (targetsCache && now() - targetsCache.at < TARGETS_TTL_MS) {
       return targetsCache.value;
     }
-    const value = await deps.mentionTargets();
-    targetsCache = { at: now(), value };
-    return value;
+    const generation = targetsGeneration;
+    if (targetsInFlight?.generation === generation) {
+      return targetsInFlight.promise;
+    }
+    const request = deps.mentionTargets();
+    const promise = request.then(
+      async (value) => {
+        // Invalidation may race an async gateway probe. Never let that stale
+        // completion repopulate the cache or escape to the caller; join/start
+        // the current generation instead.
+        if (generation !== targetsGeneration) return getTargets();
+        targetsCache = { at: now(), value };
+        return value;
+      },
+      async (error: unknown) => {
+        if (generation !== targetsGeneration) return getTargets();
+        throw error;
+      }
+    );
+    targetsInFlight = { generation, promise };
+    try {
+      return await promise;
+    } finally {
+      if (targetsInFlight?.promise === promise) targetsInFlight = null;
+    }
   }
 
   async function resolveTarget(
@@ -566,6 +605,35 @@ export function createChannelAgentBinder(
   ): Promise<MentionTarget | undefined> {
     const targets = await getTargets();
     return targets.find((target) => target.id === framework);
+  }
+
+  function effectiveLaunchEnv(profile: AgentProfile): NodeJS.ProcessEnv {
+    return {
+      ...(deps.processEnv ?? process.env),
+      ...(profile.envVars ?? {}),
+    };
+  }
+
+  function availabilityForProfile(
+    profile: AgentProfile,
+    target: MentionTarget | undefined
+  ): { available: boolean; reason: string | null } {
+    if (!target?.available) {
+      return {
+        available: false,
+        reason: target?.reason ?? 'framework unavailable',
+      };
+    }
+    if (
+      target.command &&
+      !resolveExecutablePath(target.command, effectiveLaunchEnv(profile))
+    ) {
+      return {
+        available: false,
+        reason: `${target.command} is not installed on this node (not found on PATH).`,
+      };
+    }
+    return { available: true, reason: null };
   }
 
   /**
@@ -977,6 +1045,27 @@ export function createChannelAgentBinder(
       });
     } catch (err) {
       setStatus(provisional, 'idle');
+      if (isMissingLaunchCommandError(err)) {
+        const target = await resolveTarget(framework).catch(() => undefined);
+        const command = target?.command;
+        const commandStillInstalled = command
+          ? resolveExecutablePath(command, effectiveLaunchEnv(profile)) !== null
+          : false;
+        // The probe result may have raced a config/gateway refresh. Invalidate
+        // with a generation bump so an older in-flight completion cannot put
+        // stale targets back after this failure.
+        invalidateTargets();
+        logger.warn('channel agent launch path disappeared:', err);
+        const friendlyMessage =
+          command && !commandStillInstalled
+            ? `@${senderDisplayName} could not start because the configured command "${command}" is not available on this node. Install or configure that CLI on the Relay hub, then review Settings → Agent profiles and try again.`
+            : `@${senderDisplayName} could not start because a launch path was not found on this node.${command ? ` The command "${command}" is installed; verify` : ' Verify'} the channel repo/worktree path and Settings → Agent profiles, then try again.`;
+        throw new ChannelBindingError(
+          friendlyMessage,
+          friendlyMessage,
+          command !== undefined && !commandStillInstalled
+        );
+      }
       throw new ChannelBindingError(
         `spawn failed for @${senderDisplayName}: ${errText(err)}`,
         `@${senderDisplayName} failed to start: ${errText(err)}`
@@ -1982,13 +2071,14 @@ export function createChannelAgentBinder(
           }
           return;
         }
-        if (!target.available) {
+        const availability = availabilityForProfile(profile, target);
+        if (!availability.available) {
           const senderDisplayName =
             profile.displayName || target.displayName || framework;
           postUnavailableRow(
             trigger.channelId,
             profile.id,
-            `@${senderDisplayName} is not available in channels yet — ${target.reason ?? 'channel runtime unavailable.'}`,
+            `@${senderDisplayName} is not available in channels yet — ${availability.reason ?? 'channel runtime unavailable.'}`,
             parentForTrigger(trigger)
           );
           return;
@@ -2503,9 +2593,10 @@ export function createChannelAgentBinder(
       // mark over a turn that never ran — the mark disables the row's own retry
       // affordance, so writing it for a no-op would strand the operator.
       const mentionTarget = await resolveTarget(profile.providerId);
-      if (!mentionTarget?.available) {
+      const availability = availabilityForProfile(profile, mentionTarget);
+      if (!availability.available) {
         throw new ChannelMessageNotRetryableError(
-          `@${profile.displayName || profile.providerId} is not available in channels — ${mentionTarget?.reason ?? 'framework unavailable'}`,
+          `@${profile.displayName || profile.providerId} is not available in channels — ${availability.reason ?? 'framework unavailable'}`,
           'AGENT_UNAVAILABLE'
         );
       }
@@ -2569,6 +2660,7 @@ export function createChannelAgentBinder(
     return Promise.all(
       profiles.map(async (profile) => {
         const target = targetByProvider.get(profile.providerId);
+        const availability = availabilityForProfile(profile, target);
         const binding = live.get(bindingKey(channelId, profile.id));
         const row = store.getBinding(channelId, profile.id);
         const runtimeId = binding?.runtimeId ?? row?.runtimeId ?? null;
@@ -2587,8 +2679,8 @@ export function createChannelAgentBinder(
           isDefault: profile.isDefault,
           isBuiltIn: profile.isBuiltIn,
           kind: 'framework',
-          available: target?.available ?? false,
-          reason: target?.reason ?? 'framework unavailable',
+          available: availability.available,
+          reason: availability.reason,
           ...(runtime?.role !== undefined ? { role: runtime.role } : {}),
           binding: runtimeId
             ? {
@@ -2784,9 +2876,28 @@ export function createChannelAgentBinder(
       retryInFlight.clear();
       consecutiveAgentTurns.clear();
       unavailableRowAt.clear();
-      targetsCache = null;
+      invalidateTargets();
     },
   };
+}
+
+function isMissingLaunchCommandError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const candidate = err as {
+    code?: unknown;
+    message?: unknown;
+    cause?: unknown;
+  };
+  if (candidate.code === 'ENOENT') return true;
+  if (
+    typeof candidate.message === 'string' &&
+    /(?:^|\s)ENOENT(?:\s|$|:)/.test(candidate.message)
+  ) {
+    return true;
+  }
+  return candidate.cause !== undefined && candidate.cause !== err
+    ? isMissingLaunchCommandError(candidate.cause)
+    : false;
 }
 
 function errText(err: unknown): string {

--- a/server/frameworks.ts
+++ b/server/frameworks.ts
@@ -7,7 +7,10 @@ import {
   type AgentFramework,
   type EventSourceType,
 } from './types.js';
-import { probeHermesGatewayApi } from './protocol-adapters/hermes-adapter.js';
+import {
+  channelAdapterLaunchRequirement,
+  type ChannelGatewayProbe,
+} from './protocol-adapters/index.js';
 
 export interface FrameworkAvailability {
   installed: boolean;
@@ -19,6 +22,17 @@ export interface FrameworkChannelAvailability {
   available: boolean;
   endpoint?: string;
   reason?: string;
+  /** Actual subprocess command used by the registered channel adapter. */
+  command?: string;
+}
+
+export interface FrameworkChannelAvailabilityOptions {
+  /** Roster targets defer this check until each profile's effective env is known. */
+  probeLaunchCommand?: boolean;
+  /** Test/host overrides keyed by the gateway id declared by the adapter. */
+  gatewayProbeOverrides?: Readonly<
+    Record<string, ChannelGatewayProbe | undefined>
+  >;
 }
 
 export interface FrameworkClientInfo {
@@ -113,10 +127,11 @@ export async function getFrameworkClientInfoWithRuntime(
   const frameworks = getFrameworkClientInfo(frameworkOverrides, env);
   return Promise.all(
     frameworks.map(async (framework) => {
-      if (framework.id !== 'hermes' || !framework.availability.installed) {
-        return framework;
-      }
-      const probe = await probeHermesGatewayApi(undefined, 300);
+      const requirement = channelAdapterLaunchRequirement(framework.id);
+      if (requirement?.kind !== 'gateway') return framework;
+      // Terminal installation and attached channel gateway reachability are
+      // independent: gateway adapters spawn no local CLI.
+      const probe = await requirement.probe(undefined, 300);
       return {
         ...framework,
         channelAvailability: {
@@ -132,7 +147,9 @@ export async function getFrameworkClientInfoWithRuntime(
 const CHANNEL_DEADVERTISE_REASONS: Record<string, string> = {};
 
 export async function getFrameworkChannelAvailability(
-  framework: AgentFramework
+  framework: AgentFramework,
+  env: NodeJS.ProcessEnv = process.env,
+  options: FrameworkChannelAvailabilityOptions = {}
 ): Promise<FrameworkChannelAvailability> {
   if (!framework.capabilities.supportsChannelAgents) {
     return {
@@ -142,13 +159,40 @@ export async function getFrameworkChannelAvailability(
         `${framework.displayName} is not currently available in channels.`,
     };
   }
-  if (framework.id !== 'hermes') {
-    return { available: true };
+
+  const requirement = channelAdapterLaunchRequirement(framework.id);
+  if (!requirement) {
+    return {
+      available: false,
+      reason: `${framework.displayName} has no registered channel runtime.`,
+    };
   }
-  const probe = await probeHermesGatewayApi(undefined, 500);
-  return {
-    available: probe.available,
-    endpoint: probe.endpoint,
-    ...(probe.reason ? { reason: probe.reason } : {}),
-  };
+
+  if (requirement.kind === 'gateway') {
+    const gatewayProbe =
+      options.gatewayProbeOverrides?.[requirement.gateway] ?? requirement.probe;
+    const probe = await gatewayProbe(undefined, 500);
+    return {
+      available: probe.available,
+      endpoint: probe.endpoint,
+      ...(probe.reason ? { reason: probe.reason } : {}),
+    };
+  }
+
+  if (requirement.kind === 'embedded') return { available: true };
+
+  // Framework commandOverride config currently controls terminal sessions only;
+  // channel adapters own their subprocess command. Probe that actual command so
+  // the roster never promises an override the adapter will not launch.
+  if (
+    options.probeLaunchCommand !== false &&
+    !resolveExecutablePath(requirement.command, env)
+  ) {
+    return {
+      available: false,
+      reason: `${requirement.command} is not installed on this node (not found on PATH).`,
+      command: requirement.command,
+    };
+  }
+  return { available: true, command: requirement.command };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1290,13 +1290,18 @@ function initializeHubPersistence(
 async function channelMentionTargets(config: Config): Promise<MentionTarget[]> {
   const targets: MentionTarget[] = [];
   for (const framework of listConfiguredFrameworks(config.frameworks)) {
-    const channel = await getFrameworkChannelAvailability(framework);
+    const channel = await getFrameworkChannelAvailability(
+      framework,
+      process.env,
+      { probeLaunchCommand: false }
+    );
     targets.push({
       id: framework.id,
       displayName: framework.displayName,
       kind: 'framework',
       available: channel.available,
       reason: channel.available ? null : (channel.reason ?? null),
+      ...(channel.command ? { command: channel.command } : {}),
     });
   }
   if (process.env['RELAY_MOCK_AGENT'] === '1') {

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -31,6 +31,7 @@ import { createLogger } from '../logger.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { relayControlCatalogForProvider } from '../../shared/agent-command-catalog.js';
+import { cleanEnv } from '../utils.js';
 
 const logger = createLogger('codex-native-adapter');
 
@@ -1107,6 +1108,9 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       },
       optOutNotificationMethods: [],
       cwd: typeof extra['cwd'] === 'string' ? extra['cwd'] : config.cwd,
+      ...(config.processEnv
+        ? { env: { ...cleanEnv(), ...config.processEnv } }
+        : {}),
     };
     if (typeof extra['command'] === 'string') opts.command = extra['command'];
     if (Array.isArray(extra['args'])) opts.args = extra['args'] as string[];

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -3,13 +3,40 @@ import { MockProtocolAdapterV2 } from './mock-v2-adapter.js';
 import { ClaudeProtocolAdapter } from './claude-adapter.js';
 import { LegacyProtocolAdapterV2Bridge } from './legacy-v2-bridge.js';
 import { OpenCodeProtocolAdapter } from './opencode-adapter.js';
-import { OpenCodeAttachedAdapter } from './opencode-attached-adapter.js';
-import { HermesProtocolAdapter } from './hermes-adapter.js';
+import {
+  OpenCodeAttachedAdapter,
+  probeOpenCodeAttachedApi,
+} from './opencode-attached-adapter.js';
+import {
+  HermesProtocolAdapter,
+  probeHermesGatewayApi,
+} from './hermes-adapter.js';
 import { CodexNativeProtocolAdapter } from './codex-native-adapter.js';
 import { PrimeAgentProtocolAdapter } from './prime-agent-adapter.js';
 import { PiAgentProtocolAdapter } from './pi-agent-adapter.js';
 
-export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
+/**
+ * External process requirement for a channel adapter. Kept beside the adapter
+ * factories so availability probes cannot drift toward terminal-only framework
+ * overrides that the channel adapter never consumes.
+ */
+export interface ChannelGatewayProbeResult {
+  available: boolean;
+  endpoint: string;
+  reason?: string;
+}
+
+export type ChannelGatewayProbe = (
+  extra: Record<string, unknown> | undefined,
+  timeoutMs?: number
+) => Promise<ChannelGatewayProbeResult>;
+
+export type ChannelAdapterLaunchRequirement =
+  | { kind: 'command'; command: string }
+  | { kind: 'gateway'; gateway: string; probe: ChannelGatewayProbe }
+  | { kind: 'embedded' };
+
+export const v2Adapters = {
   mock: () => new MockProtocolAdapterV2(),
   claude: () => new ClaudeProtocolAdapter(),
   codex: () => new CodexNativeProtocolAdapter(),
@@ -77,10 +104,48 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       // capability bit doesn't advertise a feature that can't render.
       telemetry: false,
     }),
-};
+} satisfies Record<string, () => ProtocolAdapterV2>;
+
+/**
+ * Kept exhaustive against the adapter factory keys. Adding a registered adapter
+ * without declaring how it launches is therefore a type error rather than a
+ * silently unavailable roster entry.
+ */
+const CHANNEL_ADAPTER_LAUNCH_REQUIREMENTS = {
+  mock: { kind: 'embedded' },
+  claude: { kind: 'command', command: 'claude' },
+  codex: { kind: 'command', command: 'codex' },
+  'prime-agent': { kind: 'command', command: 'prime-agent' },
+  pi: { kind: 'command', command: 'pi' },
+  opencode: { kind: 'command', command: 'opencode' },
+  'opencode-attached': {
+    kind: 'gateway',
+    gateway: 'opencode-attached',
+    probe: probeOpenCodeAttachedApi,
+  },
+  // Hermes channel sessions attach to the HTTP gateway and spawn no local CLI.
+  hermes: {
+    kind: 'gateway',
+    gateway: 'hermes',
+    probe: probeHermesGatewayApi,
+  },
+} satisfies Record<keyof typeof v2Adapters, ChannelAdapterLaunchRequirement>;
+
+export function channelAdapterLaunchRequirement(
+  providerId: string
+): ChannelAdapterLaunchRequirement | undefined {
+  return (
+    CHANNEL_ADAPTER_LAUNCH_REQUIREMENTS as Record<
+      string,
+      ChannelAdapterLaunchRequirement
+    >
+  )[providerId];
+}
 
 export function createAdapterV2(agentType: string): ProtocolAdapterV2 {
-  const factory = v2Adapters[agentType];
+  const factory = (v2Adapters as Record<string, () => ProtocolAdapterV2>)[
+    agentType
+  ];
   if (!factory)
     throw new Error(
       `No v2 protocol adapter registered for agent type: ${agentType}`

--- a/server/protocol-adapters/opencode-adapter.ts
+++ b/server/protocol-adapters/opencode-adapter.ts
@@ -11,6 +11,7 @@ import type {
 } from '../protocol-adapter.js';
 import type { ChatEvent, ChatEventSource } from '../../shared/chat-events.js';
 import { createLogger } from '../logger.js';
+import { cleanEnv } from '../utils.js';
 
 const logger = createLogger('opencode-adapter');
 const MAX_TRACKED_USER_MESSAGES = 100;
@@ -114,7 +115,7 @@ export class OpenCodeProtocolAdapter extends BaseProtocolAdapter {
       (config.extra?.['args'] as string[] | undefined) ?? defaultArgs
     ).map((arg) => arg.replace(/\{\{PORT\}\}/g, String(this._apiPort)));
 
-    const env = { ...process.env };
+    const env = { ...cleanEnv(), ...(config.processEnv ?? {}) };
     delete env['OPENCODE_SERVER_PASSWORD'];
     delete env['OPENCODE_SERVER_USERNAME'];
 

--- a/server/protocol-adapters/opencode-attached-adapter.ts
+++ b/server/protocol-adapters/opencode-attached-adapter.ts
@@ -3,6 +3,51 @@ import type { AdapterConfig, Attachment } from '../protocol-adapter.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('opencode-attached');
+const DEFAULT_OPENCODE_ATTACHED_ENDPOINT = 'http://127.0.0.1:4096';
+
+export interface OpenCodeAttachedProbeResult {
+  available: boolean;
+  endpoint: string;
+  reason?: string;
+}
+
+function resolveOpenCodeAttachedEndpoint(
+  extra: Record<string, unknown> | undefined
+): string {
+  const endpoint =
+    typeof extra?.['endpoint'] === 'string'
+      ? extra['endpoint']
+      : DEFAULT_OPENCODE_ATTACHED_ENDPOINT;
+  return endpoint.replace(/\/$/, '');
+}
+
+/** Probe the same HTTP health endpoint used when the attached adapter connects. */
+export async function probeOpenCodeAttachedApi(
+  extra: Record<string, unknown> | undefined,
+  timeoutMs = 500
+): Promise<OpenCodeAttachedProbeResult> {
+  const endpoint = resolveOpenCodeAttachedEndpoint(extra);
+  try {
+    const response = await fetch(`${endpoint}/global/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      return {
+        available: false,
+        endpoint,
+        reason: `OpenCode server health check failed at ${endpoint}: HTTP ${response.status}`,
+      };
+    }
+    return { available: true, endpoint };
+  } catch (err) {
+    const lastError = err instanceof Error ? err.message : String(err);
+    return {
+      available: false,
+      endpoint,
+      reason: `OpenCode server is not reachable at ${endpoint}. Start opencode serve or opencode web there and try again. Last error: ${lastError}`,
+    };
+  }
+}
 
 interface OpenCodeEvent {
   type: string;
@@ -18,18 +63,14 @@ interface OpenCodeEvent {
 export class OpenCodeAttachedAdapter extends AttachedRuntimeAdapter {
   readonly agentType = 'opencode';
 
-  private _endpoint = 'http://127.0.0.1:4096';
+  private _endpoint = DEFAULT_OPENCODE_ATTACHED_ENDPOINT;
   private _sseAbortController: AbortController | null = null;
   private _messageAbortController: AbortController | null = null;
   private _turnCounter = 0;
   private _currentTurnId: string | null = null;
 
   protected async onConnect(config: AdapterConfig): Promise<void> {
-    const endpoint =
-      typeof config.extra?.['endpoint'] === 'string'
-        ? config.extra['endpoint']
-        : 'http://127.0.0.1:4096';
-    this._endpoint = endpoint.replace(/\/$/, '');
+    this._endpoint = resolveOpenCodeAttachedEndpoint(config.extra);
 
     // Verify the server is reachable
     const healthRes = await fetch(`${this._endpoint}/global/health`).catch(

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1039,7 +1039,11 @@ interface SessionsHarness {
 
 function makeSessions(
   build: (agentType: string) => ProtocolAdapterV2,
-  opts: { throwOnCreate?: boolean; gate?: Promise<void> } = {}
+  opts: {
+    throwOnCreate?: boolean;
+    createError?: unknown;
+    gate?: Promise<void>;
+  } = {}
 ): SessionsHarness {
   const created = new Map<string, { runtime: ChannelAgentRuntime }>();
   const order: string[] = [];
@@ -1052,6 +1056,7 @@ function makeSessions(
       spawns++;
       lastParams = params;
       createParams.push(params);
+      if (opts.createError !== undefined) throw opts.createError;
       if (opts.throwOnCreate) throw new Error('boom: spawn failed');
       // Optional gate: park the spawn so a test can drive a close()/reorder race
       // between runtime creation being invoked and its continuation resuming.
@@ -1151,15 +1156,18 @@ const MOCK_TARGETS: MentionTarget[] = [
 function makeBinder(cfg: {
   build: (agentType: string) => ProtocolAdapterV2;
   targets: MentionTarget[];
+  mentionTargets?: () => Promise<MentionTarget[]>;
   knownProviderIds: string[];
   topicStore?: WorkspaceTopicStore | null;
   watchdogMs?: number;
   presenceSweepMs?: number;
   throwOnCreate?: boolean;
+  createError?: unknown;
   yolo?: boolean;
   gate?: Promise<void>;
   attachmentStore?: ChannelAttachmentStore;
   agentProfileStore?: AgentProfileStore | null;
+  processEnv?: NodeJS.ProcessEnv;
 }): {
   binder: ChannelAgentBinder;
   store: ChannelMessageStore;
@@ -1169,6 +1177,7 @@ function makeBinder(cfg: {
   const { store, hub } = makeStore();
   const sessions = makeSessions(cfg.build, {
     ...(cfg.throwOnCreate ? { throwOnCreate: true } : {}),
+    ...(cfg.createError !== undefined ? { createError: cfg.createError } : {}),
     ...(cfg.gate ? { gate: cfg.gate } : {}),
   });
   const binder = createChannelAgentBinder({
@@ -1181,7 +1190,7 @@ function makeBinder(cfg: {
       : {}),
     runtimes: sessions.sessions,
     knownProviderIds: cfg.knownProviderIds,
-    mentionTargets: async () => cfg.targets,
+    mentionTargets: cfg.mentionTargets ?? (async () => cfg.targets),
     port: 0,
     configDir: '/tmp',
     ...(cfg.watchdogMs !== undefined ? { watchdogMs: cfg.watchdogMs } : {}),
@@ -1189,6 +1198,7 @@ function makeBinder(cfg: {
       ? { presenceSweepMs: cfg.presenceSweepMs }
       : {}),
     ...(cfg.yolo !== undefined ? { yolo: cfg.yolo } : {}),
+    ...(cfg.processEnv !== undefined ? { processEnv: cfg.processEnv } : {}),
   });
   cleanup.push(() => binder.close());
   return { binder, store, hub, sessions };
@@ -2868,6 +2878,206 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
 });
 
 describe('channel-agent-binder — roster + availability', () => {
+  it('projects one provider launch failure onto every profile roster row', async () => {
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'prime-agent' }]);
+    profiles.create({
+      providerId: 'prime-agent',
+      displayName: 'Prime Reviewer',
+    });
+    const reason =
+      'prime-agent is not installed on this node (not found on PATH).';
+    const { binder } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: false,
+          reason,
+          command: 'prime-agent',
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+      agentProfileStore: profiles,
+    });
+
+    const roster = await binder.rosterForChannel(CH);
+    expect(roster).toHaveLength(2);
+    expect(
+      roster.every(
+        (entry) => entry.available === false && entry.reason === reason
+      )
+    ).toBe(true);
+  });
+
+  it('resolves command availability against each profile PATH', async () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-profile-bin-'));
+    fs.writeFileSync(path.join(binDir, 'prime-agent'), '#!/bin/sh\nexit 0\n', {
+      mode: 0o755,
+    });
+    const profiles = createAgentProfileStore(':memory:');
+    cleanup.push(() => profiles.close());
+    profiles.seedBuiltIns([{ id: 'prime-agent' }]);
+    const configured = profiles.create({
+      providerId: 'prime-agent',
+      displayName: 'Configured Prime',
+      envVars: { PATH: binDir },
+    });
+    const { binder } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: true,
+          reason: null,
+          command: 'prime-agent',
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+      agentProfileStore: profiles,
+      processEnv: { PATH: '' },
+    });
+
+    const roster = await binder.rosterForChannel(CH);
+    expect(
+      roster.find((entry) => entry.id === builtInAgentProfileId('prime-agent'))
+    ).toMatchObject({
+      available: false,
+      reason: 'prime-agent is not installed on this node (not found on PATH).',
+    });
+    expect(roster.find((entry) => entry.id === configured.id)).toMatchObject({
+      available: true,
+      reason: null,
+    });
+  });
+
+  it('turns a raced ENOENT spawn into an actionable system row', async () => {
+    const spawnError = Object.assign(new Error('spawn prime-agent ENOENT'), {
+      code: 'ENOENT',
+    });
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: true,
+          reason: null,
+          command: 'prime-agent',
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+      createError: spawnError,
+      processEnv: { PATH: '' },
+    });
+
+    let directError: unknown;
+    try {
+      await binder.ensureBinding(CH, 'prime-agent');
+    } catch (error) {
+      directError = error;
+    }
+    expect(directError).toBeInstanceOf(Error);
+    expect((directError as Error).message).toContain(
+      'configured command "prime-agent" is not available on this node'
+    );
+    expect((directError as Error).message).not.toContain('ENOENT');
+
+    post(store, binder, '@prime-agent go', ['prime-agent']);
+    await waitFor(() => systemRows(store).length > 0);
+
+    const text = systemRows(store).at(-1)!.body.text;
+    expect(text).toContain(
+      'prime-agent is not installed on this node (not found on PATH)'
+    );
+    expect(text).not.toContain('ENOENT');
+    expect(text).not.toContain('spawn prime-agent');
+  });
+
+  it('does not misdiagnose an ENOENT from a missing working directory as a missing command', async () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-cwd-bin-'));
+    fs.writeFileSync(path.join(binDir, 'prime-agent'), '#!/bin/sh\nexit 0\n', {
+      mode: 0o755,
+    });
+    const spawnError = Object.assign(new Error('spawn prime-agent ENOENT'), {
+      code: 'ENOENT',
+    });
+    const { binder } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: true,
+          reason: null,
+          command: 'prime-agent',
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+      createError: spawnError,
+      processEnv: { PATH: binDir },
+    });
+
+    let error: unknown;
+    try {
+      await binder.ensureBinding(CH, 'prime-agent');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'The command "prime-agent" is installed; verify the channel repo/worktree path'
+    );
+    expect((error as Error).message).not.toContain(
+      'configured command "prime-agent" is not available'
+    );
+  });
+
+  it('discards an in-flight target probe when shutdown invalidates its generation', async () => {
+    const stale: MentionTarget[] = [
+      {
+        id: 'stale',
+        displayName: 'Stale',
+        kind: 'framework',
+        available: true,
+        reason: null,
+      },
+    ];
+    let resolveFirst: ((targets: MentionTarget[]) => void) | undefined;
+    let calls = 0;
+    const { binder } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: [],
+      mentionTargets: () => {
+        calls += 1;
+        if (calls === 1) {
+          return new Promise<MentionTarget[]>((resolve) => {
+            resolveFirst = resolve;
+          });
+        }
+        throw new Error('closed binder must not start a fresh target probe');
+      },
+      knownProviderIds: ['stale'],
+    });
+
+    const firstRoster = binder.rosterForChannel(CH);
+    const joinedRoster = binder.rosterForChannel(CH);
+    await waitFor(() => calls === 1);
+    binder.close();
+    resolveFirst?.(stale);
+
+    await expect(firstRoster).resolves.toEqual([]);
+    await expect(joinedRoster).resolves.toEqual([]);
+    expect(calls).toBe(1);
+  });
+
   it('includes the default profile for an unseeded target provider without duplicating stored providers', async () => {
     const profiles = createAgentProfileStore(':memory:');
     cleanup.push(() => profiles.close());

--- a/test/framework-availability.test.ts
+++ b/test/framework-availability.test.ts
@@ -4,10 +4,15 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   getFrameworkAvailability,
+  getFrameworkChannelAvailability,
   getFrameworkClientInfo,
   resolveExecutablePath,
 } from '../server/frameworks.js';
 import type { AgentFramework } from '../server/types.js';
+import {
+  channelAdapterLaunchRequirement,
+  v2Adapters,
+} from '../server/protocol-adapters/index.js';
 
 function framework(command: string, id = command): AgentFramework {
   return {
@@ -26,6 +31,12 @@ function framework(command: string, id = command): AgentFramework {
       supportsAttachedRuntime: false,
     },
   };
+}
+
+function channelFramework(command: string, id = command): AgentFramework {
+  const result = framework(command, id);
+  result.capabilities.supportsChannelAgents = true;
+  return result;
 }
 
 describe('framework CLI availability', () => {
@@ -72,5 +83,115 @@ describe('framework CLI availability', () => {
         },
       }
     );
+  });
+
+  it('marks a channel provider unavailable when its actual adapter command is missing', async () => {
+    const result = await getFrameworkChannelAvailability(
+      channelFramework('terminal-only-command', 'prime-agent'),
+      { PATH: '' }
+    );
+
+    expect(result).toEqual({
+      available: false,
+      reason: 'prime-agent is not installed on this node (not found on PATH).',
+      command: 'prime-agent',
+    });
+  });
+
+  it('ignores terminal command overrides that the channel adapter does not consume', async () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-override-bin-')
+    );
+    const overridePath = path.join(tmpDir, 'override-agent');
+    fs.writeFileSync(overridePath, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const prime = channelFramework('prime-agent', 'prime-agent');
+    prime.commandOverride = 'override-agent';
+
+    await expect(
+      getFrameworkChannelAvailability(prime, { PATH: tmpDir })
+    ).resolves.toEqual({
+      available: false,
+      reason: 'prime-agent is not installed on this node (not found on PATH).',
+      command: 'prime-agent',
+    });
+  });
+
+  it('marks a channel provider available when its actual adapter command resolves', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-channel-bin-'));
+    const cliPath = path.join(tmpDir, 'prime-agent');
+    fs.writeFileSync(cliPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    await expect(
+      getFrameworkChannelAvailability(
+        channelFramework('terminal-only-command', 'prime-agent'),
+        { PATH: tmpDir }
+      )
+    ).resolves.toEqual({ available: true, command: 'prime-agent' });
+  });
+
+  it('declares a launch requirement for every registered channel adapter', () => {
+    expect(
+      Object.keys(v2Adapters).filter(
+        (providerId) => !channelAdapterLaunchRequirement(providerId)
+      )
+    ).toEqual([]);
+  });
+
+  it('probes the attached OpenCode HTTP runtime without requiring a local CLI', async () => {
+    const attached = channelFramework(
+      'terminal-only-opencode-command',
+      'opencode-attached'
+    );
+    const probes: Array<{ extra?: Record<string, unknown>; timeout?: number }> =
+      [];
+
+    await expect(
+      getFrameworkChannelAvailability(
+        attached,
+        { PATH: '' },
+        {
+          gatewayProbeOverrides: {
+            'opencode-attached': async (extra, timeout) => {
+              probes.push({ ...(extra ? { extra } : {}), timeout });
+              return { available: true, endpoint: 'http://127.0.0.1:4096' };
+            },
+          },
+        }
+      )
+    ).resolves.toEqual({
+      available: true,
+      endpoint: 'http://127.0.0.1:4096',
+    });
+    expect(probes).toEqual([{ timeout: 500 }]);
+  });
+
+  it('probes the Hermes HTTP gateway without requiring a local Hermes CLI', async () => {
+    const hermes = channelFramework('hermes', 'hermes');
+    const probes: Array<{ endpoint?: string; timeout?: number }> = [];
+
+    await expect(
+      getFrameworkChannelAvailability(
+        hermes,
+        { PATH: '' },
+        {
+          gatewayProbeOverrides: {
+            hermes: async (extra, timeout) => {
+              probes.push({
+                endpoint:
+                  typeof extra?.['endpoint'] === 'string'
+                    ? extra['endpoint']
+                    : undefined,
+                timeout,
+              });
+              return { available: true, endpoint: 'http://127.0.0.1:8642' };
+            },
+          },
+        }
+      )
+    ).resolves.toEqual({
+      available: true,
+      endpoint: 'http://127.0.0.1:8642',
+    });
+    expect(probes).toEqual([{ endpoint: undefined, timeout: 500 }]);
   });
 });

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -103,7 +103,10 @@ class StubCodexClient extends EventEmitter {
   }
 }
 
-type StubFactory = CodexClientFactory & { lastClient: StubCodexClient };
+type StubFactory = CodexClientFactory & {
+  lastClient: StubCodexClient;
+  lastOptions?: CodexAppServerClientOptions;
+};
 
 /**
  * Returns a factory that always hands out the same pre-built stub.
@@ -113,7 +116,8 @@ type StubFactory = CodexClientFactory & { lastClient: StubCodexClient };
 function makeStubFactory(): StubFactory {
   const stub = new StubCodexClient();
   let callCount = 0;
-  const factory: StubFactory = (_opts) => {
+  const factory: StubFactory = (opts) => {
+    factory.lastOptions = opts;
     // On second call (resume creates a new client), return a fresh stub
     // but update lastClient so tests can still access it.
     if (callCount++ > 0) {
@@ -260,6 +264,25 @@ describe('CodexNativeProtocolAdapter — connect', () => {
       ])
     );
 
+    await adapter.disconnect();
+  });
+
+  it('passes profile process env to the app-server subprocess', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-env' },
+    });
+
+    await adapter.connect({
+      ...config,
+      processEnv: { PATH: '/profile/bin', RELAY_PROFILE_TEST: 'yes' },
+    });
+
+    expect(factory.lastOptions?.env).toMatchObject({
+      PATH: '/profile/bin',
+      RELAY_PROFILE_TEST: 'yes',
+    });
     await adapter.disconnect();
   });
 

--- a/test/server/protocol-adapters/opencode-adapter.test.ts
+++ b/test/server/protocol-adapters/opencode-adapter.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
 import { OpenCodeProtocolAdapter } from '../../../server/protocol-adapters/opencode-adapter.js';
-import { OpenCodeAttachedAdapter } from '../../../server/protocol-adapters/opencode-attached-adapter.js';
+import {
+  OpenCodeAttachedAdapter,
+  probeOpenCodeAttachedApi,
+} from '../../../server/protocol-adapters/opencode-attached-adapter.js';
 import { mapChatEventToAgentPatchV2 } from '../../../shared/agent-chat-v1-compat.js';
 import type { ChatEvent } from '../../../shared/agent-chat-protocol.js';
 
@@ -44,6 +47,24 @@ describe('OpenCode V2 web adapter registration', () => {
     });
   });
 
+  it('probes the attached adapter default HTTP health endpoint', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    try {
+      await expect(probeOpenCodeAttachedApi(undefined, 125)).resolves.toEqual({
+        available: true,
+        endpoint: 'http://127.0.0.1:4096',
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:4096/global/health',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it('registers opencode-attached as a ProtocolAdapterV2 bridge', () => {
     const adapter = createAdapterV2('opencode-attached');
 
@@ -72,9 +93,7 @@ describe('OpenCode streaming capability is backed by real deltas', () => {
     expect(delta).toMatchObject({ type: 'chat:text-delta', delta: 'hel' });
 
     const patches = mapChatEventToAgentPatchV2(delta!);
-    expect(patches.map((patch) => patch.type)).toContain(
-      'agent-item-delta-v2'
-    );
+    expect(patches.map((patch) => patch.type)).toContain('agent-item-delta-v2');
   });
 
   it('fires chat:text-delta from the attached adapter and maps it to a V2 delta patch', () => {
@@ -88,8 +107,6 @@ describe('OpenCode streaming capability is backed by real deltas', () => {
     expect(delta).toMatchObject({ type: 'chat:text-delta', delta: 'lo world' });
 
     const patches = mapChatEventToAgentPatchV2(delta!);
-    expect(patches.map((patch) => patch.type)).toContain(
-      'agent-item-delta-v2'
-    );
+    expect(patches.map((patch) => patch.type)).toContain('agent-item-delta-v2');
   });
 });


### PR DESCRIPTION
## What
- preflight every channel-agent profile against the runtime it actually launches
- resolve command availability with each profile's effective `PATH`
- model Hermes and OpenCode-attached as HTTP gateway runtimes instead of local CLIs
- replace raw `ENOENT` output with node-aware install/config or repo-routing guidance
- make availability cache invalidation generation-safe and single-flight

## Why
Unavailable gallery/profile entries remained mentionable and failed as raw `spawn ... ENOENT`. Provider-wide checks also disagreed with profile-specific environments and HTTP-attached adapters.

## Checklist
- [x] Roster/palette availability uses the actual channel adapter requirement
- [x] Profile `PATH` overrides are honored by both probes and spawned adapters
- [x] Missing command is distinguished from a missing repo/worktree `cwd`
- [x] Gateway-only providers do not require a local binary
- [x] Registered adapter requirements are compile-time exhaustive
- [x] Adversarial review completed with all findings resolved
- [x] No install source or provider-specific policy was invented

## Verification
- 209 focused tests passed across availability, binder, Codex env propagation, and OpenCode gateway coverage
- `npm run check` — 0 errors (227 baseline warnings)
- `npm run build` — passed (existing chunk-size warnings only)
- adversarial re-review of `ee16e745` — no findings; safe to PR

Closes #1357
