### PR TITLE
fix(agent-runtime): honor provider control contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ workflow.
 - Reap owned agent process trees after channel-runtime failure or replacement,
   report aggregate runtime resource health, and let operators explicitly release
   idle channel agents (#1019)
+- Apply Codex model, reasoning-effort, and Fast Mode controls through stable
+  turn overrides, stop advertising unimplemented Claude controls, and pass
+  profile effort into Claude launches (#1375)
 - Agent profiles whose launch command is missing now appear unavailable in channel rosters and mention palettes, and spawn races report an actionable configuration error instead of raw `ENOENT` (#1357)
 - Codex reasoning cards now show expandable provider-generated summaries when available, and no longer show inactive expand chevrons when no summary exists
 - Terminal-style text field block cursors now align with the input content line

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -181,10 +181,12 @@ Only advertise controls the live provider can execute. Where provider metadata
 lists models, service tiers, or reasoning efforts, derive command arguments
 from that metadata and refresh the catalog on a model change. A missing catalog
 may use a documented static fallback; an available catalog must reject values
-it does not support. Codex currently implements Relay-owned controls including
-Fast Mode through this contract. Claude, OpenCode, and Hermes must not be
-presented as supporting a channel control until their own adapters expose and
-execute it.
+it does not support. Codex model, reasoning-effort, and Fast Mode changes use
+the stable `turn/start` override fields; Relay does not negotiate
+`experimentalApi` or call `thread/settings/update` for them. Claude profile
+model and effort values are launch-time CLI settings, not live channel
+controls. Claude, OpenCode, and Hermes must not be presented as supporting a
+channel control until their own adapters expose and execute it.
 
 ## Provider extension policy
 

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -188,6 +188,13 @@ model and effort values are launch-time CLI settings, not live channel
 controls. Claude, OpenCode, and Hermes must not be presented as supporting a
 channel control until their own adapters expose and execute it.
 
+The #1375 provider audit found no equivalent advertise-then-fail path in Pi or
+OpenCode: Pi exposes no Relay-owned channel controls, and OpenCode exposes no
+control catalog. Prime Agent's connected catalog is live-metadata-backed and
+its advertised controls have matching RPC implementations. Its pre-bind static
+preview remains a separate compatibility surface to keep aligned with the
+installed Prime RPC contract; connected empty catalogs remain authoritative.
+
 ## Provider extension policy
 
 Use:

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -2832,7 +2832,11 @@ export function createChannelAgentBinder(
         const liveCatalog = binding?.adapter?.getSlashCommands;
         const commands = (
           liveCatalog ? liveCatalog.call(binding.adapter) : baseCommands
-        ).filter((command) => command.dispatch === 'relay-control');
+        ).filter(
+          (command) =>
+            command.dispatch === 'relay-control' &&
+            (!binding || binding.adapter?.executeControlCommand !== undefined)
+        );
         return {
           id: profile.id,
           displayName: await rosterDisplayName(profile),

--- a/server/codex-app-server-client.ts
+++ b/server/codex-app-server-client.ts
@@ -195,6 +195,10 @@ export class CodexAppServerClient extends EventEmitter {
     }>('initialize', {
       clientInfo: this.options.clientInfo,
       capabilities: {
+        // Keep the default Relay transport on Codex's stable app-server
+        // contract. In particular, do not negotiate `experimentalApi` merely
+        // to mutate thread settings: model, effort, and service-tier controls
+        // are stable `turn/start` overrides.
         ...(this.options.optOutNotificationMethods?.length
           ? {
               optOutNotificationMethods: this.options.optOutNotificationMethods,

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -62,37 +62,10 @@ const CLAUDE_CAPABILITIES: AgentCapabilitySetV2 = {
   streaming: true,
 };
 
-const RELAY_CLAUDE_COMMANDS: AgentSlashCommandV2[] = [
-  {
-    id: 'relay:clear',
-    name: 'clear',
-    description: 'Start a new session with empty context',
-    aliases: ['reset', 'new'],
-    source: 'relay',
-    sourceLabel: 'Relay',
-    dispatch: 'relay-control',
-    collisionKey: 'clear',
-  },
-  {
-    id: 'relay:resume',
-    name: 'resume',
-    description: 'Resume a saved Claude session',
-    aliases: ['continue'],
-    source: 'relay',
-    sourceLabel: 'Relay',
-    dispatch: 'relay-control',
-    collisionKey: 'resume',
-  },
-  {
-    id: 'relay:model',
-    name: 'model',
-    description: 'Switch model for subsequent Claude responses',
-    source: 'relay',
-    sourceLabel: 'Relay',
-    dispatch: 'relay-control',
-    collisionKey: 'model',
-  },
-];
+// Claude stream-json has no mapped runtime-control transport. Keep its catalog
+// provider-native until an executable control contract exists; advertising a
+// Relay control without executeControlCommand only creates a dead UI action.
+const RELAY_CLAUDE_COMMANDS: AgentSlashCommandV2[] = [];
 
 /** Claude supports only once/permanent accept and deny — no cancel, no amendments. */
 const CLAUDE_APPROVAL_SUPPORT: AgentApprovalSupportV2 = {
@@ -151,6 +124,7 @@ const RESERVED_VALUE_FLAGS = new Set([
   '--resume',
   '--session-id',
   '--permission-prompt-tool',
+  '--effort',
 ]);
 
 /**
@@ -770,8 +744,8 @@ export class ClaudeProtocolAdapter
       fastModeAvailable: true,
       error: null,
     });
-    // Relay-owned controls are available immediately; the init line later
-    // merges any CLI-advertised commands on top.
+    // Claude currently has no executable Relay control lane. The init line may
+    // later surface provider-native commands as agent-dispatch entries.
     this.emitSessionUpdate({ slashCommands: RELAY_CLAUDE_COMMANDS });
   }
 
@@ -1401,11 +1375,14 @@ export class ClaudeProtocolAdapter
     args.push('--permission-mode', mode);
 
     if (config.model) args.push('--model', config.model);
+    const extra = isRecord(config.extra) ? config.extra : {};
+    if (typeof extra.effort === 'string' && extra.effort.trim()) {
+      args.push('--effort', extra.effort.trim());
+    }
     if (config.systemPromptAppendix?.trim()) {
       args.push('--append-system-prompt', config.systemPromptAppendix);
     }
 
-    const extra = isRecord(config.extra) ? config.extra : {};
     const additionalDirs = extra.additionalDirectories;
     if (Array.isArray(additionalDirs)) {
       for (const dir of additionalDirs) {

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -495,6 +495,13 @@ function filterClaudeArgs(raw: unknown): string[] {
   return out;
 }
 
+function configuredClaudeEffort(config: AdapterConfig): string | undefined {
+  const extra = isRecord(config.extra) ? config.extra : {};
+  return typeof extra.effort === 'string' && extra.effort.trim()
+    ? extra.effort.trim()
+    : undefined;
+}
+
 function mimeForAttachment(path: string, declared: string | undefined): string {
   if (declared) return declared;
   const dot = path.lastIndexOf('.');
@@ -741,7 +748,7 @@ export class ClaudeProtocolAdapter
       activeRequestIds: [],
       proposedPlanItemId: null,
       queueLength: 0,
-      fastModeAvailable: true,
+      fastModeAvailable: false,
       error: null,
     });
     // Claude currently has no executable Relay control lane. The init line may
@@ -901,6 +908,7 @@ export class ClaudeProtocolAdapter
     this.lastActivityAt = Date.now();
     if (dead)
       await this.stopOwnedClient(dead, 'session resume').catch(() => undefined);
+    const effort = configuredClaudeEffort(config);
 
     this.emitPatch({
       type: 'agent-session-snapshot-v2',
@@ -914,6 +922,7 @@ export class ClaudeProtocolAdapter
         providerSession: { claudeSessionId: sessionId },
         config: {
           ...(config.model ? { model: config.model } : {}),
+          ...(effort ? { effort } : {}),
           ...(config.permissionMode
             ? { permissionMode: config.permissionMode }
             : {}),
@@ -927,7 +936,7 @@ export class ClaudeProtocolAdapter
       activeRequestIds: [],
       proposedPlanItemId: null,
       queueLength: 0,
-      fastModeAvailable: true,
+      fastModeAvailable: false,
       error: null,
     });
     this.emitSessionUpdate({ slashCommands: RELAY_CLAUDE_COMMANDS });
@@ -1376,8 +1385,9 @@ export class ClaudeProtocolAdapter
 
     if (config.model) args.push('--model', config.model);
     const extra = isRecord(config.extra) ? config.extra : {};
-    if (typeof extra.effort === 'string' && extra.effort.trim()) {
-      args.push('--effort', extra.effort.trim());
+    const effort = configuredClaudeEffort(config);
+    if (effort) {
+      args.push('--effort', effort);
     }
     if (config.systemPromptAppendix?.trim()) {
       args.push('--append-system-prompt', config.systemPromptAppendix);
@@ -2606,6 +2616,7 @@ export class ClaudeProtocolAdapter
 
   private emitSnapshot(): void {
     if (!this.config) return;
+    const effort = configuredClaudeEffort(this.config);
     this.emitPatch({
       type: 'agent-session-snapshot-v2',
       sessionId: this.config.sessionId,
@@ -2617,6 +2628,7 @@ export class ClaudeProtocolAdapter
         capabilities: this.capabilities,
         config: {
           ...(this.config.model ? { model: this.config.model } : {}),
+          ...(effort ? { effort } : {}),
           ...(this.config.permissionMode
             ? { permissionMode: this.config.permissionMode }
             : {}),

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -135,6 +135,7 @@ const CODEX_CAPABILITIES: AgentCapabilitySetV2 = {
 
 const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] =
   relayControlCatalogForProvider('codex');
+const CODEX_MODEL_CONTROL_KEYS = new Set(['model', 'effort', 'fast']);
 /*
 export const RELAY_CODEX_COMMANDS: AgentSlashCommandV2[] = [
   {
@@ -559,7 +560,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   /** Runtime controls survive follow-up turns on this adapter, never raw prompts. */
   private pendingModelOverride: string | null = null;
   private pendingEffortOverride: string | null = null;
-  private pendingServiceTier: 'fast' | null = null;
+  private pendingServiceTier: string | null = null;
 
   // Pending approvals keyed by relay item id (e.g. "approval-{requestId}")
   private readonly pendingApprovals = new Map<
@@ -601,7 +602,9 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   // Slash commands
   private slashCommandsLoaded = false;
-  private commandCatalog: AgentSlashCommandV2[] = [...RELAY_CODEX_COMMANDS];
+  private commandCatalog: AgentSlashCommandV2[] = RELAY_CODEX_COMMANDS.filter(
+    (command) => !CODEX_MODEL_CONTROL_KEYS.has(command.collisionKey ?? '')
+  );
   private fastModeAvailable = false;
   private supportedReasoningEfforts: string[] | null = null;
   private modelCatalog: Record<string, unknown>[] = [];
@@ -627,6 +630,13 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   async connect(config: AdapterConfig): Promise<void> {
     this.config = config;
+    this.modelCatalog = [];
+    this.supportedReasoningEfforts = null;
+    this.fastModeAvailable = false;
+    this.skillCommands = [];
+    this.commandCatalog = RELAY_CODEX_COMMANDS.filter(
+      (command) => !CODEX_MODEL_CONTROL_KEYS.has(command.collisionKey ?? '')
+    );
     const client = this.createClient(config);
     this.client = client;
     this.exitedProcessRootPid = null;
@@ -819,9 +829,6 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         (entry.name === command || (entry.aliases ?? []).includes(command))
     );
     if (!known) throw new Error('unsupported Codex control command');
-    if (known.collisionKey === 'fast' && !this.fastModeAvailable) {
-      throw new Error('Codex Fast Mode is unavailable for the selected model');
-    }
     await this.handleControlAction(
       known.collisionKey ?? known.name,
       input.args?.trim() ?? ''
@@ -2774,16 +2781,22 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
         case 'model': {
           if (!arg) throw new Error('model requires an argument');
-          const clearFastTier =
-            this.pendingServiceTier === 'fast' &&
-            this.modelCatalog.length > 0 &&
-            !this.modelSupportsFast(arg);
-          await this.updateThreadSettings({
-            model: arg,
-            ...(clearFastTier ? { serviceTier: null } : {}),
-          });
+          if (this.modelCatalog.length === 0) {
+            throw new Error('Codex model metadata is unavailable');
+          }
+          if (
+            !this.modelCatalog.some(
+              (model) =>
+                model.id === arg || model.model === arg || model.name === arg
+            )
+          ) {
+            throw new Error(`model ${arg} is not available`);
+          }
+          const nextFastTier = this.pendingServiceTier
+            ? this.fastServiceTierForModel(arg)
+            : null;
           this.pendingModelOverride = arg;
-          if (clearFastTier) this.pendingServiceTier = null;
+          if (this.pendingServiceTier) this.pendingServiceTier = nextFastTier;
           this.recomputeModelCommands();
           this.emitSessionUpdate({ config: { model: arg } });
           emitControl('success', arg);
@@ -2791,6 +2804,9 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         }
 
         case 'effort': {
+          if (this.modelCatalog.length === 0) {
+            throw new Error('Codex model metadata is unavailable');
+          }
           if (
             !['low', 'medium', 'high', 'xhigh', 'max', 'ultra'].includes(arg)
           ) {
@@ -2806,7 +2822,6 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
               `effort ${arg} is not supported by the selected model`
             );
           }
-          await this.updateThreadSettings({ effort: arg });
           this.pendingEffortOverride = arg;
           this.emitSessionUpdate({ config: { effort: arg } });
           emitControl('success', arg);
@@ -2817,8 +2832,15 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           if (arg !== 'on' && arg !== 'off') {
             throw new Error('fast requires on or off');
           }
-          const serviceTier = arg === 'on' ? 'fast' : null;
-          await this.updateThreadSettings({ serviceTier });
+          const fastServiceTier = this.fastServiceTierForModel(
+            this.pendingModelOverride ?? this.config.model
+          );
+          if (arg === 'on' && !fastServiceTier) {
+            throw new Error(
+              'Codex Fast Mode is unavailable for the selected model'
+            );
+          }
+          const serviceTier = arg === 'on' ? fastServiceTier : null;
           this.pendingServiceTier = serviceTier;
           this.emitSessionUpdate({
             config: { providerOptions: { serviceTier } },
@@ -2952,18 +2974,6 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     };
   }
 
-  private async updateThreadSettings(
-    settings: Record<string, unknown>
-  ): Promise<void> {
-    if (!this.client || !this.providerSessionId) {
-      throw new Error('Codex thread is not connected');
-    }
-    await this.client.call('thread/settings/update', {
-      threadId: this.providerSessionId,
-      ...settings,
-    });
-  }
-
   private initialEffort(config: AdapterConfig): string | null {
     const extra = isRecord(config.extra) ? config.extra : {};
     return (
@@ -2972,10 +2982,13 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     );
   }
 
-  private initialServiceTier(config: AdapterConfig): 'fast' | null {
+  private initialServiceTier(config: AdapterConfig): string | null {
     const extra = isRecord(config.extra) ? config.extra : {};
     return (
-      this.pendingServiceTier ?? (extra.serviceTier === 'fast' ? 'fast' : null)
+      this.pendingServiceTier ??
+      (typeof extra.serviceTier === 'string' && extra.serviceTier
+        ? extra.serviceTier
+        : null)
     );
   }
 
@@ -2990,7 +3003,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         )
       : (this.modelCatalog.find((model) => model.isDefault === true) ??
         this.modelCatalog[0]);
-    this.fastModeAvailable = this.modelSupportsFast(selected);
+    this.fastModeAvailable = this.fastServiceTierForModel(selected) !== null;
     const efforts = selectedModel?.supportedReasoningEfforts;
     this.supportedReasoningEfforts =
       this.modelCatalog.length === 0
@@ -3005,7 +3018,33 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
             )
           : [];
     const controls = RELAY_CODEX_COMMANDS.flatMap((command) => {
+      if (
+        CODEX_MODEL_CONTROL_KEYS.has(command.collisionKey ?? '') &&
+        this.modelCatalog.length === 0
+      ) {
+        return [];
+      }
       if (command.collisionKey === 'fast' && !this.fastModeAvailable) return [];
+      if (command.collisionKey === 'model' && this.modelCatalog.length > 0) {
+        return [
+          {
+            ...command,
+            args: this.modelCatalog.flatMap((model) => {
+              const value = stringField(model.id ?? model.model);
+              if (!value) return [];
+              const label = stringField(model.displayName, value);
+              const description = stringField(model.description);
+              return [
+                {
+                  value,
+                  ...(label !== value ? { label } : {}),
+                  ...(description ? { description } : {}),
+                },
+              ];
+            }),
+          },
+        ];
+      }
       if (command.collisionKey === 'effort' && this.supportedReasoningEfforts) {
         return [
           {
@@ -3022,7 +3061,9 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     );
   }
 
-  private modelSupportsFast(modelId: string | null | undefined): boolean {
+  private fastServiceTierForModel(
+    modelId: string | null | undefined
+  ): string | null {
     const model = modelId
       ? this.modelCatalog.find(
           (candidate) =>
@@ -3033,15 +3074,25 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       : (this.modelCatalog.find((candidate) => candidate.isDefault === true) ??
         this.modelCatalog[0]);
     const tiers = model?.serviceTiers;
-    return (
-      (Array.isArray(tiers) &&
-        tiers.some(
-          (tier) =>
-            tier === 'fast' ||
-            (isRecord(tier) && (tier.value === 'fast' || tier.id === 'fast'))
-        )) ||
-      (isRecord(tiers) && tiers.fast !== false && tiers.fast !== undefined)
-    );
+    if (Array.isArray(tiers)) {
+      for (const tier of tiers) {
+        if (typeof tier === 'string') {
+          if (tier === 'fast' || tier === 'priority') return tier;
+          continue;
+        }
+        if (!isRecord(tier)) continue;
+        const id = stringField(tier.id ?? tier.value);
+        const name = stringField(tier.name).toLowerCase();
+        if (id && (id === 'fast' || name === 'fast')) return id;
+      }
+    }
+    if (isRecord(tiers)) {
+      if (typeof tiers.fast === 'string') return tiers.fast;
+      if (tiers.fast === true) return 'fast';
+      if (typeof tiers.priority === 'string') return tiers.priority;
+      if (tiers.priority === true) return 'priority';
+    }
+    return null;
   }
 
   // ── Internal: slash commands ──────────────────────────────────────────────

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -559,8 +559,10 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   private readonly queue: QueuedCodexMessage[] = [];
   /** Runtime controls survive follow-up turns on this adapter, never raw prompts. */
   private pendingModelOverride: string | null = null;
-  private pendingEffortOverride: string | null = null;
-  private pendingServiceTier: string | null = null;
+  /** undefined = profile/default, null = explicit provider reset. */
+  private pendingEffortOverride: string | null | undefined;
+  /** undefined = profile/default, null = explicit default service tier. */
+  private pendingServiceTier: string | null | undefined;
 
   // Pending approvals keyed by relay item id (e.g. "approval-{requestId}")
   private readonly pendingApprovals = new Map<
@@ -601,7 +603,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   >();
 
   // Slash commands
-  private slashCommandsLoaded = false;
+  private catalogGeneration = 0;
+  private modelCatalogReady: Promise<void> = Promise.resolve();
   private commandCatalog: AgentSlashCommandV2[] = RELAY_CODEX_COMMANDS.filter(
     (command) => !CODEX_MODEL_CONTROL_KEYS.has(command.collisionKey ?? '')
   );
@@ -629,6 +632,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   async connect(config: AdapterConfig): Promise<void> {
+    const catalogGeneration = ++this.catalogGeneration;
     this.config = config;
     this.modelCatalog = [];
     this.supportedReasoningEfforts = null;
@@ -657,7 +661,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           ...(config.model || this.pendingModelOverride
             ? { model: this.pendingModelOverride ?? config.model }
             : {}),
-          ...(this.initialServiceTier(config)
+          ...(this.initialServiceTier(config) !== undefined
             ? { serviceTier: this.initialServiceTier(config) }
             : {}),
         });
@@ -668,7 +672,6 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.providerSessionId =
       threadResult.thread.id || config.resumeSessionId || null;
     this._status = 'connected';
-    this.slashCommandsLoaded = false;
 
     this.emitSnapshot();
     this.emitLiveState({
@@ -682,7 +685,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       error: null,
     });
 
-    void this.refreshSlashCommands(config.cwd);
+    this.refreshSlashCommands(config.cwd, client, catalogGeneration);
   }
 
   async resumeSession(threadId: string): Promise<void> {
@@ -919,18 +922,16 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     });
 
     try {
+      const effort = this.initialEffort(this.config);
+      const serviceTier = this.initialServiceTier(this.config);
       await this.client.call('turn/start', {
         threadId: this.providerSessionId,
         input: buildCodexTurnInput(input.content, input.attachments),
         ...(this.pendingModelOverride
           ? { model: this.pendingModelOverride }
           : {}),
-        ...(this.initialEffort(this.config)
-          ? { effort: this.initialEffort(this.config) }
-          : {}),
-        ...(this.pendingServiceTier
-          ? { serviceTier: this.pendingServiceTier }
-          : {}),
+        ...(effort !== undefined ? { effort } : {}),
+        ...(serviceTier !== undefined ? { serviceTier } : {}),
       });
     } catch (err) {
       logger.warn('Codex turn/start failed:', err);
@@ -1191,6 +1192,8 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   private async teardownState(): Promise<void> {
+    ++this.catalogGeneration;
+    this.modelCatalogReady = Promise.resolve();
     this.rejectQueued(new Error('Codex adapter disconnecting'));
     this.pendingApprovals.clear();
     this.pendingInputRequests.clear();
@@ -1226,7 +1229,6 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.activeStartedAt = null;
     this.completedActiveTurn = false;
     this.providerSessionId = null;
-    this.slashCommandsLoaded = false;
     this.itemMap.clear();
     this.openAgentMessageNativeIds.clear();
     this.openReasoningByRelayId.clear();
@@ -1363,7 +1365,14 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
         this.emitProviderExtension({ kind: 'warning', ...p }, 'debug');
         break;
       case 'skills/changed':
-        void this.refreshSlashCommands(this.config?.cwd ?? '');
+        if (this.client) {
+          const generation = ++this.catalogGeneration;
+          this.refreshSlashCommands(
+            this.config?.cwd ?? '',
+            this.client,
+            generation
+          );
+        }
         break;
       default:
         this.emitProviderExtension({ kind: method, ...p }, 'debug');
@@ -2737,6 +2746,12 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     arg: string
   ): Promise<void> {
     if (!this.config || !this.client) return;
+    if (CODEX_MODEL_CONTROL_KEYS.has(action)) {
+      await this.awaitCurrentModelCatalog();
+      if (!this.config || !this.client) {
+        throw new Error('Codex thread is not connected');
+      }
+    }
     const sessionId = this.config.sessionId;
 
     const emitControl = (status: 'success' | 'error', details?: string) => {
@@ -2792,13 +2807,30 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           ) {
             throw new Error(`model ${arg} is not available`);
           }
-          const nextFastTier = this.pendingServiceTier
-            ? this.fastServiceTierForModel(arg)
-            : null;
+          const currentEffort = this.initialEffort(this.config);
+          const targetEfforts = this.reasoningEffortsForModel(arg);
+          const resetEffort =
+            typeof currentEffort === 'string' &&
+            !targetEfforts.includes(currentEffort);
+          const currentServiceTier = this.initialServiceTier(this.config);
+          const nextFastTier =
+            typeof currentServiceTier === 'string'
+              ? this.fastServiceTierForModel(arg)
+              : currentServiceTier;
+          const serviceTierChanged = nextFastTier !== currentServiceTier;
           this.pendingModelOverride = arg;
-          if (this.pendingServiceTier) this.pendingServiceTier = nextFastTier;
+          if (resetEffort) this.pendingEffortOverride = null;
+          if (serviceTierChanged) this.pendingServiceTier = nextFastTier;
           this.recomputeModelCommands();
-          this.emitSessionUpdate({ config: { model: arg } });
+          this.emitSessionUpdate({
+            config: {
+              model: arg,
+              ...(resetEffort ? { effort: null } : {}),
+              ...(serviceTierChanged
+                ? { providerOptions: { serviceTier: nextFastTier } }
+                : {}),
+            },
+          });
           emitControl('success', arg);
           break;
         }
@@ -2871,7 +2903,7 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           }
           await this.client.call('thread/rollback', {
             threadId: this.providerSessionId,
-            count,
+            numTurns: count,
           });
           emitControl('success', String(count));
           break;
@@ -2901,15 +2933,14 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           if (subCmd === 'set') {
             await this.client.call('thread/goal/set', {
               threadId: this.providerSessionId,
-              goal: goalText,
+              objective: goalText,
             });
           } else if (subCmd === 'get') {
-            const result = await this.client.call<{ goal: string }>(
-              'thread/goal/get',
-              {
-                threadId: this.providerSessionId,
-              }
-            );
+            const result = await this.client.call<{
+              goal: { objective: string } | null;
+            }>('thread/goal/get', {
+              threadId: this.providerSessionId,
+            });
             this.emitProviderExtension({
               kind: 'goalValue',
               goal: result.goal,
@@ -2967,56 +2998,42 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
       ...(this.pendingModelOverride
         ? { model: this.pendingModelOverride }
         : {}),
-      ...(this.pendingEffortOverride
+      ...(this.pendingEffortOverride !== undefined
         ? { effort: this.pendingEffortOverride }
         : {}),
-      providerOptions: { serviceTier: this.pendingServiceTier },
+      ...(this.pendingServiceTier !== undefined
+        ? { providerOptions: { serviceTier: this.pendingServiceTier } }
+        : {}),
     };
   }
 
-  private initialEffort(config: AdapterConfig): string | null {
+  private initialEffort(config: AdapterConfig): string | null | undefined {
+    if (this.pendingEffortOverride !== undefined) {
+      return this.pendingEffortOverride;
+    }
     const extra = isRecord(config.extra) ? config.extra : {};
-    return (
-      this.pendingEffortOverride ??
-      (typeof extra.effort === 'string' && extra.effort ? extra.effort : null)
-    );
+    return typeof extra.effort === 'string' && extra.effort
+      ? extra.effort
+      : undefined;
   }
 
-  private initialServiceTier(config: AdapterConfig): string | null {
+  private initialServiceTier(config: AdapterConfig): string | null | undefined {
+    if (this.pendingServiceTier !== undefined) {
+      return this.pendingServiceTier;
+    }
     const extra = isRecord(config.extra) ? config.extra : {};
-    return (
-      this.pendingServiceTier ??
-      (typeof extra.serviceTier === 'string' && extra.serviceTier
-        ? extra.serviceTier
-        : null)
-    );
+    return typeof extra.serviceTier === 'string' && extra.serviceTier
+      ? extra.serviceTier
+      : undefined;
   }
 
   private recomputeModelCommands(): void {
     const selected = this.pendingModelOverride ?? this.config?.model;
-    const selectedModel = selected
-      ? this.modelCatalog.find(
-          (model) =>
-            model.id === selected ||
-            model.model === selected ||
-            model.name === selected
-        )
-      : (this.modelCatalog.find((model) => model.isDefault === true) ??
-        this.modelCatalog[0]);
     this.fastModeAvailable = this.fastServiceTierForModel(selected) !== null;
-    const efforts = selectedModel?.supportedReasoningEfforts;
     this.supportedReasoningEfforts =
       this.modelCatalog.length === 0
         ? null
-        : Array.isArray(efforts)
-          ? efforts.flatMap((effort) =>
-              typeof effort === 'string'
-                ? [effort]
-                : isRecord(effort) && typeof effort.reasoningEffort === 'string'
-                  ? [effort.reasoningEffort]
-                  : []
-            )
-          : [];
+        : this.reasoningEffortsForModel(selected);
     const controls = RELAY_CODEX_COMMANDS.flatMap((command) => {
       if (
         CODEX_MODEL_CONTROL_KEYS.has(command.collisionKey ?? '') &&
@@ -3061,6 +3078,30 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
     );
   }
 
+  private reasoningEffortsForModel(
+    modelId: string | null | undefined
+  ): string[] {
+    const model = modelId
+      ? this.modelCatalog.find(
+          (candidate) =>
+            candidate.id === modelId ||
+            candidate.model === modelId ||
+            candidate.name === modelId
+        )
+      : (this.modelCatalog.find((candidate) => candidate.isDefault === true) ??
+        this.modelCatalog[0]);
+    const efforts = model?.supportedReasoningEfforts;
+    return Array.isArray(efforts)
+      ? efforts.flatMap((effort) =>
+          typeof effort === 'string'
+            ? [effort]
+            : isRecord(effort) && typeof effort.reasoningEffort === 'string'
+              ? [effort.reasoningEffort]
+              : []
+        )
+      : [];
+  }
+
   private fastServiceTierForModel(
     modelId: string | null | undefined
   ): string | null {
@@ -3097,50 +3138,79 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
 
   // ── Internal: slash commands ──────────────────────────────────────────────
 
-  private async refreshSlashCommands(cwd: string): Promise<void> {
-    if (this.slashCommandsLoaded || !this.client) return;
-
-    try {
-      const [skillsResult, modelsResult] = await Promise.all([
-        this.client.call<{ skills: unknown[] }>('skills/list', { cwd: [cwd] }),
-        this.client.call('model/list').catch(() => null),
-      ]);
-
-      const skills: AgentSlashCommandV2[] = [];
-      const rawSkills = Array.isArray(skillsResult?.skills)
-        ? skillsResult.skills
-        : Array.isArray(skillsResult)
-          ? (skillsResult as unknown[])
-          : [];
-
-      for (const skill of rawSkills) {
-        if (isRecord(skill) && typeof skill['name'] === 'string') {
-          skills.push(normalizeSkill(skill, cwd));
-        }
+  private async awaitCurrentModelCatalog(): Promise<void> {
+    while (true) {
+      const generation = this.catalogGeneration;
+      const client = this.client;
+      const ready = this.modelCatalogReady;
+      await ready;
+      if (generation === this.catalogGeneration && client === this.client) {
+        return;
       }
-
-      this.skillCommands = skills;
-      const models = Array.isArray(modelsResult)
-        ? modelsResult
-        : isRecord(modelsResult) && Array.isArray(modelsResult.data)
-          ? modelsResult.data
-          : isRecord(modelsResult) && Array.isArray(modelsResult.models)
-            ? modelsResult.models
-            : [];
-      this.modelCatalog = models.filter(isRecord);
-      this.recomputeModelCommands();
-      this.emitLiveState({ fastModeAvailable: this.fastModeAvailable });
-      this.slashCommandsLoaded = true;
-      this.emitSessionUpdate({ slashCommands: this.commandCatalog });
-    } catch (err) {
-      logger.warn('Codex skills/list fetch failed:', err);
     }
+  }
+
+  private refreshSlashCommands(
+    cwd: string,
+    client: CodexAppServerClient,
+    generation: number
+  ): void {
+    const isCurrent = () =>
+      this.catalogGeneration === generation && this.client === client;
+
+    this.modelCatalogReady = client
+      .call('model/list')
+      .then((modelsResult) => {
+        if (!isCurrent()) return;
+        const models = Array.isArray(modelsResult)
+          ? modelsResult
+          : isRecord(modelsResult) && Array.isArray(modelsResult.data)
+            ? modelsResult.data
+            : isRecord(modelsResult) && Array.isArray(modelsResult.models)
+              ? modelsResult.models
+              : [];
+        this.modelCatalog = models.filter(isRecord);
+        this.recomputeModelCommands();
+        this.emitLiveState({ fastModeAvailable: this.fastModeAvailable });
+        this.emitSessionUpdate({ slashCommands: this.commandCatalog });
+      })
+      .catch((err: unknown) => {
+        if (!isCurrent()) return;
+        this.modelCatalog = [];
+        this.recomputeModelCommands();
+        this.emitLiveState({ fastModeAvailable: false });
+        this.emitSessionUpdate({ slashCommands: this.commandCatalog });
+        logger.warn('Codex model/list fetch failed:', err);
+      });
+
+    void client
+      .call<{ skills: unknown[] }>('skills/list', { cwd: [cwd] })
+      .then((skillsResult) => {
+        if (!isCurrent()) return;
+        const rawSkills = Array.isArray(skillsResult?.skills)
+          ? skillsResult.skills
+          : Array.isArray(skillsResult)
+            ? (skillsResult as unknown[])
+            : [];
+        this.skillCommands = rawSkills.flatMap((skill) =>
+          isRecord(skill) && typeof skill['name'] === 'string'
+            ? [normalizeSkill(skill, cwd)]
+            : []
+        );
+        this.recomputeModelCommands();
+        this.emitSessionUpdate({ slashCommands: this.commandCatalog });
+      })
+      .catch((err: unknown) => {
+        if (isCurrent()) logger.warn('Codex skills/list fetch failed:', err);
+      });
   }
 
   // ── Internal: emit helpers ────────────────────────────────────────────────
 
   private emitSnapshot(): void {
     if (!this.config) return;
+    const effort = this.initialEffort(this.config);
+    const serviceTier = this.initialServiceTier(this.config);
     this.emitPatch({
       type: 'agent-session-snapshot-v2',
       sessionId: this.config.sessionId,
@@ -3155,13 +3225,11 @@ export class CodexNativeProtocolAdapter extends BaseProtocolAdapterV2 {
           : {}),
         config: {
           ...(this.config.model ? { model: this.config.model } : {}),
-          ...(this.initialEffort(this.config)
-            ? { effort: this.initialEffort(this.config)! }
-            : {}),
-          ...(this.initialServiceTier(this.config)
+          ...(effort !== undefined ? { effort } : {}),
+          ...(serviceTier !== undefined
             ? {
                 providerOptions: {
-                  serviceTier: this.initialServiceTier(this.config),
+                  serviceTier,
                 },
               }
             : {}),

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -64,7 +64,8 @@ export interface AgentSessionLiveStateV2 {
 export interface AgentSessionConfigV2 {
   cwd: string;
   model?: string;
-  effort?: string;
+  /** null explicitly resets the provider to its model-default effort. */
+  effort?: string | null;
   permissionMode?: string;
   additionalDirectories?: string[];
   providerOptions?: Record<string, unknown>;
@@ -1609,7 +1610,11 @@ function isPartialSessionConfig(value: unknown): boolean {
   if (Object.hasOwn(value, 'cwd')) return false;
   if (value.model !== undefined && typeof value.model !== 'string')
     return false;
-  if (value.effort !== undefined && typeof value.effort !== 'string')
+  if (
+    value.effort !== undefined &&
+    value.effort !== null &&
+    typeof value.effort !== 'string'
+  )
     return false;
   if (
     value.permissionMode !== undefined &&

--- a/test/agent-chat-protocol-v2.test.ts
+++ b/test/agent-chat-protocol-v2.test.ts
@@ -351,6 +351,22 @@ describe('Agent Chat Protocol v2', () => {
         config: { model: 'sonnet' },
       })
     ).toBe(true);
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        config: { effort: null },
+      })
+    ).toBe(true);
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        config: { effort: 42 },
+      })
+    ).toBe(false);
   });
 
   it('rejects malformed slash command optional string fields', () => {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1326,6 +1326,38 @@ describe('channel-agent-binder — lifecycle', () => {
     expect(connected[0]?.commands).toBeUndefined();
   });
 
+  it('does not advertise relay controls from an adapter without a control executor', async () => {
+    const { binder } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, {
+          getSlashCommands: () => [
+            {
+              name: 'model',
+              dispatch: 'relay-control',
+              collisionKey: 'model',
+            },
+          ],
+        });
+        return adapter;
+      },
+      targets: [
+        {
+          id: 'mock',
+          displayName: 'Mock',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['mock'],
+    });
+
+    await binder.ensureBinding(CH, 'mock');
+    const connected = await binder.rosterForChannel(CH);
+    expect(connected[0]?.commands).toBeUndefined();
+  });
+
   it('targets command controls by exact named-profile Actor ID across a display-name collision', async () => {
     const profiles = createAgentProfileStore(':memory:');
     cleanup.push(() => profiles.close());

--- a/test/server/codex-app-server-client.test.ts
+++ b/test/server/codex-app-server-client.test.ts
@@ -264,7 +264,13 @@ describe('CodexAppServerClient', () => {
       expect(req['jsonrpc']).toBe('2.0');
       expect(req['method']).toBe('initialize');
       expect(typeof req['id']).toBe('number');
-      expect(req['params']).toMatchObject({ clientInfo: DEFAULT_CLIENT_INFO });
+      expect(req['params']).toEqual({
+        clientInfo: DEFAULT_CLIENT_INFO,
+        capabilities: {},
+      });
+      expect(req['params']).not.toMatchObject({
+        capabilities: { experimentalApi: true },
+      });
 
       mock.serverWrite(
         makeInitResponse(req['id'] as number, {

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -221,7 +221,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     });
   });
 
-  it('connect emits snapshot + idle live-state + relay commands WITHOUT spawning', async () => {
+  it('connect does not advertise dead Relay controls without a control executor', async () => {
     const harness = makeHarness();
     const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
     const patches = collectPatches(adapter);
@@ -237,13 +237,8 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     const slash = patches.find((p) => p.type === 'agent-session-updated-v2');
     expect(
       slash?.type === 'agent-session-updated-v2' && slash.slashCommands
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'clear', source: 'relay' }),
-        expect.objectContaining({ name: 'resume', source: 'relay' }),
-        expect.objectContaining({ name: 'model', source: 'relay' }),
-      ])
-    );
+    ).toEqual([]);
+    expect(adapter.executeControlCommand).toBeUndefined();
 
     await adapter.disconnect();
   });
@@ -263,6 +258,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       systemPromptAppendix: 'Relay orchestrator playbook',
       extra: {
         additionalDirectories: ['/extra/dir'],
+        effort: 'high',
         yolo: true,
         claudeArgs: [
           '--append-system-prompt',
@@ -275,6 +271,8 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
           '-r', // short alias of --resume (value) → dropped with its value token
           'SHOULD_DROP_R',
           '-r=alias-session', // short alias (=form) → dropped
+          '--effort', // canonical profile effort wins over raw args
+          'SHOULD_DROP_EFFORT',
           '--keep-me',
         ],
       },
@@ -313,6 +311,8 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     ]);
     expect(args).toContain('--model');
     expect(args[args.indexOf('--model') + 1]).toBe('sonnet');
+    expect(args).toContain('--effort');
+    expect(args[args.indexOf('--effort') + 1]).toBe('high');
     expect(args).toContain('--add-dir');
     expect(args[args.indexOf('--add-dir') + 1]).toBe('/extra/dir');
     expect(args).toContain('--append-system-prompt');
@@ -332,6 +332,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     expect(args).not.toContain('-r');
     expect(args).not.toContain('SHOULD_DROP_R');
     expect(args).not.toContain('-r=alias-session');
+    expect(args).not.toContain('SHOULD_DROP_EFFORT');
     // CLAUDECODE stripped from the child env.
     for (const key of CHANNEL_ADAPTER_LAUNCH_CONTRACTS.claude
       .processEnvDenylist) {

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -226,7 +226,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
     const patches = collectPatches(adapter);
 
-    await adapter.connect(baseConfig());
+    await adapter.connect({ ...baseConfig(), extra: { effort: ' high ' } });
 
     expect(harness.spawns).toHaveLength(0);
     expect(patches.map((p) => p.type)).toEqual([
@@ -239,6 +239,20 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       slash?.type === 'agent-session-updated-v2' && slash.slashCommands
     ).toEqual([]);
     expect(adapter.executeControlCommand).toBeUndefined();
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-session-snapshot-v2',
+          session: expect.objectContaining({
+            config: expect.objectContaining({ effort: 'high' }),
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-live-state-updated-v2',
+          live: expect.objectContaining({ fastModeAvailable: false }),
+        }),
+      ])
+    );
 
     await adapter.disconnect();
   });
@@ -1346,7 +1360,7 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
     const harness = makeHarness();
     const adapter = new ClaudeProtocolAdapter(harness.spawnFn, inertRegistry());
     const patches = collectPatches(adapter);
-    await adapter.connect(baseConfig());
+    await adapter.connect({ ...baseConfig(), extra: { effort: 'high' } });
 
     await adapter.resumeSession('resume-xyz');
     expect(harness.spawns).toHaveLength(0);
@@ -1357,7 +1371,13 @@ describe('ClaudeProtocolAdapter (stream-json subprocess)', () => {
       resumeSnap?.type === 'agent-session-snapshot-v2' && resumeSnap.session
     ).toMatchObject({
       providerSession: { claudeSessionId: 'resume-xyz' },
+      config: { effort: 'high' },
     });
+    expect(
+      patches
+        .filter((patch) => patch.type === 'agent-live-state-updated-v2')
+        .at(-1)
+    ).toMatchObject({ live: { fastModeAvailable: false } });
 
     await adapter.sendMessage({ turnId: 'turn-1', content: 'go' });
     expect(harness.spawns).toHaveLength(1);

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -2896,14 +2896,30 @@ describe('CodexNativeProtocolAdapter — prefix rewrite', () => {
 // ── Relay-control dispatch ────────────────────────────────────────────────────
 
 describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
-  it('uses flat thread/settings/update controls and carries profile effort into turn/start', async () => {
+  it('applies effort through stable turn/start without experimental thread settings', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);
     factory.lastClient?.serverResponses.set('thread/start', {
       thread: { id: 'thread-1' },
     });
+    factory.lastClient.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'o4-mini',
+          isDefault: true,
+          serviceTiers: [],
+          supportedReasoningEfforts: [
+            { reasoningEffort: 'high' },
+            { reasoningEffort: 'ultra' },
+          ],
+        },
+      ],
+    });
     await adapter.connect({ ...config, extra: { effort: 'high' } });
     const client = factory.lastClient!;
+    await waitFor(() =>
+      adapter.getSlashCommands().some((command) => command.name === 'effort')
+    );
 
     await adapter.sendMessage({ turnId: 'turn-effort-default', content: 'go' });
     expect(
@@ -2911,13 +2927,21 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     ).toMatchObject({ effort: 'high' });
 
     await adapter.executeControlCommand?.({ command: 'effort', args: 'ultra' });
-    expect(
-      client.calls.find((call) => call.method === 'thread/settings/update')
-        ?.params
-    ).toMatchObject({
-      threadId: 'thread-1',
-      effort: 'ultra',
+    client.feedNotification('turn/started', { turn: { id: 'native-effort' } });
+    client.feedNotification('turn/completed', {
+      turn: { id: 'native-effort', status: 'completed' },
     });
+    await adapter.sendMessage({
+      turnId: 'turn-effort-override',
+      content: 'go',
+    });
+    const overrideTurn = client.calls.filter(
+      (call) => call.method === 'turn/start'
+    )[1];
+    expect(overrideTurn?.params).toMatchObject({ effort: 'ultra' });
+    expect(
+      client.calls.some((call) => call.method === 'thread/settings/update')
+    ).toBe(false);
     await adapter.disconnect();
   });
 
@@ -2944,7 +2968,7 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     await adapter.disconnect();
   });
 
-  it('rejects Fast Mode until model/list has advertised the fast service tier', async () => {
+  it('derives the stable Fast Mode service tier id from live model metadata', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);
     factory.lastClient?.serverResponses.set('thread/start', {
@@ -2956,7 +2980,7 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
           id: 'gpt-fast',
           isDefault: true,
           serviceTiers: [
-            { id: 'fast', name: 'Fast', description: 'Fast tier' },
+            { id: 'priority', name: 'Fast', description: 'Fast tier' },
           ],
           supportedReasoningEfforts: [
             { reasoningEffort: 'low', description: 'Low effort' },
@@ -2974,14 +2998,49 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
         ?.args
     ).toEqual([{ value: 'low' }, { value: 'ultra' }]);
     await adapter.executeControlCommand?.({ command: 'fast', args: 'on' });
+    await adapter.sendMessage({ turnId: 'fast-turn', content: 'go' });
     expect(
-      factory.lastClient!.calls.find(
-        (call) => call.method === 'thread/settings/update'
-      )?.params
+      factory.lastClient!.calls.find((call) => call.method === 'turn/start')
+        ?.params
     ).toMatchObject({
-      threadId: 'thread-1',
-      serviceTier: 'fast',
+      serviceTier: 'priority',
     });
+    expect(
+      factory.lastClient!.calls.some(
+        (call) => call.method === 'thread/settings/update'
+      )
+    ).toBe(false);
+    await adapter.disconnect();
+  });
+
+  it('fails model controls closed when live model metadata is unavailable', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient.serverResponses.set('model/list', []);
+    await adapter.connect(config);
+    await waitFor(() =>
+      factory.lastClient.calls.some((call) => call.method === 'model/list')
+    );
+
+    expect(
+      adapter
+        .getSlashCommands()
+        .some((command) => ['model', 'effort', 'fast'].includes(command.name))
+    ).toBe(false);
+    await expect(
+      adapter.executeControlCommand?.({ command: 'model', args: 'gpt-unknown' })
+    ).rejects.toThrow('Codex model metadata is unavailable');
+    await expect(
+      adapter.executeControlCommand?.({ command: 'fast', args: 'on' })
+    ).rejects.toThrow('Fast Mode is unavailable');
+    expect(
+      factory.lastClient.calls.some(
+        (call) => call.method === 'thread/settings/update'
+      )
+    ).toBe(false);
     await adapter.disconnect();
   });
 
@@ -3015,20 +3074,17 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
       command: 'model',
       args: 'gpt-standard',
     });
-    const updates = factory.lastClient!.calls.filter(
-      (call) => call.method === 'thread/settings/update'
-    );
-    expect(updates.at(-1)?.params).toMatchObject({
-      threadId: 'thread-1',
-      model: 'gpt-standard',
-      serviceTier: null,
-    });
-
     await adapter.sendMessage({ turnId: 'standard-turn', content: 'go' });
     const turn = factory.lastClient!.calls.find(
       (call) => call.method === 'turn/start'
     );
     expect(turn?.params).not.toHaveProperty('serviceTier');
+    expect(turn?.params).toMatchObject({ model: 'gpt-standard' });
+    expect(
+      factory.lastClient!.calls.some(
+        (call) => call.method === 'thread/settings/update'
+      )
+    ).toBe(false);
     await adapter.disconnect();
   });
 
@@ -3052,9 +3108,18 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
       adapter.getSlashCommands().some((command) => command.name === 'fast')
     );
 
+    await adapter.executeControlCommand?.({ command: 'effort', args: 'low' });
     await expect(
       adapter.executeControlCommand?.({ command: 'effort', args: 'ultra' })
     ).rejects.toThrow('not supported by the selected model');
+    await adapter.sendMessage({
+      turnId: 'after-invalid-effort',
+      content: 'go',
+    });
+    expect(
+      factory.lastClient.calls.find((call) => call.method === 'turn/start')
+        ?.params
+    ).toMatchObject({ effort: 'low' });
     expect(
       factory.lastClient!.calls.some(
         (call) => call.method === 'thread/settings/update'
@@ -3116,15 +3181,28 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     await adapter.disconnect();
   });
 
-  it('/model arg updates session config', async () => {
+  it('/model updates session config and persists on subsequent stable turns', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);
     const patches = collectPatches(adapter);
     factory.lastClient?.serverResponses.set('thread/start', {
       thread: { id: 'thread-1' },
     });
+    factory.lastClient.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-4',
+          isDefault: true,
+          serviceTiers: [],
+          supportedReasoningEfforts: [{ reasoningEffort: 'high' }],
+        },
+      ],
+    });
     await adapter.connect(config);
     const client = factory.lastClient!;
+    await waitFor(() =>
+      adapter.getSlashCommands().some((command) => command.name === 'model')
+    );
 
     await adapter.sendMessage({ turnId: 'turn-model', content: 'go' });
     client.feedNotification('turn/started', { turn: { id: 'n-1' } });
@@ -3151,6 +3229,89 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
       ])
     );
 
+    client.feedNotification('turn/completed', {
+      turn: { id: 'n-1', status: 'completed' },
+    });
+    await adapter.sendMessage({ turnId: 'after-model-1', content: 'first' });
+    client.feedNotification('turn/started', { turn: { id: 'n-2' } });
+    client.feedNotification('turn/completed', {
+      turn: { id: 'n-2', status: 'completed' },
+    });
+    await adapter.sendMessage({ turnId: 'after-model-2', content: 'second' });
+
+    expect(client.calls.filter((call) => call.method === 'turn/start')).toEqual(
+      [
+        expect.objectContaining({
+          params: expect.not.objectContaining({ model: 'gpt-4' }),
+        }),
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4' }),
+        }),
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4' }),
+        }),
+      ]
+    );
+    expect(
+      client.calls.some((call) => call.method === 'thread/settings/update')
+    ).toBe(false);
+
+    await adapter.disconnect();
+  });
+
+  it('rejects an unavailable model without mutating the pending override', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-known',
+          displayName: 'Known model',
+          description: 'Known model description',
+          isDefault: true,
+          serviceTiers: [],
+          supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+        },
+      ],
+    });
+    await adapter.connect(config);
+    await waitFor(() =>
+      adapter
+        .getSlashCommands()
+        .some(
+          (command) =>
+            command.name === 'model' && command.args?.[0]?.value === 'gpt-known'
+        )
+    );
+
+    await expect(
+      adapter.executeControlCommand?.({
+        command: 'model',
+        args: 'gpt-missing',
+      })
+    ).rejects.toThrow('model gpt-missing is not available');
+    expect(
+      patches.some(
+        (patch) =>
+          patch.type === 'agent-session-updated-v2' &&
+          patch.config?.model === 'gpt-missing'
+      )
+    ).toBe(false);
+
+    await adapter.sendMessage({ turnId: 'after-invalid-model', content: 'go' });
+    expect(
+      factory.lastClient.calls.find((call) => call.method === 'turn/start')
+        ?.params
+    ).not.toMatchObject({ model: 'gpt-missing' });
+    expect(
+      factory.lastClient.calls.some(
+        (call) => call.method === 'thread/settings/update'
+      )
+    ).toBe(false);
     await adapter.disconnect();
   });
 

