### PR TITLE
feat(chat): add collapsible reasoning details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ workflow.
   add controls, with an explicit project selector in New Chat (#1347)
 - `@agent/` opens a provider-aware command palette for channel controls,
   including Codex Fast Mode, model, and reasoning-effort changes (#1344)
+- Inspect provider-visible reasoning in provider-neutral collapsible turn details,
+  with a persisted collapsed or expanded default for new summaries (#1361)
 
 #### Changed
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -135,18 +135,19 @@ state after channel recreation.
 
 ### Zustand
 
-| Store                     | Responsibility                                                                         |
-| ------------------------- | -------------------------------------------------------------------------------------- |
-| `ui.ts`                   | Active channel/thread, dialogs, and local navigation                                   |
-| `channel-activity.ts`     | Last-read marks: local fast path, hub push/seed, monotonic-up merge, clamp-epoch fence |
-| `channel-agent-status.ts` | Live profile status keyed by channel/profile                                           |
-| `channel-queued-sends.ts` | Client-side memory of messages sent into a busy agent; drives the `queued` chip        |
-| `unread.ts`               | Unread derivation from marks against durable sequence                                  |
-| `notifications.ts`        | Notification stack entries (including the update toast)                                |
-| `notify-settings.ts`      | Operator notification preferences                                                      |
-| `notify-badge.ts`         | Derived badge count for favicon and title                                              |
-| `sessions.ts`             | Terminal/process session summaries                                                     |
-| `toasts.ts`               | Transient notifications                                                                |
+| Store                          | Responsibility                                                                         |
+| ------------------------------ | -------------------------------------------------------------------------------------- |
+| `ui.ts`                        | Active channel/thread, dialogs, and local navigation                                   |
+| `channel-activity.ts`          | Last-read marks: local fast path, hub push/seed, monotonic-up merge, clamp-epoch fence |
+| `channel-agent-status.ts`      | Live profile status keyed by channel/profile                                           |
+| `channel-queued-sends.ts`      | Client-side memory of messages sent into a busy agent; drives the `queued` chip        |
+| `unread.ts`                    | Unread derivation from marks against durable sequence                                  |
+| `notifications.ts`             | Notification stack entries (including the update toast)                                |
+| `notify-settings.ts`           | Operator notification preferences                                                      |
+| `reasoning-detail-settings.ts` | Client-local collapsed/expanded default for new reasoning details                      |
+| `notify-badge.ts`              | Derived badge count for favicon and title                                              |
+| `sessions.ts`                  | Terminal/process session summaries                                                     |
+| `toasts.ts`                    | Transient notifications                                                                |
 
 Last-read marks are not browser-local. `channel-activity.ts` persists locally as
 the fast path, then pushes to `PUT /channels/:id/read-state`, seeds from

--- a/frontend/src/components/chat/AgentDetailCard.css
+++ b/frontend/src/components/chat/AgentDetailCard.css
@@ -130,3 +130,12 @@
     max-height: 240px;
   }
 }
+
+/* Provider-visible reasoning is a turn detail, never assistant prose. */
+.ch-reasoning-detail {
+  border-left: 2px solid color-mix(in srgb, var(--accent) 65%, var(--border));
+}
+
+.ch-reasoning-detail .ch-agent-card__title {
+  color: var(--text-muted);
+}

--- a/frontend/src/components/chat/AgentDetailCard.tsx
+++ b/frontend/src/components/chat/AgentDetailCard.tsx
@@ -9,12 +9,21 @@ import {
 } from 'lucide-react';
 import type { AgentDetailCardV2 } from '../../../../shared/agent-chat-protocol-v2.js';
 import { useShikiHighlight } from '../../hooks/useShikiHighlight.js';
+import {
+  ReasoningDetail,
+  type ReasoningTerminalState,
+} from './ReasoningDetail.js';
+import type { ReasoningDetailStateApi } from './ReasoningDetailState.js';
 import './AgentDetailCard.css';
 
 interface AgentDetailCardProps {
   card: AgentDetailCardV2;
   /** Stable outer item id; isolates syntax-highlight cache entries. */
   itemId: string;
+  /** More specific channel-turn boundary for truthful reasoning labels. */
+  reasoningTerminalState?: ReasoningTerminalState | undefined;
+  reasoningViewState?: ReasoningDetailStateApi | undefined;
+  reasoningStateKey?: string | undefined;
   onUserToggle?: (itemId: string) => void;
 }
 
@@ -201,6 +210,9 @@ function CardContent({ card, itemId }: CardContentProps) {
 export const AgentDetailCard: React.FC<AgentDetailCardProps> = ({
   card,
   itemId,
+  reasoningTerminalState,
+  reasoningViewState,
+  reasoningStateKey,
   onUserToggle,
 }) => {
   const [expanded, setExpanded] = useState(false);
@@ -211,6 +223,25 @@ export const AgentDetailCard: React.FC<AgentDetailCardProps> = ({
   const size = contentSize(card);
   const title = card.path ?? card.title;
   const bodyId = `agent-detail-body-${itemId}`;
+
+  if (card.kind === 'thought') {
+    return (
+      <ReasoningDetail
+        key={itemId}
+        card={card}
+        itemId={itemId}
+        {...(reasoningStateKey ? { stateKey: reasoningStateKey } : {})}
+        size={size}
+        {...(reasoningTerminalState
+          ? { terminalState: reasoningTerminalState }
+          : {})}
+        {...(reasoningViewState ? { viewState: reasoningViewState } : {})}
+        {...(onUserToggle ? { onUserToggle } : {})}
+      >
+        <CardContent card={card} itemId={itemId} />
+      </ReasoningDetail>
+    );
+  }
 
   return (
     <div

--- a/frontend/src/components/chat/ChannelMessageGroup.tsx
+++ b/frontend/src/components/chat/ChannelMessageGroup.tsx
@@ -6,11 +6,13 @@ import type {
 } from '../../../../shared/channel-chat-protocol.js';
 import { AgentAvatar } from './AgentAvatar.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
+import { shouldRenderChannelMessage } from '../../lib/chat/reasoning-detail.js';
 import {
   displayedReplyCount,
   type DerivedReplyCount,
 } from '../../lib/chat/channel-timeline-layout.js';
 import { ChannelMessageRow } from './ChannelMessageRow.js';
+import type { ReasoningDetailStateApi } from './ReasoningDetailState.js';
 
 /** Compact wall-clock time, lowercase (DESIGN.md casing law), e.g. `3:42pm`. */
 export function formatGroupTime(iso: string): string {
@@ -43,6 +45,7 @@ interface ChannelMessageGroupProps {
   busyAgentIds?: ReadonlySet<string>;
   /** Rows a later `meta.retryOfMessageId` system row already superseded. */
   retriedMessageIds?: ReadonlySet<ChannelMessageId>;
+  reasoningViewState?: ReasoningDetailStateApi;
 }
 
 export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
@@ -58,9 +61,12 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
   onDeleteMessage,
   busyAgentIds,
   retriedMessageIds,
+  reasoningViewState,
 }) => {
+  const visibleMessages = messages.filter(shouldRenderChannelMessage);
+  if (visibleMessages.length === 0) return null;
   const identity = resolveSenderIdentity(sender);
-  const first = messages[0];
+  const first = visibleMessages[0];
   // Human messages carry no name chrome — they are always "you", right-aligned
   // bubbles in a single-operator system (spec §4). Agent/system get a header.
   const showHeader = identity.kind !== 'human';
@@ -89,13 +95,14 @@ export const ChannelMessageGroup: React.FC<ChannelMessageGroupProps> = ({
         </div>
       ) : null}
       <div className="ch-group__messages">
-        {messages.map((message) => {
+        {visibleMessages.map((message) => {
           const derived = replyCounts?.get(message.id);
           return (
             <ChannelMessageRow
               key={message.id}
               message={message}
               channelId={channelId}
+              reasoningViewState={reasoningViewState}
               highlighted={highlightedMessageId === message.id}
               retryBusy={busyAgentIds?.has(message.sender.id) ?? false}
               retried={retriedMessageIds?.has(message.id) ?? false}

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -11,6 +11,11 @@ import {
 import type { AgentDetailCardStatusV2 } from '../../../../shared/agent-chat-protocol-v2.js';
 import { AssistantMarkdown } from './AssistantMarkdown.js';
 import { AgentDetailCard } from './AgentDetailCard.js';
+import type { ReasoningDetailStateApi } from './ReasoningDetailState.js';
+import {
+  reasoningTerminalStateForMessage,
+  shouldRenderChannelMessage,
+} from '../../lib/chat/reasoning-detail.js';
 import { ChannelImagePart } from './ChannelImagePart.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
 import { createLineBreakSubmitGuard } from './composerInput.js';
@@ -707,12 +712,13 @@ const MessageRowTrailer: React.FC<{
   );
 };
 
-const STATUS_ROW_MODIFIERS: Partial<Record<ChannelMessage['status'], string>> = {
-  streaming: 'ch-msg--streaming',
-  truncated: 'ch-msg--truncated',
-  interrupted: 'ch-msg--interrupted',
-  failed: 'ch-msg--failed',
-};
+const STATUS_ROW_MODIFIERS: Partial<Record<ChannelMessage['status'], string>> =
+  {
+    streaming: 'ch-msg--streaming',
+    truncated: 'ch-msg--truncated',
+    interrupted: 'ch-msg--interrupted',
+    failed: 'ch-msg--failed',
+  };
 
 /** Row modifier classes for a prose row — one table lookup plus two flags. */
 function proseRowClassName(
@@ -765,9 +771,11 @@ interface ChannelMessageRowProps {
   retryBusy?: boolean;
   /** A later system row already superseded this one via `meta.retryOfMessageId`. */
   retried?: boolean;
+  /** Timeline-owned disclosure overrides survive grouped-row remounts. */
+  reasoningViewState?: ReasoningDetailStateApi | undefined;
 }
 
-export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
+const ChannelMessageRowContent: React.FC<ChannelMessageRowProps> = ({
   message,
   channelId,
   variant = 'default',
@@ -780,6 +788,7 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
   onDelete,
   retryBusy = false,
   retried = false,
+  reasoningViewState,
 }) => {
   const streaming = message.status === 'streaming';
   const rowRef = useRef<HTMLDivElement>(null);
@@ -866,6 +875,8 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
     );
   }, [message.body.text]);
 
+  const reasoningTerminalState = reasoningTerminalStateForMessage(message);
+
   if (variant === 'system' || message.kind === 'system') {
     return (
       <ChannelSystemMessageRow
@@ -921,6 +932,9 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
         <AgentDetailCard
           card={message.agentDetail.card}
           itemId={message.agentDetail.itemId}
+          reasoningTerminalState={reasoningTerminalState}
+          reasoningViewState={reasoningViewState}
+          reasoningStateKey={`${message.id}:${message.agentDetail.itemId}`}
         />
       ) : null}
       {deleted ? (
@@ -968,6 +982,16 @@ export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = ({
       />
     </div>
   );
+};
+
+/**
+ * A provider may open and terminalize a reasoning item without exposing any
+ * summary. Suppress the entire durable timeline row, not just its chevron.
+ */
+export const ChannelMessageRow: React.FC<ChannelMessageRowProps> = (props) => {
+  return shouldRenderChannelMessage(props.message) ? (
+    <ChannelMessageRowContent {...props} />
+  ) : null;
 };
 
 export default ChannelMessageRow;

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -6,6 +6,7 @@ import type {
   ChannelPostSteering,
 } from '../../../../shared/channel-chat-protocol.js';
 import { useChannelThread } from '../../hooks/useChannelThread.js';
+import { shouldRenderChannelMessage } from '../../lib/chat/reasoning-detail.js';
 import {
   buildTimelineNodes,
   deriveReplyCounts,
@@ -15,6 +16,7 @@ import {
 import { ChannelComposer } from './ChannelComposer.js';
 import { ChannelMessageGroup } from './ChannelMessageGroup.js';
 import { ChannelMessageRow } from './ChannelMessageRow.js';
+import { useReasoningDetailStateScope } from './ReasoningDetailState.js';
 import { useFollowingScroll } from './useFollowingScroll.js';
 import { useLiveReplyGrowth } from './useLiveReplyGrowth.js';
 
@@ -88,6 +90,13 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
     error,
     rootFloorRevision,
   } = useChannelThread(channelId, rootId, liveMessages);
+  const reasoningViewState = useReasoningDetailStateScope(
+    `thread:${channelId}:${rootId}`
+  );
+  const visibleReplies = useMemo(
+    () => replies.filter(shouldRenderChannelMessage),
+    [replies]
+  );
 
   const replyActivity = useMemo(
     () => deriveReplyCounts(root ? [root, ...replies] : replies),
@@ -109,7 +118,10 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
         liveReplyGrowth.get(root.id) ?? 0
       )
     : replies.length;
-  const nodes = useMemo(() => buildTimelineNodes(replies, null), [replies]);
+  const nodes = useMemo(
+    () => buildTimelineNodes(visibleReplies, null),
+    [visibleReplies]
+  );
   const {
     containerRef,
     contentRef,
@@ -117,7 +129,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
     scrollToBottom,
     newMessageCount,
   } = useFollowingScroll({
-    messages: replies,
+    messages: visibleReplies,
     hasMoreOlder,
     loadingOlder,
     loadOlder,
@@ -159,6 +171,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
             sender={root.sender}
             messages={[root]}
             channelId={channelId}
+            reasoningViewState={reasoningViewState}
           />
         ) : loading ? (
           <div className="ch-thread__state">loading thread…</div>
@@ -217,6 +230,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
                     key={message.id}
                     message={message}
                     channelId={channelId}
+                    reasoningViewState={reasoningViewState}
                     variant="system"
                   />
                 ));
@@ -229,6 +243,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
                   sender={node.sender}
                   messages={node.messages}
                   channelId={channelId}
+                  reasoningViewState={reasoningViewState}
                 />
               );
             })}

--- a/frontend/src/components/chat/ChannelTimeline.tsx
+++ b/frontend/src/components/chat/ChannelTimeline.tsx
@@ -21,10 +21,12 @@ import {
   channelPresenceCopy,
   type ChannelAgentPresence,
 } from '../../lib/chat/channel-agent-presence.js';
+import { shouldRenderChannelMessage } from '../../lib/chat/reasoning-detail.js';
 import { AgentBadge } from '../AgentBadge.js';
 import { TuiProgress } from '../TuiProgress.js';
 import { ChannelMessageGroup } from './ChannelMessageGroup.js';
 import { ChannelMessageRow } from './ChannelMessageRow.js';
+import { useReasoningDetailStateScope } from './ReasoningDetailState.js';
 import { useFollowingScroll } from './useFollowingScroll.js';
 import { useLiveReplyGrowth } from './useLiveReplyGrowth.js';
 
@@ -161,6 +163,10 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     ReadonlySet<ChannelMessageId>
   >(() => new Set());
 
+  const reasoningViewState = useReasoningDetailStateScope(
+    `timeline:${channelId}`
+  );
+
   const toggleSystemRun = useCallback((runKey: ChannelMessageId): void => {
     setExpandedSystemRuns((current) => {
       const next = new Set(current);
@@ -172,7 +178,14 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
   // Replies stay in the reducer for gap/catch-up correctness. Every piece of
   // main-lane geometry consumes this render-only projection so hidden reply seqs
   // cannot trigger a pill, move an anchor, or create an inline timeline row.
-  const topLevelMessages = useMemo(() => selectTopLevel(messages), [messages]);
+  const allTopLevelMessages = useMemo(
+    () => selectTopLevel(messages),
+    [messages]
+  );
+  const topLevelMessages = useMemo(
+    () => allTopLevelMessages.filter(shouldRenderChannelMessage),
+    [allTopLevelMessages]
+  );
   const replyCounts = useMemo(() => deriveReplyCounts(messages), [messages]);
 
   // #1308 item 2: rows a retry already superseded. Derived from the durable
@@ -209,7 +222,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
     fullSnapshotRevision,
   });
 
-  const earliestSeq = topLevelMessages[0]?.seq;
+  const earliestSeq = allTopLevelMessages[0]?.seq;
   const reachedBeginning = !hasMoreOlder && earliestSeq === 1;
 
   // Deep-link jump. Keyed on the request token, never on `messageId`, so a
@@ -406,6 +419,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                           key={message.id}
                           message={message}
                           channelId={channelId}
+                          reasoningViewState={reasoningViewState}
                           variant="system"
                           highlighted={highlightedMessageId === message.id}
                         />
@@ -421,6 +435,7 @@ export const ChannelTimeline: React.FC<ChannelTimelineProps> = ({
                 sender={node.sender}
                 messages={node.messages}
                 channelId={channelId}
+                reasoningViewState={reasoningViewState}
                 replyCounts={replyCounts}
                 replyGrowth={replyGrowth}
                 highlightedMessageId={highlightedMessageId}

--- a/frontend/src/components/chat/ReasoningDetail.tsx
+++ b/frontend/src/components/chat/ReasoningDetail.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { ChevronRight, CircleDot } from 'lucide-react';
+import type { AgentDetailCardV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+import {
+  shouldRenderReasoningDetail,
+  type ReasoningTerminalState,
+} from '../../lib/chat/reasoning-detail.js';
+import { useReasoningDetailSettingsStore } from '../../lib/stores/reasoning-detail-settings.js';
+import {
+  fallbackReasoningDetailState,
+  type ReasoningDetailStateApi,
+} from './ReasoningDetailState.js';
+
+export { shouldRenderReasoningDetail } from '../../lib/chat/reasoning-detail.js';
+export type { ReasoningTerminalState } from '../../lib/chat/reasoning-detail.js';
+
+interface ReasoningDetailProps {
+  card: AgentDetailCardV2;
+  itemId: string;
+  stateKey?: string;
+  size: string | null;
+  terminalState?: ReasoningTerminalState;
+  viewState?: ReasoningDetailStateApi;
+  onUserToggle?: (itemId: string) => void;
+  children: React.ReactNode;
+}
+
+function reasoningStatusLabel(
+  card: AgentDetailCardV2,
+  terminalState?: ReasoningTerminalState
+): string {
+  if (terminalState === 'interrupted' || terminalState === 'truncated') {
+    return terminalState;
+  }
+  if (terminalState === 'failed') return 'failed';
+  if (
+    terminalState === 'completed' &&
+    (card.status === 'pending' || card.status === 'running')
+  ) {
+    return 'completed';
+  }
+  if (card.status === 'running') return 'reasoning…';
+  return card.status;
+}
+
+/**
+ * Provider-neutral disclosure for provider-visible reasoning summaries. Its
+ * local state is seeded once from the persisted preference, so later setting
+ * changes affect new blocks without undoing a manual toggle on a live block.
+ */
+export const ReasoningDetail: React.FC<ReasoningDetailProps> = ({
+  card,
+  itemId,
+  stateKey = itemId,
+  size,
+  terminalState,
+  viewState = fallbackReasoningDetailState,
+  onUserToggle,
+  children,
+}) => {
+  const defaultState = useReasoningDetailSettingsStore(
+    (state) => state.settings.defaultState
+  );
+  const [expanded, setExpanded] = useState(() => {
+    const override = viewState.get(stateKey);
+    return override ? override === 'expanded' : defaultState === 'expanded';
+  });
+  const hasContent = Boolean(card.content?.trim());
+
+  if (!shouldRenderReasoningDetail(card, terminalState)) return null;
+
+  const bodyId = `reasoning-detail-body-${itemId}`;
+  const status = reasoningStatusLabel(card, terminalState);
+  const statusClass =
+    status === 'failed'
+      ? 'ch-agent-card__status--failed'
+      : status === 'reasoning…'
+        ? 'ch-agent-card__status--running'
+        : status === 'completed'
+          ? 'ch-agent-card__status--completed'
+          : 'ch-agent-card__status--cancelled';
+
+  return (
+    <div
+      className="ch-agent-card ch-reasoning-detail"
+      data-agent-card-kind="thought"
+      data-agent-card-expandable={hasContent ? 'true' : 'false'}
+      data-reasoning-detail-state={expanded ? 'expanded' : 'collapsed'}
+      role="article"
+      aria-label="Reasoning summary"
+    >
+      {hasContent ? (
+        <button
+          type="button"
+          className="ch-agent-card__toggle"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          aria-label={`${expanded ? 'Collapse' : 'Expand'} Reasoning summary (${status})`}
+          onClick={() => {
+            onUserToggle?.(itemId);
+            setExpanded((value) => {
+              const next = !value;
+              viewState.set(stateKey, next ? 'expanded' : 'collapsed');
+              return next;
+            });
+          }}
+        >
+          <ChevronRight
+            className={`ch-agent-card__chevron${expanded ? ' ch-agent-card__chevron--open' : ''}`}
+            size={14}
+            strokeWidth={1.5}
+            aria-hidden="true"
+          />
+          <span className="ch-agent-card__icon">
+            <CircleDot size={14} strokeWidth={1.5} aria-hidden="true" />
+          </span>
+          <span className="ch-agent-card__title">Reasoning summary</span>
+          {size ? <span className="ch-agent-card__size">{size}</span> : null}
+          <span className={`ch-agent-card__status ${statusClass}`}>
+            {status}
+          </span>
+        </button>
+      ) : (
+        <div className="ch-agent-card__summary" aria-live="polite">
+          <span className="ch-agent-card__icon">
+            <CircleDot size={14} strokeWidth={1.5} aria-hidden="true" />
+          </span>
+          <span className="ch-agent-card__title">Reasoning summary</span>
+          <span className={`ch-agent-card__status ${statusClass}`}>
+            {status}
+          </span>
+        </div>
+      )}
+      {expanded && hasContent ? (
+        <div id={bodyId} className="ch-agent-card__body">
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ReasoningDetail;

--- a/frontend/src/components/chat/ReasoningDetailState.ts
+++ b/frontend/src/components/chat/ReasoningDetailState.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+
+export type ReasoningDetailPresentation = 'collapsed' | 'expanded';
+
+export interface ReasoningDetailStateApi {
+  readonly scopeKey: string;
+  get: (itemId: string) => ReasoningDetailPresentation | undefined;
+  set: (itemId: string, value: ReasoningDetailPresentation) => void;
+}
+
+const fallbackOverrides = new Map<string, ReasoningDetailPresentation>();
+export const fallbackReasoningDetailState: ReasoningDetailStateApi = {
+  scopeKey: 'fallback',
+  get: (itemId) => fallbackOverrides.get(itemId),
+  set: (itemId, value) => fallbackOverrides.set(itemId, value),
+};
+
+/**
+ * Keeps manual disclosure choices outside grouped rows, whose reconciliation
+ * can remount while history streams or prepends. The map is scoped to one
+ * mounted timeline/thread view and resets when that view's scope changes.
+ */
+export function useReasoningDetailStateScope(
+  scopeKey: string
+): ReasoningDetailStateApi {
+  return useMemo(() => {
+    const overrides = new Map<string, ReasoningDetailPresentation>();
+    return {
+      scopeKey,
+      get: (itemId) => overrides.get(itemId),
+      set: (itemId, value) => overrides.set(itemId, value),
+    };
+  }, [scopeKey]);
+}
+
+/** Isolated component tests render without a timeline-owned state map. */
+export function resetFallbackReasoningDetailStateForTests(): void {
+  fallbackOverrides.clear();
+}

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -39,6 +39,7 @@ import {
 import { reloadWhenServerReturns } from '../../lib/server-restart.js';
 import { useSessionsStore } from '../../lib/stores/sessions.js';
 import { useConfigStore } from '../../lib/stores/config.js';
+import { useReasoningDetailSettingsStore } from '../../lib/stores/reasoning-detail-settings.js';
 import SettingsNotificationsSection, {
   NOTIFICATIONS_SECTION_KEYWORDS,
 } from './SettingsNotificationsSection.js';
@@ -96,6 +97,9 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
     'renamer',
     'branch name',
     'session name',
+    'reasoning summary',
+    'collapsed',
+    'expanded',
   ],
   notifications: NOTIFICATIONS_SECTION_KEYWORDS,
   'agent-profiles': ['agents', 'profiles', 'claude', 'codex', 'opencode'],
@@ -518,6 +522,12 @@ function GeneralSection({
     (notifPerm === 'denied' || notifPerm === 'unsupported') &&
     !config.defaultNotifications;
   const frameworks = useConfigStore((state) => state.frameworks);
+  const reasoningDefault = useReasoningDetailSettingsStore(
+    (state) => state.settings.defaultState
+  );
+  const setReasoningDefault = useReasoningDetailSettingsStore(
+    (state) => state.setDefaultState
+  );
   return (
     <section
       id="section-general"
@@ -587,6 +597,24 @@ function GeneralSection({
           onChange={(v) => void handlers.handleNotifChange(v)}
           disabled={notifDisabled}
         />
+      </SettingRow>
+      <SettingRow
+        name="Reasoning summaries"
+        description="Default presentation for newly created reasoning details"
+      >
+        <select
+          className="settings-dialog-select"
+          value={reasoningDefault}
+          aria-label="Default reasoning summary state"
+          onChange={(event) =>
+            setReasoningDefault(
+              event.currentTarget.value as 'collapsed' | 'expanded'
+            )
+          }
+        >
+          <option value="collapsed">Collapsed</option>
+          <option value="expanded">Expanded</option>
+        </select>
       </SettingRow>
     </section>
   );

--- a/frontend/src/lib/chat/reasoning-detail.ts
+++ b/frontend/src/lib/chat/reasoning-detail.ts
@@ -1,0 +1,42 @@
+import type { AgentDetailCardV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+import type { ChannelMessage } from '../../../../shared/channel-chat-protocol.js';
+
+export type ReasoningTerminalState =
+  | 'completed'
+  | 'interrupted'
+  | 'failed'
+  | 'truncated';
+
+export function reasoningTerminalStateForMessage(
+  message: ChannelMessage
+): ReasoningTerminalState | undefined {
+  switch (message.status) {
+    case 'complete':
+      return 'completed';
+    case 'interrupted':
+    case 'failed':
+    case 'truncated':
+      return message.status;
+    case 'streaming':
+      return undefined;
+  }
+}
+
+/** Empty live details communicate activity; empty terminal details disappear. */
+export function shouldRenderReasoningDetail(
+  card: AgentDetailCardV2,
+  terminalState?: ReasoningTerminalState
+): boolean {
+  if (card.content?.trim()) return true;
+  if (terminalState) return false;
+  return card.status === 'pending' || card.status === 'running';
+}
+
+/** Render-only timeline projection: empty terminal reasoning owns no chrome. */
+export function shouldRenderChannelMessage(message: ChannelMessage): boolean {
+  const card = message.agentDetail?.card;
+  return (
+    card?.kind !== 'thought' ||
+    shouldRenderReasoningDetail(card, reasoningTerminalStateForMessage(message))
+  );
+}

--- a/frontend/src/lib/stores/reasoning-detail-settings.ts
+++ b/frontend/src/lib/stores/reasoning-detail-settings.ts
@@ -1,0 +1,81 @@
+import { create } from 'zustand';
+
+/** Client-local presentation preference for newly mounted reasoning details. */
+export const REASONING_DETAIL_SETTINGS_KEY = 'relay-reasoning-detail-settings';
+
+export type ReasoningDetailDefault = 'collapsed' | 'expanded';
+
+export interface ReasoningDetailSettings {
+  defaultState: ReasoningDetailDefault;
+}
+
+export const DEFAULT_REASONING_DETAIL_SETTINGS: ReasoningDetailSettings =
+  Object.freeze({ defaultState: 'collapsed' });
+
+export function parseReasoningDetailSettings(
+  raw: string | null
+): ReasoningDetailSettings {
+  if (!raw) return { ...DEFAULT_REASONING_DETAIL_SETTINGS };
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      ((value as Record<string, unknown>)['defaultState'] === 'collapsed' ||
+        (value as Record<string, unknown>)['defaultState'] === 'expanded')
+    ) {
+      return {
+        defaultState: (value as Record<string, unknown>)[
+          'defaultState'
+        ] as ReasoningDetailDefault,
+      };
+    }
+  } catch {
+    // A corrupt preference degrades to the product default.
+  }
+  return { ...DEFAULT_REASONING_DETAIL_SETTINGS };
+}
+
+function loadSettings(): ReasoningDetailSettings {
+  try {
+    return parseReasoningDetailSettings(
+      localStorage.getItem(REASONING_DETAIL_SETTINGS_KEY)
+    );
+  } catch {
+    return { ...DEFAULT_REASONING_DETAIL_SETTINGS };
+  }
+}
+
+function persistSettings(settings: ReasoningDetailSettings): void {
+  try {
+    localStorage.setItem(
+      REASONING_DETAIL_SETTINGS_KEY,
+      JSON.stringify(settings)
+    );
+  } catch {
+    // localStorage can be unavailable in restricted browser contexts.
+  }
+}
+
+interface ReasoningDetailSettingsState {
+  settings: ReasoningDetailSettings;
+  setDefaultState: (defaultState: ReasoningDetailDefault) => void;
+  reset: () => void;
+}
+
+export const useReasoningDetailSettingsStore =
+  create<ReasoningDetailSettingsState>((set, get) => ({
+    settings: loadSettings(),
+    setDefaultState: (defaultState) => {
+      if (get().settings.defaultState === defaultState) return;
+      const settings = { defaultState };
+      persistSettings(settings);
+      set({ settings });
+    },
+    reset: () => {
+      const settings = { ...DEFAULT_REASONING_DETAIL_SETTINGS };
+      persistSettings(settings);
+      set({ settings });
+    },
+  }));

--- a/test/components/agent-detail-card.test.ts
+++ b/test/components/agent-detail-card.test.ts
@@ -18,6 +18,10 @@ const {
   AGENT_DETAIL_RENDER_MAX_CHARS,
   AGENT_DETAIL_RENDER_MAX_LINES,
 } = await import('../../frontend/src/components/chat/AgentDetailCard.js');
+const { useReasoningDetailSettingsStore } =
+  await import('../../frontend/src/lib/stores/reasoning-detail-settings.js');
+const { resetFallbackReasoningDetailStateForTests } =
+  await import('../../frontend/src/components/chat/ReasoningDetailState.js');
 
 let host: HTMLDivElement;
 let root: Root;
@@ -41,6 +45,8 @@ async function toggle(): Promise<void> {
 describe('AgentDetailCard', () => {
   beforeEach(() => {
     shikiMocks.useShikiHighlight.mockClear();
+    useReasoningDetailSettingsStore.getState().reset();
+    resetFallbackReasoningDetailStateForTests();
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
@@ -102,18 +108,117 @@ describe('AgentDetailCard', () => {
     );
   });
 
-  it('does not advertise a disclosure for an empty terminal thought', async () => {
+  it('uses the persisted expanded default for each new reasoning block', async () => {
+    useReasoningDetailSettingsStore.getState().setDefaultState('expanded');
+    await render({
+      kind: 'thought',
+      title: 'provider title is not presented as prose',
+      status: 'running',
+      content: 'first retained fragment',
+    });
+
+    const toggle = host.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle?.getAttribute('aria-label')).toBe(
+      'Collapse Reasoning summary (reasoning…)'
+    );
+    expect(host.textContent).toContain('Reasoning summary');
+    expect(host.textContent).not.toContain(
+      'provider title is not presented as prose'
+    );
+    expect(host.textContent).toContain('first retained fragment');
+  });
+
+  it('keeps a manual override stable while settings and streaming content change', async () => {
+    useReasoningDetailSettingsStore.getState().setDefaultState('expanded');
+    await render({
+      kind: 'thought',
+      title: 'thinking',
+      status: 'running',
+      content: 'first fragment',
+    });
+
+    // Two manual toggles leave the block expanded but mark its presentation as
+    // user-controlled. A later opposite default must affect only new blocks.
+    await toggle();
+    await toggle();
+    useReasoningDetailSettingsStore.getState().setDefaultState('collapsed');
+    await render({
+      kind: 'thought',
+      title: 'thinking',
+      status: 'running',
+      content: 'first fragment plus streamed delta',
+    });
+
+    expect(
+      host
+        .querySelector('.ch-agent-card__toggle')
+        ?.getAttribute('aria-expanded')
+    ).toBe('true');
+    expect(host.querySelector('.ch-agent-card__body')?.textContent).toContain(
+      'first fragment plus streamed delta'
+    );
+
+    await act(async () => {
+      root.render(
+        React.createElement(AgentDetailCard, {
+          card: {
+            kind: 'thought',
+            title: 'thinking',
+            status: 'running',
+            content: 'a newly created block',
+          },
+          itemId: 'durable-item-2',
+        })
+      );
+    });
+    expect(
+      host
+        .querySelector('.ch-agent-card__toggle')
+        ?.getAttribute('aria-expanded')
+    ).toBe('false');
+  });
+
+  it.each(['interrupted', 'failed', 'truncated'] as const)(
+    'shows the truthful %s terminal state while expanded',
+    async (reasoningTerminalState) => {
+      useReasoningDetailSettingsStore.getState().setDefaultState('expanded');
+      await act(async () => {
+        root.render(
+          React.createElement(AgentDetailCard, {
+            card: {
+              kind: 'thought',
+              title: 'thinking',
+              status:
+                reasoningTerminalState === 'failed' ? 'failed' : 'cancelled',
+              content: 'retained provider-visible summary',
+            },
+            itemId: `terminal-${reasoningTerminalState}`,
+            reasoningTerminalState,
+          })
+        );
+      });
+
+      expect(host.querySelector('.ch-agent-card__status')?.textContent).toBe(
+        reasoningTerminalState
+      );
+      expect(host.querySelector('.ch-agent-card__body')?.textContent).toContain(
+        'retained provider-visible summary'
+      );
+    }
+  );
+
+  it('removes an empty terminal reasoning detail', async () => {
     await render({
       kind: 'thought',
       title: 'thinking',
       status: 'completed',
     });
 
-    const card = host.querySelector('.ch-agent-card');
-    expect(card?.getAttribute('data-agent-card-expandable')).toBe('false');
-    expect(card?.querySelector('.ch-agent-card__toggle')).toBeNull();
+    expect(host.querySelector('.ch-agent-card')).toBeNull();
     expect(host.querySelector('.ch-agent-card__chevron')).toBeNull();
-    expect(card?.textContent).toContain('thinking');
   });
 
   it('tints only added and removed diff lines and reports their counts', async () => {

--- a/test/components/channel-message-row.test.ts
+++ b/test/components/channel-message-row.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 
 import { ChannelMessageRow } from '../../frontend/src/components/chat/ChannelMessageRow.js';
+import { useReasoningDetailSettingsStore } from '../../frontend/src/lib/stores/reasoning-detail-settings.js';
+import { resetFallbackReasoningDetailStateForTests } from '../../frontend/src/components/chat/ReasoningDetailState.js';
 import type {
   ChannelMessage,
   ChannelMessageId,
@@ -61,6 +63,8 @@ describe('ChannelMessageRow truncation fidelity', () => {
   let root: Root;
 
   beforeEach(() => {
+    useReasoningDetailSettingsStore.getState().reset();
+    resetFallbackReasoningDetailStateForTests();
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -125,31 +129,44 @@ describe('ChannelMessageRow truncation fidelity', () => {
     ).toContain('reasoning content survives channel persistence');
   });
 
-  it('does not advertise a disclosure for a terminal reasoning summary without detail', async () => {
+  it('removes the whole durable row when empty reasoning terminalizes', async () => {
+    const detail = (status: 'streaming' | 'complete') =>
+      agentMessage({
+        status,
+        agentDetail: {
+          itemId: 'reason-summary-only',
+          card: {
+            kind: 'thought',
+            title: 'thinking',
+            status: status === 'streaming' ? 'running' : 'completed',
+            content: '   ',
+          },
+        },
+      });
     await act(async () => {
       root.render(
         React.createElement(ChannelMessageRow, {
-          message: agentMessage({
-            agentDetail: {
-              itemId: 'reason-summary-only',
-              card: {
-                kind: 'thought',
-                title: 'thinking',
-                status: 'completed',
-                content: '   ',
-              },
-            },
-          }),
+          message: detail('streaming'),
           channelId: 'topic:eng-threads',
         })
       );
     });
 
-    const card = container.querySelector('.ch-agent-card');
-    expect(card?.getAttribute('data-agent-card-expandable')).toBe('false');
-    expect(card?.querySelector('.ch-agent-card__toggle')).toBeNull();
-    expect(card?.querySelector('.ch-agent-card__chevron')).toBeNull();
-    expect(card?.textContent).toContain('thinking');
+    expect(container.querySelector('.ch-reasoning-detail')).not.toBeNull();
+    expect(container.querySelector('.ch-agent-card__toggle')).toBeNull();
+    expect(container.textContent).toContain('reasoning…');
+
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: detail('complete'),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+
+    expect(container.querySelector('[data-channel-message-id]')).toBeNull();
+    expect(container.querySelector('.ch-agent-card__chevron')).toBeNull();
   });
 
   it('rerenders authoritative streaming card rows without overriding persisted status', async () => {
@@ -194,7 +211,7 @@ describe('ChannelMessageRow truncation fidelity', () => {
       );
     });
     expect(container.querySelector('.ch-agent-card__status')?.textContent).toBe(
-      'running'
+      'reasoning…'
     );
     expect(
       container.querySelector('.ch-agent-card__body')?.textContent

--- a/test/components/channel-timeline-scroll.test.ts
+++ b/test/components/channel-timeline-scroll.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { ChannelTimeline } from '../../frontend/src/components/chat/ChannelTimeline.js';
+import { useReasoningDetailSettingsStore } from '../../frontend/src/lib/stores/reasoning-detail-settings.js';
 import type {
   ChannelMessage,
   ChannelMessageId,
@@ -55,6 +56,27 @@ function detailMessage(seq: number): ChannelMessage {
         title: 'durable output',
         status: 'completed',
         content: 'expanded durable card content',
+      },
+    },
+  };
+}
+
+function reasoningMessage(
+  seq: number,
+  messageStatus: 'streaming' | 'complete' = 'streaming'
+): ChannelMessage {
+  return {
+    ...message(seq, ''),
+    status: messageStatus,
+    body: { text: '', format: 'markdown' },
+    agentDetail: {
+      itemId: 'reasoning-stable-item',
+      card: {
+        kind: 'thought',
+        title: 'provider summary title',
+        status: messageStatus === 'streaming' ? 'running' : 'completed',
+        content:
+          messageStatus === 'streaming' ? 'retained reasoning content' : '   ',
       },
     },
   };
@@ -167,6 +189,7 @@ async function userScroll(scrollTop: number): Promise<void> {
 
 describe('ChannelTimeline scroll model (#1193)', () => {
   beforeEach(() => {
+    useReasoningDetailSettingsStore.getState().reset();
     timelineScrollHeight = 1_000;
     timelineClientHeight = 300;
     resizeCallback = null;
@@ -342,6 +365,39 @@ describe('ChannelTimeline scroll model (#1193)', () => {
     expect(timeline().scrollTop).toBe(200);
     expect(host.querySelector('.ch-new-messages')?.textContent).toBe(
       '1 new message'
+    );
+  });
+
+  it('removes empty terminal reasoning before timeline grouping', async () => {
+    await render([reasoningMessage(1)]);
+    expect(host.querySelectorAll('.ch-group')).toHaveLength(1);
+    expect(host.querySelector('.ch-group__header')).not.toBeNull();
+
+    await render([reasoningMessage(1, 'complete')]);
+    expect(host.querySelector('.ch-group')).toBeNull();
+    expect(host.querySelector('.ch-group__header')).toBeNull();
+    expect(host.querySelector('.ch-day-divider')).toBeNull();
+  });
+
+  it('preserves a same-item manual override when its message group remounts', async () => {
+    await render([reasoningMessage(2)]);
+    const toggle = host.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    await act(async () => toggle?.click());
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+
+    // Prepending a same-sender row changes the group's React key from the
+    // reasoning message id to the new first id, remounting all grouped rows.
+    await render([message(1, 'earlier agent prose'), reasoningMessage(2)]);
+    const remounted = host.querySelector<HTMLButtonElement>(
+      '.ch-agent-card__toggle'
+    );
+    expect(remounted).not.toBe(toggle);
+    expect(remounted?.getAttribute('aria-expanded')).toBe('true');
+    expect(host.querySelector('.ch-agent-card__body')?.textContent).toContain(
+      'retained reasoning content'
     );
   });
 });

--- a/test/e2e/channel-timeline-scroll.spec.ts
+++ b/test/e2e/channel-timeline-scroll.spec.ts
@@ -123,7 +123,9 @@ test.describe('smoke channel timeline scroll UX (#1193)', () => {
 
     const card = row.locator('.ch-agent-card');
     await expect(card).toHaveAttribute('data-agent-card-kind', 'thought');
-    await expect(card.locator('.ch-agent-card__status')).toHaveText('running');
+    await expect(card.locator('.ch-agent-card__status')).toHaveText(
+      'reasoning…'
+    );
     await card.locator('.ch-agent-card__toggle').click();
     await expect(card.locator('.ch-agent-card__body')).toContainText(
       'authoritative debounced browser row'

--- a/test/stores/reasoning-detail-settings-store.test.ts
+++ b/test/stores/reasoning-detail-settings-store.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const storage: Record<string, string> = {};
+if (typeof globalThis.localStorage === 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (key: string) => storage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete storage[key];
+      },
+      clear: () => {
+        for (const key of Object.keys(storage)) delete storage[key];
+      },
+      get length() {
+        return Object.keys(storage).length;
+      },
+      key: (index: number) => Object.keys(storage)[index] ?? null,
+    },
+    writable: true,
+  });
+}
+
+const {
+  DEFAULT_REASONING_DETAIL_SETTINGS,
+  REASONING_DETAIL_SETTINGS_KEY,
+  parseReasoningDetailSettings,
+  useReasoningDetailSettingsStore,
+} = await import('../../frontend/src/lib/stores/reasoning-detail-settings.js');
+
+beforeEach(() => {
+  for (const key of Object.keys(storage)) delete storage[key];
+  useReasoningDetailSettingsStore.getState().reset();
+});
+
+describe('reasoning detail settings', () => {
+  it('defaults new reasoning details to collapsed', () => {
+    expect(DEFAULT_REASONING_DETAIL_SETTINGS).toEqual({
+      defaultState: 'collapsed',
+    });
+  });
+
+  it.each(['collapsed', 'expanded'] as const)(
+    'persists the %s default',
+    (defaultState) => {
+      useReasoningDetailSettingsStore.getState().setDefaultState(defaultState);
+      expect(
+        parseReasoningDetailSettings(
+          storage[REASONING_DETAIL_SETTINGS_KEY] ?? null
+        )
+      ).toEqual({ defaultState });
+    }
+  );
+
+  it.each([null, '', 'nope', '[]', '{"defaultState":"open"}'])(
+    'degrades %s to the collapsed default',
+    (raw) => {
+      expect(parseReasoningDetailSettings(raw)).toEqual({
+        defaultState: 'collapsed',
+      });
+    }
+  );
+});


### PR DESCRIPTION
## What
- render provider-neutral reasoning as a distinct collapsible turn detail
- persist whether newly created reasoning blocks default collapsed or expanded
- retain manual disclosure overrides across streaming rerenders and group remounts
- project empty terminal reasoning out before timeline/thread grouping
- keep live empty reasoning visible as activity and terminal states truthful

## Why
Provider-visible reasoning summaries were visually weighted like durable assistant prose. They should remain inspectable and stream live without becoming conversation text, blank timeline artifacts, or implied raw chain-of-thought.

## Checklist
- [x] One provider-neutral component handles typed thought/reasoning cards
- [x] Progressive content continues while collapsed
- [x] Native accessible disclosure control exposes expanded state
- [x] Persisted default affects new blocks without overriding manual choices
- [x] Same-item override survives prepend/group-key remount churn
- [x] Main timeline and thread scope do not leak disclosure state
- [x] Running/completed/interrupted/failed/truncated labels remain truthful
- [x] Empty terminal reasoning leaves no row, group header, or day-divider chrome
- [x] #1358 text-only packet behavior remains entirely owned by the merged base

## Verification
- 63 focused component/store/context tests passed
- independent integration review reran 175 reasoning/context/binder tests
- `npm run check` — 0 errors (227 baseline warnings)
- `git diff --check` — clean
- final adversarial review of `0f45c22f` — no findings; safe to PR

Closes #1361
