### PR TITLE
fix(chat): enforce sole orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,10 @@ workflow.
   activity rows, report shown/filtered counts, and use a smaller prose window
   so real conversation is not displaced by empty activity (#1358)
 - Bound each mention-context SQLite statement to the newest 256 raw candidates
-  and label summaries as lower bounds when older channel or thread history is omitted
-  (#1358, #1368)
+  and label summaries as lower bounds when older channel or thread history is
+  omitted (#1358, #1368)
+- Enforce one durable channel orchestrator with a transactional first-writer
+  conflict and a partial unique index, including safe legacy repair (#1365, #1368)
 - Designate-orchestrator failures now show actionable inline conflict or retry
   feedback instead of failing silently (#1352)
 - Designation errors now retire when the roster confirms an orchestrator and

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -11,6 +11,7 @@ import {
 } from './channel-context-packet.js';
 import type { ChannelAttachmentStore } from './channel-attachments.js';
 import {
+  createChannelOrchestratorConflictError,
   type ChannelBinding,
   type ChannelMessageStore,
 } from './channel-message-store.js';
@@ -446,6 +447,9 @@ export function createChannelAgentBinder(
 
   const live = new Map<string, LiveBinding>();
   const inflight = new Map<string, Promise<LiveBinding>>();
+  // Designation is a channel-level invariant, not a (channel, profile) spawn.
+  // Serialize competing profile requests before either can launch a loser.
+  const orchestratorInflight = new Map<string, Promise<LiveBinding>>();
   const consecutiveAgentTurns = new Map<
     string,
     {
@@ -717,23 +721,13 @@ export function createChannelAgentBinder(
     const topic = topicStore?.get(channelId);
     if (!topic || isDmChannel(topic) !== null) return null;
 
-    const matches = knownProfiles().filter(
-      (profile) =>
-        store.getBinding(channelId, profile.id)?.role === 'orchestrator'
+    const designated = store.getSoleOrchestratorBinding(channelId);
+    if (!designated) return null;
+    return (
+      knownProfiles().find(
+        (profile) => profile.id === designated.profileActorId
+      ) ?? null
     );
-    if (matches.length === 1) return matches[0]!;
-    if (matches.length > 1) {
-      // #1259 models one designated orchestrator. Do not pick an arbitrary
-      // runtime if corrupt/legacy state violates that invariant.
-      logger.warn(
-        'multiple orchestrator bindings found; default route skipped',
-        {
-          channelId,
-          profileActorIds: matches.map((profile) => profile.id),
-        }
-      );
-    }
-    return null;
   }
 
   function supportsSafeBoundarySteer(binding: LiveBinding): boolean {
@@ -1136,7 +1130,6 @@ export function createChannelAgentBinder(
       profileActorId,
       agentFramework: framework,
       runtimeId: created.id,
-      ...(effectiveRole ? { role: effectiveRole } : {}),
       providerSession: {
         ...(row?.providerSession ?? {}),
         ...created.providerSession,
@@ -1174,11 +1167,23 @@ export function createChannelAgentBinder(
   }
 
   function persistOrchestratorDesignation(binding: LiveBinding): void {
-    store.upsertBinding({
+    store.designateSoleOrchestrator({
       channelId: binding.channelId,
       profileActorId: binding.profileActorId,
       agentFramework: binding.framework,
-      role: 'orchestrator',
+    });
+  }
+
+  function assertSoleOrchestratorTarget(
+    channelId: string,
+    profileActorId: string
+  ): void {
+    const designated = store.getSoleOrchestratorBinding(channelId);
+    if (!designated || designated.profileActorId === profileActorId) return;
+    throw createChannelOrchestratorConflictError({
+      channelId,
+      designatedProfileActorId: designated.profileActorId,
+      requestedProfileActorId: profileActorId,
     });
   }
 
@@ -1220,23 +1225,28 @@ export function createChannelAgentBinder(
         'The requested agent profile no longer exists.'
       );
     }
-    const key = bindingKey(channelId, profile.id);
-    const pending = inflight.get(key);
-    if (pending) {
-      const binding = await pending;
-      assertBindingRole(binding, profile.providerId, 'orchestrator');
+
+    const channelPending = orchestratorInflight.get(channelId);
+    if (channelPending) {
+      // First writer wins. A failed first attempt leaves no durable reservation,
+      // so the waiter retries; a success is observed by the preflight below.
+      await channelPending.catch(() => undefined);
+      return ensureOrchestrator(channelId, framework, profileActorId);
+    }
+
+    const promise = (async () => {
+      assertSoleOrchestratorTarget(channelId, profile.id);
+      const binding = await ensureProfileBinding(
+        channelId,
+        profile,
+        'orchestrator'
+      );
       persistOrchestratorDesignation(binding);
       return binding;
-    }
-    const promise = doEnsureBinding(channelId, profile, 'orchestrator')
-      .then((binding) => {
-        persistOrchestratorDesignation(binding);
-        return binding;
-      })
-      .finally(() => {
-        inflight.delete(key);
-      });
-    inflight.set(key, promise);
+    })().finally(() => {
+      orchestratorInflight.delete(channelId);
+    });
+    orchestratorInflight.set(channelId, promise);
     return promise;
   }
 
@@ -2965,6 +2975,7 @@ export function createChannelAgentBinder(
       }
       live.clear();
       inflight.clear();
+      orchestratorInflight.clear();
       retryInFlight.clear();
       consecutiveAgentTurns.clear();
       unavailableRowAt.clear();

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -59,7 +59,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -773,6 +773,9 @@ CREATE TABLE IF NOT EXISTS channel_agent_bindings (
   updated_at            TEXT NOT NULL,
   PRIMARY KEY (channel_id, profile_actor_id)
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chab_sole_orchestrator
+  ON channel_agent_bindings(channel_id)
+  WHERE binding_role = 'orchestrator';
 `;
 
 interface ChannelMessageRow {
@@ -1077,6 +1080,14 @@ export interface ChannelBinding {
   updatedAt: string;
 }
 
+export interface SoleOrchestratorDesignationInput {
+  channelId: string;
+  profileActorId: string;
+  agentFramework: string;
+  runtimeId?: string | null;
+  providerSession?: Record<string, unknown>;
+}
+
 export interface StaleStreamSweepResult {
   channelId: string;
   truncatedIds: ChannelMessageId[];
@@ -1119,6 +1130,23 @@ export class ChannelMessageStoreError extends Error {
     super(message);
     this.name = 'ChannelMessageStoreError';
   }
+}
+
+export function createChannelOrchestratorConflictError(input: {
+  channelId: string;
+  designatedProfileActorId: string | null;
+  requestedProfileActorId: string;
+}): ChannelMessageStoreError {
+  return new ChannelMessageStoreError(
+    409,
+    'channel_orchestrator_conflict',
+    'channel already has a designated orchestrator',
+    {
+      channelId: input.channelId,
+      designatedProfileActorId: input.designatedProfileActorId ?? 'unknown',
+      requestedProfileActorId: input.requestedProfileActorId,
+    }
+  );
 }
 
 export interface ChannelMessageStore {
@@ -1272,12 +1300,21 @@ export interface ChannelMessageStore {
   listMembers(channelId: string): ChannelMemberRef[];
   findDmChannel(memberIdA: string, memberIdB: string): string | null;
   getBinding(channelId: string, profileActorId: string): ChannelBinding | null;
+  /** Returns the one durable designation guaranteed by the partial unique index. */
+  getSoleOrchestratorBinding(channelId: string): ChannelBinding | null;
+  /**
+   * First-writer designation. Repeating the same profile is idempotent; a
+   * different profile receives a stable 409 without changing either binding.
+   */
+  designateSoleOrchestrator(
+    input: SoleOrchestratorDesignationInput
+  ): ChannelBinding;
   upsertBinding(input: {
     channelId: string;
     profileActorId: string;
     agentFramework: string;
     runtimeId?: string | null;
-    role?: AgentRole | null;
+    role?: Exclude<AgentRole, 'orchestrator'> | null;
     providerSession?: Record<string, unknown>;
   }): ChannelBinding;
   sweepStaleStreaming(): StaleStreamSweepResult[];
@@ -2380,6 +2417,43 @@ function runSchemaMigrations(db: Database.Database): void {
       db.prepare('UPDATE schema_version SET version = 7').run();
     })();
   }
+  if (current < 8) {
+    db.transaction(() => {
+      const duplicates = db
+        .prepare(
+          `SELECT channel_id, COUNT(*) AS binding_count
+             FROM channel_agent_bindings
+            WHERE binding_role = 'orchestrator'
+            GROUP BY channel_id
+           HAVING COUNT(*) > 1`
+        )
+        .all() as Array<{ channel_id: string; binding_count: number }>;
+      if (duplicates.length > 0) {
+        const clear = db.prepare(
+          `UPDATE channel_agent_bindings
+              SET binding_role = NULL
+            WHERE channel_id = ? AND binding_role = 'orchestrator'`
+        );
+        let clearedBindings = 0;
+        for (const duplicate of duplicates) {
+          clearedBindings += clear.run(duplicate.channel_id).changes;
+        }
+        // Neither channel nor profile ids belong in migration telemetry.
+        logger.warn(
+          'cleared ambiguous legacy orchestrator designations before sole-role migration: channel_count=%d binding_count=%d',
+          duplicates.length,
+          clearedBindings
+        );
+      }
+      db.exec(`
+        DROP INDEX IF EXISTS idx_chab_sole_orchestrator;
+        CREATE UNIQUE INDEX idx_chab_sole_orchestrator
+          ON channel_agent_bindings(channel_id)
+          WHERE binding_role = 'orchestrator';
+      `);
+      db.prepare('UPDATE schema_version SET version = 8').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
@@ -2790,6 +2864,79 @@ export function createChannelMessageStore(
     const row = select.get(channelId, profileActorId) as BindingRow | undefined;
     return row ? bindingRowToRecord(row) : null;
   }
+
+  function getSoleOrchestratorBindingImpl(
+    channelId: string
+  ): ChannelBinding | null {
+    const row = db
+      .prepare(
+        `SELECT * FROM channel_agent_bindings
+          WHERE channel_id = ? AND binding_role = 'orchestrator'`
+      )
+      .get(channelId) as BindingRow | undefined;
+    return row ? bindingRowToRecord(row) : null;
+  }
+
+  function writeBindingImpl(
+    input: SoleOrchestratorDesignationInput & { role?: AgentRole | null }
+  ): ChannelBinding {
+    const now = nowIso();
+    const existing = db
+      .prepare(
+        'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND profile_actor_id = ?'
+      )
+      .get(input.channelId, input.profileActorId) as BindingRow | undefined;
+    const providerSessionJson = JSON.stringify(
+      input.providerSession ??
+        (existing
+          ? parseBindingProviderSession(existing.provider_session_json)
+          : {})
+    );
+    db.prepare(
+      `INSERT INTO channel_agent_bindings
+         (channel_id, profile_actor_id, agent_framework, runtime_id, binding_role, provider_session_json, created_at, updated_at)
+       VALUES (@channelId, @profileActorId, @agentFramework, @runtimeId, @bindingRole, @providerSessionJson, @createdAt, @updatedAt)
+       ON CONFLICT(channel_id, profile_actor_id) DO UPDATE SET
+         agent_framework = excluded.agent_framework,
+         runtime_id = excluded.runtime_id,
+         binding_role = excluded.binding_role,
+         provider_session_json = excluded.provider_session_json,
+         updated_at = excluded.updated_at`
+    ).run({
+      channelId: input.channelId,
+      profileActorId: input.profileActorId,
+      agentFramework: input.agentFramework,
+      runtimeId:
+        input.runtimeId !== undefined
+          ? input.runtimeId
+          : (existing?.runtime_id ?? null),
+      bindingRole:
+        input.role !== undefined
+          ? input.role
+          : (existing?.binding_role ?? null),
+      providerSessionJson,
+      createdAt: existing?.created_at ?? now,
+      updatedAt: now,
+    });
+    return getBindingImpl(input.channelId, input.profileActorId)!;
+  }
+
+  const designateSoleOrchestratorTransaction = db.transaction(
+    (input: SoleOrchestratorDesignationInput): ChannelBinding => {
+      const designated = getSoleOrchestratorBindingImpl(input.channelId);
+      if (
+        designated !== null &&
+        designated.profileActorId !== input.profileActorId
+      ) {
+        throw createChannelOrchestratorConflictError({
+          channelId: input.channelId,
+          designatedProfileActorId: designated.profileActorId,
+          requestedProfileActorId: input.profileActorId,
+        });
+      }
+      return writeBindingImpl({ ...input, role: 'orchestrator' });
+    }
+  );
 
   return {
     close() {
@@ -3599,45 +3746,44 @@ export function createChannelMessageStore(
       return getBindingImpl(channelId, profileActorId);
     },
 
+    getSoleOrchestratorBinding(channelId) {
+      return getSoleOrchestratorBindingImpl(channelId);
+    },
+
+    designateSoleOrchestrator(input) {
+      try {
+        // IMMEDIATE takes the write reservation before the conflict read, so
+        // separate store handles cannot both observe an empty designation.
+        return designateSoleOrchestratorTransaction.immediate(input);
+      } catch (error) {
+        if (error instanceof ChannelMessageStoreError) throw error;
+        if (
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          String(error.code).startsWith('SQLITE_CONSTRAINT')
+        ) {
+          const designated = getSoleOrchestratorBindingImpl(input.channelId);
+          throw createChannelOrchestratorConflictError({
+            channelId: input.channelId,
+            designatedProfileActorId: designated?.profileActorId ?? null,
+            requestedProfileActorId: input.profileActorId,
+          });
+        }
+        throw error;
+      }
+    },
+
     upsertBinding(input) {
-      const now = nowIso();
-      const profileActorId = input.profileActorId;
-      const existing = db
-        .prepare(
-          'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND profile_actor_id = ?'
-        )
-        .get(input.channelId, profileActorId) as BindingRow | undefined;
-      const providerSessionJson = JSON.stringify(
-        input.providerSession ??
-          (existing ? JSON.parse(existing.provider_session_json) : {})
-      );
-      db.prepare(
-        `INSERT INTO channel_agent_bindings
-           (channel_id, profile_actor_id, agent_framework, runtime_id, binding_role, provider_session_json, created_at, updated_at)
-         VALUES (@channelId, @profileActorId, @agentFramework, @runtimeId, @bindingRole, @providerSessionJson, @createdAt, @updatedAt)
-         ON CONFLICT(channel_id, profile_actor_id) DO UPDATE SET
-           agent_framework = excluded.agent_framework,
-           runtime_id = excluded.runtime_id,
-           binding_role = excluded.binding_role,
-           provider_session_json = excluded.provider_session_json,
-           updated_at = excluded.updated_at`
-      ).run({
-        channelId: input.channelId,
-        profileActorId,
-        agentFramework: input.agentFramework,
-        runtimeId:
-          input.runtimeId !== undefined
-            ? input.runtimeId
-            : (existing?.runtime_id ?? null),
-        bindingRole:
-          input.role !== undefined
-            ? input.role
-            : (existing?.binding_role ?? null),
-        providerSessionJson,
-        createdAt: existing?.created_at ?? now,
-        updatedAt: now,
-      });
-      return getBindingImpl(input.channelId, profileActorId)!;
+      // Untyped callers must not bypass the channel-level invariant.
+      if ((input as { role?: AgentRole | null }).role === 'orchestrator') {
+        throw new ChannelMessageStoreError(
+          400,
+          'orchestrator_requires_sole_designation',
+          'use designateSoleOrchestrator to assign the orchestrator role'
+        );
+      }
+      return writeBindingImpl(input);
     },
 
     sweepStaleStreaming() {
@@ -3802,16 +3948,23 @@ export function createChannelMessageStore(
   }
 }
 
-function bindingRowToRecord(row: BindingRow): ChannelBinding {
-  let providerSession: Record<string, unknown> = {};
+function parseBindingProviderSession(
+  providerSessionJson: string
+): Record<string, unknown> {
   try {
-    const parsed = JSON.parse(row.provider_session_json) as unknown;
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      providerSession = parsed as Record<string, unknown>;
-    }
+    const parsed = JSON.parse(providerSessionJson) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
   } catch {
-    providerSession = {};
+    return {};
   }
+}
+
+function bindingRowToRecord(row: BindingRow): ChannelBinding {
+  const providerSession = parseBindingProviderSession(
+    row.provider_session_json
+  );
   return {
     channelId: row.channel_id,
     profileActorId: row.profile_actor_id,

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -98,10 +98,17 @@ const CLAUDE_AGENT_SENDER: ChannelSenderRef = {
   displayName: 'Claude',
 };
 
-function makeStore(): { store: ChannelMessageStore; hub: ChannelHub } {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-binder-'));
-  cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
-  const store = createChannelMessageStore(path.join(dir, 'channel-chat.db'));
+function makeStore(dbPathOverride?: string): {
+  store: ChannelMessageStore;
+  hub: ChannelHub;
+} {
+  const dir = dbPathOverride
+    ? null
+    : fs.mkdtempSync(path.join(os.tmpdir(), 'relay-binder-'));
+  if (dir) cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const store = createChannelMessageStore(
+    dbPathOverride ?? path.join(dir!, 'channel-chat.db')
+  );
   cleanup.push(() => store.close());
   const hub = createChannelHub({ store, channelExists: () => true });
   cleanup.push(() => hub.close());
@@ -1179,13 +1186,14 @@ function makeBinder(cfg: {
   attachmentStore?: ChannelAttachmentStore;
   agentProfileStore?: AgentProfileStore | null;
   processEnv?: NodeJS.ProcessEnv;
+  storePath?: string;
 }): {
   binder: ChannelAgentBinder;
   store: ChannelMessageStore;
   hub: ChannelHub;
   sessions: SessionsHarness;
 } {
-  const { store, hub } = makeStore();
+  const { store, hub } = makeStore(cfg.storePath);
   const sessions = makeSessions(cfg.build, {
     ...(cfg.throwOnCreate ? { throwOnCreate: true } : {}),
     ...(cfg.createError !== undefined ? { createError: cfg.createError } : {}),
@@ -1614,6 +1622,80 @@ describe('channel-agent-binder — lifecycle', () => {
       role: 'orchestrator',
     });
     expect(agentReplies(store)).toHaveLength(0);
+  });
+
+  it('serializes competing orchestrator profiles before spawning a loser', async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const targets: MentionTarget[] = [
+      ...MOCK_TARGETS,
+      {
+        id: 'codex',
+        displayName: 'Codex',
+        kind: 'framework',
+        available: true,
+        reason: null,
+      },
+    ];
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets,
+      knownProviderIds: ['mock', 'codex'],
+      gate,
+    });
+
+    const first = binder.ensureOrchestrator(CH, 'mock');
+    const competitor = binder.ensureOrchestrator(CH, 'codex');
+    await waitFor(() => sessions.spawns() === 1);
+    expect(sessions.createParams()).toHaveLength(1);
+    releaseGate();
+    const [firstResult, competitorResult] = await Promise.allSettled([
+      first,
+      competitor,
+    ]);
+
+    expect(firstResult.status).toBe('fulfilled');
+    expect(competitorResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.objectContaining({
+        status: 409,
+        code: 'channel_orchestrator_conflict',
+        details: expect.objectContaining({
+          designatedProfileActorId: builtInAgentProfileId('mock'),
+          requestedProfileActorId: builtInAgentProfileId('codex'),
+        }),
+      }),
+    });
+    expect(sessions.spawns()).toBe(1);
+    expect(store.getSoleOrchestratorBinding(CH)?.profileActorId).toBe(
+      builtInAgentProfileId('mock')
+    );
+    expect(store.getBinding(CH, builtInAgentProfileId('codex'))).toBeNull();
+  });
+
+  it('coalesces simultaneous idempotent designation requests to one runtime', async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      gate,
+    });
+    const first = binder.ensureOrchestrator(CH, 'mock');
+    const repeated = binder.ensureOrchestrator(CH, 'mock');
+    await waitFor(() => sessions.spawns() === 1);
+    releaseGate();
+    const [a, b] = await Promise.all([first, repeated]);
+    expect(a.runtimeId).toBe(b.runtimeId);
+    expect(sessions.spawns()).toBe(1);
+    expect(store.getSoleOrchestratorBinding(CH)?.profileActorId).toBe(
+      builtInAgentProfileId('mock')
+    );
   });
 
   it('reuses a restored orchestrator binding', async () => {
@@ -4430,33 +4512,48 @@ describe('channel-agent-binder — orchestrator default-routing matrix', () => {
     }
   );
 
-  it('cold-resumes a durable orchestrator designation with an empty runtime registry', async () => {
+  it('cold-resumes a durable orchestrator designation after a store and hub restart', async () => {
     const topics = makeProductTopics();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-binder-restart-'));
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const storePath = path.join(dir, 'channel-chat.db');
+    const profileActorId = builtInAgentProfileId('orchestrator');
+    const beforeRestart = createChannelMessageStore(storePath);
+    beforeRestart.designateSoleOrchestrator({
+      channelId: CH,
+      profileActorId,
+      agentFramework: 'orchestrator',
+      runtimeId: null,
+    });
+    beforeRestart.close();
+
+    // Fresh store, hub, binder, and runtime registry model a full hub restart.
     const { binder, store, sessions } = makeBinder({
       build: (providerId) =>
         new ScriptedAdapter(providerId, {
           mode: 'reply',
           text: 'cold ack',
         }),
-      targets: [TARGETS[0]!],
-      knownProviderIds: ['orchestrator'],
+      targets: TARGETS,
+      knownProviderIds: ['orchestrator', 'worker'],
       topicStore: topics,
-    });
-    const profileActorId = builtInAgentProfileId('orchestrator');
-    // Production starts with no channel runtimes after a hub restart. The role,
-    // not runtime_id, is the durable designation source of truth.
-    store.upsertBinding({
-      channelId: CH,
-      profileActorId,
-      agentFramework: 'orchestrator',
-      runtimeId: null,
-      role: 'orchestrator',
+      storePath,
     });
     expect((await binder.rosterForChannel(CH))[0]).toMatchObject({
       id: profileActorId,
       role: 'orchestrator',
       binding: null,
     });
+    await expect(binder.ensureOrchestrator(CH, 'worker')).rejects.toMatchObject(
+      {
+        status: 409,
+        code: 'channel_orchestrator_conflict',
+      }
+    );
+    expect(sessions.spawns()).toBe(0);
+    expect(store.getSoleOrchestratorBinding(CH)?.profileActorId).toBe(
+      profileActorId
+    );
 
     post(store, binder, 'resume the plan', ['orchestrator']);
 
@@ -4491,12 +4588,11 @@ describe('channel-agent-binder — orchestrator default-routing matrix', () => {
     await waitFor(() => sessions.spawns() === 1);
     // The ordinary spawn has already captured no role and is parked. Model a
     // concurrent durable designation becoming visible before the bare post.
-    store.upsertBinding({
+    store.designateSoleOrchestrator({
       channelId: CH,
       profileActorId,
       agentFramework: 'orchestrator',
       runtimeId: null,
-      role: 'orchestrator',
     });
     post(store, binder, 'must not enter the collaborator runtime', [
       'orchestrator',

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -159,6 +159,155 @@ describe('channel-message-store schema migration', () => {
     expect(indexNames).toEqual(['idx_chm_channel_seq', 'idx_chm_thread']);
   });
 
+  it('clears ambiguous v7 orchestrators, preserves sole rows, and creates the unique index', () => {
+    const file = dbPath();
+    store(file).close();
+    const legacy = new Database(file);
+    legacy.exec(`
+      DROP INDEX idx_chab_sole_orchestrator;
+      UPDATE schema_version SET version = 7;
+      DELETE FROM channel_agent_bindings;
+      INSERT INTO channel_agent_bindings VALUES
+        ('topic:ambiguous', 'profile:a', 'claude', 'runtime:a', 'orchestrator', '{"cursor":1}', '2026-08-01', '2026-08-02'),
+        ('topic:ambiguous', 'profile:b', 'codex', 'runtime:b', 'orchestrator', '{"cursor":2}', '2026-08-03', '2026-08-04'),
+        ('topic:valid', 'profile:c', 'claude', 'runtime:c', 'orchestrator', '{"cursor":3}', '2026-08-05', '2026-08-06');
+    `);
+    legacy.close();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    cleanup.push(() => warnSpy.mockRestore());
+
+    const migrated = store(file);
+    expect(migrated.getBinding('topic:ambiguous', 'profile:a')).toMatchObject({
+      role: null,
+      runtimeId: 'runtime:a',
+      providerSession: { cursor: 1 },
+    });
+    expect(migrated.getBinding('topic:ambiguous', 'profile:b')).toMatchObject({
+      role: null,
+      runtimeId: 'runtime:b',
+      providerSession: { cursor: 2 },
+    });
+    expect(migrated.getSoleOrchestratorBinding('topic:valid')).toMatchObject({
+      profileActorId: 'profile:c',
+      role: 'orchestrator',
+      providerSession: { cursor: 3 },
+    });
+    const warning = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('ambiguous legacy orchestrator')
+    );
+    expect(format(...(warning as [string, ...unknown[]]))).toBe(
+      '[channel-message-store] cleared ambiguous legacy orchestrator designations before sole-role migration: channel_count=1 binding_count=2'
+    );
+    expect(format(...(warning as [string, ...unknown[]]))).not.toContain(
+      'topic:ambiguous'
+    );
+    const inspect = new Database(file, { readonly: true });
+    cleanup.push(() => inspect.close());
+    expect(
+      inspect
+        .prepare(
+          `SELECT name FROM sqlite_master
+            WHERE type = 'index' AND name = 'idx_chab_sole_orchestrator'`
+        )
+        .get()
+    ).toEqual({ name: 'idx_chab_sole_orchestrator' });
+    expect(
+      inspect
+        .prepare(
+          `SELECT channel_id, COUNT(*) AS count
+             FROM channel_agent_bindings
+            WHERE binding_role = 'orchestrator'
+            GROUP BY channel_id
+           HAVING COUNT(*) > 1`
+        )
+        .all()
+    ).toEqual([]);
+  });
+
+  it.each([0, 1, 2, 3, 4, 5, 6, 7])(
+    'installs the sole-orchestrator invariant from schema version %i',
+    (version) => {
+      const file = dbPath();
+      const seeded = store(file);
+      seeded.upsertBinding({
+        channelId: `topic:upgrade-${version}`,
+        profileActorId: 'profile:keeper',
+        agentFramework: 'claude',
+        runtimeId: 'runtime:keeper',
+        providerSession: { cursor: version },
+      });
+      seeded.close();
+      const legacy = new Database(file);
+      legacy.exec('DROP INDEX idx_chab_sole_orchestrator');
+      // Reconstruct the column names each numbered migration actually expects;
+      // older schemas could not yet carry a binding role.
+      if (version >= 1 && version <= 4) {
+        legacy.exec(
+          'ALTER TABLE channel_messages RENAME COLUMN source_runtime_id TO source_session_id'
+        );
+      }
+      if (version >= 1 && version <= 3) {
+        legacy.exec(
+          'ALTER TABLE channel_agent_bindings RENAME COLUMN runtime_id TO session_id'
+        );
+      }
+      legacy.prepare('UPDATE schema_version SET version = ?').run(version);
+      legacy.close();
+
+      const migrated = store(file);
+      const expectedProfile =
+        version === 1 || version === 2
+          ? builtInAgentProfileId('claude')
+          : 'profile:keeper';
+      expect(
+        migrated.getBinding(`topic:upgrade-${version}`, expectedProfile)
+      ).toMatchObject({
+        profileActorId: expectedProfile,
+        runtimeId: 'runtime:keeper',
+        role: null,
+        providerSession: { cursor: version },
+      });
+      expect(
+        migrated.getSoleOrchestratorBinding(`topic:upgrade-${version}`)
+      ).toBeNull();
+      migrated.designateSoleOrchestrator({
+        channelId: `topic:upgrade-${version}`,
+        profileActorId: expectedProfile,
+        agentFramework: 'claude',
+      });
+      expect(() =>
+        migrated.designateSoleOrchestrator({
+          channelId: `topic:upgrade-${version}`,
+          profileActorId: 'profile:loser',
+          agentFramework: 'codex',
+        })
+      ).toThrowError(expect.objectContaining({ status: 409 }));
+      const inspect = new Database(file, { readonly: true });
+      cleanup.push(() => inspect.close());
+      expect(
+        inspect
+          .prepare(
+            `SELECT name FROM sqlite_master
+              WHERE type = 'index' AND name = 'idx_chab_sole_orchestrator'`
+          )
+          .get()
+      ).toEqual({ name: 'idx_chab_sole_orchestrator' });
+      expect(
+        inspect
+          .prepare(
+            `SELECT channel_id
+               FROM channel_agent_bindings
+              WHERE binding_role = 'orchestrator'
+              GROUP BY channel_id
+             HAVING COUNT(*) > 1`
+          )
+          .all()
+      ).toEqual([]);
+    }
+  );
+
   it('widens v1 status, heals its known aliases, and preserves durable rows through v3', () => {
     const file = dbPath();
     const legacy = new Database(file);
@@ -376,7 +525,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(7);
+    ).toBe(8);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -564,7 +713,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(7);
+    ).toBe(8);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -2432,13 +2581,131 @@ describe('channel-message-store members and bindings', () => {
     expect(s.findDmChannel('human:operator', 'agent:codex')).toBeNull();
   });
 
+  it('enforces one idempotent durable orchestrator and rejects another profile', () => {
+    const s = store();
+    const first = s.designateSoleOrchestrator({
+      channelId: 'topic:sole',
+      profileActorId: 'profile:a',
+      agentFramework: 'claude',
+      runtimeId: 'runtime:a',
+      providerSession: { cursor: 7 },
+    });
+    const repeated = s.designateSoleOrchestrator({
+      channelId: 'topic:sole',
+      profileActorId: 'profile:a',
+      agentFramework: 'claude',
+    });
+    expect(repeated).toMatchObject({
+      profileActorId: 'profile:a',
+      runtimeId: 'runtime:a',
+      role: 'orchestrator',
+      providerSession: { cursor: 7 },
+      createdAt: first.createdAt,
+    });
+    expect(s.getSoleOrchestratorBinding('topic:sole')).toEqual(repeated);
+
+    expect(() =>
+      s.designateSoleOrchestrator({
+        channelId: 'topic:sole',
+        profileActorId: 'profile:b',
+        agentFramework: 'codex',
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        status: 409,
+        code: 'channel_orchestrator_conflict',
+        details: {
+          channelId: 'topic:sole',
+          designatedProfileActorId: 'profile:a',
+          requestedProfileActorId: 'profile:b',
+        },
+      })
+    );
+    expect(s.getSoleOrchestratorBinding('topic:sole')?.profileActorId).toBe(
+      'profile:a'
+    );
+    expect(s.getBinding('topic:sole', 'profile:b')).toBeNull();
+    expect(() =>
+      s.upsertBinding({
+        channelId: 'topic:other',
+        profileActorId: 'profile:b',
+        agentFramework: 'codex',
+        role: 'orchestrator',
+      } as never)
+    ).toThrowError(
+      expect.objectContaining({
+        status: 400,
+        code: 'orchestrator_requires_sole_designation',
+      })
+    );
+  });
+
+  it('keeps the sole designation across reopen and rejects raw duplicates', () => {
+    const file = dbPath();
+    const initial = store(file);
+    initial.designateSoleOrchestrator({
+      channelId: 'topic:restart-sole',
+      profileActorId: 'profile:a',
+      agentFramework: 'claude',
+    });
+    initial.close();
+    const malformed = new Database(file);
+    malformed
+      .prepare(
+        `UPDATE channel_agent_bindings
+            SET provider_session_json = '{'
+          WHERE channel_id = 'topic:restart-sole'`
+      )
+      .run();
+    malformed.close();
+
+    const reopened = store(file);
+    expect(
+      reopened.getSoleOrchestratorBinding('topic:restart-sole')?.profileActorId
+    ).toBe('profile:a');
+    expect(
+      reopened.designateSoleOrchestrator({
+        channelId: 'topic:restart-sole',
+        profileActorId: 'profile:a',
+        agentFramework: 'claude',
+      }).providerSession
+    ).toEqual({});
+    expect(() =>
+      reopened.designateSoleOrchestrator({
+        channelId: 'topic:restart-sole',
+        profileActorId: 'profile:b',
+        agentFramework: 'codex',
+      })
+    ).toThrowError(expect.objectContaining({ status: 409 }));
+    expect(() => {
+      const raw = new Database(file);
+      try {
+        raw
+          .prepare(
+            `INSERT INTO channel_agent_bindings
+              (channel_id, profile_actor_id, agent_framework, runtime_id,
+               binding_role, provider_session_json, created_at, updated_at)
+             VALUES (?, ?, ?, NULL, 'orchestrator', '{}', ?, ?)`
+          )
+          .run(
+            'topic:restart-sole',
+            'profile:raw-loser',
+            'codex',
+            '2026-08-07T00:00:00.000Z',
+            '2026-08-07T00:00:00.000Z'
+          );
+      } finally {
+        raw.close();
+      }
+    }).toThrow(/UNIQUE constraint failed/);
+  });
+
   it('stores and reads agent bindings (slice-4 landing pad)', () => {
     const s = store();
-    const created = s.upsertBinding({
+    const created = s.designateSoleOrchestrator({
       channelId: 'topic:c',
       profileActorId: builtInAgentProfileId('claude'),
       agentFramework: 'claude',
-      role: 'orchestrator',
       providerSession: { claudeSessionId: 'abc' },
     });
     expect(created.runtimeId).toBeNull();
@@ -2942,7 +3209,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(7);
+    expect(version.version).toBe(8);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -14,6 +14,7 @@ import {
   CLI_GATEWAY_ACTOR_WRITE_COMMANDS,
 } from '../server/cli-gateway-actor-auth.js';
 import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import {
   createChannelMessageStore,
   type ChannelMessageStore,
@@ -34,6 +35,8 @@ import {
   createChannelAgentBinder,
   type ChannelAgentBinder,
 } from '../server/channel-agent-binder.js';
+import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
+import type { ChannelAgentRuntime } from '../server/channel-agent-runtime.js';
 import {
   CHANNEL_IMAGE_MAX_BYTES,
   createChannelAttachmentStore,
@@ -130,7 +133,13 @@ async function harness(
   const topic = topicStore.create({ workspaceId: 'ws', title: 'General' });
   const binder =
     options.binderFactory?.({ store, hub, topicStore }) ?? options.binder;
-  if (options.binderFactory) cleanup.push(() => binder?.close?.());
+  if (options.binderFactory) {
+    cleanup.push(() => binder?.close?.());
+    const unlisten = hub.onMessagePosted((message, mentions, postOptions) =>
+      binder?.handleMessagePosted(message, mentions, postOptions)
+    );
+    cleanup.push(unlisten);
+  }
 
   const app = express();
   app.use(express.json());
@@ -211,6 +220,18 @@ async function req<T>(input: {
     ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
   });
   return { status: res.status, body: (await res.json()) as T };
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  timeoutMs = 4000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('condition timed out');
 }
 
 function fakeSocket(): ChannelSocket & { sent: ChannelEventV1[] } {
@@ -1523,6 +1544,117 @@ describe('channel routes — agent commands', () => {
 });
 
 describe('channel routes — orchestrator designation (#1259)', () => {
+  function realDesignationBinder(gated: boolean): {
+    factory: (deps: {
+      store: ChannelMessageStore;
+      hub: ChannelHub;
+      topicStore: WorkspaceTopicStore;
+    }) => ChannelAgentBinder;
+    state: { spawns: number };
+    release: () => void;
+  } {
+    const state = { spawns: 0 };
+    const runtimes = new Map<string, ChannelAgentRuntime>();
+    let release!: () => void;
+    const gate = gated
+      ? new Promise<void>((resolve) => {
+          release = resolve;
+        })
+      : Promise.resolve();
+    if (!gated) release = () => {};
+    return {
+      state,
+      release: () => release(),
+      factory: ({ store, hub, topicStore }) =>
+        createChannelAgentBinder({
+          store,
+          hub,
+          topicStore,
+          runtimes: {
+            create: async (params) => {
+              state.spawns += 1;
+              await gate;
+              const id = `runtime:${state.spawns}:${params.providerId}`;
+              const adapter = new MockProtocolAdapterV2({
+                connectMs: 0,
+                stepMs: 0,
+              });
+              await adapter.connect({
+                cwd: params.cwd,
+                port: 0,
+                sessionId: id,
+                hookToken: 'test',
+                configDir: params.configDir,
+              });
+              const runtime = {
+                id,
+                providerId: params.providerId,
+                profileActorId: params.profileActorId,
+                role: params.role,
+                status: 'active',
+                adapter,
+                cwd: params.cwd,
+                providerSession: {},
+              } as ChannelAgentRuntime;
+              runtimes.set(id, runtime);
+              return runtime;
+            },
+            get: (id) => runtimes.get(id),
+            destroy: async (id) => {
+              runtimes.delete(id);
+            },
+            onRuntimeEnd: () => () => {},
+          },
+          knownProviderIds: ['mock', 'codex'],
+          mentionTargets: async () => [
+            {
+              id: 'mock',
+              displayName: 'Mock',
+              kind: 'framework',
+              available: true,
+              reason: null,
+            },
+            {
+              id: 'codex',
+              displayName: 'Codex',
+              kind: 'framework',
+              available: true,
+              reason: null,
+            },
+          ],
+          port: 0,
+          configDir: '/tmp',
+        }),
+    };
+  }
+
+  async function postBareAndReadWinner(h: Harness): Promise<string[]> {
+    const post = await req<{ message: { id: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages`,
+      body: { text: 'continue the plan' },
+    });
+    expect(post.status).toBe(201);
+    try {
+      await waitForCondition(() =>
+        h.store
+          .history(h.channelId, { limit: 20 })
+          .some((row) => row.sender.kind === 'agent')
+      );
+    } catch {
+      throw new Error(
+        `bare route produced no agent row: ${JSON.stringify(
+          h.store.history(h.channelId, { limit: 20 })
+        )}`
+      );
+    }
+    return h.store
+      .history(h.channelId, { limit: 20 })
+      .filter((row) => row.sender.kind === 'agent')
+      .map((row) => row.sender.providerId ?? '');
+  }
+
   it('designates the persistent orchestrator via ensureOrchestrator', async () => {
     const calls: Array<{ channelId: string; framework: string }> = [];
     const h = await harness({
@@ -1549,6 +1681,80 @@ describe('channel routes — orchestrator designation (#1259)', () => {
       framework: 'claude',
     });
     expect(calls).toEqual([{ channelId: h.channelId, framework: 'claude' }]);
+  });
+
+  it('keeps sequential route designation idempotent, then bare-routes the winner', async () => {
+    const real = realDesignationBinder(false);
+    const h = await harness({ binderFactory: real.factory });
+    const designate = (framework: string) =>
+      req<{
+        ok?: boolean;
+        error?: {
+          code: string;
+          details?: Record<string, unknown>;
+        };
+      }>({
+        port: h.port,
+        method: 'POST',
+        url: `/channels/${h.channelId}/orchestrator?framework=${framework}`,
+      });
+
+    expect((await designate('mock')).status).toBe(200);
+    expect((await designate('mock')).status).toBe(200);
+    const conflict = await designate('codex');
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.error).toMatchObject({
+      code: 'SESSION_CONFLICT',
+      details: {
+        reasonCode: 'CHANNEL_ORCHESTRATOR_CONFLICT',
+        channelId: h.channelId,
+        designatedProfileActorId: builtInAgentProfileId('mock'),
+        requestedProfileActorId: builtInAgentProfileId('codex'),
+      },
+    });
+    expect(
+      h.store.getSoleOrchestratorBinding(h.channelId)?.profileActorId
+    ).toBe(builtInAgentProfileId('mock'));
+    expect(real.state.spawns).toBe(1);
+    const routedProviders = await postBareAndReadWinner(h);
+    expect(routedProviders.length).toBeGreaterThan(0);
+    expect(new Set(routedProviders)).toEqual(new Set(['mock']));
+  });
+
+  it('allows one concurrent route winner, then bare-routes only that runtime', async () => {
+    const real = realDesignationBinder(true);
+    const h = await harness({ binderFactory: real.factory });
+    const mockRequest = req<{ ok?: boolean; error?: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/orchestrator?framework=mock`,
+    });
+    const codexRequest = req<{ ok?: boolean; error?: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/orchestrator?framework=codex`,
+    });
+    await waitForCondition(() => real.state.spawns === 1);
+    // Both requests overlap while the winner's runtime launch is parked; the
+    // channel-level binder lock must keep the competitor from spawning.
+    expect(real.state.spawns).toBe(1);
+    real.release();
+    const [mock, codex] = await Promise.all([mockRequest, codexRequest]);
+    expect([mock.status, codex.status].sort()).toEqual([200, 409]);
+    const loser = mock.status === 409 ? mock : codex;
+    expect(loser.body.error?.code).toBe('SESSION_CONFLICT');
+    expect(real.state.spawns).toBe(1);
+    const sole = h.store.getSoleOrchestratorBinding(h.channelId);
+    expect(sole).not.toBeNull();
+    const winnerProvider = sole?.agentFramework ?? '';
+    const loserProfile =
+      winnerProvider === 'mock'
+        ? builtInAgentProfileId('codex')
+        : builtInAgentProfileId('mock');
+    expect(h.store.getBinding(h.channelId, loserProfile)).toBeNull();
+    const routedProviders = await postBareAndReadWinner(h);
+    expect(routedProviders.length).toBeGreaterThan(0);
+    expect(new Set(routedProviders)).toEqual(new Set([winnerProvider]));
   });
 
   it('defaults the framework to claude when omitted', async () => {


### PR DESCRIPTION
## Summary
- enforce one durable orchestrator per channel with a v8 partial unique index and an immediate first-writer transaction
- reject generic orchestrator-role upserts and return a stable 409 when another profile is already designated
- serialize binder designation by channel so competing requests cannot spawn a loser runtime
- clear ambiguous legacy duplicate roles without discarding binding/session payloads, while preserving valid sole designations

## Defining invariant
At most one `channel_agent_bindings` row per channel has `binding_role = 'orchestrator'`. Same-profile designation is idempotent; a different profile conflicts before launch. Bare posts continue routing to the retained winner across conflict and full hub/store restart.

## Validation
- `npm run check`
- focused store/binder/route suites: 300 tests passed before commit
- independent exact-head rerun: store 96, binder 129, routes 75 passed
- mutation: removing partial unique-index DDL fails raw-duplicate proof
- mutation: replacing channel serialization with per-profile serialization fails one-spawn concurrency proof
- mutation: removing conflict rejection makes the route 409 test fail

## Exact-head review
- verdict: PASS; `conflictOfInterest: none`
- base: `771a7c838bf07c7039bd97748337a0c100f8dc2b`
- head: `7e86278fdc2f21e38b19e2375207305bd086d601`
- `git-diff-sha256-v1`: `4491c46bff7529cf1282a00f4130451c5318a10b4d6ebcf63c604936183362e3`
- bytes: 46547
- P0/P1/P2/P3: none

Tracks #1368. Follow-up to #1365.
