### PR TITLE
feat(channels): add reversible archive control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ workflow.
 - Deliver durable, exactly-once upward completion callbacks for explicit
   agent-to-agent channel delegations, including restart recovery, busy-agent
   FIFO queueing, nested child fan-in, and explicit-return de-duplication (#1359)
+- Reversibly archive idle channels from the active conversation header, with
+  inline confirmation and the existing older-channel restore path (#1382)
 
 #### Changed
 
@@ -75,6 +77,8 @@ workflow.
 - Existing Codex channel conversations now recover after a hub/runtime restart,
   and user message bubbles no longer collapse into character-by-character
   wrapping (#1339)
+- Keep all-archived workspaces empty in the active channel list instead of
+  resurrecting their WorkContexts as derived ghost rows (#1382)
 
 ### Agent runtimes
 

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -114,16 +114,17 @@
 }
 
 .ch-archive-channel__progress {
-  color: currentColor;
   font-size: inherit;
 }
 
 .ch-archive-channel__error {
   min-width: 0;
+  max-width: min(36ch, 35vw);
   color: var(--status-error);
   font-size: var(--font-size-xs);
   line-height: 1.2;
   text-transform: lowercase;
+  overflow-wrap: anywhere;
 }
 
 /* agent presence chips (#1167) — one per bound/active agent, glyph + status dot

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -64,6 +64,68 @@
   margin-left: auto;
 }
 
+/* Reversible channel lifecycle control (#1382). Confirmation stays inline in
+   the header: no modal, no destructive fill, and no permanent-delete wording. */
+.ch-archive-channel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ch-archive-channel__prompt {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
+.ch-archive-channel__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
+  text-transform: lowercase;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.ch-archive-channel__button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.ch-archive-channel__button--confirm {
+  border-color: var(--status-error);
+  color: var(--status-error);
+}
+
+.ch-archive-channel__button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.ch-archive-channel__progress {
+  color: currentColor;
+  font-size: inherit;
+}
+
+.ch-archive-channel__error {
+  min-width: 0;
+  color: var(--status-error);
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
+  text-transform: lowercase;
+}
+
 /* agent presence chips (#1167) — one per bound/active agent, glyph + status dot
    + optional interrupt button. Status color: grey idle, pulsing amber busy,
    green streaming. Only DESIGN.md tokens. */
@@ -1197,6 +1259,30 @@
   .ch-header__title {
     flex: 1 1 auto;
     min-width: 4ch;
+  }
+
+  /* Touch controls meet the 44px mobile target. The lifecycle cluster takes a
+     fresh row so confirmation never crushes the title or connection state. */
+  .ch-archive-channel,
+  .ch-header > .ch-archive-channel__button {
+    order: 1;
+  }
+
+  .ch-archive-channel--confirming {
+    flex: 1 0 100%;
+    justify-content: flex-end;
+  }
+
+  .ch-archive-channel__button {
+    min-height: 44px;
+    padding-inline: 12px;
+  }
+
+  .ch-archive-channel__error {
+    order: 2;
+    flex: 1 0 100%;
+    max-width: 100%;
+    overflow-wrap: anywhere;
   }
 
   /* A failed designation gets a bounded row instead of competing with title,

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -104,13 +104,34 @@ function ChannelArchiveControl({
   const [confirming, setConfirming] = useState(false);
   const [freshCheckPending, setFreshCheckPending] = useState(false);
   const [freshCheckBlock, setFreshCheckBlock] = useState<string | null>(null);
+  const currentChannelIdRef = useRef<string | null>(channelId);
+  const archiveTriggerRef = useRef<HTMLButtonElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreTriggerFocusRef = useRef(false);
 
   useEffect(() => {
+    currentChannelIdRef.current = channelId;
     setConfirming(false);
     setFreshCheckPending(false);
     setFreshCheckBlock(null);
     resetArchive();
+    return () => {
+      if (currentChannelIdRef.current === channelId) {
+        currentChannelIdRef.current = null;
+      }
+    };
   }, [channelId, resetArchive]);
+
+  useLayoutEffect(() => {
+    if (confirming) {
+      confirmButtonRef.current?.focus();
+      return;
+    }
+    if (restoreTriggerFocusRef.current) {
+      restoreTriggerFocusRef.current = false;
+      archiveTriggerRef.current?.focus();
+    }
+  }, [confirming]);
 
   if (archived) return null;
 
@@ -136,6 +157,9 @@ function ChannelArchiveControl({
 
   const confirmArchive = async (): Promise<void> => {
     if (blocked || archivePending || freshCheckPending) return;
+    const requestedChannelId = channelId;
+    const isCurrentChannel = () =>
+      currentChannelIdRef.current === requestedChannelId;
     resetArchive();
     setFreshCheckBlock(null);
     setFreshCheckPending(true);
@@ -144,16 +168,22 @@ function ChannelArchiveControl({
       // Confirmation deliberately bypasses the 30s query freshness window.
       // The server repeats the invariant authoritatively; this fresh read keeps
       // the operator from firing a request we already know must be rejected.
-      freshRoster = await fetchChannelRoster(channelId);
-      queryClient.setQueryData(['channel-roster', channelId], freshRoster);
+      freshRoster = await fetchChannelRoster(requestedChannelId);
+      if (!isCurrentChannel()) return;
+      queryClient.setQueryData(
+        ['channel-roster', requestedChannelId],
+        freshRoster
+      );
     } catch {
+      if (!isCurrentChannel()) return;
       setFreshCheckBlock(
         'agent status could not be verified — retry before archiving'
       );
       return;
     } finally {
-      setFreshCheckPending(false);
+      if (isCurrentChannel()) setFreshCheckPending(false);
     }
+    if (!isCurrentChannel()) return;
     const freshBusy = freshRoster.filter(
       (entry) =>
         entry.binding !== null &&
@@ -170,11 +200,12 @@ function ChannelArchiveControl({
       return;
     }
     try {
-      await archiveChannel(channelId);
+      await archiveChannel(requestedChannelId);
+      if (!isCurrentChannel()) return;
       // The shared mutation does not resolve until every mounted topic/channel
       // projection has reconciled. Only then leave this now-archived channel,
       // preventing the active-only rail from immediately selecting it again.
-      if (useUiStore.getState().activeChannelId === channelId) {
+      if (useUiStore.getState().activeChannelId === requestedChannelId) {
         setActiveChannelId(null);
       }
     } catch {
@@ -193,6 +224,7 @@ function ChannelArchiveControl({
         >
           <span className="ch-archive-channel__prompt">archive?</span>
           <button
+            ref={confirmButtonRef}
             type="button"
             className="ch-archive-channel__button ch-archive-channel__button--confirm"
             onClick={() => void confirmArchive()}
@@ -226,6 +258,7 @@ function ChannelArchiveControl({
             onClick={() => {
               resetArchive();
               setFreshCheckBlock(null);
+              restoreTriggerFocusRef.current = true;
               setConfirming(false);
             }}
             disabled={archivePending || freshCheckPending}
@@ -235,6 +268,7 @@ function ChannelArchiveControl({
         </span>
       ) : (
         <button
+          ref={archiveTriggerRef}
           type="button"
           className="ch-archive-channel__button"
           onClick={() => {
@@ -935,6 +969,16 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     }
     return ids;
   }, [agentChips]);
+  const archiveBusyAgentCount = useMemo(
+    () =>
+      agentChips.filter(
+        (chip) =>
+          chip.status !== 'idle' ||
+          chip.queuedCount > 0 ||
+          chip.steeringCount > 0
+      ).length,
+    [agentChips]
+  );
 
   // #1308 slice 4 item 2b. The composer's steering cluster keys on the SAME chip
   // signal, so what the composer offers and what the header says the agent is
@@ -1214,9 +1258,10 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         ) : null}
         <span className="ch-header__spacer" />
         <ChannelArchiveControl
+          key={channelId}
           channelId={channelId}
           archived={archived}
-          busyAgentCount={busyAgentIds.size}
+          busyAgentCount={archiveBusyAgentCount}
           rosterStatus={
             rosterChipsQuery.isPending
               ? 'pending'

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -27,6 +27,7 @@ import {
   retryChannelMessage,
   HttpError,
   type ChannelAgentStatus,
+  type RosterEntry,
 } from '../../lib/api.js';
 import { isArchivedChannelPostError } from '../../lib/agent-channels.js';
 import { useArchiveTopicMutation } from '../../lib/hooks/use-archive-topic.js';
@@ -91,6 +92,7 @@ function ChannelArchiveControl({
   busyAgentCount: number;
   rosterStatus: 'pending' | 'error' | 'ready';
 }) {
+  const queryClient = useQueryClient();
   const setActiveChannelId = useUiStore((s) => s.setActiveChannelId);
   const {
     mutateAsync: archiveChannel,
@@ -100,9 +102,13 @@ function ChannelArchiveControl({
     reset: resetArchive,
   } = useArchiveTopicMutation();
   const [confirming, setConfirming] = useState(false);
+  const [freshCheckPending, setFreshCheckPending] = useState(false);
+  const [freshCheckBlock, setFreshCheckBlock] = useState<string | null>(null);
 
   useEffect(() => {
     setConfirming(false);
+    setFreshCheckPending(false);
+    setFreshCheckBlock(null);
     resetArchive();
   }, [channelId, resetArchive]);
 
@@ -129,7 +135,40 @@ function ChannelArchiveControl({
   }
 
   const confirmArchive = async (): Promise<void> => {
-    if (blocked || archivePending) return;
+    if (blocked || archivePending || freshCheckPending) return;
+    resetArchive();
+    setFreshCheckBlock(null);
+    setFreshCheckPending(true);
+    let freshRoster: RosterEntry[];
+    try {
+      // Confirmation deliberately bypasses the 30s query freshness window.
+      // The server repeats the invariant authoritatively; this fresh read keeps
+      // the operator from firing a request we already know must be rejected.
+      freshRoster = await fetchChannelRoster(channelId);
+      queryClient.setQueryData(['channel-roster', channelId], freshRoster);
+    } catch {
+      setFreshCheckBlock(
+        'agent status could not be verified — retry before archiving'
+      );
+      return;
+    } finally {
+      setFreshCheckPending(false);
+    }
+    const freshBusy = freshRoster.filter(
+      (entry) =>
+        entry.binding !== null &&
+        (entry.binding.status !== 'idle' ||
+          (entry.binding.queuedCount ?? 0) > 0 ||
+          (entry.binding.steeringCount ?? 0) > 0)
+    );
+    if (freshBusy.length > 0) {
+      setFreshCheckBlock(
+        freshBusy.length === 1
+          ? 'archive blocked — a bound agent is active'
+          : `archive blocked — ${freshBusy.length} bound agents are active`
+      );
+      return;
+    }
     try {
       await archiveChannel(channelId);
       // The shared mutation does not resolve until every mounted topic/channel
@@ -157,9 +196,17 @@ function ChannelArchiveControl({
             type="button"
             className="ch-archive-channel__button ch-archive-channel__button--confirm"
             onClick={() => void confirmArchive()}
-            disabled={blocked || archivePending}
+            disabled={blocked || archivePending || freshCheckPending}
           >
-            {archivePending ? (
+            {freshCheckPending ? (
+              <>
+                <TuiProgress
+                  variant="braille"
+                  className="ch-archive-channel__progress"
+                />{' '}
+                checking agents
+              </>
+            ) : archivePending ? (
               <>
                 <TuiProgress
                   variant="braille"
@@ -178,9 +225,10 @@ function ChannelArchiveControl({
             className="ch-archive-channel__button"
             onClick={() => {
               resetArchive();
+              setFreshCheckBlock(null);
               setConfirming(false);
             }}
-            disabled={archivePending}
+            disabled={archivePending || freshCheckPending}
           >
             cancel
           </button>
@@ -191,6 +239,7 @@ function ChannelArchiveControl({
           className="ch-archive-channel__button"
           onClick={() => {
             resetArchive();
+            setFreshCheckBlock(null);
             setConfirming(true);
           }}
           disabled={blocked}
@@ -205,6 +254,10 @@ function ChannelArchiveControl({
           {archiveError instanceof Error
             ? archiveError.message
             : 'failed to archive channel'}
+        </span>
+      ) : freshCheckBlock ? (
+        <span className="ch-archive-channel__error" role="alert">
+          {freshCheckBlock}
         </span>
       ) : null}
     </>

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -29,6 +29,7 @@ import {
   type ChannelAgentStatus,
 } from '../../lib/api.js';
 import { isArchivedChannelPostError } from '../../lib/agent-channels.js';
+import { useArchiveTopicMutation } from '../../lib/hooks/use-archive-topic.js';
 import { useRestoreTopicMutation } from '../../lib/hooks/use-restore-topic.js';
 import { isDmChannel } from '../../lib/dm-channels.js';
 import { resolveSenderIdentity } from '../../lib/chat/sender-identity.js';
@@ -77,6 +78,137 @@ function designateOrchestratorErrorCopy(error: unknown): string {
   }
 
   return DESIGNATE_ORCHESTRATOR_GENERIC_ERROR;
+}
+
+function ChannelArchiveControl({
+  channelId,
+  archived,
+  busyAgentCount,
+  rosterStatus,
+}: {
+  channelId: string;
+  archived: boolean;
+  busyAgentCount: number;
+  rosterStatus: 'pending' | 'error' | 'ready';
+}) {
+  const setActiveChannelId = useUiStore((s) => s.setActiveChannelId);
+  const {
+    mutateAsync: archiveChannel,
+    isPending: archivePending,
+    isError: archiveFailed,
+    error: archiveError,
+    reset: resetArchive,
+  } = useArchiveTopicMutation();
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    setConfirming(false);
+    resetArchive();
+  }, [channelId, resetArchive]);
+
+  if (archived) return null;
+
+  // Fail closed until the authoritative roster lands: offering archive during
+  // the initial query (or after a roster failure) creates a click window where
+  // a bound busy runtime exists but the header has not learned about it yet.
+  const blocked = rosterStatus !== 'ready' || busyAgentCount > 0;
+  let blockedCopy = '';
+  let blockedTitle = '';
+  if (rosterStatus === 'pending') {
+    blockedCopy = 'archive unavailable · checking agents';
+    blockedTitle = 'checking bound agent status before archiving';
+  } else if (rosterStatus === 'error') {
+    blockedCopy = 'archive unavailable · agent status unknown';
+    blockedTitle = 'agent status is unavailable; retry before archiving';
+  } else if (busyAgentCount > 0) {
+    blockedCopy =
+      busyAgentCount === 1
+        ? 'archive unavailable · agent active'
+        : `archive unavailable · ${busyAgentCount} agents active`;
+    blockedTitle = 'wait for every bound agent to become idle before archiving';
+  }
+
+  const confirmArchive = async (): Promise<void> => {
+    if (blocked || archivePending) return;
+    try {
+      await archiveChannel(channelId);
+      // The shared mutation does not resolve until every mounted topic/channel
+      // projection has reconciled. Only then leave this now-archived channel,
+      // preventing the active-only rail from immediately selecting it again.
+      if (useUiStore.getState().activeChannelId === channelId) {
+        setActiveChannelId(null);
+      }
+    } catch {
+      // Shared mutation owns the operator toast; the inline error below keeps
+      // the failed confirmation actionable in the header as well.
+    }
+  };
+
+  return (
+    <>
+      {confirming ? (
+        <span
+          className="ch-archive-channel ch-archive-channel--confirming"
+          role="group"
+          aria-label="confirm archive channel"
+        >
+          <span className="ch-archive-channel__prompt">archive?</span>
+          <button
+            type="button"
+            className="ch-archive-channel__button ch-archive-channel__button--confirm"
+            onClick={() => void confirmArchive()}
+            disabled={blocked || archivePending}
+          >
+            {archivePending ? (
+              <>
+                <TuiProgress
+                  variant="braille"
+                  className="ch-archive-channel__progress"
+                />{' '}
+                archiving
+              </>
+            ) : blocked ? (
+              blockedCopy
+            ) : (
+              'yes'
+            )}
+          </button>
+          <button
+            type="button"
+            className="ch-archive-channel__button"
+            onClick={() => {
+              resetArchive();
+              setConfirming(false);
+            }}
+            disabled={archivePending}
+          >
+            cancel
+          </button>
+        </span>
+      ) : (
+        <button
+          type="button"
+          className="ch-archive-channel__button"
+          onClick={() => {
+            resetArchive();
+            setConfirming(true);
+          }}
+          disabled={blocked}
+          title={blocked ? blockedTitle : 'archive channel'}
+          aria-label={blocked ? blockedCopy : 'archive channel'}
+        >
+          {blocked ? blockedCopy : 'archive'}
+        </button>
+      )}
+      {archiveFailed ? (
+        <span className="ch-archive-channel__error" role="alert">
+          {archiveError instanceof Error
+            ? archiveError.message
+            : 'failed to archive channel'}
+        </span>
+      ) : null}
+    </>
+  );
 }
 
 /**
@@ -1028,6 +1160,18 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
           </span>
         ) : null}
         <span className="ch-header__spacer" />
+        <ChannelArchiveControl
+          channelId={channelId}
+          archived={archived}
+          busyAgentCount={busyAgentIds.size}
+          rosterStatus={
+            rosterChipsQuery.isPending
+              ? 'pending'
+              : rosterChipsQuery.isError
+                ? 'error'
+                : 'ready'
+          }
+        />
         {disconnected ? (
           // Reconnect gave up (server outage/deploy > backoff budget). Surface a
           // manual affordance — NOT gated on needsCatchup, which can never flip

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1686,6 +1686,19 @@ export async function fetchWorkspaceTopics(
   };
 }
 
+/** Reversibly archive a topic while preserving its history and bindings. */
+export async function archiveWorkspaceTopic(
+  id: string
+): Promise<WorkspaceTopic> {
+  const data = await json<{ topic: WorkspaceTopic }>(
+    await fetch(`/workspace-topics/${encodeURIComponent(id)}/archive`, {
+      method: 'POST',
+      headers: { 'x-relay-capabilities': 'context:write' },
+    })
+  );
+  return data.topic;
+}
+
 /** Reactivate an archived topic (clears its archivedAt marker). */
 export async function restoreWorkspaceTopic(
   id: string

--- a/frontend/src/lib/hooks/topic-lifecycle-query-keys.ts
+++ b/frontend/src/lib/hooks/topic-lifecycle-query-keys.ts
@@ -1,0 +1,14 @@
+/**
+ * Every cached projection whose membership or archived state changes when a
+ * topic crosses the active/archive boundary. Prefix keys intentionally cover
+ * active/archived variants and search entries below each namespace.
+ */
+export function topicLifecycleQueryKeys(topicId: string): string[][] {
+  return [
+    ['channel', topicId],
+    ['workspace-topic', topicId],
+    ['workspace-topics'],
+    ['channels'],
+    ['channel-message-search'],
+  ];
+}

--- a/frontend/src/lib/hooks/use-archive-topic.ts
+++ b/frontend/src/lib/hooks/use-archive-topic.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { archiveWorkspaceTopic } from '../api.js';
+import { useToastStore } from '../stores/toasts.js';
+
+/** Every cached projection whose membership or archived state changes. */
+export function archiveTopicQueryKeys(topicId: string): string[][] {
+  return [
+    ['channel', topicId],
+    ['workspace-topic', topicId],
+    ['workspace-topics'],
+    ['channels'],
+    ['channel-message-search'],
+  ];
+}
+
+/**
+ * Shared reversible archive mutation.
+ *
+ * The mutation remains pending until every mounted reader has reconciled, so a
+ * caller can safely leave the archived channel only after the active rail and
+ * search projections can no longer select it again.
+ */
+export function useArchiveTopicMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (topicId: string) => archiveWorkspaceTopic(topicId),
+    onSuccess: async (_topic, topicId) => {
+      await Promise.all(
+        archiveTopicQueryKeys(topicId).map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey })
+        )
+      );
+    },
+    onError: (err: unknown) => {
+      useToastStore
+        .getState()
+        .showToast(
+          err instanceof Error ? err.message : 'failed to archive channel'
+        );
+    },
+  });
+}

