### PR TITLE
feat(channel): route bare posts to orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ workflow.
 
 #### Added
 
+- Route unmentioned human messages in product channels to the durably
+  designated orchestrator, including cold resume after hub restart, through the
+  existing queue and native-steer paths; explicit mentions remain authoritative
+  (#1353)
 - Run Prime Agent as a built-in terminal and channel provider through its native RPC mode (#1340)
 - Run Pi as a built-in terminal and channel provider through its native JSONL RPC mode (#1349)
 - Control Prime Agent models, reasoning, compaction, and fresh sessions from the `@agent/` command palette (#1345)

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -201,27 +201,37 @@ conversation.
 
 ## Mentions and private runtimes
 
-`server/channel-agent-binder.ts` owns mention routing:
+`server/channel-agent-binder.ts` owns message-to-agent routing:
 
 1. subscribe to newly posted channel messages;
-2. resolve mentions against agent profiles;
-3. fall back to implicit DM routing when a human message resolves none;
+2. resolve explicit mentions against agent profiles;
+3. for an unmentioned human message, resolve the DM recipient or the product
+   channel's existing designated orchestrator;
 4. start or reuse one private runtime per `(channel, profileActorId)`;
 5. build a bounded context packet from durable channel history;
-6. queue and deliver the turn to the provider adapter;
+6. queue or steer and deliver the turn through the provider adapter;
 7. mirror the provider response into the originating channel or thread.
 
-Implicit DM routing (step 3) is the routing half of "a DM is a channel with one
-agent". A message with zero resolved mentions is routed as follows:
+Implicit human routing (step 3) follows this matrix:
 
-- DM channel, human sender → the default profile for the DM's provider, exactly
-  as if the provider had been mentioned. Threads included: a thread reply in a
-  DM routes implicitly too. Both DM composers therefore drop the `@ to mention`
-  hint.
-- DM channel, agent sender → nothing. An agent's own DM post cannot re-trigger
-  the DM's agent; the mention self-filter cannot see a message with no mentions.
-- Multi-party channel → nothing, silently (debug log only). Humans chat there
-  without addressing an agent, so a system row would be spam.
+- DM channel → the default profile for the DM's provider, exactly as if the
+  provider had been mentioned. Threads included: a thread reply routes
+  implicitly too. Both DM composers therefore drop the `@ to mention` hint.
+- Non-DM product channel with a durable `role=orchestrator` binding → that
+  designated profile. Delivery uses the exact same FIFO/native-steer path as an
+  explicit mention, including thread placement and queue limits. If the hub
+  restarted and its private runtime is gone, this first turn cold-resumes a new
+  orchestrator-role runtime from the binding's provider session.
+- Non-DM channel without a designated orchestrator → nothing, silently (debug
+  log only). No role is created or upgraded by sending a message.
+- Agent or system sender → no implicit route. Agent-authored explicit mentions
+  keep the existing collaboration/brake behavior, but an unmentioned agent row
+  can never loop back into the orchestrator.
+
+Any explicit agent mention wins over these defaults and routes only to the
+mentioned profile(s). This remains true when a durable pinned mention no longer
+resolves, so Relay never silently substitutes a DM agent or orchestrator for the
+operator's intended recipient.
 
 A DM whose provider cannot be resolved at all posts one `nothing was routed`
 system row per five-minute dedupe window, because in a DM there is nobody else
@@ -269,8 +279,8 @@ placement for cold replay, but they are not counted as conversational replies.
 
 A channel may designate one persistent orchestrator profile. The designation
 route grants the orchestrator role through the operator-authenticated lane,
-starts or reuses its private runtime, and exposes the role in the channel
-roster.
+persists that role independently of the ephemeral runtime id, starts or reuses
+its private runtime, and exposes the role in the channel roster.
 
 Agent runtimes may create or operate public terminal workers through the scoped
 actor gateway when their capability grant permits it. Those workers are

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -54,10 +54,11 @@ import type { AgentRole } from '../shared/agent-roster.js';
 import { isDmChannel } from '../shared/dm-channels.js';
 import { workspaceTopicAgentRuntimeLinkPatch } from '../shared/workspace-topics.js';
 
-// @-mention routing binder (#1167, slice 4). One module owns the whole loop:
-// subscribe to hub.onMessagePosted → resolve mentions → ensure a (channel,
-// framework) channel runtime (single-flight spawn | reuse | rebind) → wire the
-// slice-2 bridge → build a context packet → deliver the turn. Single-node only.
+// Channel routing binder (#1167, #1353). One module owns the whole loop:
+// subscribe to hub.onMessagePosted → resolve explicit mentions or the implicit
+// DM/designated-orchestrator recipient → ensure a (channel, profile) runtime
+// (single-flight spawn | reuse | rebind) → wire the slice-2 bridge → build a
+// context packet → deliver the turn. Single-node only.
 //
 // It never touches the wire protocol and requires ZERO adapter changes: the
 // bridge remains the sole text mirror; the binder registers its OWN onPatch
@@ -687,6 +688,54 @@ export function createChannelAgentBinder(
     return profile.displayName || (await senderLabelFor(profile.providerId));
   }
 
+  /**
+   * Profiles the binder can safely reconstruct without inventing a deleted
+   * named profile. Built-in defaults remain available when the durable profile
+   * catalog is absent (boot/tests) or has not seeded that provider yet.
+   */
+  function knownProfiles(): AgentProfile[] {
+    const profiles = [...(deps.agentProfileStore?.list() ?? [])];
+    const seen = new Set(profiles.map((profile) => profile.id));
+    for (const providerId of deps.knownProviderIds) {
+      const profile = defaultProfileForProvider(providerId);
+      if (seen.has(profile.id)) continue;
+      seen.add(profile.id);
+      profiles.push(profile);
+    }
+    return profiles;
+  }
+
+  /**
+   * Resolve the channel's durable orchestrator designation. Runtime handles are
+   * intentionally ephemeral across hub restarts; the binding role is the source
+   * of truth and `routeOne(..., requiredRole='orchestrator')` cold-resumes it.
+   * Recipient selection itself never upgrades an ordinary collaborator row.
+   */
+  function designatedOrchestratorProfile(
+    channelId: string
+  ): AgentProfile | null {
+    const topic = topicStore?.get(channelId);
+    if (!topic || isDmChannel(topic) !== null) return null;
+
+    const matches = knownProfiles().filter(
+      (profile) =>
+        store.getBinding(channelId, profile.id)?.role === 'orchestrator'
+    );
+    if (matches.length === 1) return matches[0]!;
+    if (matches.length > 1) {
+      // #1259 models one designated orchestrator. Do not pick an arbitrary
+      // runtime if corrupt/legacy state violates that invariant.
+      logger.warn(
+        'multiple orchestrator bindings found; default route skipped',
+        {
+          channelId,
+          profileActorIds: matches.map((profile) => profile.id),
+        }
+      );
+    }
+    return null;
+  }
+
   function supportsSafeBoundarySteer(binding: LiveBinding): boolean {
     return (
       binding.adapter?.capabilities.steer === true &&
@@ -912,6 +961,21 @@ export function createChannelAgentBinder(
     return `#${topic?.display.title ?? channelId} · ${profile.displayName || framework}`;
   }
 
+  function assertRuntimeRole(
+    channelId: string,
+    framework: string,
+    runtime: ChannelAgentRuntime,
+    requiredRole?: AgentRole
+  ): void {
+    if (!requiredRole || runtime.role === requiredRole) return;
+    throw new ChannelAgentRoleConflictError(
+      channelId,
+      framework,
+      runtime.id,
+      runtime.role ?? 'unknown'
+    );
+  }
+
   async function doEnsureBinding(
     channelId: string,
     profile: AgentProfile,
@@ -922,6 +986,10 @@ export function createChannelAgentBinder(
     const profileActorId = profile.id;
     const key = bindingKey(channelId, profileActorId);
     const runtimeDisplayName = displayNameFor(channelId, framework, profile);
+    const row = store.getBinding(channelId, profileActorId);
+    // Once a profile is durably designated, every recovery path preserves that
+    // runtime role — including an explicit mention that happens after restart.
+    const effectiveRole = requiredRole ?? row?.role ?? undefined;
 
     // 2. Reuse a live entry whose private runtime is still healthy.
     const existing = live.get(key);
@@ -932,14 +1000,7 @@ export function createChannelAgentBinder(
         profileActorId
       );
       if (runtime && runtime.adapter === existing.adapter) {
-        if (requiredRole && runtime.role !== requiredRole) {
-          throw new ChannelAgentRoleConflictError(
-            channelId,
-            framework,
-            runtime.id,
-            runtime.role ?? 'unknown'
-          );
-        }
+        assertRuntimeRole(channelId, framework, runtime, effectiveRole);
         // Reuse still links: a topic row created (or re-created) after this
         // runtime was attached would otherwise never learn its participant.
         // The patch helper returns undefined when already linked, so a hot
@@ -956,21 +1017,13 @@ export function createChannelAgentBinder(
     const senderDisplayName = await rosterDisplayName(profile);
 
     // 3. Rebind a restored provider conversation to a live private runtime.
-    const row = store.getBinding(channelId, profileActorId);
     const restored = healthyRuntime(
       row?.runtimeId ?? null,
       framework,
       profileActorId
     );
     if (restored) {
-      if (requiredRole && restored.role !== requiredRole) {
-        throw new ChannelAgentRoleConflictError(
-          channelId,
-          framework,
-          restored.id,
-          restored.role ?? 'unknown'
-        );
-      }
+      assertRuntimeRole(channelId, framework, restored, effectiveRole);
       return attachRuntime(
         channelId,
         profileActorId,
@@ -1013,7 +1066,7 @@ export function createChannelAgentBinder(
         ...(row?.providerSession
           ? { providerSession: row.providerSession }
           : {}),
-        ...(requiredRole ? { role: requiredRole } : {}),
+        ...(effectiveRole ? { role: effectiveRole } : {}),
         ...(routing.repoPath ? { repoPath: routing.repoPath } : {}),
         ...(routing.worktreePath ? { worktreePath: routing.worktreePath } : {}),
         ...(yolo ? { permissionMode: YOLO_PERMISSION_MODE } : {}),
@@ -1083,6 +1136,7 @@ export function createChannelAgentBinder(
       profileActorId,
       agentFramework: framework,
       runtimeId: created.id,
+      ...(effectiveRole ? { role: effectiveRole } : {}),
       providerSession: {
         ...(row?.providerSession ?? {}),
         ...created.providerSession,
@@ -1102,6 +1156,32 @@ export function createChannelAgentBinder(
     );
   }
 
+  function assertBindingRole(
+    binding: LiveBinding,
+    framework: string,
+    requiredRole: 'orchestrator'
+  ): void {
+    const runtime = binding.runtimeId
+      ? healthyRuntime(binding.runtimeId, framework, binding.profileActorId)
+      : null;
+    if (runtime?.role === requiredRole) return;
+    throw new ChannelAgentRoleConflictError(
+      binding.channelId,
+      framework,
+      binding.runtimeId ?? 'unknown',
+      runtime?.role ?? 'unknown'
+    );
+  }
+
+  function persistOrchestratorDesignation(binding: LiveBinding): void {
+    store.upsertBinding({
+      channelId: binding.channelId,
+      profileActorId: binding.profileActorId,
+      agentFramework: binding.framework,
+      role: 'orchestrator',
+    });
+  }
+
   function ensureProfileBinding(
     channelId: string,
     profile: AgentProfile,
@@ -1109,7 +1189,13 @@ export function createChannelAgentBinder(
   ): Promise<LiveBinding> {
     const key = bindingKey(channelId, profile.id);
     const pending = inflight.get(key);
-    if (pending) return pending;
+    if (pending) {
+      if (!requiredRole) return pending;
+      return pending.then((binding) => {
+        assertBindingRole(binding, profile.providerId, requiredRole);
+        return binding;
+      });
+    }
     // Store before awaiting so concurrent mentions of one profile single-flight.
     const promise = doEnsureBinding(channelId, profile, requiredRole).finally(
       () => {
@@ -1138,24 +1224,18 @@ export function createChannelAgentBinder(
     const pending = inflight.get(key);
     if (pending) {
       const binding = await pending;
-      const runtime = binding.runtimeId
-        ? healthyRuntime(binding.runtimeId, profile.providerId, profile.id)
-        : null;
-      if (!runtime || runtime.role !== 'orchestrator') {
-        throw new ChannelAgentRoleConflictError(
-          channelId,
-          framework,
-          binding.runtimeId ?? 'unknown',
-          runtime?.role ?? 'unknown'
-        );
-      }
+      assertBindingRole(binding, profile.providerId, 'orchestrator');
+      persistOrchestratorDesignation(binding);
       return binding;
     }
-    const promise = doEnsureBinding(channelId, profile, 'orchestrator').finally(
-      () => {
+    const promise = doEnsureBinding(channelId, profile, 'orchestrator')
+      .then((binding) => {
+        persistOrchestratorDesignation(binding);
+        return binding;
+      })
+      .finally(() => {
         inflight.delete(key);
-      }
-    );
+      });
     inflight.set(key, promise);
     return promise;
   }
@@ -2023,7 +2103,8 @@ export function createChannelAgentBinder(
   function routeOne(
     trigger: ChannelMessage,
     profile: AgentProfile,
-    steering?: ChannelPostSteering
+    steering?: ChannelPostSteering,
+    requiredRole?: 'orchestrator'
   ): Promise<void> {
     return (async () => {
       try {
@@ -2070,7 +2151,11 @@ export function createChannelAgentBinder(
         }
         let binding: LiveBinding;
         try {
-          binding = await ensureProfileBinding(trigger.channelId, profile);
+          binding = await ensureProfileBinding(
+            trigger.channelId,
+            profile,
+            requiredRole
+          );
         } catch (err) {
           if (err instanceof BinderClosedError) return; // shutdown — silent
           if (err instanceof ChannelBindingError) {
@@ -2262,12 +2347,20 @@ export function createChannelAgentBinder(
       routeWithBrake(message, profiles);
       return;
     }
+    // A message-shaped system row is not a normal production shape, but sender
+    // attribution is the loop-safety boundary. It must neither route nor reset
+    // the consecutive-agent brake if one is ever presented by a caller/test.
+    if (message.sender.kind !== 'human') return;
     // Mechanics are explicit (epic #1308 rule): the steering intent comes from
     // the operator's choice on the post route, never inferred from the text.
     const steering = options?.steering;
     consecutiveAgentTurns.delete(message.channelId);
     if (profiles.length === 0) {
-      routeImplicitDm(message, steering);
+      // A durable/pinned mention may no longer resolve after a profile deletion.
+      // It is still explicit operator intent, so never fall through to a DM or
+      // orchestrator default and silently address somebody else.
+      if (routingMentions.length > 0) return;
+      routeImplicitHumanMessage(message, steering);
       return;
     }
     for (const profile of profiles) {
@@ -2308,11 +2401,11 @@ export function createChannelAgentBinder(
     const mentions = currentProfileMentions(message, message.mentions ?? []);
     let profiles = eligibleProfiles(message, mentions);
     if (profiles.length === 0) {
-      // Same implicit-DM resolution as `routeImplicitDm`: addressing a DM IS
-      // the mention, so a steered DM post carries no literal `@name` to resolve.
-      const providerId = dmProviderIdFor(message.channelId);
-      if (providerId === null) return;
-      profiles = [defaultProfileForProvider(providerId)];
+      // Explicit intent always wins, even if its pinned profile disappeared.
+      if (mentions.length > 0) return;
+      const implicit = implicitHumanRecipient(message.channelId);
+      if (!implicit) return;
+      profiles = [implicit.profile];
     }
     for (const profile of profiles) {
       const binding = live.get(bindingKey(message.channelId, profile.id));
@@ -2335,34 +2428,45 @@ export function createChannelAgentBinder(
   }
 
   /**
-   * DM implicit routing. A DM is "a channel with one agent" (ADR-020,
-   * `docs/CHANNEL_CHAT.md`), so addressing it IS the mention — a human message
-   * in a DM must reach that agent with no literal `@name` typed.
-   *
-   * Only reached when the explicit-mention resolver produced ZERO routable
-   * profiles, so an explicit `@name` can never be double-routed, and only from
-   * the human branch of `handleMessagePosted`, so an agent's own DM post can
-   * never re-trigger itself (`eligibleProfiles`' self-filter does not cover a
-   * message with no mentions at all).
+   * Resolve the one implicit recipient for an unmentioned HUMAN post. DMs keep
+   * their existing provider-default behavior. A non-DM product channel routes
+   * only when its durable binding carries role=`orchestrator`; the runtime may
+   * be cold and will resume through the same binding path. An ordinary
+   * collaborator binding never qualifies as the default.
    */
-  function routeImplicitDm(
+  function implicitHumanRecipient(
+    channelId: string
+  ): { profile: AgentProfile; requiredRole?: 'orchestrator' } | null {
+    const providerId = dmProviderIdFor(channelId);
+    if (providerId !== null) {
+      return { profile: defaultProfileForProvider(providerId) };
+    }
+    const profile = designatedOrchestratorProfile(channelId);
+    return profile ? { profile, requiredRole: 'orchestrator' } : null;
+  }
+
+  /**
+   * An unmentioned human post uses the same `routeOne` queue/steer path as an
+   * explicit mention. Sender-kind and explicit-mention gates live at the caller,
+   * so agent/system output cannot self-trigger and named intent cannot fan out.
+   */
+  function routeImplicitHumanMessage(
     message: ChannelMessage,
     steering?: ChannelPostSteering
   ): void {
-    const providerId = dmProviderIdFor(message.channelId);
-    if (providerId === null) {
-      // Legitimate in a multi-party channel: humans chat without addressing an
-      // agent. Logged, never announced — a system row here would spam #general.
+    const recipient = implicitHumanRecipient(message.channelId);
+    if (!recipient) {
+      // Legitimate in a multi-party channel with no designated orchestrator.
+      // Logged, never announced — a system row here would spam #general.
       logger.debug(
         `message posted, 0 profiles routed, channel=${message.channelId} message=${message.id}`
       );
       return;
     }
-    const profile = defaultProfileForProvider(providerId);
     logger.debug(
-      `dm implicit route, channel=${message.channelId} provider=${providerId} profile=${profile.id}`
+      `implicit human route, channel=${message.channelId} provider=${recipient.profile.providerId} profile=${recipient.profile.id}`
     );
-    void routeOne(message, profile, steering);
+    void routeOne(message, recipient.profile, steering, recipient.requiredRole);
   }
 
   function handleAssistantFinalized(message: ChannelMessage): void {
@@ -2650,6 +2754,7 @@ export function createChannelAgentBinder(
         const row = store.getBinding(channelId, profile.id);
         const runtimeId = binding?.runtimeId ?? row?.runtimeId ?? null;
         const runtime = runtimeId ? deps.runtimes.get(runtimeId) : undefined;
+        const role = runtime?.role ?? row?.role ?? undefined;
         const baseCommands = relayControlCatalogForProvider(
           profile.providerId
         ).filter((command) => command.collisionKey !== 'fast');
@@ -2666,7 +2771,7 @@ export function createChannelAgentBinder(
           kind: 'framework',
           available: availability.available,
           reason: availability.reason,
-          ...(runtime?.role !== undefined ? { role: runtime.role } : {}),
+          ...(role !== undefined ? { role } : {}),
           binding: runtimeId
             ? {
                 runtimeId,

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 
 import { createLogger } from './logger.js';
+import type { AgentRole } from '../shared/agent-roster.js';
 
 import {
   CHANNEL_CHAT_PROTOCOL_VERSION,
@@ -58,7 +59,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -734,6 +735,7 @@ CREATE TABLE IF NOT EXISTS channel_agent_bindings (
   profile_actor_id      TEXT NOT NULL,
   agent_framework       TEXT NOT NULL,
   runtime_id            TEXT,
+  binding_role          TEXT,
   provider_session_json TEXT NOT NULL DEFAULT '{}',
   created_at            TEXT NOT NULL,
   updated_at            TEXT NOT NULL,
@@ -821,6 +823,7 @@ interface BindingRow {
   profile_actor_id: string;
   agent_framework: string;
   runtime_id: string | null;
+  binding_role: AgentRole | null;
   provider_session_json: string;
   created_at: string;
   updated_at: string;
@@ -1025,6 +1028,8 @@ export interface ChannelBinding {
   /** Provider/framework spawn selector retained independently of the profile. */
   agentFramework: string;
   runtimeId: string | null;
+  /** Durable participant role; orchestrator designation survives runtime loss. */
+  role: AgentRole | null;
   providerSession: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -1230,6 +1235,7 @@ export interface ChannelMessageStore {
     profileActorId: string;
     agentFramework: string;
     runtimeId?: string | null;
+    role?: AgentRole | null;
     providerSession?: Record<string, unknown>;
   }): ChannelBinding;
   sweepStaleStreaming(): StaleStreamSweepResult[];
@@ -2302,6 +2308,24 @@ function runSchemaMigrations(db: Database.Database): void {
       }
       db.exec(`DROP TABLE IF EXISTS ${CHANNEL_SEARCH_TABLE}`);
       db.prepare('UPDATE schema_version SET version = 6').run();
+    })();
+  }
+  if (current < 7) {
+    db.transaction(() => {
+      // The runtime registry is intentionally ephemeral across hub restarts.
+      // Persist the participant role on the binding so an orchestrator remains
+      // designated even when runtime_id no longer resolves to a live handle.
+      const hasBindingRole = (
+        db.prepare(`PRAGMA table_info(channel_agent_bindings)`).all() as Array<{
+          name: string;
+        }>
+      ).some((column) => column.name === 'binding_role');
+      if (!hasBindingRole) {
+        db.exec(
+          'ALTER TABLE channel_agent_bindings ADD COLUMN binding_role TEXT'
+        );
+      }
+      db.prepare('UPDATE schema_version SET version = 7').run();
     })();
   }
 }
@@ -3494,11 +3518,12 @@ export function createChannelMessageStore(
       );
       db.prepare(
         `INSERT INTO channel_agent_bindings
-           (channel_id, profile_actor_id, agent_framework, runtime_id, provider_session_json, created_at, updated_at)
-         VALUES (@channelId, @profileActorId, @agentFramework, @runtimeId, @providerSessionJson, @createdAt, @updatedAt)
+           (channel_id, profile_actor_id, agent_framework, runtime_id, binding_role, provider_session_json, created_at, updated_at)
+         VALUES (@channelId, @profileActorId, @agentFramework, @runtimeId, @bindingRole, @providerSessionJson, @createdAt, @updatedAt)
          ON CONFLICT(channel_id, profile_actor_id) DO UPDATE SET
            agent_framework = excluded.agent_framework,
            runtime_id = excluded.runtime_id,
+           binding_role = excluded.binding_role,
            provider_session_json = excluded.provider_session_json,
            updated_at = excluded.updated_at`
       ).run({
@@ -3509,6 +3534,10 @@ export function createChannelMessageStore(
           input.runtimeId !== undefined
             ? input.runtimeId
             : (existing?.runtime_id ?? null),
+        bindingRole:
+          input.role !== undefined
+            ? input.role
+            : (existing?.binding_role ?? null),
         providerSessionJson,
         createdAt: existing?.created_at ?? now,
         updatedAt: now,
@@ -3693,6 +3722,7 @@ function bindingRowToRecord(row: BindingRow): ChannelBinding {
     profileActorId: row.profile_actor_id,
     agentFramework: row.agent_framework,
     runtimeId: row.runtime_id,
+    role: row.binding_role,
     providerSession,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1597,6 +1597,9 @@ describe('channel-agent-binder — lifecycle', () => {
     const binding = await binder.ensureOrchestrator(CH, 'mock');
 
     expect(binding.runtimeId).toBe(sessions.firstSessionId());
+    expect(store.getBinding(CH, builtInAgentProfileId('mock'))?.role).toBe(
+      'orchestrator'
+    );
     expect(sessions.lastCreateParams()).toMatchObject({
       providerId: 'mock',
       role: 'orchestrator',
@@ -1622,6 +1625,9 @@ describe('channel-agent-binder — lifecycle', () => {
     const binding = await binder.ensureOrchestrator(CH, 'mock');
 
     expect(binding.runtimeId).toBe(sessionId);
+    expect(store.getBinding(CH, builtInAgentProfileId('mock'))?.role).toBe(
+      'orchestrator'
+    );
     expect(sessions.spawns()).toBe(0);
   });
 
@@ -4272,6 +4278,311 @@ describe('channel-agent-binder — DM implicit routing', () => {
   });
 });
 
+// ── #1353: unmentioned product-channel posts use the designated orchestrator
+// binding, while explicit recipient and sender-kind gates remain authoritative.
+
+describe('channel-agent-binder — orchestrator default-routing matrix', () => {
+  const TARGETS: MentionTarget[] = [
+    {
+      id: 'orchestrator',
+      displayName: 'Orchestrator',
+      kind: 'framework',
+      available: true,
+      reason: null,
+    },
+    {
+      id: 'worker',
+      displayName: 'Worker',
+      kind: 'framework',
+      available: true,
+      reason: null,
+    },
+  ];
+
+  function makeProductTopics(): WorkspaceTopicStore {
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    topics.create({
+      id: CH,
+      workspaceId: 'ws:local',
+      title: 'product',
+    });
+    return topics;
+  }
+
+  it.each([
+    {
+      name: 'human + bare + designated => orchestrator',
+      designate: true,
+      sender: OPERATOR,
+      kind: 'message' as const,
+      text: 'please take the next step',
+      expected: { orchestrator: 1, worker: 0 },
+    },
+    {
+      name: 'human + explicit worker + designated => worker only',
+      designate: true,
+      sender: OPERATOR,
+      kind: 'message' as const,
+      text: '@worker please inspect this',
+      expected: { orchestrator: 0, worker: 1 },
+    },
+    {
+      name: 'human + bare + no designation => no dispatch',
+      designate: false,
+      sender: OPERATOR,
+      kind: 'message' as const,
+      text: 'morning everyone',
+      expected: { orchestrator: 0, worker: 0 },
+    },
+    {
+      name: 'human + bare + collaborator binding => no role upgrade',
+      designate: false,
+      collaborator: true,
+      sender: OPERATOR,
+      kind: 'message' as const,
+      text: 'do not infer a driver',
+      expected: { orchestrator: 0, worker: 0 },
+    },
+    {
+      name: 'agent + bare + designated => no default loop',
+      designate: true,
+      sender: AGENT_SENDER,
+      kind: 'message' as const,
+      text: 'still coordinating',
+      expected: { orchestrator: 0, worker: 0 },
+    },
+    {
+      name: 'system row + designated => no default loop',
+      designate: true,
+      sender: { kind: 'system' as const, id: 'system' },
+      kind: 'system' as const,
+      text: 'runtime notice',
+      expected: { orchestrator: 0, worker: 0 },
+    },
+  ])(
+    '$name',
+    async ({ designate, collaborator, sender, kind, text, expected }) => {
+      const adapters = new Map<string, ScriptedAdapter[]>();
+      const topics = makeProductTopics();
+      const { binder, store } = makeBinder({
+        build: (providerId) => {
+          const adapter = new ScriptedAdapter(providerId, {
+            mode: 'reply',
+            text: `${providerId} ack`,
+          });
+          const list = adapters.get(providerId) ?? [];
+          list.push(adapter);
+          adapters.set(providerId, list);
+          return adapter;
+        },
+        targets: TARGETS,
+        knownProviderIds: ['orchestrator', 'worker'],
+        topicStore: topics,
+      });
+      if (designate) {
+        await binder.ensureOrchestrator(CH, 'orchestrator');
+      } else if (collaborator) {
+        await binder.ensureBinding(CH, 'orchestrator');
+      }
+
+      const mentions = parseMentions(text, ['orchestrator', 'worker']);
+      const message = store.appendComplete({
+        channelId: CH,
+        kind,
+        sender,
+        text,
+        ...(mentions.length ? { mentions } : {}),
+      });
+      binder.handleMessagePosted(message, message.mentions ?? []);
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      expect(
+        (adapters.get('orchestrator') ?? []).reduce(
+          (count, adapter) => count + adapter.sendCalls.length,
+          0
+        )
+      ).toBe(expected.orchestrator);
+      expect(
+        (adapters.get('worker') ?? []).reduce(
+          (count, adapter) => count + adapter.sendCalls.length,
+          0
+        )
+      ).toBe(expected.worker);
+    }
+  );
+
+  it('cold-resumes a durable orchestrator designation with an empty runtime registry', async () => {
+    const topics = makeProductTopics();
+    const { binder, store, sessions } = makeBinder({
+      build: (providerId) =>
+        new ScriptedAdapter(providerId, {
+          mode: 'reply',
+          text: 'cold ack',
+        }),
+      targets: [TARGETS[0]!],
+      knownProviderIds: ['orchestrator'],
+      topicStore: topics,
+    });
+    const profileActorId = builtInAgentProfileId('orchestrator');
+    // Production starts with no channel runtimes after a hub restart. The role,
+    // not runtime_id, is the durable designation source of truth.
+    store.upsertBinding({
+      channelId: CH,
+      profileActorId,
+      agentFramework: 'orchestrator',
+      runtimeId: null,
+      role: 'orchestrator',
+    });
+    expect((await binder.rosterForChannel(CH))[0]).toMatchObject({
+      id: profileActorId,
+      role: 'orchestrator',
+      binding: null,
+    });
+
+    post(store, binder, 'resume the plan', ['orchestrator']);
+
+    await waitFor(() => sessions.spawns() === 1);
+    const adapter = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as ScriptedAdapter;
+    await waitFor(() => adapter.sendCalls.length === 1);
+    expect(sessions.lastCreateParams()).toMatchObject({
+      providerId: 'orchestrator',
+      profileActorId,
+      role: 'orchestrator',
+    });
+    expect(agentReplies(store, 'orchestrator')[0]?.body.text).toBe('cold ack');
+  });
+
+  it('does not discard the required orchestrator role when joining a collaborator spawn', async () => {
+    const topics = makeProductTopics();
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: (providerId) => new ScriptedAdapter(providerId, { mode: 'stall' }),
+      targets: [TARGETS[0]!],
+      knownProviderIds: ['orchestrator'],
+      topicStore: topics,
+      gate,
+    });
+    const profileActorId = builtInAgentProfileId('orchestrator');
+    const collaborator = binder.ensureBinding(CH, 'orchestrator');
+    await waitFor(() => sessions.spawns() === 1);
+    // The ordinary spawn has already captured no role and is parked. Model a
+    // concurrent durable designation becoming visible before the bare post.
+    store.upsertBinding({
+      channelId: CH,
+      profileActorId,
+      agentFramework: 'orchestrator',
+      runtimeId: null,
+      role: 'orchestrator',
+    });
+    post(store, binder, 'must not enter the collaborator runtime', [
+      'orchestrator',
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    releaseGate();
+    const collaboratorBinding = await collaborator;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    const adapter = sessions.adapterFor(
+      collaboratorBinding.runtimeId!
+    ) as ScriptedAdapter;
+    expect(sessions.createParams()).toEqual([
+      expect.not.objectContaining({ role: 'orchestrator' }),
+    ]);
+    expect(adapter.sendCalls).toHaveLength(0);
+    expect(sessions.spawns()).toBe(1);
+    expect(store.getBinding(CH, profileActorId)?.role).toBe('orchestrator');
+  });
+
+  it('keeps an implicit orchestrator reply in the triggering thread', async () => {
+    const topics = makeProductTopics();
+    const adapter = new ScriptedAdapter('orchestrator', {
+      mode: 'reply',
+      text: 'threaded ack',
+    });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: [TARGETS[0]!],
+      knownProviderIds: ['orchestrator'],
+      topicStore: topics,
+    });
+    await binder.ensureOrchestrator(CH, 'orchestrator');
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+    const trigger = post(
+      store,
+      binder,
+      'threaded implicit instruction',
+      ['orchestrator'],
+      OPERATOR,
+      root.id
+    );
+
+    await waitFor(() => agentReplies(store, 'orchestrator').length === 1);
+    expect(agentReplies(store, 'orchestrator')[0]).toMatchObject({
+      threadId: root.id,
+      parentMessageId: trigger.id,
+    });
+  });
+
+  it('preserves FIFO queue semantics for implicit turns', async () => {
+    const topics = makeProductTopics();
+    const adapter = new ScriptedAdapter('orchestrator', { mode: 'stall' });
+    const { binder, store } = makeBinder({
+      build: () => adapter,
+      targets: [TARGETS[0]!],
+      knownProviderIds: ['orchestrator'],
+      topicStore: topics,
+    });
+    const binding = await binder.ensureOrchestrator(CH, 'orchestrator');
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'root',
+    });
+
+    const first = post(
+      store,
+      binder,
+      'first implicit instruction',
+      ['orchestrator'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() => adapter.sendCalls.length === 1);
+    post(
+      store,
+      binder,
+      'second implicit instruction',
+      ['orchestrator'],
+      OPERATOR,
+      root.id
+    );
+    await waitFor(() => binding.queue.length === 1);
+    const roster = await binder.rosterForChannel(CH);
+    expect(roster[0]?.binding?.queuedCount).toBe(1);
+
+    expect(adapter.sendInputs[0]?.turnId).toBe(
+      channelTurnId(first.id, builtInAgentProfileId('orchestrator'))
+    );
+    expect(binding.parentMessageIdByTurn.get(adapter.sendCalls[0]!)).toBe(
+      first.id
+    );
+    expect(binding.queue.map((entry) => entry.trigger.threadId)).toEqual([
+      root.id,
+    ]);
+  });
+});
+
 // ── retry (#1308 slice 1 item 2) ─────────────────────────────────────────────
 
 describe('channel-agent-binder — retry', () => {
@@ -4690,6 +5001,45 @@ async function steerAdapter(
 }
 
 describe('channel-agent-binder — mid-turn steering (#1308 slice 4)', () => {
+  it('uses the native safe-boundary steer lane for an unmentioned orchestrator post', async () => {
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    topics.create({
+      id: CH,
+      workspaceId: 'ws:local',
+      title: 'product',
+    });
+    const harness = makeBinder({
+      build: (agentType) => new SteerableAdapter(agentType, true),
+      targets: STEER_TARGETS,
+      knownProviderIds: ['steer'],
+      topicStore: topics,
+    });
+    await harness.binder.ensureOrchestrator(CH, 'steer');
+
+    postSteering(
+      harness.store,
+      harness.binder,
+      'first implicit instruction',
+      ['steer'],
+      undefined
+    );
+    const adapter = await steerAdapter(harness.sessions);
+    await waitFor(() => adapter.sendCalls.length === 1);
+    postSteering(
+      harness.store,
+      harness.binder,
+      'second implicit instruction',
+      ['steer'],
+      undefined
+    );
+
+    await waitFor(() => adapter.steerInputs.length === 1);
+    expect(adapter.steerInputs[0]?.content).toContain(
+      'second implicit instruction'
+    );
+  });
+
   it('bounds accepted native steers at the aggregate queue cap', async () => {
     const { binder, store, sessions } = makeSteerBinder(true);
     postSteering(store, binder, '@steer opener', ['steer'], undefined);

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -346,7 +346,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(6);
+    ).toBe(7);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -377,11 +377,11 @@ describe('channel-message-store schema migration', () => {
       },
     ]);
 
-    // The repair is recorded as a marker ROW, not as a schema version. That is
-    // what keeps an older hub able to open this db (a version bump would make
-    // `current > SCHEMA_VERSION` throw) and makes re-arming a DELETE instead of
-    // a schema-version rewind. Two pairs matched the SQL predicate; only the
-    // one carrying the bounded echo signature was removed.
+    // The repair is recorded as a marker row rather than an additional schema
+    // bump, so re-arming remains a DELETE instead of a schema-version rewind.
+    // Schema-version compatibility is governed separately. Two pairs matched
+    // the SQL predicate; only the one carrying the bounded echo signature was
+    // removed.
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -456,13 +456,13 @@ describe('channel-message-store schema migration', () => {
       );
       INSERT INTO channel_agent_bindings VALUES (
         'topic:stranded-heal', 'agent-profile:claude:default', 'claude',
-        'runtime-stranded',
+        'runtime-stranded', NULL,
         '{"claudeSessionId":"runtime-stranded","lastDeliveredSeq":4}',
         '2026-07-19T08:00:00.000Z', '2026-07-19T08:00:00.000Z'
       );
       INSERT INTO channel_agent_bindings VALUES (
         'topic:stranded-heal', 'agent-profile:claude:reviewer', 'claude',
-        'runtime-b',
+        'runtime-b', NULL,
         '{"claudeSessionId":"runtime-b","lastDeliveredSeq":2}',
         '2026-07-19T08:00:00.000Z', '2026-07-19T08:00:00.000Z'
       );
@@ -526,15 +526,15 @@ describe('channel-message-store schema migration', () => {
 
     const inspect = new Database(file, { readonly: true });
     cleanup.push(() => inspect.close());
-    // No schema bump: the repair records a marker row, so a db healed by this
-    // hub still opens on one built before the repair existed.
+    // The repair itself records a marker rather than owning a schema version;
+    // the independent binding-role migration still advances this old fixture.
     expect(
       (
         inspect.prepare('SELECT version FROM schema_version').get() as {
           version: number;
         }
       ).version
-    ).toBe(6);
+    ).toBe(7);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -2194,9 +2194,11 @@ describe('channel-message-store members and bindings', () => {
       channelId: 'topic:c',
       profileActorId: builtInAgentProfileId('claude'),
       agentFramework: 'claude',
+      role: 'orchestrator',
       providerSession: { claudeSessionId: 'abc' },
     });
     expect(created.runtimeId).toBeNull();
+    expect(created.role).toBe('orchestrator');
     const updated = s.upsertBinding({
       channelId: 'topic:c',
       profileActorId: builtInAgentProfileId('claude'),
@@ -2204,6 +2206,8 @@ describe('channel-message-store members and bindings', () => {
       runtimeId: 'runtime-9',
     });
     expect(updated.runtimeId).toBe('runtime-9');
+    // Omitting role updates runtime state without erasing the designation.
+    expect(updated.role).toBe('orchestrator');
     expect(updated.providerSession).toEqual({ claudeSessionId: 'abc' });
 
     // Arbitrary profile ids are real actor ids, never rewritten by a prefix
@@ -2694,7 +2698,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(6);
+    expect(version.version).toBe(7);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {


### PR DESCRIPTION
## What
- route unmentioned human posts in product channels to the durably designated orchestrator
- persist `binding_role` in channel DB schema v7 so designation survives runtime loss/restart
- cold-resume the orchestrator through the existing profile binding path
- keep explicit mentions authoritative and agent/system rows non-routing
- reuse the same native-steer/FIFO/queue-cap path as explicit turns

## Why
Bare messages in orchestrator-led channels reached no agent. A first active-runtime-only implementation also lost designation after every hub restart and had a single-flight role race; durable role authority closes both gaps.

## Checklist
- [x] Explicit mentions win without implicit fanout
- [x] No orchestrator means no dispatch
- [x] Agent/system rows cannot create routing loops
- [x] Thread placement is preserved
- [x] Busy orchestrators use existing safe-boundary steer/FIFO behavior
- [x] Cold binding with an empty runtime registry resumes as `role=orchestrator`
- [x] Joined in-flight bindings validate the required role before enqueue
- [x] #1357 availability preflight and #1358 bounded packet queries remain intact
- [x] #1352 collaborator-upgrade/conflict policy remains out of scope

## Migration note
Pre-v7 databases had no durable role fact to infer safely. A previously designated orchestrator therefore needs one re-designation after the upgrade restart; subsequent restarts preserve it.

## Verification
- 236 focused binder/store/context/e2e tests passed on `d1cb1701`
- `npm run check` — 0 errors (227 baseline warnings)
- `git diff --check` — clean
- final adversarial integration review of `acaa3a3c` — no findings; safe to PR

Closes #1353
