### PR TITLE
fix(channels): keep mention context text-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ workflow.
 
 #### Fixed
 
+- Channel mention packets now exclude blank tool, reasoning, status, and system
+  activity rows, report shown/filtered counts, and use a smaller prose window
+  so real conversation is not displaced by empty activity (#1358)
 - Designate-orchestrator failures now show actionable inline conflict or retry
   feedback instead of failing silently (#1352)
 - Long channel drafts now grow to a conversation-pane-relative cap instead of

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -11,7 +11,6 @@ import {
 } from './channel-context-packet.js';
 import type { ChannelAttachmentStore } from './channel-attachments.js';
 import {
-  CHANNEL_HISTORY_MAX_LIMIT,
   type ChannelBinding,
   type ChannelMessageStore,
 } from './channel-message-store.js';
@@ -120,11 +119,6 @@ export const MAX_CONSECUTIVE_AGENT_TURNS = 4;
 const UNAVAILABLE_ROW_TTL_MS = 5 * 60 * 1000;
 /** How long a resolved framework-availability list is reused before re-probing. */
 const TARGETS_TTL_MS = 5 * 1000;
-/** Newest rows fetched before the trigger to build a packet (packet caps to N). */
-const PACKET_FETCH_WINDOW = Math.min(
-  PACKET_MAX_ROWS * 3,
-  CHANNEL_HISTORY_MAX_LIMIT
-);
 
 // ── public types ─────────────────────────────────────────────────────────────
 
@@ -1496,35 +1490,26 @@ export function createChannelAgentBinder(
       typeof row?.providerSession['lastDeliveredSeq'] === 'number'
         ? (row.providerSession['lastDeliveredSeq'] as number)
         : 0;
-    let rows: ChannelMessage[];
-    if (trigger.threadId !== null) {
-      rows = store.threadHistory(binding.channelId, trigger.threadId, {
-        beforeSeq: trigger.seq,
-        limit: PACKET_FETCH_WINDOW,
-      });
-      // A bounded newest-first page may omit the load-bearing root. Reinsert it
-      // through the existing point-read lane; the builder preserves it through
-      // row and byte trimming.
-      const root = store.getMessage(trigger.threadId);
-      if (root) rows.push(root);
-      rows = [...new Map(rows.map((message) => [message.id, message])).values()]
-        .filter((message) => message.seq < trigger.seq)
-        .sort((a, b) => a.seq - b.seq);
-    } else {
-      rows = store
-        .history(binding.channelId, {
-          beforeSeq: trigger.seq,
-          limit: PACKET_FETCH_WINDOW,
-        })
-        .filter((r) => r.seq < trigger.seq);
-    }
+    const context = store.mentionContext({
+      channelId: binding.channelId,
+      framework: binding.framework,
+      triggerSeq: trigger.seq,
+      afterSeq: lastDeliveredSeq,
+      threadRootId: trigger.threadId,
+      limit: PACKET_MAX_ROWS,
+    });
     return resolveMentionContextPacket(
       buildMentionContextPacketEnvelope({
         channelTitle: title,
         framework: binding.framework,
-        rows,
+        rows: context.rows,
         trigger,
         lastDeliveredSeq,
+        summary: {
+          totalCount: context.totalCount,
+          activityFilteredCount: context.activityFilteredCount,
+          scope: context.scope,
+        },
       }),
       deps.attachmentStore
     );
@@ -1535,7 +1520,7 @@ export function createChannelAgentBinder(
     if (!adapter) return;
     const turnId = channelTurnId(trigger.id, binding.profileActorId);
     // Build the packet BEFORE mutating any binding state: buildPacket does
-    // synchronous SQLite work (getBinding/history) that can throw. If it did so
+    // synchronous SQLite work (getBinding/mentionContext) that can throw. If it did so
     // AFTER activeTurnId was set (and before the watchdog armed), the binding
     // wedged 'turn-active' forever with no in-flight turn — the queue filled and
     // every later mention dropped. On a throw we surface a row and keep draining.

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -14,12 +14,12 @@ import type { Attachment } from './protocol-adapter-v2.js';
 // deterministic string shape (§4 of the spec). It never touches the network, the
 // store, or the adapter, so the golden test pins the exact bytes an agent sees.
 
-/** Newest N context rows retained; older eligible rows collapse to one marker. */
-export const PACKET_MAX_ROWS = 20;
+/** Newest N text context rows retained; older eligible rows collapse to one marker. */
+export const PACKET_MAX_ROWS = 16;
 /** Per-row body cap before the ellipsis marker (token frugality). */
 export const PACKET_ROW_MAX_CHARS = 2000;
 /** Whole-packet byte budget — oldest context rows drop until under (never the trigger). */
-export const PACKET_MAX_BYTES = 24 * 1024;
+export const PACKET_MAX_BYTES = 16 * 1024;
 /** Provider turns receive at most four images, regardless of retained row count. */
 export const PACKET_IMAGE_MAX_COUNT = 4;
 /** General raw-image ceiling bounds synchronous adapter encoding work. */
@@ -53,6 +53,8 @@ const ROW_TRUNCATED_SUFFIX = '…[truncated]';
  * that reads like an empty message.
  */
 const DELETED_ROW_MARKER = '[message deleted]';
+const IMAGE_ONLY_ROW_MARKER = '[image-only message]';
+const NON_TEXT_ROW_MARKER = '[non-text message]';
 const THREAD_SCOPE_MARKER =
   '[Thread scope — only this thread is shown; its root message is always included]';
 
@@ -62,7 +64,9 @@ export interface BuildMentionContextPacketInput {
   /** Framework id the packet is addressed to (`you are @<framework>`). */
   framework: string;
   /**
-   * Eligible prior rows, oldest-first. For a channel trigger this is every row
+   * Prior channel rows, oldest-first; only non-empty human/agent prose is eligible,
+   * except that a canonical thread root is always retained structurally. For a
+   * channel trigger this is every row
    * with `lastDeliveredSeq < seq < trigger.seq`. For a threaded trigger this is
    * the thread root plus prior replies; the channel delivery cursor is ignored.
    * The agent's own prior rows are skipped HERE (they already live in the reused
@@ -73,6 +77,15 @@ export interface BuildMentionContextPacketInput {
   trigger: ChannelMessage;
   /** Cursor: 0 for a first-ever mention (cold session → full orientation window). */
   lastDeliveredSeq: number;
+  /**
+   * Exact precomputed counts when the binder paginates a larger raw history.
+   * Unit callers may omit this and let the pure builder derive counts from rows.
+   */
+  summary?: {
+    totalCount: number;
+    activityFilteredCount: number;
+    scope: 'channel' | 'thread';
+  };
 }
 
 /** Stable packet result retained across adapter retry/rebind. */
@@ -127,12 +140,16 @@ function triggerAttribution(message: ChannelMessage): string {
 
 /** Render one row as `label: text`, agent-tagged, with multi-line bodies indented. */
 function renderRow(message: ChannelMessage): string {
-  // A tombstone reaching this point is a retained thread root; its body is
-  // already empty in the store, so the marker is what stands in for it. Every
-  // other deleted row was filtered out before assembly.
+  // Non-prose rows reaching this point are canonical thread roots. Render a
+  // truthful non-empty structural marker while their attachment refs continue
+  // through the envelope's image lane.
   const source = isChannelMessageDeleted(message)
     ? DELETED_ROW_MARKER
-    : message.body.text;
+    : message.body.text.trim().length > 0
+      ? message.body.text
+      : (message.parts?.length ?? 0) > 0
+        ? IMAGE_ONLY_ROW_MARKER
+        : NON_TEXT_ROW_MARKER;
   const truncated =
     source.length > PACKET_ROW_MAX_CHARS
       ? source.slice(0, PACKET_ROW_MAX_CHARS) + ROW_TRUNCATED_SUFFIX
@@ -155,12 +172,32 @@ function renderRow(message: ChannelMessage): string {
   return indentRest(`${label}: ${first}`);
 }
 
+/** Whether a durable row is human/agent prose suitable for agent context. */
+export function isMentionContextProseRow(row: ChannelMessage): boolean {
+  return (
+    row.kind === 'message' &&
+    (row.sender.kind === 'human' || row.sender.kind === 'agent') &&
+    row.agentDetail === undefined &&
+    !isChannelMessageDeleted(row) &&
+    row.body.text.trim().length > 0
+  );
+}
+
+/** Provider conversation rows already retained by the receiving agent. */
+export function isOwnMentionContextRow(
+  row: ChannelMessage,
+  framework: string
+): boolean {
+  return row.sender.kind === 'agent' && row.sender.providerId === framework;
+}
+
 /**
  * Build the deterministic context packet delivered as the agent's turn content.
  *
  * Shape (§4):
  *   [Relay channel #<title> — you are @<framework>, one participant in a multi-party chat]
- *   Recent messages, oldest first. Lines are "sender: text"; ...        (only with context)
+ *   N messages since your last turn (M shown, K activity rows filtered).
+ *   Recent text messages, oldest first. Lines are "sender: text"; ...   (only with context)
  *   […earlier messages omitted]                                          (only when >N eligible)
  *   <sender>: <text>
  *   ...
@@ -177,31 +214,37 @@ export function buildMentionContextPacketEnvelope(
   const header = `[Relay channel #${input.channelTitle} — you are @${input.framework}, one participant in a multi-party chat]`;
   const threadRootId = input.trigger.threadId;
 
-  // Eligible = rows strictly after the delivery cursor and strictly before the
-  // trigger, minus the agent's OWN prior rows (already in its reused provider
-  // conversation — re-sending wastes tokens and confuses attribution). A reused
-  // session with no interim rows therefore yields an empty window → header +
-  // footer only; a first-ever mention (cursor 0) yields the full orientation
-  // window.
-  const isOwnAgentRow = (row: ChannelMessage): boolean =>
-    row.sender.kind === 'agent' && row.sender.providerId === input.framework;
-  const eligible = input.rows.filter((row) => {
+  // Candidate rows are strictly after the delivery cursor and before the
+  // trigger, minus the agent's OWN prior prose (already retained by the reused
+  // provider conversation). Detail/activity rows are counted, then filtered,
+  // so the delivery summary is truthful without spending packet rows on blank
+  // tool/thought/status shells (#1358).
+  const candidates = input.rows.filter((row) => {
     if (row.seq >= input.trigger.seq) return false;
     if (threadRootId !== null) {
       const isRoot = row.id === threadRootId;
       if (!isRoot && row.threadId !== threadRootId) return false;
-      // A deleted row carries nothing an agent can act on, so it is dropped —
-      // except a thread root, which is structural and is retained as
-      // `DELETED_ROW_MARKER` instead (#1308 slice 1 item 4).
-      if (isChannelMessageDeleted(row)) return isRoot;
-      return isRoot || !isOwnAgentRow(row);
+      return isRoot || !isOwnMentionContextRow(row, input.framework);
     }
-    if (isChannelMessageDeleted(row)) return false;
-    return row.seq > input.lastDeliveredSeq && !isOwnAgentRow(row);
+    return (
+      row.seq > input.lastDeliveredSeq &&
+      !isOwnMentionContextRow(row, input.framework)
+    );
   });
+  const eligible = candidates.filter((row) => {
+    const isRoot = threadRootId !== null && row.id === threadRootId;
+    // Every canonical thread root is structural, including deleted, image-only,
+    // or otherwise non-text roots. Ordinary blank/activity replies still drop.
+    if (isRoot) return true;
+    return isMentionContextProseRow(row);
+  });
+  const activityFilteredCount =
+    input.summary?.activityFilteredCount ?? candidates.length - eligible.length;
+  const contextTotalCount = input.summary?.totalCount ?? candidates.length;
 
   let contextRows: ChannelMessage[];
-  let omittedEarlier = false;
+  let omittedEarlier =
+    contextTotalCount - activityFilteredCount > eligible.length;
   if (threadRootId !== null) {
     const root = eligible.find((row) => row.id === threadRootId);
     if (!root) {
@@ -234,13 +277,19 @@ export function buildMentionContextPacketEnvelope(
   ].join('\n');
 
   const assemble = (rows: ChannelMessage[], omitted: boolean): string => {
+    const summary =
+      (input.summary?.scope ??
+        (threadRootId === null ? 'channel' : 'thread')) === 'thread'
+        ? `${contextTotalCount} prior thread rows (${rows.length} shown, ${activityFilteredCount} activity rows filtered).`
+        : `${contextTotalCount} messages since your last turn (${rows.length} shown, ${activityFilteredCount} activity rows filtered).`;
     const scopeLines = threadRootId !== null ? [THREAD_SCOPE_MARKER] : [];
     if (rows.length === 0) {
-      return [header, ...scopeLines, '', footer].join('\n');
+      return [header, summary, ...scopeLines, '', footer].join('\n');
     }
     const contextBlock = [
+      summary,
       ...scopeLines,
-      'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+      'Recent text messages, oldest first. Lines are "sender: text"; agents tagged [agent].',
       ...(threadRootId !== null && omitted
         ? [renderRow(rows[0]!), OMITTED_MARKER, ...rows.slice(1).map(renderRow)]
         : [...(omitted ? [OMITTED_MARKER] : []), ...rows.map(renderRow)]),

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -118,6 +118,119 @@ export function buildChannelThreadHistorySql(
            ORDER BY m.seq ${order} LIMIT @limit`;
 }
 
+export type ChannelMentionContextScope = 'channel' | 'thread';
+
+/**
+ * Exact summary + bounded-row query used by mention delivery (#1358).
+ *
+ * Both builders deliberately share the same candidate/eligibility predicates.
+ * The count query sees the entire seq range, while the rows query sorts that
+ * range newest-first before LIMIT. Thus a million activity rows cost no JS
+ * allocations and cannot evict older prose from the packet window.
+ */
+function mentionContextCandidateSql(scope: ChannelMentionContextScope): string {
+  if (scope === 'thread') {
+    return `(
+      SELECT root.*
+        FROM channel_messages root
+       WHERE root.id = @threadRootId
+         AND root.channel_id = @channelId
+         AND root.seq < @triggerSeq
+      UNION ALL
+      SELECT reply.*
+        FROM channel_messages reply
+       WHERE reply.thread_id = @threadRootId
+         AND reply.channel_id = @channelId
+         AND reply.seq < @triggerSeq
+    )`;
+  }
+  return `(SELECT channel_row.*
+             FROM channel_messages channel_row
+            WHERE channel_row.channel_id = @channelId
+              AND channel_row.seq > @afterSeq
+              AND channel_row.seq < @triggerSeq)`;
+}
+
+function mentionContextOwnRowSql(
+  scope: ChannelMentionContextScope,
+  alias = 'm'
+): string {
+  const rootException =
+    scope === 'thread' ? `${alias}.id = @threadRootId OR ` : '';
+  return `(${rootException}NOT (
+    ${alias}.sender_kind = 'agent'
+    AND COALESCE(json_extract(${alias}.meta_json, '$.providerId'), '') = @framework
+  ))`;
+}
+
+function mentionContextEligibleSql(
+  scope: ChannelMentionContextScope,
+  alias = 'm'
+): string {
+  const structuralRoot =
+    scope === 'thread' ? `${alias}.id = @threadRootId OR ` : '';
+  return `(${structuralRoot}(
+    ${alias}.kind = 'message'
+    AND ${alias}.sender_kind IN ('human', 'agent')
+    AND json_extract(${alias}.meta_json, '$.agentDetail') IS NULL
+    AND json_extract(${alias}.meta_json, '$.${CHANNEL_DELETED_AT_META_KEY}') IS NULL
+    AND length(trim(${alias}.body_text, char(9) || char(10) || char(11) || char(12) || char(13) || char(32) || char(160) || char(5760) || char(8192) || char(8193) || char(8194) || char(8195) || char(8196) || char(8197) || char(8198) || char(8199) || char(8200) || char(8201) || char(8202) || char(8232) || char(8233) || char(8239) || char(8287) || char(12288) || char(65279))) > 0
+  ))`;
+}
+
+/** Production SQL exported so tests can lock the range-index query plan. */
+export function buildChannelMentionContextCountSql(
+  scope: ChannelMentionContextScope
+): string {
+  const eligible = mentionContextEligibleSql(scope);
+  return `SELECT COUNT(*) AS total_count,
+                 COALESCE(SUM(CASE WHEN ${eligible} THEN 0 ELSE 1 END), 0)
+                   AS activity_filtered_count
+            FROM ${mentionContextCandidateSql(scope)} m
+           WHERE ${mentionContextOwnRowSql(scope)}`;
+}
+
+/** Production SQL returning at most the packet's requested prose-row budget. */
+export function buildChannelMentionContextRowsSql(
+  scope: ChannelMentionContextScope
+): string {
+  if (scope === 'channel') {
+    // Keep this a plain descending range read. The caller reverses sixteen rows
+    // in JS; asking SQLite for ascending output through an outer query adds a
+    // temp sort to the hot path for no benefit.
+    return `SELECT m.*
+              FROM channel_messages m
+             WHERE m.channel_id = @channelId
+               AND m.seq > @afterSeq
+               AND m.seq < @triggerSeq
+               AND ${mentionContextOwnRowSql('channel')}
+               AND ${mentionContextEligibleSql('channel')}
+             ORDER BY m.seq DESC
+             LIMIT @limit`;
+  }
+  // The canonical root is structural regardless of its body/kind. Replies use
+  // the ordinary prose predicate and their own PACKET_MAX_ROWS-1 limit, so the
+  // root cannot be displaced by a long or activity-heavy thread.
+  return `SELECT root.*
+            FROM channel_messages root
+           WHERE root.id = @threadRootId
+             AND root.channel_id = @channelId
+             AND root.seq < @triggerSeq
+           UNION ALL
+          SELECT newest_reply.*
+            FROM (
+              SELECT reply.*
+                FROM channel_messages reply
+               WHERE reply.thread_id = @threadRootId
+                 AND reply.channel_id = @channelId
+                 AND reply.seq < @triggerSeq
+                 AND ${mentionContextOwnRowSql('channel', 'reply')}
+                 AND ${mentionContextEligibleSql('channel', 'reply')}
+               ORDER BY reply.seq DESC
+               LIMIT @replyLimit
+            ) newest_reply`;
+}
+
 /**
  * Production query builder for the channel-list thread aggregate (#1287 slice 5
  * item 18), exported for the same reason `buildChannelThreadHistorySql` is: this
@@ -305,10 +418,7 @@ export function channelSearchPrefixRange(
   const last = terms[terms.length - 1];
   if (last === undefined) return null;
   if ([...last].length < CHANNEL_SEARCH_MIN_QUERY_CHARS) return null;
-  const folded = last
-    .normalize('NFD')
-    .replace(/\p{M}/gu, '')
-    .toLowerCase();
+  const folded = last.normalize('NFD').replace(/\p{M}/gu, '').toLowerCase();
   const tokens = folded.split(/[^\p{L}\p{N}]+/u).filter((part) => part !== '');
   const low = tokens[tokens.length - 1];
   if (low === undefined) return null;
@@ -876,6 +986,25 @@ export interface ChannelHistoryFilter {
   threadId?: string;
 }
 
+export interface ChannelMentionContextQuery {
+  channelId: string;
+  framework: string;
+  triggerSeq: number;
+  /** Channel delivery cursor; ignored for thread scope. */
+  afterSeq: number;
+  /** Canonical root id for thread scope, otherwise null. */
+  threadRootId: string | null;
+  /** Total retained row budget, including a structural thread root. */
+  limit: number;
+}
+
+export interface ChannelMentionContextResult {
+  rows: ChannelMessage[];
+  totalCount: number;
+  activityFilteredCount: number;
+  scope: ChannelMentionContextScope;
+}
+
 export interface ChannelMessageSearchQuery {
   /** Raw operator text; normalized into an FTS5 expression by the store. */
   query: string;
@@ -992,6 +1121,13 @@ export interface ChannelMessageStore {
     clientMessageId: string
   ): ChannelMessage | null;
   history(channelId: string, filter?: ChannelHistoryFilter): ChannelMessage[];
+  /**
+   * Exact mention-delivery summary plus newest bounded prose rows. Filtering,
+   * counting, and LIMIT all happen in SQLite; callers must not page JS history.
+   */
+  mentionContext(
+    input: ChannelMentionContextQuery
+  ): ChannelMentionContextResult;
   /**
    * Ranked full-text search over durable message bodies (#1308 slice 2 item 1).
    *
@@ -2367,6 +2503,16 @@ export function createChannelMessageStore(
       WHERE m.channel_id = @channelId AND m.sender_id = @senderId
         AND m.client_message_id = @clientMessageId`
   );
+  const mentionContextStatements = {
+    channel: {
+      count: db.prepare(buildChannelMentionContextCountSql('channel')),
+      rows: db.prepare(buildChannelMentionContextRowsSql('channel')),
+    },
+    thread: {
+      count: db.prepare(buildChannelMentionContextCountSql('thread')),
+      rows: db.prepare(buildChannelMentionContextRowsSql('thread')),
+    },
+  } as const;
 
   // Single atomic INSERT: seq is allocated inside the same statement via
   // SELECT COALESCE(MAX(seq),0)+1. SQLite takes the write lock for the whole
@@ -2919,6 +3065,34 @@ export function createChannelMessageStore(
         )
         .all(params) as ChannelMessageRow[];
       return rows.reverse().map(rowToMessage);
+    },
+
+    mentionContext(input) {
+      const scope: ChannelMentionContextScope =
+        input.threadRootId === null ? 'channel' : 'thread';
+      const limit = cleanLimit(input.limit);
+      const params = {
+        channelId: input.channelId,
+        framework: input.framework,
+        triggerSeq: input.triggerSeq,
+        afterSeq: input.afterSeq,
+        threadRootId: input.threadRootId,
+        limit,
+        replyLimit: Math.max(0, limit - 1),
+      };
+      const statements = mentionContextStatements[scope];
+      const count = statements.count.get(params) as {
+        total_count: number;
+        activity_filtered_count: number;
+      };
+      const rows = statements.rows.all(params) as ChannelMessageRow[];
+      rows.sort((left, right) => left.seq - right.seq);
+      return {
+        rows: rows.map(rowToMessage),
+        totalCount: count.total_count,
+        activityFilteredCount: count.activity_filtered_count,
+        scope,
+      };
     },
 
     searchMessages(input) {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -31,10 +31,12 @@ import {
   type AgentProfileStore,
 } from '../server/agent-profile-store.js';
 import {
+  CHANNEL_HISTORY_MAX_LIMIT,
   createChannelMessageStore,
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import { createChannelHub, type ChannelHub } from '../server/channel-hub.js';
+import { PACKET_MAX_ROWS } from '../server/channel-context-packet.js';
 import type { ChannelAttachmentStore } from '../server/channel-attachments.js';
 import {
   CHANNEL_BINDING_YOLO_DEFAULT,
@@ -2491,6 +2493,168 @@ describe('channel-agent-binder — delivery + idempotency', () => {
     expect(adapter.sendInputs[1]).toEqual(adapter.sendInputs[0]);
   });
 
+  it('retains an image-only thread root as structural text and an attachment', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'binder-image-root-'));
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const payloadPath = path.join(dir, 'root.png');
+    fs.writeFileSync(payloadPath, Buffer.from('fixture'));
+    const part: ChannelImagePart = {
+      type: 'image',
+      id: 'cha:image-root',
+      mime: 'image/png',
+      w: 1,
+      h: 1,
+      bytes: 7,
+    };
+    const attachmentStore = {
+      get: (id: string) =>
+        id === part.id
+          ? {
+              part,
+              sha256: 'image-root',
+              payloadPath,
+              createdAt: 't',
+            }
+          : null,
+    } as ChannelAttachmentStore;
+    const { binder, store, sessions } = makeBinder({
+      build: () => new ScriptedAdapter('mock', { mode: 'reply', text: 'ok' }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      attachmentStore,
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: '',
+      parts: [part],
+    });
+
+    post(
+      store,
+      binder,
+      '@mock inspect the root image',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ScriptedAdapter;
+    await waitFor(() => adapter.sendInputs.length === 1);
+    expect(adapter.sendInputs[0]!.content).toContain(
+      '1 prior thread rows (1 shown, 0 activity rows filtered).'
+    );
+    expect(adapter.sendInputs[0]!.content).toContain(
+      'operator: [image-only message]'
+    );
+    expect(adapter.sendInputs[0]!.attachments).toEqual([
+      { type: 'image', path: payloadPath, mimeType: 'image/png' },
+    ]);
+  });
+
+  it('queries exact counts across a large activity-only stretch without losing older prose', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new ScriptedAdapter('mock', { mode: 'reply', text: 'ok' }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'retain this earlier prose',
+    });
+    for (let index = 0; index < CHANNEL_HISTORY_MAX_LIMIT + 5; index += 1) {
+      const detail = store.beginStream({
+        channelId: CH,
+        sender: {
+          kind: 'agent',
+          id: 'agent:other',
+          providerId: 'other',
+        },
+        source: {
+          runtimeId: 'runtime:other',
+          turnId: `turn:${index}`,
+          itemId: `thought:${index}`,
+        },
+        agentDetail: {
+          itemId: `thought:${index}`,
+          card: {
+            kind: 'thought',
+            title: 'Reasoning summary',
+            status: 'running',
+            content: 'activity must not consume prose context',
+          },
+        },
+      });
+      store.finalizeStream(detail.id, { text: '', status: 'complete' });
+    }
+
+    post(store, binder, '@mock inspect the earlier prose', ['mock']);
+    await waitFor(() => agentReplies(store, 'mock').length === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ScriptedAdapter;
+    await waitFor(() => adapter.sendInputs.length === 1);
+    const packet = adapter.sendInputs[0]!.content;
+    expect(packet).toContain('operator: retain this earlier prose');
+    expect(packet).toContain(
+      `${CHANNEL_HISTORY_MAX_LIMIT + 6} messages since your last turn (1 shown, ${CHANNEL_HISTORY_MAX_LIMIT + 5} activity rows filtered).`
+    );
+    expect(packet).not.toContain('activity must not consume prose context');
+  });
+
+  it('keeps a deleted thread root structural beside only the newest 15 of 16 replies', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new ScriptedAdapter('mock', { mode: 'reply', text: 'ok' }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'thread anchor to delete',
+    });
+    for (let index = 0; index < PACKET_MAX_ROWS; index += 1) {
+      store.appendComplete({
+        channelId: CH,
+        sender: OPERATOR,
+        text: `thread reply ${index}`,
+        parentMessageId: root.id,
+      });
+    }
+    store.deleteMessage({
+      channelId: CH,
+      messageId: root.id,
+      deleterId: OPERATOR.id,
+    });
+
+    post(
+      store,
+      binder,
+      '@mock inspect this thread',
+      ['mock'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ScriptedAdapter;
+    await waitFor(() => adapter.sendInputs.length === 1);
+    const packet = adapter.sendInputs[0]!.content;
+    expect(packet).toContain(
+      `${PACKET_MAX_ROWS + 1} prior thread rows (${PACKET_MAX_ROWS} shown, 0 activity rows filtered).`
+    );
+    expect(packet.match(/\[message deleted\]/g)).toHaveLength(1);
+    expect(packet.match(/\[…earlier messages omitted\]/g)).toHaveLength(1);
+    expect(packet).not.toContain('operator: thread reply 0\n');
+    expect(packet).toContain('operator: thread reply 1');
+    expect(packet).toContain(`operator: thread reply ${PACKET_MAX_ROWS - 1}`);
+    expect(packet).not.toContain('thread anchor to delete');
+  });
+
   it('advances the delivery cursor only after a send is accepted', async () => {
     const { binder, store } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
@@ -3465,24 +3629,21 @@ describe('channel-agent-binder — gateway agent-sender loop brake (P1 #1180)', 
 });
 
 describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () => {
-  it('a store.history throw does not wedge the binding; the next mention routes', async () => {
+  it('a store mention-context throw does not wedge the binding; the next mention routes', async () => {
     const { binder, store, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
       targets: MOCK_TARGETS,
       knownProviderIds: ['mock'],
     });
-    // Throw once from the top-level packet-fetch history call (the one with
-    // `beforeSeq`); row helpers without beforeSeq continue to work.
-    const realHistory = store.history.bind(store);
+    const realMentionContext = store.mentionContext.bind(store);
     let thrown = false;
-    (store as unknown as { history: ChannelMessageStore['history'] }).history =
-      ((id: string, filter?: Parameters<ChannelMessageStore['history']>[1]) => {
-        if (!thrown && filter && 'beforeSeq' in filter) {
-          thrown = true;
-          throw new Error('db boom');
-        }
-        return realHistory(id, filter);
-      }) as ChannelMessageStore['history'];
+    store.mentionContext = (input) => {
+      if (!thrown) {
+        thrown = true;
+        throw new Error('db boom');
+      }
+      return realMentionContext(input);
+    };
 
     post(store, binder, '@mock one', ['mock']);
     await waitFor(() =>
@@ -3496,31 +3657,21 @@ describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () 
     expect(agentReplies(store, 'mock')).toHaveLength(1);
   });
 
-  it('a store.threadHistory throw does not wedge the binding; the next mention routes', async () => {
+  it('a threaded mention-context throw does not wedge the binding; the next mention routes', async () => {
     const { binder, store, sessions } = makeBinder({
       build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
       targets: MOCK_TARGETS,
       knownProviderIds: ['mock'],
     });
-    // Throw once from the threaded packet-fetch lane. The next top-level turn
-    // uses ordinary history and proves the queue did not wedge.
-    const realThreadHistory = store.threadHistory.bind(store);
+    const realMentionContext = store.mentionContext.bind(store);
     let thrown = false;
-    (
-      store as unknown as {
-        threadHistory: ChannelMessageStore['threadHistory'];
-      }
-    ).threadHistory = ((
-      id: string,
-      rootMessageId: string,
-      filter?: Parameters<ChannelMessageStore['threadHistory']>[2]
-    ) => {
-      if (!thrown) {
+    store.mentionContext = (input) => {
+      if (!thrown && input.threadRootId !== null) {
         thrown = true;
         throw new Error('db boom');
       }
-      return realThreadHistory(id, rootMessageId, filter);
-    }) as ChannelMessageStore['threadHistory'];
+      return realMentionContext(input);
+    };
 
     const root = store.appendComplete({
       channelId: CH,
@@ -4890,7 +5041,11 @@ describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
     await waitFor(() => adapter.sendCalls.length === 2);
     const packet = adapter.sendInputs[1]!.content;
     expect(packet.trimEnd().endsWith(`@steer burst ${total - 1}`)).toBe(true);
-    expect(packet).toContain('@steer burst 0');
+    expect(packet).toContain(
+      `${total - 1} messages since your last turn (${PACKET_MAX_ROWS} shown, 0 activity rows filtered).`
+    );
+    expect(packet).toContain('[…earlier messages omitted]');
+    expect(packet).toContain(`@steer burst ${total - 1 - PACKET_MAX_ROWS}`);
     expect(adapter.concurrentPeak).toBe(1);
   });
 

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -378,6 +378,44 @@ describe('buildMentionContextPacket', () => {
     }
   });
 
+  it('filters blank activity/detail/system rows before they consume the text window', () => {
+    const detail = {
+      ...msg(2, HERMES, ''),
+      agentDetail: {
+        itemId: 'reasoning-1',
+        card: {
+          kind: 'thought' as const,
+          title: 'Reasoning summary',
+          status: 'complete' as const,
+          content: 'provider-visible reasoning',
+        },
+      },
+    };
+    const rows = [
+      msg(1, OPERATOR, 'real question'),
+      detail,
+      msg(3, SYSTEM, 'collab:wait', 'system'),
+      msg(4, HERMES, '   '),
+      msg(5, HERMES, 'real agent prose'),
+    ];
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows,
+      trigger: msg(6, OPERATOR, '@claude continue'),
+      lastDeliveredSeq: 0,
+    });
+
+    expect(packet).toContain(
+      '5 messages since your last turn (2 shown, 3 activity rows filtered).'
+    );
+    expect(packet).toContain('operator: real question');
+    expect(packet).toContain('hermes [agent]: real agent prose');
+    expect(packet).not.toContain('provider-visible reasoning');
+    expect(packet).not.toContain('collab:wait');
+    expect(packet).not.toContain('hermes [agent]:    ');
+  });
+
   it('renders the exact golden packet (own rows skipped, sender labels, footer)', () => {
     const rows = [
       msg(1, OPERATOR, 'hey team, the build is red'),
@@ -400,10 +438,10 @@ describe('buildMentionContextPacket', () => {
     expect(packet).toBe(
       [
         '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
-        'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+        '3 messages since your last turn (2 shown, 1 activity rows filtered).',
+        'Recent text messages, oldest first. Lines are "sender: text"; agents tagged [agent].',
         'operator: hey team, the build is red',
         'hermes [agent]: bisecting now',
-        '[system]: codex is not available in channels yet',
         '',
         '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
         '@claude please fix the flaky channel-hub test',
@@ -443,11 +481,11 @@ describe('buildMentionContextPacket', () => {
     expect(packet).toBe(
       [
         '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '4 prior thread rows (3 shown, 1 activity rows filtered).',
         '[Thread scope — only this thread is shown; its root message is always included]',
-        'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+        'Recent text messages, oldest first. Lines are "sender: text"; agents tagged [agent].',
         'operator: root question',
         'hermes [agent]: thread detail',
-        '[system]: thread system notice',
         'operator: thread row still streaming',
         '',
         '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
@@ -483,8 +521,9 @@ describe('buildMentionContextPacket', () => {
     expect(packet).toBe(
       [
         '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '2 prior thread rows (2 shown, 0 activity rows filtered).',
         '[Thread scope — only this thread is shown; its root message is always included]',
-        'Recent messages, oldest first. Lines are "sender: text"; agents tagged [agent], system rows tagged [system].',
+        'Recent text messages, oldest first. Lines are "sender: text"; agents tagged [agent].',
         'claude [agent]: claude-authored root',
         'operator: new human detail',
         '',
@@ -544,14 +583,14 @@ describe('buildMentionContextPacket', () => {
     });
     expect(packet).toContain('claude [agent]: load-bearing root');
     expect(packet).toContain('[…earlier messages omitted]');
-    expect(packet).not.toContain('operator: thread line 6\n');
-    expect(packet).toContain('operator: thread line 7');
+    expect(packet).not.toContain('operator: thread line 10\n');
+    expect(packet).toContain('operator: thread line 11');
     expect(packet).toContain('operator: thread line 25');
     expect(packet.indexOf('claude [agent]: load-bearing root')).toBeLessThan(
       packet.indexOf('[…earlier messages omitted]')
     );
     expect(packet.indexOf('[…earlier messages omitted]')).toBeLessThan(
-      packet.indexOf('operator: thread line 7')
+      packet.indexOf('operator: thread line 11')
     );
     const contextLines = packet
       .split('\n')
@@ -609,6 +648,7 @@ describe('buildMentionContextPacket', () => {
     expect(packet).toBe(
       [
         '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '0 messages since your last turn (0 shown, 0 activity rows filtered).',
         '',
         '[hermes [agent:hermes] mentioned you — reply to this message; your reply is posted to the channel]',
         '@claude take a look at my bisect',
@@ -640,10 +680,10 @@ describe('buildMentionContextPacket', () => {
       lastDeliveredSeq: 0,
     });
     expect(packet).toContain('[…earlier messages omitted]');
-    // Newest 20 kept: rows 6..25 present, rows 1..5 omitted.
-    expect(packet).toContain('operator: line 6');
+    // Newest PACKET_MAX_ROWS kept: rows 10..25 present, rows 1..9 omitted.
+    expect(packet).toContain('operator: line 10');
     expect(packet).toContain('operator: line 25');
-    expect(packet).not.toContain('operator: line 5\n');
+    expect(packet).not.toContain('operator: line 9\n');
     const contextLines = packet
       .split('\n')
       .filter((l) => l.startsWith('operator: line'));
@@ -717,6 +757,7 @@ describe('buildMentionContextPacket', () => {
     expect(packet).toBe(
       [
         '[Relay channel #general — you are @claude, one participant in a multi-party chat]',
+        '0 messages since your last turn (0 shown, 0 activity rows filtered).',
         '',
         '[operator [human] mentioned you — reply to this message; your reply is posted to the channel]',
         '@claude go',
@@ -806,7 +847,11 @@ describe('buildMentionContextPacket', () => {
       trigger,
       lastDeliveredSeq: 0,
     });
+    expect(packet).toContain(
+      '2 prior thread rows (2 shown, 0 activity rows filtered).'
+    );
     expect(packet).toContain('operator: [message deleted]');
     expect(packet).toContain('operator: reply one');
+    expect(packet).not.toContain('[…earlier messages omitted]');
   });
 });

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -581,9 +581,9 @@ describe('mention routing — end-to-end via the router', () => {
     await waitFor(() => adapter.contents.length === 1);
     const packet = adapter.contents[0]!;
     expect(packet).toContain('Operator: load-bearing long-thread root');
-    expect(packet).toContain('Operator: long-thread reply 47');
+    expect(packet).toContain('Operator: long-thread reply 51');
     expect(packet).toContain('Operator: long-thread reply 65');
-    expect(packet).not.toContain('Operator: long-thread reply 46\n');
+    expect(packet).not.toContain('Operator: long-thread reply 50\n');
     await waitFor(() => agentReply(h.store, h.channelId).length === 1);
     expect(agentReply(h.store, h.channelId)[0]).toMatchObject({
       threadId: root.body.message.id,

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -7,6 +7,8 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  buildChannelMentionContextCountSql,
+  buildChannelMentionContextRowsSql,
   buildChannelMessageSearchSql,
   buildChannelSearchMatchQuery,
   buildChannelThreadHistorySql,
@@ -1809,6 +1811,126 @@ describe('channel-message-store posts, threads, idempotency', () => {
 
 // #1287 slice 5 item 18: the rail surfaces threads, so the channel list needs a
 // thread projection that agrees with the in-timeline "N replies" chip.
+describe('channel-message-store mention context (#1358)', () => {
+  it('counts the exact candidate range while returning only newest eligible prose', () => {
+    const s = store();
+    const channelId = 'topic:context';
+    s.appendComplete({ channelId, sender: HUMAN, text: 'before cursor' });
+    const cursor = s.latestSeq(channelId);
+    s.appendComplete({ channelId, sender: HUMAN, text: 'older prose' });
+    s.appendComplete({ channelId, sender: AGENT, text: 'own provider prose' });
+    s.appendComplete({
+      channelId,
+      kind: 'system',
+      sender: { kind: 'system', id: 'system:relay' },
+      text: 'collab:wait',
+    });
+    s.appendComplete({ channelId, sender: HUMAN, text: '\t \n ' });
+    const detail = s.beginStream({
+      channelId,
+      sender: {
+        kind: 'agent',
+        id: 'agent:other',
+        providerId: 'other',
+      },
+      source: {
+        runtimeId: 'runtime:other',
+        turnId: 'turn:detail',
+        itemId: 'item:detail',
+      },
+      agentDetail: {
+        itemId: 'item:detail',
+        card: {
+          kind: 'thought',
+          title: 'Reasoning summary',
+          status: 'running',
+          content: 'not prose',
+        },
+      },
+    });
+    s.finalizeStream(detail.id, { text: '', status: 'complete' });
+    for (let index = 0; index < 18; index += 1) {
+      s.appendComplete({ channelId, sender: HUMAN, text: `prose ${index}` });
+    }
+    const trigger = s.appendComplete({
+      channelId,
+      sender: HUMAN,
+      text: '@claude inspect',
+    });
+
+    const context = s.mentionContext({
+      channelId,
+      framework: 'claude',
+      triggerSeq: trigger.seq,
+      afterSeq: cursor,
+      threadRootId: null,
+      limit: 16,
+    });
+    expect(context).toMatchObject({
+      totalCount: 22,
+      activityFilteredCount: 3,
+      scope: 'channel',
+    });
+    expect(context.rows).toHaveLength(16);
+    expect(context.rows.map((row) => row.body.text)).toEqual(
+      Array.from({ length: 16 }, (_, index) => `prose ${index + 2}`)
+    );
+  });
+
+  it('plans counts and bounded rows as direct indexed range reads', () => {
+    const file = dbPath();
+    const s = store(file);
+    const root = s.appendComplete({
+      channelId: 'topic:plan',
+      sender: HUMAN,
+      text: 'thread root',
+    });
+    const db = new Database(file, { readonly: true });
+    cleanup.push(() => db.close());
+    const params = {
+      channelId: 'topic:plan',
+      framework: 'claude',
+      triggerSeq: 100,
+      afterSeq: 0,
+      threadRootId: root.id,
+      limit: 16,
+      replyLimit: 15,
+    };
+    const explain = (sql: string): string =>
+      (
+        db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(params) as Array<{
+          detail: string;
+        }>
+      )
+        .map((step) => step.detail)
+        .join('\n');
+
+    const channelCount = explain(buildChannelMentionContextCountSql('channel'));
+    expect(channelCount).toMatch(
+      /SEARCH channel_row USING INDEX idx_chm_channel_seq \(channel_id=\? AND seq>\? AND seq<\?\)/
+    );
+    const channelRows = explain(buildChannelMentionContextRowsSql('channel'));
+    expect(channelRows).toMatch(
+      /SEARCH m USING INDEX idx_chm_channel_seq \(channel_id=\? AND seq>\? AND seq<\?\)/
+    );
+    expect(channelRows).not.toContain('USE TEMP B-TREE');
+    expect(channelRows).not.toMatch(/SCAN m/);
+
+    const threadCount = explain(buildChannelMentionContextCountSql('thread'));
+    expect(threadCount).toMatch(/SEARCH root USING INDEX .*\(id=\?\)/);
+    expect(threadCount).toMatch(
+      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\? AND seq<\?\)/
+    );
+    const threadRows = explain(buildChannelMentionContextRowsSql('thread'));
+    expect(threadRows).toMatch(/SEARCH root USING INDEX .*\(id=\?\)/);
+    expect(threadRows).toMatch(
+      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\? AND seq<\?\)/
+    );
+    expect(threadRows).not.toContain('USE TEMP B-TREE');
+    expect(threadRows).not.toMatch(/SCAN (?:root|reply)/);
+  });
+});
+
 describe('channel-message-store thread summaries', () => {
   it('reports live threads newest-active first with the chip reply count', () => {
     const s = store();


### PR DESCRIPTION
## What
- restrict delivered mention context to non-empty human/agent prose plus structural thread roots
- reduce the retained row window to 16 and keep the packet within a 16 KiB budget
- add exact `total / shown / activity filtered` delivery summaries
- compute counts and select only the newest eligible rows with indexed SQLite queries
- preserve deleted, image-only, and other non-text thread roots as truthful structural markers

## Why
Tool calls, reasoning cards, status rows, and blank activity rows were consuming the packet window and displacing real conversation. A first bounded-JS fix still produced truncated counts and could scan/deserialise unbounded history; this slice moves the work into indexed store queries.

## Checklist
- [x] Ordinary activity rows never consume the prose window
- [x] Own-agent prior rows remain excluded without losing a canonical root
- [x] Channel cursor and thread-scope summaries are truthful
- [x] Deleted/image-only/non-text roots remain orienting structural context
- [x] Image-only root attachment references reach the adapter lane
- [x] Exact counts do not require materialising full history in Node
- [x] Bounded row queries use range indexes without temp B-tree sorting
- [x] Adversarial review findings reproduced and resolved

## Verification
- 209 focused binder/context-packet/message-store tests passed
- `npm run check` — 0 errors (227 baseline warnings)
- `git diff --check origin/nightly...HEAD` — clean
- adversarial review of integrated `0611d507` — no findings; safe to PR

## Follow-up
This is the text-only packet/count slice of #1358. Public, capability-gated `channels.history` and `channels.roster` verbs remain a separate gateway/runtime-context slice coordinated with #1350; this PR intentionally does **not** close the issue.

Refs #1358