--- a/frontend/src/lib/hooks/use-archive-topic.ts
+++ b/frontend/src/lib/hooks/use-archive-topic.ts
@@ -2,17 +2,10 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { archiveWorkspaceTopic } from '../api.js';
 import { useToastStore } from '../stores/toasts.js';
+import { topicLifecycleQueryKeys } from './topic-lifecycle-query-keys.js';
 
-/** Every cached projection whose membership or archived state changes. */
-export function archiveTopicQueryKeys(topicId: string): string[][] {
-  return [
-    ['channel', topicId],
-    ['workspace-topic', topicId],
-    ['workspace-topics'],
-    ['channels'],
-    ['channel-message-search'],
-  ];
-}
+/** Backward-compatible test/caller name; one lifecycle key source owns both directions. */
+export const archiveTopicQueryKeys = topicLifecycleQueryKeys;
 
 /**
  * Shared reversible archive mutation.

--- a/frontend/src/lib/hooks/use-restore-topic.ts
+++ b/frontend/src/lib/hooks/use-restore-topic.ts
@@ -9,22 +9,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { restoreWorkspaceTopic } from '../api.js';
 import { useToastStore } from '../stores/toasts.js';
+import { topicLifecycleQueryKeys } from './topic-lifecycle-query-keys.js';
 
 /**
  * Every query key that renders a topic's archived state.
  *
- * `['workspace-topics']` is a PREFIX, not an exact key: TanStack matches it
- * against the sidebar's `['workspace-topics', 'with-archived']` view and its
- * `['workspace-topics', 'search', …]` results too, so the three entries here
- * cover all five readers.
+ * `['workspace-topics']`, `['channels']`, and `['channel-message-search']` are
+ * prefixes, so active/archived list and search variants reconcile together.
  */
