### PR TITLE
feat: canonicalize handoff review evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ workflow.
   including Codex Fast Mode, model, and reasoning-effort changes (#1344)
 - Inspect provider-visible reasoning in provider-neutral collapsible turn details,
   with a persisted collapsed or expanded default for new summaries (#1361)
+- Publish canonical, exact-head pipeline handoff review evidence through the
+  existing WorkContext artifact and CLI surfaces (#1368)
 
 #### Changed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Every doc listed here is linked from this index. If you add a doc, add a row.
 | Workbench boundary   | [`WORKBENCH_BOUNDARY.md`](WORKBENCH_BOUNDARY.md)                                 |
 | Agent view artifacts | [`AGENT_VIEW_ARTIFACTS.md`](AGENT_VIEW_ARTIFACTS.md)                             |
 | Handoff artifacts    | [`pipeline-handoff-artifact-template.md`](pipeline-handoff-artifact-template.md) |
+| Repository context   | [`context-map.md`](context-map.md)                                               |
 
 ### Working in this repo
 

--- a/docs/context-map.md
+++ b/docs/context-map.md
@@ -1,0 +1,81 @@
+# Repository context map
+
+This map provides stable, public-safe references for pipeline handoff and
+adversarial-review artifacts. The anchor names below are the only context-map
+references accepted by the canonical handoff validator. They identify seams,
+not ownership claims: confirm the current tree and decisive tests before
+changing behavior.
+
+## Channel routing
+
+- Owner seams: `server/channel-chat-router.ts`, `server/channel-hub.ts`, and
+  `server/channel-agent-binder.ts`.
+- Protocol contracts: `shared/channel-chat-protocol.ts`.
+- Decisive tests: `test/channel-routes.test.ts`,
+  `test/channel-agent-binder.test.ts`, and `test/channel-hub.test.ts`.
+
+## Durable bindings
+
+- Owner seams: the binding schema/store in `server/channel-hub.ts` and runtime
+  designation in `server/channel-agent-binder.ts`.
+- Decisive tests: `test/channel-hub.test.ts`,
+  `test/channel-agent-binder.test.ts`, and route-level binding cases in
+  `test/channel-routes.test.ts`.
+- Invariant: durable uniqueness belongs in SQLite; in-process serialization is
+  only the runtime-spawn backstop.
+
+## Provider adapters
+
+- Owner seams: `server/protocol-adapter.ts`, `server/protocol-adapters/`, and
+  `server/channel-agent-runtime.ts`.
+- Provider configuration: `server/config.ts` and `docs/provider-guide.md`.
+- Decisive tests: `test/server/protocol-adapters/`,
+  `test/channel-agent-runtime.test.ts`, and provider launch-contract tests.
+
+## Message storage and context
+
+- Owner seams: `server/channel-message-store.ts`,
+  `server/channel-context-packet.ts`, and `server/channel-attachments.ts`.
+- Decisive tests: `test/channel-message-store.test.ts`,
+  `test/channel-context-packet.test.ts`, and `test/channel-mention-e2e.test.ts`.
+- Fixtures: `test/fixtures/channel-chat/`.
+
+## Frontend chat surfaces
+
+- Owner seams: `frontend/src/components/chat/` and
+  `frontend/src/hooks/useChannelChatSocket.ts`.
+- Decisive tests: `test/components/`, `test/channel-thread-e2e.test.ts`, and
+  `test/e2e/channel-*.spec.ts`.
+- Visual changes must also follow `DESIGN.md`; browser claims require browser
+  evidence rather than component tests alone.
+
+## Test fixtures
+
+- Test policy and commands: `docs/QUALITY.md` and `package.json`.
+- Canonical fixtures live under `test/fixtures/`; do not place runtime state or
+  machine-specific paths in fixtures.
+- Handoff fixtures: `test/fixtures/pipeline-handoff/`.
+
+## CI and release evidence
+
+- Hosted checks: `.github/workflows/ci.yml`.
+- Publication: `.github/workflows/publish.yml` and
+  `docs/references/deployment.md`.
+- Risk doctrine: `docs/risk-contract.json` (not an executable gate until a
+  consumer is installed).
+- Hosted CI must validate repository-visible evidence and must not query or
+  reconstruct Relay runtime state.
+
+## Handoff evidence
+
+- Canonical schema and validator: `shared/pipeline-handoff-artifact.ts`.
+- Durable index/payload store: `server/work-context-artifacts.ts`.
+- API/CLI surface: `server/features/work-context-artifact-router.ts` and the
+  `handoff-artifacts` CLI verbs.
+- Decisive tests: `test/pipeline-handoff-artifact.test.ts`,
+  `test/work-context-artifacts.test.ts`,
+  `test/work-context-artifact-router.test.ts`, and
+  `test/pipeline-handoff-timeline.test.ts`.
+- `supersedesArtifactId` is canonical in the payload; request metadata is a
+  compatibility assertion. Successors retain the same head and immutable root,
+  preserve every prior stage, and append at least one new stage.

--- a/docs/pipeline-handoff-artifact-template.md
+++ b/docs/pipeline-handoff-artifact-template.md
@@ -7,6 +7,7 @@ Status: shared contract/template foundation for issue #883.
 ## Invariants
 
 - Stages are append-only layers in this exact order: `implementation` -> `qa` -> `review` -> `release`.
+- A successor records its canonical predecessor in payload-level `supersedesArtifactId`. A CLI/request flag is a compatibility assertion and must match. Supersession edges stay within one payload kind. The durable store rejects forks, changed immutable roots, changed prior stages, and cross-head successors.
 - Every artifact names the exact covered `headSha` and declares `staleIf.headShaChanges: true`. If the PR/branch head changes, all prior QA/review/release evidence is stale until refreshed for the new head.
 - Every stage carries bounded acceptance evidence, commands/checks, downstream focus, non-goals, and a stage-specific decision/verdict.
 - Not-tested evidence must use machine-readable distinctions:
@@ -22,7 +23,7 @@ Status: shared contract/template foundation for issue #883.
 Workers should publish the handoff artifact while the lane is live, not reconstruct it after the PR lands:
 
 1. **Implementation** creates the artifact with one `implementation` stage and calls `handoff-artifacts.attach` for the current WorkContext.
-2. **QA** reads the latest non-stale artifact for the same `workContextId`/PR head, appends a `qa` stage, and calls `handoff-artifacts.attach --supersedes-artifact-id <implementation-artifact-id>`.
+2. **QA** reads the latest non-stale artifact for the same `workContextId`/PR head, sets payload `supersedesArtifactId`, preserves the canonical root and implementation layer, appends a `qa` stage, and calls `handoff-artifacts.attach`. The optional `--supersedes-artifact-id` flag must equal the payload value when supplied.
 3. **Review** appends a `review` stage the same way, superseding the QA artifact.
 4. **Release** appends a `release` stage, superseding the review artifact.
 
@@ -34,7 +35,10 @@ Each publication must repeat the same public-safe `head` block for the exact PR/
     "repo": { "ownerRepo": "donovan-yohan/relay-ide" },
     "base": { "name": "nightly" },
     "branch": { "name": "issue-903-live-handoff-artifacts" },
-    "pr": { "number": 904, "url": "https://github.com/donovan-yohan/relay-ide/pull/904" },
+    "pr": {
+      "number": 904,
+      "url": "https://github.com/donovan-yohan/relay-ide/pull/904"
+    },
     "headSha": "1111111111111111111111111111111111111111",
     "staleIf": { "headShaChanges": true },
     "capturedAt": "2026-06-10T00:00:00.000Z"
@@ -44,14 +48,16 @@ Each publication must repeat the same public-safe `head` block for the exact PR/
 
 Stage-specific exact-head fields must also equal `head.headSha`:
 
-| Worker stage | Stage field that must equal `head.headSha` | Publish command shape |
-| ------------ | ------------------------------------------ | --------------------- |
-| implementation | artifact-level `head.headSha` covers the implementation layer | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file implementation.json --current-head-sha <headSha> --stage implementation --visibility public --json` |
-| QA | `testedHeadSha` | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file qa.json --current-head-sha <headSha> --supersedes-artifact-id <implementation-artifact-id> --stage qa --visibility public --json` |
-| review | `reviewedHeadSha` | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file review.json --current-head-sha <headSha> --supersedes-artifact-id <qa-artifact-id> --stage review --visibility public --json` |
-| release | `verifiedHeadSha` | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file release.json --current-head-sha <headSha> --supersedes-artifact-id <review-artifact-id> --stage release --visibility public --json` |
+| Worker stage   | Stage field that must equal `head.headSha`                    | Publish command shape                                                                                                                                                                                             |
+| -------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| implementation | artifact-level `head.headSha` covers the implementation layer | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file implementation.json --current-head-sha <headSha> --stage implementation --visibility public --json`                                 |
+| QA             | `testedHeadSha`                                               | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file qa.json --current-head-sha <headSha> --supersedes-artifact-id <implementation-artifact-id> --stage qa --visibility public --json`   |
+| review         | `reviewedHeadSha`                                             | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file review.json --current-head-sha <headSha> --supersedes-artifact-id <qa-artifact-id> --stage review --visibility public --json`       |
+| release        | `verifiedHeadSha`                                             | `relay-ide v1 handoff-artifacts attach --work-context-id <wc> --artifact-file release.json --current-head-sha <headSha> --supersedes-artifact-id <review-artifact-id> --stage release --visibility public --json` |
 
 Before public PR/issue posting, use `handoff-artifacts copy` or `renderPipelineHandoffMarkdown(artifact, { public: true })`. Public-safe output must not include local paths, private queue/task IDs, secrets/env, raw logs/transcripts, or dispatcher internals.
+
+A review stage may add one complete `adversarialReview` block. It binds the declared implementation and reviewer actor/session/run identities, exact base and reviewed head, canonical diff/context digests, allowlisted [`context-map.md`](context-map.md) references, conflict declaration, trusted-provenance disposition, findings, and evidence-backed dispositions. The block is all-or-nothing and requires contiguous implementation, QA, and review stages; legacy schema-v1 review stages remain readable without it. `provider` and `model` are informational. Until a trusted actor/session/run resolver exists, use `trustedProvenance.disposition: declared-unverified`; client-authored `verified` is rejected, and declarations must not be described as verified identity proof.
 
 The smoke fixture at `test/fixtures/pipeline-handoff/live-worker-pattern.json` demonstrates attaching an implementation layer and appending QA through the stable `handoff-artifacts.*` route surface.
 
@@ -95,7 +101,10 @@ Use this inside private Kanban comments where internal task refs may be useful. 
     "repo": { "ownerRepo": "donovan-yohan/relay-ide" },
     "base": { "name": "nightly" },
     "branch": { "name": "issue-883-handoff-schema" },
-    "pr": { "number": 883, "url": "https://github.com/donovan-yohan/relay-ide/pull/883" },
+    "pr": {
+      "number": 883,
+      "url": "https://github.com/donovan-yohan/relay-ide/pull/883"
+    },
     "headSha": "<exact git sha>",
     "staleIf": { "headShaChanges": true },
     "capturedAt": "2026-06-08T01:02:03Z"
@@ -156,24 +165,30 @@ head: <exact head sha>
 staleIf: headShaChanges=true
 
 ## Acceptance
+
 - <acceptance criterion>
 
 ## Non-goals
+
 - no workflow engine
 - no raw transcripts/env/auth/log ingestion
 
 ## implementation
+
 verdict: implemented
 <bounded implementation summary>
 
 ### Evidence
+
 - schema validation: provided — <bounded proof/ref>
 
 ### Commands
+
 - targeted tests: passed — `npm test -- test/pipeline-handoff-artifact.test.ts` — <pass/fail counts>
 - browser QA: not-applicable (not-applicable) — `not run` — Schema-only backend/shared change.
 
 ### Downstream focus
+
 - Review exact head SHA and non-goals.
 - QA should verify public rendering does not leak private refs.
 ```

--- a/server/features/work-context-artifact-router.ts
+++ b/server/features/work-context-artifact-router.ts
@@ -447,6 +447,70 @@ function persistedViewArtifactPayloadBytes(
   return Buffer.byteLength(JSON.stringify(viewArtifact, null, 2), 'utf8');
 }
 
+function canonicalPipelineArtifactForPublish(
+  res: Response,
+  input: {
+    artifact: PipelineHandoffArtifact;
+    requestSupersedesArtifactId?: string;
+    workContextId: WorkContextId;
+    operation: string;
+    maxPublishBytes: number;
+  }
+):
+  | {
+      artifact: PipelineHandoffArtifact;
+      supersedesArtifactId?: string;
+    }
+  | undefined {
+  const payloadSupersedesArtifactId = input.artifact.supersedesArtifactId;
+  if (
+    input.requestSupersedesArtifactId &&
+    payloadSupersedesArtifactId &&
+    input.requestSupersedesArtifactId !== payloadSupersedesArtifactId
+  ) {
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'artifact supersedes id does not match request metadata',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+        operation: input.operation,
+        artifactId: input.artifact.id,
+      }
+    );
+    return undefined;
+  }
+  const supersedesArtifactId =
+    payloadSupersedesArtifactId ?? input.requestSupersedesArtifactId;
+  const artifact =
+    supersedesArtifactId && !payloadSupersedesArtifactId
+      ? { ...input.artifact, supersedesArtifactId }
+      : input.artifact;
+  const payloadBytes = persistedArtifactPayloadBytes(artifact);
+  if (payloadBytes > input.maxPublishBytes) {
+    sendGatewayError(
+      res,
+      'INVALID_ARGUMENT',
+      'artifact payload exceeds publish size cap',
+      false,
+      {
+        reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
+        operation: input.operation,
+        workContextId: input.workContextId,
+        artifactId: artifact.id,
+        payloadBytes,
+        maxBytes: input.maxPublishBytes,
+      }
+    );
+    return undefined;
+  }
+  return {
+    artifact,
+    ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
+  };
+}
+
 function sameJson(left: unknown, right: unknown): boolean {
   return stableJsonEquals(left, right);
 }
@@ -631,6 +695,7 @@ function mapStoreError(
       );
       return;
     case 'superseded_artifact_not_found':
+    case 'superseded_artifact_payload_kind_mismatch':
       sendGatewayError(
         res,
         'NOT_FOUND',
@@ -638,6 +703,66 @@ function mapStoreError(
         false,
         {
           reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_NOT_FOUND',
+          ...details,
+        }
+      );
+      return;
+    case 'superseded_artifact_scope_mismatch':
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'superseded artifact belongs to a different WorkContext',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_SCOPE_MISMATCH',
+          ...details,
+        }
+      );
+      return;
+    case 'artifact_supersedes_stale_head':
+      sendGatewayError(
+        res,
+        'SESSION_CONFLICT',
+        'artifact head is stale for the superseded handoff layer',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD',
+          ...details,
+        }
+      );
+      return;
+    case 'artifact_supersedes_append_only_violation':
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'artifact must append without changing canonical root or prior stages',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
+          ...details,
+        }
+      );
+      return;
+    case 'artifact_supersedes_fork':
+      sendGatewayError(
+        res,
+        'SESSION_CONFLICT',
+        'artifact predecessor already has a successor',
+        false,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_APPEND_ONLY_VIOLATION',
+          ...details,
+        }
+      );
+      return;
+    case 'artifact_store_busy':
+      sendGatewayError(
+        res,
+        'SERVER_UNAVAILABLE',
+        'artifact store is busy; retry the request',
+        true,
+        {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_STORE_BUSY',
           ...details,
         }
       );