--- a/test/server/protocol-adapters/codex-native-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-native-adapter.test.ts
@@ -198,6 +198,17 @@ function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
   });
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 // ── Capability set ─────────────────────────────────────────────────────────────
 
 describe('CodexNativeProtocolAdapter — capability set', () => {
@@ -2989,7 +3000,11 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
         },
       ],
     });
-    await adapter.connect({ ...config, model: 'gpt-fast' });
+    await adapter.connect({
+      ...config,
+      model: 'gpt-fast',
+      extra: { serviceTier: 'priority' },
+    });
     await waitFor(() =>
       adapter.getSlashCommands().some((command) => command.name === 'fast')
     );
@@ -3005,11 +3020,122 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     ).toMatchObject({
       serviceTier: 'priority',
     });
+    factory.lastClient.feedNotification('turn/started', {
+      turn: { id: 'native-fast-on' },
+    });
+    factory.lastClient.feedNotification('turn/completed', {
+      turn: { id: 'native-fast-on', status: 'completed' },
+    });
+    await adapter.executeControlCommand?.({ command: 'fast', args: 'off' });
+    await adapter.sendMessage({ turnId: 'default-tier-turn', content: 'go' });
+    expect(
+      factory.lastClient.calls.filter((call) => call.method === 'turn/start')[1]
+        ?.params
+    ).toMatchObject({ serviceTier: null });
     expect(
       factory.lastClient!.calls.some(
         (call) => call.method === 'thread/settings/update'
       )
     ).toBe(false);