-export function restoreTopicQueryKeys(topicId: string): string[][] {
-  return [
-    ['channel', topicId],
-    ['workspace-topic', topicId],
-    ['workspace-topics'],
-  ];
-}
+export const restoreTopicQueryKeys = topicLifecycleQueryKeys;
 
 /**
  * Shared restore mutation. `mutate(topicId)` is a stable reference, so callers

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -519,6 +519,10 @@ function bindingKey(channelId: string, profileActorId: string): string {
   return `${channelId}\u0000${profileActorId}`;
 }
 
+function bindingKeyPrefix(channelId: string): string {
+  return bindingKey(channelId, '');
+}
+
 export function createChannelAgentBinder(
   deps: ChannelAgentBinderDeps
 ): ChannelAgentBinder {
@@ -844,6 +848,27 @@ export function createChannelAgentBinder(
     timer.unref?.();
   }
 
+  function releaseClaimedCompletionCallback(
+    edge: ChannelCompletionCallbackEdge,
+    context: string
+  ): void {
+    try {
+      store.releaseDeliveredCompletionCallback(edge.id);
+      drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
+    } catch (err) {
+      // This runs from a timer. A synchronous SQLite failure must neither
+      // escape the timer nor drop the per-channel archive marker. Retry the
+      // release itself: delivered rows are not claimable until this CAS lands.
+      logger.warn(context, err);
+      if (closed) return;
+      const timer = setTimeout(
+        () => releaseClaimedCompletionCallback(edge, context),
+        COMPLETION_CALLBACK_RETRY_MS
+      );
+      timer.unref?.();
+    }
+  }
+
   function claimAndRouteCompletionCallbacks(): void {
     if (closed) return;
     let edges: ChannelCompletionCallbackEdge[];
@@ -866,8 +891,10 @@ export function createChannelAgentBinder(
           'channel completion callback requester profile is unavailable',
           { callbackId: edge.id, requesterProfileId: edge.requesterProfileId }
         );
-        store.releaseDeliveredCompletionCallback(edge.id);
-        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
+        releaseClaimedCompletionCallback(
+          edge,
+          'channel completion callback unavailable-requester release failed:'
+        );
         continue;
       }
       const trigger =
@@ -878,8 +905,10 @@ export function createChannelAgentBinder(
         logger.warn('channel completion callback trigger is unavailable', {
           callbackId: edge.id,
         });
-        store.releaseDeliveredCompletionCallback(edge.id);
-        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
+        releaseClaimedCompletionCallback(
+          edge,
+          'channel completion callback missing-trigger release failed:'
+        );
         continue;
       }
       void ensureProfileBinding(edge.channelId, profile)
@@ -3878,7 +3907,7 @@ export function createChannelAgentBinder(
     channelId: string
   ): ChannelArchiveActivitySnapshot {
     const reasons = new Set<ChannelArchiveActivityReason>();
-    const prefix = `${channelId}\u0000`;
+    const prefix = bindingKeyPrefix(channelId);
     for (const [key, binding] of live) {
       if (!key.startsWith(prefix)) continue;
       if (binding.status !== 'idle') reasons.add('binding-status');

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -191,7 +191,8 @@ export type ChannelArchiveActivityReason =
   | 'binding-in-flight'
   | 'orchestrator-in-flight'
   | 'routing-in-flight'
-  | 'retry-in-flight';
+  | 'retry-in-flight'
+  | 'completion-callback';
 
 /** Synchronous snapshot used by the topic archive mutation boundary. */
 export interface ChannelArchiveActivitySnapshot {
@@ -561,6 +562,10 @@ export function createChannelAgentBinder(
     promise: Promise<MentionTarget[]>;
   } | null = null;
   let completionDrainScheduled = false;
+  // Durable satisfied/delivered callbacks are work in the requester's channel
+  // before the next-tick drain creates ordinary binding/routing state. Key by
+  // callback id so repeated retry scheduling is idempotent and channel-local.
+  const pendingCompletionCallbacks = new Map<string, string>();
   let lastCompletionCallbackPruneAt: number | null = null;
   let closed = false;
 
@@ -747,7 +752,7 @@ export function createChannelAgentBinder(
             targetTurnId: turnId,
             ...input,
           });
-      if (satisfied) drainCompletionCallbacks();
+      if (satisfied) drainCompletionCallbacks(0, [satisfied]);
       maybePruneCompletionCallbacks();
     } catch (err) {
       logger.warn('channel completion callback terminalization failed:', err);
@@ -772,7 +777,7 @@ export function createChannelAgentBinder(
             messageDisposition: deferred.messageDisposition,
           })
         : null;
