### PR TITLE
fix(dialogs): contain modal scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ workflow.
 
 #### Fixed
 
+- Keep Settings and Add Project scrolling inside their intended panes so modal
+  content cannot become displaced in an unreachable hidden scroll offset (#1384)
 - Make reasoning status styling exhaustive, distinguish nested-only designation
   conflicts from unknown 409s, and lock every channel provider to a shared
   launch-command, profile-PATH, and environment-sanitization matrix (#1368)

--- a/frontend/src/components/FileBrowser.tsx
+++ b/frontend/src/components/FileBrowser.tsx
@@ -77,7 +77,10 @@ function mergeCreatedEntry(
   entries: BrowseEntry[],
   createdEntry?: BrowseEntry
 ): BrowseEntry[] {
-  if (!createdEntry || entries.some((entry) => entry.path === createdEntry.path)) {
+  if (
+    !createdEntry ||
+    entries.some((entry) => entry.path === createdEntry.path)
+  ) {
     return entries;
   }
   return [...entries, createdEntry].sort((a, b) =>
@@ -125,6 +128,24 @@ function flattenVisible(nodes: BrowseNode[], filter: string): BrowseNode[] {
       result.push(...flattenVisible(node.children, filter));
   }
   return result;
+}
+
+/** Reveal an element in the one scroll owner that owns it, without allowing
+ * native focus scrolling to walk outward into modal structural wrappers. */
+function revealWithinScrollOwner(container: HTMLElement, target: HTMLElement) {
+  const containerRect = container.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  if (
+    targetRect.top >= containerRect.top &&
+    targetRect.bottom <= containerRect.bottom
+  )
+    return;
+  const top =
+    targetRect.top -
+    containerRect.top +
+    container.scrollTop -
+    container.clientTop;
+  container.scrollTo({ top: Math.max(0, top) });
 }
 
 interface TreeRowProps {
@@ -334,7 +355,13 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
   }, [loadRoot]);
 
   useEffect(() => {
-    if (folderParentPath) folderNameInputRef.current?.focus();
+    // The editor appears inside the Add Project dialog's explicit body
+    // scroller. Keep focus local, then reveal it in that owner only.
+    const input = folderNameInputRef.current;
+    if (!folderParentPath || !input) return;
+    input.focus({ preventScroll: true });
+    const body = input.closest<HTMLElement>('.dialog-shell__body');
+    if (body) revealWithinScrollOwner(body, input);
   }, [folderParentPath]);
 
   useImperativeHandle(ref, () => ({
@@ -396,9 +423,8 @@ const FileBrowser = forwardRef<FileBrowserHandle, Props>(function FileBrowser(
     );
     node.hasChildren = node.children.length > 0;
     const total = Math.max(data.total, entries.length);
-    node.truncatedInfo = total > entries.length
-      ? { shown: entries.length, total }
-      : null;
+    node.truncatedInfo =
+      total > entries.length ? { shown: entries.length, total } : null;
     node.expanded = true;
     syncTree(treeRef.current);
   }

--- a/frontend/src/components/dialogs/DialogShell.css
+++ b/frontend/src/components/dialogs/DialogShell.css
@@ -10,7 +10,10 @@
   border: 1px solid var(--border);
   border-radius: 0;
   padding: 0;
-  overflow: hidden;
+  /* This shell establishes the dialog's visual boundary, not a scroll owner.
+     `hidden` still has a programmatic scroll box, so scrollIntoView/focus can
+     strand its contents at an unreachable offset. */
+  overflow: clip;
   display: flex;
   flex-direction: column;
 }
@@ -82,7 +85,8 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  /* Only an explicit dialog body (or a child pane) may own scrolling. */
+  overflow: clip;
   position: relative;
 }
 
@@ -144,6 +148,8 @@
   max-width: none;
   width: 100%;
   box-sizing: border-box;
+  /* Fullscreen layouts such as Settings supply their own named scroll pane. */
+  overflow: clip;
 }
 
 /* Scroll fade indicator */

--- a/frontend/src/components/dialogs/DialogShell.tsx
+++ b/frontend/src/components/dialogs/DialogShell.tsx
@@ -51,7 +51,13 @@ function useDialogControls(
     dialogRef.current.showModal();
     requestAnimationFrame(() => {
       if (!dialogRef.current) return;
-      dialogRef.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+      // A dialog can be opened while an ancestor is scrolled. Focusing its
+      // first control must not ask the browser to scroll every containing box
+      // (including the dialog's clipping-only structural layers) in order to
+      // reveal it.
+      dialogRef.current
+        .querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+        ?.focus({ preventScroll: true });
       const body = dialogRef.current.querySelector('.dialog-shell__body');
       if (body) setScrolledBottom(body.scrollHeight <= body.clientHeight);
     });

--- a/frontend/src/components/dialogs/SettingsDialog.css
+++ b/frontend/src/components/dialogs/SettingsDialog.css
@@ -9,6 +9,11 @@
   flex-direction: column;
   gap: 32px;
   position: relative;
+  height: 100%;
+  min-height: 0;
+  /* The content wrapper lays out the TOC and sections; it must not become an
+     unreachable scroll box when a section is programmatically revealed. */
+  overflow: clip;
 }
 
 .settings-dialog-sections {
@@ -17,7 +22,10 @@
   gap: 32px;
   flex: 1;
   min-width: 0;
+  min-height: 0;
   padding: 16px 20px;
+  /* This is the only Settings content scroll owner at every viewport size. */
+  overflow-y: auto;
 }
 
 /* Desktop: side-by-side TOC + scrollable content */
@@ -25,23 +33,19 @@
   .settings-dialog-content {
     flex-direction: row;
     gap: 0;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  .settings-dialog-sections {
-    overflow-y: auto;
   }
 }
 
 .settings-dialog-section {
-  transition: opacity 200ms ease, max-height 200ms ease;
+  transition:
+    opacity 200ms ease,
+    max-height 200ms ease;
 }
 
 .settings-dialog-section.dimmed {
   opacity: 0.3;
   max-height: 0;
-  overflow: hidden;
+  overflow: clip;
   padding: 0;
   margin: 0;
 }

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -241,12 +241,12 @@ interface SettingsDialogProps {
 const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
   function SettingsDialog({ onClose }, ref) {
     const shellRef = useRef<DialogShellHandle>(null);
-    const contentElRef = useRef<HTMLDivElement | null>(null);
+    const sectionsElRef = useRef<HTMLDivElement | null>(null);
     // The post-update restart wait can run for up to 90s; closing the dialog
     // must stop it rather than let it reload the page or set state later.
     const restartWaitRef = useRef<AbortController | null>(null);
     useEffect(() => () => restartWaitRef.current?.abort(), []);
-    const [contentEl, setContentEl] = useState<HTMLDivElement | undefined>(
+    const [sectionsEl, setSectionsEl] = useState<HTMLDivElement | undefined>(
       undefined
     );
     const [config, setConfig] = useState<ConfigState>(DEFAULT_CONFIG);
@@ -276,9 +276,20 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
     // outside React (the browser's notification permission) take this instead.
     const [openNonce, setOpenNonce] = useState(0);
 
-    const contentRefCallback = useCallback((el: HTMLDivElement | null) => {
-      contentElRef.current = el;
-      setContentEl(el ?? undefined);
+    const sectionsRefCallback = useCallback((el: HTMLDivElement | null) => {
+      sectionsElRef.current = el;
+      setSectionsEl(el ?? undefined);
+    }, []);
+
+    const scrollToSection = useCallback((id: string) => {
+      const sections = sectionsElRef.current;
+      const section = sections?.querySelector<HTMLElement>(`#${id}`);
+      if (!sections || !section) return;
+      const top =
+        section.getBoundingClientRect().top -
+        sections.getBoundingClientRect().top +
+        sections.scrollTop;
+      sections.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
     }, []);
 
     const configHandlers = useConfigHandlers(
@@ -339,11 +350,7 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
         void loadAllData();
         shellRef.current?.open();
         if (scrollToId)
-          requestAnimationFrame(() =>
-            contentElRef.current
-              ?.querySelector(`#${scrollToId}`)
-              ?.scrollIntoView({ behavior: 'smooth' })
-          );
+          requestAnimationFrame(() => scrollToSection(scrollToId));
       },
       close() {
         shellRef.current?.close();
@@ -447,15 +454,15 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
         headerExtra={headerExtra}
         onClose={onClose}
       >
-        <div className="settings-dialog-content" ref={contentRefCallback}>
+        <div className="settings-dialog-content">
           {error && <p className="error-msg">{error}</p>}
           <SettingsToc
             open={tocOpen}
             onclose={() => setTocOpen(false)}
-            {...(contentEl ? { contentEl } : {})}
+            {...(sectionsEl ? { sectionsEl } : {})}
             sections={TOC_SECTIONS}
           />
-          <div className="settings-dialog-sections">
+          <div className="settings-dialog-sections" ref={sectionsRefCallback}>
             <GeneralSection
               config={config}
               notifDescription={notifDescription}

--- a/frontend/src/components/dialogs/SettingsToc.css
+++ b/frontend/src/components/dialogs/SettingsToc.css
@@ -18,7 +18,8 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  overflow: hidden;
+  /* The inner .toc-items is the TOC scroll owner. */
+  overflow: clip;
 }
 
 @media (max-width: 600px) {
@@ -56,7 +57,9 @@
   color: var(--text-muted);
   cursor: pointer;
   user-select: none;
-  transition: background 0.1s, color 0.1s;
+  transition:
+    background 0.1s,
+    color 0.1s;
 }
 
 .toc-item:hover {

--- a/frontend/src/components/dialogs/SettingsToc.tsx
+++ b/frontend/src/components/dialogs/SettingsToc.tsx
@@ -9,25 +9,38 @@ interface Section {
 
 interface Props {
   sections: Section[];
-  contentEl?: HTMLElement;
+  /** The explicit Settings content scroll owner. Do not use scrollIntoView:
+   * it may mutate clipping-only modal ancestors as well as this pane. */
+  sectionsEl?: HTMLElement;
   open: boolean;
   onclose: () => void;
 }
 
-export default function SettingsToc({ sections, contentEl, open, onclose }: Props) {
+function scrollSectionIntoView(container: HTMLElement, section: HTMLElement) {
+  const top =
+    section.getBoundingClientRect().top -
+    container.getBoundingClientRect().top +
+    container.scrollTop;
+  container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+}
+
+export default function SettingsToc({
+  sections,
+  sectionsEl,
+  open,
+  onclose,
+}: Props) {
   function scrollToSection(id: string) {
-    const el = contentEl?.querySelector(`#${id}`);
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth' });
+    const section = sectionsEl?.querySelector<HTMLElement>(`#${id}`);
+    if (section && sectionsEl) {
+      scrollSectionIntoView(sectionsEl, section);
     }
     onclose();
   }
 
   return (
     <>
-      {open && (
-        <div className="toc-backdrop" onClick={onclose} />
-      )}
+      {open && <div className="toc-backdrop" onClick={onclose} />}
       <nav
         className={['toc-drawer', open ? 'open' : ''].filter(Boolean).join(' ')}
         aria-label="Settings navigation"

--- a/frontend/src/test-sidebar-mechanics.tsx
+++ b/frontend/src/test-sidebar-mechanics.tsx
@@ -7,10 +7,77 @@ import { Sidebar } from './components/Sidebar.js';
 import SettingsDialog, {
   type SettingsDialogHandle,
 } from './components/dialogs/SettingsDialog.js';
+import AddWorkspaceDialog, {
+  type AddWorkspaceDialogHandle,
+} from './components/dialogs/AddWorkspaceDialog.js';
 import { dmChannelTopicId } from './lib/dm-channels.js';
 import { useChannelActivityStore } from './lib/stores/channel-activity.js';
 import { useSessionsStore } from './lib/stores/sessions.js';
 import { useUiStore } from './lib/stores/ui.js';
+
+const nativeFetch = window.fetch.bind(window);
+const fileBrowserEntries = [
+  {
+    name: 'project-parent',
+    path: '/workspace/project-parent',
+    isGitRepo: false,
+    hasChildren: true,
+  },
+  ...Array.from({ length: 48 }, (_, index) => ({
+    name: `project-${String(index + 1).padStart(2, '0')}`,
+    path: `/workspace/project-${String(index + 1).padStart(2, '0')}`,
+    isGitRepo: false,
+    hasChildren: false,
+  })),
+];
+const fileBrowserChildren = [
+  {
+    name: 'child-project',
+    path: '/workspace/project-parent/child-project',
+    isGitRepo: false,
+    hasChildren: false,
+  },
+];
+
+/** Keep the production Add Project dialog deterministic in this browser fixture. */
+window.fetch = (input, init) => {
+  const url = new URL(
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url,
+    window.location.href
+  );
+  if (url.pathname === '/nodes') {
+    return Promise.resolve(
+      new Response(JSON.stringify({ nodes: [] }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  }
+  if (url.pathname === '/workspaces/browse') {
+    const entries =
+      url.searchParams.get('path') === '/workspace/project-parent'
+        ? fileBrowserChildren
+        : fileBrowserEntries;
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          resolved:
+            url.searchParams.get('path') === '/workspace/project-parent'
+              ? '/workspace/project-parent'
+              : '/workspace',
+          entries,
+          truncated: false,
+          total: entries.length,
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+  }
+  return nativeFetch(input, init);
+};
 
 const CHANNEL_ID = 'topic:sidebar-smoke';
 const WORKSPACE_ID = 'workspace:sidebar-smoke';
@@ -182,6 +249,7 @@ useChannelActivityStore.setState({
 
 function Fixture(): React.ReactElement {
   const settingsRef = useRef<SettingsDialogHandle>(null);
+  const addWorkspaceRef = useRef<AddWorkspaceDialogHandle>(null);
   const activeChannelId = useUiStore((state) => state.activeChannelId);
   const activeRepoPath = useUiStore((state) => state.activeRepoPath);
   const dashboardTabIntent = useUiStore(
@@ -213,6 +281,21 @@ function Fixture(): React.ReactElement {
           >
             emit unread activity
           </button>
+          <button
+            type="button"
+            data-testid="open-add-project"
+            onClick={() => addWorkspaceRef.current?.open()}
+          >
+            open add project
+          </button>
+          <button
+            type="button"
+            data-testid="open-settings-top"
+            aria-label="open top dialog"
+            onClick={() => settingsRef.current?.open()}
+          >
+            open settings at top
+          </button>
           <output data-testid="active-channel">
             {activeChannelId ?? 'none'}
           </output>
@@ -230,6 +313,7 @@ function Fixture(): React.ReactElement {
         </section>
       </main>
       <SettingsDialog ref={settingsRef} />
+      <AddWorkspaceDialog ref={addWorkspaceRef} onWorkspacesAdded={() => {}} />
     </QueryClientProvider>
   );
 }

--- a/test/e2e/sidebar-mechanics.spec.ts
+++ b/test/e2e/sidebar-mechanics.spec.ts
@@ -61,6 +61,32 @@ async function expectMobileSidebarClosed(page: Page): Promise<void> {
     .toBeLessThanOrEqual(0);
 }
 
+async function expectStructuralScrollAtOrigin(
+  dialog: Locator,
+  options: { includeBody?: boolean; includeSettingsContent?: boolean } = {}
+): Promise<void> {
+  expect(await dialog.evaluate((element) => element.scrollTop)).toBe(0);
+  expect(
+    await dialog
+      .locator('.dialog-shell__content')
+      .evaluate((element) => element.scrollTop)
+  ).toBe(0);
+  if (options.includeBody) {
+    expect(
+      await dialog
+        .locator('.dialog-shell__body')
+        .evaluate((element) => element.scrollTop)
+    ).toBe(0);
+  }
+  if (options.includeSettingsContent) {
+    expect(
+      await dialog
+        .locator('.settings-dialog-content')
+        .evaluate((element) => element.scrollTop)
+    ).toBe(0);
+  }
+}
+
 test.describe('smoke sidebar mechanics demotion (#1194)', () => {
   test('default rail keeps channels visible without task-room mechanics', async ({
     page,
@@ -107,6 +133,194 @@ test.describe('smoke sidebar mechanics demotion (#1194)', () => {
     await expect(page.getByTestId('evidence-route')).toHaveText(
       '/workspace/example:evidence'
     );
+  });
+
+  test('native Settings opening does not shift structural scroll boxes (#1384)', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await page.getByTestId('open-settings-top').click();
+
+    const settings = page.getByRole('dialog', { name: 'settings' });
+    await expect(settings).toBeVisible();
+    await expect(page.getByLabel('Search settings')).toBeFocused();
+    await expectStructuralScrollAtOrigin(settings, {
+      includeBody: true,
+      includeSettingsContent: true,
+    });
+    expect(
+      await settings
+        .locator('.settings-dialog-sections')
+        .evaluate((element) => element.scrollTop)
+    ).toBe(0);
+  });
+
+  test('modal navigation keeps scrolling in its explicit pane (#1384)', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await page.getByRole('button', { name: 'Settings' }).click();
+
+    const settings = page.getByRole('dialog', { name: 'settings' });
+    const sections = settings.locator('.settings-dialog-sections');
+    await expect(sections).toBeVisible();
+
+    await settings.locator('.toc-item', { hasText: /^advanced$/ }).click();
+    await expect
+      .poll(() => sections.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    const advancedScrollTop = await sections.evaluate(
+      (element) => element.scrollTop
+    );
+
+    await settings.locator('.toc-item', { hasText: /^about$/ }).click();
+    await expect
+      .poll(() => sections.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(advancedScrollTop);
+
+    await sections.hover();
+    const beforeWheel = await sections.evaluate((element) => element.scrollTop);
+    await page.mouse.wheel(0, -400);
+    await expect
+      .poll(() => sections.evaluate((element) => element.scrollTop))
+      .toBeLessThan(beforeWheel);
+
+    await expectStructuralScrollAtOrigin(settings, {
+      includeBody: true,
+      includeSettingsContent: true,
+    });
+
+    await settings.getByRole('button', { name: 'Close' }).click();
+    await page.getByTestId('open-add-project').click();
+    const addProject = page.getByRole('dialog', { name: 'add project' });
+    const tree = addProject.getByRole('tree', { name: 'File browser' });
+    await expect(tree.getByText('project-48', { exact: true })).toHaveCount(1);
+
+    await tree.hover();
+    await page.mouse.wheel(0, 600);
+    await expect
+      .poll(() => tree.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    await expectStructuralScrollAtOrigin(addProject);
+
+    await tree.hover();
+    await page.mouse.wheel(0, -1000);
+    await expect
+      .poll(() => tree.evaluate((element) => element.scrollTop))
+      .toBe(0);
+    await expectStructuralScrollAtOrigin(addProject);
+
+    const parent = tree
+      .locator('.tree-row')
+      .filter({ hasText: 'project-parent' })
+      .first();
+    await parent.getByRole('button', { name: 'Expand' }).click();
+    await expect(
+      tree.getByText('child-project', { exact: true })
+    ).toBeVisible();
+    await expectStructuralScrollAtOrigin(addProject);
+
+    const child = tree
+      .locator('.tree-row')
+      .filter({ hasText: 'child-project' });
+    await child.click();
+    await expect(child).toHaveClass(/\bselected\b/);
+    await expectStructuralScrollAtOrigin(addProject);
+
+    await tree.focus();
+    await page.keyboard.press('ArrowDown');
+    await expect(parent).toHaveClass(/\bfocused\b/);
+    await page.keyboard.press('ArrowLeft');
+    await expect(tree.getByText('child-project', { exact: true })).toHaveCount(
+      0
+    );
+    await expectStructuralScrollAtOrigin(addProject);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(
+      tree.getByText('child-project', { exact: true })
+    ).toBeVisible();
+    await expectStructuralScrollAtOrigin(addProject);
+
+    await page.keyboard.press('ArrowDown');
+    await expect(child).toHaveClass(/\bfocused\b/);
+    await page.keyboard.press(' ');
+    await expect(child).not.toHaveClass(/\bselected\b/);
+    await expectStructuralScrollAtOrigin(addProject);
+
+    await parent.hover();
+    await parent
+      .getByRole('button', { name: 'new folder in project-parent' })
+      .click();
+    await expect(
+      addProject.getByLabel('new folder name in /workspace/project-parent')
+    ).toBeFocused();
+    await expect
+      .poll(() =>
+        addProject
+          .locator('.dialog-shell__body')
+          .evaluate((element) => element.scrollTop)
+      )
+      .toBeGreaterThan(0);
+    await expectStructuralScrollAtOrigin(addProject);
+  });
+
+  test('mobile drawer navigation keeps Settings scrolling in its sections pane (#1384)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 600 });
+    await openFixture(page);
+    await page.getByRole('button', { name: 'Settings' }).click();
+
+    const settings = page.getByRole('dialog', { name: 'settings' });
+    const sections = settings.locator('.settings-dialog-sections');
+    await expect(settings).toBeVisible();
+    await expect
+      .poll(() => sections.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    const advancedScrollTop = await sections.evaluate(
+      (element) => element.scrollTop
+    );
+    await expectStructuralScrollAtOrigin(settings, {
+      includeBody: true,
+      includeSettingsContent: true,
+    });
+
+    await settings.getByRole('button', { name: 'Navigation' }).click();
+    const drawer = settings.locator('.toc-drawer');
+    await expect(drawer).toHaveClass(/\bopen\b/);
+    await drawer.locator('.toc-item', { hasText: /^about$/ }).click();
+    await expect
+      .poll(() => sections.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(advancedScrollTop);
+    await expectStructuralScrollAtOrigin(settings, {
+      includeBody: true,
+      includeSettingsContent: true,
+    });
+  });
+
+  test('compact Add Project keeps its dialog body as the scroll owner (#1384)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 700, height: 360 });
+    await openFixture(page);
+    await page.getByTestId('open-add-project').click();
+
+    const addProject = page.getByRole('dialog', { name: 'add project' });
+    const body = addProject.locator('.dialog-shell__body');
+    await expect(
+      addProject.getByRole('tree', { name: 'File browser' })
+    ).toBeVisible();
+    await addProject
+      .getByText(
+        'browse for any folder on this machine. git repos get pr tracking + branch management automatically.'
+      )
+      .hover();
+    await page.mouse.wheel(0, 600);
+    await expect
+      .poll(() => body.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    await expectStructuralScrollAtOrigin(addProject);
   });
 
   test('channel selection and unread activity remain functional', async ({


### PR DESCRIPTION
## What changed

- make modal structural wrappers clipping-only instead of hidden programmatic scroll containers
- route Settings section navigation exclusively through `.settings-dialog-sections`
- keep initial dialog and Add Project folder-editor focus from scrolling structural ancestors
- reveal folder creation only within the owned compact-dialog body
- add Chromium coverage for desktop/mobile Settings and compact Add Project pointer, wheel, keyboard, expand/select, and focus behavior

## Root cause

`scrollIntoView()` and native focus scrolling walked through nested `overflow: hidden` modal ancestors. Those ancestors could acquire `scrollTop` programmatically even though pointer and wheel input could not scroll them, leaving the dialog visually displaced and recoverable only through keyboard focus.

## Exact-head evidence

PR head: `3a6b73d82beeb4696cd619f7b3413500c1531e8f`

Behavior head: `bd13a056cedb53f0386067158c13e7ba9648bfca`
(`3a6b73d8` adds only the required changelog entry.)

- `PLAYWRIGHT_PORT=3467 RELAY_IDE_E2E_FIXTURES=1 npx playwright test test/e2e/sidebar-mechanics.spec.ts --project=chromium --workers=1 --grep '#1384'` — 4 passed on an isolated server/config
- `npm test -- test/playwright-fixture-target-gate.test.ts` — 19 passed
- `npm run check` — passed with 0 errors; existing repository warnings only
- `git diff --check` — passed

## Review

- broad adversarial review: no P0; five P1/P2 acceptance/focus findings identified
- one batched fix pass addressed all findings
- focused re-review accepted four and identified one missing Settings-wrapper assertion
- exact test-only follow-up added the assertion at every Settings checkpoint; no production delta followed the focused re-review
- no P0/P1 remains unresolved

Closes #1384
