### PR TITLE
fix(channel): bound designation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ workflow.
   so real conversation is not displaced by empty activity (#1358)
 - Designate-orchestrator failures now show actionable inline conflict or retry
   feedback instead of failing silently (#1352)
+- Designation errors now retire when the roster confirms an orchestrator and
+  stay bounded without collapsing the mobile channel header (#1352)
 - Long channel drafts now grow to a conversation-pane-relative cap instead of
   inner-scrolling after six lines, while preserving most of short mobile
   timelines (#1355)

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -206,6 +206,7 @@
 
 .ch-conn-dot {
   display: inline-block;
+  flex: 0 0 8px;
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -1184,6 +1185,8 @@
 
 @media (max-width: 767px) {
   .ch-header {
+    flex-wrap: wrap;
+    row-gap: 4px;
     padding: 8px 10px;
   }
 
@@ -1193,6 +1196,22 @@
 
   .ch-header__title {
     flex: 1 1 auto;
+    min-width: 4ch;
+  }
+
+  /* A failed designation gets a bounded row instead of competing with title,
+     agent, and connection geometry in the primary header row. Visual clamping
+     does not alter the alert's full accessible text. */
+  .ch-designate-orchestrator__error {
+    display: -webkit-box;
+    order: 1;
+    flex: 1 0 100%;
+    max-width: 100%;
+    max-height: 2.4em;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
 
   /* Retain the role distinction in the shared mobile header without consuming

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -886,6 +886,14 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     (chip) => chip.role === 'orchestrator'
   );
 
+  // A designation write can commit while its response is lost. The next roster
+  // snapshot is authoritative: once its chip says orchestrator, retire any
+  // local failure from that write. Keep the render gate below as well so no
+  // intermediate commit can announce success and failure at the same time.
+  useEffect(() => {
+    if (hasOrchestrator && designateError !== null) setDesignateError(null);
+  }, [designateError, hasOrchestrator]);
+
   const channelNotFound =
     notFound ||
     (topicQuery.error instanceof HttpError && topicQuery.error.status === 404);
@@ -1014,7 +1022,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             )}
           </button>
         ) : null}
-        {designateError ? (
+        {designateError && !hasOrchestrator ? (
           <span className="ch-designate-orchestrator__error" role="alert">
             {designateError}
           </span>

--- a/frontend/src/test-channel-header.tsx
+++ b/frontend/src/test-channel-header.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './App.css';
+import './components/chat/ChannelView.css';
+
+export const DESIGNATION_ERROR =
+  'channel already has a non-orchestrator agent bound';
+
+function Fixture(): React.ReactElement {
+  return (
+    <div className="ch-view">
+      <div className="ch-header" data-testid="channel-header">
+        <span className="ch-header__title">#operator lane</span>
+        <span className="ch-header__meta">· 2 members</span>
+        <span className="ch-header__agents" aria-label="active agents">
+          <span className="ch-agent-chip ch-agent-chip--idle">
+            <span className="ch-agent-chip__dot" aria-hidden="true" />
+            <span className="ch-agent-chip__name">claude</span>
+          </span>
+        </span>
+        <button type="button" className="ch-designate-orchestrator">
+          designate orchestrator
+        </button>
+        <span className="ch-designate-orchestrator__error" role="alert">
+          {DESIGNATION_ERROR}
+        </span>
+        <span className="ch-header__spacer" />
+        <span
+          className="ch-conn-dot ch-conn-dot--on"
+          title="connected"
+          aria-label="connected"
+        />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(<Fixture />);

--- a/frontend/test-channel-header.html
+++ b/frontend/test-channel-header.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Channel header designation error test page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-channel-header.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,6 +64,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-channel-timeline.html'
   );
+  buildInputs['test-channel-header'] = resolve(
+    import.meta.dirname,
+    'test-channel-header.html'
+  );
   buildInputs['test-channel-composer'] = resolve(
     import.meta.dirname,
     'test-channel-composer.html'

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -357,6 +357,41 @@ describe('ChannelView orchestrator control (#1242)', () => {
     await flush();
   });
 
+  it('retires a lost-response failure when the roster confirms the orchestrator', async () => {
+    let roster = [rosterEntry('implementer')];
+    mocks.fetchChannelRoster.mockImplementation(async () => roster);
+    mocks.designateChannelOrchestrator.mockRejectedValue(
+      new HttpError(503, 'designation response was lost')
+    );
+
+    await render();
+
+    const designate = container.querySelector<HTMLButtonElement>(
+      '.ch-designate-orchestrator'
+    );
+    await act(async () => designate?.click());
+
+    expect(
+      container.querySelector('.ch-designate-orchestrator__error')?.textContent
+    ).toBe('could not designate orchestrator — try again');
+
+    roster = [rosterEntry('orchestrator')];
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['channel-roster', CHANNEL_ID],
+      });
+    });
+    await flush();
+
+    expect(container.querySelector('.ch-agent-chip__role')?.textContent).toBe(
+      'orchestrator'
+    );
+    expect(container.querySelector('.ch-designate-orchestrator')).toBeNull();
+    expect(
+      container.querySelector('.ch-designate-orchestrator__error')
+    ).toBeNull();
+  });
+
   it('marks a roster orchestrator with the compact lowercase role tag', async () => {
     mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('orchestrator')]);
 

--- a/test/e2e-sweep-ledger.ts
+++ b/test/e2e-sweep-ledger.ts
@@ -382,7 +382,7 @@ export const SWEPT_SPECS: readonly SweptSpec[] = [
 /** Specs kept by the sweep. Asserted against `test/e2e/` by the ledger test. */
 export const KEPT_SPEC_COUNT = 11;
 /** E2E specs added after the #1299 audit baseline. */
-export const POST_SWEEP_SPEC_COUNT = 1;
+export const POST_SWEEP_SPEC_COUNT = 2;
 
 /**
  * Specs the #1299 target audit found navigating to a page that never existed.

--- a/test/e2e/channel-header.spec.ts
+++ b/test/e2e/channel-header.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+
+const DESIGNATION_ERROR = 'channel already has a non-orchestrator agent bound';
+
+test('bounds the designation alert without collapsing the 320px channel header', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await page.goto('/test-channel-header.html');
+
+  const header = page.getByTestId('channel-header');
+  const title = header.locator('.ch-header__title');
+  const error = page.getByRole('alert');
+  const dot = header.locator('.ch-conn-dot');
+
+  await expect(header).toBeVisible();
+  await expect(title).toHaveText('#operator lane');
+  await expect(error).toHaveText(DESIGNATION_ERROR);
+  await expect(dot).toHaveAccessibleName('connected');
+
+  const metrics = await header.evaluate((element) => {
+    const titleElement =
+      element.querySelector<HTMLElement>('.ch-header__title');
+    const errorElement = element.querySelector<HTMLElement>(
+      '.ch-designate-orchestrator__error'
+    );
+    const dotElement = element.querySelector<HTMLElement>('.ch-conn-dot');
+    if (!titleElement || !errorElement || !dotElement) {
+      throw new Error('missing channel header fixture geometry');
+    }
+    const rect = (target: HTMLElement) => {
+      const bounds = target.getBoundingClientRect();
+      return {
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top,
+        bottom: bounds.bottom,
+        width: bounds.width,
+        height: bounds.height,
+      };
+    };
+    const errorStyle = getComputedStyle(errorElement);
+    const titleStyle = getComputedStyle(titleElement);
+    const dotStyle = getComputedStyle(dotElement);
+    return {
+      header: rect(element),
+      title: rect(titleElement),
+      error: rect(errorElement),
+      dot: rect(dotElement),
+      headerClientWidth: element.clientWidth,
+      headerScrollWidth: element.scrollWidth,
+      errorLineHeight: Number.parseFloat(errorStyle.lineHeight),
+      errorOverflow: errorStyle.overflow,
+      errorOrder: errorStyle.order,
+      titleMinWidth: Number.parseFloat(titleStyle.minWidth),
+      titleOverflow: titleStyle.overflow,
+      dotFlexShrink: dotStyle.flexShrink,
+      fullErrorText: errorElement.textContent,
+    };
+  });
+
+  expect(metrics.header.width).toBe(320);
+  expect(metrics.header.height).toBeLessThan(90);
+  expect(metrics.headerScrollWidth).toBeLessThanOrEqual(
+    metrics.headerClientWidth
+  );
+
+  expect(metrics.error.top).toBeGreaterThanOrEqual(metrics.title.bottom + 3);
+  expect(metrics.error.top).toBeGreaterThanOrEqual(metrics.dot.bottom + 3);
+  expect(metrics.error.left).toBeGreaterThanOrEqual(metrics.header.left + 9);
+  expect(metrics.error.right).toBeLessThanOrEqual(metrics.header.right - 9);
+  expect(metrics.error.height).toBeGreaterThan(metrics.errorLineHeight);
+  expect(metrics.error.height).toBeLessThanOrEqual(
+    metrics.errorLineHeight * 2 + 1
+  );
+  expect(metrics.errorOverflow).toBe('hidden');
+  expect(metrics.errorOrder).toBe('1');
+  expect(metrics.fullErrorText?.trim()).toBe(DESIGNATION_ERROR);
+
+  expect(metrics.title.width).toBeGreaterThanOrEqual(metrics.titleMinWidth);
+  expect(metrics.title.width).toBeGreaterThan(25);
+  expect(metrics.title.height).toBeGreaterThan(0);
+  expect(metrics.titleOverflow).toBe('hidden');
+
+  expect(metrics.dot.width).toBe(8);
+  expect(metrics.dot.height).toBe(8);
+  expect(metrics.dotFlexShrink).toBe('0');
+});


### PR DESCRIPTION
## What
- retire a local designation failure once the authoritative roster reports an orchestrator
- gate error rendering so success and failure cannot coexist during the same render
- move the mobile designation alert to a bounded two-line row
- protect the channel title and 8px connection indicator from flex collapse
- add real Chromium geometry/accessibility coverage at 320px

## Why
A Prime reviewer launched through a self-hosted Relay PTY produced two late adversarial findings against #1360: an unbounded error collapsed the mobile header, and a lost POST response followed by roster refresh could leave a stale failure beside a confirmed orchestrator. This follow-up closes both findings before the review campaign is considered complete.

## Verification
- 23 focused lifecycle/ledger tests passed
- real Chromium header test: 1/1 passed; 320px client/scroll width, 84.78px bounded header
- `npm run check` — 0 errors (227 baseline warnings)
- `git diff --check` — clean
- exact-SHA independent adversarial review — no findings; safe to PR

Follow-up to #1360 and #1352.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared stale orchestrator designation errors after the channel roster confirms successful designation.
  * Improved mobile channel header layout, including error wrapping, title sizing, overflow handling, and connection indicator visibility.

* **Tests**
  * Added coverage for orchestrator designation recovery and responsive channel header behavior across narrow viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->