@@ -1134,7 +1259,7 @@ export function createWorkContextArtifactRouter(
         scopeForRequest: writeScopeFromBody,
       })
     ),
-    // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- publish validates either handoff artifacts or static view artifacts before shared store/pin handling.
+
     (req, res) => {
       const operation = req.path.startsWith('/pipeline-handoff-artifacts')
         ? 'attach'
@@ -1251,26 +1376,23 @@ export function createWorkContextArtifactRouter(
         );
         return;
       }
-      const payloadBytes = persistedArtifactPayloadBytes(artifact);
-      if (payloadBytes > maxPublishBytes) {
-        sendGatewayError(
-          res,
-          'INVALID_ARGUMENT',
-          'artifact payload exceeds publish size cap',
-          false,
-          {
-            reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
-            operation,
-            workContextId,
-            artifactId: artifact.id,
-            payloadBytes,
-            maxBytes: maxPublishBytes,
-          }
-        );
-        return;
-      }
+      const canonical = canonicalPipelineArtifactForPublish(res, {
+        artifact,
+        ...(readString(body['supersedesArtifactId'])
+          ? {
+              requestSupersedesArtifactId: readString(
+                body['supersedesArtifactId']
+              )!,
+            }
+          : {}),
+        workContextId,
+        operation,
+        maxPublishBytes,
+      });
+      if (!canonical) return;
+      const { artifact: canonicalArtifact, supersedesArtifactId } = canonical;
       const current = currentHeadSha(req, body);