+    await adapter.disconnect();
+  });
+
+  it('awaits a delayed cold model catalog before executing the first control', async () => {
+    const models = deferred<unknown>();
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient.serverResponses.set('model/list', models.promise);
+    factory.lastClient.serverResponses.set(
+      'skills/list',
+      new Error('skills unavailable')
+    );
+    await adapter.connect(config);
+
+    let settled = false;
+    const command = adapter
+      .executeControlCommand({ command: 'model', args: 'gpt-delayed' })
+      .finally(() => {
+        settled = true;
+      });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+
+    models.resolve({
+      data: [
+        {
+          id: 'gpt-delayed',
+          supportedReasoningEfforts: [{ reasoningEffort: 'medium' }],
+          serviceTiers: [],
+        },
+      ],
+    });
+    await expect(command).resolves.toMatchObject({
+      config: { model: 'gpt-delayed' },
+    });
+    await adapter.disconnect();
+  });
+
+  it('ignores a stale prior-client catalog and awaits the current generation', async () => {
+    const staleModels = deferred<unknown>();
+    const oldClient = new StubCodexClient();
+    oldClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-old' },
+    });
+    oldClient.serverResponses.set('model/list', staleModels.promise);
+    oldClient.serverResponses.set(
+      'skills/list',
+      new Error('old skills unavailable')
+    );
+    const newClient = new StubCodexClient();
+    newClient.serverResponses.set('thread/resume', {
+      thread: { id: 'thread-new' },
+    });
+    newClient.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-current',
+          supportedReasoningEfforts: [{ reasoningEffort: 'high' }],
+          serviceTiers: [],
+        },
+      ],
+    });
+    newClient.serverResponses.set(
+      'skills/list',
+      new Error('new skills unavailable')
+    );
+    const clients = [oldClient, newClient];
+    const factory: CodexClientFactory = () =>
+      clients.shift() as unknown as CodexAppServerClient;
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    await adapter.connect(config);
+
+    const command = adapter.executeControlCommand({
+      command: 'model',
+      args: 'gpt-current',
+    });
+    await adapter.resumeSession('thread-new');
+    staleModels.resolve({
+      data: [
+        {
+          id: 'gpt-stale',
+          supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+          serviceTiers: [],
+        },
+      ],
+    });
+
+    await expect(command).resolves.toMatchObject({
+      config: { model: 'gpt-current' },
+    });
+    expect(
+      adapter
+        .getSlashCommands()
+        .find((entry) => entry.name === 'model')
+        ?.args?.map((arg) => arg.value)
+    ).toEqual(['gpt-current']);
     await adapter.disconnect();
   });
 
