### PR TITLE
feat(cli): add durable channel subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ workflow.
   existing WorkContext artifact and CLI surfaces (#1368)
 - Expose stable CLI gateway commands for scoped channel list, get, history,
   thread-history, roster, and post access (#1372)
+- Stream scoped channel replies through a durable, resumable
+  `channels.subscribe` CLI gateway contract without per-message blocking waits
+  (#1389)
 - Deliver durable, exactly-once upward completion callbacks for explicit
   agent-to-agent channel delegations, including restart recovery, busy-agent
   FIFO queueing, nested child fan-in, and explicit-return de-duplication (#1359)

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1596,6 +1596,7 @@ const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'channels.list',
   'channels.get',
   'channels.history',
+  'channels.subscribe',
   'channels.threads.history',
   'channels.roster',
   'channels.post',
@@ -2710,6 +2711,72 @@ function gatewayTargetPayload(
 function writeGatewayNdjson(envelope: RelayCliGatewayEnvelope): boolean {
   return process.stdout.write(`${JSON.stringify(envelope)}
 `);
+}
+
+/**
+ * Write one streaming gateway frame without treating stdout's high-water mark
+ * as a dropped frame. A piped consumer may intentionally close early (for
+ * example, `head` after it has its result); EPIPE is therefore a clean local
+ * cancellation signal, not a gateway failure to print over the broken pipe.
+ */
+function writeGatewayNdjsonDrained(
+  envelope: RelayCliGatewayEnvelope
+): Promise<boolean> {
+  const payload = `${JSON.stringify(envelope)}\n`;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let writeCompleted = false;
+    let drainCompleted = false;
+    let accepted = false;
+
+    const cleanup = (): void => {
+      process.stdout.removeListener('error', onError);
+      process.stdout.removeListener('drain', onDrain);
+    };
+    const settle = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const finishIfReady = (): void => {
+      if (writeCompleted && (accepted || drainCompleted)) settle(true);
+    };
+    const onError = (error: Error): void => {
+      if ((error as NodeJS.ErrnoException).code === 'EPIPE') {
+        settle(false);
+      } else {
+        fail(error);
+      }
+    };
+    const onDrain = (): void => {
+      drainCompleted = true;
+      finishIfReady();
+    };
+    const onWrite = (error?: Error | null): void => {
+      if (error) {
+        onError(error);
+        return;
+      }
+      writeCompleted = true;
+      finishIfReady();
+    };
+
+    process.stdout.once('error', onError);
+    try {
+      accepted = process.stdout.write(payload, onWrite);
+    } catch (error) {
+      onError(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+    if (!accepted) process.stdout.once('drain', onDrain);
+  });
 }
 
 async function runGatewaySessionStream(sessionArgs: string[]): Promise<never> {
@@ -5286,6 +5353,8 @@ type ChannelCliValueFlag =
   | '--limit'
   | '--before-seq'
   | '--after-seq'
+  | '--max-events'
+  | '--idle-timeout-ms'
   | '--input-json';
 
 /** Strict, command-local parser for the six stable channel gateway commands. */
@@ -5427,7 +5496,7 @@ function validateChannelPostCliInput(input: Record<string, unknown>): void {
   }
 }
 
-async function runGatewayChannels(gatewayArgs: string[]): Promise<never> {
+async function runGatewayChannels(gatewayArgs: string[]): Promise<void> {
   const subcommand = gatewayArgs[1];
   const channelArgs = gatewayArgs.slice(2);
 
@@ -5487,6 +5556,49 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<never> {
       capabilities: ['context:read'],
     });
     printGatewayEnvelope(gatewayOk('channels.history', result), 0);
+  }
+
+  if (subcommand === 'subscribe') {
+    const values = parseChannelCliFlags('channels.subscribe', channelArgs, [
+      '--channel-id',
+      '--after-seq',
+      '--max-events',
+      '--idle-timeout-ms',
+    ]);
+    const channelId = requiredChannelCliString(
+      'channels.subscribe',
+      values,
+      '--channel-id'
+    );
+    const readBoundedInt = (
+      flag: '--after-seq' | '--max-events' | '--idle-timeout-ms',
+      minimum: number,
+      maximum: number
+    ): number | undefined => {
+      const value = values.get(flag);
+      if (value === undefined) return undefined;
+      const parsed = Number(value);
+      if (
+        !Number.isSafeInteger(parsed) ||
+        parsed < minimum ||
+        parsed > maximum
+      ) {
+        gatewayInvalid('channels.subscribe', `${flag} has an invalid value`, {
+          field: flag.slice(2),
+          value,
+        });
+      }
+      return parsed;
+    };
+    const afterSeq = readBoundedInt('--after-seq', 0, Number.MAX_SAFE_INTEGER);
+    const maxEvents = readBoundedInt('--max-events', 1, 10000);
+    const idleTimeoutMs = readBoundedInt('--idle-timeout-ms', 1, 300000);
+    return runGatewayChannelsSubscribe({
+      channelId,
+      ...(afterSeq !== undefined ? { afterSeq } : {}),
+      ...(maxEvents !== undefined ? { maxEvents } : {}),
+      ...(idleTimeoutMs !== undefined ? { idleTimeoutMs } : {}),
+    });
   }
 
   if (subcommand === 'threads' && channelArgs[0] === 'history') {
@@ -5569,6 +5681,193 @@ async function runGatewayChannels(gatewayArgs: string[]): Promise<never> {
   gatewayInvalid('channels.list', 'unknown channels command', {
     args: gatewayArgs,
   });
+}
+
+async function runGatewayChannelsSubscribe(input: {
+  channelId: string;
+  afterSeq?: number;
+  maxEvents?: number;
+  idleTimeoutMs?: number;
+}): Promise<void> {
+  const commandName = 'channels.subscribe' as const;
+  const token = gatewayRequiredToken(commandName);
+  const actorToken = gatewayActorToken();
+  const query = new URLSearchParams();
+  if (input.afterSeq !== undefined)
+    query.set('afterSeq', String(input.afterSeq));
+  const controller = new AbortController();
+  const stop = (): void => controller.abort();
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+  let res: Response;
+  try {
+    res = await fetch(
+      `http://127.0.0.1:${gatewayWsPort()}/channels/${encodeURIComponent(input.channelId)}/subscribe?${query.toString()}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/x-ndjson',
+          'x-relay-cli-gateway': 'v1',
+          'x-relay-capabilities': 'context:read',
+          ...(actorToken
+            ? {
+                'x-relay-cli-actor-token': 'v1',
+                'x-relay-cli-command': commandName,
+              }
+            : {}),
+          ...(gatewayCorrelationId()
+            ? { 'x-relay-correlation-id': gatewayCorrelationId()! }
+            : {}),
+        },
+        signal: controller.signal,
+      }
+    );
+  } catch (error) {
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'SERVER_UNAVAILABLE',
+        message: `could not connect to Relay hub: ${error instanceof Error ? error.message : String(error)}`,
+        retryable: true,
+        details: { channelId: input.channelId },
+      }),
+      1
+    );
+  }
+  if (!res.ok) {
+    const raw = await res.text().catch(() => '');
+    let upstream: Record<string, unknown> | undefined;
+    try {
+      const parsed = raw ? JSON.parse(raw) : undefined;
+      if (parsed && typeof parsed === 'object')
+        upstream = parsed as Record<string, unknown>;
+    } catch {
+      upstream = raw ? { raw } : undefined;
+    }
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: normalizeGatewayErrorCode(res.status, upstream),
+        message: gatewayErrorMessage(res.status, upstream),
+        retryable: gatewayErrorRetryable(res.status, upstream),
+        details: {
+          ...sanitizedGatewayErrorDetails(res.status, upstream),
+          channelId: input.channelId,
+        },
+      }),
+      1
+    );
+  }
+  if (!res.body) {
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'UPSTREAM_ERROR',
+        message: 'hub channel subscription response had no body stream',
+        retryable: true,
+      }),
+      1
+    );
+  }
+  let buffer = '';
+  let events = 0;
+  let idleTimer: NodeJS.Timeout | undefined;
+  let normalClose = false;
+  let stdoutWriteError: Error | undefined;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  const cancelStream = (): void => {
+    controller.abort();
+    void reader?.cancel().catch(() => {
+      /* AbortController already closes the fetch body; cancellation is best effort. */
+    });
+  };
+  // `Writable` can emit EPIPE after its individual write callback ran. Keep a
+  // subscription-scoped listener until teardown so an early downstream close
+  // never becomes an unhandled process error between frames.
+  const onStdoutError = (error: Error): void => {
+    if ((error as NodeJS.ErrnoException).code === 'EPIPE') {
+      normalClose = true;
+      cancelStream();
+      return;
+    }
+    stdoutWriteError = error;
+    cancelStream();
+  };
+  process.stdout.on('error', onStdoutError);
+  const resetIdle = (): void => {
+    if (idleTimer) clearTimeout(idleTimer);
+    if (input.idleTimeoutMs !== undefined) {
+      idleTimer = setTimeout(cancelStream, input.idleTimeoutMs);
+      idleTimer.unref?.();
+    }
+  };
+  const emit = async (line: string): Promise<boolean> => {
+    if (!line) return true;
+    let frame: Record<string, unknown>;
+    try {
+      frame = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      return true;
+    }
+    if (frame['frame'] === 'event') events += 1;
+    if (frame['frame'] === 'closed') normalClose = frame['retryable'] !== true;
+    const written = await writeGatewayNdjsonDrained(
+      gatewayOk(commandName, frame)
+    );
+    if (!written) {
+      normalClose = true;
+      cancelStream();
+      return false;
+    }
+    resetIdle();
+    if (input.maxEvents !== undefined && events >= input.maxEvents) {
+      normalClose = true;
+      cancelStream();
+      return false;
+    }
+    return true;
+  };
+  resetIdle();
+  try {
+    reader = (res.body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+    let keepReading = true;
+    while (keepReading) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let newline = buffer.indexOf('\n');
+      while (newline >= 0) {
+        keepReading = await emit(buffer.slice(0, newline).trim());
+        buffer = buffer.slice(newline + 1);
+        if (!keepReading) break;
+        newline = buffer.indexOf('\n');
+      }
+    }
+    if (keepReading) {
+      buffer += decoder.decode();
+      await emit(buffer.trim());
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      await writeGatewayNdjsonDrained(
+        gatewayError(commandName, {
+          code: 'UPSTREAM_ERROR',
+          message: `channel subscription failed: ${error instanceof Error ? error.message : String(error)}`,
+          retryable: true,
+          details: { channelId: input.channelId, events },
+        })
+      );
+      process.exitCode = 1;
+    }
+  } finally {
+    if (idleTimer) clearTimeout(idleTimer);
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+    process.stdout.removeListener('error', onStdoutError);
+  }
+  process.exitCode = stdoutWriteError
+    ? 1
+    : normalClose || controller.signal.aborted
+      ? 0
+      : 1;
 }
 
 async function readGatewayCockpitGroups(
@@ -5779,7 +6078,7 @@ async function runGatewayWebhooks(gatewayArgs: string[]): Promise<never> {
   });
 }
 
-async function runGatewayV1(): Promise<never> {
+async function runGatewayV1(): Promise<void> {
   const gatewayArgs = args.slice(1);
   const json = gatewayArgs.includes('--json');
   const top = gatewayArgs[0];
@@ -5803,36 +6102,35 @@ async function runGatewayV1(): Promise<never> {
   // Top-level group → handler. All handlers take the full gateway argv and never
   // return (each prints an envelope and exits). A table keeps this dispatch flat
   // instead of an ever-growing if-chain.
-  const gatewayGroupHandlers: Record<string, (a: string[]) => Promise<never>> =
-    {
-      nodes: runGatewayNodes,
-      repos: runGatewayRepos,
-      workspaces: runGatewayWorkspaces,
-      worktrees: runGatewayWorktrees,
-      sessions: runGatewaySessions,
-      tickets: runGatewayTickets,
-      branches: runGatewayBranches,
-      files: runGatewayFiles,
-      'work-contexts': runGatewayWorkContexts,
-      context: runGatewayContext,
-      inbox: runGatewayInbox,
-      handoffs: runGatewayHandoffs,
-      'work-context-messages': runGatewayWorkContextMessages,
-      'work-context-artifacts': runGatewayWorkContextArtifacts,
-      'handoff-artifacts': runGatewayHandoffArtifacts,
-      'workflow-runs': runGatewayWorkflowRuns,
-      'automation-runs': runGatewayAutomationRuns,
-      'pr-overseer': runGatewayPrOverseer,
-      'workspace-surfaces': runGatewayWorkspaceSurfaces,
-      'workspace-topics': runGatewayWorkspaceTopics,
-      channels: runGatewayChannels,
-      cockpit: runGatewayCockpit,
-      artifacts: runGatewayArtifacts,
-      supervisor: runGatewaySupervisor,
-      events: runGatewayEvents,
-      settings: runGatewaySettings,
-      webhooks: runGatewayWebhooks,
-    };
+  const gatewayGroupHandlers: Record<string, (a: string[]) => Promise<void>> = {
+    nodes: runGatewayNodes,
+    repos: runGatewayRepos,
+    workspaces: runGatewayWorkspaces,
+    worktrees: runGatewayWorktrees,
+    sessions: runGatewaySessions,
+    tickets: runGatewayTickets,
+    branches: runGatewayBranches,
+    files: runGatewayFiles,
+    'work-contexts': runGatewayWorkContexts,
+    context: runGatewayContext,
+    inbox: runGatewayInbox,
+    handoffs: runGatewayHandoffs,
+    'work-context-messages': runGatewayWorkContextMessages,
+    'work-context-artifacts': runGatewayWorkContextArtifacts,
+    'handoff-artifacts': runGatewayHandoffArtifacts,
+    'workflow-runs': runGatewayWorkflowRuns,
+    'automation-runs': runGatewayAutomationRuns,
+    'pr-overseer': runGatewayPrOverseer,
+    'workspace-surfaces': runGatewayWorkspaceSurfaces,
+    'workspace-topics': runGatewayWorkspaceTopics,
+    channels: runGatewayChannels,
+    cockpit: runGatewayCockpit,
+    artifacts: runGatewayArtifacts,
+    supervisor: runGatewaySupervisor,
+    events: runGatewayEvents,
+    settings: runGatewaySettings,
+    webhooks: runGatewayWebhooks,
+  };
   const groupHandler = top ? gatewayGroupHandlers[top] : undefined;
   if (groupHandler) return groupHandler(gatewayArgs);
   gatewayInvalid('contract.list', 'unknown v1 gateway command', {
@@ -8957,4 +9255,4 @@ if (args.includes('--allow-degraded')) {
   process.env['RELAY_IDE_ALLOW_DEGRADED'] = '1';
 }
 
-await import('../server/index.js');
+if (command !== 'v1') await import('../server/index.js');

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -89,6 +89,27 @@ The hub coalesces text deltas and applies socket watermarks. A lagging client
 can reconnect from its last durable sequence instead of requiring an
 unbounded in-memory queue.
 
+External agents use the separate actor-authenticated NDJSON adapter:
+
+```sh
+relay-ide v1 channels subscribe --channel-id topic:general --after-seq 42 --json
+```
+
+It shares the hub's register-before-replay handoff and bounded subscriber set;
+there is no second replay ring. Each frame reports the last safe `durableSeq`.
+Only committed rows advance it, so text deltas can be rendered live without
+moving the reconnect cursor past their owning row. Exact `channelIds` scope and
+`context:read` are checked before registration, and revoked actor credentials
+terminate established streams on their next validation interval.
+
+The CLI output is a discriminated v1 frame stream: every `open`, `event`, and
+`closed` frame has `schemaVersion: 1`, `channelId`, `sequence`, `occurredAt`,
+and `durableSeq`;
+`event` frames carry a required versioned channel-event payload, and `closed`
+frames carry a required reason plus retryability. A bounded consumer stops
+parsing immediately after its `--max-events` frame and cancels the upstream
+reader; stdout backpressure is drained rather than treated as a dropped frame.
+
 ### Read state and unread
 
 Unread is derived client-side; the _marker_ it derives from converges through

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -124,12 +124,26 @@ a public session id, identifies an agent in a conversation. Public session and
 inbox commands operate on terminal execution records or WorkContexts; they do not
 launch, resume, or address private channel runtimes.
 
-**Gateway channel surface: `channels.post` only.** It is the sole channel verb
-declared in `shared/cli-gateway-contract.ts`. Channel reads — list, get,
-history, threads, roster, search — are authenticated browser routes and are
-**not** gateway verbs today. An adapter that needs to read a channel uses those
-HTTP routes with a scoped actor credential; do not assume `channels.list` or
-`channels.history` exists because the gateway "covers channels".
+The stable gateway exposes scoped list/get/history/thread-history/roster/post
+commands plus a durable `channels.subscribe` stream. Search and browser-only
+conveniences remain outside the gateway contract.
+
+`relay-ide v1 channels subscribe --channel-id <id> --after-seq <N> --json`
+emits one NDJSON envelope per versioned `open`, `event`, or `closed` frame.
+Every frame requires `schemaVersion: 1`, `channelId`, `sequence`, `occurredAt`,
+and `durableSeq`.
+`event` additionally requires `payload` (a `ChannelEventV1` or
+`channel-heartbeat-v1`); `closed` additionally requires `reason` and
+`retryable`. `afterSeq` is exclusive; persist each frame's `durableSeq` and
+supply it on reconnect. Created and
+authoritative full-row update/completion events may advance that cursor.
+Streaming text deltas are ephemeral and never do. One connection can therefore
+observe replies to multiple posted messages without holding one wait per post.
+Use `--max-events` or `--idle-timeout-ms` for bounded automation. A retryable
+closed frame means reconnect from the last durable sequence. The CLI awaits
+stdout drain instead of dropping frames; a downstream closed pipe is treated as
+clean local cancellation and promptly cancels the upstream reader. The stream uses
+`context:read` plus the actor credential's exact `channelIds` scope.
 
 The former public agent-session and terminal hand-back contracts are
 superseded. Public terminals are always human-driven. `sessions.input` and
@@ -145,6 +159,9 @@ conversation transport.
 - **Terminal cockpit (`cockpit.list` / `cockpit.get` / `relay-ide cockpit`, #934 slices).** A read-first terminal surface for operators on SSH/devboxes. It composes Active Work through the CLI gateway and orders WorkContexts with the same attention copy as the Active Work UI: approval/input first, then offline/revoked/stale last-known contexts, then errors/running/live. Each list row carries why attention is needed, node freshness, session durability, actor/control mode, TaskRefs, artifact counts/latest refs, and explicit action availability before attach. Offline/stale/revoked nodes keep the last-known WorkContext/session context but live controls are disabled with typed reasons; destructive controls are outside this MVP. The selected-item detail path (`cockpit get --work-context-id`) adds exact follow-up command hints for bounded status/evidence (`work-contexts get/resume`, `context list`, artifact list/show/export/read, inbox/interventions) and attach discovery when the session is live/fresh. Capability hints: `session:read` + `context:read`.
 
 ### Cursor / resume / gap / backpressure (metadata topics)
+
+This section describes the in-memory metadata bus. Channel subscriptions use
+the durable SQLite sequence contract above and do not share this cursor space.
 
 `inbox`, `attention`, `context`, `work-context-artifacts`, `handoff-artifacts`, `workflow-runs`, `automation-runs`, and `pr-overseer` share one in-memory metadata bus, so they share the same resume contract:
 

--- a/docs/MCP_HARNESS_RELAY_BRIDGE.md
+++ b/docs/MCP_HARNESS_RELAY_BRIDGE.md
@@ -110,6 +110,13 @@ human-emulation proof. Explicit
 `append_external_event` calls are a fallback for providers with no usable
 connector, not the normal mirroring architecture.
 
+For channel replies, the bridge consumes the stable
+`channels.subscribe --channel-id <id> --after-seq <N>` NDJSON contract. It keeps
+one background subscription for multiple outstanding posts and correlates
+authoritative message rows using their existing source/thread metadata. This
+removes per-message blocking waits, but it does not claim that MCP can wake an
+idle Codex Desktop task; host wake/injection support remains provider-owned.
+
 ### Thin falsification experiment before broad investment
 
 Build no transcript importer first. In a private isolated hub, implement only

--- a/server/channel-hub.ts
+++ b/server/channel-hub.ts
@@ -64,8 +64,31 @@ export interface ChannelSocket {
   on(event: 'close' | 'error', handler: () => void): void;
 }
 
+/**
+ * Transport-neutral, server-to-client channel event sink.  The browser
+ * WebSocket lane is one adapter; HTTP streaming clients use the same handoff
+ * rather than reimplementing a second replay/live race window.
+ *
+ * `send` returns false when the transport cannot accept another frame.  This
+ * is intentionally stronger than Node's `ServerResponse.write()` convention:
+ * the hub must remove an abandoned subscriber immediately instead of allowing
+ * a response buffer to become an unbounded second event log.
+ */
+export interface ChannelEventSink {
+  readonly ready: boolean;
+  readonly bufferedAmount?: number;
+  send(event: ChannelEventV1): boolean;
+  close(reason: ChannelSubscriptionCloseReason): void;
+  onClose(handler: () => void): void;
+}
+
+export type ChannelSubscriptionCloseReason =
+  | { code: 'not-found' }
+  | { code: 'backpressure'; latestSeq: number }
+  | { code: 'transport-closed' };
+
 interface Subscriber {
-  ws: ChannelSocket;
+  sink: ChannelEventSink;
   channelId: string;
   /** live events queue here until the connect-time snapshot has been sent. */
   buffering: boolean;
@@ -132,6 +155,15 @@ export interface ChannelHub {
     ws: ChannelSocket,
     input: { channelId: string; sinceSeq: number | null }
   ): void;
+  /**
+   * Register a non-WebSocket transport. The subscriber is registered before
+   * its durable replay is read, exactly like `handleConnection`; call the
+   * returned cleanup when the owning HTTP response closes.
+   */
+  subscribe(
+    sink: ChannelEventSink,
+    input: { channelId: string; afterSeq: number | null }
+  ): () => void;
   broadcastCreated(
     message: ChannelMessage,
     mentions?: ChannelMention[],
@@ -178,16 +210,17 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     return new Date().toISOString();
   }
 
-  function bufferedAmount(ws: ChannelSocket): number {
-    return typeof ws.bufferedAmount === 'number' ? ws.bufferedAmount : 0;
+  function bufferedAmount(sink: ChannelEventSink): number {
+    return typeof sink.bufferedAmount === 'number' ? sink.bufferedAmount : 0;
   }
 
-  function rawSend(ws: ChannelSocket, event: ChannelEventV1): void {
-    if (ws.readyState !== WS_OPEN) return;
+  function rawSend(sink: ChannelEventSink, event: ChannelEventV1): boolean {
+    if (!sink.ready) return false;
     try {
-      ws.send(JSON.stringify(event));
+      return sink.send(event);
     } catch (err) {
       logger.warn('channel-hub send failed:', err);
+      return false;
     }
   }
 
@@ -228,16 +261,22 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
    *  - draining below 256KB clears lagging and emits `channel-resync-required-v1`.
    */
   function deliver(sub: Subscriber, event: ChannelEventV1): void {
-    const ws = sub.ws;
-    if (ws.readyState !== WS_OPEN) return;
-    const buffered = bufferedAmount(ws);
+    const sink = sub.sink;
+    if (!sink.ready) return;
+    const buffered = bufferedAmount(sink);
     if (buffered > HARD_LIMIT_BYTES) {
-      closeSubscriber(sub, CHANNEL_WS_BACKPRESSURE_CLOSE_CODE);
+      closeSubscriber(sub, {
+        code: 'backpressure',
+        latestSeq: latestSeqFor(sub.channelId),
+      });
       return;
     }
     if (sub.lagging && buffered < WATERMARK_LOW_BYTES) {
       sub.lagging = false;
-      rawSend(ws, resyncEvent(sub.channelId));
+      if (!rawSend(sink, resyncEvent(sub.channelId))) {
+        closeSubscriber(sub, { code: 'transport-closed' });
+        return;
+      }
     }
     if (event.type === 'channel-message-delta-v1') {
       if (sub.lagging) return; // suppress deltas while lagging
@@ -246,13 +285,18 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
         return;
       }
     }
-    rawSend(ws, event);
+    if (!rawSend(sink, event)) {
+      closeSubscriber(sub, { code: 'transport-closed' });
+    }
   }
 
-  function closeSubscriber(sub: Subscriber, code: number): void {
+  function closeSubscriber(
+    sub: Subscriber,
+    reason: ChannelSubscriptionCloseReason
+  ): void {
     removeSubscriber(sub.channelId, sub);
     try {
-      sub.ws.close(code);
+      sub.sink.close(reason);
     } catch {
       /* ignore */
     }
@@ -268,7 +312,10 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
           sub.queue.length >= connectQueueMaxEvents ||
           sub.queueBytes + eventBytes > connectQueueMaxBytes
         ) {
-          closeSubscriber(sub, CHANNEL_WS_BACKPRESSURE_CLOSE_CODE);
+          closeSubscriber(sub, {
+            code: 'backpressure',
+            latestSeq: latestSeqFor(channelId),
+          });
           continue;
         }
         sub.queue.push(event);
@@ -488,71 +535,119 @@ export function createChannelHub(options: ChannelHubOptions): ChannelHub {
     }
   }
 
+  function subscribe(
+    sink: ChannelEventSink,
+    { channelId, afterSeq }: { channelId: string; afterSeq: number | null }
+  ): () => void {
+    if (!store || !channelExists(channelId)) {
+      try {
+        sink.close({ code: 'not-found' });
+      } catch {
+        /* ignore */
+      }
+      return () => {};
+    }
+    const sub: Subscriber = {
+      sink,
+      channelId,
+      buffering: true,
+      queue: [],
+      queueBytes: 0,
+      snapshotLatestSeq: 0,
+      snapshotInFlight: new Map(),
+      lagging: false,
+    };
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      removeSubscriber(channelId, sub);
+    };
+    // Install the cleanup before registration: a response/socket that dies at
+    // the snapshot boundary must not remain retained in the hub.
+    sink.onClose(cleanup);
+
+    // Register FIRST so live events during snapshot build queue rather than
+    // race; better-sqlite3 reads are synchronous, so the queue + dedupe below
+    // is defense in depth.
+    addSubscriber(channelId, sub);
+
+    // Flush any pending accumulator text BEFORE reading the snapshot so the
+    // snapshot's recorded deltaIndex matches the overlaid text exactly; the
+    // flush delta queues on this buffering subscriber and is deduped below.
+    flushPendingForChannel(channelId);
+
+    const snapshot = buildSnapshot(channelId, afterSeq);
+    if (snapshot.type === 'channel-snapshot-v1') {
+      sub.snapshotLatestSeq = snapshot.latestSeq;
+      for (const ref of snapshot.inFlight) {
+        sub.snapshotInFlight.set(ref.messageId, ref.deltaIndex);
+      }
+    }
+    deliver(sub, snapshot);
+    if (!sink.ready) {
+      cleanup();
+      return cleanup;
+    }
+
+    // Flush queued live events with dedupe: drop committed events with
+    // seq <= snapshot endSeq; drop deltas with deltaIndex <= the snapshot's
+    // recorded index for that message (dedupe stream events by messageId +
+    // deltaIndex, NOT seq); always forward completed (idempotent replace-by-id).
+    const queued = sub.queue;
+    sub.queue = [];
+    sub.queueBytes = 0;
+    sub.buffering = false;
+    for (const event of queued) {
+      if (
+        event.type === 'channel-message-created-v1' &&
+        event.message.seq <= sub.snapshotLatestSeq
+      ) {
+        continue;
+      }
+      if (event.type === 'channel-message-delta-v1') {
+        const recorded = sub.snapshotInFlight.get(event.messageId);
+        if (recorded !== undefined && event.deltaIndex <= recorded) continue;
+      }
+      deliver(sub, event);
+      if (!sink.ready) break;
+    }
+    return cleanup;
+  }
+
   return {
     handleConnection(ws, { channelId, sinceSeq }) {
-      if (!store || !channelExists(channelId)) {
-        try {
-          ws.close(CHANNEL_WS_NOT_FOUND_CLOSE_CODE);
-        } catch {
-          /* ignore */
-        }
-        return;
-      }
-      const sub: Subscriber = {
-        ws,
-        channelId,
-        buffering: true,
-        queue: [],
-        queueBytes: 0,
-        snapshotLatestSeq: 0,
-        snapshotInFlight: new Map(),
-        lagging: false,
-      };
-      // Register FIRST so live events during snapshot build queue rather than
-      // race; better-sqlite3 reads are synchronous, so the queue + dedupe below
-      // is defense in depth.
-      addSubscriber(channelId, sub);
-
-      // Flush any pending accumulator text BEFORE reading the snapshot so the
-      // snapshot's recorded deltaIndex matches the overlaid text exactly; the
-      // flush delta queues on this buffering socket and is deduped below.
-      flushPendingForChannel(channelId);
-
-      const snapshot = buildSnapshot(channelId, sinceSeq);
-      if (snapshot.type === 'channel-snapshot-v1') {
-        sub.snapshotLatestSeq = snapshot.latestSeq;
-        for (const ref of snapshot.inFlight) {
-          sub.snapshotInFlight.set(ref.messageId, ref.deltaIndex);
-        }
-      }
-      deliver(sub, snapshot);
-      if (ws.readyState !== WS_OPEN) return;
-
-      // Flush queued live events with dedupe: drop committed events with
-      // seq <= snapshot endSeq; drop deltas with deltaIndex <= the snapshot's
-      // recorded index for that message (dedupe stream events by messageId +
-      // deltaIndex, NOT seq); always forward completed (idempotent replace-by-id).
-      const queued = sub.queue;
-      sub.queue = [];
-      sub.queueBytes = 0;
-      sub.buffering = false;
-      for (const event of queued) {
-        if (
-          event.type === 'channel-message-created-v1' &&
-          event.message.seq <= sub.snapshotLatestSeq
-        ) {
-          continue;
-        }
-        if (event.type === 'channel-message-delta-v1') {
-          const recorded = sub.snapshotInFlight.get(event.messageId);
-          if (recorded !== undefined && event.deltaIndex <= recorded) continue;
-        }
-        deliver(sub, event);
-      }
-
-      ws.on('close', () => removeSubscriber(channelId, sub));
-      ws.on('error', () => removeSubscriber(channelId, sub));
+      subscribe(
+        {
+          get ready() {
+            return ws.readyState === WS_OPEN;
+          },
+          get bufferedAmount() {
+            return ws.bufferedAmount ?? 0;
+          },
+          send(event) {
+            ws.send(JSON.stringify(event));
+            return true;
+          },
+          close(reason) {
+            ws.close(
+              reason.code === 'not-found'
+                ? CHANNEL_WS_NOT_FOUND_CLOSE_CODE
+                : reason.code === 'backpressure'
+                  ? CHANNEL_WS_BACKPRESSURE_CLOSE_CODE
+                  : 1011
+            );
+          },
+          onClose(handler) {
+            ws.on('close', handler);
+            ws.on('error', handler);
+          },
+        },
+        { channelId, afterSeq: sinceSeq }
+      );
     },
+
+    subscribe,
 
     broadcastCreated(message, mentions, options) {
       broadcast(message.channelId, {

--- a/server/channel-subscription-router.ts
+++ b/server/channel-subscription-router.ts
@@ -1,0 +1,404 @@
+import { Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+
+import type { ChannelEventV1 } from '../shared/channel-chat-protocol.js';
+import { authenticatedCliGatewayActorCredential } from './cli-gateway-actor-auth.js';
+import type {
+  ChannelEventSink,
+  ChannelHub,
+  ChannelSubscriptionCloseReason,
+} from './channel-hub.js';
+
+const CONTEXT_READ = 'context:read';
+const DEFAULT_HEARTBEAT_MS = 15_000;
+const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
+const DEFAULT_WRITABLE_HARD_LIMIT_BYTES = 4 * 1024 * 1024;
+
+export interface ChannelSubscriptionRouterDeps {
+  hub: ChannelHub;
+  /**
+   * The index-owned v1 actor-auth gate. It must bind this route to the
+   * `channels.subscribe` command before this handler runs.
+   */
+  requireSubscribeAuth: RequestHandler;
+  now?: () => Date;
+  heartbeatMs?: number;
+  drainTimeoutMs?: number;
+  writableHardLimitBytes?: number;
+  /** Deterministic test seam; production uses ServerResponse.write directly. */
+  writeResponse?: (res: Response, data: string) => boolean;
+  /** Rechecked immediately before every streamed frame (including heartbeats). */
+  isStillAuthorized?: (req: Request, channelId: string) => boolean;
+}
+
+export interface ChannelSubscriptionFrame {
+  schemaVersion: 1;
+  frame: 'open' | 'event' | 'closed';
+  channelId: string;
+  sequence: number;
+  occurredAt: string;
+  /**
+   * Exclusive durable cursor safe to supply as `afterSeq` on reconnect. It is
+   * present on every frame and only advances from a committed row/safe replay;
+   * streaming deltas and heartbeats repeat the last value unchanged.
+   */
+  durableSeq: number;
+  /** Channel event payloads are authoritative rows; heartbeat is explicitly ephemeral. */
+  payload?: ChannelEventV1 | { type: 'channel-heartbeat-v1' };
+  reason?:
+    | 'not-found'
+    | 'backpressure'
+    | 'transport-closed'
+    | 'authorization-revoked';
+  retryable?: boolean;
+  latestSeq?: number;
+}
+
+function queryAfterSeq(req: Request): number | null | 'invalid' {
+  const value = req.query['afterSeq'];
+  if (value === undefined || value === '') return null;
+  if (typeof value !== 'string' || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    return 'invalid';
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : 'invalid';
+}
+
+function requestHasContextRead(req: Request): boolean {
+  const actor = authenticatedCliGatewayActorCredential(req);
+  if (actor) return actor.capabilities.includes(CONTEXT_READ);
+  return (req.header('x-relay-capabilities') ?? '')
+    .split(/[\s,]+/)
+    .some((capability) => capability === CONTEXT_READ);
+}
+
+function actorMayReadChannel(req: Request, channelId: string): boolean {
+  const actor = authenticatedCliGatewayActorCredential(req);
+  // Browser/session clients retain their established access lane. A scoped
+  // actor with no channelIds is deliberately fail-closed for this enumeration
+  // capable, long-lived route.
+  return !actor || actor.scope?.channelIds?.includes(channelId) === true;
+}
+
+function advanceDurableCursor(current: number, event: ChannelEventV1): number {
+  if (event.type === 'channel-message-created-v1') {
+    // A live gap must never become the next resume cursor. The existing client
+    // reducer will request catch-up; keep the last contiguous durable row here.
+    return event.message.seq === current + 1 ? event.message.seq : current;
+  }
+  if (event.type !== 'channel-snapshot-v1') return current;
+  if (!event.truncated) return event.latestSeq;
+
+  // A byte/row-truncated snapshot may advertise a head beyond omitted rows.
+  // Advance only through the contiguous committed prefix actually carried by
+  // the frame. Resync rows at/below the cursor are replacements, not progress.
+  let contiguous = event.mode === 'catchup' ? current : 0;
+  const freshSeqs = [...new Set(event.messages.map((message) => message.seq))]
+    .filter((seq) => seq > contiguous)
+    .sort((a, b) => a - b);
+  for (const seq of freshSeqs) {
+    if (seq !== contiguous + 1) break;
+    contiguous = seq;
+  }
+  return contiguous;
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: 'INVALID_ARGUMENT' | 'FORBIDDEN' | 'NOT_FOUND',
+  message: string,
+  details?: Record<string, unknown>
+): void {
+  res.status(status).json({
+    error: { code, message, retryable: false, ...(details ? { details } : {}) },
+  });
+}
+
+/**
+ * Durable channel subscription endpoint.  It intentionally emits NDJSON (not
+ * browser SSE): bearer auth is ordinary HTTP, consumers can parse frames from
+ * any harness, and the payload stays identical to the existing WebSocket
+ * channel protocol. The channel hub owns replay/live handoff and limits.
+ */
+export function createChannelSubscriptionRouter(
+  deps: ChannelSubscriptionRouterDeps
+): Router {
+  const router = Router();
+  const now = deps.now ?? (() => new Date());
+  const heartbeatMs = deps.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const drainTimeoutMs = deps.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+  const writableHardLimitBytes =
+    deps.writableHardLimitBytes ?? DEFAULT_WRITABLE_HARD_LIMIT_BYTES;
+  const writeResponse = deps.writeResponse ?? ((res, data) => res.write(data));
+  const isStillAuthorized = deps.isStillAuthorized ?? (() => true);
+
+  router.get(
+    '/channels/:id/subscribe',
+    deps.requireSubscribeAuth,
+    (req, res) => {
+      if (req.header('x-relay-cli-gateway') !== 'v1') {
+        sendError(
+          res,
+          400,
+          'INVALID_ARGUMENT',
+          'channel subscription requires x-relay-cli-gateway: v1'
+        );
+        return;
+      }
+      const channelId = req.params['id'] ?? '';
+      const afterSeq = queryAfterSeq(req);
+      if (afterSeq === 'invalid') {
+        sendError(
+          res,
+          400,
+          'INVALID_ARGUMENT',
+          'afterSeq must be a non-negative safe integer',
+          { field: 'afterSeq' }
+        );
+        return;
+      }
+      if (!requestHasContextRead(req)) {
+        sendError(
+          res,
+          403,
+          'FORBIDDEN',
+          'missing required capability: context:read',
+          {
+            capability: CONTEXT_READ,
+          }
+        );
+        return;
+      }
+      if (!actorMayReadChannel(req, channelId)) {
+        sendError(
+          res,
+          403,
+          'FORBIDDEN',
+          'actor is not scoped to this channel',
+          {
+            channelId,
+            reasonCode: 'CHANNEL_OUT_OF_SCOPE',
+          }
+        );
+        return;
+      }
+      // Avoid committing response headers for an id the hub already knows is
+      // absent. This is a read-only preflight; registration below remains the
+      // authoritative race-free replay/live operation.
+      if (!deps.hub.channelExists(channelId)) {
+        sendError(res, 404, 'NOT_FOUND', 'channel not found', { channelId });
+        return;
+      }
+
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/x-ndjson; charset=utf-8');
+      res.setHeader('cache-control', 'no-store, no-transform');
+      res.setHeader('x-accel-buffering', 'no');
+      res.flushHeaders?.();
+
+      let sequence = 0;
+      let ended = false;
+      let waitingForDrain = false;
+      let unsubscribe: (() => void) | undefined;
+      let heartbeat: NodeJS.Timeout | undefined;
+      let drainDeadline: NodeJS.Timeout | undefined;
+      let durableSeq = afterSeq ?? 0;
+      const sinkCloseHandlers = new Set<() => void>();
+
+      const writeFrame = (frame: ChannelSubscriptionFrame): boolean => {
+        if (ended || res.destroyed || res.writableEnded) return false;
+        if (res.writableLength > writableHardLimitBytes) {
+          finish('backpressure', undefined, true);
+          return false;
+        }
+        const accepted = writeResponse(res, `${JSON.stringify(frame)}\n`);
+        if (res.writableLength > writableHardLimitBytes) {
+          finish('backpressure', undefined, true);
+          return false;
+        }
+        if (!accepted && !waitingForDrain) {
+          waitingForDrain = true;
+          res.once('drain', onDrain);
+          drainDeadline = setTimeout(() => {
+            // The bytes that crossed the stream high-water mark were accepted,
+            // but they cannot remain retained forever on an idle channel.
+            finish('backpressure', undefined, true);
+          }, drainTimeoutMs);
+          drainDeadline.unref?.();
+        }
+        // Node accepted the bytes even when it returned false. The hub observes
+        // writableLength via bufferedAmount and applies its 1/4MB watermarks;
+        // no route-level replay queue is introduced.
+        return true;
+      };
+
+      const onDrain = (): void => {
+        waitingForDrain = false;
+        if (drainDeadline) clearTimeout(drainDeadline);
+        drainDeadline = undefined;
+      };
+
+      const cleanup = (): void => {
+        if (heartbeat) clearInterval(heartbeat);
+        heartbeat = undefined;
+        if (drainDeadline) clearTimeout(drainDeadline);
+        drainDeadline = undefined;
+        res.off('drain', onDrain);
+        req.off('aborted', onTransportClosed);
+        req.off('error', onTransportClosed);
+        req.off('close', onRequestClosed);
+        res.off('close', onTransportClosed);
+        res.off('error', onTransportClosed);
+        const current = unsubscribe;
+        unsubscribe = undefined;
+        current?.();
+        sinkCloseHandlers.clear();
+      };
+
+      const onTransportClosed = (): void => {
+        if (ended) return;
+        ended = true;
+        for (const handler of [...sinkCloseHandlers]) handler();
+        sinkCloseHandlers.clear();
+        cleanup();
+      };
+
+      const onRequestClosed = (): void => {
+        // IncomingMessage emits close after a normally completed GET request on
+        // current Node versions. Only treat it as transport loss when aborted
+        // or when the response/socket is also closed.
+        if (req.aborted || res.destroyed || res.writableEnded) {
+          onTransportClosed();
+        }
+      };
+
+      const finish = (
+        reason: NonNullable<ChannelSubscriptionFrame['reason']>,
+        latestSeq?: number,
+        retryable = reason === 'backpressure' || reason === 'transport-closed'
+      ): void => {
+        if (ended) return;
+        ended = true;
+        cleanup();
+        // A client that is already backpressured cannot reliably consume a
+        // closing frame; it still gets a bounded EOF and resumes from its last
+        // durable cursor. Healthy clients receive an explicit reconnect cause.
+        if (!res.destroyed && !res.writableEnded) {
+          try {
+            res.write(
+              `${JSON.stringify({
+                frame: 'closed',
+                schemaVersion: 1,
+                channelId,
+                sequence: sequence++,
+                occurredAt: now().toISOString(),
+                durableSeq,
+                reason,
+                retryable,
+                ...(latestSeq === undefined ? {} : { latestSeq }),
+              } satisfies ChannelSubscriptionFrame)}\n`
+            );
+          } catch {
+            /* closing a failed transport */
+          }
+        }
+        try {
+          res.end();
+        } catch {
+          /* response already closed */
+        }
+      };
+
+      const sink: ChannelEventSink = {
+        get ready() {
+          return (
+            !ended && !req.destroyed && !res.destroyed && !res.writableEnded
+          );
+        },
+        get bufferedAmount() {
+          return res.writableLength;
+        },
+        send(event) {
+          if (!isStillAuthorized(req, channelId)) {
+            finish('authorization-revoked');
+            return false;
+          }
+          if (waitingForDrain) {
+            finish('backpressure', undefined, true);
+            return false;
+          }
+          durableSeq = advanceDurableCursor(durableSeq, event);
+          return writeFrame({
+            frame: 'event',
+            schemaVersion: 1,
+            channelId,
+            sequence: sequence++,
+            occurredAt: now().toISOString(),
+            payload: event,
+            durableSeq,
+          });
+        },
+        close(reason: ChannelSubscriptionCloseReason) {
+          finish(
+            reason.code,
+            reason.code === 'backpressure' ? reason.latestSeq : undefined
+          );
+        },
+        onClose(handler) {
+          sinkCloseHandlers.add(handler);
+        },
+      };
+
+      req.once('aborted', onTransportClosed);
+      req.once('error', onTransportClosed);
+      req.once('close', onRequestClosed);
+      res.once('close', onTransportClosed);
+      res.once('error', onTransportClosed);
+
+      if (
+        !writeFrame({
+          frame: 'open',
+          schemaVersion: 1,
+          channelId,
+          sequence: sequence++,
+          occurredAt: now().toISOString(),
+          durableSeq,
+        })
+      ) {
+        finish('transport-closed');
+        return;
+      }
+
+      unsubscribe = deps.hub.subscribe(sink, { channelId, afterSeq });
+      if (!sink.ready) {
+        cleanup();
+        return;
+      }
+      // Heartbeats have no channel event or durable cursor. They keep proxy
+      // idle timers from silently severing an otherwise healthy subscription.
+      heartbeat = setInterval(() => {
+        if (!isStillAuthorized(req, channelId)) {
+          finish('authorization-revoked');
+          return;
+        }
+        // Heartbeats are disposable liveness signals. Never append them to a
+        // response already above its high-water mark; the drain deadline owns
+        // bounded termination if the client never resumes reading.
+        if (waitingForDrain) return;
+        writeFrame({
+          frame: 'event',
+          schemaVersion: 1,
+          channelId,
+          sequence: sequence++,
+          occurredAt: now().toISOString(),
+          durableSeq,
+          payload: { type: 'channel-heartbeat-v1' },
+        });
+      }, heartbeatMs);
+      heartbeat.unref?.();
+    }
+  );
+
+  return router;
+}

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -72,6 +72,7 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'channels.list',
   'channels.get',
   'channels.history',
+  'channels.subscribe',
   'channels.threads.history',
   'channels.roster',
   'context.get',
@@ -351,6 +352,7 @@ export function cliGatewayActorCommandCapabilities(
     command === 'channels.list' ||
     command === 'channels.get' ||
     command === 'channels.history' ||
+    command === 'channels.subscribe' ||
     command === 'channels.threads.history' ||
     command === 'channels.roster'
   )

--- a/server/index.ts
+++ b/server/index.ts
@@ -249,6 +249,7 @@ import {
 } from './channel-attachments.js';
 import { createChannelHub, type ChannelHub } from './channel-hub.js';
 import { createChannelChatRouter } from './channel-chat-router.js';
+import { createChannelSubscriptionRouter } from './channel-subscription-router.js';
 import {
   createChannelAgentBinder,
   type ChannelAgentBinder,
@@ -2655,6 +2656,27 @@ async function main(): Promise<void> {
             : {}),
           ...(options ?? {}),
         }),
+    })
+  );
+  app.use(
+    createChannelSubscriptionRouter({
+      hub: channelHub,
+      requireSubscribeAuth: requireCliGatewayAuthForActorCommand(
+        'channels.subscribe',
+        { scopeForRequest: channelScopeFromParams }
+      ),
+      isStillAuthorized: (req, channelId) => {
+        if (!isCliGatewayActorTokenRequest(req)) return true;
+        const validation = validateCliGatewayActorCredential(
+          cliGatewayActorRegistry,
+          {
+            token: bearerActorToken(req),
+            capabilities: ['context:read'],
+            scope: { channelIds: [channelId] },
+          }
+        );
+        return !('reason' in validation);
+      },
     })
   );
   // #765 / ADR-019: context.* / inbox.* gateway verbs. #759 wires the router

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -98,6 +98,7 @@ export type RelayCliGatewayCommand =
   | 'channels.list'
   | 'channels.get'
   | 'channels.history'
+  | 'channels.subscribe'
   | 'channels.threads.history'
   | 'channels.roster'
   | 'channels.post'
@@ -3334,6 +3335,102 @@ const channelHistoryInputSchema: RelayJsonSchema = {
   not: { required: ['beforeSeq', 'afterSeq'] },
 };
 
+const channelSubscribeInputSchema: RelayJsonSchema = {
+  title: 'ChannelsSubscribeInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    channelId: stringSchema,
+    afterSeq: { type: 'integer', minimum: 0 },
+    maxEvents: { type: 'integer', minimum: 1, maximum: 10000 },
+    idleTimeoutMs: { type: 'integer', minimum: 1, maximum: 300000 },
+  },
+  required: ['channelId'],
+};
+
+const channelSubscribeFrameSchema: RelayJsonSchema = {
+  title: 'ChannelsSubscribeFrameData',
+  description:
+    'Versioned NDJSON frames. Discriminate on frame; event.payload is a ChannelEventV1 or channel-heartbeat-v1 payload.',
+  oneOf: [
+    {
+      title: 'ChannelsSubscribeOpenFrameV1',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        schemaVersion: { const: 1 },
+        frame: { const: 'open' },
+        channelId: stringSchema,
+        sequence: { type: 'integer', minimum: 0 },
+        occurredAt: stringSchema,
+        durableSeq: { type: 'integer', minimum: 0 },
+      },
+      required: [
+        'schemaVersion',
+        'frame',
+        'channelId',
+        'sequence',
+        'occurredAt',
+        'durableSeq',
+      ],
+    },
+    {
+      title: 'ChannelsSubscribeEventFrameV1',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        schemaVersion: { const: 1 },
+        frame: { const: 'event' },
+        channelId: stringSchema,
+        sequence: { type: 'integer', minimum: 0 },
+        occurredAt: stringSchema,
+        durableSeq: { type: 'integer', minimum: 0 },
+        payload: {
+          type: 'object',
+          additionalProperties: true,
+          properties: { type: stringSchema },
+          required: ['type'],
+        },
+      },
+      required: [
+        'schemaVersion',
+        'frame',
+        'channelId',
+        'sequence',
+        'occurredAt',
+        'durableSeq',
+        'payload',
+      ],
+    },
+    {
+      title: 'ChannelsSubscribeClosedFrameV1',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        schemaVersion: { const: 1 },
+        frame: { const: 'closed' },
+        channelId: stringSchema,
+        sequence: { type: 'integer', minimum: 0 },
+        occurredAt: stringSchema,
+        durableSeq: { type: 'integer', minimum: 0 },
+        reason: stringSchema,
+        retryable: booleanSchema,
+        latestSeq: { type: 'integer', minimum: 0 },
+      },
+      required: [
+        'schemaVersion',
+        'frame',
+        'channelId',
+        'sequence',
+        'occurredAt',
+        'durableSeq',
+        'reason',
+        'retryable',
+      ],
+    },
+  ],
+};
+
 const channelThreadHistoryInputSchema: RelayJsonSchema = {
   title: 'ChannelsThreadHistoryInput',
   type: 'object',
@@ -6468,6 +6565,39 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'INVALID_ARGUMENT',
       'NOT_FOUND',
       'SERVER_UNAVAILABLE',
+    ],
+  },
+  {
+    name: 'channels.subscribe',
+    cli: [
+      'relay-ide',
+      'v1',
+      'channels',
+      'subscribe',
+      '--channel-id',
+      '<id>',
+      '--after-seq',
+      '<n>',
+      '--json',
+    ],
+    summary:
+      'Stream durable channel events after an exclusive sequence cursor; ephemeral deltas never advance the resume cursor.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: channelSubscribeInputSchema,
+    outputSchema: okOutput(
+      'ChannelsSubscribeFrameOutput',
+      channelSubscribeFrameSchema
+    ),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
     ],
   },
   {

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -170,6 +170,7 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'channels.list': 'list channels',
   'channels.get': 'channel details',
   'channels.history': 'channel message history',
+  'channels.subscribe': 'subscribe to channel messages',
   'channels.threads.history': 'channel thread history',
   'channels.roster': 'channel roster',
   'channels.post': 'post channel message',
@@ -199,6 +200,7 @@ const STREAM_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
   'sessions.stream',
   'sessions.wait',
   'events.subscribe',
+  'channels.subscribe',
 ]);
 
 const DESTRUCTIVE_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([

--- a/test/channel-hub.test.ts
+++ b/test/channel-hub.test.ts
@@ -12,6 +12,7 @@ import {
   CHANNEL_WS_BACKPRESSURE_CLOSE_CODE,
   createChannelHub,
   type ChannelHub,
+  type ChannelEventSink,
   type ChannelSocket,
 } from '../server/channel-hub.js';
 import {
@@ -70,6 +71,40 @@ function fakeSocket(): FakeSocket {
     },
     emit(event) {
       handlers[event]?.();
+    },
+  };
+}
+
+function fakeSink(): ChannelEventSink & {
+  bufferedAmount: number;
+  sent: ChannelEventV1[];
+  closed: string | null;
+  emitClose(): void;
+} {
+  const handlers: Array<() => void> = [];
+  let ready = true;
+  return {
+    bufferedAmount: 0,
+    get ready() {
+      return ready;
+    },
+    sent: [],
+    closed: null,
+    send(event) {
+      this.sent.push(event);
+      return true;
+    },
+    close(reason) {
+      this.closed = reason.code;
+      ready = false;
+      for (const handler of handlers) handler();
+    },
+    onClose(handler) {
+      handlers.push(handler);
+    },
+    emitClose() {
+      ready = false;
+      for (const handler of handlers) handler();
     },
   };
 }
@@ -805,6 +840,51 @@ describe('channel-hub backpressure', () => {
 });
 
 describe('channel-hub connection lifecycle', () => {
+  it('shares the register-before-replay handoff with a non-WebSocket sink', () => {
+    const s = store();
+    const hub = hubWith(s);
+    const initial = s.appendComplete({
+      channelId: 'topic:c',
+      sender: HUMAN,
+      text: 'before',
+    });
+    const sink = fakeSink();
+    const originalSend = sink.send;
+    let injected = false;
+    sink.send = function (event) {
+      const accepted = originalSend.call(this, event);
+      if (injected || event.type !== 'channel-snapshot-v1') return accepted;
+      injected = true;
+      const committedDuringReplay = s.appendComplete({
+        channelId: 'topic:c',
+        sender: HUMAN,
+        text: 'during',
+      });
+      hub.broadcastCreated(committedDuringReplay);
+      return accepted;
+    };
+
+    const unsubscribe = hub.subscribe(sink, {
+      channelId: 'topic:c',
+      afterSeq: 0,
+    });
+
+    expect(sink.sent[0]).toMatchObject({
+      type: 'channel-snapshot-v1',
+      latestSeq: initial.seq,
+    });
+    expect(
+      sink.sent.filter(
+        (event) =>
+          event.type === 'channel-message-created-v1' &&
+          event.message.body.text === 'during'
+      )
+    ).toHaveLength(1);
+    expect(hub.subscriberCount('topic:c')).toBe(1);
+    unsubscribe();
+    expect(hub.subscriberCount('topic:c')).toBe(0);
+  });
+
   it('closes unknown channels with 4404', () => {
     const s = store();
     const hub = hubWith(s, { channelExists: () => false });

--- a/test/channel-subscription-routes.test.ts
+++ b/test/channel-subscription-routes.test.ts
@@ -1,0 +1,276 @@
+import * as http from 'node:http';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { attachAuthenticatedCliGatewayActorCredential } from '../server/cli-gateway-actor-auth.js';
+import { createChannelSubscriptionRouter } from '../server/channel-subscription-router.js';
+import type { ChannelEventSink, ChannelHub } from '../server/channel-hub.js';
+import type { ChannelMessage } from '../shared/channel-chat-protocol.js';
+import type { ScopedActorCredentialRecord } from '../shared/scoped-actor-credentials.js';
+
+const servers: http.Server[] = [];
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close();
+});
+
+async function listen(input: {
+  channelIds: string[];
+  subscribe?: (sink: ChannelEventSink, afterSeq: number | null) => void;
+  isStillAuthorized?: () => boolean;
+  onUnsubscribe?: () => void;
+  heartbeatMs?: number;
+  drainTimeoutMs?: number;
+  writeResponse?: (res: express.Response, data: string) => boolean;
+}): Promise<number> {
+  const app = express();
+  app.use((req, _res, next) => {
+    attachAuthenticatedCliGatewayActorCredential(req, {
+      id: 'credential:test',
+      actor: { type: 'agent', id: 'actor:test', displayName: 'Test' },
+      capabilities: ['context:read'],
+      scope: { channelIds: input.channelIds },
+    } as ScopedActorCredentialRecord);
+    next();
+  });
+  const hub = {
+    channelExists: (id: string) => id === 'topic:a' || id === 'topic:b',
+    subscribe: (sink: ChannelEventSink, value: { afterSeq: number | null }) => {
+      input.subscribe?.(sink, value.afterSeq);
+      return () => input.onUnsubscribe?.();
+    },
+  } as unknown as ChannelHub;
+  app.use(
+    createChannelSubscriptionRouter({
+      hub,
+      requireSubscribeAuth: (_req, _res, next) => next(),
+      heartbeatMs: input.heartbeatMs ?? 60_000,
+      ...(input.drainTimeoutMs !== undefined
+        ? { drainTimeoutMs: input.drainTimeoutMs }
+        : {}),
+      ...(input.writeResponse ? { writeResponse: input.writeResponse } : {}),
+      ...(input.isStillAuthorized
+        ? { isStillAuthorized: input.isStillAuthorized }
+        : {}),
+    })
+  );
+  const server = http.createServer(app);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing port');
+  return address.port;
+}
+
+describe('channel subscription route', () => {
+  it('rejects an actor outside the exact channel scope before subscribing', async () => {
+    let subscribed = false;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: () => {
+        subscribed = true;
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Ab/subscribe`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    expect(response.status).toBe(403);
+    expect(subscribed).toBe(false);
+  });
+
+  it('keeps ephemeral deltas on the last committed durable cursor', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink, afterSeq) => {
+        expect(afterSeq).toBe(4);
+        sink.send({
+          type: 'channel-message-delta-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-11T00:00:00.000Z',
+          messageId: 'chm:test',
+          deltaIndex: 1,
+          delta: { text: 'later' },
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 4, 4]);
+    expect(frames.map((frame) => frame.frame)).toEqual([
+      'open',
+      'event',
+      'closed',
+    ]);
+  });
+
+  it('closes before delivery when the actor is revoked mid-stream', async () => {
+    let authorized = true;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      isStillAuthorized: () => authorized,
+      subscribe: (sink) => {
+        authorized = false;
+        sink.send({
+          type: 'channel-message-created-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-11T00:00:00.000Z',
+          message: { seq: 8 } as ChannelMessage,
+        });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames).toMatchObject([
+      { frame: 'open', durableSeq: 0 },
+      {
+        frame: 'closed',
+        durableSeq: 0,
+        reason: 'authorization-revoked',
+        retryable: false,
+      },
+    ]);
+  });
+
+  it('advances only through snapshot rows contiguous with afterSeq', async () => {
+    const port = await listen({
+      channelIds: ['topic:a'],
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-snapshot-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-11T00:00:00.000Z',
+          mode: 'catchup',
+          messages: [
+            { seq: 5 } as ChannelMessage,
+            { seq: 6 } as ChannelMessage,
+            { seq: 8 } as ChannelMessage,
+          ],
+          members: [],
+          latestSeq: 12,
+          inFlight: [],
+          truncated: true,
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=4`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(frames.map((frame) => frame.durableSeq)).toEqual([4, 6, 6]);
+  });
+
+  it('flushes a large accepted snapshot after res.write signals backpressure', async () => {
+    const largeText = 'x'.repeat(128 * 1024);
+    let unsubscribed = 0;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      onUnsubscribe: () => {
+        unsubscribed += 1;
+      },
+      subscribe: (sink) => {
+        sink.send({
+          type: 'channel-snapshot-v1',
+          channelId: 'topic:a',
+          timestamp: '2026-08-11T00:00:00.000Z',
+          mode: 'catchup',
+          messages: [
+            {
+              seq: 1,
+              body: { text: largeText },
+            } as ChannelMessage,
+          ],
+          members: [],
+          latestSeq: 1,
+          inFlight: [],
+          truncated: false,
+        });
+        sink.close({ code: 'transport-closed' });
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe?afterSeq=0`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const text = await response.text();
+    expect(text).toContain(largeText);
+    expect(text).toContain('"durableSeq":1');
+    expect(unsubscribed).toBe(1);
+  });
+
+  it('cleans the subscription and heartbeat when the client aborts', async () => {
+    let unsubscribed = 0;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      heartbeatMs: 5,
+      onUnsubscribe: () => {
+        unsubscribed += 1;
+      },
+    });
+    const controller = new AbortController();
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe`,
+      {
+        headers: { 'x-relay-cli-gateway': 'v1' },
+        signal: controller.signal,
+      }
+    );
+    await response.body?.getReader().read();
+    controller.abort();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(unsubscribed).toBe(1);
+  });
+
+  it('bounds a non-draining idle subscription and cleans up exactly once', async () => {
+    let writes = 0;
+    let unsubscribed = 0;
+    const port = await listen({
+      channelIds: ['topic:a'],
+      heartbeatMs: 1,
+      drainTimeoutMs: 15,
+      writeResponse: () => {
+        writes += 1;
+        return false;
+      },
+      onUnsubscribe: () => {
+        unsubscribed += 1;
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${port}/channels/topic%3Aa/subscribe`,
+      { headers: { 'x-relay-cli-gateway': 'v1' } }
+    );
+    const frames = (await response.text())
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(writes).toBe(1); // open crossed high-water; heartbeats were suppressed
+    expect(unsubscribed).toBe(1);
+    expect(frames).toMatchObject([
+      {
+        schemaVersion: 1,
+        frame: 'closed',
+        reason: 'backpressure',
+        retryable: true,
+      },
+    ]);
+  });
+});

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -446,6 +446,7 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
     'channels.list',
     'channels.get',
     'channels.history',
+    'channels.subscribe',
     'channels.threads.history',
     'channels.roster',
     'context.get',
@@ -481,12 +482,13 @@ test('classifies only server-bound read-only CLI gateway actor routes into the a
       command
     ).toBe('scoped-actor-credential');
   }
-  // The five channel read verbs classify into the scoped-actor-credential read
+  // Channel read verbs classify into the scoped-actor-credential read
   // lane (GET), and a read verb on POST is not an actor read route.
   for (const command of [
     'channels.list',
     'channels.get',
     'channels.history',
+    'channels.subscribe',
     'channels.threads.history',
     'channels.roster',
   ] as const) {

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -120,6 +120,16 @@ function schemaAcceptsCommandInput(
   return schemaMatches(commandSpec(commandName).inputSchema, value);
 }
 
+function schemaAcceptsChannelsSubscribeFrame(
+  value: Record<string, unknown>
+): boolean {
+  const output = commandSpec('channels.subscribe').outputSchema;
+  const data = output.properties?.['data'];
+  if (!data)
+    throw new Error('channels.subscribe output data schema is missing');
+  return schemaMatches(data, value);
+}
+
 function schemaAcceptsSessionWait(value: Record<string, unknown>): boolean {
   return schemaAcceptsCommandInput('sessions.wait', value);
 }
@@ -236,6 +246,7 @@ describe('CLI gateway contract', () => {
       'channels.list',
       'channels.get',
       'channels.history',
+      'channels.subscribe',
       'channels.threads.history',
       'channels.roster',
       'channels.post',
@@ -257,11 +268,12 @@ describe('CLI gateway contract', () => {
     }
   });
 
-  it('declares the five channel read verbs as stable gateway commands', () => {
+  it('declares the channel read verbs as stable gateway commands', () => {
     const readVerbs = [
       'channels.list',
       'channels.get',
       'channels.history',
+      'channels.subscribe',
       'channels.threads.history',
       'channels.roster',
     ] as const;
@@ -285,7 +297,11 @@ describe('CLI gateway contract', () => {
       ]) {
         expect(spec.errorCodes).toContain(code);
       }
-      if (verb === 'channels.history' || verb === 'channels.threads.history') {
+      if (
+        verb === 'channels.history' ||
+        verb === 'channels.subscribe' ||
+        verb === 'channels.threads.history'
+      ) {
         expect(spec.errorCodes).toContain('NOT_FOUND');
       }
     }
@@ -294,6 +310,108 @@ describe('CLI gateway contract', () => {
       'channels.threads.history'
     );
     expect(commandSpec('channels.post').name).toBe('channels.post');
+  });
+
+  it('models a bounded exclusive channel subscription cursor', () => {
+    expect(
+      schemaAcceptsCommandInput('channels.subscribe', {
+        channelId: 'channel-1',
+        afterSeq: 0,
+        maxEvents: 10,
+        idleTimeoutMs: 1000,
+      })
+    ).toBe(true);
+    for (const input of [
+      { channelId: 'channel-1', afterSeq: -1 },
+      { channelId: 'channel-1', maxEvents: 0 },
+      { channelId: 'channel-1', idleTimeoutMs: 300001 },
+      { channelId: 'channel-1', unknown: true },
+    ]) {
+      expect(schemaAcceptsCommandInput('channels.subscribe', input)).toBe(
+        false
+      );
+    }
+    expect(commandSpec('channels.subscribe').outputSchema).toMatchObject({
+      properties: {
+        data: {
+          oneOf: [
+            { properties: { frame: { const: 'open' } } },
+            { properties: { frame: { const: 'event' } } },
+            { properties: { frame: { const: 'closed' } } },
+          ],
+        },
+      },
+    });
+    expect(
+      schemaAcceptsChannelsSubscribeFrame({
+        schemaVersion: 1,
+        frame: 'open',
+        channelId: 'channel-1',
+        sequence: 0,
+        occurredAt: '2026-08-11T00:00:00.000Z',
+        durableSeq: 0,
+      })
+    ).toBe(true);
+    expect(
+      schemaAcceptsChannelsSubscribeFrame({
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'channel-1',
+        sequence: 1,
+        occurredAt: '2026-08-11T00:00:01.000Z',
+        durableSeq: 0,
+        payload: { type: 'channel-heartbeat-v1' },
+      })
+    ).toBe(true);
+    expect(
+      schemaAcceptsChannelsSubscribeFrame({
+        schemaVersion: 1,
+        frame: 'closed',
+        channelId: 'channel-1',
+        sequence: 2,
+        occurredAt: '2026-08-11T00:00:02.000Z',
+        durableSeq: 0,
+        reason: 'transport-closed',
+        retryable: true,
+      })
+    ).toBe(true);
+    for (const invalidFrame of [
+      {
+        schemaVersion: 1,
+        frame: 'event',
+        channelId: 'channel-1',
+        sequence: 1,
+        occurredAt: '2026-08-11T00:00:01.000Z',
+        durableSeq: 0,
+      },
+      {
+        schemaVersion: 1,
+        frame: 'closed',
+        channelId: 'channel-1',
+        sequence: 2,
+        occurredAt: '2026-08-11T00:00:02.000Z',
+        durableSeq: 0,
+        reason: 'transport-closed',
+      },
+      {
+        schemaVersion: 1,
+        frame: 'open',
+        channelId: 'channel-1',
+        sequence: 0,
+        occurredAt: '2026-08-11T00:00:00.000Z',
+        durableSeq: 0,
+        payload: { type: 'channel-heartbeat-v1' },
+      },
+      {
+        frame: 'open',
+        channelId: 'channel-1',
+        sequence: 0,
+        occurredAt: '2026-08-11T00:00:00.000Z',
+        durableSeq: 0,
+      },
+    ]) {
+      expect(schemaAcceptsChannelsSubscribeFrame(invalidFrame)).toBe(false);
+    }
   });
 
   it('models channel pagination inputs and directional cursors exactly', () => {

--- a/test/cli-gateway/channels-subscribe.test.ts
+++ b/test/cli-gateway/channels-subscribe.test.ts
@@ -1,0 +1,259 @@
+import { execFile, execFileSync, spawn } from 'node:child_process';
+import * as http from 'node:http';
+import * as path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { commandSpec } from '../../shared/cli-gateway-contract.js';
+
+const RELAY_BIN = path.resolve('dist/bin/relay-ide.js');
+
+beforeAll(() => {
+  execFileSync('npm', ['run', 'build:server'], {
+    cwd: path.resolve('.'),
+    env: process.env,
+    stdio: 'inherit',
+  });
+}, 60_000);
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [RELAY_BIN, ...args],
+      { encoding: 'utf8', env, timeout: 10_000 },
+      (error, stdout, stderr) => {
+        if (error) reject(new Error(stderr || stdout));
+        else resolve(stdout);
+      }
+    );
+  });
+}
+
+function runCliAndCloseStdout(
+  args: string[],
+  env: NodeJS.ProcessEnv
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [RELAY_BIN, ...args], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    let closedStdout = false;
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('CLI did not exit after downstream stdout closed'));
+    }, 10_000);
+    child.stdout.on('data', () => {
+      if (closedStdout) return;
+      closedStdout = true;
+      child.stdout.destroy();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stderr });
+    });
+  });
+}
+
+describe('channels.subscribe CLI gateway command', () => {
+  it('declares the resumable actor-readable streaming command', () => {
+    expect(commandSpec('channels.subscribe')).toMatchObject({
+      stable: true,
+      transport: 'hub-http',
+      capabilityHints: ['context:read'],
+      cli: [
+        'relay-ide',
+        'v1',
+        'channels',
+        'subscribe',
+        '--channel-id',
+        '<id>',
+        '--after-seq',
+        '<n>',
+        '--json',
+      ],
+    });
+  });
+
+  it('forwards frames incrementally with actor auth and an exclusive cursor', async () => {
+    let request: http.IncomingMessage | undefined;
+    const server = http.createServer((req, res) => {
+      request = req;
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+      res.write(
+        `${JSON.stringify({ schemaVersion: 1, frame: 'open', channelId: 'topic:test', sequence: 0, durableSeq: 4 })}\n`
+      );
+      res.write(
+        `${JSON.stringify({ schemaVersion: 1, frame: 'event', channelId: 'topic:test', sequence: 1, occurredAt: '2026-08-11T00:00:01.000Z', durableSeq: 5, payload: { type: 'channel-message-created-v1' } })}\n`
+      );
+      res.end(
+        `${JSON.stringify({ schemaVersion: 1, frame: 'closed', channelId: 'topic:test', sequence: 2, occurredAt: '2026-08-11T00:00:02.000Z', durableSeq: 5, reason: 'normal', retryable: false })}\n`
+      );
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('missing port');
+    try {
+      const stdout = await runCli(
+        [
+          'v1',
+          'channels',
+          'subscribe',
+          '--channel-id',
+          'topic:test',
+          '--after-seq',
+          '4',
+          '--json',
+        ],
+        {
+          ...process.env,
+          RELAY_IDE_PORT: String(address.port),
+          RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test.[REDACTED]',
+          RELAY_IDE_BROWSER_TOKEN: '',
+        }
+      );
+      const lines = stdout
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      expect(lines).toMatchObject([
+        {
+          ok: true,
+          command: 'channels.subscribe',
+          data: { frame: 'open', durableSeq: 4 },
+        },
+        {
+          ok: true,
+          command: 'channels.subscribe',
+          data: { frame: 'event', durableSeq: 5 },
+        },
+        {
+          ok: true,
+          command: 'channels.subscribe',
+          data: { frame: 'closed', durableSeq: 5 },
+        },
+      ]);
+      expect(request?.url).toBe('/channels/topic%3Atest/subscribe?afterSeq=4');
+      expect(request?.headers).toMatchObject({
+        'x-relay-cli-gateway': 'v1',
+        'x-relay-cli-command': 'channels.subscribe',
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-capabilities': 'context:read',
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  it('stops parsing a shared chunk and cancels the reader at --max-events', async () => {
+    let closeRequest!: () => void;
+    const requestClosed = new Promise<void>((resolve) => {
+      closeRequest = resolve;
+    });
+    const server = http.createServer((req, res) => {
+      req.once('close', closeRequest);
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+      res.write(
+        `${JSON.stringify({ schemaVersion: 1, frame: 'open', channelId: 'topic:test', sequence: 0, occurredAt: '2026-08-11T00:00:00.000Z', durableSeq: 0 })}\n`
+      );
+      res.write(
+        [1, 2, 3]
+          .map((sequence) =>
+            JSON.stringify({
+              schemaVersion: 1,
+              frame: 'event',
+              channelId: 'topic:test',
+              sequence,
+              occurredAt: `2026-08-11T00:00:0${sequence}.000Z`,
+              durableSeq: sequence,
+              payload: { type: 'channel-message-created-v1' },
+            })
+          )
+          .join('\n') + '\n'
+      );
+      // Deliberately keep the response open: the client must actively cancel
+      // rather than merely stop consuming its local buffer.
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('missing port');
+    try {
+      const stdout = await runCli(
+        [
+          'v1',
+          'channels',
+          'subscribe',
+          '--channel-id',
+          'topic:test',
+          '--max-events',
+          '1',
+          '--json',
+        ],
+        {
+          ...process.env,
+          RELAY_IDE_PORT: String(address.port),
+          RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test.[REDACTED]',
+          RELAY_IDE_BROWSER_TOKEN: '',
+        }
+      );
+      await expect(requestClosed).resolves.toBeUndefined();
+      const frames = stdout
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).data);
+      expect(frames.map((frame) => frame.frame)).toEqual(['open', 'event']);
+      expect(frames[1]?.sequence).toBe(1);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('treats a downstream EPIPE as clean cancellation instead of dropping into an error', async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+      res.write(
+        `${JSON.stringify({ schemaVersion: 1, frame: 'open', channelId: 'topic:test', sequence: 0, occurredAt: '2026-08-11T00:00:00.000Z', durableSeq: 0 })}\n`
+      );
+      setTimeout(() => {
+        res.write(
+          `${JSON.stringify({ schemaVersion: 1, frame: 'event', channelId: 'topic:test', sequence: 1, occurredAt: '2026-08-11T00:00:01.000Z', durableSeq: 1, payload: { type: 'channel-message-created-v1' } })}\n`
+        );
+      }, 25).unref();
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('missing port');
+    try {
+      const result = await runCliAndCloseStdout(
+        ['v1', 'channels', 'subscribe', '--channel-id', 'topic:test', '--json'],
+        {
+          ...process.env,
+          RELAY_IDE_PORT: String(address.port),
+          RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test.[REDACTED]',
+          RELAY_IDE_BROWSER_TOKEN: '',
+        }
+      );
+      expect(result.code, result.stderr).toBe(0);
+      expect(result.stderr).not.toContain('EPIPE');
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- add actor-authenticated `v1 channels subscribe` NDJSON streaming over the durable channel sequence log
- share the channel hub replay/live subscriber seam with browser WebSockets
- expose replay-safe `durableSeq`, bounded CLI termination, and discriminated versioned frames
- revalidate scoped actor credentials throughout a stream and close fail-closed on revocation
- bound HTTP/stdout backpressure, heartbeat drain waits, and disconnect cleanup
- document the external-agent subscription contract and MCP/desktop bridge direction

## Why

Third-party agent harnesses such as Codex Desktop need to post work through Relay and consume replies asynchronously without one blocking CLI process per request. The durable channel log already provides the correct replay authority; this change exposes it through a scoped, provider-neutral CLI/API contract.

## Dogfood and adversarial review

Codex Desktop posted one review request through Relay to Claude Code and Prime Agent while `channels.subscribe` consumed live frames asynchronously. Prime's review found cursor, Node drain, cleanup, CLI truncation/event-limit, and schema defects; all were fixed in one batch. A focused re-review found one idle-heartbeat backpressure gap, which is fixed with heartbeat suppression, a 4 MB hard cap, a five-second drain deadline, and a non-reading-client regression.

Dogfood follow-ups: #1390, #1391, #1392.

## Exact-head evidence

Head: `5c6381e06d9c95c536e05c3eab80df04a116ccef`

- `npm run check` — pass
- `npm test` — pass
- `npm run build` — pass
- focused subscription/auth/contract/CLI suite — 5 files, 81 tests pass
- focused heartbeat-only non-reader regression — 7 route tests pass
- `git diff --check origin/nightly...HEAD` — pass
- pre-push server-startup timing test transiently failed once, then passed focused 9/9; CI remains the merge gate

Closes #1389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `channels.subscribe`, a durable NDJSON stream for channel replies.
  - Supports cursor-based resume, bounded event counts, idle timeouts, heartbeats, cancellation, and reconnect metadata.
  - Enforces channel authorization throughout active subscriptions.
  - Handles backpressure, disconnected clients, and graceful stream closure.

- **Documentation**
  - Added CLI usage, protocol details, authorization behavior, reconnection guidance, and integration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->