### PR TITLE
feat(orchestration): deliver delegation completion callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ workflow.
   existing WorkContext artifact and CLI surfaces (#1368)
 - Expose stable CLI gateway commands for scoped channel list, get, history,
   thread-history, roster, and post access (#1372)
+- Deliver durable, exactly-once upward completion callbacks for explicit
+  agent-to-agent channel delegations, including restart recovery, busy-agent
+  FIFO queueing, nested child fan-in, and explicit-return de-duplication (#1359)
 
 #### Changed
 

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -265,6 +265,52 @@ patches and channel messages. It:
 The provider adapter protocol remains internal execution infrastructure.
 Conversation state and rendering are always channel-native.
 
+### Delegation completion callbacks
+
+An explicit agent-to-agent `@mention` creates a durable, per-routed-turn
+callback edge from the delegator to the delegatee. The edge is scoped to the
+channel and thread, original trigger message, requester and target profile,
+target runtime, and target turn identity. It is Relay routing state, never a
+synthetic chat row.
+
+The directional invariant is: **delegation travels downward; completion travels
+upward; completion never creates a reverse delegation.** The one-shot lifecycle
+is `pending → satisfied → delivered → consumed`; guarded SQLite transitions make
+late or duplicate provider terminal patches inert. A delivered callback remains
+recoverable until the requester adapter resolves its typed-trigger acceptance;
+hub startup re-offers any such volatile FIFO offer. Relay uses the same
+deterministic recipient turn id and client-message id on every re-offer. Only
+that post-accept CAS consumes the edge, so a crash before Relay calls the
+adapter cannot lose it and a late Relay retry cannot fabricate a second Relay
+wake. The generic provider adapter contract has no durable provider acceptance
+receipt or declared external idempotency capability, however: a process crash
+after an external provider accepts input but before Relay observes the promise
+may produce an at-least-once external dispatch on recovery. Consumed rows retain
+bounded idempotency history while unresolved parent/child ancestry is preserved.
+
+- Completed, failed, interrupted, unexpected-disconnect, safe-idle fallback,
+  and watchdog terminalization can satisfy an edge. A watchdog with no prose
+  response explicitly carries `no-terminal-message`.
+- A raw provider `idle` is not enough. Approval/waiting state keeps the edge
+  pending until Relay's guarded terminal lifecycle observes a real boundary.
+- Relay sends a typed internal completion trigger that references the delegatee
+  final message and terminal reason. It does not add a row pretending the
+  delegatee wrote an `@mention`. If the delegatee already explicitly returns to
+  its requester in its final row, that ordinary route consumes the edge and
+  suppresses the automatic duplicate.
+- Nested delegation is durable fan-in: if B delegates C (or C and D) while
+  handling A, B's first terminal stores its evidence but A waits. Each child
+  completion wakes B once; only the last callback-triggered B continuation
+  releases A. A callback-triggered response has no reverse edge unless it makes
+  a new explicit downstream delegation.
+
+Callback delivery uses the existing per-profile FIFO, so a busy requester is
+queued behind its live turn. Downward callback edges are persisted before the
+delegatee enters that FIFO; queue-cap rejection terminalizes that edge upward
+instead of silently losing it. The consecutive agent-turn brake remains in
+force for every normal mention route and admits child intent only after its
+turn passes the brake.
+
 ## Threads
 
 Thread replies use the root message id as `threadId` and

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -13,6 +13,9 @@ import type { ChannelAttachmentStore } from './channel-attachments.js';
 import {
   createChannelOrchestratorConflictError,
   type ChannelBinding,
+  type ChannelCompletionCallbackEdge,
+  type ChannelCompletionCallbackMessageDisposition,
+  type ChannelCompletionCallbackTerminalReason,
   type ChannelMessageStore,
 } from './channel-message-store.js';
 import type { ChannelHub, ChannelMessagePostedOptions } from './channel-hub.js';
@@ -121,6 +124,12 @@ export const MAX_CONSECUTIVE_AGENT_TURNS = 4;
 const UNAVAILABLE_ROW_TTL_MS = 5 * 60 * 1000;
 /** How long a resolved framework-availability list is reused before re-probing. */
 const TARGETS_TTL_MS = 5 * 1000;
+/** Claim in bounded pages so a large recovered outbox cannot strand its tail. */
+const COMPLETION_CALLBACK_BATCH_LIMIT = 100;
+const COMPLETION_CALLBACK_RETRY_MS = 25;
+const COMPLETION_CALLBACK_PRUNE_INTERVAL_MS = 5 * 60 * 1000;
+const CALLBACK_NO_TERMINAL_MESSAGE = 'no-terminal-message' as const;
+const CALLBACK_UNEXPECTED_DISCONNECT = 'unexpected-disconnect' as const;
 
 // ── public types ─────────────────────────────────────────────────────────────
 
@@ -257,6 +266,8 @@ export interface ChannelAgentBinder {
   ): Promise<{ config?: Record<string, unknown> }>;
   isControlMessage(text: string): boolean;
   setStatusBroadcaster(broadcaster: ChannelAgentStatusBroadcaster): void;
+  /** Replays persisted callback work only after boot store sweeps complete. */
+  recoverCompletionCallbacks(): Promise<void>;
   close(): void;
 }
 
@@ -264,6 +275,10 @@ export interface ChannelAgentBinder {
 
 interface QueuedTurn {
   trigger: ChannelMessage;
+  /** Relay-internal upward completion trigger; never serialized as a chat row. */
+  completionCallback?: ChannelCompletionCallbackEdge;
+  /** Explicit agent delegation whose edge was durably admitted before this FIFO entry. */
+  callbackEdgeRequest?: CallbackEdgeRequest;
   /**
    * Set only by `handleSendFailure`'s re-enqueue after a rebind. Such a trigger
    * is BELOW the binding's delivery cursor (a newer turn already succeeded and
@@ -273,6 +288,12 @@ interface QueuedTurn {
    * where the packet footer renders it unconditionally. See `pump`.
    */
   reEnqueued?: true;
+}
+
+interface CallbackEdgeRequest {
+  requesterProfileId: string;
+  /** The ancestor edge to satisfy when the callback recipient finishes. */
+  continuationParentCallbackId?: string;
 }
 
 export interface LiveBinding {
@@ -290,6 +311,25 @@ export interface LiveBinding {
   activeTurnId: string | null;
   /** Immediate thread parent keyed by routed turn; retained past binder idle. */
   parentMessageIdByTurn: Map<string, string | null>;
+  /** Last terminal prose row by turn, available before the terminal patch lands. */
+  finalMessageByTurn: Map<string, ChannelMessage>;
+  /** Child callback and ancestor edge awaited by its internal callback turn. */
+  continuationByTurn: Map<
+    string,
+    { childCallbackId: string; parentCallbackId: string }
+  >;
+  /** Claimed callback triggers that have not yet been accepted by their adapter. */
+  completionCallbackByTurn: Map<string, ChannelCompletionCallbackEdge>;
+  /** A provider may terminalize synchronously before sendMessage resolves. */
+  deferredCompletionTerminalByTurn: Map<
+    string,
+    {
+      terminalReason: ChannelCompletionCallbackTerminalReason;
+      terminalMessageId?: string;
+      messageDisposition: ChannelCompletionCallbackMessageDisposition;
+      continuation?: { childCallbackId: string; parentCallbackId: string };
+    }
+  >;
   /** Anonymous turn-0 cannot be associated safely after retained generations overlap. */
   turnZeroFallbackUnsafe: boolean;
   /** Context packet for the active turn (kept so a retry re-sends identical content). */
@@ -490,6 +530,8 @@ export function createChannelAgentBinder(
     generation: number;
     promise: Promise<MentionTarget[]>;
   } | null = null;
+  let completionDrainScheduled = false;
+  let lastCompletionCallbackPruneAt: number | null = null;
   let closed = false;
 
   const unsubRuntimeEnd = deps.runtimes.onRuntimeEnd((runtimeId) =>
@@ -574,6 +616,246 @@ export function createChannelAgentBinder(
   function releaseTurnParent(binding: LiveBinding, turnId: string): void {
     const key = parentKeyForTurn(binding, turnId);
     if (key !== undefined) binding.parentMessageIdByTurn.delete(key);
+  }
+
+  /** Stable edge and callback-turn identities make late terminal patches inert. */
+  function completionCallbackEdgeId(targetTurnId: string): string {
+    return `chcb:${targetTurnId}`;
+  }
+
+  function completionCallbackTurnId(
+    edge: ChannelCompletionCallbackEdge,
+    requesterProfileId: string
+  ): string {
+    return channelTurnId(edge.id as ChannelMessage['id'], requesterProfileId);
+  }
+
+  function requesterProfileForAgentMessage(
+    message: ChannelMessage
+  ): string | null {
+    if (message.sender.kind !== 'agent') return null;
+    if (deps.agentProfileStore?.get(message.sender.id))
+      return message.sender.id;
+    return message.sender.providerId
+      ? defaultProfileForProvider(message.sender.providerId).id
+      : null;
+  }
+
+  function profileForActorId(profileActorId: string): AgentProfile | null {
+    const stored = deps.agentProfileStore?.get(profileActorId);
+    if (stored) return stored;
+    const providerId = deps.knownProviderIds.find(
+      (candidate) => builtInAgentProfileId(candidate) === profileActorId
+    );
+    return providerId ? defaultProfileForProvider(providerId) : null;
+  }
+
+  function completionDisposition(
+    finalMessage: ChannelMessage | undefined
+  ): ChannelCompletionCallbackMessageDisposition {
+    return finalMessage ? 'final-message' : CALLBACK_NO_TERMINAL_MESSAGE;
+  }
+
+  /**
+   * Keep idempotency rows bounded on a live hub too, not just after a restart.
+   * The store keeps unresolved ancestry out of the delete set; rate limiting
+   * makes this a tiny amortized write on callback lifecycle transitions.
+   */
+  function maybePruneCompletionCallbacks(): void {
+    const timestamp = now();
+    if (
+      lastCompletionCallbackPruneAt !== null &&
+      timestamp - lastCompletionCallbackPruneAt <
+        COMPLETION_CALLBACK_PRUNE_INTERVAL_MS
+    ) {
+      return;
+    }
+    lastCompletionCallbackPruneAt = timestamp;
+    try {
+      store.pruneConsumedCompletionCallbacks();
+    } catch (err) {
+      logger.warn('channel completion callback retention prune failed:', err);
+    }
+  }
+
+  function terminalizeCompletionCallback(
+    binding: LiveBinding,
+    turnId: string,
+    terminalReason: ChannelCompletionCallbackTerminalReason
+  ): void {
+    const finalMessage = binding.finalMessageByTurn.get(turnId);
+    try {
+      const continuation = binding.continuationByTurn.get(turnId);
+      const input = {
+        terminalReason,
+        ...(finalMessage ? { terminalMessageId: finalMessage.id } : {}),
+        messageDisposition: completionDisposition(finalMessage),
+      };
+      const callback = binding.completionCallbackByTurn.get(turnId);
+      // The adapter has not accepted this internal callback yet. A terminal
+      // patch may race sendMessage (including a watchdog or runtime death), but
+      // consuming now would make a crash between CAS and send permanently lose
+      // the callback. Hold the terminal evidence until acceptance instead.
+      if (
+        callback &&
+        store.getCompletionCallback(callback.id)?.state === 'delivered'
+      ) {
+        binding.deferredCompletionTerminalByTurn.set(turnId, {
+          ...input,
+          ...(continuation ? { continuation } : {}),
+        });
+        return;
+      }
+      const satisfied = continuation
+        ? store.completeChildContinuation({
+            callbackId: continuation.childCallbackId,
+            ...input,
+          })
+        : store.satisfyCompletionCallback({
+            channelId: binding.channelId,
+            targetProfileId: binding.profileActorId,
+            targetTurnId: turnId,
+            ...input,
+          });
+      if (satisfied) drainCompletionCallbacks();
+      maybePruneCompletionCallbacks();
+    } catch (err) {
+      logger.warn('channel completion callback terminalization failed:', err);
+    }
+  }
+
+  function flushDeferredCompletionTerminal(
+    binding: LiveBinding,
+    turnId: string
+  ): void {
+    const deferred = binding.deferredCompletionTerminalByTurn.get(turnId);
+    if (!deferred) return;
+    binding.deferredCompletionTerminalByTurn.delete(turnId);
+    try {
+      const satisfied = deferred.continuation
+        ? store.completeChildContinuation({
+            callbackId: deferred.continuation.childCallbackId,
+            terminalReason: deferred.terminalReason,
+            ...(deferred.terminalMessageId
+              ? { terminalMessageId: deferred.terminalMessageId }
+              : {}),
+            messageDisposition: deferred.messageDisposition,
+          })
+        : null;
+      if (satisfied) drainCompletionCallbacks();
+    } catch (err) {
+      logger.warn(
+        'channel deferred completion callback terminalization failed:',
+        err
+      );
+    }
+  }
+
+  /**
+   * An unaccepted callback turn must stay recoverable. This intentionally does
+   * not terminalize its ancestor relation: no provider accepted the typed
+   * trigger, so completion would be a fabricated acknowledgement.
+   */
+  function releaseUnacceptedCompletionCallbackTurn(
+    binding: LiveBinding,
+    turnId: string
+  ): boolean {
+    const callback = binding.completionCallbackByTurn.get(turnId);
+    if (!callback) return false;
+    try {
+      store.releaseDeliveredCompletionCallback(callback.id);
+      drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+    } catch (err) {
+      logger.warn(
+        'channel unaccepted completion callback release failed:',
+        err
+      );
+    }
+    binding.completionCallbackByTurn.delete(turnId);
+    binding.deferredCompletionTerminalByTurn.delete(turnId);
+    return true;
+  }
+
+  /**
+   * Claims durable satisfied edges before touching a live binding. The durable
+   * CAS is the exactly-once boundary for duplicate/late terminal patches; the
+   * FIFO below is only delivery scheduling for a busy requester.
+   */
+  function drainCompletionCallbacks(delayMs = 0): void {
+    if (closed || completionDrainScheduled) return;
+    // Let the provider's terminal patch finish its current microtask fan-out
+    // before the upward callback enters another agent's FIFO. That preserves
+    // one terminal boundary between downward delegation and upward completion;
+    // the durable CAS below remains the correctness boundary.
+    completionDrainScheduled = true;
+    const timer = setTimeout(() => {
+      completionDrainScheduled = false;
+      claimAndRouteCompletionCallbacks();
+    }, delayMs);
+    timer.unref?.();
+  }
+
+  function claimAndRouteCompletionCallbacks(): void {
+    if (closed) return;
+    let edges: ChannelCompletionCallbackEdge[];
+    try {
+      edges = store.claimSatisfiedCompletionCallbacks(
+        COMPLETION_CALLBACK_BATCH_LIMIT
+      );
+    } catch (err) {
+      logger.warn('channel completion callback claim failed:', err);
+      return;
+    }
+    for (const edge of edges) {
+      const profile = profileForActorId(edge.requesterProfileId);
+      if (!profile) {
+        logger.warn(
+          'channel completion callback requester profile is unavailable',
+          { callbackId: edge.id, requesterProfileId: edge.requesterProfileId }
+        );
+        store.releaseDeliveredCompletionCallback(edge.id);
+        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        continue;
+      }
+      const trigger =
+        (edge.terminalMessageId
+          ? store.getMessage(edge.terminalMessageId)
+          : null) ?? store.getMessage(edge.triggerMessageId);
+      if (!trigger) {
+        logger.warn('channel completion callback trigger is unavailable', {
+          callbackId: edge.id,
+        });
+        store.releaseDeliveredCompletionCallback(edge.id);
+        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        continue;
+      }
+      void ensureProfileBinding(edge.channelId, profile)
+        .then((binding) => {
+          if (closed) return;
+          if (!enqueueTurn(binding, trigger, undefined, false, edge)) {
+            // Queue admission is a durable boundary too. A full/released
+            // requester must re-offer this claimed edge rather than stranding it.
+            store.releaseDeliveredCompletionCallback(edge.id);
+            drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+          }
+        })
+        .catch((err) => {
+          if (closed || err instanceof BinderClosedError) return;
+          logger.warn('channel completion callback routing failed:', err);
+          try {
+            store.releaseDeliveredCompletionCallback(edge.id);
+            drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+          } catch (releaseErr) {
+            logger.warn(
+              'channel completion callback claim release failed:',
+              releaseErr
+            );
+          }
+        });
+    }
+    if (edges.length === COMPLETION_CALLBACK_BATCH_LIMIT) {
+      drainCompletionCallbacks();
+    }
   }
 
   // ── availability targets ────────────────────────────────────────────────────
@@ -812,7 +1094,7 @@ export function createChannelAgentBinder(
         framework: binding.framework,
         turnId: binding.activeTurnId,
       });
-      finishTurn(binding);
+      finishTurn(binding, 'watchdog');
     }, watchdogMs);
     binding.watchdog.unref?.();
   }
@@ -844,6 +1126,10 @@ export function createChannelAgentBinder(
       status: 'idle',
       activeTurnId: null,
       parentMessageIdByTurn: new Map(),
+      finalMessageByTurn: new Map(),
+      continuationByTurn: new Map(),
+      completionCallbackByTurn: new Map(),
+      deferredCompletionTerminalByTurn: new Map(),
       turnZeroFallbackUnsafe: false,
       activeContent: null,
       activeAttachments: [],
@@ -933,7 +1219,7 @@ export function createChannelAgentBinder(
       displayName: senderDisplayName,
       parentMessageIdForTurn: (turnId) => parentForTurn(binding, turnId),
       onAssistantMessageFinalized: (message) =>
-        handleAssistantFinalized(message),
+        handleAssistantFinalized(binding, message),
     });
     binding.patchUnlisten = runtime.adapter.onPatch((patch) =>
       handleBindingPatch(binding, patch)
@@ -1314,14 +1600,75 @@ export function createChannelAgentBinder(
     binding: LiveBinding,
     trigger: ChannelMessage,
     steering?: ChannelPostSteering,
-    reEnqueued = false
-  ): void {
+    reEnqueued = false,
+    completionCallback?: ChannelCompletionCallbackEdge,
+    callbackEdgeRequest?: CallbackEdgeRequest
+  ): boolean {
+    // A delegation becomes durable at FIFO admission, not when the provider
+    // eventually starts it. This preserves a queued B/C target across restart
+    // and gives rejection a concrete edge to terminalize upward.
+    let admittedDelegationTurnId: string | undefined;
+    if (callbackEdgeRequest) {
+      if (binding.runtimeId === null) {
+        logger.warn(
+          'channel completion callback admission has no target runtime'
+        );
+        return false;
+      }
+      admittedDelegationTurnId = channelTurnId(
+        trigger.id,
+        binding.profileActorId
+      );
+      try {
+        store.createCompletionCallback({
+          id: completionCallbackEdgeId(admittedDelegationTurnId),
+          channelId: binding.channelId,
+          threadId: trigger.threadId,
+          triggerMessageId: trigger.id,
+          requesterProfileId: callbackEdgeRequest.requesterProfileId,
+          targetProfileId: binding.profileActorId,
+          targetRuntimeId: binding.runtimeId,
+          targetTurnId: admittedDelegationTurnId,
+          ...(callbackEdgeRequest.continuationParentCallbackId
+            ? {
+                continuationParentCallbackId:
+                  callbackEdgeRequest.continuationParentCallbackId,
+              }
+            : {}),
+        });
+        maybePruneCompletionCallbacks();
+      } catch (err) {
+        logger.warn('channel completion callback admission failed:', err);
+        return false;
+      }
+    }
+    const rejectAdmittedDelegation = () => {
+      if (!admittedDelegationTurnId) return;
+      try {
+        const satisfied = store.satisfyCompletionCallback({
+          channelId: binding.channelId,
+          targetProfileId: binding.profileActorId,
+          targetTurnId: admittedDelegationTurnId,
+          terminalReason: 'error',
+          messageDisposition: CALLBACK_NO_TERMINAL_MESSAGE,
+        });
+        if (satisfied) drainCompletionCallbacks();
+        maybePruneCompletionCallbacks();
+      } catch (err) {
+        logger.warn(
+          'channel completion callback admission rejection failed:',
+          err
+        );
+      }
+    };
     // Native harnesses get the user's next instruction at their own tool-safe
     // boundary. Keep this ahead of the queue branch: while a turn is live the
     // regular pump cannot dispatch, whereas a provider steer is explicitly
     // designed to alter that live turn without interrupting its current tool.
     if (
       !reEnqueued &&
+      completionCallback === undefined &&
+      callbackEdgeRequest === undefined &&
       steering !== 'interrupt' &&
       binding.activeTurnId !== null &&
       binding.adapter?.capabilities.steer === true &&
@@ -1333,14 +1680,24 @@ export function createChannelAgentBinder(
           `@${binding.displayName} has ${QUEUE_CAP} messages pending — message dropped`,
           { parentMessageId: parentForTrigger(trigger) }
         );
-        return;
+        rejectAdmittedDelegation();
+        return false;
       }
       enqueueSteering(binding, trigger);
-      return;
+      return true;
     }
     const entry: QueuedTurn = reEnqueued
-      ? { trigger, reEnqueued: true }
-      : { trigger };
+      ? {
+          trigger,
+          reEnqueued: true,
+          ...(completionCallback ? { completionCallback } : {}),
+          ...(callbackEdgeRequest ? { callbackEdgeRequest } : {}),
+        }
+      : {
+          trigger,
+          ...(completionCallback ? { completionCallback } : {}),
+          ...(callbackEdgeRequest ? { callbackEdgeRequest } : {}),
+        };
     if (occupiedTurnSlots(binding) >= QUEUE_CAP) {
       const tailIndex = binding.queue.length - 1;
       const tail = binding.queue[tailIndex];
@@ -1353,6 +1710,10 @@ export function createChannelAgentBinder(
         tail &&
         !tail.reEnqueued &&
         !reEnqueued &&
+        tail.completionCallback === undefined &&
+        completionCallback === undefined &&
+        tail.callbackEdgeRequest === undefined &&
+        callbackEdgeRequest === undefined &&
         coalescesIntoOneTurn(tail.trigger, trigger)
       ) {
         // A human run drains as one turn triggered by its NEWEST member, so
@@ -1364,14 +1725,15 @@ export function createChannelAgentBinder(
         emitAgentStatus(binding);
         if (steering === 'interrupt') steerInterrupt(binding, trigger);
         pump(binding);
-        return;
+        return true;
       }
       postSystemRow(
         binding.channelId,
         `@${binding.displayName} has ${QUEUE_CAP} messages pending — message dropped`,
         { parentMessageId: parentForTrigger(trigger) }
       );
-      return;
+      rejectAdmittedDelegation();
+      return false;
     }
     binding.queue.push(entry);
     emitAgentStatus(binding);
@@ -1382,6 +1744,7 @@ export function createChannelAgentBinder(
     // send" degrades cleanly to plain "send".
     if (steering === 'interrupt') steerInterrupt(binding, trigger);
     pump(binding);
+    return true;
   }
 
   function occupiedTurnSlots(binding: LiveBinding): number {
@@ -1563,10 +1926,16 @@ export function createChannelAgentBinder(
     // would be neither trigger nor context row and would vanish entirely, the
     // exact loss coalescing exists to avoid. Alone it is the trigger, and the
     // footer renders the trigger unconditionally.
-    if (!head.reEnqueued) {
+    if (
+      !head.reEnqueued &&
+      head.completionCallback === undefined &&
+      head.callbackEdgeRequest === undefined
+    ) {
       while (
         take < binding.queue.length &&
         !binding.queue[take]!.reEnqueued &&
+        binding.queue[take]!.completionCallback === undefined &&
+        binding.queue[take]!.callbackEdgeRequest === undefined &&
         coalescesIntoOneTurn(head.trigger, binding.queue[take]!.trigger)
       ) {
         take += 1;
@@ -1584,7 +1953,13 @@ export function createChannelAgentBinder(
     for (const entry of batch) {
       if (entry.trigger.seq > trigger.seq) trigger = entry.trigger;
     }
-    sendTurn(binding, trigger);
+    const completionCallback = batch.find(
+      (entry) => entry.completionCallback !== undefined
+    )?.completionCallback;
+    const callbackEdgeRequest = batch.find(
+      (entry) => entry.callbackEdgeRequest !== undefined
+    )?.callbackEdgeRequest;
+    sendTurn(binding, trigger, completionCallback, callbackEdgeRequest);
   }
 
   function buildPacket(
@@ -1625,10 +2000,32 @@ export function createChannelAgentBinder(
     );
   }
 
-  function sendTurn(binding: LiveBinding, trigger: ChannelMessage): void {
+  function buildCompletionCallbackPacket(
+    binding: LiveBinding,
+    trigger: ChannelMessage,
+    callback: ChannelCompletionCallbackEdge
+  ): ResolvedMentionContextPacket {
+    const packet = buildPacket(binding, trigger);
+    const finalReference = callback.terminalMessageId
+      ? `finalMessageId=${callback.terminalMessageId}`
+      : 'finalMessageId=none';
+    return {
+      ...packet,
+      content: `${packet.content}\n\n[Relay internal completion callback]\nThis is a typed Relay completion trigger, not a chat message or a new delegation.\ncallbackId=${callback.id}\ndelegateeProfileId=${callback.targetProfileId}\ntargetTurnId=${callback.targetTurnId}\nterminalReason=${callback.terminalReason ?? 'unknown'}\nmessageDisposition=${callback.messageDisposition ?? 'no-terminal-message'}\n${finalReference}\nContinue the requester workflow if needed; do not infer a reverse callback edge from this trigger.`,
+    };
+  }
+
+  function sendTurn(
+    binding: LiveBinding,
+    trigger: ChannelMessage,
+    completionCallback?: ChannelCompletionCallbackEdge,
+    callbackEdgeRequest?: CallbackEdgeRequest
+  ): void {
     const adapter = binding.adapter;
     if (!adapter) return;
-    const turnId = channelTurnId(trigger.id, binding.profileActorId);
+    const turnId = completionCallback
+      ? completionCallbackTurnId(completionCallback, binding.profileActorId)
+      : channelTurnId(trigger.id, binding.profileActorId);
     // Build the packet BEFORE mutating any binding state: buildPacket does
     // synchronous SQLite work (getBinding/mentionContext) that can throw. If it did so
     // AFTER activeTurnId was set (and before the watchdog armed), the binding
@@ -1636,7 +2033,9 @@ export function createChannelAgentBinder(
     // every later mention dropped. On a throw we surface a row and keep draining.
     let packet: ResolvedMentionContextPacket;
     try {
-      packet = buildPacket(binding, trigger);
+      packet = completionCallback
+        ? buildCompletionCallbackPacket(binding, trigger, completionCallback)
+        : buildPacket(binding, trigger);
     } catch (err) {
       logger.warn('channel binder packet build failed:', err);
       postSystemRow(
@@ -1644,6 +2043,17 @@ export function createChannelAgentBinder(
         `@${binding.displayName} could not build the message context: ${errText(err)}`,
         { parentMessageId: parentForTrigger(trigger) }
       );
+      if (completionCallback) {
+        try {
+          store.releaseDeliveredCompletionCallback(completionCallback.id);
+          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        } catch (releaseErr) {
+          logger.warn(
+            'channel completion callback packet-failure release failed:',
+            releaseErr
+          );
+        }
+      }
       pump(binding); // activeTurnId is still null — keep the queue draining
       return;
     }
@@ -1662,20 +2072,38 @@ export function createChannelAgentBinder(
       turnId,
       parentForTrigger(trigger) ?? null
     );
+    if (completionCallback?.continuationParentCallbackId) {
+      binding.continuationByTurn.set(turnId, {
+        childCallbackId: completionCallback.id,
+        parentCallbackId: completionCallback.continuationParentCallbackId,
+      });
+    }
+    if (completionCallback) {
+      binding.completionCallbackByTurn.set(turnId, completionCallback);
+    }
     binding.sawStream = false;
     binding.waitingOn = null;
     binding.activeContent = packet.content;
     binding.activeAttachments = packet.attachments;
     setStatus(binding, 'thinking');
     armWatchdog(binding);
-    deliver(binding, adapter, turnId, trigger);
+    deliver(
+      binding,
+      adapter,
+      turnId,
+      trigger,
+      completionCallback,
+      callbackEdgeRequest
+    );
   }
 
   function deliver(
     binding: LiveBinding,
     adapter: ProtocolAdapterV2,
     turnId: string,
-    trigger: ChannelMessage
+    trigger: ChannelMessage,
+    completionCallback?: ChannelCompletionCallbackEdge,
+    callbackEdgeRequest?: CallbackEdgeRequest
   ): void {
     adapter
       .sendMessage({
@@ -1687,10 +2115,37 @@ export function createChannelAgentBinder(
         // Deterministic per routed (message, framework) turn (Amendment 3): a
         // retry reuses the same turn identity. `clientMessageId` is forward-compat
         // only — no adapter dedupes on it today.
-        clientMessageId: `${trigger.id}:${binding.profileActorId}`,
+        clientMessageId: completionCallback
+          ? `${completionCallback.id}:${binding.profileActorId}`
+          : `${trigger.id}:${binding.profileActorId}`,
       })
-      .then(() => advanceCursor(binding, trigger))
-      .catch((err) => handleSendFailure(binding, trigger, turnId, err));
+      .then(() => {
+        if (!completionCallback) {
+          advanceCursor(binding, trigger);
+          return;
+        }
+        // `sendMessage` acceptance is the callback's delivery boundary. The
+        // CAS deliberately follows acceptance so a crash-before-send reopens
+        // the claim after restart; repeat acceptance then sees consumed=false
+        // and cannot synthesize a second upward continuation.
+        if (store.consumeCompletionCallback(completionCallback.id)) {
+          flushDeferredCompletionTerminal(binding, turnId);
+          maybePruneCompletionCallbacks();
+          if (binding.activeTurnId !== turnId) {
+            binding.completionCallbackByTurn.delete(turnId);
+          }
+        }
+      })
+      .catch((err) =>
+        handleSendFailure(
+          binding,
+          trigger,
+          turnId,
+          err,
+          completionCallback,
+          callbackEdgeRequest
+        )
+      );
   }
 
   function advanceCursor(binding: LiveBinding, trigger: ChannelMessage): void {
@@ -1745,7 +2200,9 @@ export function createChannelAgentBinder(
     binding: LiveBinding,
     trigger: ChannelMessage,
     turnId: string,
-    err: unknown
+    err: unknown,
+    completionCallback?: ChannelCompletionCallbackEdge,
+    callbackEdgeRequest?: CallbackEdgeRequest
   ): Promise<void> {
     if (closed) return; // shutdown in progress — no rows, no re-delivery
     // A rejected sendMessage means the turn was NEVER accepted (Amendment 3), so
@@ -1766,7 +2223,14 @@ export function createChannelAgentBinder(
         if (closed) return;
         if (rebound.adapter && rebound.activeTurnId === turnId) {
           // Same binding still owns this turn — redeliver identical content.
-          deliver(rebound, rebound.adapter, turnId, trigger);
+          deliver(
+            rebound,
+            rebound.adapter,
+            turnId,
+            trigger,
+            completionCallback,
+            callbackEdgeRequest
+          );
           return;
         }
         if (rebound.adapter) {
@@ -1780,12 +2244,37 @@ export function createChannelAgentBinder(
           // already advanced the delivery cursor past this trigger's seq, so it
           // must get its own turn rather than be coalesced into a later packet
           // that would filter it out (see `QueuedTurn.reEnqueued` and `pump`).
-          enqueueTurn(rebound, trigger, undefined, true);
+          enqueueTurn(
+            rebound,
+            trigger,
+            undefined,
+            true,
+            completionCallback,
+            callbackEdgeRequest
+          );
           return;
         }
       } catch {
         // fall through to the error row
       }
+    }
+    if (completionCallback) {
+      releaseUnacceptedCompletionCallbackTurn(binding, turnId);
+      releaseTurnParent(binding, turnId);
+      binding.finalMessageByTurn.delete(turnId);
+      binding.continuationByTurn.delete(turnId);
+      if (binding.activeTurnId === turnId) {
+        binding.activeTurnId = null;
+        binding.activeContent = null;
+        binding.activeAttachments = [];
+        binding.waitingOn = null;
+        binding.sawStream = false;
+        disarmWatchdog(binding);
+        setStatus(binding, 'idle');
+        emitAgentStatus(binding);
+        pump(binding);
+      }
+      return;
     }
     postSystemRow(
       binding.channelId,
@@ -1793,7 +2282,7 @@ export function createChannelAgentBinder(
       { parentMessageId: parentForTrigger(trigger) }
     );
     releaseTurnParent(binding, turnId);
-    finishTurn(binding);
+    finishTurn(binding, 'error');
   }
 
   /**
@@ -1806,6 +2295,45 @@ export function createChannelAgentBinder(
    */
   function dropQueuedTurns(binding: LiveBinding): void {
     for (const queued of binding.queue) {
+      if (queued.completionCallback) {
+        // This is an upward callback that was claimed into an in-memory FIFO
+        // but never handed to the dead runtime. Re-offer it; do not pretend the
+        // requester accepted it or terminalize a reverse relation.
+        try {
+          store.releaseDeliveredCompletionCallback(
+            queued.completionCallback.id
+          );
+          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        } catch (err) {
+          logger.warn(
+            'channel queued completion callback release failed:',
+            err
+          );
+        }
+      }
+      if (queued.callbackEdgeRequest) {
+        // A downward target already has its durable edge at FIFO admission. Its
+        // dead runtime is a guarded terminal outcome, so wake the delegator
+        // through normal callback routing rather than silently losing the
+        // parent intent (or waiting for a hub restart to discover it).
+        try {
+          const targetTurnId = channelTurnId(
+            queued.trigger.id,
+            binding.profileActorId
+          );
+          const satisfied = store.satisfyCompletionCallback({
+            channelId: binding.channelId,
+            targetProfileId: binding.profileActorId,
+            targetTurnId,
+            terminalReason: CALLBACK_UNEXPECTED_DISCONNECT,
+            messageDisposition: CALLBACK_NO_TERMINAL_MESSAGE,
+          });
+          if (satisfied) drainCompletionCallbacks();
+          maybePruneCompletionCallbacks();
+        } catch (err) {
+          logger.warn('channel queued delegation terminalization failed:', err);
+        }
+      }
       postSystemRow(
         binding.channelId,
         `@${binding.displayName} runtime ended before delivering a queued message.`,
@@ -1814,6 +2342,38 @@ export function createChannelAgentBinder(
     }
     binding.queue = [];
     for (const steering of binding.steeringQueue) {
+      if (steering.completionCallback) {
+        try {
+          store.releaseDeliveredCompletionCallback(
+            steering.completionCallback.id
+          );
+          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        } catch (err) {
+          logger.warn('channel queued steering callback release failed:', err);
+        }
+      }
+      if (steering.callbackEdgeRequest) {
+        try {
+          const targetTurnId = channelTurnId(
+            steering.trigger.id,
+            binding.profileActorId
+          );
+          const satisfied = store.satisfyCompletionCallback({
+            channelId: binding.channelId,
+            targetProfileId: binding.profileActorId,
+            targetTurnId,
+            terminalReason: CALLBACK_UNEXPECTED_DISCONNECT,
+            messageDisposition: CALLBACK_NO_TERMINAL_MESSAGE,
+          });
+          if (satisfied) drainCompletionCallbacks();
+          maybePruneCompletionCallbacks();
+        } catch (err) {
+          logger.warn(
+            'channel queued steering delegation terminalization failed:',
+            err
+          );
+        }
+      }
       postSystemRow(
         binding.channelId,
         `@${binding.displayName} runtime ended before accepting a steering message.`,
@@ -1835,6 +2395,18 @@ export function createChannelAgentBinder(
    * queued-send chips key off (#1308 slice 4).
    */
   function markDeadRuntimeIdle(binding: LiveBinding): void {
+    if (binding.activeTurnId !== null) {
+      const activeTurnId = binding.activeTurnId;
+      if (!releaseUnacceptedCompletionCallbackTurn(binding, activeTurnId)) {
+        terminalizeCompletionCallback(
+          binding,
+          activeTurnId,
+          CALLBACK_UNEXPECTED_DISCONNECT
+        );
+      }
+      binding.finalMessageByTurn.delete(activeTurnId);
+      binding.continuationByTurn.delete(activeTurnId);
+    }
     binding.activeTurnId = null;
     binding.activeContent = null;
     binding.activeAttachments = [];
@@ -1849,8 +2421,22 @@ export function createChannelAgentBinder(
     emitAgentStatus(binding);
   }
 
-  function finishTurn(binding: LiveBinding): void {
-    if (binding.activeTurnId === null) return;
+  function finishTurn(
+    binding: LiveBinding,
+    terminalReason: ChannelCompletionCallbackTerminalReason = 'safe-idle'
+  ): void {
+    const terminalTurnId = binding.activeTurnId;
+    if (terminalTurnId === null) return;
+    terminalizeCompletionCallback(binding, terminalTurnId, terminalReason);
+    const callback = binding.completionCallbackByTurn.get(terminalTurnId);
+    if (
+      callback &&
+      store.getCompletionCallback(callback.id)?.state === 'consumed'
+    ) {
+      binding.completionCallbackByTurn.delete(terminalTurnId);
+    }
+    binding.finalMessageByTurn.delete(terminalTurnId);
+    binding.continuationByTurn.delete(terminalTurnId);
     binding.activeTurnId = null;
     binding.activeContent = null;
     binding.activeAttachments = [];
@@ -1935,7 +2521,14 @@ export function createChannelAgentBinder(
           patch.turnId === binding.activeTurnId ||
           completedParentKey === binding.activeTurnId
         ) {
-          finishTurn(binding);
+          finishTurn(
+            binding,
+            patch.status === 'interrupted'
+              ? 'interrupt'
+              : patch.status === 'failed'
+                ? 'error'
+                : 'completed'
+          );
         }
         break;
       }
@@ -1986,7 +2579,7 @@ export function createChannelAgentBinder(
             binding.turnZeroFallbackUnsafe = false;
           }
           if (targetsActiveTurn) {
-            finishTurn(binding);
+            finishTurn(binding, 'error');
           }
         }
         break;
@@ -2044,7 +2637,7 @@ export function createChannelAgentBinder(
         binding.announcedApprovals.size === 0 &&
         binding.waitingOn === null
       ) {
-        finishTurn(binding);
+        finishTurn(binding, 'safe-idle');
       }
       return;
     }
@@ -2134,14 +2727,26 @@ export function createChannelAgentBinder(
     trigger: ChannelMessage,
     profile: AgentProfile,
     steering?: ChannelPostSteering,
-    requiredRole?: 'orchestrator'
+    requiredRole?: 'orchestrator',
+    callbackEdgeRequest?: CallbackEdgeRequest
   ): Promise<void> {
     return (async () => {
+      const releaseDeferredParent = () => {
+        const parentId = callbackEdgeRequest?.continuationParentCallbackId;
+        if (!parentId) return;
+        try {
+          const released = store.releaseDeferredCompletionCallback(parentId);
+          if (released?.state === 'satisfied') drainCompletionCallbacks();
+        } catch (err) {
+          logger.warn('channel completion callback defer release failed:', err);
+        }
+      };
       try {
         const framework = profile.providerId;
         const target = await resolveTarget(framework);
         if (closed) return; // close() raced the availability probe
         if (!target) {
+          releaseDeferredParent();
           // Not a known framework. In a multi-party channel an unroutable
           // @name stays silent (§1). In a DM there is nobody ELSE to answer the
           // HUMAN, so silence reads as the product being broken — say so.
@@ -2169,6 +2774,7 @@ export function createChannelAgentBinder(
         }
         const availability = availabilityForProfile(profile, target);
         if (!availability.available) {
+          releaseDeferredParent();
           const senderDisplayName =
             profile.displayName || target.displayName || framework;
           postUnavailableRow(
@@ -2189,6 +2795,7 @@ export function createChannelAgentBinder(
         } catch (err) {
           if (err instanceof BinderClosedError) return; // shutdown — silent
           if (err instanceof ChannelBindingError) {
+            releaseDeferredParent();
             if (err.unavailable) {
               postUnavailableRow(
                 trigger.channelId,
@@ -2206,9 +2813,31 @@ export function createChannelAgentBinder(
           throw err;
         }
         if (closed) return; // never enqueue/spawn a turn after close()
-        enqueueTurn(binding, trigger, steering);
+        const admitted = enqueueTurn(
+          binding,
+          trigger,
+          steering,
+          false,
+          undefined,
+          callbackEdgeRequest
+        );
+        if (!admitted && callbackEdgeRequest?.continuationParentCallbackId) {
+          const targetTurnId = channelTurnId(
+            trigger.id,
+            binding.profileActorId
+          );
+          // FIFO rejection creates and terminalizes its own child edge. Only a
+          // failure BEFORE durable admission needs to release the announced
+          // parent intent directly.
+          if (
+            !store.getCompletionCallback(completionCallbackEdgeId(targetTurnId))
+          ) {
+            releaseDeferredParent();
+          }
+        }
       } catch (err) {
         if (closed || err instanceof BinderClosedError) return;
+        releaseDeferredParent();
         logger.warn('channel binder route failed:', err);
       }
     })();
@@ -2302,7 +2931,9 @@ export function createChannelAgentBinder(
    */
   function routeWithBrake(
     message: ChannelMessage,
-    profiles: AgentProfile[]
+    profiles: AgentProfile[],
+    callbackSuppressedProfiles = new Set<string>(),
+    prepareContinuation?: () => string | undefined
   ): void {
     if (profiles.length === 0) return;
     const sourceRuntime = message.source?.runtimeId
@@ -2313,8 +2944,24 @@ export function createChannelAgentBinder(
       // participant. It must keep coordinating even after worker traffic trips
       // the brake, and its turns must not consume the worker-turn allowance.
       // Human posts still reset the ordinary brake state below.
+      const continuationParentCallbackId = prepareContinuation?.();
       for (const profile of profiles) {
-        void routeOne(message, profile);
+        void routeOne(
+          message,
+          profile,
+          undefined,
+          undefined,
+          callbackSuppressedProfiles.has(profile.id)
+            ? undefined
+            : requesterProfileForAgentMessage(message) !== null
+              ? {
+                  requesterProfileId: requesterProfileForAgentMessage(message)!,
+                  ...(continuationParentCallbackId
+                    ? { continuationParentCallbackId }
+                    : {}),
+                }
+              : undefined
+        );
       }
       return;
     }
@@ -2343,8 +2990,26 @@ export function createChannelAgentBinder(
       state.allowedTurnKeys.add(turnKey);
       state.count += 1;
     }
+    // This happens only after the one dispatch was admitted by the brake. An
+    // at-cap/paused mention therefore never announces a child intent that no
+    // route can later balance.
+    const continuationParentCallbackId = prepareContinuation?.();
     for (const profile of profiles) {
-      void routeOne(message, profile);
+      const requesterProfileId = requesterProfileForAgentMessage(message);
+      void routeOne(
+        message,
+        profile,
+        undefined,
+        undefined,
+        callbackSuppressedProfiles.has(profile.id) || !requesterProfileId
+          ? undefined
+          : {
+              requesterProfileId,
+              ...(continuationParentCallbackId
+                ? { continuationParentCallbackId }
+                : {}),
+            }
+      );
     }
   }
 
@@ -2499,14 +3164,124 @@ export function createChannelAgentBinder(
     void routeOne(message, recipient.profile, steering, recipient.requiredRole);
   }
 
-  function handleAssistantFinalized(message: ChannelMessage): void {
+  function consumeAncestorExplicitReturn(
+    binding: LiveBinding,
+    sourceTurnId: string,
+    profiles: AgentProfile[],
+    explicitReturnProfiles: Set<string>
+  ): void {
+    // C's callback reaches B on a new B turn, while A→B is still keyed to
+    // B's original delegated turn. An explicit `@A` from that continuation is
+    // a return, not a new B→A delegation.
+    const inherited =
+      binding.continuationByTurn.get(sourceTurnId)?.parentCallbackId;
+    if (!inherited) return;
+    try {
+      const parent = store.getCompletionCallback(inherited);
+      const returnsToAncestor =
+        parent !== null &&
+        profiles.some((profile) => profile.id === parent.requesterProfileId);
+      if (!returnsToAncestor || parent === null) return;
+      const consumed = store.consumeAncestorCompletionCallbackForExplicitReturn(
+        parent.id
+      );
+      if (consumed) explicitReturnProfiles.add(consumed.requesterProfileId);
+    } catch (err) {
+      logger.warn(
+        'channel completion callback ancestor explicit-return consume failed:',
+        err
+      );
+    }
+  }
+
+  function handleAssistantFinalized(
+    binding: LiveBinding,
+    message: ChannelMessage
+  ): void {
     if (closed) return;
+    const sourceTurnId = message.source?.turnId;
+    if (sourceTurnId) binding.finalMessageByTurn.set(sourceTurnId, message);
     const mentions = parseMentions(
       message.body.text,
       deps.knownProviderIds,
       deps.agentProfileStore?.list()
     );
-    routeWithBrake(message, eligibleProfiles(message, mentions));
+    const profiles = eligibleProfiles(message, mentions);
+    const explicitReturnProfiles = new Set<string>();
+    if (sourceTurnId && profiles.length > 0) {
+      try {
+        const consumed = store.consumeCompletionCallbacksForExplicitReturn({
+          channelId: message.channelId,
+          targetProfileId: binding.profileActorId,
+          targetTurnId: sourceTurnId,
+          requesterProfileIds: profiles.map((profile) => profile.id),
+        });
+        for (const edge of consumed) {
+          explicitReturnProfiles.add(edge.requesterProfileId);
+        }
+      } catch (err) {
+        logger.warn(
+          'channel completion callback explicit-return consume failed:',
+          err
+        );
+      }
+    }
+    if (sourceTurnId && profiles.length > 0) {
+      consumeAncestorExplicitReturn(
+        binding,
+        sourceTurnId,
+        profiles,
+        explicitReturnProfiles
+      );
+    }
+    const delegatedProfiles = profiles.filter(
+      (profile) => !explicitReturnProfiles.has(profile.id)
+    );
+    const prepareContinuation =
+      sourceTurnId && delegatedProfiles.length > 0
+        ? (): string | undefined => {
+            try {
+              // A continuation callback keeps its original ancestor open; a
+              // normal delegated turn discovers that ancestor by target turn.
+              const inherited =
+                binding.continuationByTurn.get(sourceTurnId)?.parentCallbackId;
+              const parent = inherited
+                ? store.announceContinuationChildren(
+                    inherited,
+                    delegatedProfiles.length
+                  )
+                : store.deferCompletionCallbackForChild({
+                    channelId: message.channelId,
+                    targetProfileId: binding.profileActorId,
+                    targetTurnId: sourceTurnId,
+                    expectedChildCount: delegatedProfiles.length,
+                  });
+              return parent?.state === 'pending' ? parent.id : undefined;
+            } catch (err) {
+              logger.warn(
+                'channel completion callback continuation defer failed:',
+                err
+              );
+              return undefined;
+            }
+          }
+        : undefined;
+    routeWithBrake(
+      message,
+      profiles,
+      explicitReturnProfiles,
+      prepareContinuation
+    );
+  }
+
+  async function recoverCompletionCallbacks(): Promise<void> {
+    if (closed) return;
+    try {
+      store.recoverCompletionCallbacks();
+      drainCompletionCallbacks();
+    } catch (err) {
+      logger.warn('channel completion callback recovery failed:', err);
+    }
   }
 
   // ── runtime death ───────────────────────────────────────────────────────────
@@ -2520,6 +3295,18 @@ export function createChannelAgentBinder(
    * disarmed while `waitingOn !== null` and unarmed once a turn is over).
    */
   function releaseBinding(key: string, binding: LiveBinding): void {
+    if (binding.activeTurnId !== null) {
+      const activeTurnId = binding.activeTurnId;
+      if (!releaseUnacceptedCompletionCallbackTurn(binding, activeTurnId)) {
+        terminalizeCompletionCallback(
+          binding,
+          activeTurnId,
+          CALLBACK_UNEXPECTED_DISCONNECT
+        );
+      }
+      binding.finalMessageByTurn.delete(activeTurnId);
+      binding.continuationByTurn.delete(activeTurnId);
+    }
     binding.unbind?.(); // bridge finalizes any open stream 'interrupted'
     binding.patchUnlisten?.();
     disarmWatchdog(binding);
@@ -2531,6 +3318,10 @@ export function createChannelAgentBinder(
     binding.patchUnlisten = null;
     binding.activeTurnId = null;
     binding.parentMessageIdByTurn.clear();
+    binding.finalMessageByTurn.clear();
+    binding.continuationByTurn.clear();
+    binding.completionCallbackByTurn.clear();
+    binding.deferredCompletionTerminalByTurn.clear();
     binding.activeContent = null;
     binding.activeAttachments = [];
     binding.waitingOn = null;
@@ -3007,6 +3798,7 @@ export function createChannelAgentBinder(
     rosterForChannel,
     executeCommand,
     isControlMessage,
+    recoverCompletionCallbacks,
     setStatusBroadcaster(broadcaster) {
       statusBroadcaster = broadcaster;
     },
@@ -3019,6 +3811,10 @@ export function createChannelAgentBinder(
         binding.unbind?.();
         binding.patchUnlisten?.();
         binding.parentMessageIdByTurn.clear();
+        binding.finalMessageByTurn.clear();
+        binding.continuationByTurn.clear();
+        binding.completionCallbackByTurn.clear();
+        binding.deferredCompletionTerminalByTurn.clear();
         // Terminal presence on shutdown (#1307). The socket carries transitions
         // only, so a binding torn down mid-turn would leave every attached
         // client pinned at thinking/streaming/waiting until something else made

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -59,7 +59,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 8;
+const SCHEMA_VERSION = 12;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -776,6 +776,45 @@ CREATE TABLE IF NOT EXISTS channel_agent_bindings (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chab_sole_orchestrator
   ON channel_agent_bindings(channel_id)
   WHERE binding_role = 'orchestrator';
+
+CREATE TABLE IF NOT EXISTS channel_completion_callbacks (
+  id                    TEXT PRIMARY KEY,
+  channel_id            TEXT NOT NULL,
+  thread_id             TEXT,
+  trigger_message_id    TEXT NOT NULL,
+  requester_profile_id  TEXT NOT NULL,
+  target_profile_id     TEXT NOT NULL,
+  target_runtime_id     TEXT NOT NULL,
+  target_turn_id        TEXT NOT NULL,
+  -- A child delegation may continue an already-open ancestor edge. This is
+  -- relation data, deliberately separate from the one-shot edge lifecycle.
+  continuation_parent_callback_id TEXT,
+  awaiting_child        INTEGER NOT NULL DEFAULT 0 CHECK (awaiting_child IN (0, 1)),
+  pending_child_intents INTEGER NOT NULL DEFAULT 0,
+  continuation_completed_at TEXT,
+  state                 TEXT NOT NULL
+                          CHECK (state IN ('pending','satisfied','delivered','consumed')),
+  terminal_reason       TEXT,
+  terminal_message_id   TEXT,
+  message_disposition   TEXT,
+  created_at            TEXT NOT NULL,
+  satisfied_at          TEXT,
+  delivered_at          TEXT,
+  consumed_at           TEXT,
+  updated_at            TEXT NOT NULL,
+  UNIQUE(channel_id, target_profile_id, target_turn_id)
+);
+CREATE INDEX IF NOT EXISTS idx_chcc_recovery
+  ON channel_completion_callbacks(state, created_at)
+  WHERE state IN ('pending','satisfied','delivered');
+CREATE INDEX IF NOT EXISTS idx_chcc_target_turn
+ON channel_completion_callbacks(channel_id, target_profile_id, target_turn_id);
+CREATE INDEX IF NOT EXISTS idx_chcc_continuation_parent
+ON channel_completion_callbacks(continuation_parent_callback_id)
+WHERE continuation_parent_callback_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_chcc_consumed_retention
+ON channel_completion_callbacks(consumed_at)
+WHERE state = 'consumed';
 `;
 
 interface ChannelMessageRow {
@@ -861,6 +900,30 @@ interface BindingRow {
   binding_role: AgentRole | null;
   provider_session_json: string;
   created_at: string;
+  updated_at: string;
+}
+
+interface CompletionCallbackRow {
+  id: string;
+  channel_id: string;
+  thread_id: string | null;
+  trigger_message_id: string;
+  requester_profile_id: string;
+  target_profile_id: string;
+  target_runtime_id: string;
+  target_turn_id: string;
+  continuation_parent_callback_id: string | null;
+  awaiting_child: number;
+  pending_child_intents: number;
+  continuation_completed_at: string | null;
+  state: ChannelCompletionCallbackState;
+  terminal_reason: ChannelCompletionCallbackTerminalReason | null;
+  terminal_message_id: string | null;
+  message_disposition: ChannelCompletionCallbackMessageDisposition | null;
+  created_at: string;
+  satisfied_at: string | null;
+  delivered_at: string | null;
+  consumed_at: string | null;
   updated_at: string;
 }
 
@@ -1078,6 +1141,93 @@ export interface ChannelBinding {
   providerSession: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
+}
+
+/** Durable one-shot state for an upward delegation-completion callback. */
+export type ChannelCompletionCallbackState =
+  | 'pending'
+  | 'satisfied'
+  | 'delivered'
+  | 'consumed';
+
+/** Guarded terminal event that satisfied a delegated routed turn. */
+export type ChannelCompletionCallbackTerminalReason =
+  | 'completed'
+  | 'error'
+  | 'interrupt'
+  | 'unexpected-disconnect'
+  | 'safe-idle'
+  | 'watchdog';
+
+/** Whether Relay could bind the callback to a terminal assistant message. */
+export type ChannelCompletionCallbackMessageDisposition =
+  | 'final-message'
+  | 'no-terminal-message';
+
+/** Keep settled edge identities long enough for late provider patches to no-op. */
+const COMPLETION_CALLBACK_CONSUMED_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+
+/**
+ * A durable callback edge is Relay-internal routing state, not a chat row.
+ * Its unique target turn makes duplicate and late provider terminal patches a
+ * no-op at the persistence boundary.
+ */
+export interface ChannelCompletionCallbackEdge {
+  id: string;
+  channelId: string;
+  threadId: string | null;
+  triggerMessageId: string;
+  requesterProfileId: string;
+  targetProfileId: string;
+  targetRuntimeId: string;
+  targetTurnId: string;
+  /** Ancestor edge satisfied only after this callback-triggered turn ends. */
+  continuationParentCallbackId: string | null;
+  /** A delegatee explicitly delegated further before its own return. */
+  awaitingChild: boolean;
+  /** Child routes announced by this turn that have not resolved yet. */
+  pendingChildIntents: number;
+  /** The callback recipient completed its upward continuation once. */
+  continuationCompletedAt: string | null;
+  state: ChannelCompletionCallbackState;
+  terminalReason: ChannelCompletionCallbackTerminalReason | null;
+  terminalMessageId: string | null;
+  messageDisposition: ChannelCompletionCallbackMessageDisposition | null;
+  createdAt: string;
+  satisfiedAt: string | null;
+  deliveredAt: string | null;
+  consumedAt: string | null;
+  updatedAt: string;
+}
+
+export interface CreateChannelCompletionCallbackInput {
+  /** Deterministic identity supplied by the binder for one routed target turn. */
+  id: string;
+  channelId: string;
+  threadId: string | null;
+  triggerMessageId: string;
+  requesterProfileId: string;
+  targetProfileId: string;
+  targetRuntimeId: string;
+  targetTurnId: string;
+  /** The still-pending ancestor edge this child completes into, if any. */
+  continuationParentCallbackId?: string | null;
+}
+
+export interface SatisfyChannelCompletionCallbackInput {
+  channelId: string;
+  targetProfileId: string;
+  targetTurnId: string;
+  terminalReason: ChannelCompletionCallbackTerminalReason;
+  terminalMessageId?: string | null;
+  messageDisposition: ChannelCompletionCallbackMessageDisposition;
+}
+
+export interface CompleteChildContinuationInput {
+  callbackId: string;
+  terminalReason: ChannelCompletionCallbackTerminalReason;
+  terminalMessageId?: string | null;
+  messageDisposition: ChannelCompletionCallbackMessageDisposition;
 }
 
 export interface SoleOrchestratorDesignationInput {
@@ -1317,6 +1467,82 @@ export interface ChannelMessageStore {
     role?: Exclude<AgentRole, 'orchestrator'> | null;
     providerSession?: Record<string, unknown>;
   }): ChannelBinding;
+  /** Idempotently records a downward delegation once its routed target turn exists. */
+  createCompletionCallback(
+    input: CreateChannelCompletionCallbackInput
+  ): ChannelCompletionCallbackEdge;
+  /** CAS: only the first guarded terminal event may satisfy a pending edge. */
+  satisfyCompletionCallback(
+    input: SatisfyChannelCompletionCallbackInput
+  ): ChannelCompletionCallbackEdge | null;
+  /**
+   * Marks an incoming edge as waiting for a child delegation. Its original
+   * target turn may terminalize, but the callback remains pending until the
+   * child callback re-enters the delegatee and that continuation terminalizes.
+   */
+  deferCompletionCallbackForChild(input: {
+    channelId: string;
+    targetProfileId: string;
+    targetTurnId: string;
+    expectedChildCount: number;
+  }): ChannelCompletionCallbackEdge | null;
+  /** Adds child route intents while an existing callback continuation delegates again. */
+  announceContinuationChildren(
+    callbackId: string,
+    expectedChildCount: number
+  ): ChannelCompletionCallbackEdge | null;
+  /**
+   * CASes one consumed child callback's recipient continuation, then satisfies
+   * its parent only after every persisted child continuation has terminalized.
+   */
+  completeChildContinuation(
+    input: CompleteChildContinuationInput
+  ): ChannelCompletionCallbackEdge | null;
+  /**
+   * If a downstream route could not be created, releases the durable defer so
+   * the already-recorded terminal result can still return upward.
+   */
+  releaseDeferredCompletionCallback(
+    id: string
+  ): ChannelCompletionCallbackEdge | null;
+  getCompletionCallback(id: string): ChannelCompletionCallbackEdge | null;
+  /**
+   * CAS: claims satisfied work for one live binder. A delivered row is still
+   * recovery-visible until the internal callback trigger starts its recipient
+   * turn and consumes it.
+   */
+  claimSatisfiedCompletionCallbacks(
+    limit?: number
+  ): ChannelCompletionCallbackEdge[];
+  /** Return an undeliverable in-memory claim to durable retryable work. */
+  releaseDeliveredCompletionCallback(id: string): boolean;
+  /** CAS: records that the one typed internal trigger has begun its recipient turn. */
+  consumeCompletionCallback(id: string): boolean;
+  /**
+   * A delegatee's explicit final return consumes its own pending edge before
+   * the normal mention path routes that one return upward.
+   */
+  consumeCompletionCallbacksForExplicitReturn(input: {
+    channelId: string;
+    targetProfileId: string;
+    targetTurnId: string;
+    requesterProfileIds: readonly string[];
+  }): ChannelCompletionCallbackEdge[];
+  /**
+   * An ancestor-directed explicit return may arrive on a callback continuation
+   * turn whose id differs from the ancestor's original delegated target turn.
+   */
+  consumeAncestorCompletionCallbackForExplicitReturn(
+    id: string
+  ): ChannelCompletionCallbackEdge | null;
+  /**
+   * Restart recovery never promotes raw idle. It re-offers volatile delivered
+   * work and terminalizes orphaned pending routed turns as disconnects, using
+   * durable terminal message evidence where it exists.
+   */
+  recoverCompletionCallbacks(): ChannelCompletionCallbackEdge[];
+  /** Bounded retention for settled callback idempotency history. */
+  pruneConsumedCompletionCallbacks(olderThanMs?: number): number;
   sweepStaleStreaming(): StaleStreamSweepResult[];
   sweepOrphans(persistedTopicIds: Set<string>): {
     channelsDeleted: string[];
@@ -2454,6 +2680,107 @@ function runSchemaMigrations(db: Database.Database): void {
       db.prepare('UPDATE schema_version SET version = 8').run();
     })();
   }
+  if (current < 9) {
+    db.transaction(() => {
+      // Completion callbacks are an outbox-like one-shot ledger. It is a
+      // separate table rather than message meta because an edge has its own
+      // guarded lifecycle and must survive a hub restart even when the target
+      // produced no terminal chat row.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS channel_completion_callbacks (
+          id                    TEXT PRIMARY KEY,
+          channel_id            TEXT NOT NULL,
+          thread_id             TEXT,
+          trigger_message_id    TEXT NOT NULL,
+          requester_profile_id  TEXT NOT NULL,
+          target_profile_id     TEXT NOT NULL,
+          target_runtime_id     TEXT NOT NULL,
+          target_turn_id        TEXT NOT NULL,
+          state                 TEXT NOT NULL
+                                  CHECK (state IN ('pending','satisfied','delivered','consumed')),
+          terminal_reason       TEXT,
+          terminal_message_id   TEXT,
+          message_disposition   TEXT,
+          created_at            TEXT NOT NULL,
+          satisfied_at          TEXT,
+          delivered_at          TEXT,
+          consumed_at           TEXT,
+          updated_at            TEXT NOT NULL,
+          UNIQUE(channel_id, target_profile_id, target_turn_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_chcc_recovery
+          ON channel_completion_callbacks(state, created_at)
+          WHERE state IN ('pending','satisfied','delivered');
+        CREATE INDEX IF NOT EXISTS idx_chcc_target_turn
+          ON channel_completion_callbacks(channel_id, target_profile_id, target_turn_id);
+      `);
+      db.prepare('UPDATE schema_version SET version = 9').run();
+    })();
+  }
+  if (current < 10) {
+    db.transaction(() => {
+      // Preserve the one-shot state machine while making ancestry durable.
+      // These columns allow A→B→C to return C→B→A without turning B's
+      // original terminal patch into a premature callback to A.
+      const columns = db
+        .prepare(`PRAGMA table_info(channel_completion_callbacks)`)
+        .all() as Array<{
+        name: string;
+      }>;
+      if (
+        !columns.some(
+          (column) => column.name === 'continuation_parent_callback_id'
+        )
+      ) {
+        db.exec(
+          'ALTER TABLE channel_completion_callbacks ADD COLUMN continuation_parent_callback_id TEXT'
+        );
+      }
+      if (!columns.some((column) => column.name === 'awaiting_child')) {
+        db.exec(
+          'ALTER TABLE channel_completion_callbacks ADD COLUMN awaiting_child INTEGER NOT NULL DEFAULT 0'
+        );
+      }
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_chcc_continuation_parent
+          ON channel_completion_callbacks(continuation_parent_callback_id)
+          WHERE continuation_parent_callback_id IS NOT NULL;
+      `);
+      db.prepare('UPDATE schema_version SET version = 10').run();
+    })();
+  }
+  if (current < 11) {
+    db.transaction(() => {
+      const columns = db
+        .prepare(`PRAGMA table_info(channel_completion_callbacks)`)
+        .all() as Array<{
+        name: string;
+      }>;
+      if (!columns.some((column) => column.name === 'pending_child_intents')) {
+        db.exec(
+          'ALTER TABLE channel_completion_callbacks ADD COLUMN pending_child_intents INTEGER NOT NULL DEFAULT 0'
+        );
+      }
+      if (
+        !columns.some((column) => column.name === 'continuation_completed_at')
+      ) {
+        db.exec(
+          'ALTER TABLE channel_completion_callbacks ADD COLUMN continuation_completed_at TEXT'
+        );
+      }
+      db.prepare('UPDATE schema_version SET version = 11').run();
+    })();
+  }
+  if (current < 12) {
+    db.transaction(() => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_chcc_consumed_retention
+          ON channel_completion_callbacks(consumed_at)
+          WHERE state = 'consumed';
+      `);
+      db.prepare('UPDATE schema_version SET version = 12').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
@@ -2794,6 +3121,22 @@ export function createChannelMessageStore(
   );
   // Compiled once: `GET /channels` runs this per channel per list fetch.
   const threadSummaryStmt = db.prepare(buildChannelThreadSummarySql());
+  const selectCompletionCallbackById = db.prepare(
+    'SELECT * FROM channel_completion_callbacks WHERE id = ?'
+  );
+  const selectTerminalCallbackMessage = db.prepare(
+    `SELECT id, status
+       FROM channel_messages
+      WHERE channel_id = @channelId
+        AND sender_kind = 'agent'
+        AND sender_id = @targetProfileId
+        AND source_runtime_id = @targetRuntimeId
+        AND source_turn_id = @targetTurnId
+        AND kind = 'message'
+        AND json_extract(meta_json, '$.agentDetail') IS NULL
+        AND status <> 'streaming'
+      ORDER BY seq DESC LIMIT 1`
+  );
 
   function memberRowToRef(row: MemberRow): ChannelMemberRef {
     return {
@@ -2920,6 +3263,506 @@ export function createChannelMessageStore(
     });
     return getBindingImpl(input.channelId, input.profileActorId)!;
   }
+
+  const createCompletionCallbackImpl = db.transaction(
+    (
+      input: CreateChannelCompletionCallbackInput
+    ): ChannelCompletionCallbackEdge => {
+      const timestamp = nowIso();
+      const continuationParentCallbackId =
+        input.continuationParentCallbackId ?? null;
+      if (continuationParentCallbackId) {
+        const parent = selectCompletionCallbackById.get(
+          continuationParentCallbackId
+        ) as CompletionCallbackRow | undefined;
+        // A child may only consume an intent announced by the callback turn it
+        // is returning to. Rejecting a corrupt/replayed relation rolls back the
+        // whole operation, including the child insert and parent's intent.
+        if (
+          !parent ||
+          parent.channel_id !== input.channelId ||
+          parent.target_profile_id !== input.requesterProfileId ||
+          parent.state !== 'pending' ||
+          parent.awaiting_child !== 1 ||
+          parent.pending_child_intents < 1
+        ) {
+          throw new Error('completion callback continuation parent is invalid');
+        }
+      }
+      const findTarget = db.prepare(
+        `SELECT * FROM channel_completion_callbacks
+          WHERE channel_id = ? AND target_profile_id = ? AND target_turn_id = ?`
+      );
+      const existing = findTarget.get(
+        input.channelId,
+        input.targetProfileId,
+        input.targetTurnId
+      ) as CompletionCallbackRow | undefined;
+      if (existing) {
+        // Retrying a durable admission is safe; repointing one target turn at a
+        // different ancestor is corruption and must not silently steal an intent.
+        if (
+          existing.requester_profile_id !== input.requesterProfileId ||
+          existing.continuation_parent_callback_id !==
+            continuationParentCallbackId
+        ) {
+          throw new Error(
+            'completion callback target turn conflicts with relation'
+          );
+        }
+        return completionCallbackRowToRecord(existing);
+      }
+      const inserted = db
+        .prepare(
+          `INSERT INTO channel_completion_callbacks
+           (id, channel_id, thread_id, trigger_message_id, requester_profile_id,
+            target_profile_id, target_runtime_id, target_turn_id,
+            continuation_parent_callback_id, state,
+            created_at, updated_at)
+         VALUES
+           (@id, @channelId, @threadId, @triggerMessageId, @requesterProfileId,
+            @targetProfileId, @targetRuntimeId, @targetTurnId,
+            @continuationParentCallbackId, 'pending',
+            @createdAt, @updatedAt)`
+        )
+        .run({
+          ...input,
+          continuationParentCallbackId,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
+      if (inserted.changes !== 1) {
+        throw new Error('completion callback insert did not persist');
+      }
+      if (continuationParentCallbackId) {
+        // Insert and decrement are deliberately one transaction: a crash or
+        // malformed relation can never leave a child without its matching intent.
+        const decremented = db
+          .prepare(
+            `UPDATE channel_completion_callbacks
+              SET pending_child_intents = pending_child_intents - 1,
+                  updated_at = ?
+            WHERE id = ? AND state = 'pending' AND awaiting_child = 1
+              AND pending_child_intents > 0`
+          )
+          .run(timestamp, continuationParentCallbackId);
+        if (decremented.changes !== 1) {
+          throw new Error(
+            'completion callback continuation intent disappeared'
+          );
+        }
+      }
+      const row = selectCompletionCallbackById.get(input.id) as
+        | CompletionCallbackRow
+        | undefined;
+      if (!row) throw new Error('completion callback insert did not persist');
+      return completionCallbackRowToRecord(row);
+    }
+  );
+
+  function satisfyCompletionCallbackImpl(
+    input: SatisfyChannelCompletionCallbackInput
+  ): ChannelCompletionCallbackEdge | null {
+    const timestamp = nowIso();
+    const result = db
+      .prepare(
+        `UPDATE channel_completion_callbacks
+            SET state = 'satisfied', terminal_reason = @terminalReason,
+                terminal_message_id = @terminalMessageId,
+                message_disposition = @messageDisposition,
+                satisfied_at = @timestamp, updated_at = @timestamp
+          WHERE channel_id = @channelId
+            AND target_profile_id = @targetProfileId
+            AND target_turn_id = @targetTurnId
+            AND state = 'pending' AND awaiting_child = 0`
+      )
+      .run({
+        ...input,
+        terminalMessageId: input.terminalMessageId ?? null,
+        timestamp,
+      });
+    if (result.changes === 0) {
+      // A parent that delegated further still records the terminal evidence of
+      // its original turn. `releaseDeferred...` can use it if the child never
+      // becomes routable; a real continuation overwrites it atomically later.
+      db.prepare(
+        `UPDATE channel_completion_callbacks
+            SET terminal_reason = @terminalReason,
+                terminal_message_id = @terminalMessageId,
+                message_disposition = @messageDisposition,
+                updated_at = @timestamp
+          WHERE channel_id = @channelId
+            AND target_profile_id = @targetProfileId
+            AND target_turn_id = @targetTurnId
+            AND state = 'pending' AND awaiting_child = 1`
+      ).run({
+        ...input,
+        terminalMessageId: input.terminalMessageId ?? null,
+        timestamp,
+      });
+      return null;
+    }
+    const row = db
+      .prepare(
+        `SELECT * FROM channel_completion_callbacks
+          WHERE channel_id = ? AND target_profile_id = ? AND target_turn_id = ?`
+      )
+      .get(input.channelId, input.targetProfileId, input.targetTurnId) as
+      | CompletionCallbackRow
+      | undefined;
+    return row ? completionCallbackRowToRecord(row) : null;
+  }
+
+  function deferCompletionCallbackForChildImpl(input: {
+    channelId: string;
+    targetProfileId: string;
+    targetTurnId: string;
+    expectedChildCount: number;
+  }): ChannelCompletionCallbackEdge | null {
+    const timestamp = nowIso();
+    const result = db
+      .prepare(
+        `UPDATE channel_completion_callbacks
+            SET awaiting_child = 1,
+                pending_child_intents = pending_child_intents + @expectedChildCount,
+                updated_at = @timestamp
+          WHERE channel_id = @channelId
+            AND target_profile_id = @targetProfileId
+            AND target_turn_id = @targetTurnId
+            AND state = 'pending'`
+      )
+      .run({ ...input, timestamp });
+    if (result.changes === 0) return null;
+    const row = db
+      .prepare(
+        `SELECT * FROM channel_completion_callbacks
+          WHERE channel_id = ? AND target_profile_id = ? AND target_turn_id = ?`
+      )
+      .get(input.channelId, input.targetProfileId, input.targetTurnId) as
+      | CompletionCallbackRow
+      | undefined;
+    return row ? completionCallbackRowToRecord(row) : null;
+  }
+
+  function announceContinuationChildrenImpl(
+    callbackId: string,
+    expectedChildCount: number
+  ): ChannelCompletionCallbackEdge | null {
+    if (expectedChildCount < 1) return null;
+    const timestamp = nowIso();
+    const result = db
+      .prepare(
+        `UPDATE channel_completion_callbacks
+            SET awaiting_child = 1,
+                pending_child_intents = pending_child_intents + ?,
+                updated_at = ?
+          WHERE id = ? AND state = 'pending'`
+      )
+      .run(expectedChildCount, timestamp, callbackId);
+    if (result.changes === 0) return null;
+    const row = selectCompletionCallbackById.get(callbackId) as
+      | CompletionCallbackRow
+      | undefined;
+    return row ? completionCallbackRowToRecord(row) : null;
+  }
+
+  const completeChildContinuationImpl = db.transaction(
+    (
+      input: CompleteChildContinuationInput
+    ): ChannelCompletionCallbackEdge | null => {
+      const timestamp = nowIso();
+      const child = selectCompletionCallbackById.get(input.callbackId) as
+        | CompletionCallbackRow
+        | undefined;
+      if (
+        !child ||
+        child.state !== 'consumed' ||
+        !child.continuation_parent_callback_id ||
+        child.continuation_completed_at !== null
+      ) {
+        return null;
+      }
+      const marked = db
+        .prepare(
+          `UPDATE channel_completion_callbacks
+              SET continuation_completed_at = ?, updated_at = ?
+            WHERE id = ? AND state = 'consumed'
+              AND continuation_completed_at IS NULL`
+        )
+        .run(timestamp, timestamp, input.callbackId);
+      if (marked.changes === 0) return null;
+      const remaining = db
+        .prepare(
+          `SELECT COUNT(*) AS count
+             FROM channel_completion_callbacks
+            WHERE continuation_parent_callback_id = ?
+              AND continuation_completed_at IS NULL`
+        )
+        .get(child.continuation_parent_callback_id) as { count: number };
+      if (remaining.count > 0) return null;
+      const parentUpdate = db
+        .prepare(
+          `UPDATE channel_completion_callbacks
+              SET state = 'satisfied', awaiting_child = 0,
+                  terminal_reason = @terminalReason,
+                  terminal_message_id = @terminalMessageId,
+                  message_disposition = @messageDisposition,
+                  satisfied_at = @timestamp, updated_at = @timestamp
+            WHERE id = @callbackId AND state = 'pending' AND awaiting_child = 1
+              AND pending_child_intents = 0`
+        )
+        .run({
+          callbackId: child.continuation_parent_callback_id,
+          terminalReason: input.terminalReason,
+          terminalMessageId: input.terminalMessageId ?? null,
+          messageDisposition: input.messageDisposition,
+          timestamp,
+        });
+      if (parentUpdate.changes === 0) return null;
+      const parent = selectCompletionCallbackById.get(
+        child.continuation_parent_callback_id
+      ) as CompletionCallbackRow | undefined;
+      return parent ? completionCallbackRowToRecord(parent) : null;
+    }
+  );
+
+  function releaseDeferredCompletionCallbackImpl(
+    id: string
+  ): ChannelCompletionCallbackEdge | null {
+    const timestamp = nowIso();
+    // One route target vanished after the parent announced a fan-out. Decrement
+    // only its own durable intent; any sibling child still keeps the parent
+    // pending. Once every route failed, use the original terminal evidence.
+    db.prepare(
+      `UPDATE channel_completion_callbacks
+          SET pending_child_intents = MAX(0, pending_child_intents - 1),
+              updated_at = ?
+        WHERE id = ? AND state = 'pending' AND awaiting_child = 1`
+    ).run(timestamp, id);
+    const result = db
+      .prepare(
+        `UPDATE channel_completion_callbacks
+            SET awaiting_child = 0,
+                state = CASE WHEN terminal_reason IS NULL THEN 'pending' ELSE 'satisfied' END,
+                satisfied_at = CASE WHEN terminal_reason IS NULL THEN satisfied_at ELSE @timestamp END,
+                updated_at = @timestamp
+          WHERE id = @id AND state = 'pending' AND awaiting_child = 1
+            AND pending_child_intents = 0
+            AND NOT EXISTS (
+              SELECT 1 FROM channel_completion_callbacks child
+               WHERE child.continuation_parent_callback_id = @id
+            )`
+      )
+      .run({ id, timestamp });
+    if (result.changes === 0) return null;
+    const row = selectCompletionCallbackById.get(id) as
+      | CompletionCallbackRow
+      | undefined;
+    return row ? completionCallbackRowToRecord(row) : null;
+  }
+
+  const claimSatisfiedCompletionCallbacksImpl = db.transaction(
+    (limit: number): ChannelCompletionCallbackEdge[] => {
+      const candidates = db
+        .prepare(
+          `SELECT * FROM channel_completion_callbacks
+            WHERE state = 'satisfied'
+            ORDER BY satisfied_at ASC, created_at ASC, id ASC
+            LIMIT ?`
+        )
+        .all(limit) as CompletionCallbackRow[];
+      const claim = db.prepare(
+        `UPDATE channel_completion_callbacks
+            SET state = 'delivered', delivered_at = ?, updated_at = ?
+          WHERE id = ? AND state = 'satisfied'`
+      );
+      const timestamp = nowIso();
+      const claimed: ChannelCompletionCallbackEdge[] = [];
+      for (const candidate of candidates) {
+        if (claim.run(timestamp, timestamp, candidate.id).changes === 0) {
+          continue;
+        }
+        const row = selectCompletionCallbackById.get(candidate.id) as
+          | CompletionCallbackRow
+          | undefined;
+        if (row) claimed.push(completionCallbackRowToRecord(row));
+      }
+      return claimed;
+    }
+  );
+
+  function releaseDeliveredCompletionCallbackImpl(id: string): boolean {
+    const timestamp = nowIso();
+    return (
+      db
+        .prepare(
+          `UPDATE channel_completion_callbacks
+              SET state = 'satisfied', delivered_at = NULL, updated_at = ?
+            WHERE id = ? AND state = 'delivered'`
+        )
+        .run(timestamp, id).changes === 1
+    );
+  }
+
+  const pruneConsumedCompletionCallbacksImpl = db.transaction(
+    (olderThanMs: number): number => {
+      const cutoff = new Date(Date.now() - olderThanMs).toISOString();
+      // Do not sever ancestry while a child is still incomplete, or while this
+      // row itself is a child of an unresolved parent. Settled subtrees prune
+      // together only after the retention window preserves late-patch no-ops.
+      return db
+        .prepare(
+          `DELETE FROM channel_completion_callbacks AS settled
+            WHERE settled.state = 'consumed'
+              AND settled.consumed_at IS NOT NULL
+              AND settled.consumed_at < @cutoff
+              AND NOT EXISTS (
+                SELECT 1 FROM channel_completion_callbacks child
+                 WHERE child.continuation_parent_callback_id = settled.id
+                   AND (child.state <> 'consumed'
+                        OR child.continuation_completed_at IS NULL)
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM channel_completion_callbacks parent
+                 WHERE parent.id = settled.continuation_parent_callback_id
+                   AND parent.state <> 'consumed'
+              )`
+        )
+        .run({ cutoff }).changes;
+    }
+  );
+
+  const consumeCompletionCallbacksForExplicitReturnImpl = db.transaction(
+    (input: {
+      channelId: string;
+      targetProfileId: string;
+      targetTurnId: string;
+      requesterProfileIds: readonly string[];
+    }): ChannelCompletionCallbackEdge[] => {
+      if (input.requesterProfileIds.length === 0) return [];
+      const marks = input.requesterProfileIds.map(() => '?').join(', ');
+      const candidates = db
+        .prepare(
+          `SELECT * FROM channel_completion_callbacks
+            WHERE channel_id = ? AND target_profile_id = ? AND target_turn_id = ?
+              AND requester_profile_id IN (${marks})
+              AND state IN ('pending','satisfied','delivered')`
+        )
+        .all(
+          input.channelId,
+          input.targetProfileId,
+          input.targetTurnId,
+          ...input.requesterProfileIds
+        ) as CompletionCallbackRow[];
+      const consume = db.prepare(
+        `UPDATE channel_completion_callbacks
+            SET state = 'consumed', consumed_at = ?, updated_at = ?
+          WHERE id = ? AND state IN ('pending','satisfied','delivered')`
+      );
+      const timestamp = nowIso();
+      const consumed: ChannelCompletionCallbackEdge[] = [];
+      for (const candidate of candidates) {
+        if (consume.run(timestamp, timestamp, candidate.id).changes === 0) {
+          continue;
+        }
+        const row = selectCompletionCallbackById.get(candidate.id) as
+          | CompletionCallbackRow
+          | undefined;
+        if (row) consumed.push(completionCallbackRowToRecord(row));
+      }
+      return consumed;
+    }
+  );
+
+  function consumeAncestorCompletionCallbackForExplicitReturnImpl(
+    id: string
+  ): ChannelCompletionCallbackEdge | null {
+    const timestamp = nowIso();
+    const result = db
+      .prepare(
+        `UPDATE channel_completion_callbacks
+            SET state = 'consumed', consumed_at = ?, updated_at = ?
+          WHERE id = ? AND state IN ('pending','satisfied','delivered')`
+      )
+      .run(timestamp, timestamp, id);
+    if (result.changes === 0) return null;
+    const row = selectCompletionCallbackById.get(id) as
+      | CompletionCallbackRow
+      | undefined;
+    return row ? completionCallbackRowToRecord(row) : null;
+  }
+
+  const recoverCompletionCallbacksImpl = db.transaction(
+    (): ChannelCompletionCallbackEdge[] => {
+      const timestamp = nowIso();
+      // `delivered` means a callback was in the in-memory FIFO. The process
+      // restart discarded that FIFO, so re-offer it; `consumed` is intentionally
+      // never reopened because its recipient turn had already started.
+      db.prepare(
+        `UPDATE channel_completion_callbacks
+            SET state = 'satisfied', delivered_at = NULL, updated_at = ?
+          WHERE state = 'delivered'`
+      ).run(timestamp);
+      // A restart between marking B's parent edge and creating C's target turn
+      // leaves no child relationship. That is not a live delegation, so release
+      // the defer and let B's persisted terminal evidence recover normally.
+      db.prepare(
+        `UPDATE channel_completion_callbacks
+            SET awaiting_child = 0, pending_child_intents = 0, updated_at = ?
+          WHERE state = 'pending' AND awaiting_child = 1
+            AND NOT EXISTS (
+              SELECT 1 FROM channel_completion_callbacks child
+               WHERE child.continuation_parent_callback_id = channel_completion_callbacks.id
+            )`
+      ).run(timestamp);
+      const pending = db
+        .prepare(
+          `SELECT * FROM channel_completion_callbacks
+            WHERE state = 'pending' AND awaiting_child = 0
+            ORDER BY created_at ASC, id ASC`
+        )
+        .all() as CompletionCallbackRow[];
+      for (const edge of pending) {
+        const message = selectTerminalCallbackMessage.get({
+          channelId: edge.channel_id,
+          targetProfileId: edge.target_profile_id,
+          targetRuntimeId: edge.target_runtime_id,
+          targetTurnId: edge.target_turn_id,
+        }) as { id: string; status: string } | undefined;
+        const terminalReason: ChannelCompletionCallbackTerminalReason =
+          message?.status === 'complete'
+            ? 'completed'
+            : message?.status === 'failed'
+              ? 'error'
+              : message?.status === 'interrupted'
+                ? 'interrupt'
+                : 'unexpected-disconnect';
+        db.prepare(
+          `UPDATE channel_completion_callbacks
+              SET state = 'satisfied', terminal_reason = ?,
+                  terminal_message_id = ?, message_disposition = ?,
+                  satisfied_at = ?, updated_at = ?
+            WHERE id = ? AND state = 'pending'`
+        ).run(
+          terminalReason,
+          message?.id ?? null,
+          message ? 'final-message' : 'no-terminal-message',
+          timestamp,
+          timestamp,
+          edge.id
+        );
+      }
+      return (
+        db
+          .prepare(
+            `SELECT * FROM channel_completion_callbacks
+              WHERE state = 'satisfied'
+              ORDER BY satisfied_at ASC, created_at ASC, id ASC`
+          )
+          .all() as CompletionCallbackRow[]
+      ).map(completionCallbackRowToRecord);
+    }
+  );
 
   const designateSoleOrchestratorTransaction = db.transaction(
     (input: SoleOrchestratorDesignationInput): ChannelBinding => {
@@ -3786,6 +4629,83 @@ export function createChannelMessageStore(
       return writeBindingImpl(input);
     },
 
+    createCompletionCallback(input) {
+      return createCompletionCallbackImpl(input);
+    },
+
+    satisfyCompletionCallback(input) {
+      return satisfyCompletionCallbackImpl(input);
+    },
+
+    deferCompletionCallbackForChild(input) {
+      return deferCompletionCallbackForChildImpl(input);
+    },
+
+    announceContinuationChildren(callbackId, expectedChildCount) {
+      return announceContinuationChildrenImpl(callbackId, expectedChildCount);
+    },
+
+    completeChildContinuation(input) {
+      return completeChildContinuationImpl(input);
+    },
+
+    releaseDeferredCompletionCallback(id) {
+      return releaseDeferredCompletionCallbackImpl(id);
+    },
+
+    getCompletionCallback(id) {
+      const row = selectCompletionCallbackById.get(id) as
+        | CompletionCallbackRow
+        | undefined;
+      return row ? completionCallbackRowToRecord(row) : null;
+    },
+
+    claimSatisfiedCompletionCallbacks(limit = 100) {
+      const bounded = Math.max(1, Math.min(1_000, Math.floor(limit)));
+      return claimSatisfiedCompletionCallbacksImpl(bounded);
+    },
+
+    releaseDeliveredCompletionCallback(id) {
+      return releaseDeliveredCompletionCallbackImpl(id);
+    },
+
+    consumeCompletionCallback(id) {
+      const timestamp = nowIso();
+      return (
+        db
+          .prepare(
+            `UPDATE channel_completion_callbacks
+                SET state = 'consumed', consumed_at = ?, updated_at = ?
+              WHERE id = ? AND state = 'delivered'`
+          )
+          .run(timestamp, timestamp, id).changes > 0
+      );
+    },
+
+    consumeCompletionCallbacksForExplicitReturn(input) {
+      return consumeCompletionCallbacksForExplicitReturnImpl(input);
+    },
+
+    consumeAncestorCompletionCallbackForExplicitReturn(id) {
+      return consumeAncestorCompletionCallbackForExplicitReturnImpl(id);
+    },
+
+    recoverCompletionCallbacks() {
+      const recovered = recoverCompletionCallbacksImpl();
+      pruneConsumedCompletionCallbacksImpl(
+        COMPLETION_CALLBACK_CONSUMED_RETENTION_MS
+      );
+      return recovered;
+    },
+
+    pruneConsumedCompletionCallbacks(
+      olderThanMs = COMPLETION_CALLBACK_CONSUMED_RETENTION_MS
+    ) {
+      return pruneConsumedCompletionCallbacksImpl(
+        Math.max(0, Math.floor(olderThanMs))
+      );
+    },
+
     sweepStaleStreaming() {
       const channels = db
         .prepare(
@@ -3847,6 +4767,7 @@ export function createChannelMessageStore(
         'channel_messages',
         'channel_members',
         'channel_agent_bindings',
+        'channel_completion_callbacks',
         // Read marks are swept for the same reason bindings are: a channel the
         // topic store no longer knows about is gone, and its marker would
         // otherwise be resurrected verbatim by a channel later created under the
@@ -3877,6 +4798,9 @@ export function createChannelMessageStore(
           );
           db.prepare(
             'DELETE FROM channel_agent_bindings WHERE channel_id = ?'
+          ).run(id);
+          db.prepare(
+            'DELETE FROM channel_completion_callbacks WHERE channel_id = ?'
           ).run(id);
           db.prepare(
             `DELETE FROM ${CHANNEL_READ_STATE_TABLE} WHERE channel_id = ?`
@@ -3973,6 +4897,34 @@ function bindingRowToRecord(row: BindingRow): ChannelBinding {
     role: row.binding_role,
     providerSession,
     createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function completionCallbackRowToRecord(
+  row: CompletionCallbackRow
+): ChannelCompletionCallbackEdge {
+  return {
+    id: row.id,
+    channelId: row.channel_id,
+    threadId: row.thread_id,
+    triggerMessageId: row.trigger_message_id,
+    requesterProfileId: row.requester_profile_id,
+    targetProfileId: row.target_profile_id,
+    targetRuntimeId: row.target_runtime_id,
+    targetTurnId: row.target_turn_id,
+    continuationParentCallbackId: row.continuation_parent_callback_id,
+    awaitingChild: row.awaiting_child === 1,
+    pendingChildIntents: row.pending_child_intents,
+    continuationCompletedAt: row.continuation_completed_at,
+    state: row.state,
+    terminalReason: row.terminal_reason,
+    terminalMessageId: row.terminal_message_id,
+    messageDisposition: row.message_disposition,
+    createdAt: row.created_at,
+    satisfiedAt: row.satisfied_at,
+    deliveredAt: row.delivered_at,
+    consumedAt: row.consumed_at,
     updatedAt: row.updated_at,
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -3204,6 +3204,12 @@ async function main(): Promise<void> {
         cliGatewayActorRegistry.revoke(credentialId, input),
     },
   });
+  // Configure the runtime factory before replaying the durable callback outbox:
+  // recovery can now spawn/rebind its requester profile instead of claiming an
+  // edge into a half-configured binder and leaving it delivered until restart.
+  if (channelAgentBinder) {
+    await channelAgentBinder.recoverCompletionCallbacks();
+  }
 
   // Mount hooks router BEFORE auth middleware — hook callbacks come from localhost Claude Code
   const hooksRouter = createHooksRouter({

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
@@ -76,6 +77,993 @@ const CHANNEL_COMMAND_CONTRACTS: Array<[string, string]> = Object.entries(
 const cleanup: Array<() => void> = [];
 afterEach(() => {
   while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+describe('channel-agent-binder — durable delegation completion callbacks', () => {
+  const callbackTargets = ['a', 'b', 'c', 'd'].map((id) => ({
+    id,
+    displayName: id.toUpperCase(),
+    kind: 'framework' as const,
+    available: true,
+    reason: null,
+  }));
+  const A: ChannelSenderRef = {
+    kind: 'agent',
+    id: builtInAgentProfileId('a'),
+    providerId: 'a',
+    displayName: 'A',
+  };
+
+  it('wakes a silent successful delegator exactly once with a typed internal trigger', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: 'work complete' }
+            : { mode: 'stall' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-delegates-b',
+      'a-item',
+      '@b investigate this',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    const a = adapters.get('a')!;
+    const b = adapters.get('b')!;
+    expect(a.sendInputs[0]?.content).toContain(
+      '[Relay internal completion callback]'
+    );
+    expect(a.sendInputs[0]?.content).toContain('terminalReason=completed');
+    const bTurn = channelTurnId(delegated.id, builtInAgentProfileId('b'));
+    expect(store.getCompletionCallback(`chcb:${bTurn}`)).toMatchObject({
+      state: 'consumed',
+      messageDisposition: 'final-message',
+    });
+    b.emitTerminal('completed'); // duplicate/late terminal patch
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(a.sendCalls).toHaveLength(1);
+    // Internal callbacks never manufacture a chat row attributed to B or A.
+    expect(
+      rows(store).filter((row) => row.body.text.includes('internal completion'))
+    ).toHaveLength(0);
+  });
+
+  it('uses B’s explicit final @A once and consumes the automatic duplicate', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: '@a completed explicitly' }
+            : { mode: 'stall' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-explicit-b',
+      'a-item',
+      '@b investigate this',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    const a = adapters.get('a')!;
+    expect(a.sendInputs[0]?.content).not.toContain(
+      '[Relay internal completion callback]'
+    );
+    const bTurn = channelTurnId(delegated.id, builtInAgentProfileId('b'));
+    expect(store.getCompletionCallback(`chcb:${bTurn}`)).toMatchObject({
+      state: 'consumed',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(a.sendCalls).toHaveLength(1);
+  });
+
+  for (const scenario of [
+    {
+      name: 'error',
+      reason: 'error',
+      end: (adapter: ScriptedAdapter) => adapter.emitError(),
+    },
+    {
+      name: 'interrupt',
+      reason: 'interrupt',
+      end: (adapter: ScriptedAdapter) => adapter.emitTerminal('interrupted'),
+    },
+    {
+      name: 'unexpected disconnect',
+      reason: 'unexpected-disconnect',
+      end: (adapter: ScriptedAdapter) => adapter.emitUnexpectedDisconnect(),
+    },
+  ] as const) {
+    it(`wakes the delegator on ${scenario.name} with the guarded reason`, async () => {
+      const adapters = new Map<string, ScriptedAdapter>();
+      const { binder, store } = makeBinder({
+        build: (provider) => {
+          const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+          adapters.set(provider, adapter);
+          return adapter;
+        },
+        targets: callbackTargets,
+        knownProviderIds: ['a', 'b', 'c', 'd'],
+      });
+      postAgentTurnRow(
+        store,
+        binder,
+        `a-${scenario.reason}`,
+        'a-item',
+        '@b investigate this',
+        ['a', 'b', 'c', 'd'],
+        'runtime:a',
+        A
+      );
+      await waitFor(() => adapters.has('b'));
+      scenario.end(adapters.get('b')!);
+      await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+      expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+        `terminalReason=${scenario.reason}`
+      );
+    });
+  }
+
+  it('marks a watchdog callback no-terminal-message', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      watchdogMs: 10,
+    });
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-watchdog',
+      'a-item',
+      '@b investigate this',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'terminalReason=watchdog'
+    );
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'messageDisposition=no-terminal-message'
+    );
+  });
+
+  it('keeps an approval-related bare idle pending until the real terminal patch', async () => {
+    const adapters = new Map<string, ScriptedAdapter | ApprovalAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter =
+          provider === 'b'
+            ? new ApprovalAdapter(provider)
+            : new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      watchdogMs: 10,
+    });
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-approval',
+      'a-item',
+      '@b investigate this',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.has('b'));
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    expect(adapters.has('a')).toBe(false);
+    const bTurn = channelTurnId(delegated.id, builtInAgentProfileId('b'));
+    expect(store.getCompletionCallback(`chcb:${bTurn}`)).toMatchObject({
+      state: 'pending',
+    });
+  });
+
+  it('unwinds A → B → C as C → B → A without a downward callback', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply-sequence', texts: ['@c investigate', 'B final'] }
+            : { mode: 'stall' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-nested',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.has('c'));
+    // B has terminalized its first turn, but C is still active: A must wait.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(adapters.has('a')).toBe(false);
+    adapters.get('c')!.emitTerminal('completed');
+    await waitFor(() => adapters.get('b')?.sendCalls.length === 2);
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('c')!.sendCalls).toHaveLength(1);
+    expect(adapters.get('b')!.sendCalls).toHaveLength(2);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'terminalReason=completed'
+    );
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    // B’s completion callback returns upward only; it never re-notifies C.
+    expect(adapters.get('c')!.sendCalls).toHaveLength(1);
+  });
+
+  it('enqueues a completion callback behind a busy delegator FIFO', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: 'B done' }
+            : { mode: 'stall' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    post(store, binder, '@a keep working', ['a', 'b', 'c', 'd']);
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-busy-delegates-b',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.has('b'));
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(adapters.get('a')!.sendCalls).toHaveLength(1);
+    adapters.get('a')!.emitTerminal('completed');
+    await waitFor(() => adapters.get('a')!.sendCalls.length === 2);
+    expect(adapters.get('a')!.sendInputs[1]?.content).toContain(
+      '[Relay internal completion callback]'
+    );
+  });
+
+  it('treats a nested B callback final @A as an upward return, never B → A delegation', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? {
+                mode: 'reply-sequence',
+                texts: ['@c investigate', '@a B explicitly returned'],
+              }
+            : { mode: 'stall' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-nested-explicit-return',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.has('c'));
+    adapters.get('c')!.emitTerminal('completed');
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).not.toContain(
+      '[Relay internal completion callback]'
+    );
+    const bTurn = channelTurnId(delegated.id, builtInAgentProfileId('b'));
+    expect(store.getCompletionCallback(`chcb:${bTurn}`)).toMatchObject({
+      state: 'consumed',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(adapters.get('a')!.sendCalls).toHaveLength(1);
+    expect(adapters.get('c')!.sendCalls).toHaveLength(1);
+  });
+
+  it('recovers a persisted pending callback after a hub restart', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-callback-restart-')
+    );
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const storePath = path.join(dir, 'channel-chat.db');
+    const first = makeBinder({
+      build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    postAgentTurnRow(
+      first.store,
+      first.binder,
+      'a-restart-delegates-b',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => first.sessions.spawns() === 1);
+    first.binder.close();
+    first.store.close();
+
+    const adapters = new Map<string, ScriptedAdapter>();
+    const restarted = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    await restarted.binder.recoverCompletionCallbacks();
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'terminalReason=unexpected-disconnect'
+    );
+  });
+
+  it('converges reciprocal A and B mentions without ping-ponging', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: '@a B explicitly returned' }
+            : { mode: 'reply', text: 'A acknowledged without delegating' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-b-mutual',
+      'a-item',
+      '@b delegated work',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(adapters.get('b')!.sendCalls).toHaveLength(1);
+    expect(adapters.get('a')!.sendCalls).toHaveLength(1);
+  });
+
+  it('does not rearm a reverse delegation when callback handling has no new @mention', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: 'B finished silently' }
+            : { mode: 'reply', text: 'A handled the callback' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-no-rearm',
+      'a-item',
+      '@b delegated work',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      '[Relay internal completion callback]'
+    );
+    expect(adapters.get('b')!.sendCalls).toHaveLength(1);
+    expect(
+      agentReplies(store, 'a').some(
+        (row) => row.body.text === 'A handled the callback'
+      )
+    ).toBe(true);
+  });
+
+  it('replays a callback after crash-before-send and consumes only after acceptance', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-callback-preaccept-')
+    );
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const storePath = path.join(dir, 'channel-chat.db');
+    const firstAdapters = new Map<string, ScriptedAdapter | DeferredAdapter>();
+    const first = makeBinder({
+      build: (provider) => {
+        const adapter =
+          provider === 'a'
+            ? new DeferredAdapter(provider)
+            : new ScriptedAdapter(provider, { mode: 'reply', text: 'B done' });
+        firstAdapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    const delegated = postAgentTurnRow(
+      first.store,
+      first.binder,
+      'a-preaccept-b',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => firstAdapters.get('a') instanceof DeferredAdapter);
+    const deferred = firstAdapters.get('a') as DeferredAdapter;
+    await waitFor(() => deferred.sendCalls.length === 1);
+    const firstDispatch = deferred.sendInputs[0]!;
+    const edgeId = `chcb:${channelTurnId(delegated.id, builtInAgentProfileId('b'))}`;
+    expect(first.store.getCompletionCallback(edgeId)).toMatchObject({
+      state: 'delivered',
+    });
+    first.binder.close();
+    first.store.close();
+
+    const restartedAdapters = new Map<string, ScriptedAdapter>();
+    const restarted = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        restartedAdapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    await restarted.binder.recoverCompletionCallbacks();
+    await waitFor(() => restartedAdapters.get('a')?.sendCalls.length === 1);
+    const recoveredDispatch = restartedAdapters.get('a')!.sendInputs[0]!;
+    // Relay replays the same deterministic provider-facing identifiers. The
+    // generic adapter contract does not promise provider-side dedupe, but a
+    // provider that honors either identity sees the same dispatch on recovery.
+    expect(recoveredDispatch.turnId).toBe(firstDispatch.turnId);
+    expect(recoveredDispatch.clientMessageId).toBe(
+      firstDispatch.clientMessageId
+    );
+    expect(restarted.store.getCompletionCallback(edgeId)).toMatchObject({
+      state: 'consumed',
+    });
+    restarted.binder.close();
+    restarted.store.close();
+
+    const postAcceptance = makeBinder({
+      build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    await postAcceptance.binder.recoverCompletionCallbacks();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(postAcceptance.sessions.spawns()).toBe(0);
+  });
+
+  it('persists a busy delegatee admission across restart before that turn starts', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-callback-busy-restart-')
+    );
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const storePath = path.join(dir, 'channel-chat.db');
+    const first = makeBinder({
+      build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    post(first.store, first.binder, '@b keep working', ['a', 'b', 'c', 'd']);
+    await waitFor(() => first.sessions.spawns() === 1);
+    const delegated = postAgentTurnRow(
+      first.store,
+      first.binder,
+      'a-queued-b',
+      'a-item',
+      '@b queued delegation',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    const edgeId = `chcb:${channelTurnId(delegated.id, builtInAgentProfileId('b'))}`;
+    await waitFor(() => first.store.getCompletionCallback(edgeId) !== null);
+    expect(first.store.getCompletionCallback(edgeId)).toMatchObject({
+      state: 'pending',
+    });
+    first.binder.close();
+    first.store.close();
+
+    const adapters = new Map<string, ScriptedAdapter>();
+    const restarted = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    await restarted.binder.recoverCompletionCallbacks();
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'terminalReason=unexpected-disconnect'
+    );
+  });
+
+  it('recovers a nested child admitted behind a busy delegatee FIFO and unwinds upward', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-callback-nested-queue-')
+    );
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const storePath = path.join(dir, 'channel-chat.db');
+    const first = makeBinder({
+      build: (provider) =>
+        new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: '@c delegated while C is busy' }
+            : { mode: 'stall' }
+        ),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    post(first.store, first.binder, '@c keep working', ['a', 'b', 'c', 'd']);
+    await waitFor(() => first.sessions.spawns() === 1);
+    postAgentTurnRow(
+      first.store,
+      first.binder,
+      'a-nested-queued-c',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => agentReplies(first.store, 'b').length === 1);
+    const cTrigger = agentReplies(first.store, 'b')[0]!;
+    const childId = `chcb:${channelTurnId(cTrigger.id, builtInAgentProfileId('c'))}`;
+    await waitFor(() => first.store.getCompletionCallback(childId) !== null);
+    expect(first.store.getCompletionCallback(childId)).toMatchObject({
+      state: 'pending',
+    });
+    first.binder.close();
+    first.store.close();
+
+    const adapters = new Map<string, ScriptedAdapter>();
+    const restarted = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: 'B resumed and completed' }
+            : { mode: 'stall' }
+        );
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    await restarted.binder.recoverCompletionCallbacks();
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      '[Relay internal completion callback]'
+    );
+  });
+
+  it('releases an unaccepted callback on runtime death and rebinds it exactly once', async () => {
+    const aAdapters: Array<DeferredAdapter | ScriptedAdapter> = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (provider) => {
+        if (provider === 'a') {
+          const adapter =
+            aAdapters.length === 0
+              ? new DeferredAdapter(provider)
+              : new ScriptedAdapter(provider, { mode: 'stall' });
+          aAdapters.push(adapter);
+          return adapter;
+        }
+        return new ScriptedAdapter(provider, { mode: 'reply', text: 'B done' });
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-dead-preaccept-b',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => aAdapters[0] instanceof DeferredAdapter);
+    await waitFor(
+      () => (aAdapters[0] as DeferredAdapter).sendCalls.length === 1
+    );
+    // B is the first spawned runtime; A's still-unaccepted callback is second.
+    sessions.fireEnd('sess-2-a');
+    await waitFor(() => aAdapters.length === 2);
+    await waitFor(
+      () => (aAdapters[1] as ScriptedAdapter).sendCalls.length === 1
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect((aAdapters[1] as ScriptedAdapter).sendCalls).toHaveLength(1);
+  });
+
+  it('retries transient callback routing after configured runtimes and preserves orchestrator role', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store, sessions } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      createErrorOnce: new Error('transient runtime launch failure'),
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'callback trigger',
+    });
+    store.designateSoleOrchestrator({
+      channelId: CH,
+      profileActorId: builtInAgentProfileId('a'),
+      agentFramework: 'a',
+    });
+    const edge = store.createCompletionCallback({
+      id: 'chcb:transient-recovery',
+      channelId: CH,
+      threadId: null,
+      triggerMessageId: trigger.id,
+      requesterProfileId: builtInAgentProfileId('a'),
+      targetProfileId: builtInAgentProfileId('b'),
+      targetRuntimeId: 'runtime:b',
+      targetTurnId: 'turn:transient-recovery',
+    });
+    store.satisfyCompletionCallback({
+      channelId: edge.channelId,
+      targetProfileId: edge.targetProfileId,
+      targetTurnId: edge.targetTurnId,
+      terminalReason: 'error',
+      messageDisposition: 'no-terminal-message',
+    });
+    await binder.recoverCompletionCallbacks();
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(sessions.spawns()).toBe(2);
+    expect(sessions.lastCreateParams()?.role).toBe('orchestrator');
+  });
+
+  it('terminalizes a delegatee FIFO-cap rejection upward instead of dropping its edge', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    post(store, binder, '@b occupy the worker', ['a', 'b', 'c', 'd']);
+    await waitFor(() => adapters.get('b')?.sendCalls.length === 1);
+    for (let index = 0; index < 8; index += 1) {
+      post(store, binder, `@b queued ${index}`, ['a', 'b', 'c', 'd']);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-cap-delegates-b',
+      'a-item',
+      '@b one too many',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'terminalReason=error'
+    );
+  });
+
+  it('queues a callback-bearing delegation behind a busy steerable agent instead of steering it', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: (provider) => {
+        return new SteerableAdapter(provider, true);
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    post(store, binder, '@b keep the native turn active', ['a', 'b', 'c', 'd']);
+    await waitFor(() => sessions.spawns() === 1);
+    const b = sessions.adapterFor(
+      sessions.firstSessionId()
+    ) as SteerableAdapter;
+    await waitFor(() => b.sendCalls.length === 1);
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-steerable-delegates-b',
+      'a-item',
+      '@b must be its own callback edge',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(b.steerAttempts).toHaveLength(0);
+    expect(b.sendCalls).toHaveLength(1);
+    b.completeLatest();
+    await waitFor(() => b.sendCalls.length === 2);
+    const targetTurnId = channelTurnId(
+      delegated.id,
+      builtInAgentProfileId('b')
+    );
+    expect(b.sendInputs[1]?.turnId).toBe(targetTurnId);
+    expect(store.getCompletionCallback(`chcb:${targetTurnId}`)).toMatchObject({
+      targetTurnId,
+    });
+  });
+
+  it('releases a queued upward callback when its busy requester runtime dies', async () => {
+    const aAdapters: ScriptedAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(
+          provider,
+          provider === 'b'
+            ? { mode: 'reply', text: 'B done' }
+            : { mode: 'stall' }
+        );
+        if (provider === 'a') aAdapters.push(adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    post(store, binder, '@a keep working', ['a', 'b', 'c', 'd']);
+    await waitFor(() => aAdapters[0]?.sendCalls.length === 1);
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-upward-queued-delegates-b',
+      'a-item',
+      '@b investigate',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    const edgeId = `chcb:${channelTurnId(delegated.id, builtInAgentProfileId('b'))}`;
+    await waitFor(
+      () => store.getCompletionCallback(edgeId)?.state === 'delivered'
+    );
+    sessions.fireEnd('sess-1-a');
+    await waitFor(() => aAdapters.length === 2);
+    await waitFor(() => aAdapters[1]?.sendCalls.length === 1);
+    expect(store.getCompletionCallback(edgeId)).toMatchObject({
+      state: 'consumed',
+    });
+  });
+
+  it('terminalizes a queued downward delegation when its delegatee runtime dies', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store, sessions } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, { mode: 'stall' });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    post(store, binder, '@b keep working', ['a', 'b', 'c', 'd']);
+    await waitFor(() => adapters.get('b')?.sendCalls.length === 1);
+    const delegated = postAgentTurnRow(
+      store,
+      binder,
+      'a-downward-queued-delegates-b',
+      'a-item',
+      '@b queued work',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    const edgeId = `chcb:${channelTurnId(delegated.id, builtInAgentProfileId('b'))}`;
+    await waitFor(
+      () => store.getCompletionCallback(edgeId)?.state === 'pending'
+    );
+    sessions.fireEnd('sess-1-b');
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 1);
+    expect(adapters.get('a')!.sendInputs[0]?.content).toContain(
+      'terminalReason=unexpected-disconnect'
+    );
+    expect(store.getCompletionCallback(edgeId)).toMatchObject({
+      state: 'consumed',
+    });
+  });
+
+  it('prunes expired settled callback rows during live callback mutation without restart', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-callback-live-prune-')
+    );
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const storePath = path.join(dir, 'channel-chat.db');
+    const { binder, store } = makeBinder({
+      build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      storePath,
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'old callback trigger',
+    });
+    const old = store.createCompletionCallback({
+      id: 'chcb:expired-live-row',
+      channelId: CH,
+      threadId: null,
+      triggerMessageId: trigger.id,
+      requesterProfileId: builtInAgentProfileId('a'),
+      targetProfileId: builtInAgentProfileId('b'),
+      targetRuntimeId: 'runtime:b',
+      targetTurnId: 'turn:expired-live-row',
+    });
+    store.satisfyCompletionCallback({
+      channelId: old.channelId,
+      targetProfileId: old.targetProfileId,
+      targetTurnId: old.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    store.claimSatisfiedCompletionCallbacks();
+    expect(store.consumeCompletionCallback(old.id)).toBe(true);
+    const raw = new Database(storePath);
+    raw
+      .prepare(
+        `UPDATE channel_completion_callbacks
+          SET consumed_at = ?, updated_at = ?
+        WHERE id = ?`
+      )
+      .run(
+        new Date(Date.now() - 8 * 24 * 60 * 60 * 1_000).toISOString(),
+        new Date().toISOString(),
+        old.id
+      );
+    raw.close();
+
+    postAgentTurnRow(
+      store,
+      binder,
+      'a-prune-live-delegates-b',
+      'a-item',
+      '@b trigger a live callback mutation',
+      ['a', 'b', 'c', 'd'],
+      'runtime:a',
+      A
+    );
+    await waitFor(() => store.getCompletionCallback(old.id) === null);
+  });
+
+  it('drains more than one bounded recovery batch without stranding callback edges', async () => {
+    const adapters = new Map<string, ScriptedAdapter>();
+    const { binder, store } = makeBinder({
+      build: (provider) => {
+        const adapter = new ScriptedAdapter(provider, {
+          mode: 'reply',
+          text: 'ack',
+        });
+        adapters.set(provider, adapter);
+        return adapter;
+      },
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'batch callback trigger',
+    });
+    for (let index = 0; index < 101; index += 1) {
+      const edge = store.createCompletionCallback({
+        id: `chcb:batch:${index}`,
+        channelId: CH,
+        threadId: null,
+        triggerMessageId: trigger.id,
+        requesterProfileId: builtInAgentProfileId('a'),
+        targetProfileId: builtInAgentProfileId('b'),
+        targetRuntimeId: 'runtime:b',
+        targetTurnId: `turn:batch:${index}`,
+      });
+      store.satisfyCompletionCallback({
+        channelId: edge.channelId,
+        targetProfileId: edge.targetProfileId,
+        targetTurnId: edge.targetTurnId,
+        terminalReason: 'completed',
+        messageDisposition: 'no-terminal-message',
+      });
+    }
+    await binder.recoverCompletionCallbacks();
+    await waitFor(() => adapters.get('a')?.sendCalls.length === 101, 8000);
+    expect(store.claimSatisfiedCompletionCallbacks()).toEqual([]);
+  });
 });
 
 const CH = 'topic:test';
@@ -195,6 +1183,8 @@ type ScriptMode =
   | { mode: 'stall' }
   | { mode: 'reply'; text: string }
   | { mode: 'reply-items'; texts: string[] }
+  | { mode: 'reply-items-once-then-stall'; texts: string[] }
+  | { mode: 'reply-sequence'; texts: string[] }
   | { mode: 'reject' }
   | { mode: 'reject-once-then-reply'; text: string };
 
@@ -212,6 +1202,7 @@ class ScriptedAdapter extends BaseProtocolAdapterV2 {
   private _status: AdapterStatus = 'disconnected';
   private sid = 'scripted';
   private rejected = false;
+  private lastTurnId: string | null = null;
 
   constructor(
     readonly agentType: string,
@@ -238,18 +1229,71 @@ class ScriptedAdapter extends BaseProtocolAdapterV2 {
   async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
     this.sendCalls.push(input.turnId);
     this.sendInputs.push(input);
+    this.lastTurnId = input.turnId;
     if (this.script.mode === 'reject-once-then-reply' && !this.rejected) {
       this.rejected = true;
       throw new Error('transport down');
     }
     if (this.script.mode === 'reject') throw new Error('transport down');
-    if (this.script.mode === 'stall') return; // resolve, never complete
+    if (
+      this.script.mode === 'stall' ||
+      (this.script.mode === 'reply-items-once-then-stall' &&
+        this.sendCalls.length > 1)
+    ) {
+      return; // resolve, never complete
+    }
     this.runReplyItems(
       input.turnId,
-      this.script.mode === 'reply-items'
+      this.script.mode === 'reply-items' ||
+        this.script.mode === 'reply-items-once-then-stall'
         ? this.script.texts
-        : [this.script.text]
+        : this.script.mode === 'reply-sequence'
+          ? [
+              this.script.texts[
+                Math.min(
+                  this.sendCalls.length - 1,
+                  this.script.texts.length - 1
+                )
+              ] ?? '',
+            ]
+          : [this.script.text]
     );
+  }
+
+  emitTerminal(status: 'completed' | 'interrupted' | 'failed'): void {
+    if (!this.lastTurnId) return;
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: this.lastTurnId,
+      status,
+    });
+  }
+
+  emitError(message = 'scripted error'): void {
+    this.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      ...(this.lastTurnId ? { turnId: this.lastTurnId } : {}),
+      message,
+    });
+  }
+
+  emitUnexpectedDisconnect(): void {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      live: {
+        status: 'disconnected',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        queueLength: 0,
+      },
+    });
   }
 
   private runReplyItems(turnId: string, texts: string[]): void {
@@ -645,6 +1689,7 @@ class DeferredAdapter extends BaseProtocolAdapterV2 {
     queue: false,
   };
   readonly sendCalls: string[] = [];
+  readonly sendInputs: AgentSendMessageInputV2[] = [];
   private _status: AdapterStatus = 'disconnected';
   private sid = 'deferred';
   private readonly pending = new Map<
@@ -673,6 +1718,7 @@ class DeferredAdapter extends BaseProtocolAdapterV2 {
 
   sendMessage(input: AgentSendMessageInputV2): Promise<void> {
     this.sendCalls.push(input.turnId);
+    this.sendInputs.push(input);
     return new Promise<void>((resolve, reject) => {
       this.pending.set(input.turnId, { resolve, reject });
     });
@@ -1061,6 +2107,7 @@ function makeSessions(
   opts: {
     throwOnCreate?: boolean;
     createError?: unknown;
+    createErrorOnce?: unknown;
     gate?: Promise<void>;
   } = {}
 ): SessionsHarness {
@@ -1069,6 +2116,7 @@ function makeSessions(
   const endCbs: Array<(id: string) => void> = [];
   const destroyCalls: string[] = [];
   let spawns = 0;
+  let createErrorOnceRaised = false;
   let lastParams: CreateChannelAgentRuntimeParams | undefined;
   const createParams: CreateChannelAgentRuntimeParams[] = [];
   const sessions: BinderRuntimes = {
@@ -1077,6 +2125,10 @@ function makeSessions(
       lastParams = params;
       createParams.push(params);
       if (opts.createError !== undefined) throw opts.createError;
+      if (opts.createErrorOnce !== undefined && !createErrorOnceRaised) {
+        createErrorOnceRaised = true;
+        throw opts.createErrorOnce;
+      }
       if (opts.throwOnCreate) throw new Error('boom: spawn failed');
       // Optional gate: park the spawn so a test can drive a close()/reorder race
       // between runtime creation being invoked and its continuation resuming.
@@ -1185,6 +2237,7 @@ function makeBinder(cfg: {
   presenceSweepMs?: number;
   throwOnCreate?: boolean;
   createError?: unknown;
+  createErrorOnce?: unknown;
   yolo?: boolean;
   gate?: Promise<void>;
   attachmentStore?: ChannelAttachmentStore;
@@ -1201,6 +2254,9 @@ function makeBinder(cfg: {
   const sessions = makeSessions(cfg.build, {
     ...(cfg.throwOnCreate ? { throwOnCreate: true } : {}),
     ...(cfg.createError !== undefined ? { createError: cfg.createError } : {}),
+    ...(cfg.createErrorOnce !== undefined
+      ? { createErrorOnce: cfg.createErrorOnce }
+      : {}),
     ...(cfg.gate ? { gate: cfg.gate } : {}),
   });
   const binder = createChannelAgentBinder({
@@ -3011,7 +4067,10 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
     const build = (agentType: string) =>
       agentType === 'a'
         ? new ScriptedAdapter('a', {
-            mode: 'reply-items',
+            // Completion callbacks are now intentionally delivered back to A.
+            // Keep this fan-out-counting fixture focused on A's FIRST provider
+            // turn so a callback re-entry cannot manufacture another batch.
+            mode: 'reply-items-once-then-stall',
             texts: ['one @b @c', 'two @b', 'three @b', 'four @b'],
           })
         : new ScriptedAdapter(agentType, { mode: 'reply', text: 'done' });

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -36,6 +36,7 @@ import { createChannelChatRouter } from '../server/channel-chat-router.js';
 import {
   createChannelAgentBinder,
   type BinderRuntimes,
+  type ChannelAgentBinder,
   type MentionTarget,
 } from '../server/channel-agent-binder.js';
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
@@ -52,7 +53,10 @@ import {
   createWorkspaceTopicStore,
   type WorkspaceTopicStore,
 } from '../server/workspace-topics.js';
-import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+import {
+  parseMentions,
+  type ChannelMessage,
+} from '../shared/channel-chat-protocol.js';
 import type { ChannelAgentRuntime } from '../server/channel-agent-runtime.js';
 
 const cleanup: Array<() => void> = [];
@@ -220,6 +224,7 @@ interface Harness {
   store: ChannelMessageStore;
   hub: ChannelHub;
   channelId: string;
+  binder: ChannelAgentBinder;
   adapters: () => ProtocolAdapterV2[];
 }
 
@@ -323,7 +328,11 @@ function realActorAuthDeps(registry: ScopedActorCredentialRegistry): {
 async function harness(
   build: (agentType: string) => ProtocolAdapterV2 = () =>
     new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
-  opts: { actorRegistry?: ScopedActorCredentialRegistry } = {}
+  opts: {
+    actorRegistry?: ScopedActorCredentialRegistry;
+    targets?: MentionTarget[];
+    knownProviderIds?: string[];
+  } = {}
 ): Promise<Harness> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-mention-e2e-'));
   cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -341,14 +350,21 @@ async function harness(
   cleanup.push(() => hub.close());
   const topic = topicStore.create({ workspaceId: 'ws', title: 'General' });
 
+  const knownProviderIds = opts.knownProviderIds ?? [
+    'mock',
+    'claude',
+    'codex',
+    'opencode',
+    'hermes',
+  ];
   const adapters: ProtocolAdapterV2[] = [];
   const binder = createChannelAgentBinder({
     store,
     hub,
     topicStore,
     runtimes: makeSessions(build, adapters),
-    knownProviderIds: ['mock', 'claude', 'codex', 'opencode', 'hermes'],
-    mentionTargets: async () => TARGETS,
+    knownProviderIds,
+    mentionTargets: async () => opts.targets ?? TARGETS,
     port: 0,
     configDir: dir,
   });
@@ -380,7 +396,7 @@ async function harness(
       hub,
       topicStore,
       binder,
-      knownProviderIds: ['mock', 'claude', 'codex', 'opencode', 'hermes'],
+      knownProviderIds,
       ...(opts.actorRegistry ? realActorAuthDeps(opts.actorRegistry) : {}),
     })
   );
@@ -394,6 +410,7 @@ async function harness(
     store,
     hub,
     channelId: topic.id,
+    binder,
     adapters: () => adapters,
   };
 }
@@ -460,6 +477,65 @@ describe('mention routing — end-to-end via the router', () => {
       h.store.getBinding(h.channelId, builtInAgentProfileId('mock'))
         ?.providerSession['lastDeliveredSeq']
     ).toBe(res.body.message.seq);
+  });
+
+  it('delivers a typed completion trigger after an agent @mention without fabricating an @mention row', async () => {
+    const targets: MentionTarget[] = ['a', 'b'].map((id) => ({
+      id,
+      displayName: id.toUpperCase(),
+      kind: 'framework' as const,
+      available: true,
+      reason: null,
+    }));
+    const h = await harness(
+      (provider) =>
+        new RecordingAdapter(
+          provider,
+          provider === 'b' ? 'B finished silently' : 'A acknowledged'
+        ),
+      { targets, knownProviderIds: ['a', 'b'] }
+    );
+    const text = '@b delegate this';
+    const stream = h.store.beginStream({
+      channelId: h.channelId,
+      sender: {
+        kind: 'agent',
+        id: builtInAgentProfileId('a'),
+        providerId: 'a',
+        displayName: 'A',
+      },
+      source: {
+        runtimeId: 'runtime:a',
+        turnId: 'a-delegates-b',
+        itemId: 'a-1',
+      },
+      mentions: parseMentions(text, ['a', 'b']),
+    });
+    const delegated = h.store.finalizeStream(stream.id, {
+      text,
+      status: 'complete',
+    })!;
+    h.binder.handleMessagePosted(delegated, delegated.mentions ?? []);
+
+    await waitFor(() => h.adapters().length === 2);
+    const a = h
+      .adapters()
+      .find(
+        (adapter) => (adapter as RecordingAdapter).agentType === 'a'
+      ) as RecordingAdapter;
+    await waitFor(() => a.contents.length === 1);
+    expect(a.contents[0]).toContain('[Relay internal completion callback]');
+    expect(a.contents[0]).toContain('terminalReason=completed');
+    const rows = h.store.history(h.channelId, { limit: 20 });
+    expect(rows.map((row) => row.body.text)).toEqual(
+      expect.arrayContaining([text, 'B finished silently', 'A acknowledged'])
+    );
+    expect(
+      rows.filter((row) => row.body.text.includes('[Relay internal completion'))
+    ).toHaveLength(0);
+    expect(rows.some((row) => row.body.text === '@a B finished silently')).toBe(
+      false
+    );
   });
 
   it('a CLI-gateway-actor @mock post routes identically to a browser post', async () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -525,7 +525,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(8);
+    ).toBe(12);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -713,7 +713,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(8);
+    ).toBe(12);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -3209,7 +3209,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(8);
+    expect(version.version).toBe(12);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {
@@ -3641,5 +3641,399 @@ describe('channel-message-store read state (#1308 slice 3 item 1)', () => {
       lastReadSeq: 1,
       advanced: true,
     });
+  });
+});
+
+describe('channel completion callback edge store', () => {
+  function edgeInput(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'chcb:turn:delegatee:1',
+      channelId: 'topic:callbacks',
+      threadId: null,
+      triggerMessageId: 'chm:trigger',
+      requesterProfileId: 'agent-profile:claude:default',
+      targetProfileId: 'agent-profile:codex:default',
+      targetRuntimeId: 'runtime:codex:1',
+      targetTurnId: 'turn:delegatee:1',
+      ...overrides,
+    };
+  }
+
+  it('persists one target-turn edge and CASes pending through consumed exactly once', () => {
+    const file = dbPath();
+    const first = store(file);
+    const created = first.createCompletionCallback(edgeInput());
+    expect(created).toMatchObject({
+      state: 'pending',
+      channelId: 'topic:callbacks',
+      requesterProfileId: 'agent-profile:claude:default',
+      targetProfileId: 'agent-profile:codex:default',
+      targetRuntimeId: 'runtime:codex:1',
+      targetTurnId: 'turn:delegatee:1',
+    });
+    // The target turn is the durable idempotency boundary, not binder memory.
+    expect(
+      first.createCompletionCallback(
+        edgeInput({ id: 'different-id', targetRuntimeId: 'runtime:retry' })
+      )
+    ).toMatchObject({ id: created.id, targetRuntimeId: 'runtime:codex:1' });
+    expect(
+      first.satisfyCompletionCallback({
+        channelId: 'topic:callbacks',
+        targetProfileId: 'agent-profile:codex:default',
+        targetTurnId: 'turn:delegatee:1',
+        terminalReason: 'completed',
+        terminalMessageId: 'chm:final',
+        messageDisposition: 'final-message',
+      })
+    ).toMatchObject({ state: 'satisfied', terminalReason: 'completed' });
+    expect(
+      first.satisfyCompletionCallback({
+        channelId: 'topic:callbacks',
+        targetProfileId: 'agent-profile:codex:default',
+        targetTurnId: 'turn:delegatee:1',
+        terminalReason: 'error',
+        messageDisposition: 'no-terminal-message',
+      })
+    ).toBeNull();
+    expect(first.claimSatisfiedCompletionCallbacks()).toMatchObject([
+      { id: created.id, state: 'delivered', terminalReason: 'completed' },
+    ]);
+    expect(first.consumeCompletionCallback(created.id)).toBe(true);
+    expect(first.consumeCompletionCallback(created.id)).toBe(false);
+    first.close();
+
+    const reopened = store(file);
+    expect(reopened.recoverCompletionCallbacks()).toEqual([]);
+  });
+
+  it('recovers volatile delivery and terminalizes restart-orphaned pending turns from durable evidence only', () => {
+    const s = store();
+    const final = s.beginStream({
+      channelId: 'topic:callbacks',
+      sender: {
+        kind: 'agent',
+        id: 'agent-profile:codex:default',
+        providerId: 'codex',
+      },
+      source: {
+        runtimeId: 'runtime:codex:1',
+        turnId: 'turn:delegatee:1',
+        itemId: 'assistant:final',
+      },
+    });
+    const finalized = s.finalizeStream(final.id, {
+      text: 'finished without mentioning the requester',
+      status: 'complete',
+    })!;
+    const evidenced = s.createCompletionCallback(edgeInput());
+    const silent = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:turn:silent',
+        targetRuntimeId: 'runtime:codex:2',
+        targetTurnId: 'turn:silent',
+      })
+    );
+    s.satisfyCompletionCallback({
+      channelId: evidenced.channelId,
+      targetProfileId: evidenced.targetProfileId,
+      targetTurnId: evidenced.targetTurnId,
+      terminalReason: 'completed',
+      terminalMessageId: finalized.id,
+      messageDisposition: 'final-message',
+    });
+    expect(s.claimSatisfiedCompletionCallbacks()).toHaveLength(1);
+
+    const recovered = s.recoverCompletionCallbacks();
+    expect(recovered).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: evidenced.id,
+          state: 'satisfied',
+          terminalReason: 'completed',
+          terminalMessageId: finalized.id,
+          messageDisposition: 'final-message',
+        }),
+        expect.objectContaining({
+          id: silent.id,
+          state: 'satisfied',
+          terminalReason: 'unexpected-disconnect',
+          messageDisposition: 'no-terminal-message',
+        }),
+      ])
+    );
+    expect(s.claimSatisfiedCompletionCallbacks()).toHaveLength(2);
+  });
+
+  it('persists an ancestor defer until its child callback continuation terminalizes', () => {
+    const s = store();
+    const parent = s.createCompletionCallback(edgeInput());
+    expect(
+      s.deferCompletionCallbackForChild({
+        channelId: parent.channelId,
+        targetProfileId: parent.targetProfileId,
+        targetTurnId: parent.targetTurnId,
+        expectedChildCount: 1,
+      })
+    ).toMatchObject({ id: parent.id, state: 'pending', awaitingChild: true });
+    // B's first terminal event records its row but does not wake A yet.
+    expect(
+      s.satisfyCompletionCallback({
+        channelId: parent.channelId,
+        targetProfileId: parent.targetProfileId,
+        targetTurnId: parent.targetTurnId,
+        terminalReason: 'completed',
+        terminalMessageId: 'chm:b-delegated-c',
+        messageDisposition: 'final-message',
+      })
+    ).toBeNull();
+    const child = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:turn:c',
+        requesterProfileId: parent.targetProfileId,
+        targetProfileId: 'agent-profile:hermes:default',
+        targetRuntimeId: 'runtime:hermes:1',
+        targetTurnId: 'turn:c',
+        continuationParentCallbackId: parent.id,
+      })
+    );
+    expect(child.continuationParentCallbackId).toBe(parent.id);
+    expect(s.getCompletionCallback(parent.id)).toMatchObject({
+      awaitingChild: true,
+      pendingChildIntents: 0,
+    });
+    s.satisfyCompletionCallback({
+      channelId: child.channelId,
+      targetProfileId: child.targetProfileId,
+      targetTurnId: child.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    s.claimSatisfiedCompletionCallbacks();
+    expect(s.consumeCompletionCallback(child.id)).toBe(true);
+    expect(s.getCompletionCallback(child.id)).toMatchObject({
+      state: 'consumed',
+      continuationCompletedAt: null,
+    });
+    expect(s.getCompletionCallback(parent.id)).toMatchObject({
+      state: 'pending',
+      awaitingChild: true,
+      pendingChildIntents: 0,
+    });
+    const continuation = s.completeChildContinuation({
+      callbackId: child.id,
+      terminalReason: 'completed',
+      terminalMessageId: 'chm:b-final',
+      messageDisposition: 'final-message',
+    });
+    expect(s.getCompletionCallback(child.id)).toMatchObject({
+      continuationCompletedAt: expect.any(String),
+    });
+    expect(continuation).toMatchObject({
+      id: parent.id,
+      state: 'satisfied',
+      terminalMessageId: 'chm:b-final',
+      awaitingChild: false,
+    });
+    expect(s.claimSatisfiedCompletionCallbacks()).toMatchObject([
+      { id: parent.id, state: 'delivered' },
+    ]);
+  });
+
+  it('fans in staggered child continuations without releasing the parent twice', () => {
+    const s = store();
+    const parent = s.createCompletionCallback(edgeInput());
+    s.deferCompletionCallbackForChild({
+      channelId: parent.channelId,
+      targetProfileId: parent.targetProfileId,
+      targetTurnId: parent.targetTurnId,
+      expectedChildCount: 2,
+    });
+    s.satisfyCompletionCallback({
+      channelId: parent.channelId,
+      targetProfileId: parent.targetProfileId,
+      targetTurnId: parent.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    const c = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:turn:c',
+        requesterProfileId: parent.targetProfileId,
+        targetProfileId: 'agent-profile:hermes:default',
+        targetRuntimeId: 'runtime:hermes:1',
+        targetTurnId: 'turn:c',
+        continuationParentCallbackId: parent.id,
+      })
+    );
+    const d = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:turn:d',
+        requesterProfileId: parent.targetProfileId,
+        targetProfileId: 'agent-profile:gemini:default',
+        targetRuntimeId: 'runtime:gemini:1',
+        targetTurnId: 'turn:d',
+        continuationParentCallbackId: parent.id,
+      })
+    );
+    for (const child of [c, d]) {
+      s.satisfyCompletionCallback({
+        channelId: child.channelId,
+        targetProfileId: child.targetProfileId,
+        targetTurnId: child.targetTurnId,
+        terminalReason: 'completed',
+        messageDisposition: 'no-terminal-message',
+      });
+    }
+    expect(s.claimSatisfiedCompletionCallbacks()).toHaveLength(2);
+    expect(s.consumeCompletionCallback(c.id)).toBe(true);
+    expect(s.consumeCompletionCallback(d.id)).toBe(true);
+    expect(
+      s.completeChildContinuation({
+        callbackId: c.id,
+        terminalReason: 'completed',
+        messageDisposition: 'no-terminal-message',
+      })
+    ).toBeNull();
+    // A duplicate or late terminal patch cannot finish C twice or release A.
+    expect(
+      s.completeChildContinuation({
+        callbackId: c.id,
+        terminalReason: 'error',
+        messageDisposition: 'no-terminal-message',
+      })
+    ).toBeNull();
+    expect(s.getCompletionCallback(parent.id)).toMatchObject({
+      state: 'pending',
+      awaitingChild: true,
+    });
+    expect(
+      s.completeChildContinuation({
+        callbackId: d.id,
+        terminalReason: 'completed',
+        terminalMessageId: 'chm:b-after-d',
+        messageDisposition: 'final-message',
+      })
+    ).toMatchObject({
+      id: parent.id,
+      state: 'satisfied',
+      terminalMessageId: 'chm:b-after-d',
+    });
+  });
+
+  it('rolls back a corrupt child relation without spending its parent intent', () => {
+    const file = dbPath();
+    const s = store(file);
+    const parent = s.createCompletionCallback(edgeInput());
+    s.deferCompletionCallbackForChild({
+      channelId: parent.channelId,
+      targetProfileId: parent.targetProfileId,
+      targetTurnId: parent.targetTurnId,
+      expectedChildCount: 1,
+    });
+    expect(() =>
+      s.createCompletionCallback(
+        edgeInput({
+          id: 'chcb:bad-child',
+          targetProfileId: 'agent-profile:hermes:default',
+          targetRuntimeId: 'runtime:hermes:1',
+          targetTurnId: 'turn:bad-child',
+          requesterProfileId: 'agent-profile:not-the-parent',
+          continuationParentCallbackId: parent.id,
+        })
+      )
+    ).toThrow('continuation parent is invalid');
+    expect(s.getCompletionCallback(parent.id)).toMatchObject({
+      state: 'pending',
+      awaitingChild: true,
+      pendingChildIntents: 1,
+    });
+    expect(s.getCompletionCallback('chcb:bad-child')).toBeNull();
+    s.close();
+
+    const reopened = store(file);
+    expect(reopened.getCompletionCallback(parent.id)).toMatchObject({
+      state: 'pending',
+      pendingChildIntents: 1,
+    });
+  });
+
+  it('prunes only settled callback subtrees after bounded retention', async () => {
+    const s = store();
+    const settled = s.createCompletionCallback(
+      edgeInput({ id: 'chcb:settled' })
+    );
+    s.satisfyCompletionCallback({
+      channelId: settled.channelId,
+      targetProfileId: settled.targetProfileId,
+      targetTurnId: settled.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    s.claimSatisfiedCompletionCallbacks();
+    expect(s.consumeCompletionCallback(settled.id)).toBe(true);
+
+    const parent = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:retained-parent',
+        targetTurnId: 'turn:retained-parent',
+      })
+    );
+    s.deferCompletionCallbackForChild({
+      channelId: parent.channelId,
+      targetProfileId: parent.targetProfileId,
+      targetTurnId: parent.targetTurnId,
+      expectedChildCount: 1,
+    });
+    const child = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:retained-child',
+        requesterProfileId: parent.targetProfileId,
+        targetProfileId: 'agent-profile:hermes:default',
+        targetRuntimeId: 'runtime:hermes:1',
+        targetTurnId: 'turn:retained-child',
+        continuationParentCallbackId: parent.id,
+      })
+    );
+    s.satisfyCompletionCallback({
+      channelId: child.channelId,
+      targetProfileId: child.targetProfileId,
+      targetTurnId: child.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    s.claimSatisfiedCompletionCallbacks();
+    expect(s.consumeCompletionCallback(child.id)).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(s.pruneConsumedCompletionCallbacks(0)).toBe(1);
+    expect(s.getCompletionCallback(settled.id)).toBeNull();
+    // The child remains as idempotency and ancestry evidence until it completes
+    // its continuation into the still-pending parent.
+    expect(s.getCompletionCallback(child.id)).toMatchObject({
+      state: 'consumed',
+      continuationCompletedAt: null,
+    });
+    expect(s.getCompletionCallback(parent.id)).toMatchObject({
+      state: 'pending',
+    });
+  });
+
+  it('sweeps callback edges with their orphaned channels', () => {
+    const s = store();
+    s.createCompletionCallback(edgeInput({ channelId: 'topic:gone' }));
+    s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:live',
+        channelId: 'topic:live',
+        targetTurnId: 'turn:live',
+      })
+    );
+    expect(s.sweepOrphans(new Set(['topic:live']))).toMatchObject({
+      channelsDeleted: ['topic:gone'],
+    });
+    expect(s.recoverCompletionCallbacks()).toMatchObject([
+      { id: 'chcb:live', channelId: 'topic:live' },
+    ]);
   });
 });

--- a/test/channel-thread-e2e.test.ts
+++ b/test/channel-thread-e2e.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   createChannelAgentBinder,
   type BinderRuntimes,
+  type ChannelAgentBinder,
   type MentionTarget,
 } from '../server/channel-agent-binder.js';
 import { createChannelChatRouter } from '../server/channel-chat-router.js';
@@ -18,13 +19,25 @@ import {
   type ChannelMessageStore,
 } from '../server/channel-message-store.js';
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
-import type { ProtocolAdapterV2 } from '../server/protocol-adapter-v2.js';
+import {
+  BaseProtocolAdapterV2,
+  type AdapterConfig,
+  type AdapterStatus,
+  type AgentInterruptInputV2,
+  type AgentSendMessageInputV2,
+  type ProtocolAdapterV2,
+} from '../server/protocol-adapter-v2.js';
 import type { ChannelAgentRuntime } from '../server/channel-agent-runtime.js';
+import { builtInAgentProfileId } from '../shared/agent-profile.js';
 import {
   createWorkspaceTopicStore,
   type WorkspaceTopicStore,
 } from '../server/workspace-topics.js';
-import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+import {
+  parseMentions,
+  type ChannelMessage,
+} from '../shared/channel-chat-protocol.js';
+import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -42,24 +55,95 @@ const TARGETS: MentionTarget[] = [
   },
 ];
 
+class ThreadRecordingAdapter extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = { text: true, streaming: true };
+  readonly contents: string[] = [];
+  private _status: AdapterStatus = 'disconnected';
+  private sid = 'thread-recording';
+  constructor(
+    readonly agentType: string,
+    private readonly reply: string
+  ) {
+    super();
+  }
+  get status(): AdapterStatus {
+    return this._status;
+  }
+  async connect(config: AdapterConfig): Promise<void> {
+    this._status = 'connected';
+    this.sid = config.sessionId;
+  }
+  protected async onDisconnect(): Promise<void> {
+    this._status = 'disconnected';
+  }
+  async reconnect(): Promise<void> {}
+  async resumeSession(): Promise<void> {}
+  async interrupt(_input: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(): Promise<void> {}
+  async respondToInput(): Promise<void> {}
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    this.contents.push(input.content);
+    const itemId = `a-${input.turnId}`;
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      item: { type: 'assistantMessage', id: itemId, text: '' },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      itemId,
+      delta: { text: this.reply },
+    });
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      item: {
+        type: 'assistantMessage',
+        id: itemId,
+        text: this.reply,
+        status: 'completed',
+      },
+    });
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sid,
+      timestamp: 't',
+      turnId: input.turnId,
+      status: 'completed',
+    });
+  }
+}
+
 interface Harness {
   port: number;
   store: ChannelMessageStore;
   topicStore: WorkspaceTopicStore;
   hub: ChannelHub;
   channelId: string;
+  binder: ChannelAgentBinder;
+  adapters: () => ProtocolAdapterV2[];
 }
 
-function mockSessions(): BinderRuntimes {
+function mockSessions(
+  build: (provider: string) => ProtocolAdapterV2 = () =>
+    new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+  adapters: ProtocolAdapterV2[] = []
+): BinderRuntimes {
   const sessions = new Map<string, ChannelAgentRuntime>();
   const endHandlers = new Set<(id: string) => void>();
   return {
     async create(params) {
       const id = `session-${sessions.size + 1}`;
-      const adapter: ProtocolAdapterV2 = new MockProtocolAdapterV2({
-        connectMs: 1,
-        stepMs: 1,
-      });
+      const adapter = build(params.providerId);
+      adapters.push(adapter);
       await adapter.connect({
         cwd: params.cwd,
         port: 0,
@@ -93,7 +177,13 @@ function mockSessions(): BinderRuntimes {
   };
 }
 
-async function createHarness(): Promise<Harness> {
+async function createHarness(
+  opts: {
+    build?: (provider: string) => ProtocolAdapterV2;
+    targets?: MentionTarget[];
+    knownProviderIds?: string[];
+  } = {}
+): Promise<Harness> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-thread-e2e-'));
   cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
 
@@ -114,13 +204,15 @@ async function createHarness(): Promise<Harness> {
     title: 'Thread round trip',
   });
 
+  const adapters: ProtocolAdapterV2[] = [];
+  const knownProviderIds = opts.knownProviderIds ?? ['mock'];
   const binder = createChannelAgentBinder({
     store,
     hub,
     topicStore,
-    runtimes: mockSessions(),
-    knownProviderIds: ['mock'],
-    mentionTargets: async () => TARGETS,
+    runtimes: mockSessions(opts.build, adapters),
+    knownProviderIds,
+    mentionTargets: async () => opts.targets ?? TARGETS,
     port: 0,
     configDir: dir,
   });
@@ -137,7 +229,7 @@ async function createHarness(): Promise<Harness> {
       hub,
       topicStore,
       binder,
-      knownProviderIds: ['mock'],
+      knownProviderIds,
     })
   );
   const server = http.createServer(app);
@@ -151,6 +243,8 @@ async function createHarness(): Promise<Harness> {
     topicStore,
     hub,
     channelId: topic.id,
+    binder,
+    adapters: () => adapters,
   };
 }
 
@@ -238,5 +332,67 @@ describe('channel thread mention round trip', () => {
     // The four detail cards persist in-thread (with a thread_id) but are not
     // conversational replies — only the human trigger and the mock reply count.
     expect(harness.store.getMessage(root.message.id)?.replyCount).toBe(2);
+  });
+
+  it('retains thread scope when a delegated agent receives its typed completion callback', async () => {
+    const targets: MentionTarget[] = ['a', 'b'].map((id) => ({
+      id,
+      displayName: id.toUpperCase(),
+      kind: 'framework' as const,
+      available: true,
+      reason: null,
+    }));
+    const harness = await createHarness({
+      build: (provider) =>
+        new ThreadRecordingAdapter(
+          provider,
+          provider === 'b' ? 'B thread result' : 'A thread follow-up'
+        ),
+      targets,
+      knownProviderIds: ['a', 'b'],
+    });
+    const root = await post(harness, { text: 'thread callback root' });
+    await post(harness, { text: 'unrelated channel update' });
+    const text = '@b investigate in this thread';
+    const stream = harness.store.beginStream({
+      channelId: harness.channelId,
+      sender: {
+        kind: 'agent',
+        id: builtInAgentProfileId('a'),
+        providerId: 'a',
+        displayName: 'A',
+      },
+      source: { runtimeId: 'runtime:a', turnId: 'a-thread-b', itemId: 'a-1' },
+      parentMessageId: root.message.id,
+      mentions: parseMentions(text, ['a', 'b']),
+    });
+    const delegated = harness.store.finalizeStream(stream.id, {
+      text,
+      status: 'complete',
+    })!;
+    harness.binder.handleMessagePosted(delegated, delegated.mentions ?? []);
+
+    await waitFor(() => harness.adapters().length === 2);
+    const a = harness
+      .adapters()
+      .find(
+        (adapter) => (adapter as ThreadRecordingAdapter).agentType === 'a'
+      ) as ThreadRecordingAdapter;
+    await waitFor(() => a.contents.length === 1);
+    expect(a.contents[0]).toContain('[Relay internal completion callback]');
+    expect(a.contents[0]).toContain(
+      '[Thread scope — only this thread is shown; its root message is always included]'
+    );
+    expect(a.contents[0]).toContain('thread callback root');
+    expect(a.contents[0]).not.toContain('unrelated channel update');
+    const prose = harness.store
+      .history(harness.channelId, { limit: 20 })
+      .filter((message) => !message.agentDetail);
+    const aFollowUp = prose.find(
+      (message) => message.body.text === 'A thread follow-up'
+    )!;
+    expect(aFollowUp).toMatchObject({
+      threadId: root.message.id,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- persist durable per-turn delegation callback edges with guarded one-shot lifecycle and restart recovery
- wake delegators through typed internal FIFO triggers when delegate turns terminalize, without fabricating chat mentions
- preserve downward delegation and upward completion direction across nested and multi-child fan-in
- suppress automatic duplicates for explicit ancestor returns and prevent callback-origin reverse delegation
- handle success, error, interrupt, disconnect, guarded idle, watchdog, busy queues, loop brakes, runtime death, and retention

## Invariant

> Delegation travels downward; completion travels upward; completion never creates a reverse delegation.

## Verification

- exact head: `1ac7d09a0f862d33379cb8f54179e360fcc029e7`
- focused callback matrix: 9 files changed, 278 tests passed
- push hook: 14 changed test files, 578 tests passed
- `npm run check`: passed with 0 errors and 237 existing warnings
- `npm run build`: passed
- full `npm test` after build: 477 files, 6,492 tests passed
- `git diff --check`: clean
- state-machine/CAS invariant evidence recorded and validated

## Adversarial review

A read-only `gpt-5.6-sol` reviewer audited restart recovery, duplicate terminal events, ancestor detection, fan-in, FIFO/backpressure, and loop behavior. The first pass found five P1 and two P2 durability gaps; the focused re-review cleared four fixes and found three immediate P1 plus one P2 closure gap. All actionable Relay-side findings were fixed with focused regressions.

## Local non-production dogfood

- isolated self-host backend/frontend: `127.0.0.1:10001` / `127.0.0.1:10002`
- isolated config: `~/.config/relay-ide/self-host/1359-delegation-completion-callback-9cda1d73fad9/`
- human triggered Claude; Claude delegated to Codex through an explicit channel mention
- Codex replied `done` without mentioning Claude
- Relay automatically woke Claude through the typed completion callback; Claude acknowledged the delegated result
- durable edge reached `consumed` with terminal reason `completed` and the Codex final-message id
- isolated hub was stopped cleanly after proof

## Delivery boundary

Relay uses deterministic callback turn/client identities and exactly-once CAS after adapter acceptance. Current provider adapters do not expose a persisted acceptance receipt or dedupe `clientMessageId`, so a process crash after external provider acceptance but before Relay records consumption remains an explicitly documented at-least-once provider-dispatch ambiguity rather than a false universal exactly-once claim.

Closes #1359