### PR TITLE
fix(channels): bound external callback failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ workflow.
 
 #### Fixed
 
+- Terminalize completion callbacks to unavailable requester profiles as durable,
+  inspectable `undeliverable` rows instead of repeatedly retrying or spawning a
+  fabricated external requester runtime; scoped external actors continue to
+  observe replies through durable channel history/subscriptions (#1392)
 - Keep Settings and Add Project scrolling inside their intended panes so modal
   content cannot become displaced in an unreachable hidden scroll offset (#1384)
 - Make reasoning status styling exhaustive, distinguish nested-only designation

--- a/docs/CHANNEL_CHAT.md
+++ b/docs/CHANNEL_CHAT.md
@@ -296,8 +296,12 @@ synthetic chat row.
 
 The directional invariant is: **delegation travels downward; completion travels
 upward; completion never creates a reverse delegation.** The one-shot lifecycle
-is `pending → satisfied → delivered → consumed`; guarded SQLite transitions make
-late or duplicate provider terminal patches inert. A delivered callback remains
+is `pending → satisfied → delivered → consumed`, with a separate terminal
+`delivered → undeliverable` outcome when Relay cannot ever deliver the internal
+callback; guarded SQLite transitions make late or duplicate provider terminal
+patches inert. `undeliverable` retains the delegatee's terminal reason plus a
+safe Relay delivery reason, is excluded from recovery/claims, and prunes under
+the same bounded settled-history policy. A delivered callback remains
 recoverable until the requester adapter resolves its typed-trigger acceptance;
 hub startup re-offers any such volatile FIFO offer. Relay uses the same
 deterministic recipient turn id and client-message id on every re-offer. Only
@@ -331,6 +335,23 @@ delegatee enters that FIFO; queue-cap rejection terminalizes that edge upward
 instead of silently losing it. The consecutive agent-turn brake remains in
 force for every normal mention route and admits child intent only after its
 turn passes the brake.
+
+An externally authenticated actor is not an installed requester profile. It
+observes a mentioned agent's reply through the authorized durable channel
+history/subscription surface; Relay does not provision a profile or launch a
+runtime for its provider id. If a legacy/internal automatic callback names an
+unavailable requester profile, Relay immediately terminalizes that callback as
+`undeliverable` with `requester-profile-unavailable` rather than retrying it.
+If SQLite cannot persist that terminal CAS, Relay makes a capped exponential
+storage-write retry (not a requester/profile retry), then leaves the durable
+row `delivered` and the channel archive-unsafe with an inspectable terminalization
+failure reason plus one final diagnostic. It never claims `undeliverable` unless
+the CAS actually landed.
+For nested delegation, any upward ancestry that depends on that impossible
+continuation terminalizes as `continuation-undeliverable`; Relay never invents
+a reverse delegation or acceptance. Transient binding/adapter failures remain
+on the recoverable delivery path. Correlated external run status is deliberately
+separate work (#1391).
 
 ## Threads
 

--- a/server/channel-agent-binder.ts
+++ b/server/channel-agent-binder.ts
@@ -131,6 +131,8 @@ const TARGETS_TTL_MS = 5 * 1000;
 /** Claim in bounded pages so a large recovered outbox cannot strand its tail. */
 const COMPLETION_CALLBACK_BATCH_LIMIT = 100;
 const COMPLETION_CALLBACK_RETRY_MS = 25;
+const COMPLETION_CALLBACK_TERMINALIZATION_MAX_ATTEMPTS = 5;
+const COMPLETION_CALLBACK_TERMINALIZATION_MAX_RETRY_MS = 1_000;
 const COMPLETION_CALLBACK_PRUNE_INTERVAL_MS = 5 * 60 * 1000;
 const CALLBACK_NO_TERMINAL_MESSAGE = 'no-terminal-message' as const;
 const CALLBACK_UNEXPECTED_DISCONNECT = 'unexpected-disconnect' as const;
@@ -192,7 +194,9 @@ export type ChannelArchiveActivityReason =
   | 'orchestrator-in-flight'
   | 'routing-in-flight'
   | 'retry-in-flight'
-  | 'completion-callback';
+  | 'completion-callback'
+  /** SQLite could not persist a non-delivery terminal state after bounded retry. */
+  | 'completion-callback-terminalization-failed';
 
 /** Synchronous snapshot used by the topic archive mutation boundary. */
 export interface ChannelArchiveActivitySnapshot {
@@ -629,6 +633,14 @@ export function createChannelAgentBinder(
   // before the next-tick drain creates ordinary binding/routing state. Key by
   // callback id so repeated retry scheduling is idempotent and channel-local.
   const pendingCompletionCallbacks = new Map<string, string>();
+  // A persistence outage must not turn a deterministic missing-profile result
+  // into a 25ms hot loop. This is intentionally in-memory only: restart makes
+  // the durable delivered row recoverable again, while an exhausted live binder
+  // remains archive-unsafe rather than claiming a CAS it could not record.
+  const terminalizationRetryByCallbackId = new Map<
+    string,
+    { attempts: number; scheduled: boolean; exhausted: boolean }
+  >();
   let lastCompletionCallbackPruneAt: number | null = null;
   let closed = false;
 
@@ -934,6 +946,92 @@ export function createChannelAgentBinder(
     }
   }
 
+  /**
+   * A missing requester profile is a deterministic delivery failure, never a
+   * request to provision or retry that external actor. Only a failed SQLite CAS
+   * retries here, against the already-claimed row, so recovery cannot turn the
+   * deterministic classification into a provider/log loop.
+   */
+  function terminalizeUnavailableRequesterCallback(
+    edge: ChannelCompletionCallbackEdge
+  ): void {
+    if (closed) return;
+    const retry = terminalizationRetryByCallbackId.get(edge.id) ?? {
+      attempts: 0,
+      scheduled: false,
+      exhausted: false,
+    };
+    // A callback may be encountered through a timer and a caller in the same
+    // turn. One scheduled CAS sequence owns it; exhausted work remains visible
+    // through archive activity until an operator restarts or repairs storage.
+    if (retry.scheduled || retry.exhausted) return;
+    try {
+      const terminalized = store.terminalizeDeliveredCompletionCallback({
+        id: edge.id,
+        channelId: edge.channelId,
+        threadId: edge.threadId,
+        deliveryReason: 'requester-profile-unavailable',
+      });
+      pendingCompletionCallbacks.delete(edge.id);
+      terminalizationRetryByCallbackId.delete(edge.id);
+      if (terminalized) {
+        logger.warn(
+          'channel completion callback terminalized: requester profile unavailable',
+          {
+            callbackId: edge.id,
+            requesterProfileId: edge.requesterProfileId,
+            deliveryReason: terminalized.deliveryReason,
+          }
+        );
+        maybePruneCompletionCallbacks();
+      }
+    } catch (err) {
+      retry.attempts += 1;
+      if (retry.attempts >= COMPLETION_CALLBACK_TERMINALIZATION_MAX_ATTEMPTS) {
+        retry.exhausted = true;
+        terminalizationRetryByCallbackId.set(edge.id, retry);
+        // Final, deliberately singular escalation. The durable row is still
+        // delivered, so leave the archive fence intact and never say it became
+        // undeliverable merely because the intended CAS could not be written.
+        logger.error(
+          'channel completion callback unavailable-requester terminalization exhausted',
+          {
+            callbackId: edge.id,
+            requesterProfileId: edge.requesterProfileId,
+            attempts: retry.attempts,
+            error: errText(err),
+          }
+        );
+        return;
+      }
+      if (closed) return;
+      const delayMs = Math.min(
+        COMPLETION_CALLBACK_RETRY_MS * 2 ** (retry.attempts - 1),
+        COMPLETION_CALLBACK_TERMINALIZATION_MAX_RETRY_MS
+      );
+      retry.scheduled = true;
+      terminalizationRetryByCallbackId.set(edge.id, retry);
+      // Rate-limit diagnostics to the first failure and the single exhaustion
+      // event. The retry is a storage-write recovery, never a profile retry.
+      if (retry.attempts === 1) {
+        logger.warn(
+          'channel completion callback unavailable-requester terminalization delayed',
+          {
+            callbackId: edge.id,
+            requesterProfileId: edge.requesterProfileId,
+            retryInMs: delayMs,
+            error: errText(err),
+          }
+        );
+      }
+      const timer = setTimeout(() => {
+        retry.scheduled = false;
+        terminalizeUnavailableRequesterCallback(edge);
+      }, delayMs);
+      timer.unref?.();
+    }
+  }
+
   function claimAndRouteCompletionCallbacks(): void {
     if (closed) return;
     let edges: ChannelCompletionCallbackEdge[];
@@ -952,14 +1050,11 @@ export function createChannelAgentBinder(
       trackCompletionCallbacks([edge]);
       const profile = profileForActorId(edge.requesterProfileId);
       if (!profile) {
-        logger.warn(
-          'channel completion callback requester profile is unavailable',
-          { callbackId: edge.id, requesterProfileId: edge.requesterProfileId }
-        );
-        releaseClaimedCompletionCallback(
-          edge,
-          'channel completion callback unavailable-requester release failed:'
-        );
+        // The durable CAS is the terminal boundary. Do not re-offer an
+        // external actor as though it were an installed profile or invent a
+        // runtime for it; that actor still observes the delegatee's durable
+        // channel reply through its scoped subscription/history contract.
+        terminalizeUnavailableRequesterCallback(edge);
         continue;
       }
       const trigger =
@@ -4260,6 +4355,15 @@ export function createChannelAgentBinder(
     ) {
       reasons.add('completion-callback');
     }
+    for (const [callbackId, retry] of terminalizationRetryByCallbackId) {
+      if (
+        retry.exhausted &&
+        pendingCompletionCallbacks.get(callbackId) === channelId
+      ) {
+        reasons.add('completion-callback-terminalization-failed');
+        break;
+      }
+    }
     return { active: reasons.size > 0, reasons: Array.from(reasons) };
   }
 
@@ -4319,6 +4423,7 @@ export function createChannelAgentBinder(
       retryInFlight.clear();
       routingInFlightByChannel.clear();
       pendingCompletionCallbacks.clear();
+      terminalizationRetryByCallbackId.clear();
       consecutiveAgentTurns.clear();
       unavailableRowAt.clear();
       invalidateTargets();

--- a/server/channel-message-store.ts
+++ b/server/channel-message-store.ts
@@ -61,7 +61,7 @@ import {
 //    catch-up window, and thread parent stays valid. Nothing in this file may
 //    ever issue `DELETE FROM channel_messages` for an operator action.
 
-const SCHEMA_VERSION = 13;
+const SCHEMA_VERSION = 14;
 const logger = createLogger('channel-message-store');
 export const CHANNEL_HISTORY_DEFAULT_LIMIT = 50;
 export const CHANNEL_HISTORY_MAX_LIMIT = 200;
@@ -809,14 +809,19 @@ CREATE TABLE IF NOT EXISTS channel_completion_callbacks (
   pending_child_intents INTEGER NOT NULL DEFAULT 0,
   continuation_completed_at TEXT,
   state                 TEXT NOT NULL
-                          CHECK (state IN ('pending','satisfied','delivered','consumed')),
+                          CHECK (state IN ('pending','satisfied','delivered','consumed','undeliverable')),
   terminal_reason       TEXT,
   terminal_message_id   TEXT,
   message_disposition   TEXT,
+  -- Delivery failure is deliberately separate from the delegatee terminal
+  -- reason: no requester accepted this callback, but the delegated turn may
+  -- still have completed normally.
+  delivery_reason       TEXT,
   created_at            TEXT NOT NULL,
   satisfied_at          TEXT,
   delivered_at          TEXT,
   consumed_at           TEXT,
+  undeliverable_at      TEXT,
   updated_at            TEXT NOT NULL,
   UNIQUE(channel_id, target_profile_id, target_turn_id)
 );
@@ -828,9 +833,9 @@ ON channel_completion_callbacks(channel_id, target_profile_id, target_turn_id);
 CREATE INDEX IF NOT EXISTS idx_chcc_continuation_parent
 ON channel_completion_callbacks(continuation_parent_callback_id)
 WHERE continuation_parent_callback_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_chcc_consumed_retention
-ON channel_completion_callbacks(consumed_at)
-WHERE state = 'consumed';
+CREATE INDEX IF NOT EXISTS idx_chcc_settled_retention
+ON channel_completion_callbacks(state, consumed_at, undeliverable_at)
+WHERE state IN ('consumed','undeliverable');
 `;
 
 interface ChannelMessageRow {
@@ -938,10 +943,12 @@ interface CompletionCallbackRow {
   terminal_reason: ChannelCompletionCallbackTerminalReason | null;
   terminal_message_id: string | null;
   message_disposition: ChannelCompletionCallbackMessageDisposition | null;
+  delivery_reason: ChannelCompletionCallbackDeliveryReason | null;
   created_at: string;
   satisfied_at: string | null;
   delivered_at: string | null;
   consumed_at: string | null;
+  undeliverable_at: string | null;
   updated_at: string;
 }
 
@@ -1173,7 +1180,9 @@ export type ChannelCompletionCallbackState =
   | 'pending'
   | 'satisfied'
   | 'delivered'
-  | 'consumed';
+  | 'consumed'
+  /** Callback delivery cannot ever reach its requester; never retry it. */
+  | 'undeliverable';
 
 /** Guarded terminal event that satisfied a delegated routed turn. */
 export type ChannelCompletionCallbackTerminalReason =
@@ -1188,6 +1197,11 @@ export type ChannelCompletionCallbackTerminalReason =
 export type ChannelCompletionCallbackMessageDisposition =
   | 'final-message'
   | 'no-terminal-message';
+
+/** Safe, Relay-owned reason for a non-delivery terminal disposition. */
+export type ChannelCompletionCallbackDeliveryReason =
+  | 'requester-profile-unavailable'
+  | 'continuation-undeliverable';
 
 /** Keep settled edge identities long enough for late provider patches to no-op. */
 const COMPLETION_CALLBACK_CONSUMED_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
@@ -1218,10 +1232,13 @@ export interface ChannelCompletionCallbackEdge {
   terminalReason: ChannelCompletionCallbackTerminalReason | null;
   terminalMessageId: string | null;
   messageDisposition: ChannelCompletionCallbackMessageDisposition | null;
+  /** Why Relay terminalized delivery without invoking a requester runtime. */
+  deliveryReason: ChannelCompletionCallbackDeliveryReason | null;
   createdAt: string;
   satisfiedAt: string | null;
   deliveredAt: string | null;
   consumedAt: string | null;
+  undeliverableAt: string | null;
   updatedAt: string;
 }
 
@@ -1560,6 +1577,17 @@ export interface ChannelMessageStore {
   ): ChannelCompletionCallbackEdge[];
   /** Return an undeliverable in-memory claim to durable retryable work. */
   releaseDeliveredCompletionCallback(id: string): boolean;
+  /**
+   * CAS a claimed callback into non-retryable delivery failure. If it belongs
+   * to a nested continuation, terminalize its unresolved ancestors too: there
+   * is no requester turn that could safely manufacture an upward return.
+   */
+  terminalizeDeliveredCompletionCallback(input: {
+    id: string;
+    channelId: string;
+    threadId: string | null;
+    deliveryReason: ChannelCompletionCallbackDeliveryReason;
+  }): ChannelCompletionCallbackEdge | null;
   /** CAS: records that the one typed internal trigger has begun its recipient turn. */
   consumeCompletionCallback(id: string): boolean;
   /**
@@ -2920,6 +2948,79 @@ function runSchemaMigrations(db: Database.Database): void {
       db.prepare('UPDATE schema_version SET version = 13').run();
     })();
   }
+  if (current < 14) {
+    db.transaction(() => {
+      // SQLite CHECK constraints cannot be widened in place. Rebuild the
+      // callback ledger atomically so existing recovery rows keep every durable
+      // identity and terminal fact while a new non-delivery terminal state is
+      // introduced. This is intentionally a state-machine migration, not a
+      // reinterpretation of `consumed`: no requester adapter accepted the
+      // callback, so claiming it consumed would fabricate an acknowledgement.
+      db.exec(`
+        DROP INDEX IF EXISTS idx_chcc_recovery;
+        DROP INDEX IF EXISTS idx_chcc_target_turn;
+        DROP INDEX IF EXISTS idx_chcc_continuation_parent;
+        DROP INDEX IF EXISTS idx_chcc_consumed_retention;
+        DROP INDEX IF EXISTS idx_chcc_settled_retention;
+        CREATE TABLE channel_completion_callbacks_v14 (
+          id                    TEXT PRIMARY KEY,
+          channel_id            TEXT NOT NULL,
+          thread_id             TEXT,
+          trigger_message_id    TEXT NOT NULL,
+          requester_profile_id  TEXT NOT NULL,
+          target_profile_id     TEXT NOT NULL,
+          target_runtime_id     TEXT NOT NULL,
+          target_turn_id        TEXT NOT NULL,
+          continuation_parent_callback_id TEXT,
+          awaiting_child        INTEGER NOT NULL DEFAULT 0 CHECK (awaiting_child IN (0, 1)),
+          pending_child_intents INTEGER NOT NULL DEFAULT 0,
+          continuation_completed_at TEXT,
+          state                 TEXT NOT NULL
+                                CHECK (state IN ('pending','satisfied','delivered','consumed','undeliverable')),
+          terminal_reason       TEXT,
+          terminal_message_id   TEXT,
+          message_disposition   TEXT,
+          delivery_reason       TEXT,
+          created_at            TEXT NOT NULL,
+          satisfied_at          TEXT,
+          delivered_at          TEXT,
+          consumed_at           TEXT,
+          undeliverable_at      TEXT,
+          updated_at            TEXT NOT NULL,
+          UNIQUE(channel_id, target_profile_id, target_turn_id)
+        );
+        INSERT INTO channel_completion_callbacks_v14 (
+          id, channel_id, thread_id, trigger_message_id, requester_profile_id,
+          target_profile_id, target_runtime_id, target_turn_id,
+          continuation_parent_callback_id, awaiting_child, pending_child_intents,
+          continuation_completed_at, state, terminal_reason, terminal_message_id,
+          message_disposition, delivery_reason, created_at, satisfied_at,
+          delivered_at, consumed_at, undeliverable_at, updated_at
+        )
+        SELECT id, channel_id, thread_id, trigger_message_id, requester_profile_id,
+               target_profile_id, target_runtime_id, target_turn_id,
+               continuation_parent_callback_id, awaiting_child, pending_child_intents,
+               continuation_completed_at, state, terminal_reason, terminal_message_id,
+               message_disposition, NULL, created_at, satisfied_at,
+               delivered_at, consumed_at, NULL, updated_at
+          FROM channel_completion_callbacks;
+        DROP TABLE channel_completion_callbacks;
+        ALTER TABLE channel_completion_callbacks_v14 RENAME TO channel_completion_callbacks;
+        CREATE INDEX idx_chcc_recovery
+          ON channel_completion_callbacks(state, created_at)
+          WHERE state IN ('pending','satisfied','delivered');
+        CREATE INDEX idx_chcc_target_turn
+          ON channel_completion_callbacks(channel_id, target_profile_id, target_turn_id);
+        CREATE INDEX idx_chcc_continuation_parent
+          ON channel_completion_callbacks(continuation_parent_callback_id)
+          WHERE continuation_parent_callback_id IS NOT NULL;
+        CREATE INDEX idx_chcc_settled_retention
+          ON channel_completion_callbacks(state, consumed_at, undeliverable_at)
+          WHERE state IN ('consumed','undeliverable');
+      `);
+      db.prepare('UPDATE schema_version SET version = 14').run();
+    })();
+  }
 }
 
 export function initChannelMessageStore(
@@ -3894,6 +3995,67 @@ export function createChannelMessageStore(
     );
   }
 
+  const terminalizeDeliveredCompletionCallbackImpl = db.transaction(
+    (input: {
+      id: string;
+      channelId: string;
+      threadId: string | null;
+      deliveryReason: ChannelCompletionCallbackDeliveryReason;
+    }): ChannelCompletionCallbackEdge | null => {
+      const timestamp = nowIso();
+      // `delivered` is the binder's durable claim. Limiting the first update to
+      // that state is the CAS boundary: a late missing-profile observation can
+      // neither overwrite a consumed acceptance nor re-terminalize a retry.
+      const terminalized = db
+        .prepare(
+          `UPDATE channel_completion_callbacks
+            SET state = 'undeliverable', delivery_reason = ?,
+                  undeliverable_at = ?, updated_at = ?
+            WHERE id = ? AND channel_id = ? AND thread_id IS ?
+              AND state = 'delivered'`
+        )
+        .run(
+          input.deliveryReason,
+          timestamp,
+          timestamp,
+          input.id,
+          input.channelId,
+          input.threadId
+        );
+      if (terminalized.changes === 0) return null;
+
+      const edge = selectCompletionCallbackById.get(input.id) as
+        | CompletionCallbackRow
+        | undefined;
+      if (!edge)
+        throw new Error('completion callback terminalization lost row');
+
+      // A nested child is the sole route by which its requester can produce the
+      // continuation that wakes each ancestor. Once delivery is impossible,
+      // preserve the directional invariant by terminalizing that unresolved
+      // upward ancestry too — never manufacture an adapter callback to pretend
+      // the absent requester accepted it.
+      let parentId = edge.continuation_parent_callback_id;
+      const seenAncestorIds = new Set<string>([edge.id]);
+      while (parentId && !seenAncestorIds.has(parentId)) {
+        seenAncestorIds.add(parentId);
+        const parent = selectCompletionCallbackById.get(parentId) as
+          | CompletionCallbackRow
+          | undefined;
+        if (!parent) break;
+        db.prepare(
+          `UPDATE channel_completion_callbacks
+              SET state = 'undeliverable',
+                  delivery_reason = 'continuation-undeliverable',
+                  undeliverable_at = ?, updated_at = ?
+            WHERE id = ? AND state IN ('pending','satisfied','delivered')`
+        ).run(timestamp, timestamp, parent.id);
+        parentId = parent.continuation_parent_callback_id;
+      }
+      return completionCallbackRowToRecord(edge);
+    }
+  );
+
   const pruneConsumedCompletionCallbacksImpl = db.transaction(
     (olderThanMs: number): number => {
       const cutoff = new Date(Date.now() - olderThanMs).toISOString();
@@ -3903,19 +4065,19 @@ export function createChannelMessageStore(
       return db
         .prepare(
           `DELETE FROM channel_completion_callbacks AS settled
-            WHERE settled.state = 'consumed'
-              AND settled.consumed_at IS NOT NULL
-              AND settled.consumed_at < @cutoff
+            WHERE settled.state IN ('consumed','undeliverable')
+              AND COALESCE(settled.consumed_at, settled.undeliverable_at) < @cutoff
               AND NOT EXISTS (
                 SELECT 1 FROM channel_completion_callbacks child
                  WHERE child.continuation_parent_callback_id = settled.id
-                   AND (child.state <> 'consumed'
-                        OR child.continuation_completed_at IS NULL)
+                   AND (child.state NOT IN ('consumed','undeliverable')
+                        OR (child.state = 'consumed'
+                            AND child.continuation_completed_at IS NULL))
               )
               AND NOT EXISTS (
                 SELECT 1 FROM channel_completion_callbacks parent
                  WHERE parent.id = settled.continuation_parent_callback_id
-                   AND parent.state <> 'consumed'
+                   AND parent.state NOT IN ('consumed','undeliverable')
               )`
         )
         .run({ cutoff }).changes;
@@ -4979,6 +5141,10 @@ export function createChannelMessageStore(
       return releaseDeliveredCompletionCallbackImpl(id);
     },
 
+    terminalizeDeliveredCompletionCallback(input) {
+      return terminalizeDeliveredCompletionCallbackImpl(input);
+    },
+
     consumeCompletionCallback(id) {
       const timestamp = nowIso();
       return (
@@ -5232,10 +5398,12 @@ function completionCallbackRowToRecord(
     terminalReason: row.terminal_reason,
     terminalMessageId: row.terminal_message_id,
     messageDisposition: row.message_disposition,
+    deliveryReason: row.delivery_reason,
     createdAt: row.created_at,
     satisfiedAt: row.satisfied_at,
     deliveredAt: row.delivered_at,
     consumedAt: row.consumed_at,
+    undeliverableAt: row.undeliverable_at,
     updatedAt: row.updated_at,
   };
 }

--- a/test/channel-agent-binder.test.ts
+++ b/test/channel-agent-binder.test.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 
 import Database from 'better-sqlite3';
 import express from 'express';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MockProtocolAdapterV2 } from '../server/protocol-adapters/mock-v2-adapter.js';
 import { CHANNEL_ADAPTER_LAUNCH_CONTRACTS } from '../server/protocol-adapters/index.js';
@@ -191,8 +191,8 @@ describe('channel-agent-binder — durable delegation completion callbacks', () 
     await waitFor(() => !binder.archiveActivityForChannel(CH).active);
   });
 
-  it('contains a synchronous callback release failure and retains the archive fence', async () => {
-    const { binder, store } = makeBinder({
+  it('terminalizes an unavailable requester once and releases the archive fence', async () => {
+    const { binder, store, sessions } = makeBinder({
       build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
       targets: callbackTargets,
       knownProviderIds: ['a', 'b', 'c', 'd'],
@@ -219,29 +219,92 @@ describe('channel-agent-binder — durable delegation completion callbacks', () 
       terminalReason: 'completed',
       messageDisposition: 'no-terminal-message',
     });
-    const originalRelease =
-      store.releaseDeliveredCompletionCallback.bind(store);
-    let releaseAttempts = 0;
-    store.releaseDeliveredCompletionCallback = (id) => {
-      releaseAttempts += 1;
-      if (releaseAttempts === 1) throw new Error('sqlite release failed');
-      return originalRelease(id);
+    const terminalize =
+      store.terminalizeDeliveredCompletionCallback.bind(store);
+    let terminalizeAttempts = 0;
+    store.terminalizeDeliveredCompletionCallback = (input) => {
+      terminalizeAttempts += 1;
+      return terminalize(input);
     };
 
     await binder.recoverCompletionCallbacks();
-    await waitFor(() => releaseAttempts >= 2);
-    expect(binder.archiveActivityForChannel(CH)).toMatchObject({
-      active: true,
-      reasons: expect.arrayContaining(['completion-callback']),
+    await waitFor(
+      () => store.getCompletionCallback(edge.id)?.state === 'undeliverable'
+    );
+    expect(store.getCompletionCallback(edge.id)).toMatchObject({
+      state: 'undeliverable',
+      terminalReason: 'completed',
+      deliveryReason: 'requester-profile-unavailable',
     });
-
-    // Close is the terminal cleanup for this intentionally undeliverable edge;
-    // its retry timer observes `closed` and cannot resurrect the marker.
-    binder.close();
     expect(binder.archiveActivityForChannel(CH)).toEqual({
       active: false,
       reasons: [],
     });
+    expect(sessions.spawns()).toBe(0); // never fabricate a requester runtime
+    await binder.recoverCompletionCallbacks();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(terminalizeAttempts).toBe(1);
+    expect(store.claimSatisfiedCompletionCallbacks()).toEqual([]);
+  });
+
+  it('bounds unavailable-requester terminalization persistence retries without clearing archive safety', async () => {
+    vi.useFakeTimers();
+    try {
+      const { binder, store } = makeBinder({
+        build: (provider) => new ScriptedAdapter(provider, { mode: 'stall' }),
+        targets: callbackTargets,
+        knownProviderIds: ['a', 'b', 'c', 'd'],
+      });
+      const trigger = store.appendComplete({
+        channelId: CH,
+        sender: OPERATOR,
+        text: 'persistence outage callback',
+      });
+      const edge = store.createCompletionCallback({
+        id: 'chcb:terminalization-storage-outage',
+        channelId: CH,
+        threadId: null,
+        triggerMessageId: trigger.id,
+        requesterProfileId: 'agent-profile:missing',
+        targetProfileId: builtInAgentProfileId('b'),
+        targetRuntimeId: 'runtime:b',
+        targetTurnId: 'turn:terminalization-storage-outage',
+      });
+      store.satisfyCompletionCallback({
+        channelId: edge.channelId,
+        targetProfileId: edge.targetProfileId,
+        targetTurnId: edge.targetTurnId,
+        terminalReason: 'completed',
+        messageDisposition: 'no-terminal-message',
+      });
+      let attempts = 0;
+      store.terminalizeDeliveredCompletionCallback = () => {
+        attempts += 1;
+        throw new Error('sqlite disk I/O error');
+      };
+
+      await binder.recoverCompletionCallbacks();
+      await vi.advanceTimersByTimeAsync(0); // first claim + failed CAS
+      expect(attempts).toBe(1);
+      await vi.advanceTimersByTimeAsync(25 + 50 + 100 + 200);
+      expect(attempts).toBe(5);
+      // The fifth failed CAS escalates in memory but must not pretend the
+      // durable row reached `undeliverable` or make the channel archivable.
+      expect(store.getCompletionCallback(edge.id)).toMatchObject({
+        state: 'delivered',
+      });
+      expect(binder.archiveActivityForChannel(CH)).toMatchObject({
+        active: true,
+        reasons: expect.arrayContaining([
+          'completion-callback',
+          'completion-callback-terminalization-failed',
+        ]),
+      });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(attempts).toBe(5);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('wakes a silent successful delegator exactly once with a typed internal trigger', async () => {

--- a/test/channel-mention-e2e.test.ts
+++ b/test/channel-mention-e2e.test.ts
@@ -54,6 +54,7 @@ import {
   type WorkspaceTopicStore,
 } from '../server/workspace-topics.js';
 import {
+  channelTurnId,
   parseMentions,
   type ChannelMessage,
 } from '../shared/channel-chat-protocol.js';
@@ -846,6 +847,84 @@ describe('mention routing — real scoped-actor auth composition (P2 #1180)', ()
           m.kind === 'system' && m.body.text.includes('Mention chain paused')
       );
     expect(paused).toHaveLength(1);
+  });
+
+  it('lets an external scoped actor observe the durable reply without a requester profile', async () => {
+    const registry = createCliGatewayActorRegistry();
+    const h = await harness(
+      (provider) => new RecordingAdapter(provider, 'durable external reply'),
+      { actorRegistry: registry }
+    );
+    // This is a real external actor identity, deliberately absent from the
+    // profile store and built-in provider catalog. The actor reads the target's
+    // durable channel reply; Relay must not create a faux requester runtime.
+    const issued = issueCliGatewayActorCredential(registry, {
+      actor: {
+        type: 'agent',
+        id: 'codex-desktop-dogfood',
+        displayName: 'Codex Desktop',
+      },
+      capabilities: ['context:read', 'context:write'],
+      scope: { channelIds: [h.channelId] },
+    });
+    const post = await req<{ message: ChannelMessage }>({
+      port: h.port,
+      method: 'POST',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages`,
+      body: { text: '@mock report back' },
+      headers: {
+        authorization: `Bearer ${issued.token}`,
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'channels.post',
+      },
+    });
+    expect(post.status).toBe(201);
+    expect(post.body.message.sender).toMatchObject({
+      kind: 'agent',
+      id: 'agent:codex-desktop-dogfood',
+    });
+    await waitFor(() => agentReply(h.store, h.channelId).length === 1);
+    expect(agentReply(h.store, h.channelId)[0]).toMatchObject({
+      body: { text: 'durable external reply' },
+      sender: { id: 'agent-profile:mock:default' },
+    });
+    // Verify the actor's real authorization surface, not the test's internal
+    // store: this is the durable history contract external requesters use to
+    // observe replies without acquiring an installed requester profile.
+    const history = await req<{ messages: ChannelMessage[] }>({
+      port: h.port,
+      method: 'GET',
+      url: `/channels/${encodeURIComponent(h.channelId)}/messages?limit=20`,
+      headers: {
+        authorization: `Bearer ${issued.token}`,
+        'x-relay-cli-actor-token': 'v1',
+        'x-relay-cli-command': 'channels.history',
+      },
+    });
+    expect(history.status).toBe(200);
+    expect(history.body.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          body: expect.objectContaining({ text: 'durable external reply' }),
+          sender: expect.objectContaining({ id: 'agent-profile:mock:default' }),
+        }),
+      ])
+    );
+    const callbackId = `chcb:${channelTurnId(
+      post.body.message.id,
+      builtInAgentProfileId('mock')
+    )}`;
+    await waitFor(
+      () => h.store.getCompletionCallback(callbackId)?.state === 'undeliverable'
+    );
+    expect(h.store.getCompletionCallback(callbackId)).toMatchObject({
+      state: 'undeliverable',
+      deliveryReason: 'requester-profile-unavailable',
+      terminalReason: 'completed',
+    });
+    expect(h.adapters()).toHaveLength(1);
+    await h.binder.recoverCompletionCallbacks();
+    expect(h.store.claimSatisfiedCompletionCallbacks()).toEqual([]);
   });
 
   it('rejects a bogus bearer token (no fabricated credential accepted)', async () => {

--- a/test/channel-message-store.test.ts
+++ b/test/channel-message-store.test.ts
@@ -65,6 +65,86 @@ const AGENT: ChannelSenderRef = {
 };
 
 describe('channel-message-store schema migration', () => {
+  it('rebuilds a v13 callback ledger without losing recoverable rows', () => {
+    const file = dbPath();
+    const current = store(file);
+    current.createCompletionCallback({
+      id: 'chcb:v13-keeper',
+      channelId: 'topic:v13',
+      threadId: 'chm:thread-v13',
+      triggerMessageId: 'chm:trigger-v13',
+      requesterProfileId: 'agent-profile:external:default',
+      targetProfileId: 'agent-profile:mock:default',
+      targetRuntimeId: 'runtime:mock:v13',
+      targetTurnId: 'turn:v13',
+    });
+    current.close();
+    const legacy = new Database(file);
+    legacy.exec(`
+      DROP INDEX IF EXISTS idx_chcc_recovery;
+      DROP INDEX IF EXISTS idx_chcc_target_turn;
+      DROP INDEX IF EXISTS idx_chcc_continuation_parent;
+      DROP INDEX IF EXISTS idx_chcc_settled_retention;
+      CREATE TABLE channel_completion_callbacks_v13 (
+        id TEXT PRIMARY KEY, channel_id TEXT NOT NULL, thread_id TEXT,
+        trigger_message_id TEXT NOT NULL, requester_profile_id TEXT NOT NULL,
+        target_profile_id TEXT NOT NULL, target_runtime_id TEXT NOT NULL,
+        target_turn_id TEXT NOT NULL, continuation_parent_callback_id TEXT,
+        awaiting_child INTEGER NOT NULL DEFAULT 0,
+        pending_child_intents INTEGER NOT NULL DEFAULT 0,
+        continuation_completed_at TEXT, state TEXT NOT NULL
+          CHECK (state IN ('pending','satisfied','delivered','consumed')),
+        terminal_reason TEXT, terminal_message_id TEXT, message_disposition TEXT,
+        created_at TEXT NOT NULL, satisfied_at TEXT, delivered_at TEXT,
+        consumed_at TEXT, updated_at TEXT NOT NULL,
+        UNIQUE(channel_id, target_profile_id, target_turn_id)
+      );
+      INSERT INTO channel_completion_callbacks_v13
+        (id, channel_id, thread_id, trigger_message_id, requester_profile_id,
+         target_profile_id, target_runtime_id, target_turn_id,
+         continuation_parent_callback_id, awaiting_child, pending_child_intents,
+         continuation_completed_at, state, terminal_reason, terminal_message_id,
+         message_disposition, created_at, satisfied_at, delivered_at, consumed_at,
+         updated_at)
+      SELECT id, channel_id, thread_id, trigger_message_id, requester_profile_id,
+             target_profile_id, target_runtime_id, target_turn_id,
+             continuation_parent_callback_id, awaiting_child, pending_child_intents,
+             continuation_completed_at, state, terminal_reason, terminal_message_id,
+             message_disposition, created_at, satisfied_at, delivered_at, consumed_at,
+             updated_at
+        FROM channel_completion_callbacks;
+      DROP TABLE channel_completion_callbacks;
+      ALTER TABLE channel_completion_callbacks_v13 RENAME TO channel_completion_callbacks;
+      UPDATE schema_version SET version = 13;
+    `);
+    legacy.close();
+
+    const migrated = store(file);
+    expect(migrated.getCompletionCallback('chcb:v13-keeper')).toMatchObject({
+      state: 'pending',
+      channelId: 'topic:v13',
+      threadId: 'chm:thread-v13',
+      deliveryReason: null,
+      undeliverableAt: null,
+    });
+    const inspect = new Database(file, { readonly: true });
+    cleanup.push(() => inspect.close());
+    expect(
+      (
+        inspect.prepare('SELECT version FROM schema_version').get() as {
+          version: number;
+        }
+      ).version
+    ).toBe(14);
+    expect(
+      (
+        inspect
+          .prepare('PRAGMA table_info(channel_completion_callbacks)')
+          .all() as Array<{ name: string }>
+      ).map((column) => column.name)
+    ).toEqual(expect.arrayContaining(['delivery_reason', 'undeliverable_at']));
+  });
+
   it('migrates a v2 binding to its built-in profile without changing durable fields on reopen', () => {
     const file = dbPath();
     const legacy = new Database(file);
@@ -525,7 +605,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(13);
+    ).toBe(14);
     expect(
       (
         inspect.prepare('PRAGMA table_info(channel_messages)').all() as Array<{
@@ -713,7 +793,7 @@ describe('channel-message-store schema migration', () => {
           version: number;
         }
       ).version
-    ).toBe(13);
+    ).toBe(14);
     expect(
       inspect
         .prepare('SELECT heal_id, candidates, healed FROM channel_heal_state')
@@ -3295,7 +3375,7 @@ describe('channel-message-store full-text search (#1308 slice 2 item 1)', () => 
       .get() as { version: number };
     counted.close();
     expect(rows.count).toBe(1);
-    expect(version.version).toBe(13);
+    expect(version.version).toBe(14);
   });
 
   it('backfills across more than one batch without dropping or duplicating rows', () => {
@@ -3791,6 +3871,105 @@ describe('channel completion callback edge store', () => {
 
     const reopened = store(file);
     expect(reopened.recoverCompletionCallbacks()).toEqual([]);
+  });
+
+  it('CAS-terminalizes an unavailable requester without recovery, while retaining bounded evidence', async () => {
+    const s = store();
+    const edge = s.createCompletionCallback(
+      edgeInput({ threadId: 'chm:thread-root' })
+    );
+    s.satisfyCompletionCallback({
+      channelId: edge.channelId,
+      targetProfileId: edge.targetProfileId,
+      targetTurnId: edge.targetTurnId,
+      terminalReason: 'completed',
+      terminalMessageId: 'chm:delegatee-final',
+      messageDisposition: 'final-message',
+    });
+    expect(s.claimSatisfiedCompletionCallbacks()).toHaveLength(1);
+    // Thread scope participates in the CAS; a root-scope caller cannot spend a
+    // claimed callback from a named conversation.
+    expect(
+      s.terminalizeDeliveredCompletionCallback({
+        id: edge.id,
+        channelId: edge.channelId,
+        threadId: null,
+        deliveryReason: 'requester-profile-unavailable',
+      })
+    ).toBeNull();
+    expect(
+      s.terminalizeDeliveredCompletionCallback({
+        id: edge.id,
+        channelId: edge.channelId,
+        threadId: edge.threadId,
+        deliveryReason: 'requester-profile-unavailable',
+      })
+    ).toMatchObject({
+      state: 'undeliverable',
+      terminalReason: 'completed',
+      deliveryReason: 'requester-profile-unavailable',
+      terminalMessageId: 'chm:delegatee-final',
+      undeliverableAt: expect.any(String),
+    });
+    expect(s.claimSatisfiedCompletionCallbacks()).toEqual([]);
+    expect(s.recoverCompletionCallbacks()).toEqual([]);
+    expect(
+      s.terminalizeDeliveredCompletionCallback({
+        id: edge.id,
+        channelId: edge.channelId,
+        threadId: edge.threadId,
+        deliveryReason: 'requester-profile-unavailable',
+      })
+    ).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(s.pruneConsumedCompletionCallbacks(0)).toBe(1);
+    expect(s.getCompletionCallback(edge.id)).toBeNull();
+  });
+
+  it('terminalizes unresolved continuation ancestry rather than fabricating an upward callback', () => {
+    const s = store();
+    const parent = s.createCompletionCallback(edgeInput({ id: 'chcb:parent' }));
+    s.deferCompletionCallbackForChild({
+      channelId: parent.channelId,
+      targetProfileId: parent.targetProfileId,
+      targetTurnId: parent.targetTurnId,
+      expectedChildCount: 1,
+    });
+    const child = s.createCompletionCallback(
+      edgeInput({
+        id: 'chcb:child',
+        requesterProfileId: parent.targetProfileId,
+        targetProfileId: 'agent-profile:hermes:default',
+        targetRuntimeId: 'runtime:hermes:1',
+        targetTurnId: 'turn:child',
+        continuationParentCallbackId: parent.id,
+      })
+    );
+    s.satisfyCompletionCallback({
+      channelId: child.channelId,
+      targetProfileId: child.targetProfileId,
+      targetTurnId: child.targetTurnId,
+      terminalReason: 'completed',
+      messageDisposition: 'no-terminal-message',
+    });
+    expect(s.claimSatisfiedCompletionCallbacks()).toMatchObject([
+      { id: child.id, state: 'delivered' },
+    ]);
+    s.terminalizeDeliveredCompletionCallback({
+      id: child.id,
+      channelId: child.channelId,
+      threadId: child.threadId,
+      deliveryReason: 'requester-profile-unavailable',
+    });
+    expect(s.getCompletionCallback(child.id)).toMatchObject({
+      state: 'undeliverable',
+      deliveryReason: 'requester-profile-unavailable',
+    });
+    expect(s.getCompletionCallback(parent.id)).toMatchObject({
+      state: 'undeliverable',
+      deliveryReason: 'continuation-undeliverable',
+    });
+    expect(s.recoverCompletionCallbacks()).toEqual([]);
   });
 
   it('recovers volatile delivery and terminalizes restart-orphaned pending turns from durable evidence only', () => {


### PR DESCRIPTION
## What changed

- add SQLite schema v14 with a durable `undeliverable` callback state and separate delivery reason/timestamp
- terminalize callbacks for external requesters with no installed provider profile without creating a runtime
- preserve thread scope and terminalize impossible nested continuation ancestry directionally
- bound terminalization-storage failures to five exponential attempts while retaining an explicit archive-safety fence on exhaustion
- prove scoped external actors receive the agent reply through authenticated channel history

## Root cause

The callback router treated a missing requester profile as retryable. It released the claimed row and scheduled another attempt every 25 ms, so an external actor that correctly consumed replies from durable channel history caused an immortal callback and multi-megabyte log storm.

## Review and dogfood

The original #1389 Codex Desktop → Relay → Claude/Prime dogfood reproduced the failure. Broad review found the remaining SQLite-error hot loop and an internal-only receipt assertion; both were fixed in one batch. Focused re-review reported no remaining P0/P1 findings.

## Exact-head evidence

Head: `28e2fd738be046f7071dd79d03f90b52d8cb1d12`

- focused store/binder/scoped-actor E2E: 294 tests passed
- focused remediation re-review: 186 tests passed
- `npm run check`: pass; existing warnings only
- `npm test`: pass
- `npm run build`: pass; existing Vite warnings only
- `git diff --check origin/nightly...HEAD`: pass
- changed-test pre-push hook hit one unrelated binder timing assertion once; the exact test passed immediately in isolation

Closes #1392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Completion callbacks for unavailable requester profiles are now recorded as inspectable `undeliverable` entries instead of being repeatedly retried.
  - Relay and continuation failure reasons are retained for troubleshooting.
  - External actors can continue viewing replies through durable channel history and subscriptions.

- **Bug Fixes**
  - Prevented fabricated requester runtimes from being created.
  - Added bounded retry handling and cleanup for terminalization failures.
  - Undeliverable callbacks are excluded from recovery loops and eventually pruned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->