-      if (satisfied) drainCompletionCallbacks();
+      if (satisfied) drainCompletionCallbacks(0, [satisfied]);
     } catch (err) {
       logger.warn(
         'channel deferred completion callback terminalization failed:',
@@ -794,7 +799,7 @@ export function createChannelAgentBinder(
     if (!callback) return false;
     try {
       store.releaseDeliveredCompletionCallback(callback.id);
-      drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+      drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [callback]);
     } catch (err) {
       logger.warn(
         'channel unaccepted completion callback release failed:',
@@ -811,7 +816,21 @@ export function createChannelAgentBinder(
    * CAS is the exactly-once boundary for duplicate/late terminal patches; the
    * FIFO below is only delivery scheduling for a busy requester.
    */
-  function drainCompletionCallbacks(delayMs = 0): void {
+  function trackCompletionCallbacks(
+    edges: readonly ChannelCompletionCallbackEdge[]
+  ): void {
+    for (const edge of edges) {
+      pendingCompletionCallbacks.set(edge.id, edge.channelId);
+    }
+  }
+
+  function drainCompletionCallbacks(
+    delayMs = 0,
+    edges: readonly ChannelCompletionCallbackEdge[] = []
+  ): void {
+    // Track even when a drain timer already exists. Many terminal patches can
+    // fan into that one timer, and every affected channel must remain blocked.
+    trackCompletionCallbacks(edges);
     if (closed || completionDrainScheduled) return;
     // Let the provider's terminal patch finish its current microtask fan-out
     // before the upward callback enters another agent's FIFO. That preserves
@@ -834,9 +853,13 @@ export function createChannelAgentBinder(
       );
     } catch (err) {
       logger.warn('channel completion callback claim failed:', err);
+      // Durable work is still satisfied, so keep its per-channel marker and
+      // retry instead of either losing delivery or declaring archive-safe.
+      drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
       return;
     }
     for (const edge of edges) {
+      trackCompletionCallbacks([edge]);
       const profile = profileForActorId(edge.requesterProfileId);
       if (!profile) {
         logger.warn(
@@ -844,7 +867,7 @@ export function createChannelAgentBinder(
           { callbackId: edge.id, requesterProfileId: edge.requesterProfileId }
         );
         store.releaseDeliveredCompletionCallback(edge.id);
-        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
         continue;
       }
       const trigger =
@@ -856,7 +879,7 @@ export function createChannelAgentBinder(
           callbackId: edge.id,
         });
         store.releaseDeliveredCompletionCallback(edge.id);
-        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+        drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
         continue;
       }
       void ensureProfileBinding(edge.channelId, profile)
@@ -866,15 +889,19 @@ export function createChannelAgentBinder(
             // Queue admission is a durable boundary too. A full/released
             // requester must re-offer this claimed edge rather than stranding it.
             store.releaseDeliveredCompletionCallback(edge.id);
-            drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+            drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
+            return;
           }
+          // enqueueTurn synchronously installs active/queued binding state, so
+          // that invariant takes over without an archive-visible gap.
+          pendingCompletionCallbacks.delete(edge.id);
         })
         .catch((err) => {
           if (closed || err instanceof BinderClosedError) return;
           logger.warn('channel completion callback routing failed:', err);
           try {
             store.releaseDeliveredCompletionCallback(edge.id);
-            drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+            drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [edge]);
           } catch (releaseErr) {
             logger.warn(
               'channel completion callback claim release failed:',
@@ -1682,7 +1709,7 @@ export function createChannelAgentBinder(
           terminalReason: 'error',
           messageDisposition: CALLBACK_NO_TERMINAL_MESSAGE,
         });
-        if (satisfied) drainCompletionCallbacks();
+        if (satisfied) drainCompletionCallbacks(0, [satisfied]);
         maybePruneCompletionCallbacks();
       } catch (err) {
         logger.warn(
@@ -2076,7 +2103,9 @@ export function createChannelAgentBinder(
       if (completionCallback) {
         try {
           store.releaseDeliveredCompletionCallback(completionCallback.id);
-          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [
+            completionCallback,
+          ]);
         } catch (releaseErr) {
           logger.warn(
             'channel completion callback packet-failure release failed:',
@@ -2333,7 +2362,9 @@ export function createChannelAgentBinder(
           store.releaseDeliveredCompletionCallback(
             queued.completionCallback.id
           );
-          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [
+            queued.completionCallback,
+          ]);
         } catch (err) {
           logger.warn(
             'channel queued completion callback release failed:',
@@ -2358,7 +2389,7 @@ export function createChannelAgentBinder(
             terminalReason: CALLBACK_UNEXPECTED_DISCONNECT,
             messageDisposition: CALLBACK_NO_TERMINAL_MESSAGE,
           });
-          if (satisfied) drainCompletionCallbacks();
+          if (satisfied) drainCompletionCallbacks(0, [satisfied]);
           maybePruneCompletionCallbacks();
         } catch (err) {
           logger.warn('channel queued delegation terminalization failed:', err);
@@ -2377,7 +2408,9 @@ export function createChannelAgentBinder(
           store.releaseDeliveredCompletionCallback(
             steering.completionCallback.id
           );
-          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS);
+          drainCompletionCallbacks(COMPLETION_CALLBACK_RETRY_MS, [
+            steering.completionCallback,
+          ]);
         } catch (err) {
           logger.warn('channel queued steering callback release failed:', err);
         }
@@ -2395,7 +2428,7 @@ export function createChannelAgentBinder(
             terminalReason: CALLBACK_UNEXPECTED_DISCONNECT,
             messageDisposition: CALLBACK_NO_TERMINAL_MESSAGE,
           });
-          if (satisfied) drainCompletionCallbacks();
+          if (satisfied) drainCompletionCallbacks(0, [satisfied]);
           maybePruneCompletionCallbacks();
         } catch (err) {
           logger.warn(
@@ -2770,7 +2803,9 @@ export function createChannelAgentBinder(
         if (!parentId) return;
         try {
           const released = store.releaseDeferredCompletionCallback(parentId);
-          if (released?.state === 'satisfied') drainCompletionCallbacks();
+          if (released?.state === 'satisfied') {
+            drainCompletionCallbacks(0, [released]);
+          }
         } catch (err) {
           logger.warn('channel completion callback defer release failed:', err);
         }
@@ -3224,7 +3259,10 @@ export function createChannelAgentBinder(
       const consumed = store.consumeAncestorCompletionCallbackForExplicitReturn(
         parent.id
       );
-      if (consumed) explicitReturnProfiles.add(consumed.requesterProfileId);
+      if (consumed) {
+        pendingCompletionCallbacks.delete(consumed.id);
+        explicitReturnProfiles.add(consumed.requesterProfileId);
+      }
     } catch (err) {
       logger.warn(
         'channel completion callback ancestor explicit-return consume failed:',
@@ -3256,6 +3294,7 @@ export function createChannelAgentBinder(
           requesterProfileIds: profiles.map((profile) => profile.id),
         });
         for (const edge of consumed) {
+          pendingCompletionCallbacks.delete(edge.id);
           explicitReturnProfiles.add(edge.requesterProfileId);
         }
       } catch (err) {
@@ -3316,8 +3355,8 @@ export function createChannelAgentBinder(
   async function recoverCompletionCallbacks(): Promise<void> {
     if (closed) return;
     try {
-      store.recoverCompletionCallbacks();
-      drainCompletionCallbacks();
+      const recovered = store.recoverCompletionCallbacks();
+      drainCompletionCallbacks(0, recovered);
     } catch (err) {
       logger.warn('channel completion callback recovery failed:', err);
     }
@@ -3865,6 +3904,13 @@ export function createChannelAgentBinder(
     if (Array.from(retryInFlight).some((key) => key.startsWith(prefix))) {
       reasons.add('retry-in-flight');
     }
+    if (
+      Array.from(pendingCompletionCallbacks.values()).some(
+        (pendingChannelId) => pendingChannelId === channelId
+      )
+    ) {
+      reasons.add('completion-callback');
+    }
     return { active: reasons.size > 0, reasons: Array.from(reasons) };
   }
 
@@ -3921,6 +3967,7 @@ export function createChannelAgentBinder(
       orchestratorInflight.clear();
       retryInFlight.clear();
       routingInFlightByChannel.clear();
+      pendingCompletionCallbacks.clear();
       consecutiveAgentTurns.clear();
       unavailableRowAt.clear();
       invalidateTargets();

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -183,6 +183,22 @@ export interface ChannelAgentRosterEntry {
   commands?: AgentSlashCommandV2[];
 }
 
+export type ChannelArchiveActivityReason =
+  | 'binding-status'
+  | 'active-turn'
+  | 'queued-turn'
+  | 'steering'
+  | 'binding-in-flight'
+  | 'orchestrator-in-flight'
+  | 'routing-in-flight'
+  | 'retry-in-flight';
+
+/** Synchronous snapshot used by the topic archive mutation boundary. */
+export interface ChannelArchiveActivitySnapshot {
+  active: boolean;
+  reasons: ChannelArchiveActivityReason[];
+}
+
 export type ChannelAgentStatusBroadcaster = (
   type: string,
   data: Record<string, unknown>
@@ -261,6 +277,11 @@ export interface ChannelAgentBinder {
     decision: AgentApprovalDecisionV2
   ): Promise<void>;
   rosterForChannel(channelId: string): Promise<ChannelAgentRosterEntry[]>;
+  /**
+   * Synchronous by design: callers check this and archive in one JS turn, so a
+   * new binder operation cannot interleave between the invariant and mutation.
+   */
+  archiveActivityForChannel(channelId: string): ChannelArchiveActivitySnapshot;
   executeCommand(
     channelId: string,
     profileActorId: string,
@@ -528,6 +549,10 @@ export function createChannelAgentBinder(
   // This marker is taken synchronously with the busy check and held until the
   // route settles, so the second caller is refused rather than admitted.
   const retryInFlight = new Set<string>();
+  // `routeOne` awaits target discovery before `inflight` owns a binding key.
+  // Count that earlier window too, otherwise archive can race a mention that is
+  // already admitted but has not started spawning its runtime yet.
+  const routingInFlightByChannel = new Map<string, number>();
   let statusBroadcaster: ChannelAgentStatusBroadcaster | null = null;
   let targetsCache: { at: number; value: MentionTarget[] } | null = null;
   let targetsGeneration = 0;
@@ -2735,6 +2760,10 @@ export function createChannelAgentBinder(
     requiredRole?: 'orchestrator',
     callbackEdgeRequest?: CallbackEdgeRequest
   ): Promise<void> {
+    routingInFlightByChannel.set(
+      trigger.channelId,
+      (routingInFlightByChannel.get(trigger.channelId) ?? 0) + 1
+    );
     return (async () => {
       const releaseDeferredParent = () => {
         const parentId = callbackEdgeRequest?.continuationParentCallbackId;
@@ -2845,7 +2874,12 @@ export function createChannelAgentBinder(
         releaseDeferredParent();
         logger.warn('channel binder route failed:', err);
       }
-    })();
+    })().finally(() => {
+      const remaining =
+        (routingInFlightByChannel.get(trigger.channelId) ?? 1) - 1;
+      if (remaining <= 0) routingInFlightByChannel.delete(trigger.channelId);
+      else routingInFlightByChannel.set(trigger.channelId, remaining);
+    });
   }
 
   /** Eligible profile-resolved, non-self mentions in routing order. */
@@ -3801,6 +3835,39 @@ export function createChannelAgentBinder(
     return false;
   }
 
+  function archiveActivityForChannel(
+    channelId: string
+  ): ChannelArchiveActivitySnapshot {
+    const reasons = new Set<ChannelArchiveActivityReason>();
+    const prefix = `${channelId}\u0000`;
+    for (const [key, binding] of live) {
+      if (!key.startsWith(prefix)) continue;
+      if (binding.status !== 'idle') reasons.add('binding-status');
+      if (binding.activeTurnId !== null) reasons.add('active-turn');
+      if (binding.queue.length > 0) reasons.add('queued-turn');
+      if (
+        binding.steeringQueue.length > 0 ||
+        binding.steeringInFlight ||
+        binding.steeringAcceptedCount > 0
+      ) {
+        reasons.add('steering');
+      }
+    }
+    if (Array.from(inflight.keys()).some((key) => key.startsWith(prefix))) {
+      reasons.add('binding-in-flight');
+    }
+    if (orchestratorInflight.has(channelId)) {
+      reasons.add('orchestrator-in-flight');
+    }
+    if ((routingInFlightByChannel.get(channelId) ?? 0) > 0) {
+      reasons.add('routing-in-flight');
+    }
+    if (Array.from(retryInFlight).some((key) => key.startsWith(prefix))) {
+      reasons.add('retry-in-flight');
+    }
+    return { active: reasons.size > 0, reasons: Array.from(reasons) };
+  }
+
   return {
     handleMessagePosted,
     ensureBinding,
@@ -3811,6 +3878,7 @@ export function createChannelAgentBinder(
     retryMessage,
     respondToApproval,
     rosterForChannel,
+    archiveActivityForChannel,
     executeCommand,
     isControlMessage,
     recoverCompletionCallbacks,
@@ -3852,6 +3920,7 @@ export function createChannelAgentBinder(
       inflight.clear();
       orchestratorInflight.clear();
       retryInFlight.clear();
+      routingInFlightByChannel.clear();
       consecutiveAgentTurns.clear();
       unavailableRowAt.clear();
       invalidateTargets();

--- a/server/index.ts
+++ b/server/index.ts
@@ -2570,6 +2570,9 @@ async function main(): Promise<void> {
       surfaceStore: workspaceSurfaceStore,
       workContextStore,
       getConfig,
+      channelArchiveActivity: channelAgentBinder
+        ? (channelId) => channelAgentBinder.archiveActivityForChannel(channelId)
+        : null,
       requireAuth: requireCliGatewayAuth,
       requireReadActorAuth: requireCliGatewayAuthForActorCommand,
       requireWriteActorAuth: requireCliGatewayAuthForActorCommand,

--- a/server/workspace-topics.ts
+++ b/server/workspace-topics.ts
@@ -1343,6 +1343,16 @@ export function createWorkspaceTopicsRouter(
             limit: WORKSPACE_TOPICS_LIST_SENTINEL_LIMIT,
           })
         : [];
+      const hasAnyPersistedTopic = options.store
+        ? options.store.list({
+            ...(workspaceId ? { workspaceId } : {}),
+            includeArchived: true,
+            // Derived fallback is all-or-nothing, so one row is enough to prove
+            // this workspace has crossed from its cold-start scaffold into
+            // durable channel ownership.
+            limit: 1,
+          }).length > 0
+        : false;
       // All-or-nothing on purpose (#1287 audit item 23): the derived lane is a
       // cold-start scaffold for a hub with no channels yet, so one UNARCHIVED
       // persisted row hides EVERY derived row rather than unioning them — a
@@ -1352,20 +1362,12 @@ export function createWorkspaceTopicsRouter(
       // (`collectSearchTopics`) deliberately does union, so search can still
       // reach a masked WorkContext.
       //
-      // KNOWN HOLE (accepted debt, not a claim of correctness): `persisted` is
-      // filtered by `includeArchived`, and the store drops `status =
-      // 'archived'` rows when it is false (see `list()` above). So with
-      // `includeArchived=false` and EVERY channel in the workspace archived,
-      // `persisted.length === 0` and this flips back to the derived scaffold —
-      // re-surfacing the archived channels' WorkContexts as derived rows under
-      // different ids (`derived-<contextId>`), which neither dedupe against nor
-      // inherit the archive filter. The guard only holds while >= 1 unarchived
-      // row survives. Gating on the UNFILTERED row count
-      // (`store.list({ workspaceId, includeArchived: true })`) would close it;
-      // that is a product call about what an all-archived workspace should
-      // render, deliberately not made in the #1287 slice 0 hygiene pass.
+      // Archive is reversible operator intent, not permission to resurrect the
+      // same WorkContext under a new derived id. Gate fallback on the unfiltered
+      // persisted row count so an all-archived workspace correctly renders an
+      // empty active list; its rows remain reachable through includeArchived.
       // See docs/LEARNINGS.md L-20260801-derived-topics-are-all-or-nothing.
-      const derived = persisted.length === 0;
+      const derived = !hasAnyPersistedTopic;
       const allTopics = derived
         ? fallbackTopics({
             workContextStore: options.workContextStore,

--- a/server/workspace-topics.ts
+++ b/server/workspace-topics.ts
@@ -1287,6 +1287,18 @@ export interface WorkspaceTopicsRouterOptions {
   surfaceStore?: WorkspaceSurfaceStore | null;
   workContextStore?: WorkContextStore;
   getConfig?: () => Config;
+  /**
+   * Synchronous binder invariant for reversible archive. `undefined` means the
+   * embedding has no binder (unit/minimal topic router, therefore no agent
+   * activity); explicit `null` means production expected a binder but it is
+   * unavailable, which fails closed rather than guessing that agents are idle.
+   */
+  channelArchiveActivity?:
+    | ((channelId: string) => {
+        active: boolean;
+        reasons: readonly string[];
+      })
+    | null;
   requireAuth?: RequestHandler;
   requireReadAuth?: RequestHandler;
   requireReadActorAuth?: (
@@ -1609,6 +1621,34 @@ export function createWorkspaceTopicsRouter(
       const id = req.params['id'] ?? '';
       try {
         assertWorkspaceTopicId(id);
+        if (options.channelArchiveActivity === null) {
+          sendGatewayError(
+            res,
+            'SERVER_UNAVAILABLE',
+            'agent activity cannot be verified; retry when channel runtimes are available',
+            true,
+            { reasonCode: 'CHANNEL_ARCHIVE_ACTIVITY_UNAVAILABLE', id }
+          );
+          return;
+        }
+        const activity = options.channelArchiveActivity?.(id);
+        if (activity?.active) {
+          sendGatewayError(
+            res,
+            'SESSION_CONFLICT',
+            'channel has active agent work; wait for every bound agent to become idle before archiving',
+            false,
+            {
+              reasonCode: 'CHANNEL_ARCHIVE_AGENT_ACTIVE',
+              id,
+              activityReasons: activity.reasons,
+            }
+          );
+          return;
+        }
+        // No await is permitted between the synchronous binder snapshot above
+        // and this mutation. JavaScript cannot admit new binder work between
+        // them, and archive itself never interrupts or releases a runtime.
         const topic = options.store.archive(id);
         if (!topic) {
           sendGatewayError(

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1,8 +1,10 @@
 import * as fs from 'node:fs';
+import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import Database from 'better-sqlite3';
+import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
@@ -56,6 +58,7 @@ import type {
 } from '../server/channel-agent-runtime.js';
 import {
   createWorkspaceTopicStore,
+  createWorkspaceTopicsRouter,
   type WorkspaceTopicStore,
 } from '../server/workspace-topics.js';
 import {
@@ -94,6 +97,99 @@ describe('channel-agent-binder — durable delegation completion callbacks', () 
     providerId: 'a',
     displayName: 'A',
   };
+
+  it('blocks archive from callback scheduling through requester binding admission', async () => {
+    let releaseSpawn!: () => void;
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    topics.create({ id: CH, workspaceId: 'ws:test', title: 'Test' });
+    const { binder, store } = makeBinder({
+      build: (provider) =>
+        new ScriptedAdapter(
+          provider,
+          provider === 'a'
+            ? { mode: 'reply', text: 'callback acknowledged' }
+            : { mode: 'stall' }
+        ),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+      topicStore: topics,
+      gate: spawnGate,
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'durable callback trigger',
+    });
+    const edge = store.createCompletionCallback({
+      id: 'chcb:archive-window',
+      channelId: CH,
+      threadId: null,
+      triggerMessageId: trigger.id,
+      requesterProfileId: builtInAgentProfileId('a'),
+      targetProfileId: builtInAgentProfileId('b'),
+      targetRuntimeId: 'runtime:b',
+      targetTurnId: 'turn:archive-window',
+    });
+    store.satisfyCompletionCallback({
+      channelId: edge.channelId,
+      targetProfileId: edge.targetProfileId,
+      targetTurnId: edge.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+
+    // Recovery schedules claim on setTimeout(0). Before that timer can run,
+    // the requester's channel is already authoritatively active.
+    await binder.recoverCompletionCallbacks();
+    expect(binder.archiveActivityForChannel(CH)).toMatchObject({
+      active: true,
+      reasons: expect.arrayContaining(['completion-callback']),
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createWorkspaceTopicsRouter({
+        store: topics,
+        channelArchiveActivity: (channelId) =>
+          binder.archiveActivityForChannel(channelId),
+      })
+    );
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    cleanup.push(() => server.close());
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('missing callback archive test address');
+    }
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/workspace-topics/${encodeURIComponent(CH)}/archive`,
+      {
+        method: 'POST',
+        headers: { 'x-relay-capabilities': 'context:write' },
+      }
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'SESSION_CONFLICT',
+        details: { reasonCode: 'CHANNEL_ARCHIVE_AGENT_ACTIVE' },
+      },
+    });
+    expect(topics.get(CH)?.status).toBe('active');
+
+    releaseSpawn();
+    await waitFor(
+      () => store.getCompletionCallback(edge.id)?.state === 'consumed'
+    );
+    await waitFor(() => !binder.archiveActivityForChannel(CH).active);
+  });
 
   it('wakes a silent successful delegator exactly once with a typed internal trigger', async () => {
     const adapters = new Map<string, ScriptedAdapter>();

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -191,6 +191,59 @@ describe('channel-agent-binder — durable delegation completion callbacks', () 
     await waitFor(() => !binder.archiveActivityForChannel(CH).active);
   });
 
+  it('contains a synchronous callback release failure and retains the archive fence', async () => {
+    const { binder, store } = makeBinder({
+      build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
+      targets: callbackTargets,
+      knownProviderIds: ['a', 'b', 'c', 'd'],
+    });
+    const trigger = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'missing requester callback',
+    });
+    const edge = store.createCompletionCallback({
+      id: 'chcb:release-throws',
+      channelId: CH,
+      threadId: null,
+      triggerMessageId: trigger.id,
+      requesterProfileId: 'agent-profile:missing',
+      targetProfileId: builtInAgentProfileId('b'),
+      targetRuntimeId: 'runtime:b',
+      targetTurnId: 'turn:release-throws',
+    });
+    store.satisfyCompletionCallback({
+      channelId: edge.channelId,
+      targetProfileId: edge.targetProfileId,
+      targetTurnId: edge.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    const originalRelease =
+      store.releaseDeliveredCompletionCallback.bind(store);
+    let releaseAttempts = 0;
+    store.releaseDeliveredCompletionCallback = (id) => {
+      releaseAttempts += 1;
+      if (releaseAttempts === 1) throw new Error('sqlite release failed');
+      return originalRelease(id);
+    };
+
+    await binder.recoverCompletionCallbacks();
+    await waitFor(() => releaseAttempts >= 2);
+    expect(binder.archiveActivityForChannel(CH)).toMatchObject({
+      active: true,
+      reasons: expect.arrayContaining(['completion-callback']),
+    });
+
+    // Close is the terminal cleanup for this intentionally undeliverable edge;
+    // its retry timer observes `closed` and cannot resurrect the marker.
+    binder.close();
+    expect(binder.archiveActivityForChannel(CH)).toEqual({
+      active: false,
+      reasons: [],
+    });
+  });
+
   it('wakes a silent successful delegator exactly once with a typed internal trigger', async () => {
     const adapters = new Map<string, ScriptedAdapter>();
     const { binder, store } = makeBinder({

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -2287,6 +2287,36 @@ function makeBinder(cfg: {
 // ── tests ────────────────────────────────────────────────────────────────────
 
 describe('channel-agent-binder — lifecycle', () => {
+  it('reports binding admission synchronously and returns to archive-safe when idle', async () => {
+    let releaseSpawn!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    const { binder } = makeBinder({
+      build: (agentType) => new ScriptedAdapter(agentType, { mode: 'stall' }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      gate,
+    });
+
+    expect(binder.archiveActivityForChannel(CH)).toEqual({
+      active: false,
+      reasons: [],
+    });
+    const binding = binder.ensureBinding(CH, 'mock');
+    expect(binder.archiveActivityForChannel(CH)).toMatchObject({
+      active: true,
+      reasons: expect.arrayContaining(['binding-in-flight']),
+    });
+
+    releaseSpawn();
+    await binding;
+    expect(binder.archiveActivityForChannel(CH)).toEqual({
+      active: false,
+      reasons: [],
+    });
+  });
+
   it('discovers and executes only confirmed Codex controls without persisting or routing a message', async () => {
     const calls: Array<{
       command: string;

--- a/test/components/channel-restore-mutation.test.ts
+++ b/test/components/channel-restore-mutation.test.ts
@@ -83,15 +83,12 @@ vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
   ChannelThreadPanel: () => null,
 }));
 
-const { ChannelView } = await import(
-  '../../frontend/src/components/chat/ChannelView.js'
-);
-const { restoreTopicQueryKeys, useRestoreTopicMutation } = await import(
-  '../../frontend/src/lib/hooks/use-restore-topic.js'
-);
-const { useToastStore } = await import(
-  '../../frontend/src/lib/stores/toasts.js'
-);
+const { ChannelView } =
+  await import('../../frontend/src/components/chat/ChannelView.js');
+const { restoreTopicQueryKeys, useRestoreTopicMutation } =
+  await import('../../frontend/src/lib/hooks/use-restore-topic.js');
+const { useToastStore } =
+  await import('../../frontend/src/lib/stores/toasts.js');
 const { HttpError } = await import('../../frontend/src/lib/api.js');
 
 function topicFixture(status: 'active' | 'archived' = 'archived') {
@@ -119,6 +116,8 @@ async function flush(): Promise<void> {
 /** Seed the readers that must not keep rendering the archived state. */
 function seedTopicCaches(): void {
   queryClient.setQueryData(['channel', CHANNEL_ID], { archived: true });
+  queryClient.setQueryData(['channels'], { channels: [] });
+  queryClient.setQueryData(['channel-message-search', 'lane'], { results: [] });
   queryClient.setQueryData(['workspace-topics'], { topics: [] });
   queryClient.setQueryData(['workspace-topics', 'with-archived'], {
     topics: [],
@@ -164,11 +163,13 @@ afterEach(async () => {
 });
 
 describe('shared restore mutation (#1287)', () => {
-  it('names every reader of a topic archived state, list keys by prefix', () => {
+  it('names every lifecycle reader, list and search keys by prefix', () => {
     expect(restoreTopicQueryKeys(CHANNEL_ID)).toEqual([
       ['channel', CHANNEL_ID],
       ['workspace-topic', CHANNEL_ID],
       ['workspace-topics'],
+      ['channels'],
+      ['channel-message-search'],
     ]);
   });
 
@@ -207,6 +208,8 @@ describe('shared restore mutation (#1287)', () => {
       ['workspace-topics'],
       ['workspace-topics', 'with-archived'],
       ['workspace-topics', 'search', 'lane', 'all', 'with-archived'],
+      ['channels'],
+      ['channel-message-search', 'lane'],
     ]) {
       expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
     }

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   fetchWorkspaceTopic: vi.fn(),
   fetchChannelRoster: vi.fn(),
   designateChannelOrchestrator: vi.fn(),
+  archiveWorkspaceTopic: vi.fn(),
 }));
 
 vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
@@ -24,6 +25,7 @@ vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
     fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
     fetchChannelRoster: mocks.fetchChannelRoster,
     designateChannelOrchestrator: mocks.designateChannelOrchestrator,
+    archiveWorkspaceTopic: mocks.archiveWorkspaceTopic,
   };
 });
 
@@ -73,7 +75,12 @@ vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
 
 const { ChannelView } =
   await import('../../frontend/src/components/chat/ChannelView.js');
+const { archiveTopicQueryKeys } =
+  await import('../../frontend/src/lib/hooks/use-archive-topic.js');
 const { HttpError } = await import('../../frontend/src/lib/api.js');
+const { useToastStore } =
+  await import('../../frontend/src/lib/stores/toasts.js');
+const { useUiStore } = await import('../../frontend/src/lib/stores/ui.js');
 
 const CHANNEL_ID = 'topic:operator-lane';
 const CODEX_DM_CHANNEL_ID = dmChannelTopicId('codex', 'ws:local');
@@ -136,7 +143,15 @@ beforeEach(() => {
   mocks.fetchWorkspaceTopic.mockReset();
   mocks.fetchChannelRoster.mockReset();
   mocks.designateChannelOrchestrator.mockReset();
+  mocks.archiveWorkspaceTopic.mockReset();
   mocks.fetchWorkspaceTopic.mockResolvedValue(topicFixture());
+  mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('orchestrator')]);
+  mocks.archiveWorkspaceTopic.mockResolvedValue({
+    ...topicFixture(),
+    status: 'archived',
+  });
+  useToastStore.setState({ toasts: [] });
+  useUiStore.getState().setActiveChannelId(null);
   vi.stubGlobal('matchMedia', () => ({
     matches: false,
     addEventListener: () => {},
@@ -421,5 +436,105 @@ describe('ChannelView orchestrator control (#1242)', () => {
       'orchestrator'
     );
     expect(container.querySelector('.ch-designate-orchestrator')).toBeNull();
+  });
+});
+
+describe('ChannelView reversible archive control (#1382)', () => {
+  it('fails closed while bound-agent status is still loading', async () => {
+    mocks.fetchChannelRoster.mockReturnValue(new Promise(() => {}));
+    await render();
+
+    const archive = container.querySelector<HTMLButtonElement>(
+      '.ch-header > .ch-archive-channel__button'
+    );
+    expect(archive?.disabled).toBe(true);
+    expect(archive?.textContent).toContain('checking agents');
+    expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
+  });
+
+  it('requires inline confirmation, reconciles every reader, then leaves the channel', async () => {
+    useUiStore.getState().setActiveChannelId(CHANNEL_ID);
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    await render();
+
+    const archive = container.querySelector<HTMLButtonElement>(
+      '.ch-header > .ch-archive-channel__button'
+    );
+    expect(archive?.textContent).toBe('archive');
+
+    await act(async () => archive?.click());
+    expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[aria-label="confirm archive channel"]')
+    ).not.toBeNull();
+
+    const confirm = container.querySelector<HTMLButtonElement>(
+      '.ch-archive-channel__button--confirm'
+    );
+    await act(async () => confirm?.click());
+    await flush();
+
+    expect(mocks.archiveWorkspaceTopic).toHaveBeenCalledWith(CHANNEL_ID);
+    for (const queryKey of archiveTopicQueryKeys(CHANNEL_ID)) {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey });
+    }
+    expect(useUiStore.getState().activeChannelId).toBeNull();
+  });
+
+  it('keeps archive disabled and explains why while a bound agent is active', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      {
+        ...rosterEntry('orchestrator'),
+        binding: {
+          runtimeId: 'runtime:claude-1',
+          status: 'thinking',
+        },
+      },
+    ]);
+    await render();
+
+    const archive = container.querySelector<HTMLButtonElement>(
+      '.ch-header > .ch-archive-channel__button'
+    );
+    expect(archive?.disabled).toBe(true);
+    expect(archive?.textContent).toContain('agent active');
+    expect(archive?.getAttribute('aria-label')).toContain('agent active');
+    await act(async () => archive?.click());
+    expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
+  });
+
+  it('keeps a failed confirmation retryable with inline and toast feedback', async () => {
+    mocks.archiveWorkspaceTopic.mockRejectedValue(
+      new Error('archive store unavailable')
+    );
+    await render();
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-header > .ch-archive-channel__button'
+        )
+        ?.click()
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-archive-channel__button--confirm'
+        )
+        ?.click()
+    );
+    await flush();
+
+    expect(
+      container.querySelector('.ch-archive-channel__error')?.textContent
+    ).toBe('archive store unavailable');
+    expect(
+      useToastStore.getState().toasts.map((toast) => toast.message)
+    ).toContain('archive store unavailable');
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '.ch-archive-channel__button--confirm'
+      )?.disabled
+    ).toBe(false);
   });
 });

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -452,6 +452,42 @@ describe('ChannelView reversible archive control (#1382)', () => {
     expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
   });
 
+  it('fails closed with clear copy when the initial roster is unavailable', async () => {
+    mocks.fetchChannelRoster.mockRejectedValue(new Error('roster offline'));
+    await render();
+
+    const archive = container.querySelector<HTMLButtonElement>(
+      '.ch-header > .ch-archive-channel__button'
+    );
+    expect(archive?.disabled).toBe(true);
+    expect(archive?.textContent).toContain('agent status unknown');
+  });
+
+  it('focuses confirmation and returns focus to the trigger after cancel', async () => {
+    await render();
+    const archive = container.querySelector<HTMLButtonElement>(
+      '.ch-header > .ch-archive-channel__button'
+    );
+    await act(async () => archive?.click());
+
+    const confirm = container.querySelector<HTMLButtonElement>(
+      '.ch-archive-channel__button--confirm'
+    );
+    expect(document.activeElement).toBe(confirm);
+    const cancel = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        '.ch-archive-channel--confirming .ch-archive-channel__button'
+      )
+    ).find((button) => button.textContent === 'cancel');
+    await act(async () => cancel?.click());
+
+    expect(document.activeElement).toBe(
+      container.querySelector<HTMLButtonElement>(
+        '.ch-header > .ch-archive-channel__button'
+      )
+    );
+  });
+
   it('requires inline confirmation, reconciles every reader, then leaves the channel', async () => {
     useUiStore.getState().setActiveChannelId(CHANNEL_ID);
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
@@ -503,6 +539,27 @@ describe('ChannelView reversible archive control (#1382)', () => {
     expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
   });
 
+  it('treats an idle binding with queued work as archive-busy', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([
+      {
+        ...rosterEntry('orchestrator'),
+        binding: {
+          runtimeId: 'runtime:claude-1',
+          status: 'idle',
+          queuedCount: 1,
+          steeringCount: 0,
+        },
+      },
+    ]);
+    await render();
+
+    const archive = container.querySelector<HTMLButtonElement>(
+      '.ch-header > .ch-archive-channel__button'
+    );
+    expect(archive?.disabled).toBe(true);
+    expect(archive?.textContent).toContain('agent active');
+  });
+
   it('revalidates cached idle status and blocks when the confirmation roster is busy', async () => {
     mocks.fetchChannelRoster
       .mockResolvedValueOnce([rosterEntry('orchestrator')])
@@ -543,6 +600,97 @@ describe('ChannelView reversible archive control (#1382)', () => {
         '.ch-archive-channel__button--confirm'
       )?.disabled
     ).toBe(true);
+  });
+
+  it('keeps confirmation retryable when the fresh roster check fails', async () => {
+    mocks.fetchChannelRoster
+      .mockResolvedValueOnce([rosterEntry('orchestrator')])
+      .mockRejectedValueOnce(new Error('fresh roster offline'));
+    await render();
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-header > .ch-archive-channel__button'
+        )
+        ?.click()
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-archive-channel__button--confirm'
+        )
+        ?.click()
+    );
+    await flush();
+
+    expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('.ch-archive-channel__error')?.textContent
+    ).toBe('agent status could not be verified — retry before archiving');
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '.ch-archive-channel__button--confirm'
+      )?.disabled
+    ).toBe(false);
+  });
+
+  it('drops stale confirmation results after switching channels', async () => {
+    let settleFreshRoster!: (value: ReturnType<typeof rosterEntry>[]) => void;
+    const delayedFreshRoster = new Promise<ReturnType<typeof rosterEntry>[]>(
+      (resolve) => {
+        settleFreshRoster = resolve;
+      }
+    );
+    mocks.fetchChannelRoster
+      .mockResolvedValueOnce([rosterEntry('orchestrator')])
+      .mockReturnValueOnce(delayedFreshRoster)
+      .mockResolvedValue([rosterEntry('orchestrator')]);
+    await render();
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-header > .ch-archive-channel__button'
+        )
+        ?.click()
+    );
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-archive-channel__button--confirm'
+        )
+        ?.click();
+    });
+
+    const nextChannelId = 'topic:next-lane';
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(ChannelView, { channelId: nextChannelId })
+        )
+      );
+    });
+    await flush();
+    settleFreshRoster([
+      {
+        ...rosterEntry('orchestrator'),
+        binding: {
+          runtimeId: 'runtime:claude-1',
+          status: 'streaming',
+        },
+      },
+    ]);
+    await flush();
+
+    expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
+    expect(container.querySelector('.ch-archive-channel__error')).toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '.ch-header > .ch-archive-channel__button'
+      )?.textContent
+    ).toBe('archive');
   });
 
   it('keeps a failed confirmation retryable with inline and toast feedback', async () => {

--- a/test/components/channel-view-orchestrator.test.ts
+++ b/test/components/channel-view-orchestrator.test.ts
@@ -503,6 +503,48 @@ describe('ChannelView reversible archive control (#1382)', () => {
     expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
   });
 
+  it('revalidates cached idle status and blocks when the confirmation roster is busy', async () => {
+    mocks.fetchChannelRoster
+      .mockResolvedValueOnce([rosterEntry('orchestrator')])
+      .mockResolvedValueOnce([
+        {
+          ...rosterEntry('orchestrator'),
+          binding: {
+            runtimeId: 'runtime:claude-1',
+            status: 'streaming',
+          },
+        },
+      ]);
+    await render();
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-header > .ch-archive-channel__button'
+        )
+        ?.click()
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '.ch-archive-channel__button--confirm'
+        )
+        ?.click()
+    );
+    await flush();
+
+    expect(mocks.fetchChannelRoster).toHaveBeenCalledTimes(2);
+    expect(mocks.archiveWorkspaceTopic).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('.ch-archive-channel__error')?.textContent
+    ).toBe('archive blocked — a bound agent is active');
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '.ch-archive-channel__button--confirm'
+      )?.disabled
+    ).toBe(true);
+  });
+
   it('keeps a failed confirmation retryable with inline and toast feedback', async () => {
     mocks.archiveWorkspaceTopic.mockRejectedValue(
       new Error('archive store unavailable')

--- a/test/workspace-topic-archive-api.test.ts
+++ b/test/workspace-topic-archive-api.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { archiveWorkspaceTopic } from '../frontend/src/lib/api.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('workspace topic archive API (#1382)', () => {
+  it('posts the reversible lifecycle route with context write authority', async () => {
+    const topic = {
+      id: 'topic:release-lane',
+      workspaceId: 'ws:local',
+      status: 'archived',
+      display: { title: 'release lane' },
+      routingDefaults: {},
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ topic }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(archiveWorkspaceTopic(topic.id)).resolves.toEqual(topic);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/workspace-topics/topic%3Arelease-lane/archive',
+      {
+        method: 'POST',
+        headers: { 'x-relay-capabilities': 'context:write' },
+      }
+    );
+  });
+});

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -3,7 +3,7 @@ import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import express, { type RequestHandler } from 'express';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   bearerActorToken,
@@ -99,6 +99,12 @@ async function listen(input: {
   store?: WorkspaceTopicStore | null;
   surfaceStore?: WorkspaceSurfaceStore | null;
   workContextStore?: WorkContextStore;
+  channelArchiveActivity?:
+    | ((channelId: string) => {
+        active: boolean;
+        reasons: readonly string[];
+      })
+    | null;
   getConfig?: () => Config;
   requireReadActorAuth?: (
     expectedCommand:
@@ -130,6 +136,7 @@ async function listen(input: {
       store: input.store ?? null,
       surfaceStore: input.surfaceStore,
       workContextStore: input.workContextStore,
+      channelArchiveActivity: input.channelArchiveActivity,
       getConfig: input.getConfig,
       requireReadActorAuth: input.requireReadActorAuth,
       requireWriteActorAuth: input.requireWriteActorAuth,
@@ -1051,6 +1058,83 @@ describe('workspace topics foundation', () => {
       '/workspace-topics?workspaceId=ws-1'
     );
     expect(activeAgain.body.topics).toHaveLength(1);
+  });
+
+  it('rejects active binder work without changing topic state, then archives when idle', async () => {
+    const store = topicStore();
+    const topic = store.create({
+      id: 'topic:runtime-guard',
+      workspaceId: 'ws-1',
+      title: 'Runtime guard',
+    });
+    let active = true;
+    const channelArchiveActivity = vi.fn(() => ({
+      active,
+      reasons: active ? ['active-turn', 'queued-turn'] : [],
+    }));
+    const { port } = await listen({ store, channelArchiveActivity });
+
+    const refused = await writeJson<{
+      error: {
+        code: string;
+        message: string;
+        details?: Record<string, unknown>;
+      };
+    }>({
+      port,
+      method: 'POST',
+      url: `/workspace-topics/${encodeURIComponent(topic.id)}/archive`,
+      body: {},
+    });
+    expect(refused.status).toBe(409);
+    expect(refused.body.error).toMatchObject({
+      code: 'SESSION_CONFLICT',
+      details: {
+        reasonCode: 'CHANNEL_ARCHIVE_AGENT_ACTIVE',
+        activityReasons: ['active-turn', 'queued-turn'],
+      },
+    });
+    expect(refused.body.error.message).toContain('wait for every bound agent');
+    expect(store.get(topic.id)?.status).toBe('active');
+
+    active = false;
+    const archived = await writeJson<{ topic: WorkspaceTopic }>({
+      port,
+      method: 'POST',
+      url: `/workspace-topics/${encodeURIComponent(topic.id)}/archive`,
+      body: {},
+    });
+    expect(archived.status).toBe(200);
+    expect(archived.body.topic.status).toBe('archived');
+    expect(channelArchiveActivity).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when production cannot verify channel runtime activity', async () => {
+    const store = topicStore();
+    const topic = store.create({
+      id: 'topic:binder-unavailable',
+      workspaceId: 'ws-1',
+      title: 'Binder unavailable',
+    });
+    const { port } = await listen({
+      store,
+      channelArchiveActivity: null,
+    });
+
+    const refused = await writeJson<{
+      error: { code: string; details?: Record<string, unknown> };
+    }>({
+      port,
+      method: 'POST',
+      url: `/workspace-topics/${encodeURIComponent(topic.id)}/archive`,
+      body: {},
+    });
+    expect(refused.status).toBe(503);
+    expect(refused.body.error).toMatchObject({
+      code: 'SERVER_UNAVAILABLE',
+      details: { reasonCode: 'CHANNEL_ARCHIVE_ACTIVITY_UNAVAILABLE' },
+    });
+    expect(store.get(topic.id)?.status).toBe('active');
   });
 
   it('authorizes update and archive against persisted topic workContext refs', async () => {

--- a/test/workspace-topics.test.ts
+++ b/test/workspace-topics.test.ts
@@ -1230,6 +1230,44 @@ describe('workspace topics foundation', () => {
     });
   });
 
+  it('keeps an all-archived workspace empty instead of resurrecting derived ghost rows', async () => {
+    const store = topicStore();
+    const topic = store.create({
+      id: 'topic:archived-lane',
+      workspaceId: 'ws-derived',
+      title: 'Archived lane',
+      linkedRefs: { workContextIds: ['wc-topic-1'] },
+    });
+    store.archive(topic.id);
+    const workContextStore = {
+      list: () => [workContext()],
+    } as unknown as WorkContextStore;
+    const { port } = await listen({ store, workContextStore });
+
+    const activeOnly = await getJson<WorkspaceTopicListResponse>(
+      port,
+      '/workspace-topics?workspaceId=ws-derived'
+    );
+    expect(activeOnly.status).toBe(200);
+    expect(activeOnly.body).toMatchObject({
+      topics: [],
+      derived: false,
+      truncated: false,
+    });
+
+    const withArchived = await getJson<WorkspaceTopicListResponse>(
+      port,
+      '/workspace-topics?workspaceId=ws-derived&includeArchived=true'
+    );
+    expect(withArchived.body.derived).toBe(false);
+    expect(withArchived.body.topics).toHaveLength(1);
+    expect(withArchived.body.topics[0]).toMatchObject({
+      id: topic.id,
+      status: 'archived',
+      source: 'persisted',
+    });
+  });
+
   it('marks derived topic lists truncated when the sentinel entry exists', async () => {
     let requestedLimit: number | undefined;
     let requestedWorkspaceId: string | undefined;


### PR DESCRIPTION
Closes #1382

## What changed

- adds a reversible Archive action to the active channel header with inline confirmation, visible failures, and a 44px mobile touch target
- waits for fresh roster state and refuses archive while any bound agent work is active or cannot be verified
- enforces the same invariant synchronously on the server, including queued, routing, retry, steering, orchestrator, and durable completion-callback windows
- reconciles channel/topic/list/search caches before leaving the archived channel and preserves the existing older-channel restore path
- prevents an all-archived workspace from resurrecting WorkContexts as derived ghost channels

Permanent deletion is intentionally out of scope; archive preserves history, DMs, durable bindings, and runtime state.

## Why

Relay could already archive and restore channels through backend and CLI contracts, but the chat UI had no archive affordance. The list fallback also treated an all-archived workspace as a cold-start workspace, causing archived work to reappear under derived IDs. The new UI and server guard make cleanup reversible without hiding an active agent runtime.

## Verification

- `npm run check` (0 errors; existing warning baseline only)
- `npm run build` (passes; existing Vite chunk warnings only)
- `HERMES_API_ENDPOINT=http://127.0.0.1:9 npm test` — 478 files / 6,510 tests passed; external live Hermes probes intentionally unavailable
- pre-push changed suite — 113 files / 1,353 tests passed
- isolated Playwright runtime proof at 320x568: 44px Archive target, inline confirmation, persisted archived status, and visible Restore control
- adversarial review plus focused safety re-review; all P0/P1 findings resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reversible archiving for idle channels with inline confirmation and restoration support.
  - Added progress, disabled, and error states, including improved mobile controls.
  - Prevented archiving while channel activity is in progress, with clear conflict messaging.

- **Bug Fixes**
  - Archived workspaces no longer reappear as inactive or ghost channels.
  - Added retry handling when activity status cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->