### PR TITLE
feat(channels): isolate parallel thread runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ workflow.
   FIFO queueing, nested child fan-in, and explicit-return de-duplication (#1359)
 - Reversibly archive idle channels from the active conversation header, with
   inline confirmation and the existing older-channel restore path (#1382)
+- Add durable named conversations with isolated thread-scoped agent runtimes,
+  controls, and recent activity navigation (#1386)
 
 #### Changed
 

--- a/frontend/src/components/TopicSidebarShell.css
+++ b/frontend/src/components/TopicSidebarShell.css
@@ -1422,6 +1422,46 @@
     grid-column: 1 / -1;
   }
 
+  /* A newly named conversation is useful before it has replies, so the mobile
+     rail keeps one compact recent-thread target below its channel row. */
+  .topic-mobile-thread {
+    display: flex;
+    grid-column: 1 / -1;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    min-height: 32px;
+    padding: 5px 10px 6px calc(8px + var(--icon-slot-width));
+    border: 0;
+    border-top: 1px solid var(--border-subtle, var(--border));
+    background: transparent;
+    color: var(--text-muted);
+    font: inherit;
+    font-size: var(--font-size-xs);
+    text-align: left;
+    touch-action: manipulation;
+  }
+
+  .topic-mobile-thread:active,
+  .topic-mobile-thread:focus-visible {
+    background: var(--surface-hover);
+    color: var(--text);
+    outline: none;
+  }
+
+  .topic-mobile-thread__title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .topic-mobile-thread__meta {
+    flex: 0 0 auto;
+    color: var(--accent);
+    white-space: nowrap;
+  }
+
   .topic-mobile-row.selected,
   .topic-mobile-row:active,
   .topic-mobile-row:focus-visible {

--- a/frontend/src/components/TopicSidebarShell.tsx
+++ b/frontend/src/components/TopicSidebarShell.tsx
@@ -72,6 +72,7 @@ import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import {
   channelAgentStatusKey,
+  channelThreadStatusSuffix,
   resolveEffectiveAgentStatus,
   useChannelAgentStatusStore,
 } from '../lib/stores/channel-agent-status.js';
@@ -224,6 +225,7 @@ function channelRowSenderLabel(
  * message it hangs off, not by its newest reply.
  */
 function threadRowPreview(thread: ChannelRailThreadSummary): string {
+  if (thread.title?.trim()) return boundedTopicLatestStatus(thread.title);
   const text = thread.preview.replace(/\s+/g, ' ').trim();
   const sender = channelRowSenderLabel({
     seq: 0,
@@ -242,6 +244,21 @@ function threadRowPreview(thread: ChannelRailThreadSummary): string {
 
 function replyCountLabel(replyCount: number): string {
   return `${replyCount} repl${replyCount === 1 ? 'y' : 'ies'}`;
+}
+
+function threadActivityLabel(
+  channelId: string,
+  rootMessageId: string,
+  statuses: Readonly<Record<string, ChannelAgentStatus>>
+): 'working' | 'needs attention' | 'idle' {
+  const prefix = `${channelId} `;
+  const suffix = channelThreadStatusSuffix(rootMessageId);
+  const values = Object.entries(statuses)
+    .filter(([key]) => key.startsWith(prefix) && key.endsWith(suffix))
+    .map(([, status]) => status);
+  if (values.some((status) => status === 'waiting')) return 'needs attention';
+  if (values.some((status) => status !== 'idle')) return 'working';
+  return 'idle';
 }
 
 /** Compact last-activity stamp for a hydrated row; null without a summary. */
@@ -1061,6 +1078,7 @@ function TopicMobileAttentionRow({
   statusByChannelAgent,
   onNudge,
   onInterrupt,
+  onOpenThread,
   depth,
   selected,
   onSelect,
@@ -1073,6 +1091,9 @@ function TopicMobileAttentionRow({
     clientMessageId: string
   ) => Promise<void>;
   onInterrupt: (channelId: string, agentId: string) => Promise<void>;
+  onOpenThread?:
+    | ((channelId: string, rootMessageId: string) => void)
+    | undefined;
   depth: number;
   selected: boolean;
   onSelect: (id: string) => void;
@@ -1084,6 +1105,14 @@ function TopicMobileAttentionRow({
   // status line remains the fallback for rows the channel list does not cover.
   const preview = channelRowPreview(summary);
   const timestamp = channelRowTimestamp(summary);
+  const recentThread = selectRailRowThreads(summary).threads[0];
+  const recentThreadActivity = recentThread
+    ? threadActivityLabel(
+        item.id,
+        recentThread.rootMessageId,
+        statusByChannelAgent
+      )
+    : 'idle';
   const resumeDisabledReason = sessionAttachDisabledReason(session);
   const resumesDerivedSession = Boolean(
     item.source === 'derived' &&
@@ -1142,6 +1171,25 @@ function TopicMobileAttentionRow({
           <StatusGlyph tone={item.tone} />
         </span>
       </button>
+      {recentThread ? (
+        <button
+          type="button"
+          className="topic-mobile-thread"
+          data-thread-root-id={recentThread.rootMessageId}
+          onClick={() => onOpenThread?.(item.id, recentThread.rootMessageId)}
+          disabled={!onOpenThread}
+          aria-label={`open recent conversation — ${threadRowPreview(recentThread)}`}
+        >
+          <span className="topic-mobile-thread__title">
+            {threadRowPreview(recentThread)}
+          </span>
+          <span className="topic-mobile-thread__meta">
+            {recentThreadActivity === 'idle'
+              ? replyCountLabel(recentThread.replyCount)
+              : recentThreadActivity}
+          </span>
+        </button>
+      ) : null}
       <MobileCockpitRowActions
         item={item}
         statuses={statusByChannelAgent}
@@ -1547,6 +1595,7 @@ function TopicRowThreads({
   channelId,
   channelTitle,
   summary,
+  statusByChannelAgent,
   expandedIds,
   onToggle,
   onOpenThread,
@@ -1554,6 +1603,7 @@ function TopicRowThreads({
   channelId: string;
   channelTitle: string;
   summary: ChannelRailSummary | null;
+  statusByChannelAgent: Readonly<Record<string, ChannelAgentStatus>>;
   expandedIds: Set<string>;
   onToggle: (id: string) => void;
   onOpenThread?:
@@ -1596,6 +1646,11 @@ function TopicRowThreads({
           {threads.map((thread) => {
             const preview = threadRowPreview(thread);
             const stamp = formatRelativeTimeCompact(thread.lastReplyAt);
+            const activity = threadActivityLabel(
+              channelId,
+              thread.rootMessageId,
+              statusByChannelAgent
+            );
             return (
               <li
                 key={thread.rootMessageId}
@@ -1618,6 +1673,7 @@ function TopicRowThreads({
                     <span className="topic-thread-row__meta">
                       {replyCountLabel(thread.replyCount)}
                       {stamp ? ` · ${stamp}` : ''}
+                      {activity !== 'idle' ? ` · ${activity}` : ''}
                     </span>
                   </span>
                 </button>
@@ -1752,6 +1808,7 @@ function TopicRow({
         channelId={item.id}
         channelTitle={item.title}
         summary={summary}
+        statusByChannelAgent={statusByChannelAgent}
         expandedIds={expandedIds}
         onToggle={onToggle}
         onOpenThread={onOpenThread}
@@ -2093,6 +2150,7 @@ function MobileRailRows({
   statusByChannelAgent,
   onNudge,
   onInterrupt,
+  onOpenThread,
   selectedId,
   onSelect,
   depth = 0,
@@ -2105,6 +2163,9 @@ function MobileRailRows({
     clientMessageId: string
   ) => Promise<void>;
   onInterrupt: (channelId: string, agentId: string) => Promise<void>;
+  onOpenThread?:
+    | ((channelId: string, rootMessageId: string) => void)
+    | undefined;
   selectedId: string | null;
   onSelect: (id: string) => void;
   depth?: number;
@@ -2116,6 +2177,7 @@ function MobileRailRows({
         statusByChannelAgent={statusByChannelAgent}
         onNudge={onNudge}
         onInterrupt={onInterrupt}
+        onOpenThread={onOpenThread}
         depth={depth}
         selected={selectedId === node.item.id}
         onSelect={onSelect}
@@ -2126,6 +2188,7 @@ function MobileRailRows({
           statusByChannelAgent={statusByChannelAgent}
           onNudge={onNudge}
           onInterrupt={onInterrupt}
+          onOpenThread={onOpenThread}
           selectedId={selectedId}
           onSelect={onSelect}
           depth={depth + 1}
@@ -2140,6 +2203,7 @@ function MobileRailSection({
   statusByChannelAgent,
   onNudge,
   onInterrupt,
+  onOpenThread,
   selectedId,
   onSelect,
 }: {
@@ -2151,6 +2215,9 @@ function MobileRailSection({
     clientMessageId: string
   ) => Promise<void>;
   onInterrupt: (channelId: string, agentId: string) => Promise<void>;
+  onOpenThread?:
+    | ((channelId: string, rootMessageId: string) => void)
+    | undefined;
   selectedId: string | null;
   onSelect: (id: string) => void;
 }) {
@@ -2162,6 +2229,7 @@ function MobileRailSection({
           statusByChannelAgent={statusByChannelAgent}
           onNudge={onNudge}
           onInterrupt={onInterrupt}
+          onOpenThread={onOpenThread}
           selectedId={selectedId}
           onSelect={onSelect}
         />
@@ -2175,6 +2243,7 @@ function MobileRailSection({
               statusByChannelAgent={statusByChannelAgent}
               onNudge={onNudge}
               onInterrupt={onInterrupt}
+              onOpenThread={onOpenThread}
               selectedId={selectedId}
               onSelect={onSelect}
             />
@@ -2196,6 +2265,7 @@ function TopicMobileCockpit({
   onSelect,
   onNudge,
   onInterrupt,
+  onOpenThread,
   onCreateTaskRoom,
   onResumeLast,
   onSelectSession,
@@ -2216,6 +2286,9 @@ function TopicMobileCockpit({
     clientMessageId: string
   ) => Promise<void>;
   onInterrupt: (channelId: string, agentId: string) => Promise<void>;
+  onOpenThread?:
+    | ((channelId: string, rootMessageId: string) => void)
+    | undefined;
   onCreateTaskRoom?: (() => void) | undefined;
   onResumeLast?: (() => void) | undefined;
   onSelectSession?: ((id: string) => void) | undefined;
@@ -2314,6 +2387,7 @@ function TopicMobileCockpit({
                   statusByChannelAgent={statusByChannelAgent}
                   onNudge={onNudge}
                   onInterrupt={onInterrupt}
+                  onOpenThread={onOpenThread}
                   selectedId={selectedId}
                   onSelect={onSelect}
                 />
@@ -2337,6 +2411,7 @@ function TopicMobileCockpit({
               statusByChannelAgent={statusByChannelAgent}
               onNudge={onNudge}
               onInterrupt={onInterrupt}
+              onOpenThread={onOpenThread}
               selectedId={selectedId}
               onSelect={onSelect}
             />
@@ -3451,6 +3526,7 @@ export function TopicSidebarView({
         onSelect={selectMobile}
         onNudge={postMobileNudge}
         onInterrupt={interruptMobileAgent}
+        onOpenThread={openThread}
         onSelectSession={onSelectSession}
         onSelectWorkspace={selectWorkspaceLane}
         {...(onCreateTaskRoom

--- a/frontend/src/components/chat/ChannelComposer.tsx
+++ b/frontend/src/components/chat/ChannelComposer.tsx
@@ -11,6 +11,7 @@ import type {
   ChannelImagePart,
   ChannelMemberRef,
   ChannelMessagePart,
+  ChannelMessageId,
   ChannelPostSteering,
 } from '../../../../shared/channel-chat-protocol.js';
 import {
@@ -271,6 +272,8 @@ interface PendingImage {
 interface ChannelComposerProps {
   channelId: string;
   channelTitle: string;
+  /** Canonical thread root for every provider control issued from this composer. */
+  threadId?: ChannelMessageId | null;
   placeholder?: string;
   /** Human channel members, folded into the @mention contact set (#1236). */
   members?: readonly ChannelMemberRef[];
@@ -302,6 +305,7 @@ interface ChannelComposerProps {
 export const ChannelComposer: React.FC<ChannelComposerProps> = ({
   channelId,
   channelTitle,
+  threadId = null,
   placeholder,
   members,
   implicitCommandProviderId,
@@ -721,6 +725,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         command: command.name,
         ...(normalizedArgs ? { args: normalizedArgs } : {}),
         ...(confirmed ? { confirmed: true } : {}),
+        ...(threadId ? { threadId } : {}),
       })
         .then(() => {
           // The control may have changed the provider's live catalog. Invalidate
@@ -749,7 +754,7 @@ export const ChannelComposer: React.FC<ChannelComposerProps> = ({
         })
         .finally(() => setCommandPending(false));
     },
-    [channelId, commandPending, commandTrigger, queryClient]
+    [channelId, commandPending, commandTrigger, queryClient, threadId]
   );
 
   const selectCommand = useCallback(

--- a/frontend/src/components/chat/ChannelMessageRow.tsx
+++ b/frontend/src/components/chat/ChannelMessageRow.tsx
@@ -275,7 +275,8 @@ const ChannelSystemMessageRow: React.FC<{
                 channelId,
                 String(message.meta?.agentId),
                 String(message.meta?.approvalRequestId),
-                { kind: 'accept', scope: 'once' }
+                { kind: 'accept', scope: 'once' },
+                message.threadId
               ).catch(() => {})
             }
           >
@@ -289,7 +290,8 @@ const ChannelSystemMessageRow: React.FC<{
                 channelId,
                 String(message.meta?.agentId),
                 String(message.meta?.approvalRequestId),
-                { kind: 'decline' }
+                { kind: 'decline' },
+                message.threadId
               ).catch(() => {})
             }
           >

--- a/frontend/src/components/chat/ChannelThreadPanel.tsx
+++ b/frontend/src/components/chat/ChannelThreadPanel.tsx
@@ -35,6 +35,7 @@ const DM_THREAD_PLACEHOLDER = 'reply in thread…  ·  shift+enter for newline';
 interface ChannelThreadPanelProps {
   channelId: string;
   channelTitle: string;
+  threadTitle?: string;
   /** True when the channel is a DM (one agent, implicit routing). */
   isDm?: boolean;
   /** Codex DM provider hint for bare `/command` syntax. */
@@ -42,6 +43,7 @@ interface ChannelThreadPanelProps {
   rootId: ChannelMessageId;
   liveMessages: ChannelMessage[];
   onClose: () => void;
+  onRename?: (title: string) => Promise<void>;
   onSend: (
     text: string,
     clientMessageId: string,
@@ -68,11 +70,13 @@ interface ChannelThreadPanelProps {
 export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
   channelId,
   channelTitle,
+  threadTitle,
   isDm = false,
   implicitCommandProviderId,
   rootId,
   liveMessages,
   onClose,
+  onRename,
   onSend,
   busyAgentLabels,
   busyAgentSteeringMode,
@@ -92,7 +96,9 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
     loading,
     error,
     rootFloorRevision,
+    threadTitle: fetchedThreadTitle,
   } = useChannelThread(channelId, rootId, liveMessages);
+  const durableThreadTitle = threadTitle?.trim() || fetchedThreadTitle?.trim();
   const reasoningViewState = useReasoningDetailStateScope(
     `thread:${channelId}:${rootId}`
   );
@@ -149,7 +155,9 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
       }}
     >
       <header className="ch-thread__header">
-        <span className="ch-thread__title">thread</span>
+        <span className="ch-thread__title">
+          {durableThreadTitle || 'thread'}
+        </span>
         <span className="ch-thread__count">
           · {replyCount} repl{replyCount === 1 ? 'y' : 'ies'}
         </span>
@@ -166,6 +174,21 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
             ‹ back
           </span>
         </button>
+        {onRename ? (
+          <button
+            type="button"
+            className="ch-thread__rename"
+            onClick={() => {
+              const next = window.prompt(
+                'conversation title',
+                durableThreadTitle ?? ''
+              );
+              if (next?.trim()) void onRename(next);
+            }}
+          >
+            rename
+          </button>
+        ) : null}
       </header>
 
       <div className="ch-thread__root">
@@ -266,6 +289,7 @@ export const ChannelThreadPanel: React.FC<ChannelThreadPanelProps> = ({
       <ChannelComposer
         channelId={channelId}
         channelTitle={channelTitle}
+        threadId={rootId}
         placeholder={isDm ? DM_THREAD_PLACEHOLDER : THREAD_PLACEHOLDER}
         {...(implicitCommandProviderId ? { implicitCommandProviderId } : {})}
         onSend={onSend}

--- a/frontend/src/components/chat/ChannelView.css
+++ b/frontend/src/components/chat/ChannelView.css
@@ -1088,6 +1088,25 @@
   background: color-mix(in srgb, var(--text-muted) 10%, transparent);
 }
 
+.ch-thread__rename {
+  min-height: 28px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.ch-thread__rename:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
 .ch-thread__close-mobile {
   display: none;
 }

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -19,11 +19,15 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useChannelChatSocket } from '../../hooks/useChannelChatSocket.js';
 import {
   fetchWorkspaceTopic,
+  updateWorkspaceTopic,
+  createChannelThread,
+  renameChannelThread,
   fetchChannelRoster,
   designateChannelOrchestrator,
   deleteChannelMessage,
   editChannelMessage,
   interruptChannelAgent,
+  restartChannelAgentRuntimes,
   retryChannelMessage,
   HttpError,
   type ChannelAgentStatus,
@@ -327,6 +331,163 @@ interface ChannelViewProps {
   channelId: string;
 }
 
+interface SteerTargets {
+  agentIds: string[];
+  labels: string[];
+  queueAgentIds: string[];
+  queueLabels: string[];
+  mode: 'all' | 'some' | 'none';
+}
+
+interface ScopedSteerTargets {
+  root: SteerTargets;
+  activeThreadRootId: ChannelMessageId | null;
+  activeThread: SteerTargets;
+}
+
+const EMPTY_STEER_TARGETS: SteerTargets = {
+  agentIds: [],
+  labels: [],
+  queueAgentIds: [],
+  queueLabels: [],
+  mode: 'none',
+};
+
+function targetsForConversation(
+  scopedTargets: ScopedSteerTargets,
+  threadId: ChannelMessageId | null
+): SteerTargets {
+  if (threadId === null) return scopedTargets.root;
+  if (scopedTargets.activeThreadRootId === threadId) {
+    return scopedTargets.activeThread;
+  }
+  return EMPTY_STEER_TARGETS;
+}
+
+function ChannelDesignateControl({
+  available,
+  pending,
+  error,
+  onDesignate,
+}: {
+  available: boolean;
+  pending: boolean;
+  error: string | null;
+  onDesignate: () => void;
+}) {
+  if (!available && error === null) return null;
+  return (
+    <>
+      {available ? (
+        <button
+          type="button"
+          className="ch-designate-orchestrator"
+          onClick={onDesignate}
+          disabled={pending}
+        >
+          {pending ? (
+            <>
+              <TuiProgress
+                variant="braille"
+                className="ch-designate-orchestrator__progress"
+              />{' '}
+              designating
+            </>
+          ) : (
+            'designate orchestrator'
+          )}
+        </button>
+      ) : null}
+      {error ? (
+        <span className="ch-designate-orchestrator__error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+function ChannelConversationActions({
+  visible,
+  applyPending,
+  onCreateThread,
+  onEditInstructions,
+  onApplyInstructions,
+}: {
+  visible: boolean;
+  applyPending: boolean;
+  onCreateThread: () => void;
+  onEditInstructions: () => void;
+  onApplyInstructions: () => void;
+}) {
+  if (!visible) return null;
+  return (
+    <>
+      <button
+        type="button"
+        className="ch-reconnect-btn"
+        onClick={onCreateThread}
+      >
+        new conversation
+      </button>
+      <button
+        type="button"
+        className="ch-reconnect-btn"
+        onClick={onEditInstructions}
+        title="saves defaults; current runtimes keep their prompt until applied"
+      >
+        instructions
+      </button>
+      <button
+        type="button"
+        className="ch-reconnect-btn"
+        onClick={onApplyInstructions}
+        disabled={applyPending}
+        title="restarts idle runtimes in this conversation; busy turns keep their current instructions"
+      >
+        {applyPending ? 'applying instructions' : 'apply instructions'}
+      </button>
+    </>
+  );
+}
+
+function ChannelConnectionStatus({
+  connected,
+  disconnected,
+  onReconnect,
+}: {
+  connected: boolean;
+  disconnected: boolean;
+  onReconnect: () => void;
+}) {
+  const state = connected
+    ? 'connected'
+    : disconnected
+      ? 'disconnected'
+      : 'reconnecting';
+  return (
+    <>
+      {disconnected ? (
+        <button
+          type="button"
+          className="ch-reconnect-btn"
+          onClick={onReconnect}
+          title="disconnected — reconnect"
+        >
+          reconnect
+        </button>
+      ) : null}
+      <span
+        className={`ch-conn-dot${connected ? ' ch-conn-dot--on' : ''}${
+          disconnected ? ' ch-conn-dot--off' : ''
+        }`}
+        title={state}
+        aria-label={state}
+      />
+    </>
+  );
+}
+
 export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const {
     channel,
@@ -399,6 +560,107 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       : null;
 
   const title = channel?.title ?? topicQuery.data?.display.title ?? channelId;
+  const activeThreadTitle =
+    channel?.threads?.find(
+      (thread) => thread.rootMessageId === activeThreadRootId
+    )?.title ?? undefined;
+  const [applyInstructionsPending, setApplyInstructionsPending] =
+    useState(false);
+
+  const refreshThreadNavigation = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['channels'] });
+  }, [queryClient]);
+
+  const handleCreateThread = useCallback(async () => {
+    const requested = window.prompt('new conversation title');
+    if (!requested?.trim()) return;
+    try {
+      const thread = await createChannelThread(channelId, requested);
+      await refreshThreadNavigation();
+      setActiveThreadRootId(thread.rootMessageId as ChannelMessageId);
+    } catch {
+      showToast('could not create conversation');
+    }
+  }, [channelId, refreshThreadNavigation, setActiveThreadRootId]);
+
+  const handleRenameThread = useCallback(
+    async (rootMessageId: ChannelMessageId, requested: string) => {
+      try {
+        await renameChannelThread(channelId, rootMessageId, requested);
+        await refreshThreadNavigation();
+      } catch {
+        showToast('could not rename conversation');
+        throw new Error('conversation rename failed');
+      }
+    },
+    [channelId, refreshThreadNavigation]
+  );
+
+  const handleEditChannelInstructions = useCallback(async () => {
+    const current = topicQuery.data?.promptDefaults ?? {};
+    const systemPrompt = window.prompt(
+      'shared channel system prompt (blank clears)',
+      current.systemPrompt ?? ''
+    );
+    if (systemPrompt === null) return;
+    const instructions = window.prompt(
+      'shared channel instructions (blank clears)',
+      current.instructions ?? ''
+    );
+    if (instructions === null) return;
+    try {
+      await updateWorkspaceTopic(channelId, {
+        promptDefaults: {
+          ...(current.starterPrompt
+            ? { starterPrompt: current.starterPrompt }
+            : {}),
+          ...(current.contextPacketIds
+            ? { contextPacketIds: current.contextPacketIds }
+            : {}),
+          ...(systemPrompt.trim() ? { systemPrompt: systemPrompt.trim() } : {}),
+          ...(instructions.trim() ? { instructions: instructions.trim() } : {}),
+        },
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['workspace-topic', channelId],
+      });
+      showToast(
+        'instructions saved — apply them to restart idle runtimes in this conversation'
+      );
+    } catch {
+      showToast('could not save channel instructions');
+    }
+  }, [channelId, queryClient, topicQuery.data?.promptDefaults]);
+
+  const handleApplyChannelInstructions = useCallback(async () => {
+    if (applyInstructionsPending) return;
+    const scopeLabel = activeThreadRootId ? 'this conversation' : 'the channel';
+    setApplyInstructionsPending(true);
+    try {
+      const result = await restartChannelAgentRuntimes(
+        channelId,
+        activeThreadRootId
+      );
+      await queryClient.invalidateQueries({
+        queryKey: ['channel-roster', channelId],
+      });
+      showToast(
+        result.restarted > 0
+          ? `instructions applied — restarted ${result.restarted} idle runtime${
+              result.restarted === 1 ? '' : 's'
+            } in ${scopeLabel}`
+          : `instructions are saved — no runtime is active in ${scopeLabel}`
+      );
+    } catch (error) {
+      showToast(
+        error instanceof HttpError && error.status === 409
+          ? 'instructions are saved — the active turn keeps its current instructions. Wait until it is idle, then apply again.'
+          : 'could not apply channel instructions'
+      );
+    } finally {
+      setApplyInstructionsPending(false);
+    }
+  }, [activeThreadRootId, applyInstructionsPending, channelId, queryClient]);
 
   // Unread line: captured once on mount (per channelId, since ChatHome keys this
   // component by channelId). Absent marker → null → no unread line drawn.
@@ -470,18 +732,10 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
    * the current set without being rebuilt on every status transition. Assigned
    * further down, once `agentChips` exists.
    */
-  const steerTargetsRef = useRef<{
-    agentIds: string[];
-    labels: string[];
-    queueAgentIds: string[];
-    queueLabels: string[];
-    mode: 'all' | 'some' | 'none';
-  }>({
-    agentIds: [],
-    labels: [],
-    queueAgentIds: [],
-    queueLabels: [],
-    mode: 'none',
+  const steerTargetsRef = useRef<ScopedSteerTargets>({
+    root: EMPTY_STEER_TARGETS,
+    activeThreadRootId: null,
+    activeThread: EMPTY_STEER_TARGETS,
   });
 
   /**
@@ -498,13 +752,19 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       steering: ChannelPostSteering | undefined,
       threadId: ChannelMessageId | null
     ) => {
-      const targets = steerTargetsRef.current;
+      const scopedTargets = steerTargetsRef.current;
+      // The main and thread composers send through this one callback. Choose
+      // targets from the same conversation scope as the outgoing row; falling
+      // back to root here would mark an idle thread as queued behind unrelated
+      // root work.
+      const targets = targetsForConversation(scopedTargets, threadId);
       const statusStore = useChannelAgentStatusStore.getState();
       // Snapshot BEFORE the round trip: a turn that drains while the POST is in
       // flight must not leave a chip behind on a message it already consumed.
       const drainSeqs = snapshotQueueDrainSeqs(
         channelId,
         targets.queueAgentIds,
+        threadId,
         statusStore.queueDrainSeqByChannelAgent
       );
       const message = await post(text, {
@@ -828,18 +1088,32 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     };
   }, [channelId]);
 
-  const streamingProfileProviders = useMemo(() => {
-    const providers = new Map<string, string | undefined>();
+  const streamingProfiles = useMemo(() => {
+    const profiles = new Map<
+      string,
+      { agentId: string; threadId: string | null; providerId?: string }
+    >();
     for (const message of reducer.messages) {
       if (message.status !== 'streaming' || message.sender.kind !== 'agent')
         continue;
       // Agent sender ids are profile Actor ids. Keep stream state in the same
       // identity namespace as roster/status rather than collapsing profiles by
       // provider.
-      providers.set(message.sender.id, message.sender.providerId);
+      const key = channelAgentStatusKey(
+        channelId,
+        message.sender.id,
+        message.threadId
+      );
+      profiles.set(key, {
+        agentId: message.sender.id,
+        threadId: message.threadId,
+        ...(message.sender.providerId
+          ? { providerId: message.sender.providerId }
+          : {}),
+      });
     }
-    return providers;
-  }, [reducer.messages]);
+    return profiles;
+  }, [channelId, reducer.messages]);
 
   // Presence suppression keys on MAIN-LANE streaming rows only. `ChannelTimeline`
   // renders `selectTopLevel(messages)`, so an agent streaming a reply inside a
@@ -860,19 +1134,40 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   const agentChips = useMemo(() => {
     const roster = rosterChipsQuery.data ?? [];
     const rosterById = new Map(roster.map((entry) => [entry.id, entry]));
-    const candidateIds = new Set<string>();
+    const candidates = new Map<
+      string,
+      { agentId: string; threadId: string | null }
+    >();
     for (const entry of roster) {
-      if (entry.binding != null) candidateIds.add(entry.id);
+      if (entry.binding != null) {
+        candidates.set(channelAgentStatusKey(channelId, entry.id), {
+          agentId: entry.id,
+          threadId: null,
+        });
+      }
     }
     const prefix = `${channelId} `;
     for (const key of Object.keys(statusMap)) {
-      if (key.startsWith(prefix)) candidateIds.add(key.slice(prefix.length));
+      if (!key.startsWith(prefix)) continue;
+      const encoded = key.slice(prefix.length);
+      const scopeStart = encoded.indexOf('\u0000');
+      const agentId = encoded.slice(
+        0,
+        scopeStart === -1 ? undefined : scopeStart
+      );
+      if (!agentId) continue;
+      candidates.set(key, {
+        agentId,
+        threadId: scopeStart === -1 ? null : encoded.slice(scopeStart + 1),
+      });
     }
-    for (const profileId of streamingProfileProviders.keys())
-      candidateIds.add(profileId);
+    for (const [key, candidate] of streamingProfiles) {
+      candidates.set(key, candidate);
+    }
 
     const chips: Array<{
       agentId: string;
+      threadId: string | null;
       status: ChannelAgentStatus;
       role?: AgentRole;
       queuedCount: number;
@@ -880,32 +1175,35 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       steerSupported: boolean;
       identity: ReturnType<typeof resolveSenderIdentity>;
     }> = [];
-    for (const agentId of candidateIds) {
+    for (const { agentId, threadId } of candidates.values()) {
       const entry = rosterById.get(agentId);
-      const key = channelAgentStatusKey(channelId, agentId);
-      const streaming = streamingProfileProviders.has(agentId);
+      const key = channelAgentStatusKey(channelId, agentId, threadId);
+      const streaming = streamingProfiles.has(key);
+      // The roster represents the channel-root binding only. A thread must
+      // derive solely from its thread-scoped status/message lanes.
+      const rosterBinding = threadId === null ? entry?.binding : undefined;
       const status = resolveEffectiveAgentStatus({
         socketStatus: statusMap[key],
         socketUpdatedAt: statusUpdatedAtMap[key],
-        rosterStatus: entry?.binding?.status,
+        rosterStatus: rosterBinding?.status,
         rosterUpdatedAt,
         streaming,
         // Staleness floor (#1307): only a roster that says "nothing is bound"
         // may retire a busy socket status, so a long live turn keeps its chip.
-        rosterHasLiveBinding: entry?.binding != null,
+        rosterHasLiveBinding: rosterBinding != null,
       });
       // Same lane the status came from (#1308 slice 4 item 2c), so the presence
       // row can never pair a live status with a stale count or the reverse.
       const queuedCount = resolveEffectiveQueuedCount({
         socketQueuedCount: queuedCountMap[key],
         socketUpdatedAt: statusUpdatedAtMap[key],
-        rosterQueuedCount: entry?.binding?.queuedCount,
+        rosterQueuedCount: rosterBinding?.queuedCount,
         rosterUpdatedAt,
       });
       const steeringCount = resolveEffectiveQueuedCount({
         socketQueuedCount: steeringCountMap[key],
         socketUpdatedAt: statusUpdatedAtMap[key],
-        rosterQueuedCount: entry?.binding?.steeringCount,
+        rosterQueuedCount: rosterBinding?.steeringCount,
         rosterUpdatedAt,
       });
       const socketSteerSupported = Object.hasOwn(steerSupportedMap, key)
@@ -917,15 +1215,15 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
         resolveEffectiveQueuedCount({
           socketQueuedCount: socketSteerSupported,
           socketUpdatedAt: statusUpdatedAtMap[key],
-          rosterQueuedCount: entry?.binding?.steerSupported ? 1 : 0,
+          rosterQueuedCount: rosterBinding?.steerSupported ? 1 : 0,
           rosterUpdatedAt,
         }) > 0;
       // Show a chip for a bound agent (even when idle) or one that is currently
       // active/streaming — but drop an unbound agent whose only signal is a stale
       // socket status the roster has since superseded to idle.
-      if (entry?.binding == null && status === 'idle' && !streaming) continue;
+      if (rosterBinding == null && status === 'idle' && !streaming) continue;
       const providerId =
-        entry?.providerId ?? streamingProfileProviders.get(agentId);
+        entry?.providerId ?? streamingProfiles.get(key)?.providerId;
       const identity = resolveSenderIdentity({
         kind: 'agent',
         id: agentId,
@@ -934,6 +1232,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
       });
       chips.push({
         agentId,
+        threadId,
         status,
         queuedCount,
         steeringCount,
@@ -951,9 +1250,18 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     queuedCountMap,
     steeringCountMap,
     steerSupportedMap,
-    streamingProfileProviders,
+    streamingProfiles,
     channelId,
   ]);
+
+  const rootAgentChips = useMemo(
+    () => agentChips.filter((chip) => chip.threadId === null),
+    [agentChips]
+  );
+  const activeConversationAgentChips = useMemo(
+    () => agentChips.filter((chip) => chip.threadId === activeThreadRootId),
+    [activeThreadRootId, agentChips]
+  );
 
   // In-timeline presence rows (#1277). Same chip signal, so a reload rebuilds
   // the rows from `resolveEffectiveAgentStatus` for free — no new WS event. The
@@ -964,8 +1272,8 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     topLevelStreamingAgentIds
   );
   const agentPresence = useMemo(
-    () => selectChannelAgentPresence(agentChips, presenceSuppression),
-    [agentChips, presenceSuppression]
+    () => selectChannelAgentPresence(rootAgentChips, presenceSuppression),
+    [rootAgentChips, presenceSuppression]
   );
 
   // #1308 item 2 storm brake, client half. Same `agentChips` signal the presence
@@ -974,11 +1282,11 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   // operator from firing a request that is already known to be rejected.
   const busyAgentIds = useMemo(() => {
     const ids = new Set<string>();
-    for (const chip of agentChips) {
+    for (const chip of rootAgentChips) {
       if (chip.status !== 'idle') ids.add(chip.agentId);
     }
     return ids;
-  }, [agentChips]);
+  }, [rootAgentChips]);
   const archiveBusyAgentCount = useMemo(
     () =>
       agentChips.filter(
@@ -995,26 +1303,49 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   // doing can never disagree.
   const busyAgentLabels = useMemo(
     () =>
-      agentChips
+      rootAgentChips
         .filter((chip) => chip.status !== 'idle')
         .map((chip) => chip.identity.label),
-    [agentChips]
+    [rootAgentChips]
   );
   const busyAgentSteeringMode = useMemo((): 'all' | 'some' | 'none' => {
-    const busy = agentChips.filter((chip) => chip.status !== 'idle');
+    const busy = rootAgentChips.filter((chip) => chip.status !== 'idle');
     if (busy.length === 0 || busy.every((chip) => !chip.steerSupported)) {
       return 'none';
     }
     return busy.every((chip) => chip.steerSupported) ? 'all' : 'some';
-  }, [agentChips]);
+  }, [rootAgentChips]);
   const busyQueueFallback = useMemo(
     () =>
-      agentChips.filter(
+      rootAgentChips.filter(
         (chip) => chip.status !== 'idle' && !chip.steerSupported
       ),
-    [agentChips]
+    [rootAgentChips]
   );
-  const steerTargets = useMemo(
+  const activeThreadBusyAgentLabels = useMemo(
+    () =>
+      activeConversationAgentChips
+        .filter((chip) => chip.status !== 'idle')
+        .map((chip) => chip.identity.label),
+    [activeConversationAgentChips]
+  );
+  const activeThreadBusySteeringMode = useMemo((): 'all' | 'some' | 'none' => {
+    const busy = activeConversationAgentChips.filter(
+      (chip) => chip.status !== 'idle'
+    );
+    if (busy.length === 0 || busy.every((chip) => !chip.steerSupported)) {
+      return 'none';
+    }
+    return busy.every((chip) => chip.steerSupported) ? 'all' : 'some';
+  }, [activeConversationAgentChips]);
+  const activeThreadBusyQueueFallback = useMemo(
+    () =>
+      activeConversationAgentChips.filter(
+        (chip) => chip.status !== 'idle' && !chip.steerSupported
+      ),
+    [activeConversationAgentChips]
+  );
+  const steerTargets = useMemo<SteerTargets>(
     () => ({
       agentIds: [...busyAgentIds],
       labels: busyAgentLabels,
@@ -1024,12 +1355,35 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     }),
     [busyAgentIds, busyAgentLabels, busyQueueFallback, busyAgentSteeringMode]
   );
+  const activeThreadSteerTargets = useMemo<SteerTargets>(
+    () => ({
+      agentIds: activeConversationAgentChips
+        .filter((chip) => chip.status !== 'idle')
+        .map((chip) => chip.agentId),
+      labels: activeThreadBusyAgentLabels,
+      queueAgentIds: activeThreadBusyQueueFallback.map((chip) => chip.agentId),
+      queueLabels: activeThreadBusyQueueFallback.map(
+        (chip) => chip.identity.label
+      ),
+      mode: activeThreadBusySteeringMode,
+    }),
+    [
+      activeConversationAgentChips,
+      activeThreadBusyAgentLabels,
+      activeThreadBusyQueueFallback,
+      activeThreadBusySteeringMode,
+    ]
+  );
   // Send handlers must only observe a committed UI state. Updating the ref
   // during render lets an abandoned concurrent render steer a different set of
   // agents than the operator could actually see.
   useLayoutEffect(() => {
-    steerTargetsRef.current = steerTargets;
-  }, [steerTargets]);
+    steerTargetsRef.current = {
+      root: steerTargets,
+      activeThreadRootId,
+      activeThread: activeThreadSteerTargets,
+    };
+  }, [activeThreadRootId, activeThreadSteerTargets, steerTargets]);
 
   // Wired only while the channel is live, exactly like edit/delete below: a
   // retry re-runs a turn against an archived (read-only) channel, so the route
@@ -1096,10 +1450,10 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
   );
 
   const handleInterruptAgent = useCallback(
-    (agentId: string) => {
+    (agentId: string, threadId: string | null = null) => {
       // 404 (no live binding) / 409 (NO_ACTIVE_TURN) both mean "already idle" —
       // swallow so a race between the click and the agent finishing is silent.
-      void interruptChannelAgent(channelId, agentId).catch(() => {});
+      void interruptChannelAgent(channelId, agentId, threadId).catch(() => {});
     },
     [channelId]
   );
@@ -1121,7 +1475,7 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
     }
   }, [channelId, queryClient]);
 
-  const hasOrchestrator = agentChips.some(
+  const hasOrchestrator = rootAgentChips.some(
     (chip) => chip.role === 'orchestrator'
   );
 
@@ -1200,11 +1554,13 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
                 chip.status === 'waiting';
               return (
                 <span
-                  key={chip.agentId}
+                  key={`${chip.agentId}\u0000${chip.threadId ?? ''}`}
                   className={`ch-agent-chip ch-agent-chip--${chip.status}`}
                   title={`${chip.identity.label}${
                     chip.role ? ` · ${chip.role}` : ''
-                  } · ${chip.status}`}
+                  } · ${chip.status}${
+                    chip.threadId ? ' · conversation runtime' : ''
+                  }`}
                 >
                   {chip.identity.glyph ? (
                     <span
@@ -1226,9 +1582,13 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
                     <button
                       type="button"
                       className="ch-agent-chip__stop"
-                      aria-label={`interrupt ${chip.identity.label}`}
+                      aria-label={`interrupt ${chip.identity.label}${
+                        chip.threadId ? ' in conversation' : ''
+                      }`}
                       title="interrupt"
-                      onClick={() => handleInterruptAgent(chip.agentId)}
+                      onClick={() =>
+                        handleInterruptAgent(chip.agentId, chip.threadId)
+                      }
                     >
                       ■
                     </button>
@@ -1238,35 +1598,25 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             })}
           </span>
         ) : null}
-        {topicQuery.isSuccess &&
-        !isDm &&
-        rosterChipsQuery.isSuccess &&
-        !hasOrchestrator ? (
-          <button
-            type="button"
-            className="ch-designate-orchestrator"
-            onClick={() => void handleDesignateOrchestrator()}
-            disabled={designatePending}
-          >
-            {designatePending ? (
-              <>
-                <TuiProgress
-                  variant="braille"
-                  className="ch-designate-orchestrator__progress"
-                />{' '}
-                designating
-              </>
-            ) : (
-              'designate orchestrator'
-            )}
-          </button>
-        ) : null}
-        {designateError && !hasOrchestrator ? (
-          <span className="ch-designate-orchestrator__error" role="alert">
-            {designateError}
-          </span>
-        ) : null}
+        <ChannelDesignateControl
+          available={
+            topicQuery.isSuccess &&
+            !isDm &&
+            rosterChipsQuery.isSuccess &&
+            !hasOrchestrator
+          }
+          pending={designatePending}
+          error={hasOrchestrator ? null : designateError}
+          onDesignate={() => void handleDesignateOrchestrator()}
+        />
         <span className="ch-header__spacer" />
+        <ChannelConversationActions
+          visible={!isDm && !archived}
+          applyPending={applyInstructionsPending}
+          onCreateThread={() => void handleCreateThread()}
+          onEditInstructions={() => void handleEditChannelInstructions()}
+          onApplyInstructions={() => void handleApplyChannelInstructions()}
+        />
         <ChannelArchiveControl
           key={channelId}
           channelId={channelId}
@@ -1280,37 +1630,12 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
                 : 'ready'
           }
         />
-        {disconnected ? (
-          // Reconnect gave up (server outage/deploy > backoff budget). Surface a
-          // manual affordance — NOT gated on needsCatchup, which can never flip
-          // true while the socket is dead (#1178).
-          <button
-            type="button"
-            className="ch-reconnect-btn"
-            onClick={resync}
-            title="disconnected — reconnect"
-          >
-            reconnect
-          </button>
-        ) : null}
-        <span
-          className={`ch-conn-dot${connected ? ' ch-conn-dot--on' : ''}${
-            disconnected ? ' ch-conn-dot--off' : ''
-          }`}
-          title={
-            connected
-              ? 'connected'
-              : disconnected
-                ? 'disconnected'
-                : 'reconnecting'
-          }
-          aria-label={
-            connected
-              ? 'connected'
-              : disconnected
-                ? 'disconnected'
-                : 'reconnecting'
-          }
+        {/* Reconnect is intentionally not gated on needsCatchup: a dead socket
+            cannot receive the transition that sets it (#1178). */}
+        <ChannelConnectionStatus
+          connected={connected}
+          disconnected={disconnected}
+          onReconnect={resync}
         />
       </div>
 
@@ -1374,14 +1699,16 @@ export const ChannelView: React.FC<ChannelViewProps> = ({ channelId }) => {
             key={activeThreadRootId}
             channelId={channelId}
             channelTitle={title}
+            {...(activeThreadTitle ? { threadTitle: activeThreadTitle } : {})}
             isDm={isDm}
             implicitCommandProviderId={implicitCommandProviderId}
             rootId={activeThreadRootId}
             liveMessages={reducer.messages}
             onClose={() => setActiveThreadRootId(null)}
+            onRename={(next) => handleRenameThread(activeThreadRootId, next)}
             onSend={handleThreadSend}
-            busyAgentLabels={busyAgentLabels}
-            busyAgentSteeringMode={busyAgentSteeringMode}
+            busyAgentLabels={activeThreadBusyAgentLabels}
+            busyAgentSteeringMode={activeThreadBusySteeringMode}
             postPending={postPending}
             storeDown={storeDown}
             archived={archived}

--- a/frontend/src/hooks/useChannelThread.ts
+++ b/frontend/src/hooks/useChannelThread.ts
@@ -10,6 +10,8 @@ const THREAD_HISTORY_PAGE_LIMIT = 50;
 export interface UseChannelThreadState {
   root: ChannelMessage | null;
   replies: ChannelMessage[];
+  /** Durable title returned by the root-inclusive thread route. */
+  threadTitle?: string;
   hasMoreOlder: boolean;
   loadingOlder: boolean;
   loadOlder: () => Promise<void>;
@@ -75,6 +77,7 @@ export function useChannelThread(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [rootFloorRevision, setRootFloorRevision] = useState(0);
+  const [threadTitle, setThreadTitle] = useState<string | undefined>();
 
   const requestKeyRef = useRef('');
   const backfillRef = useRef(backfill);
@@ -100,6 +103,7 @@ export function useChannelThread(
     setLoadingOlder(false);
     setError(null);
     setRootFloorRevision(0);
+    setThreadTitle(undefined);
 
     if (rootId === null) {
       setLoading(false);
@@ -119,6 +123,8 @@ export function useChannelThread(
         );
         backfillRef.current = next;
         setBackfill(next);
+        if (page.thread?.rootMessageId === rootId)
+          setThreadTitle(page.thread.title);
         if (page.messages.some((message) => message.id === rootId)) {
           setRootFloorRevision((revision) => revision + 1);
         }
@@ -227,6 +233,8 @@ export function useChannelThread(
       const next = mergeThreadPage(backfillRef.current, page.messages, rootId);
       backfillRef.current = next;
       setBackfill(next);
+      if (page.thread?.rootMessageId === rootId)
+        setThreadTitle(page.thread.title);
       if (page.messages.some((message) => message.id === rootId)) {
         setRootFloorRevision((revision) => revision + 1);
       }
@@ -249,6 +257,7 @@ export function useChannelThread(
   return {
     root,
     replies,
+    ...(threadTitle ? { threadTitle } : {}),
     hasMoreOlder,
     loadingOlder,
     loadOlder,

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -643,7 +643,11 @@ export function useEventSocket({
         // `recordStatus` lands.
         const previous =
           useChannelAgentStatusStore.getState().statusByChannelAgent[
-            channelAgentStatusKey(msg.channelId, msg.agentId)
+            channelAgentStatusKey(
+              msg.channelId,
+              msg.agentId,
+              msg.threadId ?? null
+            )
           ];
         useChannelAgentStatusStore.getState().recordStatus(
           msg.channelId,
@@ -654,7 +658,8 @@ export function useEventSocket({
           // "nothing queued", which is also what an unqueued binding reports.
           msg.queuedCount ?? 0,
           msg.steeringCount ?? 0,
-          msg.steerSupported ?? false
+          msg.steerSupported ?? false,
+          msg.threadId ?? null
         );
         // #1308 slice 5: the ONE trigger the socket carries end to end. Default
         // OFF, so this is inert until the operator opts in from Settings.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -41,6 +41,7 @@ import {
   type WorkspaceTopicCreateInput,
   type WorkspaceTopicListResponse,
   type WorkspaceTopicSearchResponse,
+  type WorkspaceTopicUpdateInput,
 } from '../../../shared/workspace-topics.js';
 import type {
   ChannelImagePart,
@@ -1722,6 +1723,24 @@ export async function fetchWorkspaceTopic(id: string): Promise<WorkspaceTopic> {
   return data.topic;
 }
 
+/** Update one persisted channel/topic field group. */
+export async function updateWorkspaceTopic(
+  id: string,
+  input: WorkspaceTopicUpdateInput
+): Promise<WorkspaceTopic> {
+  const data = await json<{ topic: WorkspaceTopic }>(
+    await fetch(`/workspace-topics/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify(input),
+    })
+  );
+  return data.topic;
+}
+
 /**
  * Create a bare workspace topic (POST /workspace-topics) with no attached
  * WorkContext — used by the DM-as-channel flow (#1166), which needs only the
@@ -1784,6 +1803,7 @@ export interface ChannelSummaryView {
    */
   threads?: {
     rootMessageId: string;
+    title?: string;
     replyCount: number;
     lastReplyAt: string;
     preview: string;
@@ -1962,6 +1982,20 @@ export interface ChannelHistoryPage {
   messages: ChannelMessage[];
   hasMore: boolean;
   nextCursor?: { afterSeq?: number; beforeSeq?: number };
+  /** Present on the root-inclusive thread route. */
+  thread?: { rootMessageId: ChannelMessageId; title: string };
+}
+
+export interface ChannelThreadSummary {
+  rootMessageId: string;
+  title: string;
+  replyCount: number;
+  lastReplyAt: string;
+  preview: string;
+  rootSenderId: string;
+  rootSenderKind: 'human' | 'agent' | 'system';
+  rootSenderDisplayName?: string;
+  providerId?: string;
 }
 
 export async function fetchChannelHistory(
@@ -2025,7 +2059,55 @@ export async function fetchChannelThreadHistory(
     messages: Array.isArray(data.messages) ? data.messages : [],
     hasMore: Boolean(data.hasMore),
     ...(data.nextCursor ? { nextCursor: data.nextCursor } : {}),
+    ...(data.thread &&
+    typeof data.thread.rootMessageId === 'string' &&
+    typeof data.thread.title === 'string'
+      ? {
+          thread: {
+            rootMessageId: data.thread.rootMessageId as ChannelMessageId,
+            title: data.thread.title,
+          },
+        }
+      : {}),
   };
+}
+
+export async function createChannelThread(
+  channelId: string,
+  title: string
+): Promise<ChannelThreadSummary> {
+  const data = await json<{ thread: ChannelThreadSummary }>(
+    await fetch(`/channels/${encodeURIComponent(channelId)}/threads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-relay-capabilities': 'context:write',
+      },
+      body: JSON.stringify({ title }),
+    })
+  );
+  return data.thread;
+}
+
+export async function renameChannelThread(
+  channelId: string,
+  rootMessageId: string,
+  title: string
+): Promise<ChannelThreadSummary> {
+  const data = await json<{ thread: ChannelThreadSummary }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/threads/${encodeURIComponent(rootMessageId)}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ title }),
+      }
+    )
+  );
+  return data.thread;
 }
 
 export async function postChannelMessage(
@@ -2165,6 +2247,8 @@ export async function executeChannelAgentCommand(
     args?: string;
     /** Required by the server for context-changing/destructive controls. */
     confirmed?: boolean;
+    /** Canonical thread root; absent addresses the root-channel runtime only. */
+    threadId?: string | null;
   }
 ): Promise<{ config?: Record<string, unknown> }> {
   const data = await json<{ config?: Record<string, unknown> }>(
@@ -2181,13 +2265,38 @@ export async function executeChannelAgentCommand(
 }
 
 /**
+ * Explicitly apply saved channel instructions to one conversation by restarting
+ * its idle runtimes. Busy turns are rejected by the server and keep their
+ * existing provider prompt until the operator applies again after they finish.
+ */
+export async function restartChannelAgentRuntimes(
+  channelId: string,
+  threadId?: string | null
+): Promise<{ restarted: number }> {
+  return json<{ restarted: number }>(
+    await fetch(
+      `/channels/${encodeURIComponent(channelId)}/agent-runtimes/restart`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify(threadId ? { threadId } : {}),
+      }
+    )
+  );
+}
+
+/**
  * Interrupt the given agent's active turn in a channel. Lets `HttpError`
  * propagate: callers ignore 404 (no live binding) / 409 (NO_ACTIVE_TURN, agent
  * idle) since both mean "nothing to interrupt".
  */
 export async function interruptChannelAgent(
   channelId: string,
-  agentId: string
+  agentId: string,
+  threadId?: string | null
 ): Promise<void> {
   await json<{ ok: true }>(
     await fetch(
@@ -2200,7 +2309,7 @@ export async function interruptChannelAgent(
           'Content-Type': 'application/json',
           'x-relay-capabilities': 'context:write',
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify(threadId ? { threadId } : {}),
       }
     )
   );
@@ -2343,7 +2452,8 @@ export async function respondChannelApproval(
   channelId: string,
   agentId: string,
   requestId: string,
-  decision: unknown
+  decision: unknown,
+  threadId?: string | null
 ): Promise<void> {
   await json<{ ok: true }>(
     await fetch(
@@ -2356,7 +2466,11 @@ export async function respondChannelApproval(
           'Content-Type': 'application/json',
           'x-relay-capabilities': 'context:write',
         },
-        body: JSON.stringify({ requestId, decision }),
+        body: JSON.stringify({
+          requestId,
+          decision,
+          ...(threadId ? { threadId } : {}),
+        }),
       }
     )
   );

--- a/frontend/src/lib/state/topic-nav.ts
+++ b/frontend/src/lib/state/topic-nav.ts
@@ -161,6 +161,8 @@ export interface TopicNavNode {
  */
 export interface ChannelRailThreadSummary {
   rootMessageId: string;
+  /** Durable user title; optional for older hubs. */
+  title?: string;
   replyCount: number;
   lastReplyAt: string;
   preview: string;
@@ -305,7 +307,9 @@ export function selectRailRowThreads(summary: ChannelRailSummary | null): {
   threadCount: number;
 } {
   const threads = summary?.threads ?? [];
-  const shown = threads.filter((thread) => thread.replyCount > 0);
+  // Named conversations are deliberately visible before their first reply:
+  // creation is durable operator intent, not a transient composer draft.
+  const shown = threads;
   return {
     threads: shown,
     threadCount: Math.max(summary?.threadCount ?? 0, shown.length),

--- a/frontend/src/lib/stores/channel-agent-status.ts
+++ b/frontend/src/lib/stores/channel-agent-status.ts
@@ -6,12 +6,20 @@
 import { create } from 'zustand';
 import type { ChannelAgentStatus } from '../api.js';
 
-/** Composite key for the status/runtime maps: `"<channelId> <agentId>"`. */
+/** Composite key for root and thread-scoped runtime status. */
 export function channelAgentStatusKey(
   channelId: string,
-  agentId: string
+  agentId: string,
+  threadId: string | null = null
 ): string {
-  return `${channelId} ${agentId}`;
+  return threadId === null
+    ? `${channelId} ${agentId}`
+    : `${channelId} ${agentId}\u0000${threadId}`;
+}
+
+/** Prefix that selects only one conversation scope from the live status map. */
+export function channelThreadStatusSuffix(threadId: string): string {
+  return `\u0000${threadId}`;
 }
 
 interface ChannelAgentStatusState {
@@ -58,7 +66,8 @@ interface ChannelAgentStatusState {
     runtimeId: string | null,
     queuedCount?: number,
     steeringCount?: number,
-    steerSupported?: boolean
+    steerSupported?: boolean,
+    threadId?: string | null
   ) => void;
   /** Drop every agent status/runtime entry for a channel. */
   clearChannel: (channelId: string) => void;
@@ -84,10 +93,11 @@ export const useChannelAgentStatusStore = create<ChannelAgentStatusState>(
       runtimeId,
       queuedCount = 0,
       steeringCount = 0,
-      steerSupported = false
+      steerSupported = false,
+      threadId = null
     ) =>
       set((state) => {
-        const key = channelAgentStatusKey(channelId, agentId);
+        const key = channelAgentStatusKey(channelId, agentId, threadId);
         if (
           state.statusByChannelAgent[key] === status &&
           state.runtimeByChannelAgent[key] === runtimeId &&

--- a/frontend/src/lib/stores/channel-queued-sends.ts
+++ b/frontend/src/lib/stores/channel-queued-sends.ts
@@ -109,11 +109,12 @@ export const useChannelQueuedSendsStore = create<ChannelQueuedSendsState>(
 export function snapshotQueueDrainSeqs(
   channelId: string,
   agentIds: readonly string[],
+  threadId: string | null,
   drainSeqByChannelAgent: Readonly<Record<string, number>>
 ): Record<string, number> {
   const snapshot: Record<string, number> = {};
   for (const agentId of agentIds) {
-    const key = channelAgentStatusKey(channelId, agentId);
+    const key = channelAgentStatusKey(channelId, agentId, threadId);
     snapshot[key] = drainSeqByChannelAgent[key] ?? 0;
   }
   return snapshot;

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -136,6 +136,8 @@ export type EventMessage =
   | {
       type: 'channel-agent-status';
       channelId: string;
+      /** Null/root for legacy channel runtimes; a root id for a conversation. */
+      threadId?: string | null;
       agentId: string;
       status: 'spawning' | 'thinking' | 'streaming' | 'waiting' | 'idle';
       runtimeId: string | null;

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -251,9 +251,17 @@ export interface ChannelAgentBinder {
     framework?: string,
     profileActorId?: string
   ): Promise<LiveBinding>;
-  interrupt(channelId: string, agentId: string): Promise<void>;
+  interrupt(
+    channelId: string,
+    agentId: string,
+    threadId?: string | null
+  ): Promise<void>;
   /** Explicit operator release; only an actually idle, unqueued binding may end. */
-  release(channelId: string, agentId: string): Promise<void>;
+  release(
+    channelId: string,
+    agentId: string,
+    threadId?: string | null
+  ): Promise<void>;
   /**
    * Apply steering to an ALREADY-persisted row (#1308 slice 4). Used by the post
    * route when `clientMessageId` idempotency returns an existing row: the
@@ -275,7 +283,8 @@ export interface ChannelAgentBinder {
     channelId: string,
     agentId: string,
     requestId: string,
-    decision: AgentApprovalDecisionV2
+    decision: AgentApprovalDecisionV2,
+    threadId?: string | null
   ): Promise<void>;
   rosterForChannel(channelId: string): Promise<ChannelAgentRosterEntry[]>;
   /**
@@ -288,8 +297,18 @@ export interface ChannelAgentBinder {
     profileActorId: string,
     command: string,
     args?: string,
-    confirmed?: boolean
+    confirmed?: boolean,
+    threadId?: string | null
   ): Promise<{ config?: Record<string, unknown> }>;
+  /**
+   * Recreate every idle runtime in exactly one conversation scope so its
+   * provider receives updated channel instructions at launch. A busy turn is
+   * never interrupted or silently reconfigured.
+   */
+  restartScope(
+    channelId: string,
+    threadId?: string | null
+  ): Promise<{ restarted: number }>;
   /** `channelId` permits DM-only bare controls without reserving group prose. */
   isControlMessage(text: string, channelId?: string): boolean;
   setStatusBroadcaster(broadcaster: ChannelAgentStatusBroadcaster): void;
@@ -325,6 +344,8 @@ interface CallbackEdgeRequest {
 
 export interface LiveBinding {
   channelId: string;
+  /** Null is the root-channel execution scope. */
+  threadId: string | null;
   /** Actor id, not provider id: one profile owns one live channel runtime. */
   profileActorId: string;
   framework: string;
@@ -423,6 +444,25 @@ export class ChannelAgentReleaseRefusedError extends Error {
   }
 }
 
+/** A configuration apply never abandons an active or queued provider turn. */
+export class ChannelAgentRestartRefusedError extends Error {
+  constructor(
+    readonly channelId: string,
+    readonly threadId: string | null,
+    readonly profileActorId: string,
+    readonly status: ChannelAgentStatus,
+    readonly reasonCode:
+      | 'CHANNEL_AGENT_NOT_IDLE'
+      | 'CHANNEL_AGENT_QUEUE_NOT_EMPTY'
+      | 'CHANNEL_AGENT_WAITING_ON_OPERATOR'
+  ) {
+    super(
+      `agent ${profileActorId} cannot apply instructions while ${reasonCode}`
+    );
+    this.name = 'ChannelAgentRestartRefusedError';
+  }
+}
+
 /**
  * The row cannot be re-routed: it is not a retryable agent row, its turn id was
  * not binder-minted (a provider-labelled item), or the original trigger has
@@ -516,12 +556,26 @@ class BinderClosedError extends Error {
 
 const SYSTEM_SENDER = { kind: 'system', id: 'system' } as const;
 
-function bindingKey(channelId: string, profileActorId: string): string {
-  return `${channelId}\u0000${profileActorId}`;
+function bindingKey(
+  channelId: string,
+  profileActorId: string,
+  threadId: string | null = null
+): string {
+  // An explicit empty component is the root/channel scope. It keeps a thread
+  // queue, provider-session identity and controls from collapsing into root.
+  return `${channelId}\u0000${threadId ?? ''}\u0000${profileActorId}`;
+}
+
+/** Autonomous agent chains are isolated just like their runtime bindings. */
+function conversationScopeKey(
+  channelId: string,
+  threadId: string | null = null
+): string {
+  return `${channelId}\u0000${threadId ?? ''}`;
 }
 
 function bindingKeyPrefix(channelId: string): string {
-  return bindingKey(channelId, '');
+  return `${channelId}\u0000`;
 }
 
 export function createChannelAgentBinder(
@@ -536,6 +590,10 @@ export function createChannelAgentBinder(
 
   const live = new Map<string, LiveBinding>();
   const inflight = new Map<string, Promise<LiveBinding>>();
+  // An explicit instruction apply has a destructive middle (runtime teardown).
+  // Coalesce duplicate browser/API clicks for one conversation so two applies
+  // cannot both pass the idle preflight and recreate competing runtimes.
+  const restartInFlight = new Map<string, Promise<{ restarted: number }>>();
   // Designation is a channel-level invariant, not a (channel, profile) spawn.
   // Serialize competing profile requests before either can launch a loser.
   const orchestratorInflight = new Map<string, Promise<LiveBinding>>();
@@ -648,9 +706,15 @@ export function createChannelAgentBinder(
     turnId: string
   ): string | undefined {
     const key = parentKeyForTurn(binding, turnId);
-    return key === undefined
-      ? undefined
-      : (binding.parentMessageIdByTurn.get(key) ?? undefined);
+    const triggerParent =
+      key === undefined
+        ? undefined
+        : (binding.parentMessageIdByTurn.get(key) ?? undefined);
+    // An ambiguous provider fallback must not borrow a possibly wrong trigger,
+    // but a thread-scoped runtime still knows its durable conversation root.
+    // Keep its output in that conversation rather than leaking it to the root
+    // channel just because the immediate parent was deliberately withheld.
+    return triggerParent ?? binding.threadId ?? undefined;
   }
 
   function releaseTurnParent(binding: LiveBinding, turnId: string): void {
@@ -912,7 +976,12 @@ export function createChannelAgentBinder(
         );
         continue;
       }
-      void ensureProfileBinding(edge.channelId, profile)
+      void ensureProfileBinding(
+        edge.channelId,
+        profile,
+        undefined,
+        edge.threadId
+      )
         .then((binding) => {
           if (closed) return;
           if (!enqueueTurn(binding, trigger, undefined, false, edge)) {
@@ -1152,6 +1221,7 @@ export function createChannelAgentBinder(
     binding.emittedSteerSupported = steerSupported;
     statusBroadcaster?.('channel-agent-status', {
       channelId: binding.channelId,
+      threadId: binding.threadId,
       agentId: binding.profileActorId,
       status: binding.status,
       runtimeId: binding.runtimeId ?? null,
@@ -1199,10 +1269,12 @@ export function createChannelAgentBinder(
     channelId: string,
     profileActorId: string,
     framework: string,
-    displayName: string
+    displayName: string,
+    threadId: string | null = null
   ): LiveBinding {
     return {
       channelId,
+      threadId,
       profileActorId,
       framework,
       displayName,
@@ -1264,9 +1336,10 @@ export function createChannelAgentBinder(
     profileActorId: string,
     framework: string,
     senderDisplayName: string,
-    runtime: Pick<ChannelAgentRuntime, 'id' | 'adapter' | 'agentAttribution'>
+    runtime: Pick<ChannelAgentRuntime, 'id' | 'adapter' | 'agentAttribution'>,
+    threadId: string | null = null
   ): LiveBinding {
-    const key = bindingKey(channelId, profileActorId);
+    const key = bindingKey(channelId, profileActorId, threadId);
     const existing = live.get(key);
     // Tear down any prior wiring before re-binding a fresh adapter.
     existing?.unbind?.();
@@ -1286,7 +1359,14 @@ export function createChannelAgentBinder(
     }
     const binding =
       existing ??
-      newLiveBinding(channelId, profileActorId, framework, senderDisplayName);
+      newLiveBinding(
+        channelId,
+        profileActorId,
+        framework,
+        senderDisplayName,
+        threadId
+      );
+    binding.threadId = threadId;
     binding.profileActorId = profileActorId;
     binding.displayName = senderDisplayName;
     binding.runtimeId = runtime.id;
@@ -1323,7 +1403,8 @@ export function createChannelAgentBinder(
   function healthyRuntime(
     runtimeId: string | null,
     framework: string,
-    profileActorId: string
+    profileActorId: string,
+    threadId: string | null = null
   ): ChannelAgentRuntime | null {
     if (!runtimeId) return null;
     const runtime = deps.runtimes.get(runtimeId);
@@ -1331,6 +1412,7 @@ export function createChannelAgentBinder(
       runtime &&
       runtime.providerId === framework &&
       runtime.profileActorId === profileActorId &&
+      (runtime.threadId ?? null) === threadId &&
       runtime.status === 'active' &&
       runtime.adapter
     ) {
@@ -1346,6 +1428,28 @@ export function createChannelAgentBinder(
   ): string {
     const topic = topicStore?.get(channelId);
     return `#${topic?.display.title ?? channelId} · ${profile.displayName || framework}`;
+  }
+
+  /**
+   * One provider-neutral composition path for every channel runtime. Defaults
+   * are captured when a runtime is spawned/restarted; changing a topic never
+   * mutates a live provider context behind the operator's back.
+   */
+  function composedRuntimePrompt(
+    topic:
+      | ReturnType<NonNullable<ChannelAgentBinderDeps['topicStore']>['get']>
+      | undefined,
+    profile: AgentProfile
+  ): string | undefined {
+    const parts = [
+      topic?.promptDefaults.systemPrompt,
+      topic?.promptDefaults.instructions,
+      profile.systemPrompt,
+    ].filter(
+      (part): part is string =>
+        typeof part === 'string' && part.trim().length > 0
+    );
+    return parts.length > 0 ? parts.join('\n\n') : undefined;
   }
 
   function assertRuntimeRole(
@@ -1366,14 +1470,15 @@ export function createChannelAgentBinder(
   async function doEnsureBinding(
     channelId: string,
     profile: AgentProfile,
-    requiredRole?: 'orchestrator'
+    requiredRole?: 'orchestrator',
+    threadId: string | null = null
   ): Promise<LiveBinding> {
     if (closed) throw new BinderClosedError();
     const framework = profile.providerId;
     const profileActorId = profile.id;
-    const key = bindingKey(channelId, profileActorId);
+    const key = bindingKey(channelId, profileActorId, threadId);
     const runtimeDisplayName = displayNameFor(channelId, framework, profile);
-    const row = store.getBinding(channelId, profileActorId);
+    const row = store.getBinding(channelId, profileActorId, threadId);
     // Once a profile is durably designated, every recovery path preserves that
     // runtime role — including an explicit mention that happens after restart.
     const effectiveRole = requiredRole ?? row?.role ?? undefined;
@@ -1384,7 +1489,8 @@ export function createChannelAgentBinder(
       const runtime = healthyRuntime(
         existing.runtimeId,
         framework,
-        profileActorId
+        profileActorId,
+        threadId
       );
       if (runtime && runtime.adapter === existing.adapter) {
         assertRuntimeRole(channelId, framework, runtime, effectiveRole);
@@ -1407,7 +1513,8 @@ export function createChannelAgentBinder(
     const restored = healthyRuntime(
       row?.runtimeId ?? null,
       framework,
-      profileActorId
+      profileActorId,
+      threadId
     );
     if (restored) {
       assertRuntimeRole(channelId, framework, restored, effectiveRole);
@@ -1416,7 +1523,8 @@ export function createChannelAgentBinder(
         profileActorId,
         framework,
         senderDisplayName,
-        restored
+        restored,
+        threadId
       );
     }
 
@@ -1434,17 +1542,25 @@ export function createChannelAgentBinder(
 
     // 4. Spawn a fresh private runtime for this channel participant.
     const routing = topic?.routingDefaults ?? {};
+    const inheritedPrompt = composedRuntimePrompt(topic, profile);
     const cwd =
       routing.cwd ?? routing.worktreePath ?? routing.repoPath ?? os.homedir();
     const provisional =
       existing ??
-      newLiveBinding(channelId, profileActorId, framework, senderDisplayName);
+      newLiveBinding(
+        channelId,
+        profileActorId,
+        framework,
+        senderDisplayName,
+        threadId
+      );
     live.set(key, provisional);
     setStatus(provisional, 'spawning');
     let created: ChannelAgentRuntime;
     try {
       created = await deps.runtimes.create({
         channelId,
+        threadId,
         providerId: framework,
         profileActorId,
         cwd,
@@ -1462,8 +1578,8 @@ export function createChannelAgentBinder(
         ...(profile.envVars !== undefined
           ? { processEnv: profile.envVars }
           : {}),
-        ...(profile.systemPrompt !== undefined
-          ? { systemPrompt: profile.systemPrompt }
+        ...(inheritedPrompt !== undefined
+          ? { systemPrompt: inheritedPrompt }
           : {}),
         ...(profile.provider !== undefined || profile.effort !== undefined
           ? {
@@ -1517,10 +1633,12 @@ export function createChannelAgentBinder(
       profileActorId,
       framework,
       senderDisplayName,
-      created
+      created,
+      threadId
     );
     store.upsertBinding({
       channelId,
+      threadId,
       profileActorId,
       agentFramework: framework,
       runtimeId: created.id,
@@ -1549,7 +1667,12 @@ export function createChannelAgentBinder(
     requiredRole: 'orchestrator'
   ): void {
     const runtime = binding.runtimeId
-      ? healthyRuntime(binding.runtimeId, framework, binding.profileActorId)
+      ? healthyRuntime(
+          binding.runtimeId,
+          framework,
+          binding.profileActorId,
+          binding.threadId
+        )
       : null;
     if (runtime?.role === requiredRole) return;
     throw new ChannelAgentRoleConflictError(
@@ -1584,9 +1707,10 @@ export function createChannelAgentBinder(
   function ensureProfileBinding(
     channelId: string,
     profile: AgentProfile,
-    requiredRole?: 'orchestrator'
+    requiredRole?: 'orchestrator',
+    threadId: string | null = null
   ): Promise<LiveBinding> {
-    const key = bindingKey(channelId, profile.id);
+    const key = bindingKey(channelId, profile.id, threadId);
     const pending = inflight.get(key);
     if (pending) {
       if (!requiredRole) return pending;
@@ -1596,11 +1720,14 @@ export function createChannelAgentBinder(
       });
     }
     // Store before awaiting so concurrent mentions of one profile single-flight.
-    const promise = doEnsureBinding(channelId, profile, requiredRole).finally(
-      () => {
-        inflight.delete(key);
-      }
-    );
+    const promise = doEnsureBinding(
+      channelId,
+      profile,
+      requiredRole,
+      threadId
+    ).finally(() => {
+      inflight.delete(key);
+    });
     inflight.set(key, promise);
     return promise;
   }
@@ -1848,8 +1975,9 @@ export function createChannelAgentBinder(
 
   function isCurrentBinding(binding: LiveBinding): boolean {
     return (
-      live.get(bindingKey(binding.channelId, binding.profileActorId)) ===
-      binding
+      live.get(
+        bindingKey(binding.channelId, binding.profileActorId, binding.threadId)
+      ) === binding
     );
   }
 
@@ -2058,7 +2186,11 @@ export function createChannelAgentBinder(
   ): ResolvedMentionContextPacket {
     const topic = topicStore?.get(binding.channelId);
     const title = topic?.display.title ?? binding.channelId;
-    const row = store.getBinding(binding.channelId, binding.profileActorId);
+    const row = store.getBinding(
+      binding.channelId,
+      binding.profileActorId,
+      binding.threadId
+    );
     const lastDeliveredSeq =
       typeof row?.providerSession['lastDeliveredSeq'] === 'number'
         ? (row.providerSession['lastDeliveredSeq'] as number)
@@ -2242,14 +2374,15 @@ export function createChannelAgentBinder(
 
   function advanceCursor(binding: LiveBinding, trigger: ChannelMessage): void {
     if (closed) return; // never write to a closing store from an in-flight send
-    // Thread packets deliberately ignore the channel-global cursor. Advancing it
-    // here would make a later top-level mention skip intervening channel rows.
-    if (trigger.threadId !== null) return;
     const triggerSeq = trigger.seq;
     // Cursor advances only on send acceptance (§4): a failed send re-offers the
     // rows next mention (at-least-once). Never lower the cursor.
     try {
-      const row = store.getBinding(binding.channelId, binding.profileActorId);
+      const row = store.getBinding(
+        binding.channelId,
+        binding.profileActorId,
+        binding.threadId
+      );
       const prev = row?.providerSession ?? {};
       const current =
         typeof prev['lastDeliveredSeq'] === 'number'
@@ -2258,6 +2391,7 @@ export function createChannelAgentBinder(
       if (triggerSeq <= current) return;
       store.upsertBinding({
         channelId: binding.channelId,
+        threadId: binding.threadId,
         profileActorId: binding.profileActorId,
         agentFramework: binding.framework,
         providerSession: { ...prev, lastDeliveredSeq: triggerSeq },
@@ -2273,9 +2407,14 @@ export function createChannelAgentBinder(
   ): void {
     if (closed) return;
     try {
-      const row = store.getBinding(binding.channelId, binding.profileActorId);
+      const row = store.getBinding(
+        binding.channelId,
+        binding.profileActorId,
+        binding.threadId
+      );
       store.upsertBinding({
         channelId: binding.channelId,
+        threadId: binding.threadId,
         profileActorId: binding.profileActorId,
         agentFramework: binding.framework,
         providerSession: {
@@ -2311,7 +2450,12 @@ export function createChannelAgentBinder(
             `@${binding.displayName} could not receive the message: its profile no longer exists.`
           );
         }
-        const rebound = await ensureProfileBinding(binding.channelId, profile);
+        const rebound = await ensureProfileBinding(
+          binding.channelId,
+          profile,
+          undefined,
+          binding.threadId
+        );
         if (closed) return;
         if (rebound.adapter && rebound.activeTurnId === turnId) {
           // Same binding still owns this turn — redeliver identical content.
@@ -2892,7 +3036,8 @@ export function createChannelAgentBinder(
           binding = await ensureProfileBinding(
             trigger.channelId,
             profile,
-            requiredRole
+            requiredRole,
+            trigger.threadId
           );
         } catch (err) {
           if (err instanceof BinderClosedError) return; // shutdown — silent
@@ -3073,10 +3218,11 @@ export function createChannelAgentBinder(
       return;
     }
     const turnKey = agentTurnBrakeKey(message);
-    let state = consecutiveAgentTurns.get(message.channelId);
+    const scopeKey = conversationScopeKey(message.channelId, message.threadId);
+    let state = consecutiveAgentTurns.get(scopeKey);
     if (!state) {
       state = { count: 0, allowedTurnKeys: new Set(), paused: false };
-      consecutiveAgentTurns.set(message.channelId, state);
+      consecutiveAgentTurns.set(scopeKey, state);
     }
     // Pause is a per-dispatch safety check, not a turn-admission check. A turn
     // may legitimately finalize several assistant items, but none may route
@@ -3156,7 +3302,9 @@ export function createChannelAgentBinder(
     // Mechanics are explicit (epic #1308 rule): the steering intent comes from
     // the operator's choice on the post route, never inferred from the text.
     const steering = options?.steering;
-    consecutiveAgentTurns.delete(message.channelId);
+    consecutiveAgentTurns.delete(
+      conversationScopeKey(message.channelId, message.threadId)
+    );
     if (profiles.length === 0) {
       // A durable/pinned mention may no longer resolve after a profile deletion.
       // It is still explicit operator intent, so never fall through to a DM or
@@ -3210,7 +3358,9 @@ export function createChannelAgentBinder(
       profiles = [implicit.profile];
     }
     for (const profile of profiles) {
-      const binding = live.get(bindingKey(message.channelId, profile.id));
+      const binding = live.get(
+        bindingKey(message.channelId, profile.id, message.threadId)
+      );
       if (!binding) continue;
       // Never cancel the turn THIS message triggered. Between the two POSTs the
       // queued message may have drained, so the binding is now running the very
@@ -3446,6 +3596,7 @@ export function createChannelAgentBinder(
     try {
       store.upsertBinding({
         channelId: binding.channelId,
+        threadId: binding.threadId,
         profileActorId: binding.profileActorId,
         agentFramework: binding.framework,
         runtimeId: null,
@@ -3483,7 +3634,8 @@ export function createChannelAgentBinder(
         healthyRuntime(
           binding.runtimeId,
           binding.framework,
-          binding.profileActorId
+          binding.profileActorId,
+          binding.threadId
         )
       ) {
         continue;
@@ -3500,21 +3652,38 @@ export function createChannelAgentBinder(
 
   // ── control verbs ───────────────────────────────────────────────────────────
 
-  async function interrupt(channelId: string, agentId: string): Promise<void> {
-    const binding =
-      live.get(bindingKey(channelId, agentId)) ??
-      live.get(bindingKey(channelId, builtInAgentProfileId(agentId)));
+  function controlBinding(
+    channelId: string,
+    agentId: string,
+    threadId: string | null
+  ): LiveBinding | undefined {
+    return (
+      live.get(bindingKey(channelId, agentId, threadId)) ??
+      live.get(bindingKey(channelId, builtInAgentProfileId(agentId), threadId))
+    );
+  }
+
+  async function interrupt(
+    channelId: string,
+    agentId: string,
+    threadId: string | null = null
+  ): Promise<void> {
+    const binding = controlBinding(channelId, agentId, threadId);
     if (!binding || !binding.adapter) throw new ChannelAgentNotFoundError();
     if (binding.activeTurnId === null)
       throw new ChannelAgentNoActiveTurnError();
     await binding.adapter.interrupt({ turnId: binding.activeTurnId });
   }
 
-  async function release(channelId: string, agentId: string): Promise<void> {
-    const key = bindingKey(channelId, agentId);
+  async function release(
+    channelId: string,
+    agentId: string,
+    threadId: string | null = null
+  ): Promise<void> {
+    const key = bindingKey(channelId, agentId, threadId);
     const binding =
       live.get(key) ??
-      live.get(bindingKey(channelId, builtInAgentProfileId(agentId)));
+      live.get(bindingKey(channelId, builtInAgentProfileId(agentId), threadId));
     if (!binding || !binding.runtimeId) throw new ChannelAgentNotFoundError();
     if (binding.waitingOn !== null) {
       throw new ChannelAgentReleaseRefusedError(
@@ -3536,7 +3705,9 @@ export function createChannelAgentBinder(
       binding.status !== 'idle' ||
       binding.activeTurnId !== null ||
       binding.steeringInFlight ||
-      inflight.has(bindingKey(channelId, binding.profileActorId))
+      inflight.has(
+        bindingKey(channelId, binding.profileActorId, binding.threadId)
+      )
     ) {
       throw new ChannelAgentReleaseRefusedError(
         channelId,
@@ -3631,7 +3802,7 @@ export function createChannelAgentBinder(
     // Without the marker two retries in that window — two devices, or two failed
     // rows for the same profile — would both read an idle (or, on a cold
     // binding, absent) binding and both enqueue.
-    const key = bindingKey(channelId, profile.id);
+    const key = bindingKey(channelId, profile.id, trigger.threadId);
     const binding = live.get(key);
     if (
       binding &&
@@ -3689,11 +3860,10 @@ export function createChannelAgentBinder(
     channelId: string,
     agentId: string,
     requestId: string,
-    decision: AgentApprovalDecisionV2
+    decision: AgentApprovalDecisionV2,
+    threadId: string | null = null
   ): Promise<void> {
-    const binding =
-      live.get(bindingKey(channelId, agentId)) ??
-      live.get(bindingKey(channelId, builtInAgentProfileId(agentId)));
+    const binding = controlBinding(channelId, agentId, threadId);
     if (!binding || !binding.adapter) throw new ChannelAgentNotFoundError();
     await binding.adapter.respondToApproval({ requestId, decision });
   }
@@ -3773,7 +3943,8 @@ export function createChannelAgentBinder(
     profileActorId: string,
     command: string,
     args?: string,
-    confirmed?: boolean
+    confirmed?: boolean,
+    threadId: string | null = null
   ): Promise<{ config?: Record<string, unknown> }> {
     // Actor id is the sole authority boundary. Never resolve a display name here.
     const targets = await getTargets();
@@ -3802,7 +3973,7 @@ export function createChannelAgentBinder(
     if (!target?.available) {
       throw new ChannelAgentCommandError('agent is unavailable', 'UNAVAILABLE');
     }
-    let binding = live.get(bindingKey(channelId, profileActorId));
+    let binding = live.get(bindingKey(channelId, profileActorId, threadId));
     let preview =
       binding?.adapter?.getSlashCommands?.() ??
       relayControlCatalogForProvider(profile.providerId).filter(
@@ -3816,7 +3987,12 @@ export function createChannelAgentBinder(
     // require live discovery intentionally publish no static entry, so the
     // same path binds and reselects only after their catalog is authoritative.
     if (!selected && !binding) {
-      binding = await ensureProfileBinding(channelId, profile);
+      binding = await ensureProfileBinding(
+        channelId,
+        profile,
+        undefined,
+        threadId
+      );
       preview = binding.adapter?.getSlashCommands?.() ?? [];
       selected = preview.find(
         (entry) => entry.name === name || (entry.aliases ?? []).includes(name)
@@ -3840,7 +4016,12 @@ export function createChannelAgentBinder(
         'CONFIRMATION_REQUIRED'
       );
     }
-    binding ??= await ensureProfileBinding(channelId, profile);
+    binding ??= await ensureProfileBinding(
+      channelId,
+      profile,
+      undefined,
+      threadId
+    );
     if (!binding.adapter?.executeControlCommand) {
       throw new ChannelAgentCommandError(
         'provider command controls are unavailable',
@@ -3862,6 +4043,124 @@ export function createChannelAgentBinder(
       }
       throw error;
     }
+  }
+
+  function restartScope(
+    channelId: string,
+    threadId: string | null = null
+  ): Promise<{ restarted: number }> {
+    const scopeKey = conversationScopeKey(channelId, threadId);
+    const existing = restartInFlight.get(scopeKey);
+    if (existing) return existing;
+    const operation = restartScopeImpl(channelId, threadId);
+    restartInFlight.set(scopeKey, operation);
+    return operation.finally(() => {
+      if (restartInFlight.get(scopeKey) === operation) {
+        restartInFlight.delete(scopeKey);
+      }
+    });
+  }
+
+  async function restartScopeImpl(
+    channelId: string,
+    threadId: string | null
+  ): Promise<{ restarted: number }> {
+    const scoped = [...live.values()].filter(
+      (binding) =>
+        binding.channelId === channelId && binding.threadId === threadId
+    );
+    if (scoped.length === 0) return { restarted: 0 };
+
+    // Fail before changing anything: an instruction apply is explicit, but it
+    // must never discard a provider turn, queued operator intent, or approval.
+    for (const binding of scoped) {
+      if (binding.waitingOn !== null) {
+        throw new ChannelAgentRestartRefusedError(
+          channelId,
+          threadId,
+          binding.profileActorId,
+          binding.status,
+          'CHANNEL_AGENT_WAITING_ON_OPERATOR'
+        );
+      }
+      if (binding.queue.length > 0 || binding.steeringQueue.length > 0) {
+        throw new ChannelAgentRestartRefusedError(
+          channelId,
+          threadId,
+          binding.profileActorId,
+          binding.status,
+          'CHANNEL_AGENT_QUEUE_NOT_EMPTY'
+        );
+      }
+      if (
+        binding.status !== 'idle' ||
+        binding.activeTurnId !== null ||
+        binding.steeringInFlight ||
+        inflight.has(
+          bindingKey(channelId, binding.profileActorId, binding.threadId)
+        )
+      ) {
+        throw new ChannelAgentRestartRefusedError(
+          channelId,
+          threadId,
+          binding.profileActorId,
+          binding.status,
+          'CHANNEL_AGENT_NOT_IDLE'
+        );
+      }
+    }
+
+    const storedProfiles = deps.agentProfileStore?.list() ?? [];
+    const planned = scoped.map((binding) => {
+      const profile =
+        storedProfiles.find(
+          (candidate) => candidate.id === binding.profileActorId
+        ) ??
+        (binding.profileActorId === builtInAgentProfileId(binding.framework)
+          ? defaultProfileForProvider(binding.framework)
+          : null);
+      if (!profile) {
+        throw new ChannelBindingError(
+          `agent profile ${binding.profileActorId} no longer exists`,
+          `@${binding.displayName} cannot restart because its profile was removed.`
+        );
+      }
+      return {
+        binding,
+        profile,
+        role:
+          store.getBinding(channelId, binding.profileActorId, threadId)?.role ??
+          undefined,
+      };
+    });
+
+    for (const { binding, profile, role } of planned) {
+      const key = bindingKey(channelId, binding.profileActorId, threadId);
+      const runtimeId = binding.runtimeId;
+      if (!runtimeId) continue;
+      // Restart is a new provider conversation. Retaining a prior provider
+      // session could silently preserve the old provider-side instructions.
+      store.upsertBinding({
+        channelId,
+        threadId,
+        profileActorId: binding.profileActorId,
+        agentFramework: binding.framework,
+        runtimeId,
+        providerSession: {},
+      });
+      await deps.runtimes.destroy(runtimeId);
+      // Production runtime teardown broadcasts this synchronously, but own the
+      // state transition here too so a conservative runtime manager cannot make
+      // a restart accidentally reuse the just-destroyed adapter.
+      if (live.get(key) === binding) releaseBinding(key, binding);
+      await ensureProfileBinding(
+        channelId,
+        profile,
+        role === 'orchestrator' ? 'orchestrator' : undefined,
+        threadId
+      );
+    }
+    return { restarted: planned.length };
   }
 
   function isControlMessage(text: string, channelId?: string): boolean {
@@ -3976,6 +4275,7 @@ export function createChannelAgentBinder(
     rosterForChannel,
     archiveActivityForChannel,
     executeCommand,
+    restartScope,
     isControlMessage,
     recoverCompletionCallbacks,
     setStatusBroadcaster(broadcaster) {
@@ -4014,6 +4314,7 @@ export function createChannelAgentBinder(
       }
       live.clear();
       inflight.clear();
+      restartInFlight.clear();
       orchestratorInflight.clear();
       retryInFlight.clear();
       routingInFlightByChannel.clear();

--- a/server/channel-agent-runtime.ts
+++ b/server/channel-agent-runtime.ts
@@ -38,6 +38,8 @@ export interface CreateChannelAgentRuntimeParams {
   id?: string;
   /** Durable channel binding; required for an orchestrator actor lease. */
   channelId?: string;
+  /** Conversation scope for a channel runtime; null is the root channel. */
+  threadId?: string | null;
   providerId: string;
   profileActorId: string;
   role?: AgentRole;
@@ -66,6 +68,7 @@ export interface CreateChannelAgentRuntimeParams {
  */
 export interface ChannelAgentRuntime {
   id: string;
+  threadId?: string | null;
   providerId: string;
   profileActorId: string;
   role?: AgentRole;
@@ -421,6 +424,7 @@ export class ChannelAgentRuntimeManager {
     const now = new Date().toISOString();
     const runtime: ChannelAgentRuntime = {
       id,
+      threadId: params.threadId ?? null,
       providerId: params.providerId,
       profileActorId: params.profileActorId,
       ...(params.role ? { role: params.role } : {}),
@@ -510,11 +514,13 @@ export class ChannelAgentRuntimeManager {
         ? { resumeSessionId: savedResumeId }
         : {}),
       systemPromptAppendix: [
+        // Channel/profile material is provider-neutral but never gets to
+        // redefine Relay's runtime boundary: the Relay appendix comes last.
+        params.systemPrompt,
         collaborationPromptAppendix({
           provider: params.providerId,
           ...(params.role ? { role: params.role } : {}),
         }),
-        params.systemPrompt,
       ]
         .filter((part): part is string => Boolean(part?.trim()))
         .join('\n\n'),

--- a/server/channel-chat-router.ts
+++ b/server/channel-chat-router.ts
@@ -29,6 +29,7 @@ import {
 } from './channel-attachments.js';
 import {
   ChannelAgentBusyError,
+  ChannelAgentRestartRefusedError,
   ChannelAgentReleaseRefusedError,
   ChannelAgentNoActiveTurnError,
   ChannelAgentCommandError,
@@ -204,6 +205,46 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function bodyRecord(req: Request): Record<string, unknown> {
   return isRecord(req.body) ? req.body : {};
+}
+
+/** A control must name its thread explicitly; malformed scope never falls back to root. */
+function controlThreadScope(
+  res: Response,
+  body: Record<string, unknown>
+): string | null | undefined {
+  const raw = body['threadId'];
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  sendGatewayError(
+    res,
+    'INVALID_ARGUMENT',
+    'threadId must be a non-empty string when provided',
+    false,
+    { field: 'threadId' }
+  );
+  return undefined;
+}
+
+/**
+ * Thread-scoped actions may only address a durable thread root in this channel.
+ * In particular, commands must not turn an arbitrary client string into a new
+ * hidden runtime scope.
+ */
+function requireKnownThreadScope(
+  store: ChannelMessageStore,
+  res: Response,
+  channelId: string,
+  threadId: string | null
+): boolean {
+  if (threadId === null || store.getThreadTitle(channelId, threadId) !== null) {
+    return true;
+  }
+  sendGatewayError(res, 'NOT_FOUND', 'thread not found', false, {
+    channelId,
+    threadId,
+    reasonCode: 'CHANNEL_THREAD_NOT_FOUND',
+  });
+  return false;
 }
 
 /**
@@ -558,6 +599,8 @@ function createAgentCommandsHandler(
       });
       return;
     }
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
     const binder = binderOr503(res, deps.binder);
     if (!binder) return;
     const body = req.body as Record<string, unknown>;
@@ -566,6 +609,9 @@ function createAgentCommandsHandler(
     const command = typeof body['command'] === 'string' ? body['command'] : '';
     const args = typeof body['args'] === 'string' ? body['args'] : undefined;
     const confirmed = body['confirmed'] === true;
+    const threadId = controlThreadScope(res, body);
+    if (threadId === undefined) return;
+    if (!requireKnownThreadScope(store, res, topic.id, threadId)) return;
     if (!profileId || !command) {
       sendGatewayError(
         res,
@@ -576,7 +622,7 @@ function createAgentCommandsHandler(
       return;
     }
     binder
-      .executeCommand(topic.id, profileId, command, args, confirmed)
+      .executeCommand(topic.id, profileId, command, args, confirmed, threadId)
       .then((result) => res.json({ ok: true, ...result }))
       .catch((error) => {
         if (error instanceof ChannelAgentCommandError) {
@@ -1418,6 +1464,10 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
           deps.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES
         );
         res.json({
+          thread: {
+            rootMessageId,
+            title: store.getThreadTitle(id, rootMessageId),
+          },
           messages: budgeted.rows,
           ...(budgeted.hasMore
             ? { hasMore: true, nextCursor: budgeted.nextCursor }
@@ -1428,6 +1478,77 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       }
     }
   );
+
+  // A conversation is cheap until a profile is actually summoned. The durable
+  // system root gives the existing thread/message model a stable id without
+  // fabricating a human prompt or allocating an agent runtime.
+  router.post('/channels/:id/threads', postAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const title = bodyRecord(req)['title'];
+    if (typeof title !== 'string') {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'title is required', false, {
+        field: 'title',
+      });
+      return;
+    }
+    try {
+      const thread = store.createThread({ channelId: topic.id, title });
+      const root = store.getMessage(thread.rootMessageId);
+      if (root) deps.hub?.broadcastCreated(root);
+      res.status(201).json({ thread });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
+
+  router.patch('/channels/:id/threads/:rootMessageId', postAuth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const title = bodyRecord(req)['title'];
+    if (typeof title !== 'string') {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'title is required', false, {
+        field: 'title',
+      });
+      return;
+    }
+    try {
+      const thread = store.renameThread({
+        channelId: topic.id,
+        rootMessageId: req.params['rootMessageId'] ?? '',
+        title,
+      });
+      if (!thread) {
+        sendGatewayError(res, 'NOT_FOUND', 'thread root not found', false, {
+          reasonCode: 'THREAD_ROOT_NOT_FOUND',
+        });
+        return;
+      }
+      res.json({ thread });
+    } catch (error) {
+      mapStoreError(res, error);
+    }
+  });
 
   // The existing post parser sits at the configured threshold; this security
   // denial is deliberately kept adjacent to attachment canonicalization.
@@ -1839,6 +1960,46 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
     createAgentCommandsHandler(deps, requirePersistedChannel)
   );
 
+  // Apply a saved topic prompt by restarting idle bindings in one conversation
+  // scope. It is deliberately separate from the topic PATCH: saving defaults
+  // never mutates a live provider turn behind the operator's back.
+  router.post('/channels/:id/agent-runtimes/restart', auth, (req, res) => {
+    if (denyScopedActorPrivateRoute(req, res)) return;
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const topic = requirePersistedChannel(req, res);
+    if (!topic) return;
+    if (topic.status === 'archived') {
+      sendGatewayError(res, 'SESSION_CONFLICT', 'channel is archived', false, {
+        channelId: topic.id,
+        reasonCode: 'CHANNEL_ARCHIVED',
+      });
+      return;
+    }
+    const store = storeOr503(res, deps.store);
+    if (!store) return;
+    const binder = binderOr503(res, deps.binder);
+    if (!binder) return;
+    const threadId = controlThreadScope(res, bodyRecord(req));
+    if (threadId === undefined) return;
+    if (!requireKnownThreadScope(store, res, topic.id, threadId)) return;
+    binder
+      .restartScope(topic.id, threadId)
+      .then((result) => res.json({ ok: true, ...result }))
+      .catch((error) => {
+        if (error instanceof ChannelAgentRestartRefusedError) {
+          sendGatewayError(res, 'SESSION_CONFLICT', error.message, true, {
+            channelId: topic.id,
+            threadId: error.threadId,
+            profileActorId: error.profileActorId,
+            status: error.status,
+            reasonCode: error.reasonCode,
+          });
+          return;
+        }
+        mapStoreError(res, error);
+      });
+  });
+
   // #1259 slice 4: operator designates (spawns / resumes) the persistent
   // orchestrator for a product channel. Operator lane ONLY — scoped actors are
   // forbidden from creating orchestrator runtimes directly; the durable
@@ -1905,8 +2066,10 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       const binder = binderOr503(res, deps.binder);
       if (!binder) return;
       const agentId = req.params['agentId'] ?? '';
+      const threadId = controlThreadScope(res, bodyRecord(req));
+      if (threadId === undefined) return;
       binder
-        .interrupt(topic.id, agentId)
+        .interrupt(topic.id, agentId, threadId)
         .then(() => res.json({ ok: true }))
         .catch((error) => {
           if (error instanceof ChannelAgentNotFoundError) {
@@ -1953,8 +2116,10 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       const binder = binderOr503(res, deps.binder);
       if (!binder) return;
       const agentId = req.params['agentId'] ?? '';
+      const threadId = controlThreadScope(res, bodyRecord(req));
+      if (threadId === undefined) return;
       binder
-        .release(topic.id, agentId)
+        .release(topic.id, agentId, threadId)
         .then(() => res.json({ ok: true }))
         .catch((error) => {
           if (error instanceof ChannelAgentNotFoundError) {
@@ -2068,6 +2233,8 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
       if (!binder) return;
       const agentId = req.params['agentId'] ?? '';
       const body = bodyRecord(req);
+      const threadId = controlThreadScope(res, body);
+      if (threadId === undefined) return;
       const requestId = body['requestId'];
       if (typeof requestId !== 'string' || requestId.length === 0) {
         sendGatewayError(
@@ -2102,7 +2269,8 @@ export function createChannelChatRouter(deps: ChannelChatRouterDeps): Router {
           topic.id,
           agentId,
           requestId,
-          decision as unknown as AgentApprovalDecisionV2
+          decision as unknown as AgentApprovalDecisionV2,
+          threadId
         )
         .then(() => res.json({ ok: true }))
         .catch((error) => {

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -61,7 +61,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 12;
+const SCHEMA_VERSION = 13;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -82,6 +82,8 @@ const CHANNEL_SUMMARY_MENTION_SCAN_MAX_CHARS = 8_000;
  */
 export const CHANNEL_THREAD_SUMMARY_LIMIT = 3;
 const CHANNEL_THREAD_SUMMARY_MAX_LIMIT = 20;
+export const CHANNEL_THREAD_TITLE_MAX_CHARS = 160;
+const DEFAULT_THREAD_TITLE = 'untitled conversation';
 
 export type ChannelThreadHistoryQueryMode = 'default' | 'after' | 'before';
 
@@ -290,30 +292,28 @@ export function buildChannelMentionContextRowsSql(
  * primary-key probe of `root` shape the query-plan test locks in.
  */
 export function buildChannelThreadSummarySql(): string {
-  return `SELECT root.id             AS root_id,
-                root.body_text      AS root_body,
-                root.sender_id      AS root_sender_id,
-                root.sender_kind    AS root_sender_kind,
-                root.sender_display AS root_sender_display,
-                root.meta_json      AS root_meta_json,
-                agg.reply_count     AS reply_count,
-                agg.last_reply_at   AS last_reply_at,
-                COUNT(*) OVER ()    AS thread_total
-           FROM (
-             SELECT thread_id,
-                    COUNT(*)        AS reply_count,
-                    MAX(created_at) AS last_reply_at,
-                    MAX(seq)        AS last_reply_seq
-               FROM channel_messages
-              WHERE channel_id = @channelId
-                AND thread_id IS NOT NULL
-                AND json_extract(meta_json, '$.agentDetail') IS NULL
-              GROUP BY thread_id
-           ) agg
-           CROSS JOIN channel_messages root
-             ON root.id = agg.thread_id AND root.channel_id = @channelId
-          ORDER BY agg.last_reply_seq DESC
-          LIMIT @limit`;
+  return `SELECT root.id                         AS root_id,
+                  root.body_text                  AS root_body,
+                  thread.title                    AS thread_title,
+                  root.sender_id                  AS root_sender_id,
+                  root.sender_kind                AS root_sender_kind,
+                  root.sender_display             AS root_sender_display,
+                  root.meta_json                  AS root_meta_json,
+                  (SELECT COUNT(*)
+                     FROM channel_messages reply INDEXED BY idx_chm_thread
+                    WHERE reply.thread_id = thread.root_message_id
+                      AND reply.channel_id = thread.channel_id
+                      AND json_extract(reply.meta_json, '$.agentDetail') IS NULL)
+                                                   AS reply_count,
+                  thread.updated_at               AS last_reply_at,
+                  COUNT(*) OVER ()                AS thread_total
+             FROM channel_threads thread
+             CROSS JOIN channel_messages root
+               ON root.id = thread.root_message_id
+              AND root.channel_id = thread.channel_id
+            WHERE thread.channel_id = @channelId
+            ORDER BY thread.updated_at DESC, root.seq DESC
+            LIMIT @limit`;
 }
 
 // ── full-text search index (#1308 slice 2 item 1) ───────────────────────────
@@ -766,6 +766,9 @@ CREATE TABLE IF NOT EXISTS channel_members (
 
 CREATE TABLE IF NOT EXISTS channel_agent_bindings (
   channel_id            TEXT NOT NULL,
+  -- Empty is the explicit root-channel scope. SQLite composite primary keys do
+  -- not give NULL the conflict semantics this binding identity needs.
+  thread_scope_id       TEXT NOT NULL DEFAULT '',
   profile_actor_id      TEXT NOT NULL,
   agent_framework       TEXT NOT NULL,
   runtime_id            TEXT,
@@ -773,11 +776,22 @@ CREATE TABLE IF NOT EXISTS channel_agent_bindings (
   provider_session_json TEXT NOT NULL DEFAULT '{}',
   created_at            TEXT NOT NULL,
   updated_at            TEXT NOT NULL,
-  PRIMARY KEY (channel_id, profile_actor_id)
+  PRIMARY KEY (channel_id, thread_scope_id, profile_actor_id)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chab_sole_orchestrator
   ON channel_agent_bindings(channel_id)
-  WHERE binding_role = 'orchestrator';
+  WHERE binding_role = 'orchestrator' AND thread_scope_id = '';
+
+CREATE TABLE IF NOT EXISTS channel_threads (
+  channel_id      TEXT NOT NULL,
+  root_message_id TEXT NOT NULL,
+  title           TEXT NOT NULL,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  PRIMARY KEY (channel_id, root_message_id)
+);
+CREATE INDEX IF NOT EXISTS idx_channel_threads_recent
+  ON channel_threads(channel_id, updated_at DESC);
 
 CREATE TABLE IF NOT EXISTS channel_completion_callbacks (
   id                    TEXT PRIMARY KEY,
@@ -862,6 +876,7 @@ interface ChannelSearchRow {
 interface ThreadSummaryRow {
   root_id: string;
   root_body: string;
+  thread_title: string;
   root_sender_id: string;
   root_sender_kind: string;
   root_sender_display: string | null;
@@ -896,6 +911,7 @@ function readStateRowToState(row: ChannelReadStateRow): ChannelReadState {
 
 interface BindingRow {
   channel_id: string;
+  thread_scope_id: string;
   profile_actor_id: string;
   agent_framework: string;
   runtime_id: string | null;
@@ -1056,6 +1072,8 @@ type ChannelSenderKindLoose = ChannelSenderRef['kind'];
  */
 export interface ChannelThreadSummary {
   rootMessageId: ChannelMessageId;
+  /** Durable user title; old rows deterministically inherit their root prose. */
+  title: string;
   /**
    * Conversational replies only — the same exclusion `replyCountSql` applies, so
    * a rail row and the in-timeline "N replies" chip can never disagree.
@@ -1136,6 +1154,8 @@ export interface ChannelMessageSearchQuery {
 
 export interface ChannelBinding {
   channelId: string;
+  /** Null is the legacy/root-channel execution scope. */
+  threadId: string | null;
   /** Durable AgentProfile actor identity; binding/session ownership key. */
   profileActorId: string;
   /** Provider/framework spawn selector retained independently of the profile. */
@@ -1237,6 +1257,8 @@ export interface CompleteChildContinuationInput {
 
 export interface SoleOrchestratorDesignationInput {
   channelId: string;
+  /** Root/channel scope is null; retained here for the common binding writer. */
+  threadId?: string | null;
   profileActorId: string;
   agentFramework: string;
   runtimeId?: string | null;
@@ -1446,6 +1468,18 @@ export interface ChannelMessageStore {
     channelId: string,
     limit?: number
   ): ChannelThreadSummaryPage;
+  /** Creates an empty, named conversation without allocating an agent runtime. */
+  createThread(input: {
+    channelId: string;
+    title: string;
+  }): ChannelThreadSummary;
+  /** Renames a durable thread root. Existing unnamed roots are lazily claimed. */
+  renameThread(input: {
+    channelId: string;
+    rootMessageId: string;
+    title: string;
+  }): ChannelThreadSummary | null;
+  getThreadTitle(channelId: string, rootMessageId: string): string | null;
   upsertMember(input: {
     channelId: string;
     kind: 'human' | 'agent';
@@ -1454,7 +1488,11 @@ export interface ChannelMessageStore {
   }): ChannelMemberRef;
   listMembers(channelId: string): ChannelMemberRef[];
   findDmChannel(memberIdA: string, memberIdB: string): string | null;
-  getBinding(channelId: string, profileActorId: string): ChannelBinding | null;
+  getBinding(
+    channelId: string,
+    profileActorId: string,
+    threadId?: string | null
+  ): ChannelBinding | null;
   /** Returns the one durable designation guaranteed by the partial unique index. */
   getSoleOrchestratorBinding(channelId: string): ChannelBinding | null;
   /**
@@ -1466,6 +1504,7 @@ export interface ChannelMessageStore {
   ): ChannelBinding;
   upsertBinding(input: {
     channelId: string;
+    threadId?: string | null;
     profileActorId: string;
     agentFramework: string;
     runtimeId?: string | null;
@@ -2820,6 +2859,67 @@ function runSchemaMigrations(db: Database.Database): void {
       db.prepare('UPDATE schema_version SET version = 12').run();
     })();
   }
+  if (current < 13) {
+    db.transaction(() => {
+      // A root-channel binding was the whole pre-#1386 contract. Preserve every
+      // one under the explicit empty scope before making thread identity part of
+      // the primary key; NULL would not make ON CONFLICT deterministic in SQLite.
+      db.exec(`
+        DROP INDEX IF EXISTS idx_chab_sole_orchestrator;
+        CREATE TABLE channel_agent_bindings_v13 (
+          channel_id            TEXT NOT NULL,
+          thread_scope_id       TEXT NOT NULL DEFAULT '',
+          profile_actor_id      TEXT NOT NULL,
+          agent_framework       TEXT NOT NULL,
+          runtime_id            TEXT,
+          binding_role          TEXT,
+          provider_session_json TEXT NOT NULL DEFAULT '{}',
+          created_at            TEXT NOT NULL,
+          updated_at            TEXT NOT NULL,
+          PRIMARY KEY (channel_id, thread_scope_id, profile_actor_id)
+        );
+        INSERT INTO channel_agent_bindings_v13
+          (channel_id, thread_scope_id, profile_actor_id, agent_framework,
+           runtime_id, binding_role, provider_session_json, created_at, updated_at)
+        SELECT channel_id, '', profile_actor_id, agent_framework,
+               runtime_id, binding_role, provider_session_json, created_at, updated_at
+          FROM channel_agent_bindings;
+        DROP TABLE channel_agent_bindings;
+        ALTER TABLE channel_agent_bindings_v13 RENAME TO channel_agent_bindings;
+        CREATE UNIQUE INDEX idx_chab_sole_orchestrator
+          ON channel_agent_bindings(channel_id)
+          WHERE binding_role = 'orchestrator' AND thread_scope_id = '';
+
+        CREATE TABLE IF NOT EXISTS channel_threads (
+          channel_id      TEXT NOT NULL,
+          root_message_id TEXT NOT NULL,
+          title           TEXT NOT NULL,
+          created_at      TEXT NOT NULL,
+          updated_at      TEXT NOT NULL,
+          PRIMARY KEY (channel_id, root_message_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_channel_threads_recent
+          ON channel_threads(channel_id, updated_at DESC);
+
+        INSERT OR IGNORE INTO channel_threads
+          (channel_id, root_message_id, title, created_at, updated_at)
+        SELECT root.channel_id,
+               root.id,
+               COALESCE(NULLIF(TRIM(SUBSTR(root.body_text, 1, 160)), ''),
+                        '${DEFAULT_THREAD_TITLE}'),
+               root.created_at,
+               root.updated_at
+          FROM channel_messages root
+         WHERE root.thread_id IS NULL
+           AND EXISTS (
+             SELECT 1 FROM channel_messages reply
+              WHERE reply.channel_id = root.channel_id
+                AND reply.thread_id = root.id
+           );
+      `);
+      db.prepare('UPDATE schema_version SET version = 13').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
@@ -3160,6 +3260,67 @@ export function createChannelMessageStore(
   );
   // Compiled once: `GET /channels` runs this per channel per list fetch.
   const threadSummaryStmt = db.prepare(buildChannelThreadSummarySql());
+  const threadSummaryByRootStmt = db.prepare(
+    `SELECT root.id                         AS root_id,
+            root.body_text                  AS root_body,
+            thread.title                    AS thread_title,
+            root.sender_id                  AS root_sender_id,
+            root.sender_kind                AS root_sender_kind,
+            root.sender_display             AS root_sender_display,
+            root.meta_json                  AS root_meta_json,
+            (SELECT COUNT(*)
+               FROM channel_messages reply INDEXED BY idx_chm_thread
+              WHERE reply.thread_id = thread.root_message_id
+                AND reply.channel_id = thread.channel_id
+                AND json_extract(reply.meta_json, '$.agentDetail') IS NULL)
+                                             AS reply_count,
+            thread.updated_at               AS last_reply_at,
+            1                               AS thread_total
+       FROM channel_threads thread
+       JOIN channel_messages root
+         ON root.id = thread.root_message_id
+        AND root.channel_id = thread.channel_id
+      WHERE thread.channel_id = ? AND thread.root_message_id = ?`
+  );
+
+  function threadSummaryFromRow(row: ThreadSummaryRow): ChannelThreadSummary {
+    const meta = parseMeta(row.root_meta_json);
+    const providerId =
+      typeof meta?.['providerId'] === 'string'
+        ? (meta['providerId'] as string)
+        : undefined;
+    return {
+      rootMessageId: row.root_id as ChannelMessageId,
+      title: row.thread_title,
+      replyCount: row.reply_count,
+      lastReplyAt: row.last_reply_at,
+      preview: row.root_body.slice(0, CHANNEL_SUMMARY_PREVIEW_MAX_CHARS),
+      rootSenderId: row.root_sender_id,
+      rootSenderKind: row.root_sender_kind as ChannelSenderKindLoose,
+      ...(row.root_sender_display
+        ? { rootSenderDisplayName: row.root_sender_display }
+        : {}),
+      ...(providerId ? { providerId } : {}),
+    };
+  }
+
+  function listChannelThreadSummariesImpl(
+    channelId: string,
+    limit = CHANNEL_THREAD_SUMMARY_LIMIT
+  ): ChannelThreadSummaryPage {
+    const capped = Math.max(
+      1,
+      Math.min(CHANNEL_THREAD_SUMMARY_MAX_LIMIT, Math.floor(limit))
+    );
+    const rows = threadSummaryStmt.all({
+      channelId,
+      limit: capped,
+    }) as ThreadSummaryRow[];
+    return {
+      threads: rows.map(threadSummaryFromRow),
+      threadCount: rows[0]?.thread_total ?? 0,
+    };
+  }
   const selectCompletionCallbackById = db.prepare(
     'SELECT * FROM channel_completion_callbacks WHERE id = ?'
   );
@@ -3188,6 +3349,81 @@ export function createChannelMessageStore(
   function getMessageById(id: string): ChannelMessage | null {
     const row = selectById.get(id) as ChannelMessageRow | undefined;
     return row ? rowToMessage(row) : null;
+  }
+
+  function threadTitleFromRoot(root: ChannelMessageRow): string {
+    const compact = root.body_text.replace(/\s+/g, ' ').trim();
+    return (
+      compact.slice(0, CHANNEL_THREAD_TITLE_MAX_CHARS) || DEFAULT_THREAD_TITLE
+    );
+  }
+
+  function normalizeThreadTitle(title: string): string {
+    const compact = title.replace(/\s+/g, ' ').trim();
+    if (!compact) {
+      throw new ChannelMessageStoreError(
+        400,
+        'channel_thread_title_empty',
+        'thread title must not be empty'
+      );
+    }
+    if (compact.length > CHANNEL_THREAD_TITLE_MAX_CHARS) {
+      throw new ChannelMessageStoreError(
+        400,
+        'channel_thread_title_too_long',
+        `thread title must not exceed ${CHANNEL_THREAD_TITLE_MAX_CHARS} characters`,
+        { max: CHANNEL_THREAD_TITLE_MAX_CHARS }
+      );
+    }
+    return compact;
+  }
+
+  /** Claim a legacy root exactly once when it first becomes a real thread. */
+  function ensureThreadRecord(channelId: string, rootMessageId: string): void {
+    const root = selectById.get(rootMessageId) as ChannelMessageRow | undefined;
+    if (!root || root.channel_id !== channelId || root.thread_id !== null) {
+      throw new ChannelMessageStoreError(
+        404,
+        'thread_root_not_found',
+        'thread root not found',
+        { channelId, rootMessageId }
+      );
+    }
+    db.prepare(
+      `INSERT INTO channel_threads
+         (channel_id, root_message_id, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(channel_id, root_message_id) DO NOTHING`
+    ).run(
+      channelId,
+      rootMessageId,
+      threadTitleFromRoot(root),
+      root.created_at,
+      root.updated_at
+    );
+  }
+
+  function touchThreadRecord(
+    channelId: string,
+    rootMessageId: string,
+    updatedAt: string
+  ): void {
+    ensureThreadRecord(channelId, rootMessageId);
+    db.prepare(
+      `UPDATE channel_threads
+          SET updated_at = CASE WHEN updated_at < ? THEN ? ELSE updated_at END
+        WHERE channel_id = ? AND root_message_id = ?`
+    ).run(updatedAt, updatedAt, channelId, rootMessageId);
+  }
+
+  function threadSummaryForRoot(
+    channelId: string,
+    rootMessageId: string
+  ): ChannelThreadSummary | null {
+    const row = threadSummaryByRootStmt.get(channelId, rootMessageId) as
+      | ThreadSummaryRow
+      | undefined;
+    return row ? threadSummaryFromRow(row) : null;
   }
 
   function appendCompleteImpl(input: AppendCompleteInput): ChannelMessage {
@@ -3233,17 +3469,22 @@ export function createChannelMessageStore(
       updatedAt: now,
       completedAt: now,
     });
+    if (threadId !== null) touchThreadRecord(input.channelId, threadId, now);
     return rowToMessage(row);
   }
 
   function getBindingImpl(
     channelId: string,
-    profileActorId: string
+    profileActorId: string,
+    threadId: string | null = null
   ): ChannelBinding | null {
     const select = db.prepare(
-      'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND profile_actor_id = ?'
+      `SELECT * FROM channel_agent_bindings
+        WHERE channel_id = ? AND thread_scope_id = ? AND profile_actor_id = ?`
     );
-    const row = select.get(channelId, profileActorId) as BindingRow | undefined;
+    const row = select.get(channelId, threadId ?? '', profileActorId) as
+      | BindingRow
+      | undefined;
     return row ? bindingRowToRecord(row) : null;
   }
 
@@ -3253,7 +3494,9 @@ export function createChannelMessageStore(
     const row = db
       .prepare(
         `SELECT * FROM channel_agent_bindings
-          WHERE channel_id = ? AND binding_role = 'orchestrator'`
+          WHERE channel_id = ?
+            AND thread_scope_id = ''
+            AND binding_role = 'orchestrator'`
       )
       .get(channelId) as BindingRow | undefined;
     return row ? bindingRowToRecord(row) : null;
@@ -3265,9 +3508,12 @@ export function createChannelMessageStore(
     const now = nowIso();
     const existing = db
       .prepare(
-        'SELECT * FROM channel_agent_bindings WHERE channel_id = ? AND profile_actor_id = ?'
+        `SELECT * FROM channel_agent_bindings
+          WHERE channel_id = ? AND thread_scope_id = ? AND profile_actor_id = ?`
       )
-      .get(input.channelId, input.profileActorId) as BindingRow | undefined;
+      .get(input.channelId, input.threadId ?? '', input.profileActorId) as
+      | BindingRow
+      | undefined;
     const providerSessionJson = JSON.stringify(
       input.providerSession ??
         (existing
@@ -3276,9 +3522,9 @@ export function createChannelMessageStore(
     );
     db.prepare(
       `INSERT INTO channel_agent_bindings
-         (channel_id, profile_actor_id, agent_framework, runtime_id, binding_role, provider_session_json, created_at, updated_at)
-       VALUES (@channelId, @profileActorId, @agentFramework, @runtimeId, @bindingRole, @providerSessionJson, @createdAt, @updatedAt)
-       ON CONFLICT(channel_id, profile_actor_id) DO UPDATE SET
+         (channel_id, thread_scope_id, profile_actor_id, agent_framework, runtime_id, binding_role, provider_session_json, created_at, updated_at)
+       VALUES (@channelId, @threadScopeId, @profileActorId, @agentFramework, @runtimeId, @bindingRole, @providerSessionJson, @createdAt, @updatedAt)
+       ON CONFLICT(channel_id, thread_scope_id, profile_actor_id) DO UPDATE SET
          agent_framework = excluded.agent_framework,
          runtime_id = excluded.runtime_id,
          binding_role = excluded.binding_role,
@@ -3286,6 +3532,7 @@ export function createChannelMessageStore(
          updated_at = excluded.updated_at`
     ).run({
       channelId: input.channelId,
+      threadScopeId: input.threadId ?? '',
       profileActorId: input.profileActorId,
       agentFramework: input.agentFramework,
       runtimeId:
@@ -3300,7 +3547,11 @@ export function createChannelMessageStore(
       createdAt: existing?.created_at ?? now,
       updatedAt: now,
     });
-    return getBindingImpl(input.channelId, input.profileActorId)!;
+    return getBindingImpl(
+      input.channelId,
+      input.profileActorId,
+      input.threadId ?? null
+    )!;
   }
 
   const createCompletionCallbackImpl = db.transaction(
@@ -3885,6 +4136,7 @@ export function createChannelMessageStore(
         updatedAt: now,
         completedAt: null,
       });
+      if (threadId !== null) touchThreadRecord(input.channelId, threadId, now);
       return rowToMessage(row);
     },
 
@@ -4554,41 +4806,50 @@ export function createChannelMessageStore(
       channelId,
       limit = CHANNEL_THREAD_SUMMARY_LIMIT
     ) {
-      const capped = Math.max(
-        1,
-        Math.min(CHANNEL_THREAD_SUMMARY_MAX_LIMIT, Math.floor(limit))
-      );
-      // Channel-scoped through idx_chm_channel_seq (see the query-plan test), so
-      // this walks the same rows the summary's COUNT(*) already does rather than
-      // the whole thread index.
-      const rows = threadSummaryStmt.all({
-        channelId,
-        limit: capped,
-      }) as ThreadSummaryRow[];
-      return {
-        threads: rows.map((row) => {
-          const meta = parseMeta(row.root_meta_json);
-          const providerId =
-            typeof meta?.['providerId'] === 'string'
-              ? (meta['providerId'] as string)
-              : undefined;
-          return {
-            rootMessageId: row.root_id as ChannelMessageId,
-            replyCount: row.reply_count,
-            lastReplyAt: row.last_reply_at,
-            preview: row.root_body.slice(0, CHANNEL_SUMMARY_PREVIEW_MAX_CHARS),
-            rootSenderId: row.root_sender_id,
-            rootSenderKind: row.root_sender_kind as ChannelSenderKindLoose,
-            ...(row.root_sender_display
-              ? { rootSenderDisplayName: row.root_sender_display }
-              : {}),
-            ...(providerId ? { providerId } : {}),
-          };
-        }),
-        // Every joined row shares the same window total; zero rows means zero
-        // threads with a resolvable root, which is what the page can show.
-        threadCount: rows[0]?.thread_total ?? 0,
-      };
+      return listChannelThreadSummariesImpl(channelId, limit);
+    },
+
+    createThread(input) {
+      const title = normalizeThreadTitle(input.title);
+      const root = appendCompleteImpl({
+        channelId: input.channelId,
+        kind: 'system',
+        sender: { kind: 'system', id: 'system' },
+        text: 'conversation created',
+        meta: { threadRoot: true },
+      });
+      const now = nowIso();
+      db.prepare(
+        `INSERT INTO channel_threads
+           (channel_id, root_message_id, title, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`
+      ).run(input.channelId, root.id, title, now, now);
+      const summary = threadSummaryForRoot(input.channelId, root.id);
+      if (!summary) throw new Error('created thread was not readable');
+      return summary;
+    },
+
+    renameThread(input) {
+      const title = normalizeThreadTitle(input.title);
+      ensureThreadRecord(input.channelId, input.rootMessageId);
+      const changed = db
+        .prepare(
+          `UPDATE channel_threads SET title = ?, updated_at = ?
+            WHERE channel_id = ? AND root_message_id = ?`
+        )
+        .run(title, nowIso(), input.channelId, input.rootMessageId).changes;
+      if (changed === 0) return null;
+      return threadSummaryForRoot(input.channelId, input.rootMessageId);
+    },
+
+    getThreadTitle(channelId, rootMessageId) {
+      const row = db
+        .prepare(
+          `SELECT title FROM channel_threads
+            WHERE channel_id = ? AND root_message_id = ?`
+        )
+        .get(channelId, rootMessageId) as { title: string } | undefined;
+      return row?.title ?? null;
     },
 
     upsertMember(input) {
@@ -4634,8 +4895,8 @@ export function createChannelMessageStore(
       return row?.channel_id ?? null;
     },
 
-    getBinding(channelId, profileActorId) {
-      return getBindingImpl(channelId, profileActorId);
+    getBinding(channelId, profileActorId, threadId = null) {
+      return getBindingImpl(channelId, profileActorId, threadId);
     },
 
     getSoleOrchestratorBinding(channelId) {
@@ -4940,6 +5201,7 @@ function bindingRowToRecord(row: BindingRow): ChannelBinding {
   );
   return {
     channelId: row.channel_id,
+    threadId: row.thread_scope_id || null,
     profileActorId: row.profile_actor_id,
     agentFramework: row.agent_framework,
     runtimeId: row.runtime_id,

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -1310,7 +1310,8 @@ function postAgentTurnRow(
   text: string,
   knownIds: string[],
   runtimeId = 'runtime:orchestrator',
-  sender: ChannelSenderRef = AGENT_SENDER
+  sender: ChannelSenderRef = AGENT_SENDER,
+  parentMessageId?: string
 ): ChannelMessage {
   const mentions = parseMentions(text, knownIds);
   const stream = store.beginStream({
@@ -1318,6 +1319,7 @@ function postAgentTurnRow(
     sender,
     source: { runtimeId, turnId, itemId },
     ...(mentions.length ? { mentions } : {}),
+    ...(parentMessageId ? { parentMessageId } : {}),
   });
   const message = store.finalizeStream(stream.id, {
     text,
@@ -2296,6 +2298,7 @@ function makeSessions(
         id,
         providerId: params.providerId,
         profileActorId: params.profileActorId,
+        threadId: params.threadId ?? null,
         ...(params.role !== undefined ? { role: params.role } : {}),
         status: 'active',
         adapter,
@@ -2529,6 +2532,49 @@ describe('channel-agent-binder — lifecycle', () => {
       liveRoster[0]?.commands?.find((command) => command.name === 'model')?.args
     ).toEqual([{ value: 'gpt-fast', label: 'GPT Fast' }]);
     expect(rows(store)).toHaveLength(0);
+  });
+
+  it('executes a provider command in its exact thread runtime without creating root state', async () => {
+    const commands: string[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: (agentType) => {
+        const adapter = new ScriptedAdapter(agentType, { mode: 'stall' });
+        Object.assign(adapter, {
+          getSlashCommands: () => [
+            { name: 'compact', dispatch: 'relay-control' },
+          ],
+          executeControlCommand: async ({ command }: { command: string }) => {
+            commands.push(command);
+            return {};
+          },
+        });
+        return adapter;
+      },
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'conversation root',
+    });
+    const profileId = builtInAgentProfileId('mock');
+
+    await binder.executeCommand(
+      CH,
+      profileId,
+      'compact',
+      undefined,
+      undefined,
+      root.id
+    );
+
+    expect(commands).toEqual(['compact']);
+    expect(sessions.createParams()).toEqual([
+      expect.objectContaining({ threadId: root.id }),
+    ]);
+    expect(store.getBinding(CH, profileId)).toBeNull();
+    expect(store.getBinding(CH, profileId, root.id)?.runtimeId).toBeTruthy();
   });
 
   it('does not advertise unbound Prime controls and treats a connected empty catalog as authoritative', async () => {
@@ -3263,6 +3309,173 @@ describe('channel-agent-binder — lifecycle', () => {
     expect(reply.parentMessageId).toBeNull();
   });
 
+  it('isolates one profile into concurrent thread runtimes and captures channel instructions at spawn', async () => {
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    topics.create({
+      id: CH,
+      workspaceId: 'ws:test',
+      title: 'threaded work',
+      promptDefaults: {
+        systemPrompt: 'You are working in a shared channel.',
+        instructions: 'Keep each conversation self-contained.',
+      },
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      topicStore: topics,
+    });
+    const first = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'first root',
+    });
+    const second = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'second root',
+    });
+
+    post(store, binder, '@mock first thread', ['mock'], OPERATOR, first.id);
+    post(store, binder, '@mock second thread', ['mock'], OPERATOR, second.id);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+
+    expect(sessions.spawns()).toBe(2);
+    expect(sessions.createParams()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          threadId: first.id,
+          systemPrompt:
+            'You are working in a shared channel.\n\nKeep each conversation self-contained.',
+        }),
+        expect.objectContaining({
+          threadId: second.id,
+          systemPrompt:
+            'You are working in a shared channel.\n\nKeep each conversation self-contained.',
+        }),
+      ])
+    );
+    const profileId = builtInAgentProfileId('mock');
+    const firstBinding = store.getBinding(CH, profileId, first.id);
+    const secondBinding = store.getBinding(CH, profileId, second.id);
+    expect(firstBinding?.runtimeId).toBeTruthy();
+    expect(secondBinding?.runtimeId).toBeTruthy();
+    expect(firstBinding?.runtimeId).not.toBe(secondBinding?.runtimeId);
+    expect(agentReplies(store, 'mock').map((reply) => reply.threadId)).toEqual(
+      expect.arrayContaining([first.id, second.id])
+    );
+  });
+
+  it('keeps a live thread prompt stable until explicit apply, then restarts only that scope with the new prompt', async () => {
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    topics.create({
+      id: CH,
+      workspaceId: 'ws:test',
+      title: 'prompt apply',
+      promptDefaults: { systemPrompt: 'old shared instructions' },
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      topicStore: topics,
+    });
+    const first = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'first root',
+    });
+    const second = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'second root',
+    });
+    post(store, binder, '@mock first', ['mock'], OPERATOR, first.id);
+    post(store, binder, '@mock second', ['mock'], OPERATOR, second.id);
+    await waitFor(() => agentReplies(store, 'mock').length === 2);
+    expect(sessions.createParams()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          threadId: first.id,
+          systemPrompt: 'old shared instructions',
+        }),
+        expect.objectContaining({
+          threadId: second.id,
+          systemPrompt: 'old shared instructions',
+        }),
+      ])
+    );
+
+    topics.update(CH, {
+      promptDefaults: { systemPrompt: 'new shared instructions' },
+    });
+    // Topic persistence alone never rewrites a live provider runtime.
+    expect(sessions.spawns()).toBe(2);
+    expect(sessions.createParams()[0]?.systemPrompt).toBe(
+      'old shared instructions'
+    );
+
+    await expect(binder.restartScope(CH, first.id)).resolves.toEqual({
+      restarted: 1,
+    });
+    expect(sessions.spawns()).toBe(3);
+    expect(sessions.createParams()[2]).toMatchObject({
+      threadId: first.id,
+      systemPrompt: 'new shared instructions',
+    });
+    expect(
+      store.getBinding(CH, builtInAgentProfileId('mock'), second.id)?.runtimeId
+    ).toBeTruthy();
+    expect(sessions.destroyCalls()).toHaveLength(1);
+  });
+
+  it('refuses prompt apply while the selected thread has a live turn', async () => {
+    const topics = createWorkspaceTopicStore({ dbPath: ':memory:' });
+    cleanup.push(() => topics.close());
+    topics.create({
+      id: CH,
+      workspaceId: 'ws:test',
+      title: 'busy prompt apply',
+      promptDefaults: { systemPrompt: 'old instructions' },
+    });
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 80 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+      topicStore: topics,
+    });
+    const root = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'busy root',
+    });
+    post(store, binder, '@mock work', ['mock'], OPERATOR, root.id);
+    await waitFor(() =>
+      rows(store).some(
+        (message) =>
+          message.threadId === root.id &&
+          message.sender.providerId === 'mock' &&
+          message.status === 'streaming'
+      )
+    );
+    topics.update(CH, {
+      promptDefaults: { systemPrompt: 'new instructions' },
+    });
+
+    await expect(binder.restartScope(CH, root.id)).rejects.toMatchObject({
+      reasonCode: 'CHANNEL_AGENT_NOT_IDLE',
+    });
+    expect(sessions.spawns()).toBe(1);
+    expect(sessions.destroyCalls()).toEqual([]);
+    expect(sessions.createParams()[0]).toMatchObject({
+      threadId: root.id,
+      systemPrompt: 'old instructions',
+    });
+  });
+
   it.each([
     ['the routed turn id', false],
     ['the unambiguous Hermes turn-0 fallback', true],
@@ -3341,7 +3554,7 @@ describe('channel-agent-binder — lifecycle', () => {
     });
   });
 
-  it('fails closed when a turn-0 fallback could belong to multiple turns', async () => {
+  it('fails closed to the known conversation root when a turn-0 fallback is ambiguous', async () => {
     const { binder, store } = makeBinder({
       build: (agentType) => new LateOpeningReplyAdapter(agentType, true),
       targets: MOCK_TARGETS,
@@ -3352,17 +3565,14 @@ describe('channel-agent-binder — lifecycle', () => {
       sender: OPERATOR,
       text: 'root one',
     });
-    const rootTwo = store.appendComplete({
-      channelId: CH,
-      sender: OPERATOR,
-      text: 'root two',
-    });
     post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
-    post(store, binder, '@mock two', ['mock'], OPERATOR, rootTwo.id);
+    post(store, binder, '@mock two', ['mock'], OPERATOR, rootOne.id);
     await waitFor(() => agentReplies(store, 'mock').length === 2);
     for (const reply of agentReplies(store, 'mock')) {
-      expect(reply.threadId).toBeNull();
-      expect(reply.parentMessageId).toBeNull();
+      expect(reply.threadId).toBe(rootOne.id);
+      // The two provider fallback rows cannot safely borrow either trigger,
+      // but the runtime itself is scoped to this durable conversation.
+      expect(reply.parentMessageId).toBe(rootOne.id);
     }
   });
 
@@ -3401,16 +3611,6 @@ describe('channel-agent-binder — lifecycle', () => {
       sender: OPERATOR,
       text: 'root one',
     });
-    const rootTwo = store.appendComplete({
-      channelId: CH,
-      sender: OPERATOR,
-      text: 'root two',
-    });
-    const rootThree = store.appendComplete({
-      channelId: CH,
-      sender: OPERATOR,
-      text: 'root three',
-    });
     post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
     const triggerTwo = post(
       store,
@@ -3418,7 +3618,7 @@ describe('channel-agent-binder — lifecycle', () => {
       '@mock two',
       ['mock'],
       OPERATOR,
-      rootTwo.id
+      rootOne.id
     );
     await waitFor(() => sessions.spawns() === 1);
     const adapter = sessions.adapterFor(
@@ -3428,7 +3628,7 @@ describe('channel-agent-binder — lifecycle', () => {
     adapter.emitLate(adapter.sendCalls[1]!);
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     expect(agentReplies(store, 'mock')[0]).toMatchObject({
-      threadId: rootTwo.id,
+      threadId: rootOne.id,
       parentMessageId: triggerTwo.id,
     });
     // Exact terminal evidence identifies and releases B, clearing the overlap
@@ -3440,13 +3640,13 @@ describe('channel-agent-binder — lifecycle', () => {
       '@mock three',
       ['mock'],
       OPERATOR,
-      rootThree.id
+      rootOne.id
     );
     await waitFor(() => adapter.sendCalls.length === 3);
     adapter.emitLate('turn-0', 'valid fallback');
     await waitFor(() => agentReplies(store, 'mock').length === 2);
     expect(agentReplies(store, 'mock')[1]).toMatchObject({
-      threadId: rootThree.id,
+      threadId: rootOne.id,
       parentMessageId: triggerThree.id,
     });
   });
@@ -3462,13 +3662,8 @@ describe('channel-agent-binder — lifecycle', () => {
       sender: OPERATOR,
       text: 'root one',
     });
-    const rootTwo = store.appendComplete({
-      channelId: CH,
-      sender: OPERATOR,
-      text: 'root two',
-    });
     post(store, binder, '@mock one', ['mock'], OPERATOR, rootOne.id);
-    post(store, binder, '@mock two', ['mock'], OPERATOR, rootTwo.id);
+    post(store, binder, '@mock two', ['mock'], OPERATOR, rootOne.id);
     await waitFor(() => sessions.spawns() === 1);
     const adapter = sessions.adapterFor(
       sessions.firstSessionId()
@@ -3479,8 +3674,8 @@ describe('channel-agent-binder — lifecycle', () => {
     adapter.emitLate('turn-0', 'stale reply');
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     expect(agentReplies(store, 'mock')[0]).toMatchObject({
-      threadId: null,
-      parentMessageId: null,
+      threadId: rootOne.id,
+      parentMessageId: rootOne.id,
     });
   });
 
@@ -3490,20 +3685,8 @@ describe('channel-agent-binder — lifecycle', () => {
       targets: MOCK_TARGETS,
       knownProviderIds: ['mock'],
     });
-    const root = store.appendComplete({
-      channelId: CH,
-      sender: OPERATOR,
-      text: 'root',
-    });
     post(store, binder, '@mock first', ['mock']);
-    const successor = post(
-      store,
-      binder,
-      '@mock successor',
-      ['mock'],
-      OPERATOR,
-      root.id
-    );
+    post(store, binder, '@mock successor', ['mock']);
     await waitFor(() => sessions.spawns() === 1);
     const adapter = sessions.adapterFor(
       sessions.firstSessionId()
@@ -3520,8 +3703,8 @@ describe('channel-agent-binder — lifecycle', () => {
     adapter.emitLate(adapter.sendCalls[1]!, 'successor late reply');
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     expect(agentReplies(store, 'mock')[0]).toMatchObject({
-      threadId: root.id,
-      parentMessageId: successor.id,
+      threadId: null,
+      parentMessageId: null,
     });
     adapter.emitCompleted(adapter.sendCalls[1]!);
     expect(binding.parentMessageIdByTurn.size).toBe(0);
@@ -3629,7 +3812,7 @@ describe('channel-agent-binder — lifecycle', () => {
     ).toHaveLength(0);
   });
 
-  it('queue overflow past the cap drops a non-coalescing message with a system row', async () => {
+  it('keeps queue caps isolated between conversations', async () => {
     const { binder, store } = makeBinder({
       build: () => new ScriptedAdapter('stall', { mode: 'stall' }),
       targets: [
@@ -3658,9 +3841,9 @@ describe('channel-agent-binder — lifecycle', () => {
       post(store, binder, `@stall a${i}`, ['stall'], OPERATOR, rootA.id);
     }
     await new Promise((r) => setTimeout(r, 120));
-    // A thread-B post cannot be represented by the thread-A tail, so the cap
-    // refuses it explicitly rather than silently losing it.
-    const overflow = post(
+    // Thread B owns an independent runtime/queue, so thread A's cap cannot
+    // drop its post.
+    const independent = post(
       store,
       binder,
       '@stall b0',
@@ -3668,16 +3851,15 @@ describe('channel-agent-binder — lifecycle', () => {
       OPERATOR,
       rootB.id
     );
-    await waitFor(() =>
-      systemRows(store).some((m) => m.body.text.includes('message dropped'))
+    await waitFor(
+      () =>
+        store.getBinding(CH, builtInAgentProfileId('stall'), rootB.id)
+          ?.runtimeId != null
     );
-    const dropped = systemRows(store).filter((m) =>
-      m.body.text.includes('message dropped')
-    );
-    expect(dropped).toHaveLength(1);
-    expect(dropped[0]!.body.text).toContain('has 8 messages pending');
-    expect(dropped[0]!.threadId).toBe(rootB.id);
-    expect(dropped[0]!.parentMessageId).toBe(overflow.id);
+    expect(
+      systemRows(store).filter((m) => m.body.text.includes('message dropped'))
+    ).toHaveLength(0);
+    expect(independent.threadId).toBe(rootB.id);
   });
 
   it('runtime death unbinds, clears the binding, and respawns on next mention', async () => {
@@ -4522,6 +4704,103 @@ describe('channel-agent-binder — agent-to-agent brake', () => {
     await waitFor(() => agentReplies(store).length > beforeReset, 6000);
     expect(agentReplies(store).length).toBeGreaterThan(beforeReset);
   });
+
+  it('isolates the autonomous-turn brake and its human reset by thread root', async () => {
+    const { binder, store } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 1 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const first = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'first root',
+    });
+    const second = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'second root',
+    });
+
+    for (let index = 0; index < MAX_CONSECUTIVE_AGENT_TURNS; index += 1) {
+      postAgentTurnRow(
+        store,
+        binder,
+        `first-${index}`,
+        'item-0',
+        '@mock continue first',
+        ['mock'],
+        'runtime:first',
+        AGENT_SENDER,
+        first.id
+      );
+    }
+    await waitFor(
+      () =>
+        agentReplies(store, 'mock').filter(
+          (message) => message.threadId === first.id
+        ).length === MAX_CONSECUTIVE_AGENT_TURNS
+    );
+    postAgentTurnRow(
+      store,
+      binder,
+      'first-cap',
+      'item-0',
+      '@mock pause first',
+      ['mock'],
+      'runtime:first',
+      AGENT_SENDER,
+      first.id
+    );
+    await waitFor(() =>
+      systemRows(store).some(
+        (message) =>
+          message.threadId === first.id &&
+          message.body.text.includes('Mention chain paused')
+      )
+    );
+
+    // A separate conversation still admits autonomous work, and a human there
+    // must not reset the paused chain above.
+    postAgentTurnRow(
+      store,
+      binder,
+      'second-first',
+      'item-0',
+      '@mock continue second',
+      ['mock'],
+      'runtime:second',
+      AGENT_SENDER,
+      second.id
+    );
+    await waitFor(() =>
+      agentReplies(store, 'mock').some(
+        (message) => message.threadId === second.id
+      )
+    );
+    post(store, binder, '@mock human second', ['mock'], OPERATOR, second.id);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const firstRepliesBefore = agentReplies(store, 'mock').filter(
+      (message) => message.threadId === first.id
+    ).length;
+    postAgentTurnRow(
+      store,
+      binder,
+      'first-still-paused',
+      'item-0',
+      '@mock remain paused',
+      ['mock'],
+      'runtime:first',
+      AGENT_SENDER,
+      first.id
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(
+      agentReplies(store, 'mock').filter(
+        (message) => message.threadId === first.id
+      )
+    ).toHaveLength(firstRepliesBefore);
+  });
 });
 
 describe('channel-agent-binder — roster + availability', () => {
@@ -5024,6 +5303,53 @@ describe('channel-agent-binder — watchdog + cross-node + interrupt', () => {
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     await expect(binder.interrupt(CH, 'mock')).rejects.toThrow(); // idle
   });
+
+  it('interrupts only the selected thread runtime for a shared profile', async () => {
+    const { binder, store, sessions } = makeBinder({
+      build: () => new MockProtocolAdapterV2({ connectMs: 1, stepMs: 80 }),
+      targets: MOCK_TARGETS,
+      knownProviderIds: ['mock'],
+    });
+    const first = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'first root',
+    });
+    const second = store.appendComplete({
+      channelId: CH,
+      sender: OPERATOR,
+      text: 'second root',
+    });
+    post(store, binder, '@mock first', ['mock'], OPERATOR, first.id);
+    post(store, binder, '@mock second', ['mock'], OPERATOR, second.id);
+    await waitFor(
+      () =>
+        rows(store).filter(
+          (message) =>
+            message.sender.providerId === 'mock' &&
+            message.status === 'streaming'
+        ).length >= 2
+    );
+    expect(sessions.spawns()).toBe(2);
+
+    await binder.interrupt(CH, 'mock', first.id);
+    await waitFor(() =>
+      rows(store).some(
+        (message) =>
+          message.sender.providerId === 'mock' &&
+          message.threadId === first.id &&
+          message.status === 'interrupted'
+      )
+    );
+    expect(
+      rows(store).some(
+        (message) =>
+          message.sender.providerId === 'mock' &&
+          message.threadId === second.id &&
+          message.status === 'interrupted'
+      )
+    ).toBe(false);
+  });
 });
 
 // ── #1180 review findings ─────────────────────────────────────────────────────
@@ -5189,7 +5515,7 @@ describe('channel-agent-binder — buildPacket failure recovery (P2 #1180)', () 
     expect(failure.threadId).toBe(root.id);
     expect(failure.parentMessageId).toBe(failedTrigger.id);
     // Binding recovered (not stuck turn-active): the next mention delivers.
-    post(store, binder, '@mock two', ['mock']);
+    post(store, binder, '@mock two', ['mock'], OPERATOR, root.id);
     await waitFor(() => agentReplies(store, 'mock').length === 1);
     expect(sessions.spawns()).toBe(1); // reused, not respawned/wedged
     expect(agentReplies(store, 'mock')).toHaveLength(1);
@@ -5337,7 +5663,13 @@ describe('channel-agent-binder — approval round-trip + watchdog pause (Amendme
     expect(approvalRow.parentMessageId).toBe(trigger.id);
 
     const a = built[0]!;
-    await binder.respondToApproval(CH, 'mock', requestId, { kind: 'accept' });
+    await binder.respondToApproval(
+      CH,
+      'mock',
+      requestId,
+      { kind: 'accept' },
+      root.id
+    );
     // Adapter received the mapped decision.
     expect(a.respondCalls).toHaveLength(1);
     expect(a.respondCalls[0]).toMatchObject({
@@ -6002,12 +6334,16 @@ describe('channel-agent-binder — orchestrator default-routing matrix', () => {
 
   it('keeps an implicit orchestrator reply in the triggering thread', async () => {
     const topics = makeProductTopics();
-    const adapter = new ScriptedAdapter('orchestrator', {
-      mode: 'reply',
-      text: 'threaded ack',
-    });
-    const { binder, store } = makeBinder({
-      build: () => adapter,
+    const adapters: ScriptedAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: () => {
+        const adapter = new ScriptedAdapter('orchestrator', {
+          mode: 'reply',
+          text: 'threaded ack',
+        });
+        adapters.push(adapter);
+        return adapter;
+      },
       targets: [TARGETS[0]!],
       knownProviderIds: ['orchestrator'],
       topicStore: topics,
@@ -6028,22 +6364,28 @@ describe('channel-agent-binder — orchestrator default-routing matrix', () => {
     );
 
     await waitFor(() => agentReplies(store, 'orchestrator').length === 1);
+    expect(sessions.spawns()).toBe(2);
+    expect(adapters).toHaveLength(2);
     expect(agentReplies(store, 'orchestrator')[0]).toMatchObject({
       threadId: root.id,
       parentMessageId: trigger.id,
     });
   });
 
-  it('preserves FIFO queue semantics for implicit turns', async () => {
+  it('preserves FIFO queue semantics for implicit thread turns', async () => {
     const topics = makeProductTopics();
-    const adapter = new ScriptedAdapter('orchestrator', { mode: 'stall' });
-    const { binder, store } = makeBinder({
-      build: () => adapter,
+    const adapters: ScriptedAdapter[] = [];
+    const { binder, store, sessions } = makeBinder({
+      build: () => {
+        const adapter = new ScriptedAdapter('orchestrator', { mode: 'stall' });
+        adapters.push(adapter);
+        return adapter;
+      },
       targets: [TARGETS[0]!],
       knownProviderIds: ['orchestrator'],
       topicStore: topics,
     });
-    const binding = await binder.ensureOrchestrator(CH, 'orchestrator');
+    await binder.ensureOrchestrator(CH, 'orchestrator');
     const root = store.appendComplete({
       channelId: CH,
       sender: OPERATOR,
@@ -6058,7 +6400,10 @@ describe('channel-agent-binder — orchestrator default-routing matrix', () => {
       OPERATOR,
       root.id
     );
-    await waitFor(() => adapter.sendCalls.length === 1);
+    await waitFor(
+      () => adapters.length === 2 && adapters[1]!.sendCalls.length === 1
+    );
+    const threadAdapter = adapters[1]!;
     post(
       store,
       binder,
@@ -6067,19 +6412,19 @@ describe('channel-agent-binder — orchestrator default-routing matrix', () => {
       OPERATOR,
       root.id
     );
-    await waitFor(() => binding.queue.length === 1);
-    const roster = await binder.rosterForChannel(CH);
-    expect(roster[0]?.binding?.queuedCount).toBe(1);
+    await waitFor(() =>
+      binder.archiveActivityForChannel(CH).reasons.includes('queued-turn')
+    );
+    expect(sessions.spawns()).toBe(2);
 
-    expect(adapter.sendInputs[0]?.turnId).toBe(
+    expect(threadAdapter.sendInputs[0]?.turnId).toBe(
       channelTurnId(first.id, builtInAgentProfileId('orchestrator'))
     );
-    expect(binding.parentMessageIdByTurn.get(adapter.sendCalls[0]!)).toBe(
-      first.id
-    );
-    expect(binding.queue.map((entry) => entry.trigger.threadId)).toEqual([
-      root.id,
-    ]);
+    expect(threadAdapter.sendCalls).toHaveLength(1);
+    expect(
+      store.getBinding(CH, builtInAgentProfileId('orchestrator'), root.id)
+        ?.runtimeId
+    ).toBeTruthy();
   });
 });
 

--- a/test/channel-agent-status-reconcile.test.ts
+++ b/test/channel-agent-status-reconcile.test.ts
@@ -172,6 +172,28 @@ describe('useChannelAgentStatusStore — timestamped reconciliation state', () =
     expect(state.updatedAtByChannelAgent[key]).toBeGreaterThanOrEqual(before);
   });
 
+  it('keeps a profile status isolated per thread scope', () => {
+    const state = useChannelAgentStatusStore.getState();
+    state.recordStatus('c1', 'mock', 'streaming', 'root-runtime');
+    state.recordStatus(
+      'c1',
+      'mock',
+      'thinking',
+      'thread-runtime',
+      0,
+      0,
+      false,
+      'chm:thread-1'
+    );
+    const rootKey = channelAgentStatusKey('c1', 'mock');
+    const threadKey = channelAgentStatusKey('c1', 'mock', 'chm:thread-1');
+    const current = useChannelAgentStatusStore.getState();
+    expect(current.statusByChannelAgent[rootKey]).toBe('streaming');
+    expect(current.runtimeByChannelAgent[rootKey]).toBe('root-runtime');
+    expect(current.statusByChannelAgent[threadKey]).toBe('thinking');
+    expect(current.runtimeByChannelAgent[threadKey]).toBe('thread-runtime');
+  });
+
   it('clearChannel drops status, session, AND updatedAt for that channel only', () => {
     const s = useChannelAgentStatusStore.getState();
     s.recordStatus('c1', 'mock', 'streaming', 's1');

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -249,6 +249,7 @@ function makeSessions(
       });
       const runtime = {
         id,
+        threadId: params.threadId ?? null,
         providerId: params.providerId,
         profileActorId: params.profileActorId,
         status: 'active',
@@ -591,14 +592,16 @@ describe('mention routing — end-to-end via the router', () => {
     expect(trigger.body.message.threadId).toBe(root.body.message.id);
 
     await waitFor(() => agentReply(h.store, h.channelId).length === 1);
-    const adapter = h.adapters()[0] as RecordingAdapter;
-    expect(adapter.contents).toHaveLength(1);
-    expect(adapter.contents[0]).toContain(
+    const threadAdapter = h.adapters()[0] as RecordingAdapter;
+    expect(threadAdapter.contents).toHaveLength(1);
+    expect(threadAdapter.contents[0]).toContain(
       '[Thread scope — only this thread is shown; its root message is always included]'
     );
-    expect(adapter.contents[0]).toContain('root discussion');
-    expect(adapter.contents[0]).toContain('prior thread detail');
-    expect(adapter.contents[0]).not.toContain('unrelated top-level update');
+    expect(threadAdapter.contents[0]).toContain('root discussion');
+    expect(threadAdapter.contents[0]).toContain('prior thread detail');
+    expect(threadAdapter.contents[0]).not.toContain(
+      'unrelated top-level update'
+    );
     const reply = agentReply(h.store, h.channelId)[0]!;
     expect(reply.sender.id).toBe('agent-profile:mock:default');
     expect(reply.body.text).toBe('thread ack');
@@ -617,9 +620,13 @@ describe('mention routing — end-to-end via the router', () => {
       url,
       body: { text: '@mock now answer at top level' },
     });
-    await waitFor(() => adapter.contents.length === 2);
-    expect(adapter.contents[1]).toContain('unrelated top-level update');
-    expect(adapter.contents[1]).not.toContain('[Thread scope —');
+    // Runtime identity is conversation-scoped: this root mention launches a
+    // root runtime rather than borrowing the thread's provider session.
+    await waitFor(() => h.adapters().length === 2);
+    const rootAdapter = h.adapters()[1] as RecordingAdapter;
+    await waitFor(() => rootAdapter.contents.length === 1);
+    expect(rootAdapter.contents[0]).toContain('unrelated top-level update');
+    expect(rootAdapter.contents[0]).not.toContain('[Thread scope —');
     await waitFor(() => agentReply(h.store, h.channelId).length === 2);
     expect(agentReply(h.store, h.channelId)[1]!.threadId).toBeNull();
   });

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -168,9 +168,9 @@ describe('channel-message-store schema migration', () => {
       UPDATE schema_version SET version = 7;
       DELETE FROM channel_agent_bindings;
       INSERT INTO channel_agent_bindings VALUES
-        ('topic:ambiguous', 'profile:a', 'claude', 'runtime:a', 'orchestrator', '{"cursor":1}', '2026-08-01', '2026-08-02'),
-        ('topic:ambiguous', 'profile:b', 'codex', 'runtime:b', 'orchestrator', '{"cursor":2}', '2026-08-03', '2026-08-04'),
-        ('topic:valid', 'profile:c', 'claude', 'runtime:c', 'orchestrator', '{"cursor":3}', '2026-08-05', '2026-08-06');
+        ('topic:ambiguous', '', 'profile:a', 'claude', 'runtime:a', 'orchestrator', '{"cursor":1}', '2026-08-01', '2026-08-02'),
+        ('topic:ambiguous', '', 'profile:b', 'codex', 'runtime:b', 'orchestrator', '{"cursor":2}', '2026-08-03', '2026-08-04'),
+        ('topic:valid', '', 'profile:c', 'claude', 'runtime:c', 'orchestrator', '{"cursor":3}', '2026-08-05', '2026-08-06');
     `);
     legacy.close();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -525,7 +525,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(12);
+    ).toBe(13);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -634,13 +634,13 @@ describe('channel-message-store schema migration', () => {
         '2026-07-19T09:10:00.001Z'
       );
       INSERT INTO channel_agent_bindings VALUES (
-        'topic:stranded-heal', 'agent-profile:claude:default', 'claude',
+        'topic:stranded-heal', '', 'agent-profile:claude:default', 'claude',
         'runtime-stranded', NULL,
         '{"claudeSessionId":"runtime-stranded","lastDeliveredSeq":4}',
         '2026-07-19T08:00:00.000Z', '2026-07-19T08:00:00.000Z'
       );
       INSERT INTO channel_agent_bindings VALUES (
-        'topic:stranded-heal', 'agent-profile:claude:reviewer', 'claude',
+        'topic:stranded-heal', '', 'agent-profile:claude:reviewer', 'claude',
         'runtime-b', NULL,
         '{"claudeSessionId":"runtime-b","lastDeliveredSeq":2}',
         '2026-07-19T08:00:00.000Z', '2026-07-19T08:00:00.000Z'
@@ -713,7 +713,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(12);
+    ).toBe(13);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -2496,7 +2496,7 @@ describe('channel-message-store thread summaries', () => {
     expect(page.threadCount).toBe(page.threads.length);
   });
 
-  it('plans the channel-list thread aggregate as a channel-scoped index walk', () => {
+  it('plans channel-list conversations from the durable recent-thread index', () => {
     const p = dbPath();
     const s = store(p);
     const root = s.appendComplete({
@@ -2519,22 +2519,20 @@ describe('channel-message-store thread summaries', () => {
       .prepare(`EXPLAIN QUERY PLAN ${buildChannelThreadSummarySql()}`)
       .all({ channelId: 'topic:t', limit: 3 }) as Array<{ detail: string }>;
     const details = plan.map((row) => row.detail).join('\n');
-    expect(details).toContain('idx_chm_channel_seq');
-    // Never a full-table walk: both channel_messages references stay scoped to
-    // the one channel, so this costs the same order of work as the summary's
-    // own COUNT(*) no matter how many channels the hub holds.
-    expect(details).not.toMatch(/SCAN (?:channel_messages|root)\b/);
-    // Absence of the word SCAN is not enough. Drop the CROSS JOIN hint and
-    // SQLite drives from `root` instead, reported as
-    // `SEARCH root USING INDEX idx_chm_channel_seq (channel_id=?)` — a SEARCH
-    // bound on the channel alone is a range walk of EVERY message in the
-    // channel, and it pays for a transient index over `agg` on each execution.
-    // That plan is ~1.5x slower at 5k messages and diverges as transcripts
-    // grow, so assert the join shape: the page must be driven by the thread
-    // groups, with `root` reached by primary key.
+    // Durable conversations, including intentionally empty ones, drive the
+    // page by most-recent activity. Roots and replies remain point/index
+    // lookups rather than a channel_messages walk.
+    expect(details).toMatch(
+      /SEARCH thread USING INDEX idx_channel_threads_recent \(channel_id=\?\)/
+    );
     expect(details).toMatch(
       /SEARCH root USING (?:COVERING )?INDEX sqlite_autoindex_channel_messages_1 \(id=\?\)/
     );
+    expect(details).toMatch(
+      /SEARCH reply USING INDEX idx_chm_thread \(thread_id=\?\)/
+    );
+    expect(details).not.toContain('idx_chm_channel_seq');
+    expect(details).not.toMatch(/SCAN (?:channel_messages|root|reply)\b/);
     expect(details).not.toContain('AUTOMATIC COVERING INDEX');
   });
 
@@ -2558,9 +2556,95 @@ describe('channel-message-store thread summaries', () => {
       rootSenderKind: 'agent',
     });
   });
+
+  it('persists explicit conversation titles, including an empty conversation, across reopen', () => {
+    const file = dbPath();
+    const initial = store(file);
+    const created = initial.createThread({
+      channelId: 'topic:named',
+      title: 'Investigate provider resume semantics',
+    });
+    expect(created).toMatchObject({
+      title: 'Investigate provider resume semantics',
+      replyCount: 0,
+    });
+    expect(initial.listChannelThreadSummaries('topic:named')).toEqual({
+      threadCount: 1,
+      threads: [
+        expect.objectContaining({
+          rootMessageId: created.rootMessageId,
+          title: 'Investigate provider resume semantics',
+          replyCount: 0,
+        }),
+      ],
+    });
+
+    expect(
+      initial.renameThread({
+        channelId: 'topic:named',
+        rootMessageId: created.rootMessageId,
+        title: 'Provider restart notes',
+      })
+    ).toMatchObject({ title: 'Provider restart notes' });
+    initial.close();
+
+    const reopened = store(file);
+    expect(reopened.getThreadTitle('topic:named', created.rootMessageId)).toBe(
+      'Provider restart notes'
+    );
+    expect(
+      reopened.threadHistory('topic:named', created.rootMessageId)
+    ).toHaveLength(1);
+  });
 });
 
 describe('channel-message-store members and bindings', () => {
+  it('keeps one profile binding per thread scope without replacing its siblings', () => {
+    const s = store();
+    const first = s.createThread({ channelId: 'topic:scope', title: 'first' });
+    const second = s.createThread({
+      channelId: 'topic:scope',
+      title: 'second',
+    });
+    for (const [threadId, runtimeId] of [
+      [first.rootMessageId, 'runtime:first'],
+      [second.rootMessageId, 'runtime:second'],
+    ] as const) {
+      s.upsertBinding({
+        channelId: 'topic:scope',
+        threadId,
+        profileActorId: 'agent-profile:mock:default',
+        agentFramework: 'mock',
+        runtimeId,
+        providerSession: { providerThread: threadId },
+      });
+    }
+
+    expect(
+      s.getBinding(
+        'topic:scope',
+        'agent-profile:mock:default',
+        first.rootMessageId
+      )
+    ).toMatchObject({
+      runtimeId: 'runtime:first',
+      providerSession: { providerThread: first.rootMessageId },
+    });
+    expect(
+      s.getBinding(
+        'topic:scope',
+        'agent-profile:mock:default',
+        second.rootMessageId
+      )
+    ).toMatchObject({
+      runtimeId: 'runtime:second',
+      providerSession: { providerThread: second.rootMessageId },
+    });
+    expect(
+      s.getBinding('topic:scope', 'agent-profile:mock:default')
+    ).toBeNull();
+  });
+
   it('upserts and lists members and finds a DM channel', () => {
     const s = store();
     s.upsertMember({
@@ -3211,7 +3295,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(12);
+    expect(version.version).toBe(13);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {

--- a/test/channel-queued-sends.test.ts
+++ b/test/channel-queued-sends.test.ts
@@ -115,6 +115,7 @@ describe('queued-send marks (#1308 slice 4)', () => {
     const snapshot = snapshotQueueDrainSeqs(
       CHANNEL,
       [CLAUDE],
+      null,
       useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
     );
     expect(
@@ -126,7 +127,7 @@ describe('queued-send marks (#1308 slice 4)', () => {
   });
 
   it('retires the moment that generation advances', () => {
-    const snapshot = snapshotQueueDrainSeqs(CHANNEL, [CLAUDE], {});
+    const snapshot = snapshotQueueDrainSeqs(CHANNEL, [CLAUDE], null, {});
     useChannelAgentStatusStore
       .getState()
       .recordStatus(CHANNEL, CLAUDE, 'thinking', 'rt:1', 0);
@@ -148,6 +149,7 @@ describe('queued-send marks (#1308 slice 4)', () => {
     const snapshot = snapshotQueueDrainSeqs(
       CHANNEL,
       [CLAUDE, hermes],
+      null,
       drainSeqs
     );
     const multi = {
@@ -193,6 +195,7 @@ describe('queued-send marks (#1308 slice 4)', () => {
     const snapshot = snapshotQueueDrainSeqs(
       CHANNEL,
       [CLAUDE],
+      null,
       useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
     );
     useChannelQueuedSendsStore
@@ -211,6 +214,7 @@ describe('queued-send marks (#1308 slice 4)', () => {
     const fresh = snapshotQueueDrainSeqs(
       CHANNEL,
       [CLAUDE],
+      null,
       useChannelAgentStatusStore.getState().queueDrainSeqByChannelAgent
     );
     useChannelQueuedSendsStore.getState().markQueuedSend('chm:3', mark(fresh));

--- a/test/channel-routes.test.ts
+++ b/test/channel-routes.test.ts
@@ -1998,6 +1998,24 @@ describe('channel routes — agent commands', () => {
     expect(archived.status).toBe(409);
     expect(calls).toHaveLength(0);
     h.topicStore.restore(h.channelId);
+    const unknown = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-commands`,
+      body: {
+        profileId: 'agent-profile:codex:default',
+        command: 'model',
+        threadId: 'chm:not-a-thread',
+      },
+    });
+    expect(unknown.status).toBe(404);
+    expect(unknown.body.error.code).toBe('NOT_FOUND');
+    expect(calls).toHaveLength(0);
+    const thread = h.store.createThread({
+      channelId: h.channelId,
+      title: 'Command scope',
+    });
+    const rowsBefore = h.store.history(h.channelId, { limit: 10 });
     const ok = await req<{ ok: boolean }>({
       port: h.port,
       method: 'POST',
@@ -2006,11 +2024,70 @@ describe('channel routes — agent commands', () => {
         profileId: 'agent-profile:codex:default',
         command: 'model',
         args: 'gpt-fast',
+        threadId: thread.rootMessageId,
       },
     });
     expect(ok.status).toBe(200);
-    expect(calls).toHaveLength(1);
-    expect(h.store.history(h.channelId, { limit: 10 })).toHaveLength(0);
+    expect(calls).toEqual([
+      [
+        h.channelId,
+        'agent-profile:codex:default',
+        'model',
+        'gpt-fast',
+        false,
+        thread.rootMessageId,
+      ],
+    ]);
+    expect(h.store.history(h.channelId, { limit: 10 })).toEqual(rowsBefore);
+  });
+
+  it('restarts only the requested conversation scope and refuses malformed scope', async () => {
+    const calls: unknown[] = [];
+    const h = await harness({
+      binder: {
+        restartScope: async (...args: unknown[]) => {
+          calls.push(args);
+          return { restarted: 2 };
+        },
+      },
+    });
+
+    const malformed = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-runtimes/restart`,
+      body: { threadId: '' },
+    });
+    expect(malformed.status).toBe(400);
+    expect(malformed.body.error.code).toBe('INVALID_ARGUMENT');
+    expect(calls).toEqual([]);
+
+    const unknown = await req<{ error: { code: string } }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-runtimes/restart`,
+      body: { threadId: 'chm:not-a-thread' },
+    });
+    expect(unknown.status).toBe(404);
+    expect(unknown.body.error.code).toBe('NOT_FOUND');
+    expect(calls).toEqual([]);
+
+    const thread = h.store.createThread({
+      channelId: h.channelId,
+      title: 'Apply scope',
+    });
+
+    const restarted = await req<{ ok: boolean; restarted: number }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agent-runtimes/restart`,
+      body: { threadId: thread.rootMessageId },
+    });
+    expect(restarted).toMatchObject({
+      status: 200,
+      body: { ok: true, restarted: 2 },
+    });
+    expect(calls).toEqual([[h.channelId, thread.rootMessageId]]);
   });
 
   const realControlBinder = ({
@@ -2470,6 +2547,40 @@ describe('channel routes — explicit idle agent release', () => {
     expect(res).toMatchObject({ status: 200, body: { ok: true } });
     expect(calls).toEqual([
       { channelId: h.channelId, agentId: 'agent-profile:codex:default' },
+    ]);
+  });
+
+  it('passes an explicit thread scope to the release control without falling back to root', async () => {
+    const calls: Array<{
+      channelId: string;
+      agentId: string;
+      threadId: string | null | undefined;
+    }> = [];
+    const h = await harness({
+      binder: {
+        release: async (
+          channelId: string,
+          agentId: string,
+          threadId?: string | null
+        ) => {
+          calls.push({ channelId, agentId, threadId });
+        },
+      },
+    });
+    const res = await req<{ ok: boolean }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${h.channelId}/agents/mock/release`,
+      body: { threadId: 'chm:thread-one' },
+    });
+
+    expect(res).toMatchObject({ status: 200, body: { ok: true } });
+    expect(calls).toEqual([
+      {
+        channelId: h.channelId,
+        agentId: 'mock',
+        threadId: 'chm:thread-one',
+      },
     ]);
   });
 

--- a/test/channel-thread-e2e.test.ts
+++ b/test/channel-thread-e2e.test.ts
@@ -155,6 +155,7 @@ function mockSessions(
         id,
         providerId: params.providerId,
         profileActorId: params.profileActorId,
+        threadId: params.threadId ?? null,
         status: 'active',
         adapter,
         cwd: params.cwd,
@@ -277,6 +278,98 @@ async function waitFor(condition: () => boolean, timeoutMs = 4_000) {
 }
 
 describe('channel thread mention round trip', () => {
+  it('creates, renames, and revisits a durable empty conversation', async () => {
+    const harness = await createHarness();
+    const create = await fetch(
+      `http://127.0.0.1:${harness.port}/channels/${encodeURIComponent(harness.channelId)}/threads`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ title: 'Runtime isolation audit' }),
+      }
+    );
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as {
+      thread: { rootMessageId: string; title: string; replyCount: number };
+    };
+    expect(created.thread).toMatchObject({
+      title: 'Runtime isolation audit',
+      replyCount: 0,
+    });
+
+    const rename = await fetch(
+      `http://127.0.0.1:${harness.port}/channels/${encodeURIComponent(harness.channelId)}/threads/${encodeURIComponent(created.thread.rootMessageId)}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-relay-capabilities': 'context:write',
+        },
+        body: JSON.stringify({ title: 'Runtime isolation shipped' }),
+      }
+    );
+    expect(rename.status).toBe(200);
+    expect((await rename.json()) as { thread: { title: string } }).toEqual({
+      thread: expect.objectContaining({ title: 'Runtime isolation shipped' }),
+    });
+    const history = harness.store.threadHistory(
+      harness.channelId,
+      created.thread.rootMessageId
+    );
+    expect(history).toHaveLength(1);
+    expect(
+      harness.store.getThreadTitle(
+        harness.channelId,
+        created.thread.rootMessageId
+      )
+    ).toBe('Runtime isolation shipped');
+  });
+
+  it('runs one provider profile in independent concurrent thread runtimes', async () => {
+    const harness = await createHarness({
+      build: (provider) => new ThreadRecordingAdapter(provider, 'thread ack'),
+    });
+    const first = await post(harness, { text: 'first root' });
+    const second = await post(harness, { text: 'second root' });
+    await post(harness, {
+      text: '@mock inspect first scope',
+      threadId: first.message.id,
+    });
+    await post(harness, {
+      text: '@mock inspect second scope',
+      threadId: second.message.id,
+    });
+
+    await waitFor(() => harness.adapters().length === 2);
+    await waitFor(
+      () =>
+        harness.store
+          .history(harness.channelId, { limit: 30 })
+          .filter(
+            (message) =>
+              message.sender.id === builtInAgentProfileId('mock') &&
+              message.status === 'complete'
+          ).length === 2
+    );
+    const profileId = builtInAgentProfileId('mock');
+    const firstBinding = harness.store.getBinding(
+      harness.channelId,
+      profileId,
+      first.message.id
+    );
+    const secondBinding = harness.store.getBinding(
+      harness.channelId,
+      profileId,
+      second.message.id
+    );
+    expect(firstBinding?.runtimeId).toBeTruthy();
+    expect(secondBinding?.runtimeId).toBeTruthy();
+    expect(firstBinding?.runtimeId).not.toBe(secondBinding?.runtimeId);
+  });
+
   it('persists the human trigger and mock reply in one thread with a live root count', async () => {
     const harness = await createHarness();
     const root = await post(harness, { text: 'root needing an agent answer' });

--- a/test/components/channel-composer.test.ts
+++ b/test/components/channel-composer.test.ts
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type {
   ChannelImagePart,
+  ChannelMessageId,
   ChannelMessagePart,
 } from '../../shared/channel-chat-protocol.js';
 import {
@@ -148,6 +149,7 @@ const primeRoster: RosterEntry[] = [
 ];
 
 interface RenderOpts {
+  threadId?: ChannelMessageId;
   onSend?: (
     text: string,
     clientMessageId: string,
@@ -178,6 +180,7 @@ async function renderComposer(opts: RenderOpts = {}): Promise<QueryClient> {
           ...(opts.implicitCommandProviderId
             ? { implicitCommandProviderId: opts.implicitCommandProviderId }
             : {}),
+          ...(opts.threadId ? { threadId: opts.threadId } : {}),
           onSend: opts.onSend ?? (() => Promise.resolve()),
           postPending: opts.postPending ?? false,
           storeDown: opts.storeDown ?? false,
@@ -647,6 +650,30 @@ describe('ChannelComposer (#1178)', () => {
     });
     expect(onSend).not.toHaveBeenCalled();
     expect(ta.value).toBe('');
+  });
+
+  it('dispatches a threaded slash command to its exact runtime scope', async () => {
+    const onSend = vi.fn(async () => {});
+    await renderComposer({
+      threadId: 'chm:thread-42' as ChannelMessageId,
+      onSend,
+    });
+    const ta = container.querySelector(
+      '.ch-composer__ta'
+    ) as HTMLTextAreaElement;
+
+    await act(async () => setNativeValue(ta, '@codex/fast'));
+    await settleRoster();
+    await pressKey('Enter');
+    await pressKey('Enter');
+
+    expect(executeChannelAgentCommand).toHaveBeenCalledWith('topic:general', {
+      profileId: 'agent-profile:codex:default',
+      command: 'fast',
+      args: 'on',
+      threadId: 'chm:thread-42',
+    });
+    expect(onSend).not.toHaveBeenCalled();
   });
 
   it('holds a reserved bare Codex control until its live roster resolves', async () => {

--- a/test/components/channel-steering.test.ts
+++ b/test/components/channel-steering.test.ts
@@ -88,9 +88,13 @@ vi.mock('../../frontend/src/hooks/useChannelChatSocket.js', () => ({
 // here because its composer is a SECOND send path (`threadId` is attached by
 // `ChannelView`, not by the composer) and has to inherit the steering cluster.
 vi.mock('../../frontend/src/hooks/useChannelThread.js', () => ({
-  useChannelThread: () => ({
+  useChannelThread: (
+    _channelId: string,
+    rootId: ChannelMessageId,
+    liveMessages: ChannelMessage[]
+  ) => ({
     root: mocks.threadRoot,
-    replies: [],
+    replies: liveMessages.filter((message) => message.threadId === rootId),
     hasMoreOlder: false,
     loadingOlder: false,
     loadOlder: vi.fn(),
@@ -578,7 +582,7 @@ describe('presence queue depth (#1308 slice 4 item 2c)', () => {
 });
 
 describe('thread composer inherits steering (#1308 slice 4 item 2d)', () => {
-  it('offers the cluster in the thread lane and threads the flag through its own send path', async () => {
+  it('does not inherit a root busy agent into an idle thread', async () => {
     mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('streaming')]);
     const rootMessage = humanMessage(1, 'root question', null);
     mocks.messages = [rootMessage];
@@ -596,13 +600,82 @@ describe('thread composer inherits steering (#1308 slice 4 item 2d)', () => {
     expect(threadComposer).not.toBeNull();
     expect(
       container.querySelector('.ch-thread .ch-composer__steer')
-    ).not.toBeNull();
+    ).toBeNull();
 
-    await typeAndPressEnter(threadComposer!, 'reply now', { metaKey: true });
+    await typeAndPressEnter(threadComposer!, 'reply now');
 
     expect(mocks.post).toHaveBeenCalledTimes(1);
     const opts = mocks.post.mock.calls[0]![1] as PostOpts;
     expect(opts.threadId).toBe(rootMessage.id);
-    expect(opts.steering).toBe('interrupt');
+    expect(opts.steering).toBeUndefined();
+    await render();
+    expect(queuedChips()).toEqual([]);
+  });
+
+  it('snapshots and retires queued markers by the selected thread runtime', async () => {
+    mocks.fetchChannelRoster.mockResolvedValue([rosterEntry('idle')]);
+    const rootMessage = humanMessage(1, 'root question', null);
+    mocks.messages = [rootMessage];
+    mocks.threadRoot = rootMessage;
+    await render();
+
+    await act(async () => {
+      useUiStore.getState().requestChannelThread(CHANNEL_ID, rootMessage.id);
+    });
+    await flush();
+
+    await act(async () => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(
+          CHANNEL_ID,
+          CLAUDE_ID,
+          'streaming',
+          RUNTIME_ID,
+          1,
+          0,
+          false,
+          rootMessage.id
+        );
+    });
+    await flush();
+
+    const threadComposer = container.querySelector<HTMLTextAreaElement>(
+      '.ch-thread .ch-composer__ta'
+    );
+    expect(threadComposer).not.toBeNull();
+    expect(
+      container.querySelector('.ch-thread .ch-composer__steer')
+    ).not.toBeNull();
+    await typeAndPressEnter(threadComposer!, 'queue this reply');
+    await render();
+
+    expect(queuedChips()).toEqual(['queued — claude is mid-turn']);
+
+    // A similarly named root binding draining does not retire a thread marker.
+    await act(async () => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(CHANNEL_ID, CLAUDE_ID, 'idle', RUNTIME_ID, 0);
+    });
+    await flush();
+    expect(queuedChips()).toEqual(['queued — claude is mid-turn']);
+
+    await act(async () => {
+      useChannelAgentStatusStore
+        .getState()
+        .recordStatus(
+          CHANNEL_ID,
+          CLAUDE_ID,
+          'idle',
+          RUNTIME_ID,
+          0,
+          0,
+          false,
+          rootMessage.id
+        );
+    });
+    await flush();
+    expect(queuedChips()).toEqual([]);
   });
 });

--- a/test/components/channel-view-thread-intent.test.ts
+++ b/test/components/channel-view-thread-intent.test.ts
@@ -13,6 +13,8 @@ import type { ChannelMessageId } from '../../shared/channel-chat-protocol.js';
 const mocks = vi.hoisted(() => ({
   fetchWorkspaceTopic: vi.fn(),
   fetchChannelRoster: vi.fn(),
+  interruptChannelAgent: vi.fn(),
+  restartChannelAgentRuntimes: vi.fn(),
 }));
 
 vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
@@ -22,6 +24,8 @@ vi.mock('../../frontend/src/lib/api.js', async (importOriginal) => {
     ...actual,
     fetchWorkspaceTopic: mocks.fetchWorkspaceTopic,
     fetchChannelRoster: mocks.fetchChannelRoster,
+    interruptChannelAgent: mocks.interruptChannelAgent,
+    restartChannelAgentRuntimes: mocks.restartChannelAgentRuntimes,
   };
 });
 
@@ -73,6 +77,8 @@ vi.mock('../../frontend/src/components/chat/ChannelThreadPanel.js', () => ({
 const { ChannelView } =
   await import('../../frontend/src/components/chat/ChannelView.js');
 const { useUiStore } = await import('../../frontend/src/lib/stores/ui.js');
+const { useChannelAgentStatusStore } =
+  await import('../../frontend/src/lib/stores/channel-agent-status.js');
 
 const CHANNEL_ID = 'topic:alpha';
 const OTHER_CHANNEL_ID = 'topic:beta';
@@ -116,6 +122,8 @@ function openThreadRoot(): string | null {
 beforeEach(() => {
   mocks.fetchWorkspaceTopic.mockReset();
   mocks.fetchChannelRoster.mockReset();
+  mocks.interruptChannelAgent.mockReset();
+  mocks.restartChannelAgentRuntimes.mockReset();
   mocks.fetchWorkspaceTopic.mockResolvedValue({
     id: CHANNEL_ID,
     workspaceId: 'ws:local',
@@ -123,6 +131,8 @@ beforeEach(() => {
     routingDefaults: {},
   });
   mocks.fetchChannelRoster.mockResolvedValue([]);
+  mocks.interruptChannelAgent.mockResolvedValue(undefined);
+  mocks.restartChannelAgentRuntimes.mockResolvedValue({ restarted: 1 });
   vi.stubGlobal('matchMedia', () => ({
     matches: false,
     addEventListener: () => {},
@@ -132,6 +142,15 @@ beforeEach(() => {
     activeChannelId: null,
     activeThreadRootId: null,
     pendingChannelThread: null,
+  });
+  useChannelAgentStatusStore.setState({
+    statusByChannelAgent: {},
+    runtimeByChannelAgent: {},
+    queuedCountByChannelAgent: {},
+    steeringCountByChannelAgent: {},
+    steerSupportedByChannelAgent: {},
+    queueDrainSeqByChannelAgent: {},
+    updatedAtByChannelAgent: {},
   });
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 0 } },
@@ -222,5 +241,45 @@ describe('ChannelView thread-open intent (#1287 slice 5 item 18)', () => {
 
     expect(openThreadRoot()).toBeNull();
     expect(useUiStore.getState().activeThreadRootId).toBeNull();
+  });
+
+  it('keeps stop and instruction apply scoped to the open conversation', async () => {
+    useUiStore.getState().setActiveChannelId(CHANNEL_ID);
+    useUiStore.getState().requestChannelThread(CHANNEL_ID, ROOT_ID);
+    await render(CHANNEL_ID);
+    useChannelAgentStatusStore
+      .getState()
+      .recordStatus(
+        CHANNEL_ID,
+        'agent-profile:mock:default',
+        'streaming',
+        'runtime:thread',
+        0,
+        0,
+        false,
+        ROOT_ID
+      );
+    await flush();
+
+    const stop = container.querySelector<HTMLButtonElement>(
+      '.ch-agent-chip__stop'
+    );
+    expect(stop?.getAttribute('aria-label')).toContain('in conversation');
+    await act(async () => stop?.click());
+    expect(mocks.interruptChannelAgent).toHaveBeenCalledWith(
+      CHANNEL_ID,
+      'agent-profile:mock:default',
+      ROOT_ID
+    );
+
+    const apply = [
+      ...container.querySelectorAll<HTMLButtonElement>('button'),
+    ].find((button) => button.textContent === 'apply instructions');
+    await act(async () => apply?.click());
+    await flush();
+    expect(mocks.restartChannelAgentRuntimes).toHaveBeenCalledWith(
+      CHANNEL_ID,
+      ROOT_ID
+    );
   });
 });

--- a/test/hooks/useChannelThread.test.ts
+++ b/test/hooks/useChannelThread.test.ts
@@ -140,6 +140,7 @@ describe('useChannelThread', () => {
       // A newest-first long-thread page may not reach the root at all.
       messages: [fetchedReply],
       hasMore: false,
+      thread: { rootMessageId: rootId, title: 'durable reopen title' },
     });
     const liveRoot = row('chm:root', 1, null, 'live root');
     const liveReply = row('chm:reply-3', 3, rootId, 'live reply');
@@ -159,6 +160,7 @@ describe('useChannelThread', () => {
       fetchedReply.id,
       liveReply.id,
     ]);
+    expect(latest.threadTitle).toBe('durable reopen title');
 
     await render([liveReply, otherReply]);
     expect(latest.root?.body.text).toBe('live root');

--- a/test/lib/channel-thread-api.test.ts
+++ b/test/lib/channel-thread-api.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  executeChannelAgentCommand,
   fetchChannelThreadHistory,
   postChannelMessage,
+  restartChannelAgentRuntimes,
 } from '../../frontend/src/lib/api.js';
 import type {
   ChannelMessage,
@@ -39,6 +41,7 @@ describe('channel thread API client', () => {
           messages: [row()],
           hasMore: true,
           nextCursor: { beforeSeq: 40 },
+          thread: { rootMessageId: rootId, title: 'release work' },
         }),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
@@ -59,6 +62,7 @@ describe('channel thread API client', () => {
       messages: [row()],
       hasMore: true,
       nextCursor: { beforeSeq: 40 },
+      thread: { rootMessageId: rootId, title: 'release work' },
     });
   });
 
@@ -84,5 +88,39 @@ describe('channel thread API client', () => {
       threadId: rootId,
     });
     expect(String(init.body)).not.toContain('parentMessageId');
+  });
+
+  it('serializes command and instruction-apply controls with the exact thread scope', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ restarted: 1 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await executeChannelAgentCommand('topic:eng', {
+      profileId: 'agent-profile:mock:default',
+      command: 'compact',
+      threadId: rootId,
+    });
+    await restartChannelAgentRuntimes('topic:eng', rootId);
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1].body))).toEqual({
+      profileId: 'agent-profile:mock:default',
+      command: 'compact',
+      threadId: rootId,
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1].body))).toEqual({
+      threadId: rootId,
+    });
   });
 });

--- a/test/topic-nav.test.ts
+++ b/test/topic-nav.test.ts
@@ -1070,7 +1070,7 @@ describe('rail thread rows (#1287 slice 5 item 18)', () => {
     ).toEqual({ threads: [], threadCount: 0 });
   });
 
-  it('drops a zero-reply root and never under-reports the total', () => {
+  it('keeps a zero-reply conversation and never under-reports the total', () => {
     const shown = thread({ rootMessageId: 'chm:live' });
     const result = selectRailRowThreads(
       summary({
@@ -1078,7 +1078,10 @@ describe('rail thread rows (#1287 slice 5 item 18)', () => {
         threadCount: 2,
       })
     );
-    expect(result.threads.map((t) => t.rootMessageId)).toEqual(['chm:live']);
+    expect(result.threads.map((t) => t.rootMessageId)).toEqual([
+      'chm:live',
+      'chm:empty',
+    ]);
     expect(result.threadCount).toBe(2);
   });
 

--- a/test/topic-sidebar-shell.test.ts
+++ b/test/topic-sidebar-shell.test.ts
@@ -35,7 +35,10 @@ import {
   hasUnseenActivity,
   useChannelActivityStore,
 } from '../frontend/src/lib/stores/channel-activity.js';
-import { useChannelAgentStatusStore } from '../frontend/src/lib/stores/channel-agent-status.js';
+import {
+  channelAgentStatusKey,
+  useChannelAgentStatusStore,
+} from '../frontend/src/lib/stores/channel-agent-status.js';
 import type {
   ChannelRailSummary,
   ChannelRailThreadSummary,
@@ -962,6 +965,53 @@ describe('TopicSidebarView', () => {
         'claude: how should the binder key runtimes?'
       );
       expect(block?.querySelector('.topic-thread-row')).toBeNull();
+    });
+
+    it('uses the durable conversation title and only its scoped live activity', async () => {
+      const rootId = 'chm:root-activity';
+      useChannelAgentStatusStore.setState({
+        statusByChannelAgent: {
+          [channelAgentStatusKey('topic:alpha', 'agent:mock', rootId)]:
+            'thinking',
+          [channelAgentStatusKey('topic:alpha', 'agent:mock', 'chm:other')]:
+            'waiting',
+        },
+      });
+      await renderWithThreads([
+        makeThread({
+          rootMessageId: rootId,
+          title: 'Provider session isolation',
+          replyCount: 0,
+        }),
+      ]);
+
+      expect(
+        threadsBlock()?.querySelector('.topic-threads__latest')?.textContent
+      ).toBe('Provider session isolation');
+      await act(async () => {
+        threadsBlock()
+          ?.querySelector<HTMLButtonElement>('.topic-threads__toggle')
+          ?.click();
+      });
+      const row = container.querySelector('.topic-thread-row');
+      expect(
+        row?.querySelector('.topic-thread-row__preview')?.textContent
+      ).toBe('Provider session isolation');
+      expect(
+        row?.querySelector('.topic-thread-row__meta')?.textContent
+      ).toContain('working');
+      expect(row?.textContent).not.toContain('needs attention');
+
+      const mobileRecent = container.querySelector<HTMLButtonElement>(
+        `.topic-mobile-thread[data-thread-root-id="${rootId}"]`
+      );
+      expect(mobileRecent?.textContent).toContain('Provider session isolation');
+      expect(mobileRecent?.textContent).toContain('working');
+      await act(async () => mobileRecent?.click());
+      expect(useUiStore.getState().pendingChannelThread).toEqual({
+        channelId: 'topic:alpha',
+        rootMessageId: rootId,
+      });
     });
 
     it('leaves a channel with no threads exactly as it was', async () => {


### PR DESCRIPTION
## Summary

- make channel threads durable titled conversations, including zero-reply and migrated threads
- scope bindings, provider sessions, queues, controls, presence, completion, and loop brakes by channel, thread, and profile
- inherit channel instructions provider-neutrally and apply edits to existing idle runtimes only through explicit scoped restart
- show titled conversation activity on desktop and mobile with thread-correct slash commands, interrupts, and queued-send state

## Why

Threads were already separate message histories, but the same agent profile shared one channel-level runtime and provider session across every thread. That allowed queues, steering, interrupts, status, and fallback replies to leak between otherwise independent conversations.

## Validation

- adversarial review: four P1 findings fixed; focused re-review finding fixed
- `npm run check -- --pretty false`
- `npm run build`
- `npm test`: 6,567/6,568 passed; live Hermes image-input probe timed out once at 30s
- isolated `npm test -- --run test/hermes-image-input.test.ts`: 8/8 passed in 20.7s
- rebased overlap suite: 340/340 passed
- nightly subscription suite: 82/82 passed
- `git diff --check origin/nightly...HEAD`

Closes #1386