@@ -3078,13 +3204,100 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     const turn = factory.lastClient!.calls.find(
       (call) => call.method === 'turn/start'
     );
-    expect(turn?.params).not.toHaveProperty('serviceTier');
-    expect(turn?.params).toMatchObject({ model: 'gpt-standard' });
+    expect(turn?.params).toMatchObject({
+      model: 'gpt-standard',
+      serviceTier: null,
+    });
     expect(
       factory.lastClient!.calls.some(
         (call) => call.method === 'thread/settings/update'
       )
     ).toBe(false);
+    await adapter.disconnect();
+  });
+
+  it('resets an incompatible effective effort atomically with a model switch', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-deep',
+          supportedReasoningEfforts: [{ reasoningEffort: 'ultra' }],
+          serviceTiers: [],
+        },
+        {
+          id: 'gpt-light',
+          supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+          serviceTiers: [],
+        },
+      ],
+    });
+    await adapter.connect({
+      ...config,
+      model: 'gpt-deep',
+      extra: { effort: 'ultra' },
+    });
+    await adapter.executeControlCommand?.({
+      command: 'model',
+      args: 'gpt-light',
+    });
+    await adapter.sendMessage({ turnId: 'light-turn', content: 'go' });
+
+    expect(
+      factory.lastClient.calls.find((call) => call.method === 'turn/start')
+        ?.params
+    ).toMatchObject({ model: 'gpt-light', effort: null });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-session-updated-v2',
+          config: expect.objectContaining({ model: 'gpt-light', effort: null }),
+        }),
+      ])
+    );
+    await adapter.disconnect();
+  });
+
+  it('preserves a compatible effective effort across a model switch', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient.serverResponses.set('model/list', {
+      data: [
+        {
+          id: 'gpt-a',
+          supportedReasoningEfforts: [{ reasoningEffort: 'medium' }],
+          serviceTiers: [],
+        },
+        {
+          id: 'gpt-b',
+          supportedReasoningEfforts: [
+            { reasoningEffort: 'low' },
+            { reasoningEffort: 'medium' },
+          ],
+          serviceTiers: [],
+        },
+      ],
+    });
+    await adapter.connect({
+      ...config,
+      model: 'gpt-a',
+      extra: { effort: 'medium' },
+    });
+    await adapter.executeControlCommand?.({ command: 'model', args: 'gpt-b' });
+    await adapter.sendMessage({ turnId: 'compatible-turn', content: 'go' });
+
+    expect(
+      factory.lastClient.calls.find((call) => call.method === 'turn/start')
+        ?.params
+    ).toMatchObject({ model: 'gpt-b', effort: 'medium' });
     await adapter.disconnect();
   });
 
