### PR TITLE
fix(chat): bound mention context scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ workflow.
 - Channel mention packets now exclude blank tool, reasoning, status, and system
   activity rows, report shown/filtered counts, and use a smaller prose window
   so real conversation is not displaced by empty activity (#1358)
+- Bound each mention-context SQLite statement to the newest 256 raw candidates
+  and label summaries as lower bounds when older channel or thread history is omitted
+  (#1358, #1368)
 - Designate-orchestrator failures now show actionable inline conflict or retry
   feedback instead of failing silently (#1352)
 - Designation errors now retire when the roster confirms an orchestrator and

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -1588,6 +1588,8 @@ export function createChannelAgentBinder(
         summary: {
           totalCount: context.totalCount,
           activityFilteredCount: context.activityFilteredCount,
+          candidateScanBudget: context.candidateScanBudget,
+          candidateScanTruncated: context.candidateScanTruncated,
           scope: context.scope,
         },
       }),

--- a/server/channel-context-packet.ts
+++ b/server/channel-context-packet.ts
@@ -78,12 +78,17 @@ export interface BuildMentionContextPacketInput {
   /** Cursor: 0 for a first-ever mention (cold session → full orientation window). */
   lastDeliveredSeq: number;
   /**
-   * Exact precomputed counts when the binder paginates a larger raw history.
-   * Unit callers may omit this and let the pure builder derive counts from rows.
+   * Precomputed counts for the scanned candidate window. They are exact unless
+   * `candidateScanTruncated` is true, in which case packet copy labels them as
+   * lower bounds. Unit callers may omit this and derive exact counts from rows.
    */
   summary?: {
     totalCount: number;
     activityFilteredCount: number;
+    /** Maximum raw candidates examined by each semantic count/row statement. */
+    candidateScanBudget?: number;
+    /** Counts cover the newest bounded candidate window, not all older history. */
+    candidateScanTruncated?: boolean;
     scope: 'channel' | 'thread';
   };
 }
@@ -244,6 +249,7 @@ export function buildMentionContextPacketEnvelope(
 
   let contextRows: ChannelMessage[];
   let omittedEarlier =
+    input.summary?.candidateScanTruncated === true ||
     contextTotalCount - activityFilteredCount > eligible.length;
   if (threadRootId !== null) {
     const root = eligible.find((row) => row.id === threadRootId);
@@ -277,11 +283,17 @@ export function buildMentionContextPacketEnvelope(
   ].join('\n');
 
   const assemble = (rows: ChannelMessage[], omitted: boolean): string => {
+    const truncated = input.summary?.candidateScanTruncated === true;
+    const boundedPrefix = truncated ? 'At least ' : '';
+    const scope =
+      input.summary?.scope ?? (threadRootId === null ? 'channel' : 'thread');
+    const boundedDetails = truncated
+      ? `; activity rows filtered: at least ${activityFilteredCount}; newest ${input.summary?.candidateScanBudget ?? 'bounded'} raw ${scope === 'thread' ? 'reply ' : ''}candidates scanned`
+      : `, ${activityFilteredCount} activity rows filtered`;
     const summary =
-      (input.summary?.scope ??
-        (threadRootId === null ? 'channel' : 'thread')) === 'thread'
-        ? `${contextTotalCount} prior thread rows (${rows.length} shown, ${activityFilteredCount} activity rows filtered).`
-        : `${contextTotalCount} messages since your last turn (${rows.length} shown, ${activityFilteredCount} activity rows filtered).`;
+      scope === 'thread'
+        ? `${boundedPrefix}${contextTotalCount} prior thread rows (${rows.length} shown${boundedDetails}).`
+        : `${boundedPrefix}${contextTotalCount} messages since your last turn (${rows.length} shown${boundedDetails}).`;
     const scopeLines = threadRootId !== null ? [THREAD_SCOPE_MARKER] : [];
     if (rows.length === 0) {
       return [header, summary, ...scopeLines, '', footer].join('\n');

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -121,13 +121,43 @@ export function buildChannelThreadHistorySql(
 
 export type ChannelMentionContextScope = 'channel' | 'thread';
 
+/** Raw candidate window per semantic statement: 16× the packet row budget. */
+export const MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET = 256;
+
+/**
+ * Indexed lookahead that finds the exclusive lower seq bound for a candidate
+ * window. One OFFSET read examines at most budget + 1 index entries; each
+ * subsequent count/row statement is constrained to at most the newest budget
+ * entries (at most `3 * budget + 1` visits across the three statements).
+ */
+export function buildChannelMentionContextBoundarySql(
+  scope: ChannelMentionContextScope
+): string {
+  if (scope === 'thread') {
+    return `SELECT reply.seq
+              FROM channel_messages reply INDEXED BY idx_chm_thread
+             WHERE reply.thread_id = @threadRootId
+               AND reply.seq < @triggerSeq
+             ORDER BY reply.seq DESC
+             LIMIT 1 OFFSET @candidateBudget`;
+  }
+  return `SELECT channel_row.seq
+            FROM channel_messages channel_row INDEXED BY idx_chm_channel_seq
+           WHERE channel_row.channel_id = @channelId
+             AND channel_row.seq > @afterSeq
+             AND channel_row.seq < @triggerSeq
+           ORDER BY channel_row.seq DESC
+           LIMIT 1 OFFSET @candidateBudget`;
+}
+
 /**
  * Exact summary + bounded-row query used by mention delivery (#1358).
  *
  * Both builders deliberately share the same candidate/eligibility predicates.
- * The count query sees the entire seq range, while the rows query sorts that
- * range newest-first before LIMIT. Thus a million activity rows cost no JS
- * allocations and cannot evict older prose from the packet window.
+ * The caller first narrows the range to the newest deterministic candidate
+ * budget; counts are exact within that window and carry an explicit truncation
+ * bit when older candidates exist. Activity rows cost no JS allocations and
+ * cannot make either SQL query scan an unbounded cursor range.
  */
 function mentionContextCandidateSql(scope: ChannelMentionContextScope): string {
   if (scope === 'thread') {
@@ -142,13 +172,14 @@ function mentionContextCandidateSql(scope: ChannelMentionContextScope): string {
         FROM channel_messages reply
        WHERE reply.thread_id = @threadRootId
          AND reply.channel_id = @channelId
+         AND reply.seq > @candidateAfterSeq
          AND reply.seq < @triggerSeq
     )`;
   }
   return `(SELECT channel_row.*
              FROM channel_messages channel_row
             WHERE channel_row.channel_id = @channelId
-              AND channel_row.seq > @afterSeq
+              AND channel_row.seq > @candidateAfterSeq
               AND channel_row.seq < @triggerSeq)`;
 }
 
@@ -202,7 +233,7 @@ export function buildChannelMentionContextRowsSql(
     return `SELECT m.*
               FROM channel_messages m
              WHERE m.channel_id = @channelId
-               AND m.seq > @afterSeq
+               AND m.seq > @candidateAfterSeq
                AND m.seq < @triggerSeq
                AND ${mentionContextOwnRowSql('channel')}
                AND ${mentionContextEligibleSql('channel')}
@@ -224,6 +255,7 @@ export function buildChannelMentionContextRowsSql(
                 FROM channel_messages reply
                WHERE reply.thread_id = @threadRootId
                  AND reply.channel_id = @channelId
+                 AND reply.seq > @candidateAfterSeq
                  AND reply.seq < @triggerSeq
                  AND ${mentionContextOwnRowSql('channel', 'reply')}
                  AND ${mentionContextEligibleSql('channel', 'reply')}
@@ -1003,8 +1035,18 @@ export interface ChannelMentionContextQuery {
 
 export interface ChannelMentionContextResult {
   rows: ChannelMessage[];
+  /** Exact count inside the bounded candidate window. */
   totalCount: number;
+  /** Exact filtered count inside the bounded candidate window. */
   activityFilteredCount: number;
+  /** Maximum raw candidates examined by each semantic count/row statement. */
+  candidateScanBudget: number;
+  /**
+   * True when older raw index entries exist outside the bounded window. Thread
+   * probes are deliberately conservative and can include corrupt cross-channel
+   * entries sharing the same thread id; no such row enters the semantic result.
+   */
+  candidateScanTruncated: boolean;
   scope: ChannelMentionContextScope;
 }
 
@@ -2140,6 +2182,16 @@ function ensureLegacyClaudeEchoHeal(db: Database.Database): void {
 
 function runMigrations(db: Database.Database): void {
   runSchemaMigrations(db);
+  // Repair legacy/hand-built schema-version rows that predate index backstops.
+  // Mention-context budgeting is only a work bound when its boundary probe is an
+  // indexed range read, so prepare-time `INDEXED BY` must fail neither open nor
+  // on an otherwise readable older database.
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_chm_channel_seq
+      ON channel_messages(channel_id, seq);
+    CREATE INDEX IF NOT EXISTS idx_chm_thread
+      ON channel_messages(thread_id, seq) WHERE thread_id IS NOT NULL;
+  `);
   db.exec(CHANNEL_READ_STATE_SCHEMA_SQL);
   // Order matters both ways: the heal translates `channel_read_state` (created
   // above) and may drop the search index, which `ensureChannelSearchIndex`
@@ -2338,6 +2390,12 @@ export function initChannelMessageStore(
 
 export interface ChannelMessageStoreOptions {
   /**
+   * Raw timeline candidates examined by one mention-context query. The default
+   * is `MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET`; tests may lower it to prove the
+   * deterministic degradation path without machine-dependent timing.
+   */
+  mentionContextCandidateScanBudget?: number;
+  /**
    * Wall-clock ceiling for one ranked index read, in milliseconds. Defaults to
    * `CHANNEL_SEARCH_TIME_BUDGET_MS`.
    *
@@ -2375,6 +2433,19 @@ export function createChannelMessageStore(
   } catch (error) {
     db.close();
     throw error;
+  }
+
+  const mentionContextCandidateScanBudget =
+    options.mentionContextCandidateScanBudget ??
+    MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET;
+  if (
+    !Number.isSafeInteger(mentionContextCandidateScanBudget) ||
+    mentionContextCandidateScanBudget < 1 ||
+    mentionContextCandidateScanBudget > MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET
+  ) {
+    throw new RangeError(
+      `mentionContextCandidateScanBudget must be an integer from 1 through ${MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET}`
+    );
   }
 
   // ── search cost guards (#1316) ────────────────────────────────────────────
@@ -2529,10 +2600,12 @@ export function createChannelMessageStore(
   );
   const mentionContextStatements = {
     channel: {
+      boundary: db.prepare(buildChannelMentionContextBoundarySql('channel')),
       count: db.prepare(buildChannelMentionContextCountSql('channel')),
       rows: db.prepare(buildChannelMentionContextRowsSql('channel')),
     },
     thread: {
+      boundary: db.prepare(buildChannelMentionContextBoundarySql('thread')),
       count: db.prepare(buildChannelMentionContextCountSql('thread')),
       rows: db.prepare(buildChannelMentionContextRowsSql('thread')),
     },
@@ -3095,16 +3168,36 @@ export function createChannelMessageStore(
       const scope: ChannelMentionContextScope =
         input.threadRootId === null ? 'channel' : 'thread';
       const limit = cleanLimit(input.limit);
-      const params = {
+      const baseParams = {
         channelId: input.channelId,
         framework: input.framework,
         triggerSeq: input.triggerSeq,
         afterSeq: input.afterSeq,
         threadRootId: input.threadRootId,
+        candidateBudget: mentionContextCandidateScanBudget,
+      };
+      const statements = mentionContextStatements[scope];
+      const boundary = statements.boundary.get(baseParams) as
+        | { seq: number }
+        | undefined;
+      const candidateScanTruncated = boundary !== undefined;
+      const candidateAfterSeq =
+        boundary?.seq ?? (scope === 'channel' ? input.afterSeq : -1);
+      const params = {
+        ...baseParams,
+        candidateAfterSeq,
         limit,
         replyLimit: Math.max(0, limit - 1),
       };
-      const statements = mentionContextStatements[scope];
+      if (candidateScanTruncated) {
+        logger.warn(
+          'mention_context_candidate_budget_truncated channel_id=%s scope=%s raw_index_entries_at_least=%d candidate_budget=%d',
+          input.channelId,
+          scope,
+          mentionContextCandidateScanBudget + 1,
+          mentionContextCandidateScanBudget
+        );
+      }
       const count = statements.count.get(params) as {
         total_count: number;
         activity_filtered_count: number;
@@ -3115,6 +3208,8 @@ export function createChannelMessageStore(
         rows: rows.map(rowToMessage),
         totalCount: count.total_count,
         activityFilteredCount: count.activity_filtered_count,
+        candidateScanBudget: mentionContextCandidateScanBudget,
+        candidateScanTruncated,
         scope,
       };
     },

--- a/test/channel-context-packet.test.ts
+++ b/test/channel-context-packet.test.ts
@@ -416,6 +416,31 @@ describe('buildMentionContextPacket', () => {
     expect(packet).not.toContain('hermes [agent]:    ');
   });
 
+  it('labels bounded candidate counts as lower bounds', () => {
+    const packet = buildMentionContextPacket({
+      channelTitle: 'general',
+      framework: 'claude',
+      rows: [
+        msg(3, OPERATOR, 'recent prose'),
+        msg(4, SYSTEM, 'activity', 'system'),
+      ],
+      trigger: msg(5, OPERATOR, '@claude continue'),
+      lastDeliveredSeq: 0,
+      summary: {
+        totalCount: 2,
+        activityFilteredCount: 1,
+        candidateScanBudget: 3,
+        candidateScanTruncated: true,
+        scope: 'channel',
+      },
+    });
+
+    expect(packet).toContain(
+      'At least 2 messages since your last turn (1 shown; activity rows filtered: at least 1; newest 3 raw candidates scanned).'
+    );
+    expect(packet).toContain('[…earlier messages omitted]');
+  });
+
   it('renders the exact golden packet (own rows skipped, sender labels, footer)', () => {
     const rows = [
       msg(1, OPERATOR, 'hey team, the build is red'),

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -7,6 +7,7 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  buildChannelMentionContextBoundarySql,
   buildChannelMentionContextCountSql,
   buildChannelMentionContextRowsSql,
   buildChannelMessageSearchSql,
@@ -19,6 +20,7 @@ import {
   registerChannelSearchTick,
   ChannelMessageStoreError,
   ChannelSearchRefusedError,
+  MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET,
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import {
@@ -45,6 +47,7 @@ function dbPath(): string {
 function store(
   pathOverride?: string,
   options?: {
+    mentionContextCandidateScanBudget?: number;
     searchTimeBudgetMs?: number;
     searchCostPreflight?: 'auto' | 'unavailable';
   }
@@ -127,6 +130,33 @@ describe('channel-message-store schema migration', () => {
         .prepare('SELECT COUNT(*) AS count FROM channel_agent_bindings')
         .get()
     ).toEqual({ count: 1 });
+  });
+
+  it('repairs missing mention-context indexes before preparing bounded reads', () => {
+    const file = dbPath();
+    store(file).close();
+    const damaged = new Database(file);
+    damaged.exec(`
+      DROP INDEX idx_chm_channel_seq;
+      DROP INDEX idx_chm_thread;
+    `);
+    damaged.close();
+
+    // `createChannelMessageStore` prepares INDEXED BY statements before return;
+    // reopening therefore proves repair happened before the bounded reads load.
+    store(file).close();
+    const inspect = new Database(file, { readonly: true });
+    cleanup.push(() => inspect.close());
+    const indexNames = (
+      inspect
+        .prepare(
+          `SELECT name FROM sqlite_master
+            WHERE type = 'index' AND name IN ('idx_chm_channel_seq', 'idx_chm_thread')
+            ORDER BY name`
+        )
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    expect(indexNames).toEqual(['idx_chm_channel_seq', 'idx_chm_thread']);
   });
 
   it('widens v1 status, heals its known aliases, and preserves durable rows through v3', () => {
@@ -1869,11 +1899,205 @@ describe('channel-message-store mention context (#1358)', () => {
     expect(context).toMatchObject({
       totalCount: 22,
       activityFilteredCount: 3,
+      candidateScanBudget: MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET,
+      candidateScanTruncated: false,
       scope: 'channel',
     });
     expect(context.rows).toHaveLength(16);
     expect(context.rows.map((row) => row.body.text)).toEqual(
       Array.from({ length: 16 }, (_, index) => `prose ${index + 2}`)
+    );
+  });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET + 1,
+    Number.MAX_SAFE_INTEGER,
+  ])(
+    'rejects invalid candidate budget %s at store creation',
+    (candidateBudget) => {
+      expect(() =>
+        store(undefined, {
+          mentionContextCandidateScanBudget: candidateBudget,
+        })
+      ).toThrow(
+        new RangeError(
+          `mentionContextCandidateScanBudget must be an integer from 1 through ${MENTION_CONTEXT_CANDIDATE_SCAN_BUDGET}`
+        )
+      );
+    }
+  );
+
+  it('degrades channel context deterministically to the newest candidate budget', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    cleanup.push(() => warnSpy.mockRestore());
+    const s = store(undefined, { mentionContextCandidateScanBudget: 3 });
+    const channelId = 'topic:context-budget';
+    for (let index = 0; index < 5; index += 1) {
+      s.appendComplete({ channelId, sender: HUMAN, text: `prose ${index}` });
+    }
+    const trigger = s.appendComplete({
+      channelId,
+      sender: HUMAN,
+      text: '@claude inspect',
+    });
+
+    const context = s.mentionContext({
+      channelId,
+      framework: 'claude',
+      triggerSeq: trigger.seq,
+      afterSeq: 0,
+      threadRootId: null,
+      limit: 16,
+    });
+
+    expect(context).toMatchObject({
+      totalCount: 3,
+      activityFilteredCount: 0,
+      candidateScanBudget: 3,
+      candidateScanTruncated: true,
+      scope: 'channel',
+    });
+    expect(context.rows.map((row) => row.body.text)).toEqual([
+      'prose 2',
+      'prose 3',
+      'prose 4',
+    ]);
+    const budgetLine = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('mention_context_candidate_budget_truncated')
+    );
+    expect(format(...(budgetLine as [string, ...unknown[]]))).toBe(
+      '[channel-message-store] mention_context_candidate_budget_truncated channel_id=topic:context-budget scope=channel raw_index_entries_at_least=4 candidate_budget=3'
+    );
+  });
+
+  it('keeps a structural thread root outside the bounded reply window', () => {
+    const s = store(undefined, { mentionContextCandidateScanBudget: 3 });
+    const channelId = 'topic:thread-context-budget';
+    const root = s.appendComplete({ channelId, sender: HUMAN, text: '' });
+    for (let index = 0; index < 5; index += 1) {
+      s.appendComplete({
+        channelId,
+        sender: HUMAN,
+        text: `reply ${index}`,
+        parentMessageId: root.id,
+      });
+    }
+    const trigger = s.appendComplete({
+      channelId,
+      sender: HUMAN,
+      text: '@claude inspect',
+      parentMessageId: root.id,
+    });
+
+    const context = s.mentionContext({
+      channelId,
+      framework: 'claude',
+      triggerSeq: trigger.seq,
+      afterSeq: 0,
+      threadRootId: root.id,
+      limit: 16,
+    });
+
+    expect(context).toMatchObject({
+      totalCount: 4,
+      activityFilteredCount: 0,
+      candidateScanBudget: 3,
+      candidateScanTruncated: true,
+      scope: 'thread',
+    });
+    expect(context.rows.map((row) => row.body.text)).toEqual([
+      '',
+      'reply 2',
+      'reply 3',
+      'reply 4',
+    ]);
+  });
+
+  it('bounds corrupt cross-channel thread collisions without leaking their rows', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    cleanup.push(() => warnSpy.mockRestore());
+    const file = dbPath();
+    const s = store(file, { mentionContextCandidateScanBudget: 3 });
+    const channelId = 'topic:thread-owner';
+    const root = s.appendComplete({
+      channelId,
+      sender: HUMAN,
+      text: 'owner root',
+    });
+    s.appendComplete({
+      channelId,
+      sender: HUMAN,
+      text: 'owner reply outside conservative window',
+      parentMessageId: root.id,
+    });
+    for (let index = 0; index < 5; index += 1) {
+      s.appendComplete({
+        channelId,
+        sender: HUMAN,
+        text: `owner filler ${index}`,
+      });
+    }
+
+    const corrupt = new Database(file);
+    const insert = corrupt.prepare(`
+      INSERT INTO channel_messages (
+        id, channel_id, seq, kind, status, sender_kind, sender_id,
+        thread_id, parent_message_id, body_text, body_format, created_at, updated_at
+      ) VALUES (
+        @id, @channelId, @seq, 'message', 'complete', 'human', 'human:other',
+        @threadId, @threadId, @body, 'markdown', @now, @now
+      )
+    `);
+    for (let seq = 3; seq <= 6; seq += 1) {
+      insert.run({
+        id: `chm:corrupt-cross-channel-${seq}`,
+        channelId: 'topic:other',
+        seq,
+        threadId: root.id,
+        body: `must-not-leak-${seq}`,
+        now: '2026-08-07T00:00:00.000Z',
+      });
+    }
+    corrupt.close();
+    const trigger = s.appendComplete({
+      channelId,
+      sender: HUMAN,
+      text: '@claude inspect',
+      parentMessageId: root.id,
+    });
+
+    const context = s.mentionContext({
+      channelId,
+      framework: 'claude',
+      triggerSeq: trigger.seq,
+      afterSeq: 0,
+      threadRootId: root.id,
+      limit: 16,
+    });
+
+    expect(context).toMatchObject({
+      totalCount: 1,
+      activityFilteredCount: 0,
+      candidateScanBudget: 3,
+      candidateScanTruncated: true,
+      scope: 'thread',
+    });
+    expect(context.rows.map((row) => row.id)).toEqual([root.id]);
+    expect(JSON.stringify(context)).not.toContain('must-not-leak');
+    const budgetLine = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('mention_context_candidate_budget_truncated')
+    );
+    expect(format(...(budgetLine as [string, ...unknown[]]))).toBe(
+      '[channel-message-store] mention_context_candidate_budget_truncated channel_id=topic:thread-owner scope=thread raw_index_entries_at_least=4 candidate_budget=3'
     );
   });
 
@@ -1892,6 +2116,8 @@ describe('channel-message-store mention context (#1358)', () => {
       framework: 'claude',
       triggerSeq: 100,
       afterSeq: 0,
+      candidateAfterSeq: 0,
+      candidateBudget: 4096,
       threadRootId: root.id,
       limit: 16,
       replyLimit: 15,
@@ -1904,6 +2130,24 @@ describe('channel-message-store mention context (#1358)', () => {
       )
         .map((step) => step.detail)
         .join('\n');
+
+    const channelBoundary = explain(
+      buildChannelMentionContextBoundarySql('channel')
+    );
+    expect(channelBoundary).toMatch(
+      /SEARCH channel_row USING COVERING INDEX idx_chm_channel_seq \(channel_id=\? AND seq>\? AND seq<\?\)/
+    );
+    expect(channelBoundary).not.toContain('USE TEMP B-TREE');
+    const threadBoundarySql = buildChannelMentionContextBoundarySql('thread');
+    // The raw thread probe intentionally omits channel_id: idx_chm_thread is
+    // keyed by thread+seq, so every visited entry must count toward the budget,
+    // including corrupt cross-channel collisions.
+    expect(threadBoundarySql).not.toContain('channel_id');
+    const threadBoundary = explain(threadBoundarySql);
+    expect(threadBoundary).toMatch(
+      /SEARCH reply USING (?:COVERING )?INDEX idx_chm_thread \(thread_id=\? AND seq<\?\)/
+    );
+    expect(threadBoundary).not.toContain('USE TEMP B-TREE');
 
     const channelCount = explain(buildChannelMentionContextCountSql('channel'));
     expect(channelCount).toMatch(
@@ -1919,12 +2163,12 @@ describe('channel-message-store mention context (#1358)', () => {
     const threadCount = explain(buildChannelMentionContextCountSql('thread'));
     expect(threadCount).toMatch(/SEARCH root USING INDEX .*\(id=\?\)/);
     expect(threadCount).toMatch(
-      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\? AND seq<\?\)/
+      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\? AND seq>\? AND seq<\?\)/
     );
     const threadRows = explain(buildChannelMentionContextRowsSql('thread'));
     expect(threadRows).toMatch(/SEARCH root USING INDEX .*\(id=\?\)/);
     expect(threadRows).toMatch(
-      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\? AND seq<\?\)/
+      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\? AND seq>\? AND seq<\?\)/
     );
     expect(threadRows).not.toContain('USE TEMP B-TREE');
     expect(threadRows).not.toMatch(/SCAN (?:root|reply)/);


### PR DESCRIPTION
## Summary
- cap each mention-context semantic SQLite statement to the newest 256 raw candidates through an indexed budget+1 boundary read
- preserve structural thread roots while marking truncated channel/thread summaries as explicit lower bounds
- repair required legacy indexes before bounded statements prepare and emit privacy-safe truncation telemetry
- validate the injectable test budget within the production ceiling

## Defining invariant
A mention-context read performs at most one `B + 1` indexed boundary lookahead and at most `B` raw candidate visits in each semantic count/row statement; thread roots are separate point reads. Returned rows never cross channel scope, and truncated numeric summaries never claim full-history exactness.

## Validation
- `npm run check`
- `npx vitest run test/channel-message-store.test.ts test/channel-context-packet.test.ts test/channel-agent-binder.test.ts --reporter=dot` (234 passed before final amend; store suite 85 passed after final validation change)
- mutation: bypassing `candidateAfterSeq` fails the channel/thread bounded-window tests
- mutation: adding `channel_id` to the conservative thread boundary probe fails the locked SQL invariant
- exact-head adversarial review required on `3cc9230330bf32684d83b05fda4783bd04d36a25` / `0abb14f44454e98989305adadb334826fb7583d67c1604be7b5bae6e31aeb63a`

## Review evidence
- base: `98b029033d26a5713f29dfeffe0b3cdc249fb36a`
- head: `3cc9230330bf32684d83b05fda4783bd04d36a25`
- `git-diff-sha256-v1`: `0abb14f44454e98989305adadb334826fb7583d67c1604be7b5bae6e31aeb63a`
- bytes: 26859

Tracks #1368. Follow-up to #1364 / #1358.
