### PR TITLE
feat(chat): add bare Codex model controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ workflow.
   add controls, with an explicit project selector in New Chat (#1347)
 - `@agent/` opens a provider-aware command palette for channel controls,
   including Codex Fast Mode, model, and reasoning-effort changes (#1344)
+- In Codex DMs and their thread composers, bare `/model` and `/effort` open the
+  same live provider command palette and apply to the exact DM profile without
+  posting a channel message
 - Inspect provider-visible reasoning in provider-neutral collapsible turn details,
   with a persisted collapsed or expanded default for new summaries (#1361)
 - Publish canonical, exact-head pipeline handoff review evidence through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ workflow.
   add controls, with an explicit project selector in New Chat (#1347)
 - `@agent/` opens a provider-aware command palette for channel controls,
   including Codex Fast Mode, model, and reasoning-effort changes (#1344)
-- In Codex DMs and their thread composers, bare `/model` and `/effort` open the
-  same live provider command palette and apply to the exact DM profile without
-  posting a channel message
+- In agent DMs and their thread composers, bare `/model` and `/effort` are
+  discovered generically from the DM provider's live exact-default-profile
+  catalog and apply to the exact DM profile without posting a channel message;
+  agent chat rows show immutable per-turn model and effort attribution when
+  exposed by the provider
 - Inspect provider-visible reasoning in provider-neutral collapsible turn details,
   with a persisted collapsed or expanded default for new summaries (#1361)
 - Publish canonical, exact-head pipeline handoff review evidence through the

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -179,6 +179,17 @@ message or create a mention context packet. Normal posts that look like a
 targeted control (`@agent/command` or `@agent /command`) are rejected so they
 cannot accidentally route as prose.
 
+In a Codex direct message, Relay has one provider target, so its main and thread
+composers also accept bare `/model` and `/effort` through that same control lane.
+The palette resolves the exact current default profile from the live roster and
+then reads that profile's catalog: models and effort choices are never
+reconstructed from a UI display name or assumed built-in profile id. Unknown
+Codex slash input, including native `/skill` syntax, and all non-Codex DM slash
+input remain ordinary prompt text. A raw bare Codex control posted to a DM is
+rejected before persistence with `CHANNEL_COMMAND_REQUIRES_CONTROL_LANE`; a bare
+slash input in a group channel remains ordinary prose because it has no
+unambiguous target.
+
 Only advertise controls the live provider can execute. Where provider metadata
 lists models, service tiers, or reasoning efforts, derive command arguments
 from that metadata and refresh the catalog on a model change. A missing catalog
@@ -189,6 +200,11 @@ the stable `turn/start` override fields; Relay does not negotiate
 model and effort values are launch-time CLI settings, not live channel
 controls. Claude, OpenCode, and Hermes must not be presented as supporting a
 channel control until their own adapters expose and execute it.
+
+Codex model and effort choices are subsequent-turn overrides on the current
+channel runtime/thread. Relay does not create durable cross-runtime profile
+preferences for these controls; after the runtime or thread is replaced, the
+provider and current session configuration again determine the effective values.
 
 The #1375 provider audit found no equivalent advertise-then-fail path in Pi or
 OpenCode: Pi exposes no Relay-owned channel controls, and OpenCode exposes no

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -157,10 +157,7 @@ function detectImplicitCommandTrigger(
   providerId: string | undefined,
   roster: readonly RosterEntry[] | undefined
 ): CommandTrigger | null {
-  // Bare controls are intentionally a Codex DM affordance. Other providers'
-  // slash input remains ordinary prompt text until they independently expose a
-  // product contract for it.
-  if (providerId !== 'codex') return null;
+  if (!providerId) return null;
   const beforeCaret = text.slice(0, caret);
   const match = /^\/(\S*)/.exec(beforeCaret);
   if (!match) return null;
@@ -168,7 +165,7 @@ function detectImplicitCommandTrigger(
   const commandEnd = commandQuery.length + 1;
   const rest = beforeCaret.slice(commandEnd);
   if (/\n/.test(rest)) return null;
-  const reservedControls = relayControlInputGuardCatalogForProvider('codex');
+  const reservedControls = relayControlInputGuardCatalogForProvider(providerId);
   const isReservedControl =
     commandQuery.length === 0 ||
     reservedControls.some((command) => commandMatches(command, commandQuery));
@@ -178,7 +175,7 @@ function detectImplicitCommandTrigger(
     // live default profile/catalog arrives. No profile id is available yet, so
     // this trigger can only display loading and swallow palette navigation.
     return {
-      target: { profileId: '', displayName: 'Codex' },
+      target: { profileId: '', displayName: providerId },
       rosterEntry: undefined,
       resolving: true,
       replacementStart: 0,
@@ -192,7 +189,7 @@ function detectImplicitCommandTrigger(
   );
   if (!rosterEntry) {
     return {
-      target: { profileId: '', displayName: 'Codex' },
+      target: { profileId: '', displayName: providerId },
       rosterEntry: undefined,
       unavailable: true,
       replacementStart: 0,
@@ -204,16 +201,15 @@ function detectImplicitCommandTrigger(
   const controls = (rosterEntry.commands ?? []).filter(
     (command) => command.dispatch === 'relay-control'
   );
-  // Until the exact live default profile supplies a matching control, this is
-  // native Codex slash input (for example `/skill`) or ordinary prose — never a
-  // blocked, empty command palette.
+  // Until the exact live default profile supplies a matching reserved control,
+  // native provider slash input and ordinary prose stay sendable.
   const commandAvailable =
     controls.length > 0 &&
     (commandQuery.length === 0 ||
       controls.some((command) => commandMatches(command, commandQuery)));
   if (!commandAvailable) {
-    // The reserved input must not become a normal post after a completed but
-    // empty/failed model-list discovery (or a missing default profile). That
+    // Reserved input must not become a normal post after a completed but empty
+    // or failed discovery (or a missing default profile). That
     // would only reach the server's control-lane rejection instead of giving
     // the operator an actionable unavailable state.
     return {
@@ -278,7 +274,7 @@ interface ChannelComposerProps {
   placeholder?: string;
   /** Human channel members, folded into the @mention contact set (#1236). */
   members?: readonly ChannelMemberRef[];
-  /** Codex DM provider hint; the exact default profile resolves from the roster. */
+  /** DM provider hint; the exact default profile resolves from the live roster. */
   implicitCommandProviderId?: string | undefined;
   /** Idempotent send: the SAME clientMessageId is reused across manual retries. */
   onSend: (
@@ -458,7 +454,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   // first @ per channel and cached 30s; TanStack dedupes with the header query.
   const trigger = detectTrigger(draft, caret, ['@']);
   const implicitCommandDraft =
-    implicitCommandProviderId === 'codex' && /^\//.test(draft);
+    implicitCommandProviderId !== undefined && /^\//.test(draft);
   const rosterQuery = useQuery({
     queryKey: ['channel-roster', channelId],
     queryFn: () => fetchChannelRoster(channelId),

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -20,6 +20,7 @@ import {
   type MentionContact,
 } from '../../../../shared/mention-contacts.js';
 import type { AgentSlashCommandV2 } from '../../../../shared/agent-chat-protocol-v2.js';
+import { relayControlInputGuardCatalogForProvider } from '../../../../shared/agent-command-catalog.js';
 import { createBrowserId } from '../../lib/browserId.js';
 import {
   executeChannelAgentCommand,
@@ -74,11 +75,20 @@ function defaultSendLabel(steeringMode: BusyAgentSteeringMode): string {
 
 type CommandPhase = 'arguments' | 'confirm' | null;
 
-interface MentionCommandTrigger {
-  contact: MentionContact;
+interface CommandTarget {
+  profileId: string;
+  displayName: string;
+}
+
+interface CommandTrigger {
+  target: CommandTarget;
   rosterEntry: RosterEntry | undefined;
-  /** Includes the selected profile mention and immediately-adjacent `/`. */
-  commandStart: number;
+  /** True while a reserved bare Codex control awaits its live roster catalog. */
+  resolving?: boolean;
+  /** True when a reserved bare Codex control has no live executable catalog. */
+  unavailable?: boolean;
+  /** Span replaced when a palette command is chosen. */
+  replacementStart: number;
   /** End of the command-name token (before a possible argument). */
   commandEnd: number;
   commandQuery: string;
@@ -99,7 +109,7 @@ function detectMentionCommandTrigger(
   caret: number,
   contacts: readonly MentionContact[],
   roster: readonly RosterEntry[]
-): MentionCommandTrigger | null {
+): CommandTrigger | null {
   const beforeCaret = text.slice(0, caret);
   let best:
     | { contact: MentionContact; index: number; needle: string }
@@ -123,12 +133,112 @@ function detectMentionCommandTrigger(
   const commandQuery = nameMatch?.[1] ?? '';
   const commandEnd = best.index + best.needle.length + commandQuery.length;
   return {
-    contact: best.contact,
+    target: {
+      profileId: best.contact.id,
+      displayName: best.contact.displayName,
+    },
     rosterEntry: roster.find((entry) => entry.id === best.contact.id),
-    commandStart: best.index,
+    // This deliberately consumes the optional space between the mention and
+    // slash, preserving the established compact @agent/command form.
+    replacementStart: best.index + mentionInsertText(best.contact).length,
     commandEnd,
     commandQuery,
     argument: rest.slice(commandQuery.length).trim(),
+  };
+}
+
+/**
+ * A bare control is meaningful only in a DM that supplied its exact target.
+ * Do not make arbitrary group-channel slash prose a globally-reserved syntax.
+ */
+function detectImplicitCommandTrigger(
+  text: string,
+  caret: number,
+  providerId: string | undefined,
+  roster: readonly RosterEntry[] | undefined
+): CommandTrigger | null {
+  // Bare controls are intentionally a Codex DM affordance. Other providers'
+  // slash input remains ordinary prompt text until they independently expose a
+  // product contract for it.
+  if (providerId !== 'codex') return null;
+  const beforeCaret = text.slice(0, caret);
+  const match = /^\/(\S*)/.exec(beforeCaret);
+  if (!match) return null;
+  const commandQuery = match[1] ?? '';
+  const commandEnd = commandQuery.length + 1;
+  const rest = beforeCaret.slice(commandEnd);
+  if (/\n/.test(rest)) return null;
+  const reservedControls = relayControlInputGuardCatalogForProvider('codex');
+  const isReservedControl =
+    commandQuery.length === 0 ||
+    reservedControls.some((command) => commandMatches(command, commandQuery));
+  if (!isReservedControl) return null;
+  if (!roster) {
+    // A fast Enter must not fall through to the normal post path before the
+    // live default profile/catalog arrives. No profile id is available yet, so
+    // this trigger can only display loading and swallow palette navigation.
+    return {
+      target: { profileId: '', displayName: 'Codex' },
+      rosterEntry: undefined,
+      resolving: true,
+      replacementStart: 0,
+      commandEnd,
+      commandQuery,
+      argument: rest.trim(),
+    };
+  }
+  const rosterEntry = roster.find(
+    (entry) => entry.providerId === providerId && entry.isDefault
+  );
+  if (!rosterEntry) {
+    return {
+      target: { profileId: '', displayName: 'Codex' },
+      rosterEntry: undefined,
+      unavailable: true,
+      replacementStart: 0,
+      commandEnd,
+      commandQuery,
+      argument: rest.trim(),
+    };
+  }
+  const controls = (rosterEntry.commands ?? []).filter(
+    (command) => command.dispatch === 'relay-control'
+  );
+  // Until the exact live default profile supplies a matching control, this is
+  // native Codex slash input (for example `/skill`) or ordinary prose — never a
+  // blocked, empty command palette.
+  const commandAvailable =
+    controls.length > 0 &&
+    (commandQuery.length === 0 ||
+      controls.some((command) => commandMatches(command, commandQuery)));
+  if (!commandAvailable) {
+    // The reserved input must not become a normal post after a completed but
+    // empty/failed model-list discovery (or a missing default profile). That
+    // would only reach the server's control-lane rejection instead of giving
+    // the operator an actionable unavailable state.
+    return {
+      target: {
+        profileId: rosterEntry.id,
+        displayName: rosterEntry.displayName,
+      },
+      rosterEntry,
+      unavailable: true,
+      replacementStart: 0,
+      commandEnd,
+      commandQuery,
+      argument: rest.trim(),
+    };
+  }
+  return {
+    target: {
+      profileId: rosterEntry.id,
+      displayName: rosterEntry.displayName,
+    },
+    rosterEntry,
+    replacementStart: 0,
+    commandEnd,
+    commandQuery,
+    argument: rest.trim(),
   };
 }
 
@@ -168,6 +278,8 @@ interface ChannelComposerProps {
   placeholder?: string;
   /** Human channel members, folded into the @mention contact set (#1236). */
   members?: readonly ChannelMemberRef[];
+  /** Codex DM provider hint; the exact default profile resolves from the roster. */
+  implicitCommandProviderId?: string | undefined;
   /** Idempotent send: the SAME clientMessageId is reused across manual retries. */
   onSend: (
     text: string,
@@ -196,6 +308,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   channelTitle,
   placeholder,
   members,
+  implicitCommandProviderId,
   onSend,
   busyAgentLabels,
   busyAgentSteeringMode = 'none',
@@ -344,11 +457,13 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   // mentions) — see slashTrigger.detectTrigger. Roster is fetched lazily on the
   // first @ per channel and cached 30s; TanStack dedupes with the header query.
   const trigger = detectTrigger(draft, caret, ['@']);
+  const implicitCommandDraft =
+    implicitCommandProviderId === 'codex' && /^\//.test(draft);
   const rosterQuery = useQuery({
     queryKey: ['channel-roster', channelId],
     queryFn: () => fetchChannelRoster(channelId),
     staleTime: 30_000,
-    enabled: trigger !== null,
+    enabled: trigger !== null || implicitCommandDraft,
     retry: false,
   });
   // Memoize on the query string + roster data + members so palette navigation
@@ -367,8 +482,15 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
     [triggerQuery, contacts]
   );
   const commandTrigger = useMemo(
-    () => detectMentionCommandTrigger(draft, caret, contacts, rosterData ?? []),
-    [draft, caret, contacts, rosterData]
+    () =>
+      detectMentionCommandTrigger(draft, caret, contacts, rosterData ?? []) ??
+      detectImplicitCommandTrigger(
+        draft,
+        caret,
+        implicitCommandProviderId,
+        rosterData
+      ),
+    [draft, caret, contacts, implicitCommandProviderId, rosterData]
   );
   const commandEntries = useMemo(
     () =>
@@ -590,16 +712,16 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         setSelectedCommand(command);
         setCommandPhase('confirm');
         setCommandStatus(
-          `confirm /${command.name} for @${commandTrigger.contact.displayName}`
+          `confirm /${command.name} for @${commandTrigger.target.displayName}`
         );
         return;
       }
       setCommandPending(true);
       setCommandStatus(
-        `running /${command.name} for @${commandTrigger.contact.displayName}…`
+        `running /${command.name} for @${commandTrigger.target.displayName}…`
       );
       void executeChannelAgentCommand(channelId, {
-        profileId: commandTrigger.contact.id,
+        profileId: commandTrigger.target.profileId,
         command: command.name,
         ...(normalizedArgs ? { args: normalizedArgs } : {}),
         ...(confirmed ? { confirmed: true } : {}),
@@ -611,7 +733,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
             queryKey: ['channel-roster', channelId],
           });
           setCommandStatus(
-            `/${command.name} applied to @${commandTrigger.contact.displayName}`
+            `/${command.name} applied to @${commandTrigger.target.displayName}`
           );
           setDraft('');
           setCaret(0);
@@ -639,17 +761,10 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
       if (!commandTrigger) return;
       const replacement = `/${command.name}`;
       const nextDraft =
-        draft.slice(
-          0,
-          commandTrigger.commandStart +
-            mentionInsertText(commandTrigger.contact).length
-        ) +
+        draft.slice(0, commandTrigger.replacementStart) +
         replacement +
         draft.slice(commandTrigger.commandEnd);
-      const nextCaret =
-        commandTrigger.commandStart +
-        mentionInsertText(commandTrigger.contact).length +
-        replacement.length;
+      const nextCaret = commandTrigger.replacementStart + replacement.length;
       setDraft(nextDraft);
       setCaret(nextCaret);
       setActiveIndex(0);
@@ -921,15 +1036,21 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
           activeIndex={activeIndex}
           visible={commandPaletteVisible}
           disabled={commandPending}
-          label={`commands for ${commandTrigger?.contact.displayName ?? 'agent'}`}
+          label={`commands for ${commandTrigger?.target.displayName ?? 'agent'}`}
           emptyMessage={
             commandPhase === 'arguments' && selectedCommand
               ? commandTrigger?.argument
                 ? `press enter to use “${commandTrigger.argument}”`
                 : `type ${selectedCommand.argumentHint ?? 'a value'}`
-              : commandPending
-                ? 'applying command…'
-                : 'no commands available for this agent'
+              : commandTrigger?.resolving
+                ? rosterQuery.isError
+                  ? 'commands unavailable'
+                  : 'loading commands…'
+                : commandTrigger?.unavailable
+                  ? 'commands unavailable'
+                  : commandPending
+                    ? 'applying command…'
+                    : 'no commands available for this agent'
           }
           onSelect={activateCommandRow}
         />

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -664,10 +664,26 @@ const MessageRowTrailer: React.FC<{
   queuedNotice = null,
 }) => {
   const truncationLabel = truncationLabelForMessage(message);
+  const attribution =
+    message.sender.kind === 'agent' ? message.agentAttribution : undefined;
   const showThreadChip =
     message.threadId === null && replyCount > 0 && onOpenThread !== undefined;
   return (
     <>
+      {attribution ? (
+        <span className="ch-msg__attribution" aria-label="agent configuration">
+          {attribution.model ? (
+            <span className="ch-msg__attribution-part">
+              model: {attribution.model}
+            </span>
+          ) : null}
+          {attribution.effort ? (
+            <span className="ch-msg__attribution-part">
+              effort: {attribution.effort}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
       {queuedNotice ? (
         // The one thing the durable row cannot say: this message reached a busy
         // agent and is waiting for its next turn. Steering intent is never

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -37,6 +37,8 @@ interface ChannelThreadPanelProps {
   channelTitle: string;
   /** True when the channel is a DM (one agent, implicit routing). */
   isDm?: boolean;
+  /** Codex DM provider hint for bare `/command` syntax. */
+  implicitCommandProviderId?: string | undefined;
   rootId: ChannelMessageId;
   liveMessages: ChannelMessage[];
   onClose: () => void;
@@ -67,6 +69,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
   channelId,
   channelTitle,
   isDm = false,
+  implicitCommandProviderId,
   rootId,
   liveMessages,
   onClose,
@@ -264,6 +267,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
         channelId={channelId}
         channelTitle={channelTitle}
         placeholder={isDm ? DM_THREAD_PLACEHOLDER : THREAD_PLACEHOLDER}
+        {...(implicitCommandProviderId ? { implicitCommandProviderId } : {})}
         onSend={onSend}
         {...(busyAgentLabels ? { busyAgentLabels } : {})}
         {...(busyAgentSteeringMode ? { busyAgentSteeringMode } : {})}

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -809,6 +809,23 @@
 }
 
 /* trailing status tags — interrupted / failed / truncated */
+.ch-msg__attribution {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-self: flex-start;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  opacity: 0.8;
+}
+
+.ch-msg__attribution-part + .ch-msg__attribution-part::before {
+  content: '·';
+  margin-right: 6px;
+}
+
 .ch-msg__tag {
   font-family: var(--font-mono);
   font-size: 0.7rem;

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -69,6 +69,12 @@ const DESIGNATE_ORCHESTRATOR_ROLE_CONFLICT =
 const DESIGNATE_ORCHESTRATOR_GENERIC_ERROR =
   'could not designate orchestrator — try again';
 
+function implicitCommandProviderForDm(
+  providerId: string | null
+): string | undefined {
+  return providerId === 'codex' ? providerId : undefined;
+}
+
 function designateOrchestratorErrorCopy(error: unknown): string {
   if (
     error instanceof HttpError &&
@@ -379,6 +385,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         providerId: dmProviderId,
       })
     : null;
+  // Only Codex DMs opt into bare controls. The composers resolve the exact
+  // current default profile from the live roster, matching binder DM routing.
+  const implicitCommandProviderId = implicitCommandProviderForDm(dmProviderId);
 
   // A DM addresses its one agent implicitly — the binder routes an unmentioned
   // message to it — so the composer must not tell you to type `@` at the very
@@ -1347,6 +1356,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             channelTitle={title}
             {...(dmPlaceholder ? { placeholder: dmPlaceholder } : {})}
             {...(channel?.members ? { members: channel.members } : {})}
+            implicitCommandProviderId={implicitCommandProviderId}
             onSend={handleSend}
             busyAgentLabels={busyAgentLabels}
             busyAgentSteeringMode={busyAgentSteeringMode}
@@ -1364,6 +1374,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             channelId={channelId}
             channelTitle={title}
             isDm={isDm}
+            implicitCommandProviderId={implicitCommandProviderId}
             rootId={activeThreadRootId}
             liveMessages={reducer.messages}
             onClose={() => setActiveThreadRootId(null)}

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -72,7 +72,7 @@ const DESIGNATE_ORCHESTRATOR_GENERIC_ERROR =
 function implicitCommandProviderForDm(
   providerId: string | null
 ): string | undefined {
-  return providerId === 'codex' ? providerId : undefined;
+  return providerId ?? undefined;
 }
 
 function designateOrchestratorErrorCopy(error: unknown): string {
@@ -385,8 +385,9 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         providerId: dmProviderId,
       })
     : null;
-  // Only Codex DMs opt into bare controls. The composers resolve the exact
-  // current default profile from the live roster, matching binder DM routing.
+  // A DM supplies one exact provider target. The composers resolve that
+  // provider's current default profile and live control catalog from the
+  // roster, matching binder DM routing without a vendor-specific UI branch.
   const implicitCommandProviderId = implicitCommandProviderForDm(dmProviderId);
 
   // A DM addresses its one agent implicitly — the binder routes an unmentioned

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -290,7 +290,8 @@ export interface ChannelAgentBinder {
     args?: string,
     confirmed?: boolean
   ): Promise<{ config?: Record<string, unknown> }>;
-  isControlMessage(text: string): boolean;
+  /** `channelId` permits DM-only bare controls without reserving group prose. */
+  isControlMessage(text: string, channelId?: string): boolean;
   setStatusBroadcaster(broadcaster: ChannelAgentStatusBroadcaster): void;
   /** Replays persisted callback work only after boot store sweeps complete. */
   recoverCompletionCallbacks(): Promise<void>;
@@ -3860,7 +3861,24 @@ export function createChannelAgentBinder(
     }
   }
 
-  function isControlMessage(text: string): boolean {
+  function isControlMessage(text: string, channelId?: string): boolean {
+    // A DM has an unambiguous provider target, so a raw Relay control cannot
+    // fall through to durable channel prose. Group channels deliberately keep
+    // bare slash text ordinary: no exact target has been supplied there.
+    const topic = channelId ? deps.topicStore?.get(channelId) : undefined;
+    const dmProviderId = topic ? isDmChannel(topic) : null;
+    const bareCommand = /^\s*\/([^\s]+)(?:\s|$)/.exec(text)?.[1]?.toLowerCase();
+    if (
+      dmProviderId &&
+      bareCommand &&
+      relayControlInputGuardCatalogForProvider(dmProviderId).some(
+        (entry) =>
+          entry.name === bareCommand ||
+          (entry.aliases ?? []).includes(bareCommand)
+      )
+    ) {
+      return true;
+    }
     const profiles =
       deps.agentProfileStore?.list() ??
       deps.knownProviderIds.map((providerId) =>

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -1264,7 +1264,7 @@ export function createChannelAgentBinder(
     profileActorId: string,
     framework: string,
     senderDisplayName: string,
-    runtime: { id: string; adapter: ProtocolAdapterV2 }
+    runtime: Pick<ChannelAgentRuntime, 'id' | 'adapter' | 'agentAttribution'>
   ): LiveBinding {
     const key = bindingKey(channelId, profileActorId);
     const existing = live.get(key);
@@ -1304,6 +1304,9 @@ export function createChannelAgentBinder(
       // label. One private runtime belongs to one profile.
       profileActorId,
       displayName: senderDisplayName,
+      ...(runtime.agentAttribution
+        ? { initialAgentAttribution: runtime.agentAttribution }
+        : {}),
       parentMessageIdForTurn: (turnId) => parentForTurn(binding, turnId),
       onAssistantMessageFinalized: (message) =>
         handleAssistantFinalized(binding, message),

--- a/server/channel-agent-bridge.ts
+++ b/server/channel-agent-bridge.ts
@@ -9,6 +9,7 @@ import {
   agentDetailCardForItem,
   type AgentDetailCardStatusV2,
   type AgentDetailCardV2,
+  type AgentSessionConfigV2,
   type AgentPatchV2,
 } from '../shared/agent-chat-protocol-v2.js';
 import type { ChannelHub } from './channel-hub.js';
@@ -21,7 +22,9 @@ import { PACKET_IMAGE_DEGRADATION_META_KEY } from './channel-context-packet.js';
 import {
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
   CHANNEL_AGENT_DETAIL_MAX_BYTES,
+  CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS,
   type ChannelAgentDetail,
+  type ChannelAgentAttribution,
   type ChannelImagePart,
   type ChannelMessage,
   type ChannelSenderRef,
@@ -60,6 +63,25 @@ export const CHANNEL_BRIDGE_DETAIL_TITLE_MAX_CHARS = 1024;
 export const CHANNEL_BRIDGE_DETAIL_LANGUAGE_MAX_CHARS = 128;
 export const CHANNEL_BRIDGE_DETAIL_COMMAND_MAX_CHARS = 4096;
 export const CHANNEL_BRIDGE_DETAIL_PATH_MAX_CHARS = 4096;
+
+/** Keep provider-supplied model/effort display data small and inert. */
+function boundedAgentAttribution(config: {
+  model?: string | undefined;
+  effort?: string | null | undefined;
+}): ChannelAgentAttribution | undefined {
+  const scalar = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.trim()
+      ? value.trim().slice(0, CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS)
+      : undefined;
+  const model = scalar(config.model);
+  const effort = scalar(config.effort);
+  return model || effort
+    ? {
+        ...(model ? { model } : {}),
+        ...(effort ? { effort } : {}),
+      }
+    : undefined;
+}
 
 function diffCounts(content: string): { additions: number; deletions: number } {
   let additions = 0;
@@ -270,6 +292,8 @@ export interface BindSessionToChannelInput {
    * regardless of caller.
    */
   profileActorId?: string;
+  /** Current adapter session config captured before this bridge attached. */
+  initialAgentAttribution?: ChannelAgentAttribution;
   /** Resolve the immediate parent for a routed turn, if it began in a thread. */
   parentMessageIdForTurn?: (turnId: string) => string | undefined;
   /**
@@ -315,6 +339,12 @@ export function bindSessionToChannel(
   const turnsWithRows = new Set<string>();
   const recentFinalizedItemKeys = new Set<string>();
   const turnImages = new Map<string, TurnImageState>();
+  // Config updates apply to future turns. The first row in a turn captures a
+  // copy so a later /model or /effort can never rewrite siblings or history.
+  const turnAttributions = new Map<string, ChannelAgentAttribution | null>();
+  let currentAttribution = input.initialAgentAttribution
+    ? { ...input.initialAgentAttribution }
+    : undefined;
   let closed = false;
 
   function itemSourceKey(
@@ -506,6 +536,38 @@ export function bindSessionToChannel(
     ...(input.displayName ? { displayName: input.displayName } : {}),
   };
 
+  function attributionForTurn(
+    turnId: string
+  ): ChannelAgentAttribution | undefined {
+    if (!turnAttributions.has(turnId)) {
+      turnAttributions.set(
+        turnId,
+        currentAttribution ? { ...currentAttribution } : null
+      );
+    }
+    const attribution = turnAttributions.get(turnId);
+    return attribution ? { ...attribution } : undefined;
+  }
+
+  function applySessionConfig(
+    config: Partial<Omit<AgentSessionConfigV2, 'cwd'>>,
+    replace: boolean
+  ): void {
+    const next = replace
+      ? boundedAgentAttribution(config)
+      : boundedAgentAttribution({
+          model:
+            config.model !== undefined
+              ? config.model
+              : currentAttribution?.model,
+          effort:
+            config.effort !== undefined
+              ? config.effort
+              : currentAttribution?.effort,
+        });
+    currentAttribution = next ? { ...next } : undefined;
+  }
+
   function openStream(
     turnId: string,
     canonicalItemId: string,
@@ -522,11 +584,13 @@ export function bindSessionToChannel(
       return null;
     }
     const parentMessageId = input.parentMessageIdForTurn?.(turnId);
+    const agentAttribution = attributionForTurn(turnId);
     const message = store.beginStream({
       channelId,
       sender,
       source: { runtimeId, turnId, itemId: canonicalItemId },
       ...(initialText ? { text: initialText } : {}),
+      ...(agentAttribution ? { agentAttribution } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
     if (message.status !== 'streaming') {
@@ -582,11 +646,13 @@ export function bindSessionToChannel(
     }
     const agentDetail = boundChannelAgentDetail(itemId, sourceCard);
     const parentMessageId = input.parentMessageIdForTurn?.(patch.turnId);
+    const agentAttribution = attributionForTurn(patch.turnId);
     const message = store.beginStream({
       channelId,
       sender,
       source: { runtimeId: patch.sessionId, turnId: patch.turnId, itemId },
       agentDetail,
+      ...(agentAttribution ? { agentAttribution } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
     if (message.status !== 'streaming') {
@@ -836,6 +902,7 @@ export function bindSessionToChannel(
         invokeAssistantFinalized(turnId, deferred);
       }
       turnImages.delete(turnId);
+      turnAttributions.delete(turnId);
     }
   }
 
@@ -854,6 +921,7 @@ export function bindSessionToChannel(
       invokeAssistantFinalized(turnId, message);
     }
     turnImages.delete(turnId);
+    turnAttributions.delete(turnId);
   }
 
   function markTurnImagesTerminal(turnId: string | undefined): void {
@@ -869,6 +937,7 @@ export function bindSessionToChannel(
         invokeAssistantFinalized(id, message);
       }
       turnImages.delete(id);
+      turnAttributions.delete(id);
     }
   }
 
@@ -880,12 +949,14 @@ export function bindSessionToChannel(
   ): boolean {
     if (closed) return false;
     const itemId = canonicalAssistantItemId(patch.item);
+    const agentAttribution = attributionForTurn(patch.turnId);
     const started = store.beginStream({
       channelId,
       sender,
       source: { runtimeId: patch.sessionId, turnId: patch.turnId, itemId },
       text,
       ...(parts.length > 0 ? { parts } : {}),
+      ...(agentAttribution ? { agentAttribution } : {}),
       ...(parentMessageId ? { parentMessageId } : {}),
     });
     if (started.status !== 'streaming') return true;
@@ -1058,11 +1129,20 @@ export function bindSessionToChannel(
     }
     if (turnId === undefined) {
       turnsWithRows.clear();
+      // A disconnect can still have image ingestion in flight. Keep those
+      // snapshots until their own settlement path emits (or drops) the row.
+      for (const id of turnAttributions.keys()) {
+        if (!turnImages.has(id)) turnAttributions.delete(id);
+      }
       assistantItemAliases.clear();
       detailItemAliases.clear();
       reportRetention();
     } else {
       turnsWithRows.delete(turnId);
+      // Delayed image ingest creates its durable image row after the provider
+      // terminal boundary. Its model/effort must remain the turn's original
+      // snapshot rather than whatever a later control selected meanwhile.
+      if (!turnImages.has(turnId)) turnAttributions.delete(turnId);
       for (const [itemId, alias] of assistantItemAliases) {
         if (alias.turnId === turnId) assistantItemAliases.delete(itemId);
       }
@@ -1077,8 +1157,20 @@ export function bindSessionToChannel(
 
   function handlePatch(patch: AgentPatchV2): void {
     switch (patch.type) {
+      case 'agent-session-snapshot-v2': {
+        applySessionConfig(patch.session.config, true);
+        break;
+      }
+      case 'agent-session-updated-v2': {
+        if (patch.config) applySessionConfig(patch.config, false);
+        break;
+      }
       case 'agent-item-started-v2': {
         if (patch.item.type === 'imageView') {
+          // Ingestion is asynchronous, but the provider item marks the turn's
+          // durable image-row boundary now. Capture before any later control
+          // update can change the current session config.
+          attributionForTurn(patch.turnId);
           const state = imageState(patch.turnId);
           const parentMessageId = input.parentMessageIdForTurn?.(patch.turnId);
           if (state.admitted >= CHANNEL_BRIDGE_IMAGE_MAX_PER_TURN) {

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -5,6 +5,10 @@ import type {
   AgentSessionLiveStateV2,
 } from '../shared/agent-chat-protocol-v2.js';
 import {
+  CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS,
+  type ChannelAgentAttribution,
+} from '../shared/channel-chat-protocol.js';
+import {
   collaborationPromptAppendix,
   type AgentRole,
 } from '../shared/agent-roster.js';
@@ -86,6 +90,8 @@ export interface ChannelAgentRuntime {
   lastActivity: string;
   adapter: ProtocolAdapterV2;
   providerSession: Record<string, string>;
+  /** Last authoritative adapter config, reduced to durable row attribution. */
+  agentAttribution?: ChannelAgentAttribution | undefined;
 }
 
 /** Deliberately aggregate-only: safe for unauthenticated health reporting. */
@@ -156,6 +162,39 @@ function providerSessionFromPatch(
     return patch.session.providerSession;
   }
   return undefined;
+}
+
+function agentAttributionFromConfig(config: {
+  model?: string | undefined;
+  effort?: string | null | undefined;
+}): ChannelAgentAttribution | undefined {
+  const scalar = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.trim()
+      ? value.trim().slice(0, CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS)
+      : undefined;
+  const model = scalar(config.model);
+  const effort = scalar(config.effort);
+  return model || effort
+    ? {
+        ...(model ? { model } : {}),
+        ...(effort ? { effort } : {}),
+      }
+    : undefined;
+}
+
+function agentAttributionFromPatch(
+  patch: AgentPatchV2,
+  prior: ChannelAgentAttribution | undefined
+): ChannelAgentAttribution | undefined {
+  if (patch.type === 'agent-session-snapshot-v2') {
+    return agentAttributionFromConfig(patch.session.config);
+  }
+  if (patch.type !== 'agent-session-updated-v2' || !patch.config) return prior;
+  return agentAttributionFromConfig({
+    model: patch.config.model !== undefined ? patch.config.model : prior?.model,
+    effort:
+      patch.config.effort !== undefined ? patch.config.effort : prior?.effort,
+  });
 }
 
 type ChannelAgentState = ChannelAgentRuntime['agentState'];
@@ -373,6 +412,12 @@ export class ChannelAgentRuntimeManager {
       processEnv
     );
 
+    const initialAgentAttribution = agentAttributionFromConfig({
+      ...(params.model ? { model: params.model } : {}),
+      ...(typeof params.extra?.['effort'] === 'string'
+        ? { effort: params.extra['effort'] }
+        : {}),
+    });
     const now = new Date().toISOString();
     const runtime: ChannelAgentRuntime = {
       id,
@@ -394,6 +439,9 @@ export class ChannelAgentRuntimeManager {
       lastActivity: now,
       adapter,
       providerSession: {},
+      ...(initialAgentAttribution
+        ? { agentAttribution: initialAgentAttribution }
+        : {}),
     };
     this.runtimes.set(id, runtime);
     this.captureOwnedProcessSnapshot(id, runtime);
@@ -403,6 +451,10 @@ export class ChannelAgentRuntimeManager {
       if (this.runtimes.get(id) !== runtime) return;
       this.captureOwnedProcessSnapshot(id, runtime);
       const providerSession = providerSessionFromPatch(patch);
+      runtime.agentAttribution = agentAttributionFromPatch(
+        patch,
+        runtime.agentAttribution
+      );
       if (providerSession) {
         runtime.providerSession = {
           ...runtime.providerSession,

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -595,9 +595,10 @@ function createAgentCommandsHandler(
 function rejectChannelControlMessage(
   res: Response,
   binder: ChannelAgentBinder | null | undefined,
-  text: string
+  text: string,
+  channelId?: string
 ): boolean {
-  if (!binder?.isControlMessage?.(text)) return false;
+  if (!binder?.isControlMessage?.(text, channelId)) return false;
   sendGatewayError(
     res,
     'INVALID_ARGUMENT',
@@ -1494,7 +1495,7 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     }
     // Provider-neutral binder catalog owns the recognition rule, including
     // exact profile identity and both @profile/command and @profile /command.
-    if (rejectChannelControlMessage(res, deps.binder, text)) return;
+    if (rejectChannelControlMessage(res, deps.binder, text, id)) return;
     let parts: import('../shared/channel-chat-protocol.js').ChannelMessagePart[] =
       [];
     if (body['parts'] !== undefined) {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -9,6 +9,7 @@ import type { AgentRole } from '../shared/agent-roster.js';
 import {
   CHANNEL_CHAT_PROTOCOL_VERSION,
   CHANNEL_AGENT_DETAIL_MAX_BYTES,
+  CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS,
   CHANNEL_DELETED_AT_META_KEY,
   CHANNEL_EDITED_AT_META_KEY,
   CHANNEL_MESSAGE_BODY_MAX_BYTES,
@@ -26,6 +27,7 @@ import {
   isChannelAgentDetail,
   parseMentions,
   type ChannelAgentDetail,
+  type ChannelAgentAttribution,
   type ChannelMessageSearchHit,
   type ChannelSearchUnavailableReason,
   type ChannelBodyFormat,
@@ -934,6 +936,7 @@ export interface ChannelMessageMeta {
   /** Legacy UI marker reserved exclusively for the 256KB size limit. */
   truncated?: boolean;
   agentDetail?: ChannelAgentDetail;
+  agentAttribution?: ChannelAgentAttribution;
   /** Internal lifecycle marker; stripped before rows cross the wire. */
   agentDetailTerminalAuthority?: 'provisional' | 'explicit';
   [key: string]: unknown;
@@ -963,6 +966,8 @@ export interface BeginStreamInput {
   mentions?: ChannelMention[];
   parts?: ChannelMessagePart[];
   agentDetail?: ChannelAgentDetail;
+  /** Immutable provider config snapshot for an agent-authored row. */
+  agentAttribution?: ChannelAgentAttribution;
 }
 
 export interface FinalizeStreamInput {
@@ -1599,6 +1604,35 @@ function assertAgentDetail(detail: ChannelAgentDetail | undefined): void {
   }
 }
 
+function isAgentAttribution(value: unknown): value is ChannelAgentAttribution {
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (candidate.model !== undefined || candidate.effort !== undefined) &&
+    (candidate.model === undefined ||
+      (typeof candidate.model === 'string' &&
+        candidate.model.length <= CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS)) &&
+    (candidate.effort === undefined ||
+      (typeof candidate.effort === 'string' &&
+        candidate.effort.length <= CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS))
+  );
+}
+
+function assertAgentAttribution(
+  attribution: ChannelAgentAttribution | undefined
+): void {
+  if (attribution === undefined) return;
+  if (!isAgentAttribution(attribution)) {
+    throw new ChannelMessageStoreError(
+      400,
+      'channel_agent_attribution_invalid',
+      'channel agent attribution is invalid or exceeds the display cap'
+    );
+  }
+}
+
 function assertMessagePayloadSize(
   text: string,
   detail: ChannelAgentDetail | undefined
@@ -1697,6 +1731,9 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
   if (isChannelAgentDetail(meta?.agentDetail)) {
     message.agentDetail = meta.agentDetail;
   }
+  if (isAgentAttribution(meta?.agentAttribution)) {
+    message.agentAttribution = meta.agentAttribution;
+  }
   // Surface app-level meta (e.g. #1167 approval payloads) while keeping the
   // internal routing keys off the wire — providerId rides `sender.providerId`,
   // mentions/truncated have dedicated fields above.
@@ -1706,6 +1743,7 @@ function rowToMessage(row: ChannelMessageRow): ChannelMessage {
       mentions: _m,
       parts: _parts,
       agentDetail: _agentDetail,
+      agentAttribution: _agentAttribution,
       agentDetailTerminalAuthority: _agentDetailTerminalAuthority,
       truncated: _t,
       ...rest
@@ -1755,6 +1793,7 @@ function buildMeta(input: {
 }): string | null {
   assertMessageParts(input.extra?.parts);
   assertAgentDetail(input.extra?.agentDetail);
+  assertAgentAttribution(input.extra?.agentAttribution);
   assertMessageParts(input.parts);
   const meta: ChannelMessageMeta = { ...(input.extra ?? {}) };
   if (input.mentions && input.mentions.length > 0)
@@ -3802,6 +3841,7 @@ export function createChannelMessageStore(
 
       const initialText = input.text ?? '';
       assertMessagePayloadSize(initialText, input.agentDetail);
+      assertAgentAttribution(input.agentAttribution);
       assertMessageParts(input.parts);
       const threadId = resolveThread(input.channelId, input.parentMessageId);
       const now = nowIso();
@@ -3821,8 +3861,17 @@ export function createChannelMessageStore(
         metaJson: buildMeta({
           ...(input.mentions ? { mentions: input.mentions } : {}),
           ...(input.parts ? { parts: input.parts } : {}),
-          ...(input.agentDetail
-            ? { extra: { agentDetail: input.agentDetail } }
+          ...(input.agentDetail || input.agentAttribution
+            ? {
+                extra: {
+                  ...(input.agentDetail
+                    ? { agentDetail: input.agentDetail }
+                    : {}),
+                  ...(input.agentAttribution
+                    ? { agentAttribution: input.agentAttribution }
+                    : {}),
+                },
+              }
             : {}),
           ...(input.sender.providerId
             ? { providerId: input.sender.providerId }

--- a/shared/channel-chat-protocol.ts
+++ b/shared/channel-chat-protocol.ts
@@ -25,6 +25,8 @@ export const CHANNEL_IMAGE_ALT_MAX_LENGTH = 500;
 export const CHANNEL_MESSAGE_BODY_MAX_BYTES = 256 * 1024;
 /** Card metadata shares the message-row budget and is bounded independently. */
 export const CHANNEL_AGENT_DETAIL_MAX_BYTES = 256 * 1024;
+/** Bounded display scalars carried with one agent-authored row. */
+export const CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS = 512;
 
 export type ChannelMessageId = `chm:${string}`;
 export type ChannelAttachmentId = `cha:${string}`;
@@ -142,6 +144,16 @@ export interface ChannelAgentDetail {
   card: AgentDetailCardV2;
 }
 
+/**
+ * Provider-neutral execution settings captured when an agent row is created.
+ * These are presentation metadata, not mutable session state: changing a
+ * provider's next-turn model or effort must never relabel a prior reply.
+ */
+export interface ChannelAgentAttribution {
+  model?: string;
+  effort?: string;
+}
+
 export interface ChannelMessage {
   schemaVersion: 1;
   id: ChannelMessageId;
@@ -161,6 +173,8 @@ export interface ChannelMessage {
   source?: ChannelMessageSource;
   /** Present on agent activity rows; prose rows leave this absent. */
   agentDetail?: ChannelAgentDetail;
+  /** Model/effort snapshot for an agent-authored prose or detail row. */
+  agentAttribution?: ChannelAgentAttribution;
   /**
    * Opaque row metadata surfaced to clients (#1167). System rows carry actionable
    * payloads here — e.g. an approval request `{ approvalRequestId, agentId,
@@ -918,6 +932,19 @@ function isMemberRef(value: unknown): value is ChannelMemberRef {
   );
 }
 
+function isAgentAttribution(value: unknown): value is ChannelAgentAttribution {
+  return (
+    isRecord(value) &&
+    (value.model !== undefined || value.effort !== undefined) &&
+    (value.model === undefined ||
+      (typeof value.model === 'string' &&
+        value.model.length <= CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS)) &&
+    (value.effort === undefined ||
+      (typeof value.effort === 'string' &&
+        value.effort.length <= CHANNEL_AGENT_ATTRIBUTION_MAX_CHARS))
+  );
+}
+
 export function isChannelMessage(value: unknown): value is ChannelMessage {
   if (!isRecord(value)) return false;
   if (value.schemaVersion !== CHANNEL_CHAT_PROTOCOL_VERSION) return false;
@@ -950,6 +977,12 @@ export function isChannelMessage(value: unknown): value is ChannelMessage {
   if (
     value.agentDetail !== undefined &&
     !isChannelAgentDetail(value.agentDetail)
+  ) {
+    return false;
+  }
+  if (
+    value.agentAttribution !== undefined &&
+    !isAgentAttribution(value.agentAttribution)
   ) {
     return false;
   }

--- a/test/channel-agent-bridge.test.ts
+++ b/test/channel-agent-bridge.test.ts
@@ -296,6 +296,108 @@ describe('channel-agent-bridge lifecycle', () => {
     });
   });
 
+  it('snapshots provider-neutral model and effort onto prose and detail rows', () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    bindSessionToChannel({
+      channelId: 'topic:attribution',
+      agentFramework: 'prime-agent',
+      adapter,
+      store,
+      hub,
+      initialAgentAttribution: { model: 'prime/a', effort: 'low' },
+    });
+
+    adapter.broadcastPatch(assistantStarted('s', 'turn-1', 'answer-1'));
+    // A control change affects later turns only. The same turn's later detail
+    // row retains the first row's immutable config snapshot.
+    adapter.broadcastPatch({
+      type: 'agent-session-updated-v2',
+      sessionId: 's',
+      timestamp: 't',
+      config: { model: 'prime/b', effort: 'high' },
+    });
+    adapter.broadcastPatch(reasoningStarted('s', 'turn-1', 'reason-1'));
+    adapter.broadcastPatch(assistantStarted('s', 'turn-2', 'answer-2'));
+
+    expect(store.history('topic:attribution')).toEqual([
+      expect.objectContaining({
+        agentAttribution: { model: 'prime/a', effort: 'low' },
+      }),
+      expect.objectContaining({
+        agentDetail: expect.any(Object),
+        agentAttribution: { model: 'prime/a', effort: 'low' },
+      }),
+      expect.objectContaining({
+        agentAttribution: { model: 'prime/b', effort: 'high' },
+      }),
+    ]);
+  });
+
+  it('keeps a delayed image row on its turn config after a later control change', async () => {
+    const { store, hub } = makeStore();
+    const adapter = new MockProtocolAdapterV2();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-image-config-'));
+    cleanup.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const source = path.join(dir, 'generated.png');
+    fs.writeFileSync(source, Buffer.from('agent image fixture'));
+    let releaseIngest!: (part: ChannelImagePart) => void;
+    const attachmentStore = {
+      ingest: vi.fn(
+        () =>
+          new Promise<ChannelImagePart>((resolve) => {
+            releaseIngest = resolve;
+          })
+      ),
+    } as unknown as ChannelAttachmentStore;
+    bindSessionToChannel({
+      channelId: 'topic:image-config',
+      agentFramework: 'codex',
+      adapter,
+      store,
+      hub,
+      attachmentStore,
+      initialAgentAttribution: { model: 'gpt-5.6', effort: 'low' },
+    });
+
+    adapter.broadcastPatch({
+      type: 'agent-item-started-v2',
+      sessionId: 's',
+      timestamp: 't',
+      turnId: 'turn-image',
+      item: {
+        type: 'imageView',
+        id: 'image-1',
+        source,
+        status: 'running',
+      },
+    });
+    await vi.waitFor(() => expect(attachmentStore.ingest).toHaveBeenCalled());
+    adapter.broadcastPatch(turnCompleted('s', 'turn-image'));
+    adapter.broadcastPatch({
+      type: 'agent-session-updated-v2',
+      sessionId: 's',
+      timestamp: 't',
+      config: { model: 'gpt-5.6-fast', effort: 'high' },
+    });
+
+    releaseIngest({
+      type: 'image',
+      id: 'cha:delayed-config',
+      mime: 'image/png',
+      w: 2,
+      h: 3,
+      bytes: 19,
+    });
+    await vi.waitFor(() =>
+      expect(store.history('topic:image-config')).toHaveLength(1)
+    );
+    expect(store.history('topic:image-config')[0]?.agentAttribution).toEqual({
+      model: 'gpt-5.6',
+      effort: 'low',
+    });
+  });
+
   it.each(
     (['completed', 'failed', 'interrupted'] as const).flatMap((turnStatus) =>
       (['completed', 'failed', 'cancelled'] as const).map((itemStatus) => [

--- a/test/channel-agent-runtime.test.ts
+++ b/test/channel-agent-runtime.test.ts
@@ -99,6 +99,14 @@ class TestAdapter implements ProtocolAdapterV2 {
       providerSession: { threadId },
     });
   }
+  emitConfig(config: { model?: string; effort?: string | null }): void {
+    this.emitPatch({
+      type: 'agent-session-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: '2026-07-26T00:00:00.000Z',
+      config,
+    });
+  }
   emitLiveState(live: Partial<AgentSessionLiveStateV2>): void {
     this.emitPatch({
       type: 'agent-live-state-updated-v2',
@@ -194,6 +202,33 @@ afterEach(async () => {
 });
 
 describe('ChannelAgentRuntimeManager agentState (#1254)', () => {
+  it('keeps the latest authoritative model and effort for future channel turns', async () => {
+    const { channelAgentRuntimes } = await runtimeModule();
+    const runtime = await channelAgentRuntimes.create({
+      id: 'channel-runtime',
+      providerId: 'codex',
+      profileActorId: 'agent-profile:codex:default',
+      cwd: '/tmp',
+      displayName: '#eng · Codex',
+      port: 3456,
+      configDir: '/tmp',
+      model: 'gpt-5.6',
+      extra: { effort: 'low' },
+    });
+
+    expect(runtime.agentAttribution).toEqual({
+      model: 'gpt-5.6',
+      effort: 'low',
+    });
+    adapterState.last!.emitConfig({ model: 'gpt-5.6-fast', effort: 'high' });
+    expect(runtime.agentAttribution).toEqual({
+      model: 'gpt-5.6-fast',
+      effort: 'high',
+    });
+    adapterState.last!.emitConfig({ effort: null });
+    expect(runtime.agentAttribution).toEqual({ model: 'gpt-5.6-fast' });
+  });
+
   it('leaves initializing as soon as the first turn runs and lands idle when it completes', async () => {
     const { channelAgentRuntimes } = await runtimeModule();
     // Codex delivers its first prompt natively (#1240), so the turn lifecycle

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -1035,6 +1035,7 @@ describe('channel-message-store streaming lifecycle', () => {
           content: 'inspect',
         },
       },
+      agentAttribution: { model: 'claude-sonnet', effort: 'high' },
     });
     const updated = first.updateAgentDetail(begun.id, {
       itemId: 'reason-1',
@@ -1083,6 +1084,7 @@ describe('channel-message-store streaming lifecycle', () => {
             content: 'inspect the channel bridge',
           }),
         }),
+        agentAttribution: { model: 'claude-sonnet', effort: 'high' },
       }),
     ]);
   });

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -2073,6 +2073,48 @@ describe('channel routes — agent commands', () => {
     expect(res.status).toBe(400);
     expect(h.store.history(h.channelId, { limit: 10 })).toHaveLength(0);
   });
+
+  it.each(['/model gpt-5.6', '/effort high'])(
+    'rejects bare DM control %s before persistence',
+    async (text) => {
+      const h = await harness({ binderFactory: realControlBinder });
+      const dm = h.topicStore.create(
+        dmChannelCreateInput({
+          providerId: 'codex',
+          providerDisplayName: 'Codex',
+          workspaceId: 'ws:local',
+        })
+      );
+      const res = await req<{
+        error: { details?: { reasonCode?: string } };
+      }>({
+        port: h.port,
+        method: 'POST',
+        url: `/channels/${dm.id}/messages`,
+        body: { text },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.details?.reasonCode).toBe(
+        'CHANNEL_COMMAND_REQUIRES_CONTROL_LANE'
+      );
+      expect(h.store.history(dm.id, { limit: 10 })).toHaveLength(0);
+    }
+  );
+
+  it('keeps bare group-channel slash text as ordinary persisted prose', async () => {
+    const h = await harness({ binderFactory: realControlBinder });
+    const res = await req<{ message: { body: { text: string } } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/messages`,
+      body: { text: '/model gpt-5.6' },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.message.body.text).toBe('/model gpt-5.6');
+    expect(h.store.history(h.channelId, { limit: 10 })).toHaveLength(1);
+  });
 });
 
 describe('channel routes — orchestrator designation (#1259)', () => {

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -2102,6 +2102,34 @@ describe('channel routes — agent commands', () => {
     }
   );
 
+  it.each(['/model prime/a', '/thinking high', '/effort high'])(
+    'rejects bare Prime DM control %s before persistence',
+    async (text) => {
+      const h = await harness({ binderFactory: realControlBinder });
+      const dm = h.topicStore.create(
+        dmChannelCreateInput({
+          providerId: 'prime-agent',
+          providerDisplayName: 'Prime Agent',
+          workspaceId: 'ws:local',
+        })
+      );
+      const res = await req<{
+        error: { details?: { reasonCode?: string } };
+      }>({
+        port: h.port,
+        method: 'POST',
+        url: `/channels/${dm.id}/messages`,
+        body: { text },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.details?.reasonCode).toBe(
+        'CHANNEL_COMMAND_REQUIRES_CONTROL_LANE'
+      );
+      expect(h.store.history(dm.id, { limit: 10 })).toHaveLength(0);
+    }
+  );
+
   it('keeps bare group-channel slash text as ordinary persisted prose', async () => {
     const h = await harness({ binderFactory: realControlBinder });
     const res = await req<{ message: { body: { text: string } } }>({

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -117,6 +117,36 @@ const codexRoster: RosterEntry[] = [
   },
 ];
 
+const primeRoster: RosterEntry[] = [
+  {
+    id: 'agent-profile:prime-agent:default',
+    displayName: 'Prime',
+    providerId: 'prime-agent',
+    isDefault: true,
+    isBuiltIn: true,
+    kind: 'framework',
+    available: true,
+    reason: null,
+    binding: null,
+    commands: [
+      {
+        id: 'relay:prime-agent:thinking',
+        name: 'thinking',
+        aliases: ['effort'],
+        description: 'Set Prime Agent reasoning depth',
+        args: [
+          { value: 'low', label: 'low' },
+          { value: 'high', label: 'high' },
+        ],
+        source: 'builtin',
+        sourceLabel: 'Prime Agent',
+        dispatch: 'relay-control',
+        collisionKey: 'thinking',
+      },
+    ],
+  },
+];
+
 interface RenderOpts {
   onSend?: (
     text: string,
@@ -704,6 +734,36 @@ describe('ChannelComposer (#1178)', () => {
     });
     expect(onSend).not.toHaveBeenCalled();
     expect(ta.value).toBe('');
+  });
+
+  it('uses the exact non-Codex DM provider profile and live control catalog', async () => {
+    vi.mocked(fetchChannelRoster).mockResolvedValue(primeRoster);
+    const onSend = vi.fn(async () => {});
+    await renderComposer({
+      onSend,
+      implicitCommandProviderId: 'prime-agent',
+    });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/effort'));
+    await settleRoster();
+
+    expect(
+      container.querySelector(
+        '[role="listbox"][aria-label="commands for Prime"]'
+      )?.textContent
+    ).toContain('/thinking');
+    await pressKey('Enter');
+    await pressKey('ArrowDown');
+    await pressKey('Enter');
+
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:prime-agent:default',
+      command: 'thinking',
+      args: 'high',
+    });
+    expect(onSend).not.toHaveBeenCalled();
   });
 
   it('keeps a bare group-channel slash draft as ordinary prose', async () => {

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -56,6 +56,34 @@ const codexRoster: RosterEntry[] = [
     binding: null,
     commands: [
       {
+        id: 'relay:model',
+        name: 'model',
+        description: 'Switch model for subsequent Codex responses',
+        argumentHint: '<model>',
+        args: [
+          { value: 'gpt-5.4', label: 'gpt-5.4' },
+          { value: 'gpt-5.6', label: 'gpt-5.6' },
+        ],
+        source: 'relay',
+        sourceLabel: 'Relay',
+        dispatch: 'relay-control',
+        collisionKey: 'model',
+      },
+      {
+        id: 'relay:effort',
+        name: 'effort',
+        description: 'Set Codex reasoning effort for subsequent responses',
+        argumentHint: '<effort>',
+        args: [
+          { value: 'low', label: 'low' },
+          { value: 'high', label: 'high' },
+        ],
+        source: 'relay',
+        sourceLabel: 'Relay',
+        dispatch: 'relay-control',
+        collisionKey: 'effort',
+      },
+      {
         id: 'relay:fast',
         name: 'fast',
         description: 'Enable or disable Codex Fast Mode',
@@ -100,6 +128,7 @@ interface RenderOpts {
   archived?: boolean;
   onRestore?: () => void;
   restorePending?: boolean;
+  implicitCommandProviderId?: string;
 }
 
 async function renderComposer(opts: RenderOpts = {}): Promise<QueryClient> {
@@ -116,6 +145,9 @@ async function renderComposer(opts: RenderOpts = {}): Promise<QueryClient> {
         React.createElement(ChannelComposer, {
           channelId: 'topic:general',
           channelTitle: 'general',
+          ...(opts.implicitCommandProviderId
+            ? { implicitCommandProviderId: opts.implicitCommandProviderId }
+            : {}),
           onSend: opts.onSend ?? (() => Promise.resolve()),
           postPending: opts.postPending ?? false,
           storeDown: opts.storeDown ?? false,
@@ -553,6 +585,214 @@ describe('ChannelComposer (#1178)', () => {
       args: 'on',
     });
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('uses the DM target and live roster values for bare /model without posting', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({
+      onSend,
+      implicitCommandProviderId: 'codex',
+    });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/model'));
+    await settleRoster();
+
+    expect(
+      container.querySelector(
+        '[role="listbox"][aria-label="commands for Codex"]'
+      )?.textContent
+    ).toContain('/model');
+    await pressKey('Enter');
+    // The enumerated choices come from the currently fetched roster, not a
+    // display-name or static UI list. Choose the second live model.
+    await pressKey('ArrowDown');
+    await pressKey('Enter');
+
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:default',
+      command: 'model',
+      args: 'gpt-5.6',
+    });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(ta.value).toBe('');
+  });
+
+  it('holds a reserved bare Codex control until its live roster resolves', async () => {
+    let resolveRoster: ((value: RosterEntry[]) => void) | undefined;
+    vi.mocked(fetchChannelRoster).mockImplementation(
+      () =>
+        new Promise<RosterEntry[]>((resolve) => {
+          resolveRoster = resolve;
+        })
+    );
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend, implicitCommandProviderId: 'codex' });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/model'));
+    await act(async () => Promise.resolve());
+    expect(fetchChannelRoster).toHaveBeenCalledWith('topic:general');
+
+    // Before the exact default profile and its live catalog arrive, Enter is a
+    // loading-palette action, never a 400-producing normal channel post.
+    await pressKey('Enter');
+    expect(onSend).not.toHaveBeenCalled();
+    expect(executeChannelAgentCommand).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('loading commands…');
+
+    await act(async () => {
+      resolveRoster?.(codexRoster);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() =>
+      expect(container.textContent).not.toContain('loading commands…')
+    );
+    expect(container.textContent).toContain('/model');
+    await pressKey('Enter');
+    expect(container.textContent).toContain('gpt-5.4');
+  });
+
+  it.each([
+    [
+      'a default without model controls',
+      [{ ...codexRoster[0]!, commands: [] }],
+    ],
+    ['no current default profile', [{ ...codexRoster[0]!, isDefault: false }]],
+  ])(
+    'keeps /model unavailable rather than posting when the roster has %s',
+    async (_caseName, roster) => {
+      vi.mocked(fetchChannelRoster).mockResolvedValue(roster);
+      const onSend = vi.fn(async () => {});
+      await renderComposer({ onSend, implicitCommandProviderId: 'codex' });
+      const ta = container.querySelector(
+        '.ch-composer__ta'
+      ) as HTMLTextAreaElement;
+      await act(async () => setNativeValue(ta, '/model'));
+      await settleRoster();
+
+      expect(container.textContent).toContain('commands unavailable');
+      await pressKey('Enter');
+      expect(onSend).not.toHaveBeenCalled();
+      expect(executeChannelAgentCommand).not.toHaveBeenCalled();
+    }
+  );
+
+  it('uses the DM target for bare /effort without consuming a model turn', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({
+      onSend,
+      implicitCommandProviderId: 'codex',
+    });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/effort'));
+    await settleRoster();
+
+    await pressKey('Enter');
+    await pressKey('ArrowDown');
+    await pressKey('Enter');
+
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:default',
+      command: 'effort',
+      args: 'high',
+    });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(ta.value).toBe('');
+  });
+
+  it('keeps a bare group-channel slash draft as ordinary prose', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend });
+    await typeAndEnter('/model gpt-5.6');
+
+    expect(executeChannelAgentCommand).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith(
+      '/model gpt-5.6',
+      expect.any(String),
+      [],
+      undefined
+    );
+    expect(
+      (container.querySelector('[role="listbox"]') as HTMLElement).style.display
+    ).toBe('none');
+  });
+
+  it('uses a promoted custom Codex default instead of the dormant built-in id', async () => {
+    vi.mocked(fetchChannelRoster).mockResolvedValue([
+      {
+        ...codexRoster[0]!,
+        id: 'agent-profile:codex:promoted-default',
+        displayName: 'Codex Primary',
+        isBuiltIn: false,
+      },
+    ]);
+    const onSend = vi.fn(async () => {});
+    await renderComposer({ onSend, implicitCommandProviderId: 'codex' });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/model'));
+    await settleRoster();
+
+    await pressKey('Enter');
+    await pressKey('Enter');
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:promoted-default',
+      command: 'model',
+      args: 'gpt-5.4',
+    });
+    expect(executeChannelAgentCommand).not.toHaveBeenCalledWith(
+      'topic:general',
+      expect.objectContaining({ profileId: 'agent-profile:codex:default' })
+    );
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('keeps unknown Codex slash input and non-Codex DM slash input sendable', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({
+      onSend,
+      implicitCommandProviderId: 'codex',
+    });
+    let ta = container.querySelector('.ch-composer__ta') as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/skill investigate'));
+    await settleRoster();
+    expect(
+      (container.querySelector('[role="listbox"]') as HTMLElement).style.display
+    ).toBe('none');
+    await pressKey('Enter');
+    expect(executeChannelAgentCommand).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith(
+      '/skill investigate',
+      expect.any(String),
+      [],
+      undefined
+    );
+
+    vi.mocked(onSend).mockClear();
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await renderComposer({ onSend, implicitCommandProviderId: 'claude' });
+    ta = container.querySelector('.ch-composer__ta') as HTMLTextAreaElement;
+    await act(async () => setNativeValue(ta, '/model sonnet'));
+    await settleRoster();
+    expect(
+      (container.querySelector('[role="listbox"]') as HTMLElement).style.display
+    ).toBe('none');
+    await pressKey('Enter');
+    expect(executeChannelAgentCommand).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith(
+      '/model sonnet',
+      expect.any(String),
+      [],
+      undefined
+    );
   });
 
   it('accepts the single space inserted by mention selection before / commands', async () => {

--- a/test/components/channel-message-row.test.ts
+++ b/test/components/channel-message-row.test.ts
@@ -98,6 +98,33 @@ describe('ChannelMessageRow truncation fidelity', () => {
     }
   );
 
+  it('renders durable model and effort only when an agent row carries them', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: agentMessage({
+            agentAttribution: { model: 'gpt-5.6', effort: 'high' },
+          }),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+
+    expect(container.querySelector('.ch-msg__attribution')?.textContent).toBe(
+      'model: gpt-5.6effort: high'
+    );
+
+    await act(async () => {
+      root.render(
+        React.createElement(ChannelMessageRow, {
+          message: agentMessage({}),
+          channelId: 'topic:eng-threads',
+        })
+      );
+    });
+    expect(container.querySelector('.ch-msg__attribution')).toBeNull();
+  });
+
   it('renders a persisted reasoning card collapsed and expands its content', async () => {
     await act(async () => {
       root.render(

--- a/test/components/channel-view-dm-composer.test.ts
+++ b/test/components/channel-view-dm-composer.test.ts
@@ -20,6 +20,7 @@ import { dmChannelTopicId } from '../../shared/dm-channels.js';
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const DM_CHANNEL_ID = dmChannelTopicId('claude', 'ws:local');
+const CODEX_DM_CHANNEL_ID = dmChannelTopicId('codex', 'ws:local');
 const GROUP_CHANNEL_ID = 'topic:general';
 
 const mocks = vi.hoisted(() => ({
@@ -99,9 +100,8 @@ vi.mock('../../frontend/src/components/chat/ChannelComposer.js', () => ({
   },
 }));
 
-const { ChannelView } = await import(
-  '../../frontend/src/components/chat/ChannelView.js'
-);
+const { ChannelView } =
+  await import('../../frontend/src/components/chat/ChannelView.js');
 const { useUiStore } = await import('../../frontend/src/lib/stores/ui.js');
 
 const THREAD_ROOT_ID = 'chm:root-1' as ChannelMessageId;
@@ -133,6 +133,10 @@ async function render(channelId: string): Promise<void> {
 
 function latestPlaceholder(): unknown {
   return mocks.composerProps.at(-1)?.['placeholder'];
+}
+
+function latestCommandProviderHint(): unknown {
+  return mocks.composerProps.at(-1)?.['implicitCommandProviderId'];
 }
 
 /** Every placeholder any composer has been handed this render pass. */
@@ -205,6 +209,7 @@ describe('ChannelView composer copy', () => {
     // The DM routes implicitly — never prompt for the `@` it does not need.
     expect(placeholder as string).not.toContain('to mention');
     expect(placeholder as string).not.toContain('#');
+    expect(latestCommandProviderHint()).toBeUndefined();
   });
 
   it('leaves a multi-party channel on the default `#channel` copy', async () => {
@@ -246,6 +251,7 @@ describe('ChannelView composer copy', () => {
     expect(placeholders().some((copy) => copy.includes('to mention'))).toBe(
       false
     );
+    expect(latestCommandProviderHint()).toBeUndefined();
   });
 
   it('keeps the mention hint on a multi-party thread composer', async () => {
@@ -266,5 +272,23 @@ describe('ChannelView composer copy', () => {
     expect(placeholders()).toContain(
       'reply in thread…  ·  @ to mention · shift+enter for newline'
     );
+    expect(latestCommandProviderHint()).toBeUndefined();
+  });
+
+  it('passes only the Codex DM provider hint to main and thread composers', async () => {
+    mocks.channelId = CODEX_DM_CHANNEL_ID;
+    mocks.channelTitle = 'Codex';
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: CODEX_DM_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'Codex' },
+      routingDefaults: { providerId: 'codex' },
+    });
+
+    await render(CODEX_DM_CHANNEL_ID);
+    expect(latestCommandProviderHint()).toBe('codex');
+    mocks.composerProps.length = 0;
+    await openThread(CODEX_DM_CHANNEL_ID);
+    expect(latestCommandProviderHint()).toBe('codex');
   });
 });

--- a/test/components/channel-view-dm-composer.test.ts
+++ b/test/components/channel-view-dm-composer.test.ts
@@ -21,6 +21,7 @@ import { dmChannelTopicId } from '../../shared/dm-channels.js';
 
 const DM_CHANNEL_ID = dmChannelTopicId('claude', 'ws:local');
 const CODEX_DM_CHANNEL_ID = dmChannelTopicId('codex', 'ws:local');
+const PRIME_DM_CHANNEL_ID = dmChannelTopicId('prime-agent', 'ws:local');
 const GROUP_CHANNEL_ID = 'topic:general';
 
 const mocks = vi.hoisted(() => ({
@@ -209,7 +210,7 @@ describe('ChannelView composer copy', () => {
     // The DM routes implicitly — never prompt for the `@` it does not need.
     expect(placeholder as string).not.toContain('to mention');
     expect(placeholder as string).not.toContain('#');
-    expect(latestCommandProviderHint()).toBeUndefined();
+    expect(latestCommandProviderHint()).toBe('claude');
   });
 
   it('leaves a multi-party channel on the default `#channel` copy', async () => {
@@ -251,7 +252,7 @@ describe('ChannelView composer copy', () => {
     expect(placeholders().some((copy) => copy.includes('to mention'))).toBe(
       false
     );
-    expect(latestCommandProviderHint()).toBeUndefined();
+    expect(latestCommandProviderHint()).toBe('claude');
   });
 
   it('keeps the mention hint on a multi-party thread composer', async () => {
@@ -275,7 +276,7 @@ describe('ChannelView composer copy', () => {
     expect(latestCommandProviderHint()).toBeUndefined();
   });
 
-  it('passes only the Codex DM provider hint to main and thread composers', async () => {
+  it('passes the DM provider hint to main and thread composers', async () => {
     mocks.channelId = CODEX_DM_CHANNEL_ID;
     mocks.channelTitle = 'Codex';
     mocks.fetchWorkspaceTopic.mockResolvedValue({
@@ -290,5 +291,22 @@ describe('ChannelView composer copy', () => {
     mocks.composerProps.length = 0;
     await openThread(CODEX_DM_CHANNEL_ID);
     expect(latestCommandProviderHint()).toBe('codex');
+  });
+
+  it('passes a non-Codex provider hint without substituting a built-in profile', async () => {
+    mocks.channelId = PRIME_DM_CHANNEL_ID;
+    mocks.channelTitle = 'Prime';
+    mocks.fetchWorkspaceTopic.mockResolvedValue({
+      id: PRIME_DM_CHANNEL_ID,
+      workspaceId: 'ws:local',
+      display: { title: 'Prime' },
+      routingDefaults: { providerId: 'prime-agent' },
+    });
+
+    await render(PRIME_DM_CHANNEL_ID);
+    expect(latestCommandProviderHint()).toBe('prime-agent');
+    mocks.composerProps.length = 0;
+    await openThread(PRIME_DM_CHANNEL_ID);
+    expect(latestCommandProviderHint()).toBe('prime-agent');
   });
 });


### PR DESCRIPTION
## Summary
- add bare `/model` and `/effort` controls to Codex DM and thread composers
- resolve the current live default Codex profile and route commands through the non-persistent control endpoint
- keep native slash commands and group-channel slash text sendable, while showing loading or unavailable states for reserved controls
- reject raw DM control messages before persistence as a server-side safety net

## Verification
- focused composer, DM view, and channel route suite: 123/123 passed
- Codex adapter next-turn control suite: 93/93 passed
- `npm run check`: passed with no errors
- `npm run build`: passed
- `git diff --check`: passed
- adversarial review and focused re-review: no unresolved P0/P1 findings