-      if (current && artifact.head.headSha !== current) {
+      if (current && canonicalArtifact.head.headSha !== current) {
         sendGatewayError(
           res,
           'SESSION_CONFLICT',
@@ -1280,8 +1402,8 @@ export function createWorkContextArtifactRouter(
             reasonCode: 'WORK_CONTEXT_ARTIFACT_STALE_HEAD',
             operation,
             workContextId,
-            artifactId: artifact.id,
-            artifactHeadSha: artifact.head.headSha,
+            artifactId: canonicalArtifact.id,
+            artifactHeadSha: canonicalArtifact.head.headSha,
             currentHeadSha: current,
           }
         );
@@ -1299,9 +1421,8 @@ export function createWorkContextArtifactRouter(
       const title = readString(body['title']);
       const summary = readString(body['summary']);
       const capturedAt = readString(body['capturedAt']);
-      const supersedesArtifactId = readString(body['supersedesArtifactId']);
       const input: StorePipelineHandoffArtifactInput = {
-        artifact: artifact as PipelineHandoffArtifact,
+        artifact: canonicalArtifact,
         workContextId,
         ...(artifactIdOverride ? { id: artifactIdOverride } : {}),
         ...(projectId ? { projectId } : {}),
@@ -1319,7 +1440,7 @@ export function createWorkContextArtifactRouter(
         if (
           !ensureAppendOnlySupersedes(res, s, {
             workContextId,
-            artifact: artifact as PipelineHandoffArtifact,
+            artifact: canonicalArtifact,
             ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
             operation,
           })

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -21,6 +21,7 @@ import {
   type AgentViewManifest,
   type ViewArtifactPackage,
 } from '../shared/agent-view-artifact.js';
+import { stableJsonEquals } from '../shared/stable-json.js';
 import {
   ARTIFACT_KINDS,
   type ArtifactKind,
@@ -275,6 +276,12 @@ export class WorkContextArtifactStoreError extends Error {
   }
 }
 
+function isSqliteBusyError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null || !('code' in err)) return false;
+  const code = String((err as { code?: unknown }).code ?? '');
+  return code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED';
+}
+
 export function initWorkContextArtifactStore(
   configDir: string
 ): WorkContextArtifactStore {
@@ -287,7 +294,31 @@ export function initWorkContextArtifactStore(
 export function createWorkContextArtifactStore(input: {
   dbPath: string;
   payloadRoot?: string;
+  busyTimeoutMs?: number;
 }): WorkContextArtifactStore {
+  try {
+    return createWorkContextArtifactStoreUnsafe(input);
+  } catch (err) {
+    if (isSqliteBusyError(err)) {
+      throw new WorkContextArtifactStoreError(503, 'artifact_store_busy');
+    }
+    throw err;
+  }
+}
+
+function createWorkContextArtifactStoreUnsafe(input: {
+  dbPath: string;
+  payloadRoot?: string;
+  busyTimeoutMs?: number;
+}): WorkContextArtifactStore {
+  if (
+    input.busyTimeoutMs !== undefined &&
+    (!Number.isInteger(input.busyTimeoutMs) ||
+      input.busyTimeoutMs < 1 ||
+      input.busyTimeoutMs > 5000)
+  ) {
+    throw new WorkContextArtifactStoreError(400, 'invalid_busy_timeout');
+  }
   mkdirSync(path.dirname(input.dbPath), { recursive: true });
   const payloadRoot =
     input.payloadRoot ??
@@ -295,6 +326,7 @@ export function createWorkContextArtifactStore(input: {
   mkdirSync(payloadRoot, { recursive: true });
 
   const db = new Database(input.dbPath);
+  db.pragma(`busy_timeout = ${input.busyTimeoutMs ?? 5000}`);
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
   db.exec(
@@ -354,7 +386,8 @@ export function createWorkContextArtifactStore(input: {
 
   function mustValidateSupersedes(
     id: string | undefined,
-    workContextId: WorkContextId
+    workContextId: WorkContextId,
+    expectedPayloadKind?: WorkContextArtifactPayloadKind
   ): void {
     if (!id) return;
     const row = selectById.get(id) as WorkContextArtifactRow | undefined;
@@ -369,6 +402,94 @@ export function createWorkContextArtifactStore(input: {
         400,
         'superseded_artifact_scope_mismatch'
       );
+    }
+    if (expectedPayloadKind && row.payload_kind !== expectedPayloadKind) {
+      throw new WorkContextArtifactStoreError(
+        400,
+        'superseded_artifact_payload_kind_mismatch'
+      );
+    }
+  }
+
+  function readStoredPipelineArtifact(
+    row: WorkContextArtifactRow
+  ): PipelineHandoffArtifact {
+    if (row.payload_kind !== 'pipeline-handoff-artifact') {
+      throw new WorkContextArtifactStoreError(
+        400,
+        'superseded_artifact_payload_kind_mismatch'
+      );
+    }
+    const raw = readFileSync(row.payload_path, 'utf8');
+    assertPayloadSha256(raw, row);
+    const payload = JSON.parse(raw) as unknown;
+    if (!isPipelineHandoffArtifact(payload)) {
+      throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+    }
+    return payload;
+  }
+
+  function immutableHandoffRoot(artifact: PipelineHandoffArtifact): unknown {
+    return {
+      schemaVersion: artifact.schemaVersion,
+      title: artifact.title,
+      createdAt: artifact.createdAt,
+      scope: artifact.scope,
+      head: artifact.head,
+    };
+  }
+
+  function mustValidatePipelineSupersedes(
+    id: string | undefined,
+    workContextId: WorkContextId,
+    successor: PipelineHandoffArtifact
+  ): void {
+    if (!id) return;
+    const row = selectById.get(id) as WorkContextArtifactRow | undefined;
+    if (!row) {
+      throw new WorkContextArtifactStoreError(
+        400,
+        'superseded_artifact_not_found'
+      );
+    }
+    if (row.work_context_id !== workContextId) {
+      throw new WorkContextArtifactStoreError(
+        400,
+        'superseded_artifact_scope_mismatch'
+      );
+    }
+    const predecessor = readStoredPipelineArtifact(row);
+    if (predecessor.head.headSha !== successor.head.headSha) {
+      throw new WorkContextArtifactStoreError(
+        409,
+        'artifact_supersedes_stale_head'
+      );
+    }
+    if (
+      !stableJsonEquals(
+        immutableHandoffRoot(predecessor),
+        immutableHandoffRoot(successor)
+      ) ||
+      successor.stages.length <= predecessor.stages.length ||
+      !predecessor.stages.every((stage, index) =>
+        stableJsonEquals(stage, successor.stages[index])
+      )
+    ) {
+      throw new WorkContextArtifactStoreError(
+        400,
+        'artifact_supersedes_append_only_violation'
+      );
+    }
+    const existingChild = db
+      .prepare(
+        `SELECT id FROM work_context_artifacts
+         WHERE supersedes_artifact_id = ?
+           AND payload_kind = 'pipeline-handoff-artifact'
+         LIMIT 1`
+      )
+      .get(id) as { id: string } | undefined;
+    if (existingChild) {
+      throw new WorkContextArtifactStoreError(409, 'artifact_supersedes_fork');
     }
   }
 
@@ -419,7 +540,27 @@ export function createWorkContextArtifactStore(input: {
         assertNonEmptyString(storeInput.title, 'title');
       if (storeInput.summary !== undefined)
         assertNonEmptyString(storeInput.summary, 'summary');
-      const validation = validatePipelineHandoffArtifact(storeInput.artifact);
+      const payloadSupersedesArtifactId =
+        storeInput.artifact.supersedesArtifactId;
+      if (
+        storeInput.supersedesArtifactId &&
+        payloadSupersedesArtifactId &&
+        storeInput.supersedesArtifactId !== payloadSupersedesArtifactId
+      ) {
+        throw new WorkContextArtifactStoreError(
+          400,
+          'artifact_supersedes_mismatch'
+        );
+      }
+      const supersedesArtifactId =
+        payloadSupersedesArtifactId ?? storeInput.supersedesArtifactId;
+      // Normalize legacy request-only callers so payload and index metadata have
+      // one canonical predecessor identity on every newly stored row.
+      const artifact: PipelineHandoffArtifact =
+        supersedesArtifactId && !payloadSupersedesArtifactId
+          ? { ...storeInput.artifact, supersedesArtifactId }
+          : storeInput.artifact;
+      const validation = validatePipelineHandoffArtifact(artifact);
       if (!validation.valid) {
         throw new WorkContextArtifactStoreError(
           400,
@@ -429,36 +570,23 @@ export function createWorkContextArtifactStore(input: {
       }
       if (storeInput.id !== undefined) {
         assertNonEmptyString(storeInput.id, 'id');
-        if (
-          storeInput.artifact.id !== undefined &&
-          storeInput.id !== storeInput.artifact.id
-        ) {
+        if (artifact.id !== undefined && storeInput.id !== artifact.id) {
           throw new WorkContextArtifactStoreError(400, 'artifact_id_mismatch');
         }
       }
       const artifactId =
-        storeInput.id ?? storeInput.artifact.id ?? `artifact:${randomUUID()}`;
-      mustNotAlreadyExist(artifactId);
-      mustValidateSupersedes(
-        storeInput.supersedesArtifactId,
-        storeInput.workContextId
-      );
-
+        storeInput.id ?? artifact.id ?? `artifact:${randomUUID()}`;
       const taskRef = storeInput.taskRef ?? firstTaskRef(storeInput.artifact);
       if (!taskRef) {
         throw new WorkContextArtifactStoreError(400, 'task_ref_required');
       }
       assertValidTaskRef(taskRef);
-      const taskRefs = dedupeTaskRefs([
-        taskRef,
-        ...storeInput.artifact.scope.taskRefs,
-      ]);
+      const taskRefs = dedupeTaskRefs([taskRef, ...artifact.scope.taskRefs]);
       for (const indexedTaskRef of taskRefs) assertValidTaskRef(indexedTaskRef);
       const now = new Date().toISOString();
-      const capturedAt =
-        storeInput.capturedAt ?? storeInput.artifact.head.capturedAt;
+      const capturedAt = storeInput.capturedAt ?? artifact.head.capturedAt;
       assertIsoTimestamp(capturedAt, 'capturedAt');
-      const payloadJson = JSON.stringify(storeInput.artifact, null, 2);
+      const payloadJson = JSON.stringify(artifact, null, 2);
       const payloadSha256 = sha256Hex(payloadJson);
       const payloadPath = writePayloadFile(payloadJson, payloadSha256);
       const payloadBytes = Buffer.byteLength(payloadJson, 'utf8');
@@ -472,8 +600,8 @@ export function createWorkContextArtifactStore(input: {
           ? { provenanceActorId: storeInput.provenanceActorId }
           : {}),
         kind: storeInput.kind ?? 'report',
-        title: storeInput.title ?? storeInput.artifact.title,
-        summary: storeInput.summary ?? storeInput.artifact.scope.summary,
+        title: storeInput.title ?? artifact.title,
+        summary: storeInput.summary ?? artifact.scope.summary,
         visibility: storeInput.visibility ?? DEFAULT_VISIBILITY,
         createdAt: now,
         updatedAt: now,
@@ -482,19 +610,23 @@ export function createWorkContextArtifactStore(input: {
         payloadMediaType: DEFAULT_PAYLOAD_MEDIA_TYPE,
         payloadSha256,
         payloadBytes,
-        ...(storeInput.artifact.head.pr?.number
-          ? { prNumber: storeInput.artifact.head.pr.number }
+        ...(artifact.head.pr?.number
+          ? { prNumber: artifact.head.pr.number }
           : {}),
-        headSha: storeInput.artifact.head.headSha,
-        baseName: storeInput.artifact.head.base.name,
-        ...(storeInput.artifact.head.branch?.name
-          ? { branchName: storeInput.artifact.head.branch.name }
+        headSha: artifact.head.headSha,
+        baseName: artifact.head.base.name,
+        ...(artifact.head.branch?.name
+          ? { branchName: artifact.head.branch.name }
           : {}),
-        ...(storeInput.supersedesArtifactId
-          ? { supersedesArtifactId: storeInput.supersedesArtifactId }
-          : {}),
+        ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
       };
-      db.transaction(() => {
+      const persist = db.transaction(() => {
+        mustNotAlreadyExist(artifactId);
+        mustValidatePipelineSupersedes(
+          supersedesArtifactId,
+          storeInput.workContextId,
+          artifact
+        );
         insertArtifact.run({
           id: metadata.id,
           workContextId: metadata.workContextId,
@@ -534,7 +666,15 @@ export function createWorkContextArtifactStore(input: {
             taskRefStatus: indexedTaskRef.status ?? null,
           });
         }
-      })();
+      });
+      try {
+        persist.immediate();
+      } catch (err) {
+        if (isSqliteBusyError(err)) {
+          throw new WorkContextArtifactStoreError(503, 'artifact_store_busy');
+        }
+        throw err;
+      }
       return { metadata, payloadPath };
     },
 
@@ -569,12 +709,10 @@ export function createWorkContextArtifactStore(input: {
       }
       const artifactId =
         storeInput.id ?? storeInput.viewArtifact.manifest.revision.id;
-      mustNotAlreadyExist(artifactId);
       const manifestSupersedesArtifactId =
         storeInput.viewArtifact.manifest.revision.supersedes;
       const supersedesArtifactId =
         storeInput.supersedesArtifactId ?? manifestSupersedesArtifactId;
-      mustValidateSupersedes(supersedesArtifactId, storeInput.workContextId);
       if (
         storeInput.supersedesArtifactId &&
         manifestSupersedesArtifactId &&
@@ -641,7 +779,13 @@ export function createWorkContextArtifactStore(input: {
         payloadBytes,
         ...(supersedesArtifactId ? { supersedesArtifactId } : {}),
       };
-      db.transaction(() => {
+      const persist = db.transaction(() => {
+        mustNotAlreadyExist(artifactId);
+        mustValidateSupersedes(
+          supersedesArtifactId,
+          storeInput.workContextId,
+          'agent-view-artifact'
+        );
         insertArtifact.run({
           id: metadata.id,
           workContextId: metadata.workContextId,
@@ -681,7 +825,15 @@ export function createWorkContextArtifactStore(input: {
             taskRefStatus: indexedTaskRef.status ?? null,
           });
         }
-      })();
+      });
+      try {
+        persist.immediate();
+      } catch (err) {
+        if (isSqliteBusyError(err)) {
+          throw new WorkContextArtifactStoreError(503, 'artifact_store_busy');
+        }
+        throw err;
+      }
       return { metadata, payloadPath };
     },
 
@@ -792,6 +944,7 @@ export function createWorkContextArtifactStore(input: {
           FROM work_context_artifacts newer
           WHERE newer.supersedes_artifact_id = work_context_artifacts.id
             AND newer.work_context_id = work_context_artifacts.work_context_id
+            AND newer.payload_kind = work_context_artifacts.payload_kind
         )`);
       }
       const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';

--- a/shared/pipeline-handoff-artifact.ts
+++ b/shared/pipeline-handoff-artifact.ts
@@ -1,4 +1,8 @@
-import { ARTIFACT_KINDS, type TaskRef, type ArtifactKind } from './work-context.js';
+import {
+  ARTIFACT_KINDS,
+  type TaskRef,
+  type ArtifactKind,
+} from './work-context.js';
 
 export const PIPELINE_HANDOFF_ARTIFACT_SCHEMA_VERSION = 1 as const;
 
@@ -9,8 +13,7 @@ export const PIPELINE_HANDOFF_STAGES = [
   'release',
 ] as const;
 
-export type PipelineHandoffStageName =
-  (typeof PIPELINE_HANDOFF_STAGES)[number];
+export type PipelineHandoffStageName = (typeof PIPELINE_HANDOFF_STAGES)[number];
 
 export const PIPELINE_HANDOFF_EVIDENCE_DISPOSITIONS = [
   'provided',
@@ -70,6 +73,54 @@ export const PIPELINE_HANDOFF_REVIEW_VERDICTS = [
 
 export type PipelineHandoffReviewVerdict =
   (typeof PIPELINE_HANDOFF_REVIEW_VERDICTS)[number];
+
+export const PIPELINE_HANDOFF_REVIEW_FINDING_SEVERITIES = [
+  'P0',
+  'P1',
+  'P2',
+  'P3',
+] as const;
+export type PipelineHandoffReviewFindingSeverity =
+  (typeof PIPELINE_HANDOFF_REVIEW_FINDING_SEVERITIES)[number];
+
+export const PIPELINE_HANDOFF_REVIEW_FINDING_DISPOSITIONS = [
+  'fixed',
+  'follow-up',
+  'refuted',
+  'unresolved',
+] as const;
+export type PipelineHandoffReviewFindingDispositionKind =
+  (typeof PIPELINE_HANDOFF_REVIEW_FINDING_DISPOSITIONS)[number];
+
+export const PIPELINE_HANDOFF_TRUSTED_PROVENANCE_DISPOSITIONS = [
+  'verified',
+  'declared-unverified',
+  'unresolvable',
+  'mismatched',
+] as const;
+export type PipelineHandoffTrustedProvenanceDisposition =
+  (typeof PIPELINE_HANDOFF_TRUSTED_PROVENANCE_DISPOSITIONS)[number];
+
+export const PIPELINE_HANDOFF_REVIEW_CONFLICTS = [
+  'none',
+  'declared',
+  'unknown',
+] as const;
+export type PipelineHandoffReviewConflict =
+  (typeof PIPELINE_HANDOFF_REVIEW_CONFLICTS)[number];
+
+export const PIPELINE_HANDOFF_CONTEXT_MAP_REFS = [
+  'docs/context-map.md#channel-routing',
+  'docs/context-map.md#durable-bindings',
+  'docs/context-map.md#provider-adapters',
+  'docs/context-map.md#message-storage-and-context',
+  'docs/context-map.md#frontend-chat-surfaces',
+  'docs/context-map.md#test-fixtures',
+  'docs/context-map.md#ci-and-release-evidence',
+  'docs/context-map.md#handoff-evidence',
+] as const;
+export type PipelineHandoffContextMapRef =
+  (typeof PIPELINE_HANDOFF_CONTEXT_MAP_REFS)[number];
 
 export const PIPELINE_HANDOFF_RELEASE_VERDICTS = [
   'released',
@@ -163,8 +214,7 @@ export interface PipelineHandoffStageBase {
   nonGoals: string[];
 }
 
-export interface PipelineHandoffImplementationStage
-  extends PipelineHandoffStageBase {
+export interface PipelineHandoffImplementationStage extends PipelineHandoffStageBase {
   stage: 'implementation';
   decision: PipelineHandoffImplementationDecision;
   changedFiles: string[];
@@ -178,12 +228,85 @@ export interface PipelineHandoffQaStage extends PipelineHandoffStageBase {
   findings: string[];
 }
 
+export interface PipelineHandoffReviewParticipant {
+  actorId: string;
+  sessionId: string;
+  runId: string;
+  relayGlobalSessionId: string;
+  /** Informational only; never an independence proof. */
+  provider: string;
+  /** Informational only; never an independence proof. */
+  model: string;
+}
+
+export interface PipelineHandoffReviewLocation {
+  /** Repository-relative path only. */
+  path: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+export type PipelineHandoffReviewEvidenceRef =
+  | { kind: 'artifact-id'; artifactId: string }
+  | {
+      kind: 'repository';
+      path: string;
+      lineStart?: number;
+      lineEnd?: number;
+    };
+
+export interface PipelineHandoffReviewFindingFollowUp {
+  owner: string;
+  taskRef: TaskRef;
+  riskAcceptedRationale: string;
+}
+
+export interface PipelineHandoffReviewFindingDisposition {
+  kind: PipelineHandoffReviewFindingDispositionKind;
+  summary: string;
+  evidenceRefs: PipelineHandoffReviewEvidenceRef[];
+  followUp?: PipelineHandoffReviewFindingFollowUp;
+}
+
+export interface PipelineHandoffReviewFinding {
+  id: string;
+  severity: PipelineHandoffReviewFindingSeverity;
+  summary: string;
+  location: PipelineHandoffReviewLocation;
+  evidenceSummary: string;
+  disposition: PipelineHandoffReviewFindingDisposition;
+}
+
+export interface PipelineHandoffAdversarialReviewEvidence {
+  promptVersion: string;
+  baseSha: string;
+  diffSha256: string;
+  implementation: PipelineHandoffReviewParticipant;
+  reviewer: PipelineHandoffReviewParticipant & {
+    independentFromImplementation: boolean;
+    conflictOfInterest: PipelineHandoffReviewConflict;
+    conflictSummary?: string;
+  };
+  trustedProvenance: {
+    disposition: PipelineHandoffTrustedProvenanceDisposition;
+    summary: string;
+  };
+  context: {
+    digestSha256: string;
+    refs: PipelineHandoffContextMapRef[];
+  };
+  findings: PipelineHandoffReviewFinding[];
+  containsNoRawTranscriptOrSecrets: true;
+}
+
 export interface PipelineHandoffReviewStage extends PipelineHandoffStageBase {
   stage: 'review';
   verdict: PipelineHandoffReviewVerdict;
   reviewedHeadSha: string;
   blockers: string[];
   nitsOrFollowUps: string[];
+  /** Optional additive structured evidence; later gates decide when required. */
+  adversarialReview?: PipelineHandoffAdversarialReviewEvidence;
 }
 
 export interface PipelineHandoffReleaseStage extends PipelineHandoffStageBase {
@@ -207,6 +330,8 @@ export interface PipelineHandoffArtifact {
   title: string;
   createdAt: string;
   updatedAt: string;
+  /** Canonical append-only predecessor; request metadata must agree when given. */
+  supersedesArtifactId?: string;
   scope: PipelineHandoffScope;
   head: PipelineHandoffHeadRef;
   /** Append-only stage layers in implementation -> QA -> review -> release order. */
@@ -233,6 +358,17 @@ const IMPLEMENTATION_DECISION_SET = new Set<string>(
 const QA_VERDICT_SET = new Set<string>(PIPELINE_HANDOFF_QA_VERDICTS);
 const REVIEW_VERDICT_SET = new Set<string>(PIPELINE_HANDOFF_REVIEW_VERDICTS);
 const RELEASE_VERDICT_SET = new Set<string>(PIPELINE_HANDOFF_RELEASE_VERDICTS);
+const REVIEW_FINDING_SEVERITY_SET = new Set<string>(
+  PIPELINE_HANDOFF_REVIEW_FINDING_SEVERITIES
+);
+const REVIEW_FINDING_DISPOSITION_SET = new Set<string>(
+  PIPELINE_HANDOFF_REVIEW_FINDING_DISPOSITIONS
+);
+const TRUSTED_PROVENANCE_DISPOSITION_SET = new Set<string>(
+  PIPELINE_HANDOFF_TRUSTED_PROVENANCE_DISPOSITIONS
+);
+const REVIEW_CONFLICT_SET = new Set<string>(PIPELINE_HANDOFF_REVIEW_CONFLICTS);
+const CONTEXT_MAP_REF_SET = new Set<string>(PIPELINE_HANDOFF_CONTEXT_MAP_REFS);
 const ARTIFACT_KIND_SET = ARTIFACT_KINDS;
 const GIT_SHA_RE = /^[a-f0-9]{40,64}$/i;
 const SHA256_RE = /^[a-f0-9]{64}$/i;
@@ -276,10 +412,21 @@ const FORBIDDEN_FIELD_NAMES = new Set<string>([
   'xRelayNodeCredential',
 ]);
 
+const REVIEW_FORBIDDEN_FIELD_NAMES = new Set<string>([
+  'prompt',
+  'rawPrompt',
+  'providerPayload',
+  'log',
+  'logs',
+  'commandArguments',
+  'arguments',
+  'argv',
+  'args',
+]);
+
 const SECRET_TEXT_RE =
   /(?:bearer\s+[a-z0-9._~+/-]+=*|sk-[a-z0-9_-]{8,}|relay-(?:sac|ohg|grant|auth|pair)-v1[a-z0-9._-]*|pair_[a-z0-9_-]{8,}|node_[a-z0-9._~+/=-]+\.secret_[a-z0-9._~+/=-]+|secret_[a-z0-9._~+/=-]+)/gi;
-const ABSOLUTE_LOCAL_PATH_RE =
-  /(?:^|[\s:=('"])(?:\/home\/[^\s)'"]+|\/Users\/[^\s)'"]+|\/tmp\/[^\s)'"]+)/g;
+const ABSOLUTE_LOCAL_PATH_RE = /(?<![a-z0-9._:/<-])\/(?!\/)[^\s)\]}'",;<>]+/gi;
 const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
 const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
 const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
@@ -297,7 +444,9 @@ function isOptionalString(value: unknown): boolean {
 }
 
 function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
 }
 
 function isEnumValue(value: unknown, values: Set<string>): value is string {
@@ -348,7 +497,7 @@ function isForbiddenFieldName(key: string): boolean {
   return (
     /(?:auth|authorization|bearer|credential|grant|pairtoken|pairingtoken|secret|token)/.test(
       normalized
-    ) && !['taskrefs'].includes(normalized)
+    ) && !['taskrefs', 'containsnorawtranscriptorsecrets'].includes(normalized)
   );
 }
 
@@ -373,6 +522,49 @@ function collectUnsafeFields(
   return errors;
 }
 
+function containsControlText(value: string): boolean {
+  return /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(value);
+}
+
+function collectUnsafeReviewFields(
+  value: unknown,
+  path: string,
+  errors: string[]
+): void {
+  if (typeof value === 'string') {
+    if (containsControlText(value)) {
+      errors.push(`unsafe adversarial review control text rejected: ${path}`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectUnsafeReviewFields(item, `${path}[${index}]`, errors)
+    );
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    const normalized = normalizedFieldName(key);
+    if (
+      Array.from(REVIEW_FORBIDDEN_FIELD_NAMES).some(
+        (forbidden) => normalized === normalizedFieldName(forbidden)
+      )
+    ) {
+      errors.push(`unsafe adversarial review field rejected: ${path}.${key}`);
+    }
+    collectUnsafeReviewFields(nested, `${path}.${key}`, errors);
+  }
+}
+
+function isBoundedString(value: unknown, maxLength = 2048): value is string {
+  return hasString(value) && value.length <= maxLength;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
 function collectUnsafePublicText(
   value: unknown,
   path = '$',
@@ -395,7 +587,9 @@ function collectUnsafePublicText(
       errors.push(`local absolute path rejected from public handoff: ${path}`);
     }
     if (KANBAN_TASK_ID_RE.test(value)) {
-      errors.push(`private Kanban task id rejected from public handoff: ${path}`);
+      errors.push(
+        `private Kanban task id rejected from public handoff: ${path}`
+      );
     }
     return errors;
   }
@@ -412,20 +606,29 @@ function collectUnsafePublicText(
   return errors;
 }
 
-function validateTaskRef(value: unknown, errors: string[], path: string): boolean {
+function validateTaskRef(
+  value: unknown,
+  errors: string[],
+  path: string
+): boolean {
   if (!isRecord(value)) {
     errors.push(`${path} must be a task ref object`);
     return false;
   }
   if (!hasString(value.kind)) errors.push(`${path}.kind is required`);
   if (!hasString(value.id)) errors.push(`${path}.id is required`);
-  if (!isOptionalString(value.title)) errors.push(`${path}.title must be a string`);
+  if (!isOptionalString(value.title))
+    errors.push(`${path}.title must be a string`);
   if (!isOptionalString(value.url)) errors.push(`${path}.url must be a string`);
-  if (!isOptionalString(value.status)) errors.push(`${path}.status must be a string`);
+  if (!isOptionalString(value.status))
+    errors.push(`${path}.status must be a string`);
   return true;
 }
 
-function validateHead(value: unknown, errors: string[]): value is PipelineHandoffHeadRef {
+function validateHead(
+  value: unknown,
+  errors: string[]
+): value is PipelineHandoffHeadRef {
   if (!isRecord(value)) {
     errors.push('head is required');
     return false;
@@ -445,7 +648,11 @@ function validateHead(value: unknown, errors: string[]): value is PipelineHandof
   if (!isRecord(value.base) || !hasString(value.base.name)) {
     errors.push('head.base.name is required');
   }
-  if (isRecord(value.base) && value.base.sha !== undefined && !isSha(value.base.sha)) {
+  if (
+    isRecord(value.base) &&
+    value.base.sha !== undefined &&
+    !isSha(value.base.sha)
+  ) {
     errors.push('head.base.sha must be a git sha when present');
   }
   if (value.branch !== undefined) {
@@ -467,10 +674,7 @@ function validateHead(value: unknown, errors: string[]): value is PipelineHandof
     }
   }
   if (!isSha(value.headSha)) errors.push('head.headSha must be a git sha');
-  if (
-    !isRecord(value.staleIf) ||
-    value.staleIf.headShaChanges !== true
-  ) {
+  if (!isRecord(value.staleIf) || value.staleIf.headShaChanges !== true) {
     errors.push('head.staleIf.headShaChanges must be true');
   }
   if (!isIsoTimestamp(value.capturedAt)) {
@@ -479,7 +683,10 @@ function validateHead(value: unknown, errors: string[]): value is PipelineHandof
   return errors.length === 0;
 }
 
-function validateScope(value: unknown, errors: string[]): value is PipelineHandoffScope {
+function validateScope(
+  value: unknown,
+  errors: string[]
+): value is PipelineHandoffScope {
   if (!isRecord(value)) {
     errors.push('scope is required');
     return false;
@@ -494,7 +701,8 @@ function validateScope(value: unknown, errors: string[]): value is PipelineHando
     );
     if (
       !value.taskRefs.some(
-        (taskRef) => isRecord(taskRef) && GITHUB_TASK_KINDS.has(String(taskRef.kind))
+        (taskRef) =>
+          isRecord(taskRef) && GITHUB_TASK_KINDS.has(String(taskRef.kind))
       )
     ) {
       errors.push('scope.taskRefs must include a GitHub issue or PR ref');
@@ -503,7 +711,8 @@ function validateScope(value: unknown, errors: string[]): value is PipelineHando
   if (!isStringArray(value.acceptance) || value.acceptance.length === 0) {
     errors.push('scope.acceptance requires at least one item');
   }
-  if (!isStringArray(value.nonGoals)) errors.push('scope.nonGoals must be strings');
+  if (!isStringArray(value.nonGoals))
+    errors.push('scope.nonGoals must be strings');
   return true;
 }
 
@@ -534,7 +743,8 @@ function validateEvidence(
           errors.push(`${artifactPath} must be an object`);
           return;
         }
-        if (!hasString(artifact.id)) errors.push(`${artifactPath}.id is required`);
+        if (!hasString(artifact.id))
+          errors.push(`${artifactPath}.id is required`);
         if (!isEnumValue(artifact.kind, ARTIFACT_KIND_SET)) {
           errors.push(`${artifactPath}.kind must be a valid artifact kind`);
         }
@@ -547,8 +757,13 @@ function validateEvidence(
         if (!isOptionalString(artifact.summary)) {
           errors.push(`${artifactPath}.summary must be a string`);
         }
-        if (artifact.hashSha256 !== undefined && !isSha256(artifact.hashSha256)) {
-          errors.push(`${artifactPath}.hashSha256 must be a 64-character sha256 when present`);
+        if (
+          artifact.hashSha256 !== undefined &&
+          !isSha256(artifact.hashSha256)
+        ) {
+          errors.push(
+            `${artifactPath}.hashSha256 must be a 64-character sha256 when present`
+          );
         }
       });
     }
@@ -594,13 +809,17 @@ function validateStageBase(
     errors.push(`${path} must be a stage object`);
     return false;
   }
-  if (!isEnumValue(stage.stage, STAGE_SET)) errors.push(`${path}.stage is invalid`);
+  if (!isEnumValue(stage.stage, STAGE_SET))
+    errors.push(`${path}.stage is invalid`);
   if (!isIsoTimestamp(stage.addedAt)) {
     errors.push(`${path}.addedAt must be an ISO timestamp`);
   }
   if (!hasString(stage.actorId)) errors.push(`${path}.actorId is required`);
   if (!hasString(stage.summary)) errors.push(`${path}.summary is required`);
-  if (!Array.isArray(stage.acceptanceEvidence) || stage.acceptanceEvidence.length === 0) {
+  if (
+    !Array.isArray(stage.acceptanceEvidence) ||
+    stage.acceptanceEvidence.length === 0
+  ) {
     errors.push(`${path}.acceptanceEvidence requires at least one item`);
   } else {
     stage.acceptanceEvidence.forEach((item, index) =>
@@ -614,10 +833,14 @@ function validateStageBase(
       validateCommand(item, errors, `${path}.commands[${index}]`)
     );
   }
-  if (!isStringArray(stage.downstreamFocus) || stage.downstreamFocus.length === 0) {
+  if (
+    !isStringArray(stage.downstreamFocus) ||
+    stage.downstreamFocus.length === 0
+  ) {
     errors.push(`${path}.downstreamFocus requires at least one item`);
   }
-  if (!isStringArray(stage.nonGoals)) errors.push(`${path}.nonGoals must be strings`);
+  if (!isStringArray(stage.nonGoals))
+    errors.push(`${path}.nonGoals must be strings`);
   return true;
 }
 
@@ -656,11 +879,377 @@ function validateQaStage(
   }
 }
 
+function validateReviewParticipant(
+  value: unknown,
+  errors: string[],
+  path: string
+): value is PipelineHandoffReviewParticipant {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be a participant object`);
+    return false;
+  }
+  for (const field of [
+    'actorId',
+    'sessionId',
+    'runId',
+    'relayGlobalSessionId',
+    'provider',
+    'model',
+  ] as const) {
+    if (!isBoundedString(value[field], 256)) {
+      errors.push(
+        `${path}.${field} is required and must be at most 256 characters`
+      );
+    }
+  }
+  return true;
+}
+
+function validateReviewLocation(
+  value: unknown,
+  errors: string[],
+  path: string
+): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be a location object`);
+    return;
+  }
+  if (
+    !isSafeRelativePath(value.path) ||
+    value.path.length > 512 ||
+    value.path.includes('\\')
+  ) {
+    errors.push(
+      `${path}.path must be a bounded repository-relative public-safe path`
+    );
+  }
+  if (value.lineStart !== undefined && !isPositiveInteger(value.lineStart)) {
+    errors.push(`${path}.lineStart must be a positive integer`);
+  }
+  if (value.lineEnd !== undefined && !isPositiveInteger(value.lineEnd)) {
+    errors.push(`${path}.lineEnd must be a positive integer`);
+  }
+  if (
+    typeof value.lineStart === 'number' &&
+    typeof value.lineEnd === 'number' &&
+    value.lineEnd < value.lineStart
+  ) {
+    errors.push(`${path}.lineEnd must be greater than or equal to lineStart`);
+  }
+}
+
+function validateReviewEvidenceRef(
+  value: unknown,
+  errors: string[],
+  path: string
+): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an evidence ref object`);
+    return;
+  }
+  if (value.kind === 'artifact-id') {
+    if (!isBoundedString(value.artifactId, 256)) {
+      errors.push(`${path}.artifactId is required and must be bounded`);
+    }
+    return;
+  }
+  if (value.kind === 'repository') {
+    validateReviewLocation(value, errors, path);
+    return;
+  }
+  errors.push(`${path}.kind must be artifact-id or repository`);
+}
+
+function validateReviewFinding(
+  value: unknown,
+  errors: string[],
+  path: string
+): value is PipelineHandoffReviewFinding {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be a finding object`);
+    return false;
+  }
+  if (!isBoundedString(value.id, 256))
+    errors.push(`${path}.id is required and bounded`);
+  if (!isEnumValue(value.severity, REVIEW_FINDING_SEVERITY_SET)) {
+    errors.push(`${path}.severity is invalid`);
+  }
+  if (!isBoundedString(value.summary))
+    errors.push(`${path}.summary is required and bounded`);
+  if (!isBoundedString(value.evidenceSummary)) {
+    errors.push(`${path}.evidenceSummary is required and bounded`);
+  }
+  validateReviewLocation(value.location, errors, `${path}.location`);
+  if (!isRecord(value.disposition)) {
+    errors.push(`${path}.disposition is required`);
+    return true;
+  }
+  const disposition = value.disposition;
+  if (!isEnumValue(disposition.kind, REVIEW_FINDING_DISPOSITION_SET)) {
+    errors.push(`${path}.disposition.kind is invalid`);
+  }
+  if (!isBoundedString(disposition.summary)) {
+    errors.push(`${path}.disposition.summary is required and bounded`);
+  }
+  if (
+    !Array.isArray(disposition.evidenceRefs) ||
+    disposition.evidenceRefs.length > 8
+  ) {
+    errors.push(`${path}.disposition.evidenceRefs must contain at most 8 refs`);
+  } else {
+    disposition.evidenceRefs.forEach((ref, index) =>
+      validateReviewEvidenceRef(
+        ref,
+        errors,
+        `${path}.disposition.evidenceRefs[${index}]`
+      )
+    );
+    if (
+      (disposition.kind === 'fixed' || disposition.kind === 'refuted') &&
+      disposition.evidenceRefs.length === 0
+    ) {
+      errors.push(`${path}.disposition ${disposition.kind} requires evidence`);
+    }
+  }
+  if (disposition.kind === 'follow-up') {
+    if (value.severity === 'P0' || value.severity === 'P1') {
+      errors.push(`${path}.disposition follow-up is not allowed for P0/P1`);
+    }
+    if (!isRecord(disposition.followUp)) {
+      errors.push(`${path}.disposition.followUp is required`);
+    } else {
+      if (!isBoundedString(disposition.followUp.owner, 256)) {
+        errors.push(
+          `${path}.disposition.followUp.owner is required and bounded`
+        );
+      }
+      validateTaskRef(
+        disposition.followUp.taskRef,
+        errors,
+        `${path}.disposition.followUp.taskRef`
+      );
+      if (
+        !isRecord(disposition.followUp.taskRef) ||
+        disposition.followUp.taskRef.kind !== 'github-issue'
+      ) {
+        errors.push(
+          `${path}.disposition.followUp.taskRef must be a GitHub issue`
+        );
+      } else if (
+        !isBoundedString(disposition.followUp.taskRef.id, 256) ||
+        (disposition.followUp.taskRef.title !== undefined &&
+          !isBoundedString(disposition.followUp.taskRef.title, 512)) ||
+        (disposition.followUp.taskRef.url !== undefined &&
+          !isBoundedString(disposition.followUp.taskRef.url, 2048)) ||
+        (disposition.followUp.taskRef.status !== undefined &&
+          !isBoundedString(disposition.followUp.taskRef.status, 256))
+      ) {
+        errors.push(
+          `${path}.disposition.followUp.taskRef fields must be bounded`
+        );
+      }
+      if (!isBoundedString(disposition.followUp.riskAcceptedRationale)) {
+        errors.push(
+          `${path}.disposition.followUp.riskAcceptedRationale is required and bounded`
+        );
+      }
+    }
+  } else if (disposition.followUp !== undefined) {
+    errors.push(`${path}.disposition.followUp is only valid for follow-up`);
+  }
+  return true;
+}
+
+function validateTrustedReviewProvenance(
+  value: unknown,
+  verdict: unknown,
+  errors: string[],
+  path: string
+): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} is required`);
+    return;
+  }
+  if (!isEnumValue(value.disposition, TRUSTED_PROVENANCE_DISPOSITION_SET)) {
+    errors.push(`${path}.disposition is invalid`);
+  } else if (value.disposition === 'verified') {
+    errors.push(`${path} verified requires a trusted server resolver`);
+  }
+  if (
+    verdict === 'approved' &&
+    (value.disposition === 'unresolvable' || value.disposition === 'mismatched')
+  ) {
+    errors.push(`${path} cannot be ${String(value.disposition)} for approval`);
+  }
+  if (!isBoundedString(value.summary)) {
+    errors.push(`${path}.summary is required and bounded`);
+  }
+}
+
+function validateAdversarialReview(
+  value: unknown,
+  errors: string[],
+  path: string,
+  artifactBaseSha: unknown,
+  implementationActorId: unknown,
+  stageActorId: unknown,
+  verdict: unknown
+): void {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be an adversarial review object`);
+    return;
+  }
+  collectUnsafeReviewFields(value, path, errors);
+  // Structured review evidence is durable/exportable by contract, so reject
+  // rather than merely redact unsafe text at this boundary.
+  collectUnsafePublicText(value, path, errors);
+  if (!isBoundedString(value.promptVersion, 256)) {
+    errors.push(`${path}.promptVersion is required and bounded`);
+  }
+  if (!isSha(value.baseSha)) errors.push(`${path}.baseSha must be a git sha`);
+  if (!isSha(artifactBaseSha)) {
+    errors.push(`${path} requires artifact head.base.sha`);
+  } else if (value.baseSha !== artifactBaseSha) {
+    errors.push(`${path}.baseSha must equal artifact head.base.sha`);
+  }
+  if (!isSha256(value.diffSha256)) {
+    errors.push(`${path}.diffSha256 must be a 64-character sha256`);
+  }
+  const implementationValid = validateReviewParticipant(
+    value.implementation,
+    errors,
+    `${path}.implementation`
+  );
+  if (
+    implementationValid &&
+    isRecord(value.implementation) &&
+    value.implementation.actorId !== implementationActorId
+  ) {
+    errors.push(
+      `${path}.implementation.actorId must equal implementation stage actorId`
+    );
+  }
+  const reviewerValid = validateReviewParticipant(
+    value.reviewer,
+    errors,
+    `${path}.reviewer`
+  );
+  if (reviewerValid && isRecord(value.reviewer)) {
+    if (value.reviewer.independentFromImplementation !== true) {
+      errors.push(
+        `${path}.reviewer.independentFromImplementation must be true`
+      );
+    }
+    if (!isEnumValue(value.reviewer.conflictOfInterest, REVIEW_CONFLICT_SET)) {
+      errors.push(`${path}.reviewer.conflictOfInterest is invalid`);
+    }
+    if (
+      value.reviewer.conflictOfInterest !== 'none' &&
+      !isBoundedString(value.reviewer.conflictSummary)
+    ) {
+      errors.push(
+        `${path}.reviewer.conflictSummary is required for a conflict`
+      );
+    }
+    if (
+      value.reviewer.conflictOfInterest === 'none' &&
+      value.reviewer.conflictSummary !== undefined
+    ) {
+      errors.push(
+        `${path}.reviewer.conflictSummary is not allowed when conflictOfInterest is none`
+      );
+    }
+    if (stageActorId !== value.reviewer.actorId) {
+      errors.push(`${path}.reviewer.actorId must equal review stage actorId`);
+    }
+    if (
+      verdict === 'approved' &&
+      value.reviewer.conflictOfInterest !== 'none'
+    ) {
+      errors.push(
+        `${path}.reviewer.conflictOfInterest must be none for approval`
+      );
+    }
+  }
+  if (
+    implementationValid &&
+    reviewerValid &&
+    isRecord(value.implementation) &&
+    isRecord(value.reviewer)
+  ) {
+    for (const field of [
+      'actorId',
+      'sessionId',
+      'runId',
+      'relayGlobalSessionId',
+    ] as const) {
+      if (value.implementation[field] === value.reviewer[field]) {
+        errors.push(`${path} implementation and reviewer ${field} must differ`);
+      }
+    }
+  }
+  validateTrustedReviewProvenance(
+    value.trustedProvenance,
+    verdict,
+    errors,
+    `${path}.trustedProvenance`
+  );
+  if (!isRecord(value.context)) {
+    errors.push(`${path}.context is required`);
+  } else {
+    if (!isSha256(value.context.digestSha256)) {
+      errors.push(`${path}.context.digestSha256 must be a 64-character sha256`);
+    }
+    if (
+      !Array.isArray(value.context.refs) ||
+      value.context.refs.length === 0 ||
+      value.context.refs.length > 16 ||
+      !value.context.refs.every((ref) => isEnumValue(ref, CONTEXT_MAP_REF_SET))
+    ) {
+      errors.push(
+        `${path}.context.refs must contain 1-16 allowlisted context refs`
+      );
+    } else if (new Set(value.context.refs).size !== value.context.refs.length) {
+      errors.push(`${path}.context.refs must be unique`);
+    }
+  }
+  if (!Array.isArray(value.findings) || value.findings.length > 100) {
+    errors.push(`${path}.findings must contain at most 100 findings`);
+  } else {
+    const findingIds = new Set<string>();
+    value.findings.forEach((finding, index) => {
+      if (
+        validateReviewFinding(finding, errors, `${path}.findings[${index}]`) &&
+        isRecord(finding)
+      ) {
+        if (findingIds.has(String(finding.id))) {
+          errors.push(`${path}.findings[${index}].id must be unique`);
+        }
+        findingIds.add(String(finding.id));
+        if (
+          verdict === 'approved' &&
+          isRecord(finding.disposition) &&
+          finding.disposition.kind === 'unresolved'
+        ) {
+          errors.push(
+            `${path}.findings[${index}] cannot be unresolved for approval`
+          );
+        }
+      }
+    });
+  }
+  if (value.containsNoRawTranscriptOrSecrets !== true) {
+    errors.push(`${path}.containsNoRawTranscriptOrSecrets must be true`);
+  }
+}
+
 function validateReviewStage(
   record: Record<string, unknown>,
   errors: string[],
   path: string,
-  headSha: string
+  headSha: string,
+  baseSha: unknown,
+  implementationActorId: unknown
 ): void {
   if (!isEnumValue(record.verdict, REVIEW_VERDICT_SET)) {
     errors.push(`${path}.verdict is invalid`);
@@ -673,6 +1262,17 @@ function validateReviewStage(
   }
   if (!isStringArray(record.nitsOrFollowUps)) {
     errors.push(`${path}.nitsOrFollowUps must be strings`);
+  }
+  if (record.adversarialReview !== undefined) {
+    validateAdversarialReview(
+      record.adversarialReview,
+      errors,
+      `${path}.adversarialReview`,
+      baseSha,
+      implementationActorId,
+      record.actorId,
+      record.verdict
+    );
   }
 }
 
@@ -701,7 +1301,9 @@ function validateStageSpecific(
   stage: PipelineHandoffStageBase,
   errors: string[],
   path: string,
-  headSha: string
+  headSha: string,
+  baseSha: unknown,
+  implementationActorId: unknown
 ): void {
   const record = stage as unknown as Record<string, unknown>;
   switch (stage.stage) {
@@ -712,7 +1314,14 @@ function validateStageSpecific(
       validateQaStage(record, errors, path, headSha);
       break;
     case 'review':
-      validateReviewStage(record, errors, path, headSha);
+      validateReviewStage(
+        record,
+        errors,
+        path,
+        headSha,
+        baseSha,
+        implementationActorId
+      );
       break;
     case 'release':
       validateReleaseStage(record, errors, path, headSha);
@@ -754,6 +1363,12 @@ export function validatePipelineHandoffArtifact(
     errors.push('schemaVersion is unsupported');
   }
   if (!hasString(artifact.id)) errors.push('id is required');
+  if (
+    artifact.supersedesArtifactId !== undefined &&
+    !isBoundedString(artifact.supersedesArtifactId, 256)
+  ) {
+    errors.push('supersedesArtifactId must be a non-empty bounded artifact id');
+  }
   if (!hasString(artifact.title)) errors.push('title is required');
   if (!isIsoTimestamp(artifact.createdAt)) {
     errors.push('createdAt must be an ISO timestamp');
@@ -768,19 +1383,50 @@ export function validatePipelineHandoffArtifact(
     errors.push('stages requires at least an implementation layer');
   } else {
     const stages: PipelineHandoffStage[] = [];
-    const headSha = isRecord(artifact.head) && typeof artifact.head.headSha === 'string'
-      ? artifact.head.headSha
-      : '';
+    const headSha =
+      isRecord(artifact.head) && typeof artifact.head.headSha === 'string'
+        ? artifact.head.headSha
+        : '';
+    const baseSha =
+      isRecord(artifact.head) && isRecord(artifact.head.base)
+        ? artifact.head.base.sha
+        : undefined;
+    const implementationActorId =
+      isRecord(artifact.stages[0]) &&
+      artifact.stages[0].stage === 'implementation'
+        ? artifact.stages[0].actorId
+        : undefined;
     artifact.stages.forEach((stage, index) => {
       const path = `stages[${index}]`;
       if (validateStageBase(stage, errors, path)) {
-        validateStageSpecific(stage, errors, path, headSha);
+        validateStageSpecific(
+          stage,
+          errors,
+          path,
+          headSha,
+          baseSha,
+          implementationActorId
+        );
         stages.push(stage as PipelineHandoffStage);
       }
     });
     validateAppendOnlyStageOrder(stages, errors);
     if (stages[0]?.stage !== 'implementation') {
       errors.push('stages must start with implementation');
+    }
+    const structuredReviewIndex = stages.findIndex(
+      (stage) =>
+        stage.stage === 'review' && stage.adversarialReview !== undefined
+    );
+    if (
+      structuredReviewIndex !== -1 &&
+      (structuredReviewIndex !== 2 ||
+        stages[0]?.stage !== 'implementation' ||
+        stages[1]?.stage !== 'qa')
+    ) {
+      errors.push(
+        'structured adversarial review requires contiguous implementation -> QA -> review stages'
+      );
     }
   }
 
@@ -810,17 +1456,18 @@ function redactPublicText(value: string): string {
   UNC_PATH_RE.lastIndex = 0;
   KANBAN_TASK_ID_RE.lastIndex = 0;
   return value
+    .replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]+/gu, ' ')
     .replace(SECRET_TEXT_RE, '[redacted-secret]')
     .replace(ABSOLUTE_LOCAL_PATH_RE, (match) => {
-      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      const prefix = ' \t:=(\'"'.includes(match[0] ?? '') ? match[0] : '';
       return `${prefix}[redacted-local-path]`;
     })
     .replace(WINDOWS_ABSOLUTE_PATH_RE, (match) => {
-      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      const prefix = ' \t:=(\'"'.includes(match[0] ?? '') ? match[0] : '';
       return `${prefix}[redacted-local-path]`;
     })
     .replace(UNC_PATH_RE, (match) => {
-      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      const prefix = ' \t:=(\'"'.includes(match[0] ?? '') ? match[0] : '';
       return `${prefix}[redacted-local-path]`;
     })
     .replace(KANBAN_TASK_ID_RE, '[redacted-kanban-task]');
@@ -828,7 +1475,8 @@ function redactPublicText(value: string): string {
 
 function sanitizeTextTree<T>(value: T): T {
   if (typeof value === 'string') return redactPublicText(value) as T;
-  if (Array.isArray(value)) return value.map((item) => sanitizeTextTree(item)) as T;
+  if (Array.isArray(value))
+    return value.map((item) => sanitizeTextTree(item)) as T;
   if (!isRecord(value)) return value;
   const out: Record<string, unknown> = {};
   for (const [key, nested] of Object.entries(value)) {
@@ -849,10 +1497,42 @@ export function sanitizePipelineHandoffArtifactForPublic(
   sanitized.scope.nonGoals = sanitized.scope.nonGoals.filter(
     (nonGoal) => !/kanban|internal dispatcher|local worktree/i.test(nonGoal)
   );
-  sanitized.stages = sanitized.stages.map((stage) => ({
-    ...stage,
-    actorId: stage.actorId.startsWith('agent:') ? 'agent' : stage.actorId,
-  })) as PipelineHandoffStage[];
+  const hasStructuredReview = sanitized.stages.some(
+    (stage) => stage.stage === 'review' && stage.adversarialReview !== undefined
+  );
+  const publicActorAliases = new Map<string, string>();
+  const publicActorId = (actorId: string): string => {
+    if (!actorId.startsWith('agent:')) return actorId;
+    if (!hasStructuredReview) return 'agent';
+    const existing = publicActorAliases.get(actorId);
+    if (existing) return existing;
+    const alias = `agent:public-${publicActorAliases.size + 1}`;
+    publicActorAliases.set(actorId, alias);
+    return alias;
+  };
+  sanitized.stages = sanitized.stages.map((stage) => {
+    const actorId = publicActorId(stage.actorId);
+    if (stage.stage !== 'review' || !stage.adversarialReview) {
+      return { ...stage, actorId };
+    }
+    return {
+      ...stage,
+      actorId,
+      adversarialReview: {
+        ...stage.adversarialReview,
+        implementation: {
+          ...stage.adversarialReview.implementation,
+          actorId: publicActorId(
+            stage.adversarialReview.implementation.actorId
+          ),
+        },
+        reviewer: {
+          ...stage.adversarialReview.reviewer,
+          actorId: publicActorId(stage.adversarialReview.reviewer.actorId),
+        },
+      },
+    };
+  }) as PipelineHandoffStage[];
   return sanitized;
 }
 
@@ -874,13 +1554,44 @@ export function validatePublicPipelineHandoffArtifact(
 }
 
 function evidenceLine(evidence: PipelineHandoffEvidence): string {
-  const reason = evidence.reason ? ` (${evidence.reason})` : '';
-  return `- ${evidence.label}: ${evidence.disposition}${reason} — ${evidence.summary}`;
+  const reason = evidence.reason
+    ? ` (${escapeMarkdownInline(evidence.reason)})`
+    : '';
+  return `- ${escapeMarkdownInline(evidence.label)}: ${evidence.disposition}${reason} — ${escapeMarkdownInline(evidence.summary)}`;
+}
+
+function markdownCodeSpan(value: string): string {
+  const normalized = value.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]+/gu, ' ');
+  const longestRun = Math.max(
+    0,
+    ...Array.from(normalized.matchAll(/`+/g), (match) => match[0].length)
+  );
+  const fence = '`'.repeat(longestRun + 1);
+  return longestRun === 0
+    ? `${fence}${normalized}${fence}`
+    : `${fence} ${normalized} ${fence}`;
 }
 
 function commandLine(command: PipelineHandoffCommandEvidence): string {
-  const reason = command.reason ? ` (${command.reason})` : '';
-  return `- ${command.label}: ${command.status}${reason} — \`${command.command}\` — ${command.summary}`;
+  const reason = command.reason
+    ? ` (${escapeMarkdownInline(command.reason)})`
+    : '';
+  return `- ${escapeMarkdownInline(command.label)}: ${command.status}${reason} — ${markdownCodeSpan(command.command)} — ${escapeMarkdownInline(command.summary)}`;
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value
+    .replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]+/gu, ' ')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/\\\[(redacted-(?:secret|local-path|kanban-task))\\\]/g, '[$1]');
 }
 
 function stageVerdict(stage: PipelineHandoffStage): string {
@@ -904,22 +1615,31 @@ export function renderPipelineHandoffMarkdown(
     ? sanitizePipelineHandoffArtifactForPublic(artifact)
     : artifact;
   const taskRefs = rendered.scope.taskRefs
-    .map((taskRef) => (taskRef.url ? `${taskRef.kind} ${taskRef.url}` : `${taskRef.kind} ${taskRef.id}`))
+    .map((taskRef) =>
+      taskRef.url
+        ? `${taskRef.kind} ${escapeMarkdownInline(taskRef.url)}`
+        : `${taskRef.kind} ${escapeMarkdownInline(taskRef.id)}`
+    )
     .join(', ');
   const lines = [
-    `# Pipeline handoff artifact: ${rendered.title}`,
+    `# Pipeline handoff artifact: ${escapeMarkdownInline(rendered.title)}`,
     '',
     `schemaVersion: ${rendered.schemaVersion}`,
-    `scope: ${rendered.scope.summary}`,
+    `scope: ${escapeMarkdownInline(rendered.scope.summary)}`,
     `taskRefs: ${taskRefs}`,
     `head: ${rendered.head.headSha}`,
+    ...(rendered.supersedesArtifactId
+      ? [`supersedes: ${escapeMarkdownInline(rendered.supersedesArtifactId)}`]
+      : []),
     `staleIf: headShaChanges=${String(rendered.head.staleIf.headShaChanges)}`,
     '',
     '## Acceptance',
-    ...rendered.scope.acceptance.map((item) => `- ${item}`),
+    ...rendered.scope.acceptance.map(
+      (item) => `- ${escapeMarkdownInline(item)}`
+    ),
     '',
     '## Non-goals',
-    ...rendered.scope.nonGoals.map((item) => `- ${item}`),
+    ...rendered.scope.nonGoals.map((item) => `- ${escapeMarkdownInline(item)}`),
   ];
 
   for (const stage of rendered.stages) {
@@ -927,7 +1647,7 @@ export function renderPipelineHandoffMarkdown(
       '',
       `## ${stage.stage}`,
       `verdict: ${stageVerdict(stage)}`,
-      stage.summary,
+      escapeMarkdownInline(stage.summary),
       '',
       '### Evidence',
       ...stage.acceptanceEvidence.map(evidenceLine),
@@ -938,8 +1658,34 @@ export function renderPipelineHandoffMarkdown(
         : ['- none recorded']),
       '',
       '### Downstream focus',
-      ...stage.downstreamFocus.map((item) => `- ${item}`)
+      ...stage.downstreamFocus.map((item) => `- ${escapeMarkdownInline(item)}`)
     );
+    if (stage.stage === 'review' && stage.adversarialReview) {
+      const review = stage.adversarialReview;
+      const inline = escapeMarkdownInline;
+      lines.push(
+        '',
+        '### Adversarial review',
+        `promptVersion: ${inline(review.promptVersion)}`,
+        `reviewedHead: ${stage.reviewedHeadSha}`,
+        `baseHead: ${review.baseSha}`,
+        `diffSha256: ${review.diffSha256}`,
+        `implementation: ${inline(review.implementation.actorId)} / ${inline(review.implementation.sessionId)} / ${inline(review.implementation.runId)}`,
+        `reviewer: ${inline(review.reviewer.actorId)} / ${inline(review.reviewer.sessionId)} / ${inline(review.reviewer.runId)}`,
+        `conflictOfInterest: ${review.reviewer.conflictOfInterest}`,
+        `trustedProvenanceDeclaration: ${review.trustedProvenance.disposition} — ${inline(review.trustedProvenance.summary)}`,
+        `contextDigestSha256: ${review.context.digestSha256}`,
+        `contextRefs: ${review.context.refs.join(', ')}`,
+        '',
+        '#### Findings',
+        ...(review.findings.length > 0
+          ? review.findings.map(
+              (finding) =>
+                `- ${inline(finding.id)} [${finding.severity}] ${inline(finding.location.path)}:${finding.location.lineStart ?? 1} — ${inline(finding.summary)} — ${finding.disposition.kind}: ${inline(finding.disposition.summary)}`
+            )
+          : ['- none'])
+      );
+    }
   }
   return `${lines.join('\n')}\n`;
 }

--- a/test/pipeline-handoff-artifact.test.ts
+++ b/test/pipeline-handoff-artifact.test.ts
@@ -10,6 +10,7 @@ import {
   sanitizePipelineHandoffArtifactForPublic,
   validatePipelineHandoffArtifact,
   validatePublicPipelineHandoffArtifact,
+  type PipelineHandoffAdversarialReviewEvidence,
   type PipelineHandoffArtifact,
   type PipelineHandoffImplementationStage,
   type PipelineHandoffQaStage,
@@ -19,17 +20,18 @@ import {
 } from '../shared/pipeline-handoff-artifact.js';
 
 const now = '2026-06-08T01:02:03Z';
+const baseSha = 'cccccccccccccccccccccccccccccccccccccccc';
 const headSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const nextHeadSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
 function evidence(
-  disposition: PipelineHandoffStage['acceptanceEvidence'][number]['disposition'] =
-    'provided'
+  disposition: PipelineHandoffStage['acceptanceEvidence'][number]['disposition'] = 'provided'
 ): PipelineHandoffStage['acceptanceEvidence'][number] {
   return {
     label: 'acceptance evidence',
     disposition,
-    summary: disposition === 'provided' ? 'bounded proof ref recorded' : 'not run',
+    summary:
+      disposition === 'provided' ? 'bounded proof ref recorded' : 'not run',
     ...(disposition === 'provided'
       ? {}
       : { reason: `${disposition} is machine-readable` }),
@@ -80,6 +82,68 @@ function qaStage(): PipelineHandoffQaStage {
   };
 }
 
+function adversarialReview(): PipelineHandoffAdversarialReviewEvidence {
+  return {
+    promptVersion: 'adversarial-review-v1',
+    baseSha,
+    diffSha256: 'd'.repeat(64),
+    implementation: {
+      actorId: 'agent:kani-backend',
+      sessionId: 'session:implementer',
+      runId: 'run:implementer',
+      relayGlobalSessionId: 'global-session:implementer',
+      provider: 'prime-agent',
+      model: 'gpt-5.6',
+    },
+    reviewer: {
+      actorId: 'agent:fugu-reviewer',
+      sessionId: 'session:reviewer',
+      runId: 'run:reviewer',
+      relayGlobalSessionId: 'global-session:reviewer',
+      provider: 'codex',
+      model: 'gpt-5.6',
+      independentFromImplementation: true,
+      conflictOfInterest: 'none',
+    },
+    trustedProvenance: {
+      disposition: 'declared-unverified',
+      summary: 'auditable declaration pending a trusted Relay resolver',
+    },
+    context: {
+      digestSha256: 'e'.repeat(64),
+      refs: [
+        'docs/context-map.md#handoff-evidence',
+        'docs/context-map.md#test-fixtures',
+      ],
+    },
+    findings: [
+      {
+        id: 'finding:p2:1',
+        severity: 'P2',
+        summary: 'bounded finding summary',
+        location: {
+          path: 'shared/pipeline-handoff-artifact.ts',
+          lineStart: 1,
+          lineEnd: 2,
+        },
+        evidenceSummary: 'direct test reproduces the behavior',
+        disposition: {
+          kind: 'fixed',
+          summary: 'fixed at the canonical validator seam',
+          evidenceRefs: [
+            {
+              kind: 'repository',
+              path: 'test/pipeline-handoff-artifact.test.ts',
+              lineStart: 1,
+            },
+          ],
+        },
+      },
+    ],
+    containsNoRawTranscriptOrSecrets: true,
+  };
+}
+
 function reviewStage(): PipelineHandoffReviewStage {
   return {
     stage: 'review',
@@ -113,7 +177,9 @@ function releaseStage(): PipelineHandoffReleaseStage {
   };
 }
 
-function baseArtifact(stages: PipelineHandoffStage[] = [implementationStage()]): PipelineHandoffArtifact {
+function baseArtifact(
+  stages: PipelineHandoffStage[] = [implementationStage()]
+): PipelineHandoffArtifact {
   return {
     schemaVersion: PIPELINE_HANDOFF_ARTIFACT_SCHEMA_VERSION,
     id: 'pipeline-handoff:883:aaaaaaaa',
@@ -143,9 +209,12 @@ function baseArtifact(stages: PipelineHandoffStage[] = [implementationStage()]):
     },
     head: {
       repo: { ownerRepo: 'donovan-yohan/relay-ide' },
-      base: { name: 'nightly' },
+      base: { name: 'nightly', sha: baseSha },
       branch: { name: 'issue-883-handoff-schema' },
-      pr: { number: 883, url: 'https://github.com/donovan-yohan/relay-ide/pull/883' },
+      pr: {
+        number: 883,
+        url: 'https://github.com/donovan-yohan/relay-ide/pull/883',
+      },
       headSha,
       staleIf: { headShaChanges: true },
       capturedAt: now,
@@ -155,7 +224,12 @@ function baseArtifact(stages: PipelineHandoffStage[] = [implementationStage()]):
 }
 
 function fullStageArtifact(): PipelineHandoffArtifact {
-  return baseArtifact([implementationStage(), qaStage(), reviewStage(), releaseStage()]);
+  return baseArtifact([
+    implementationStage(),
+    qaStage(),
+    reviewStage(),
+    releaseStage(),
+  ]);
 }
 
 describe('PipelineHandoffArtifact schema', () => {
@@ -176,6 +250,342 @@ describe('PipelineHandoffArtifact schema', () => {
     expect(PIPELINE_HANDOFF_COMMAND_STATUSES).toContain('not-applicable');
   });
 
+  it('validates additive structured adversarial review evidence and predecessor identity', () => {
+    const review = reviewStage();
+    review.adversarialReview = adversarialReview();
+    const artifact = baseArtifact([implementationStage(), qaStage(), review]);
+    artifact.supersedesArtifactId = 'artifact:predecessor';
+
+    expect(validatePipelineHandoffArtifact(artifact)).toEqual({
+      valid: true,
+      errors: [],
+    });
+    const rendered = renderPipelineHandoffMarkdown(artifact);
+    expect(rendered).toContain('supersedes: artifact:predecessor');
+    expect(rendered).toContain('### Adversarial review');
+    expect(rendered).toContain(`reviewedHead: ${headSha}`);
+    expect(rendered).toContain(`baseHead: ${baseSha}`);
+    expect(rendered).toContain(`diffSha256: ${'d'.repeat(64)}`);
+    expect(rendered).toContain('conflictOfInterest: none');
+    expect(rendered).toContain(
+      'trustedProvenanceDeclaration: declared-unverified'
+    );
+    expect(rendered).toContain(
+      'contextRefs: docs/context-map.md#handoff-evidence, docs/context-map.md#test-fixtures'
+    );
+    expect(rendered).toContain('finding:p2:1 [P2]');
+    const publicArtifact = sanitizePipelineHandoffArtifactForPublic(artifact);
+    expect(publicArtifact.supersedesArtifactId).toBe('artifact:predecessor');
+    const publicReview = publicArtifact.stages[2] as PipelineHandoffReviewStage;
+    expect(publicReview.adversarialReview?.reviewer.sessionId).toBe(
+      'session:reviewer'
+    );
+    expect(
+      validatePublicPipelineHandoffArtifact(publicArtifact).errors
+    ).toEqual([]);
+    expect(publicReview.adversarialReview?.implementation.actorId).toBe(
+      publicArtifact.stages[0]?.actorId
+    );
+    expect(publicReview.adversarialReview?.reviewer.actorId).toBe(
+      publicReview.actorId
+    );
+    expect(publicReview.adversarialReview?.reviewer.actorId).not.toBe(
+      publicReview.adversarialReview?.implementation.actorId
+    );
+  });
+
+  it('escapes inline Markdown and HTML in structured review rendering', () => {
+    const review = reviewStage();
+    review.adversarialReview = adversarialReview();
+    review.adversarialReview.findings[0]!.summary =
+      '`code` [link](https://example.com) <script>alert(1)</script>';
+    const artifact = baseArtifact([implementationStage(), qaStage(), review]);
+
+    expect(validatePipelineHandoffArtifact(artifact).valid).toBe(true);
+    const rendered = renderPipelineHandoffMarkdown(artifact);
+    expect(rendered).toContain('\\`code\\`');
+    expect(rendered).toContain('\\[link\\]\\(https://example.com\\)');
+    expect(rendered).toContain('&lt;script&gt;alert\\(1\\)&lt;/script&gt;');
+    expect(rendered).not.toContain('<script>');
+  });
+
+  it('requires artifact base SHA when structured review evidence declares its base', () => {
+    const review = reviewStage();
+    review.adversarialReview = adversarialReview();
+    const artifact = baseArtifact([implementationStage(), qaStage(), review]);
+    delete artifact.head.base.sha;
+
+    expect(validatePipelineHandoffArtifact(artifact).errors).toContain(
+      'stages[2].adversarialReview requires artifact head.base.sha'
+    );
+  });
+
+  it('requires QA before a structured adversarial review', () => {
+    const review = reviewStage();
+    review.adversarialReview = adversarialReview();
+    const artifact = baseArtifact([implementationStage(), review]);
+
+    expect(validatePipelineHandoffArtifact(artifact).errors).toContain(
+      'structured adversarial review requires contiguous implementation -> QA -> review stages'
+    );
+  });
+
+  it('keeps legacy schema-v1 review stages valid without structured evidence', () => {
+    const artifact = baseArtifact([
+      implementationStage(),
+      qaStage(),
+      reviewStage(),
+    ]);
+    expect(validatePipelineHandoffArtifact(artifact)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  it.each([
+    {
+      name: 'partial evidence block',
+      mutate: (review: Record<string, unknown>) => {
+        review.adversarialReview = { promptVersion: 'v1' };
+      },
+      error: 'baseSha',
+    },
+    {
+      name: 'same actor identity',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (evidence.implementation as Record<string, unknown>).actorId = (
+          evidence.reviewer as Record<string, unknown>
+        ).actorId;
+      },
+      error: 'actorId must differ',
+    },
+    {
+      name: 'implementation actor does not match implementation stage',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (evidence.implementation as Record<string, unknown>).actorId =
+          'agent:unrelated-implementer';
+      },
+      error: 'implementation.actorId must equal implementation stage actorId',
+    },
+    {
+      name: 'forged verified provenance',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (evidence.trustedProvenance as Record<string, unknown>).disposition =
+          'verified';
+      },
+      error: 'verified requires a trusted server resolver',
+    },
+    {
+      name: 'approved provenance mismatch',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (evidence.trustedProvenance as Record<string, unknown>).disposition =
+          'mismatched';
+      },
+      error: 'cannot be mismatched for approval',
+    },
+    {
+      name: 'same Relay global session identity',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (
+          evidence.implementation as Record<string, unknown>
+        ).relayGlobalSessionId = (
+          evidence.reviewer as Record<string, unknown>
+        ).relayGlobalSessionId;
+      },
+      error: 'relayGlobalSessionId must differ',
+    },
+    {
+      name: 'unresolved approved finding',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        (finding.disposition as Record<string, unknown>).kind = 'unresolved';
+      },
+      error: 'cannot be unresolved for approval',
+    },
+    {
+      name: 'approved conflict declaration',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const reviewer = evidence.reviewer as Record<string, unknown>;
+        reviewer.conflictOfInterest = 'declared';
+        reviewer.conflictSummary = 'reviewer authored an adjacent patch';
+      },
+      error: 'must be none for approval',
+    },
+    {
+      name: 'P1 follow-up',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.severity = 'P1';
+        finding.disposition = {
+          kind: 'follow-up',
+          summary: 'deferred',
+          evidenceRefs: [],
+          followUp: {
+            owner: 'owner',
+            taskRef: {
+              kind: 'github-issue',
+              id: '1368',
+              url: 'https://github.com/donovan-yohan/relay-ide/issues/1368',
+            },
+            riskAcceptedRationale: 'bounded rationale',
+          },
+        };
+      },
+      error: 'follow-up is not allowed for P0/P1',
+    },
+    {
+      name: 'fixed without evidence',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        (finding.disposition as Record<string, unknown>).evidenceRefs = [];
+      },
+      error: 'requires evidence',
+    },
+    {
+      name: 'absolute finding path',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        (finding.location as Record<string, unknown>).path = '/tmp/secret.ts';
+      },
+      error: 'repository-relative',
+    },
+    {
+      name: 'unknown context reference',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (evidence.context as Record<string, unknown>).refs = [
+          'docs/unknown.md',
+        ];
+      },
+      error: 'allowlisted context refs',
+    },
+    {
+      name: 'none conflict with contradictory summary',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        (evidence.reviewer as Record<string, unknown>).conflictSummary =
+          'I authored this patch';
+      },
+      error: 'conflictSummary is not allowed',
+    },
+    {
+      name: 'non-home absolute evidence path',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.evidenceSummary = 'read /root/.ssh/id_rsa during review';
+      },
+      error: 'local absolute path rejected',
+    },
+    {
+      name: 'multiline Markdown injection',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.summary = 'bounded finding\n\n## release\nverdict: released';
+      },
+      error: 'unsafe adversarial review control text rejected',
+    },
+    {
+      name: 'bracket-delimited absolute path',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.evidenceSummary = 'reviewed [/root/.ssh/id_rsa]';
+      },
+      error: 'local absolute path rejected',
+    },
+    {
+      name: 'comma-delimited absolute path',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.evidenceSummary = 'reviewed paths,/etc/relay/config';
+      },
+      error: 'local absolute path rejected',
+    },
+    ...[
+      ['C1 next-line', '\u0085'],
+      ['Unicode line separator', '\u2028'],
+      ['bidi override', '\u202e'],
+    ].map(([label, character]) => ({
+      name: label,
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.summary = `before${character}after`;
+      },
+      error: 'unsafe adversarial review control text rejected',
+    })),
+    {
+      name: 'raw prompt field',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        evidence.prompt = 'raw reviewer prompt';
+      },
+      error: 'unsafe adversarial review field',
+    },
+    {
+      name: 'secret-looking finding evidence',
+      mutate: (review: Record<string, unknown>) => {
+        const evidence = review.adversarialReview as Record<string, unknown>;
+        const finding = (
+          evidence.findings as Array<Record<string, unknown>>
+        )[0]!;
+        finding.evidenceSummary = 'observed Bearer abcdefghijk in output';
+      },
+      error: 'secret-looking text rejected',
+    },
+  ])('rejects $name in structured review evidence', ({ mutate, error }) => {
+    const review = reviewStage() as unknown as Record<string, unknown>;
+    review.adversarialReview = adversarialReview();
+    mutate(review);
+    const artifact = baseArtifact([
+      implementationStage(),
+      qaStage(),
+      review as unknown as PipelineHandoffReviewStage,
+    ]);
+    const result = validatePipelineHandoffArtifact(artifact);
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('\n')).toContain(error);
+  });
+
+  it('rejects malformed predecessor ids', () => {
+    const artifact = baseArtifact();
+    artifact.supersedesArtifactId = '';
+    expect(validatePipelineHandoffArtifact(artifact).errors).toContain(
+      'supersedesArtifactId must be a non-empty bounded artifact id'
+    );
+  });
+
   it('rejects non-append-only stage order and stale exact-head verdicts', () => {
     const artifact = baseArtifact([
       implementationStage(),
@@ -189,8 +599,12 @@ describe('PipelineHandoffArtifact schema', () => {
     const result = validatePipelineHandoffArtifact(artifact);
 
     expect(result.valid).toBe(false);
-    expect(result.errors.join('\n')).toContain('reviewedHeadSha must equal artifact head.headSha');
-    expect(result.errors.join('\n')).toContain('implementation -> QA -> review -> release order');
+    expect(result.errors.join('\n')).toContain(
+      'reviewedHeadSha must equal artifact head.headSha'
+    );
+    expect(result.errors.join('\n')).toContain(
+      'implementation -> QA -> review -> release order'
+    );
   });
 
   it('evaluates staleIf.headShaChanges by exact head SHA only', () => {
@@ -250,13 +664,17 @@ describe('PipelineHandoffArtifact schema', () => {
     };
 
     const schemaResult = validatePipelineHandoffArtifact(unsafe);
-    const publicResult = validatePublicPipelineHandoffArtifact(unsafe as PipelineHandoffArtifact);
+    const publicResult = validatePublicPipelineHandoffArtifact(
+      unsafe as PipelineHandoffArtifact
+    );
 
     expect(schemaResult.valid).toBe(false);
     expect(schemaResult.errors.join('\n')).toContain('$.relayGrantHandle');
     expect(schemaResult.errors.join('\n')).toContain('$.stages[0].pairToken');
     expect(publicResult.valid).toBe(false);
-    expect(publicResult.errors.join('\n')).toContain('secret-looking text rejected');
+    expect(publicResult.errors.join('\n')).toContain(
+      'secret-looking text rejected'
+    );
     expect(publicResult.errors.join('\n')).not.toContain('pair_abcd1234');
   });
 
@@ -275,10 +693,14 @@ describe('PipelineHandoffArtifact schema', () => {
     ]);
 
     const publicResult = validatePublicPipelineHandoffArtifact(artifact);
-    const publicMarkdown = renderPipelineHandoffMarkdown(artifact, { public: true });
+    const publicMarkdown = renderPipelineHandoffMarkdown(artifact, {
+      public: true,
+    });
 
     expect(publicResult.valid).toBe(false);
-    expect(publicResult.errors.join('\n')).toContain('secret-looking text rejected');
+    expect(publicResult.errors.join('\n')).toContain(
+      'secret-looking text rejected'
+    );
     expect(publicResult.errors.join('\n')).not.toContain(nodeCredential);
     expect(publicResult.errors.join('\n')).not.toContain(standaloneSecret);
     expect(publicMarkdown).not.toContain(nodeCredential);
@@ -296,7 +718,11 @@ describe('PipelineHandoffArtifact schema', () => {
             ...evidence(),
             artifacts: [
               { id: 'diff-1', kind: 'diff', hashSha256: validHash },
-              { id: 'report-1', kind: 'not-a-kind', hashSha256: 'd'.repeat(40) },
+              {
+                id: 'report-1',
+                kind: 'not-a-kind',
+                hashSha256: 'd'.repeat(40),
+              },
             ],
           },
         ],
@@ -306,8 +732,12 @@ describe('PipelineHandoffArtifact schema', () => {
     const result = validatePipelineHandoffArtifact(artifact);
 
     expect(result.valid).toBe(false);
-    expect(result.errors.join('\n')).toContain('kind must be a valid artifact kind');
-    expect(result.errors.join('\n')).toContain('hashSha256 must be a 64-character sha256');
+    expect(result.errors.join('\n')).toContain(
+      'kind must be a valid artifact kind'
+    );
+    expect(result.errors.join('\n')).toContain(
+      'hashSha256 must be a 64-character sha256'
+    );
     expect(result.errors.join('\n')).not.toContain(validHash);
   });
 
@@ -315,7 +745,10 @@ describe('PipelineHandoffArtifact schema', () => {
     const artifact = baseArtifact([
       {
         ...implementationStage(),
-        changedFiles: ['C:\\Users\\donovan\\secret.txt', '\\\\server\\share\\secret.txt'],
+        changedFiles: [
+          'C:\\Users\\donovan\\secret.txt',
+          '\\\\server\\share\\secret.txt',
+        ],
       },
     ]);
 
@@ -327,6 +760,35 @@ describe('PipelineHandoffArtifact schema', () => {
     expect(result.errors.join('\n')).not.toContain('\\\\server\\share');
   });
 
+  it('escapes every untrusted Markdown field and safely frames commands', () => {
+    const implementation = implementationStage();
+    implementation.summary = 'ok\n\n## release\nverdict: released';
+    implementation.acceptanceEvidence[0] = {
+      ...implementation.acceptanceEvidence[0]!,
+      label: '[fake](https://example.com)',
+      summary: '<script>alert(1)</script>',
+    };
+    implementation.commands[0] = {
+      ...implementation.commands[0]!,
+      label: '`forged`',
+      command: 'npm test `\n## release',
+      summary: '[click](https://example.com)',
+    };
+    implementation.downstreamFocus = ['safe\u2028## review'];
+    const artifact = baseArtifact([implementation]);
+    artifact.title = 'title\n## release';
+    artifact.scope.acceptance = ['accept\n## release'];
+
+    const rendered = renderPipelineHandoffMarkdown(artifact, { public: true });
+
+    expect(rendered).not.toContain('\n## release\nverdict: released');
+    expect(rendered).not.toContain('<script>');
+    expect(rendered).toContain('&lt;script&gt;alert\\(1\\)&lt;/script&gt;');
+    expect(rendered).toContain('\\[fake\\]\\(https://example.com\\)');
+    expect(rendered).toContain('`` npm test ` ## release ``');
+    expect(rendered.match(/^## release$/gm)).toBeNull();
+  });
+
   it('redacts/omits unsafe fields for public PR or issue handoff comments', () => {
     const artifact = baseArtifact([
       {
@@ -336,7 +798,8 @@ describe('PipelineHandoffArtifact schema', () => {
         commands: [
           {
             ...command(),
-            command: 'cd /home/donovanyohan/private/worktree && npm test -- test/pipeline-handoff-artifact.test.ts',
+            command:
+              'cd /home/donovanyohan/private/worktree && npm test -- test/pipeline-handoff-artifact.test.ts',
           },
         ],
       },
@@ -344,16 +807,24 @@ describe('PipelineHandoffArtifact schema', () => {
 
     const publicResult = validatePublicPipelineHandoffArtifact(artifact);
     expect(publicResult.valid).toBe(false);
-    expect(publicResult.errors.join('\n')).toContain('local absolute path rejected');
-    expect(publicResult.errors.join('\n')).toContain('private Kanban task id rejected');
-    expect(publicResult.errors.join('\n')).toContain('secret-looking text rejected');
+    expect(publicResult.errors.join('\n')).toContain(
+      'local absolute path rejected'
+    );
+    expect(publicResult.errors.join('\n')).toContain(
+      'private Kanban task id rejected'
+    );
+    expect(publicResult.errors.join('\n')).toContain(
+      'secret-looking text rejected'
+    );
     expect(publicResult.errors.join('\n')).not.toContain('C:\\Users\\donovan');
     expect(publicResult.errors.join('\n')).not.toContain('\\\\server\\share');
     expect(publicResult.errors.join('\n')).not.toContain('t_93c3c750');
     expect(publicResult.errors.join('\n')).not.toContain('pair_abcd1234');
 
     const sanitized = sanitizePipelineHandoffArtifactForPublic(artifact);
-    const publicMarkdown = renderPipelineHandoffMarkdown(artifact, { public: true });
+    const publicMarkdown = renderPipelineHandoffMarkdown(artifact, {
+      public: true,
+    });
 
     expect(sanitized.scope.taskRefs.map((taskRef) => taskRef.kind)).toEqual([
       'github-issue',

--- a/test/work-context-artifact-router.test.ts
+++ b/test/work-context-artifact-router.test.ts
@@ -18,6 +18,7 @@ import {
 import { ScopedActorCredentialRegistry } from '../shared/scoped-actor-credentials.js';
 import {
   createWorkContextArtifactStore,
+  WorkContextArtifactStoreError,
   type WorkContextArtifactStore,
 } from '../server/work-context-artifacts.js';
 import type {
@@ -981,6 +982,7 @@ describe('WorkContext artifact router', () => {
 
     const appendEquivalentArtifact = artifact({
       id: 'pipeline-handoff:router:handoff-append-reordered',
+      supersedesArtifactId: attachedArtifact.id,
       stages: [
         reorderJsonObjectKeys(
           attachedArtifact.stages[0]
@@ -999,11 +1001,43 @@ describe('WorkContext artifact router', () => {
         body: JSON.stringify({
           workContextId,
           artifact: appendEquivalentArtifact,
-          supersedesArtifactId: attachedArtifact.id,
         }),
       }
     );
     expect(appendEquivalent.status).toBe(201);
+    expect(await json(appendEquivalent)).toMatchObject({
+      artifact: {
+        metadata: { supersedesArtifactId: attachedArtifact.id },
+      },
+    });
+
+    const mismatchedPredecessor = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'artifact:write,context:read',
+        },
+        body: JSON.stringify({
+          workContextId,
+          artifact: {
+            ...appendEquivalentArtifact,
+            id: 'pipeline-handoff:router:handoff-mismatch',
+          },
+          supersedesArtifactId: 'pipeline-handoff:router:other',
+        }),
+      }
+    );
+    expect(mismatchedPredecessor.status).toBe(400);
+    expect(await json(mismatchedPredecessor)).toMatchObject({
+      error: {
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_VALIDATION_FAILED',
+          operation: 'attach',
+        },
+      },
+    });
 
     const appendViolationArtifact = artifact({
       id: 'pipeline-handoff:router:handoff-append-violation',
@@ -1228,6 +1262,43 @@ describe('WorkContext artifact router', () => {
     });
   });
 
+  it('maps agent view store contention to a retryable 503 envelope', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-view-busy';
+    const busyStore: WorkContextArtifactStore = {
+      ...store,
+      storeAgentViewArtifact() {
+        throw new WorkContextArtifactStoreError(503, 'artifact_store_busy');
+      },
+    };
+    const { baseUrl } = await serve({
+      root,
+      store: busyStore,
+      workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
+    });
+
+    const response = await fetch(`${baseUrl}/work-context-artifacts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'artifact:write,context:read',
+      },
+      body: JSON.stringify({ workContextId, viewArtifact: viewArtifact() }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(await json(response)).toMatchObject({
+      error: {
+        code: 'SERVER_UNAVAILABLE',
+        retryable: true,
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_STORE_BUSY',
+          storeCode: 'artifact_store_busy',
+        },
+      },
+    });
+  });
+
   it('publishes agent view artifacts and exposes an authenticated package route', async () => {
     const { root, store } = tmpStore();
     const workContextId = 'wc:router-view';
@@ -1329,6 +1400,56 @@ describe('WorkContext artifact router', () => {
           operation: 'attach',
         },
       },
+    });
+  });
+
+  it('rejects cross-kind view supersession without hiding the handoff route', async () => {
+    const { root, store } = tmpStore();
+    const workContextId = 'wc:router-cross-kind';
+    const handoff = store.storePipelineHandoffArtifact({
+      workContextId,
+      artifact: artifact({ id: 'pipeline-handoff:router:cross-kind' }),
+    });
+    const { baseUrl } = await serve({
+      root,
+      store,
+      workContextStore: fakeWorkContextStore(createWorkContext(workContextId)),
+    });
+    const pkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        revision: {
+          id: 'agent-view:router:cross-kind',
+          supersedes: handoff.metadata.id,
+        },
+      },
+    });
+
+    const publish = await fetch(`${baseUrl}/work-context-artifacts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'artifact:write,context:read',
+      },
+      body: JSON.stringify({ workContextId, viewArtifact: pkg }),
+    });
+    expect(publish.status).toBe(404);
+    expect(await json(publish)).toMatchObject({
+      error: {
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_SUPERSEDES_NOT_FOUND',
+          storeCode: 'superseded_artifact_payload_kind_mismatch',
+        },
+      },
+    });
+
+    const list = await fetch(
+      `${baseUrl}/pipeline-handoff-artifacts?workContextId=${encodeURIComponent(workContextId)}`,
+      { headers: { 'x-relay-capabilities': 'context:read' } }
+    );
+    expect(list.status).toBe(200);
+    expect(await json(list)).toMatchObject({
+      artifacts: [{ metadata: { id: handoff.metadata.id } }],
     });
   });
 
@@ -1505,6 +1626,64 @@ describe('WorkContext artifact router', () => {
     expect(JSON.stringify(publicBody)).toContain('[redacted-kanban-task]');
     expect(JSON.stringify(publicBody)).not.toContain('private raw html');
     expect(JSON.stringify(publicBody)).not.toContain('files');
+  });
+
+  it('size-checks the canonical payload after request-only predecessor normalization', async () => {
+    const fixture = loadLiveWorkerPatternFixture();
+    const successor = appendQaArtifact(fixture);
+    const { root, store } = tmpStore();
+    store.storePipelineHandoffArtifact({
+      workContextId: fixture.workContextId,
+      artifact: fixture.implementationArtifact,
+    });
+    const unnormalizedBytes = Buffer.byteLength(
+      JSON.stringify(successor, null, 2),
+      'utf8'
+    );
+    const canonicalBytes = Buffer.byteLength(
+      JSON.stringify(
+        {
+          ...successor,
+          supersedesArtifactId: fixture.implementationArtifact.id,
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+    expect(canonicalBytes).toBeGreaterThan(unnormalizedBytes);
+    const { baseUrl } = await serve({
+      root,
+      store,
+      workContextStore: fakeWorkContextStore(
+        createWorkContext(fixture.workContextId)
+      ),
+      maxPublishBytes: unnormalizedBytes,
+    });
+
+    const response = await fetch(`${baseUrl}/pipeline-handoff-artifacts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'artifact:write,context:read',
+      },
+      body: JSON.stringify({
+        workContextId: fixture.workContextId,
+        artifact: successor,
+        supersedesArtifactId: fixture.implementationArtifact.id,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await json(response)).toMatchObject({
+      error: {
+        details: {
+          reasonCode: 'WORK_CONTEXT_ARTIFACT_OVERSIZE_PAYLOAD',
+          payloadBytes: canonicalBytes,
+          maxBytes: unnormalizedBytes,
+        },
+      },
+    });
   });
 
   it('enforces publish and export guardrails with persisted public bytes', async () => {

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { createRequire } from 'node:module';
+import { Worker } from 'node:worker_threads';
 
 import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -131,6 +133,112 @@ function artifact(
     ],
     ...input,
   };
+}
+
+function appendedArtifact(
+  predecessor: PipelineHandoffArtifact,
+  id: string
+): PipelineHandoffArtifact {
+  return {
+    ...predecessor,
+    id,
+    supersedesArtifactId: predecessor.id,
+    updatedAt: '2026-06-08T12:10:00.000Z',
+    stages: [
+      ...predecessor.stages,
+      {
+        ...predecessor.stages[0],
+        stage: 'qa',
+        addedAt: '2026-06-08T12:10:00.000Z',
+        actorId: 'agent:kani-validator',
+        summary: 'validated the immutable canonical handoff root',
+        decision: 'validated',
+        verdict: 'passed',
+        testedHeadSha: predecessor.head.headSha,
+        findings: [],
+      },
+    ],
+  };
+}
+
+function structuredReviewArtifact(): PipelineHandoffArtifact {
+  const implementation = artifact({
+    id: 'pipeline-handoff:structured-public:aaaaaaaa',
+    head: {
+      ...artifact().head,
+      base: { name: 'nightly', sha: 'c'.repeat(40) },
+    },
+  });
+  const qa = appendedArtifact(
+    implementation,
+    'pipeline-handoff:structured-public:qa'
+  ).stages[1]!;
+  return {
+    ...implementation,
+    stages: [
+      implementation.stages[0]!,
+      qa,
+      {
+        ...implementation.stages[0]!,
+        stage: 'review',
+        actorId: 'agent:structured-reviewer',
+        summary: 'independent review approved the exact head',
+        verdict: 'approved',
+        reviewedHeadSha: implementation.head.headSha,
+        blockers: [],
+        nitsOrFollowUps: [],
+        adversarialReview: {
+          promptVersion: 'adversarial-review-v1',
+          baseSha: 'c'.repeat(40),
+          diffSha256: 'd'.repeat(64),
+          implementation: {
+            actorId: implementation.stages[0]!.actorId,
+            sessionId: 'session:implementation',
+            runId: 'run:implementation',
+            relayGlobalSessionId: 'global:implementation',
+            provider: 'prime-agent',
+            model: 'gpt-5.6',
+          },
+          reviewer: {
+            actorId: 'agent:structured-reviewer',
+            sessionId: 'session:review',
+            runId: 'run:review',
+            relayGlobalSessionId: 'global:review',
+            provider: 'codex',
+            model: 'gpt-5.6',
+            independentFromImplementation: true,
+            conflictOfInterest: 'none',
+          },
+          trustedProvenance: {
+            disposition: 'declared-unverified',
+            summary: 'auditable declaration pending a trusted resolver',
+          },
+          context: {
+            digestSha256: 'e'.repeat(64),
+            refs: ['docs/context-map.md#handoff-evidence'],
+          },
+          findings: [],
+          containsNoRawTranscriptOrSecrets: true,
+        },
+      },
+    ],
+  };
+}
+
+function expectStoreErrorCode(fn: () => unknown, code: string): void {
+  let didThrow = false;
+  let caught: unknown;
+  try {
+    fn();
+  } catch (err) {
+    didThrow = true;
+    caught = err;
+  }
+  if (!didThrow) {
+    throw new Error(`store unexpectedly accepted input; expected ${code}`);
+  }
+  expect(caught).toBeInstanceOf(WorkContextArtifactStoreError);
+  expect((caught as WorkContextArtifactStoreError).code).toBe(code);
 }
 
 function viewArtifact(
@@ -423,6 +531,98 @@ describe('WorkContext artifact store/index', () => {
         .list({ workContextId: 'wc:view-manifest-supersede' })
         .map((entry) => entry.metadata.id)
     ).toEqual([replacement.metadata.id]);
+  });
+
+  it('rejects cross-kind agent view predecessor edges', () => {
+    const { store } = tmpStore();
+    const handoff = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:view-cross-kind',
+      artifact: artifact({ id: 'pipeline-handoff:cross-kind:aaaaaaaa' }),
+    });
+    const pkg = viewArtifact({
+      manifest: {
+        ...viewArtifact().manifest,
+        revision: {
+          id: 'agent-view:cross-kind:bbbbbbbb',
+          supersedes: handoff.metadata.id,
+        },
+      },
+    });
+
+    expectStoreErrorCode(
+      () =>
+        store.storeAgentViewArtifact({
+          workContextId: 'wc:view-cross-kind',
+          viewArtifact: pkg,
+        }),
+      'superseded_artifact_payload_kind_mismatch'
+    );
+    expect(
+      store
+        .list({ workContextId: 'wc:view-cross-kind' })
+        .map((entry) => entry.metadata.id)
+    ).toEqual([handoff.metadata.id]);
+  });
+
+  it('maps contended agent view writes to a stable busy store error', async () => {
+    const root = tmpRoot('work-context-artifacts-view-busy-');
+    const store = createWorkContextArtifactStore({
+      dbPath: path.join(root, 'index.db'),
+      payloadRoot: path.join(root, 'payloads'),
+      busyTimeoutMs: 25,
+    });
+    cleanup.push(() => store.close());
+    const worker = new Worker(
+      `
+        const { parentPort, workerData } = require('node:worker_threads');
+        const Database = require(workerData.betterSqlitePath);
+        const db = new Database(workerData.dbPath);
+        db.exec('BEGIN IMMEDIATE');
+        parentPort.postMessage('locked');
+        setTimeout(() => {
+          db.exec('COMMIT');
+          db.close();
+          parentPort.postMessage('released');
+        }, 100);
+      `,
+      {
+        eval: true,
+        workerData: {
+          betterSqlitePath: createRequire(import.meta.url).resolve(
+            'better-sqlite3'
+          ),
+          dbPath: path.join(root, 'index.db'),
+        },
+      }
+    );
+    cleanup.push(() => void worker.terminate());
+    const message = (expected: string) =>
+      new Promise<void>((resolve, reject) => {
+        const onMessage = (value: unknown) => {
+          if (value !== expected) return;
+          worker.off('error', reject);
+          resolve();
+        };
+        worker.once('error', reject);
+        worker.on('message', onMessage);
+      });
+    await message('locked');
+    const released = message('released');
+
+    expectStoreErrorCode(
+      () =>
+        store.storeAgentViewArtifact({
+          workContextId: 'wc:view-busy',
+          viewArtifact: viewArtifact({
+            manifest: {
+              ...viewArtifact().manifest,
+              revision: { id: 'agent-view:busy:aaaaaaaa' },
+            },
+          }),
+        }),
+      'artifact_store_busy'
+    );
+    await released;
   });
 
   it('rejects top-level visibility that disagrees with an agent view export policy', () => {
@@ -768,14 +968,24 @@ describe('WorkContext artifact store/index', () => {
       })
     ).toThrow(WorkContextArtifactStoreError);
 
+    const originalArtifact = artifact();
     const replacementArtifact = artifact({
       id: 'pipeline-handoff:example:bbbbbbbb',
       updatedAt: '2026-06-08T12:10:00.000Z',
-      head: {
-        ...artifact().head,
-        headSha: nextHeadSha,
-        capturedAt: '2026-06-08T12:10:00.000Z',
-      },
+      stages: [
+        ...originalArtifact.stages,
+        {
+          ...originalArtifact.stages[0],
+          stage: 'qa',
+          addedAt: '2026-06-08T12:10:00.000Z',
+          actorId: 'agent:kani-validator',
+          summary: 'validated the immutable canonical handoff root',
+          decision: 'validated',
+          verdict: 'passed',
+          testedHeadSha: originalArtifact.head.headSha,
+          findings: [],
+        },
+      ],
     });
     const replacement = store.storePipelineHandoffArtifact({
       workContextId: 'wc:append-only',
@@ -784,6 +994,9 @@ describe('WorkContext artifact store/index', () => {
     });
 
     expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
+    expect(store.read(replacement.metadata.id)?.payload).toMatchObject({
+      supersedesArtifactId: first.metadata.id,
+    });
     expect(store.get(first.metadata.id)?.metadata.headSha).toBe(headSha);
     expect(
       store
@@ -796,6 +1009,235 @@ describe('WorkContext artifact store/index', () => {
         .map((entry) => entry.metadata.id)
         .sort()
     ).toEqual([first.metadata.id, replacement.metadata.id].sort());
+  });
+
+  it('uses payload supersedes identity as canonical index metadata', () => {
+    const { store } = tmpStore();
+    const predecessor = artifact({ id: 'pipeline-handoff:canonical:aaaaaaaa' });
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:canonical-payload',
+      artifact: predecessor,
+    });
+    const successor = appendedArtifact(
+      predecessor,
+      'pipeline-handoff:canonical:bbbbbbbb'
+    );
+
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:canonical-payload',
+      visibility: 'public',
+      artifact: successor,
+    });
+
+    expect(stored.metadata.supersedesArtifactId).toBe(predecessor.id);
+    expect(store.read(stored.metadata.id)?.payload).toEqual(successor);
+    expect(store.publicSummary(stored.metadata.id)).toMatchObject({
+      metadata: { supersedesArtifactId: predecessor.id },
+      payload: { supersedesArtifactId: predecessor.id },
+    });
+  });
+
+  it('rejects conflicting request and payload predecessor identities', () => {
+    const { store } = tmpStore();
+    const predecessor = artifact({ id: 'pipeline-handoff:mismatch:aaaaaaaa' });
+    const successor = appendedArtifact(
+      predecessor,
+      'pipeline-handoff:mismatch:bbbbbbbb'
+    );
+
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-mismatch',
+          artifact: successor,
+          supersedesArtifactId: 'pipeline-handoff:other:cccccccc',
+        }),
+      'artifact_supersedes_mismatch'
+    );
+  });
+
+  it('enforces same-head immutable-root append-only chains and rejects forks', () => {
+    const { store } = tmpStore();
+    const predecessor = artifact({ id: 'pipeline-handoff:chain:aaaaaaaa' });
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:canonical-chain',
+      artifact: predecessor,
+    });
+    const valid = appendedArtifact(
+      predecessor,
+      'pipeline-handoff:chain:bbbbbbbb'
+    );
+
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-chain',
+          artifact: {
+            ...valid,
+            id: 'pipeline-handoff:chain:stale-head',
+            head: { ...valid.head, headSha: nextHeadSha },
+            stages: [
+              valid.stages[0]!,
+              { ...valid.stages[1]!, testedHeadSha: nextHeadSha },
+            ],
+          },
+        }),
+      'artifact_supersedes_stale_head'
+    );
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-chain',
+          artifact: {
+            ...valid,
+            id: 'pipeline-handoff:chain:changed-root',
+            title: 'Rewritten handoff title',
+          },
+        }),
+      'artifact_supersedes_append_only_violation'
+    );
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-chain',
+          artifact: {
+            ...valid,
+            id: 'pipeline-handoff:chain:changed-stage',
+            stages: [
+              { ...valid.stages[0]!, summary: 'rewritten prior stage' },
+              valid.stages[1]!,
+            ],
+          },
+        }),
+      'artifact_supersedes_append_only_violation'
+    );
+
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:canonical-chain',
+      artifact: valid,
+    });
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-chain',
+          artifact: {
+            ...valid,
+            id: 'pipeline-handoff:chain:cccccccc',
+          },
+        }),
+      'artifact_supersedes_fork'
+    );
+  });
+
+  it('waits across SQLite handles and returns a stable fork conflict', async () => {
+    const { root, store } = tmpStore();
+    const predecessor = artifact({ id: 'pipeline-handoff:race:aaaaaaaa' });
+    store.storePipelineHandoffArtifact({
+      workContextId: 'wc:canonical-race',
+      artifact: predecessor,
+    });
+    const successor = appendedArtifact(
+      predecessor,
+      'pipeline-handoff:race:bbbbbbbb'
+    );
+    const worker = new Worker(
+      `
+        const { parentPort, workerData } = require('node:worker_threads');
+        const Database = require(workerData.betterSqlitePath);
+        const db = new Database(workerData.dbPath);
+        db.pragma('busy_timeout = 5000');
+        db.exec('BEGIN IMMEDIATE');
+        parentPort.postMessage('locked');
+        setTimeout(() => {
+          db.prepare(\`
+            INSERT INTO work_context_artifacts (
+              id, work_context_id, project_id, task_ref_kind, task_ref_id,
+              stage, provenance_actor_id, kind, title, summary, visibility,
+              created_at, updated_at, captured_at, payload_kind,
+              payload_media_type, payload_path, payload_sha256, payload_bytes,
+              pr_number, head_sha, base_name, branch_name,
+              supersedes_artifact_id, metadata_json
+            )
+            SELECT ?, work_context_id, project_id, task_ref_kind, task_ref_id,
+              stage, provenance_actor_id, kind, title, summary, visibility,
+              created_at, updated_at, captured_at, payload_kind,
+              payload_media_type, payload_path, payload_sha256, payload_bytes,
+              pr_number, head_sha, base_name, branch_name, ?, metadata_json
+            FROM work_context_artifacts WHERE id = ?
+          \`).run(workerData.childId, workerData.predecessorId, workerData.predecessorId);
+          db.exec('COMMIT');
+          db.close();
+          parentPort.postMessage('committed');
+        }, 100);
+      `,
+      {
+        eval: true,
+        workerData: {
+          betterSqlitePath: createRequire(import.meta.url).resolve(
+            'better-sqlite3'
+          ),
+          dbPath: path.join(root, 'index.db'),
+          predecessorId: predecessor.id,
+          childId: 'pipeline-handoff:race:worker-child',
+        },
+      }
+    );
+    cleanup.push(() => void worker.terminate());
+    const message = (expected: string) =>
+      new Promise<void>((resolve, reject) => {
+        const onMessage = (value: unknown) => {
+          if (value !== expected) return;
+          worker.off('error', reject);
+          resolve();
+        };
+        worker.once('error', reject);
+        worker.on('message', onMessage);
+      });
+    await message('locked');
+    const committed = message('committed');
+
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-race',
+          artifact: successor,
+        }),
+      'artifact_supersedes_fork'
+    );
+    await committed;
+
+    const db = new Database(path.join(root, 'index.db'), { readonly: true });
+    const children = db
+      .prepare(
+        'SELECT id FROM work_context_artifacts WHERE supersedes_artifact_id = ?'
+      )
+      .all(predecessor.id) as Array<{ id: string }>;
+    db.close();
+    expect(children.map((row) => row.id)).toEqual([
+      'pipeline-handoff:race:worker-child',
+    ]);
+  });
+
+  it('rejects a pipeline predecessor that names another artifact payload kind', () => {
+    const { store } = tmpStore();
+    const view = store.storeAgentViewArtifact({
+      workContextId: 'wc:canonical-kind',
+      viewArtifact: viewArtifact(),
+    });
+    const predecessor = artifact({ id: view.metadata.id });
+    const successor = appendedArtifact(
+      predecessor,
+      'pipeline-handoff:canonical-kind:bbbbbbbb'
+    );
+
+    expectStoreErrorCode(
+      () =>
+        store.storePipelineHandoffArtifact({
+          workContextId: 'wc:canonical-kind',
+          artifact: successor,
+        }),
+      'superseded_artifact_payload_kind_mismatch'
+    );
   });
 
   it('rejects invalid handoff payloads before indexing metadata', () => {
@@ -863,6 +1305,28 @@ describe('WorkContext artifact store/index', () => {
         publicPayload as PipelineHandoffArtifact
       ).valid
     ).toBe(true);
+  });
+
+  it('keeps structured review identity bindings valid in public summaries', () => {
+    const { store } = tmpStore();
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:structured-public-copy',
+      visibility: 'public',
+      artifact: structuredReviewArtifact(),
+    });
+
+    const publicCopy = store.publicSummary(stored.metadata.id);
+    const payload = publicCopy?.payload as PipelineHandoffArtifact;
+    expect(validatePublicPipelineHandoffArtifact(payload).errors).toEqual([]);
+    const review = payload.stages[2] as Extract<
+      PipelineHandoffArtifact['stages'][number],
+      { stage: 'review' }
+    >;
+    expect(review.adversarialReview?.implementation.actorId).toBe(
+      payload.stages[0]?.actorId
+    );
+    expect(review.adversarialReview?.reviewer.actorId).toBe(review.actorId);
+    expect(review.actorId).not.toBe(payload.stages[0]?.actorId);
   });
 
   it('returns public summaries for agent view artifacts with sanitized manifest only', () => {


### PR DESCRIPTION
## Summary
- add the stable `docs/context-map.md` allowlist and structured schema-v1 adversarial-review evidence to the canonical `PipelineHandoffArtifact`
- make payload-level `supersedesArtifactId` canonical while retaining request-only compatibility and exact equality checks
- centralize same-head, immutable-root, prior-stage, same-kind, fork-free successor enforcement in the WorkContext artifact store
- preserve predecessor/review evidence through public summaries and structurally safe Markdown without treating declared provenance as trusted proof

## Safety and compatibility
- legacy schema-v1 review stages remain readable without structured evidence
- client-authored `trustedProvenance: verified` is rejected until a trusted resolver exists; current evidence is explicitly rendered as a declaration
- structured public copies use consistent role-distinct actor aliases, general path/control sanitization, and context-safe Markdown rendering
- agent-view and handoff supersession edges cannot cross payload kinds
- immediate SQLite transactions plus a bounded busy timeout serialize both payload lanes; remaining contention maps to retryable store errors
- hosted CI integration and executable risk/review gates remain later slices; this PR does not query Relay state from CI

## Validation
- `npm run check` (0 errors; 227 existing warnings)
- `npm test` (476 files, 6,382 tests passed)
- `npm run build`
- focused artifact/store/router/timeline tests (101 passed)
- push changed-test gate passed
- named mutation proofs kill store/prefix/mismatch/identity/provenance/structured-chain/path/control/Markdown/public-alias/canonical-size/same-kind/BUSY/immediate mutations

## Review evidence
- base: `44f4082a45517b103ff21560a2f1869e72f82b31`
- head: `b6b5867dfe4551980fd60005bb649bc9cf26bbef`
- canonical binary diff SHA-256: `052d200471aa166c7d17f95dfa46b49d1a2d0e935ec29cf02102f8d2e19d8e1e`
- canonical binary diff bytes: `127099`
- two independent exact-head re-reviews plus changelog and CodeRabbit-only confirmations PASS with no P0-P3 after all findings were fixed
- conflict of interest: none

Tracks #1368.