@@ -3159,7 +3372,7 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
     await adapter.disconnect();
   });
 
-  it('/rollback <n> calls thread/rollback with count', async () => {
+  it('/rollback <n> calls thread/rollback with the stable numTurns field', async () => {
     const factory = makeStubFactory();
     const adapter = new CodexNativeProtocolAdapter(factory);
     factory.lastClient?.serverResponses.set('thread/start', {
@@ -3176,8 +3389,59 @@ describe('CodexNativeProtocolAdapter — relay-control dispatch', () => {
       client.calls.some((c) => c.method === 'thread/rollback')
     );
     const rollback = client.calls.find((c) => c.method === 'thread/rollback');
-    expect(rollback?.params).toMatchObject({ count: 3 });
+    expect(rollback?.params).toMatchObject({ numTurns: 3 });
+    expect(rollback?.params).not.toHaveProperty('count');
 
+    await adapter.disconnect();
+  });
+
+  it('/goal uses the stable objective field and preserves the returned object', async () => {
+    const factory = makeStubFactory();
+    const adapter = new CodexNativeProtocolAdapter(factory);
+    const patches = collectPatches(adapter);
+    factory.lastClient.serverResponses.set('thread/start', {
+      thread: { id: 'thread-1' },
+    });
+    factory.lastClient.serverResponses.set('thread/goal/get', {
+      goal: {
+        threadId: 'thread-1',
+        objective: 'Ship safely',
+        status: 'active',
+      },
+    });
+    await adapter.connect(config);
+
+    await adapter.sendMessage({ turnId: 'turn-goal', content: 'go' });
+    factory.lastClient.feedNotification('turn/started', {
+      turn: { id: 'native-goal' },
+    });
+    await adapter.sendMessage({
+      turnId: 'turn-goal-set',
+      content: '/goal set Ship safely',
+    });
+    await adapter.sendMessage({
+      turnId: 'turn-goal-get',
+      content: '/goal get',
+    });
+
+    expect(
+      factory.lastClient.calls.find((call) => call.method === 'thread/goal/set')
+        ?.params
+    ).toMatchObject({ threadId: 'thread-1', objective: 'Ship safely' });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-started-v2',
+          item: expect.objectContaining({
+            type: 'providerExtension',
+            payload: expect.objectContaining({
+              kind: 'goalValue',
+              goal: expect.objectContaining({ objective: 'Ship safely' }),
+            }),
+          }),
+        }),
+      ])
+    );
     await adapter.disconnect();
   });
 


