### PR TITLE
fix input block cursor alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ workflow.
 
 - Agent profiles whose launch command is missing now appear unavailable in channel rosters and mention palettes, and spawn races report an actionable configuration error instead of raw `ENOENT` (#1357)
 - Codex reasoning cards now show expandable provider-generated summaries when available, and no longer show inactive expand chevrons when no summary exists
+- Terminal-style text field block cursors now align with the input content line
+  and remain aligned while the text scrolls.
 
 ## [0.1.1] - 2026-08-05
 

--- a/frontend/src/components/TuiInput.css
+++ b/frontend/src/components/TuiInput.css
@@ -51,8 +51,6 @@
 
 .tui-cursor {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
   font-family: var(--font-mono);
   font-size: var(--font-size-base);
   color: var(--text);
@@ -66,6 +64,11 @@
 }
 
 @keyframes cursor-blink {
-  0%, 100% { opacity: 0.7; }
-  50% { opacity: 0; }
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 0;
+  }
 }

--- a/frontend/src/components/TuiInput.tsx
+++ b/frontend/src/components/TuiInput.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import './TuiInput.css';
+import { getTuiCursorGeometry } from './tuiCursorGeometry.js';
 
 export interface TuiInputProps {
   value?: string;
@@ -9,6 +10,7 @@ export interface TuiInputProps {
   id?: string;
   onInput?: (e: React.FormEvent<HTMLInputElement>) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onScroll?: (e: React.UIEvent<HTMLInputElement>) => void;
   onChange?: (value: string) => void;
   className?: string;
   autoFocus?: boolean;
@@ -23,6 +25,7 @@ export const TuiInput: React.FC<TuiInputProps> = ({
   id,
   onInput,
   onKeyDown,
+  onScroll,
   onChange,
   className = '',
   autoFocus = false,
@@ -33,18 +36,21 @@ export const TuiInput: React.FC<TuiInputProps> = ({
   const [isFocused, setIsFocused] = useState(false);
   const [isIdle, setIsIdle] = useState(true);
   const [cursorLeft, setCursorLeft] = useState(0);
+  const [cursorTop, setCursorTop] = useState(0);
   const [cursorHeight, setCursorHeight] = useState(16);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
     setPrefersReducedMotion(mq.matches);
-    
+
     const handler = (e: MediaQueryListEvent) => {
       setPrefersReducedMotion(e.matches);
     };
-    
+
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, []);
@@ -52,37 +58,61 @@ export const TuiInput: React.FC<TuiInputProps> = ({
   const updateCursorPosition = useCallback(() => {
     if (!inputRef.current || !measureRef.current) return;
 
+    const inputValue = inputRef.current.value;
     const selStart = inputRef.current.selectionStart ?? 0;
-    const textBeforeCursor = type === 'password'
-      ? '\u2022'.repeat(selStart)
-      : (value ?? '').slice(0, selStart);
+    const textBeforeCursor =
+      type === 'password'
+        ? '\u2022'.repeat(selStart)
+        : inputValue.slice(0, selStart);
 
+    const computedStyle = window.getComputedStyle(inputRef.current);
+    // The marker must use the input's resolved typography. A surrounding form
+    // may override the input's weight, spacing, or font variation settings.
+    measureRef.current.style.font = computedStyle.font;
+    measureRef.current.style.fontKerning = computedStyle.fontKerning;
+    measureRef.current.style.fontFeatureSettings =
+      computedStyle.fontFeatureSettings;
+    measureRef.current.style.fontVariationSettings =
+      computedStyle.fontVariationSettings;
+    measureRef.current.style.letterSpacing = computedStyle.letterSpacing;
+    measureRef.current.style.wordSpacing = computedStyle.wordSpacing;
     measureRef.current.textContent = textBeforeCursor || '';
     const textBeforeCursorWidth = measureRef.current.offsetWidth;
 
-    const computedStyle = window.getComputedStyle(inputRef.current);
     const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+    const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+    const paddingTop = parseFloat(computedStyle.paddingTop) || 0;
+    const paddingBottom = parseFloat(computedStyle.paddingBottom) || 0;
     const borderLeft = parseFloat(computedStyle.borderLeftWidth) || 0;
-
-    let left = borderLeft + paddingLeft + textBeforeCursorWidth;
+    const borderTop = parseFloat(computedStyle.borderTopWidth) || 0;
+    let fullTextWidth = 0;
 
     if (computedStyle.textAlign === 'center') {
-      const fullText = type === 'password'
-        ? '\u2022'.repeat((value ?? '').length)
-        : (value ?? '');
+      const fullText =
+        type === 'password' ? '\u2022'.repeat(inputValue.length) : inputValue;
       measureRef.current.textContent = fullText;
-      const fullTextWidth = measureRef.current.offsetWidth;
-
-      const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
-      const contentWidth = inputRef.current.clientWidth - paddingLeft - paddingRight;
-      const centerOffset = (contentWidth - fullTextWidth) / 2;
-
-      left = borderLeft + paddingLeft + centerOffset + textBeforeCursorWidth;
+      fullTextWidth = measureRef.current.offsetWidth;
     }
 
-    setCursorLeft(left);
-    setCursorHeight(inputRef.current.offsetHeight || 16);
-  }, [type, value]);
+    const cursor = getTuiCursorGeometry({
+      borderLeft,
+      borderTop,
+      paddingLeft,
+      paddingRight,
+      paddingTop,
+      paddingBottom,
+      clientHeight: inputRef.current.clientHeight,
+      clientWidth: inputRef.current.clientWidth,
+      scrollLeft: inputRef.current.scrollLeft,
+      textBeforeCursorWidth,
+      fullTextWidth,
+      textAlign: computedStyle.textAlign,
+    });
+
+    setCursorLeft(cursor.left);
+    setCursorTop(cursor.top);
+    setCursorHeight(cursor.height);
+  }, [type]);
 
   useEffect(() => {
     updateCursorPosition();
@@ -98,11 +128,11 @@ export const TuiInput: React.FC<TuiInputProps> = ({
 
   const handleInput = (e: React.FormEvent<HTMLInputElement>) => {
     const newValue = (e.target as HTMLInputElement).value;
-    
+
     if (onChange) {
       onChange(newValue);
     }
-    
+
     setIsIdle(false);
     if (idleTimeoutRef.current !== undefined) {
       clearTimeout(idleTimeoutRef.current);
@@ -110,9 +140,9 @@ export const TuiInput: React.FC<TuiInputProps> = ({
     idleTimeoutRef.current = setTimeout(() => {
       setIsIdle(true);
     }, 530);
-    
+
     updateCursorPosition();
-    
+
     if (onInput) {
       onInput(e);
     }
@@ -126,9 +156,9 @@ export const TuiInput: React.FC<TuiInputProps> = ({
     idleTimeoutRef.current = setTimeout(() => {
       setIsIdle(true);
     }, 530);
-    
+
     requestAnimationFrame(updateCursorPosition);
-    
+
     if (onKeyDown) {
       onKeyDown(e);
     }
@@ -152,7 +182,14 @@ export const TuiInput: React.FC<TuiInputProps> = ({
     requestAnimationFrame(updateCursorPosition);
   };
 
-  const wrapperClasses = ['tui-input-wrapper', className].filter(Boolean).join(' ');
+  const handleScroll = (event: React.UIEvent<HTMLInputElement>) => {
+    updateCursorPosition();
+    onScroll?.(event);
+  };
+
+  const wrapperClasses = ['tui-input-wrapper', className]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <div className={wrapperClasses}>
@@ -169,6 +206,7 @@ export const TuiInput: React.FC<TuiInputProps> = ({
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClick={handleClick}
+        onScroll={handleScroll}
         autoFocus={autoFocus}
         {...(rest as React.InputHTMLAttributes<HTMLInputElement>)}
       />
@@ -178,7 +216,12 @@ export const TuiInput: React.FC<TuiInputProps> = ({
       {isFocused && !disabled && (
         <span
           className={`tui-cursor${isIdle && !prefersReducedMotion ? ' blinking' : ''}`}
-          style={{ left: `${cursorLeft}px`, height: `${cursorHeight}px` }}
+          style={{
+            left: `${cursorLeft}px`,
+            top: `${cursorTop}px`,
+            height: `${cursorHeight}px`,
+            lineHeight: `${cursorHeight}px`,
+          }}
           aria-hidden="true"
         >
           {'\u2588'}

--- a/frontend/src/components/tuiCursorGeometry.ts
+++ b/frontend/src/components/tuiCursorGeometry.ts
@@ -1,0 +1,55 @@
+export interface TuiCursorGeometryInput {
+  borderLeft: number;
+  borderTop: number;
+  paddingLeft: number;
+  paddingRight: number;
+  paddingTop: number;
+  paddingBottom: number;
+  clientHeight: number;
+  clientWidth: number;
+  scrollLeft: number;
+  textBeforeCursorWidth: number;
+  fullTextWidth?: number;
+  textAlign: string;
+}
+
+export interface TuiCursorGeometry {
+  left: number;
+  top: number;
+  height: number;
+}
+
+/**
+ * Position the block cursor in the input's text content box, not its border
+ * box. The browser scrolls an overflowing input independently of its wrapper,
+ * so the measured insertion position must be translated by `scrollLeft`.
+ */
+export function getTuiCursorGeometry({
+  borderLeft,
+  borderTop,
+  paddingLeft,
+  paddingRight,
+  paddingTop,
+  paddingBottom,
+  clientHeight,
+  clientWidth,
+  scrollLeft,
+  textBeforeCursorWidth,
+  fullTextWidth = 0,
+  textAlign,
+}: TuiCursorGeometryInput): TuiCursorGeometry {
+  const contentWidth = clientWidth - paddingLeft - paddingRight;
+  const alignmentOffset =
+    textAlign === 'center' ? (contentWidth - fullTextWidth) / 2 : 0;
+
+  return {
+    left:
+      borderLeft +
+      paddingLeft +
+      alignmentOffset +
+      textBeforeCursorWidth -
+      scrollLeft,
+    top: borderTop + paddingTop,
+    height: Math.max(1, clientHeight - paddingTop - paddingBottom),
+  };
+}

--- a/test/components/TuiInput.test.ts
+++ b/test/components/TuiInput.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Window } from 'happy-dom';
+import { describe, it, expect, vi } from 'vitest';
+import TuiInput from '../../frontend/src/components/TuiInput.js';
+import { getTuiCursorGeometry } from '../../frontend/src/components/tuiCursorGeometry.js';
 
-// Note: Full DOM testing would require a test runner with JSX support (e.g., Vitest + React Testing Library)
+// Most behavior is deterministic; the scroll regression below mounts the
+// component with the repo's existing happy-dom dependency.
 
 describe('TuiInput', () => {
   describe('Props Interface', () => {
@@ -251,6 +257,164 @@ describe('TuiInput', () => {
       const inputHeight = 24;
       const cursorHeight = inputHeight || 16;
       expect(cursorHeight).toBe(24);
+    });
+
+    it('anchors the cursor to the text content line instead of the input border box', () => {
+      expect(
+        getTuiCursorGeometry({
+          borderLeft: 1,
+          borderTop: 1,
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 8,
+          paddingBottom: 8,
+          clientHeight: 38,
+          clientWidth: 300,
+          scrollLeft: 0,
+          textBeforeCursorWidth: 42,
+          textAlign: 'left',
+        })
+      ).toEqual({ left: 51, top: 9, height: 22 });
+    });
+
+    it('keeps the cursor aligned after the input scrolls horizontally', () => {
+      expect(
+        getTuiCursorGeometry({
+          borderLeft: 1,
+          borderTop: 1,
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 8,
+          paddingBottom: 8,
+          clientHeight: 38,
+          clientWidth: 120,
+          scrollLeft: 36,
+          textBeforeCursorWidth: 112,
+          textAlign: 'left',
+        }).left
+      ).toBe(85);
+    });
+
+    it('uses the measured text width with the centered input content box', () => {
+      expect(
+        getTuiCursorGeometry({
+          borderLeft: 1,
+          borderTop: 1,
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 8,
+          paddingBottom: 8,
+          clientHeight: 38,
+          clientWidth: 200,
+          scrollLeft: 0,
+          textBeforeCursorWidth: 24,
+          fullTextWidth: 48,
+          textAlign: 'center',
+        }).left
+      ).toBe(101);
+    });
+
+    it('tracks an input scroll without replacing the caller callback', async () => {
+      const domWindow = new Window();
+      const originalWindow = globalThis.window;
+      const originalDocument = globalThis.document;
+      const originalNavigator = Object.getOwnPropertyDescriptor(
+        globalThis,
+        'navigator'
+      );
+      const originalActEnvironment = (
+        globalThis as {
+          IS_REACT_ACT_ENVIRONMENT?: boolean;
+        }
+      ).IS_REACT_ACT_ENVIRONMENT;
+      const callerOnScroll = vi.fn();
+      const container = domWindow.document.createElement('div');
+
+      Object.assign(globalThis, {
+        window: domWindow,
+        document: domWindow.document,
+      });
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: domWindow.navigator,
+      });
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = true;
+      const root = createRoot(container);
+      vi.spyOn(domWindow, 'getComputedStyle').mockReturnValue({
+        font: 'normal 14px monospace',
+        fontKerning: 'auto',
+        fontFeatureSettings: 'normal',
+        fontVariationSettings: 'normal',
+        letterSpacing: 'normal',
+        wordSpacing: 'normal',
+        paddingLeft: '8px',
+        paddingRight: '8px',
+        paddingTop: '8px',
+        paddingBottom: '8px',
+        borderLeftWidth: '1px',
+        borderTopWidth: '1px',
+        textAlign: 'left',
+      } as CSSStyleDeclaration);
+
+      try {
+        await act(async () => {
+          root.render(
+            React.createElement(TuiInput, {
+              value: 'asdas',
+              onScroll: callerOnScroll,
+            })
+          );
+        });
+
+        const input = container.querySelector('input');
+        const measure = container.querySelector('.tui-measure');
+        expect(input).not.toBeNull();
+        expect(measure).not.toBeNull();
+        if (!input || !measure) return;
+
+        Object.defineProperties(input, {
+          clientHeight: { configurable: true, value: 38 },
+          clientWidth: { configurable: true, value: 120 },
+          scrollLeft: { configurable: true, value: 0, writable: true },
+        });
+        Object.defineProperty(measure, 'offsetWidth', {
+          configurable: true,
+          value: 42,
+        });
+        input.setSelectionRange(5, 5);
+
+        await act(async () => {
+          input.dispatchEvent(
+            new domWindow.FocusEvent('focusin', { bubbles: true })
+          );
+        });
+        const cursor = container.querySelector('.tui-cursor') as HTMLElement;
+        expect(cursor.style.left).toBe('51px');
+
+        input.scrollLeft = 36;
+        await act(async () => {
+          input.dispatchEvent(new domWindow.Event('scroll', { bubbles: true }));
+        });
+
+        expect(callerOnScroll).toHaveBeenCalledTimes(1);
+        expect(callerOnScroll.mock.calls[0]?.[0].target).toBe(input);
+        expect(cursor.style.left).toBe('15px');
+      } finally {
+        await act(async () => root.unmount());
+        vi.restoreAllMocks();
+        Object.assign(globalThis, {
+          window: originalWindow,
+          document: originalDocument,
+        });
+        if (originalNavigator) {
+          Object.defineProperty(globalThis, 'navigator', originalNavigator);
+        }
+        (
+          globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- align terminal-style block cursors with the input content line instead of the full border box
- measure the live input value and resolved typography, including centered and password fields
- keep cursor placement synchronized with horizontal input scrolling while preserving caller scroll handlers
- add pure geometry coverage plus a rendered input scroll regression
- record the user-visible fix in the changelog

## Root cause

`TuiInput` sized its cursor overlay to the entire bordered input. The block glyph still occupied one text line, so centering the oversized overlay placed the visible cursor near the field's top edge instead of beside the text.

## User impact

Focused text fields now show the block cursor inline with entered text, including when long values scroll horizontally.

## Validation

- `npm run check`
- `npm test -- test/components/TuiInput.test.ts` (31 passed)
- `npm run build:frontend`
- pre-push changed-test gate (39 passed)
- focused adversarial review and re-review: no unresolved P0/P1/P2 findings
- `npx prettier --check CHANGELOG.md`
- `git diff --check`

Exact head: `b46c37f1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal-style cursor alignment with input text.
  * Cursor remains correctly positioned while horizontally scrolling.
  * Center-aligned and password-masked text now display accurate cursor placement.
  * Cursor height adapts to the input’s typography and dimensions.

* **Tests**
  * Added coverage for cursor positioning, scrolling, centered text, callbacks, and cleanup.

* **Documentation**
  * Updated the changelog with the cursor alignment improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->