### PR TITLE
fix(prime): fail closed on discovered controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ workflow.
   (#1353)
 - Run Prime Agent as a built-in terminal and channel provider through its native RPC mode (#1340)
 - Run Pi as a built-in terminal and channel provider through its native JSONL RPC mode (#1349)
-- Control Prime Agent models, reasoning, compaction, and fresh sessions from the `@agent/` command palette (#1345)
+- Discover Prime Agent model and live-evidenced reasoning controls from the
+  connected runtime in the `@agent/` command palette (#1345, #1377)
 - Create and name new folders directly in the local Add Project browser (#1338)
 - Start project-scoped channels and direct messages from per-project sidebar
   add controls, with an explicit project selector in New Chat (#1347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ workflow.
 - Apply Codex model, reasoning-effort, and Fast Mode controls through stable
   turn overrides, stop advertising unimplemented Claude controls, and pass
   profile effort into Claude launches (#1375)
+- Discover Prime Agent controls from the current RPC runtime before advertising
+  them, and retract only a control that the runtime explicitly reports missing (#1377)
 - Agent profiles whose launch command is missing now appear unavailable in channel rosters and mention palettes, and spawn races report an actionable configuration error instead of raw `ENOENT` (#1357)
 - Codex reasoning cards now show expandable provider-generated summaries when available, and no longer show inactive expand chevrons when no summary exists
 - Terminal-style text field block cursors now align with the input content line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,9 @@ workflow.
 - Apply Codex model, reasoning-effort, and Fast Mode controls through stable
   turn overrides, stop advertising unimplemented Claude controls, and pass
   profile effort into Claude launches (#1375)
-- Discover Prime Agent controls from the current RPC runtime before advertising
-  them, and retract only a control that the runtime explicitly reports missing (#1377)
+- Discover Prime Agent model controls from the current RPC runtime before
+  advertising them, show thinking only for explicit live model metadata, and
+  keep fresh-session and compaction controls hidden pending a capability source (#1377)
 - Agent profiles whose launch command is missing now appear unavailable in channel rosters and mention palettes, and spawn races report an actionable configuration error instead of raw `ENOENT` (#1357)
 - Codex reasoning cards now show expandable provider-generated summaries when available, and no longer show inactive expand chevrons when no summary exists
 - Terminal-style text field block cursors now align with the input content line

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -42,7 +42,7 @@ lifecycle, `message_update` text and
 thinking deltas to assistant and reasoning items, and
 `tool_execution_start|update|end` to canonical command, file-change, or dynamic
 tool items. It advertises text, reasoning, tools, command execution, file
-changes, queueing, interrupt, resume, compaction, telemetry, and streaming; unsupported
+changes, queueing, interrupt, resume, telemetry, and streaming; unsupported
 approval, question, plan, and queue-cancellation operations remain false. Because Prime steering stays within one native run, Relay queues concurrent
 messages locally and sends a fresh RPC prompt after each `agent_end`, preserving
 one durable Relay turn per message. Channel subprocesses currently launch with
@@ -50,17 +50,19 @@ one durable Relay turn per message. Channel subprocesses currently launch with
 to Relay approvals/questions yet.
 
 The channel command palette discovers Prime models from the connected RPC
-runtime and exposes native `model`, `thinking`/`effort`, `compact`, and confirmed
-`new`/`clear` controls. These execute on Relay's authenticated control lane, not
-as persisted chat messages or token-consuming prompts. Model and thinking
-arguments are validated against live Prime metadata; if discovery is unavailable,
-the adapter fails closed instead of guessing. Prime skills, prompt templates,
-and TUI-only commands are not exposed as channel controls. This control surface
-is installed-tested with Prime Agent 0.7.0. It assumes strict-LF JSONL records,
-a correlated `get_state` readiness response, `agent_end` as the settled run
-boundary, and `sessionActions.queuedCount` as a finite non-negative integer; a
-runtime that cannot return a valid live model catalog publishes no connected
-command catalog.
+runtime and exposes `model`, plus `thinking`/`effort` only when the selected
+live model explicitly supplies supported thinking levels. These execute on
+Relay's authenticated control lane, not as persisted chat messages or
+token-consuming prompts. Fresh-session and compaction controls are intentionally
+hidden until Prime supplies an authoritative non-mutating capability source for
+their RPC methods. Model and thinking arguments are validated against live Prime
+metadata; if discovery is unavailable, the adapter fails closed instead of
+guessing. Prime skills, prompt templates, and TUI-only commands are not exposed
+as channel controls. This control surface is installed-tested with Prime Agent
+0.7.0. It assumes strict-LF JSONL records, a correlated `get_state` readiness
+response, `agent_end` as the settled run boundary, and
+`sessionActions.queuedCount` as a finite non-negative integer; a runtime that
+cannot return a valid live model catalog publishes no connected command catalog.
 
 The `prime-agent` executable is also available as a normal terminal launch, but
 that surface stays a generic PTY: Relay does not parse terminal output or infer
@@ -191,10 +193,14 @@ channel control until their own adapters expose and execute it.
 The #1375 provider audit found no equivalent advertise-then-fail path in Pi or
 OpenCode: Pi exposes no Relay-owned channel controls, and OpenCode exposes no
 control catalog. Prime Agent has no pre-bind control preview: its connected
-catalog is live-metadata-backed and remains empty until the current RPC runtime
-has completed discovery. A missing native Prime control retracts only that
-control for the active runtime generation and returns a typed unavailable
-result; reconnect invalidates the prior discovery result.
+catalog remains empty until the current RPC runtime has completed discovery.
+The available-model catalog proves only model selection; reasoning depth appears
+only when the selected model explicitly returns supported thinking levels.
+Fresh-session and compaction controls remain hidden because the current RPC
+contract has no authoritative non-mutating capability source for those methods.
+A missing live-evidenced native control retracts only that control for the
+active runtime generation and returns a typed unavailable result; reconnect
+invalidates the prior discovery result.
 
 ## Provider extension policy
 

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -190,10 +190,11 @@ channel control until their own adapters expose and execute it.
 
 The #1375 provider audit found no equivalent advertise-then-fail path in Pi or
 OpenCode: Pi exposes no Relay-owned channel controls, and OpenCode exposes no
-control catalog. Prime Agent's connected catalog is live-metadata-backed and
-its advertised controls have matching RPC implementations. Its pre-bind static
-preview remains a separate compatibility surface to keep aligned with the
-installed Prime RPC contract; connected empty catalogs remain authoritative.
+control catalog. Prime Agent has no pre-bind control preview: its connected
+catalog is live-metadata-backed and remains empty until the current RPC runtime
+has completed discovery. A missing native Prime control retracts only that
+control for the active runtime generation and returns a typed unavailable
+result; reconnect invalidates the prior discovery result.
 
 ## Provider extension policy
 

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import './ChannelComposer.css';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   ChannelImagePart,
   ChannelMemberRef,
@@ -205,6 +205,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   onRestore,
   restorePending,
 }) => {
+  const queryClient = useQueryClient();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lineBreakGuardRef = useRef(createLineBreakSubmitGuard());
   // Idempotency (§6.3): one clientMessageId per draft attempt, reused on retry
@@ -604,6 +605,11 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         ...(confirmed ? { confirmed: true } : {}),
       })
         .then(() => {
+          // The control may have changed the provider's live catalog. Invalidate
+          // before clearing the trigger so this active query immediately refetches.
+          void queryClient.invalidateQueries({
+            queryKey: ['channel-roster', channelId],
+          });
           setCommandStatus(
             `/${command.name} applied to @${commandTrigger.contact.displayName}`
           );
@@ -614,13 +620,18 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           setPaletteDismissed(true);
         })
         .catch((error) => {
+          // An UNAVAILABLE_COMMAND response retracts a stale control on the
+          // server; refresh here rather than waiting for the 30s roster cache.
+          void queryClient.invalidateQueries({
+            queryKey: ['channel-roster', channelId],
+          });
           const detail =
             error instanceof Error ? error.message : 'command failed';
           setCommandStatus(`/${command.name} failed: ${detail}`);
         })
         .finally(() => setCommandPending(false));
     },
-    [channelId, commandPending, commandTrigger]
+    [channelId, commandPending, commandTrigger, queryClient]
   );
 
   const selectCommand = useCallback(

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -17,6 +17,7 @@ import {
 } from './channel-message-store.js';
 import type { ChannelHub, ChannelMessagePostedOptions } from './channel-hub.js';
 import {
+  AgentControlUnavailableError,
   AgentSteerRejectedError,
   type Attachment,
   type ProtocolAdapterV2,
@@ -25,7 +26,10 @@ import type {
   ChannelAgentRuntime,
   CreateChannelAgentRuntimeParams,
 } from './channel-agent-runtime.js';
-import { relayControlCatalogForProvider } from '../shared/agent-command-catalog.js';
+import {
+  relayControlCatalogForProvider,
+  relayControlInputGuardCatalogForProvider,
+} from '../shared/agent-command-catalog.js';
 import type { WorkspaceTopicStore } from './workspace-topics.js';
 import type { AgentProfileStore } from './agent-profile-store.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
@@ -412,6 +416,7 @@ export class ChannelAgentCommandError extends Error {
       | 'UNKNOWN_COMMAND'
       | 'UNSUPPORTED_DISPATCH'
       | 'UNSUPPORTED_PROVIDER'
+      | 'UNAVAILABLE_COMMAND'
       | 'CONFIRMATION_REQUIRED'
   ) {
     super(message);
@@ -2910,9 +2915,9 @@ export function createChannelAgentBinder(
     let selected = preview.find(
       (entry) => entry.name === name || (entry.aliases ?? []).includes(name)
     );
-    // Static catalog entries make pre-bind previews possible. Other adapters
-    // may expose their own relay controls only after connect; discover those
-    // through the same adapter contract rather than a provider branch.
+    // Static catalog entries make pre-bind previews possible. Providers that
+    // require live discovery intentionally publish no static entry, so the
+    // same path binds and reselects only after their catalog is authoritative.
     if (!selected && !binding) {
       binding = await ensureProfileBinding(channelId, profile);
       preview = binding.adapter?.getSlashCommands?.() ?? [];
@@ -2945,11 +2950,21 @@ export function createChannelAgentBinder(
         'UNSUPPORTED_PROVIDER'
       );
     }
-    return binding.adapter.executeControlCommand({
-      command: selected.name,
-      ...(args ? { args } : {}),
-      ...(confirmed !== undefined ? { confirmed } : {}),
-    });
+    try {
+      return await binding.adapter.executeControlCommand({
+        command: selected.name,
+        ...(args ? { args } : {}),
+        ...(confirmed !== undefined ? { confirmed } : {}),
+      });
+    } catch (error) {
+      if (error instanceof AgentControlUnavailableError) {
+        throw new ChannelAgentCommandError(
+          error.message,
+          'UNAVAILABLE_COMMAND'
+        );
+      }
+      throw error;
+    }
   }
 
   function isControlMessage(text: string): boolean {
@@ -2984,7 +2999,7 @@ export function createChannelAgentBinder(
         ?.toLowerCase();
       if (
         command &&
-        relayControlCatalogForProvider(mention.providerId).some(
+        relayControlInputGuardCatalogForProvider(mention.providerId).some(
           (entry) =>
             entry.name === command || (entry.aliases ?? []).includes(command)
         )

--- a/server/prime-agent-rpc-client.ts
+++ b/server/prime-agent-rpc-client.ts
@@ -5,6 +5,26 @@ export interface PrimeAgentRpcMessage extends Record<string, unknown> {
   type: string;
 }
 
+/** A correlated native RPC failure, retaining the command and response shape. */
+export class PrimeAgentRpcResponseError extends Error {
+  constructor(
+    readonly command: string,
+    readonly response: PrimeAgentRpcMessage
+  ) {
+    const detail =
+      typeof response.error === 'string'
+        ? response.error
+        : response.error &&
+            typeof response.error === 'object' &&
+            typeof (response.error as Record<string, unknown>).message ===
+              'string'
+          ? String((response.error as Record<string, unknown>).message)
+          : `${command} failed`;
+    super(detail);
+    this.name = 'PrimeAgentRpcResponseError';
+  }
+}
+
 export interface PrimeAgentRpcClientOptions {
   command?: string;
   args?: string[];
@@ -268,11 +288,7 @@ export class PrimeAgentRpcClient extends EventEmitter {
           );
         } else if (message.success !== true) {
           pending.reject(
-            new Error(
-              typeof message.error === 'string'
-                ? message.error
-                : `${pending.command} failed`
-            )
+            new PrimeAgentRpcResponseError(pending.command, message)
           );
         } else {
           pending.resolve(message);

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -50,6 +50,17 @@ export class AgentSteerRejectedError extends Error {
   }
 }
 
+/** A live provider has explicitly reported that one control is unavailable. */
+export class AgentControlUnavailableError extends Error {
+  constructor(
+    readonly command: string,
+    message = `provider control /${command} is unavailable`
+  ) {
+    super(message);
+    this.name = 'AgentControlUnavailableError';
+  }
+}
+
 export interface AgentApprovalResponseInputV2 {
   requestId: string;
   decision: AgentApprovalDecisionV2;

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -1,7 +1,10 @@
 import { PRIME_AGENT_CHANNEL_COMMAND } from './launch-commands.js';
 import * as fs from 'node:fs';
 import { spawn as nodeSpawn } from 'node:child_process';
-import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import {
+  AgentControlUnavailableError,
+  BaseProtocolAdapterV2,
+} from '../protocol-adapter-v2.js';
 import type {
   AdapterConfig,
   AdapterStatus,
@@ -19,10 +22,11 @@ import type {
   AgentUsageV2,
 } from '../../shared/agent-chat-protocol-v2.js';
 import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
-import { relayControlCatalogForProvider } from '../../shared/agent-command-catalog.js';
+import { primeAgentControlDefinitions } from '../../shared/agent-command-catalog.js';
 import { cleanEnv } from '../utils.js';
 import {
   PrimeAgentRpcClient,
+  PrimeAgentRpcResponseError,
   type PrimeAgentRpcClientOptions,
   type PrimeAgentRpcMessage,
 } from '../prime-agent-rpc-client.js';
@@ -165,11 +169,13 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   private queueAdvanceInFlight = false;
   private providerExtensionSequence = 0;
   private readonly items = new Map<string, AgentItemV2>();
-  private commandCatalog = relayControlCatalogForProvider('prime-agent');
+  private commandCatalog: AgentSlashCommandV2[] = [];
   private modelCatalog: RpcRecord[] = [];
   private currentModel: RpcRecord | null = null;
   private thinkingLevel: string | null = null;
-  private controlInFlight = false;
+  private readonly unavailableControlKeys = new Set<string>();
+  private nextControlId = 0;
+  private controlInFlightId: number | null = null;
 
   constructor(
     private readonly clientFactory: ClientFactory = (options) =>
@@ -194,6 +200,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   async connect(config: AdapterConfig): Promise<void> {
     this.config = config;
     this._status = 'connecting';
+    this.clearControlDiscovery();
     const args = ['--mode', 'rpc', '--no-extensions'];
     const provider = string(config.extra?.['provider']);
     const thinking = string(config.extra?.['effort']);
@@ -232,9 +239,11 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     });
     try {
       const response = await client.start();
+      if (!current()) return;
       this.applyState(record(response.data));
       this._status = 'connected';
-      await this.refreshControlCommands();
+      await this.refreshControlCommands(client, generation);
+      if (!current()) return;
       this.emitSnapshot();
       this.emitSessionUpdate();
       this.emitLive({
@@ -250,8 +259,11 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
         error: null,
       });
     } catch (error) {
-      this._status = 'disconnected';
-      await client.stop().catch(() => undefined);
+      if (current()) {
+        this._status = 'disconnected';
+        this.clearControlDiscovery();
+        await client.stop().catch(() => undefined);
+      }
       throw error;
     }
   }
@@ -262,6 +274,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.activeTurnId = null;
     this.queued.length = 0;
     this.queueAdvanceInFlight = false;
+    this.clearControlDiscovery();
     this.items.clear();
     this.anonymousToolIds.clear();
     this.pendingAnonymousToolIds.clear();
@@ -271,6 +284,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const client = this.client;
     this.client = null;
     this.clientGeneration += 1;
+    this.clearControlDiscovery();
     await client?.stop();
   }
 
@@ -298,7 +312,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
-    if (this.controlInFlight) {
+    if (this.controlInFlightId !== null) {
       throw new Error('Prime Agent control command is in progress');
     }
     const client = this.requireClient();
@@ -335,15 +349,17 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     input: AgentControlCommandInputV2
   ): Promise<{ config?: Record<string, unknown> }> {
     const client = this.requireClient();
+    const generation = this.clientGeneration;
     if (this.activeTurnId || this.queued.length > 0) {
       throw new Error(
         'Prime Agent controls are unavailable while a turn is active'
       );
     }
-    if (this.controlInFlight) {
+    if (this.controlInFlightId !== null) {
       throw new Error('another Prime Agent control command is in progress');
     }
-    this.controlInFlight = true;
+    const controlId = ++this.nextControlId;
+    this.controlInFlightId = controlId;
     try {
       const command = input.command.trim().toLowerCase();
       const known = this.commandCatalog.find(
@@ -360,7 +376,12 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
 
       switch (action) {
         case 'clear': {
-          const response = await client.call('new_session');
+          const response = await this.callNativeControl(
+            client,
+            generation,
+            action,
+            'new_session'
+          );
           if (record(response.data).cancelled === true) {
             throw new Error('Prime Agent cancelled the new session request');
           }
@@ -378,10 +399,16 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
               'model must be selected from the live Prime Agent catalog'
             );
           }
-          await client.call('set_model', {
-            provider: string(selected.provider),
-            modelId: string(selected.id),
-          });
+          await this.callNativeControl(
+            client,
+            generation,
+            action,
+            'set_model',
+            {
+              provider: string(selected.provider),
+              modelId: string(selected.id),
+            }
+          );
           break;
         }
         case 'thinking': {
@@ -391,23 +418,32 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
               `thinking must be one of: ${allowed.join(', ') || 'none available'}`
             );
           }
-          await client.call('set_thinking_level', { level: args });
+          await this.callNativeControl(
+            client,
+            generation,
+            action,
+            'set_thinking_level',
+            { level: args }
+          );
           break;
         }
         case 'compact':
-          await client.call('compact');
+          await this.callNativeControl(client, generation, action, 'compact');
           break;
         default:
           throw new Error('unsupported Prime Agent control command');
       }
 
       const state = await client.call('get_state');
+      if (!this.isCurrentClient(client, generation)) {
+        throw new Error('Prime Agent control connection changed');
+      }
       this.applyState(record(state.data));
       this.recomputeControlCommands();
       this.emitSessionUpdate();
       return { config: this.currentControlConfig() };
     } finally {
-      this.controlInFlight = false;
+      if (this.controlInFlightId === controlId) this.controlInFlightId = null;
     }
   }
 
@@ -1045,10 +1081,13 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     });
   }
 
-  private async refreshControlCommands(): Promise<void> {
-    const client = this.requireClient();
+  private async refreshControlCommands(
+    client: PrimeAgentRpcClient,
+    generation: number
+  ): Promise<void> {
     try {
       const response = await client.call('get_available_models');
+      if (!this.isCurrentClient(client, generation)) return;
       const models = record(response.data).models;
       this.modelCatalog = Array.isArray(models)
         ? models.map(record).filter((model) => this.modelValue(model) !== '')
@@ -1060,8 +1099,8 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     } catch {
       // Older or malformed Prime Agent runtimes must not receive guessed
       // controls: an advertised command is an executable capability promise.
-      this.modelCatalog = [];
-      this.commandCatalog = [];
+      if (this.isCurrentClient(client, generation))
+        this.clearControlDiscovery();
       return;
     }
     this.recomputeControlCommands();
@@ -1089,9 +1128,14 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   private recomputeControlCommands(): void {
-    const controls = relayControlCatalogForProvider('prime-agent');
+    const controls = primeAgentControlDefinitions();
     const thinkingLevels = this.availableThinkingLevels(this.currentModel);
     this.commandCatalog = controls.flatMap((command) => {
+      if (
+        command.collisionKey &&
+        this.unavailableControlKeys.has(command.collisionKey)
+      )
+        return [];
       if (command.collisionKey === 'model') {
         if (this.modelCatalog.length === 0) return [];
         return [
@@ -1153,6 +1197,77 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     this.currentModel = string(model.id) ? model : null;
     this.thinkingLevel = string(data.thinkingLevel) || null;
   }
+  private clearControlDiscovery(): void {
+    this.commandCatalog = [];
+    this.modelCatalog = [];
+    this.currentModel = null;
+    this.thinkingLevel = null;
+    this.unavailableControlKeys.clear();
+    this.controlInFlightId = null;
+  }
+  private isCurrentClient(
+    client: PrimeAgentRpcClient,
+    generation: number
+  ): boolean {
+    return this.client === client && this.clientGeneration === generation;
+  }
+  private async callNativeControl(
+    client: PrimeAgentRpcClient,
+    generation: number,
+    control: string,
+    method: string,
+    fields?: RpcRecord
+  ): Promise<PrimeAgentRpcMessage> {
+    try {
+      const response = fields
+        ? await client.call(method, fields)
+        : await client.call(method);
+      if (!this.isCurrentClient(client, generation))
+        throw new Error('Prime Agent control connection changed');
+      return response;
+    } catch (error) {
+      if (this.isUnavailableNativeControlError(error, method)) {
+        this.retractControl(control, client, generation);
+        throw new AgentControlUnavailableError(
+          control,
+          `Prime Agent no longer supports /${control} on this runtime`
+        );
+      }
+      throw error;
+    }
+  }
+  private retractControl(
+    control: string,
+    client: PrimeAgentRpcClient,
+    generation: number
+  ): void {
+    if (!this.isCurrentClient(client, generation)) return;
+    this.unavailableControlKeys.add(control);
+    this.recomputeControlCommands();
+    this.emitSessionUpdate();
+  }
+  private isUnavailableNativeControlError(
+    error: unknown,
+    method: string
+  ): boolean {
+    if (
+      !(error instanceof PrimeAgentRpcResponseError) ||
+      error.command !== method
+    )
+      return false;
+    const escapedMethod = method.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const message = error.message;
+    return (
+      new RegExp(
+        `^(?:unknown|unsupported)\\s+(?:rpc\\s+)?(?:method|command)\\s*:?\\s*${escapedMethod}\\b`,
+        'i'
+      ).test(message) ||
+      new RegExp(
+        `^(?:(?:rpc\\s+)?(?:method|command)\\s+not\\s+found\\s*:?\\s*${escapedMethod}|${escapedMethod}\\s+(?:method|command)\\s+(?:is\\s+)?(?:unknown|unsupported|not found))\\b`,
+        'i'
+      ).test(message)
+    );
+  }
   private emitSnapshot(): void {
     if (!this.config) return;
     this.emitPatch({
@@ -1196,6 +1311,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     const client = this.client;
     this.client = null;
     this.clientGeneration += 1;
+    this.clearControlDiscovery();
     void client?.stop().catch(() => undefined);
     this.emitError(error.message);
     this.emitLive({

--- a/server/protocol-adapters/prime-agent-adapter.ts
+++ b/server/protocol-adapters/prime-agent-adapter.ts
@@ -47,7 +47,7 @@ const CAPABILITIES: AgentCapabilitySetV2 = {
   resume: true,
   fork: false,
   rollback: false,
-  compact: true,
+  compact: false,
   telemetry: true,
   rateLimits: false,
   streaming: true,
@@ -375,21 +375,6 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
       const args = input.args?.trim() ?? '';
 
       switch (action) {
-        case 'clear': {
-          const response = await this.callNativeControl(
-            client,
-            generation,
-            action,
-            'new_session'
-          );
-          if (record(response.data).cancelled === true) {
-            throw new Error('Prime Agent cancelled the new session request');
-          }
-          this.providerSessionId = null;
-          this.providerSessionFile = null;
-          this.items.clear();
-          break;
-        }
         case 'model': {
           const selected = this.modelCatalog.find(
             (model) => this.modelValue(model) === args
@@ -427,9 +412,6 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
           );
           break;
         }
-        case 'compact':
-          await this.callNativeControl(client, generation, action, 'compact');
-          break;
         default:
           throw new Error('unsupported Prime Agent control command');
       }
@@ -782,17 +764,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
     input: AgentSendMessageInputV2,
     payload: RpcRecord
   ): Promise<void> {
-    if (input.content.trim() !== '/compact') {
-      await client.call('prompt', payload);
-      return;
-    }
-    const response = await client.call('compact');
-    this.emitProviderExtension({
-      kind: 'contextCompaction',
-      ...record(response.data),
-    });
-    this.completeTurn('completed');
-    void this.advanceQueuedTurn();
+    await client.call('prompt', payload);
   }
 
   private async advanceQueuedTurn(): Promise<void> {
@@ -1115,11 +1087,11 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
   }
 
   private availableThinkingLevels(model: RpcRecord | null): string[] {
-    if (!model) return [];
-    if (model.reasoning !== true) return ['off'];
+    if (!model || model.reasoning !== true) return [];
     const levelMap = record(model.thinkingLevelMap);
+    if (Object.keys(levelMap).length === 0) return [];
     const levels = ['off', 'minimal', 'low', 'medium', 'high'].filter(
-      (level) => levelMap[level] !== null
+      (level) => Object.hasOwn(levelMap, level) && levelMap[level] !== null
     );
     for (const level of ['xhigh', 'max']) {
       if (level in levelMap && levelMap[level] !== null) levels.push(level);
@@ -1129,7 +1101,11 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
 
   private recomputeControlCommands(): void {
     const controls = primeAgentControlDefinitions();
-    const thinkingLevels = this.availableThinkingLevels(this.currentModel);
+    const selectedModel = this.modelCatalog.find(
+      (model) =>
+        this.modelValue(model) === this.modelValue(this.currentModel ?? {})
+    );
+    const thinkingLevels = this.availableThinkingLevels(selectedModel ?? null);
     this.commandCatalog = controls.flatMap((command) => {
       if (
         command.collisionKey &&
@@ -1164,7 +1140,7 @@ export class PrimeAgentProtocolAdapter extends BaseProtocolAdapterV2 {
           },
         ];
       }
-      return [command];
+      return [];
     });
   }
 

--- a/shared/agent-command-catalog.ts
+++ b/shared/agent-command-catalog.ts
@@ -141,17 +141,6 @@ const CODEX_CONTROLS: AgentSlashCommandV2[] = [
  */
 const PRIME_AGENT_CONTROL_DEFINITIONS: AgentSlashCommandV2[] = [
   {
-    id: 'relay:prime-agent:new',
-    name: 'new',
-    aliases: ['clear', 'reset'],
-    description: 'Start a fresh Prime Agent session',
-    source: 'builtin',
-    sourceLabel: 'Prime Agent',
-    dispatch: 'relay-control',
-    collisionKey: 'clear',
-    destructive: true,
-  },
-  {
     id: 'relay:prime-agent:model',
     name: 'model',
     description: 'Switch the model for subsequent Prime Agent responses',
@@ -175,15 +164,6 @@ const PRIME_AGENT_CONTROL_DEFINITIONS: AgentSlashCommandV2[] = [
     dispatch: 'relay-control',
     collisionKey: 'thinking',
   },
-  {
-    id: 'relay:prime-agent:compact',
-    name: 'compact',
-    description: 'Compact the current Prime Agent session context',
-    source: 'builtin',
-    sourceLabel: 'Prime Agent',
-    dispatch: 'relay-control',
-    collisionKey: 'compact',
-  },
 ];
 
 export function relayControlCatalogForProvider(
@@ -202,9 +182,10 @@ export function primeAgentControlDefinitions(): AgentSlashCommandV2[] {
 }
 
 /**
- * Controls reserved from ordinary channel prose. This is intentionally wider
- * than the advertised catalog: an undiscovered Prime control must still not
- * be mistaken for a normal targeted message.
+ * Controls reserved from ordinary channel prose. Prime's candidate set is
+ * limited to controls that its connected adapter can discover and execute;
+ * undiscovered candidates are not advertised, but are still kept off the
+ * ordinary-message lane.
  */
 export function relayControlInputGuardCatalogForProvider(
   providerId: string

--- a/shared/agent-command-catalog.ts
+++ b/shared/agent-command-catalog.ts
@@ -134,7 +134,12 @@ const CODEX_CONTROLS: AgentSlashCommandV2[] = [
   },
 ];
 
-const PRIME_AGENT_CONTROLS: AgentSlashCommandV2[] = [
+/**
+ * Prime controls are definitions for its connected adapter, not a pre-bind
+ * preview. Unlike Codex, Prime has no static control contract that Relay can
+ * safely promise before the current RPC runtime has completed discovery.
+ */
+const PRIME_AGENT_CONTROL_DEFINITIONS: AgentSlashCommandV2[] = [
   {
     id: 'relay:prime-agent:new',
     name: 'new',
@@ -184,12 +189,36 @@ const PRIME_AGENT_CONTROLS: AgentSlashCommandV2[] = [
 export function relayControlCatalogForProvider(
   providerId: string
 ): AgentSlashCommandV2[] {
+  const controls = providerId === 'codex' ? CODEX_CONTROLS : [];
+  return cloneCatalog(controls);
+}
+
+/**
+ * Returns Prime's candidate controls for a connected adapter to narrow using
+ * the current RPC runtime's live discovery result.
+ */
+export function primeAgentControlDefinitions(): AgentSlashCommandV2[] {
+  return cloneCatalog(PRIME_AGENT_CONTROL_DEFINITIONS);
+}
+
+/**
+ * Controls reserved from ordinary channel prose. This is intentionally wider
+ * than the advertised catalog: an undiscovered Prime control must still not
+ * be mistaken for a normal targeted message.
+ */
+export function relayControlInputGuardCatalogForProvider(
+  providerId: string
+): AgentSlashCommandV2[] {
   const controls =
-    providerId === 'codex'
-      ? CODEX_CONTROLS
-      : providerId === 'prime-agent'
-        ? PRIME_AGENT_CONTROLS
+    providerId === 'prime-agent'
+      ? PRIME_AGENT_CONTROL_DEFINITIONS
+      : providerId === 'codex'
+        ? CODEX_CONTROLS
         : [];
+  return cloneCatalog(controls);
+}
+
+function cloneCatalog(controls: AgentSlashCommandV2[]): AgentSlashCommandV2[] {
   return controls.map((command) => ({
     ...command,
     ...(command.aliases ? { aliases: [...command.aliases] } : {}),

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
 import { CHANNEL_ADAPTER_LAUNCH_CONTRACTS } from '../server/protocol-adapters/index.js';
 import {
+  AgentControlUnavailableError,
   AgentSteerRejectedError,
   BaseProtocolAdapterV2,
   type AdapterConfig,
@@ -1295,7 +1296,7 @@ describe('channel-agent-binder — lifecycle', () => {
     expect(rows(store)).toHaveLength(0);
   });
 
-  it('treats a connected adapter command catalog as authoritative, including empty', async () => {
+  it('does not advertise unbound Prime controls and treats a connected empty catalog as authoritative', async () => {
     const { binder } = makeBinder({
       build: (agentType) => {
         const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
@@ -1315,15 +1316,110 @@ describe('channel-agent-binder — lifecycle', () => {
     });
 
     const preview = await binder.rosterForChannel(CH);
-    expect(preview[0]?.commands?.map((command) => command.name)).toEqual([
-      'new',
-      'model',
-      'thinking',
-      'compact',
-    ]);
+    expect(preview[0]?.commands).toBeUndefined();
+    expect(binder.isControlMessage('@prime-agent /compact')).toBe(true);
     await binder.ensureBinding(CH, 'prime-agent');
     const connected = await binder.rosterForChannel(CH);
     expect(connected[0]?.commands).toBeUndefined();
+  });
+
+  it('waits for a cold Prime binding to discover the requested control before dispatch', async () => {
+    let releaseDiscovery!: () => void;
+    const discovery = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    let enteredDiscovery!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      enteredDiscovery = resolve;
+    });
+    const calls: string[] = [];
+    const { binder } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        const connect = adapter.connect.bind(adapter);
+        let discovered = false;
+        Object.assign(adapter, {
+          connect: async (adapterConfig: AdapterConfig) => {
+            enteredDiscovery();
+            await discovery;
+            await connect(adapterConfig);
+            discovered = true;
+          },
+          getSlashCommands: () =>
+            discovered
+              ? [
+                  {
+                    name: 'compact',
+                    dispatch: 'relay-control' as const,
+                    collisionKey: 'compact',
+                  },
+                ]
+              : [],
+          executeControlCommand: async (input: { command: string }) => {
+            calls.push(input.command);
+            return {};
+          },
+        });
+        return adapter;
+      },
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+    });
+    const profileId = builtInAgentProfileId('prime-agent');
+    expect((await binder.rosterForChannel(CH))[0]?.commands).toBeUndefined();
+
+    const command = binder.executeCommand(CH, profileId, 'compact');
+    await entered;
+    expect(calls).toEqual([]);
+    releaseDiscovery();
+    await command;
+    expect(calls).toEqual(['compact']);
+  });
+
+  it('maps a live provider control retraction to a typed unavailable result', async () => {
+    const { binder } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, {
+          getSlashCommands: () => [
+            {
+              name: 'compact',
+              dispatch: 'relay-control' as const,
+              collisionKey: 'compact',
+            },
+          ],
+          executeControlCommand: async () => {
+            throw new AgentControlUnavailableError(
+              'compact',
+              'Prime Agent no longer supports /compact on this runtime'
+            );
+          },
+        });
+        return adapter;
+      },
+      targets: [
+        {
+          id: 'prime-agent',
+          displayName: 'Prime Agent',
+          kind: 'framework',
+          available: true,
+          reason: null,
+        },
+      ],
+      knownProviderIds: ['prime-agent'],
+    });
+
+    await expect(
+      binder.executeCommand(CH, builtInAgentProfileId('prime-agent'), 'compact')
+    ).rejects.toMatchObject({ reasonCode: 'UNAVAILABLE_COMMAND' });
   });
 
   it('does not advertise relay controls from an adapter without a control executor', async () => {

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1297,9 +1297,13 @@ describe('channel-agent-binder — lifecycle', () => {
   });
 
   it('does not advertise unbound Prime controls and treats a connected empty catalog as authoritative', async () => {
-    const { binder } = makeBinder({
+    let adapter: ScriptedAdapter | null = null;
+    const { binder, store } = makeBinder({
       build: (agentType) => {
-        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        adapter = new ScriptedAdapter(agentType, {
+          mode: 'reply',
+          text: 'ack',
+        });
         Object.assign(adapter, { getSlashCommands: () => [] });
         return adapter;
       },
@@ -1317,10 +1321,22 @@ describe('channel-agent-binder — lifecycle', () => {
 
     const preview = await binder.rosterForChannel(CH);
     expect(preview[0]?.commands).toBeUndefined();
-    expect(binder.isControlMessage('@prime-agent /compact')).toBe(true);
+    expect(binder.isControlMessage('@prime-agent /model')).toBe(true);
+    expect(binder.isControlMessage('@prime-agent /thinking high')).toBe(true);
+    expect(binder.isControlMessage('@prime-agent /effort high')).toBe(true);
+    expect(binder.isControlMessage('@prime-agent /compact')).toBe(false);
+    expect(binder.isControlMessage('@prime-agent /new')).toBe(false);
+    expect(binder.isControlMessage('@prime-agent /clear')).toBe(false);
+    expect(binder.isControlMessage('@prime-agent /reset')).toBe(false);
     await binder.ensureBinding(CH, 'prime-agent');
     const connected = await binder.rosterForChannel(CH);
     expect(connected[0]?.commands).toBeUndefined();
+    expect(adapter).not.toBeNull();
+    post(store, binder, '@prime-agent /compact', ['prime-agent']);
+    post(store, binder, '@prime-agent /new', ['prime-agent']);
+    await waitFor(() => adapter!.sendInputs.length === 2);
+    expect(adapter!.sendInputs[0]!.content).toContain('/compact');
+    expect(adapter!.sendInputs[1]!.content).toContain('/new');
   });
 
   it('waits for a cold Prime binding to discover the requested control before dispatch', async () => {

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   executeChannelAgentCommand,
   fetchChannelRoster,
+  HttpError,
   uploadChannelImages,
   type RosterEntry,
 } from '../../frontend/src/lib/api.js';
@@ -101,7 +102,7 @@ interface RenderOpts {
   restorePending?: boolean;
 }
 
-async function renderComposer(opts: RenderOpts = {}): Promise<void> {
+async function renderComposer(opts: RenderOpts = {}): Promise<QueryClient> {
   // ChannelComposer lazily fetches the @mention roster via useQuery, so it must
   // render under a QueryClientProvider even when the palette never opens.
   const queryClient = new QueryClient({
@@ -125,6 +126,7 @@ async function renderComposer(opts: RenderOpts = {}): Promise<void> {
       )
     );
   });
+  return queryClient;
 }
 
 async function typeAndEnter(text: string): Promise<void> {
@@ -592,6 +594,62 @@ describe('ChannelComposer (#1178)', () => {
       args: 'on',
     });
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('immediately invalidates and refetches the roster after a successful control', async () => {
+    vi.mocked(fetchChannelRoster)
+      .mockResolvedValueOnce(codexRoster)
+      .mockResolvedValueOnce(codexRoster);
+    const queryClient = await renderComposer();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/fast'));
+    await settleRoster();
+
+    await pressKey('Enter');
+    await pressKey('Enter');
+
+    await vi.waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: ['channel-roster', 'topic:general'],
+      })
+    );
+    await vi.waitFor(() => expect(fetchChannelRoster).toHaveBeenCalledTimes(2));
+  });
+
+  it('immediately refreshes the roster after an unavailable control retracts', async () => {
+    vi.mocked(fetchChannelRoster)
+      .mockResolvedValueOnce(codexRoster)
+      .mockResolvedValueOnce([]);
+    vi.mocked(executeChannelAgentCommand).mockRejectedValue(
+      new HttpError(
+        400,
+        'Prime Agent no longer supports /fast on this runtime',
+        'INVALID_ARGUMENT',
+        false,
+        { reasonCode: 'UNAVAILABLE_COMMAND' }
+      )
+    );
+    const queryClient = await renderComposer();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '@codex/fast'));
+    await settleRoster();
+
+    await pressKey('Enter');
+    await pressKey('Enter');
+
+    await vi.waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: ['channel-roster', 'topic:general'],
+      })
+    );
+    await vi.waitFor(() => expect(fetchChannelRoster).toHaveBeenCalledTimes(2));
+    expect(container.textContent).toContain('no longer supports /fast');
   });
 
   it('escapes the command palette without losing the exact draft or posting it', async () => {

--- a/test/server/prime-agent-rpc-client.test.ts
+++ b/test/server/prime-agent-rpc-client.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import type { ChildProcess } from 'node:child_process';
-import { PrimeAgentRpcClient } from '../../server/prime-agent-rpc-client.js';
+import {
+  PrimeAgentRpcClient,
+  PrimeAgentRpcResponseError,
+} from '../../server/prime-agent-rpc-client.js';
 
 function fakeChild() {
   const child = new EventEmitter() as EventEmitter & {
@@ -115,9 +118,27 @@ describe('PrimeAgentRpcClient', () => {
       );
     });
     await client.start();
-    await expect(client.call('prompt', { message: 'x' })).rejects.toThrow(
-      'nope'
+    await expect(client.call('prompt', { message: 'x' })).rejects.toMatchObject(
+      {
+        name: 'PrimeAgentRpcResponseError',
+        command: 'prompt',
+        message: 'nope',
+        response: expect.objectContaining({
+          command: 'prompt',
+          success: false,
+        }),
+      }
     );
+    await expect(
+      Promise.reject(
+        new PrimeAgentRpcResponseError('compact', {
+          type: 'response',
+          command: 'compact',
+          success: false,
+          error: { message: 'method not found: compact' },
+        })
+      )
+    ).rejects.toThrow('method not found: compact');
   });
 
   it('bounds oversized records and a trailing unterminated tail', async () => {

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -4,8 +4,10 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   PrimeAgentRpcClient,
+  PrimeAgentRpcResponseError,
   type PrimeAgentRpcClientOptions,
 } from '../../../server/prime-agent-rpc-client.js';
+import { AgentControlUnavailableError } from '../../../server/protocol-adapter-v2.js';
 import { PrimeAgentProtocolAdapter } from '../../../server/protocol-adapters/prime-agent-adapter.js';
 import { CHANNEL_ADAPTER_LAUNCH_CONTRACTS } from '../../../server/protocol-adapters/index.js';
 
@@ -230,6 +232,197 @@ describe('PrimeAgentProtocolAdapter', () => {
         }),
       ])
     );
+  });
+
+  it('keeps the catalog empty until delayed current-runtime discovery completes', async () => {
+    const { adapter, call } = harness();
+    let releaseDiscovery!: (value: Record<string, unknown>) => void;
+    const discovery = new Promise<Record<string, unknown>>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    call.mockImplementation(async (type) => {
+      if (type === 'get_available_models') return await discovery;
+      return { type: 'response', command: type, success: true };
+    });
+
+    const connected = adapter.connect(config);
+    await vi.waitFor(() =>
+      expect(call).toHaveBeenCalledWith('get_available_models')
+    );
+    expect(adapter.getSlashCommands()).toEqual([]);
+
+    releaseDiscovery({
+      type: 'response',
+      command: 'get_available_models',
+      success: true,
+      data: {
+        models: [
+          {
+            id: 'delayed-prime',
+            provider: 'prime-inference',
+            reasoning: false,
+          },
+        ],
+      },
+    });
+    await connected;
+
+    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual(
+      expect.arrayContaining(['new', 'model', 'thinking', 'compact'])
+    );
+  });
+
+  it('retracts only a native method-not-found control and returns typed unavailability', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    call.mockImplementation(async (type) => {
+      if (type === 'set_model') {
+        throw new PrimeAgentRpcResponseError('set_model', {
+          type: 'response',
+          command: 'set_model',
+          success: false,
+          error: 'unknown command: set_model',
+        });
+      }
+      return { type: 'response', command: type, success: true };
+    });
+
+    await expect(
+      adapter.executeControlCommand({
+        command: 'model',
+        args: 'prime-inference/gpt-prime',
+      })
+    ).rejects.toBeInstanceOf(AgentControlUnavailableError);
+    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual(
+      expect.not.arrayContaining(['model'])
+    );
+    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual(
+      expect.arrayContaining(['new', 'thinking', 'compact'])
+    );
+  });
+
+  it('does not retract controls for ordinary provider or validation failures', async () => {
+    const { adapter, call } = harness();
+    await adapter.connect(config);
+    call.mockImplementation(async (type) => {
+      if (type === 'set_model') {
+        throw new PrimeAgentRpcResponseError('set_model', {
+          type: 'response',
+          command: 'set_model',
+          success: false,
+          error: 'unknown model: prime-inference/gpt-prime',
+        });
+      }
+      return { type: 'response', command: type, success: true };
+    });
+
+    await expect(
+      adapter.executeControlCommand({
+        command: 'model',
+        args: 'prime-inference/gpt-prime',
+      })
+    ).rejects.toThrow('unknown model');
+    await expect(
+      adapter.executeControlCommand({
+        command: 'thinking',
+        args: 'turbo',
+      })
+    ).rejects.toThrow('thinking must be one of');
+    expect(adapter.getSlashCommands().map((command) => command.name)).toContain(
+      'model'
+    );
+  });
+
+  it('fences stale discovery when a reconnect replaces its RPC client', async () => {
+    const first = new PrimeAgentRpcClient();
+    const second = new PrimeAgentRpcClient();
+    const startResponse = {
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: {
+        sessionId: 'prime-session',
+        model: {
+          id: 'current',
+          provider: 'prime-inference',
+          reasoning: false,
+        },
+      },
+    };
+    vi.spyOn(first, 'start').mockResolvedValue(startResponse);
+    vi.spyOn(second, 'start').mockResolvedValue(startResponse);
+    vi.spyOn(first, 'stop').mockResolvedValue();
+    vi.spyOn(second, 'stop').mockResolvedValue();
+    let releaseFirstDiscovery!: (value: Record<string, unknown>) => void;
+    const firstDiscovery = new Promise<Record<string, unknown>>((resolve) => {
+      releaseFirstDiscovery = resolve;
+    });
+    const firstCall = vi
+      .spyOn(first, 'call')
+      .mockImplementation(async (type) => {
+        if (type === 'get_available_models') return await firstDiscovery;
+        return { type: 'response', command: type, success: true };
+      });
+    vi.spyOn(second, 'call').mockResolvedValue({
+      type: 'response',
+      command: 'get_available_models',
+      success: true,
+      data: {
+        models: [
+          {
+            id: 'fresh',
+            provider: 'prime-inference',
+            reasoning: false,
+          },
+        ],
+      },
+    });
+    const clients = [first, second];
+    const adapter = new PrimeAgentProtocolAdapter(() => {
+      const client = clients.shift();
+      if (!client) throw new Error('unexpected Prime client');
+      return client;
+    });
+
+    const staleConnect = adapter.connect(config);
+    await vi.waitFor(() =>
+      expect(firstCall).toHaveBeenCalledWith('get_available_models')
+    );
+    first.emit('close', 0);
+    await adapter.reconnect();
+    const modelArgs = () =>
+      adapter.getSlashCommands().find((command) => command.name === 'model')
+        ?.args;
+    expect(modelArgs()).toEqual([
+      {
+        value: 'prime-inference/fresh',
+        label: 'fresh',
+        description: 'prime-inference',
+      },
+    ]);
+
+    releaseFirstDiscovery({
+      type: 'response',
+      command: 'get_available_models',
+      success: true,
+      data: {
+        models: [
+          {
+            id: 'stale',
+            provider: 'prime-inference',
+            reasoning: false,
+          },
+        ],
+      },
+    });
+    await staleConnect;
+    expect(modelArgs()).toEqual([
+      {
+        value: 'prime-inference/fresh',
+        label: 'fresh',
+        description: 'prime-inference',
+      },
+    ]);
   });
 
   it('clears stale optional state after a fresh Prime session', async () => {

--- a/test/server/protocol-adapters/prime-agent-adapter.test.ts
+++ b/test/server/protocol-adapters/prime-agent-adapter.test.ts
@@ -143,7 +143,7 @@ describe('PrimeAgentProtocolAdapter', () => {
       resume: true,
       approvals: false,
       questions: false,
-      compact: true,
+      compact: false,
       telemetry: true,
     });
     const snapshot = patches.find(
@@ -162,9 +162,12 @@ describe('PrimeAgentProtocolAdapter', () => {
     const { adapter, call, patches } = harness();
     await adapter.connect(config);
 
+    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual([
+      'model',
+      'thinking',
+    ]);
     expect(adapter.getSlashCommands()).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ name: 'new', destructive: true }),
         expect.objectContaining({
           name: 'model',
           args: expect.arrayContaining([
@@ -176,9 +179,8 @@ describe('PrimeAgentProtocolAdapter', () => {
         }),
         expect.objectContaining({
           name: 'thinking',
-          args: expect.arrayContaining([{ value: 'xhigh' }]),
+          args: [{ value: 'xhigh' }],
         }),
-        expect.objectContaining({ name: 'compact' }),
       ])
     );
 
@@ -201,20 +203,13 @@ describe('PrimeAgentProtocolAdapter', () => {
     });
     await adapter.executeControlCommand({
       command: 'thinking',
-      args: 'high',
+      args: 'xhigh',
     });
-    await adapter.executeControlCommand({ command: 'compact' });
-    await expect(
-      adapter.executeControlCommand({ command: 'new' })
-    ).rejects.toThrow('requires confirmation');
-    await adapter.executeControlCommand({ command: 'new', confirmed: true });
 
     expect(call.mock.calls).toEqual(
       expect.arrayContaining([
         ['set_model', { provider: 'prime-inference', modelId: 'claude-prime' }],
-        ['set_thinking_level', { level: 'high' }],
-        ['compact'],
-        ['new_session'],
+        ['set_thinking_level', { level: 'xhigh' }],
       ])
     );
     expect(patches).toEqual(
@@ -222,13 +217,6 @@ describe('PrimeAgentProtocolAdapter', () => {
         expect.objectContaining({
           type: 'agent-session-updated-v2',
           slashCommands: expect.any(Array),
-        }),
-        expect.objectContaining({
-          type: 'agent-session-updated-v2',
-          providerSession: {
-            primeAgentSessionId: 'prime-2',
-            primeAgentSessionFile: '/tmp/prime-2.jsonl',
-          },
         }),
       ])
     );
@@ -267,9 +255,9 @@ describe('PrimeAgentProtocolAdapter', () => {
     });
     await connected;
 
-    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual(
-      expect.arrayContaining(['new', 'model', 'thinking', 'compact'])
-    );
+    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual([
+      'model',
+    ]);
   });
 
   it('retracts only a native method-not-found control and returns typed unavailability', async () => {
@@ -296,9 +284,9 @@ describe('PrimeAgentProtocolAdapter', () => {
     expect(adapter.getSlashCommands().map((command) => command.name)).toEqual(
       expect.not.arrayContaining(['model'])
     );
-    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual(
-      expect.arrayContaining(['new', 'thinking', 'compact'])
-    );
+    expect(adapter.getSlashCommands().map((command) => command.name)).toEqual([
+      'thinking',
+    ]);
   });
 
   it('does not retract controls for ordinary provider or validation failures', async () => {
@@ -425,46 +413,6 @@ describe('PrimeAgentProtocolAdapter', () => {
     ]);
   });
 
-  it('clears stale optional state after a fresh Prime session', async () => {
-    const { adapter, call, patches } = harness();
-    await adapter.connect(config);
-    call.mockImplementation(async (type) => {
-      if (type === 'new_session') {
-        return {
-          type: 'response',
-          command: type,
-          success: true,
-          data: { cancelled: false },
-        };
-      }
-      if (type === 'get_state') {
-        return {
-          type: 'response',
-          command: type,
-          success: true,
-          data: { sessionId: 'prime-empty' },
-        };
-      }
-      return { type: 'response', command: type, success: true };
-    });
-
-    const result = await adapter.executeControlCommand({
-      command: 'new',
-      confirmed: true,
-    });
-    expect(result.config).toEqual({});
-    expect(patches.at(-1)).toMatchObject({
-      type: 'agent-session-updated-v2',
-      providerSession: { primeAgentSessionId: 'prime-empty' },
-      config: {},
-    });
-    expect(
-      (patches.at(-1)?.providerSession as Record<string, unknown>)?.[
-        'primeAgentSessionFile'
-      ]
-    ).toBeUndefined();
-  });
-
   it('serializes controls against prompts and other controls', async () => {
     const { adapter, call } = harness();
     await adapter.connect(config);
@@ -508,7 +456,7 @@ describe('PrimeAgentProtocolAdapter', () => {
       adapter.sendMessage({ turnId: 'racing-turn', content: 'hello' })
     ).rejects.toThrow('control command is in progress');
     await expect(
-      adapter.executeControlCommand({ command: 'compact' })
+      adapter.executeControlCommand({ command: 'thinking', args: 'xhigh' })
     ).rejects.toThrow('another Prime Agent control command is in progress');
 
     releaseModel();
@@ -1035,26 +983,25 @@ describe('PrimeAgentProtocolAdapter', () => {
     );
   });
 
-  it('runs /compact through native RPC and terminalizes the Relay turn', async () => {
+  it('sends literal /compact text as a normal Prime prompt', async () => {
     const { adapter, call, patches } = harness();
     call.mockImplementation(async (type) => ({
       type: 'response',
       command: type,
       success: true,
-      ...(type === 'compact' ? { data: { tokensBefore: 100 } } : {}),
     }));
     await adapter.connect(config);
     await adapter.sendMessage({ turnId: 'compact', content: '/compact' });
     expect(call.mock.calls.map(([type]) => type)).toEqual([
       'get_available_models',
-      'compact',
+      'prompt',
     ]);
-    expect(patches).toEqual(
+    expect(call).toHaveBeenCalledWith('prompt', { message: '/compact' });
+    expect(patches).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'agent-turn-completed-v2',
           turnId: 'compact',
-          status: 'completed',
         }),
       ])
     );


### PR DESCRIPTION
## What

Make Prime Agent channel controls fail closed against the connected runtime:

- unbound Prime profiles advertise no mutable controls;
- a cold command binds first and reselects from the authoritative live catalog;
- model choices come from the live model catalog, and thinking appears only for explicitly returned thinking levels;
- unproven `new`/`clear`/`reset` and `compact` controls are hidden and route as ordinary Prime input;
- correlated native method-not-found responses retract only the affected control and return typed `UNAVAILABLE_COMMAND` copy;
- discovery, control completion, and state updates are fenced to the current RPC client generation;
- the composer immediately refreshes its roster after control success or failure, so retracted controls disappear without waiting for cache expiry.

## Why

Relay previously showed static Prime controls before the current runtime had completed discovery. A runtime could publish a smaller catalog—or lack a native method entirely—after Relay had already promised the command in the UI.

Fixes #1377

## Risk seams and adversarial review

- Preserves failed native RPC envelopes at the client boundary; only correlated, method-specific missing-command responses trigger capability retraction.
- Unknown model, invalid thinking level, timeouts, transport closure, credentials, and ordinary provider errors do not retract controls.
- Independent review found optimistic `new`/`compact` exposure and a stale roster cache; both were fixed in one batch.
- Focused re-review caught the removed controls remaining in the input guard; the shared candidate catalog and message-routing tests now agree.
- `prime-agent` is not installed on this machine, so the opt-in live model-backed RPC smoke could not run. The existing mock RPC, binder, composer, check, build, and hosted CI gates remain authoritative for this change.

## Checklist

- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] Docs updated — `docs/provider-guide.md`
- [x] Tests added/updated, with exact-head commands below
- [x] New HTTP route — none
- [x] New gateway verb — none
- [x] UI change conforms to the existing command-palette/query patterns; no visual design change

## Verification

Exact candidate:

- HEAD `239912fe6024062159761142949f8fcae7866618`
- tree `dc2b5b67207ee95ebd1d9c5d36b5129b6ac231d0`
- focused Prime/RPC/binder tests → 171/171 passed
- focused composer-inclusive fix suite → 191/191 passed
- full `npm test` → passed in 91.8s
- `npm run check` → 0 errors / 236 existing warnings
- `npm run build` → passed; known Vite import/chunk warnings only
- `git diff --check origin/nightly...HEAD` → passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prime Agent controls are now discovered from the active runtime and shown only when supported.
  * Live thinking and model options are conditionally available based on runtime capabilities.
  * Unsupported controls are clearly reported and forwarded as regular messages when appropriate.

* **Bug Fixes**
  * Prevented stale controls from appearing after reconnects or connection failures.
  * Channel command catalogs now refresh immediately after control execution succeeds or fails.
  * Improved error details for failed runtime commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->