### PR DESCRIPTION
## What

Make Relay's provider runtime controls truthful and executable:

- Codex `/model`, `/effort`, and `/fast` now use stable `turn/start` overrides instead of unnegotiated experimental `thread/settings/update` calls.
- Fast Mode derives the live tier ID (`priority` in Codex 0.147.0), preserves explicit `null` resets, and reconciles tier/effort when models change.
- Cold Codex controls await generation-fenced model discovery; stale clients cannot repopulate the catalog.
- Codex rollback/goal controls use the current stable request/response shapes.
- Claude no longer advertises dead live controls, and launch-time effort is reflected in argv and observable session state.
- Shared provider config can represent an explicit `effort: null` reset.

## Why

Relay advertised `/model` but failed with:

```text
/model failed: thread/settings/update requires experimentalApi capability
```

The current [Codex App Server contract](https://learn.chatgpt.com/docs/app-server) requires explicit experimental capability negotiation for experimental requests, while stable `turn/start` already supports persistent model, effort, and service-tier overrides. Relay should derive visible controls from contracts it can actually execute.

Fixes #1375

Provider-audit follow-ups: #1377 (Prime Agent pre-bind discovery) and #1378 (OpenCode profile validation/effort truthfulness). Pi's launch-time model/thinking contract was verified and needs no change.

## Risk seams and adversarial review

- Reviewed exact implementation range before full CI; the first pass found three P1 state/race defects and three P2 observability/docs defects.
- One batched fix pass added tri-state reset propagation, incompatible-effort reconciliation, client-generation fencing, truthful Claude state, and current stable Codex RPC shapes.
- Focused re-review of the fix commit closed every finding and found no new P0/P1.
- No paid/model-backed turn was submitted; protocol behavior is proven by the installed Codex 0.147.0 stable generated schema, a live non-model app-server handshake/model catalog, Claude 2.1.224 CLI help, and adapter tests.

## Checklist

- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] Docs updated — `docs/provider-guide.md` records the Codex, Claude, Pi, Prime Agent, and OpenCode control contracts
- [x] Tests added/updated, with exact-head commands below
- [x] New HTTP route — none
- [x] New gateway verb — none
- [x] UI change — none

## Verification

Exact rebased candidate:

- HEAD `5cd85ea476889ecb92b0d8a3052eb3fbe6a209b2`
- tree `a4fad300baee0a25e9193fa47afec8491c49f7e3`
- changed-test hook → 67 files / 1,154 tests passed after rebuilding the rebased `dist`
- focused provider/protocol suite → 5 files / 301 tests passed
- `npm test` → 476/477 files and 6,458/6,459 tests passed; the sole failure was an unrelated load-sensitive `FileFeedbackPanel` async assertion. Neither the test nor component differs from `nightly`; the file then passed six consecutive isolated runs (12/12 tests).
- `npm run check` → 0 errors / 237 existing warnings
- `npm run build` → passed; only existing CodeMirror import and chunk-size warnings
- `git diff --check origin/nightly...HEAD` → passed
- focused adversarial re-review suite → 142/142 passed
- hosted GitHub CI → full unit suite, build/type/lint, and E2E smoke passed on exact head
